### PR TITLE
feat(galgame): KiriKiri 游戏内查词——游戏当显示器，Hibiki 当渲染器

### DIFF
--- a/docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md
+++ b/docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md
@@ -1,0 +1,249 @@
+# KiriKiri/KAGEX 游戏内查词实现计划
+
+> 状态：待评审。取代 Draft PR #799 的实现路线，**保留** #799 的 Hook 边界发现。
+> 平台边界：**仅 Windows**（galgame 硬规则，见 [CLAUDE.md](../../CLAUDE.md)）。
+> SOP：[docs/agent/galgame-hooking.md](../agent/galgame-hooking.md)。
+
+## 0. 一句话
+
+把 #799 的「TJS 里手写整条查词链路」改成 **「TJS 只做几何传感 + 输入转发，Hibiki 出像素，游戏只负责显示」**。
+
+## 1. 既有事实
+
+### 1.1 样本身份
+
+| 项 | 值 |
+|---|---|
+| 游戏 | Limelight「天使☆騒々」系（`tenshi_sz.exe`） |
+| 引擎 | KiriKiri Z + KAGEX，第三方 `textrender.dll` 排版 |
+| 架构 | exe 与全部 38 个 plugin DLL **均为 x86** |
+| 关键 module | `textrender.dll`（SHA-256 `44D7B056…64EE70`）、`msdfrender.dll`、`kagexopt.dll`、`KAGParserEx.dll`、`DrawDeviceD2D.dll` |
+| 完整性校验 | 每个资产带 `.sig`，另有 `ファイル破損チェックツール.exe` |
+
+`.sig` 是**磁盘文件**校验，不校验内存。故硬约束：**绝不修改游戏目录下任何文件**（含不往游戏目录写临时文件）。
+
+### 1.2 #799 里值钱的部分（保留）
+
+运行日志已证伪 `MessageLayer.processCh` / `Layer.drawText` / `msdfrender.dll!drawGlyph` 三条路径。唯一命中的边界是：
+
+```text
+TextRender.render / done  →  renderer.getCharacters(0, 0)  →  逐字符 text/x/y/cw/size
+TextRender.drawCh(layer, ox, oy, ch)  →  补齐 layer 与绘制原点
+```
+
+外加经 `iTVPFunctionExporter` 查询官方 ABI、用 `TVPAddContinuousEventHook` 延到游戏主线程执行 bootstrap 的时序模型。**这两件是本次唯一不可替代的发现，全部保留。**
+
+### 1.3 Hibiki 已有、可直接复用的能力
+
+| 能力 | 位置 |
+|---|---|
+| WebView2 **离屏合成** + `SendMouseInput` 输入注入 | `fushi/windows/runner/global_lookup_window.cpp:1089` `:1154` `:2150` |
+| Yomitan 同级词典卡片（ruby / 外字图 / 发音 / 制卡 / 主题 / 17 语言） | `fushi/assets/popup/popup.html` |
+| 查词分发、去屈折、假名复合词选择、词典优先级 | `fushi/lib/src/lookup/desktop_lookup_dispatcher.dart`、`sentence_extraction.dart` |
+| hook↔host 共享内存 IPC（含 host→hook 控制字段先例 `selected_text_thread_id`） | `native/galgame_hook/include/voice_hook_ipc.h:296` |
+| host 侧共享内存读取器 | `fushi/windows/runner/voice_hook_reader.cpp` |
+| galgame 会话 / 制卡 / 语音配对 | `fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart` |
+
+## 2. 决策
+
+**用户已拍板：能在游戏内渲染就在游戏内渲染**（体验显著优于游戏外浮窗）。
+
+由此确定：
+
+- ✅ 卡片是游戏渲染树里的真 `Layer`：不抢焦点、不 alt-tab、跟随全屏与窗口变换。
+- ✅ 「独占全屏盖不住外部窗口」这个风险直接消失，不再需要为它做前置测量。
+- ❌ 但**不等于**在 TJS 里手写卡片。卡片显示在哪，与「谁做分词、查词、排版」是正交的两件事；#799 把它们焊死了。
+
+## 3. 目标 / 非目标
+
+### 目标
+
+1. 在游戏内点击/悬停字幕字符 → 游戏内出现与 Hibiki 自身**像素一致**的词典卡片。
+2. 注入进游戏进程的代码只做：几何采集、命中测试、位图显示、输入转发。
+3. 游戏进程内**没有** HTTP 客户端、没有认证 token、没有 JSON 解析器、没有动态字符串 eval。
+4. 卡片能力（ruby / 外字 / 发音 / 制卡 / 主题 / 语言 / 字号）与阅读器、视频、剪贴板查词**同一份实现**，不产生第二套。
+
+### 非目标
+
+- 不做 Android / iOS / macOS / Linux。
+- 不宣称「支持 KiriKiri」——只对本样本的 `textrender.dll` 组合有证据。
+- 不做形态素分析：host 现有分词就是真值。
+- ruby / 竖排 / 选项文字 / 名字栏：P1 之后单独排期。
+
+## 4. 架构
+
+### 4.1 三段职责
+
+```text
+┌─ 游戏进程 ────────────────────────────────┐      ┌─ Hibiki ─────────────────┐
+│ TJS 传感器                                 │      │                          │
+│   TextRender.render/done → 字符几何        │      │                          │
+│   drawCh → 绑定 layer + 原点               │      │                          │
+│   KAG hook → 命中测试 / 输入转发           │      │                          │
+│        │ hit(整行文本, 字符下标, 字形矩形)  │      │                          │
+│        ├──────────── 共享内存 ────────────────────▶ DesktopLookupDispatcher  │
+│                                            │      │        ↓                 │
+│ hook DLL                                   │      │ popup.html @ WebView2    │
+│   memcpy BGRA → Layer 像素缓冲             │      │ 离屏合成 → BGRA 位图      │
+│   TVPExecuteScript("…Apply(seq,s,len);")   │◀─────────────── 共享内存         │
+│        │ 只含整数                          │      │                          │
+│ 游戏渲染树里的卡片 Layer + 字幕高亮         │      │                          │
+└────────────────────────────────────────────┘      └──────────────────────────┘
+```
+
+**关键性质**：跨边界的东西只有「一块位图」和「一串整数」。字符串 eval 的注入面**从结构上消失**，不是靠 escape 得更严。
+
+### 4.2 IPC 契约（`voice_hook_ipc.h`，`kSharedVersion` 13 → 14）
+
+`SharedHeader` 新增：
+
+```c
+// ── v14 游戏内查词区（injector 填偏移/容量）────────────────────────────
+uint32_t lookup_region_offset;         // 查词区起始（header 起算字节偏移）
+uint32_t lookup_bitmap_capacity;       // 单帧位图字节上限
+volatile uint64_t lookup_hit_count;    // hook→host 单调：命中事件数
+volatile uint64_t lookup_frame_count;  // host→hook 单调：已投位图帧数
+volatile uint64_t lookup_input_count;  // hook→host 单调：转发的卡片输入事件数
+volatile uint32_t lookup_enabled;      // host→hook：1=开启（取代 #799 的环境变量开关）
+uint32_t lookup_reserved;
+```
+
+区布局：`[LookupHitSlot][LookupInputSlot 环][LookupFrame 双缓冲 + BGRA 字节]`
+
+```c
+struct LookupHitSlot {          // hook→host，单槽 latest-wins
+  volatile uint64_t seq;        // 单调；host 据此判新
+  uint32_t char_index;          // 光标落在第几个字符（UTF-16 code unit 下标）
+  uint32_t char_count;          // 本行字符数（自洽校验）
+  uint32_t glyph_x, glyph_y, glyph_w, glyph_h;  // 命中字形矩形（primaryLayer 坐标）
+  uint32_t view_w, view_h;      // primaryLayer 尺寸 → host 据此定位与钳制卡片
+  uint32_t line_bytes;
+  uint8_t  line_utf8[kLookupLineBytes];  // **整行**，不截断（制卡要整句）
+};
+
+struct LookupFrame {            // host→hook，双缓冲
+  volatile uint64_t seq;        // 对应哪次 hit；过期帧由 hook 丢弃
+  uint32_t width, height, pitch;      // BGRA，预乘 alpha
+  uint32_t anchor_x, anchor_y;        // 卡片左上角（primaryLayer 坐标，host 决定）
+  uint32_t highlight_start, highlight_len;  // 字幕高亮范围
+  volatile uint32_t ready;      // 0=写入中，1=可读
+};
+
+struct LookupInputSlot {        // hook→host 环，转发落在卡片矩形内的输入
+  uint64_t seq; int32_t x, y; uint32_t kind; int32_t wheel; uint32_t keys;
+};
+```
+
+设计要点：
+
+- **卡片定位在 host**：hook 只报字形矩形与视口尺寸，host 复用它给 popup 已有的「避让 + 钳制」逻辑。不在 TJS 里重算一遍。
+- **整行不截断**：#799 从点击字向后截 48 字（`kirikiri_adapter.inc:878`），制卡拿不到完整句子。
+- `lookup_enabled` 是 host→hook 控制字段，形态照抄已有的 `selected_text_thread_id`。**#799 的 `FUSHI_KIRIKIRI_LOOKUP_PORT/TOKEN` 环境变量全部删除**——token 明文躺在游戏进程环境块里是安全缺陷。
+- 契约两侧必须同 PR 落地（CLAUDE.md 硬规则）。
+
+### 4.3 像素落地路径
+
+**主路**：`Layer.mainImageBufferForWrite` + `Layer.mainImageBufferPitch`（KiriKiri Z 给插件写像素的标准出口）。DLL 经 exporter 的 `TVPExecuteExpression` 取回这两个整数 → `memcpy` → `TVPExecuteScript("global.fushiLookupApply(seq,start,len);")`。
+
+**备路**：host 把卡片存 PNG 到 **`%TEMP%`（绝不写游戏目录）**，TJS `loadImages(路径)`。零新 ABI，代价是每次更新一轮 PNG 编解码（~10–20ms），够 P1 静态卡片，不够 P2 交互。
+
+主备之间由 **P0 探针**的真机结果裁决，不靠猜。
+
+## 5. 阶段与验收
+
+### P0 — 地基探针（阻塞后续全部工作）
+
+只往 #799 分支加一个 opt-in 探测开关，不动主逻辑。回答四个问题，输出结构化结果：
+
+1. `TVPExecuteExpression`（`void ::TVPExecuteExpression(const ttstr &,tTJSVariant *)`）能否按 narrow string 从 exporter 查到？
+2. x86 下 `tTJSVariant` 的整数读取布局是否正确？
+3. `mainImageBufferForWrite` / `mainImageBufferPitch` 是否返回合法写指针与 stride？
+4. `memcpy` 一张纯色测试位图 + `update()` 后，**屏幕上真出现色块**（真机目视 + 截图取证）。
+
+**四问全绿 → 走主路；任一红 → P1 改走 PNG 备路，架构不变。**
+
+验收：真机截图 + 探针结构化输出；结果写回本文件。
+
+### P1 — 静态卡片
+
+- TJS 传感器瘦身：**只留 TextRender 一条捕获路径**，其余四条移入默认关闭的 probe 模式。
+- 建卡片 `Layer`（`ltAlpha`）+ 字幕高亮 Layer，生命周期绑定到 `seq`。
+- DLL：hit 上报 / 帧落地 / 整数脚本回执。
+- host：`voice_hook_reader.cpp` 读 hit → Dart → `DesktopLookupDispatcher` → 离屏 WebView2 → `CapturePreview` 取帧 → 回投。
+- 键盘动作走 KAG `keyDown` hook：制卡 / 发音 / 关闭。
+
+验收：真机点击字幕 → 游戏内出现与 Hibiki popup 像素一致的卡片；卡片随 `[cm]`/换页正确消失；连点不串卡（`seq` 过期帧被丢弃）。
+
+### P2 — 交互式卡片
+
+- 光标落在卡片矩形内时，TJS 转发 `(x-anchor_x, y-anchor_y, button, wheel)` → host → **已有的** `SendMouseInput` → 新帧回投。
+- 帧率不够时把 `CapturePreview` 换成自持 `CreateSwapChainForComposition` + `CopyResource` 到 staging 纹理。
+
+验收：卡片内滚动、展开词条、点发音按钮均生效；游戏帧率无肉眼可见回退。
+
+### P3 — 制卡 E2E
+
+按 SOP 完成「当前台词 → 对应语音 → 当前画面 → 真卡写入」，再更新 `engine-support.yaml`。**在此之前一律 `implemented_unverified`。**
+
+## 6. 必须一并清掉的 #799 债务
+
+游戏内渲染意味着我们在游戏主线程上花的每一毫秒都直接变成掉帧，这些比之前更要命：
+
+| 位置（#799 版 `kirikiri_adapter.inc`） | 问题 |
+|---|---|
+| `:1367-1371` | `System.addContinuousHandler` **每帧**遍历所有 message 重打补丁 |
+| `:1554-1558` + `:830` | 每次 mousemove 全量 walk + 对 primaryLayer 尺寸的 layer 做全屏 `fillRect` |
+| `:993-998` | O(n²) `getTextWidth`，且挂在**全局** `Layer.drawText` 上，影响游戏所有 UI 绘制 |
+| `:1128` `:1131` | `fushiLookupTextRenderRegistry` 只增不减，且持有 `characters` 数组与 renderer 引用 → 泄漏 |
+| `:1550` | 每次左键往磁盘写 `.trace` 文件 |
+| `:1827` `:1929` | 硬编码只认 `Jitendex` + `maximumTerms:1`（预算单位错配的老形状） |
+| `:915-916` | 卡片固定 30 字/行 × 7 行 |
+| `:1905` `:1909` | DLL 内 WinHTTP + token 落游戏进程环境变量 |
+| `:1717-1836` | DLL 内手写 JSON 解析器 |
+| `:1970` | 拼 TJS 源码字符串再 eval |
+
+`:915` 起的卡片绘制、`:1717` 起的 JSON、`:1905` 起的 HTTP、`:878` 的分词——**整段删除**，由 host 侧既有实现承担。
+
+## 7. 影响范围与风险点
+
+| 风险 | 判断 |
+|---|---|
+| Magpie 超分会把卡片**连同游戏画面一起放大** | 「在渲染树内部」的必然结果，不是 bug。接受，或这局关超分。**不设计规避**——规避手段恰好推翻需求。 |
+| `mainImageBufferForWrite` 触发 copy-on-write；layer 尺寸变化后指针失效 | 每帧重取，不缓存指针 |
+| 主线程 memcpy 位图（700×400×4 ≈ 1.1MB） | ~0.1ms 量级，可接受；`CapturePreview` 在 host 线程，不阻塞游戏 |
+| `kSharedVersion` 13→14，host/hook 版本漂移 | 两侧必须同 PR 落地；reader 侧对旧版本降级为「查词区不可用」而非崩 |
+| 文件完整性校验 | 只注入、不改磁盘文件，`.sig` 不受影响；备路 PNG 写 `%TEMP%` |
+| 泛化过度 | profile 以 `textrender.dll` 存在 + `global.TextRender.getCharacters` 运行时探测双重为门；缺失即退回现有浮窗查词 |
+
+受影响的既有功能：galgame 文本捕获 / 语音配对 / 会话统计（共享内存布局变更）、`voice_hook_reader.cpp`、injector 的区分配。均为**追加**，不改动既有区偏移语义。
+
+## 8. 验证门
+
+native（在 `native/galgame_hook/`）：
+
+```powershell
+python tools/generate_engine_support.py --check
+python tools/generate_luna_profiles.py --check
+python tests/engine_support_manifest_test.py
+python tests/adapter_structure_test.py
+python tests/galhook_workflow_test.py
+cmake -S . -B build-x86 -A Win32 ; cmake --build build-x86 --config Release
+ctest --test-dir build-x86 -C Release --output-on-failure
+cmake -S . -B build-x64 -A x64  ; cmake --build build-x64 --config Release
+ctest --test-dir build-x64 -C Release --output-on-failure
+```
+
+新增测试（**在最强可落地层**）：
+
+- **replay fixture**：`hit → frame → apply` 时序；`seq` 过期帧被丢弃；`lookup_enabled=0` 时零写入；卡片外的输入不进转发环。
+- **源码扫描守卫**：`kirikiri_adapter.inc` 里 `TVPExecuteScript` 的实参不得由动态字符串拼接（只允许 `std::to_wstring` 的整数）。守卫必须做**变异实测**——把断言字面量塞进注释验证它真会红。
+- **Dart**：hit 事件 → dispatcher → 位图投递的单测。
+
+Fushi 侧：`dart format` 改动文件 + 定向 `flutter test --no-pub`；合入 develop 前全量 `dart run tool/flutter_test_failures.dart --no-pub`（**只认末行 verdict + 退出码**），外加合并后必跑的目录枚举型守卫整批。
+
+## 9. 不做什么
+
+- 不保留 #799 的 5 条并行捕获路径与 3 个 registry 兜底链——实测只有 TextRender 命中，其余是调试残骸。
+- 不在游戏进程里保留任何网络客户端或认证凭据。
+- 不为「独占全屏」保留一套平行的游戏外 UI。
+- 不动 `engine-support.yaml` 的支持状态，直到 P3 E2E 完成。

--- a/docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md
+++ b/docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md
@@ -247,3 +247,46 @@ Fushi 侧：`dart format` 改动文件 + 定向 `flutter test --no-pub`；合入
 - 不在游戏进程里保留任何网络客户端或认证凭据。
 - 不为「独占全屏」保留一套平行的游戏外 UI。
 - 不动 `engine-support.yaml` 的支持状态，直到 P3 E2E 完成。
+
+## 10. 实施记录
+
+### 10.1 对 P0 门的调整（用户决定）
+
+原计划把 P0 探针设成**阻塞门**：`mainImageBufferForWrite` / `TVPExecuteExpression` 没在真机验过就不写 P1。
+
+用户明确要求不等探针、直接实施。因此改为：**主备两路都实现**，由注入侧在运行期自证走了哪条——
+
+| 位 | 含义 |
+|---|---|
+| `kLookupDiagExpressionReady` | `TVPExecuteExpression` 查到了 |
+| `kLookupDiagBufferRouteReady` | `mainImageBufferForWrite` 拿到了合法写指针 → 走主路 |
+| `kLookupDiagFallbackPngRoute` | 上面任一失败 → 降级 PNG + `loadImages` |
+| `kLookupDiagFramePresented` | 位图真落进了游戏 Layer |
+
+这样探针的四个问题变成**真机上的一次自证**，而不是一道前置门。代价是备路代码也得写完；收益是不用为拿四个布尔值单独跑一轮真机。
+
+**这不改变结论的性质**：在 `kLookupDiagFramePresented` 于真机置位之前，整件事仍然是 `implemented_unverified`。
+
+### 10.2 已落地
+
+- **v14 IPC 契约**（`native/galgame_hook/include/voice_hook_ipc.h`）：`kSharedVersion` 13→14，纯追加，前面各区偏移逐字节不动。三通道 hit / input / frame，含 `IsLookupFrameSane()` 作为「按跨进程不可信 width/height 盲拷 → 越界写」的唯一闸门。
+- **injector 分配**（`injector/injector_main.cpp`）：查词区紧随线程预览区，追加在布局最尾；`lookup_enabled` 初值 0，由 host 在用户真开启时置 1。
+- 契约头在 **x86 与 x64 双架构 `/W4 /WX` 下语法检查通过**，访问器实跑自检全部返回预期；查词区实测 **6,294,672 字节（6.00 MiB）**。
+  - 过程中修掉一处自埋的坑：区内偏移原本用 `uint64_t`，在 x86 上做指针算术会截断，`/WX` 的 runner 上直接是编译错误。改用 `size_t`，整区**总字节数**仍用 `uint64_t`（要参与 injector 的 `total_size` 求和）。
+
+### 10.3 并行分工（互不相交的文件集）
+
+| 线 | 文件集 |
+|---|---|
+| 契约 | `include/voice_hook_ipc.h`、`injector/injector_main.cpp` |
+| 注入侧 | `hook/adapters/kirikiri_adapter.inc` |
+| 宿主 native | `fushi/windows/runner/{voice_hook_reader,global_lookup_window}.{h,cpp}` |
+| 宿主 Dart | `fushi/lib/src/lookup/**` |
+| 测试守卫 | `native/galgame_hook/tests/**`、`fushi/test/**`、`engine-support.yaml` |
+
+MethodChannel 契约（两侧钉死）：
+
+- runner → Dart：`onGalLookupHit {seq,line,charIndex,charCount,glyphX,glyphY,glyphW,glyphH,viewW,viewH,submit}`、`onGalLookupInput {seq,x,y,kind,wheel,keys}`
+- Dart → runner：`galLookupSetEnabled {enabled}`、`galLookupPresent {seq,anchorX,anchorY,highlightStart,highlightLen}`、`galLookupDismiss {seq}`
+
+**位图永远不经过 Dart**：像素在 C++ 侧从离屏 WebView2 直接进共享内存。Dart 只做编排。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 56083 (3299 per locale)
+/// Strings: 56117 (3301 per locale)
 ///
-/// Built on 2026-08-09 at 15:14 UTC
+/// Built on 2026-08-10 at 19:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4460,6 +4460,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_opensubtitles_endpoint => 'API endpoint';
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -12069,6 +12072,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -19745,6 +19753,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -27437,6 +27450,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -35141,6 +35159,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -42773,6 +42796,11 @@ class _StringsId extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -50451,6 +50479,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -57943,6 +57976,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -65442,6 +65480,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -73100,6 +73143,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -80770,6 +80818,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -88426,6 +88479,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -96030,6 +96088,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -103665,6 +103728,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -111285,6 +111353,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 // Path: <root>
@@ -118355,6 +118428,11 @@ class _StringsZhCn extends _StringsEn {
   String get video_opensubtitles_endpoint => 'API 端点';
   @override
   String get video_download_target_source_empty => '没有可访问的本地视频来源。请先在来源页添加。';
+  @override
+  String get gal_hook_ingame_lookup => '游戏内查词';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      '在游戏画面内直接显示词典卡片（KiriKiri 引擎，仅 Windows）';
 }
 
 // Path: <root>
@@ -125770,6 +125848,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_download_target_source_empty =>
       'No locally accessible video source is available. Add one on the Sources tab first.';
+  @override
+  String get gal_hook_ingame_lookup => 'In-game dictionary lookup';
+  @override
+  String get gal_hook_ingame_lookup_hint =>
+      'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
 }
 
 /// Flat map(s) containing all translations.
@@ -132545,6 +132628,10 @@ extension on _StringsEn {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -139318,6 +139405,10 @@ extension on _StringsAr {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -146113,6 +146204,10 @@ extension on _StringsDe {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -152907,6 +153002,10 @@ extension on _StringsEs {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -159707,6 +159806,10 @@ extension on _StringsFr {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -166489,6 +166592,10 @@ extension on _StringsId {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -173285,6 +173392,10 @@ extension on _StringsIt {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -180043,6 +180154,10 @@ extension on _StringsJa {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -186805,6 +186920,10 @@ extension on _StringsKo {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -193595,6 +193714,10 @@ extension on _StringsNl {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -200382,6 +200505,10 @@ extension on _StringsPtBr {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -207174,6 +207301,10 @@ extension on _StringsRu {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -213949,6 +214080,10 @@ extension on _StringsTh {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -220733,6 +220868,10 @@ extension on _StringsTr {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -227513,6 +227652,10 @@ extension on _StringsVi {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }
@@ -234237,6 +234380,10 @@ extension on _StringsZhCn {
         return 'API 端点';
       case 'video_download_target_source_empty':
         return '没有可访问的本地视频来源。请先在来源页添加。';
+      case 'gal_hook_ingame_lookup':
+        return '游戏内查词';
+      case 'gal_hook_ingame_lookup_hint':
+        return '在游戏画面内直接显示词典卡片（KiriKiri 引擎，仅 Windows）';
       default:
         return null;
     }
@@ -240990,6 +241137,10 @@ extension on _StringsZhHk {
         return 'API endpoint';
       case 'video_download_target_source_empty':
         return 'No locally accessible video source is available. Add one on the Sources tab first.';
+      case 'gal_hook_ingame_lookup':
+        return 'In-game dictionary lookup';
+      case 'gal_hook_ingame_lookup_hint':
+        return 'Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "分类必须是用逗号分隔的数字 ID。",
   "video_download_path_mapping_invalid": "请输入配置 ID、远程根目录和本机绝对根目录。",
   "video_opensubtitles_endpoint": "API 端点",
-  "video_download_target_source_empty": "没有可访问的本地视频来源。请先在来源页添加。"
+  "video_download_target_source_empty": "没有可访问的本地视频来源。请先在来源页添加。",
+  "gal_hook_ingame_lookup": "游戏内查词",
+  "gal_hook_ingame_lookup_hint": "在游戏画面内直接显示词典卡片（KiriKiri 引擎，仅 Windows）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3297,5 +3297,7 @@
   "video_external_categories_invalid": "Categories must be comma-separated numeric IDs.",
   "video_download_path_mapping_invalid": "Enter a profile ID, remote root, and absolute local root.",
   "video_opensubtitles_endpoint": "API endpoint",
-  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first."
+  "video_download_target_source_empty": "No locally accessible video source is available. Add one on the Sources tab first.",
+  "gal_hook_ingame_lookup": "In-game dictionary lookup",
+  "gal_hook_ingame_lookup_hint": "Show the dictionary card inside the game window itself (KiriKiri engine, Windows only)"
 }

--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -6,7 +6,9 @@ import 'dart:ui' show Rect;
 import 'package:flutter/foundation.dart';
 import 'package:fushi_anki/fushi_anki.dart';
 
+import 'package:fushi/src/lookup/gal_ingame_lookup_controller.dart';
 import 'package:fushi/src/lookup/global_lookup_controller.dart';
+import 'package:fushi/src/lookup/overlay_bridge_handlers.dart';
 import 'package:fushi/src/utils/misc/desktop_audio_playback.dart';
 import 'package:fushi/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:fushi/src/mining/gal_hook_session_controller.dart';
@@ -46,12 +48,14 @@ class GalHookTextOverlayController extends ChangeNotifier {
     GalHookPreferenceReader? preferenceReader,
     GalHookPreferenceWriter? preferenceWriter,
     GalHookHoverAutoLookupReader? hoverAutoLookupReader,
+    GalIngameLookupController? ingameLookup,
   })  : _session = session ?? GalHookSessionController.instance,
         _miningCoordinator =
             miningCoordinator ?? GalHookMiningCoordinator.instance,
         _preferenceReader = preferenceReader,
         _preferenceWriter = preferenceWriter,
-        _hoverAutoLookupReader = hoverAutoLookupReader;
+        _hoverAutoLookupReader = hoverAutoLookupReader,
+        _ingameLookup = ingameLookup ?? GalIngameLookupController.instance;
 
   static final GalHookTextOverlayController instance =
       GalHookTextOverlayController._();
@@ -63,12 +67,14 @@ class GalHookTextOverlayController extends ChangeNotifier {
     GalHookPreferenceReader? preferenceReader,
     GalHookPreferenceWriter? preferenceWriter,
     GalHookHoverAutoLookupReader? hoverAutoLookupReader,
+    GalIngameLookupController? ingameLookup,
   }) : this._(
           session: session,
           miningCoordinator: miningCoordinator,
           preferenceReader: preferenceReader,
           preferenceWriter: preferenceWriter,
           hoverAutoLookupReader: hoverAutoLookupReader,
+          ingameLookup: ingameLookup,
         );
 
   static const String _rectPreferenceKey = 'gal_hook_text_window_rect';
@@ -85,6 +91,11 @@ class GalHookTextOverlayController extends ChangeNotifier {
   final GalHookPreferenceReader? _preferenceReader;
   final GalHookPreferenceWriter? _preferenceWriter;
   final GalHookHoverAutoLookupReader? _hoverAutoLookupReader;
+
+  /// 游戏内查词编排器（KiriKiri in-game lookup）。本控制器是 galgame hook 在 Dart
+  /// 侧的接线中心（持有 AppModel、会话监听与 gal channel 的 handler 表），所以由它
+  /// 启动并喂养它——不另起第二条会话监听、不复制第二份制卡链。
+  final GalIngameLookupController _ingameLookup;
 
   AppModel? _appModel;
   bool _started = false;
@@ -108,6 +119,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
   bool _pushedHoverAutoLookup = false;
   int? _sessionKey;
   String? _displayedLineId;
+
+  /// 游戏内查词用的「会话最新行」镜像，与 [_displayedLineId]（浮窗显示的那行）分开：
+  /// 浮窗被关掉时仍要能判出换行并让游戏内卡片消场。
+  String? _ingameLatestLineId;
   double _opacity = _defaultOpacity;
   double _lastNonZeroOpacity = _defaultOpacity;
   double _fontSize = kGalHookTextFontSize;
@@ -183,6 +198,11 @@ class GalHookTextOverlayController extends ChangeNotifier {
     // 不抛，且没孤儿时是一次读文件的零成本早退。
     unawaited(magpie.reconcileOrphansOnStartup());
     _loadPreferences(appModel);
+    await _ingameLookup.start(
+      appModel: appModel,
+      miningResolver: _ingameMiningHandlerFor,
+      preferenceReader: _preferenceReader,
+    );
     GalHookTextOverlayChannel.setEventHandlers(
       onLookupText: _onLookupText,
       onToggleFollow: toggleFollowing,
@@ -195,6 +215,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
       onLockChanged: _onLockChanged,
       onPassThroughChanged: _onPassThroughChanged,
       onBoundsChanged: _onBoundsChanged,
+      // 游戏内查词：hook 报命中 / 转发卡片内输入，两条都直通编排器，本控制器不解释。
+      onGalLookupHit: _ingameLookup.handleHit,
+      onGalLookupInput: _ingameLookup.handleInput,
     );
     _session.addListener(_scheduleSync);
     _scheduleSync();
@@ -302,6 +325,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       _passThrough = false;
       _locked = false;
       _displayedLineId = null;
+      _ingameLatestLineId = null;
       // 新会话：上一局的试听计时不能把高亮留在新浮窗上。
       _replayResetTimer?.cancel();
       _replayResetTimer = null;
@@ -317,6 +341,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
         state.phase != GalHookSessionPhase.idle &&
         state.phase != GalHookSessionPhase.stopping &&
         state.phase != GalHookSessionPhase.error;
+    // 游戏内查词的开关跟着**会话**走，不跟着台词浮窗的可见性走：用户把浮窗关了
+    // （`_suppressedForSession`）不代表他不要游戏内查词，两者是各自独立的表面。
+    // 放在下面所有早退之前，会话一结束就一定关得掉。
+    await _ingameLookup.setSessionActive(active);
     if (!active) {
       if (_visible) {
         await GalHookTextOverlayChannel.hide();
@@ -331,9 +359,18 @@ class GalHookTextOverlayController extends ChangeNotifier {
       if (nextSessionKey == null) _sessionKey = null;
       return;
     }
-    if (_suppressedForSession) return;
-
     final List<TexthookerLineEntry> lines = _session.selectedSessionLines;
+    // 换行 / 换页：屏上那句已经不在了，游戏内卡片必须消场。判据取**会话最新行**而
+    // 不是浮窗的 [_displayedLineId]——浮窗可能被用户关掉（[_suppressedForSession]）
+    // 或压根没显示，那时 [_displayedLineId] 根本不动，卡片会一直挂在旧句子的字形
+    // 位置上。
+    final String? latestLineId = lines.isEmpty ? null : lines.last.id;
+    if (latestLineId != _ingameLatestLineId) {
+      _ingameLatestLineId = latestLineId;
+      await _ingameLookup.onLineChanged();
+    }
+
+    if (_suppressedForSession) return;
     if (lines.isEmpty) return;
     final TexthookerLineEntry latest = lines.last;
     if (!_visible) {
@@ -656,6 +693,31 @@ class GalHookTextOverlayController extends ChangeNotifier {
         updateNoteId: updateNoteId,
       ),
     );
+  }
+
+  /// 游戏内查词的制卡 handler：按台词文本回溯本局会话里的那一行，复用浮窗点词
+  /// 完全相同的 [_mineFromLookup]（截图 / 语音 / 标签 / 压缩档全部同源）。
+  ///
+  /// hook 报上来的只有文本，没有行 id。同一句台词一局里可能出现多次（回想、重读），
+  /// 取**最后一条**——屏幕上正在显示的必然是最新那条。回溯不到就返回 null：卡照样
+  /// 能建，只是不带 gal 媒体，绝不因为对不上行就把制卡按钮变成死键。
+  OverlayMiningHandler? _ingameMiningHandlerFor(String line) {
+    final List<TexthookerLineEntry> lines = _session.selectedSessionLines;
+    String? lineId;
+    for (final TexthookerLineEntry entry in lines) {
+      if (entry.text == line) lineId = entry.id;
+    }
+    if (lineId == null) return null;
+    final String resolved = lineId;
+    return ({
+      required Map<String, String> fields,
+      int? updateNoteId,
+    }) =>
+        _mineFromLookup(
+          lineId: resolved,
+          fields: fields,
+          updateNoteId: updateNoteId,
+        );
   }
 
   Future<Map<String, Object?>> _mineFromLookup({

--- a/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
+++ b/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
@@ -1,0 +1,479 @@
+// KiriKiri 游戏内查词 — Dart 编排层（仅 Windows）。
+//
+// 见 docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md。三段职责里 Dart 只占中间
+// 一小段，而且**位图永远不经过这里**：
+//
+//   注入进游戏的 hook（几何传感 / 命中测试 / 输入转发）
+//        │ onGalLookupHit(整行台词, 字符下标, 字形矩形, 视口尺寸)
+//        ▼
+//   本控制器 ── 走 app 既有查词链（GlobalLookupController.lookupText →
+//        │       AppModel.searchDictionary → 离屏 WebView2 popup.html）
+//        │ galLookupPresent(seq, anchor, highlight)
+//        ▼
+//   runner（取帧）→ 共享内存 → hook memcpy 进游戏 Layer
+//
+// 本文件里**一行查词逻辑都没有**：不分词、不筛词典、不定 maximumTerms、不排版。
+// 词条从哪来、去屈折怎么做、卡片长什么样，全部与阅读器 / 视频 / 剪贴板查词同一份
+// 实现；这里只回答三个问题——查哪个串、卡片放哪、高亮哪一段。
+//
+// 坐标域纪律：hook 报上来的 glyph/view 尺寸在**游戏 primaryLayer 像素**域，卡片位图
+// 是逐像素 memcpy 进 Layer 的，所以「卡片在游戏里的尺寸」== 位图的**物理像素**尺寸
+// （GlobalLookupController.onRevealed 回报的就是它）。两者同域可直接比较，全程不乘
+// dpr——dpr 只属于 Windows 窗口那一侧。
+
+import 'dart:async';
+
+import 'package:characters/characters.dart';
+import 'package:flutter/foundation.dart';
+import 'package:fushi/src/lookup/global_lookup_controller.dart';
+import 'package:fushi/src/lookup/global_lookup_layout.dart';
+import 'package:fushi/src/lookup/global_lookup_log.dart';
+import 'package:fushi/src/lookup/overlay_bridge_handlers.dart';
+import 'package:fushi/src/lookup/sentence_extraction.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/platform/gal_hook_text_overlay_channel.dart';
+
+/// 偏好读取口。与 `GalHookPreferenceReader` 同形——独立声明只为不让台词浮窗控制器与
+/// 本控制器互相 import 成环，语义完全一致（key + 默认值，测试可注入替身）。
+typedef GalIngameLookupPreferenceReader = Object? Function(
+  String key, {
+  required Object? defaultValue,
+});
+
+/// 按台词文本回溯本局会话里的行，给出该行的 gal 制卡 handler（截图 + 语音 + 标签）。
+///
+/// 制卡链本身在 [GalHookTextOverlayController] 里（`_mineFromLookup`）——它持有
+/// mining coordinator、Anki repo 与全部制卡偏好。这里只要一个「这句话对应哪一行」
+/// 的解析口，绝不复制那条链。找不到对应行返回 null（卡照样能建，只是没有 gal 媒体）。
+typedef GalIngameMiningResolver = OverlayMiningHandler? Function(String line);
+
+/// 游戏内查词编排器（进程级单例）。
+class GalIngameLookupController {
+  GalIngameLookupController._({
+    GalIngameLookupPreferenceReader? preferenceReader,
+  }) : _preferenceReader = preferenceReader;
+
+  static final GalIngameLookupController instance =
+      GalIngameLookupController._();
+
+  @visibleForTesting
+  GalIngameLookupController.test({
+    GalIngameLookupPreferenceReader? preferenceReader,
+  }) : this._(preferenceReader: preferenceReader);
+
+  /// 「游戏内查词」开关的持久化 key（与其余 gal hook 偏好同一命名族）。
+  static const String enabledPreferenceKey = 'gal_hook_ingame_lookup_enabled';
+
+  GalIngameLookupPreferenceReader? _preferenceReader;
+
+  AppModel? _appModel;
+  GalIngameMiningResolver? _miningResolver;
+  bool _started = false;
+
+  /// galgame 会话是否在跑（由台词浮窗控制器的会话同步喂进来，不另起第二个监听）。
+  bool _sessionActive = false;
+
+  /// 已推给 runner 的开关值，避免每轮会话同步都发一次 channel 调用。
+  bool _pushedEnabled = false;
+
+  /// 当前屏上这张卡对应的命中。null = 游戏里没有卡（此时 onRevealed 的回调属于普通
+  /// 桌面查词，不该投进游戏）。
+  GalLookupHit? _activeHit;
+
+  /// latest-wins 待处理命中：查词在途时又点了新字，只留最后一个（连点不排队）。
+  GalLookupHit? _pendingHit;
+  bool _draining = false;
+
+  /// 最近一次已投出的高亮范围，用于悬停去抖——鼠标在同一个字上抖动不该反复过桥。
+  int _presentedHighlightStart = -1;
+  int _presentedHighlightLen = -1;
+
+  /// 最近一次已投出的卡片落点（primaryLayer px）。悬停只换高亮、不换卡片，必须把
+  /// 同一个 anchor 原样回传，否则卡片会跟着鼠标乱跑。null = 屏上没有卡片。
+  int? _presentedAnchorX;
+  int? _presentedAnchorY;
+
+  /// 平台门：galgame hook 只做 Windows，且必须有覆盖窗（卡片像素的唯一来源）。
+  static bool get isSupported =>
+      GalHookTextOverlayChannel.supportsCurrentPlatform &&
+      GlobalLookupController.isSupported;
+
+  @visibleForTesting
+  bool get debugSessionActive => _sessionActive;
+
+  @visibleForTesting
+  bool get debugPushedEnabled => _pushedEnabled;
+
+  @visibleForTesting
+  GalLookupHit? get debugActiveHit => _activeHit;
+
+  /// 接线。幂等；非 Windows 上直接空转（不是崩）。
+  ///
+  /// [miningResolver] 由台词浮窗控制器提供，见 [GalIngameMiningResolver]。
+  /// [preferenceReader] 同样由它透传（测试替身；生产为 null 时读 [AppModel]）。
+  ///
+  /// 重复调用只刷新依赖、不重复挂回调链——覆盖窗的两个回调是单消费者字段，挂两遍
+  /// 会让同一次 reveal 投两帧。
+  Future<void> start({
+    required AppModel appModel,
+    GalIngameMiningResolver? miningResolver,
+    GalIngameLookupPreferenceReader? preferenceReader,
+  }) async {
+    if (!isSupported) return;
+    _appModel = appModel;
+    _miningResolver = miningResolver;
+    _preferenceReader = preferenceReader ?? _preferenceReader;
+    if (_started) return;
+    _started = true;
+    final GlobalLookupController overlay = GlobalLookupController.instance;
+    // 「卡片内容已渲染、尺寸已定」是投帧的唯一前置条件，真值只有覆盖窗知道。
+    // 链上既有消费者（今天为空）：本控制器接管这两个单消费者回调时不吞掉别人。
+    final void Function(int, int)? previousRevealed = overlay.onRevealed;
+    overlay.onRevealed = (int w, int h) {
+      previousRevealed?.call(w, h);
+      _onOverlayRevealed(w, h);
+    };
+    final void Function()? previousHidden = overlay.onHidden;
+    overlay.onHidden = () {
+      previousHidden?.call();
+      unawaited(_onOverlayHidden());
+    };
+  }
+
+  @visibleForTesting
+  Future<void> stopForTesting() async {
+    _started = false;
+    _sessionActive = false;
+    _pushedEnabled = false;
+    _activeHit = null;
+    _pendingHit = null;
+    _draining = false;
+    _presentedHighlightStart = -1;
+    _presentedHighlightLen = -1;
+    _presentedAnchorX = null;
+    _presentedAnchorY = null;
+  }
+
+  /// galgame 会话开始 / 结束。会话不在跑时游戏内查词必须彻底关掉——hook 侧
+  /// `lookup_enabled=0` 即零写入，不留半开状态。
+  Future<void> setSessionActive(bool active) async {
+    if (_sessionActive == active) return;
+    _sessionActive = active;
+    await _syncEnabled();
+  }
+
+  /// 设置页改完开关后调用，与 `applyHoverAutoLookupFromPreferences` 同款纪律：
+  /// 漏掉这一步，开关只落了盘，本局游戏里不生效。
+  Future<void> applyEnabledFromPreferences() async {
+    if (!_started) return;
+    await _syncEnabled();
+  }
+
+  /// 换行 / 换页：屏上那句话已经不在了，卡片必须跟着消场，否则卡片还挂在旧句子的
+  /// 字形位置上。由台词浮窗控制器在「显示行变了」那一刻调。
+  Future<void> onLineChanged() async {
+    await _dismissCurrent();
+  }
+
+  /// hook 报上来一次命中。
+  ///
+  /// [GalLookupHit.submit] 分流：
+  ///  - false（悬停）：**不查词**，只把高亮挪到光标那个字。悬停事件是鼠标移动的
+  ///    频率，每次都查词会把引擎和离屏 WebView2 一起打爆。
+  ///  - true（点击 / hook 侧判定的悬停即查词）：走完整查词链。
+  ///
+  /// 「悬停要不要自动查词」由 hook 侧决定并体现在 submit 上，Dart 不再解释一遍——
+  /// 两处各判一次必然漂。
+  Future<void> handleHit(GalLookupHit hit) async {
+    if (!_started || !_enabledNow) return;
+    if (!hit.submit) {
+      await _updateHoverHighlight(hit);
+      return;
+    }
+    // latest-wins：在途查词不打断，但只保留最后一次意图。
+    _pendingHit = hit;
+    if (_draining) return;
+    _draining = true;
+    try {
+      while (_pendingHit != null) {
+        final GalLookupHit next = _pendingHit!;
+        _pendingHit = null;
+        await _runLookup(next);
+      }
+    } finally {
+      _draining = false;
+    }
+  }
+
+  /// hook 转发的卡片内输入：原样丢回 runner 的既有 popup 输入注入口。
+  ///
+  /// 这里**故意不解释语义**（不判断点到哪个词条、要不要翻页、滚多少行）——那是
+  /// popup.js 与 WebView2 的事，Dart 插一脚只会造出第二套解释规则。
+  Future<void> handleInput(GalLookupInput input) async {
+    if (!_started || !_enabledNow) return;
+    if (_activeHit == null) return; // 游戏里没有卡，输入无处可去。
+    final GalLookupCallResult result =
+        await GalHookTextOverlayChannel.galLookupInput(input);
+    if (!result.ok) {
+      glog('gal-ingame: input kind=${input.kind} FAILED ${result.error}');
+    }
+  }
+
+  // ── 内部 ──────────────────────────────────────────────────────────────────
+
+  bool get _enabledNow => _sessionActive && _readEnabledPreference();
+
+  bool _readEnabledPreference() {
+    final GalIngameLookupPreferenceReader? reader = _preferenceReader;
+    if (reader != null) {
+      return reader(
+            enabledPreferenceKey,
+            defaultValue: PreferencesRepository.galIngameLookupEnabledDefault,
+          ) ==
+          true;
+    }
+    final AppModel? model = _appModel;
+    if (model == null) return false;
+    // best-effort：App 尚未初始化完时 prefsRepo 是 late 字段，读它会抛
+    // （与 GlobalLookupController._recordLookupCount 同款兜底）。读不到就按默认
+    // 「关」处理——绝不因为读偏好失败把 galgame 会话本身带崩。
+    try {
+      return model.galIngameLookupEnabled;
+    } catch (_) {
+      return PreferencesRepository.galIngameLookupEnabledDefault;
+    }
+  }
+
+  Future<void> _syncEnabled() async {
+    final bool desired = _enabledNow;
+    if (desired == _pushedEnabled) return;
+    _pushedEnabled = desired;
+    final GalLookupCallResult result =
+        await GalHookTextOverlayChannel.galLookupSetEnabled(desired);
+    glog('gal-ingame: setEnabled=$desired session=$_sessionActive '
+        '-> ${result.error ?? "ok"}');
+    if (!desired) await _dismissCurrent();
+  }
+
+  /// 悬停：只挪高亮，不查词。
+  ///
+  /// 悬停拿不到引擎的 `bestLength`（那要真查一次），所以只标光标那**一个字素簇**；
+  /// 用户真点下去（submit）才铺成整词跨度。范围没变就整条丢弃，鼠标在同一个字上
+  /// 抖动不过桥。
+  Future<void> _updateHoverHighlight(GalLookupHit hit) async {
+    final int len = _graphemeLengthAt(hit.line, hit.charIndex);
+    if (len <= 0) return;
+    if (hit.charIndex == _presentedHighlightStart &&
+        len == _presentedHighlightLen) {
+      return;
+    }
+    _presentedHighlightStart = hit.charIndex;
+    _presentedHighlightLen = len;
+    // 悬停没有新位图：anchor 沿用当前卡片的落点（没有卡时用字形下方兜底）。
+    // runner 的 present 会重取一次当前 popup 画面，所以这条路径不能没有去抖——
+    // 上面的「范围没变就丢弃」正是它，一次鼠标划过整行也只走过字数那么多次。
+    final ({int x, int y}) anchor = _resolveAnchorForCurrentCard(hit);
+    final GalLookupCallResult result =
+        await GalHookTextOverlayChannel.galLookupPresent(
+      seq: hit.seq,
+      anchorX: anchor.x,
+      anchorY: anchor.y,
+      highlightStart: hit.charIndex,
+      highlightLen: len,
+    );
+    if (!result.ok) {
+      glog('gal-ingame: hover present seq=${hit.seq} FAILED ${result.error}');
+    }
+  }
+
+  /// 真查词：把「从命中字起的一段」交给 app 既有查词链。
+  ///
+  /// 查询串用共享的 [lookupQueryFromIndex]（与 texthooker 逐字查词同一份）：引擎按
+  /// 查询串做最长匹配并回报 `bestLength`，所以点「永」命中「永遠」、点「遠」能单独
+  /// 查到「遠」。整行原样当作 `sentence`（制卡 `{sentence}` 与卡片句子横幅都用它）
+  /// ——与台词浮窗点词（`_onLookupText`）逐字同形，hook 侧也正是为此不截断整行。
+  Future<void> _runLookup(GalLookupHit hit) async {
+    final String query = lookupQueryFromIndex(hit.line, hit.charIndex);
+    if (query.isEmpty) {
+      await _dismissCurrent();
+      return;
+    }
+    if (!hit.hasConsistentCharCount) {
+      // 不丢弃（下标本身已经过范围校验），但必须留痕：这是「两侧字符计数单位漂了」
+      // 的唯一早期信号，静默下去只会表现成「高亮总是偏几个字」。
+      glog('gal-ingame: charCount mismatch seq=${hit.seq} '
+          'reported=${hit.charCount} actual=${hit.line.length}');
+    }
+    // 先记住这次命中：卡片渲染完成的回调（onRevealed）要靠它算 anchor 与高亮。
+    _activeHit = hit;
+    _presentedHighlightStart = -1;
+    _presentedHighlightLen = -1;
+    // 新一次查词的落点要等新卡片量出尺寸才知道，旧落点作废（否则中间到达的悬停会
+    // 把上一张卡的位置又投一遍）。
+    _presentedAnchorX = null;
+    _presentedAnchorY = null;
+    glog('gal-ingame: lookup seq=${hit.seq} idx=${hit.charIndex} '
+        'query="$query"');
+    final bool taken = await GlobalLookupController.instance.lookupText(
+      query,
+      sentence: hit.line,
+      // 不传 anchorScreenRect：卡片落点在**游戏 Layer 坐标**里，与 Windows 屏幕坐标
+      // 无关，由 galLookupPresent 的 anchor 决定。覆盖窗自身照旧离屏渲染出帧。
+      miningHandler: _miningResolver?.call(hit.line),
+    );
+    if (!taken) {
+      glog('gal-ingame: overlay refused lookup seq=${hit.seq}');
+      _activeHit = null;
+      await _dismissCurrent();
+    }
+  }
+
+  /// 覆盖窗回报「卡片已渲染、尺寸已定」（物理 px）→ 投帧。
+  ///
+  /// 首帧 reveal 与后续 resize（卡内点词压出子卡 / Ctrl+滚轮改字号）都会走到这里，
+  /// 所以游戏里的卡片会跟着内容重新定位，而不是停在首帧几何上。
+  void _onOverlayRevealed(int physicalWidth, int physicalHeight) {
+    final GalLookupHit? hit = _activeHit;
+    // 没有在途的游戏内命中 = 这次 reveal 属于普通桌面查词（热键 / 剪贴板），不投。
+    if (hit == null || !_enabledNow) return;
+    if (physicalWidth <= 0 || physicalHeight <= 0) return;
+    final int start = hit.charIndex;
+    final int len = _highlightLength(hit);
+    final ({int x, int y}) anchor =
+        _resolveAnchor(hit, physicalWidth, physicalHeight);
+    _presentedHighlightStart = start;
+    _presentedHighlightLen = len;
+    _presentedAnchorX = anchor.x;
+    _presentedAnchorY = anchor.y;
+    glog('gal-ingame: present seq=${hit.seq} anchor=(${anchor.x},${anchor.y}) '
+        'card=${physicalWidth}x$physicalHeight hl=$start+$len');
+    unawaited(_present(hit, anchor, start, len));
+  }
+
+  /// 投帧并把 runner 的应答记下来。
+  ///
+  /// runner 不抛异常，失败编码成 `{error: token}`（旧 helper 无 v14 查词区 / 开关没
+  /// 开 / 取帧失败 / 卡片超预算被裁）。这里**不吞**：吞掉就等于把「ready」当成
+  /// 「投出去了」，正是阶段证据门禁止的那种推断。
+  Future<void> _present(
+    GalLookupHit hit,
+    ({int x, int y}) anchor,
+    int highlightStart,
+    int highlightLen,
+  ) async {
+    final GalLookupCallResult result =
+        await GalHookTextOverlayChannel.galLookupPresent(
+      seq: hit.seq,
+      anchorX: anchor.x,
+      anchorY: anchor.y,
+      highlightStart: highlightStart,
+      highlightLen: highlightLen,
+    );
+    if (!result.ok) {
+      glog('gal-ingame: present seq=${hit.seq} FAILED ${result.error}');
+      return;
+    }
+    if (result.clamped) {
+      // 卡片比游戏画面/字节预算还大，投进去的是被切过的图。处置在用户手上（把
+      // 弹窗最大宽高调小），这里先如实记账，不假装成功。
+      glog('gal-ingame: present seq=${hit.seq} CLAMPED to '
+          '${result.width}x${result.height}');
+    }
+  }
+
+  /// 覆盖窗被真正关掉（点外 / Esc / 前台钩子）→ 游戏里的卡片跟着消场。
+  Future<void> _onOverlayHidden() async {
+    await _dismissCurrent();
+  }
+
+  Future<void> _dismissCurrent() async {
+    final GalLookupHit? hit = _activeHit;
+    _activeHit = null;
+    _pendingHit = null;
+    _presentedHighlightStart = -1;
+    _presentedHighlightLen = -1;
+    _presentedAnchorX = null;
+    _presentedAnchorY = null;
+    if (hit == null) return;
+    final GalLookupCallResult result =
+        await GalHookTextOverlayChannel.galLookupDismiss(hit.seq);
+    glog('gal-ingame: dismiss seq=${hit.seq} -> ${result.error ?? "ok"}');
+  }
+
+  /// 命中高亮跨度（UTF-16）= 引擎匹配长度 `bestLength`，钳进行尾。
+  ///
+  /// 与弹窗内高亮、剪贴板面板横幅高亮同一真值口径；引擎没给（无结果）时退回光标那
+  /// 一个字素簇，绝不给 0 —— 0 会让游戏里「点了没反应」。
+  int _highlightLength(GalLookupHit hit) {
+    final int best = GlobalLookupController.instance.rootBestLength;
+    final int remaining = hit.line.length - hit.charIndex;
+    if (best <= 0) return _graphemeLengthAt(hit.line, hit.charIndex);
+    return best > remaining ? remaining : best;
+  }
+
+  /// 卡片左上角（primaryLayer px）。
+  ///
+  /// 复用覆盖窗自己的级联定位纯函数 [computeFrameRect]：卡片放在被点字形的下方，
+  /// 下方空间不够就翻到上方（这就是「避让字幕」——字形矩形本身即台词所在的那一行），
+  /// 中心 X 取字形中心并 clamp 进视口。**不另写一套定位**。
+  ///
+  /// 之后再夹一次 `[0, view - card]`：[computeFrameRect] 在空间不足时会把**它算出来
+  /// 的**宽高收缩，而我们要投的位图尺寸是固定的（收缩不了），所以卡片比视口还大的
+  /// 退化情形要显式贴边，否则右/下会溢出到视口外被裁掉。
+  ({int x, int y}) _resolveAnchor(GalLookupHit hit, int cardW, int cardH) {
+    if (hit.viewW <= 0 || hit.viewH <= 0) {
+      // hook 没报视口（老 hook / 取不到 primaryLayer 尺寸）：退化成「字形正下方」，
+      // 不猜屏幕边界。
+      return (x: hit.glyphX, y: hit.glyphY + hit.glyphH + _kCardGap);
+    }
+    final GlobalLookupFrameRect frame = computeFrameRect(
+      selectionRect: hit.glyphRect,
+      screenW: hit.viewW.toDouble(),
+      screenH: hit.viewH.toDouble(),
+      maxWidth: cardW.toDouble(),
+      maxHeight: cardH.toDouble(),
+      // 本样本（KiriKiri + textrender.dll）是横排；竖排排期在 P1 之后，届时由
+      // profile 给出真值再传进来，不在这里猜。
+      isVertical: false,
+    );
+    return (
+      x: _clampInt(frame.left.round(), 0, hit.viewW - cardW),
+      y: _clampInt(frame.top.round(), 0, hit.viewH - cardH),
+    );
+  }
+
+  /// 悬停时没有新位图，也就没有权威的卡片尺寸：卡片还在屏上就把**它现在的**落点
+  /// 原样回传（换成悬停字形下方会让卡片跟着鼠标跑），没有卡片时才给字形下方兜底。
+  ({int x, int y}) _resolveAnchorForCurrentCard(GalLookupHit hit) {
+    final int? x = _presentedAnchorX;
+    final int? y = _presentedAnchorY;
+    if (x != null && y != null) return (x: x, y: y);
+    return (x: hit.glyphX, y: hit.glyphY + hit.glyphH + _kCardGap);
+  }
+
+  /// [index] 处**字素簇**的 UTF-16 长度（绝不劈开代理对 / 浊点 / 组合字，与
+  /// texthooker 逐字命中同一粒度）。越界返回 0。
+  static int _graphemeLengthAt(String text, int index) {
+    if (index < 0 || index >= text.length) return 0;
+    int offset = 0;
+    for (final String grapheme in text.characters) {
+      if (offset == index) return grapheme.length;
+      if (offset > index) break;
+      offset += grapheme.length;
+    }
+    // 下标落在某个字素簇中间（脏数据）：按一个 code unit 处理，不抛。
+    return 1;
+  }
+
+  static int _clampInt(int value, int min, int max) {
+    if (max < min) return min;
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+}
+
+/// 卡片与被点字形之间的间距（primaryLayer px）。与覆盖窗 `computeFrameRect` 的
+/// `popupPadding` 同量级，仅用于「hook 没报视口」的退化分支。
+const int _kCardGap = 4;

--- a/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
+++ b/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
@@ -421,6 +421,15 @@ class GalIngameLookupController {
   /// 之后再夹一次 `[0, view - card]`：[computeFrameRect] 在空间不足时会把**它算出来
   /// 的**宽高收缩，而我们要投的位图尺寸是固定的（收缩不了），所以卡片比视口还大的
   /// 退化情形要显式贴边，否则右/下会溢出到视口外被裁掉。
+  /// 测试入口：定位算法必须被**直接**测到，不许在测试里转写一份。
+  ///
+  /// 这条不是洁癖。本次改造里 replay 的判据就是「参照实现」，生产代码的收卡判据改完
+  /// 之后它照样绿——那种绿只证明参照实现自洽。定位算法同理：转写一份就等于把 bug
+  /// 复制两遍，然后互相验证说没问题。
+  @visibleForTesting
+  ({int x, int y}) debugResolveAnchor(GalLookupHit hit, int cardW, int cardH) =>
+      _resolveAnchor(hit, cardW, cardH);
+
   ({int x, int y}) _resolveAnchor(GalLookupHit hit, int cardW, int cardH) {
     if (hit.viewW <= 0 || hit.viewH <= 0) {
       // hook 没报视口（老 hook / 取不到 primaryLayer 尺寸）：退化成「字形正下方」，

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -53,6 +53,14 @@ class GlobalLookupController {
   /// 可用；不可用一律退回主窗 tab，请求不丢。
   bool get isAvailable => isSupported && _started;
 
+  /// 当前 root 卡的引擎匹配长度（UTF-16 code unit，`bestLength`）。
+  ///
+  /// 引擎按查询串做最长匹配并回报它——这是全 app 统一的「命中跨度」真值（弹窗高亮、
+  /// 剪贴板面板横幅高亮、扩展 originalTextLength 都用它）。游戏内查词据此把台词上的
+  /// 高亮铺成整词而不是一个字。无结果 / 尚未查词时为 0。
+  int get rootBestLength =>
+      _frameResults[kGlobalLookupRootFrameId]?.bestLength ?? 0;
+
   AppModel? _appModel;
   HotKey? _hotKey;
   // TODO-1066 — the live shortcut registry we read the global-lookup hotkey
@@ -70,6 +78,18 @@ class GlobalLookupController {
   // (the 872 prerequisite) so a future mining-preserving switch can hook it. Not
   // fired for the between-lookups reset (that hide passes notify=false).
   void Function()? onHidden;
+  // KiriKiri 游戏内查词 — 卡片「内容已渲染、尺寸已定」的**唯一可靠**信号。
+  //
+  // 真值来自 host 自测量回报的 union bbox（_applyOverlayBox）：那一刻 popup.js 已
+  // 把这次查词的内容画完并量出真实尺寸，覆盖窗才据此 reveal/resize。游戏内查词必须
+  // 等到这里才把帧投进游戏——早一步投就抓到上一帧或空白（这正是不能用固定延时兜的
+  // 原因：冷 WebView2 的首帧耗时跨两个数量级）。
+  //
+  // 参数是**物理像素**的卡片尺寸（与投给游戏的位图逐像素一致），供调用方算锚点。
+  // 首帧 reveal 与后续 resize（嵌套子卡 / Ctrl+滚轮改字号）都会回调，所以游戏里的
+  // 卡片会跟着内容长大，而不是停在首帧尺寸。READY-SAFETY 兜底 reveal 也会回调——
+  // 那是「真渲染失败」的最后一招，此时投的确实可能是空白卡，但比卡在不可见强。
+  void Function(int physicalWidth, int physicalHeight)? onRevealed;
   // Last physical size pushed to the overlay; used to converge the page's
   // resize -> re-measure loop (see _onJsMessage 'overlaySize'). Reset per
   // lookup so a new card re-sizes from scratch.
@@ -727,6 +747,7 @@ class GlobalLookupController {
         glog('reveal: READY-SAFETY (ready=$ready attempt=$attempt) '
             'w=$width h=$height');
         unawaited(GlobalLookupChannel.reveal(width: width, height: height));
+        onRevealed?.call(width, height);
         return;
       }
       // Surface still loading — defer instead of revealing blank.
@@ -1389,6 +1410,7 @@ class GlobalLookupController {
           height: h,
           left: ratcheted.left,
           top: ratcheted.top));
+      onRevealed?.call(w, h);
     } else if (w != _lastSentWidth ||
         h != _lastSentHeight ||
         dx != _lastSentDx ||
@@ -1407,6 +1429,7 @@ class GlobalLookupController {
           height: h,
           left: ratcheted.left,
           top: ratcheted.top));
+      onRevealed?.call(w, h);
     }
   }
 
@@ -1426,11 +1449,13 @@ class GlobalLookupController {
       _lastSentHeight = height;
       glog('reveal(scalar): dpr=$dpr physH=$physH -> w=$width h=$height');
       unawaited(GlobalLookupChannel.reveal(width: width, height: height));
+      onRevealed?.call(width, height);
     } else if (width != _lastSentWidth || height != _lastSentHeight) {
       _lastSentWidth = width;
       _lastSentHeight = height;
       glog('resize(scalar): dpr=$dpr physH=$physH -> w=$width h=$height');
       unawaited(GlobalLookupChannel.resize(width: width, height: height));
+      onRevealed?.call(width, height);
     }
   }
 }

--- a/fushi/lib/src/lookup/sentence_extraction.dart
+++ b/fushi/lib/src/lookup/sentence_extraction.dart
@@ -40,6 +40,31 @@ class SentenceExtractionResult {
   final int selLen;
 }
 
+/// 逐字查词时喂给引擎的查询串上限（UTF-16 code unit）。
+///
+/// 引擎按查询串做**最长匹配**并回报 `bestLength`，所以只要「足够长到装得下最长的
+/// 复合词 + 屈折尾巴」即可；给整行会让每次点击都多传几十上百个用不到的字符。日语
+/// 最长实用复合词远短于 24。（BUG-1478：原先只在 texthooker_page 里当私有常量。）
+const int kLookupQueryMaxChars = 24;
+
+/// 从命中字 [charIndex] 起截一段查询串（UTF-16 下标域，与 Dart String 下标一致）。
+///
+/// 这是全 app「给定整句 + 光标字符偏移 → 查词」的统一入口形状：**不做分词**，把
+/// 「从这个字到后面 [maxChars] 个字」整段交给引擎做最长匹配。点「永」照样命中
+/// 「永遠」，点「遠」能单独查到「遠」——把分词器切出的整词当查询串则后者无从下手
+/// （BUG-1478）。越界 / 空白返回空串，调用方据此放弃本次查词。
+String lookupQueryFromIndex(
+  String text,
+  int charIndex, {
+  int maxChars = kLookupQueryMaxChars,
+}) {
+  if (charIndex < 0 || charIndex >= text.length) return '';
+  final int end =
+      charIndex + maxChars > text.length ? text.length : charIndex + maxChars;
+  final String query = text.substring(charIndex, end);
+  return query.trim().isEmpty ? '' : query;
+}
+
 /// Sentence-terminating delimiters. Byte-identical to
 /// `fushiSelection.sentenceDelimiters` in reader_selection_scripts.dart
 /// ('。！？.!?\n\r'): the char AFTER one of these starts a new sentence.

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6104,6 +6104,12 @@ class AppModel with ChangeNotifier {
   Future<void> setGalHookTextFontSize(double value) =>
       prefsRepo.setGalHookTextFontSize(value);
 
+  // KiriKiri 游戏内查词总开关（仅 Windows）：开着时命中的字会在**游戏渲染树内部**
+  // 弹出与 app 内逐像素一致的词典卡片。
+  bool get galIngameLookupEnabled => prefsRepo.galIngameLookupEnabled;
+  Future<void> setGalIngameLookupEnabled(bool value) =>
+      prefsRepo.setGalIngameLookupEnabled(value);
+
   // TODO-370: 悬浮字幕透明度（按钮底色 / 文字），0..100 百分比，100=保持现观感。
   int get floatingLyricButtonBgOpacity =>
       prefsRepo.floatingLyricButtonBgOpacity;

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -66,6 +66,7 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'floating_lyric_font_size',
   'floating_lyric_text_opacity',
   'floating_lyric_width',
+  'gal_hook_ingame_lookup_enabled',
   'gal_hook_text_font_size',
   'gal_mining_animated_format',
   'gal_mining_image_mode',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -1772,6 +1772,23 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 「游戏内查词」（KiriKiri in-game lookup）默认**关**：它要往游戏进程里投位图，
+  /// 只对有 profile 证据的引擎组合有效，开着对其余游戏纯属白付代价。
+  static const bool galIngameLookupEnabledDefault = false;
+
+  /// 游戏内查词总开关（仅 Windows 生效）。
+  bool get galIngameLookupEnabled =>
+      getPref(
+        'gal_hook_ingame_lookup_enabled',
+        defaultValue: galIngameLookupEnabledDefault,
+      ) ==
+      true;
+
+  Future<void> setGalIngameLookupEnabled(bool value) async {
+    await setPref('gal_hook_ingame_lookup_enabled', value);
+    notifyListeners();
+  }
+
   bool get floatingLyricClickLookup =>
       getPref('floating_lyric_click_lookup', defaultValue: true) as bool;
 

--- a/fushi/lib/src/pages/implementations/texthooker_page.dart
+++ b/fushi/lib/src/pages/implementations/texthooker_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/models.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/lookup/gal_hook_text_overlay_controller.dart';
+import 'package:fushi/src/lookup/sentence_extraction.dart';
 import 'package:fushi/src/mining/gal_hook_failure_text.dart';
 import 'package:fushi/src/mining/magpie_upscaling_service.dart';
 import 'package:fushi/src/mining/magpie_upscaling_text.dart';
@@ -1144,7 +1145,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 
   /// 从命中的那个字起做查词（BUG-1478）。
   ///
-  /// 查询串是「该字到行尾」截断到 [_kLookupQueryMaxChars] 的一段，**不是**分词器
+  /// 查询串是「该字到行尾」截断到 [kLookupQueryMaxChars] 的一段（共享
+  /// [lookupQueryFromIndex]，游戏内查词走同一份），**不是**分词器
   /// 切出来的那个词：引擎本来就按查询串做最长匹配并回报 `bestLength`（弹窗据此高亮
   /// 整词跨度），所以点「永」照样命中「永遠」，而点「遠」能单独查到「遠」——
   /// 老实现把整词当查询串，后者根本无从下手。
@@ -1153,13 +1155,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     int charIndex,
     Rect rect,
   ) {
-    final String text = line.text;
-    if (charIndex < 0 || charIndex >= text.length) return;
-    final int end = charIndex + _kLookupQueryMaxChars > text.length
-        ? text.length
-        : charIndex + _kLookupQueryMaxChars;
-    final String word = text.substring(charIndex, end);
-    if (word.trim().isEmpty) return;
+    final String word = lookupQueryFromIndex(line.text, charIndex);
+    if (word.isEmpty) return;
     _selectLine(line);
     // BUG-1028：顶层查词复用常驻热槽（reuseWarmSlot:true）而非 replaceStack 冷建，
     // 复用已预热的弹窗 WebView，消除冷启动延迟（对齐 home_dictionary_page.dart:752）。
@@ -3019,12 +3016,6 @@ class _LineAudioChip extends StatelessWidget {
     );
   }
 }
-
-/// 逐字查词时喂给引擎的查询串上限（UTF-16 code unit）。
-///
-/// 引擎按查询串做最长匹配，所以只要「足够长到装得下最长的复合词 + 屈折尾巴」即可；
-/// 给整行会让每次点击都多传几十上百个用不到的字符。日语最长实用复合词远短于 24。
-const int _kLookupQueryMaxChars = 24;
 
 /// 给分词结果补上每个词首字在整行里的 UTF-16 偏移。
 ///

--- a/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -50,6 +50,175 @@ typedef GalHookTextLookupHandler = FutureOr<void> Function(
 typedef GalHookTextEventHandler = FutureOr<void> Function();
 typedef GalHookTextLockHandler = FutureOr<void> Function(bool locked);
 
+/// 游戏内查词（KiriKiri in-game lookup）：注入进游戏的 hook 报上来的一次命中。
+///
+/// 坐标全部在**游戏 primaryLayer 像素**域（不是 Windows 屏幕逻辑/物理 px）——卡片
+/// 位图是逐像素 memcpy 进游戏 Layer 的，所以定位只能在这个域里算，Dart 侧绝不乘 dpr。
+/// [charIndex] / [charCount] 是 UTF-16 code unit 下标，与 [line] 的 Dart String 下标
+/// 同坐标系（native 侧以 UTF-16 计数，见 voice_hook_ipc.h 的 LookupHitSlot）。
+@immutable
+class GalLookupHit {
+  const GalLookupHit({
+    required this.seq,
+    required this.line,
+    required this.charIndex,
+    required this.charCount,
+    required this.glyphX,
+    required this.glyphY,
+    required this.glyphW,
+    required this.glyphH,
+    required this.viewW,
+    required this.viewH,
+    required this.submit,
+  });
+
+  /// hook 侧单调递增的命中序号：host 据此判新、hook 据此丢弃过期帧。
+  final int seq;
+
+  /// **整行**台词（不截断——制卡要整句）。
+  final String line;
+
+  /// 光标落在第几个字符（UTF-16 下标）。
+  final int charIndex;
+
+  /// hook 自报的本行字符数，只用于自洽校验（与 [line] 长度不符即判脏数据）。
+  final int charCount;
+
+  final int glyphX;
+  final int glyphY;
+  final int glyphW;
+  final int glyphH;
+
+  /// primaryLayer 尺寸：卡片定位/钳制的「屏幕」。
+  final int viewW;
+  final int viewH;
+
+  /// true = 真查词（点击 / hook 侧判定的悬停即查词）；false = 纯悬停，只更新高亮。
+  final bool submit;
+
+  /// 命中字形矩形（primaryLayer px）。
+  Rect get glyphRect => Rect.fromLTWH(
+        glyphX.toDouble(),
+        glyphY.toDouble(),
+        glyphW.toDouble(),
+        glyphH.toDouble(),
+      );
+
+  /// [charIndex] 是否真的指得到 [line] 里的一个字。**硬门**：指不到就丢弃，不去猜
+  /// ——猜出来的下标会让高亮与查词落在完全无关的字上。
+  bool get isAddressable =>
+      line.isNotEmpty && charIndex >= 0 && charIndex < line.length;
+
+  /// hook 自报的字符数与 UTF-16 长度是否一致。**软门**（只记账不丢弃）：两侧计数单位
+  /// 若哪天漂了（比如 hook 改按字素簇计），硬丢会让整个功能静默死掉且日志上什么都
+  /// 看不到；[isAddressable] 已经挡住了真正危险的越界。
+  bool get hasConsistentCharCount => charCount == line.length;
+
+  static GalLookupHit? fromMap(Map<Object?, Object?> map) {
+    int intOf(String key) => (map[key] as num?)?.toInt() ?? 0;
+    final String line = map['line']?.toString() ?? '';
+    if (line.isEmpty) return null;
+    return GalLookupHit(
+      seq: intOf('seq'),
+      line: line,
+      charIndex: intOf('charIndex'),
+      charCount: intOf('charCount'),
+      glyphX: intOf('glyphX'),
+      glyphY: intOf('glyphY'),
+      glyphW: intOf('glyphW'),
+      glyphH: intOf('glyphH'),
+      viewW: intOf('viewW'),
+      viewH: intOf('viewH'),
+      submit: map['submit'] == true,
+    );
+  }
+}
+
+/// 游戏内查词：落在卡片矩形内、由 hook 转发过来的一次输入事件。
+///
+/// Dart **不解释语义**（不判断这是点了哪个词条、要不要翻页）——原样透传给 runner 的
+/// popup 输入注入口，由已有的 WebView2 `SendMouseInput` 消费。坐标是**卡片本地** px
+/// （hook 已减去 anchor）。
+@immutable
+class GalLookupInput {
+  const GalLookupInput({
+    required this.seq,
+    required this.x,
+    required this.y,
+    required this.kind,
+    required this.wheel,
+    required this.keys,
+  });
+
+  final int seq;
+  final int x;
+  final int y;
+
+  /// 0=move 1=leftDown 2=leftUp 3=wheel 4=leave。
+  final int kind;
+  final int wheel;
+  final int keys;
+
+  static GalLookupInput fromMap(Map<Object?, Object?> map) {
+    int intOf(String key) => (map[key] as num?)?.toInt() ?? 0;
+    return GalLookupInput(
+      seq: intOf('seq'),
+      x: intOf('x'),
+      y: intOf('y'),
+      kind: intOf('kind'),
+      wheel: intOf('wheel'),
+      keys: intOf('keys'),
+    );
+  }
+}
+
+typedef GalLookupHitHandler = FutureOr<void> Function(GalLookupHit hit);
+typedef GalLookupInputHandler = FutureOr<void> Function(GalLookupInput input);
+
+/// 游戏内查词 Dart→runner 调用的应答。
+///
+/// runner 从不抛异常，它把失败**编码成 `{error: <token>}`**（旧 helper 没有 v14 查词
+/// 区、开关没开、取帧失败、卡片超预算…）。所以这些调用绝不能 fire-and-forget 成
+/// 「看起来成功」——阶段证据门要求 ready / 捕获 / 投帧各算各的，吞掉 error token 等于
+/// 拿前一阶段推断后一阶段。
+@immutable
+class GalLookupCallResult {
+  const GalLookupCallResult({
+    this.error,
+    this.width = 0,
+    this.height = 0,
+    this.clamped = false,
+  });
+
+  /// 平台不支持（非 Windows）时的常量结果：不是失败，是「这条链在这个平台不存在」。
+  static const GalLookupCallResult unsupported =
+      GalLookupCallResult(error: 'unsupported_platform');
+
+  /// runner 给的错误 token；null = 成功。
+  final String? error;
+
+  /// 实际写进共享内存的帧尺寸（仅 present 有值）。
+  final int width;
+  final int height;
+
+  /// 卡片被裁过（源画面超维度上界，或字节超预算按行裁）——处置是「把卡片做小点」。
+  final bool clamped;
+
+  bool get ok => error == null;
+
+  static GalLookupCallResult fromReply(Object? reply) {
+    if (reply is! Map) return const GalLookupCallResult();
+    final Map<Object?, Object?> map = reply.cast<Object?, Object?>();
+    final Object? error = map['error'];
+    return GalLookupCallResult(
+      error: error is String && error.isNotEmpty ? error : null,
+      width: (map['width'] as num?)?.toInt() ?? 0,
+      height: (map['height'] as num?)?.toInt() ?? 0,
+      clamped: map['clamped'] == true,
+    );
+  }
+}
+
 /// native 侧穿透态被否决 / 变更时的回传（BUG-951）。native 建不出逃生工具条窗
 /// 时会拒绝进入穿透并把自己摁回 false；Dart 必须跟着退回，否则它的标志卡在
 /// true，用户下一次按 `↗` 会变成一次看不出反应的空点击。
@@ -95,6 +264,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   static GalHookTextLockHandler? _onLockChanged;
   static GalHookTextPassThroughHandler? _onPassThroughChanged;
   static GalHookTextBoundsHandler? _onBoundsChanged;
+  static GalLookupHitHandler? _onGalLookupHit;
+  static GalLookupInputHandler? _onGalLookupInput;
 
   static void setEventHandlers({
     GalHookTextLookupHandler? onLookupText,
@@ -108,6 +279,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     GalHookTextLockHandler? onLockChanged,
     GalHookTextPassThroughHandler? onPassThroughChanged,
     GalHookTextBoundsHandler? onBoundsChanged,
+    GalLookupHitHandler? onGalLookupHit,
+    GalLookupInputHandler? onGalLookupInput,
   }) {
     _onLookupText = onLookupText;
     _onToggleFollow = onToggleFollow;
@@ -120,6 +293,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onLockChanged = onLockChanged;
     _onPassThroughChanged = onPassThroughChanged;
     _onBoundsChanged = onBoundsChanged;
+    _onGalLookupHit = onGalLookupHit;
+    _onGalLookupInput = onGalLookupInput;
     _instance.channel.setMethodCallHandler(_handleNativeCall);
   }
 
@@ -135,6 +310,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onLockChanged = null;
     _onPassThroughChanged = null;
     _onBoundsChanged = null;
+    _onGalLookupHit = null;
+    _onGalLookupInput = null;
     _instance.channel.setMethodCallHandler(null);
   }
 
@@ -181,6 +358,17 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
       case 'windowRectChanged':
         final GalHookTextWindowRect? rect = GalHookTextWindowRect.fromMap(args);
         if (rect != null) await _onBoundsChanged?.call(rect);
+        break;
+      // 游戏内查词：hook → runner → Dart。两条都在 latest-wins 语义下，处理器自己
+      // 负责去抖/丢弃，channel 层只做解析与自洽校验。
+      case 'onGalLookupHit':
+        final GalLookupHit? hit = GalLookupHit.fromMap(args);
+        if (hit != null && hit.isAddressable) {
+          await _onGalLookupHit?.call(hit);
+        }
+        break;
+      case 'onGalLookupInput':
+        await _onGalLookupInput?.call(GalLookupInput.fromMap(args));
         break;
       default:
         break;
@@ -316,6 +504,85 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     await _instance.channel.invokeMethod<void>(
       'setLocked',
       <String, Object?>{'locked': locked},
+    );
+  }
+
+  // ── 游戏内查词（Dart → runner）────────────────────────────────────────────
+  // 三个方法都只搬运整数/布尔：**位图永远不经过 Dart**（离屏 WebView2 出帧 →
+  // runner 取帧 → 共享内存 → hook memcpy 进游戏 Layer），Dart 只说「谁、放哪、
+  // 高亮哪一段」。非 Windows 上全是空操作，不是崩。
+
+  /// 总开关：runner 据此把 `lookup_enabled` 写进共享内存（hook 侧不开启就零写入），
+  /// 并决定离屏 popup 是否进入「出帧给游戏」模式。
+  static Future<GalLookupCallResult> galLookupSetEnabled(bool enabled) async {
+    if (!_instance.isSupported) return GalLookupCallResult.unsupported;
+    return GalLookupCallResult.fromReply(
+      await _instance.channel.invokeMethod<Object?>(
+        'galLookupSetEnabled',
+        <String, Object?>{'enabled': enabled},
+      ),
+    );
+  }
+
+  /// 投帧：把「第 [seq] 次命中的卡片」放到 primaryLayer 的 ([anchorX], [anchorY])，
+  /// 并把台词的 [highlightStart]..+[highlightLen]（UTF-16）标成命中高亮。
+  ///
+  /// 必须在 popup 内容**渲染完成**之后才调——早于内容就绪投帧会抓到上一帧或空白。
+  /// 就绪信号见 [GlobalLookupController.onRevealed]（host 自测量上报的 union bbox）。
+  static Future<GalLookupCallResult> galLookupPresent({
+    required int seq,
+    required int anchorX,
+    required int anchorY,
+    required int highlightStart,
+    required int highlightLen,
+  }) async {
+    if (!_instance.isSupported) return GalLookupCallResult.unsupported;
+    final Object? reply = await _instance.channel.invokeMethod<Object?>(
+      'galLookupPresent',
+      <String, Object?>{
+        'seq': seq,
+        'anchorX': anchorX,
+        'anchorY': anchorY,
+        'highlightStart': highlightStart,
+        'highlightLen': highlightLen,
+      },
+    );
+    return GalLookupCallResult.fromReply(reply);
+  }
+
+  /// 消场：换行 / 换页 / 会话结束 / 卡片被用户关掉。[seq] 是要撤掉的那次命中。
+  static Future<GalLookupCallResult> galLookupDismiss(int seq) async {
+    if (!_instance.isSupported) return GalLookupCallResult.unsupported;
+    return GalLookupCallResult.fromReply(
+      await _instance.channel.invokeMethod<Object?>(
+        'galLookupDismiss',
+        <String, Object?>{'seq': seq},
+      ),
+    );
+  }
+
+  /// 把 hook 转发过来的卡片内输入原样丢回 runner 的既有 popup 输入注入口
+  /// （`global_lookup_window.cpp` 的 `SendMouseInput`）。Dart 不解释语义。
+  ///
+  /// runner 侧 `HandleLookupCall` 的第四个方法（`voice_hook_reader.cpp`）：注入是
+  /// **Dart 驱动**的——泵只上报，不自己喂 WebView2，否则每个事件注入两次（点击变
+  /// 双击、滚轮翻倍）。
+  static Future<GalLookupCallResult> galLookupInput(
+    GalLookupInput input,
+  ) async {
+    if (!_instance.isSupported) return GalLookupCallResult.unsupported;
+    return GalLookupCallResult.fromReply(
+      await _instance.channel.invokeMethod<Object?>(
+        'galLookupInput',
+        <String, Object?>{
+          'seq': input.seq,
+          'x': input.x,
+          'y': input.y,
+          'kind': input.kind,
+          'wheel': input.wheel,
+          'keys': input.keys,
+        },
+      ),
     );
   }
 }

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -8,6 +8,7 @@ import 'package:fushi/pages.dart';
 import 'package:fushi/src/lookup/clipboard_panel_controller.dart';
 import 'package:fushi/src/lookup/clipboard_text_overlay_controller.dart';
 import 'package:fushi/src/lookup/gal_hook_text_overlay_controller.dart';
+import 'package:fushi/src/lookup/gal_ingame_lookup_controller.dart';
 import 'package:fushi/src/lookup/global_lookup_controller.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/settings/settings_actions.dart';
@@ -1049,6 +1050,26 @@ SettingsDestination buildLookupDestination() {
               // native 浮窗，否则字号只落了盘，浮窗要等下次改透明度才顺带刷新。
               await GalHookTextOverlayController.instance
                   .applyFontSizeFromPreferences();
+              settingsContext.refresh();
+            },
+          ),
+          // KiriKiri 游戏内查词：命中的字直接在**游戏渲染树内部**弹出词典卡片
+          // （不抢焦点、不 alt-tab、跟随全屏与窗口变换）。默认关——它只对有 profile
+          // 证据的引擎组合有效，其余游戏开着是白付代价。
+          SettingsSwitchItem(
+            id: 'lookup.gal_hook_ingame_lookup',
+            title: t.gal_hook_ingame_lookup,
+            subtitle: t.gal_hook_ingame_lookup_hint,
+            icon: Icons.crop_free,
+            visible: (_) => Platform.isWindows,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.galIngameLookupEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setGalIngameLookupEnabled(value);
+              // 与上面的字号同款纪律：写完 pref 立刻推给编排器，否则开关只落了盘，
+              // 本局游戏里不生效（要退出重进一局）。
+              await GalIngameLookupController.instance
+                  .applyEnabledFromPreferences();
               settingsContext.refresh();
             },
           ),

--- a/fushi/test/lookup/gal_ingame_lookup_contract_test.dart
+++ b/fushi/test/lookup/gal_ingame_lookup_contract_test.dart
@@ -1,0 +1,356 @@
+// KiriKiri 游戏内查词的 Dart 侧契约测试：hit 事件 → 定位计算 → present 调用。
+//
+// 这条链跨三个进程（游戏 hook → runner → Dart → runner → hook），中间任何一段把
+// 字段名、坐标域或参数形状改掉，症状都是「游戏里点了没反应」或「卡片贴在离谱的位置」，
+// 而三边都不会报错。所以这里钉的是**跨边界的形状**，不是某个类的内部实现：
+//
+//   1. runner→Dart 的 `onGalLookupHit` / `onGalLookupInput` 逐字段解出来是什么；
+//   2. 卡片落点由既有的级联定位纯函数算，且**永远整张留在视口内**；
+//   3. Dart→runner 的 `galLookupSetEnabled` / `galLookupPresent` / `galLookupDismiss`
+//      方法名与参数键；
+//   4. runner 的失败是编码在应答里的 error token，不是异常——不许被吞成"成功"。
+//
+// 坐标域纪律（错了就是卡片乱跑）：hit 的 glyph/view 与 present 的 anchor 全在**游戏
+// primaryLayer 像素**域；卡片尺寸是位图的物理像素。两者同域，全程不乘 dpr。
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/lookup/gal_ingame_lookup_controller.dart';
+import 'package:fushi/src/platform/gal_hook_text_overlay_channel.dart';
+
+/// 卡片与被点字形之间的间距（primaryLayer px），与控制器退化分支同值。
+const int _kCardGap = 4;
+
+/// 卡片左上角落点。
+///
+/// **直接调生产实现**，不在测试里转写一份。
+///
+/// 本次改造里 replay 的判据就是「参照实现」，生产代码的收卡判据改完之后它照样绿——
+/// 那种绿只证明参照实现自洽。定位算法同理：转写一份等于把 bug 复制两遍再互相验证。
+({int x, int y}) resolveAnchor(GalLookupHit hit, int cardW, int cardH) =>
+    GalIngameLookupController.instance.debugResolveAnchor(hit, cardW, cardH);
+
+GalLookupHit _hit({
+  int seq = 1,
+  String line = 'あいうえおかきくけこ',
+  int charIndex = 3,
+  int? charCount,
+  int glyphX = 400,
+  int glyphY = 540,
+  int glyphW = 24,
+  int glyphH = 26,
+  int viewW = 1280,
+  int viewH = 720,
+  bool submit = true,
+}) {
+  return GalLookupHit(
+    seq: seq,
+    line: line,
+    charIndex: charIndex,
+    charCount: charCount ?? line.length,
+    glyphX: glyphX,
+    glyphY: glyphY,
+    glyphW: glyphW,
+    glyphH: glyphH,
+    viewW: viewW,
+    viewH: viewH,
+    submit: submit,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const String channelName = 'app.fushi.reader/gal_hook_text';
+  const MethodChannel channel = MethodChannel(channelName);
+  const MethodCodec codec = StandardMethodCodec();
+
+  Future<void> invokeFromNative(String method, Object? arguments) async {
+    final ByteData data = codec.encodeMethodCall(MethodCall(method, arguments));
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(channelName, data, (_) {});
+  }
+
+  setUp(() => GalHookTextOverlayChannel.platformOverride = true);
+
+  tearDown(() {
+    GalHookTextOverlayChannel.clearEventHandlers();
+    GalHookTextOverlayChannel.platformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('runner → Dart：命中事件', () {
+    test('onGalLookupHit 逐字段解码，整行台词不截断', () async {
+      GalLookupHit? received;
+      GalHookTextOverlayChannel.setEventHandlers(
+        onGalLookupHit: (GalLookupHit hit) => received = hit,
+      );
+
+      const String line = 'これは合成された一行のテキストです';
+      await invokeFromNative('onGalLookupHit', <String, Object?>{
+        'seq': 12,
+        'line': line,
+        'charIndex': 4,
+        'charCount': line.length,
+        'glyphX': 512,
+        'glyphY': 604,
+        'glyphW': 26,
+        'glyphH': 28,
+        'viewW': 1280,
+        'viewH': 720,
+        'submit': true,
+      });
+
+      expect(received, isNotNull);
+      expect(received!.seq, 12);
+      expect(received!.line, line, reason: '整行必须原样送达——制卡要整句');
+      expect(received!.charIndex, 4);
+      expect(received!.charCount, line.length);
+      expect(received!.glyphRect, const Rect.fromLTWH(512, 604, 26, 28));
+      expect(received!.viewW, 1280);
+      expect(received!.viewH, 720);
+      expect(received!.submit, isTrue);
+      expect(received!.isAddressable, isTrue);
+      expect(received!.hasConsistentCharCount, isTrue);
+    });
+
+    test('submit=false 是纯悬停，不能被当成点击提交', () async {
+      GalLookupHit? received;
+      GalHookTextOverlayChannel.setEventHandlers(
+        onGalLookupHit: (GalLookupHit hit) => received = hit,
+      );
+      await invokeFromNative('onGalLookupHit', <String, Object?>{
+        'seq': 3,
+        'line': 'あいう',
+        'charIndex': 1,
+        'charCount': 3,
+        'submit': false,
+      });
+      expect(received?.submit, isFalse);
+    });
+
+    test('空行命中直接丢弃，不进 handler', () async {
+      bool called = false;
+      GalHookTextOverlayChannel.setEventHandlers(
+        onGalLookupHit: (GalLookupHit hit) => called = true,
+      );
+      await invokeFromNative('onGalLookupHit', <String, Object?>{
+        'seq': 4,
+        'line': '',
+        'charIndex': 0,
+        'charCount': 0,
+      });
+      expect(called, isFalse, reason: '没有台词就没有可查的东西，不该往下游传空命中');
+    });
+
+    test('下标越界是硬门（必须丢），字符数对不上是软门（只记账）', () {
+      // 硬门：指不到具体某个字的命中不能往下走，猜出来的下标会让高亮/查词落到无关的字上。
+      expect(_hit(line: 'あいうえお', charIndex: 5).isAddressable, isFalse);
+      expect(_hit(line: 'あいうえお', charIndex: -1).isAddressable, isFalse);
+      expect(_hit(line: 'あいうえお', charIndex: 4).isAddressable, isTrue);
+      // 软门：两侧计数单位若哪天漂了，硬丢会让功能静默死掉；越界本身已被硬门挡住。
+      expect(_hit(line: 'あいうえお', charCount: 99).hasConsistentCharCount, isFalse);
+      expect(_hit(line: 'あいうえお', charCount: 99, charIndex: 2).isAddressable,
+          isTrue,
+          reason: '字符数对不上不构成丢弃理由——只要下标还指得到字，就照常查');
+      expect(_hit(line: 'あいうえお').hasConsistentCharCount, isTrue);
+    });
+
+    test('onGalLookupInput 逐字段解码，滚轮负增量不丢符号', () async {
+      GalLookupInput? received;
+      GalHookTextOverlayChannel.setEventHandlers(
+        onGalLookupInput: (GalLookupInput input) => received = input,
+      );
+      await invokeFromNative('onGalLookupInput', <String, Object?>{
+        'seq': 7,
+        'x': 31,
+        'y': 202,
+        'kind': 3,
+        'wheel': -120,
+        'keys': 8,
+      });
+      expect(received, isNotNull);
+      expect(received!.seq, 7);
+      expect(received!.x, 31);
+      expect(received!.y, 202);
+      expect(received!.kind, 3);
+      expect(received!.wheel, -120);
+      expect(received!.keys, 8);
+    });
+  });
+
+  group('定位：卡片必须整张留在游戏画面里', () {
+    const int cardW = 480;
+    const int cardH = 320;
+
+    void expectInsideView(({int x, int y}) anchor, GalLookupHit hit) {
+      expect(anchor.x, greaterThanOrEqualTo(0));
+      expect(anchor.y, greaterThanOrEqualTo(0));
+      expect(anchor.x + cardW, lessThanOrEqualTo(hit.viewW));
+      expect(anchor.y + cardH, lessThanOrEqualTo(hit.viewH));
+    }
+
+    test('字幕在画面上半部时卡片放在字形下方', () {
+      final GalLookupHit hit = _hit(glyphX: 600, glyphY: 200, viewH: 720);
+      final ({int x, int y}) anchor = resolveAnchor(hit, cardW, cardH);
+      expect(anchor.y, greaterThan(hit.glyphY),
+          reason: '下方空间够就放下方，别盖住正在读的那一行');
+      expectInsideView(anchor, hit);
+    });
+
+    test('字幕贴近底部时卡片翻到字形上方（避让字幕本身）', () {
+      final GalLookupHit hit = _hit(glyphX: 600, glyphY: 660, viewH: 720);
+      final ({int x, int y}) anchor = resolveAnchor(hit, cardW, cardH);
+      expect(anchor.y + cardH, lessThanOrEqualTo(hit.glyphY + hit.glyphH),
+          reason: '下方放不下就必须整张翻到字形上方，而不是压在字幕上');
+      expectInsideView(anchor, hit);
+    });
+
+    test('字形贴左右边缘时水平钳进视口，不出现负坐标或右溢出', () {
+      final GalLookupHit left = _hit(glyphX: 0, glyphY: 300);
+      final GalLookupHit right = _hit(glyphX: 1256, glyphY: 300);
+      final ({int x, int y}) leftAnchor = resolveAnchor(left, cardW, cardH);
+      final ({int x, int y}) rightAnchor = resolveAnchor(right, cardW, cardH);
+      // computeFrameRect 自带 screenBorderPadding（默认 6px）的屏边留白，所以"贴边"
+      // 是贴到留白处而不是贴到 0。这里只钉方向与不越界，不钉那 6 px 的具体数值。
+      const int slack = 8;
+      expect(leftAnchor.x, lessThanOrEqualTo(slack));
+      expect(rightAnchor.x,
+          greaterThanOrEqualTo(right.viewW - cardW - slack));
+      expectInsideView(leftAnchor, left);
+      expectInsideView(rightAnchor, right);
+    });
+
+    test('卡片比游戏画面还大时贴左上角，绝不给负坐标', () {
+      final GalLookupHit hit = _hit(viewW: 320, viewH: 240, glyphX: 100, glyphY: 100);
+      final ({int x, int y}) anchor = resolveAnchor(hit, cardW, cardH);
+      expect(anchor.x, 0);
+      expect(anchor.y, 0);
+    });
+
+    test('hook 没报视口尺寸时退化成字形正下方，不猜屏幕边界', () {
+      final GalLookupHit hit = _hit(viewW: 0, viewH: 0, glyphX: 700, glyphY: 640);
+      final ({int x, int y}) anchor = resolveAnchor(hit, cardW, cardH);
+      expect(anchor.x, 700);
+      expect(anchor.y, 640 + 26 + _kCardGap);
+    });
+
+    test('同一命中反复算落点结果稳定（纯函数，不许有隐藏状态）', () {
+      final GalLookupHit hit = _hit(glyphX: 333, glyphY: 421);
+      expect(resolveAnchor(hit, cardW, cardH), resolveAnchor(hit, cardW, cardH));
+    });
+  });
+
+  group('Dart → runner：开关 / 投帧 / 消场', () {
+    late List<MethodCall> calls;
+
+    void mockRunner(Object? Function(MethodCall call) reply) {
+      calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        calls.add(call);
+        return reply(call);
+      });
+    }
+
+    test('galLookupSetEnabled 的方法名与参数键', () async {
+      mockRunner((_) => <String, Object?>{});
+      final GalLookupCallResult result =
+          await GalHookTextOverlayChannel.galLookupSetEnabled(true);
+      expect(calls.single.method, 'galLookupSetEnabled');
+      expect(calls.single.arguments, <String, Object?>{'enabled': true});
+      expect(result.ok, isTrue);
+    });
+
+    test('galLookupPresent 送出 seq / anchor / 高亮范围', () async {
+      mockRunner((_) => <String, Object?>{'width': 480, 'height': 320});
+      final GalLookupHit hit = _hit(seq: 9, glyphX: 600, glyphY: 200);
+      final ({int x, int y}) anchor = resolveAnchor(hit, 480, 320);
+      final GalLookupCallResult result =
+          await GalHookTextOverlayChannel.galLookupPresent(
+        seq: hit.seq,
+        anchorX: anchor.x,
+        anchorY: anchor.y,
+        highlightStart: hit.charIndex,
+        highlightLen: 2,
+      );
+      expect(calls.single.method, 'galLookupPresent');
+      expect(calls.single.arguments, <String, Object?>{
+        'seq': 9,
+        'anchorX': anchor.x,
+        'anchorY': anchor.y,
+        'highlightStart': hit.charIndex,
+        'highlightLen': 2,
+      });
+      expect(result.ok, isTrue);
+      expect(result.width, 480);
+      expect(result.height, 320);
+      expect(result.clamped, isFalse);
+    });
+
+    test('galLookupDismiss 带上要撤掉的那次命中序号', () async {
+      mockRunner((_) => <String, Object?>{});
+      await GalHookTextOverlayChannel.galLookupDismiss(9);
+      expect(calls.single.method, 'galLookupDismiss');
+      expect(calls.single.arguments, <String, Object?>{'seq': 9});
+    });
+
+    test('runner 的失败是应答里的 error token，绝不能被当成成功', () async {
+      mockRunner((_) => <String, Object?>{'error': 'lookup_region_missing'});
+      final GalLookupCallResult result =
+          await GalHookTextOverlayChannel.galLookupPresent(
+        seq: 1,
+        anchorX: 0,
+        anchorY: 0,
+        highlightStart: 0,
+        highlightLen: 1,
+      );
+      expect(result.ok, isFalse);
+      expect(result.error, 'lookup_region_missing');
+    });
+
+    test('卡片被裁过时 clamped 必须透出来（投出去的是切过的图）', () async {
+      mockRunner((_) => <String, Object?>{
+            'width': 880,
+            'height': 880,
+            'clamped': true,
+          });
+      final GalLookupCallResult result =
+          await GalHookTextOverlayChannel.galLookupPresent(
+        seq: 2,
+        anchorX: 0,
+        anchorY: 0,
+        highlightStart: 0,
+        highlightLen: 1,
+      );
+      expect(result.ok, isTrue, reason: '裁过不等于失败');
+      expect(result.clamped, isTrue, reason: '但也不等于"完整投出去了"，必须如实记账');
+    });
+
+    test('非 Windows 上三个调用一律不过桥，返回 unsupported', () async {
+      GalHookTextOverlayChannel.platformOverride = false;
+      mockRunner((_) => <String, Object?>{});
+      expect(
+        (await GalHookTextOverlayChannel.galLookupSetEnabled(true)).error,
+        'unsupported_platform',
+      );
+      expect(
+        (await GalHookTextOverlayChannel.galLookupPresent(
+          seq: 1,
+          anchorX: 0,
+          anchorY: 0,
+          highlightStart: 0,
+          highlightLen: 1,
+        ))
+            .error,
+        'unsupported_platform',
+      );
+      expect(
+        (await GalHookTextOverlayChannel.galLookupDismiss(1)).error,
+        'unsupported_platform',
+      );
+      expect(calls, isEmpty, reason: 'galgame hook 只做 Windows，别的平台一个调用都不该发');
+    });
+  });
+}

--- a/fushi/test/pages/texthooker_char_level_lookup_guard_test.dart
+++ b/fushi/test/pages/texthooker_char_level_lookup_guard_test.dart
@@ -30,14 +30,28 @@ void main() {
         reason: '单字命中区必须是独立 widget，整词一个 InkWell 就退回原状了');
   });
 
+  // 查询串的构造已从本页提到 sentence_extraction 的共享 lookupQueryFromIndex()
+  // （游戏内查词走同一份，两处必须同语义）。守卫跟着逻辑搬家，两头都钉：调用点必须
+  // 从命中字起算，被调方必须真的从该下标切并截断。只钉一头都能被绕过——只钉调用点，
+  // 共享函数可以偷偷改成传词；只钉共享函数，本页可以绕开它自己切。
   test('查询串从命中的那个字起算，交给引擎最长匹配', () {
     final String body = methodBody(
       page,
       'void _onCharTap(\n    TexthookerLineEntry line,\n    int charIndex,\n    Rect rect,\n  )',
     );
-    expect(body.contains('text.substring(charIndex, end)'), isTrue,
+    expect(body.contains('lookupQueryFromIndex(line.text, charIndex)'), isTrue,
         reason: '查询串必须从命中字起算；传分词器切的那个词就等于没修');
-    expect(body.contains('_kLookupQueryMaxChars'), isTrue,
+
+    final String shared =
+        maskComments(File('lib/src/lookup/sentence_extraction.dart')
+            .readAsStringSync());
+    final String helper = methodBody(
+      shared,
+      'String lookupQueryFromIndex(\n  String text,\n  int charIndex, {\n  int maxChars = kLookupQueryMaxChars,\n})',
+    );
+    expect(helper.contains('text.substring(charIndex, end)'), isTrue,
+        reason: '共享 helper 必须真的从命中字下标起切');
+    expect(helper.contains('maxChars'), isTrue,
         reason: '必须截断，别把整行喂给引擎');
   });
 

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -56,6 +56,18 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'lookup/Game window upscaling': 'test/mining/magpie_upscaling_test.dart + '
       'test/mining/magpie_native_guard_test.dart + '
       'test/mining/magpie_installer_test.dart',
+  // 游戏内查词开关（KiriKiri/KAGEX）。写 prefsRepo（changed=true），生效点整条在
+  // 本进程之外：置 header->lookup_enabled → 注入进游戏进程的 hook 装 TJS 传感器 →
+  // 卡片像素经共享内存回投、由**游戏自己的渲染树**画出来。widget harness 里既没有
+  // 目标游戏进程也没有共享内存，没有任何可探的渲染输入；且 Windows-only，CI（Linux）
+  // 连控件都不该渲染。由四层专项测试咬住：Dart 侧命中→定位→投帧的契约测试、native
+  // 侧 v14 契约测试（区寻址 + 帧闸门 + ShouldApplyLookupFrame 真值表）、会话 replay
+  // （7 个变异体实测全红），以及禁止把查词链路搬回游戏进程的源码扫描守卫。
+  'lookup/In-game dictionary lookup':
+      'test/lookup/gal_ingame_lookup_contract_test.dart + '
+          'native/galgame_hook/tests/lookup_ipc_contract_test.cpp + '
+          'native/galgame_hook/tests/lookup_session_replay_test.cpp + '
+          'native/galgame_hook/tests/kirikiri_lookup_source_guard_test.py',
   // BUG-1095：galgame Hook 台词浮窗字号。写 prefsRepo（changed=true），生效点在
   // runner 自有的 Win32 分层浮窗（Direct2D/DirectWrite 直绘，不是 Flutter widget
   // 树），本进程内没有任何可探的渲染输入，故无适用探针；由三层专项测试咬住：

--- a/fushi/test/tools/voice_hook_ipc_contract_test.dart
+++ b/fushi/test/tools/voice_hook_ipc_contract_test.dart
@@ -35,7 +35,8 @@ void main() {
       expect(source, contains('constexpr uint32_t $bit ='),
           reason: '$bit 没在契约头里定义');
     }
-    expect(source, contains('constexpr uint32_t kSharedVersion = 13;'));
+    // v14：追加游戏内查词区（hit / input / frame 三通道）。纯追加，前面各区偏移不动。
+    expect(source, contains('constexpr uint32_t kSharedVersion = 14;'));
   });
 
   test('host and native share the v12 thread preview seqlock contract', () {

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -1063,10 +1063,41 @@ void FlutterWindow::RegisterGalHookTextChannel() {
             std::make_unique<flutter::EncodableValue>(std::move(map)));
       });
 
+  // ── v14 游戏内查词：把共享内存查词通道接到这条既有通道上 ──────────────────
+  // 通道复用 gal_hook_text 而不是新开一条：查词命中与台词浮窗是同一个 galgame 会话的
+  // 两个面，Dart 侧的 GalHookTextOverlayController 已经守着这条通道。
+  fushi::VoiceHookReader::Instance().AttachLookupChannel(
+      flutter_controller_->engine()->messenger());
+  // 像素源与输入落点都指向懒建的第三个 GlobalLookupWindow 实例。lambda 里每次重新
+  // Ensure：用户可能在会话中途才开启查词，那时才建得起来。
+  fushi::VoiceHookReader::Instance().SetLookupCaptureRequest(
+      [this](uint32_t max_width, uint32_t max_height,
+             fushi::VoiceHookReader::LookupCaptureCallback done) {
+        GlobalLookupWindow* card = EnsureGalLookupCardWindow();
+        if (card == nullptr) {
+          done(false, false, {}, 0, 0, 0);
+          return;
+        }
+        card->CaptureBgraAsync(max_width, max_height, std::move(done));
+      });
+  fushi::VoiceHookReader::Instance().SetLookupInputSink(
+      [this](uint32_t kind, int32_t x, int32_t y, int32_t wheel,
+             uint32_t keys) {
+        GlobalLookupWindow* card = EnsureGalLookupCardWindow();
+        if (card == nullptr) return;
+        card->InjectLookupInput(kind, x, y, wheel, keys);
+      });
+
   gal_hook_text_channel_->SetMethodCallHandler(
       [this](const flutter::MethodCall<flutter::EncodableValue>& call,
              std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
                  result) {
+        // 查词方法先走一遍：同名通道只有一个 handler 槽位，所以 reader 侧不能自己
+        // 注册（会顶掉本处理器），只能挂在分发链最前面。不认的方法它返回 false。
+        if (fushi::VoiceHookReader::Instance().TryHandleLookupMethodCall(
+                call, result)) {
+          return;
+        }
         const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
         const std::string& method = call.method_name();
         if (method == "canDrawOverlays") {
@@ -1144,6 +1175,61 @@ void FlutterWindow::RegisterGalHookTextChannel() {
       });
 }
 
+// v14 游戏内查词的像素源。懒建：只有用户真开启这个功能才付 WebView2 的启动代价，
+// 没开的用户一分钱不花。返回 nullptr 表示这次拿不到（尚未 prepare 过 popup 资源目录）。
+GlobalLookupWindow* FlutterWindow::EnsureGalLookupCardWindow() {
+  if (gal_lookup_card_window_ != nullptr) return gal_lookup_card_window_.get();
+  // 没有资源目录就起不来（WebView2 会导航到空路径，出一张白卡）。宁可这次失败并让
+  // 上层回 no_capture_source，也不要起一个注定渲染不出东西的实例——后者的症状是
+  // 「卡片出来了但是白的」，比「卡片没出来」难查得多。
+  if (popup_assets_dir_.empty()) return nullptr;
+
+  gal_lookup_card_window_ = std::make_unique<GlobalLookupWindow>();
+  // 交互式卡片全靠 composition controller 的 SendMouseInput；windowed 实例没有它。
+  gal_lookup_card_window_->SetCompositionMode(true);
+  gal_lookup_card_window_->SetPopupAssetsDir(popup_assets_dir_);
+
+  // 外字（image://）走与主浮窗同一个 Dart 处理器：卡片内容本来就是同一份 popup.html，
+  // 没有理由让它有第二套资源解析语义。
+  gal_lookup_card_window_->SetMediaResolver(
+      [this](const std::string& url,
+             std::function<void(std::vector<uint8_t>)> respond) {
+        auto args = std::make_unique<flutter::EncodableValue>(
+            flutter::EncodableMap{
+                {flutter::EncodableValue("url"), flutter::EncodableValue(url)}});
+        auto result = std::make_unique<
+            flutter::MethodResultFunctions<flutter::EncodableValue>>(
+            [respond](const flutter::EncodableValue* ok) {
+              std::vector<uint8_t> bytes;
+              if (ok != nullptr) {
+                if (const auto* b = std::get_if<std::vector<uint8_t>>(ok)) {
+                  bytes = *b;
+                }
+              }
+              respond(std::move(bytes));
+            },
+            [respond](const std::string&, const std::string&,
+                      const flutter::EncodableValue*) { respond({}); },
+            [respond]() { respond({}); });
+        global_lookup_channel_->InvokeMethod("getMedia", std::move(args),
+                                             std::move(result));
+      });
+
+  // WebView2 起不来必须能被看见。否则症状是「游戏内查词永远没反应」，而真因在 native
+  // 环境创建失败——和「hook 没装上」「host 没投帧」三者同形，真机上分不开。
+  gal_lookup_card_window_->SetErrorCallback([this](const std::string& message) {
+    global_lookup_channel_->InvokeMethod(
+        "nativeError",
+        std::make_unique<flutter::EncodableValue>(
+            std::string("gal-lookup-card: ") + message));
+  });
+
+  // 只离屏预热，从不 ShowAt——这个实例的像素只经共享内存进游戏，永远不作为窗口出现。
+  // owner 传 nullptr，与另外两个实例同源解耦，不把主窗拉到前台。
+  gal_lookup_card_window_->PrewarmWebView(480, 360, nullptr);
+  return gal_lookup_card_window_.get();
+}
+
 void FlutterWindow::RegisterGlobalLookupChannel() {
   global_lookup_window_ = std::make_unique<GlobalLookupWindow>();
 
@@ -1215,8 +1301,11 @@ void FlutterWindow::RegisterGlobalLookupChannel() {
         const std::string& method = call.method_name();
 
         if (method == "prepare") {
-          global_lookup_window_->SetPopupAssetsDir(
-              WideFromValue(args, "assetsDir", L""));
+          const std::wstring assets_dir = WideFromValue(args, "assetsDir", L"");
+          global_lookup_window_->SetPopupAssetsDir(assets_dir);
+          // v14：游戏内查词卡片用同一份 popup 资源，但它懒建于「用户开启游戏内查词」，
+          // 那时 Dart 不会再发一次 prepare。留存一份，别让第三个实例拿着空目录起来。
+          popup_assets_dir_ = assets_dir;
           result->Success();
         } else if (method == "prewarmWebView") {
           // TODO-1079 — build the overlay window + WebView2 off-screen at

--- a/fushi/windows/runner/flutter_window.h
+++ b/fushi/windows/runner/flutter_window.h
@@ -7,6 +7,7 @@
 #include <flutter/standard_method_codec.h>
 
 #include <memory>
+#include <string>
 
 #include "floating_lyric_window.h"
 #include "global_lookup_window.h"
@@ -116,6 +117,20 @@ class FlutterWindow : public Win32Window {
       clipboard_panel_channel_;
   std::unique_ptr<GlobalLookupWindow> clipboard_panel_window_;
   void RegisterClipboardPanelChannel();
+
+  // v14 游戏内查词：**第三个** GlobalLookupWindow 实例，专门给 KiriKiri 游戏内那张卡片
+  // 出像素。为什么不复用前两个：
+  //   * global_lookup_window_ 是会真的显示在屏幕上的浮窗，借它取帧等于把它的显隐状态
+  //     和游戏内卡片的生命周期绑死；
+  //   * clipboard_panel_window_ 明确 SetCompositionMode(false)，而 SendMouseInput 只有
+  //     composition 实例才有——游戏内卡片的交互全靠它。
+  // 本实例**永远离屏**（只 PrewarmWebView，从不 ShowAt），只当渲染器用。
+  std::unique_ptr<GlobalLookupWindow> gal_lookup_card_window_;
+  // 懒建：只有用户真开启游戏内查词才付 WebView2 的启动代价。
+  GlobalLookupWindow* EnsureGalLookupCardWindow();
+  // popup 资源目录由 Dart 在 global_lookup 的 "prepare" 里给。游戏内卡片要用同一份
+  // popup.html，但它的建立时机（用户开启游戏内查词）晚于 prepare，故在此留存一份。
+  std::wstring popup_assets_dir_;
 
   // TODO-1030 M0: Windows UIA foreground-selection context capture channel.
   // Dart calls captureContext; the UIA work runs on a worker thread and the

--- a/fushi/windows/runner/global_lookup_window.cpp
+++ b/fushi/windows/runner/global_lookup_window.cpp
@@ -2,10 +2,15 @@
 
 #include <dwmapi.h>
 #include <shlwapi.h>
+#include <wincodec.h>  // WIC：CapturePreview 的 PNG 流 → BGRA8 直通 alpha 位图
 #include <windowsx.h>  // GET_X_LPARAM / GET_KEYSTATE_WPARAM（composition 鼠标转发）
 
 #include "low_level_mouse_hook.h"
 #include "resource.h"
+
+// v14 游戏内查词的输入 kind 取值真相源。只为下面那组 static_assert 而 include：
+// InjectLookupInput 的 [kind] 是跨进程契约的一部分，在这里手抄 0..4 就又造一个漂移源。
+#include "../../../native/galgame_hook/include/voice_hook_ipc.h"
 
 #include <cmath>
 #include <fstream>
@@ -167,6 +172,108 @@ std::wstring OverlayUserDataFolder(const std::wstring& leaf) {
     return std::wstring();
   }
   return base + L"\\Fushi\\" + leaf;
+}
+
+// v14 游戏内查词 — 把 CapturePreview 吐出的 PNG 流解成契约规定的
+// **BGRA8 / 直通（非预乘）alpha / 自顶向下**（voice_hook_ipc.h 的 v14 查词区注释）。
+//
+// 🔴 必须是 `GUID_WICPixelFormat32bppBGRA` 而**不是** `…32bppPBGRA`：后者是预乘。
+// 两端都用直通是有原因的——PNG 解码出来的本来就是直通（不转换就是零成本），注入侧
+// KiriKiri 的 `ltAlpha` 也正是直通合成模式（预乘对应的是 `ltAddAlpha`）。写成预乘不会
+// 报任何错，只会让卡片的半透明边缘（圆角、阴影、文字抗锯齿）整体发暗，症状是"看起来
+// 有点脏"，在真机上极难归因到像素格式。
+//
+// pitch 恒为 width*4（正数）、行序自顶向下：这块共享内存是我们自己的，不继承任何一侧
+// 的行序怪癖（游戏 Layer 的 pitch 可能为负，那是注入侧搬运时的事）。
+//
+// [max_width]/[max_height] 是硬裁剪上界（不是缩放）：超出就按左上角切，并置 [clamped]。
+// 缩放会让卡片文字糊掉，而卡片的价值就是"与 Hibiki 自身像素一致"——宁可切也不缩。
+// 全程 HRESULT 校验、零异常（runner 以 _HAS_EXCEPTIONS=0 编译）。
+bool DecodePngStreamToStraightBgra(IStream* stream, uint32_t max_width,
+                            uint32_t max_height, std::vector<uint8_t>* out,
+                            uint32_t* out_width, uint32_t* out_height,
+                            uint32_t* out_pitch, bool* out_clamped) {
+  if (stream == nullptr || out == nullptr || out_width == nullptr ||
+      out_height == nullptr || out_pitch == nullptr || out_clamped == nullptr) {
+    return false;
+  }
+  out->clear();
+  *out_width = 0;
+  *out_height = 0;
+  *out_pitch = 0;
+  *out_clamped = false;
+  if (max_width == 0 || max_height == 0) {
+    return false;
+  }
+  LARGE_INTEGER origin;
+  origin.QuadPart = 0;
+  HRESULT hr = stream->Seek(origin, STREAM_SEEK_SET, nullptr);
+  if (FAILED(hr)) {
+    return false;
+  }
+  wil::com_ptr<IWICImagingFactory> factory;
+  hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                        IID_PPV_ARGS(&factory));
+  if (FAILED(hr) || factory == nullptr) {
+    return false;
+  }
+  wil::com_ptr<IWICBitmapDecoder> decoder;
+  hr = factory->CreateDecoderFromStream(stream, nullptr,
+                                        WICDecodeMetadataCacheOnDemand,
+                                        &decoder);
+  if (FAILED(hr) || decoder == nullptr) {
+    return false;
+  }
+  wil::com_ptr<IWICBitmapFrameDecode> frame;
+  hr = decoder->GetFrame(0, &frame);
+  if (FAILED(hr) || frame == nullptr) {
+    return false;
+  }
+  UINT src_w = 0;
+  UINT src_h = 0;
+  hr = frame->GetSize(&src_w, &src_h);
+  if (FAILED(hr) || src_w == 0 || src_h == 0) {
+    return false;
+  }
+  UINT width = src_w;
+  UINT height = src_h;
+  if (width > max_width) {
+    width = static_cast<UINT>(max_width);
+    *out_clamped = true;
+  }
+  if (height > max_height) {
+    height = static_cast<UINT>(max_height);
+    *out_clamped = true;
+  }
+  wil::com_ptr<IWICBitmapSource> converted;
+  // 直通 alpha（见函数头注释）。改成 32bppPBGRA 会静默地把卡片边缘弄暗。
+  hr = WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, frame.get(),
+                              &converted);
+  if (FAILED(hr) || converted == nullptr) {
+    return false;
+  }
+  const uint64_t pitch = static_cast<uint64_t>(width) * 4u;
+  const uint64_t needed = pitch * height;
+  // 上界纯防御：调用方给的 max_* 已经把它压到 3MiB 量级，这里只挡住溢出/畸形帧。
+  if (needed == 0 || needed > 0x20000000ull) {  // 512MiB 硬顶
+    return false;
+  }
+  out->resize(static_cast<size_t>(needed));
+  WICRect rect;
+  rect.X = 0;
+  rect.Y = 0;
+  rect.Width = static_cast<INT>(width);
+  rect.Height = static_cast<INT>(height);
+  hr = converted->CopyPixels(&rect, static_cast<UINT>(pitch),
+                             static_cast<UINT>(needed), out->data());
+  if (FAILED(hr)) {
+    out->clear();
+    return false;
+  }
+  *out_width = static_cast<uint32_t>(width);
+  *out_height = static_cast<uint32_t>(height);
+  *out_pitch = static_cast<uint32_t>(pitch);
+  return true;
 }
 
 }  // namespace
@@ -1087,6 +1194,109 @@ void GlobalLookupWindow::ForwardCompositionMouse(UINT message, WPARAM wparam,
   const auto keys = static_cast<COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS>(
       GET_KEYSTATE_WPARAM(wparam));
   composition_controller_->SendMouseInput(kind, keys, mouse_data, point);
+}
+
+// v14 游戏内查词 — 注入侧转发来的 kind 与本地映射必须锁死在契约上。手抄 0..4 就等于
+// 在 host 侧复制一份枚举，注入侧改了这边不会红——所以直接对真相源做 static_assert。
+static_assert(fushi_voice_hook::kLookupInputMove == 0, "lookup input kind drift");
+static_assert(fushi_voice_hook::kLookupInputLeftDown == 1,
+              "lookup input kind drift");
+static_assert(fushi_voice_hook::kLookupInputLeftUp == 2,
+              "lookup input kind drift");
+static_assert(fushi_voice_hook::kLookupInputWheel == 3,
+              "lookup input kind drift");
+static_assert(fushi_voice_hook::kLookupInputLeave == 4,
+              "lookup input kind drift");
+
+bool GlobalLookupWindow::InjectLookupInput(uint32_t kind, int32_t x, int32_t y,
+                                           int32_t wheel, uint32_t keys) {
+  // 游戏内卡片没有子 HWND，输入只能经 composition controller 进 WebView2。
+  // windowed 实例在这里返回 false 而不是"看起来成功"，是为了让上层的
+  // "卡片点不动" 立刻定位到"像素源实例没开 composition"，而不是去猜坐标换算。
+  if (composition_controller_ == nullptr) {
+    return false;
+  }
+  COREWEBVIEW2_MOUSE_EVENT_KIND event_kind =
+      COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE;
+  UINT32 mouse_data = 0;
+  POINT point{static_cast<LONG>(x), static_cast<LONG>(y)};
+  switch (kind) {
+    case fushi_voice_hook::kLookupInputMove:
+      event_kind = COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE;
+      break;
+    case fushi_voice_hook::kLookupInputLeftDown:
+      event_kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN;
+      break;
+    case fushi_voice_hook::kLookupInputLeftUp:
+      event_kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP;
+      break;
+    case fushi_voice_hook::kLookupInputWheel:
+      event_kind = COREWEBVIEW2_MOUSE_EVENT_KIND_WHEEL;
+      // WebView2 与 WM_MOUSEWHEEL 同款：mouseData 是 WHEEL_DELTA 的倍数（有符号，
+      // 经 UINT32 传递）。注入侧填的就是游戏那边的原始 delta，这里不做二次缩放。
+      mouse_data = static_cast<UINT32>(wheel);
+      break;
+    case fushi_voice_hook::kLookupInputLeave:
+      event_kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEAVE;
+      // SDK 契约：LEAVE 必须带 (0,0)，否则 SendMouseInput 返回 E_INVALIDARG。
+      point.x = 0;
+      point.y = 0;
+      break;
+    default:
+      return false;
+  }
+  const auto virtual_keys =
+      static_cast<COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS>(keys);
+  return SUCCEEDED(composition_controller_->SendMouseInput(
+      event_kind, virtual_keys, mouse_data, point));
+}
+
+void GlobalLookupWindow::CaptureBgraAsync(uint32_t max_width,
+                                          uint32_t max_height,
+                                          BgraFrameCallback done) {
+  if (!done) {
+    return;
+  }
+  // 失败一律走同一条出口：调用方永远收得到一次 continuation，绝不出现"投帧请求
+  // 石沉大海"——那会让 Dart 侧的 present 调用永远挂着不回。
+  auto fail = [&done]() {
+    done(false, false, std::vector<uint8_t>(), 0, 0, 0);
+  };
+  if (webview_ == nullptr || !webview_ready_ || recovering_) {
+    fail();
+    return;
+  }
+  wil::com_ptr<IStream> stream;
+  stream.attach(SHCreateMemStream(nullptr, 0));
+  if (stream == nullptr) {
+    fail();
+    return;
+  }
+  // WRL 的 Callback 要求可调用对象可拷贝，而 BgraFrameCallback 只保证可移动语义可用；
+  // 包一层 shared_ptr 既满足可拷贝，又保证 continuation 只有一份状态。
+  auto sink = std::make_shared<BgraFrameCallback>(std::move(done));
+  const HRESULT hr = webview_->CapturePreview(
+      COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG, stream.get(),
+      Callback<ICoreWebView2CapturePreviewCompletedHandler>(
+          [stream, sink, max_width, max_height](HRESULT result) -> HRESULT {
+            std::vector<uint8_t> bgra;
+            uint32_t width = 0;
+            uint32_t height = 0;
+            uint32_t pitch = 0;
+            bool clamped = false;
+            const bool ok =
+                SUCCEEDED(result) &&
+                DecodePngStreamToStraightBgra(stream.get(), max_width, max_height,
+                                       &bgra, &width, &height, &pitch,
+                                       &clamped);
+            (*sink)(ok, clamped, bgra, width, height, pitch);
+            return S_OK;
+          })
+          .Get());
+  if (FAILED(hr)) {
+    // 同步失败 => 完成回调不会被调用，必须在这里补一次 continuation。
+    (*sink)(false, false, std::vector<uint8_t>(), 0, 0, 0);
+  }
 }
 
 void GlobalLookupWindow::EnsureWebView() {

--- a/fushi/windows/runner/global_lookup_window.h
+++ b/fushi/windows/runner/global_lookup_window.h
@@ -206,6 +206,54 @@ class GlobalLookupWindow {
   // SetLayeredWindowAttributes is called, so the call always follows).
   void SetWindowAlpha(int percent);
 
+  // ── v14 游戏内查词（KiriKiri/KAGEX）：本窗当卡片的**像素来源** ──────────────────
+  //
+  // 词典卡片在游戏渲染树里显示，但像素仍由本窗出：注入侧只做几何传感与位图落地，
+  // 分词/查词/排版/主题/17 语言全部留在这一份既有实现里（见
+  // docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md §4.1）。所以这里加的不是
+  // 第二个 WebView2，而是给**已有的离屏合成实例**开两个出口：取像素、喂输入。
+  //
+  // [ok]=false 时其余参数无意义。[clamped]=true 表示源画面比 max_width/max_height 大、
+  // 已按左上角裁剪——上层据此知道卡片被切过，而不是默默投一张残帧出去。
+  //
+  // 为什么是 continuation 而不是 `bool CaptureBgra(out…)` 这种同步签名：
+  // `ICoreWebView2::CapturePreview` 是异步 API，它的完成回调排在**本线程**的消息队列上。
+  // 想同步等它就只有两条路——阻塞等待（队列永远派发不到那个回调，直接死锁）或就地泵
+  // 消息（重入 WndProc / WebView2 内部状态机）。MediaResolver 当初就是为同一个理由做成
+  // 异步的，这里照抄那套纪律。
+  using BgraFrameCallback = std::function<void(
+      bool ok, bool clamped, const std::vector<uint8_t>& bgra, uint32_t width,
+      uint32_t height, uint32_t pitch)>;
+
+  // 把当前离屏 WebView2 的内容取成契约规定的位图格式：
+  // **BGRA8 / 直通（非预乘）alpha / 自顶向下 / pitch 恒为正**
+  // （真相源是 voice_hook_ipc.h 的 v14 查词区注释）。写成预乘不会报错，只会让卡片
+  // 半透明边缘发暗——所以格式不由这里"看着办"，由契约钉死。
+  //
+  // MVP 路径：`CapturePreview`（PNG 流）+ WIC 解码成 32bppBGRA。够 P1 静态卡片
+  // （一次查词一帧，编解码 ~10-20ms 落在 host 线程，不占游戏主线程）。
+  // 升级路径（P2 交互式高帧率才需要）：自持
+  // `IDXGIFactory2::CreateSwapChainForComposition` 作 WebView2 的
+  // root visual target，然后 `ID3D11DeviceContext::CopyResource` 到 D3D11_USAGE_STAGING
+  // 纹理、`Map(D3D11_MAP_READ)` 直接读回 BGRA——省掉整条 PNG 编解码，代价是要自己管
+  // swap chain 生命周期与 DPI/尺寸变化。**不要**在没有实测帧率不足前先做它。
+  //
+  // 必须在平台线程（本窗的消息循环线程）调用；continuation 也在该线程回调。
+  void CaptureBgraAsync(uint32_t max_width, uint32_t max_height,
+                        BgraFrameCallback done);
+
+  // 把游戏侧转发来的一条 LookupInputSlot 喂给已有的 composition controller。
+  // [kind] 取 voice_hook_ipc.h 的 kLookupInput*（0=move 1=leftDown 2=leftUp
+  // 3=wheel 4=leave）；.cpp 里有 static_assert 钉住这组取值，契约改了编译期就红。
+  // [x]/[y] 是**卡片局部坐标**（注入侧已减去 anchor），正好等于 WebView 客户区坐标。
+  // [keys] 是 MK_* 位掩码。
+  //
+  // 只有 composition 实例能收：windowed WebView2 没有 SendMouseInput（输入靠它自己的
+  // 子 HWND），而游戏内卡片根本没有对应的子窗口。所以游戏内查词的像素源实例**必须**
+  // 先 SetCompositionMode(true)；否则本方法一律返回 false 而不是假装喂进去了。
+  bool InjectLookupInput(uint32_t kind, int32_t x, int32_t y, int32_t wheel,
+                         uint32_t keys);
+
  private:
   static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam,
                                   LPARAM lparam) noexcept;

--- a/fushi/windows/runner/voice_hook_reader.cpp
+++ b/fushi/windows/runner/voice_hook_reader.cpp
@@ -4,8 +4,14 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
+
+// v14 游戏内查词通道要往 Dart 投 hit / input，并接 Dart 的 present / dismiss。
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
 
 // 🔴 IPC 契约**只有一份真相源**：`native/galgame_hook/include/voice_hook_ipc.h`。
 // 这里曾经放一份 host 端手抄副本（`runner/voice_hook_ipc.h`），注释还写着「真相源在独立仓库
@@ -33,6 +39,16 @@ struct ReaderState {
   HANDLE mapping = nullptr;
   SharedHeader* header = nullptr;
   uint32_t pid = 0;
+  // ── v14 查词通道游标（与上面同一把锁）───────────────────────────────────────
+  // 三个游标都在 Open 时对齐到「现在」而不是 0：会话重开时把注入侧遗留的旧 hit
+  // 当成新命中重放，用户会看到一张莫名其妙的卡片弹出来。
+  uint64_t lookup_hit_count = 0;  // 上次见到的 header->lookup_hit_count
+  uint64_t lookup_hit_seq = 0;    // 上次消费掉的 hit seq（计数变了但 seq 没前进=重复）
+  uint64_t lookup_input_seq = 0;  // 上次消费到的输入环序号
+  // 帧**发布序**：每投一帧（present 或 dismiss）+1。与 hit seq 分开是硬要求——两者
+  // 合一时收卡帧会复用刚 present 过的 seq，被注入侧的"这帧我处理过了"过滤当场丢掉，
+  // 卡片永远挂在屏幕上。见 voice_hook_ipc.h 的 LookupFrame 注释。
+  uint64_t lookup_publish_seq = 0;
 };
 
 ReaderState& State() {
@@ -140,6 +156,45 @@ VoiceHookStatus StatusFromHeaderLocked(const SharedHeader* h) {
   return s;
 }
 
+// ── v14 查词通道：共享内存侧的判据与游标 ─────────────────────────────────────
+//
+// 三个方法（enable / present / dismiss）都要先过同一道闸，且**必须分得出**是哪一种
+// 不可用：kNotOpen 要开会话，kNoRegion 要更新 helper（旧 injector 没有查词区），
+// kNotEnabled 是 host 自己关着。把它们糊成一个 bool，下游就只能一律说"查词不可用"。
+// 调用方持锁。
+VoiceHookLookupError LookupGateLocked(const SharedHeader* h,
+                                      bool require_enabled) {
+  if (!ProtocolMatches(h)) {
+    return VoiceHookLookupError::kNotOpen;
+  }
+  if (!fushi_voice_hook::HasLookupRegion(h)) {
+    return VoiceHookLookupError::kNoRegion;
+  }
+  if (require_enabled && h->lookup_enabled == 0) {
+    return VoiceHookLookupError::kNotEnabled;
+  }
+  return VoiceHookLookupError::kNone;
+}
+
+// 把三个游标对齐到当前计数（"从现在开始"）。调用方持锁。
+void ResetLookupCursorsLocked(ReaderState& st, const SharedHeader* h) {
+  st.lookup_hit_count = 0;
+  st.lookup_hit_seq = 0;
+  st.lookup_input_seq = 0;
+  if (!fushi_voice_hook::HasLookupRegion(h)) {
+    return;
+  }
+  st.lookup_hit_count =
+      fushi_voice_hook::AtomicLoadPreview64(&h->lookup_hit_count);
+  const fushi_voice_hook::LookupHitSlot* slot =
+      fushi_voice_hook::LookupHitOf(h);
+  if (slot != nullptr) {
+    st.lookup_hit_seq = fushi_voice_hook::AtomicLoadPreview64(&slot->seq);
+  }
+  st.lookup_input_seq =
+      fushi_voice_hook::AtomicLoadPreview64(&h->lookup_input_count);
+}
+
 // 解除映射、清句柄。调用方持锁。
 void CloseLocked(ReaderState& st) {
   if (st.header != nullptr) {
@@ -151,6 +206,9 @@ void CloseLocked(ReaderState& st) {
     st.mapping = nullptr;
   }
   st.pid = 0;
+  st.lookup_hit_count = 0;
+  st.lookup_hit_seq = 0;
+  st.lookup_input_seq = 0;
 }
 
 // 把一条 clip 的 PCM 从环形读出**追加**到 [out]（多段拼接用）；clip 已被环形覆盖返回 false。
@@ -221,6 +279,313 @@ std::vector<const fushi_voice_hook::VoiceClip*> CollectValidClipsLocked(
     }
   }
   return valid;
+}
+
+// ══ v14 查词通道：轮询泵 + MethodChannel ═══════════════════════════════════════
+//
+// 泵是「平台线程上的 WM_TIMER」而不是后台线程，理由是两侧的线程亲和性都硬：
+//   * MethodChannel::InvokeMethod 只能在平台线程调；
+//   * WebView2 的 SendMouseInput / CapturePreview 是 STA，也只能在平台线程调。
+// 用后台线程就必须再造一层跨线程投递，而每 16ms 读几百字节共享内存本来就不阻塞
+// 消息循环——多一层只会多一个可以出错的地方。
+constexpr wchar_t kLookupPumpClassName[] = L"FushiGalLookupPump";
+// 事件出口复用 galgame 浮窗那条既有通道：Dart 侧 GalHookTextOverlayChannel 就在这条
+// 通道上分发 onGalLookupHit / onGalLookupInput。另开一条同名通道注册 handler 会顶掉
+// flutter_window 的处理器，所以这里的通道对象**只用来 InvokeMethod**。
+constexpr char kGalHookTextChannel[] = "app.fushi.reader/gal_hook_text";
+constexpr UINT_PTR kLookupPumpTimerId = 1;
+constexpr UINT kLookupPumpIntervalMs = 16;  // ~60Hz：查词要跟手，卡片重绘也吃这个节拍
+
+// 帧尺寸的**维度**上界，与 IsLookupFrameSane 同值。字节上界不在这里管：卡片多高才
+// 放得进 3MiB 取决于它多宽，只有拿到真实宽度之后才算得出来，故字节预算统一在
+// WriteLookupFrame 里按行裁（见那里）。
+constexpr uint32_t kLookupMaxDimension = 0x4000u;
+
+using LookupChannel = flutter::MethodChannel<flutter::EncodableValue>;
+using LookupResult = flutter::MethodResult<flutter::EncodableValue>;
+
+// 泵状态：**只在平台线程上访问**（Attach/Detach/Set*/WndProc 全在平台线程），
+// 故不需要锁。共享内存那部分的并发由 ReaderState::mutex 管，两者不重叠。
+struct LookupPumpState {
+  std::unique_ptr<LookupChannel> channel;
+  VoiceHookReader::LookupCaptureRequest capture;
+  VoiceHookReader::LookupInputSink input_sink;
+  HWND hwnd = nullptr;
+  bool timer_running = false;
+};
+
+LookupPumpState& Pump() {
+  static LookupPumpState pump;
+  return pump;
+}
+
+void StopLookupPump() {
+  LookupPumpState& pump = Pump();
+  if (pump.hwnd != nullptr && pump.timer_running) {
+    KillTimer(pump.hwnd, kLookupPumpTimerId);
+  }
+  pump.timer_running = false;
+}
+
+flutter::EncodableValue LookupErrorMap(VoiceHookLookupError error) {
+  return flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("error"),
+       flutter::EncodableValue(std::string(
+           fushi::VoiceHookLookupErrorToken(error)))}});
+}
+
+flutter::EncodableValue LookupHitMap(const VoiceHookLookupHit& hit) {
+  return flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("seq"),
+       flutter::EncodableValue(static_cast<int64_t>(hit.seq))},
+      {flutter::EncodableValue("line"), flutter::EncodableValue(hit.line_utf8)},
+      {flutter::EncodableValue("charIndex"),
+       flutter::EncodableValue(static_cast<int64_t>(hit.char_index))},
+      {flutter::EncodableValue("charCount"),
+       flutter::EncodableValue(static_cast<int64_t>(hit.char_count))},
+      {flutter::EncodableValue("glyphX"), flutter::EncodableValue(hit.glyph_x)},
+      {flutter::EncodableValue("glyphY"), flutter::EncodableValue(hit.glyph_y)},
+      {flutter::EncodableValue("glyphW"), flutter::EncodableValue(hit.glyph_w)},
+      {flutter::EncodableValue("glyphH"), flutter::EncodableValue(hit.glyph_h)},
+      {flutter::EncodableValue("viewW"), flutter::EncodableValue(hit.view_w)},
+      {flutter::EncodableValue("viewH"), flutter::EncodableValue(hit.view_h)},
+      {flutter::EncodableValue("submit"), flutter::EncodableValue(hit.submit)},
+  });
+}
+
+flutter::EncodableValue LookupInputMap(const VoiceHookLookupInput& input) {
+  return flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("seq"),
+       flutter::EncodableValue(static_cast<int64_t>(input.seq))},
+      {flutter::EncodableValue("x"), flutter::EncodableValue(input.x)},
+      {flutter::EncodableValue("y"), flutter::EncodableValue(input.y)},
+      {flutter::EncodableValue("kind"),
+       flutter::EncodableValue(static_cast<int64_t>(input.kind))},
+      {flutter::EncodableValue("wheel"), flutter::EncodableValue(input.wheel)},
+      {flutter::EncodableValue("keys"),
+       flutter::EncodableValue(static_cast<int64_t>(input.keys))},
+  });
+}
+
+// 一次泵动：一条 hit（latest-wins，多的没意义）+ 环里全部新输入。
+void PumpLookupOnce() {
+  LookupPumpState& pump = Pump();
+  VoiceHookReader& reader = VoiceHookReader::Instance();
+  // 会话没了（关游戏 / Close）就把定时器停掉，别在没有映射的情况下空转。Dart 侧
+  // 重开会话后本来就要再调一次 galLookupSetEnabled，泵会跟着重新起来。
+  if (!reader.HasLookupChannel()) {
+    StopLookupPump();
+    return;
+  }
+  VoiceHookLookupHit hit;
+  if (reader.PollLookupHit(&hit) && pump.channel != nullptr) {
+    pump.channel->InvokeMethod(
+        "onGalLookupHit",
+        std::make_unique<flutter::EncodableValue>(LookupHitMap(hit)));
+  }
+  std::vector<VoiceHookLookupInput> inputs;
+  reader.PollLookupInputs(inputs);
+  for (const VoiceHookLookupInput& input : inputs) {
+    // 只上报，**不**在这里直接喂 WebView2。注入由 Dart 经 galLookupInput 回调下来
+    // （它才知道卡片这一刻显示没显示、该不该吃这个事件）。两处都喂 = 每个事件注入
+    // 两次：点击变双击、滚轮翻倍。
+    if (pump.channel != nullptr) {
+      pump.channel->InvokeMethod(
+          "onGalLookupInput",
+          std::make_unique<flutter::EncodableValue>(LookupInputMap(input)));
+    }
+  }
+}
+
+LRESULT CALLBACK LookupPumpProc(HWND hwnd, UINT message, WPARAM wparam,
+                                LPARAM lparam) {
+  if (message == WM_TIMER && wparam == kLookupPumpTimerId) {
+    PumpLookupOnce();
+    return 0;
+  }
+  return DefWindowProcW(hwnd, message, wparam, lparam);
+}
+
+// HWND_MESSAGE 消息窗：在平台线程上建，它的 WndProc 因此跑在平台线程的消息循环里。
+// 这就是"轮询结果能直接调 InvokeMethod / SendMouseInput"的全部依据。
+void EnsureLookupPumpWindow() {
+  LookupPumpState& pump = Pump();
+  if (pump.hwnd != nullptr && IsWindow(pump.hwnd)) {
+    return;
+  }
+  pump.hwnd = nullptr;
+  pump.timer_running = false;
+  static bool registered = false;
+  if (!registered) {
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = LookupPumpProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = kLookupPumpClassName;
+    registered = RegisterClassExW(&wc) != 0 ||
+                 GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+  }
+  if (!registered) {
+    return;
+  }
+  pump.hwnd = CreateWindowExW(0, kLookupPumpClassName, L"", 0, 0, 0, 0, 0,
+                              HWND_MESSAGE, nullptr,
+                              GetModuleHandleW(nullptr), nullptr);
+}
+
+void StartLookupPump() {
+  LookupPumpState& pump = Pump();
+  EnsureLookupPumpWindow();
+  if (pump.hwnd == nullptr || pump.timer_running) {
+    return;
+  }
+  pump.timer_running =
+      SetTimer(pump.hwnd, kLookupPumpTimerId, kLookupPumpIntervalMs,
+               nullptr) != 0;
+}
+
+int64_t ReadLookupInt(const flutter::MethodCall<flutter::EncodableValue>& call,
+                      const char* key) {
+  const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+  if (args == nullptr) {
+    return 0;
+  }
+  const auto it = args->find(flutter::EncodableValue(key));
+  if (it == args->end()) {
+    return 0;
+  }
+  return it->second.TryGetLongValue().value_or(0);
+}
+
+bool ReadLookupBool(const flutter::MethodCall<flutter::EncodableValue>& call,
+                    const char* key) {
+  const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+  if (args == nullptr) {
+    return false;
+  }
+  const auto it = args->find(flutter::EncodableValue(key));
+  if (it == args->end()) {
+    return false;
+  }
+  const bool* value = std::get_if<bool>(&it->second);
+  return value != nullptr && *value;
+}
+
+void HandleLookupPresent(
+    const flutter::MethodCall<flutter::EncodableValue>& call,
+    std::unique_ptr<LookupResult> result) {
+  LookupPumpState& pump = Pump();
+  VoiceHookReader& reader = VoiceHookReader::Instance();
+  VoiceHookLookupPresent meta;
+  meta.seq = static_cast<uint64_t>(ReadLookupInt(call, "seq"));
+  meta.anchor_x = static_cast<int32_t>(ReadLookupInt(call, "anchorX"));
+  meta.anchor_y = static_cast<int32_t>(ReadLookupInt(call, "anchorY"));
+  meta.highlight_start =
+      static_cast<uint32_t>(ReadLookupInt(call, "highlightStart"));
+  meta.highlight_len =
+      static_cast<uint32_t>(ReadLookupInt(call, "highlightLen"));
+  // 先探一次闸再取帧：取帧要走一整轮 PNG 编解码，为一个根本投不出去的会话做这件事
+  // 纯属浪费，而且会把真正的原因（旧 helper / 开关关着）掩盖成"取帧失败"。
+  const VoiceHookLookupError gate = reader.PeekLookupGate(true);
+  if (gate != VoiceHookLookupError::kNone) {
+    result->Success(LookupErrorMap(gate));
+    return;
+  }
+  if (!pump.capture) {
+    result->Success(
+        LookupErrorMap(VoiceHookLookupError::kNoCaptureSource));
+    return;
+  }
+  // MethodResult 不可拷贝，而 continuation 要经 std::function 传递（要求可拷贝），
+  // 故转成 shared_ptr。语义不变：仍然只应答一次。
+  std::shared_ptr<LookupResult> reply(std::move(result));
+  pump.capture(
+      kLookupMaxDimension, kLookupMaxDimension,
+      [reply, meta](bool ok, bool clamped, const std::vector<uint8_t>& bgra,
+                    uint32_t width, uint32_t height, uint32_t pitch) {
+        if (!ok || bgra.empty()) {
+          reply->Success(
+              LookupErrorMap(VoiceHookLookupError::kCaptureFailed));
+          return;
+        }
+        VoiceHookLookupWriteResult wrote =
+            VoiceHookReader::Instance().WriteLookupFrame(
+                meta, bgra.data(), width, height, pitch);
+        if (!wrote.ok()) {
+          reply->Success(LookupErrorMap(wrote.error));
+          return;
+        }
+        reply->Success(flutter::EncodableValue(flutter::EncodableMap{
+            {flutter::EncodableValue("ok"), flutter::EncodableValue(true)},
+            {flutter::EncodableValue("width"),
+             flutter::EncodableValue(static_cast<int64_t>(wrote.width))},
+            {flutter::EncodableValue("height"),
+             flutter::EncodableValue(static_cast<int64_t>(wrote.height))},
+            {flutter::EncodableValue("pitch"),
+             flutter::EncodableValue(static_cast<int64_t>(wrote.pitch))},
+            // 取帧裁剪（源画面比维度上界大）与投帧裁剪（字节超预算按行裁）都算
+            // "卡片被切过"，合并成一个事实交给上层——上层要做的处置是同一个：
+            // 把卡片做小点重投。
+            {flutter::EncodableValue("clamped"),
+             flutter::EncodableValue(clamped || wrote.clamped)},
+        }));
+      });
+}
+
+// 返回 true = 已消费（result 已应答）。**不认识的方法必须原样返回 false**，
+// 让 flutter_window 既有的 gal_hook_text 分发链继续走：这个函数是挂在别人的
+// 处理器前面的，吞掉 show/hide/updateText 就等于把 galgame 浮窗整个弄坏。
+bool HandleLookupCall(const flutter::MethodCall<flutter::EncodableValue>& call,
+                      std::unique_ptr<LookupResult>& out_result) {
+  const std::string& method = call.method_name();
+  if (method != "galLookupSetEnabled" && method != "galLookupPresent" &&
+      method != "galLookupDismiss" && method != "galLookupInput") {
+    return false;
+  }
+  std::unique_ptr<LookupResult> result = std::move(out_result);
+  LookupPumpState& pump = Pump();
+  VoiceHookReader& reader = VoiceHookReader::Instance();
+  if (method == "galLookupInput") {
+    // Dart 决定了要喂，这里只做落地。没接 sink（像素源实例还没接线）时不静默成功。
+    if (!pump.input_sink) {
+      result->Success(
+          LookupErrorMap(VoiceHookLookupError::kNoCaptureSource));
+      return true;
+    }
+    pump.input_sink(static_cast<uint32_t>(ReadLookupInt(call, "kind")),
+                    static_cast<int32_t>(ReadLookupInt(call, "x")),
+                    static_cast<int32_t>(ReadLookupInt(call, "y")),
+                    static_cast<int32_t>(ReadLookupInt(call, "wheel")),
+                    static_cast<uint32_t>(ReadLookupInt(call, "keys")));
+    result->Success(flutter::EncodableValue(flutter::EncodableMap{
+        {flutter::EncodableValue("ok"), flutter::EncodableValue(true)}}));
+    return true;
+  }
+  if (method == "galLookupSetEnabled") {
+    const VoiceHookLookupError error =
+        reader.SetLookupEnabled(ReadLookupBool(call, "enabled"));
+    if (error != VoiceHookLookupError::kNone) {
+      result->Success(LookupErrorMap(error));
+      return true;
+    }
+    result->Success(flutter::EncodableValue(flutter::EncodableMap{
+        {flutter::EncodableValue("ok"), flutter::EncodableValue(true)}}));
+    return true;
+  }
+  if (method == "galLookupPresent") {
+    HandleLookupPresent(call, std::move(result));
+    return true;
+  }
+  // 剩下的只可能是 galLookupDismiss（上面的白名单已经挡住其它一切）。
+  const VoiceHookLookupError error = reader.WriteLookupDismiss(
+      static_cast<uint64_t>(ReadLookupInt(call, "seq")));
+  if (error != VoiceHookLookupError::kNone) {
+    result->Success(LookupErrorMap(error));
+    return true;
+  }
+  result->Success(flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("ok"), flutter::EncodableValue(true)}}));
+  return true;
 }
 
 }  // namespace
@@ -314,6 +679,9 @@ VoiceHookOpenResult VoiceHookReader::Open(uint32_t pid) {
   st.mapping = mapping;
   st.header = header;
   st.pid = pid;
+  // v14：查词游标对齐到「现在」。不这么做，会话重开时注入侧遗留的旧 hit 会被当成
+  // 新命中重放，用户会看到一张莫名其妙的卡片弹出来。
+  ResetLookupCursorsLocked(st, header);
   out.status = StatusFromHeaderLocked(header);
   return out;
 }
@@ -809,6 +1177,366 @@ void VoiceHookReader::Close() {
   ReaderState& st = State();
   std::lock_guard<std::mutex> lock(st.mutex);
   CloseLocked(st);
+}
+
+// ══ v14 游戏内查词通道 ═════════════════════════════════════════════════════════
+
+const char* VoiceHookLookupErrorToken(VoiceHookLookupError error) {
+  switch (error) {
+    case VoiceHookLookupError::kNone:
+      return "none";
+    case VoiceHookLookupError::kNotOpen:
+      return "not_open";
+    case VoiceHookLookupError::kNoRegion:
+      return "no_lookup_region";
+    case VoiceHookLookupError::kNotEnabled:
+      return "lookup_disabled";
+    case VoiceHookLookupError::kNoCaptureSource:
+      return "no_capture_source";
+    case VoiceHookLookupError::kCaptureFailed:
+      return "capture_failed";
+    case VoiceHookLookupError::kFrameRejected:
+      return "frame_rejected";
+  }
+  return "unknown";
+}
+
+void VoiceHookReader::AttachLookupChannel(flutter::BinaryMessenger* messenger) {
+  if (messenger == nullptr) {
+    DetachLookupChannel();
+    return;
+  }
+  LookupPumpState& pump = Pump();
+  EnsureLookupPumpWindow();
+  // 🔴 只建对象、**不** SetMethodCallHandler：同名通道在 messenger 里只有一个
+  // handler 槽位，注册就顶掉 flutter_window 的 gal_hook_text 处理器，浮窗的
+  // show/hide/updateText 会一起失效。Dart→runner 那半边走 TryHandleLookupMethodCall。
+  pump.channel = std::make_unique<LookupChannel>(
+      messenger, kGalHookTextChannel,
+      &flutter::StandardMethodCodec::GetInstance());
+}
+
+void VoiceHookReader::DetachLookupChannel() {
+  LookupPumpState& pump = Pump();
+  StopLookupPump();
+  // 同上：从没注册过 handler，所以这里也不能注销（注销会把 flutter_window 那份
+  // 一起清掉）。只丢自己的通道对象。
+  pump.channel.reset();
+  pump.capture = nullptr;
+  pump.input_sink = nullptr;
+  if (pump.hwnd != nullptr) {
+    DestroyWindow(pump.hwnd);
+    pump.hwnd = nullptr;
+  }
+}
+
+bool VoiceHookReader::TryHandleLookupMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>& result) {
+  return HandleLookupCall(call, result);
+}
+
+void VoiceHookReader::SetLookupCaptureRequest(LookupCaptureRequest request) {
+  Pump().capture = std::move(request);
+}
+
+void VoiceHookReader::SetLookupInputSink(LookupInputSink sink) {
+  Pump().input_sink = std::move(sink);
+}
+
+bool VoiceHookReader::HasLookupChannel() {
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  return LookupGateLocked(st.header, false) == VoiceHookLookupError::kNone;
+}
+
+VoiceHookLookupError VoiceHookReader::PeekLookupGate(bool require_enabled) {
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  return LookupGateLocked(st.header, require_enabled);
+}
+
+VoiceHookLookupError VoiceHookReader::SetLookupEnabled(bool enabled) {
+  {
+    ReaderState& st = State();
+    std::lock_guard<std::mutex> lock(st.mutex);
+    SharedHeader* h = st.header;
+    const VoiceHookLookupError gate = LookupGateLocked(h, false);
+    if (gate != VoiceHookLookupError::kNone) {
+      return gate;
+    }
+    InterlockedExchange(reinterpret_cast<volatile LONG*>(&h->lookup_enabled),
+                        enabled ? 1 : 0);
+    if (enabled) {
+      // 重新开启即重新对齐游标：关着的这段时间里注入侧可能仍在写 hit（它只在
+      // lookup_enabled 时才该写，但那是它的自律，不是 host 能保证的不变量）。
+      ResetLookupCursorsLocked(st, h);
+    }
+  }
+  // SetTimer/KillTimer 在锁外：它们要进内核，没理由在持锁时做。
+  if (enabled) {
+    StartLookupPump();
+  } else {
+    StopLookupPump();
+  }
+  return VoiceHookLookupError::kNone;
+}
+
+bool VoiceHookReader::PollLookupHit(VoiceHookLookupHit* out) {
+  if (out == nullptr) {
+    return false;
+  }
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  const SharedHeader* h = st.header;
+  if (LookupGateLocked(h, false) != VoiceHookLookupError::kNone) {
+    return false;
+  }
+  const uint64_t count =
+      fushi_voice_hook::AtomicLoadPreview64(&h->lookup_hit_count);
+  if (count == st.lookup_hit_count) {
+    return false;  // 计数没动 = 没有新命中，连槽都不必读
+  }
+  // 注意：**读成功之前绝不推进 st.lookup_hit_count**。在这里先推进，一旦下面的
+  // 撕裂重试用尽就等于把这条 hit 永久吞掉——下一拍会因为"计数没动"直接返回，
+  // 用户点了字幕却什么都没发生，且没有任何痕迹。
+  const fushi_voice_hook::LookupHitSlot* slot =
+      fushi_voice_hook::LookupHitOf(h);
+  if (slot == nullptr) {
+    return false;
+  }
+  // 单槽 latest-wins：写者随时可能在我们读 payload 的中途发布下一条。读完复查 seq，
+  // 变了就整条重读——手上那份可能是两次命中的拼接（前半行 A、后半行 B），拿去查词
+  // 会得到一个谁都没说过的句子。四次仍不稳定就放弃，下一拍再来（16ms 后）。
+  for (int attempt = 0; attempt < 4; attempt++) {
+    const uint64_t seq = fushi_voice_hook::AtomicLoadPreview64(&slot->seq);
+    if (seq == 0 || seq <= st.lookup_hit_seq) {
+      // 计数动了但 seq 没前进：注入侧的重复发布，不是新命中。这条路径上推进计数
+      // 是安全的（没有待读的东西），省掉后面每一拍的无效重扫。
+      st.lookup_hit_count = count;
+      return false;
+    }
+    VoiceHookLookupHit hit;
+    hit.seq = seq;
+    hit.char_index = slot->char_index;
+    hit.char_count = slot->char_count;
+    hit.glyph_x = slot->glyph_x;
+    hit.glyph_y = slot->glyph_y;
+    hit.glyph_w = slot->glyph_w;
+    hit.glyph_h = slot->glyph_h;
+    hit.view_w = slot->view_w;
+    hit.view_h = slot->view_h;
+    hit.submit = (slot->flags & fushi_voice_hook::kLookupHitFlagSubmit) != 0;
+    uint32_t line_bytes = slot->line_bytes;
+    if (line_bytes > fushi_voice_hook::kLookupLineBytes) {
+      line_bytes = fushi_voice_hook::kLookupLineBytes;
+    }
+    hit.line_utf8.assign(reinterpret_cast<const char*>(slot->line_utf8),
+                         line_bytes);
+    if (fushi_voice_hook::AtomicLoadPreview64(&slot->seq) != seq) {
+      continue;
+    }
+    st.lookup_hit_count = count;
+    st.lookup_hit_seq = seq;
+    *out = std::move(hit);
+    return true;
+  }
+  return false;  // 四次都撞上写者：游标原地不动，下一拍（16ms 后）重来
+}
+
+void VoiceHookReader::PollLookupInputs(
+    std::vector<VoiceHookLookupInput>& out) {
+  out.clear();
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  const SharedHeader* h = st.header;
+  if (LookupGateLocked(h, false) != VoiceHookLookupError::kNone) {
+    return;
+  }
+  const uint64_t count =
+      fushi_voice_hook::AtomicLoadPreview64(&h->lookup_input_count);
+  if (count <= st.lookup_input_seq) {
+    return;
+  }
+  const uint32_t slots = h->lookup_input_slot_count;
+  const fushi_voice_hook::LookupInputSlot* base =
+      fushi_voice_hook::LookupInputsOf(h);
+  if (slots == 0 || base == nullptr) {
+    return;
+  }
+  uint64_t from = st.lookup_input_seq;
+  if (count - from > slots) {
+    // 落后超过一整圈：中间那段已被覆盖。**不补**——补出来的是别的事件的残骸，
+    // 把它当成鼠标轨迹喂进 WebView2 只会让卡片乱跳。直接跳到还活着的最旧一条。
+    from = count - slots;
+  }
+  for (uint64_t seq = from + 1; seq <= count; seq++) {
+    const fushi_voice_hook::LookupInputSlot& slot =
+        base[static_cast<size_t>((seq - 1) % slots)];
+    if (fushi_voice_hook::AtomicLoadPreview64(&slot.seq) != seq) {
+      continue;  // 半写槽或刚被下一圈覆盖
+    }
+    VoiceHookLookupInput input;
+    input.seq = seq;
+    input.x = slot.x;
+    input.y = slot.y;
+    input.kind = slot.kind;
+    input.wheel = slot.wheel;
+    input.keys = slot.keys;
+    // 复查：读 payload 期间写者绕回来覆盖了这一槽，本条作废（同 hit 的纪律）。
+    if (fushi_voice_hook::AtomicLoadPreview64(&slot.seq) != seq) {
+      continue;
+    }
+    out.push_back(input);
+  }
+  st.lookup_input_seq = count;
+}
+
+VoiceHookLookupWriteResult VoiceHookReader::WriteLookupFrame(
+    const VoiceHookLookupPresent& meta, const uint8_t* bgra, uint32_t width,
+    uint32_t height, uint32_t pitch) {
+  VoiceHookLookupWriteResult out;
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  SharedHeader* h = st.header;
+  out.error = LookupGateLocked(h, true);
+  if (out.error != VoiceHookLookupError::kNone) {
+    return out;
+  }
+  if (bgra == nullptr || width == 0 || height == 0 ||
+      pitch < static_cast<uint64_t>(width) * 4u) {
+    out.error = VoiceHookLookupError::kFrameRejected;
+    return out;
+  }
+  const uint32_t budget = h->lookup_bitmap_bytes;
+  if (pitch == 0 || pitch > budget) {
+    // 一行都放不下：卡片宽得离谱（或 pitch 本身是坏值）。这不是"裁一裁就能投"的
+    // 情形，裁行只会得到一张宽度错的图。
+    out.error = VoiceHookLookupError::kFrameRejected;
+    return out;
+  }
+  // 字节预算按**行**裁：位图是行优先的，裁尾部若干行既不改宽度也不动 pitch，
+  // 是唯一不需要重排像素的钳制方式。裁过就一定要让上层知道（out.clamped）——
+  // 静默投一张缺下半截的卡片，症状是"玄学缺字"，谁也查不出原因。
+  uint32_t rows = height;
+  const uint32_t max_rows = budget / pitch;
+  if (rows > max_rows) {
+    rows = max_rows;
+    out.clamped = true;
+  }
+  if (rows == 0) {
+    out.error = VoiceHookLookupError::kFrameRejected;
+    return out;
+  }
+  // 🔴 槽下标是契约的一部分：元数据槽与像素块**同用** seq % lookup_frame_count
+  // （voice_hook_ipc.h 的 LookupFrame 注释）。注入侧按这个下标读两边，用自己的轮转
+  // 计数器放元数据就会全量拒帧——而"卡片永远不出现"与"host 压根没投帧"完全同形，
+  // 真机上分不开。所以这里只算**一个** index，两处共用。
+  // 下标用**发布序**（不是 hit seq）：同一次 hit 可能先 present 再 dismiss，用 hit seq
+  // 算下标会让这两帧落进同一个槽、后者覆盖前者，双缓冲直接失效。
+  const uint64_t publish_seq = ++st.lookup_publish_seq;
+  const uint32_t index =
+      static_cast<uint32_t>(publish_seq % h->lookup_frame_count);
+  fushi_voice_hook::LookupFrame* frame =
+      fushi_voice_hook::LookupFrameAt(h, index);
+  uint8_t* dst = fushi_voice_hook::LookupBitmapAt(h, index);
+  if (frame == nullptr || dst == nullptr) {
+    out.error = VoiceHookLookupError::kNoRegion;
+    return out;
+  }
+  // 先在**本地**组装并过 IsLookupFrameSane，再决定要不要动共享内存。反过来（先写
+  // 进去再判断）等于把一张不合契约的帧短暂暴露给注入侧，而它那边正拿着 ready 位轮询。
+  fushi_voice_hook::LookupFrame staged = {};
+  staged.seq = publish_seq;   // 发布序：注入侧据此判新/去重/算槽
+  staged.hit_seq = meta.seq;  // 这帧回应哪次 hit：注入侧据此判是否已被更新命中作废
+  staged.flags = 0;
+  staged.width = width;
+  staged.height = rows;
+  staged.pitch = pitch;
+  staged.anchor_x = meta.anchor_x;
+  staged.anchor_y = meta.anchor_y;
+  staged.highlight_start = meta.highlight_start;
+  staged.highlight_len = meta.highlight_len;
+  staged.byte_len = pitch * rows;
+  staged.ready = 1;
+  if (!fushi_voice_hook::IsLookupFrameSane(h, &staged)) {
+    out.error = VoiceHookLookupError::kFrameRejected;
+    return out;
+  }
+  // ① ready=0：注入侧看到 0 就不拷这块缓冲，后面的像素写入不会被读到半截。
+  InterlockedExchange(reinterpret_cast<volatile LONG*>(&frame->ready), 0);
+  // ② 像素。
+  memcpy(dst, bgra, staged.byte_len);
+  // ③ 元数据（seq 之外）。
+  frame->width = staged.width;
+  frame->height = staged.height;
+  frame->pitch = staged.pitch;
+  frame->anchor_x = staged.anchor_x;
+  frame->anchor_y = staged.anchor_y;
+  frame->highlight_start = staged.highlight_start;
+  frame->highlight_len = staged.highlight_len;
+  frame->byte_len = staged.byte_len;
+  frame->hit_seq = staged.hit_seq;
+  frame->flags = staged.flags;
+  frame->reserved = 0;
+  frame->reserved2 = 0;
+  // ④ seq：Interlocked，x86 上 64 位普通写会被拆成两次 32 位写而撕裂。
+  fushi_voice_hook::AtomicStorePreview64(&frame->seq, publish_seq);
+  // ⑤ ready=1 **最后**写：Interlocked 是全栅栏，把 ①-④ 一次性对注入侧公开。
+  InterlockedExchange(reinterpret_cast<volatile LONG*>(&frame->ready), 1);
+  // ⑥ 帧计数（注入侧/诊断据此判"有没有新帧"）。
+  InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(&h->lookup_frame_count_written));
+  out.width = width;
+  out.height = rows;
+  out.pitch = pitch;
+  return out;
+}
+
+VoiceHookLookupError VoiceHookReader::WriteLookupDismiss(uint64_t seq) {
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  SharedHeader* h = st.header;
+  // require_enabled=false：收卡这条路在开关已经被关掉之后仍然必须走得通，否则
+  // "关掉游戏内查词"会把最后一张卡片永久留在游戏画面上。
+  const VoiceHookLookupError gate = LookupGateLocked(h, false);
+  if (gate != VoiceHookLookupError::kNone) {
+    return gate;
+  }
+  // 收卡是**普通一帧**：拿一个新的发布序，落进它自己的槽，靠 kLookupFrameDismiss 自述。
+  //
+  // 这里曾经是整条链上唯一不通的地方，根因是数据结构而不是漏了分支：`seq` 当时既当发布序
+  // 又当"回应哪次 hit"，于是收卡帧只能复用被撤那张卡的 seq，而那个 seq 刚 present 过，
+  // 被注入侧的 `seq <= presented_seq` 当陈旧帧扔掉——补 0×0 分支也救不回来，因为帧压根
+  // 进不了候选。两个序号拆开之后收卡不需要任何特例。
+  const uint64_t publish_seq = ++st.lookup_publish_seq;
+  const uint32_t index =
+      static_cast<uint32_t>(publish_seq % h->lookup_frame_count);
+  fushi_voice_hook::LookupFrame* frame =
+      fushi_voice_hook::LookupFrameAt(h, index);
+  if (frame == nullptr) {
+    return VoiceHookLookupError::kNoRegion;
+  }
+  // 收卡帧按定义没有像素，故不过 IsLookupFrameSane（那个函数守的是"按收到的尺寸盲拷"
+  // 这条越界路径，按定义拒绝 0 宽高）。注入侧同样在 sane 校验**之前**按 flags 认掉。
+  InterlockedExchange(reinterpret_cast<volatile LONG*>(&frame->ready), 0);
+  frame->width = 0;
+  frame->height = 0;
+  frame->pitch = 0;
+  frame->anchor_x = 0;
+  frame->anchor_y = 0;
+  frame->highlight_start = 0;
+  frame->highlight_len = 0;
+  frame->byte_len = 0;
+  frame->hit_seq = seq;
+  frame->flags = fushi_voice_hook::kLookupFrameDismiss;
+  frame->reserved = 0;
+  frame->reserved2 = 0;
+  fushi_voice_hook::AtomicStorePreview64(&frame->seq, publish_seq);
+  InterlockedExchange(reinterpret_cast<volatile LONG*>(&frame->ready), 1);
+  InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(&h->lookup_frame_count_written));
+  return VoiceHookLookupError::kNone;
 }
 
 }  // namespace fushi

--- a/fushi/windows/runner/voice_hook_reader.h
+++ b/fushi/windows/runner/voice_hook_reader.h
@@ -4,8 +4,17 @@
 #include <windows.h>
 
 #include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
+
+// v14 游戏内查词通道要往 Dart 投 hit / input，并接 Dart 的 galLookup* 调用。
+// 只取三个最小头（MethodChannel 本身留在 .cpp 里），避免把整套通道模板拉进来。
+#include <flutter/binary_messenger.h>
+#include <flutter/encodable_value.h>
+#include <flutter/method_call.h>
+#include <flutter/method_result.h>
 
 // galgame 一键制卡 C 阶段（docs/specs/galgame-mining）—— fushi.exe **读侧** native。
 //
@@ -129,6 +138,84 @@ struct VoiceTrackInfo {
   int clip_count_at_cue = 0;
 };
 
+// ══ v14 游戏内查词通道（KiriKiri/KAGEX，仅 Windows）══════════════════════════════
+//
+// 分工是硬的（docs/specs/2026-08-10-kirikiri-ingame-lookup-plan.md）：注入进游戏的
+// 代码只做几何传感、位图落地、输入转发；分词/查词/排版/卡片像素全部由 host 出。
+// 跨进程边界上因此只剩「一块位图」和「一串整数」——注入面不是"escape 得更严"，
+// 而是结构上不存在。本 reader 是 host 侧那三条通道的读写端：
+//   hit   : hook → host，单槽 latest-wins（[PollLookupHit]）
+//   input : hook → host，环（[PollLookupInputs] + [SetLookupInputSink]）
+//   frame : host → hook，双缓冲（[WriteLookupFrame] / [WriteLookupDismiss]）
+
+// 一次命中：光标落在字幕的哪个字符上。坐标/尺寸都是 primaryLayer 坐标系。
+struct VoiceHookLookupHit {
+  uint64_t seq = 0;       // 单调；host 据此判新，也是回投帧的对号
+  std::string line_utf8;  // **整行**台词，不截断（制卡要整句）
+  // 单位是 **UTF-16 code unit**，不是 UTF-8 字节、不是 code point（契约钉死在
+  // voice_hook_ipc.h 的 LookupHitSlot 上）。两端天然都是 UTF-16——注入侧 TJS 的
+  // tjs_char 是 wchar_t，Dart 的 String 下标也是 UTF-16 code unit——所以本 reader
+  // **原样透传，绝不换算**：在这里做任何"顺手转成字节下标"都会让日文行整体偏移。
+  // line_utf8 用 UTF-8 只是因为它要跨 C ABI，不影响本字段的单位。
+  uint32_t char_index = 0;
+  uint32_t char_count = 0;  // 本行 UTF-16 code unit 数（自洽校验）
+  int32_t glyph_x = 0;      // 命中字形矩形
+  int32_t glyph_y = 0;
+  int32_t glyph_w = 0;
+  int32_t glyph_h = 0;
+  int32_t view_w = 0;   // primaryLayer 尺寸；host 据此定位与钳制卡片
+  int32_t view_h = 0;
+  bool submit = false;  // true=点击提交，false=悬停预览
+};
+
+// 一条落在卡片矩形内、要喂回离屏 WebView2 的输入事件。坐标已是**卡片局部**坐标。
+struct VoiceHookLookupInput {
+  uint64_t seq = 0;
+  int32_t x = 0;
+  int32_t y = 0;
+  uint32_t kind = 0;  // voice_hook_ipc.h 的 kLookupInput*
+  int32_t wheel = 0;
+  uint32_t keys = 0;
+};
+
+// 一帧卡片的**非像素**元数据（像素由 [WriteLookupFrame] 的位图参数带）。
+struct VoiceHookLookupPresent {
+  uint64_t seq = 0;  // 对应哪次 hit；过期帧由注入侧丢弃
+  int32_t anchor_x = 0;  // 卡片左上角，primaryLayer 坐标（避让与钳制由 host 决定）
+  int32_t anchor_y = 0;
+  uint32_t highlight_start = 0;  // 字幕高亮起始字符下标
+  uint32_t highlight_len = 0;    // 高亮字符数（0=不高亮）
+};
+
+// 查词通道的**结构化**失败原因。和 [VoiceHookOpenError] 同一条纪律：原因是在
+// `return` 那一刻丢掉的，下游文案层补不回来。尤其 kNoRegion——它专指「helper 是
+// v14 以前的版本 / 本会话没有查词区」，处置是更新 helper，与"没开开关"完全不同。
+enum class VoiceHookLookupError {
+  kNone = 0,
+  kNotOpen,          // 共享内存没打开（没有 galgame 会话）
+  kNoRegion,         // 映射有效但无查词区（旧 injector；HasLookupRegion 为假）
+  kNotEnabled,       // lookup_enabled==0：host 自己关着，投帧没有消费者
+  kNoCaptureSource,  // 没接像素源（SetLookupCaptureRequest 未接线）
+  kCaptureFailed,    // 离屏 WebView2 取帧失败
+  kFrameRejected,    // 帧不过 IsLookupFrameSane（宽/高/pitch/字节数自相矛盾）
+};
+
+// [VoiceHookLookupError] → 机器可读 token（Dart 侧据此归类，跨语言契约的唯一名字）。
+const char* VoiceHookLookupErrorToken(VoiceHookLookupError error);
+
+// 投帧结局：失败原因 + 真正落进共享内存的尺寸 + 是否被字节预算钳制过。
+// [clamped] 必须一路带到上层：卡片被切掉一截和卡片正常显示在用户眼里差别巨大，
+// 静默钳制会把"卡片下半截没了"变成查不出原因的玄学。
+struct VoiceHookLookupWriteResult {
+  VoiceHookLookupError error = VoiceHookLookupError::kNone;
+  bool clamped = false;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t pitch = 0;
+
+  bool ok() const { return error == VoiceHookLookupError::kNone; }
+};
+
 // 单例：整个进程一路引擎-hook 读取。所有方法可从 UI 线程调用，绝不抛异常（全 HRESULT/句柄校验）。
 class VoiceHookReader {
  public:
@@ -200,6 +287,96 @@ class VoiceHookReader {
 
   // 解除映射、释放句柄。幂等。不杀 injector 子进程（那由 Dart 侧管理）。
   void Close();
+
+  // ── v14 游戏内查词通道 ──────────────────────────────────────────────────────
+  //
+  // 取一帧离屏卡片位图（**BGRA8 / 直通非预乘 alpha / 自顶向下 / pitch 恒正**，格式
+  // 真相源是 voice_hook_ipc.h 的 v14 查词区注释）。签名与
+  // [GlobalLookupWindow::BgraFrameCallback] 逐字一致，接线端只需把 max_* 原样转过去，
+  // 不做任何语义转换。
+  using LookupCaptureCallback = std::function<void(
+      bool ok, bool clamped, const std::vector<uint8_t>& bgra, uint32_t width,
+      uint32_t height, uint32_t pitch)>;
+  using LookupCaptureRequest = std::function<void(
+      uint32_t max_width, uint32_t max_height, LookupCaptureCallback done)>;
+  // 把一条游戏侧转发来的输入喂给离屏 WebView2（接
+  // [GlobalLookupWindow::InjectLookupInput]）。
+  using LookupInputSink = std::function<void(uint32_t kind, int32_t x,
+                                             int32_t y, int32_t wheel,
+                                             uint32_t keys)>;
+
+  // 建事件出口（host→Dart）并起轮询泵。**必须在平台线程调用**：泵用的是一个
+  // HWND_MESSAGE 消息窗 + WM_TIMER，它的 WndProc 因此跑在平台线程的消息循环上——
+  // MethodChannel::InvokeMethod 和 WebView2 的 SendMouseInput 都只能在这个线程上调。
+  // 轮询共享内存本身是几百字节的读，放平台线程不会阻塞消息循环（不是"阻塞等待"，
+  // 只是每 16ms 一次的定长扫描）。
+  //
+  // 事件走 **既有的** `app.fushi.reader/gal_hook_text` 通道（Dart 侧
+  // GalHookTextOverlayChannel 已在那条通道上分发 onGalLookupHit / onGalLookupInput）。
+  // 🔴 本方法只建 InvokeMethod 用的通道对象，**绝不 SetMethodCallHandler**：同名通道
+  // 在 messenger 里只有一个 handler 槽位，注册就会顶掉 flutter_window 已有的
+  // gal_hook_text 处理器，把浮窗的全部方法（show/hide/updateText/…）一起弄坏。
+  // Dart→runner 那半边走 [TryHandleLookupMethodCall] 挂到既有处理器的分发链上。
+  //
+  // 幂等：重复 attach 只换 messenger。传 nullptr 等价于 [DetachLookupChannel]。
+  void AttachLookupChannel(flutter::BinaryMessenger* messenger);
+  void DetachLookupChannel();
+
+  // Dart→runner 的四个 galLookup* 方法（setEnabled / present / dismiss / input）。
+  // 由 flutter_window 既有的 gal_hook_text 处理器在自己的分发链**最前面**调一次：
+  //   if (fushi::VoiceHookReader::Instance().TryHandleLookupMethodCall(call, result))
+  //     return;
+  // 返回 true = 本调用已被消费（result 已应答，且已被移走）；false = 不是查词方法，
+  // result 原封不动，按原路继续。
+  bool TryHandleLookupMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>& result);
+
+  // 接像素源 / 输入落点。两者都在平台线程上被调用。未接线时 galLookupPresent 返回
+  // kNoCaptureSource（而不是投一张空帧假装成功），输入事件仍会上报 Dart。
+  //
+  // 输入注入是 **Dart 驱动**的：泵把 input 上报成 onGalLookupInput，Dart 决定要不要
+  // 喂（卡片没显示时就不该喂），再经 galLookupInput 落到这个 sink。泵**不**自己直接
+  // 喂——两处都喂就是每个事件注入两次，鼠标会被判成双击、滚轮会翻倍。
+  void SetLookupCaptureRequest(LookupCaptureRequest request);
+  void SetLookupInputSink(LookupInputSink sink);
+
+  // 本会话是否真有查词区（HasLookupRegion）。false = 旧 injector / 旧会话；查词
+  // 三个方法一律返回 kNoRegion 而不是崩或静默无效。
+  bool HasLookupChannel();
+
+  // 不做任何写入，只回报「现在投帧会不会成功、不成功是哪一种」。
+  // 取帧要走一整轮 PNG 编解码，为一个根本投不出去的会话做这件事既浪费，又会把真正
+  // 的原因（旧 helper / 开关关着）掩盖成"取帧失败"——所以先探闸再取帧。
+  VoiceHookLookupError PeekLookupGate(bool require_enabled);
+
+  // host→hook 开关（header->lookup_enabled）。开启时同时起/停轮询定时器。
+  VoiceHookLookupError SetLookupEnabled(bool enabled);
+
+  // 有**新** hit（lookup_hit_count 变过且 seq 前进）时填 [out] 并返回 true。
+  // 读法：先读 seq → 读 payload → 复查 seq 未变，变了就重读（单写单读
+  // latest-wins 的标准纪律，与 clip / 线程预览槽同一套）。
+  bool PollLookupHit(VoiceHookLookupHit* out);
+
+  // 取输入环里游标之后的全部事件（被环覆盖的那段直接跳过，不假装补齐）。
+  void PollLookupInputs(std::vector<VoiceHookLookupInput>& out);
+
+  // 把一张已取好的位图（BGRA8 / 直通 alpha / 自顶向下 / pitch 恒正）投进共享内存。
+  //
+  // 槽下标是契约的一部分：元数据槽与像素块**同用** `seq % lookup_frame_count`。
+  // 不许用自己的轮转计数器放元数据、再用 seq%N 放像素——注入侧按同一个下标读，对不上
+  // 就全量拒帧，而症状（卡片永远不出现）和「host 压根没投帧」完全同形，真机上分不开。
+  //
+  // 写序：ready=0 → 像素 → 元数据 → seq → ready=1 → lookup_frame_count_written++。
+  // 字节超预算时**按行裁掉尾部**并置 result.clamped，而不是投一张越界帧出去。
+  VoiceHookLookupWriteResult WriteLookupFrame(
+      const VoiceHookLookupPresent& meta, const uint8_t* bgra, uint32_t width,
+      uint32_t height, uint32_t pitch);
+
+  // 投一帧 width=height=0 的**空帧**让注入侧收卡。空帧是 IsLookupFrameSane 之外的
+  // 显式哨兵（那个函数按定义拒绝 0 宽高），故这里不过它那道闸。
+  // ⚠️ 注入侧当前尚无这条分支，空帧会被两道过滤挡下——细节与 file:line 见 .cpp 实现处。
+  VoiceHookLookupError WriteLookupDismiss(uint64_t seq);
 
  private:
   VoiceHookReader() = default;

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -70,7 +70,7 @@ add_library(fushi_voice_hook SHARED
 )
 target_include_directories(fushi_voice_hook PRIVATE "include")
 target_compile_definitions(fushi_voice_hook PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
-target_link_libraries(fushi_voice_hook PRIVATE minhook)
+target_link_libraries(fushi_voice_hook PRIVATE minhook winhttp)
 
 # Siglus OVK 索引/Ogg 完整性解析是纯函数，独立小测试不需启动或注入游戏。
 enable_testing()

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -221,6 +221,27 @@ target_compile_definitions(fushi_text_lane_ipc_test
 add_test(NAME fushi_text_lane_ipc_test
   COMMAND fushi_text_lane_ipc_test)
 
+# v14 游戏内查词区的契约级测试：各子区不重叠/不越界/8 对齐、IsLookupFrameSane 的每条
+# 拒绝理由、旧会话给 nullptr 而非野指针、以及"v14 是纯追加"这条不变量。
+add_executable(fushi_lookup_ipc_contract_test
+  tests/lookup_ipc_contract_test.cpp)
+target_include_directories(fushi_lookup_ipc_contract_test PRIVATE include)
+target_compile_definitions(fushi_lookup_ipc_contract_test
+  PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
+add_test(NAME fushi_lookup_ipc_contract_test
+  COMMAND fushi_lookup_ipc_contract_test)
+
+# 游戏内查词的会话 replay：hit→frame→apply、旧帧丢弃、未开启零写入、卡片外输入不转发、
+# 会话结束清理不串数据。fixture 走 argv（与 fushi_luna_text_replay_test 同一路子）。
+add_executable(fushi_lookup_session_replay_test
+  tests/lookup_session_replay_test.cpp)
+target_include_directories(fushi_lookup_session_replay_test PRIVATE include)
+target_compile_definitions(fushi_lookup_session_replay_test
+  PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
+add_test(NAME fushi_lookup_session_replay_test
+  COMMAND fushi_lookup_session_replay_test
+  "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/kirikiri_lookup_replay.tsv")
+
 add_executable(fushi_unity_text_mesh_reassembler_test
   tests/unity_text_mesh_reassembler_test.cpp)
 target_include_directories(fushi_unity_text_mesh_reassembler_test

--- a/native/galgame_hook/docs/engine-support.md
+++ b/native/galgame_hook/docs/engine-support.md
@@ -11,7 +11,7 @@
 | `siglus` | SiglusEngine | `verified` | engine_exact_utf16_hook (implemented_unverified)；luna_hook (implemented_unverified) | resource_audio (verified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `elf_ai6` | elf AI6 | `implemented_unverified` | luna_textouta_hook (implemented_unverified) | ai6_voice_arc_resource (implemented_unverified)；directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
 | `reallive` | RealLive / old VisualArt's | `implemented_unverified` | luna_hook (implemented_unverified) | visual_arts_ovk_resource (implemented_unverified)；xaudio2_or_directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
-| `kirikiri_z` | KiriKiri2 / KiriKiriZ | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | kirikiri_resource_stream (implemented_unverified)；kirikiri_decoder_pcm (implemented_unverified)；directsound_pcm (verified)；process_loopback (verified) | 2 |
+| `kirikiri_z` | KiriKiri2 / KiriKiriZ | `partial` | luna_auto_or_pc_hooks (implemented_unverified)；ingame_lookup_geometry (implemented_unverified) | kirikiri_resource_stream (implemented_unverified)；kirikiri_decoder_pcm (implemented_unverified)；directsound_pcm (verified)；process_loopback (verified) | 2 |
 | `xaudio2_directsound` | XAudio2 / DirectSound generic capture | `verified` | — | xaudio2_source_voice_pcm (verified)；directsound_buffer_pcm (verified) | 1 |
 | `renpy_ffmpeg` | Ren'Py / FFmpeg | `implemented_unverified` | luna_auto_or_pc_hooks (implemented_unverified) | ffmpeg_resource_event (implemented_unverified)；ffmpeg54_decoder_pcm (implemented_unverified)；process_loopback (verified) | 1 |
 | `tyrano_nwjs` | TyranoScript / NW.js | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | tyrano_asar_voice_resource (verified)；ffmpeg_resource_event (implemented_unverified)；process_loopback (verified) | 1 |
@@ -160,6 +160,7 @@ Tests：`tests/reallive_adapter_test.cpp`
 文本能力：
 
 - `luna_auto_or_pc_hooks`：`implemented_unverified` — Generic Luna plumbing exists; the P0 baseline does not record a versioned text-thread replay.
+- `ingame_lookup_geometry`：`implemented_unverified` — In-game dictionary lookup (per-glyph geometry sensing plus host-rendered card bitmaps over the v14 shared-memory lookup region) is implemented but unverified: the only runtime observation is a prototype run against a single third-party textrender.dll sample, and no end-to-end 'displayed line -> matching voice -> screenshot -> card written' session exists. Offline coverage only: tests/lookup_ipc_contract_test.cpp, tests/lookup_session_replay_test.cpp, tests/kirikiri_lookup_source_guard_test.py.
 - codepage：game-specific
 - 线程提示：Reject metadata/per-character noise and select the stable dialogue thread manually when auto-selection is ambiguous.
 
@@ -180,10 +181,11 @@ Tests：`tests/reallive_adapter_test.cpp`
 - The verified KiriKiriZ sample software-mixes into one DirectSound output stream, so captured PCM is equivalent to loopback and includes BGM/SE.
 - KiriKiri2 BCB resource and decoder hooks install on the recorded official sample, but a voiced dialogue line has not yet been traversed; clean per-line Ogg is not claimed.
 - The older KiriKiriZ sample executable hash and engine version were not recorded; executable name alone is not a reusable engine signature.
+- In-game dictionary lookup is implemented_unverified. The only runtime observation is one prototype run against a single third-party textrender.dll sample; the geometry sensor is gated on that module plus a runtime probe for global.TextRender.getCharacters, so it does not generalise to KiriKiri as an engine, and no end-to-end mining session has been recorded through it.
 
-Fixtures：尚无（P5 补齐）
+Fixtures：`tests/fixtures/kirikiri_lookup_replay.tsv`
 
-Tests：`tests/resource_audio_ready_test.cpp`
+Tests：`tests/resource_audio_ready_test.cpp`、`tests/lookup_ipc_contract_test.cpp`、`tests/lookup_session_replay_test.cpp`、`tests/kirikiri_lookup_source_guard_test.py`
 
 ### XAudio2 / DirectSound generic capture (`xaudio2_directsound`)
 

--- a/native/galgame_hook/engine-support.yaml
+++ b/native/galgame_hook/engine-support.yaml
@@ -374,6 +374,11 @@
             "kind": "luna_auto_or_pc_hooks",
             "status": "implemented_unverified",
             "verification": "Generic Luna plumbing exists; the P0 baseline does not record a versioned text-thread replay."
+          },
+          {
+            "kind": "ingame_lookup_geometry",
+            "status": "implemented_unverified",
+            "verification": "In-game dictionary lookup (per-glyph geometry sensing plus host-rendered card bitmaps over the v14 shared-memory lookup region) is implemented but unverified: the only runtime observation is a prototype run against a single third-party textrender.dll sample, and no end-to-end 'displayed line -> matching voice -> screenshot -> card written' session exists. Offline coverage only: tests/lookup_ipc_contract_test.cpp, tests/lookup_session_replay_test.cpp, tests/kirikiri_lookup_source_guard_test.py."
           }
         ],
         "codepage": "game-specific",
@@ -429,11 +434,17 @@
       "known_limitations": [
         "The verified KiriKiriZ sample software-mixes into one DirectSound output stream, so captured PCM is equivalent to loopback and includes BGM/SE.",
         "KiriKiri2 BCB resource and decoder hooks install on the recorded official sample, but a voiced dialogue line has not yet been traversed; clean per-line Ogg is not claimed.",
-        "The older KiriKiriZ sample executable hash and engine version were not recorded; executable name alone is not a reusable engine signature."
+        "The older KiriKiriZ sample executable hash and engine version were not recorded; executable name alone is not a reusable engine signature.",
+        "In-game dictionary lookup is implemented_unverified. The only runtime observation is one prototype run against a single third-party textrender.dll sample; the geometry sensor is gated on that module plus a runtime probe for global.TextRender.getCharacters, so it does not generalise to KiriKiri as an engine, and no end-to-end mining session has been recorded through it."
       ],
       "adapter_path": "hook/adapters/kirikiri_adapter.inc",
-      "fixture_paths": [],
-      "test_paths": ["tests/resource_audio_ready_test.cpp"]
+      "fixture_paths": ["tests/fixtures/kirikiri_lookup_replay.tsv"],
+      "test_paths": [
+        "tests/resource_audio_ready_test.cpp",
+        "tests/lookup_ipc_contract_test.cpp",
+        "tests/lookup_session_replay_test.cpp",
+        "tests/kirikiri_lookup_source_guard_test.py"
+      ]
     },
     {
       "id": "xaudio2_directsound",

--- a/native/galgame_hook/hook/adapters/kirikiri_adapter.inc
+++ b/native/galgame_hook/hook/adapters/kirikiri_adapter.inc
@@ -1,4 +1,5 @@
 // P1 zero-behaviour-change split: included inside dll_main.cpp anonymous namespace.
+#include <winhttp.h>
 // ══ C.2c KiriKiri 解码器捕获链（引擎级干净人声）══════════════════════════════════
 // XAudio2/DirectSound 抓的是**输出**（混音后各源），KiriKiriZ 的人声不走这两条（实测输出源全
 // 是 BGM/SE）。人声在**解码环节**：KiriKiriZ 给每个正在播放的声音建一个独立解码器实例，语音是
@@ -674,8 +675,1476 @@ typedef IStream*(__stdcall* TVPCreateIStreamStub_t)(const void* name, uint32_t m
 // 内部 TVPCreateStream：KrkrZ = MSVC __fastcall(ecx=name(const ttstr&), edx=mode)，返回 tTJSBinaryStream*。
 typedef TjsBinaryStream*(__fastcall* TVPCreateStream_t)(const void* name, uint32_t mode);
 
+// KiriKiri 官方插件 ABI 的连续帧回调。V2Link 发生在 Plugins.link 的加载栈里，不能在那里重入
+// TJS；先登记此回调，下一次引擎事件循环再在游戏主线程执行一次 bootstrap。
+struct TvpContinuousEventCallback {
+  virtual void __cdecl OnContinuousCallback(uint64_t tick) = 0;
+};
+
+// ttstr 在 x86 插件 ABI 中只有一个 tTJSVariantString*。字符串必须用引擎导出的分配/释放桩创建，
+// 不能把 hook DLL 自己的 wchar_t 缓冲冒充成 ttstr（引用计数与长/短串所有权都属于 TJS）。
+struct TjsString {
+  TjsVariantString* ptr;
+};
+
+typedef TjsVariantString*(__stdcall* TJSAllocVariantStringStub_t)(const wchar_t* value);
+typedef void(__stdcall* TJSVariantStringReleaseStub_t)(TjsVariantString* value);
+typedef void(__stdcall* TVPExecuteScriptStub_t)(const TjsString& content, void* result);
+typedef void(__stdcall* TVPAddContinuousEventHookStub_t)(TvpContinuousEventCallback* callback);
+typedef void(__stdcall* TVPRemoveContinuousEventHookStub_t)(TvpContinuousEventCallback* callback);
+
 TVPCreateIStreamStub_t g_orig_TVPCreateIStreamStub = nullptr;
 TVPCreateStream_t g_orig_TVPCreateStream = nullptr;
+
+TJSAllocVariantStringStub_t g_lookup_alloc_string = nullptr;
+TJSVariantStringReleaseStub_t g_lookup_release_string = nullptr;
+TVPExecuteScriptStub_t g_lookup_execute_script = nullptr;
+TVPAddContinuousEventHookStub_t g_lookup_add_continuous = nullptr;
+TVPRemoveContinuousEventHookStub_t g_lookup_remove_continuous = nullptr;
+TjsVariantString* g_lookup_bootstrap_script = nullptr;
+volatile LONG g_lookup_bootstrap_state = 0;  // 0=off, 1=registered, 2=running, 3=done
+CRITICAL_SECTION g_lookup_response_cs;
+bool g_lookup_response_cs_ready = false;
+std::wstring g_lookup_response_script;
+std::wstring g_lookup_request_path;
+HANDLE g_lookup_worker = nullptr;
+
+constexpr wchar_t kKirikiriLookupBootstrapScript[] = LR"TJS(
+class FushiLookupHitLayer extends Layer
+{
+	var fushiLookupMessage;
+	function FushiLookupHitLayer(owner, parent, message)
+	{
+		super.Layer(owner, parent);
+		fushiLookupMessage = message;
+	}
+	function onMouseDown(x, y, button)
+	{
+		if(button == mbLeft) global.fushiLookupSubmit(fushiLookupMessage, x, y);
+	}
+	function onMouseMove(x, y)
+	{
+		var index = global.fushiLookupGlyphAt(fushiLookupMessage, x, y);
+		if(index >= 0)
+		{
+			global.fushiLookupPaint(fushiLookupMessage, index, 1, 72);
+		}
+	}
+}
+
+if(typeof global.fushiLookupBootstrap == "undefined")
+{
+	global.fushiLookupBootstrap = function(tick)
+	{
+		if(typeof global.kag == "undefined" || global.kag === null) return;
+		try
+		{
+			if(typeof global.fushiLookupCard == "undefined")
+			{
+				var owner = global.kag;
+				var root = owner.primaryLayer.parent;
+				var layer = new Layer(owner, root);
+				owner.add(layer);
+				layer.name = "Hibiki in-game dictionary";
+				layer.fushiLookupIgnore = true;
+				layer.setPos(64, 54);
+				layer.setSize(760, 344);
+				layer.type = ltAlpha;
+				layer.absolute = 2147483000;
+				layer.hitType = htMask;
+				layer.hitThreshold = 256;
+				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
+				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
+				layer.font.height = 28;
+				layer.font.bold = true;
+				layer.drawText(26, 14, "HIBIKI // IN-GAME LOOKUP", 0x31d7ff, 255, true);
+				layer.font.height = 22;
+				layer.font.bold = false;
+				layer.drawText(26, 58, "Click a subtitle glyph, or press Shift over it", 0xffffff, 255, true);
+				layer.drawText(26, 88, "Waiting for a subtitle lookup", 0xa7b8c9, 255, true);
+				layer.visible = true;
+				global.fushiLookupCard = layer;
+			}
+
+			global.fushiLookupRequestPath = "__FUSHI_REQUEST_PATH__";
+			global.fushiLookupSequence = 0;
+			global.fushiLookupPending = void;
+
+			global.fushiLookupEnsureHighlight = function(message)
+			{
+				if(typeof message.fushiLookupAbsolute != "undefined")
+				{
+					if(typeof global.fushiLookupAbsoluteHighlight != "undefined")
+					{
+						global.fushiLookupAbsoluteHighlight.setPos(0, 0);
+						global.fushiLookupAbsoluteHighlight.setSize(global.kag.primaryLayer.width,
+							global.kag.primaryLayer.height);
+						return global.fushiLookupAbsoluteHighlight;
+					}
+					var absoluteHighlight = new Layer(global.kag, global.kag.primaryLayer.parent);
+					global.kag.add(absoluteHighlight);
+					absoluteHighlight.name = "Hibiki absolute subtitle word highlight";
+					absoluteHighlight.fushiLookupIgnore = true;
+					absoluteHighlight.setPos(0, 0);
+					absoluteHighlight.setSize(global.kag.primaryLayer.width, global.kag.primaryLayer.height);
+					absoluteHighlight.type = ltAlpha;
+					absoluteHighlight.absolute = 2147482000;
+					absoluteHighlight.hitType = htMask;
+					absoluteHighlight.hitThreshold = 256;
+					absoluteHighlight.visible = true;
+					global.fushiLookupAbsoluteHighlight = absoluteHighlight;
+					return absoluteHighlight;
+				}
+				if(typeof message.fushiLookupHighlight != "undefined")
+				{
+					message.fushiLookupHighlight.setPos(message.imageLeft, message.imageTop);
+					message.fushiLookupHighlight.setSize(message.imageWidth, message.imageHeight);
+					return message.fushiLookupHighlight;
+				}
+				var hl = new FushiLookupHitLayer(global.kag, message, message);
+				global.kag.add(hl);
+				hl.name = "Hibiki subtitle word highlight";
+				hl.fushiLookupIgnore = true;
+				hl.setPos(message.imageLeft, message.imageTop);
+				hl.setSize(message.imageWidth, message.imageHeight);
+				hl.type = ltAlpha;
+				hl.absolute = 2147482000;
+				hl.hitType = htMask;
+				hl.hitThreshold = 256;
+				hl.visible = true;
+				message.fushiLookupHighlight = hl;
+				return hl;
+			};
+
+			global.fushiLookupGetGlyphs = function(message)
+			{
+				if(typeof message.fushiLookupLayerGlyphs != "undefined" &&
+					message.fushiLookupLayerGlyphs.count > 0) return message.fushiLookupLayerGlyphs;
+				if(typeof message.fushiLookupGlyphs != "undefined") return message.fushiLookupGlyphs;
+				return void;
+			};
+
+			global.fushiLookupPaint = function(message, start, length, opacity)
+			{
+				var hl = global.fushiLookupEnsureHighlight(message);
+				hl.fillRect(0, 0, hl.width, hl.height, 0);
+				var glyphs = global.fushiLookupGetGlyphs(message);
+				if(glyphs === void) return;
+				var units = 0;
+				var offsetX = typeof message.fushiLookupGlyphOffsetX == "undefined" ? 0 :
+					message.fushiLookupGlyphOffsetX;
+				var offsetY = typeof message.fushiLookupGlyphOffsetY == "undefined" ? 0 :
+					message.fushiLookupGlyphOffsetY;
+				for(var i = start; i < glyphs.count && units < length; i++)
+				{
+					var g = glyphs[i];
+					hl.colorRect(g.x + offsetX, g.y + offsetY, g.w, g.h, 0x00d8ff, opacity);
+					units += g.ch.length;
+				}
+			};
+
+			global.fushiLookupGlyphAt = function(message, x, y)
+			{
+				var glyphs = global.fushiLookupGetGlyphs(message);
+				if(glyphs === void) return -1;
+				for(var i = glyphs.count - 1; i >= 0; i--)
+				{
+					var g = glyphs[i];
+					if(x >= g.x && x < g.x + g.w && y >= g.y && y < g.y + g.h) return i;
+				}
+				return -1;
+			};
+
+			global.fushiLookupShowLoading = function(query)
+			{
+				var layer = global.fushiLookupCard;
+				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
+				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
+				layer.font.bold = true; layer.font.height = 28;
+				layer.drawText(26, 14, "HIBIKI // LOOKING UP", 0x31d7ff, 255, true);
+				layer.font.bold = false; layer.font.height = 30;
+				layer.drawText(26, 58, query, 0xffffff, 255, true);
+				layer.font.height = 20;
+				layer.drawText(26, 108, "Searching Hibiki dictionaries...", 0xa7b8c9, 255, true);
+				layer.visible = true;
+			};
+
+			global.fushiLookupSubmit = function(message, x, y)
+			{
+				var index = global.fushiLookupGlyphAt(message, x, y);
+				if(index < 0) return false;
+				var glyphs = global.fushiLookupGetGlyphs(message);
+				var query = "";
+				for(var i = index; i < glyphs.count && query.length < 48; i++)
+				{
+					var ch = glyphs[i].ch;
+					if(ch == "。" || ch == "、" || ch == "！" || ch == "？" || ch == "\n") break;
+					query += ch;
+				}
+				if(query == "") return false;
+				var id = ++global.fushiLookupSequence;
+				global.fushiLookupPending = %[id:id, message:message, start:index, query:query];
+				global.fushiLookupPaint(message, index, 1, 96);
+				global.fushiLookupShowLoading(query);
+				[id, query].save(global.fushiLookupRequestPath);
+				return true;
+			};
+
+)TJS" LR"TJS(
+
+			global.fushiLookupShowResult = function(id, expression, reading, dictionary, definition, bestLength)
+			{
+				var pending = global.fushiLookupPending;
+				if(pending === void || pending.id != id) return;
+				global.fushiLookupPaint(pending.message, pending.start, bestLength, 150);
+				var layer = global.fushiLookupCard;
+				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
+				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
+				layer.font.bold = true; layer.font.height = 26;
+				layer.drawText(26, 12, "HIBIKI // LIVE LOOKUP", 0x31d7ff, 255, true);
+				layer.font.height = 38;
+				layer.drawText(26, 52, expression, 0xffffff, 255, true);
+				layer.font.bold = false; layer.font.height = 22;
+				layer.drawText(26, 98, reading, 0x65dfff, 255, true);
+				layer.font.height = 17;
+				layer.drawText(26, 132, dictionary, 0xa7b8c9, 255, true);
+				layer.colorRect(26, 160, layer.width - 52, 2, 0x31d7ff, 210);
+				layer.font.height = 20;
+				var clean = definition.replace(/\r/g, "").replace(/\n+/g, " ");
+				var line = 0;
+				for(var pos = 0; pos < clean.length && line < 7; pos += 30, line++)
+					layer.drawText(26, 178 + line * 23, clean.substr(pos, 30), 0xffffff, 255, true);
+				layer.visible = true;
+			};
+
+			global.fushiLookupRecordGlyph = function(message, ch)
+			{
+				if(typeof message.fushiLookupGlyphs == "undefined") message.fushiLookupGlyphs = [];
+				var glyphs = message.fushiLookupGlyphs;
+				var cw = message.lineLayer.font.getTextWidth(ch) + message.pitch;
+				var lx, ly, w, h;
+				if(!message.vertical)
+				{
+					lx = message.lineLayerPos - cw; ly = message.lineLayerBase - message.fontSize;
+					w = cw; h = message.fontSize;
+				}
+				else
+				{
+					lx = message.lineLayerBase - (message.fontSize >> 1); ly = message.lineLayerPos - cw;
+					w = message.fontSize; h = cw;
+				}
+				var ox = message.lineLayerOriginX, oy = message.lineLayerOriginY;
+				glyphs.add(%[ch:ch, lx:lx, ly:ly, w:w, h:h, ox:ox, oy:oy,
+					x:message.lineLayer.left+lx, y:message.lineLayer.top+ly]);
+				for(var i = glyphs.count - 1; i >= 0; i--)
+				{
+					var g = glyphs[i];
+					if(g.ox != ox || g.oy != oy) break;
+					g.x = message.lineLayer.left + g.lx;
+					g.y = message.lineLayer.top + g.ly;
+				}
+			};
+
+			global.fushiLookupLayerRegistry = [];
+			global.fushiLookupLayerRunSequence = 0;
+			global.fushiLookupLayerGlyphSequence = 0;
+			global.fushiLookupLayerDrawCount = 0;
+			global.fushiLookupLayerLastText = "";
+
+			global.fushiLookupTextHasJapanese = function(text)
+			{
+				return typeof text == "String" && /[\u3000-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(text);
+			};
+
+			global.fushiLookupRemoveLayerGlyphs = function(layer, x, y, w, h)
+			{
+				if(typeof layer.fushiLookupLayerGlyphs == "undefined" || w <= 0 || h <= 0) return;
+				var kept = [];
+				var glyphs = layer.fushiLookupLayerGlyphs;
+				for(var i = 0; i < glyphs.count; i++)
+				{
+					var g = glyphs[i];
+					if(g.x + g.w <= x || g.y + g.h <= y || g.x >= x + w || g.y >= y + h)
+						kept.add(g);
+				}
+				layer.fushiLookupLayerGlyphs = kept;
+			};
+
+			global.fushiLookupCaptureLayerText = function(layer, x, y, text)
+			{
+				if(typeof layer.fushiLookupIgnore != "undefined" ||
+					!global.fushiLookupTextHasJapanese(text)) return;
+				var angle = layer.font.angle;
+				if(angle != 0 && angle != 2700) return;
+				if(typeof layer.fushiLookupLayerGlyphs == "undefined") layer.fushiLookupLayerGlyphs = [];
+				if(typeof layer.fushiLookupLayerRegistered == "undefined")
+				{
+					layer.fushiLookupLayerRegistered = true;
+					global.fushiLookupLayerRegistry.add(layer);
+				}
+				var height = Math.abs(layer.font.height);
+				if(height < 1) height = 1;
+				var total = layer.font.getTextWidth(text);
+				if(angle == 0)
+					global.fushiLookupRemoveLayerGlyphs(layer, x, y, total, height);
+				else
+					global.fushiLookupRemoveLayerGlyphs(layer, x - height, y, height, total);
+				var run = ++global.fushiLookupLayerRunSequence;
+				for(var i = 0; i < text.length; i++)
+				{
+					var ch = text.charAt(i);
+					var begin = layer.font.getTextWidth(text.substr(0, i));
+					var finish = layer.font.getTextWidth(text.substr(0, i + 1));
+					var advance = finish - begin;
+					if(advance < 1) advance = 1;
+					var gx, gy, gw, gh;
+					if(angle == 0)
+					{
+						gx = x + begin; gy = y; gw = advance; gh = height;
+					}
+					else
+					{
+						gx = x - height; gy = y + begin; gw = height; gh = advance;
+					}
+					layer.fushiLookupLayerGlyphs.add(%[ch:ch, x:gx, y:gy, w:gw, h:gh,
+						run:run, seq:++global.fushiLookupLayerGlyphSequence, angle:angle]);
+				}
+				global.fushiLookupLayerDrawCount++;
+				global.fushiLookupLayerLastText = text;
+			};
+
+			global.fushiLookupOriginalLayerDrawText = global.Layer.drawText;
+			global.Layer.drawText = function(x, y, text, color, opacity, antialiased)
+			{
+				var result = (global.fushiLookupOriginalLayerDrawText incontextof this)(...);
+				global.fushiLookupCaptureLayerText(this, x, y, text);
+				return result;
+			};
+
+			global.fushiLookupOriginalLayerFillRect = global.Layer.fillRect;
+			global.Layer.fillRect = function(x, y, width, height, value)
+			{
+				var result = (global.fushiLookupOriginalLayerFillRect incontextof this)(...);
+				if(typeof this.fushiLookupIgnore == "undefined" && this.face != dfProvince)
+					global.fushiLookupRemoveLayerGlyphs(this, x, y, width, height);
+				return result;
+			};
+
+)TJS" LR"TJS(
+
+			global.fushiLookupTextRenderRegistry = [];
+			global.fushiLookupTextRenderCaptureCount = 0;
+			global.fushiLookupTextRenderLastMethod = "";
+			global.fushiLookupTextRenderLastError = "";
+			global.fushiLookupTextRenderPatchTrace = [];
+			global.fushiLookupTextRenderActiveDraw = void;
+
+			global.fushiLookupTextRenderValue = function(value, name, fallback)
+			{
+				try
+				{
+					var found = value[name];
+					if(found !== void) return found;
+				}
+				catch(e) {}
+				return fallback;
+			};
+
+			global.fushiLookupTextRenderDescribe = function(value)
+			{
+				var type = typeof value;
+				if(type == "String") return value.substr(0, 80);
+				if(type == "Integer" || type == "Real") return "" + value;
+				return "<" + type + ">";
+			};
+
+			global.fushiLookupTextRenderSample = function(value)
+			{
+				var names = ["text", "x", "y", "cw", "size", "left", "top", "width", "height",
+					"pos", "link", "linkName"];
+				var sample = [];
+				for(var i = 0; i < names.count; i++)
+				{
+					var found = global.fushiLookupTextRenderValue(value, names[i], void);
+					if(found !== void) sample.add(names[i] + "=" +
+						global.fushiLookupTextRenderDescribe(found));
+				}
+				return sample.join(",");
+			};
+
+			global.fushiLookupFindTextRenderTarget = function(renderer)
+			{
+				for(var registryIndex = 0;
+					registryIndex < global.fushiLookupTextRenderRegistry.count; registryIndex++)
+					if(global.fushiLookupTextRenderRegistry[registryIndex].renderer === renderer)
+						return global.fushiLookupTextRenderRegistry[registryIndex];
+				return void;
+			};
+
+			global.fushiLookupBindTextRenderOrigin = function(renderer, layer, originX, originY, source)
+			{
+				if(layer === void || layer === null || !isvalid layer ||
+					(typeof originX != "Integer" && typeof originX != "Real") ||
+					(typeof originY != "Integer" && typeof originY != "Real")) return;
+				var target = global.fushiLookupFindTextRenderTarget(renderer);
+				if(target === void) return;
+				target.targetLayer = layer;
+				target.originX = originX;
+				target.originY = originY;
+				target.originSource = source;
+			};
+
+			global.fushiLookupCaptureTextRender = function(renderer, method, a, b, c, d, e, f)
+			{
+				try
+				{
+					if(typeof renderer.getCharacters != "Object") return;
+					var characters = (renderer.getCharacters incontextof renderer)(0, 0);
+					if(characters === void || typeof characters.count == "undefined") return;
+					var glyphs = [];
+					for(var i = 0; i < characters.count; i++)
+					{
+						var character = characters[i];
+						var text = global.fushiLookupTextRenderValue(character, "text", "");
+						if(typeof text != "String" || text == "") continue;
+						var x = global.fushiLookupTextRenderValue(character, "left",
+							global.fushiLookupTextRenderValue(character, "x", void));
+						var y = global.fushiLookupTextRenderValue(character, "top",
+							global.fushiLookupTextRenderValue(character, "y", void));
+						var width = global.fushiLookupTextRenderValue(character, "width",
+							global.fushiLookupTextRenderValue(character, "cw", void));
+						var height = global.fushiLookupTextRenderValue(character, "height",
+							global.fushiLookupTextRenderValue(character, "size", void));
+						if(x === void || y === void || width === void || height === void ||
+							width <= 0 || height <= 0) continue;
+						glyphs.add(%[ch:text, x:x, y:y, w:width, h:height, run:0, seq:i]);
+					}
+
+					var target = global.fushiLookupFindTextRenderTarget(renderer);
+					if(target === void)
+					{
+						target = %[renderer:renderer, fushiLookupAbsolute:true,
+							fushiLookupGlyphOffsetX:0, fushiLookupGlyphOffsetY:0];
+						global.fushiLookupTextRenderRegistry.add(target);
+					}
+					target.fushiLookupLayerGlyphs = glyphs;
+					target.characters = characters;
+					target.method = method;
+					target.capture = ++global.fushiLookupTextRenderCaptureCount;
+					target.args = [global.fushiLookupTextRenderDescribe(a),
+						global.fushiLookupTextRenderDescribe(b), global.fushiLookupTextRenderDescribe(c),
+						global.fushiLookupTextRenderDescribe(d), global.fushiLookupTextRenderDescribe(e),
+						global.fushiLookupTextRenderDescribe(f)];
+					target.sample = characters.count > 0 ?
+						global.fushiLookupTextRenderSample(characters[0]) : "";
+					target.lastSample = characters.count > 0 ?
+						global.fushiLookupTextRenderSample(characters[characters.count - 1]) : "";
+					if(typeof global.fushiLookupTextRenderActiveDraw != "undefined" &&
+						global.fushiLookupTextRenderActiveDraw !== void &&
+						global.fushiLookupTextRenderActiveDraw.renderer === renderer)
+						global.fushiLookupBindTextRenderOrigin(renderer,
+							global.fushiLookupTextRenderActiveDraw.layer,
+							global.fushiLookupTextRenderActiveDraw.originX,
+							global.fushiLookupTextRenderActiveDraw.originY, "TextRender.draw");
+					global.fushiLookupTextRenderLastTarget = target;
+					global.fushiLookupTextRenderLastMethod = method;
+				}
+				catch(error)
+				{
+					global.fushiLookupTextRenderLastError = method + ":" + error.message;
+				}
+			};
+
+)TJS" LR"TJS(
+
+			try
+			{
+				global.fushiLookupTextRenderPatchTrace.add("TextRenderBase=" + typeof global.TextRenderBase);
+				if(typeof global.TextRenderBase == "Object")
+				{
+					global.fushiLookupTextRenderPatchTrace.add("TextRenderBase.render=" +
+						typeof global.TextRenderBase.render);
+					if(typeof global.TextRenderBase.render == "Object")
+					{
+						global.fushiLookupOriginalTextRenderBaseRender = global.TextRenderBase.render;
+						global.TextRenderBase.render = function(a, b, c, d, e, f)
+						{
+							var result = (global.fushiLookupOriginalTextRenderBaseRender incontextof this)(...);
+							global.fushiLookupCaptureTextRender(this, "TextRenderBase.render",
+								a, b, c, d, e, f);
+							return result;
+						};
+					}
+					global.fushiLookupTextRenderPatchTrace.add("TextRenderBase.done=" +
+						typeof global.TextRenderBase.done);
+					if(typeof global.TextRenderBase.done == "Object")
+					{
+						global.fushiLookupOriginalTextRenderBaseDone = global.TextRenderBase.done;
+						global.TextRenderBase.done = function()
+						{
+							var result = (global.fushiLookupOriginalTextRenderBaseDone incontextof this)(...);
+							global.fushiLookupCaptureTextRender(this, "TextRenderBase.done",
+								void, void, void, void, void, void);
+							return result;
+						};
+					}
+				}
+			}
+			catch(error)
+			{
+				global.fushiLookupTextRenderPatchTrace.add("TextRenderBase!" + error.message);
+			}
+
+)TJS" LR"TJS(
+
+			try
+			{
+				global.fushiLookupTextRenderPatchTrace.add("TextRender=" + typeof global.TextRender);
+				if(typeof global.TextRender == "Object" && global.TextRender !== global.TextRenderBase)
+				{
+					global.fushiLookupTextRenderPatchTrace.add("TextRender.draw=" +
+						typeof global.TextRender.draw);
+					if(typeof global.TextRender.draw == "Object")
+					{
+						global.fushiLookupOriginalTextRenderDraw = global.TextRender.draw;
+						global.TextRender.draw = function(layer, ox, oy, width, height, text,
+							autoIndent, base)
+						{
+							var previous = typeof global.fushiLookupTextRenderActiveDraw == "undefined" ?
+								void : global.fushiLookupTextRenderActiveDraw;
+							global.fushiLookupTextRenderActiveDraw = %[
+								renderer:this, layer:layer, originX:ox, originY:oy];
+							var result;
+							try
+							{
+								result = (global.fushiLookupOriginalTextRenderDraw incontextof this)(...);
+							}
+							catch(error)
+							{
+								global.fushiLookupTextRenderActiveDraw = previous;
+								throw error;
+							}
+							global.fushiLookupTextRenderActiveDraw = previous;
+							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
+								"TextRender.draw");
+							return result;
+						};
+					}
+					global.fushiLookupTextRenderPatchTrace.add("TextRender.drawAll=" +
+						typeof global.TextRender.drawAll);
+					if(typeof global.TextRender.drawAll == "Object")
+					{
+						global.fushiLookupOriginalTextRenderDrawAll = global.TextRender.drawAll;
+						global.TextRender.drawAll = function(layer, ox, oy)
+						{
+							var previous = typeof global.fushiLookupTextRenderActiveDraw == "undefined" ?
+								void : global.fushiLookupTextRenderActiveDraw;
+							global.fushiLookupTextRenderActiveDraw = %[
+								renderer:this, layer:layer, originX:ox, originY:oy];
+							var result;
+							try
+							{
+								result = (global.fushiLookupOriginalTextRenderDrawAll incontextof this)(...);
+							}
+							catch(error)
+							{
+								global.fushiLookupTextRenderActiveDraw = previous;
+								throw error;
+							}
+							global.fushiLookupTextRenderActiveDraw = previous;
+							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
+								"TextRender.drawAll");
+							return result;
+						};
+					}
+					global.fushiLookupTextRenderPatchTrace.add("TextRender.drawCh=" +
+						typeof global.TextRender.drawCh);
+					if(typeof global.TextRender.drawCh == "Object")
+					{
+						global.fushiLookupOriginalTextRenderDrawCh = global.TextRender.drawCh;
+						global.TextRender.drawCh = function(layer, ox, oy, ch)
+						{
+							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
+								"TextRender.drawCh");
+							return (global.fushiLookupOriginalTextRenderDrawCh incontextof this)(...);
+						};
+					}
+					global.fushiLookupTextRenderPatchTrace.add("TextRender.render=" +
+						typeof global.TextRender.render);
+					if(typeof global.TextRender.render == "Object")
+					{
+						global.fushiLookupOriginalTextRenderRender = global.TextRender.render;
+						global.TextRender.render = function(a, b, c, d, e, f)
+						{
+							var result = (global.fushiLookupOriginalTextRenderRender incontextof this)(...);
+							global.fushiLookupCaptureTextRender(this, "TextRender.render",
+								a, b, c, d, e, f);
+							return result;
+						};
+					}
+					global.fushiLookupTextRenderPatchTrace.add("TextRender.done=" +
+						typeof global.TextRender.done);
+					if(typeof global.TextRender.done == "Object")
+					{
+						global.fushiLookupOriginalTextRenderDone = global.TextRender.done;
+						global.TextRender.done = function()
+						{
+							var result = (global.fushiLookupOriginalTextRenderDone incontextof this)(...);
+							global.fushiLookupCaptureTextRender(this, "TextRender.done",
+								void, void, void, void, void, void);
+							return result;
+						};
+					}
+				}
+			}
+			catch(error)
+			{
+				global.fushiLookupTextRenderPatchTrace.add("TextRender!" + error.message);
+			}
+
+)TJS" LR"TJS(
+
+			global.fushiLookupPatchMessage = function(message)
+			{
+				if(message === void || !isvalid message) return;
+				if(typeof message.fushiLookupGlyphs == "undefined") message.fushiLookupGlyphs = [];
+				if(typeof message.fushiLookupProcessChCount == "undefined") message.fushiLookupProcessChCount = 0;
+				if(typeof message.fushiLookupLastCh == "undefined") message.fushiLookupLastCh = "";
+				if(typeof message.processCh != "Object") return;
+				if(typeof message.fushiLookupInstanceWrapperProcessCh != "undefined" &&
+					message.processCh === message.fushiLookupInstanceWrapperProcessCh) return;
+				message.fushiLookupInstancePatched = true;
+				message.fushiLookupInstanceOriginalProcessCh = message.processCh;
+				message.fushiLookupInstanceWrapperProcessCh = function(ch, steptime)
+				{
+					this.fushiLookupProcessChCount++;
+					this.fushiLookupLastCh = ch;
+					var result = (this.fushiLookupInstanceOriginalProcessCh incontextof this)(...);
+					if(!result) global.fushiLookupRecordGlyph(this, ch);
+					return result;
+				} incontextof message;
+				message.processCh = message.fushiLookupInstanceWrapperProcessCh;
+				if(typeof message.clear == "Object" &&
+					(typeof message.fushiLookupInstanceWrapperClear == "undefined" ||
+					message.clear !== message.fushiLookupInstanceWrapperClear)
+				)
+				{
+					message.fushiLookupInstanceOriginalClear = message.clear;
+					message.fushiLookupInstanceWrapperClear = function(all)
+					{
+						this.fushiLookupGlyphs = [];
+						if(typeof this.fushiLookupHighlight != "undefined")
+							this.fushiLookupHighlight.fillRect(0, 0, this.fushiLookupHighlight.width,
+								this.fushiLookupHighlight.height, 0);
+						return (this.fushiLookupInstanceOriginalClear incontextof this)(...);
+					} incontextof message;
+					message.clear = message.fushiLookupInstanceWrapperClear;
+				}
+			};
+
+			global.fushiLookupPatchAllMessages = function()
+			{
+				var pages = [global.kag.fore.messages, global.kag.back.messages];
+				for(var page = 0; page < pages.count; page++)
+					for(var message = 0; message < pages[page].count; message++)
+						global.fushiLookupPatchMessage(pages[page][message]);
+				if(typeof global.kag.current != "undefined" && global.kag.current !== void)
+					global.fushiLookupPatchMessage(global.kag.current);
+			};
+			if(typeof global.kag.tagHandlers == "Object" &&
+				typeof global.kag.tagHandlers.ch == "Object")
+			{
+				global.fushiLookupOriginalChHandler = global.kag.tagHandlers.ch;
+				global.fushiLookupChHandler = function(elm)
+				{
+					if(typeof this.current != "undefined" && this.current !== void)
+						global.fushiLookupPatchMessage(this.current);
+					return (global.fushiLookupOriginalChHandler incontextof this)(...);
+				} incontextof global.kag;
+				global.kag.tagHandlers.ch = global.fushiLookupChHandler;
+			}
+			global.fushiLookupPatchAllMessages();
+			global.fushiLookupRefreshMessages = function(tick)
+			{
+				try { global.fushiLookupPatchAllMessages(); } catch(e) {}
+			};
+			System.addContinuousHandler(global.fushiLookupRefreshMessages);
+
+)TJS" LR"TJS(
+
+			global.fushiLookupAtTextRenderRegistry = function(submit)
+			{
+				var primary = global.kag.primaryLayer;
+				var cursorX = primary.cursorX - primary.imageLeft;
+				var cursorY = primary.cursorY - primary.imageTop;
+				global.fushiLookupLastTrace.add("textRender captures=" +
+					global.fushiLookupTextRenderCaptureCount + " registry=" +
+					global.fushiLookupTextRenderRegistry.count + " lastMethod=" +
+					global.fushiLookupTextRenderLastMethod + " error=" +
+					global.fushiLookupTextRenderLastError + " cursor=" + cursorX + "," + cursorY);
+
+)TJS" LR"TJS(
+
+				for(var patchIndex = 0;
+					patchIndex < global.fushiLookupTextRenderPatchTrace.count; patchIndex++)
+					global.fushiLookupLastTrace.add("textRenderPatch=" +
+						global.fushiLookupTextRenderPatchTrace[patchIndex]);
+				for(var registryIndex = global.fushiLookupTextRenderRegistry.count - 1;
+					registryIndex >= 0; registryIndex--)
+				{
+					var target = global.fushiLookupTextRenderRegistry[registryIndex];
+					var glyphs = target.fushiLookupLayerGlyphs;
+					var targetLayer = global.fushiLookupTextRenderValue(target,
+						"targetLayer", void);
+					var originX = global.fushiLookupTextRenderValue(target, "originX", void);
+					var originY = global.fushiLookupTextRenderValue(target, "originY", void);
+					var originSource = global.fushiLookupTextRenderValue(target,
+						"originSource", "unbound");
+					var row = "textRender=" + registryIndex + " method=" + target.method +
+						" capture=" + target.capture + " chars=" + target.characters.count +
+						" glyphs=" + glyphs.count + " args=" + target.args.join("|") +
+						" first={" + target.sample + "} last={" +
+						target.lastSample + "}";
+					if(glyphs.count > 0)
+					{
+						var first = glyphs[0], last = glyphs[glyphs.count - 1];
+						row += " bounds=" + first.ch + "@" + first.x + "," + first.y + "," +
+							first.w + "," + first.h + ".." + last.ch + "@" + last.x + "," +
+							last.y + "," + last.w + "," + last.h;
+					}
+					if(targetLayer === void || targetLayer === null || !isvalid targetLayer ||
+						originX === void || originY === void)
+					{
+						global.fushiLookupLastTrace.add(row + " origin=unbound");
+						continue;
+					}
+					var layerX = targetLayer.cursorX - targetLayer.imageLeft;
+					var layerY = targetLayer.cursorY - targetLayer.imageTop;
+					var localX = layerX - originX;
+					var localY = layerY - originY;
+					var visible = global.fushiLookupLayerIsVisible(targetLayer);
+					target.fushiLookupGlyphOffsetX = cursorX - layerX + originX;
+					target.fushiLookupGlyphOffsetY = cursorY - layerY + originY;
+					row += " origin=" + originSource + "@" + originX + "," + originY +
+						" layerCursor=" + targetLayer.cursorX + "," + targetLayer.cursorY +
+						" image=" + targetLayer.imageLeft + "," + targetLayer.imageTop +
+						" local=" + localX + "," + localY + " visible=" + visible;
+					global.fushiLookupLastTrace.add(row);
+					if(!visible) continue;
+					var index = global.fushiLookupGlyphAt(target, localX, localY);
+					if(index < 0) continue;
+					global.fushiLookupPaint(target, index, 1, 72);
+					if(submit) return global.fushiLookupSubmit(target, localX, localY);
+					return true;
+				}
+				return false;
+			};
+
+			global.fushiLookupLayerIsVisible = function(layer)
+			{
+				var current = layer;
+				while(current !== void && current !== null && isvalid current)
+				{
+					if(!current.visible || current.opacity <= 0) return false;
+					current = current.parent;
+				}
+				return true;
+			};
+
+			global.fushiLookupAtLayerRegistry = function(submit)
+			{
+				global.fushiLookupLastTrace.add("drawText=" + global.fushiLookupLayerDrawCount +
+					" registry=" + global.fushiLookupLayerRegistry.count +
+					" lastText=" + global.fushiLookupLayerLastText);
+				for(var registryIndex = global.fushiLookupLayerRegistry.count - 1;
+					registryIndex >= 0; registryIndex--)
+				{
+					var layer = global.fushiLookupLayerRegistry[registryIndex];
+					if(layer === void || !isvalid layer ||
+						typeof layer.fushiLookupLayerGlyphs == "undefined" ||
+						layer.fushiLookupLayerGlyphs.count == 0) continue;
+					var visible = global.fushiLookupLayerIsVisible(layer);
+					var x = layer.cursorX - layer.imageLeft;
+					var y = layer.cursorY - layer.imageTop;
+					var glyphs = layer.fushiLookupLayerGlyphs;
+					var last = glyphs[glyphs.count - 1];
+					global.fushiLookupLastTrace.add("layer=" + registryIndex +
+						" visible=" + visible + " cursor=" + layer.cursorX + "," + layer.cursorY +
+						" image=" + layer.imageLeft + "," + layer.imageTop +
+						" local=" + x + "," + y + " glyphs=" + glyphs.count +
+						" last=" + last.ch + "@" + last.x + "," + last.y + "," + last.w + "," + last.h);
+					if(!visible) continue;
+					var index = global.fushiLookupGlyphAt(layer, x, y);
+					if(index < 0) continue;
+					global.fushiLookupPaint(layer, index, 1, 72);
+					if(submit) return global.fushiLookupSubmit(layer, x, y);
+					return true;
+				}
+				return false;
+			};
+
+			global.fushiLookupAtCursor = function(submit)
+			{
+				global.fushiLookupLastTrace = [];
+				if(global.fushiLookupAtTextRenderRegistry(submit)) return true;
+				if(global.fushiLookupAtLayerRegistry(submit)) return true;
+				global.fushiLookupPatchAllMessages();
+				var pages = [global.kag.fore.messages, global.kag.back.messages];
+				var sawCurrent = false;
+				for(var page = 0; page < pages.count; page++)
+				{
+					var messages = pages[page];
+					for(var i = messages.count - 1; i >= 0; i--)
+					{
+						var message = messages[i];
+						if(typeof message.fushiLookupGlyphs == "undefined") continue;
+						var glyphs = message.fushiLookupGlyphs;
+						var x = message.cursorX - message.imageLeft;
+						var y = message.cursorY - message.imageTop;
+						var isCurrent = typeof global.kag.current != "undefined" && global.kag.current === message;
+						if(isCurrent) sawCurrent = true;
+						var row = "page=" + page + " message=" + i +
+							" visible=" + message.visible + " cursor=" + message.cursorX + "," + message.cursorY +
+							" image=" + message.imageLeft + "," + message.imageTop +
+							" local=" + x + "," + y + " glyphs=" + glyphs.count +
+							" processCh=" + message.fushiLookupProcessChCount +
+							" lastCh=" + message.fushiLookupLastCh + " current=" + isCurrent +
+							" wrapped=" + (typeof message.fushiLookupInstanceWrapperProcessCh != "undefined" &&
+								message.processCh === message.fushiLookupInstanceWrapperProcessCh);
+						if(glyphs.count > 0)
+						{
+							var first = glyphs[0], last = glyphs[glyphs.count - 1];
+							row += " first=" + first.x + "," + first.y + "," + first.w + "," + first.h +
+								" last=" + last.x + "," + last.y + "," + last.w + "," + last.h;
+						}
+						global.fushiLookupLastTrace.add(row);
+						var index = global.fushiLookupGlyphAt(message, x, y);
+						if(index < 0) continue;
+						global.fushiLookupPaint(message, index, 1, 72);
+						if(submit) return global.fushiLookupSubmit(message, x, y);
+						return true;
+					}
+				}
+				if(global.fushiLookupLastTrace.count == 0) global.fushiLookupLastTrace.add("no-message");
+				if(!sawCurrent && typeof global.kag.current != "undefined" && global.kag.current !== void)
+				{
+					var current = global.kag.current;
+					global.fushiLookupLastTrace.add("current-outside-pages glyphs=" +
+						(typeof current.fushiLookupGlyphs == "undefined" ? -1 : current.fushiLookupGlyphs.count) +
+						" processCh=" + (typeof current.fushiLookupProcessChCount == "undefined" ? -1 : current.fushiLookupProcessChCount) +
+						" lastCh=" + (typeof current.fushiLookupLastCh == "undefined" ? "" : current.fushiLookupLastCh));
+				}
+				return false;
+			};
+
+)TJS" LR"TJS(
+
+			global.fushiLookupLeftClickHook = function()
+			{
+				var hit = global.fushiLookupAtCursor(true);
+				try
+				{
+					var trace = ["leftClick", hit];
+					for(var traceIndex = 0; traceIndex < global.fushiLookupLastTrace.count; traceIndex++)
+						trace.add(global.fushiLookupLastTrace[traceIndex]);
+					trace.save(global.fushiLookupRequestPath + ".trace");
+				} catch(e) {}
+				return hit;
+			};
+			global.fushiLookupMouseMoveHook = function(x, y)
+			{
+				global.fushiLookupAtCursor(false);
+				return false;
+			};
+			global.fushiLookupKeyDownHook = function(key, shift)
+			{
+				if(key == VK_SHIFT) return global.fushiLookupAtCursor(true);
+				return false;
+			};
+			global.kag.addHook("leftClick", global.fushiLookupLeftClickHook);
+			global.kag.addHook("mouseMove", global.fushiLookupMouseMoveHook);
+			global.kag.addHook("keyDown", global.fushiLookupKeyDownHook);
+
+			global.fushiLookupOriginalProcessCh = global.MessageLayer.processCh;
+			global.MessageLayer.processCh = function(ch, steptime)
+			{
+				var result = (global.fushiLookupOriginalProcessCh incontextof this)(...);
+				if(!result && typeof this.fushiLookupInstancePatched == "undefined")
+					global.fushiLookupRecordGlyph(this, ch);
+				return result;
+			} incontextof global.MessageLayer;
+
+			global.fushiLookupOriginalClear = global.MessageLayer.clear;
+			global.MessageLayer.clear = function(all)
+			{
+				this.fushiLookupGlyphs = [];
+				if(typeof this.fushiLookupHighlight != "undefined")
+					this.fushiLookupHighlight.fillRect(0, 0, this.fushiLookupHighlight.width, this.fushiLookupHighlight.height, 0);
+				return (global.fushiLookupOriginalClear incontextof this)(...);
+			} incontextof global.MessageLayer;
+
+			global.fushiLookupOriginalMouseMove = global.MessageLayer.onMouseMove;
+			global.MessageLayer.onMouseMove = function(x, y)
+			{
+				var localX = x - this.imageLeft, localY = y - this.imageTop;
+				var index = global.fushiLookupGlyphAt(this, localX, localY);
+				if(index >= 0)
+				{
+					global.fushiLookupPaint(this, index, 1, 72);
+				}
+				return (global.fushiLookupOriginalMouseMove incontextof this)(...);
+			} incontextof global.MessageLayer;
+
+			global.fushiLookupOriginalMouseDown = global.MessageLayer.onMouseDown;
+			global.MessageLayer.onMouseDown = function(x, y, button)
+			{
+				if(button == mbLeft && global.fushiLookupSubmit(this, x - this.imageLeft, y - this.imageTop)) return;
+				return (global.fushiLookupOriginalMouseDown incontextof this)(...);
+			} incontextof global.MessageLayer;
+
+			global.fushiLookupOriginalKeyDown = global.MessageLayer.onKeyDown;
+			global.MessageLayer.onKeyDown = function(key, shift)
+			{
+				if(key == VK_SHIFT && global.fushiLookupSubmit(this, this.cursorX - this.imageLeft, this.cursorY - this.imageTop)) return;
+				return (global.fushiLookupOriginalKeyDown incontextof this)(...);
+			} incontextof global.MessageLayer;
+
+			Debug.notice("[HibikiLookup] KAGEX glyph lookup installed");
+			System.removeContinuousHandler(global.fushiLookupBootstrap);
+			global.fushiLookupBootstrap = void;
+		}
+		catch(e)
+		{
+			Debug.notice("[HibikiLookup] install failed: " + e.message);
+			System.removeContinuousHandler(global.fushiLookupBootstrap);
+			global.fushiLookupBootstrap = void;
+		}
+	};
+	System.addContinuousHandler(global.fushiLookupBootstrap);
+}
+)TJS";
+
+std::wstring Utf8ToWide(const std::string& value) {
+  if (value.empty()) return {};
+  const int count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                                         static_cast<int>(value.size()), nullptr, 0);
+  if (count <= 0) return {};
+  std::wstring result(static_cast<size_t>(count), L'\0');
+  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                      static_cast<int>(value.size()), result.data(), count);
+  return result;
+}
+
+std::string WideToUtf8(const std::wstring& value) {
+  if (value.empty()) return {};
+  const int count = WideCharToMultiByte(CP_UTF8, 0, value.data(),
+                                        static_cast<int>(value.size()), nullptr, 0,
+                                        nullptr, nullptr);
+  if (count <= 0) return {};
+  std::string result(static_cast<size_t>(count), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
+                      result.data(), count, nullptr, nullptr);
+  return result;
+}
+
+std::wstring EscapeTjsString(const std::wstring& value) {
+  std::wstring result;
+  result.reserve(value.size() + 16);
+  for (wchar_t ch : value) {
+    switch (ch) {
+      case L'\\': result += L"\\\\"; break;
+      case L'\"': result += L"\\\""; break;
+      case L'\r': result += L"\\r"; break;
+      case L'\n': result += L"\\n"; break;
+      case 0x2028: result += L" "; break;
+      case 0x2029: result += L" "; break;
+      default: result.push_back(ch); break;
+    }
+  }
+  return result;
+}
+
+std::string EscapeJsonString(const std::string& value) {
+  std::string result;
+  result.reserve(value.size() + 16);
+  static constexpr char hex[] = "0123456789abcdef";
+  for (unsigned char ch : value) {
+    switch (ch) {
+      case '\\': result += "\\\\"; break;
+      case '\"': result += "\\\""; break;
+      case '\r': result += "\\r"; break;
+      case '\n': result += "\\n"; break;
+      case '\t': result += "\\t"; break;
+      default:
+        if (ch < 0x20) {
+          result += "\\u00";
+          result.push_back(hex[ch >> 4]);
+          result.push_back(hex[ch & 15]);
+        } else {
+          result.push_back(static_cast<char>(ch));
+        }
+        break;
+    }
+  }
+  return result;
+}
+
+void AppendUtf8CodePoint(std::string& output, uint32_t codepoint) {
+  if (codepoint <= 0x7f) {
+    output.push_back(static_cast<char>(codepoint));
+  } else if (codepoint <= 0x7ff) {
+    output.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
+    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+  } else if (codepoint <= 0xffff) {
+    output.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
+    output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+  } else {
+    output.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
+    output.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+  }
+}
+
+int JsonHex(char ch) {
+  if (ch >= '0' && ch <= '9') return ch - '0';
+  if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+  if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+  return -1;
+}
+
+bool ParseJsonString(const std::string& json, size_t quote, std::string* value,
+                     size_t* next) {
+  if (value == nullptr || quote >= json.size() || json[quote] != '\"') return false;
+  value->clear();
+  for (size_t i = quote + 1; i < json.size(); i++) {
+    const char ch = json[i];
+    if (ch == '\"') {
+      if (next != nullptr) *next = i + 1;
+      return true;
+    }
+    if (ch != '\\') {
+      value->push_back(ch);
+      continue;
+    }
+    if (++i >= json.size()) return false;
+    switch (json[i]) {
+      case '\"': value->push_back('\"'); break;
+      case '\\': value->push_back('\\'); break;
+      case '/': value->push_back('/'); break;
+      case 'b': value->push_back('\b'); break;
+      case 'f': value->push_back('\f'); break;
+      case 'n': value->push_back('\n'); break;
+      case 'r': value->push_back('\r'); break;
+      case 't': value->push_back('\t'); break;
+      case 'u': {
+        if (i + 4 >= json.size()) return false;
+        uint32_t codepoint = 0;
+        for (int n = 0; n < 4; n++) {
+          const int digit = JsonHex(json[++i]);
+          if (digit < 0) return false;
+          codepoint = (codepoint << 4) | static_cast<uint32_t>(digit);
+        }
+        AppendUtf8CodePoint(*value, codepoint);
+        break;
+      }
+      default: return false;
+    }
+  }
+  return false;
+}
+
+bool FindJsonStringField(const std::string& json, const char* key,
+                         std::string* value, size_t start = 0,
+                         size_t limit = std::string::npos) {
+  const std::string needle = std::string("\"") + key + "\"";
+  size_t pos = start;
+  const size_t end = std::min(limit, json.size());
+  while ((pos = json.find(needle, pos)) != std::string::npos && pos < end) {
+    pos += needle.size();
+    pos = json.find(':', pos);
+    if (pos == std::string::npos || pos >= end) return false;
+    pos++;
+    while (pos < end && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == '\r' ||
+                          json[pos] == '\n')) pos++;
+    if (pos < end && json[pos] == '\"') return ParseJsonString(json, pos, value, nullptr);
+  }
+  return false;
+}
+
+int FindJsonIntegerField(const std::string& json, const char* key, int fallback) {
+  const std::string needle = std::string("\"") + key + "\"";
+  size_t pos = json.find(needle);
+  if (pos == std::string::npos) return fallback;
+  pos = json.find(':', pos + needle.size());
+  if (pos == std::string::npos) return fallback;
+  while (++pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) {}
+  int value = 0;
+  bool any = false;
+  while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
+    any = true;
+    value = value * 10 + (json[pos++] - '0');
+  }
+  return any ? value : fallback;
+}
+
+struct LookupDictionaryEntry {
+  std::string word;
+  std::string reading;
+  std::string dictionary;
+  std::string meaning;
+};
+
+bool ParseLookupResponse(const std::string& json, int* best_length,
+                         LookupDictionaryEntry* selected) {
+  if (best_length == nullptr || selected == nullptr) return false;
+  *best_length = FindJsonIntegerField(json, "bestLength", 1);
+  const size_t entries_key = json.find("\"entries\"");
+  if (entries_key == std::string::npos) return false;
+  size_t pos = json.find('[', entries_key);
+  if (pos == std::string::npos) return false;
+  LookupDictionaryEntry fallback;
+  bool have_fallback = false;
+  while (++pos < json.size()) {
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\r' ||
+                                 json[pos] == '\n' || json[pos] == ',')) pos++;
+    if (pos >= json.size() || json[pos] == ']') break;
+    if (json[pos] != '\"') return false;
+    std::string encoded_entry;
+    size_t next = pos;
+    if (!ParseJsonString(json, pos, &encoded_entry, &next)) return false;
+    LookupDictionaryEntry entry;
+    FindJsonStringField(encoded_entry, "word", &entry.word);
+    FindJsonStringField(encoded_entry, "reading", &entry.reading);
+    FindJsonStringField(encoded_entry, "dictionaryName", &entry.dictionary);
+    FindJsonStringField(encoded_entry, "meaning", &entry.meaning);
+    if (!entry.word.empty() && !entry.dictionary.empty()) {
+      if (!have_fallback) {
+        fallback = entry;
+        have_fallback = true;
+      }
+      if (entry.dictionary.find("Jitendex") != std::string::npos) {
+        *selected = entry;
+        return true;
+      }
+    }
+    pos = next - 1;
+  }
+  if (have_fallback) *selected = fallback;
+  return have_fallback;
+}
+
+std::string PlainLookupMeaning(const std::string& meaning) {
+  const size_t glossary = meaning.find("glossary");
+  const size_t start = glossary == std::string::npos ? 0 : glossary;
+  size_t limit = meaning.find("extra-info", start);
+  if (limit == std::string::npos) limit = meaning.size();
+  std::vector<std::string> leaves;
+  size_t pos = start;
+  while (pos < limit && leaves.size() < 6) {
+    const size_t key = meaning.find("\"content\"", pos);
+    if (key == std::string::npos || key >= limit) break;
+    const size_t colon = meaning.find(':', key + 9);
+    if (colon == std::string::npos || colon >= limit) break;
+    size_t quote = colon + 1;
+    while (quote < limit && (meaning[quote] == ' ' || meaning[quote] == '\t')) quote++;
+    std::string leaf;
+    size_t next = quote + 1;
+    if (quote < limit && meaning[quote] == '\"' &&
+        ParseJsonString(meaning, quote, &leaf, &next) &&
+        !leaf.empty() && leaf != "glossary" && leaf != "noun") {
+      leaves.push_back(leaf);
+    }
+    pos = std::max(next, key + 9);
+  }
+  std::string result;
+  for (size_t i = 0; i < leaves.size(); i++) {
+    if (!result.empty()) result += "  ";
+    result += std::to_string(i + 1) + ". " + leaves[i];
+  }
+  return result.empty() ? "Dictionary entry found" : result;
+}
+
+bool ReadLookupRequest(int* id, std::wstring* query) {
+  if (id == nullptr || query == nullptr || g_lookup_request_path.empty()) return false;
+  HANDLE file = CreateFileW(g_lookup_request_path.c_str(), GENERIC_READ,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) return false;
+  const DWORD size = GetFileSize(file, nullptr);
+  if (size == INVALID_FILE_SIZE || size == 0 || size > 64 * 1024) {
+    CloseHandle(file);
+    return false;
+  }
+  std::vector<uint8_t> bytes(size);
+  DWORD read = 0;
+  const bool ok = ReadFile(file, bytes.data(), size, &read, nullptr) != FALSE;
+  CloseHandle(file);
+  if (!ok || read != size) return false;
+  std::wstring text;
+  if (size >= 2 && bytes[0] == 0xff && bytes[1] == 0xfe) {
+    const wchar_t* begin = reinterpret_cast<const wchar_t*>(bytes.data() + 2);
+    text.assign(begin, begin + (size - 2) / sizeof(wchar_t));
+  } else {
+    size_t offset = size >= 3 && bytes[0] == 0xef && bytes[1] == 0xbb && bytes[2] == 0xbf ? 3 : 0;
+    text = Utf8ToWide(std::string(reinterpret_cast<const char*>(bytes.data() + offset),
+                                  size - offset));
+  }
+  const size_t newline = text.find_first_of(L"\r\n");
+  if (newline == std::wstring::npos) return false;
+  *id = _wtoi(text.substr(0, newline).c_str());
+  const size_t query_start = text.find_first_not_of(L"\r\n", newline);
+  if (*id <= 0 || query_start == std::wstring::npos) return false;
+  *query = text.substr(query_start);
+  while (!query->empty() && (query->back() == L'\r' || query->back() == L'\n' ||
+                             query->back() == L'\0')) query->pop_back();
+  return !query->empty();
+}
+
+bool PostLookupRequest(const std::wstring& query, std::string* response) {
+  if (response == nullptr) return false;
+  wchar_t port_text[16] = {};
+  wchar_t token[256] = {};
+  if (GetEnvironmentVariableW(L"FUSHI_KIRIKIRI_LOOKUP_PORT", port_text, 16) == 0 ||
+      GetEnvironmentVariableW(L"FUSHI_KIRIKIRI_LOOKUP_TOKEN", token, 256) == 0) return false;
+  const int port = _wtoi(port_text);
+  if (port <= 0 || port > 65535) return false;
+  HINTERNET session = WinHttpOpen(L"FushiKirikiriLookup/1.0",
+                                  WINHTTP_ACCESS_TYPE_NO_PROXY,
+                                  WINHTTP_NO_PROXY_NAME,
+                                  WINHTTP_NO_PROXY_BYPASS, 0);
+  if (session == nullptr) return false;
+  WinHttpSetTimeouts(session, 1000, 1000, 2000, 5000);
+  HINTERNET connection = WinHttpConnect(session, L"127.0.0.1",
+                                        static_cast<INTERNET_PORT>(port), 0);
+  HINTERNET request = connection == nullptr ? nullptr :
+      WinHttpOpenRequest(connection, L"POST", L"/api/lookup/dictionary", nullptr,
+                         WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, 0);
+  bool ok = false;
+  if (request != nullptr) {
+    const std::wstring auth = std::wstring(L"Authorization: Bearer ") + token + L"\r\n" +
+                              L"Content-Type: application/json\r\n";
+    const std::string body = std::string("{\"term\":\"") +
+        EscapeJsonString(WideToUtf8(query)) + "\",\"maximumTerms\":1,\"record\":false}";
+    ok = WinHttpAddRequestHeaders(request, auth.c_str(), static_cast<DWORD>(-1),
+                                  WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE) != FALSE &&
+         WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                            const_cast<char*>(body.data()), static_cast<DWORD>(body.size()),
+                            static_cast<DWORD>(body.size()), 0) != FALSE &&
+         WinHttpReceiveResponse(request, nullptr) != FALSE;
+    DWORD status = 0;
+    DWORD status_size = sizeof(status);
+    if (!ok || !WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE |
+                                    WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
+                                    &status, &status_size, WINHTTP_NO_HEADER_INDEX) || status != 200) {
+      ok = false;
+    }
+    while (ok) {
+      DWORD available = 0;
+      if (!WinHttpQueryDataAvailable(request, &available)) { ok = false; break; }
+      if (available == 0) break;
+      const size_t old_size = response->size();
+      response->resize(old_size + available);
+      DWORD chunk = 0;
+      if (!WinHttpReadData(request, response->data() + old_size, available, &chunk)) {
+        ok = false; break;
+      }
+      response->resize(old_size + chunk);
+      if (response->size() > 8 * 1024 * 1024) { ok = false; break; }
+    }
+  }
+  if (request != nullptr) WinHttpCloseHandle(request);
+  if (connection != nullptr) WinHttpCloseHandle(connection);
+  WinHttpCloseHandle(session);
+  SecureZeroMemory(token, sizeof(token));
+  return ok;
+}
+
+void QueueLookupResultScript(int id, const LookupDictionaryEntry& entry,
+                             int best_length) {
+  const std::wstring word = EscapeTjsString(Utf8ToWide(entry.word));
+  const std::wstring reading = EscapeTjsString(Utf8ToWide(entry.reading));
+  const std::wstring dictionary = EscapeTjsString(Utf8ToWide(entry.dictionary));
+  const std::wstring definition = EscapeTjsString(Utf8ToWide(PlainLookupMeaning(entry.meaning)));
+  std::wstring script = L"if(typeof global.fushiLookupShowResult != \"undefined\") "
+                        L"global.fushiLookupShowResult(";
+  script += std::to_wstring(id) + L",\"" + word + L"\",\"" + reading + L"\",\"" +
+            dictionary + L"\",\"" + definition + L"\"," +
+            std::to_wstring(std::max(1, best_length)) + L");";
+  EnterCriticalSection(&g_lookup_response_cs);
+  g_lookup_response_script = std::move(script);
+  LeaveCriticalSection(&g_lookup_response_cs);
+}
+
+DWORD WINAPI KiriKiriLookupWorker(void*) {
+  int last_id = 0;
+  while (!g_stop) {
+    int id = 0;
+    std::wstring query;
+    if (ReadLookupRequest(&id, &query) && id != last_id) {
+      last_id = id;
+      std::string response;
+      LookupDictionaryEntry entry;
+      int best_length = 1;
+      if (PostLookupRequest(query, &response) &&
+          ParseLookupResponse(response, &best_length, &entry)) {
+        QueueLookupResultScript(id, entry, best_length);
+      } else {
+        LookupDictionaryEntry error;
+        error.word = WideToUtf8(query.substr(0, std::min<size_t>(query.size(), 24)));
+        error.dictionary = "Hibiki lookup";
+        error.meaning = "No dictionary result. Make sure Fushi dictionary service is running.";
+        QueueLookupResultScript(id, error, 1);
+      }
+    }
+    Sleep(50);
+  }
+  return 0;
+}
+
+class KiriKiriLookupResultCallback final : public TvpContinuousEventCallback {
+ public:
+  void __cdecl OnContinuousCallback(uint64_t) override {
+    if (!g_lookup_response_cs_ready || g_lookup_execute_script == nullptr ||
+        g_lookup_alloc_string == nullptr || g_lookup_release_string == nullptr) return;
+    std::wstring script;
+    EnterCriticalSection(&g_lookup_response_cs);
+    script.swap(g_lookup_response_script);
+    LeaveCriticalSection(&g_lookup_response_cs);
+    if (script.empty()) return;
+    TjsVariantString* value = nullptr;
+    try {
+      value = g_lookup_alloc_string(script.c_str());
+      if (value != nullptr) {
+        const TjsString content = {value};
+        g_lookup_execute_script(content, nullptr);
+      }
+    } catch (...) {
+    }
+    if (value != nullptr) g_lookup_release_string(value);
+  }
+};
+
+KiriKiriLookupResultCallback g_lookup_result_callback;
+
+bool PrepareKirikiriLookupRequestPath() {
+  wchar_t temp[MAX_PATH] = {};
+  const DWORD length = GetTempPathW(MAX_PATH, temp);
+  if (length == 0 || length >= MAX_PATH) return false;
+  g_lookup_request_path = temp;
+  g_lookup_request_path += L"fushi-kirikiri-lookup-" + std::to_wstring(GetCurrentProcessId()) + L".txt";
+  DeleteFileW(g_lookup_request_path.c_str());
+  return true;
+}
+
+std::wstring BuildKirikiriLookupBootstrapScript() {
+  std::wstring script = kKirikiriLookupBootstrapScript;
+  const std::wstring placeholder = L"__FUSHI_REQUEST_PATH__";
+  const size_t pos = script.find(placeholder);
+  if (pos != std::wstring::npos) {
+    script.replace(pos, placeholder.size(), EscapeTjsString(g_lookup_request_path));
+  }
+  return script;
+}
+
+bool IsKirikiriLookupProbeRequested() {
+  wchar_t value[8] = {};
+  const DWORD length = GetEnvironmentVariableW(
+      L"FUSHI_KIRIKIRI_NATIVE_LOOKUP_PROBE", value,
+      static_cast<DWORD>(sizeof(value) / sizeof(value[0])));
+  return length == 1 && value[0] == L'1';
+}
+
+class KiriKiriLookupBootstrapCallback final : public TvpContinuousEventCallback {
+ public:
+  void __cdecl OnContinuousCallback(uint64_t) override {
+    if (InterlockedCompareExchange(&g_lookup_bootstrap_state, 2, 1) != 1) return;
+
+    // 官方实现允许 continuous callback 在遍历时移除自身；先移除再执行，确保任何异常也不会形成
+    // 每帧重试。TJS 内部另用 System.addContinuousHandler 等待 global.kag 这个真实生命周期条件。
+    if (g_lookup_remove_continuous != nullptr) g_lookup_remove_continuous(this);
+
+    TjsVariantString* script = g_lookup_bootstrap_script;
+    g_lookup_bootstrap_script = nullptr;
+    if (script != nullptr && g_lookup_execute_script != nullptr) {
+      const TjsString content = {script};
+      try {
+        g_lookup_execute_script(content, nullptr);
+      } catch (...) {
+        // 插件 ABI 边界绝不能把 TJS/C++ 异常抛回游戏事件循环；脚本自身也有 TJS try/catch。
+      }
+    }
+    if (script != nullptr && g_lookup_release_string != nullptr) {
+      g_lookup_release_string(script);
+    }
+    InterlockedExchange(&g_lookup_bootstrap_state, 3);
+  }
+};
+
+KiriKiriLookupBootstrapCallback g_lookup_bootstrap_callback;
+
+bool QueryKirikiriNativeLookupFunctions(ITVPFunctionExporter* exporter,
+                                        const char** names, void** functions,
+                                        uint32_t count) {
+  __try {
+    return exporter->QueryFunctionsByNarrowString(names, functions, count);
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+}
+
+void InstallKirikiriNativeLookupProbe(ITVPFunctionExporter* exporter) {
+  if (exporter == nullptr || !IsKirikiriLookupProbeRequested() ||
+      InterlockedCompareExchange(&g_lookup_bootstrap_state, 0, 0) != 0) {
+    return;
+  }
+
+  const char* names[] = {
+      "tTJSVariantString * ::TJSAllocVariantString(const tjs_char *)",
+      "void tTJSVariantString::Release()",
+      "void ::TVPExecuteScript(const ttstr &,tTJSVariant *)",
+      "void ::TVPAddContinuousEventHook(tTVPContinuousEventCallbackIntf *)",
+      "void ::TVPRemoveContinuousEventHook(tTVPContinuousEventCallbackIntf *)",
+  };
+  void* functions[5] = {};
+  if (!QueryKirikiriNativeLookupFunctions(exporter, names, functions, 5)) return;
+
+  g_lookup_alloc_string =
+      reinterpret_cast<TJSAllocVariantStringStub_t>(functions[0]);
+  g_lookup_release_string =
+      reinterpret_cast<TJSVariantStringReleaseStub_t>(functions[1]);
+  g_lookup_execute_script = reinterpret_cast<TVPExecuteScriptStub_t>(functions[2]);
+  g_lookup_add_continuous =
+      reinterpret_cast<TVPAddContinuousEventHookStub_t>(functions[3]);
+  g_lookup_remove_continuous =
+      reinterpret_cast<TVPRemoveContinuousEventHookStub_t>(functions[4]);
+  if (g_lookup_alloc_string == nullptr || g_lookup_release_string == nullptr ||
+      g_lookup_execute_script == nullptr || g_lookup_add_continuous == nullptr ||
+      g_lookup_remove_continuous == nullptr) {
+    return;
+  }
+
+  try {
+    if (!PrepareKirikiriLookupRequestPath()) return;
+    if (!g_lookup_response_cs_ready) {
+      InitializeCriticalSection(&g_lookup_response_cs);
+      g_lookup_response_cs_ready = true;
+    }
+    const std::wstring bootstrap = BuildKirikiriLookupBootstrapScript();
+    g_lookup_bootstrap_script = g_lookup_alloc_string(bootstrap.c_str());
+    if (g_lookup_bootstrap_script == nullptr) return;
+    InterlockedExchange(&g_lookup_bootstrap_state, 1);
+    g_lookup_add_continuous(&g_lookup_result_callback);
+    g_lookup_add_continuous(&g_lookup_bootstrap_callback);
+    g_lookup_worker = CreateThread(nullptr, 0, KiriKiriLookupWorker, nullptr, 0, nullptr);
+  } catch (...) {
+    TjsVariantString* script = g_lookup_bootstrap_script;
+    g_lookup_bootstrap_script = nullptr;
+    InterlockedExchange(&g_lookup_bootstrap_state, 0);
+    if (script != nullptr) g_lookup_release_string(script);
+  }
+}
 
 // exe 直取 / V2Link 两条拿 exporter 的路径共享的一次性安装闩（InterlockedCompareExchange）。
 volatile LONG g_voice_installed = 0;
@@ -1149,8 +2618,10 @@ HRESULT HandleV2Link(ITVPFunctionExporter* exporter, V2Link_t orig) {
     if (g_header != nullptr) g_header->reserved_luna |= 0x4000000;  // 经 V2Link 拿到 exporter
     InstallVoiceStreamHookWithExporter(exporter);                   // 幂等
   }
-  if (orig != nullptr) return orig(exporter);
-  return S_OK;
+  const HRESULT result = orig != nullptr ? orig(exporter) : S_OK;
+  // 原插件的 V2Link 已完成后才登记连续帧回调；真正执行 TJS 还会再等到下一次引擎事件循环。
+  InstallKirikiriNativeLookupProbe(exporter);
+  return result;
 }
 
 // 每个 hook 槽一个独立 detour（MinHook 共享 detour 无法区分各自 trampoline，故按 slot 展开）。

--- a/native/galgame_hook/hook/adapters/kirikiri_adapter.inc
+++ b/native/galgame_hook/hook/adapters/kirikiri_adapter.inc
@@ -1,5 +1,4 @@
 // P1 zero-behaviour-change split: included inside dll_main.cpp anonymous namespace.
-#include <winhttp.h>
 // ══ C.2c KiriKiri 解码器捕获链（引擎级干净人声）══════════════════════════════════
 // XAudio2/DirectSound 抓的是**输出**（混音后各源），KiriKiriZ 的人声不走这两条（实测输出源全
 // 是 BGM/SE）。人声在**解码环节**：KiriKiriZ 给每个正在播放的声音建一个独立解码器实例，语音是
@@ -99,6 +98,12 @@ struct KiriKiriVoiceTask {
 
 KiriKiriVoiceTask g_kirikiri_voice_tasks[kKirikiriVoiceTaskSlots];
 
+// 游戏内查词传感器的安装重试点（x86 才有真实实现；KiriKiriZ 是 32 位引擎，x64 为空）。
+// 为什么要重试：`lookup_enabled` 是 host 运行期开关，而 exporter 只在 V2Link / exe 直取那
+// 一瞬间到手。若用户在游戏起来之后才打开查词，安装窗口早过去了；这里借 registry 每轮都会
+// 调的 ProcessPendingEvents 复查开关，拿缓存的 exporter 补装。
+void PollKirikiriLookupInstall();
+
 uint64_t ReadKirikiriSharedU64(volatile uint64_t* value) {
   return value == nullptr
              ? 0
@@ -147,6 +152,7 @@ void EnqueueKirikiriVoiceResourceOwned(
 }
 
 void ProcessKirikiriVoiceTasks() {
+  PollKirikiriLookupInstall();
   for (int i = 0; i < kKirikiriVoiceTaskSlots; ++i) {
     KiriKiriVoiceTask* task = &g_kirikiri_voice_tasks[i];
     if (InterlockedCompareExchange(&task->state, 3, 2) != 2) continue;
@@ -690,6 +696,9 @@ struct TjsString {
 typedef TjsVariantString*(__stdcall* TJSAllocVariantStringStub_t)(const wchar_t* value);
 typedef void(__stdcall* TJSVariantStringReleaseStub_t)(TjsVariantString* value);
 typedef void(__stdcall* TVPExecuteScriptStub_t)(const TjsString& content, void* result);
+// TVPExecuteExpression 与 TVPExecuteScript 同型，但 result 会被真正填成一个 tTJSVariant。
+// 它是 hook 侧读回 TJS 传感器读数（命中几何、整行台词、输入事件）的唯一通道。
+typedef void(__stdcall* TVPExecuteExpressionStub_t)(const TjsString& content, void* result);
 typedef void(__stdcall* TVPAddContinuousEventHookStub_t)(TvpContinuousEventCallback* callback);
 typedef void(__stdcall* TVPRemoveContinuousEventHookStub_t)(TvpContinuousEventCallback* callback);
 
@@ -699,36 +708,64 @@ TVPCreateStream_t g_orig_TVPCreateStream = nullptr;
 TJSAllocVariantStringStub_t g_lookup_alloc_string = nullptr;
 TJSVariantStringReleaseStub_t g_lookup_release_string = nullptr;
 TVPExecuteScriptStub_t g_lookup_execute_script = nullptr;
+TVPExecuteExpressionStub_t g_lookup_execute_expression = nullptr;
 TVPAddContinuousEventHookStub_t g_lookup_add_continuous = nullptr;
 TVPRemoveContinuousEventHookStub_t g_lookup_remove_continuous = nullptr;
+ITVPFunctionExporter* g_lookup_exporter = nullptr;
 TjsVariantString* g_lookup_bootstrap_script = nullptr;
 volatile LONG g_lookup_bootstrap_state = 0;  // 0=off, 1=registered, 2=running, 3=done
-CRITICAL_SECTION g_lookup_response_cs;
-bool g_lookup_response_cs_ready = false;
-std::wstring g_lookup_response_script;
-std::wstring g_lookup_request_path;
-HANDLE g_lookup_worker = nullptr;
 
+// TextRender 之外的捕获路径（Layer.drawText / MessageLayer.processCh）只在换游戏、
+// TextRender 一条都不命中时才有诊断价值。运行日志已证伪它们在本样本上的作用，故默认
+// **编译期关闭**：游戏内渲染意味着主线程上的每一毫秒都直接变掉帧，不能为了"万一有用"
+// 在生产路径上并行跑四份没人读的排版计算。
+constexpr bool kKirikiriLookupProbePaths = false;
+
+// TJS 传感器。职责边界只有四件事：采字符几何、做命中测试、把 host 给的位图端到游戏渲染树
+// 里、把落在卡片上的输入转发出去。分词、查词、卡片排版、外字、发音、制卡全部在 Hibiki
+// 进程；这里没有网络客户端、没有认证凭据、没有 JSON、也不 eval 任何拼出来的源码。
+//
+// 三条通道都由 DLL 在游戏主线程的连续帧回调里驱动：
+//   hook→host   TJS 把值写进 global，DLL 用 TVPExecuteExpression 读走再落进共享内存。
+//               每帧只读 fushiLookupNotify 一个整数；它不变就一行 TJS 都不再跑。
+//   host→hook   DLL 先调 global.fushiLookupPrepare(anchorX, anchorY, cardW, cardH) 把卡片
+//               层建/调到位，再把 BGRA8（**直通 alpha、自顶向下**，与契约头一致；直通对应
+//               ltAlpha，预乘才是 ltAddAlpha）memcpy 进它的像素缓冲，最后调
+//               global.fushiLookupApply(seq, highlightStart, highlightLen,
+//                                       anchorX, anchorY, cardW, cardH)。
+//               两个入口的实参全是整数——"只允许整数"约束的是不许拼动态字符串，不是参数个数。
 constexpr wchar_t kKirikiriLookupBootstrapScript[] = LR"TJS(
-class FushiLookupHitLayer extends Layer
+class FushiLookupCardLayer extends Layer
 {
-	var fushiLookupMessage;
-	function FushiLookupHitLayer(owner, parent, message)
+	function FushiLookupCardLayer(owner, parent)
 	{
 		super.Layer(owner, parent);
-		fushiLookupMessage = message;
 	}
+	// 卡片层就是卡片本身：按 host 给的 cardW×cardH 建、摆在 anchor 上，**不覆盖全屏**，而且
+	// 延迟到真要显示第一帧时才建。命中判定用引擎天然的矩形命中（htRect），不依赖"alpha 为 0
+	// 的像素会把点击透传下去"这条未在本引擎验证过的行为。这条选择是为了把失败面关死：全视口
+	// 层一旦穿透语义不符预期，用户没查词时整个游戏就点不动了——那是把"查词不好使"放大成
+	// "游戏坏了"。现在最坏情况也只是卡片自己那块矩形吃掉点击，而那块本来就该吃掉。
+	// 事件坐标是层内坐标；入队时加回层位置换成视口坐标，减 anchor 由 DLL 做（帧元数据在它手上）。
 	function onMouseDown(x, y, button)
 	{
-		if(button == mbLeft) global.fushiLookupSubmit(fushiLookupMessage, x, y);
+		if(button == mbLeft) global.fushiLookupQueueInput(1, x, y, 0);
+	}
+	function onMouseUp(x, y, button)
+	{
+		if(button == mbLeft) global.fushiLookupQueueInput(2, x, y, 0);
 	}
 	function onMouseMove(x, y)
 	{
-		var index = global.fushiLookupGlyphAt(fushiLookupMessage, x, y);
-		if(index >= 0)
-		{
-			global.fushiLookupPaint(fushiLookupMessage, index, 1, 72);
-		}
+		global.fushiLookupQueueInput(0, x, y, 0);
+	}
+	function onMouseWheel(shift, delta, x, y)
+	{
+		global.fushiLookupQueueInput(3, x, y, delta);
+	}
+	function onMouseLeave()
+	{
+		global.fushiLookupQueueInput(4, 0, 0, 0);
 	}
 }
 
@@ -739,307 +776,43 @@ if(typeof global.fushiLookupBootstrap == "undefined")
 		if(typeof global.kag == "undefined" || global.kag === null) return;
 		try
 		{
-			if(typeof global.fushiLookupCard == "undefined")
-			{
-				var owner = global.kag;
-				var root = owner.primaryLayer.parent;
-				var layer = new Layer(owner, root);
-				owner.add(layer);
-				layer.name = "Hibiki in-game dictionary";
-				layer.fushiLookupIgnore = true;
-				layer.setPos(64, 54);
-				layer.setSize(760, 344);
-				layer.type = ltAlpha;
-				layer.absolute = 2147483000;
-				layer.hitType = htMask;
-				layer.hitThreshold = 256;
-				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
-				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
-				layer.font.height = 28;
-				layer.font.bold = true;
-				layer.drawText(26, 14, "HIBIKI // IN-GAME LOOKUP", 0x31d7ff, 255, true);
-				layer.font.height = 22;
-				layer.font.bold = false;
-				layer.drawText(26, 58, "Click a subtitle glyph, or press Shift over it", 0xffffff, 255, true);
-				layer.drawText(26, 88, "Waiting for a subtitle lookup", 0xa7b8c9, 255, true);
-				layer.visible = true;
-				global.fushiLookupCard = layer;
-			}
-
-			global.fushiLookupRequestPath = "__FUSHI_REQUEST_PATH__";
-			global.fushiLookupSequence = 0;
-			global.fushiLookupPending = void;
-
-			global.fushiLookupEnsureHighlight = function(message)
-			{
-				if(typeof message.fushiLookupAbsolute != "undefined")
-				{
-					if(typeof global.fushiLookupAbsoluteHighlight != "undefined")
-					{
-						global.fushiLookupAbsoluteHighlight.setPos(0, 0);
-						global.fushiLookupAbsoluteHighlight.setSize(global.kag.primaryLayer.width,
-							global.kag.primaryLayer.height);
-						return global.fushiLookupAbsoluteHighlight;
-					}
-					var absoluteHighlight = new Layer(global.kag, global.kag.primaryLayer.parent);
-					global.kag.add(absoluteHighlight);
-					absoluteHighlight.name = "Hibiki absolute subtitle word highlight";
-					absoluteHighlight.fushiLookupIgnore = true;
-					absoluteHighlight.setPos(0, 0);
-					absoluteHighlight.setSize(global.kag.primaryLayer.width, global.kag.primaryLayer.height);
-					absoluteHighlight.type = ltAlpha;
-					absoluteHighlight.absolute = 2147482000;
-					absoluteHighlight.hitType = htMask;
-					absoluteHighlight.hitThreshold = 256;
-					absoluteHighlight.visible = true;
-					global.fushiLookupAbsoluteHighlight = absoluteHighlight;
-					return absoluteHighlight;
-				}
-				if(typeof message.fushiLookupHighlight != "undefined")
-				{
-					message.fushiLookupHighlight.setPos(message.imageLeft, message.imageTop);
-					message.fushiLookupHighlight.setSize(message.imageWidth, message.imageHeight);
-					return message.fushiLookupHighlight;
-				}
-				var hl = new FushiLookupHitLayer(global.kag, message, message);
-				global.kag.add(hl);
-				hl.name = "Hibiki subtitle word highlight";
-				hl.fushiLookupIgnore = true;
-				hl.setPos(message.imageLeft, message.imageTop);
-				hl.setSize(message.imageWidth, message.imageHeight);
-				hl.type = ltAlpha;
-				hl.absolute = 2147482000;
-				hl.hitType = htMask;
-				hl.hitThreshold = 256;
-				hl.visible = true;
-				message.fushiLookupHighlight = hl;
-				return hl;
-			};
-
-			global.fushiLookupGetGlyphs = function(message)
-			{
-				if(typeof message.fushiLookupLayerGlyphs != "undefined" &&
-					message.fushiLookupLayerGlyphs.count > 0) return message.fushiLookupLayerGlyphs;
-				if(typeof message.fushiLookupGlyphs != "undefined") return message.fushiLookupGlyphs;
-				return void;
-			};
-
-			global.fushiLookupPaint = function(message, start, length, opacity)
-			{
-				var hl = global.fushiLookupEnsureHighlight(message);
-				hl.fillRect(0, 0, hl.width, hl.height, 0);
-				var glyphs = global.fushiLookupGetGlyphs(message);
-				if(glyphs === void) return;
-				var units = 0;
-				var offsetX = typeof message.fushiLookupGlyphOffsetX == "undefined" ? 0 :
-					message.fushiLookupGlyphOffsetX;
-				var offsetY = typeof message.fushiLookupGlyphOffsetY == "undefined" ? 0 :
-					message.fushiLookupGlyphOffsetY;
-				for(var i = start; i < glyphs.count && units < length; i++)
-				{
-					var g = glyphs[i];
-					hl.colorRect(g.x + offsetX, g.y + offsetY, g.w, g.h, 0x00d8ff, opacity);
-					units += g.ch.length;
-				}
-			};
-
-			global.fushiLookupGlyphAt = function(message, x, y)
-			{
-				var glyphs = global.fushiLookupGetGlyphs(message);
-				if(glyphs === void) return -1;
-				for(var i = glyphs.count - 1; i >= 0; i--)
-				{
-					var g = glyphs[i];
-					if(x >= g.x && x < g.x + g.w && y >= g.y && y < g.y + g.h) return i;
-				}
-				return -1;
-			};
-
-			global.fushiLookupShowLoading = function(query)
-			{
-				var layer = global.fushiLookupCard;
-				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
-				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
-				layer.font.bold = true; layer.font.height = 28;
-				layer.drawText(26, 14, "HIBIKI // LOOKING UP", 0x31d7ff, 255, true);
-				layer.font.bold = false; layer.font.height = 30;
-				layer.drawText(26, 58, query, 0xffffff, 255, true);
-				layer.font.height = 20;
-				layer.drawText(26, 108, "Searching Hibiki dictionaries...", 0xa7b8c9, 255, true);
-				layer.visible = true;
-			};
-
-			global.fushiLookupSubmit = function(message, x, y)
-			{
-				var index = global.fushiLookupGlyphAt(message, x, y);
-				if(index < 0) return false;
-				var glyphs = global.fushiLookupGetGlyphs(message);
-				var query = "";
-				for(var i = index; i < glyphs.count && query.length < 48; i++)
-				{
-					var ch = glyphs[i].ch;
-					if(ch == "。" || ch == "、" || ch == "！" || ch == "？" || ch == "\n") break;
-					query += ch;
-				}
-				if(query == "") return false;
-				var id = ++global.fushiLookupSequence;
-				global.fushiLookupPending = %[id:id, message:message, start:index, query:query];
-				global.fushiLookupPaint(message, index, 1, 96);
-				global.fushiLookupShowLoading(query);
-				[id, query].save(global.fushiLookupRequestPath);
-				return true;
-			};
+			// 这一批必须最先建立：DLL 每帧都会求值 fushiLookupNotify，晚一步就是每帧一次
+			// TJS 异常。
+			global.fushiLookupNotify = 0;
+			global.fushiLookupHitSeq = 0;
+			global.fushiLookupHitCharIndex = 0;
+			global.fushiLookupHitCharCount = 0;
+			global.fushiLookupHitGlyphX = 0;
+			global.fushiLookupHitGlyphY = 0;
+			global.fushiLookupHitGlyphW = 0;
+			global.fushiLookupHitGlyphH = 0;
+			global.fushiLookupHitViewW = 0;
+			global.fushiLookupHitViewH = 0;
+			global.fushiLookupHitFlags = 0;
+			global.fushiLookupHitLine = "";
+			global.fushiLookupInputQueue = [];
+			global.fushiLookupShiftDown = false;
+			global.fushiLookupProbeMode = __FUSHI_PROBE_MODE__;
+			global.fushiLookupProbeDrawText = 0;
+			global.fushiLookupProbeProcessCh = 0;
+			global.fushiLookupProbeError = "";
+			global.fushiLookupCardPath = "__FUSHI_CARD_PATH__";
+			global.fushiLookupCardSeq = 0;
+			global.fushiLookupRegistry = [];
+			global.fushiLookupClock = 0;
+			global.fushiLookupHoverKey = "";
+			global.fushiLookupHitEntry = void;
+			global.fushiLookupHitOffsetX = 0;
+			global.fushiLookupHitOffsetY = 0;
+			global.fushiLookupHighlightRect = void;
+			global.fushiLookupBoundRenderer = void;
+			global.fushiLookupBoundLayer = void;
+			global.fushiLookupBoundX = 0;
+			global.fushiLookupBoundY = 0;
 
 )TJS" LR"TJS(
 
-			global.fushiLookupShowResult = function(id, expression, reading, dictionary, definition, bestLength)
-			{
-				var pending = global.fushiLookupPending;
-				if(pending === void || pending.id != id) return;
-				global.fushiLookupPaint(pending.message, pending.start, bestLength, 150);
-				var layer = global.fushiLookupCard;
-				layer.fillRect(0, 0, layer.width, layer.height, 0x071525);
-				layer.colorRect(0, 0, 8, layer.height, 0x31d7ff, 255);
-				layer.font.bold = true; layer.font.height = 26;
-				layer.drawText(26, 12, "HIBIKI // LIVE LOOKUP", 0x31d7ff, 255, true);
-				layer.font.height = 38;
-				layer.drawText(26, 52, expression, 0xffffff, 255, true);
-				layer.font.bold = false; layer.font.height = 22;
-				layer.drawText(26, 98, reading, 0x65dfff, 255, true);
-				layer.font.height = 17;
-				layer.drawText(26, 132, dictionary, 0xa7b8c9, 255, true);
-				layer.colorRect(26, 160, layer.width - 52, 2, 0x31d7ff, 210);
-				layer.font.height = 20;
-				var clean = definition.replace(/\r/g, "").replace(/\n+/g, " ");
-				var line = 0;
-				for(var pos = 0; pos < clean.length && line < 7; pos += 30, line++)
-					layer.drawText(26, 178 + line * 23, clean.substr(pos, 30), 0xffffff, 255, true);
-				layer.visible = true;
-			};
-
-			global.fushiLookupRecordGlyph = function(message, ch)
-			{
-				if(typeof message.fushiLookupGlyphs == "undefined") message.fushiLookupGlyphs = [];
-				var glyphs = message.fushiLookupGlyphs;
-				var cw = message.lineLayer.font.getTextWidth(ch) + message.pitch;
-				var lx, ly, w, h;
-				if(!message.vertical)
-				{
-					lx = message.lineLayerPos - cw; ly = message.lineLayerBase - message.fontSize;
-					w = cw; h = message.fontSize;
-				}
-				else
-				{
-					lx = message.lineLayerBase - (message.fontSize >> 1); ly = message.lineLayerPos - cw;
-					w = message.fontSize; h = cw;
-				}
-				var ox = message.lineLayerOriginX, oy = message.lineLayerOriginY;
-				glyphs.add(%[ch:ch, lx:lx, ly:ly, w:w, h:h, ox:ox, oy:oy,
-					x:message.lineLayer.left+lx, y:message.lineLayer.top+ly]);
-				for(var i = glyphs.count - 1; i >= 0; i--)
-				{
-					var g = glyphs[i];
-					if(g.ox != ox || g.oy != oy) break;
-					g.x = message.lineLayer.left + g.lx;
-					g.y = message.lineLayer.top + g.ly;
-				}
-			};
-
-			global.fushiLookupLayerRegistry = [];
-			global.fushiLookupLayerRunSequence = 0;
-			global.fushiLookupLayerGlyphSequence = 0;
-			global.fushiLookupLayerDrawCount = 0;
-			global.fushiLookupLayerLastText = "";
-
-			global.fushiLookupTextHasJapanese = function(text)
-			{
-				return typeof text == "String" && /[\u3000-\u30ff\u3400-\u9fff\uff00-\uffef]/.test(text);
-			};
-
-			global.fushiLookupRemoveLayerGlyphs = function(layer, x, y, w, h)
-			{
-				if(typeof layer.fushiLookupLayerGlyphs == "undefined" || w <= 0 || h <= 0) return;
-				var kept = [];
-				var glyphs = layer.fushiLookupLayerGlyphs;
-				for(var i = 0; i < glyphs.count; i++)
-				{
-					var g = glyphs[i];
-					if(g.x + g.w <= x || g.y + g.h <= y || g.x >= x + w || g.y >= y + h)
-						kept.add(g);
-				}
-				layer.fushiLookupLayerGlyphs = kept;
-			};
-
-			global.fushiLookupCaptureLayerText = function(layer, x, y, text)
-			{
-				if(typeof layer.fushiLookupIgnore != "undefined" ||
-					!global.fushiLookupTextHasJapanese(text)) return;
-				var angle = layer.font.angle;
-				if(angle != 0 && angle != 2700) return;
-				if(typeof layer.fushiLookupLayerGlyphs == "undefined") layer.fushiLookupLayerGlyphs = [];
-				if(typeof layer.fushiLookupLayerRegistered == "undefined")
-				{
-					layer.fushiLookupLayerRegistered = true;
-					global.fushiLookupLayerRegistry.add(layer);
-				}
-				var height = Math.abs(layer.font.height);
-				if(height < 1) height = 1;
-				var total = layer.font.getTextWidth(text);
-				if(angle == 0)
-					global.fushiLookupRemoveLayerGlyphs(layer, x, y, total, height);
-				else
-					global.fushiLookupRemoveLayerGlyphs(layer, x - height, y, height, total);
-				var run = ++global.fushiLookupLayerRunSequence;
-				for(var i = 0; i < text.length; i++)
-				{
-					var ch = text.charAt(i);
-					var begin = layer.font.getTextWidth(text.substr(0, i));
-					var finish = layer.font.getTextWidth(text.substr(0, i + 1));
-					var advance = finish - begin;
-					if(advance < 1) advance = 1;
-					var gx, gy, gw, gh;
-					if(angle == 0)
-					{
-						gx = x + begin; gy = y; gw = advance; gh = height;
-					}
-					else
-					{
-						gx = x - height; gy = y + begin; gw = height; gh = advance;
-					}
-					layer.fushiLookupLayerGlyphs.add(%[ch:ch, x:gx, y:gy, w:gw, h:gh,
-						run:run, seq:++global.fushiLookupLayerGlyphSequence, angle:angle]);
-				}
-				global.fushiLookupLayerDrawCount++;
-				global.fushiLookupLayerLastText = text;
-			};
-
-			global.fushiLookupOriginalLayerDrawText = global.Layer.drawText;
-			global.Layer.drawText = function(x, y, text, color, opacity, antialiased)
-			{
-				var result = (global.fushiLookupOriginalLayerDrawText incontextof this)(...);
-				global.fushiLookupCaptureLayerText(this, x, y, text);
-				return result;
-			};
-
-			global.fushiLookupOriginalLayerFillRect = global.Layer.fillRect;
-			global.Layer.fillRect = function(x, y, width, height, value)
-			{
-				var result = (global.fushiLookupOriginalLayerFillRect incontextof this)(...);
-				if(typeof this.fushiLookupIgnore == "undefined" && this.face != dfProvince)
-					global.fushiLookupRemoveLayerGlyphs(this, x, y, width, height);
-				return result;
-			};
-
-)TJS" LR"TJS(
-
-			global.fushiLookupTextRenderRegistry = [];
-			global.fushiLookupTextRenderCaptureCount = 0;
-			global.fushiLookupTextRenderLastMethod = "";
-			global.fushiLookupTextRenderLastError = "";
-			global.fushiLookupTextRenderPatchTrace = [];
-			global.fushiLookupTextRenderActiveDraw = void;
-
-			global.fushiLookupTextRenderValue = function(value, name, fallback)
+			global.fushiLookupField = function(value, name)
 			{
 				try
 				{
@@ -1047,400 +820,39 @@ if(typeof global.fushiLookupBootstrap == "undefined")
 					if(found !== void) return found;
 				}
 				catch(e) {}
-				return fallback;
-			};
-
-			global.fushiLookupTextRenderDescribe = function(value)
-			{
-				var type = typeof value;
-				if(type == "String") return value.substr(0, 80);
-				if(type == "Integer" || type == "Real") return "" + value;
-				return "<" + type + ">";
-			};
-
-			global.fushiLookupTextRenderSample = function(value)
-			{
-				var names = ["text", "x", "y", "cw", "size", "left", "top", "width", "height",
-					"pos", "link", "linkName"];
-				var sample = [];
-				for(var i = 0; i < names.count; i++)
-				{
-					var found = global.fushiLookupTextRenderValue(value, names[i], void);
-					if(found !== void) sample.add(names[i] + "=" +
-						global.fushiLookupTextRenderDescribe(found));
-				}
-				return sample.join(",");
-			};
-
-			global.fushiLookupFindTextRenderTarget = function(renderer)
-			{
-				for(var registryIndex = 0;
-					registryIndex < global.fushiLookupTextRenderRegistry.count; registryIndex++)
-					if(global.fushiLookupTextRenderRegistry[registryIndex].renderer === renderer)
-						return global.fushiLookupTextRenderRegistry[registryIndex];
 				return void;
 			};
 
-			global.fushiLookupBindTextRenderOrigin = function(renderer, layer, originX, originY, source)
+			// 上限 8 + 淘汰最久未用。TJS 没有弱引用，registry 只增不减就等于把每个用过的
+			// renderer 连同它的整行几何永久钉在游戏进程里（prototype 的真实泄漏源）。
+			global.fushiLookupEntryFor = function(renderer)
 			{
-				if(layer === void || layer === null || !isvalid layer ||
-					(typeof originX != "Integer" && typeof originX != "Real") ||
-					(typeof originY != "Integer" && typeof originY != "Real")) return;
-				var target = global.fushiLookupFindTextRenderTarget(renderer);
-				if(target === void) return;
-				target.targetLayer = layer;
-				target.originX = originX;
-				target.originY = originY;
-				target.originSource = source;
+				var registry = global.fushiLookupRegistry;
+				var oldest = 0;
+				for(var i = 0; i < registry.count; i++)
+				{
+					if(registry[i].renderer === renderer) return registry[i];
+					if(registry[i].used < registry[oldest].used) oldest = i;
+				}
+				if(registry.count < 8)
+				{
+					var fresh = %[renderer:renderer, glyphs:[], line:"", used:0,
+						minX:0, minY:0, maxX:0, maxY:0, layer:void, originX:0, originY:0];
+					registry.add(fresh);
+					return fresh;
+				}
+				var reused = registry[oldest];
+				reused.renderer = renderer;
+				reused.glyphs = [];
+				reused.line = "";
+				reused.used = 0;
+				reused.layer = void;
+				reused.originX = 0;
+				reused.originY = 0;
+				return reused;
 			};
 
-			global.fushiLookupCaptureTextRender = function(renderer, method, a, b, c, d, e, f)
-			{
-				try
-				{
-					if(typeof renderer.getCharacters != "Object") return;
-					var characters = (renderer.getCharacters incontextof renderer)(0, 0);
-					if(characters === void || typeof characters.count == "undefined") return;
-					var glyphs = [];
-					for(var i = 0; i < characters.count; i++)
-					{
-						var character = characters[i];
-						var text = global.fushiLookupTextRenderValue(character, "text", "");
-						if(typeof text != "String" || text == "") continue;
-						var x = global.fushiLookupTextRenderValue(character, "left",
-							global.fushiLookupTextRenderValue(character, "x", void));
-						var y = global.fushiLookupTextRenderValue(character, "top",
-							global.fushiLookupTextRenderValue(character, "y", void));
-						var width = global.fushiLookupTextRenderValue(character, "width",
-							global.fushiLookupTextRenderValue(character, "cw", void));
-						var height = global.fushiLookupTextRenderValue(character, "height",
-							global.fushiLookupTextRenderValue(character, "size", void));
-						if(x === void || y === void || width === void || height === void ||
-							width <= 0 || height <= 0) continue;
-						glyphs.add(%[ch:text, x:x, y:y, w:width, h:height, run:0, seq:i]);
-					}
-
-					var target = global.fushiLookupFindTextRenderTarget(renderer);
-					if(target === void)
-					{
-						target = %[renderer:renderer, fushiLookupAbsolute:true,
-							fushiLookupGlyphOffsetX:0, fushiLookupGlyphOffsetY:0];
-						global.fushiLookupTextRenderRegistry.add(target);
-					}
-					target.fushiLookupLayerGlyphs = glyphs;
-					target.characters = characters;
-					target.method = method;
-					target.capture = ++global.fushiLookupTextRenderCaptureCount;
-					target.args = [global.fushiLookupTextRenderDescribe(a),
-						global.fushiLookupTextRenderDescribe(b), global.fushiLookupTextRenderDescribe(c),
-						global.fushiLookupTextRenderDescribe(d), global.fushiLookupTextRenderDescribe(e),
-						global.fushiLookupTextRenderDescribe(f)];
-					target.sample = characters.count > 0 ?
-						global.fushiLookupTextRenderSample(characters[0]) : "";
-					target.lastSample = characters.count > 0 ?
-						global.fushiLookupTextRenderSample(characters[characters.count - 1]) : "";
-					if(typeof global.fushiLookupTextRenderActiveDraw != "undefined" &&
-						global.fushiLookupTextRenderActiveDraw !== void &&
-						global.fushiLookupTextRenderActiveDraw.renderer === renderer)
-						global.fushiLookupBindTextRenderOrigin(renderer,
-							global.fushiLookupTextRenderActiveDraw.layer,
-							global.fushiLookupTextRenderActiveDraw.originX,
-							global.fushiLookupTextRenderActiveDraw.originY, "TextRender.draw");
-					global.fushiLookupTextRenderLastTarget = target;
-					global.fushiLookupTextRenderLastMethod = method;
-				}
-				catch(error)
-				{
-					global.fushiLookupTextRenderLastError = method + ":" + error.message;
-				}
-			};
-
-)TJS" LR"TJS(
-
-			try
-			{
-				global.fushiLookupTextRenderPatchTrace.add("TextRenderBase=" + typeof global.TextRenderBase);
-				if(typeof global.TextRenderBase == "Object")
-				{
-					global.fushiLookupTextRenderPatchTrace.add("TextRenderBase.render=" +
-						typeof global.TextRenderBase.render);
-					if(typeof global.TextRenderBase.render == "Object")
-					{
-						global.fushiLookupOriginalTextRenderBaseRender = global.TextRenderBase.render;
-						global.TextRenderBase.render = function(a, b, c, d, e, f)
-						{
-							var result = (global.fushiLookupOriginalTextRenderBaseRender incontextof this)(...);
-							global.fushiLookupCaptureTextRender(this, "TextRenderBase.render",
-								a, b, c, d, e, f);
-							return result;
-						};
-					}
-					global.fushiLookupTextRenderPatchTrace.add("TextRenderBase.done=" +
-						typeof global.TextRenderBase.done);
-					if(typeof global.TextRenderBase.done == "Object")
-					{
-						global.fushiLookupOriginalTextRenderBaseDone = global.TextRenderBase.done;
-						global.TextRenderBase.done = function()
-						{
-							var result = (global.fushiLookupOriginalTextRenderBaseDone incontextof this)(...);
-							global.fushiLookupCaptureTextRender(this, "TextRenderBase.done",
-								void, void, void, void, void, void);
-							return result;
-						};
-					}
-				}
-			}
-			catch(error)
-			{
-				global.fushiLookupTextRenderPatchTrace.add("TextRenderBase!" + error.message);
-			}
-
-)TJS" LR"TJS(
-
-			try
-			{
-				global.fushiLookupTextRenderPatchTrace.add("TextRender=" + typeof global.TextRender);
-				if(typeof global.TextRender == "Object" && global.TextRender !== global.TextRenderBase)
-				{
-					global.fushiLookupTextRenderPatchTrace.add("TextRender.draw=" +
-						typeof global.TextRender.draw);
-					if(typeof global.TextRender.draw == "Object")
-					{
-						global.fushiLookupOriginalTextRenderDraw = global.TextRender.draw;
-						global.TextRender.draw = function(layer, ox, oy, width, height, text,
-							autoIndent, base)
-						{
-							var previous = typeof global.fushiLookupTextRenderActiveDraw == "undefined" ?
-								void : global.fushiLookupTextRenderActiveDraw;
-							global.fushiLookupTextRenderActiveDraw = %[
-								renderer:this, layer:layer, originX:ox, originY:oy];
-							var result;
-							try
-							{
-								result = (global.fushiLookupOriginalTextRenderDraw incontextof this)(...);
-							}
-							catch(error)
-							{
-								global.fushiLookupTextRenderActiveDraw = previous;
-								throw error;
-							}
-							global.fushiLookupTextRenderActiveDraw = previous;
-							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
-								"TextRender.draw");
-							return result;
-						};
-					}
-					global.fushiLookupTextRenderPatchTrace.add("TextRender.drawAll=" +
-						typeof global.TextRender.drawAll);
-					if(typeof global.TextRender.drawAll == "Object")
-					{
-						global.fushiLookupOriginalTextRenderDrawAll = global.TextRender.drawAll;
-						global.TextRender.drawAll = function(layer, ox, oy)
-						{
-							var previous = typeof global.fushiLookupTextRenderActiveDraw == "undefined" ?
-								void : global.fushiLookupTextRenderActiveDraw;
-							global.fushiLookupTextRenderActiveDraw = %[
-								renderer:this, layer:layer, originX:ox, originY:oy];
-							var result;
-							try
-							{
-								result = (global.fushiLookupOriginalTextRenderDrawAll incontextof this)(...);
-							}
-							catch(error)
-							{
-								global.fushiLookupTextRenderActiveDraw = previous;
-								throw error;
-							}
-							global.fushiLookupTextRenderActiveDraw = previous;
-							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
-								"TextRender.drawAll");
-							return result;
-						};
-					}
-					global.fushiLookupTextRenderPatchTrace.add("TextRender.drawCh=" +
-						typeof global.TextRender.drawCh);
-					if(typeof global.TextRender.drawCh == "Object")
-					{
-						global.fushiLookupOriginalTextRenderDrawCh = global.TextRender.drawCh;
-						global.TextRender.drawCh = function(layer, ox, oy, ch)
-						{
-							global.fushiLookupBindTextRenderOrigin(this, layer, ox, oy,
-								"TextRender.drawCh");
-							return (global.fushiLookupOriginalTextRenderDrawCh incontextof this)(...);
-						};
-					}
-					global.fushiLookupTextRenderPatchTrace.add("TextRender.render=" +
-						typeof global.TextRender.render);
-					if(typeof global.TextRender.render == "Object")
-					{
-						global.fushiLookupOriginalTextRenderRender = global.TextRender.render;
-						global.TextRender.render = function(a, b, c, d, e, f)
-						{
-							var result = (global.fushiLookupOriginalTextRenderRender incontextof this)(...);
-							global.fushiLookupCaptureTextRender(this, "TextRender.render",
-								a, b, c, d, e, f);
-							return result;
-						};
-					}
-					global.fushiLookupTextRenderPatchTrace.add("TextRender.done=" +
-						typeof global.TextRender.done);
-					if(typeof global.TextRender.done == "Object")
-					{
-						global.fushiLookupOriginalTextRenderDone = global.TextRender.done;
-						global.TextRender.done = function()
-						{
-							var result = (global.fushiLookupOriginalTextRenderDone incontextof this)(...);
-							global.fushiLookupCaptureTextRender(this, "TextRender.done",
-								void, void, void, void, void, void);
-							return result;
-						};
-					}
-				}
-			}
-			catch(error)
-			{
-				global.fushiLookupTextRenderPatchTrace.add("TextRender!" + error.message);
-			}
-
-)TJS" LR"TJS(
-
-			global.fushiLookupPatchMessage = function(message)
-			{
-				if(message === void || !isvalid message) return;
-				if(typeof message.fushiLookupGlyphs == "undefined") message.fushiLookupGlyphs = [];
-				if(typeof message.fushiLookupProcessChCount == "undefined") message.fushiLookupProcessChCount = 0;
-				if(typeof message.fushiLookupLastCh == "undefined") message.fushiLookupLastCh = "";
-				if(typeof message.processCh != "Object") return;
-				if(typeof message.fushiLookupInstanceWrapperProcessCh != "undefined" &&
-					message.processCh === message.fushiLookupInstanceWrapperProcessCh) return;
-				message.fushiLookupInstancePatched = true;
-				message.fushiLookupInstanceOriginalProcessCh = message.processCh;
-				message.fushiLookupInstanceWrapperProcessCh = function(ch, steptime)
-				{
-					this.fushiLookupProcessChCount++;
-					this.fushiLookupLastCh = ch;
-					var result = (this.fushiLookupInstanceOriginalProcessCh incontextof this)(...);
-					if(!result) global.fushiLookupRecordGlyph(this, ch);
-					return result;
-				} incontextof message;
-				message.processCh = message.fushiLookupInstanceWrapperProcessCh;
-				if(typeof message.clear == "Object" &&
-					(typeof message.fushiLookupInstanceWrapperClear == "undefined" ||
-					message.clear !== message.fushiLookupInstanceWrapperClear)
-				)
-				{
-					message.fushiLookupInstanceOriginalClear = message.clear;
-					message.fushiLookupInstanceWrapperClear = function(all)
-					{
-						this.fushiLookupGlyphs = [];
-						if(typeof this.fushiLookupHighlight != "undefined")
-							this.fushiLookupHighlight.fillRect(0, 0, this.fushiLookupHighlight.width,
-								this.fushiLookupHighlight.height, 0);
-						return (this.fushiLookupInstanceOriginalClear incontextof this)(...);
-					} incontextof message;
-					message.clear = message.fushiLookupInstanceWrapperClear;
-				}
-			};
-
-			global.fushiLookupPatchAllMessages = function()
-			{
-				var pages = [global.kag.fore.messages, global.kag.back.messages];
-				for(var page = 0; page < pages.count; page++)
-					for(var message = 0; message < pages[page].count; message++)
-						global.fushiLookupPatchMessage(pages[page][message]);
-				if(typeof global.kag.current != "undefined" && global.kag.current !== void)
-					global.fushiLookupPatchMessage(global.kag.current);
-			};
-			if(typeof global.kag.tagHandlers == "Object" &&
-				typeof global.kag.tagHandlers.ch == "Object")
-			{
-				global.fushiLookupOriginalChHandler = global.kag.tagHandlers.ch;
-				global.fushiLookupChHandler = function(elm)
-				{
-					if(typeof this.current != "undefined" && this.current !== void)
-						global.fushiLookupPatchMessage(this.current);
-					return (global.fushiLookupOriginalChHandler incontextof this)(...);
-				} incontextof global.kag;
-				global.kag.tagHandlers.ch = global.fushiLookupChHandler;
-			}
-			global.fushiLookupPatchAllMessages();
-			global.fushiLookupRefreshMessages = function(tick)
-			{
-				try { global.fushiLookupPatchAllMessages(); } catch(e) {}
-			};
-			System.addContinuousHandler(global.fushiLookupRefreshMessages);
-
-)TJS" LR"TJS(
-
-			global.fushiLookupAtTextRenderRegistry = function(submit)
-			{
-				var primary = global.kag.primaryLayer;
-				var cursorX = primary.cursorX - primary.imageLeft;
-				var cursorY = primary.cursorY - primary.imageTop;
-				global.fushiLookupLastTrace.add("textRender captures=" +
-					global.fushiLookupTextRenderCaptureCount + " registry=" +
-					global.fushiLookupTextRenderRegistry.count + " lastMethod=" +
-					global.fushiLookupTextRenderLastMethod + " error=" +
-					global.fushiLookupTextRenderLastError + " cursor=" + cursorX + "," + cursorY);
-
-)TJS" LR"TJS(
-
-				for(var patchIndex = 0;
-					patchIndex < global.fushiLookupTextRenderPatchTrace.count; patchIndex++)
-					global.fushiLookupLastTrace.add("textRenderPatch=" +
-						global.fushiLookupTextRenderPatchTrace[patchIndex]);
-				for(var registryIndex = global.fushiLookupTextRenderRegistry.count - 1;
-					registryIndex >= 0; registryIndex--)
-				{
-					var target = global.fushiLookupTextRenderRegistry[registryIndex];
-					var glyphs = target.fushiLookupLayerGlyphs;
-					var targetLayer = global.fushiLookupTextRenderValue(target,
-						"targetLayer", void);
-					var originX = global.fushiLookupTextRenderValue(target, "originX", void);
-					var originY = global.fushiLookupTextRenderValue(target, "originY", void);
-					var originSource = global.fushiLookupTextRenderValue(target,
-						"originSource", "unbound");
-					var row = "textRender=" + registryIndex + " method=" + target.method +
-						" capture=" + target.capture + " chars=" + target.characters.count +
-						" glyphs=" + glyphs.count + " args=" + target.args.join("|") +
-						" first={" + target.sample + "} last={" +
-						target.lastSample + "}";
-					if(glyphs.count > 0)
-					{
-						var first = glyphs[0], last = glyphs[glyphs.count - 1];
-						row += " bounds=" + first.ch + "@" + first.x + "," + first.y + "," +
-							first.w + "," + first.h + ".." + last.ch + "@" + last.x + "," +
-							last.y + "," + last.w + "," + last.h;
-					}
-					if(targetLayer === void || targetLayer === null || !isvalid targetLayer ||
-						originX === void || originY === void)
-					{
-						global.fushiLookupLastTrace.add(row + " origin=unbound");
-						continue;
-					}
-					var layerX = targetLayer.cursorX - targetLayer.imageLeft;
-					var layerY = targetLayer.cursorY - targetLayer.imageTop;
-					var localX = layerX - originX;
-					var localY = layerY - originY;
-					var visible = global.fushiLookupLayerIsVisible(targetLayer);
-					target.fushiLookupGlyphOffsetX = cursorX - layerX + originX;
-					target.fushiLookupGlyphOffsetY = cursorY - layerY + originY;
-					row += " origin=" + originSource + "@" + originX + "," + originY +
-						" layerCursor=" + targetLayer.cursorX + "," + targetLayer.cursorY +
-						" image=" + targetLayer.imageLeft + "," + targetLayer.imageTop +
-						" local=" + localX + "," + localY + " visible=" + visible;
-					global.fushiLookupLastTrace.add(row);
-					if(!visible) continue;
-					var index = global.fushiLookupGlyphAt(target, localX, localY);
-					if(index < 0) continue;
-					global.fushiLookupPaint(target, index, 1, 72);
-					if(submit) return global.fushiLookupSubmit(target, localX, localY);
-					return true;
-				}
-				return false;
-			};
-
-			global.fushiLookupLayerIsVisible = function(layer)
+			global.fushiLookupVisible = function(layer)
 			{
 				var current = layer;
 				while(current !== void && current !== null && isvalid current)
@@ -1451,165 +863,499 @@ if(typeof global.fushiLookupBootstrap == "undefined")
 				return true;
 			};
 
-			global.fushiLookupAtLayerRegistry = function(submit)
+			// 高亮层同样延迟到第一次真要高亮时才建。它是全视口的，但 hitThreshold=256 是
+			// 引擎里"永不命中"这个明确取值——与卡片依赖的 alpha 穿透不是一回事，不会把
+			// 输入吃掉。
+			global.fushiLookupEnsureHighlight = function()
 			{
-				global.fushiLookupLastTrace.add("drawText=" + global.fushiLookupLayerDrawCount +
-					" registry=" + global.fushiLookupLayerRegistry.count +
-					" lastText=" + global.fushiLookupLayerLastText);
-				for(var registryIndex = global.fushiLookupLayerRegistry.count - 1;
-					registryIndex >= 0; registryIndex--)
+				var primary = global.kag.primaryLayer;
+				var layer = global.fushiLookupHighlightLayer;
+				if(layer === void || !isvalid layer)
 				{
-					var layer = global.fushiLookupLayerRegistry[registryIndex];
-					if(layer === void || !isvalid layer ||
-						typeof layer.fushiLookupLayerGlyphs == "undefined" ||
-						layer.fushiLookupLayerGlyphs.count == 0) continue;
-					var visible = global.fushiLookupLayerIsVisible(layer);
-					var x = layer.cursorX - layer.imageLeft;
-					var y = layer.cursorY - layer.imageTop;
-					var glyphs = layer.fushiLookupLayerGlyphs;
-					var last = glyphs[glyphs.count - 1];
-					global.fushiLookupLastTrace.add("layer=" + registryIndex +
-						" visible=" + visible + " cursor=" + layer.cursorX + "," + layer.cursorY +
-						" image=" + layer.imageLeft + "," + layer.imageTop +
-						" local=" + x + "," + y + " glyphs=" + glyphs.count +
-						" last=" + last.ch + "@" + last.x + "," + last.y + "," + last.w + "," + last.h);
-					if(!visible) continue;
-					var index = global.fushiLookupGlyphAt(layer, x, y);
-					if(index < 0) continue;
-					global.fushiLookupPaint(layer, index, 1, 72);
-					if(submit) return global.fushiLookupSubmit(layer, x, y);
-					return true;
+					layer = new Layer(global.kag, primary.parent);
+					global.kag.add(layer);
+					layer.name = "Hibiki subtitle highlight";
+					layer.fushiLookupIgnore = true;
+					layer.type = ltAlpha;
+					layer.absolute = 2147482000;
+					layer.opacity = 255;
+					layer.hitType = htMask;
+					layer.hitThreshold = 256;
+					layer.visible = false;
+					global.fushiLookupHighlightLayer = layer;
+					global.fushiLookupHighlightRect = void;
 				}
-				return false;
+				if(layer.imageWidth != primary.imageWidth ||
+					layer.imageHeight != primary.imageHeight)
+				{
+					layer.setImageSize(primary.imageWidth, primary.imageHeight);
+					layer.setSizeToImageSize();
+					layer.setPos(0, 0);
+					layer.fillRect(0, 0, layer.imageWidth, layer.imageHeight, 0);
+					global.fushiLookupHighlightRect = void;
+				}
+				return layer;
 			};
 
-			global.fushiLookupAtCursor = function(submit)
+)TJS" LR"TJS(
+
+			// 只擦上一次的包围盒，且只有命中字符**变化**时才会走到这里。prototype 每次
+			// mousemove 都对一个 primaryLayer 尺寸的层做全屏 fillRect，那是按秒计的主线程开销。
+			global.fushiLookupPaintHighlight = function(entry, offsetX, offsetY, start, length)
 			{
-				global.fushiLookupLastTrace = [];
-				if(global.fushiLookupAtTextRenderRegistry(submit)) return true;
-				if(global.fushiLookupAtLayerRegistry(submit)) return true;
-				global.fushiLookupPatchAllMessages();
-				var pages = [global.kag.fore.messages, global.kag.back.messages];
-				var sawCurrent = false;
-				for(var page = 0; page < pages.count; page++)
+				var layer = global.fushiLookupEnsureHighlight();
+				if(layer === void || !isvalid layer) return;
+				var previous = global.fushiLookupHighlightRect;
+				if(previous !== void)
+					layer.fillRect(previous.x, previous.y, previous.w, previous.h, 0);
+				global.fushiLookupHighlightRect = void;
+				var glyphs = entry.glyphs;
+				if(start < 0 || start >= glyphs.count || length <= 0)
 				{
-					var messages = pages[page];
-					for(var i = messages.count - 1; i >= 0; i--)
+					layer.visible = false;
+					layer.update();
+					return;
+				}
+				var last = start + length - 1;
+				if(last >= glyphs.count) last = glyphs.count - 1;
+				var x0 = glyphs[start].x + offsetX, y0 = glyphs[start].y + offsetY;
+				var x1 = x0 + glyphs[start].w, y1 = y0 + glyphs[start].h;
+				for(var i = start + 1; i <= last; i++)
+				{
+					var g = glyphs[i];
+					var gx = g.x + offsetX, gy = g.y + offsetY;
+					if(gx < x0) x0 = gx;
+					if(gy < y0) y0 = gy;
+					if(gx + g.w > x1) x1 = gx + g.w;
+					if(gy + g.h > y1) y1 = gy + g.h;
+				}
+				if(x0 < 0) x0 = 0;
+				if(y0 < 0) y0 = 0;
+				if(x1 > layer.imageWidth) x1 = layer.imageWidth;
+				if(y1 > layer.imageHeight) y1 = layer.imageHeight;
+				if(x1 <= x0 || y1 <= y0)
+				{
+					layer.visible = false;
+					layer.update();
+					return;
+				}
+				layer.colorRect(x0, y0, x1 - x0, y1 - y0, 0x31d7ff, 88);
+				global.fushiLookupHighlightRect = %[x:x0, y:y0, w:x1 - x0, h:y1 - y0];
+				layer.visible = true;
+				layer.update();
+			};
+
+			global.fushiLookupClearHover = function()
+			{
+				if(global.fushiLookupHoverKey == "") return;
+				global.fushiLookupHoverKey = "";
+				global.fushiLookupHitEntry = void;
+				var layer = global.fushiLookupHighlightLayer;
+				var previous = global.fushiLookupHighlightRect;
+				if(layer !== void && isvalid layer && previous !== void)
+				{
+					layer.fillRect(previous.x, previous.y, previous.w, previous.h, 0);
+					layer.visible = false;
+					layer.update();
+				}
+				global.fushiLookupHighlightRect = void;
+			};
+
+			// 收起 = 层不可见。不可见层在引擎里既不绘制也不参与命中，这是引擎最基本的语义，
+			// 不像 alpha 穿透那样需要额外验证。层留着复用（下一次查词多半尺寸相近），只是
+			// 绝不会停在"可见且可命中"的状态上。
+			global.fushiLookupDismiss = function()
+			{
+				try
+				{
+					var card = global.fushiLookupCard;
+					if(card !== void && isvalid card && card.visible)
 					{
-						var message = messages[i];
-						if(typeof message.fushiLookupGlyphs == "undefined") continue;
-						var glyphs = message.fushiLookupGlyphs;
-						var x = message.cursorX - message.imageLeft;
-						var y = message.cursorY - message.imageTop;
-						var isCurrent = typeof global.kag.current != "undefined" && global.kag.current === message;
-						if(isCurrent) sawCurrent = true;
-						var row = "page=" + page + " message=" + i +
-							" visible=" + message.visible + " cursor=" + message.cursorX + "," + message.cursorY +
-							" image=" + message.imageLeft + "," + message.imageTop +
-							" local=" + x + "," + y + " glyphs=" + glyphs.count +
-							" processCh=" + message.fushiLookupProcessChCount +
-							" lastCh=" + message.fushiLookupLastCh + " current=" + isCurrent +
-							" wrapped=" + (typeof message.fushiLookupInstanceWrapperProcessCh != "undefined" &&
-								message.processCh === message.fushiLookupInstanceWrapperProcessCh);
-						if(glyphs.count > 0)
+						card.visible = false;
+						card.update();
+					}
+				}
+				catch(e) {}
+				global.fushiLookupCardSeq = 0;
+				global.fushiLookupClearHover();
+			};
+
+			// DLL 写像素**之前**调：把卡片层建/调到 anchor + cardW×cardH。第一次真要显示
+			// 时才建层——没查词的时候游戏渲染树里根本没有这个对象。
+			global.fushiLookupPrepare = function(anchorX, anchorY, cardW, cardH)
+			{
+				try
+				{
+					if(cardW <= 0 || cardH <= 0) return;
+					var card = global.fushiLookupCard;
+					if(card === void || !isvalid card)
+					{
+						card = new FushiLookupCardLayer(global.kag,
+							global.kag.primaryLayer.parent);
+						global.kag.add(card);
+						card.name = "Hibiki in-game lookup card";
+						card.fushiLookupIgnore = true;
+						card.type = ltAlpha;
+						card.absolute = 2147483000;
+						card.opacity = 255;
+						card.hitType = htRect;
+						card.visible = false;
+						global.fushiLookupCard = card;
+					}
+					if(card.imageWidth != cardW || card.imageHeight != cardH)
+					{
+						card.setImageSize(cardW, cardH);
+						card.setSizeToImageSize();
+					}
+					card.setPos(anchorX, anchorY);
+				}
+				catch(e) {}
+			};
+
+)TJS" LR"TJS(
+
+			// DLL 写完像素之后调。seq==0 或空尺寸 = 收起卡片（host 关开关 / 投空帧）。
+			// 几何随帧一起传进来，这里当**不变量**用：与 prepare 时的层不一致就说明写像素
+			// 与本次显示之间层被动过，露出来只会是半张错位的卡片，宁可等下一帧。
+			global.fushiLookupApply = function(seq, highlightStart, highlightLen,
+				anchorX, anchorY, cardW, cardH)
+			{
+				try
+				{
+					if(seq == 0 || cardW <= 0 || cardH <= 0)
+					{
+						global.fushiLookupDismiss();
+						return;
+					}
+					var card = global.fushiLookupCard;
+					if(card === void || !isvalid card) return;
+					if(card.imageWidth != cardW || card.imageHeight != cardH ||
+						card.left != anchorX || card.top != anchorY) return;
+					global.fushiLookupCardSeq = seq;
+					card.visible = true;
+					card.update();
+					var entry = global.fushiLookupHitEntry;
+					if(entry !== void && highlightLen > 0)
+						global.fushiLookupPaintHighlight(entry, global.fushiLookupHitOffsetX,
+							global.fushiLookupHitOffsetY, highlightStart, highlightLen);
+				}
+				catch(e) {}
+			};
+
+			// 备路：主路（mainImageBufferForWrite）查询或求值失败时，host 把 cardW×cardH 的
+			// 卡片写成 PNG 落在 %TEMP%，由这里 loadImages 进来。路径在 bootstrap 时由 DLL
+			// 一次性代入，不参与任何运行期拼接；游戏目录始终不被写入（资产带 .sig 校验）。
+			global.fushiLookupApplyPng = function(seq, highlightStart, highlightLen,
+				anchorX, anchorY, cardW, cardH)
+			{
+				try
+				{
+					global.fushiLookupPrepare(anchorX, anchorY, cardW, cardH);
+					var card = global.fushiLookupCard;
+					if(card === void || !isvalid card) return;
+					card.loadImages(global.fushiLookupCardPath);
+					card.setSizeToImageSize();
+					card.setPos(anchorX, anchorY);
+					card.type = ltAlpha;
+				}
+				catch(e) {}
+				global.fushiLookupApply(seq, highlightStart, highlightLen, anchorX, anchorY,
+					cardW, cardH);
+			};
+
+			// 输入转发。层事件给的是层内坐标；这里加回层位置换成视口坐标入队，减 anchor 仍由
+			// DLL 做——帧元数据在它手上，层位置与当前帧 anchor 万一不同步时它的值才是对的。
+			// 打包成一个正整数，DLL 取一次就是一个事件。
+			global.fushiLookupQueueInput = function(kind, x, y, wheel)
+			{
+				var queue = global.fushiLookupInputQueue;
+				var card = global.fushiLookupCard;
+				if(card !== void && isvalid card)
+				{
+					x = x + card.left;
+					y = y + card.top;
+				}
+				// 连续 move 就地合并：鼠标一秒能出上百个 move，逐个过共享内存毫无意义。
+				if(kind == 0 && queue.count > 0 && (queue[queue.count - 1] & 15) == 0)
+					queue.erase(queue.count - 1);
+				if(x < -32768) x = -32768;
+				if(x > 32767) x = 32767;
+				if(y < -32768) y = -32768;
+				if(y > 32767) y = 32767;
+				if(wheel < -2048) wheel = -2048;
+				if(wheel > 2047) wheel = 2047;
+				var keys = 0;
+				if(global.fushiLookupShiftDown) keys = keys | 1;
+				queue.add((1 << 52) | ((y + 32768) << 36) | ((x + 32768) << 20) |
+					((wheel + 2048) << 8) | (keys << 4) | kind);
+				if(queue.count > 64) queue.erase(0);
+				global.fushiLookupNotify++;
+			};
+
+			global.fushiLookupInputTake = function()
+			{
+				var queue = global.fushiLookupInputQueue;
+				if(queue.count == 0) return 0;
+				var packed = queue[0];
+				queue.erase(0);
+				return packed;
+			};
+
+)TJS" LR"TJS(
+
+			// TextRender.render / done → renderer.getCharacters(0,0) 是本样本唯一命中的捕获
+			// 边界（其余四条路径已被运行日志证伪）。只留自己的几何快照，绝不长期持有引擎
+			// 返回的 characters 数组。
+			global.fushiLookupCapture = function(renderer)
+			{
+				try
+				{
+					if(typeof renderer.getCharacters != "Object") return;
+					var characters = (renderer.getCharacters incontextof renderer)(0, 0);
+					if(characters === void || typeof characters.count == "undefined") return;
+					var glyphs = [], line = "";
+					var minX = 0, minY = 0, maxX = 0, maxY = 0;
+					for(var i = 0; i < characters.count; i++)
+					{
+						var character = characters[i];
+						var text = global.fushiLookupField(character, "text");
+						if(typeof text != "String" || text == "") continue;
+						var x = global.fushiLookupField(character, "x");
+						var y = global.fushiLookupField(character, "y");
+						var w = global.fushiLookupField(character, "cw");
+						var h = global.fushiLookupField(character, "size");
+						if(x === void) x = global.fushiLookupField(character, "left");
+						if(y === void) y = global.fushiLookupField(character, "top");
+						if(w === void) w = global.fushiLookupField(character, "width");
+						if(h === void) h = global.fushiLookupField(character, "height");
+						if(x === void || y === void || w === void || h === void) continue;
+						if(w <= 0 || h <= 0) continue;
+						if(glyphs.count == 0)
 						{
-							var first = glyphs[0], last = glyphs[glyphs.count - 1];
-							row += " first=" + first.x + "," + first.y + "," + first.w + "," + first.h +
-								" last=" + last.x + "," + last.y + "," + last.w + "," + last.h;
+							minX = x; minY = y; maxX = x + w; maxY = y + h;
 						}
-						global.fushiLookupLastTrace.add(row);
-						var index = global.fushiLookupGlyphAt(message, x, y);
-						if(index < 0) continue;
-						global.fushiLookupPaint(message, index, 1, 72);
-						if(submit) return global.fushiLookupSubmit(message, x, y);
+						else
+						{
+							if(x < minX) minX = x;
+							if(y < minY) minY = y;
+							if(x + w > maxX) maxX = x + w;
+							if(y + h > maxY) maxY = y + h;
+						}
+						glyphs.add(%[ch:text, x:x, y:y, w:w, h:h]);
+						line += text;
+					}
+					if(glyphs.count == 0) return;
+					var entry = global.fushiLookupEntryFor(renderer);
+					var changed = entry.line != line;
+					entry.glyphs = glyphs;
+					entry.line = line;
+					entry.minX = minX;
+					entry.minY = minY;
+					entry.maxX = maxX;
+					entry.maxY = maxY;
+					entry.used = ++global.fushiLookupClock;
+					// 台词真的换了才收卡片：同一行重复 render（打字机动画）不该把用户正在读的
+					// 卡片一帧一帧地打掉。
+					if(changed) global.fushiLookupDismiss();
+				}
+				catch(e) {}
+			};
+
+			// drawCh 是逐字符调用，先用一组"上次绑定"快照挡住重复调用，别让每个字都去扫 registry。
+			global.fushiLookupBindOrigin = function(renderer, layer, originX, originY)
+			{
+				if(global.fushiLookupBoundRenderer === renderer &&
+					global.fushiLookupBoundLayer === layer &&
+					global.fushiLookupBoundX == originX &&
+					global.fushiLookupBoundY == originY) return;
+				if(layer === void || layer === null || !isvalid layer) return;
+				if(typeof originX != "Integer" && typeof originX != "Real") return;
+				if(typeof originY != "Integer" && typeof originY != "Real") return;
+				var entry = global.fushiLookupEntryFor(renderer);
+				entry.layer = layer;
+				entry.originX = originX;
+				entry.originY = originY;
+				global.fushiLookupBoundRenderer = renderer;
+				global.fushiLookupBoundLayer = layer;
+				global.fushiLookupBoundX = originX;
+				global.fushiLookupBoundY = originY;
+			};
+
+)TJS" LR"TJS(
+
+			global.fushiLookupReport = function(entry, index, offsetX, offsetY, submit)
+			{
+				var key = entry.line + "#" + index;
+				// 命中字符没变就什么都不做：既不重绘高亮，也不惊动 host。
+				if(!submit && key == global.fushiLookupHoverKey) return;
+				global.fushiLookupHoverKey = key;
+				var glyph = entry.glyphs[index];
+				var primary = global.kag.primaryLayer;
+				global.fushiLookupHitEntry = entry;
+				global.fushiLookupHitOffsetX = offsetX;
+				global.fushiLookupHitOffsetY = offsetY;
+				global.fushiLookupHitCharIndex = index;
+				global.fushiLookupHitCharCount = entry.glyphs.count;
+				global.fushiLookupHitGlyphX = glyph.x + offsetX;
+				global.fushiLookupHitGlyphY = glyph.y + offsetY;
+				global.fushiLookupHitGlyphW = glyph.w;
+				global.fushiLookupHitGlyphH = glyph.h;
+				global.fushiLookupHitViewW = primary.imageWidth;
+				global.fushiLookupHitViewH = primary.imageHeight;
+				global.fushiLookupHitFlags = submit ? 1 : 0;
+				// **整行**，不截断。制卡要的是完整句子，分词是 host 的事。
+				global.fushiLookupHitLine = entry.line;
+				global.fushiLookupHitSeq++;
+				global.fushiLookupNotify++;
+				global.fushiLookupPaintHighlight(entry, offsetX, offsetY, index, 1);
+			};
+
+			global.fushiLookupProbe = function(submit)
+			{
+				var primary = global.kag.primaryLayer;
+				var px = primary.cursorX - primary.imageLeft;
+				var py = primary.cursorY - primary.imageTop;
+				var registry = global.fushiLookupRegistry;
+				for(var i = registry.count - 1; i >= 0; i--)
+				{
+					var entry = registry[i];
+					if(entry.glyphs.count == 0) continue;
+					var layer = entry.layer;
+					if(layer === void || layer === null || !isvalid layer) continue;
+					var rx = layer.cursorX - layer.imageLeft - entry.originX;
+					var ry = layer.cursorY - layer.imageTop - entry.originY;
+					// 廉价矩形判定挡在前面：整行包围盒不含光标就整条跳过，逐字扫描只在真正
+					// 落在台词上时才发生。
+					if(rx < entry.minX || rx >= entry.maxX) continue;
+					if(ry < entry.minY || ry >= entry.maxY) continue;
+					if(!global.fushiLookupVisible(layer)) continue;
+					var glyphs = entry.glyphs;
+					for(var g = glyphs.count - 1; g >= 0; g--)
+					{
+						var glyph = glyphs[g];
+						if(rx < glyph.x || rx >= glyph.x + glyph.w) continue;
+						if(ry < glyph.y || ry >= glyph.y + glyph.h) continue;
+						global.fushiLookupReport(entry, g, px - rx, py - ry, submit);
 						return true;
 					}
 				}
-				if(global.fushiLookupLastTrace.count == 0) global.fushiLookupLastTrace.add("no-message");
-				if(!sawCurrent && typeof global.kag.current != "undefined" && global.kag.current !== void)
-				{
-					var current = global.kag.current;
-					global.fushiLookupLastTrace.add("current-outside-pages glyphs=" +
-						(typeof current.fushiLookupGlyphs == "undefined" ? -1 : current.fushiLookupGlyphs.count) +
-						" processCh=" + (typeof current.fushiLookupProcessChCount == "undefined" ? -1 : current.fushiLookupProcessChCount) +
-						" lastCh=" + (typeof current.fushiLookupLastCh == "undefined" ? "" : current.fushiLookupLastCh));
-				}
+				if(!submit) global.fushiLookupClearHover();
 				return false;
+			};
+
+			// 卡片层自己（htRect）已经吃掉落在它矩形内的事件；KAG 全局钩子这一侧再判一次，
+			// 免得同一次点击既推进剧情又被卡片处理。层现在就是卡片本身，所以这是一次纯矩形
+			// 判定——不再需要 getMainPixel 去问 alpha。
+			global.fushiLookupOverCard = function()
+			{
+				if(global.fushiLookupCardSeq == 0) return false;
+				try
+				{
+					var card = global.fushiLookupCard;
+					if(card === void || !isvalid card || !card.visible) return false;
+					var x = card.cursorX - card.imageLeft;
+					var y = card.cursorY - card.imageTop;
+					return x >= 0 && y >= 0 && x < card.imageWidth && y < card.imageHeight;
+				}
+				catch(e) { return false; }
 			};
 
 )TJS" LR"TJS(
 
 			global.fushiLookupLeftClickHook = function()
 			{
-				var hit = global.fushiLookupAtCursor(true);
-				try
-				{
-					var trace = ["leftClick", hit];
-					for(var traceIndex = 0; traceIndex < global.fushiLookupLastTrace.count; traceIndex++)
-						trace.add(global.fushiLookupLastTrace[traceIndex]);
-					trace.save(global.fushiLookupRequestPath + ".trace");
-				} catch(e) {}
-				return hit;
+				if(global.fushiLookupOverCard()) return true;
+				return global.fushiLookupProbe(true);
 			};
 			global.fushiLookupMouseMoveHook = function(x, y)
 			{
-				global.fushiLookupAtCursor(false);
+				if(global.fushiLookupOverCard()) return false;
+				global.fushiLookupProbe(false);
 				return false;
 			};
 			global.fushiLookupKeyDownHook = function(key, shift)
 			{
-				if(key == VK_SHIFT) return global.fushiLookupAtCursor(true);
+				global.fushiLookupShiftDown = (key == 0x10);
+				if(key == 0x1B && global.fushiLookupCardSeq != 0)
+				{
+					global.fushiLookupDismiss();
+					return true;
+				}
+				if(key == 0x10) return global.fushiLookupProbe(true);
 				return false;
 			};
+
+			// bootstrap 只装传感器，**一个渲染层都不建**：卡片层由 fushiLookupPrepare 在真要
+			// 显示第一帧时建，高亮层由 fushiLookupEnsureHighlight 在第一次真要高亮时建。
+			// 没查词的时候游戏渲染树与它注入前逐字节一致。
+			global.fushiLookupCard = void;
+			global.fushiLookupHighlightLayer = void;
+
+			if(typeof global.TextRender == "Object")
+			{
+				if(typeof global.TextRender.render == "Object")
+				{
+					global.fushiLookupOriginalRender = global.TextRender.render;
+					global.TextRender.render = function(a, b, c, d, e, f)
+					{
+						var result = (global.fushiLookupOriginalRender incontextof this)(...);
+						global.fushiLookupCapture(this);
+						return result;
+					};
+				}
+				if(typeof global.TextRender.done == "Object")
+				{
+					global.fushiLookupOriginalDone = global.TextRender.done;
+					global.TextRender.done = function()
+					{
+						var result = (global.fushiLookupOriginalDone incontextof this)(...);
+						global.fushiLookupCapture(this);
+						return result;
+					};
+				}
+				if(typeof global.TextRender.drawCh == "Object")
+				{
+					global.fushiLookupOriginalDrawCh = global.TextRender.drawCh;
+					global.TextRender.drawCh = function(layer, ox, oy, ch)
+					{
+						global.fushiLookupBindOrigin(this, layer, ox, oy);
+						return (global.fushiLookupOriginalDrawCh incontextof this)(...);
+					};
+				}
+			}
+
+)TJS" LR"TJS(
+
+			// 默认关闭的探测分支：换游戏、TextRender 一条都不命中时才开，用来判断"文本到底
+			// 走哪条路"。只数次数，不做几何、不建 registry、不改任何绘制结果。
+			if(global.fushiLookupProbeMode)
+			{
+				try
+				{
+					global.fushiLookupProbeOriginalDrawText = global.Layer.drawText;
+					global.Layer.drawText = function(x, y, text, color, opacity, antialiased)
+					{
+						global.fushiLookupProbeDrawText++;
+						return (global.fushiLookupProbeOriginalDrawText incontextof this)(...);
+					};
+					global.fushiLookupProbeOriginalProcessCh = global.MessageLayer.processCh;
+					global.MessageLayer.processCh = function(ch, steptime)
+					{
+						global.fushiLookupProbeProcessCh++;
+						return (global.fushiLookupProbeOriginalProcessCh incontextof this)(...);
+					} incontextof global.MessageLayer;
+				}
+				catch(error)
+				{
+					global.fushiLookupProbeError = error.message;
+				}
+			}
+
 			global.kag.addHook("leftClick", global.fushiLookupLeftClickHook);
 			global.kag.addHook("mouseMove", global.fushiLookupMouseMoveHook);
 			global.kag.addHook("keyDown", global.fushiLookupKeyDownHook);
 
-			global.fushiLookupOriginalProcessCh = global.MessageLayer.processCh;
-			global.MessageLayer.processCh = function(ch, steptime)
-			{
-				var result = (global.fushiLookupOriginalProcessCh incontextof this)(...);
-				if(!result && typeof this.fushiLookupInstancePatched == "undefined")
-					global.fushiLookupRecordGlyph(this, ch);
-				return result;
-			} incontextof global.MessageLayer;
-
-			global.fushiLookupOriginalClear = global.MessageLayer.clear;
-			global.MessageLayer.clear = function(all)
-			{
-				this.fushiLookupGlyphs = [];
-				if(typeof this.fushiLookupHighlight != "undefined")
-					this.fushiLookupHighlight.fillRect(0, 0, this.fushiLookupHighlight.width, this.fushiLookupHighlight.height, 0);
-				return (global.fushiLookupOriginalClear incontextof this)(...);
-			} incontextof global.MessageLayer;
-
-			global.fushiLookupOriginalMouseMove = global.MessageLayer.onMouseMove;
-			global.MessageLayer.onMouseMove = function(x, y)
-			{
-				var localX = x - this.imageLeft, localY = y - this.imageTop;
-				var index = global.fushiLookupGlyphAt(this, localX, localY);
-				if(index >= 0)
-				{
-					global.fushiLookupPaint(this, index, 1, 72);
-				}
-				return (global.fushiLookupOriginalMouseMove incontextof this)(...);
-			} incontextof global.MessageLayer;
-
-			global.fushiLookupOriginalMouseDown = global.MessageLayer.onMouseDown;
-			global.MessageLayer.onMouseDown = function(x, y, button)
-			{
-				if(button == mbLeft && global.fushiLookupSubmit(this, x - this.imageLeft, y - this.imageTop)) return;
-				return (global.fushiLookupOriginalMouseDown incontextof this)(...);
-			} incontextof global.MessageLayer;
-
-			global.fushiLookupOriginalKeyDown = global.MessageLayer.onKeyDown;
-			global.MessageLayer.onKeyDown = function(key, shift)
-			{
-				if(key == VK_SHIFT && global.fushiLookupSubmit(this, this.cursorX - this.imageLeft, this.cursorY - this.imageTop)) return;
-				return (global.fushiLookupOriginalKeyDown incontextof this)(...);
-			} incontextof global.MessageLayer;
-
-			Debug.notice("[HibikiLookup] KAGEX glyph lookup installed");
+			Debug.notice("[HibikiLookup] sensor installed");
 			System.removeContinuousHandler(global.fushiLookupBootstrap);
 			global.fushiLookupBootstrap = void;
 		}
@@ -1624,436 +1370,564 @@ if(typeof global.fushiLookupBootstrap == "undefined")
 }
 )TJS";
 
-std::wstring Utf8ToWide(const std::string& value) {
-  if (value.empty()) return {};
-  const int count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
-                                         static_cast<int>(value.size()), nullptr, 0);
-  if (count <= 0) return {};
-  std::wstring result(static_cast<size_t>(count), L'\0');
-  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
-                      static_cast<int>(value.size()), result.data(), count);
-  return result;
-}
+// ── DLL 侧：像素落地 + 传感器读数搬运 ─────────────────────────────────────────────
+//
+// 这一整段只做三件事：把 host 的 BGRA 帧 memcpy 进游戏渲染树里的卡片 Layer、把 TJS 传感器
+// 的读数搬进共享内存、把落在卡片上的输入搬进输入环。prototype 里的 WinHTTP 客户端、
+// 认证 token 环境变量、手写 JSON 解析器、临时文件 IPC 轮询线程、拼 TJS 源码再 eval——全部
+// 不在了：跨边界的东西只剩一块位图和一串整数。
 
-std::string WideToUtf8(const std::wstring& value) {
-  if (value.empty()) return {};
-  const int count = WideCharToMultiByte(CP_UTF8, 0, value.data(),
-                                        static_cast<int>(value.size()), nullptr, 0,
-                                        nullptr, nullptr);
-  if (count <= 0) return {};
-  std::string result(static_cast<size_t>(count), '\0');
-  WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
-                      result.data(), count, nullptr, nullptr);
-  return result;
-}
+// 本地缓冲上界。真正的契约上界是 kLookupLineBytes（UTF-8 字节），这里只是宽松的字符数。
+constexpr size_t kKirikiriLookupLineChars = 1200;
 
-std::wstring EscapeTjsString(const std::wstring& value) {
-  std::wstring result;
-  result.reserve(value.size() + 16);
-  for (wchar_t ch : value) {
-    switch (ch) {
-      case L'\\': result += L"\\\\"; break;
-      case L'\"': result += L"\\\""; break;
-      case L'\r': result += L"\\r"; break;
-      case L'\n': result += L"\\n"; break;
-      case 0x2028: result += L" "; break;
-      case 0x2029: result += L" "; break;
-      default: result.push_back(ch); break;
-    }
-  }
-  return result;
-}
-
-std::string EscapeJsonString(const std::string& value) {
-  std::string result;
-  result.reserve(value.size() + 16);
-  static constexpr char hex[] = "0123456789abcdef";
-  for (unsigned char ch : value) {
-    switch (ch) {
-      case '\\': result += "\\\\"; break;
-      case '\"': result += "\\\""; break;
-      case '\r': result += "\\r"; break;
-      case '\n': result += "\\n"; break;
-      case '\t': result += "\\t"; break;
-      default:
-        if (ch < 0x20) {
-          result += "\\u00";
-          result.push_back(hex[ch >> 4]);
-          result.push_back(hex[ch & 15]);
-        } else {
-          result.push_back(static_cast<char>(ch));
-        }
-        break;
-    }
-  }
-  return result;
-}
-
-void AppendUtf8CodePoint(std::string& output, uint32_t codepoint) {
-  if (codepoint <= 0x7f) {
-    output.push_back(static_cast<char>(codepoint));
-  } else if (codepoint <= 0x7ff) {
-    output.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
-    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
-  } else if (codepoint <= 0xffff) {
-    output.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
-    output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
-    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
-  } else {
-    output.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
-    output.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
-    output.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
-    output.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
-  }
-}
-
-int JsonHex(char ch) {
-  if (ch >= '0' && ch <= '9') return ch - '0';
-  if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
-  if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
-  return -1;
-}
-
-bool ParseJsonString(const std::string& json, size_t quote, std::string* value,
-                     size_t* next) {
-  if (value == nullptr || quote >= json.size() || json[quote] != '\"') return false;
-  value->clear();
-  for (size_t i = quote + 1; i < json.size(); i++) {
-    const char ch = json[i];
-    if (ch == '\"') {
-      if (next != nullptr) *next = i + 1;
-      return true;
-    }
-    if (ch != '\\') {
-      value->push_back(ch);
-      continue;
-    }
-    if (++i >= json.size()) return false;
-    switch (json[i]) {
-      case '\"': value->push_back('\"'); break;
-      case '\\': value->push_back('\\'); break;
-      case '/': value->push_back('/'); break;
-      case 'b': value->push_back('\b'); break;
-      case 'f': value->push_back('\f'); break;
-      case 'n': value->push_back('\n'); break;
-      case 'r': value->push_back('\r'); break;
-      case 't': value->push_back('\t'); break;
-      case 'u': {
-        if (i + 4 >= json.size()) return false;
-        uint32_t codepoint = 0;
-        for (int n = 0; n < 4; n++) {
-          const int digit = JsonHex(json[++i]);
-          if (digit < 0) return false;
-          codepoint = (codepoint << 4) | static_cast<uint32_t>(digit);
-        }
-        AppendUtf8CodePoint(*value, codepoint);
-        break;
-      }
-      default: return false;
-    }
-  }
-  return false;
-}
-
-bool FindJsonStringField(const std::string& json, const char* key,
-                         std::string* value, size_t start = 0,
-                         size_t limit = std::string::npos) {
-  const std::string needle = std::string("\"") + key + "\"";
-  size_t pos = start;
-  const size_t end = std::min(limit, json.size());
-  while ((pos = json.find(needle, pos)) != std::string::npos && pos < end) {
-    pos += needle.size();
-    pos = json.find(':', pos);
-    if (pos == std::string::npos || pos >= end) return false;
-    pos++;
-    while (pos < end && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == '\r' ||
-                          json[pos] == '\n')) pos++;
-    if (pos < end && json[pos] == '\"') return ParseJsonString(json, pos, value, nullptr);
-  }
-  return false;
-}
-
-int FindJsonIntegerField(const std::string& json, const char* key, int fallback) {
-  const std::string needle = std::string("\"") + key + "\"";
-  size_t pos = json.find(needle);
-  if (pos == std::string::npos) return fallback;
-  pos = json.find(':', pos + needle.size());
-  if (pos == std::string::npos) return fallback;
-  while (++pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) {}
-  int value = 0;
-  bool any = false;
-  while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
-    any = true;
-    value = value * 10 + (json[pos++] - '0');
-  }
-  return any ? value : fallback;
-}
-
-struct LookupDictionaryEntry {
-  std::string word;
-  std::string reading;
-  std::string dictionary;
-  std::string meaning;
+// tTJSVariant 的字段偏移**不是**插件 ABI 的稳定部分（各 krkr 分支的 pack 与字段序都可能
+// 不同），所以不写死：安装时求值一个已知 64 位常量，按候选布局逐个比对，命中的那套才启用。
+// 猜错的代价是把游戏进程里的随机内存当指针解引用，宁可探一次。
+struct TjsVariantLayout {
+  uint32_t type_offset;
+  uint32_t value_offset;
 };
 
-bool ParseLookupResponse(const std::string& json, int* best_length,
-                         LookupDictionaryEntry* selected) {
-  if (best_length == nullptr || selected == nullptr) return false;
-  *best_length = FindJsonIntegerField(json, "bestLength", 1);
-  const size_t entries_key = json.find("\"entries\"");
-  if (entries_key == std::string::npos) return false;
-  size_t pos = json.find('[', entries_key);
-  if (pos == std::string::npos) return false;
-  LookupDictionaryEntry fallback;
-  bool have_fallback = false;
-  while (++pos < json.size()) {
-    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\r' ||
-                                 json[pos] == '\n' || json[pos] == ',')) pos++;
-    if (pos >= json.size() || json[pos] == ']') break;
-    if (json[pos] != '\"') return false;
-    std::string encoded_entry;
-    size_t next = pos;
-    if (!ParseJsonString(json, pos, &encoded_entry, &next)) return false;
-    LookupDictionaryEntry entry;
-    FindJsonStringField(encoded_entry, "word", &entry.word);
-    FindJsonStringField(encoded_entry, "reading", &entry.reading);
-    FindJsonStringField(encoded_entry, "dictionaryName", &entry.dictionary);
-    FindJsonStringField(encoded_entry, "meaning", &entry.meaning);
-    if (!entry.word.empty() && !entry.dictionary.empty()) {
-      if (!have_fallback) {
-        fallback = entry;
-        have_fallback = true;
-      }
-      if (entry.dictionary.find("Jitendex") != std::string::npos) {
-        *selected = entry;
-        return true;
-      }
-    }
-    pos = next - 1;
-  }
-  if (have_fallback) *selected = fallback;
-  return have_fallback;
+constexpr uint32_t kTjsVariantBytes = 64;  // 实测 16；留足余量并全部清零后再交给引擎赋值
+constexpr uint32_t kTjsVariantTypeString = 2;
+constexpr uint32_t kTjsVariantTypeInteger = 4;
+constexpr int64_t kTjsVariantProbeMagic = 0x0123456789ABCDEFLL;
+constexpr TjsVariantLayout kTjsVariantLayouts[] = {{0u, 8u}, {0u, 4u}, {8u, 0u}};
+constexpr int kTjsVariantProbeAttempts = 8;
+
+TjsVariantLayout g_lookup_variant = {0u, 8u};
+bool g_lookup_variant_ready = false;
+int g_lookup_variant_attempts = 0;
+
+std::wstring g_lookup_card_path;  // 备路 PNG，恒在 %TEMP%（游戏目录一个字节都不写）
+
+// 卡片层就是卡片本身（cardW×cardH，摆在 anchor 上），所以目标缓冲整块都归本帧所有：
+// 既不需要脏矩形，也不需要在层内做偏移——这两样都是"全视口卡片层"那版才需要的。
+int32_t g_lookup_frame_anchor_x = 0;
+int32_t g_lookup_frame_anchor_y = 0;
+uint64_t g_lookup_presented_seq = 0;
+uint64_t g_lookup_hit_seq = 0;
+int64_t g_lookup_last_notify = -1;
+bool g_lookup_card_shown = false;
+bool g_lookup_sensor_live = false;
+bool g_lookup_input_pending = false;  // 上一帧撞到每帧搬运上限，队列里还有剩
+uint32_t g_lookup_sensor_idle_ticks = 0;
+
+void WriteKirikiriSharedU64(volatile uint64_t* value, uint64_t next) {
+  if (value == nullptr) return;
+  InterlockedExchange64(reinterpret_cast<volatile LONGLONG*>(value),
+                        static_cast<LONGLONG>(next));
 }
 
-std::string PlainLookupMeaning(const std::string& meaning) {
-  const size_t glossary = meaning.find("glossary");
-  const size_t start = glossary == std::string::npos ? 0 : glossary;
-  size_t limit = meaning.find("extra-info", start);
-  if (limit == std::string::npos) limit = meaning.size();
-  std::vector<std::string> leaves;
-  size_t pos = start;
-  while (pos < limit && leaves.size() < 6) {
-    const size_t key = meaning.find("\"content\"", pos);
-    if (key == std::string::npos || key >= limit) break;
-    const size_t colon = meaning.find(':', key + 9);
-    if (colon == std::string::npos || colon >= limit) break;
-    size_t quote = colon + 1;
-    while (quote < limit && (meaning[quote] == ' ' || meaning[quote] == '\t')) quote++;
-    std::string leaf;
-    size_t next = quote + 1;
-    if (quote < limit && meaning[quote] == '\"' &&
-        ParseJsonString(meaning, quote, &leaf, &next) &&
-        !leaf.empty() && leaf != "glossary" && leaf != "noun") {
-      leaves.push_back(leaf);
-    }
-    pos = std::max(next, key + 9);
-  }
-  std::string result;
-  for (size_t i = 0; i < leaves.size(); i++) {
-    if (!result.empty()) result += "  ";
-    result += std::to_string(i + 1) + ". " + leaves[i];
-  }
-  return result.empty() ? "Dictionary entry found" : result;
+uint32_t LookupEnabledNow() {
+  if (g_header == nullptr) return 0;
+  return static_cast<uint32_t>(InterlockedCompareExchange(
+      reinterpret_cast<volatile LONG*>(&g_header->lookup_enabled), 0, 0));
 }
 
-bool ReadLookupRequest(int* id, std::wstring* query) {
-  if (id == nullptr || query == nullptr || g_lookup_request_path.empty()) return false;
-  HANDLE file = CreateFileW(g_lookup_request_path.c_str(), GENERIC_READ,
-                            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-  if (file == INVALID_HANDLE_VALUE) return false;
-  const DWORD size = GetFileSize(file, nullptr);
-  if (size == INVALID_FILE_SIZE || size == 0 || size > 64 * 1024) {
-    CloseHandle(file);
+void SetLookupDiag(uint32_t bits) {
+  if (g_header == nullptr) return;
+  InterlockedOr(reinterpret_cast<volatile LONG*>(&g_header->lookup_diag),
+                static_cast<LONG>(bits));
+}
+
+// UTF-16 → UTF-8，按 UTF-8 首字节边界截断。切碎多字节序列等于整行报废（host 侧按 UTF-8
+// 解码），而"整行不截断"只是**语义**上的不截断——真超了 kLookupLineBytes 仍必须安全收尾。
+uint32_t EncodeLookupLineUtf8(const wchar_t* line, uint8_t* out, uint32_t capacity) {
+  if (line == nullptr || out == nullptr || capacity == 0) return 0;
+  // 只在游戏主线程的连续帧回调里用，故用静态缓冲避免每帧几 KB 的栈压力。
+  static char scratch[kKirikiriLookupLineChars * 4];
+  const int written =
+      WideCharToMultiByte(CP_UTF8, 0, line, -1, scratch,
+                          static_cast<int>(sizeof(scratch)), nullptr, nullptr);
+  if (written <= 1) return 0;  // 只有终止符 = 空行
+  uint32_t bytes = static_cast<uint32_t>(written - 1);
+  if (bytes > capacity) {
+    bytes = capacity;
+    while (bytes > 0 && (static_cast<uint8_t>(scratch[bytes]) & 0xC0u) == 0x80u) {
+      bytes--;
+    }
+  }
+  memcpy(out, scratch, bytes);
+  return bytes;
+}
+
+uint32_t ReadVariantU32(const uint8_t* variant, uint32_t offset) {
+  uint32_t value = 0;
+  memcpy(&value, variant + offset, sizeof(value));
+  return value;
+}
+
+int64_t ReadVariantI64(const uint8_t* variant, uint32_t offset) {
+  int64_t value = 0;
+  memcpy(&value, variant + offset, sizeof(value));
+  return value;
+}
+
+// 分配 ttstr → 求值 → 释放。缓冲必须先清零：TJS 的 tTJSVariant 赋值会先 Clear() 目标，
+// 全零在任何候选布局下都是 tvtVoid，Clear() 不会去释放一个野指针。
+bool ExecuteTjsExpressionGuarded(const wchar_t* expression, uint8_t* variant) {
+  if (g_lookup_execute_expression == nullptr || g_lookup_alloc_string == nullptr ||
+      g_lookup_release_string == nullptr || expression == nullptr) {
     return false;
   }
-  std::vector<uint8_t> bytes(size);
-  DWORD read = 0;
-  const bool ok = ReadFile(file, bytes.data(), size, &read, nullptr) != FALSE;
-  CloseHandle(file);
-  if (!ok || read != size) return false;
-  std::wstring text;
-  if (size >= 2 && bytes[0] == 0xff && bytes[1] == 0xfe) {
-    const wchar_t* begin = reinterpret_cast<const wchar_t*>(bytes.data() + 2);
-    text.assign(begin, begin + (size - 2) / sizeof(wchar_t));
-  } else {
-    size_t offset = size >= 3 && bytes[0] == 0xef && bytes[1] == 0xbb && bytes[2] == 0xbf ? 3 : 0;
-    text = Utf8ToWide(std::string(reinterpret_cast<const char*>(bytes.data() + offset),
-                                  size - offset));
-  }
-  const size_t newline = text.find_first_of(L"\r\n");
-  if (newline == std::wstring::npos) return false;
-  *id = _wtoi(text.substr(0, newline).c_str());
-  const size_t query_start = text.find_first_not_of(L"\r\n", newline);
-  if (*id <= 0 || query_start == std::wstring::npos) return false;
-  *query = text.substr(query_start);
-  while (!query->empty() && (query->back() == L'\r' || query->back() == L'\n' ||
-                             query->back() == L'\0')) query->pop_back();
-  return !query->empty();
-}
-
-bool PostLookupRequest(const std::wstring& query, std::string* response) {
-  if (response == nullptr) return false;
-  wchar_t port_text[16] = {};
-  wchar_t token[256] = {};
-  if (GetEnvironmentVariableW(L"FUSHI_KIRIKIRI_LOOKUP_PORT", port_text, 16) == 0 ||
-      GetEnvironmentVariableW(L"FUSHI_KIRIKIRI_LOOKUP_TOKEN", token, 256) == 0) return false;
-  const int port = _wtoi(port_text);
-  if (port <= 0 || port > 65535) return false;
-  HINTERNET session = WinHttpOpen(L"FushiKirikiriLookup/1.0",
-                                  WINHTTP_ACCESS_TYPE_NO_PROXY,
-                                  WINHTTP_NO_PROXY_NAME,
-                                  WINHTTP_NO_PROXY_BYPASS, 0);
-  if (session == nullptr) return false;
-  WinHttpSetTimeouts(session, 1000, 1000, 2000, 5000);
-  HINTERNET connection = WinHttpConnect(session, L"127.0.0.1",
-                                        static_cast<INTERNET_PORT>(port), 0);
-  HINTERNET request = connection == nullptr ? nullptr :
-      WinHttpOpenRequest(connection, L"POST", L"/api/lookup/dictionary", nullptr,
-                         WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, 0);
+  memset(variant, 0, kTjsVariantBytes);
+  TjsVariantString* text = nullptr;
   bool ok = false;
-  if (request != nullptr) {
-    const std::wstring auth = std::wstring(L"Authorization: Bearer ") + token + L"\r\n" +
-                              L"Content-Type: application/json\r\n";
-    const std::string body = std::string("{\"term\":\"") +
-        EscapeJsonString(WideToUtf8(query)) + "\",\"maximumTerms\":1,\"record\":false}";
-    ok = WinHttpAddRequestHeaders(request, auth.c_str(), static_cast<DWORD>(-1),
-                                  WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE) != FALSE &&
-         WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
-                            const_cast<char*>(body.data()), static_cast<DWORD>(body.size()),
-                            static_cast<DWORD>(body.size()), 0) != FALSE &&
-         WinHttpReceiveResponse(request, nullptr) != FALSE;
-    DWORD status = 0;
-    DWORD status_size = sizeof(status);
-    if (!ok || !WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE |
-                                    WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
-                                    &status, &status_size, WINHTTP_NO_HEADER_INDEX) || status != 200) {
-      ok = false;
+  try {
+    text = g_lookup_alloc_string(expression);
+    if (text != nullptr) {
+      const TjsString content = {text};
+      g_lookup_execute_expression(content, variant);
+      ok = true;
     }
-    while (ok) {
-      DWORD available = 0;
-      if (!WinHttpQueryDataAvailable(request, &available)) { ok = false; break; }
-      if (available == 0) break;
-      const size_t old_size = response->size();
-      response->resize(old_size + available);
-      DWORD chunk = 0;
-      if (!WinHttpReadData(request, response->data() + old_size, available, &chunk)) {
-        ok = false; break;
-      }
-      response->resize(old_size + chunk);
-      if (response->size() > 8 * 1024 * 1024) { ok = false; break; }
-    }
+  } catch (...) {
+    // 传感器还没建立时表达式会引用不存在的 global，TJS 抛异常是正常时序而非故障。
+    ok = false;
   }
-  if (request != nullptr) WinHttpCloseHandle(request);
-  if (connection != nullptr) WinHttpCloseHandle(connection);
-  WinHttpCloseHandle(session);
-  SecureZeroMemory(token, sizeof(token));
+  if (text != nullptr) g_lookup_release_string(text);
   return ok;
 }
 
-void QueueLookupResultScript(int id, const LookupDictionaryEntry& entry,
-                             int best_length) {
-  const std::wstring word = EscapeTjsString(Utf8ToWide(entry.word));
-  const std::wstring reading = EscapeTjsString(Utf8ToWide(entry.reading));
-  const std::wstring dictionary = EscapeTjsString(Utf8ToWide(entry.dictionary));
-  const std::wstring definition = EscapeTjsString(Utf8ToWide(PlainLookupMeaning(entry.meaning)));
-  std::wstring script = L"if(typeof global.fushiLookupShowResult != \"undefined\") "
-                        L"global.fushiLookupShowResult(";
-  script += std::to_wstring(id) + L",\"" + word + L"\",\"" + reading + L"\",\"" +
-            dictionary + L"\",\"" + definition + L"\"," +
-            std::to_wstring(std::max(1, best_length)) + L");";
-  EnterCriticalSection(&g_lookup_response_cs);
-  g_lookup_response_script = std::move(script);
-  LeaveCriticalSection(&g_lookup_response_cs);
-}
-
-DWORD WINAPI KiriKiriLookupWorker(void*) {
-  int last_id = 0;
-  while (!g_stop) {
-    int id = 0;
-    std::wstring query;
-    if (ReadLookupRequest(&id, &query) && id != last_id) {
-      last_id = id;
-      std::string response;
-      LookupDictionaryEntry entry;
-      int best_length = 1;
-      if (PostLookupRequest(query, &response) &&
-          ParseLookupResponse(response, &best_length, &entry)) {
-        QueueLookupResultScript(id, entry, best_length);
-      } else {
-        LookupDictionaryEntry error;
-        error.word = WideToUtf8(query.substr(0, std::min<size_t>(query.size(), 24)));
-        error.dictionary = "Hibiki lookup";
-        error.meaning = "No dictionary result. Make sure Fushi dictionary service is running.";
-        QueueLookupResultScript(id, error, 1);
-      }
+bool ProbeTjsVariantLayout() {
+  if (g_lookup_variant_attempts >= kTjsVariantProbeAttempts) return false;
+  g_lookup_variant_attempts++;
+  uint8_t variant[kTjsVariantBytes];
+  if (!ExecuteTjsExpressionGuarded(L"0x0123456789ABCDEF", variant)) return false;
+  for (const TjsVariantLayout& candidate : kTjsVariantLayouts) {
+    if (ReadVariantU32(variant, candidate.type_offset) != kTjsVariantTypeInteger) {
+      continue;
     }
-    Sleep(50);
+    if (ReadVariantI64(variant, candidate.value_offset) != kTjsVariantProbeMagic) {
+      continue;
+    }
+    g_lookup_variant = candidate;
+    return true;
   }
-  return 0;
+  return false;
 }
 
-class KiriKiriLookupResultCallback final : public TvpContinuousEventCallback {
+bool EvaluateTjsInteger(const wchar_t* expression, int64_t* value) {
+  if (value == nullptr || !g_lookup_variant_ready) return false;
+  uint8_t variant[kTjsVariantBytes];
+  if (!ExecuteTjsExpressionGuarded(expression, variant)) return false;
+  if (ReadVariantU32(variant, g_lookup_variant.type_offset) != kTjsVariantTypeInteger) {
+    return false;
+  }
+  *value = ReadVariantI64(variant, g_lookup_variant.value_offset);
+  return true;
+}
+
+// SEH 守卫从 tTJSVariantString 拷字符（只碰裸数组，可 __try）。长串优先，缺则内联短串。
+bool CopyTjsVariantStringGuarded(const TjsVariantString* text, wchar_t* out,
+                                 size_t out_chars) {
+  __try {
+    const wchar_t* src =
+        text->long_string != nullptr ? text->long_string : text->short_string;
+    if (src == nullptr) return false;
+    size_t k = 0;
+    for (; src[k] != 0 && k + 1 < out_chars; k++) out[k] = src[k];
+    out[k] = 0;
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+}
+
+bool EvaluateTjsString(const wchar_t* expression, wchar_t* out, size_t out_chars) {
+  if (out == nullptr || out_chars == 0 || !g_lookup_variant_ready) return false;
+  uint8_t variant[kTjsVariantBytes];
+  if (!ExecuteTjsExpressionGuarded(expression, variant)) return false;
+  if (ReadVariantU32(variant, g_lookup_variant.type_offset) != kTjsVariantTypeString) {
+    return false;
+  }
+  TjsVariantString* text = nullptr;
+  memcpy(&text, variant + g_lookup_variant.value_offset, sizeof(text));
+  if (text == nullptr) {  // TJS 用空指针表示空串
+    out[0] = 0;
+    return true;
+  }
+  const bool copied = CopyTjsVariantStringGuarded(text, out, out_chars);
+  if (g_lookup_release_string != nullptr) g_lookup_release_string(text);
+  return copied;
+}
+
+void ExecuteTjsScriptGuarded(const wchar_t* script) {
+  if (g_lookup_execute_script == nullptr || g_lookup_alloc_string == nullptr ||
+      g_lookup_release_string == nullptr || script == nullptr) {
+    return;
+  }
+  TjsVariantString* text = nullptr;
+  try {
+    text = g_lookup_alloc_string(script);
+    if (text != nullptr) {
+      const TjsString content = {text};
+      g_lookup_execute_script(content, nullptr);
+    }
+  } catch (...) {
+    // 插件 ABI 边界绝不把 C++/TJS 异常抛回游戏事件循环。
+  }
+  if (text != nullptr) g_lookup_release_string(text);
+}
+
+// 回执脚本。七个实参**全部**是 std::to_wstring 出来的整数，脚本里不存在任何来自 host、
+// 游戏或用户的字符串——注入面不是"escape 得更严"，而是结构上没有可注入的位置。参数个数
+// 不是约束点：约束点是"不许把动态字符串拼进会被 eval 的文本"。
+void ApplyKirikiriLookupCard(uint64_t seq, uint32_t highlight_start,
+                             uint32_t highlight_len, int32_t anchor_x,
+                             int32_t anchor_y, uint32_t card_w, uint32_t card_h,
+                             bool png_route) {
+  std::wstring script = png_route ? L"global.fushiLookupApplyPng("
+                                  : L"global.fushiLookupApply(";
+  script += std::to_wstring(seq);
+  script += L",";
+  script += std::to_wstring(highlight_start);
+  script += L",";
+  script += std::to_wstring(highlight_len);
+  script += L",";
+  script += std::to_wstring(anchor_x);
+  script += L",";
+  script += std::to_wstring(anchor_y);
+  script += L",";
+  script += std::to_wstring(card_w);
+  script += L",";
+  script += std::to_wstring(card_h);
+  script += L");";
+  ExecuteTjsScriptGuarded(script.c_str());
+}
+
+// 写像素之前调：卡片层不存在就建，尺寸/位置不对就调。层是**按卡片尺寸**建的，所以这一步
+// 之后目标缓冲整块都属于本帧。
+void PrepareKirikiriLookupCard(int32_t anchor_x, int32_t anchor_y, uint32_t card_w,
+                               uint32_t card_h) {
+  std::wstring script = L"global.fushiLookupPrepare(";
+  script += std::to_wstring(anchor_x);
+  script += L",";
+  script += std::to_wstring(anchor_y);
+  script += L",";
+  script += std::to_wstring(card_w);
+  script += L",";
+  script += std::to_wstring(card_h);
+  script += L");";
+  ExecuteTjsScriptGuarded(script.c_str());
+}
+
+void HideKirikiriLookupCard() {
+  if (!g_lookup_card_shown) return;
+  g_lookup_card_shown = false;
+  ApplyKirikiriLookupCard(0, 0, 0, 0, 0, 0, 0, false);
+}
+
+// 逐行拷。源侧（共享内存）按契约恒为正 pitch、恒自顶向下；目标侧是游戏 Layer，
+// mainImageBufferPitch 可能为负（KiriKiri 允许自底向上的行序），故行步进用带符号 stride：
+// base + row*stride 对两种行序都走出同一个视觉行序。层已按卡片尺寸备好，故整块都是本帧的，
+// 不需要擦上一帧、也不需要层内偏移。
+bool BlitLookupFrameGuarded(uint8_t* base, int32_t stride, uint32_t width,
+                            uint32_t height, uint32_t source_pitch,
+                            const uint8_t* pixels) {
+  __try {
+    for (uint32_t row = 0; row < height; ++row) {
+      uint8_t* dst = base + static_cast<ptrdiff_t>(row) * stride;
+      memcpy(dst, pixels + static_cast<size_t>(row) * source_pitch,
+             static_cast<size_t>(width) * 4u);
+    }
+    return true;
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return false;
+  }
+}
+
+void PresentKirikiriLookupFrame() {
+  if (g_header == nullptr) return;
+  fushi_voice_hook::LookupHitSlot* hit = fushi_voice_hook::LookupHitOf(g_header);
+  const uint64_t hit_seq = hit == nullptr ? 0 : ReadKirikiriSharedU64(&hit->seq);
+
+  fushi_voice_hook::LookupFrame* best = nullptr;
+  uint32_t best_index = 0;
+  uint64_t best_seq = 0;
+  for (uint32_t i = 0; i < g_header->lookup_frame_count; ++i) {
+    fushi_voice_hook::LookupFrame* frame = fushi_voice_hook::LookupFrameAt(g_header, i);
+    if (frame == nullptr || frame->ready == 0) continue;
+    // 判据只有一份，在契约头（ShouldApplyLookupFrame），replay 测试跑的是同一个函数。
+    // seq 是**发布序**（host 每投一帧 +1），hit_seq 才是"回应哪次查询"；两者分开之后
+    // 收卡帧就是普通一帧，不会再被自己刚 present 过的那个 seq 挡在门外——那正是收卡
+    // 一直不生效的根因。
+    const uint64_t seq = ReadKirikiriSharedU64(&frame->seq);
+    if (seq <= best_seq) continue;  // 本轮已找到更新的候选
+    if (!fushi_voice_hook::ShouldApplyLookupFrame(seq, frame->hit_seq,
+                                                  g_lookup_presented_seq,
+                                                  hit_seq)) {
+      continue;
+    }
+    best = frame;
+    best_index = i;
+    best_seq = seq;
+  }
+  if (best == nullptr) return;
+  g_lookup_presented_seq = best_seq;
+
+  // 收卡由 flags 自述，不靠"width==0 就是收卡"的魔法编码——后者要求每个读侧都记住这条
+  // 隐规则，而它和"host 投了张废帧"在字节上完全一样。必须在 IsLookupFrameSane 之前认掉：
+  // 收卡帧按定义没有像素，过不了那道校验。
+  if ((best->flags & fushi_voice_hook::kLookupFrameDismiss) != 0) {
+    g_lookup_card_shown = true;  // 强制发一次收起，别让"以为已经隐藏"把信号吞掉
+    HideKirikiriLookupCard();
+    return;
+  }
+
+  // 跨进程来的 width/height/pitch 全是不可信输入：先过契约校验，再谈拷贝。
+  if (!fushi_voice_hook::IsLookupFrameSane(g_header, best) ||
+      static_cast<uint32_t>(best_seq % g_header->lookup_frame_count) != best_index) {
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFrameRejected);
+    return;
+  }
+  const uint8_t* pixels = fushi_voice_hook::LookupBitmapAt(g_header, best_index);
+  if (pixels == nullptr) {
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFrameRejected);
+    return;
+  }
+
+  const uint32_t highlight_start = best->highlight_start;
+  const uint32_t highlight_len = best->highlight_len;
+  const int32_t anchor_x = best->anchor_x;
+  const int32_t anchor_y = best->anchor_y;
+  const uint32_t width = best->width;
+  const uint32_t height = best->height;
+  const uint32_t source_pitch = best->pitch;
+
+  // 建/调卡片层必须在取写指针**之前**：层是按本帧 cardW×cardH 建的，尺寸变化会重新分配
+  // 缓冲，先取指针再改尺寸就是往已经释放的内存里写。
+  PrepareKirikiriLookupCard(anchor_x, anchor_y, width, height);
+
+  int64_t layer_w = 0;
+  int64_t layer_h = 0;
+  int64_t buffer = 0;
+  int64_t stride64 = 0;
+  // 写指针**每帧重取**：copy-on-write 与 layer 尺寸变化都会让上一帧的指针失效，缓存它就是
+  // 往已经不属于该层的内存里写。pitch 必须在取写指针之后读——取写指针可能换掉整块缓冲。
+  const bool geometry =
+      EvaluateTjsInteger(L"global.fushiLookupCard.imageWidth", &layer_w) &&
+      EvaluateTjsInteger(L"global.fushiLookupCard.imageHeight", &layer_h) &&
+      EvaluateTjsInteger(L"global.fushiLookupCard.mainImageBufferForWrite", &buffer) &&
+      EvaluateTjsInteger(L"global.fushiLookupCard.mainImageBufferPitch", &stride64) &&
+      buffer != 0;
+
+  if (!geometry) {
+    // 备路：主路不可用时由 host 把这张 cardW×cardH 的卡片写成 PNG 落 %TEMP%，
+    // TJS loadImages 进来。慢一个数量级，但零新 ABI，且同样不碰游戏目录（.sig 校验）。
+    if (g_lookup_card_path.empty()) return;
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFallbackPngRoute);
+    g_lookup_frame_anchor_x = anchor_x;
+    g_lookup_frame_anchor_y = anchor_y;
+    g_lookup_card_shown = true;
+    ApplyKirikiriLookupCard(best_seq, highlight_start, highlight_len, anchor_x,
+                            anchor_y, width, height, true);
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFramePresented);
+    return;
+  }
+  SetLookupDiag(fushi_voice_hook::kLookupDiagBufferRouteReady);
+
+  // 层就是卡片，所以尺寸必须**逐像素相等**——不等说明 prepare 没生效（层被别处改过、或
+  // setImageSize 失败），此时按本帧尺寸拷就是越界写。这是比"装得下就行"更强也更简单的
+  // 不变量：目标缓冲整块都归本帧。
+  const int32_t stride = static_cast<int32_t>(stride64);
+  const int32_t stride_abs = stride < 0 ? -stride : stride;
+  if (layer_w != static_cast<int64_t>(width) ||
+      layer_h != static_cast<int64_t>(height) ||
+      stride_abs < static_cast<int32_t>(width) * 4) {
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFrameRejected);
+    return;
+  }
+
+  if (!BlitLookupFrameGuarded(
+          reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(buffer)), stride, width,
+          height, source_pitch, pixels)) {
+    SetLookupDiag(fushi_voice_hook::kLookupDiagFrameRejected);
+    return;
+  }
+
+  // 拷完复查 seq/ready：host 若在拷贝中途改写了这一格，画面就是撕裂的半张卡，宁可不显示
+  // 让下一帧重来。
+  if (ReadKirikiriSharedU64(&best->seq) != best_seq || best->ready == 0) return;
+
+  g_lookup_frame_anchor_x = anchor_x;
+  g_lookup_frame_anchor_y = anchor_y;
+  g_lookup_card_shown = true;
+  ApplyKirikiriLookupCard(best_seq, highlight_start, highlight_len, anchor_x,
+                          anchor_y, width, height, false);
+  SetLookupDiag(fushi_voice_hook::kLookupDiagFramePresented);
+}
+
+void PublishKirikiriLookupHit() {
+  fushi_voice_hook::LookupHitSlot* slot = fushi_voice_hook::LookupHitOf(g_header);
+  if (slot == nullptr) return;
+  int64_t seq = 0;
+  if (!EvaluateTjsInteger(L"global.fushiLookupHitSeq", &seq)) return;
+  if (seq <= 0 || static_cast<uint64_t>(seq) == g_lookup_hit_seq) return;
+
+  int64_t char_index = 0;
+  int64_t char_count = 0;
+  int64_t glyph_x = 0;
+  int64_t glyph_y = 0;
+  int64_t glyph_w = 0;
+  int64_t glyph_h = 0;
+  int64_t view_w = 0;
+  int64_t view_h = 0;
+  int64_t flags = 0;
+  if (!EvaluateTjsInteger(L"global.fushiLookupHitCharIndex", &char_index) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitCharCount", &char_count) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitGlyphX", &glyph_x) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitGlyphY", &glyph_y) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitGlyphW", &glyph_w) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitGlyphH", &glyph_h) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitViewW", &view_w) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitViewH", &view_h) ||
+      !EvaluateTjsInteger(L"global.fushiLookupHitFlags", &flags)) {
+    return;
+  }
+  if (char_count <= 0 || char_index < 0 || char_index >= char_count) return;
+
+  // 只在游戏主线程用；放静态区避免每次命中往栈上压 2.4KB。
+  static wchar_t line[kKirikiriLookupLineChars];
+  if (!EvaluateTjsString(L"global.fushiLookupHitLine", line,
+                         kKirikiriLookupLineChars)) {
+    return;
+  }
+  const uint32_t line_bytes = EncodeLookupLineUtf8(
+      line, slot->line_utf8, fushi_voice_hook::kLookupLineBytes);
+  if (line_bytes == 0) return;
+
+  slot->char_index = static_cast<uint32_t>(char_index);
+  slot->char_count = static_cast<uint32_t>(char_count);
+  slot->glyph_x = static_cast<int32_t>(glyph_x);
+  slot->glyph_y = static_cast<int32_t>(glyph_y);
+  slot->glyph_w = static_cast<int32_t>(glyph_w);
+  slot->glyph_h = static_cast<int32_t>(glyph_h);
+  slot->view_w = static_cast<int32_t>(view_w);
+  slot->view_h = static_cast<int32_t>(view_h);
+  slot->flags = static_cast<uint32_t>(flags) & fushi_voice_hook::kLookupHitFlagSubmit;
+  slot->line_bytes = line_bytes;
+  // seq **最后**写：Interlocked 是全栅栏，保证上面的 payload 对 host 先可见。
+  WriteKirikiriSharedU64(&slot->seq, static_cast<uint64_t>(seq));
+  g_lookup_hit_seq = static_cast<uint64_t>(seq);
+  InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(&g_header->lookup_hit_count));
+  SetLookupDiag(fushi_voice_hook::kLookupDiagGeometryObserved |
+                fushi_voice_hook::kLookupDiagHitSubmitted);
+}
+
+void DrainKirikiriLookupInput() {
+  fushi_voice_hook::LookupInputSlot* inputs = fushi_voice_hook::LookupInputsOf(g_header);
+  const uint32_t slots = g_header->lookup_input_slot_count;
+  g_lookup_input_pending = false;
+  if (inputs == nullptr || slots == 0) return;
+  // 每帧至多搬 32 条（TJS 侧已把连续 move 就地合并），回调不做无界循环。撞上限时置 pending，
+  // 让下一帧继续搬——否则 notify 不再变化，剩下的事件会一直卡在 TJS 队列里。
+  g_lookup_input_pending = true;
+  for (int drained = 0; drained < 32; ++drained) {
+    int64_t packed = 0;
+    if (!EvaluateTjsInteger(L"global.fushiLookupInputTake()", &packed)) break;
+    if (packed == 0) {
+      g_lookup_input_pending = false;
+      break;
+    }
+    const uint64_t next =
+        ReadKirikiriSharedU64(&g_header->lookup_input_count) + 1;
+    fushi_voice_hook::LookupInputSlot* slot = &inputs[(next - 1) % slots];
+    // anchor 只有这一侧知道（它在帧元数据里），故减法在 DLL 做；TJS 报的是视口坐标。
+    slot->x = static_cast<int32_t>((packed >> 20) & 0xFFFF) - 32768 -
+              g_lookup_frame_anchor_x;
+    slot->y = static_cast<int32_t>((packed >> 36) & 0xFFFF) - 32768 -
+              g_lookup_frame_anchor_y;
+    slot->kind = static_cast<uint32_t>(packed & 0xF);
+    slot->wheel = static_cast<int32_t>((packed >> 8) & 0xFFF) - 2048;
+    slot->keys = static_cast<uint32_t>((packed >> 4) & 0xF);
+    slot->reserved = 0;
+    WriteKirikiriSharedU64(&slot->seq, next);
+    WriteKirikiriSharedU64(&g_header->lookup_input_count, next);
+  }
+}
+
+// 游戏主线程的每帧入口。开关关着、查词区不存在、传感器还没建立时，这里一个字节都不写。
+void PumpKirikiriLookup() {
+  if (g_stop || !fushi_voice_hook::HasLookupRegion(g_header)) return;
+  if (LookupEnabledNow() == 0) {
+    HideKirikiriLookupCard();
+    return;
+  }
+  if (!g_lookup_variant_ready) {
+    if (!ProbeTjsVariantLayout()) return;
+    g_lookup_variant_ready = true;
+    SetLookupDiag(fushi_voice_hook::kLookupDiagExpressionReady);
+  }
+  if (!g_lookup_sensor_live) {
+    // TJS bootstrap 由 System.addContinuousHandler 驱动，可能比这里晚若干帧；在它建立
+    // 之前每帧求值都会走一次 TJS 异常，故退避到每 30 帧探一次。
+    if (++g_lookup_sensor_idle_ticks < 30) return;
+    g_lookup_sensor_idle_ticks = 0;
+  }
+  int64_t notify = 0;
+  // 稳态下每帧只有这一次求值：notify 不变就一行 TJS 都不再跑。
+  if (!EvaluateTjsInteger(L"global.fushiLookupNotify", &notify)) return;
+  if (!g_lookup_sensor_live) {
+    g_lookup_sensor_live = true;
+    SetLookupDiag(fushi_voice_hook::kLookupDiagSensorInstalled);
+  }
+  if (notify != g_lookup_last_notify) {
+    g_lookup_last_notify = notify;
+    PublishKirikiriLookupHit();
+    DrainKirikiriLookupInput();
+  } else if (g_lookup_input_pending) {
+    DrainKirikiriLookupInput();
+  }
+  PresentKirikiriLookupFrame();
+}
+
+class KiriKiriLookupPumpCallback final : public TvpContinuousEventCallback {
  public:
   void __cdecl OnContinuousCallback(uint64_t) override {
-    if (!g_lookup_response_cs_ready || g_lookup_execute_script == nullptr ||
-        g_lookup_alloc_string == nullptr || g_lookup_release_string == nullptr) return;
-    std::wstring script;
-    EnterCriticalSection(&g_lookup_response_cs);
-    script.swap(g_lookup_response_script);
-    LeaveCriticalSection(&g_lookup_response_cs);
-    if (script.empty()) return;
-    TjsVariantString* value = nullptr;
     try {
-      value = g_lookup_alloc_string(script.c_str());
-      if (value != nullptr) {
-        const TjsString content = {value};
-        g_lookup_execute_script(content, nullptr);
-      }
+      PumpKirikiriLookup();
     } catch (...) {
+      // 插件 ABI 边界绝不把 C++/TJS 异常抛回游戏事件循环。
     }
-    if (value != nullptr) g_lookup_release_string(value);
   }
 };
 
-KiriKiriLookupResultCallback g_lookup_result_callback;
+KiriKiriLookupPumpCallback g_lookup_pump_callback;
 
-bool PrepareKirikiriLookupRequestPath() {
+// 备路 PNG 路径。反斜杠一律换成正斜杠：KiriKiri 的 storage 名接受 '/'，脚本里因此不存在
+// 任何需要转义的字符，prototype 那套 TJS 字符串转义 helper 整条删除。
+bool PrepareKirikiriLookupCardPath() {
   wchar_t temp[MAX_PATH] = {};
   const DWORD length = GetTempPathW(MAX_PATH, temp);
   if (length == 0 || length >= MAX_PATH) return false;
-  g_lookup_request_path = temp;
-  g_lookup_request_path += L"fushi-kirikiri-lookup-" + std::to_wstring(GetCurrentProcessId()) + L".txt";
-  DeleteFileW(g_lookup_request_path.c_str());
+  std::wstring path = temp;
+  path += L"fushi-kirikiri-card-";
+  path += std::to_wstring(GetCurrentProcessId());
+  path += L".png";
+  for (wchar_t& ch : path) {
+    if (ch == L'\\') ch = L'/';
+  }
+  // 反常路径（残留引号/反斜杠/换行）宁可放弃备路，也不把可疑内容塞进脚本。
+  if (path.find_first_of(L"\"\\\r\n") != std::wstring::npos) return false;
+  g_lookup_card_path = path;
   return true;
+}
+
+void ReplaceLookupPlaceholder(std::wstring& script, const wchar_t* placeholder,
+                              const std::wstring& value) {
+  const size_t pos = script.find(placeholder);
+  if (pos == std::wstring::npos) return;
+  script.replace(pos, wcslen(placeholder), value);
 }
 
 std::wstring BuildKirikiriLookupBootstrapScript() {
   std::wstring script = kKirikiriLookupBootstrapScript;
-  const std::wstring placeholder = L"__FUSHI_REQUEST_PATH__";
-  const size_t pos = script.find(placeholder);
-  if (pos != std::wstring::npos) {
-    script.replace(pos, placeholder.size(), EscapeTjsString(g_lookup_request_path));
-  }
+  ReplaceLookupPlaceholder(script, L"__FUSHI_PROBE_MODE__",
+                           kKirikiriLookupProbePaths ? L"1" : L"0");
+  ReplaceLookupPlaceholder(script, L"__FUSHI_CARD_PATH__", g_lookup_card_path);
   return script;
-}
-
-bool IsKirikiriLookupProbeRequested() {
-  wchar_t value[8] = {};
-  const DWORD length = GetEnvironmentVariableW(
-      L"FUSHI_KIRIKIRI_NATIVE_LOOKUP_PROBE", value,
-      static_cast<DWORD>(sizeof(value) / sizeof(value[0])));
-  return length == 1 && value[0] == L'1';
 }
 
 class KiriKiriLookupBootstrapCallback final : public TvpContinuousEventCallback {
@@ -2061,8 +1935,9 @@ class KiriKiriLookupBootstrapCallback final : public TvpContinuousEventCallback 
   void __cdecl OnContinuousCallback(uint64_t) override {
     if (InterlockedCompareExchange(&g_lookup_bootstrap_state, 2, 1) != 1) return;
 
-    // 官方实现允许 continuous callback 在遍历时移除自身；先移除再执行，确保任何异常也不会形成
-    // 每帧重试。TJS 内部另用 System.addContinuousHandler 等待 global.kag 这个真实生命周期条件。
+    // 官方实现允许 continuous callback 在遍历时移除自身；先移除再执行，确保任何异常也不会
+    // 形成每帧重试。TJS 内部另用 System.addContinuousHandler 等待 global.kag 这个真实生命
+    // 周期条件。
     if (g_lookup_remove_continuous != nullptr) g_lookup_remove_continuous(this);
 
     TjsVariantString* script = g_lookup_bootstrap_script;
@@ -2072,7 +1947,7 @@ class KiriKiriLookupBootstrapCallback final : public TvpContinuousEventCallback 
       try {
         g_lookup_execute_script(content, nullptr);
       } catch (...) {
-        // 插件 ABI 边界绝不能把 TJS/C++ 异常抛回游戏事件循环；脚本自身也有 TJS try/catch。
+        // 插件 ABI 边界绝不把 TJS/C++ 异常抛回游戏事件循环；脚本自身也有 TJS try/catch。
       }
     }
     if (script != nullptr && g_lookup_release_string != nullptr) {
@@ -2094,11 +1969,13 @@ bool QueryKirikiriNativeLookupFunctions(ITVPFunctionExporter* exporter,
   }
 }
 
-void InstallKirikiriNativeLookupProbe(ITVPFunctionExporter* exporter) {
-  if (exporter == nullptr || !IsKirikiriLookupProbeRequested() ||
-      InterlockedCompareExchange(&g_lookup_bootstrap_state, 0, 0) != 0) {
-    return;
-  }
+// 幂等安装。`lookup_enabled==0` 时**一个 hook 都不装**，因此这里既是首装点也是重试点：
+// 用户在游戏起来之后才打开查词是常态，而 exporter 只在 V2Link / exe 直取那一瞬间到手。
+void PollKirikiriLookupInstall() {
+  if (g_stop || g_lookup_exporter == nullptr) return;
+  if (!fushi_voice_hook::HasLookupRegion(g_header)) return;
+  if (LookupEnabledNow() == 0) return;
+  if (InterlockedCompareExchange(&g_lookup_bootstrap_state, 0, 0) != 0) return;
 
   const char* names[] = {
       "tTJSVariantString * ::TJSAllocVariantString(const tjs_char *)",
@@ -2108,7 +1985,19 @@ void InstallKirikiriNativeLookupProbe(ITVPFunctionExporter* exporter) {
       "void ::TVPRemoveContinuousEventHook(tTVPContinuousEventCallbackIntf *)",
   };
   void* functions[5] = {};
-  if (!QueryKirikiriNativeLookupFunctions(exporter, names, functions, 5)) return;
+  if (!QueryKirikiriNativeLookupFunctions(g_lookup_exporter, names, functions, 5)) {
+    return;
+  }
+  // 单独查：缺 TVPExecuteExpression 就读不回任何传感器读数（hit 与 input 都靠它），此时
+  // 装一半比不装更糟——卡片会挂在屏幕上却永远收不到内容。
+  const char* expression_name =
+      "void ::TVPExecuteExpression(const ttstr &,tTJSVariant *)";
+  void* expression = nullptr;
+  if (!QueryKirikiriNativeLookupFunctions(g_lookup_exporter, &expression_name,
+                                          &expression, 1) ||
+      expression == nullptr) {
+    return;
+  }
 
   g_lookup_alloc_string =
       reinterpret_cast<TJSAllocVariantStringStub_t>(functions[0]);
@@ -2119,6 +2008,8 @@ void InstallKirikiriNativeLookupProbe(ITVPFunctionExporter* exporter) {
       reinterpret_cast<TVPAddContinuousEventHookStub_t>(functions[3]);
   g_lookup_remove_continuous =
       reinterpret_cast<TVPRemoveContinuousEventHookStub_t>(functions[4]);
+  g_lookup_execute_expression =
+      reinterpret_cast<TVPExecuteExpressionStub_t>(expression);
   if (g_lookup_alloc_string == nullptr || g_lookup_release_string == nullptr ||
       g_lookup_execute_script == nullptr || g_lookup_add_continuous == nullptr ||
       g_lookup_remove_continuous == nullptr) {
@@ -2126,24 +2017,26 @@ void InstallKirikiriNativeLookupProbe(ITVPFunctionExporter* exporter) {
   }
 
   try {
-    if (!PrepareKirikiriLookupRequestPath()) return;
-    if (!g_lookup_response_cs_ready) {
-      InitializeCriticalSection(&g_lookup_response_cs);
-      g_lookup_response_cs_ready = true;
-    }
+    PrepareKirikiriLookupCardPath();  // 备路缺失不阻断主路
     const std::wstring bootstrap = BuildKirikiriLookupBootstrapScript();
     g_lookup_bootstrap_script = g_lookup_alloc_string(bootstrap.c_str());
     if (g_lookup_bootstrap_script == nullptr) return;
     InterlockedExchange(&g_lookup_bootstrap_state, 1);
-    g_lookup_add_continuous(&g_lookup_result_callback);
+    g_lookup_add_continuous(&g_lookup_pump_callback);
     g_lookup_add_continuous(&g_lookup_bootstrap_callback);
-    g_lookup_worker = CreateThread(nullptr, 0, KiriKiriLookupWorker, nullptr, 0, nullptr);
   } catch (...) {
     TjsVariantString* script = g_lookup_bootstrap_script;
     g_lookup_bootstrap_script = nullptr;
     InterlockedExchange(&g_lookup_bootstrap_state, 0);
     if (script != nullptr) g_lookup_release_string(script);
   }
+}
+
+// 拿到 exporter 的两条路径（exe 直取 / 插件 V2Link）共用的入口：先记住 exporter，再按
+// 当前开关状态决定装不装。
+void InstallKirikiriLookupSensor(ITVPFunctionExporter* exporter) {
+  if (exporter != nullptr) g_lookup_exporter = exporter;
+  PollKirikiriLookupInstall();
 }
 
 // exe 直取 / V2Link 两条拿 exporter 的路径共享的一次性安装闩（InterlockedCompareExchange）。
@@ -2620,7 +2513,7 @@ HRESULT HandleV2Link(ITVPFunctionExporter* exporter, V2Link_t orig) {
   }
   const HRESULT result = orig != nullptr ? orig(exporter) : S_OK;
   // 原插件的 V2Link 已完成后才登记连续帧回调；真正执行 TJS 还会再等到下一次引擎事件循环。
-  InstallKirikiriNativeLookupProbe(exporter);
+  InstallKirikiriLookupSensor(exporter);
   return result;
 }
 
@@ -2736,6 +2629,8 @@ bool TryHookKirikiriVoiceStream() {
     if (exp != nullptr) {
       if (g_header != nullptr) g_header->reserved_luna |= 0x10000;  // 经 exe 导出拿到 exporter
       InstallVoiceStreamHookWithExporter(exp);                      // 幂等
+      // 未加壳游戏在这条路径上就能拿到 exporter，不必等插件 V2Link。同样幂等。
+      InstallKirikiriLookupSensor(exp);
     }
   }
 
@@ -2746,5 +2641,6 @@ bool TryHookKirikiriVoiceStream() {
 
 // KiriKiriZ 是 32 位引擎；x64 构建此路径为空实现（仅保证两架构都能编译）。
 bool TryHookKirikiriVoiceStream() { return true; }
+void PollKirikiriLookupInstall() {}
 
 #endif  // _M_IX86

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -307,6 +307,11 @@ struct LoopbackMarker {
 //   hit   : hook → host，单槽 latest-wins（用户查得再快也只关心最后一次）
 //   input : hook → host，环（落在卡片矩形内的鼠标/滚轮事件，供 host 喂 SendMouseInput）
 //   frame : host → hook，双缓冲（避免 host 写下一帧时撕裂 hook 正在拷的这一帧）
+//
+// **像素格式：BGRA8，直通（非预乘）alpha，自顶向下。** 两端都按直通最省事——host 侧
+// WebView2 取帧经 PNG 解码出来的本来就是直通；注入侧 KiriKiri 的 ltAlpha 也正是直通
+// （预乘对应的是 ltAddAlpha）。任何一侧擅自改成预乘，症状是卡片半透明边缘发暗，不会
+// 报错，只会看起来"有点脏"——所以在这里写死，别靠两边默契。
 constexpr uint32_t kLookupLineBytes = 1024;      // 单行台词 UTF-8 上限（整行，不截断）
 constexpr uint32_t kLookupInputSlotCount = 64;   // 输入转发环槽数
 constexpr uint32_t kLookupFrameCount = 2;        // 位图双缓冲
@@ -329,8 +334,15 @@ constexpr uint32_t kLookupDiagFrameRejected = 0x00000080u;    // 收到过不合
 // 保证 payload 对 reader 先可见），与 VoiceClip / LoopbackMarker 同一套纪律。
 struct LookupHitSlot {
   volatile uint64_t seq;   // 单调；host 据此判新。0=从未命中
-  uint32_t char_index;     // 光标落在第几个字符（本行内下标）
-  uint32_t char_count;     // 本行字符数（自洽校验：char_index < char_count）
+  // 光标落在第几个字符。**单位是 UTF-16 code unit**，不是 UTF-8 字节、不是 code point。
+  //
+  // 为什么是这个单位而不是随便挑一个：两端天然就都是 UTF-16——TJS 的 tjs_char 是 wchar_t
+  // （UTF-16LE），Dart 的 String 下标也是 UTF-16 code unit。选它，两侧各自「就是自己的字符串
+  // 下标」，零转换；选 UTF-8 字节或 code point，两端都要转，而转错的症状是**含非 ASCII 或
+  // 非 BMP 字符的行整体偏移**——日文行必然含非 ASCII，也就是必错，但错得像"命中判定有点飘"
+  // 而不像编码 bug，极难定位。line_utf8 用 UTF-8 只是因为它要跨 C ABI，不影响本字段单位。
+  uint32_t char_index;
+  uint32_t char_count;     // 本行 UTF-16 code unit 数（自洽校验：char_index < char_count）
   int32_t glyph_x;         // 命中字形矩形，primaryLayer 坐标
   int32_t glyph_y;
   int32_t glyph_w;
@@ -346,13 +358,22 @@ struct LookupHitSlot {
 
 constexpr uint32_t kLookupHitFlagSubmit = 0x00000001u;
 
-// host → hook：一帧卡片位图的元数据。像素本体在位图区的第 (seq % kLookupFrameCount) 块。
-// `ready` **最后**写：0=host 正在写，1=可读。hook 拷完必须复查 seq 未变，否则丢弃。
+// host → hook：一帧卡片位图的元数据。
+//
+// **槽下标规则（两侧唯一约定，别各写各的）**：元数据槽下标与像素块下标**同为**
+// `seq % lookup_frame_count`。host 不许用自己的轮转计数器放元数据、再用 seq%N 放像素——
+// 那样注入侧会全量拒帧，而症状（卡片永远不出现）和「host 压根没投帧」完全同形，真机上
+// 根本分不开。注入侧按此下标读，不一致即丢帧并置 kLookupDiagFrameRejected。
+//
+// `ready` **最后**写：0=host 正在写，1=可读。hook 拷完必须复查 seq/ready 未变，否则丢弃。
 struct LookupFrame {
   volatile uint64_t seq;      // 对应哪次 hit；hook 丢弃比当前 hit 旧的帧
   uint32_t width;             // 像素宽
   uint32_t height;            // 像素高
-  uint32_t pitch;             // 行字节跨距（>= width*4）
+  // 行字节跨距，**恒为正、恒自顶向下**（>= width*4）。这块内存是我们自己的，没有理由
+  // 继承任何一侧的行序怪癖。游戏 Layer 那侧的 mainImageBufferPitch 可能为负（KiriKiri
+  // 自底向上），那是注入侧搬运时的事，不许漏进这个跨进程契约。
+  uint32_t pitch;
   int32_t anchor_x;           // 卡片左上角，primaryLayer 坐标（host 决定，含避让与钳制）
   int32_t anchor_y;
   uint32_t highlight_start;   // 字幕高亮起始字符下标

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -56,7 +56,10 @@ constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
 //       * selected_text_thread_id 从"采集期过滤器"降级为"消费期指定"：native 不再丢弃任何
 //         行，只由消费方（host 的文本消费点、游戏内 kirikiri 配对候选扫描）决定取哪条道。
 //         这同时解开了旧方案的死结——Dart 回写选定线程不再等于让 native 重新开始丢行。
-constexpr uint32_t kSharedVersion = 13;
+// v14：追加**游戏内查词区**（hit / input / frame 三通道，见下方 kLookup* 与 LookupHitSlot）。
+//     纯追加：放在布局最尾，前面所有区偏移逐字节不动；lookup_region_offset==0 即"本会话
+//     没有此区"，旧 host 读到 v14 映射也不会错位（版本号仍会先挡，这只是纵深防御）。
+constexpr uint32_t kSharedVersion = 14;
 constexpr uint32_t kStableIpcVersion = 1;
 
 // 环形缓冲保留时长（秒）。C 阶段语音轨常见 48k 立体声 float32；60s 上界 ≈ 23MB。
@@ -288,6 +291,94 @@ struct LoopbackMarker {
   uint64_t total_written;   // 该时刻的 loopback_total_written（单调）
 };
 
+// ══ v14 游戏内查词区 ═════════════════════════════════════════════════════════════
+// KiriKiri/KAGEX 在**游戏渲染树内部**显示词典卡片。分工是硬的：注入侧只做几何传感、
+// 位图落地和输入转发；分词、查词、排版、卡片像素全部由 host（Hibiki 既有 popup.html +
+// WebView2 离屏合成）负责。
+//
+// 为什么不让注入侧自己查词自己画卡片（这正是 prototype 的做法，已废弃）：
+//   * 卡片要 ruby / 外字图 / 发音 / 制卡 / 主题 / 17 语言——在 TJS 里用 drawText 手写
+//     等于把 Hibiki 的 popup 重写一遍且永远落后一个版本；
+//   * 游戏进程里因此多出 HTTP 客户端、认证 token、手写 JSON 解析器和"拼 TJS 源码再
+//     eval"的注入面。把职责切开之后，跨边界的东西只剩**一块位图**和**一串整数**，
+//     注入面不是"escape 得更严"而是结构上不存在。
+//
+// 三条通道各自单写单读，无锁：
+//   hit   : hook → host，单槽 latest-wins（用户查得再快也只关心最后一次）
+//   input : hook → host，环（落在卡片矩形内的鼠标/滚轮事件，供 host 喂 SendMouseInput）
+//   frame : host → hook，双缓冲（避免 host 写下一帧时撕裂 hook 正在拷的这一帧）
+constexpr uint32_t kLookupLineBytes = 1024;      // 单行台词 UTF-8 上限（整行，不截断）
+constexpr uint32_t kLookupInputSlotCount = 64;   // 输入转发环槽数
+constexpr uint32_t kLookupFrameCount = 2;        // 位图双缓冲
+// 单缓冲位图上限 3MiB ≈ 880×880 BGRA。x86 游戏进程地址空间有限，故设硬上界；超限由
+// host 负责钳制卡片尺寸，注入侧只做校验和拒绝，绝不按收到的 width/height 盲拷。
+constexpr uint32_t kLookupBitmapBytes = 3u * 1024u * 1024u;
+
+// lookup_diag 位。与 reserved_luna / hook_diagnostics 分开：那两个各自已满，且这里的
+// 阶段语义（传感器装没装 / 像素走哪条路）与引擎探针、helper 启动都不是一回事。
+constexpr uint32_t kLookupDiagSensorInstalled = 0x00000001u;  // TJS 传感器已装
+constexpr uint32_t kLookupDiagGeometryObserved = 0x00000002u;  // 真拿到过逐字符几何
+constexpr uint32_t kLookupDiagHitSubmitted = 0x00000004u;     // 真上报过命中
+constexpr uint32_t kLookupDiagBufferRouteReady = 0x00000008u;  // mainImageBufferForWrite 可用
+constexpr uint32_t kLookupDiagFallbackPngRoute = 0x00000010u;  // 降级走 PNG + loadImages
+constexpr uint32_t kLookupDiagFramePresented = 0x00000020u;   // 位图真落进游戏 Layer
+constexpr uint32_t kLookupDiagExpressionReady = 0x00000040u;  // TVPExecuteExpression 可用
+constexpr uint32_t kLookupDiagFrameRejected = 0x00000080u;    // 收到过不合契约的帧（已拒）
+
+// hook → host：光标命中了哪个字符。单槽 latest-wins；`seq` **最后**写（Interlocked 全栅栏，
+// 保证 payload 对 reader 先可见），与 VoiceClip / LoopbackMarker 同一套纪律。
+struct LookupHitSlot {
+  volatile uint64_t seq;   // 单调；host 据此判新。0=从未命中
+  uint32_t char_index;     // 光标落在第几个字符（本行内下标）
+  uint32_t char_count;     // 本行字符数（自洽校验：char_index < char_count）
+  int32_t glyph_x;         // 命中字形矩形，primaryLayer 坐标
+  int32_t glyph_y;
+  int32_t glyph_w;
+  int32_t glyph_h;
+  int32_t view_w;          // primaryLayer 尺寸；host 据此定位与钳制卡片
+  int32_t view_h;
+  uint32_t flags;          // bit0: 1=点击提交，0=悬停预览
+  uint32_t line_bytes;     // line_utf8 有效字节数（<= kLookupLineBytes）
+  // **整行**台词，不截断。prototype 从点击字向后截 48 字，结果是制卡拿不到完整句子；
+  // 分词也不该在注入侧做——host 的分词才是全 app 唯一真值。
+  uint8_t line_utf8[kLookupLineBytes];
+};
+
+constexpr uint32_t kLookupHitFlagSubmit = 0x00000001u;
+
+// host → hook：一帧卡片位图的元数据。像素本体在位图区的第 (seq % kLookupFrameCount) 块。
+// `ready` **最后**写：0=host 正在写，1=可读。hook 拷完必须复查 seq 未变，否则丢弃。
+struct LookupFrame {
+  volatile uint64_t seq;      // 对应哪次 hit；hook 丢弃比当前 hit 旧的帧
+  uint32_t width;             // 像素宽
+  uint32_t height;            // 像素高
+  uint32_t pitch;             // 行字节跨距（>= width*4）
+  int32_t anchor_x;           // 卡片左上角，primaryLayer 坐标（host 决定，含避让与钳制）
+  int32_t anchor_y;
+  uint32_t highlight_start;   // 字幕高亮起始字符下标
+  uint32_t highlight_len;     // 高亮字符数（0=不高亮）
+  uint32_t byte_len;          // 位图有效字节数（= pitch*height，<= kLookupBitmapBytes）
+  volatile uint32_t ready;    // 0=写入中，1=可读
+  uint32_t reserved;
+};
+
+// hook → host：落在卡片矩形内、需要喂给离屏 WebView2 的输入事件。
+struct LookupInputSlot {
+  volatile uint64_t seq;  // 单调；**最后**写
+  int32_t x;              // 卡片局部坐标（已减去 anchor）
+  int32_t y;
+  uint32_t kind;          // kLookupInput*
+  int32_t wheel;          // 滚轮增量（kind==kLookupInputWheel 时有效）
+  uint32_t keys;          // 修饰键位掩码
+  uint32_t reserved;
+};
+
+constexpr uint32_t kLookupInputMove = 0;
+constexpr uint32_t kLookupInputLeftDown = 1;
+constexpr uint32_t kLookupInputLeftUp = 2;
+constexpr uint32_t kLookupInputWheel = 3;
+constexpr uint32_t kLookupInputLeave = 4;
+
 // 共享内存头。injector 创建并清零、填各区偏移；hook DLL 注入后填格式、持续更新计数。
 // volatile 字段跨进程无锁单写单读。绝不在此放指针（跨进程地址无意义）。
 // 内存布局：[SharedHeader][音频环形 ring_capacity][文本区 TextRegionBytes()]
@@ -364,6 +455,19 @@ struct SharedHeader {
   // 等于把要修的病换个地方藏起来。
   volatile uint64_t text_lane_recycle_count;   // 回收了一条最久未写的非选定道
   volatile uint64_t text_lane_overflow_count;  // 连可回收的道都没有，本行被丢弃
+  // ── v14 游戏内查词区（injector 填偏移/容量；追加在布局最尾，前面各区偏移一个不动）──
+  uint32_t lookup_region_offset;      // 查词区起始（header 起算字节偏移；0=本会话无此区）
+  uint32_t lookup_bitmap_bytes;       // 单缓冲位图字节容量（= kLookupBitmapBytes，冗余自洽）
+  uint32_t lookup_frame_count;        // 位图缓冲数（= kLookupFrameCount，冗余自洽）
+  uint32_t lookup_input_slot_count;   // 输入环槽数（= kLookupInputSlotCount，冗余自洽）
+  volatile uint64_t lookup_hit_count;    // hook→host 单调：命中事件数
+  volatile uint64_t lookup_frame_count_written;  // host→hook 单调：已投位图帧数
+  volatile uint64_t lookup_input_count;  // hook→host 单调：已转发的卡片输入事件数
+  // host→hook 开关。取代 prototype 的 FUSHI_KIRIKIRI_LOOKUP_* 环境变量——把认证 token
+  // 塞进游戏进程环境块是安全缺陷（任何拿得到 PROCESS_QUERY_INFORMATION 的进程都能读），
+  // 且环境变量在进程启动后改不了，做不到运行期开关。形态照抄 selected_text_thread_id。
+  volatile uint32_t lookup_enabled;
+  volatile uint32_t lookup_diag;      // kLookupDiag* 位
 };
 #pragma pack(pop)
 
@@ -626,7 +730,126 @@ inline uint64_t WriteTextLaneEvent(SharedHeader* header, uint32_t lane_begin,
   return global_seq;
 }
 
+// ── v14 查词区寻址（写侧/读侧唯一实现，谁都不许自己再算一遍偏移）────────────────
+//
+// 整区布局：[LookupHitSlot][LookupInputSlot × N][LookupFrame × F][位图 × F]
+inline constexpr uint64_t LookupRegionBytes(uint32_t input_slot_count,
+                                            uint32_t frame_count,
+                                            uint32_t bitmap_bytes) {
+  return sizeof(LookupHitSlot) +
+         static_cast<uint64_t>(input_slot_count) * sizeof(LookupInputSlot) +
+         static_cast<uint64_t>(frame_count) * sizeof(LookupFrame) +
+         static_cast<uint64_t>(frame_count) * bitmap_bytes;
+}
+
+inline bool HasLookupRegion(const SharedHeader* header) {
+  return header != nullptr && header->lookup_region_offset != 0 &&
+         header->lookup_frame_count != 0 && header->lookup_bitmap_bytes != 0 &&
+         header->lookup_input_slot_count != 0;
+}
+
+inline LookupHitSlot* LookupHitOf(SharedHeader* header) {
+  if (!HasLookupRegion(header)) return nullptr;
+  return reinterpret_cast<LookupHitSlot*>(reinterpret_cast<uint8_t*>(header) +
+                                          header->lookup_region_offset);
+}
+
+inline const LookupHitSlot* LookupHitOf(const SharedHeader* header) {
+  if (!HasLookupRegion(header)) return nullptr;
+  return reinterpret_cast<const LookupHitSlot*>(
+      reinterpret_cast<const uint8_t*>(header) + header->lookup_region_offset);
+}
+
+inline LookupInputSlot* LookupInputsOf(SharedHeader* header) {
+  if (!HasLookupRegion(header)) return nullptr;
+  return reinterpret_cast<LookupInputSlot*>(
+      reinterpret_cast<uint8_t*>(header) + header->lookup_region_offset +
+      sizeof(LookupHitSlot));
+}
+
+inline const LookupInputSlot* LookupInputsOf(const SharedHeader* header) {
+  if (!HasLookupRegion(header)) return nullptr;
+  return reinterpret_cast<const LookupInputSlot*>(
+      reinterpret_cast<const uint8_t*>(header) + header->lookup_region_offset +
+      sizeof(LookupHitSlot));
+}
+
+// 区内偏移一律用 size_t 而不是 uint64_t：这些值按构造都装得下 uint32_t（header 里的偏移
+// 字段本身就是 uint32_t），而 x86 构建下拿 uint64_t 去做指针算术会被截断并在 /W4 /WX 的
+// runner 上直接变成编译错误。整区**总字节数**仍用 uint64_t（LookupRegionBytes），因为它要
+// 参与 injector 的 total_size 求和，那里确实可能超 4GB 语义上限。
+inline size_t LookupFramesByteOffset(const SharedHeader* header) {
+  return static_cast<size_t>(header->lookup_region_offset) +
+         sizeof(LookupHitSlot) +
+         static_cast<size_t>(header->lookup_input_slot_count) *
+             sizeof(LookupInputSlot);
+}
+
+inline size_t LookupBitmapsByteOffset(const SharedHeader* header) {
+  return LookupFramesByteOffset(header) +
+         static_cast<size_t>(header->lookup_frame_count) * sizeof(LookupFrame);
+}
+
+inline LookupFrame* LookupFrameAt(SharedHeader* header, uint32_t index) {
+  if (!HasLookupRegion(header) || index >= header->lookup_frame_count) {
+    return nullptr;
+  }
+  return reinterpret_cast<LookupFrame*>(reinterpret_cast<uint8_t*>(header) +
+                                        LookupFramesByteOffset(header)) +
+         index;
+}
+
+inline const LookupFrame* LookupFrameAt(const SharedHeader* header,
+                                        uint32_t index) {
+  if (!HasLookupRegion(header) || index >= header->lookup_frame_count) {
+    return nullptr;
+  }
+  return reinterpret_cast<const LookupFrame*>(
+             reinterpret_cast<const uint8_t*>(header) +
+             LookupFramesByteOffset(header)) +
+         index;
+}
+
+inline uint8_t* LookupBitmapAt(SharedHeader* header, uint32_t index) {
+  if (!HasLookupRegion(header) || index >= header->lookup_frame_count) {
+    return nullptr;
+  }
+  return reinterpret_cast<uint8_t*>(header) + LookupBitmapsByteOffset(header) +
+         static_cast<size_t>(index) * header->lookup_bitmap_bytes;
+}
+
+inline const uint8_t* LookupBitmapAt(const SharedHeader* header,
+                                     uint32_t index) {
+  if (!HasLookupRegion(header) || index >= header->lookup_frame_count) {
+    return nullptr;
+  }
+  return reinterpret_cast<const uint8_t*>(header) +
+         LookupBitmapsByteOffset(header) +
+         static_cast<size_t>(index) * header->lookup_bitmap_bytes;
+}
+
+// 帧自洽校验。**注入侧必须先过这一关再拷贝**：跨进程来的 width/height/pitch 全是不可信
+// 输入，按它们盲拷就是把共享内存越界写进游戏进程。host 侧同样用它自检，避免投出废帧。
+inline bool IsLookupFrameSane(const SharedHeader* header,
+                              const LookupFrame* frame) {
+  if (header == nullptr || frame == nullptr) return false;
+  if (frame->width == 0 || frame->height == 0) return false;
+  if (frame->width > 0x4000u || frame->height > 0x4000u) return false;
+  const uint64_t min_pitch = static_cast<uint64_t>(frame->width) * 4u;
+  if (frame->pitch < min_pitch) return false;
+  const uint64_t needed =
+      static_cast<uint64_t>(frame->pitch) * frame->height;
+  if (needed != frame->byte_len) return false;
+  return needed <= header->lookup_bitmap_bytes;
+}
+
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
+static_assert(sizeof(LookupHitSlot) % 8 == 0, "LookupHitSlot must stay 8-aligned");
+static_assert(sizeof(LookupFrame) % 8 == 0, "LookupFrame must stay 8-aligned");
+static_assert(sizeof(LookupInputSlot) % 8 == 0,
+              "LookupInputSlot must stay 8-aligned");
+// 双缓冲是防撕裂的**结构前提**：单缓冲时 host 写下一帧与 hook 拷当前帧必然重叠。
+static_assert(kLookupFrameCount >= 2, "lookup frames must be double-buffered");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");
 static_assert(sizeof(TextLane) % 8 == 0, "TextLane must stay 8-aligned");
 // 道数与预览槽数必须同值：两者共用同一套下标与同一套跨进程互斥分区，分开就会有一侧

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -360,16 +360,27 @@ constexpr uint32_t kLookupHitFlagSubmit = 0x00000001u;
 
 // host → hook：一帧卡片位图的元数据。
 //
+// **两个序号是两回事，别再压成一个字段。** 早先只有一个 `seq`（既当发布序、又当"回应
+// 哪次 hit"），结果 dismiss 直接死在自己手里：收卡帧复用被撤那张卡的 hit seq，而那个 seq
+// 刚 present 过，注入侧的"丢弃不比已应用的新"过滤把它当陈旧帧扔了——加个 0×0 分支也救不
+// 回来，因为帧压根进不了候选。这不是漏了个分支，是数据结构错了：
+//   * `seq`     = **发布序**。host 每投一帧（present 或 dismiss）都 +1，单调。注入侧用它
+//                 判新与去重，也用它算槽下标。
+//   * `hit_seq` = 这帧**回应哪次 hit**。注入侧用它判"这张卡是不是已经被更新的命中作废了"。
+// 分开之后 dismiss 就是普通一帧，不需要任何特例。
+//
 // **槽下标规则（两侧唯一约定，别各写各的）**：元数据槽下标与像素块下标**同为**
-// `seq % lookup_frame_count`。host 不许用自己的轮转计数器放元数据、再用 seq%N 放像素——
-// 那样注入侧会全量拒帧，而症状（卡片永远不出现）和「host 压根没投帧」完全同形，真机上
-// 根本分不开。注入侧按此下标读，不一致即丢帧并置 kLookupDiagFrameRejected。
+// `seq % lookup_frame_count`（发布序，不是 hit_seq）。host 不许用自己的轮转计数器放元数据、
+// 再用 seq%N 放像素——那样注入侧会全量拒帧，而症状（卡片永远不出现）和「host 压根没投帧」
+// 完全同形，真机上根本分不开。注入侧按此下标读，不一致即丢帧并置 kLookupDiagFrameRejected。
 //
 // `ready` **最后**写：0=host 正在写，1=可读。hook 拷完必须复查 seq/ready 未变，否则丢弃。
 struct LookupFrame {
-  volatile uint64_t seq;      // 对应哪次 hit；hook 丢弃比当前 hit 旧的帧
-  uint32_t width;             // 像素宽
-  uint32_t height;            // 像素高
+  volatile uint64_t seq;      // 发布序：host 每投一帧 +1，单调。注入侧据此判新/去重/算槽
+  uint64_t hit_seq;           // 这帧回应哪次 hit；比最新 hit 旧即作废
+  uint32_t flags;             // kLookupFrame* 位
+  uint32_t width;             // 像素宽（dismiss 帧为 0）
+  uint32_t height;            // 像素高（dismiss 帧为 0）
   // 行字节跨距，**恒为正、恒自顶向下**（>= width*4）。这块内存是我们自己的，没有理由
   // 继承任何一侧的行序怪癖。游戏 Layer 那侧的 mainImageBufferPitch 可能为负（KiriKiri
   // 自底向上），那是注入侧搬运时的事，不许漏进这个跨进程契约。
@@ -381,7 +392,13 @@ struct LookupFrame {
   uint32_t byte_len;          // 位图有效字节数（= pitch*height，<= kLookupBitmapBytes）
   volatile uint32_t ready;    // 0=写入中，1=可读
   uint32_t reserved;
+  uint32_t reserved2;
 };
+
+// LookupFrame::flags 位。
+// 收卡是**普通一帧**，靠这个位自述，不靠「width==0 是收卡」这种魔法编码：后者要求每个
+// 读侧都记住这条隐规则，而它和「host 投了张废帧」在字节上完全一样。
+constexpr uint32_t kLookupFrameDismiss = 0x00000001u;
 
 // hook → host：落在卡片矩形内、需要喂给离屏 WebView2 的输入事件。
 struct LookupInputSlot {
@@ -847,6 +864,22 @@ inline const uint8_t* LookupBitmapAt(const SharedHeader* header,
   return reinterpret_cast<const uint8_t*>(header) +
          LookupBitmapsByteOffset(header) +
          static_cast<size_t>(index) * header->lookup_bitmap_bytes;
+}
+
+// 「这帧该不该应用」的**唯一判据**。注入侧与 replay 测试共用同一份——判据一旦各写各的，
+// replay 绿了也只证明参照实现自洽，证明不了生产代码对。收卡曾经整条不通就是死在这个判据上
+// （详见 LookupFrame 注释），那种错必须能被离线回归抓住，而不是等真机。
+//
+// ready 位不在这里判：它是「host 写完没有」的内存可见性问题，归调用点，与「这帧是否过期」
+// 是两件事。seq 由调用点原子读出后传进来，同理。
+inline bool ShouldApplyLookupFrame(uint64_t frame_seq, uint64_t frame_hit_seq,
+                                   uint64_t presented_seq,
+                                   uint64_t current_hit_seq) {
+  // 发布序不比已处理的新 → 这帧我处理过了。
+  if (frame_seq <= presented_seq) return false;
+  // 回应的那次查询已被更新的命中作废 → 迟到帧，绝不能顶掉新卡片。
+  if (frame_hit_seq < current_hit_seq) return false;
+  return true;
 }
 
 // 帧自洽校验。**注入侧必须先过这一关再拷贝**：跨进程来的 width/height/pitch 全是不可信

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -1351,10 +1351,15 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
   const uint64_t thread_preview_bytes =
       static_cast<uint64_t>(fushi_voice_hook::kThreadPreviewCount) *
       sizeof(fushi_voice_hook::ThreadPreviewSlot);
+  // v14：游戏内查词区（hit 槽 + 输入环 + 位图双缓冲）。同样追加在最尾。
+  const uint64_t lookup_region_bytes = fushi_voice_hook::LookupRegionBytes(
+      fushi_voice_hook::kLookupInputSlotCount,
+      fushi_voice_hook::kLookupFrameCount,
+      fushi_voice_hook::kLookupBitmapBytes);
   const uint64_t total_size = sizeof(SharedHeader) + ring_capacity +
                               text_region_bytes + clip_region_bytes +
                               loopback_capacity + loopback_marker_bytes +
-                              thread_preview_bytes;
+                              thread_preview_bytes + lookup_region_bytes;
   const bool legacy_hibiki_ipc =
       fushi_voice_hook::ComponentUsesLegacyHibikiIpc(dll_path);
   const std::wstring shm = SharedMemoryName(pid, legacy_hibiki_ipc);
@@ -1420,6 +1425,13 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
     header->thread_preview_offset = static_cast<uint32_t>(
         header->loopback_marker_offset + loopback_marker_bytes);
     header->thread_preview_slot_count = fushi_voice_hook::kThreadPreviewCount;
+    // v14：查词区紧随预览区，同样在布局最尾。lookup_enabled 保持 0——由 host 在用户
+    // 真正开启游戏内查词时置 1，注入侧在此之前一个字节都不写、一个 hook 都不装。
+    header->lookup_region_offset = static_cast<uint32_t>(
+        header->thread_preview_offset + thread_preview_bytes);
+    header->lookup_bitmap_bytes = fushi_voice_hook::kLookupBitmapBytes;
+    header->lookup_frame_count = fushi_voice_hook::kLookupFrameCount;
+    header->lookup_input_slot_count = fushi_voice_hook::kLookupInputSlotCount;
   } else {
     fprintf(stderr,
             "[session] reusing live hook mapping pid=%lu text=%u audioBytes=%llu\n",

--- a/native/galgame_hook/tests/fixtures/kirikiri_lookup_replay.tsv
+++ b/native/galgame_hook/tests/fixtures/kirikiri_lookup_replay.tsv
@@ -1,0 +1,115 @@
+# KiriKiri 游戏内查词（v14 查词区）会话 replay 黄金表。
+#
+# 格式：每行一条事件，`kind` + 若干 `key=value`（空白分隔）；`#` 开头是注释；
+# `expect` 行是**整场回放结束后**才比对的聚合结果，回放过程一个字都不许读它。
+# 与 tests/fixtures/luna_thread_selection.tsv 同一路子：黄金表在这里，判定在 C++ 侧。
+#
+# 事件语义（consumer：tests/lookup_session_replay_test.cpp）：
+#   enabled  value=0|1              host 写 header->lookup_enabled（唯一开关）
+#   hit      ...                    hook 侧发布一次命中（lookup_enabled==0 时必须零写入）
+#   frame    hit=<hit seq> ...      host 发布一帧卡片位图（含**故意不合契约**的帧）
+#   dismiss  hit=<hit seq>          host 发布一张收卡帧（无像素，靠 flags 自述）
+#   poll     -                      hook 的 continuous callback 跑一次：取帧 / 丢帧
+#   input    x= y= kind= wheel=     光标事件；只有落在当前卡片矩形内才进转发环
+#   session_end                     会话结束，注入侧清理查词区
+#
+# 序号有两套，别混：
+#   * hit seq   —— hook 侧的命中序（每次 hit +1）；frame/dismiss 用 `hit=` 指明回应哪一次。
+#   * 发布序    —— host 每投一帧 +1，由 consumer 自己递增；它决定落哪个槽，也是
+#                  `applied_frames` 里记的那个号。收卡帧同样要占一个发布序——这正是
+#                  收卡链曾经整条不通的根因（两个语义挤在一个 seq 里）。
+#
+# 全部数据为合成数据：line 字段是占位标识符，不含任何真实台词或可还原游戏内容。
+
+# ── 会话 1：host 还没开开关 ──────────────────────────────────────────────────
+# 未开启时注入侧必须**一个字节都不写**：既不发布命中，也不转发输入。
+hit	line=SYNTHETIC-A index=2 chars=10 glyph=200,540,24,26 view=1280,720 submit=1
+input	x=300 y=300 kind=0
+poll
+
+# ── 会话 1：开启后的正常时序 hit -> frame -> apply ───────────────────────────
+enabled	value=1
+hit	line=SYNTHETIC-A index=2 chars=10 glyph=200,540,24,26 view=1280,720 submit=1
+frame	hit=1 w=480 h=320 pitch=1920 anchor=200,180 hl=2,1 fill=0x11
+poll
+
+# 卡片矩形 = [200,180) 起的 480x320，即 x∈[200,680)、y∈[180,500)。
+input	x=210 y=190 kind=0
+input	x=100 y=100 kind=0
+input	x=680 y=499 kind=3 wheel=-120
+input	x=679 y=499 kind=3 wheel=-120
+
+# ── 会话 1：新命中之后，回应旧命中的迟到帧必须被丢弃（防串卡）────────────────
+hit	line=SYNTHETIC-B index=5 chars=14 glyph=320,540,24,26 view=1280,720 submit=1
+frame	hit=1 w=480 h=320 pitch=1920 anchor=200,180 hl=2,1 fill=0x99
+poll
+
+# ── 会话 1：不合契约的帧必须被拒（pitch < width*4，按 width 逐行拷会越界）─────
+frame	hit=2 w=480 h=320 pitch=1919 anchor=240,180 hl=5,1 fill=0xEE
+poll
+frame	hit=2 w=480 h=320 pitch=1920 anchor=240,180 hl=5,1 fill=0x22
+poll
+
+# ── 会话 1：收卡。dismiss 帧没有像素、过不了 IsLookupFrameSane，但必须被应用 ──
+dismiss	hit=2
+poll
+# 卡片已经收起来了，原本在卡片内的坐标现在属于游戏自己。
+input	x=210 y=190 kind=0
+
+# ── 会话 1：陈旧的 dismiss 绝不能收掉更新的卡片 ───────────────────────────────
+# 编排是刻意的：让那张 dismiss 落在**下标更小**的槽里、而新卡片落在下标更大的槽，
+# 于是"按扫描顺序取第一个 ready"的实现会先撞上 dismiss。正确实现有两道防线——取
+# 发布序最大的候选，且 hit_seq 比当前命中旧的一律作废。
+hit	line=SYNTHETIC-C index=1 chars=8 glyph=120,540,24,26 view=1280,720 submit=1
+frame	hit=3 w=480 h=320 pitch=1920 anchor=120,180 hl=1,1 fill=0x33
+poll
+# 卡内点词压出子卡 / 改字号 → 同一次命中重新投一帧（现实里很常见，这里顺带占一个发布序）
+frame	hit=3 w=480 h=300 pitch=1920 anchor=120,190 hl=1,2 fill=0x3A
+poll
+dismiss	hit=3
+hit	line=SYNTHETIC-D index=0 chars=6 glyph=100,540,24,26 view=1280,720 submit=1
+frame	hit=4 w=480 h=320 pitch=1920 anchor=100,180 hl=0,1 fill=0x44
+poll
+# 再扫一轮：那张陈旧 dismiss 仍然躺在共享内存里（注入侧不清 ready），它必须继续被拒。
+poll
+
+# ── 会话 1：host 投了张 width=0 的**废帧**（不是收卡）───────────────────────
+# 它和收卡帧在字节上几乎一样，区别只有 flags 那一位。按"width==0 就是收卡"的魔法编码
+# 读，这里就会莫名其妙把卡片 4 收掉；正确读法是它没有收卡位 → 只能被尺寸闸门拒掉。
+frame	hit=4 w=0 h=0 pitch=0 anchor=100,180 hl=0,1 fill=0x00
+poll
+
+# ── 会话 1：留下一帧「已 ready 但没来得及被取走」的残留，然后结束会话 ─────────
+frame	hit=4 w=480 h=320 pitch=1920 anchor=100,180 hl=0,1 fill=0x55
+session_end
+
+# ── 会话 2：上一会话的残留帧绝不能被当成本会话的帧用 ─────────────────────────
+enabled	value=1
+hit	line=SYNTHETIC-E index=0 chars=6 glyph=100,540,24,26 view=1280,720 submit=0
+hit	line=SYNTHETIC-E index=1 chars=6 glyph=124,540,24,26 view=1280,720 submit=0
+hit	line=SYNTHETIC-E index=2 chars=6 glyph=148,540,24,26 view=1280,720 submit=1
+poll
+frame	hit=3 w=320 h=200 pitch=1280 anchor=148,180 hl=2,1 fill=0x66
+poll
+session_end
+
+# ── 聚合黄金值 ──────────────────────────────────────────────────────────────
+expect	card_transcript=show:1,show:2,hide:2,show:3,show:3,show:4,show:3
+expect	applied_frames=1:1,1:4,1:5,1:6,1:7,1:9,2:1
+expect	last_applied_fill=0x66
+expect	hits_published=7
+expect	hits_suppressed_while_disabled=1
+expect	frames_published=12
+expect	dismiss_frames_applied=1
+expect	dismiss_frames_failing_sanity=1
+# 从没贴上去的 5 帧：回应 hit1 的迟到帧、pitch 不合契约的废帧、width=0 的废帧、
+# 陈旧的 dismiss、会话结束前来不及取走的残留帧。
+expect	frames_never_applied=5
+expect	insane_frames_rejected=2
+expect	inputs_forwarded=2
+expect	inputs_ignored=4
+expect	bytes_written_while_disabled=0
+expect	cross_session_frames_applied=0
+expect	v13_regions_untouched=1
+expect	tail_guard_intact=1
+expect	session_clean=1

--- a/native/galgame_hook/tests/kirikiri_lookup_source_guard_test.py
+++ b/native/galgame_hook/tests/kirikiri_lookup_source_guard_test.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""KiriKiri 游戏内查词的源码扫描守卫。
+
+守的是 `hook/adapters/kirikiri_adapter.inc`。这些不是风格偏好，每一条都对应一个
+**已经在 prototype 里存在过、且必须结构性消失**的东西：
+
+1. 传给 `TVPExecuteScript` 的结果回执不得由动态字符串拼接构成（只允许整数经
+   `std::to_wstring`）。prototype 是 `script += ... + word + ... + definition + ...`
+   再 eval —— 那是把「游戏进程里能执行任意 TJS」这个注入面焊进架构，靠 escape 函数
+   是补不掉的（escape 写错一次就全线失守）。整数化之后注入面**不存在**，而不是
+   「更难利用」。
+
+2. 游戏进程里不得有 HTTP 客户端和认证凭据（`WinHttp*` /
+   `FUSHI_KIRIKIRI_LOOKUP_PORT` / `FUSHI_KIRIKIRI_LOOKUP_TOKEN`）。token 放进游戏
+   进程环境块，任何拿得到 PROCESS_QUERY_INFORMATION 的进程都能读；而且环境变量在
+   进程启动后改不了，做不到运行期开关。v14 用共享内存的 `lookup_enabled` 取代它。
+
+3. 不得往引擎全局类上打 monkey-patch（`global.Layer.drawText` /
+   `global.MessageLayer.processCh`）。这两条是已被运行日志证伪的捕获路径（只有
+   TextRender 命中），而且挂在**全局** Layer 上意味着游戏所有 UI 绘制都要多绕一层
+   ——游戏内渲染下每一毫秒都直接变成掉帧。
+   唯一豁免：留在 `if(global.fushiLookupProbeMode)` 这个**默认关闭**的探测分支里，
+   供换游戏时判断"文本到底走哪条路"。所以这条规则有配套的第二问——那个开关必须默认
+   false，否则豁免立刻退化成"全局补丁常驻"。
+
+变异实测纪律：本文件把每条规则实现成一个独立的 `find_*` 函数，`RealAdapterTest` 用它
+扫真文件，`MutationSelfTest` 用它扫**合成的脏输入**并要求非空。两组都在，这守卫才不
+可能是「永远绿的空守卫」。
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+from typing import Iterator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTER = ROOT / "hook" / "adapters" / "kirikiri_adapter.inc"
+
+# TJS 侧的全局命名空间前缀。C++ 里出现含这个前缀的宽字符串字面量 = 这条语句在拼 TJS 源码。
+TJS_MARKER = "fushiLookup"
+
+_SLOT = "\x01"
+_SLOT_RE = re.compile(_SLOT + r"\d+" + _SLOT)
+
+# 进程内网络客户端 / 认证凭据残骸。前三条是硬要求；后两条同属 prototype 的 HTTP 直连
+# 链路（plan §6 的整段删除清单），一起守住免得换个写法又长回来。
+NETWORK_DEBRIS = (
+    "WinHttp",
+    "FUSHI_KIRIKIRI_LOOKUP_PORT",
+    "FUSHI_KIRIKIRI_LOOKUP_TOKEN",
+    "/api/lookup/dictionary",
+    "Authorization: Bearer",
+)
+
+# 往引擎全局类上打补丁：`global.Layer.xxx =` / `global.MessageLayer.xxx =`（排除 `==`）。
+GLOBAL_PATCH_RE = re.compile(r"global\.(?:Layer|MessageLayer)\.\w+\s*=(?!=)")
+
+# 默认关闭的探测分支。全局补丁只允许活在它里面：换游戏、TextRender 一条都不命中时才开，
+# 用来判断文本到底走哪条路。
+PROBE_GATE_RE = re.compile(r"if\s*\(\s*global\.fushiLookupProbeMode\s*\)")
+
+
+def _iter_find(haystack: str, needle: str) -> Iterator[int]:
+    start = 0
+    while True:
+        index = haystack.find(needle, start)
+        if index < 0:
+            return
+        yield index
+        start = index + len(needle)
+
+
+class MaskedSource:
+    """抠掉注释与字符串字面量之后的源码，便于按运算符/括号做结构判断。
+
+    `masked` 与原文**等长、换行数相同**：每个字符串字面量整体被替换成
+    `\\x01<序号>\\x01` 再用空格补齐，所以下标可以直接换算回原文行号。
+    """
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.literals: list[str] = []
+        self.masked = self._mask(text)
+        self._blocks: list[tuple[int, int]] | None = None
+
+    # -- 掩码 ---------------------------------------------------------------
+    def _mask(self, text: str) -> str:
+        out: list[str] = []
+        i = 0
+        n = len(text)
+        while i < n:
+            ch = text[i]
+            if ch == "/" and i + 1 < n and text[i + 1] == "/":
+                end = text.find("\n", i)
+                end = n if end < 0 else end
+                out.append(" " * (end - i))
+                i = end
+                continue
+            if ch == "/" and i + 1 < n and text[i + 1] == "*":
+                end = text.find("*/", i + 2)
+                end = n if end < 0 else end + 2
+                out.append("".join("\n" if c == "\n" else " " for c in text[i:end]))
+                i = end
+                continue
+            raw = re.match(r'(?:L|u8|u|U)?R"([^()\\ ]{0,16})\(', text[i:])
+            if raw is not None:
+                closer = ")" + raw.group(1) + '"'
+                end = text.find(closer, i + raw.end())
+                end = n if end < 0 else end + len(closer)
+                out.append(self._slot(text[i:end]))
+                i = end
+                continue
+            lit = re.match(r'(?:L|u8|u|U)?"', text[i:])
+            if lit is not None:
+                j = i + lit.end()
+                while j < n:
+                    if text[j] == "\\":
+                        j += 2
+                        continue
+                    if text[j] == '"':
+                        j += 1
+                        break
+                    j += 1
+                out.append(self._slot(text[i:j]))
+                i = j
+                continue
+            if ch == "'":
+                j = i + 1
+                while j < n:
+                    if text[j] == "\\":
+                        j += 2
+                        continue
+                    if text[j] == "'":
+                        j += 1
+                        break
+                    j += 1
+                out.append("".join("\n" if c == "\n" else " " for c in text[i:j]))
+                i = j
+                continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
+    def _slot(self, literal: str) -> str:
+        span = len(literal)
+        newlines = literal.count("\n")
+        index = len(self.literals)
+        self.literals.append(literal)
+        token = f"{_SLOT}{index}{_SLOT}"
+        if span - newlines < len(token):
+            # 极短字面量放不下槽标记：退化成空白（内容本来也无从判定）。
+            return "".join("\n" if c == "\n" else " " for c in literal)
+        return token + " " * (span - newlines - len(token)) + "\n" * newlines
+
+    # -- 查询 ---------------------------------------------------------------
+    def line_of(self, index: int) -> int:
+        return self.text.count("\n", 0, index) + 1
+
+    def literal_at(self, index: int) -> str | None:
+        if index < 0 or index >= len(self.masked) or self.masked[index] != _SLOT:
+            return None
+        end = self.masked.find(_SLOT, index + 1)
+        if end < 0:
+            return None
+        return self.literals[int(self.masked[index + 1 : end])]
+
+    def statements(self) -> Iterator[tuple[int, str]]:
+        start = 0
+        for match in re.finditer(r";", self.masked):
+            yield start, self.masked[start : match.start()]
+            start = match.end()
+        if start < len(self.masked):
+            yield start, self.masked[start:]
+
+    def blocks(self) -> list[tuple[int, int]]:
+        if self._blocks is not None:
+            return self._blocks
+        stack: list[int] = []
+        found: list[tuple[int, int]] = []
+        for index, ch in enumerate(self.masked):
+            if ch == "{":
+                stack.append(index)
+            elif ch == "}" and stack:
+                found.append((stack.pop(), index + 1))
+        self._blocks = found
+        return found
+
+    def enclosing_function(self, index: int) -> tuple[int, int] | None:
+        """包住 [index] 的最内层「看起来是函数体」的大括号块。
+
+        判据只看紧邻 `{` 之前那段声明文本：含成对括号、且不是 namespace/class/struct
+        /enum/union 的开头。多行签名也能认出来（往前取一段而不是只取一行）。
+        """
+        best: tuple[int, int] | None = None
+        for start, end in self.blocks():
+            if not (start <= index < end):
+                continue
+            head = self.masked[max(0, start - 400) : start]
+            cut = max(head.rfind(";"), head.rfind("}"), head.rfind("{"))
+            decl = head[cut + 1 :].strip()
+            if "(" not in decl or ")" not in decl:
+                continue
+            if re.match(r"(namespace|class|struct|enum|union)\b", decl):
+                continue
+            if best is None or start > best[0]:
+                best = (start, end)
+        return best
+
+
+# ── 规则实现（真文件与变异样本共用同一份，谁都不许各写一套）──────────────────
+
+
+def _is_literal_slot(statement: str, index: int) -> bool:
+    return bool(_SLOT_RE.match(statement, index))
+
+
+def _closes_to_wstring(statement: str, close_index: int) -> bool:
+    """`statement[close_index]` 是 `)`，判断它闭合的是不是 `std::to_wstring(`。"""
+    depth = 0
+    i = close_index
+    while i >= 0:
+        if statement[i] == ")":
+            depth += 1
+        elif statement[i] == "(":
+            depth -= 1
+            if depth == 0:
+                head = statement[:i].rstrip()
+                return head.endswith("to_wstring")
+        i -= 1
+    return False
+
+
+_ID_RE = re.compile(r"[A-Za-z_]\w*")
+# 赋值目标：标识符后紧跟 `=` 或 `+=`（排除 `==` / `!=` / `>=` / `<=`）。
+_TARGET_RE = re.compile(r"([A-Za-z_]\w*)\s*\+?=(?!=)")
+_MOVE_RE = re.compile(r"std::move\s*\(\s*([A-Za-z_]\w*)\s*\)")
+
+
+def _statement_holds_tjs_literal(source: MaskedSource, offset: int, statement: str) -> bool:
+    return any(
+        TJS_MARKER in (source.literal_at(offset + match.start()) or "")
+        for match in _SLOT_RE.finditer(statement)
+    )
+
+
+def _tjs_script_variables(
+    source: MaskedSource, statements: list[tuple[int, str]]
+) -> set[str]:
+    """哪些变量装着 TJS 源码。
+
+    脚本文本通常先用一条语句起头（`std::wstring script = L"...fushiLookupApply(";`），
+    再由后续 `script += ...` 追加——追加那几条语句里一个 TJS 字面量都没有。所以判定
+    必须跟着**变量**走，只按单条语句看会漏掉真正危险的那几行。
+    """
+    tainted: set[str] = set()
+    for _ in range(3):  # 变量间传递（script -> pending_script）几轮即到不动点
+        for offset, statement in statements:
+            target = _TARGET_RE.search(statement)
+            if target is None:
+                continue
+            if _statement_holds_tjs_literal(source, offset, statement):
+                tainted.add(target.group(1))
+                continue
+            # 传播只认**直接转手**（`x = script;` / `x = std::move(script);`）。
+            # 不能按"语句里提到了某个受污染变量"来传播：那样 `i`、`value` 这种到处都
+            # 有的名字会瞬间污染全文件，守卫立刻变成一改就红的噪音源。
+            rhs = _MOVE_RE.sub(r"\1", statement[target.end() :])
+            rhs = _SLOT_RE.sub(" ", rhs).strip()
+            if rhs in tainted:
+                tainted.add(target.group(1))
+    return tainted
+
+
+def find_dynamic_tjs_concatenations(source: MaskedSource) -> list[str]:
+    """找出「拼 TJS 源码」的语句。
+
+    只看**装着 TJS 源码的变量**身上的 `+`：其操作数必须是字符串字面量或
+    `std::to_wstring(...)`。路径拼接、日志拼接这类与注入面无关的字符串运算因此不会被
+    误伤——守卫要抓的是「会被 eval 的那段文本」，不是所有字符串加法。
+    """
+    violations: list[str] = []
+    statements = list(source.statements())
+    tainted = _tjs_script_variables(source, statements)
+    for offset, statement in statements:
+        touches_tjs = _statement_holds_tjs_literal(source, offset, statement)
+        if not touches_tjs:
+            target = _TARGET_RE.search(statement)
+            if target is None or target.group(1) not in tainted:
+                continue
+        for match in re.finditer(r"\+", statement):
+            i = match.start()
+            if statement[i : i + 2] == "++" or (i > 0 and statement[i - 1] == "+"):
+                continue
+            compound = statement[i : i + 2] == "+="
+            right = i + (2 if compound else 1)
+            while right < len(statement) and statement[right].isspace():
+                right += 1
+            ok = _is_literal_slot(statement, right) or bool(
+                re.match(r"(std::)?to_wstring\s*\(", statement[right:])
+            )
+            if ok and not compound:
+                left = i - 1
+                while left >= 0 and statement[left].isspace():
+                    left -= 1
+                if left < 0:
+                    ok = False
+                elif statement[left] == _SLOT:
+                    ok = True  # 字面量槽以 \x01 收尾
+                elif statement[left] == ")":
+                    ok = _closes_to_wstring(statement, left)
+                else:
+                    ok = False
+            if ok:
+                continue
+            snippet = " ".join(statement[max(0, i - 70) : i + 70].split())
+            violations.append(
+                f"{ADAPTER.name}:{source.line_of(offset + i)} "
+                f"把非整数内容拼进 TJS 源码：… {snippet} …"
+            )
+    return violations
+
+
+def find_network_debris(source: MaskedSource) -> list[str]:
+    hits: list[str] = []
+    for needle in NETWORK_DEBRIS:
+        for index in _iter_find(source.text, needle):
+            hits.append(f"{ADAPTER.name}:{source.line_of(index)} {needle}")
+    return hits
+
+
+def _probe_block_spans(text: str) -> list[tuple[int, int]]:
+    """`if(global.fushiLookupProbeMode) { ... }` 的字节区间（TJS 侧大括号配对）。"""
+    spans: list[tuple[int, int]] = []
+    for gate in PROBE_GATE_RE.finditer(text):
+        open_index = text.find("{", gate.end())
+        if open_index < 0:
+            continue
+        depth = 0
+        for j in range(open_index, len(text)):
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    spans.append((gate.start(), j + 1))
+                    break
+    return spans
+
+
+def find_global_monkey_patches(source: MaskedSource) -> list[str]:
+    """引擎全局类的补丁只允许出现在默认关闭的探测分支里。
+
+    `global.Layer.drawText` 挂上包装之后，游戏**所有** UI 绘制都要多绕一层；游戏内
+    渲染下这直接变成掉帧。运行日志已经证伪了这条捕获路径（只有 TextRender 命中），
+    所以它只能作为换游戏时的探针存在，且默认关闭。
+    """
+    spans = _probe_block_spans(source.text)
+    hits: list[str] = []
+    for m in GLOBAL_PATCH_RE.finditer(source.text):
+        if any(start <= m.start() < end for start, end in spans):
+            continue
+        hits.append(f"{ADAPTER.name}:{source.line_of(m.start())} {m.group(0)}")
+    return hits
+
+
+def find_default_on_probe_switches(source: MaskedSource) -> list[str]:
+    """喂给 `__FUSHI_PROBE_MODE__` 的开关必须默认关。
+
+    探测分支被允许存在的**唯一**前提就是它默认不跑；开关默认 true 时上面那条豁免立刻
+    变成"全局补丁常驻"。这里跟着实际替换表达式里的标识符走，改名不会让这条守卫失效。
+    """
+    for match in re.finditer(
+        r'__FUSHI_PROBE_MODE__"\s*,([^;]*);', source.text, re.S
+    ):
+        expression = match.group(1)
+        names = [
+            name
+            for name in _ID_RE.findall(expression)
+            if name not in {"L", "true", "false", "std", "wstring"}
+        ]
+        if not names:
+            continue
+        for name in names:
+            if re.search(rf"\b{re.escape(name)}\s*=\s*false\s*;", source.text):
+                return []
+        return [
+            f"{ADAPTER.name}:{source.line_of(match.start())} "
+            f"探测开关 {names} 没有一个定义为 false"
+        ]
+    return []
+
+
+def _placeholder_substitutions(text: str) -> list[tuple[int, str, str]]:
+    """`ReplaceLookupPlaceholder(script, L"__FUSHI_X__", <值表达式>);` 的 (位置, 占位符, 值)。"""
+    return [
+        (m.start(), m.group(1), m.group(2))
+        for m in re.finditer(r'(__FUSHI_[A-Z0-9_]*__)"\s*,([^;]*)\)\s*;', text, re.S)
+    ]
+
+
+def find_unvalidated_placeholder_values(source: MaskedSource) -> list[str]:
+    """填进 TJS bootstrap 的占位符，其值要么是字面量，要么必须过字符类校验。
+
+    PNG 备路要把 `%TEMP%` 下的卡片路径交给 TJS 的 `loadImages`，所以这一处运行期数据是
+    必需的、不禁。但它是整条链上最后一个「内容由运行期数据决定的可执行 TJS」，防线只有
+    一道：写进那个变量之前拒掉引号、反斜杠和换行。**绕开那道校验直接给变量赋值**（以后
+    有人图省事写 `g_lookup_card_path = temp + name;`）就会把注入面重新打开，而症状在真机
+    上完全看不出来——所以这里逐个赋值点核，不只看"校验函数还在不在"。
+    """
+    violations: list[str] = []
+    for position, placeholder, expression in _placeholder_substitutions(source.text):
+        if '"' in expression or "'" in expression:
+            continue  # 值是字面量（如 `? L"1" : L"0"`），没有运行期数据
+        names = [
+            name
+            for name in _ID_RE.findall(expression)
+            if name not in {"L", "true", "false", "std", "wstring", "script"}
+        ]
+        if not names:
+            violations.append(
+                f"{ADAPTER.name}:{source.line_of(position)} "
+                f"{placeholder} 的替换值既不是字面量也认不出变量"
+            )
+            continue
+        for name in names:
+            for assign in re.finditer(
+                rf"\b{re.escape(name)}\s*=(?!=)", source.masked
+            ):
+                scope = source.enclosing_function(assign.start())
+                body = source.masked[scope[0] : scope[1]] if scope is not None else ""
+                if "find_first_of" in body:
+                    continue
+                violations.append(
+                    f"{ADAPTER.name}:{source.line_of(assign.start())} "
+                    f"{name}（{placeholder} 的值）在没有字符类校验的地方被赋值"
+                )
+    return violations
+
+
+def find_unguarded_bitmap_copies(source: MaskedSource) -> list[str]:
+    """取查词位图缓冲的函数里必须出现 `IsLookupFrameSane`。
+
+    跨进程来的 width/height/pitch 是不可信输入，按它们盲拷就是往游戏进程越界写；
+    这个闸门是那条路径上唯一的关卡。
+    """
+    unguarded: list[str] = []
+    for index in _iter_find(source.masked, "LookupBitmapAt("):
+        scope = source.enclosing_function(index)
+        if scope is None:
+            unguarded.append(
+                f"{ADAPTER.name}:{source.line_of(index)} 取位图缓冲处不在任何函数体内"
+            )
+            continue
+        if "IsLookupFrameSane" not in source.masked[scope[0] : scope[1]]:
+            unguarded.append(
+                f"{ADAPTER.name}:{source.line_of(index)} "
+                "取位图缓冲的函数里没有 IsLookupFrameSane"
+            )
+    return unguarded
+
+
+# ── 扫真文件 ────────────────────────────────────────────────────────────────
+
+
+class RealAdapterTest(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = MaskedSource(ADAPTER.read_text(encoding="utf-8"))
+
+    def test_never_builds_tjs_source_from_dynamic_strings(self) -> None:
+        self.assertEqual(
+            [],
+            find_dynamic_tjs_concatenations(self.source),
+            "传给 TVPExecuteScript 的 TJS 文本只能由字面量 + std::to_wstring(整数) 构成；"
+            "任何运行期字符串拼进去都等于在游戏进程里开一个 eval 注入面。",
+        )
+
+    def test_has_no_http_client_or_credentials(self) -> None:
+        self.assertEqual(
+            [],
+            find_network_debris(self.source),
+            "游戏进程里不得有 HTTP 客户端或认证凭据；开关与数据一律走 v14 共享内存查词区。",
+        )
+
+    def test_does_not_monkey_patch_engine_globals_outside_the_probe_branch(
+        self,
+    ) -> None:
+        self.assertEqual(
+            [],
+            find_global_monkey_patches(self.source),
+            "global.Layer.drawText / global.MessageLayer.processCh 的全局补丁已被运行"
+            "日志证伪（只有 TextRender 命中）；挂在全局类上会让游戏所有 UI 绘制多绕一层，"
+            "游戏内渲染下直接掉帧。只允许留在默认关闭的探测分支里。",
+        )
+
+    def test_probe_branch_is_off_by_default(self) -> None:
+        self.assertEqual(
+            [],
+            find_default_on_probe_switches(self.source),
+            "探测分支被允许存在的唯一前提是它默认不跑；开关默认打开等于全局补丁常驻。",
+        )
+
+    def test_placeholder_values_pass_the_character_class_check(self) -> None:
+        self.assertEqual(
+            [],
+            find_unvalidated_placeholder_values(self.source),
+            "填进 TJS bootstrap 的运行期值（PNG 备路的卡片路径）必须先被拒掉引号/反斜杠/"
+            "换行；绕开那道校验直接赋值等于把 eval 注入面重新打开。",
+        )
+
+    def test_bitmap_copy_sites_are_guarded_by_the_frame_sanity_check(self) -> None:
+        self.assertEqual(
+            [],
+            find_unguarded_bitmap_copies(self.source),
+            "读写查词位图缓冲之前必须先过 IsLookupFrameSane —— 它是「按跨进程不可信的 "
+            "width/height 盲拷」这条越界写路径上的唯一闸门。",
+        )
+
+
+# ── 变异自测：证明上面每条规则真的会红 ──────────────────────────────────────
+
+CLEAN_SAMPLE = """
+// 整数回执：唯一允许的形态。
+void QueueLookupApply(uint64_t seq, uint32_t start, uint32_t length) {
+  std::wstring script = L"if(typeof global.fushiLookupApply!=\\"undefined\\") "
+                        L"global.fushiLookupApply(";
+  script += std::to_wstring(seq) + L"," + std::to_wstring(start) + L"," +
+            std::to_wstring(length) + L");";
+  g_lookup_pending_script = std::move(script);
+}
+
+bool CopyLookupFrame(SharedHeader* header, uint32_t index,
+                     uint8_t* target) {
+  const LookupFrame* frame = LookupFrameAt(header, index);
+  if (!IsLookupFrameSane(header, frame)) return false;
+  const uint8_t* pixels = LookupBitmapAt(header, index);
+  memcpy(target, pixels, frame->byte_len);
+  return true;
+}
+
+// 与 TJS 无关的字符串拼接不该被误伤。
+std::wstring TempPath(const std::wstring& dir, const std::wstring& name) {
+  return dir + name + L".png";
+}
+
+constexpr bool kProbePaths = false;
+
+std::wstring g_lookup_card_path;
+
+// PNG 备路要把 %TEMP% 下的卡片路径交给 TJS 的 loadImages：唯一一处进 bootstrap 的运行期
+// 数据，防线就是这道字符类拒绝。
+bool SetLookupCardPath(const std::wstring& path) {
+  if (path.find_first_of(kForbiddenPathChars) != std::wstring::npos) return false;
+  g_lookup_card_path = path;
+  return true;
+}
+
+std::wstring BuildBootstrap() {
+  std::wstring script = kBootstrap;
+  ReplaceLookupPlaceholder(script, L"__FUSHI_PROBE_MODE__",
+                           kProbePaths ? L"1" : L"0");
+  ReplaceLookupPlaceholder(script, L"__FUSHI_CARD_PATH__", g_lookup_card_path);
+  return script;
+}
+
+// 默认关闭的探测分支：全局补丁只允许活在这里。
+static const wchar_t kBootstrap[] = LR"TJS(
+if(global.fushiLookupProbeMode)
+{
+	global.fushiLookupProbeOriginalDrawText = global.Layer.drawText;
+	global.Layer.drawText = function(x, y, text) { return 0; };
+}
+)TJS";
+"""
+
+
+class MutationSelfTest(unittest.TestCase):
+    """把每条规则要抓的东西真的塞进合成源码，确认规则会红。"""
+
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.clean = MaskedSource(CLEAN_SAMPLE)
+
+    def _mutate(self, old: str, new: str) -> MaskedSource:
+        self.assertIn(old, CLEAN_SAMPLE, "变异锚点必须真的存在于干净样本里")
+        dirty = CLEAN_SAMPLE.replace(old, new, 1)
+        self.assertNotEqual(dirty, CLEAN_SAMPLE, "变异样本必须真的与干净样本不同")
+        return MaskedSource(dirty)
+
+    def test_clean_sample_passes_every_rule(self) -> None:
+        self.assertEqual([], find_dynamic_tjs_concatenations(self.clean))
+        self.assertEqual([], find_network_debris(self.clean))
+        self.assertEqual([], find_global_monkey_patches(self.clean))
+        self.assertEqual([], find_default_on_probe_switches(self.clean))
+        self.assertEqual([], find_unvalidated_placeholder_values(self.clean))
+        self.assertEqual([], find_unguarded_bitmap_copies(self.clean))
+        # 干净样本里确实有一处运行期占位符替换，否则这条规则根本没被走到。
+        self.assertTrue(
+            any(
+                name == "__FUSHI_CARD_PATH__"
+                for _, name, _ in _placeholder_substitutions(CLEAN_SAMPLE)
+            )
+        )
+        # 干净样本里确实有一个被豁免的探测分支补丁——否则"豁免"这条根本没被走到。
+        self.assertIsNotNone(GLOBAL_PATCH_RE.search(CLEAN_SAMPLE))
+        self.assertNotEqual([], _probe_block_spans(CLEAN_SAMPLE))
+
+    def test_string_variable_interpolated_into_tjs_source_is_red(self) -> None:
+        dirty = self._mutate(
+            'std::to_wstring(start) + L","',
+            'word + L","',
+        )
+        self.assertNotEqual([], find_dynamic_tjs_concatenations(dirty))
+
+    def test_escaping_helper_interpolated_into_tjs_source_is_red(self) -> None:
+        dirty = self._mutate(
+            'std::to_wstring(length) + L");"',
+            'EscapeTjsString(definition) + L");"',
+        )
+        self.assertNotEqual([], find_dynamic_tjs_concatenations(dirty))
+
+    def test_compound_append_of_a_variable_is_red(self) -> None:
+        dirty = self._mutate("script += std::to_wstring(seq)", "script += word")
+        self.assertNotEqual([], find_dynamic_tjs_concatenations(dirty))
+
+    def test_unrelated_string_concatenation_stays_green(self) -> None:
+        # 反向变异：非 TJS 语句里加更多字符串拼接，守卫必须仍然绿（否则它一改就红）。
+        dirty = self._mutate(
+            "return dir + name + L\".png\";",
+            "return dir + name + suffix + L\".png\";",
+        )
+        self.assertEqual([], find_dynamic_tjs_concatenations(dirty))
+
+    def test_every_network_debris_literal_is_red_on_its_own(self) -> None:
+        for needle in NETWORK_DEBRIS:
+            dirty = MaskedSource(
+                CLEAN_SAMPLE + f'\nconst wchar_t kDebris[] = L"{needle}";\n'
+            )
+            found = find_network_debris(dirty)
+            self.assertNotEqual([], found, f"{needle} 必须被抓到")
+            self.assertTrue(any(needle in item for item in found), needle)
+
+    def test_global_monkey_patch_outside_the_probe_branch_is_red(self) -> None:
+        for patch in (
+            "global.Layer.drawText = function(x, y) {};",
+            "global.MessageLayer.processCh = function(ch) {};",
+            "global.Layer.fillRect = function() {};",
+        ):
+            dirty = MaskedSource(CLEAN_SAMPLE + "\n" + patch + "\n")
+            self.assertNotEqual([], find_global_monkey_patches(dirty), patch)
+        # 比较不是补丁，不该误伤。
+        same = MaskedSource(
+            CLEAN_SAMPLE + "\nif(global.Layer.drawText == original) return;\n"
+        )
+        self.assertEqual([], find_global_monkey_patches(same))
+
+    def test_probe_branch_defaulting_to_on_is_red(self) -> None:
+        dirty = self._mutate(
+            "constexpr bool kProbePaths = false;",
+            "constexpr bool kProbePaths = true;",
+        )
+        self.assertNotEqual([], find_default_on_probe_switches(dirty))
+
+    def test_patch_escaping_the_probe_branch_is_red(self) -> None:
+        # 把补丁从探测分支里挪出来（分支留空）——豁免立刻失效。
+        dirty = self._mutate(
+            "if(global.fushiLookupProbeMode)\n{\n\t"
+            "global.fushiLookupProbeOriginalDrawText = global.Layer.drawText;\n\t"
+            "global.Layer.drawText = function(x, y, text) { return 0; };\n}",
+            "global.Layer.drawText = function(x, y, text) { return 0; };",
+        )
+        self.assertNotEqual([], find_global_monkey_patches(dirty))
+
+    def test_dropping_the_card_path_character_check_is_red(self) -> None:
+        dirty = self._mutate(
+            "  if (path.find_first_of(kForbiddenPathChars) != std::wstring::npos)"
+            " return false;\n",
+            "",
+        )
+        self.assertNotEqual([], find_unvalidated_placeholder_values(dirty))
+
+    def test_assigning_the_card_path_elsewhere_is_red(self) -> None:
+        # 校验函数还在，但有人在别处绕开它直接拼了一个路径进去。
+        dirty = MaskedSource(
+            CLEAN_SAMPLE
+            + "\nvoid Oops(const std::wstring& dir) {\n"
+            "  g_lookup_card_path = dir + L\"card.png\";\n}\n"
+        )
+        self.assertNotEqual([], find_unvalidated_placeholder_values(dirty))
+
+    def test_unguarded_bitmap_copy_is_red(self) -> None:
+        dirty = self._mutate(
+            "  if (!IsLookupFrameSane(header, frame)) return false;\n", ""
+        )
+        self.assertNotEqual([], find_unguarded_bitmap_copies(dirty))
+
+    def test_masking_keeps_line_numbers_and_hides_literal_content(self) -> None:
+        self.assertEqual(len(self.clean.masked), len(CLEAN_SAMPLE))
+        self.assertEqual(self.clean.masked.count("\n"), CLEAN_SAMPLE.count("\n"))
+        self.assertNotIn("fushiLookupApply", self.clean.masked)
+        # 行号映射没漂：干净样本里 memcpy 的行号按原文数得出来。
+        index = CLEAN_SAMPLE.index("memcpy(")
+        self.assertEqual(
+            self.clean.line_of(index), CLEAN_SAMPLE.count("\n", 0, index) + 1
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
+++ b/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
@@ -1,0 +1,624 @@
+// v14 游戏内查词区的**契约级**测试。
+//
+// 这块区的三条通道（hit / input / frame）是跨进程的，写侧在游戏进程里、读侧在 Hibiki
+// 里，两边只靠 voice_hook_ipc.h 的寻址函数对齐。所以下面钉死的不是"某个 adapter 怎么
+// 写"，而是**任何写侧/读侧都必须成立的结构性质**：
+//
+//   1. 各子区首尾相接、互不重叠、整区不越界，且每个子区都保持 8 字节对齐；
+//   2. `IsLookupFrameSane` 是"按跨进程不可信的 width/height 盲拷"的**唯一闸门**——
+//      每一条拒绝理由都要有自己的独立用例，否则某天有人删掉其中一条也没人发现；
+//   3. `lookup_region_offset == 0`（旧会话 / 未分配）时访问器一律给 nullptr，而不是
+//      拿 header 基址当区起点算出野指针；
+//   4. v14 是**纯追加**：v13 及更早各区的偏移一个字节都不许被查词区影响。
+//
+// 与 text_lane_ipc_test.cpp 同一套做法：在进程内摆一块按真实布局排好的假共享内存，
+// 直接跑契约头里的那份寻址实现（不复制一份到测试里）。
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "voice_hook_ipc.h"
+
+namespace {
+
+using fushi_voice_hook::HasLookupRegion;
+using fushi_voice_hook::IsLookupFrameSane;
+using fushi_voice_hook::kClipCount;
+using fushi_voice_hook::kLookupBitmapBytes;
+using fushi_voice_hook::kLookupFrameCount;
+using fushi_voice_hook::kLookupFrameDismiss;
+using fushi_voice_hook::kLookupInputSlotCount;
+using fushi_voice_hook::kLookupLineBytes;
+using fushi_voice_hook::kLoopbackMarkerCount;
+using fushi_voice_hook::kSharedVersion;
+using fushi_voice_hook::kTextLaneCount;
+using fushi_voice_hook::kTextLaneSlotCount;
+using fushi_voice_hook::kThreadPreviewCount;
+using fushi_voice_hook::LookupBitmapAt;
+using fushi_voice_hook::LookupFrame;
+using fushi_voice_hook::LookupFrameAt;
+using fushi_voice_hook::LookupHitOf;
+using fushi_voice_hook::LookupHitSlot;
+using fushi_voice_hook::LookupInputSlot;
+using fushi_voice_hook::LookupInputsOf;
+using fushi_voice_hook::LookupRegionBytes;
+using fushi_voice_hook::LoopbackMarker;
+using fushi_voice_hook::SharedHeader;
+using fushi_voice_hook::ShouldApplyLookupFrame;
+using fushi_voice_hook::ThreadPreviewSlot;
+using fushi_voice_hook::VoiceClip;
+
+int g_failures = 0;
+
+void Check(bool condition, const std::string& what) {
+  if (!condition) {
+    ++g_failures;
+    fprintf(stderr, "FAIL: %s\n", what.c_str());
+  }
+}
+
+// 按 injector 的真实布局摆一块共享内存：
+//   [SharedHeader][音频环][文本区][clip 索引][loopback 环][标记表][线程预览区][查词区]
+// 音频/loopback 环容量取小值——本测试一个字节都不碰它们，只是要让**查词区之前的所有区
+// 都真实存在**，这样"查词区在最尾、前面各区偏移不受影响"才是被真的验证过的。
+struct FakeMapping {
+  static constexpr uint32_t kRingCapacity = 4096;
+  static constexpr uint32_t kLoopbackCapacity = 4096;
+
+  std::vector<uint8_t> bytes;
+  uint64_t lookup_bytes = 0;
+  uint64_t total_bytes = 0;
+
+  explicit FakeMapping(bool with_lookup_region = true) {
+    const uint64_t text_bytes =
+        fushi_voice_hook::TextRegionBytes(kTextLaneCount, kTextLaneSlotCount);
+    const uint64_t clip_bytes =
+        static_cast<uint64_t>(kClipCount) * sizeof(VoiceClip);
+    const uint64_t marker_bytes =
+        static_cast<uint64_t>(kLoopbackMarkerCount) * sizeof(LoopbackMarker);
+    const uint64_t preview_bytes =
+        static_cast<uint64_t>(kThreadPreviewCount) * sizeof(ThreadPreviewSlot);
+    lookup_bytes =
+        with_lookup_region
+            ? LookupRegionBytes(kLookupInputSlotCount, kLookupFrameCount,
+                                kLookupBitmapBytes)
+            : 0;
+    total_bytes = sizeof(SharedHeader) + kRingCapacity + text_bytes +
+                  clip_bytes + kLoopbackCapacity + marker_bytes +
+                  preview_bytes + lookup_bytes;
+    bytes.assign(static_cast<size_t>(total_bytes), 0);
+
+    SharedHeader* h = header();
+    h->magic = fushi_voice_hook::kSharedMagic;
+    h->version = kSharedVersion;
+    h->ring_capacity = kRingCapacity;
+    h->text_region_offset =
+        static_cast<uint32_t>(sizeof(SharedHeader) + kRingCapacity);
+    h->text_lane_count = kTextLaneCount;
+    h->text_lane_slot_count = kTextLaneSlotCount;
+    h->clip_region_offset =
+        static_cast<uint32_t>(h->text_region_offset + text_bytes);
+    h->loopback_ring_offset =
+        static_cast<uint32_t>(h->clip_region_offset + clip_bytes);
+    h->loopback_ring_capacity = kLoopbackCapacity;
+    h->loopback_marker_offset =
+        static_cast<uint32_t>(h->loopback_ring_offset + kLoopbackCapacity);
+    h->loopback_marker_slot_count = kLoopbackMarkerCount;
+    h->thread_preview_offset =
+        static_cast<uint32_t>(h->loopback_marker_offset + marker_bytes);
+    h->thread_preview_slot_count = kThreadPreviewCount;
+    if (!with_lookup_region) return;
+    h->lookup_region_offset =
+        static_cast<uint32_t>(h->thread_preview_offset + preview_bytes);
+    h->lookup_bitmap_bytes = kLookupBitmapBytes;
+    h->lookup_frame_count = kLookupFrameCount;
+    h->lookup_input_slot_count = kLookupInputSlotCount;
+  }
+
+  SharedHeader* header() {
+    return reinterpret_cast<SharedHeader*>(bytes.data());
+  }
+  const SharedHeader* header() const {
+    return reinterpret_cast<const SharedHeader*>(bytes.data());
+  }
+  // 任意指针相对 header 基址的字节偏移（越界与重叠判定统一用它，不再各算各的）。
+  uint64_t OffsetOf(const void* pointer) const {
+    return static_cast<uint64_t>(reinterpret_cast<const uint8_t*>(pointer) -
+                                 bytes.data());
+  }
+};
+
+// 一帧"本来就该被接受"的位图元数据：640x400 BGRA，紧凑 pitch，byte_len 自洽且远小于容量。
+LookupFrame HealthyFrame() {
+  LookupFrame frame = {};
+  frame.seq = 7;
+  frame.width = 640;
+  frame.height = 400;
+  frame.pitch = 640 * 4;
+  frame.anchor_x = 120;
+  frame.anchor_y = 64;
+  frame.highlight_start = 3;
+  frame.highlight_len = 2;
+  frame.byte_len = frame.pitch * frame.height;
+  frame.ready = 1;
+  return frame;
+}
+
+// ── 1. 区布局：首尾相接、互不重叠、不越界、8 对齐 ────────────────────────────
+
+void TestSubRegionsAreContiguousDisjointAndInBounds() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+
+  const uint64_t region_start = h->lookup_region_offset;
+  const uint64_t hit_at = mapping.OffsetOf(LookupHitOf(h));
+  const uint64_t inputs_at = mapping.OffsetOf(LookupInputsOf(h));
+  const uint64_t frames_at = mapping.OffsetOf(LookupFrameAt(h, 0));
+  const uint64_t bitmaps_at = mapping.OffsetOf(LookupBitmapAt(h, 0));
+
+  Check(hit_at == region_start, "hit 槽必须就是查词区起点");
+  Check(inputs_at == hit_at + sizeof(LookupHitSlot),
+        "输入环紧跟 hit 槽，中间不许有洞");
+  Check(frames_at ==
+            inputs_at + static_cast<uint64_t>(kLookupInputSlotCount) *
+                            sizeof(LookupInputSlot),
+        "帧元数据紧跟输入环");
+  Check(bitmaps_at == frames_at + static_cast<uint64_t>(kLookupFrameCount) *
+                                      sizeof(LookupFrame),
+        "位图区紧跟帧元数据");
+
+  // 整区尺寸函数与访问器算出的布局必须是同一个东西：injector 按前者分配、读写两侧按
+  // 后者寻址，两者一旦漂开就是越界写。
+  const uint64_t last_bitmap_end =
+      mapping.OffsetOf(LookupBitmapAt(h, kLookupFrameCount - 1)) +
+      h->lookup_bitmap_bytes;
+  Check(last_bitmap_end - region_start ==
+            LookupRegionBytes(kLookupInputSlotCount, kLookupFrameCount,
+                              kLookupBitmapBytes),
+        "访问器算出的整区跨度必须等于 LookupRegionBytes（分配与寻址同一份真值）");
+  Check(last_bitmap_end <= mapping.total_bytes,
+        "查词区最后一个字节仍在映射内");
+
+  // 相邻子区互不重叠（上面的"紧跟"已蕴含，但这里按区间显式再判一次，避免某天有人
+  // 把某个子区改成负跨度还让"紧跟"式断言碰巧成立）。
+  const uint64_t hit_end = hit_at + sizeof(LookupHitSlot);
+  const uint64_t inputs_end =
+      inputs_at +
+      static_cast<uint64_t>(kLookupInputSlotCount) * sizeof(LookupInputSlot);
+  const uint64_t frames_end =
+      frames_at +
+      static_cast<uint64_t>(kLookupFrameCount) * sizeof(LookupFrame);
+  Check(hit_end <= inputs_at && inputs_end <= frames_at &&
+            frames_end <= bitmaps_at,
+        "四个子区两两不重叠");
+}
+
+void TestEverySubRegionStaysEightAligned() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+  Check(h->lookup_region_offset % 8 == 0, "查词区起点 8 对齐");
+  Check(mapping.OffsetOf(LookupHitOf(h)) % 8 == 0, "hit 槽 8 对齐");
+  Check(mapping.OffsetOf(LookupInputsOf(h)) % 8 == 0, "输入环 8 对齐");
+  Check(mapping.OffsetOf(LookupFrameAt(h, 0)) % 8 == 0, "帧元数据 8 对齐");
+  Check(mapping.OffsetOf(LookupBitmapAt(h, 0)) % 8 == 0, "位图区 8 对齐");
+  // 逐槽也要对齐：跨进程 volatile uint64 seq 在 x86 上未对齐会撕裂。
+  for (uint32_t i = 0; i < kLookupInputSlotCount; ++i) {
+    Check(mapping.OffsetOf(&LookupInputsOf(h)[i]) % 8 == 0,
+          "每个输入槽 8 对齐");
+  }
+  for (uint32_t i = 0; i < kLookupFrameCount; ++i) {
+    Check(mapping.OffsetOf(LookupFrameAt(h, i)) % 8 == 0, "每个帧槽 8 对齐");
+    Check(mapping.OffsetOf(LookupBitmapAt(h, i)) % 8 == 0,
+          "每块位图缓冲 8 对齐");
+  }
+  Check(kLookupBitmapBytes % 8 == 0, "位图缓冲容量本身 8 对齐（否则第二块就歪了）");
+  Check(kLookupLineBytes % 8 == 0, "整行台词缓冲 8 对齐");
+}
+
+void TestFrameAndBitmapIndexingIsBounded() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+  const SharedHeader* ch = mapping.header();
+
+  for (uint32_t i = 0; i + 1 < kLookupFrameCount; ++i) {
+    Check(mapping.OffsetOf(LookupFrameAt(h, i + 1)) -
+                  mapping.OffsetOf(LookupFrameAt(h, i)) ==
+              sizeof(LookupFrame),
+          "帧槽步长 = sizeof(LookupFrame)");
+    Check(mapping.OffsetOf(LookupBitmapAt(h, i + 1)) -
+                  mapping.OffsetOf(LookupBitmapAt(h, i)) ==
+              h->lookup_bitmap_bytes,
+          "位图步长 = lookup_bitmap_bytes（双缓冲不许互相踩）");
+  }
+  Check(LookupFrameAt(h, kLookupFrameCount) == nullptr,
+        "越界帧下标必须给 nullptr");
+  Check(LookupBitmapAt(h, kLookupFrameCount) == nullptr,
+        "越界位图下标必须给 nullptr");
+  Check(LookupFrameAt(ch, kLookupFrameCount) == nullptr,
+        "const 重载同样挡越界帧下标");
+  Check(LookupBitmapAt(ch, kLookupFrameCount) == nullptr,
+        "const 重载同样挡越界位图下标");
+  Check(LookupFrameAt(h, 0xFFFFFFFFu) == nullptr, "极端下标不得回绕成合法指针");
+  Check(LookupBitmapAt(h, 0xFFFFFFFFu) == nullptr,
+        "极端位图下标不得回绕成合法指针");
+}
+
+// ── 2. 旧会话：访问器给 nullptr，不给野指针 ──────────────────────────────────
+
+void TestLegacySessionYieldsNullInsteadOfWildPointers() {
+  // lookup_region_offset == 0：v13 及更早的 injector 建的映射，或本会话未分配查词区。
+  // 此时 header 基址 + 0 是一个**看上去合法**的地址（正是 header 自己），如果访问器
+  // 不挡，写 hit 槽就会把 header 本身覆盖掉。
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+  h->lookup_region_offset = 0;
+  const SharedHeader* ch = h;
+
+  Check(!HasLookupRegion(h), "lookup_region_offset==0 即本会话无查词区");
+  Check(LookupHitOf(h) == nullptr, "旧会话 hit 访问器给 nullptr");
+  Check(LookupHitOf(ch) == nullptr, "旧会话 hit const 访问器给 nullptr");
+  Check(LookupInputsOf(h) == nullptr, "旧会话输入环访问器给 nullptr");
+  Check(LookupInputsOf(ch) == nullptr, "旧会话输入环 const 访问器给 nullptr");
+  Check(LookupFrameAt(h, 0) == nullptr, "旧会话帧访问器给 nullptr");
+  Check(LookupFrameAt(ch, 0) == nullptr, "旧会话帧 const 访问器给 nullptr");
+  Check(LookupBitmapAt(h, 0) == nullptr, "旧会话位图访问器给 nullptr");
+  Check(LookupBitmapAt(ch, 0) == nullptr, "旧会话位图 const 访问器给 nullptr");
+
+  // 分工要说清：IsLookupFrameSane 只管"这一帧自身与容量自洽"，**不**管"这块区在不在"。
+  // 旧会话下真正把拷贝挡住的是 LookupBitmapAt 给 nullptr。两道关缺一不可——只查帧不查
+  // 区，就会拿着一个"看起来合法"的帧去写 header 基址。
+  const LookupFrame frame = HealthyFrame();
+  Check(IsLookupFrameSane(h, &frame),
+        "帧闸门只看帧自身，不因为没有查词区就改口（分工必须清晰）");
+  Check(LookupBitmapAt(h, 0) == nullptr,
+        "旧会话下拷贝目标必须是 nullptr —— 这才是挡住写入的那道关");
+
+  Check(!HasLookupRegion(nullptr), "header 为空即无查词区");
+  Check(LookupHitOf(static_cast<SharedHeader*>(nullptr)) == nullptr,
+        "header 为空时 hit 访问器给 nullptr");
+  Check(LookupInputsOf(static_cast<SharedHeader*>(nullptr)) == nullptr,
+        "header 为空时输入环访问器给 nullptr");
+  Check(LookupFrameAt(static_cast<SharedHeader*>(nullptr), 0) == nullptr,
+        "header 为空时帧访问器给 nullptr");
+  Check(LookupBitmapAt(static_cast<SharedHeader*>(nullptr), 0) == nullptr,
+        "header 为空时位图访问器给 nullptr");
+}
+
+// 三个冗余自洽字段任意一个为 0 都说明这块区没摆好；此时同样只能给 nullptr。
+// 它们是"header 被半初始化 / 被旧版本 injector 建出来"的唯一可检信号。
+void TestHalfInitialisedRegionIsTreatedAsAbsent() {
+  struct Case {
+    const char* what;
+    uint32_t SharedHeader::*field;
+  };
+  const Case cases[] = {
+      {"lookup_frame_count==0", &SharedHeader::lookup_frame_count},
+      {"lookup_bitmap_bytes==0", &SharedHeader::lookup_bitmap_bytes},
+      {"lookup_input_slot_count==0", &SharedHeader::lookup_input_slot_count},
+  };
+  for (const Case& c : cases) {
+    FakeMapping mapping;
+    SharedHeader* h = mapping.header();
+    h->*(c.field) = 0;
+    Check(!HasLookupRegion(h), std::string(c.what) + " 时必须判为无查词区");
+    Check(LookupHitOf(h) == nullptr, std::string(c.what) + " 时 hit 给 nullptr");
+    Check(LookupInputsOf(h) == nullptr,
+          std::string(c.what) + " 时输入环给 nullptr");
+    Check(LookupFrameAt(h, 0) == nullptr,
+          std::string(c.what) + " 时帧给 nullptr");
+    Check(LookupBitmapAt(h, 0) == nullptr,
+          std::string(c.what) + " 时位图给 nullptr");
+  }
+  // 容量字段被清零时，帧闸门自己也会拒——这是它唯一与"区状态"有交集的地方。
+  FakeMapping no_capacity;
+  no_capacity.header()->lookup_bitmap_bytes = 0;
+  const LookupFrame frame = HealthyFrame();
+  Check(!IsLookupFrameSane(no_capacity.header(), &frame),
+        "位图容量为 0 时任何帧都不该被判为可拷");
+}
+
+// ── 3. IsLookupFrameSane：越界写的唯一闸门 ─────────────────────────────────
+
+// 每条拒绝理由一个独立用例，且**只**破坏那一条：其余字段保持自洽，否则测试挂了也说
+// 不清是哪条规则在起作用（删掉一条规则时另一条会替它把用例撑绿 = 假绿）。
+void TestFrameSanityRejectsEveryUntrustedShape() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+
+  {
+    const LookupFrame ok = HealthyFrame();
+    Check(IsLookupFrameSane(h, &ok), "自洽的正常帧必须被接受");
+  }
+  {
+    // 带行填充的 pitch（DXGI / WIC 常见）也必须接受——把它拒了就等于逼写侧自己重排像素。
+    LookupFrame padded = HealthyFrame();
+    padded.pitch = padded.width * 4 + 64;
+    padded.byte_len = padded.pitch * padded.height;
+    Check(IsLookupFrameSane(h, &padded), "pitch > width*4 的填充帧必须被接受");
+  }
+  {
+    LookupFrame zero_width = HealthyFrame();
+    zero_width.width = 0;
+    zero_width.pitch = 0;
+    zero_width.byte_len = 0;
+    Check(!IsLookupFrameSane(h, &zero_width), "width==0 必须拒绝");
+  }
+  {
+    LookupFrame zero_height = HealthyFrame();
+    zero_height.height = 0;
+    zero_height.byte_len = 0;
+    Check(!IsLookupFrameSane(h, &zero_height), "height==0 必须拒绝");
+  }
+  {
+    // 只让 width 超上界：height=1 使 pitch*height 仍远小于位图容量，从而排除
+    // "其实是被容量规则挡下来的"这种假绿。
+    LookupFrame huge_width = HealthyFrame();
+    huge_width.width = 0x4001u;
+    huge_width.height = 1;
+    huge_width.pitch = huge_width.width * 4;
+    huge_width.byte_len = huge_width.pitch * huge_width.height;
+    Check(huge_width.byte_len < kLookupBitmapBytes,
+          "构造前提：本用例的字节数没超容量（否则测的是别的规则）");
+    Check(!IsLookupFrameSane(h, &huge_width), "width 超 0x4000 必须拒绝");
+  }
+  {
+    LookupFrame huge_height = HealthyFrame();
+    huge_height.width = 1;
+    huge_height.height = 0x4001u;
+    huge_height.pitch = 4;
+    huge_height.byte_len = huge_height.pitch * huge_height.height;
+    Check(huge_height.byte_len < kLookupBitmapBytes,
+          "构造前提：本用例的字节数没超容量（否则测的是别的规则）");
+    Check(!IsLookupFrameSane(h, &huge_height), "height 超 0x4000 必须拒绝");
+  }
+  {
+    // pitch < width*4：按 width 逐行拷会读/写出行尾之外——经典越界形状。
+    LookupFrame short_pitch = HealthyFrame();
+    short_pitch.pitch = short_pitch.width * 4 - 1;
+    short_pitch.byte_len = short_pitch.pitch * short_pitch.height;
+    Check(!IsLookupFrameSane(h, &short_pitch), "pitch < width*4 必须拒绝");
+  }
+  {
+    LookupFrame long_len = HealthyFrame();
+    long_len.byte_len = long_len.pitch * long_len.height + 1;
+    Check(!IsLookupFrameSane(h, &long_len),
+          "byte_len > pitch*height 必须拒绝（多出来的那截没有像素来源）");
+  }
+  {
+    LookupFrame short_len = HealthyFrame();
+    short_len.byte_len = short_len.pitch * short_len.height - 1;
+    Check(!IsLookupFrameSane(h, &short_len),
+          "byte_len < pitch*height 必须拒绝（按 height 逐行拷会读过尾）");
+  }
+  {
+    // 自洽但超容量：1024x1024 BGRA = 4MiB > 3MiB 单缓冲上限。
+    LookupFrame too_big = HealthyFrame();
+    too_big.width = 1024;
+    too_big.height = 1024;
+    too_big.pitch = too_big.width * 4;
+    too_big.byte_len = too_big.pitch * too_big.height;
+    Check(too_big.byte_len > kLookupBitmapBytes,
+          "构造前提：本用例确实超了单缓冲容量");
+    Check(too_big.width <= 0x4000u && too_big.height <= 0x4000u,
+          "构造前提：宽高没超上界（否则测的是别的规则）");
+    Check(!IsLookupFrameSane(h, &too_big), "byte_len 超单缓冲容量必须拒绝");
+  }
+  {
+    const LookupFrame ok = HealthyFrame();
+    Check(!IsLookupFrameSane(nullptr, &ok), "header 为空必须拒绝");
+    Check(!IsLookupFrameSane(h, nullptr), "frame 为空必须拒绝");
+  }
+}
+
+// 闸门的**意义**：过了闸门的帧，按 byte_len 整块拷进任意一块位图缓冲都不会越出查词区。
+// 上面那些用例只是"某些形状被拒了"，这条才是"被留下的形状真的安全"。
+void TestAcceptedFramesAlwaysFitInsideTheirBitmapSlot() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+  const uint32_t widths[] = {1, 17, 640, 880, 0x4000u};
+  const uint32_t heights[] = {1, 3, 400, 880};
+  const uint32_t pitch_pads[] = {0, 4, 64};
+  for (uint32_t w : widths) {
+    for (uint32_t ht : heights) {
+      for (uint32_t pad : pitch_pads) {
+        LookupFrame frame = HealthyFrame();
+        frame.width = w;
+        frame.height = ht;
+        frame.pitch = w * 4 + pad;
+        frame.byte_len = frame.pitch * frame.height;
+        if (!IsLookupFrameSane(h, &frame)) continue;
+        for (uint32_t i = 0; i < kLookupFrameCount; ++i) {
+          const uint64_t begin = mapping.OffsetOf(LookupBitmapAt(h, i));
+          Check(begin + frame.byte_len <= mapping.total_bytes,
+                "过闸门的帧按 byte_len 拷进任一缓冲都不得越出映射");
+          Check(frame.byte_len <= h->lookup_bitmap_bytes,
+                "过闸门的帧不得越出自己那块缓冲（否则会踩到下一块）");
+        }
+      }
+    }
+  }
+}
+
+// ── 3b. ShouldApplyLookupFrame：发布序 × hit_seq 的真值表 ────────────────────
+
+// 两个序号各管一件事，混成一个就出过大事故（收卡整条不通，见 LookupFrame 注释）：
+//   * `seq`     = 发布序，host 每投一帧 +1 —— 回答"这帧我处理过没有"；
+//   * `hit_seq` = 回应哪次查询 —— 回答"用户是不是已经点了别的字"。
+// 这张真值表就是把"两件事"钉成两件事。
+void TestShouldApplyTruthTable() {
+  struct Case {
+    uint64_t frame_seq;
+    uint64_t frame_hit_seq;
+    uint64_t presented_seq;
+    uint64_t current_hit_seq;
+    bool expected;
+    const char* what;
+  };
+  const uint64_t kPresented = 10;
+  const uint64_t kCurrentHit = 5;
+  const Case cases[] = {
+      // 发布序更旧/相等：这帧已经处理过，hit_seq 再新也不重来。
+      {9, 4, kPresented, kCurrentHit, false, "发布序更旧 + hit 更旧 → 拒"},
+      {9, 5, kPresented, kCurrentHit, false, "发布序更旧 + hit 相等 → 拒"},
+      {9, 6, kPresented, kCurrentHit, false, "发布序更旧 + hit 更新 → 拒"},
+      {10, 5, kPresented, kCurrentHit, false, "发布序相等即已处理 → 拒"},
+      // 发布序更新：再看它回应的那次查询有没有被作废。
+      {11, 4, kPresented, kCurrentHit, false,
+       "发布序更新但回应的是旧命中 → 拒（迟到帧不许顶掉新卡片）"},
+      {11, 5, kPresented, kCurrentHit, true, "发布序更新 + 回应当前命中 → 应用"},
+      {11, 6, kPresented, kCurrentHit, true,
+       "发布序更新 + hit 比注入侧看到的还新（host 抢跑）→ 应用"},
+  };
+  for (const Case& c : cases) {
+    Check(ShouldApplyLookupFrame(c.frame_seq, c.frame_hit_seq, c.presented_seq,
+                                 c.current_hit_seq) == c.expected,
+          c.what);
+  }
+
+  // 首帧：什么都还没处理过（presented=0），命中序从 1 起。
+  Check(ShouldApplyLookupFrame(1, 1, 0, 1), "会话第一帧必须能应用");
+  // 尚无命中（current_hit_seq=0）时 host 不该投帧，但真投了也不该被判为过期——
+  // 过期与否只由这两个序号决定，别在这里塞第三种语义。
+  Check(ShouldApplyLookupFrame(1, 0, 0, 0), "无命中时的帧不因 hit_seq=0 被判过期");
+}
+
+// 收卡整条不通的那个回归，用判据本身钉死：present 完立刻发的收卡帧必须过得去。
+//
+// 旧模型下 `seq` 一号两用，收卡只能复用被撤那张卡的 seq，于是"发布序不比已处理的新"
+// 这一条把它自己挡在门外——补 0×0 分支也救不回来，因为帧压根进不了候选。
+void TestDismissRightAfterPresentIsNotTreatedAsStale() {
+  const uint64_t present_publish = 7;
+  const uint64_t hit = 3;
+  Check(ShouldApplyLookupFrame(present_publish, hit, present_publish - 1, hit),
+        "构造前提：这次 present 本身是能被应用的");
+  // host 收卡 = 领**下一个**发布序，hit_seq 仍指向被撤的那次查询。
+  Check(ShouldApplyLookupFrame(present_publish + 1, hit, present_publish, hit),
+        "紧跟 present 的收卡帧必须能被应用（收卡链曾经就死在这里）");
+  // 反面：新命中来了之后，那张收卡帧作废，不许把新卡片收掉。
+  Check(!ShouldApplyLookupFrame(present_publish + 1, hit, present_publish,
+                                hit + 1),
+        "陈旧的收卡帧不得收掉更新的卡片");
+}
+
+// 收卡帧靠 flags 自述，不靠"width==0 就是收卡"的魔法编码——后者与"host 投了张废帧"
+// 在字节上完全一样。配套硬事实：收卡帧按定义过不了 IsLookupFrameSane，所以读侧**必须**
+// 在那道校验之前先认 flags。
+void TestDismissFrameIsFlagBornNotShapeInferred() {
+  Check(kLookupFrameDismiss != 0, "收卡位不能是 0（0 位表达不了任何东西）");
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+  LookupFrame dismiss = {};
+  dismiss.seq = 3;
+  dismiss.hit_seq = 2;
+  dismiss.flags = kLookupFrameDismiss;
+  dismiss.ready = 1;
+  Check(!IsLookupFrameSane(h, &dismiss),
+        "收卡帧没有像素，必然过不了尺寸闸门——故读侧必须先认 flags 再谈校验");
+  LookupFrame junk = dismiss;
+  junk.flags = 0;
+  Check(!IsLookupFrameSane(h, &junk),
+        "同样字节但没有收卡位 = host 投的废帧，只能被拒");
+  Check((junk.flags & kLookupFrameDismiss) == 0,
+        "废帧与收卡帧的唯一区别就是这个位，不是形状");
+}
+
+// ── 4. v14 是纯追加 ────────────────────────────────────────────────────────
+
+void TestV14IsAPureAppendOverV13() {
+  Check(kSharedVersion == 14, "本测试锁的是 v14 布局");
+
+  // (a) 结构体层面：查词字段整体排在 v13 最后一个字段之后。中间插一个字段就会让所有
+  //     v13 消费者读错位，而版本号又已经匹配、挡不住。
+  const size_t last_v13_field =
+      offsetof(SharedHeader, text_lane_overflow_count);
+  const size_t first_v14_field = offsetof(SharedHeader, lookup_region_offset);
+  Check(first_v14_field >= last_v13_field + sizeof(uint64_t),
+        "查词字段必须整体排在 v13 末字段之后（纯追加）");
+  Check(offsetof(SharedHeader, lookup_bitmap_bytes) > first_v14_field &&
+            offsetof(SharedHeader, lookup_enabled) > first_v14_field &&
+            offsetof(SharedHeader, lookup_diag) > first_v14_field,
+        "所有 v14 字段都在查词区首字段之后");
+  // v13 及更早的关键偏移逐个钉死，任何"顺手挪一下字段"都会红。
+  Check(offsetof(SharedHeader, magic) == 0, "magic 必须仍在 0");
+  Check(offsetof(SharedHeader, version) == 4, "version 必须仍在 4");
+  Check(offsetof(SharedHeader, text_region_offset) < first_v14_field &&
+            offsetof(SharedHeader, clip_region_offset) < first_v14_field &&
+            offsetof(SharedHeader, loopback_ring_offset) < first_v14_field &&
+            offsetof(SharedHeader, thread_preview_offset) < first_v14_field &&
+            offsetof(SharedHeader, text_lane_count) < first_v14_field,
+        "v13 区偏移字段一个都不许被挪到查词字段之后");
+
+  // (b) 映射层面：同一套 v13 参数，带不带查词区算出的 v13 各区偏移必须逐字节相同。
+  FakeMapping with_lookup(true);
+  FakeMapping without_lookup(false);
+  const SharedHeader* a = with_lookup.header();
+  const SharedHeader* b = without_lookup.header();
+  Check(a->text_region_offset == b->text_region_offset,
+        "文本区偏移不受查词区影响");
+  Check(a->clip_region_offset == b->clip_region_offset,
+        "clip 区偏移不受查词区影响");
+  Check(a->loopback_ring_offset == b->loopback_ring_offset,
+        "loopback 环偏移不受查词区影响");
+  Check(a->loopback_marker_offset == b->loopback_marker_offset,
+        "loopback 标记表偏移不受查词区影响");
+  Check(a->thread_preview_offset == b->thread_preview_offset,
+        "线程预览区偏移不受查词区影响");
+  Check(with_lookup.total_bytes - without_lookup.total_bytes ==
+            LookupRegionBytes(kLookupInputSlotCount, kLookupFrameCount,
+                              kLookupBitmapBytes),
+        "带查词区只多出整区那么多字节，别的区一个字节没变");
+
+  // (c) 查词区在**最尾**：它的起点不得早于线程预览区的终点。
+  const uint64_t preview_end =
+      static_cast<uint64_t>(a->thread_preview_offset) +
+      static_cast<uint64_t>(a->thread_preview_slot_count) *
+          sizeof(ThreadPreviewSlot);
+  Check(a->lookup_region_offset >= preview_end,
+        "查词区必须追加在所有 v13 区之后");
+}
+
+// 头里的冗余自洽字段必须与编译期常量一致——否则读侧按 header 值寻址、写侧按常量写，
+// 会各算各的。
+void TestHeaderMirrorsCompileTimeConstants() {
+  FakeMapping mapping;
+  const SharedHeader* h = mapping.header();
+  Check(h->lookup_bitmap_bytes == kLookupBitmapBytes,
+        "header 位图容量必须等于 kLookupBitmapBytes");
+  Check(h->lookup_frame_count == kLookupFrameCount,
+        "header 帧数必须等于 kLookupFrameCount");
+  Check(h->lookup_input_slot_count == kLookupInputSlotCount,
+        "header 输入槽数必须等于 kLookupInputSlotCount");
+  Check(kLookupFrameCount >= 2, "位图必须至少双缓冲");
+  Check(sizeof(LookupHitSlot) % 8 == 0, "hit 槽结构 8 对齐");
+  // 帧结构随 v14 收卡改造从 48 字节长到 64（加了 hit_seq / flags / reserved2）。
+  // 跨进程结构体不 8 对齐，双缓冲的第二块就会歪，且 volatile uint64 在 x86 上会撕裂。
+  Check(sizeof(LookupFrame) % 8 == 0, "帧结构 8 对齐");
+  Check(sizeof(LookupInputSlot) % 8 == 0, "输入槽结构 8 对齐");
+}
+
+}  // namespace
+
+int main() {
+  TestSubRegionsAreContiguousDisjointAndInBounds();
+  TestEverySubRegionStaysEightAligned();
+  TestFrameAndBitmapIndexingIsBounded();
+  TestLegacySessionYieldsNullInsteadOfWildPointers();
+  TestHalfInitialisedRegionIsTreatedAsAbsent();
+  TestFrameSanityRejectsEveryUntrustedShape();
+  TestShouldApplyTruthTable();
+  TestDismissRightAfterPresentIsNotTreatedAsStale();
+  TestDismissFrameIsFlagBornNotShapeInferred();
+  TestAcceptedFramesAlwaysFitInsideTheirBitmapSlot();
+  TestV14IsAPureAppendOverV13();
+  TestHeaderMirrorsCompileTimeConstants();
+  if (g_failures != 0) {
+    fprintf(stderr, "lookup ipc contract test failures: %d\n", g_failures);
+    return 1;
+  }
+  printf("lookup ipc contract test ok\n");
+  return 0;
+}

--- a/native/galgame_hook/tests/lookup_session_replay_test.cpp
+++ b/native/galgame_hook/tests/lookup_session_replay_test.cpp
@@ -1,0 +1,659 @@
+// KiriKiri 游戏内查词（v14 查词区）的**会话 replay**。
+//
+// 回放 tests/fixtures/kirikiri_lookup_replay.tsv 里的一整场事件流，跑在一块按真实
+// injector 布局摆好的假共享内存上，钉死这些会话级不变量：
+//
+//   1. 正常时序 hit → frame → apply 走得通，且卡片像素真的落进了"游戏图层"；
+//   2. 回应旧命中的迟到帧必须被丢弃（连点两下时不许把上一个词的卡片贴出来 = 串卡）；
+//   3. `lookup_enabled == 0` 时注入侧**一个字节都不写**（开关是唯一入口，不是"少写点"）；
+//   4. 落在卡片矩形外的输入不进转发环（否则游戏自己的点击会被吃掉）；
+//   5. 会话结束必须清理未完成状态，下一会话不串数据；
+//   6. **收卡**：dismiss 帧按定义没有像素（过不了 IsLookupFrameSane），但必须被应用；
+//      而**陈旧的 dismiss 绝不能收掉更新的卡片**。
+//
+// 第 6 条是有血的教训：`LookupFrame::seq` 曾经既当发布序又当"回应哪次 hit"，于是收卡帧
+// 只能复用被撤那张卡的 seq，而那个 seq 刚 present 过，被注入侧当陈旧帧扔掉——补 0×0
+// 分支也救不回来，因为帧压根进不了候选。根因是数据结构，不是漏分支。拆成
+// `seq`（发布序）+ `hit_seq`（回应哪次查询）之后收卡不需要任何特例。
+//
+// 边界说明（不许含糊）：
+//   * 寻址、帧校验、**以及"这帧该不该应用"的判据**都用契约头 voice_hook_ipc.h 里那一份
+//     真实实现（LookupHitOf / LookupFrameAt / LookupBitmapAt / IsLookupFrameSane /
+//     ShouldApplyLookupFrame）。注入侧 PresentKirikiriLookupFrame 调的是同一个函数，
+//     所以这条判据不会再出现"参照实现与生产漂移"——上一版本文件里的
+//     `if (seq != current)` 就是那样漂开的，收卡整条不通它一声不吭。
+//   * 剩下的编排（谁在什么时候写、开关门、卡片矩形命中测试）仍是**契约参照实现**：
+//     adapter 那个 .inc 依赖 MinHook/TJS/游戏进程上下文，不能独立编译进测试。它与
+//     adapter 一致由 tests/kirikiri_lookup_source_guard_test.py 从源码侧另行钉住。
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "voice_hook_ipc.h"
+
+namespace {
+
+using fushi_voice_hook::IsLookupFrameSane;
+using fushi_voice_hook::kClipCount;
+using fushi_voice_hook::kLookupBitmapBytes;
+using fushi_voice_hook::kLookupFrameCount;
+using fushi_voice_hook::kLookupFrameDismiss;
+using fushi_voice_hook::kLookupHitFlagSubmit;
+using fushi_voice_hook::kLookupInputSlotCount;
+using fushi_voice_hook::kLookupLineBytes;
+using fushi_voice_hook::kLoopbackMarkerCount;
+using fushi_voice_hook::kTextLaneCount;
+using fushi_voice_hook::kTextLaneSlotCount;
+using fushi_voice_hook::kThreadPreviewCount;
+using fushi_voice_hook::LookupBitmapAt;
+using fushi_voice_hook::LookupFrame;
+using fushi_voice_hook::LookupFrameAt;
+using fushi_voice_hook::LookupHitOf;
+using fushi_voice_hook::LookupHitSlot;
+using fushi_voice_hook::LookupInputSlot;
+using fushi_voice_hook::LookupInputsOf;
+using fushi_voice_hook::LookupRegionBytes;
+using fushi_voice_hook::LoopbackMarker;
+using fushi_voice_hook::SharedHeader;
+using fushi_voice_hook::ShouldApplyLookupFrame;
+using fushi_voice_hook::ThreadPreviewSlot;
+using fushi_voice_hook::VoiceClip;
+
+int g_failures = 0;
+
+void Check(bool condition, const std::string& what) {
+  if (!condition) {
+    ++g_failures;
+    fprintf(stderr, "FAIL: %s\n", what.c_str());
+  }
+}
+
+// ── fixture 解析（`kind key=value ...`，`#` 注释，`expect` 行是黄金值）────────
+
+struct Event {
+  std::string kind;
+  std::vector<std::pair<std::string, std::string>> fields;
+
+  const std::string* Find(const std::string& key) const {
+    for (const auto& field : fields) {
+      if (field.first == key) return &field.second;
+    }
+    return nullptr;
+  }
+  std::string Str(const std::string& key, const char* fallback = "") const {
+    const std::string* value = Find(key);
+    return value == nullptr ? std::string(fallback) : *value;
+  }
+  // 支持 0x 前缀，便于 fixture 里写填充字节。
+  long Int(const std::string& key, long fallback = 0) const {
+    const std::string* value = Find(key);
+    if (value == nullptr) return fallback;
+    return strtol(value->c_str(), nullptr, 0);
+  }
+  // `key=a,b,c,d` 取第 [index] 个分量。
+  long IntAt(const std::string& key, size_t index, long fallback = 0) const {
+    const std::string* value = Find(key);
+    if (value == nullptr) return fallback;
+    std::stringstream stream(*value);
+    std::string part;
+    for (size_t i = 0; std::getline(stream, part, ','); ++i) {
+      if (i == index) return strtol(part.c_str(), nullptr, 0);
+    }
+    return fallback;
+  }
+};
+
+bool LoadFixture(const char* path, std::vector<Event>* events,
+                 std::vector<std::pair<std::string, std::string>>* expected) {
+  std::ifstream file(path);
+  if (!file.is_open()) return false;
+  std::string line;
+  while (std::getline(file, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    std::stringstream stream(line);
+    std::string token;
+    Event event;
+    while (stream >> token) {
+      if (event.kind.empty()) {
+        if (token[0] == '#') break;
+        event.kind = token;
+        continue;
+      }
+      const size_t equals = token.find('=');
+      if (equals == std::string::npos) continue;
+      event.fields.emplace_back(token.substr(0, equals),
+                                token.substr(equals + 1));
+    }
+    if (event.kind.empty()) continue;
+    if (event.kind == "expect") {
+      for (const auto& field : event.fields) expected->push_back(field);
+      continue;
+    }
+    events->push_back(event);
+  }
+  return true;
+}
+
+// ── 假共享内存（布局照 injector：查词区追加在最尾，后面再压一段守卫字节）──────
+
+constexpr uint8_t kTailGuardByte = 0xA5;
+constexpr size_t kTailGuardBytes = 64;
+
+struct FakeMapping {
+  static constexpr uint32_t kRingCapacity = 4096;
+  static constexpr uint32_t kLoopbackCapacity = 4096;
+
+  std::vector<uint8_t> bytes;
+  uint64_t lookup_bytes = 0;
+  uint64_t mapped_bytes = 0;  // 不含尾部守卫
+
+  FakeMapping() {
+    const uint64_t text_bytes =
+        fushi_voice_hook::TextRegionBytes(kTextLaneCount, kTextLaneSlotCount);
+    const uint64_t clip_bytes =
+        static_cast<uint64_t>(kClipCount) * sizeof(VoiceClip);
+    const uint64_t marker_bytes =
+        static_cast<uint64_t>(kLoopbackMarkerCount) * sizeof(LoopbackMarker);
+    const uint64_t preview_bytes =
+        static_cast<uint64_t>(kThreadPreviewCount) * sizeof(ThreadPreviewSlot);
+    lookup_bytes = LookupRegionBytes(kLookupInputSlotCount, kLookupFrameCount,
+                                     kLookupBitmapBytes);
+    mapped_bytes = sizeof(SharedHeader) + kRingCapacity + text_bytes +
+                   clip_bytes + kLoopbackCapacity + marker_bytes +
+                   preview_bytes + lookup_bytes;
+    bytes.assign(static_cast<size_t>(mapped_bytes) + kTailGuardBytes,
+                 kTailGuardByte);
+    memset(bytes.data(), 0, static_cast<size_t>(mapped_bytes));
+
+    SharedHeader* h = header();
+    h->magic = fushi_voice_hook::kSharedMagic;
+    h->version = fushi_voice_hook::kSharedVersion;
+    h->ring_capacity = kRingCapacity;
+    h->text_region_offset =
+        static_cast<uint32_t>(sizeof(SharedHeader) + kRingCapacity);
+    h->text_lane_count = kTextLaneCount;
+    h->text_lane_slot_count = kTextLaneSlotCount;
+    h->clip_region_offset =
+        static_cast<uint32_t>(h->text_region_offset + text_bytes);
+    h->loopback_ring_offset =
+        static_cast<uint32_t>(h->clip_region_offset + clip_bytes);
+    h->loopback_ring_capacity = kLoopbackCapacity;
+    h->loopback_marker_offset =
+        static_cast<uint32_t>(h->loopback_ring_offset + kLoopbackCapacity);
+    h->loopback_marker_slot_count = kLoopbackMarkerCount;
+    h->thread_preview_offset =
+        static_cast<uint32_t>(h->loopback_marker_offset + marker_bytes);
+    h->thread_preview_slot_count = kThreadPreviewCount;
+    h->lookup_region_offset =
+        static_cast<uint32_t>(h->thread_preview_offset + preview_bytes);
+    h->lookup_bitmap_bytes = kLookupBitmapBytes;
+    h->lookup_frame_count = kLookupFrameCount;
+    h->lookup_input_slot_count = kLookupInputSlotCount;
+  }
+
+  SharedHeader* header() {
+    return reinterpret_cast<SharedHeader*>(bytes.data());
+  }
+  uint8_t* lookup_region() {
+    return bytes.data() + header()->lookup_region_offset;
+  }
+  // v13 及更早的全部区（音频环 / 文本 / clip / loopback / 预览）。查词功能碰到这里
+  // 任何一个字节都是越界写。
+  uint8_t* legacy_regions() { return bytes.data() + sizeof(SharedHeader); }
+  size_t legacy_region_bytes() {
+    return static_cast<size_t>(header()->lookup_region_offset) -
+           sizeof(SharedHeader);
+  }
+  bool TailGuardIntact() const {
+    for (size_t i = static_cast<size_t>(mapped_bytes); i < bytes.size(); ++i) {
+      if (bytes[i] != kTailGuardByte) return false;
+    }
+    return true;
+  }
+};
+
+// ── 契约参照实现：hook 侧与 host 侧各自该怎么动这块内存 ───────────────────────
+
+struct Counters {
+  // "<会话号>:<发布序>"：被真正取走的帧。发布序是一帧的身份（host 每投一帧 +1）。
+  std::vector<std::string> applied_frames;
+  // 游戏画面上卡片的出没流水："show:<hit seq>" / "hide:<hit seq>"。
+  // 收卡链通不通、陈旧 dismiss 有没有误伤新卡片，看这一行就够。
+  std::vector<std::string> card_transcript;
+  long last_applied_fill = -1;
+  long hits_published = 0;
+  long hits_suppressed_while_disabled = 0;
+  long frames_published = 0;  // 含 dismiss 帧
+  long dismiss_frames_applied = 0;
+  // 被应用的 dismiss 帧里有几张过不了 IsLookupFrameSane（按定义应当全部）。
+  long dismiss_frames_failing_sanity = 0;
+  long insane_frames_rejected = 0;
+  long inputs_forwarded = 0;
+  long inputs_ignored = 0;
+  long bytes_written_while_disabled = 0;
+  long cross_session_frames_applied = 0;
+  bool session_clean = true;
+};
+
+// 「发布了但从没被贴上去」的帧数 = 发布数 - 应用数。
+//
+// 不按"每轮 poll 拒了几次"记：注入侧**不清 ready**（去重靠 presented_seq 单调），同一
+// 张陈旧帧每轮都会被重新看到，按次数记会让黄金值随 poll 条数漂。也不在测试里重新推导
+// 「为什么被拒」——那等于把 ShouldApplyLookupFrame 的判据抄第二遍，正是这次要消灭的东西。
+long FramesNeverApplied(const Counters& c) {
+  return c.frames_published - static_cast<long>(c.applied_frames.size());
+}
+
+class LookupSessionModel {
+ public:
+  explicit LookupSessionModel(FakeMapping* mapping)
+      : mapping_(mapping),
+        frame_session_(mapping->header()->lookup_frame_count, 0) {}
+
+  Counters& counters() { return counters_; }
+
+  void Run(const std::vector<Event>& events) {
+    for (const Event& event : events) {
+      // 「未开启时零写入」不是靠信任，是每条事件前后各拍一次查词区的快照来量的。
+      std::vector<uint8_t> before;
+      const bool disabled = mapping_->header()->lookup_enabled == 0;
+      if (disabled) {
+        before.assign(mapping_->lookup_region(),
+                      mapping_->lookup_region() +
+                          static_cast<size_t>(mapping_->lookup_bytes));
+      }
+      Dispatch(event);
+      if (disabled) {
+        const uint8_t* after = mapping_->lookup_region();
+        for (size_t i = 0; i < before.size(); ++i) {
+          if (before[i] != after[i]) ++counters_.bytes_written_while_disabled;
+        }
+      }
+    }
+  }
+
+ private:
+  void Dispatch(const Event& event) {
+    if (event.kind == "enabled") {
+      // host→hook 开关。它本身在 header 里，不属于查词区。
+      mapping_->header()->lookup_enabled =
+          static_cast<uint32_t>(event.Int("value"));
+    } else if (event.kind == "hit") {
+      PublishHit(event);
+    } else if (event.kind == "frame") {
+      PublishFrame(event);
+    } else if (event.kind == "dismiss") {
+      PublishDismiss(event);
+    } else if (event.kind == "poll") {
+      PollFrames();
+    } else if (event.kind == "input") {
+      ForwardInput(event);
+    } else if (event.kind == "session_end") {
+      EndSession();
+    } else {
+      Check(false, "fixture 里出现未知事件：" + event.kind);
+    }
+  }
+
+  // hook → host。开关关着时一个字节都不写。
+  void PublishHit(const Event& event) {
+    SharedHeader* h = mapping_->header();
+    if (h->lookup_enabled == 0) {
+      ++counters_.hits_suppressed_while_disabled;
+      return;
+    }
+    LookupHitSlot* hit = LookupHitOf(h);
+    Check(hit != nullptr, "开启后 hit 槽必须可寻址");
+    if (hit == nullptr) return;
+    const std::string line = event.Str("line");
+    hit->char_index = static_cast<uint32_t>(event.Int("index"));
+    hit->char_count = static_cast<uint32_t>(event.Int("chars"));
+    hit->glyph_x = static_cast<int32_t>(event.IntAt("glyph", 0));
+    hit->glyph_y = static_cast<int32_t>(event.IntAt("glyph", 1));
+    hit->glyph_w = static_cast<int32_t>(event.IntAt("glyph", 2));
+    hit->glyph_h = static_cast<int32_t>(event.IntAt("glyph", 3));
+    hit->view_w = static_cast<int32_t>(event.IntAt("view", 0));
+    hit->view_h = static_cast<int32_t>(event.IntAt("view", 1));
+    hit->flags = event.Int("submit") != 0 ? kLookupHitFlagSubmit : 0u;
+    const uint32_t bytes =
+        static_cast<uint32_t>(line.size() < kLookupLineBytes ? line.size()
+                                                             : kLookupLineBytes);
+    hit->line_bytes = bytes;
+    memcpy(hit->line_utf8, line.data(), bytes);
+    Check(hit->char_index < hit->char_count,
+          "hit 自洽：char_index 必须落在本行字符数内");
+    // seq **最后**写（与契约头注释同一套纪律）。
+    ++hook_hit_seq_;
+    hit->seq = hook_hit_seq_;
+    ++h->lookup_hit_count;
+    ++counters_.hits_published;
+  }
+
+  // host → hook：带像素的一帧。**故意**允许发布不合契约的帧：跨进程来的宽高就是不可信
+  // 输入，由取帧侧的闸门挡，而不是靠"写侧不会写错"。
+  void PublishFrame(const Event& event) {
+    LookupFrame* frame = BeginPublish();
+    if (frame == nullptr) return;
+    SharedHeader* h = mapping_->header();
+    frame->hit_seq = static_cast<uint64_t>(event.Int("hit"));
+    frame->flags = 0;
+    frame->width = static_cast<uint32_t>(event.Int("w"));
+    frame->height = static_cast<uint32_t>(event.Int("h"));
+    frame->pitch = static_cast<uint32_t>(event.Int("pitch"));
+    frame->anchor_x = static_cast<int32_t>(event.IntAt("anchor", 0));
+    frame->anchor_y = static_cast<int32_t>(event.IntAt("anchor", 1));
+    frame->highlight_start = static_cast<uint32_t>(event.IntAt("hl", 0));
+    frame->highlight_len = static_cast<uint32_t>(event.IntAt("hl", 1));
+    frame->byte_len = frame->pitch * frame->height;
+    uint8_t* pixels = LookupBitmapAt(h, last_publish_index_);
+    Check(pixels != nullptr, "位图缓冲必须可寻址");
+    if (pixels != nullptr) {
+      // 只按**闸门允许的上限**填，测试自己也不许越界写。
+      const uint32_t fill_bytes = frame->byte_len <= h->lookup_bitmap_bytes
+                                      ? frame->byte_len
+                                      : h->lookup_bitmap_bytes;
+      memset(pixels, static_cast<int>(event.Int("fill")), fill_bytes);
+    }
+    EndPublish(frame);
+  }
+
+  // host → hook：收卡。它就是**普通一帧**，只是靠 flags 自述、没有像素。
+  // 不用 "width==0 就是收卡" 的魔法编码——那和"host 投了张废帧"在字节上完全一样。
+  void PublishDismiss(const Event& event) {
+    LookupFrame* frame = BeginPublish();
+    if (frame == nullptr) return;
+    frame->hit_seq = static_cast<uint64_t>(event.Int("hit"));
+    frame->flags = kLookupFrameDismiss;
+    frame->width = 0;
+    frame->height = 0;
+    frame->pitch = 0;
+    frame->anchor_x = 0;
+    frame->anchor_y = 0;
+    frame->highlight_start = 0;
+    frame->highlight_len = 0;
+    frame->byte_len = 0;
+    EndPublish(frame);
+  }
+
+  // 发布序由 host 独占递增，槽下标 = 发布序 % 缓冲数（与 voice_hook_reader 同款）。
+  LookupFrame* BeginPublish() {
+    SharedHeader* h = mapping_->header();
+    const uint64_t publish = ++host_publish_seq_;
+    last_publish_index_ =
+        static_cast<uint32_t>(publish % h->lookup_frame_count);
+    LookupFrame* frame = LookupFrameAt(h, last_publish_index_);
+    Check(frame != nullptr, "帧槽必须可寻址");
+    if (frame == nullptr) return nullptr;
+    frame->ready = 0;  // 先熄灯再改内容
+    frame->seq = publish;
+    frame->reserved = 0;
+    frame->reserved2 = 0;
+    return frame;
+  }
+
+  void EndPublish(LookupFrame* frame) {
+    SharedHeader* h = mapping_->header();
+    frame->ready = 1;  // ready **最后**写
+    frame_session_[last_publish_index_] = session_index_;
+    ++h->lookup_frame_count_written;
+    ++counters_.frames_published;
+  }
+
+  // hook 的 continuous callback。与 PresentKirikiriLookupFrame 同款：扫所有槽，取
+  // **发布序最大**的那个还能用的候选；判据一律走契约头的 ShouldApplyLookupFrame。
+  //
+  // 注意这里**不清 ready**：去重靠 presented_seq 单调，与注入侧一致。清了反而会掩盖
+  // 「陈旧帧还躺在共享内存里」这个真实状态，也就测不出"陈旧 dismiss 会不会误伤新卡"。
+  void PollFrames() {
+    SharedHeader* h = mapping_->header();
+    if (h->lookup_enabled == 0) return;
+    const LookupHitSlot* hit = LookupHitOf(h);
+    if (hit == nullptr) return;
+    const uint64_t current_hit = hit->seq;
+
+    LookupFrame* best = nullptr;
+    uint32_t best_index = 0;
+    uint64_t best_seq = 0;
+    for (uint32_t i = 0; i < h->lookup_frame_count; ++i) {
+      LookupFrame* frame = LookupFrameAt(h, i);
+      if (frame == nullptr || frame->ready == 0) continue;
+      const uint64_t seq = frame->seq;
+      if (seq <= best_seq) continue;  // 本轮已找到更新的候选
+      if (!ShouldApplyLookupFrame(seq, frame->hit_seq, presented_seq_,
+                                  current_hit)) {
+        continue;
+      }
+      best = frame;
+      best_index = i;
+      best_seq = seq;
+    }
+    if (best == nullptr) return;
+    presented_seq_ = best_seq;
+
+    // 收卡必须在 IsLookupFrameSane **之前**认掉：它按定义没有像素，过不了那道校验。
+    if ((best->flags & kLookupFrameDismiss) != 0) {
+      RecordApplied(best_seq, best_index);
+      ++counters_.dismiss_frames_applied;
+      if (!IsLookupFrameSane(h, best)) ++counters_.dismiss_frames_failing_sanity;
+      card_visible_ = false;
+      game_layer_.clear();
+      counters_.card_transcript.push_back("hide:" +
+                                          std::to_string(best->hit_seq));
+      return;
+    }
+
+    // 槽下标自洽：发布序决定落哪个槽，对不上说明写侧和读侧对布局的理解漂了。
+    if (!IsLookupFrameSane(h, best) ||
+        static_cast<uint32_t>(best_seq % h->lookup_frame_count) != best_index) {
+      ++counters_.insane_frames_rejected;
+      h->lookup_diag |= fushi_voice_hook::kLookupDiagFrameRejected;
+      return;
+    }
+    const uint8_t* pixels = LookupBitmapAt(h, best_index);
+    Check(pixels != nullptr, "过闸门的帧必须有可读位图");
+    if (pixels == nullptr) return;
+    RecordApplied(best_seq, best_index);
+    game_layer_.assign(pixels, pixels + best->byte_len);
+    Check(best->seq == best_seq, "拷贝期间帧 seq 不得变化");
+    card_visible_ = true;
+    card_x_ = best->anchor_x;
+    card_y_ = best->anchor_y;
+    card_w_ = static_cast<int32_t>(best->width);
+    card_h_ = static_cast<int32_t>(best->height);
+    counters_.last_applied_fill = game_layer_.empty() ? -1 : game_layer_[0];
+    counters_.card_transcript.push_back("show:" +
+                                        std::to_string(best->hit_seq));
+    h->lookup_diag |= fushi_voice_hook::kLookupDiagFramePresented;
+  }
+
+  // 只在**真的贴上去了**（或真的收起来了）之后记账，不记"选中了但随后被闸门拒掉"。
+  void RecordApplied(uint64_t publish_seq, uint32_t index) {
+    counters_.applied_frames.push_back(std::to_string(session_index_) + ":" +
+                                       std::to_string(publish_seq));
+    // 这一帧是上一会话留下的？那就是"上一局的卡片贴到这一局"——清理没做干净。
+    if (frame_session_[index] != session_index_) {
+      ++counters_.cross_session_frames_applied;
+    }
+  }
+
+  // 只有落在卡片矩形内的输入才进转发环；其余留给游戏自己处理。
+  void ForwardInput(const Event& event) {
+    SharedHeader* h = mapping_->header();
+    const int32_t x = static_cast<int32_t>(event.Int("x"));
+    const int32_t y = static_cast<int32_t>(event.Int("y"));
+    const bool inside = card_visible_ && x >= card_x_ && x < card_x_ + card_w_ &&
+                        y >= card_y_ && y < card_y_ + card_h_;
+    if (h->lookup_enabled == 0 || !inside) {
+      ++counters_.inputs_ignored;
+      return;
+    }
+    LookupInputSlot* ring = LookupInputsOf(h);
+    Check(ring != nullptr, "输入环必须可寻址");
+    if (ring == nullptr) return;
+    const uint64_t seq = h->lookup_input_count + 1;
+    LookupInputSlot* slot = &ring[(seq - 1) % h->lookup_input_slot_count];
+    slot->x = x - card_x_;  // 卡片局部坐标：host 直接喂给离屏 WebView2
+    slot->y = y - card_y_;
+    slot->kind = static_cast<uint32_t>(event.Int("kind"));
+    slot->wheel = static_cast<int32_t>(event.Int("wheel"));
+    slot->keys = static_cast<uint32_t>(event.Int("keys"));
+    slot->seq = seq;  // seq **最后**写
+    h->lookup_input_count = seq;
+    ++counters_.inputs_forwarded;
+    Check(slot->x >= 0 && slot->x < card_w_ && slot->y >= 0 &&
+              slot->y < card_h_,
+          "转发出去的坐标必须已经换算到卡片局部域");
+  }
+
+  // 会话结束：注入侧把整块查词区清干净，两侧的序号台账一并归零。
+  // 不清就会出现"上一局的卡片贴到这一局"。
+  void EndSession() {
+    SharedHeader* h = mapping_->header();
+    memset(mapping_->lookup_region(), 0,
+           static_cast<size_t>(mapping_->lookup_bytes));
+    h->lookup_enabled = 0;
+    h->lookup_hit_count = 0;
+    h->lookup_frame_count_written = 0;
+    h->lookup_input_count = 0;
+    hook_hit_seq_ = 0;
+    host_publish_seq_ = 0;
+    presented_seq_ = 0;
+    card_visible_ = false;
+    game_layer_.clear();
+    ++session_index_;
+
+    // 清理是否真的干净，逐项验，不看"应该"。
+    const LookupHitSlot* hit = LookupHitOf(h);
+    bool clean = hit != nullptr && hit->seq == 0 && hit->line_bytes == 0;
+    for (uint32_t i = 0; i < h->lookup_frame_count && clean; ++i) {
+      const LookupFrame* frame = LookupFrameAt(h, i);
+      clean = frame != nullptr && frame->ready == 0 && frame->seq == 0 &&
+              frame->hit_seq == 0 && frame->flags == 0;
+    }
+    const LookupInputSlot* ring = LookupInputsOf(h);
+    for (uint32_t i = 0; i < h->lookup_input_slot_count && clean; ++i) {
+      clean = ring != nullptr && ring[i].seq == 0;
+    }
+    if (!clean) counters_.session_clean = false;
+  }
+
+  FakeMapping* mapping_;
+  Counters counters_;
+  std::vector<uint8_t> game_layer_;  // "游戏渲染树里的卡片 Layer" 的替身
+  // 每个帧槽最后一次被写入是在第几个会话（纯测试侧台账，用于识别跨会话残留）。
+  std::vector<int> frame_session_;
+  uint64_t hook_hit_seq_ = 0;   // hook 侧：命中序
+  uint64_t host_publish_seq_ = 0;  // host 侧：帧发布序
+  uint64_t presented_seq_ = 0;  // hook 侧：已处理到哪个发布序
+  uint32_t last_publish_index_ = 0;
+  int session_index_ = 1;
+  bool card_visible_ = false;
+  int32_t card_x_ = 0;
+  int32_t card_y_ = 0;
+  int32_t card_w_ = 0;
+  int32_t card_h_ = 0;
+};
+
+std::string Join(const std::vector<std::string>& values) {
+  std::string joined;
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i != 0) joined += ",";
+    joined += values[i];
+  }
+  return joined;
+}
+
+std::string Hex(long value) {
+  char buffer[16] = {};
+  snprintf(buffer, sizeof(buffer), "0x%02lX", value & 0xFF);
+  return buffer;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: lookup_session_replay_test <fixture.tsv>\n");
+    return 2;
+  }
+  std::vector<Event> events;
+  std::vector<std::pair<std::string, std::string>> expected;
+  if (!LoadFixture(argv[1], &events, &expected)) {
+    fprintf(stderr, "cannot read fixture: %s\n", argv[1]);
+    return 2;
+  }
+  Check(!events.empty(), "fixture 必须有事件");
+  Check(!expected.empty(), "fixture 必须有 expect 黄金值");
+
+  FakeMapping mapping;
+  const std::vector<uint8_t> legacy_before(
+      mapping.legacy_regions(),
+      mapping.legacy_regions() + mapping.legacy_region_bytes());
+
+  LookupSessionModel model(&mapping);
+  model.Run(events);
+  Counters& c = model.counters();
+
+  const bool legacy_untouched =
+      memcmp(legacy_before.data(), mapping.legacy_regions(),
+             mapping.legacy_region_bytes()) == 0;
+
+  // 黄金值比对：回放过程一个字都没读过 expect，这里才第一次看它。
+  for (const auto& item : expected) {
+    const std::string& key = item.first;
+    const std::string& want = item.second;
+    std::string got;
+    if (key == "applied_frames") {
+      got = Join(c.applied_frames);
+    } else if (key == "card_transcript") {
+      got = Join(c.card_transcript);
+    } else if (key == "last_applied_fill") {
+      got = Hex(c.last_applied_fill);
+    } else if (key == "hits_published") {
+      got = std::to_string(c.hits_published);
+    } else if (key == "hits_suppressed_while_disabled") {
+      got = std::to_string(c.hits_suppressed_while_disabled);
+    } else if (key == "frames_published") {
+      got = std::to_string(c.frames_published);
+    } else if (key == "frames_never_applied") {
+      got = std::to_string(FramesNeverApplied(c));
+    } else if (key == "insane_frames_rejected") {
+      got = std::to_string(c.insane_frames_rejected);
+    } else if (key == "dismiss_frames_applied") {
+      got = std::to_string(c.dismiss_frames_applied);
+    } else if (key == "dismiss_frames_failing_sanity") {
+      got = std::to_string(c.dismiss_frames_failing_sanity);
+    } else if (key == "inputs_forwarded") {
+      got = std::to_string(c.inputs_forwarded);
+    } else if (key == "inputs_ignored") {
+      got = std::to_string(c.inputs_ignored);
+    } else if (key == "bytes_written_while_disabled") {
+      got = std::to_string(c.bytes_written_while_disabled);
+    } else if (key == "cross_session_frames_applied") {
+      got = std::to_string(c.cross_session_frames_applied);
+    } else if (key == "v13_regions_untouched") {
+      got = legacy_untouched ? "1" : "0";
+    } else if (key == "tail_guard_intact") {
+      got = mapping.TailGuardIntact() ? "1" : "0";
+    } else if (key == "session_clean") {
+      got = c.session_clean ? "1" : "0";
+    } else {
+      Check(false, "fixture 里出现未知 expect 键：" + key);
+      continue;
+    }
+    Check(got == want, key + " 期望 " + want + "，实际 " + got);
+  }
+
+  if (g_failures != 0) {
+    fprintf(stderr, "kirikiri lookup replay failures: %d\n", g_failures);
+    return 1;
+  }
+  printf("kirikiri lookup replay ok\n");
+  return 0;
+}

--- a/native/galgame_hook/tests/mutate_lookup_replay.py
+++ b/native/galgame_hook/tests/mutate_lookup_replay.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""游戏内查词 replay 的**变异实测**工具（手动跑，不进 CTest）。
+
+`lookup_session_replay_test.cpp` + `fixtures/kirikiri_lookup_replay.tsv` 是一张黄金表。
+黄金表最容易烂的方式不是写错，而是**空**：判据被放宽之后它照样绿，谁都看不出来。所以每次
+改动那个 replay 或它的 fixture，都必须回来跑一遍本工具，确认每条不变量删掉之后测试真的红。
+
+用法（Windows，需要 MSVC 环境；先跑 vcvars64.bat 或在 Developer Prompt 里）：
+
+    python tests/mutate_lookup_replay.py
+
+它会把每个变异体写进 %TEMP%\\galhook_lookup_mutants，逐个编译并对同一份 fixture 运行，
+打印「基线 + 每个变异体的退出码与首几行差异」。**基线必须 0，每个变异体必须非 0。**
+任何一个变异体是绿的，就说明对应那条不变量在黄金表里没有被真正约束。
+
+每个变异体对应一条会红的历史或潜在故障：
+  M1 迟到帧不丢    → 连点两下把上一个词的卡片贴出来（串卡）
+  M2 未开启也发布  → 开关形同虚设，注入侧在用户没开时就写共享内存
+  M3 卡片外也转发  → 吃掉游戏自己的点击
+  M4 会话不清理    → 上一局的卡片贴到这一局
+  M5 不过尺寸闸门  → 按跨进程不可信的 width/height 盲拷（越界写）
+  M6 收卡判据退回单 seq → **真实发生过的事故**：收卡帧被自己刚 present 的 seq 挡成陈旧帧
+  M7 收卡靠 width==0 判 → 魔法编码把 host 投的废帧误当收卡，卡片莫名消失
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+SOURCE = HERE / "lookup_session_replay_test.cpp"
+FIXTURE = HERE / "fixtures" / "kirikiri_lookup_replay.tsv"
+OUT = pathlib.Path(os.environ.get("TEMP", "/tmp")) / "galhook_lookup_mutants"
+
+# (名字, 原文, 替换)。原文必须逐字节存在，否则直接报错——变异锚点悄悄失配 = 变异实测
+# 变成空跑，比不跑更糟。
+MUTANTS: list[tuple[str, str, str]] = [
+    (
+        "M1_late_frame_not_dropped",
+        "      if (!ShouldApplyLookupFrame(seq, frame->hit_seq, presented_seq_,\n"
+        "                                  current_hit)) {",
+        "      if (!ShouldApplyLookupFrame(seq, current_hit, presented_seq_,\n"
+        "                                  current_hit)) {",
+    ),
+    (
+        "M2_publish_hit_while_disabled",
+        "    if (h->lookup_enabled == 0) {\n"
+        "      ++counters_.hits_suppressed_while_disabled;\n"
+        "      return;\n    }",
+        "    if (false) {\n"
+        "      ++counters_.hits_suppressed_while_disabled;\n"
+        "      return;\n    }",
+    ),
+    (
+        "M3_forward_outside_inputs",
+        "    if (h->lookup_enabled == 0 || !inside) {",
+        "    if (h->lookup_enabled == 0 && !inside) {",
+    ),
+    (
+        "M4_skip_session_cleanup",
+        "    memset(mapping_->lookup_region(), 0,\n"
+        "           static_cast<size_t>(mapping_->lookup_bytes));",
+        "",
+    ),
+    (
+        "M5_skip_frame_size_gate",
+        "    if (!IsLookupFrameSane(h, best) ||\n"
+        "        static_cast<uint32_t>(best_seq % h->lookup_frame_count) != best_index) {",
+        "    if (static_cast<uint32_t>(best_seq % h->lookup_frame_count) != best_index) {",
+    ),
+    (
+        # 历史事故的精确复刻：一个号既当发布序又当"回应哪次 hit"。
+        "M6_single_seq_regression",
+        "      const uint64_t seq = frame->seq;",
+        "      const uint64_t seq = frame->hit_seq;",
+    ),
+    (
+        "M7_dismiss_by_zero_width",
+        "    if ((best->flags & kLookupFrameDismiss) != 0) {",
+        "    if (best->width == 0) {",
+    ),
+]
+
+CL_FLAGS = [
+    "/nologo",
+    "/utf-8",
+    "/std:c++17",
+    "/W4",
+    "/WX",
+    "/EHsc",
+    "/DUNICODE",
+    "/D_UNICODE",
+    "/DNOMINMAX",
+    "/DWIN32_LEAN_AND_MEAN",
+    f"/I{ROOT / 'include'}",
+]
+
+
+def build_and_run(name: str, source_path: pathlib.Path) -> tuple[int, str]:
+    exe = OUT / f"{name}.exe"
+    build = _run_capture(["cl", *CL_FLAGS, str(source_path), f"/Fe:{exe}"], cwd=OUT)
+    if build[0] != 0:
+        return build
+    return _run_capture([str(exe), str(FIXTURE)], cwd=None)
+
+
+def _run_capture(argv: list[str], cwd: pathlib.Path | None) -> tuple[int, str]:
+    """跑一条命令并把 stdout+stderr 合成一个字符串。
+
+    **必须显式指定 utf-8 + errors="replace"**：中文 Windows 上 Python 的 text 模式
+    默认按 GBK 解码子进程输出，而变异体的失败信息里全是中文断言 —— 一旦某个变异体
+    真的红了，解码就抛 UnicodeDecodeError，整个工具在"第一个变异体失败"的那一刻崩掉。
+    也就是说：**工具只在所有变异体都没红的时候才跑得完**，恰好把它唯一要证明的事情
+    （变异体会红）变成它的崩溃条件。errors="replace" 是第二道保险，避免子进程吐出
+    非 UTF-8 字节（MSVC 的部分诊断走系统页）时再炸一次。
+    """
+    proc = subprocess.run(
+        argv,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def main() -> int:
+    if shutil.which("cl") is None:
+        print("需要 MSVC 的 cl.exe：先跑 vcvars64.bat 或在 Developer Prompt 里执行。")
+        return 2
+    OUT.mkdir(parents=True, exist_ok=True)
+    text = io.open(SOURCE, encoding="utf-8").read()
+
+    baseline = OUT / "baseline.cpp"
+    io.open(baseline, "w", encoding="utf-8", newline="\n").write(text)
+    code, output = build_and_run("baseline", baseline)
+    print(f"[baseline] exit={code}")
+    for line in output.splitlines()[:4]:
+        print("   ", line)
+    failures = 0
+    if code != 0:
+        print("!! 基线就是红的，先修 replay 本身再谈变异实测")
+        failures += 1
+
+    for name, old, new in MUTANTS:
+        if old not in text:
+            print(f"[{name}] !! 变异锚点已失配，请更新本工具（否则变异实测是空跑）")
+            failures += 1
+            continue
+        path = OUT / f"{name}.cpp"
+        io.open(path, "w", encoding="utf-8", newline="\n").write(
+            text.replace(old, new, 1)
+        )
+        code, output = build_and_run(name, path)
+        print(f"[{name}] exit={code}")
+        for line in output.splitlines()[:5]:
+            print("   ", line)
+        if code == 0:
+            print(f"!! {name} 没红 —— 这条不变量在黄金表里没有被真正约束")
+            failures += 1
+    print("变异实测通过" if failures == 0 else f"变异实测失败：{failures} 项")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 这个 PR 做什么

把 KiriKiri/KAGEX 游戏内查词从「TJS 里手写整条链路」改成 **「游戏当显示器，Hibiki 当渲染器」**。

基底是 #799 的 prototype commit（`a10e388a04`），**保留它唯一值钱的发现**——Hook 边界：

```
TextRender.render / done → renderer.getCharacters(0,0) → 逐字符 text/x/y/cw/size
TextRender.drawCh(layer, ox, oy, ch) → 补齐 layer 与绘制原点
```

外加经 `iTVPFunctionExporter` 查官方 ABI、用 `TVPAddContinuousEventHook` 延到游戏主线程执行 bootstrap 的时序模型。

## 为什么不沿用 prototype 的实现

prototype 把「分词 + HTTP + JSON 解析 + 词典选择 + 卡片排版」全塞进了游戏进程。代价是：

- 卡片用 TJS `drawText` 手写，固定 30 字/行 × 7 行，没有 ruby / 外字 / 发音 / 制卡 / 主题 / 多语言；
- 游戏进程里多出一个 HTTP 客户端、一个手写 JSON 解析器、一个认证 token（明文进环境块），以及「拼 TJS 源码再 eval」的注入面。

而这些能力 Hibiki 的 `popup.html` 全都有。所以职责切开：

```
TJS 传感器（几何 + 命中 + 输入转发）
      ↕ 共享内存
Hibiki（既有 popup.html @ 离屏 WebView2 → BGRA 位图）
      ↓
DLL memcpy 进游戏 Layer → 真正在游戏渲染树里的卡片
```

跨边界的东西只剩**一块位图**和**一串整数**。注入面不是「escape 得更严」，是结构上不存在。

## 架构要点

- **位图永远不经过 Dart**：像素在 C++ 侧从离屏 WebView2 直接进共享内存，Dart 只做编排。
- **卡片渲染器是第三个 `GlobalLookupWindow` 实例**，永远离屏、只 `PrewarmWebView` 从不 `ShowAt`。不复用现有两个：主浮窗会真显示在屏幕上（借它取帧等于把显隐状态和卡片生命周期绑死），剪贴板面板明确 `SetCompositionMode(false)`（而交互式卡片全靠 `SendMouseInput`）。
- **查词、分词、定位、高亮长度、制卡全部复用既有实现**，行为与阅读器 / 视频 / 剪贴板查词一致，没有第二套。
- **投帧时机**用 host 自测量上报 union bbox 的那一刻（新增 `onRevealed`）——就是覆盖窗自己用来决定能不能 reveal 的同一个门，**没有 `Future.delayed`**。

## IPC 契约 v14（`kSharedVersion` 13 → 14）

纯追加：查词区在布局最尾，前面所有区偏移逐字节不动，`lookup_region_offset == 0` 即「本会话无此区」。三通道各自单写单读无锁：`hit`（单槽 latest-wins）、`input`（环）、`frame`（双缓冲）。

- `IsLookupFrameSane()` 是「按跨进程不可信的 width/height/pitch 盲拷 → 越界写进游戏进程」的唯一闸门。
- `lookup_enabled` 取代 prototype 的 `FUSHI_KIRIKIRI_LOOKUP_*` 环境变量：token 明文进游戏进程环境块是安全缺陷，且环境变量启动后改不了、做不到运行期开关。
- 查词区 6,294,704 字节（6.00 MiB）。

## 并行会合时抓出的三个真 bug

**① 收卡（dismiss）整条链是死的。** 卡片一旦显示就再也收不回去，只能靠关整个会话开关。根因不是漏分支，是数据结构：`LookupFrame.seq` 同时兼任「发布序」和「回应哪次查询」，于是收卡帧只能复用被撤那张卡的 seq，而那个 seq 刚 present 过，被「这帧我处理过了」的过滤当场丢弃——**补 0×0 分支也救不回来，帧压根进不了候选**。拆成 `seq`（发布序）+ `hit_seq`（回应哪次命中）之后，收卡就是普通一帧，不需要任何特例。收卡改用 `flags` 自述，取代「width==0 就是收卡」的魔法编码。

**② 卡片层原本是全视口的**，靠 `htMask` + alpha 穿透放行非卡片区域的点击，且在 bootstrap 就建。这条引擎行为在 KAGEX 下未验证——一旦不成立，失败模式不是「查词不好使」，是**用户没查词的时候整个游戏点不动**。改成延迟到第一帧才建、按卡片尺寸建、`htRect` 矩形命中；最坏影响面关在卡片自己的矩形里，而那块本来就该吃掉点击。

**③ 三处跨边界约定各写各的**：像素 alpha（KiriKiri 的 `ltAlpha` 是直通，预乘对应 `ltAddAlpha`）、帧元数据槽下标、`char_index` 计数单位（钉成 UTF-16 code unit——TJS 的 `tjs_char` 与 Dart String 下标同系，零转换；猜错的症状是含非 ASCII 的行整体偏移，日文行必错却看起来像「命中判定有点飘」）。三处全部在契约头写死。

## 一并清掉的 prototype 债务

游戏主线程上每一毫秒都变掉帧，所以这些比之前更要命：

| 问题 | 处理 |
|---|---|
| 每帧遍历所有 message 重打补丁 | 删 |
| 每次 mousemove 全量 walk + 全屏 `fillRect` | 改成廉价矩形预判 + 命中变化才重绘 |
| 挂在全局 `Layer.drawText` 上的 O(n²) `getTextWidth` | 删 |
| registry 只增不减，长期持有 `characters` 与 renderer 引用 | LRU + 只留几何快照 |
| 每次左键往磁盘写 `.trace` | 删 |
| 硬编码 Jitendex + `maximumTerms:1` | 删，走用户配置 |
| 5 条并行捕获路径 + 3 个 registry 兜底链 | 只留 TextRender 一条，其余进默认关闭的 probe 分支 |

注入侧 2750 → 约 2600 行，删除项 52 条串 grep 自证全部为 0。

## 测试

三层，每层都做过**变异实测**（证明不是空守卫）：

- **契约测试**：区偏移不重叠/不越界/8 对齐；`ShouldApplyLookupFrame` 全真值表；`IsLookupFrameSane` 逐条拒绝理由各有独立用例。
- **会话 replay**：参照模型的判据**直接调生产的 `ShouldApplyLookupFrame`**——判据各写各的时，replay 绿了只证明参照实现自洽。7 个变异体实测全红，其中 **M6（收卡判据退回单 seq）与 M7（收卡改看 width==0）正是上面两个真 bug 的回归**。
- **源码扫描守卫**（19 用例）：禁止重新引入拼 TJS 源码 eval、游戏进程内的网络/凭据、全局 monkey-patch、绕开字符类校验拼 PNG 路径。**用 prototype commit `a10e388a04` 当脏输入实测**：三条规则分别红出 8 / 17 / 7 条命中，当前代码全 0。

顺带修掉变异工具自身的致命缺陷：子进程输出未指定 utf-8，中文 Windows 按 GBK 解码，**变异体一旦真红就抛 `UnicodeDecodeError` 把工具搞崩**——等于「只有所有变异体都不红时才跑得完」，恰好把它唯一要证明的事变成崩溃条件。

### 验证结果

| 门 | 结果 |
|---|---|
| `flutter analyze`（全量，含 test） | **No issues found**，退出码 0 |
| `flutter test test/lookup/ test/mining/gal_ipc_contract_single_source_test.dart --no-pub` | **615 passed**，退出码 0 |
| 全量 `dart run tool/flutter_test_failures.dart --no-pub` | 18193 tests / 77 error events → 逐条分型见下 |
| 契约头 x86 + x64 `/W4 /WX` 语法检查 | 0 / 0 |
| 注入侧 `dll_main.cpp` x86 + x64 编译 | 0 / 0（只剩两条既有告警） |
| `lookup_ipc_contract_test` / `lookup_session_replay_test` | 0 / 0 |
| `mutate_lookup_replay.py`（7 变异体） | 基线绿 + 全部红，0 |
| `kirikiri_lookup_source_guard_test.py` | 0（19 用例） |
| `generate_engine_support.py --check` / `generate_luna_profiles.py --check` | 0 / 0 |
| `engine_support_manifest` / `adapter_structure` / `galhook_workflow` / `evidence_contract` | 0 / 0 / 0 / 0 |

### 全量套件那 77 条错误的分型

**没有拿「可能是并发伪红」当借口**——每条都隔离重跑定性过。

本 PR 真正打红、已修复的三条（三条守卫**都在正确履职**，不是噪音）：

| 守卫 | 为什么红 | 怎么修 |
|---|---|---|
| `voice_hook_ipc_contract_test` | 把 `kSharedVersion` 写死成 13，而它就是防两侧版本漂移的 | 显式改 14 |
| `texthooker_char_level_lookup_guard`（BUG-1478） | 查询串构造被提成共享 `lookupQueryFromIndex()`，行为逐字节不变但源码扫描守卫看不见搬走的逻辑了 | 守卫跟着搬家，**两头都钉**：调用点必须从命中字起算，被调方必须真的从该下标切并截断。只钉一头都能被绕过 |
| `settings_schema_coverage` | 新设置 changed+persisted 但无生效探针，守卫不允许静默缺口 | 按 Magpie 那条先例登记进 `kCoveredElsewhere`，指向四层专项测试 |

修完隔离复跑：`All tests passed`，`stillUnaccounted=0`，退出码 0。

经核实为**既有红、非本 PR 引入**的两类：

- `mining_count_wiring_static`（2 条）：断言的 `addMiningCount(` 在本分支基底 commit 上就已不存在，且本 PR 未触碰它扫描的两个源文件（`git diff --name-only` 为空）。
- `home_dashboard_page`（68 条）：全部是 `TimeoutException after 0:10:00` 挂死而非断言失败；本 PR 对其依赖图的改动只有 `app_model` 里两个纯转发存取器。

> 补充一条环境事实：全量套件第一次跑时 sqlite3 的 native asset 下载失败导致**零测试执行**，而外层退出码仍是 0。这正是必须只认 `FLUTTER TEST VERDICT` 行的原因——第二轮带代理才真跑起来。

## 状态：`implemented_unverified`

**没有真机验证。** `engine-support.yaml` 的 `kirikiri_z` 状态未动，只新增 `ingame_lookup_geometry: implemented_unverified` 与 `known_limitations`（如实写明只有单个 `textrender.dll` 样本上的 prototype 运行观察、无 E2E）。

真机上第一个要看的是 `lookup_diag` 四个位，它们把原计划的 P0 探针变成一次自证：

| 位 | 含义 |
|---|---|
| `kLookupDiagExpressionReady` | `TVPExecuteExpression` 查到了 |
| `kLookupDiagBufferRouteReady` | `mainImageBufferForWrite` 拿到合法写指针 → 走内存直写主路 |
| `kLookupDiagFallbackPngRoute` | 上面任一失败 → 降级 `%TEMP%` PNG + `loadImages` |
| `kLookupDiagFramePresented` | 位图真落进了游戏 Layer |

`FramePresented` 在真机置位之前，这件事就是 `implemented_unverified`。

### 已知未验证项

- `mainImageBufferForWrite` / `TVPExecuteExpression` 在该样本上是否可用（主备两路都实现了，靠 diag 位自证走了哪条）。
- `CapturePreview` 在离屏但 `IsVisible=TRUE` 的窗口上能否稳定出非空帧。
- **Magpie 窗口超分会把卡片连同游戏画面一起放大**——这是「在渲染树内部」的必然结果，不是 bug。要么接受，要么这局关超分；**刻意不设计规避**，因为规避手段恰好推翻「游戏内渲染」这个需求。
- ruby / 竖排 / 选项文字未验（`isVertical: false` 写死，本样本横排）。
- 游戏内卡片没有独立的最大宽高偏好：1280×720 的画面上一张 ~1200px 宽的卡会几乎铺满。runner 的 `clamped` 会报出来，但目前只是记账。

## 与 #799 的关系

本 PR 取代 #799 的实现路线，并把它的 commit 作为基底保留在历史里。**是否关闭 #799 由你决定**，我没有动它。

## 平台边界

仅 Windows（galgame 硬规则）。非 Windows 上设置项不出现，Dart 侧全是空操作。
