### PR TITLE
fix(drag-drop,test): 拖放失败不再静默消失 + 清掉 4 类既存测试红

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 56304 (3312 per locale)
+/// Strings: 56355 (3315 per locale)
 ///
-/// Built on 2026-08-10 at 19:10 UTC
+/// Built on 2026-08-11 at 06:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4481,6 +4481,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get dict_download_import_uncancellable =>
       'Importing cannot be interrupted';
   String get dict_download_busy => 'A dictionary download is already running.';
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -12124,6 +12129,14 @@ class _StringsAr extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -19834,6 +19847,14 @@ class _StringsDe extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -27560,6 +27581,14 @@ class _StringsEs extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -35298,6 +35327,14 @@ class _StringsFr extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -42964,6 +43001,14 @@ class _StringsId extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -50676,6 +50721,14 @@ class _StringsIt extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -58202,6 +58255,14 @@ class _StringsJa extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -65735,6 +65796,14 @@ class _StringsKo extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -73427,6 +73496,14 @@ class _StringsNl extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -81131,6 +81208,14 @@ class _StringsPtBr extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -88821,6 +88906,14 @@ class _StringsRu extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -96459,6 +96552,14 @@ class _StringsTh extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -104128,6 +104229,14 @@ class _StringsTr extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -111782,6 +111891,14 @@ class _StringsVi extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 // Path: <root>
@@ -118884,6 +119001,12 @@ class _StringsZhCn extends _StringsEn {
   String get dict_download_import_uncancellable => '导入阶段无法中断';
   @override
   String get dict_download_busy => '已有词典下载正在进行。';
+  @override
+  String get drag_drop_failed => '拖入的文件处理失败，请重试。';
+  @override
+  String get tag_add_failed => '标签添加失败，请重试。';
+  @override
+  String get tag_reorder_failed => '标签排序保存失败，请重试。';
 }
 
 // Path: <root>
@@ -126333,6 +126456,14 @@ class _StringsZhHk extends _StringsEn {
       'Importing cannot be interrupted';
   @override
   String get dict_download_busy => 'A dictionary download is already running.';
+  @override
+  String get drag_drop_failed =>
+      'Couldn\'t handle the dropped files. Please try again.';
+  @override
+  String get tag_add_failed => 'Couldn\'t add the tag. Please try again.';
+  @override
+  String get tag_reorder_failed =>
+      'Couldn\'t save the new tag order. Please try again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -133139,6 +133270,12 @@ extension on _StringsEn {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -139943,6 +140080,12 @@ extension on _StringsAr {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -146769,6 +146912,12 @@ extension on _StringsDe {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -153594,6 +153743,12 @@ extension on _StringsEs {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -160425,6 +160580,12 @@ extension on _StringsFr {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -167238,6 +167399,12 @@ extension on _StringsId {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -174065,6 +174232,12 @@ extension on _StringsIt {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -180854,6 +181027,12 @@ extension on _StringsJa {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -187647,6 +187826,12 @@ extension on _StringsKo {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -194468,6 +194653,12 @@ extension on _StringsNl {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -201286,6 +201477,12 @@ extension on _StringsPtBr {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -208109,6 +208306,12 @@ extension on _StringsRu {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -214915,6 +215118,12 @@ extension on _StringsTh {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -221730,6 +221939,12 @@ extension on _StringsTr {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -228541,6 +228756,12 @@ extension on _StringsVi {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }
@@ -235295,6 +235516,12 @@ extension on _StringsZhCn {
         return '导入阶段无法中断';
       case 'dict_download_busy':
         return '已有词典下载正在进行。';
+      case 'drag_drop_failed':
+        return '拖入的文件处理失败，请重试。';
+      case 'tag_add_failed':
+        return '标签添加失败，请重试。';
+      case 'tag_reorder_failed':
+        return '标签排序保存失败，请重试。';
       default:
         return null;
     }
@@ -242079,6 +242306,12 @@ extension on _StringsZhHk {
         return 'Importing cannot be interrupted';
       case 'dict_download_busy':
         return 'A dictionary download is already running.';
+      case 'drag_drop_failed':
+        return 'Couldn\'t handle the dropped files. Please try again.';
+      case 'tag_add_failed':
+        return 'Couldn\'t add the tag. Please try again.';
+      case 'tag_reorder_failed':
+        return 'Couldn\'t save the new tag order. Please try again.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "查看进度",
   "dict_download_cancelled": "已取消下载。",
   "dict_download_import_uncancellable": "导入阶段无法中断",
-  "dict_download_busy": "已有词典下载正在进行。"
+  "dict_download_busy": "已有词典下载正在进行。",
+  "drag_drop_failed": "拖入的文件处理失败，请重试。",
+  "tag_add_failed": "标签添加失败，请重试。",
+  "tag_reorder_failed": "标签排序保存失败，请重试。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3310,5 +3310,8 @@
   "dict_download_progress_show": "View progress",
   "dict_download_cancelled": "Download cancelled.",
   "dict_download_import_uncancellable": "Importing cannot be interrupted",
-  "dict_download_busy": "A dictionary download is already running."
+  "dict_download_busy": "A dictionary download is already running.",
+  "drag_drop_failed": "Couldn't handle the dropped files. Please try again.",
+  "tag_add_failed": "Couldn't add the tag. Please try again.",
+  "tag_reorder_failed": "Couldn't save the new tag order. Please try again."
 }

--- a/fushi/lib/src/media/drag_drop/fushi_file_drop_target.dart
+++ b/fushi/lib/src/media/drag_drop/fushi_file_drop_target.dart
@@ -1,13 +1,25 @@
+import 'dart:async' show FutureOr;
 import 'dart:io' show Platform;
 
 import 'package:desktop_drop/desktop_drop.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb, visibleForTesting;
 import 'package:flutter/widgets.dart';
+
+import 'package:fushi/utils.dart';
 
 /// File drop callback. [globalPosition] uses Flutter global/view coordinates,
 /// matching rectangles produced by RenderBox.localToGlobal.
-typedef FileDropCallback = void Function(
+///
+/// 返回 [FutureOr] 而不是 `void`：处理器可能要做真实 IO（书架落点要真读包才分得出
+/// 图片型 zip 与词典包）。声明成 `void` 时 `async` 处理器抛出的异常无人可接——
+/// 见 [FushiFileDropTarget.runDrop]。
+typedef FileDropCallback = FutureOr<void> Function(
     List<String> paths, Offset globalPosition);
+
+/// 拖放处理失败时的上报通道。默认弹 error toast；测试注入自己的收集器，用来断言
+/// 「失败**一定**被上报」——只断「没抛出来」是不够的，静默吞掉同样满足那条。
+typedef DropFailureReporter = void Function(
+    Object error, StackTrace stackTrace);
 
 /// Enables desktop_drop only on desktop platforms; all other platforms pass the
 /// child through with zero runtime cost.
@@ -17,6 +29,7 @@ class FushiFileDropTarget extends StatelessWidget {
     required this.child,
     this.enabled = true,
     this.debugLabel,
+    this.onDropFailure,
     super.key,
   });
 
@@ -24,6 +37,9 @@ class FushiFileDropTarget extends StatelessWidget {
   final Widget child;
   final bool enabled;
   final String? debugLabel;
+
+  /// 见 [DropFailureReporter]。`null` = 生产默认（error toast）。
+  final DropFailureReporter? onDropFailure;
 
   static bool get _isDesktop =>
       !kIsWeb && (Platform.isWindows || Platform.isMacOS || Platform.isLinux);
@@ -53,7 +69,7 @@ class FushiFileDropTarget extends StatelessWidget {
           _log('ignored empty drop');
           return;
         }
-        onDrop(paths, detail.globalPosition);
+        runDrop(paths, detail.globalPosition);
       },
       onDragEntered: (DropEventDetails detail) {
         final bool routeVisible = _routeVisible(context);
@@ -81,6 +97,31 @@ class FushiFileDropTarget extends StatelessWidget {
       },
       child: child,
     );
+  }
+
+  /// 把 [onDrop] 的**全部**失败收在这一处，并且一定给用户一个可见结果。
+  ///
+  /// 这是所有文件拖入入口（书架 / 视频库 / 词典页 / 游戏库 / 播放页 + 四个导入
+  /// 对话框）共用的唯一咽喉。各页的路由函数挂在 desktop_drop 的 `void` 回调上，
+  /// 抛出时异常直接漂进 zone：用户看到的只有「拖了没反应」，他会以为文件类型没被
+  /// 识别，而真相是识别到一半炸了——这正是「让用户基于错误信息做决定」被剥夺的
+  /// 情形。逐个入口补 try/catch 等于把同一份补丁抄十一遍，还会漏掉以后新增的入口；
+  /// 收在这里，新入口天生带上。
+  ///
+  /// 必须 `await`：[FileDropCallback] 返回 [FutureOr]，只包同步栈的话，`async`
+  /// 处理器抛出的异常照样从 catch 底下漏走。
+  @visibleForTesting
+  Future<void> runDrop(List<String> paths, Offset globalPosition) async {
+    try {
+      await onDrop(paths, globalPosition);
+    } catch (error, stackTrace) {
+      _log('drop handler threw: $error\n$stackTrace');
+      (onDropFailure ?? _showDropFailureToast)(error, stackTrace);
+    }
+  }
+
+  void _showDropFailureToast(Object error, StackTrace stackTrace) {
+    FushiToast.show(msg: t.drag_drop_failed, severity: ToastSeverity.error);
   }
 
   bool _routeVisible(BuildContext context) {

--- a/fushi/lib/src/media/drag_drop/image_archive_probe.dart
+++ b/fushi/lib/src/media/drag_drop/image_archive_probe.dart
@@ -1,0 +1,66 @@
+import 'dart:isolate';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/drag_drop/drop_classification.dart';
+import 'package:fushi/src/media/manga/manga_module.dart';
+
+/// 「拖进来的这个 `.zip` 到底是图片型漫画包，还是 Yomitan 词典包」的预判，**跑在
+/// 后台 isolate 上**。
+///
+/// 为什么必须挪出拖放回调：`MangaModule.isImageArchive` 会把整个压缩包**同步**解出
+/// 目录（`.epub` 分支还会同步落一个临时解压树再解析 EPUB）。它原本直接长在
+/// `classifyDroppedFiles` 的注入判据里，而那是 desktop_drop 回调的同步栈——拖一个
+/// 几百 MB 的包进书架，UI 线程就在那儿卡住不画帧，用户看到的是「拖完 App 假死」。
+/// 判据本身没问题（图片包与词典包同形，不真读包分不出来，见
+/// [kDragImageArchiveProbeExtensions] 的说明），问题是它跑错了线程。
+///
+/// 结果先一次性算完再喂回 [classifyDroppedFiles] 的同步谓词，分类函数因此保持纯函数
+/// 不变——不需要为了「判据变异步」把整条分类/决策链改成异步。
+///
+/// [probe] 是测试缝：默认走真实 isolate。注入后可在 widget 测试里同步返回，也可以
+/// 让它抛出，验证失败路径（拖放不再静默消失）。
+Future<Map<String, bool>> probeDroppedImageArchives(
+  List<String> paths, {
+  Future<bool> Function(String path)? probe,
+}) async {
+  final Future<bool> Function(String path) run = probe ?? _probeInIsolate;
+  final Map<String, bool> results = <String, bool>{};
+  for (final String path in paths) {
+    if (!_needsProbe(path)) continue;
+    if (results.containsKey(path)) continue;
+    results[path] = await _neverThrows(path, run);
+  }
+  return results;
+}
+
+/// 判定本身**永不抛**：包损坏 / 没权限 / 超大都只是「这不是图片包」，让它落回按
+/// 扩展名的常规分类（`.zip` → 词典包），而不是把整次拖放炸掉。
+///
+/// 包在这里而不是包在 [_probeInIsolate] 里：注入的测试探针也要走同一条容错路径，
+/// 否则「生产吞、测试不吞」两套语义，守卫守的就不是真实行为。
+Future<bool> _neverThrows(
+  String path,
+  Future<bool> Function(String path) run,
+) async {
+  try {
+    return await run(path);
+  } catch (error, stackTrace) {
+    debugPrint('[fushi-drop] image archive probe failed for $path: $error\n'
+        '$stackTrace');
+    return false;
+  }
+}
+
+/// 只有扩展名**确实二义**的才值得开包，与 [classifyDroppedFiles] 用同一份常量。
+bool _needsProbe(String path) {
+  final String extension = p.extension(path);
+  if (extension.isEmpty) return false;
+  return kDragImageArchiveProbeExtensions
+      .contains(extension.substring(1).toLowerCase());
+}
+
+/// 单个包的真读包判定，跑在后台 isolate 上。容错在 [_neverThrows]。
+Future<bool> _probeInIsolate(String path) =>
+    Isolate.run(() => MangaModule.isImageArchive(path));

--- a/fushi/lib/src/media/tags/tag_drop.dart
+++ b/fushi/lib/src/media/tags/tag_drop.dart
@@ -1,0 +1,94 @@
+/// 「把标签拖到一个媒体/合集上」的共享落库编排（书 / 字幕书 / 视频 / 合集共用）。
+///
+/// 与 `collection_drag.dart` 的 [addMediaRefToCollection] 是同一个范式的另一半：
+/// 合集行头上并排挂着两个 `DragTarget`，落下 `MediaRef` 走那边，落下 [BookTagRow]
+/// 走这边。那边早就把「查重 → 幂等提示 → 落库 → **失败提示**」收口了，这边却仍在
+/// 五处各抄一遍，且**五处都没有 try/catch**。
+library;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/utils.dart';
+
+/// [addTagToTarget] 的结果：三种结局各自对应一条不同的用户可见提示。
+enum TagAddOutcome {
+  /// 真的写进去了。调用方据此刷新并报成功。
+  added,
+
+  /// 该目标本就有这个标签（`addTagToX` 幂等，静默 no-op 对用户就是「拖了没反应」）。
+  /// 已提示，调用方不必刷新。
+  alreadyPresent,
+
+  /// 落库失败（DB 锁 / 磁盘满 / 外键异常……）。已提示，**没有**写进去。
+  failed,
+}
+
+/// 提示通道。默认 [FushiToast.show]；测试注入自己的收集器。
+///
+/// 与 `CollectionAddNotifier` 不同，这里**带** [ToastSeverity]：本通道要送的
+/// 「已存在」是 warning、「落库失败」是 error，而这两条语义上就该被用户一眼分开
+/// （e-ink / 色觉障碍下靠图标区分，见 `toast_severity.dart`）。那边不带 severity
+/// 是为了不打断既有注入式测试，是历史包袱而非更好的形状，不要照抄。
+typedef TagAddNotifier = void Function(String message, ToastSeverity severity);
+
+/// 把 [tag] 打到某个目标上：查重 → 幂等提示 → 落库 → 失败提示。
+///
+/// 本函数**永不抛出**：任何失败都归到 [TagAddOutcome.failed] 并给出明确提示。
+/// 这正是它存在的理由——五个调用点原本都是
+/// `await db.addTagToX(...)` 裸奔，又都以 unawaited Future 挂在 `onTagDropped`
+/// 这个 `void` 回调上：写失败时异常直接漂进 zone，用户看到的只是「拖了没反应」。
+/// 而「拖了没反应」在这里恰好又是**成功幂等**的样子，他会以为标签打上了，其实
+/// 一个都没写进去——比单纯没反馈更糟。
+///
+/// [isAlreadyTagged] / [addToDb] 都可能碰 DB，所以一起收进 try 里；调用方拿到
+/// [TagAddOutcome.added] 后再自己失效 provider + 报成功（与 [addMediaRefToCollection]
+/// 同款分工：刷新要 `ref`、成功提示要 `mounted`，都属于 widget 层）。
+Future<TagAddOutcome> addTagToTarget({
+  required BookTagRow tag,
+  required Future<bool> Function() isAlreadyTagged,
+  required Future<void> Function() addToDb,
+  required String alreadyTaggedMessage,
+  TagAddNotifier? notify,
+}) async {
+  final TagAddNotifier tell = notify ??
+      (String message, ToastSeverity severity) =>
+          FushiToast.show(msg: message, severity: severity);
+  try {
+    if (await isAlreadyTagged()) {
+      tell(alreadyTaggedMessage, ToastSeverity.warning);
+      return TagAddOutcome.alreadyPresent;
+    }
+    await addToDb();
+    return TagAddOutcome.added;
+  } catch (error, stackTrace) {
+    debugPrint('addTagToTarget failed: $error\n$stackTrace');
+    tell(t.tag_add_failed, ToastSeverity.error);
+    return TagAddOutcome.failed;
+  }
+}
+
+/// 标签重排落库，返回是否真的写进去了；**永不抛出**。
+///
+/// 与 [addTagToTarget] 同一类缺陷的另一处：三个库页（书架 / 视频库 / 游戏库）各抄
+/// 一份「重排 → 落库 → 失效 provider」，都没有 try/catch，也都挂在拖放的 `void`
+/// 回调上。写失败时用户看到的是「松手后顺序自己弹回去了」，没有任何解释——他会
+/// 反复重试同一个动作。成功路径**不**提示（顺序当场变了就是反馈），只有失败才说话。
+Future<bool> reorderTagsSafely({
+  required Future<void> Function() write,
+  TagAddNotifier? notify,
+}) async {
+  try {
+    await write();
+    return true;
+  } catch (error, stackTrace) {
+    debugPrint('reorderTagsSafely failed: $error\n$stackTrace');
+    (notify ??
+        (String message, ToastSeverity severity) =>
+            FushiToast.show(msg: message, severity: severity))(
+      t.tag_reorder_failed,
+      ToastSeverity.error,
+    );
+    return false;
+  }
+}

--- a/fushi/lib/src/pages/implementations/games_library_page.dart
+++ b/fushi/lib/src/pages/implementations/games_library_page.dart
@@ -16,6 +16,7 @@ import 'package:fushi/src/media/collections/collection_shelf_row.dart'
 import 'package:fushi/src/media/collections/collection_drag.dart'
     show CollectionAddOutcome, MediaCardDraggable, addMediaRefToCollection;
 import 'package:fushi/src/media/drag_drop/fushi_file_drop_target.dart';
+import 'package:fushi/src/media/tags/tag_drop.dart' show reorderTagsSafely;
 import 'package:fushi/src/media/media_cover_service.dart';
 import 'package:fushi/src/media/metadata/scrape_batch.dart';
 import 'package:fushi/src/media/metadata/scrape_title_matcher.dart';
@@ -816,8 +817,11 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     final List<BookTagRow> reordered = List<BookTagRow>.from(tags);
     final BookTagRow moved = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, moved);
-    await _appModel.database
-        .reorderTags(reordered.map((BookTagRow tag) => tag.id).toList());
+    final bool ok = await reorderTagsSafely(
+      write: () => _appModel.database
+          .reorderTags(reordered.map((BookTagRow tag) => tag.id).toList()),
+    );
+    if (!ok) return;
     ref.invalidate(allTagsProvider);
   }
 

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -63,6 +63,7 @@ import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/media/collections/collection_drag.dart';
 import 'package:fushi/src/media/selection/media_selection_controller.dart';
 import 'package:fushi/src/media/selection/selection_gestures.dart';
+import 'package:fushi/src/media/tags/tag_drop.dart';
 import 'package:fushi/src/media/collections/collection_shelf_row.dart';
 import 'package:fushi/src/pages/implementations/jimaku_batch_dialog.dart';
 import 'package:fushi/src/pages/implementations/video_work_detail_page.dart';
@@ -1935,20 +1936,21 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (mounted) _refreshAfterTagChange();
   }
 
+  /// 「查重 → 幂等提示 → 落库 → 失败提示」收口在 [addTagToTarget]（永不抛）；这里
+  /// 只留 widget 层该管的两件事：真写进去了才刷新，`mounted` 才报成功。
   Future<void> _addTagToVideoBook(String bookUid, BookTagRow tag) async {
     final Map<String, List<BookTagRow>>? existing =
         ref.read(videoBookTagMapProvider).valueOrNull;
     final bool alreadyHas =
-        existing?[bookUid]?.any((BookTagRow t) => t.id == tag.id) ?? false;
-    if (alreadyHas) {
-      FushiToast.show(
-        msg: t.tag_already_on_book(name: tag.name),
-        severity: ToastSeverity.warning,
-      );
-      return;
-    }
-
-    await ref.read(appProvider).database.addTagToVideoBook(bookUid, tag.id);
+        existing?[bookUid]?.any((BookTagRow row) => row.id == tag.id) ?? false;
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: tag,
+      isAlreadyTagged: () async => alreadyHas,
+      addToDb: () =>
+          ref.read(appProvider).database.addTagToVideoBook(bookUid, tag.id),
+      alreadyTaggedMessage: t.tag_already_on_book(name: tag.name),
+    );
+    if (outcome != TagAddOutcome.added) return;
     ref.invalidate(videoBookTagMapProvider);
     ref.invalidate(filteredVideoBookUidsProvider);
     if (mounted) {
@@ -1967,16 +1969,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Future<void> _addTagToVideoCollection(
       int collectionId, BookTagRow tag) async {
     final FushiDatabase db = ref.read(appProvider).database;
-    final List<BookTagRow> existing =
-        await db.getTagsForCollection(collectionId);
-    if (existing.any((BookTagRow t) => t.id == tag.id)) {
-      FushiToast.show(
-        msg: t.tag_already_on_collection(name: tag.name),
-        severity: ToastSeverity.warning,
-      );
-      return;
-    }
-    await db.addTagToCollection(collectionId, tag.id);
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: tag,
+      isAlreadyTagged: () async => (await db.getTagsForCollection(collectionId))
+          .any((BookTagRow row) => row.id == tag.id),
+      addToDb: () => db.addTagToCollection(collectionId, tag.id),
+      alreadyTaggedMessage: t.tag_already_on_collection(name: tag.name),
+    );
+    if (outcome != TagAddOutcome.added) return;
     ref.invalidate(collectionTagMapProvider);
     ref.invalidate(filteredCollectionIdsProvider);
     if (mounted) {
@@ -4907,7 +4907,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final BookTagRow item = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, item);
     final List<int> orderedIds = reordered.map((BookTagRow t) => t.id).toList();
-    await ref.read(appProvider).database.reorderTags(orderedIds);
+    final bool ok = await reorderTagsSafely(
+      write: () => ref.read(appProvider).database.reorderTags(orderedIds),
+    );
+    if (!ok) return;
     ref.invalidate(allTagsProvider);
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -17,13 +17,14 @@ import 'package:fushi/src/media/audiobook/book_import_dialog.dart';
 import 'package:fushi/src/media/drag_drop/card_drop_registry.dart';
 import 'package:fushi/src/media/drag_drop/drop_classification.dart';
 import 'package:fushi/src/media/drag_drop/drop_decision.dart';
+import 'package:fushi/src/media/drag_drop/image_archive_probe.dart';
+import 'package:fushi/src/media/tags/tag_drop.dart';
 import 'package:fushi/src/media/display_title.dart';
 import 'package:fushi/src/media/drag_drop/fushi_file_drop_target.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:fushi/src/media/manga/book_format_convert.dart';
 import 'package:fushi/src/media/manga/book_format_rebuild.dart';
 import 'package:fushi/src/media/manga/manga_import_dialog.dart';
-import 'package:fushi/src/media/manga/manga_module.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_feature_flags.dart';
@@ -955,7 +956,10 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     final item = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, item);
     final orderedIds = reordered.map((t) => t.id).toList();
-    await ref.read(appProvider).database.reorderTags(orderedIds);
+    final bool ok = await reorderTagsSafely(
+      write: () => ref.read(appProvider).database.reorderTags(orderedIds),
+    );
+    if (!ok) return;
     ref.invalidate(allTagsProvider);
   }
 
@@ -963,6 +967,9 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 失效相关 provider → 成功提示。三种媒体只差「标签表 provider / DB 方法 / filtered
   /// provider / 成功文案」，作参数注入（[alreadyHas] 由各调用方按自己的标签 map 算好，
   /// [successMsg] 区分书籍 `tag_added_to_book` vs 视频 `tag_added_to_video`）。
+  ///
+  /// 「查重 → 幂等提示 → 落库 → 失败提示」收口在 [addTagToTarget]（永不抛）；这里
+  /// 只留 widget 层该管的两件事：拿到 [TagAddOutcome.added] 才刷新，`mounted` 才报成功。
   Future<void> _addTagToMedia({
     required bool alreadyHas,
     required BookTagRow tag,
@@ -970,13 +977,13 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     required List<ProviderOrFamily> invalidate,
     required String successMsg,
   }) async {
-    if (alreadyHas) {
-      FushiToast.show(
-          msg: t.tag_already_on_book(name: tag.name),
-          severity: ToastSeverity.warning);
-      return;
-    }
-    await addToDb();
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: tag,
+      isAlreadyTagged: () async => alreadyHas,
+      addToDb: addToDb,
+      alreadyTaggedMessage: t.tag_already_on_book(name: tag.name),
+    );
+    if (outcome != TagAddOutcome.added) return;
     for (final ProviderOrFamily p in invalidate) {
       ref.invalidate(p);
     }
@@ -1019,17 +1026,19 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 不复用 [_addTagToMedia]：它的「已存在」提示固定是 `tag_already_on_book`，对合集
   /// 文案不对。`addTagToCollection` 幂等，这里先查现有标签给合集专属提示，成功后失效
   /// [filteredCollectionIdsProvider] 让标签过滤下合集卡显隐立即刷新。
+  ///
+  /// 查重 + 落库 + 失败提示同样收口在 [addTagToTarget]——与 [_addTagToMedia] 的差别
+  /// 只剩「已存在」文案，不是另一套流程。
   Future<void> _addTagToCollection(int collectionId, BookTagRow tag) async {
     final FushiDatabase db = ref.read(appProvider).database;
-    final List<BookTagRow> existing =
-        await db.getTagsForCollection(collectionId);
-    if (existing.any((BookTagRow t) => t.id == tag.id)) {
-      FushiToast.show(
-          msg: t.tag_already_on_collection(name: tag.name),
-          severity: ToastSeverity.warning);
-      return;
-    }
-    await db.addTagToCollection(collectionId, tag.id);
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: tag,
+      isAlreadyTagged: () async => (await db.getTagsForCollection(collectionId))
+          .any((BookTagRow row) => row.id == tag.id),
+      addToDb: () => db.addTagToCollection(collectionId, tag.id),
+      alreadyTaggedMessage: t.tag_already_on_collection(name: tag.name),
+    );
+    if (outcome != TagAddOutcome.added) return;
     ref.invalidate(collectionTagMapProvider);
     ref.invalidate(filteredCollectionIdsProvider);
     if (mounted) {

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -1068,18 +1068,29 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
   /// 文件拖入书架后的路由：分类 → 命中测试 → 决策 → 打开对应对话框/提示。
   /// [globalPosition] 为 [FushiFileDropTarget] 透出的 Flutter global/view 坐标，
   /// 可直接与卡片登记表（同坐标系屏幕矩形）命中测试。
-  void _handleShelfDrop(List<String> paths, Offset globalPosition) {
+  Future<void> _handleShelfDrop(
+    List<String> paths,
+    Offset globalPosition,
+  ) async {
     final ModalRoute<dynamic>? route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) return;
+
+    // 图片型 .zip（一包页图的漫画）与 Yomitan 词典包同形，要真读包才分得出——与导入
+    // 对话框的分派同一判据，两条入口对「这算不算漫画」回答一致。但那次「真读包」是
+    // **同步解整个压缩包**，原来就长在下面 classifyDroppedFiles 的注入谓词里，也就
+    // 长在 desktop_drop 回调的同步栈上：拖个大包进来 UI 线程直接卡死。先离线程一次
+    // 性判完（[probeDroppedImageArchives]），再把结果当同步谓词喂回去，分类函数保持
+    // 纯函数不变。
+    final Map<String, bool> imageArchives =
+        await probeDroppedImageArchives(paths);
+    if (!mounted) return;
 
     // 目录（漫画页图文件夹）没有扩展名，纯分类函数分不出来——把真实文件系统判据
     // 注入进去（分类层本身仍不碰 IO）。
     final DroppedFiles files = classifyDroppedFiles(
       paths,
       isDirectory: (String pth) => Directory(pth).existsSync(),
-      // 图片型 .zip（一包页图的漫画）与 Yomitan 词典包同形，要真读包才分得出——
-      // 与导入对话框的分派同一判据，两条入口对「这算不算漫画」回答一致。
-      isImageArchive: MangaModule.isImageArchive,
+      isImageArchive: (String pth) => imageArchives[pth] ?? false,
     );
     debugPrint(
       '[fushi-drop] [reader-shelf] classified '

--- a/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
@@ -176,8 +176,11 @@ extension _VideoControlsTheme on _VideoFushiPageState {
       // TODO-057: 启用 media_kit 移动控制条内建的「左半区竖滑调亮度 / 右半区竖滑
       // 调音量」手势，指示器由 Hibiki 的左右百分比 HUD 接管。仅移动端有此控制条；桌面走
       // [_desktopControlsTheme]（无此手势，屏幕亮度本就不可控，诚实降级）。横滑 seek
-      // 见下方 [seekGesture]（TODO-916 症状①，按时长比例换算 + 居中 HUD 显目标绝对
-      // 时间；与既有 seek 键 085/090 / 双击全屏语义并存，竞技场先达成者胜）。
+      // 见下方 [seekGesture] + [horizontalSeekResolver]（TODO-916 症状①；换算已在
+      // BUG-1485 改成「拖过整屏 = 固定一段时长」的 [VideoHorizontalSeekGesture]，与
+      // 视频总时长**解耦**——这里原先写着「按时长比例换算」，那正是被换掉的旧公式，
+      // 别照着它推断当前行为。居中 HUD 显目标绝对时间；与既有 seek 键 085/090 /
+      // 双击全屏语义并存，竞技场先达成者胜）。
       // 单击暂停 / 字幕点击查词不受影响：media_kit 的竖直 drag 与 tap 同一手势 arena，
       // 纯点击时 drag 不启动。亮度回调经 [ScreenBrightnessController]（桌面 no-op）。
       volumeGesture: true,

--- a/fushi/test/media/drag_drop/drag_drop_platform_guard_test.dart
+++ b/fushi/test/media/drag_drop/drag_drop_platform_guard_test.dart
@@ -36,8 +36,13 @@ void main() {
     final String src = wrapper.readAsStringSync();
 
     expect(src.contains('DropDoneDetails detail'), isTrue);
-    expect(src.contains('onDrop(paths, detail.globalPosition)'), isTrue,
+    // 派发多了一跳 [FushiFileDropTarget.runDrop]（异常收口在那里），坐标语义不变：
+    // 进 runDrop 的仍是 detail.globalPosition，runDrop 原样交给 onDrop。两段都断，
+    // 中间那一跳把坐标换成 local 也会当场红。
+    expect(src.contains('runDrop(paths, detail.globalPosition)'), isTrue,
         reason: 'business handlers hit-test cards in Flutter global coords');
+    expect(src.contains('await onDrop(paths, globalPosition)'), isTrue,
+        reason: '必须 await：处理器是 FutureOr，不 await 则 async 抛出漏过 catch');
     expect(src.contains('detail.localPosition'), isTrue,
         reason: 'localPosition should still be logged for diagnostics');
     expect(src.contains('onDrop(paths, detail.localPosition)'), isFalse,
@@ -83,9 +88,11 @@ void main() {
     expect(videoDrop.contains('DropIntent.unsupportedSurface'), isTrue,
         reason: 'recognized files on the wrong surface need visible feedback');
 
+    // 书架落点要先离线程判「这个 .zip 是不是图片包」，故签名是 Future<void>；
+    // 同步解包留在 drop 栈上会把 UI 线程卡死（见 image_archive_probe.dart）。
     final String shelfDrop = functionBody(
       shelf,
-      'void _handleShelfDrop(',
+      'Future<void> _handleShelfDrop(',
       'Future<void> _openBookImportPrefilled(',
     );
     expect(shelfDrop.contains('Offset globalPosition'), isTrue);

--- a/fushi/test/media/drag_drop/drop_failure_visibility_test.dart
+++ b/fushi/test/media/drag_drop/drop_failure_visibility_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io' show FileSystemException;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/drag_drop/fushi_file_drop_target.dart';
+import 'package:fushi/src/media/drag_drop/image_archive_probe.dart';
+
+/// 拖放失败不再静默消失的守卫。
+///
+/// 背景：全部文件拖入入口（书架 / 视频库 / 词典页 / 游戏库 / 播放页 + 四个导入
+/// 对话框）都把自己的路由函数挂在 desktop_drop 的回调上。回调过去声明成 `void` 且
+/// 没有任何 try/catch，处理器一抛异常就直接漂进 zone——用户看到的只有「拖了没
+/// 反应」，而「拖了没反应」恰好又长得像「这类文件不支持」，他会得出完全错误的结论。
+///
+/// 断言分两层，缺一不可：
+///  ① 异常不许从 [FushiFileDropTarget.runDrop] 漏出去（漏出去 = 整次拖放消失）；
+///  ② 失败**必须**被上报（只断①的话，把 catch 体写空同样能过——那就是把「静默
+///     消失」换成「静默吞掉」，用户处境一模一样）。
+void main() {
+  FushiFileDropTarget targetWith(
+    FileDropCallback onDrop,
+    List<Object> reported,
+  ) =>
+      FushiFileDropTarget(
+        onDrop: onDrop,
+        onDropFailure: (Object error, StackTrace _) => reported.add(error),
+        child: const SizedBox.shrink(),
+      );
+
+  test('同步处理器抛出：不外泄且被上报', () async {
+    final List<Object> reported = <Object>[];
+    final FushiFileDropTarget target = targetWith(
+      (List<String> paths, Offset position) => throw StateError('boom-sync'),
+      reported,
+    );
+
+    await target.runDrop(<String>['/a.epub'], Offset.zero);
+
+    expect(reported, hasLength(1));
+    expect(reported.single, isA<StateError>());
+  });
+
+  test('异步处理器抛出：同样不外泄且被上报', () async {
+    // 这条是把 [FileDropCallback] 从 `void` 改成 `FutureOr<void>` 的理由：处理器
+    // 变成 `async` 之后，只包同步栈的 try/catch 接不住它抛的异常。把返回类型改回
+    // `void`（或把 runDrop 里的 await 去掉）这条就红。
+    final List<Object> reported = <Object>[];
+    final FushiFileDropTarget target = targetWith(
+      (List<String> paths, Offset position) async {
+        await Future<void>.delayed(Duration.zero);
+        throw StateError('boom-async');
+      },
+      reported,
+    );
+
+    await target.runDrop(<String>['/a.zip'], Offset.zero);
+
+    expect(reported, hasLength(1));
+    expect(reported.single, isA<StateError>());
+  });
+
+  test('处理器正常返回时不上报任何失败', () async {
+    final List<Object> reported = <Object>[];
+    final List<String> seen = <String>[];
+    final FushiFileDropTarget target = targetWith(
+      (List<String> paths, Offset position) async => seen.addAll(paths),
+      reported,
+    );
+
+    await target.runDrop(<String>['/a.epub'], Offset.zero);
+
+    expect(seen, <String>['/a.epub']);
+    expect(reported, isEmpty);
+  });
+
+  group('probeDroppedImageArchives', () {
+    test('只对扩展名二义的 .zip 开包，其余一次都不问', () async {
+      final List<String> probed = <String>[];
+      final Map<String, bool> result = await probeDroppedImageArchives(
+        <String>['/a.zip', '/b.epub', '/c.mkv', '/d', '/e.ZIP'],
+        probe: (String path) async {
+          probed.add(path);
+          return true;
+        },
+      );
+
+      expect(probed, <String>['/a.zip', '/e.ZIP'],
+          reason: '.epub / 视频 / 无扩展名都不该白开一次包');
+      expect(result, <String, bool>{'/a.zip': true, '/e.ZIP': true});
+    });
+
+    test('同一路径重复拖入只开一次包', () async {
+      int calls = 0;
+      await probeDroppedImageArchives(
+        <String>['/a.zip', '/a.zip'],
+        probe: (String path) async {
+          calls += 1;
+          return false;
+        },
+      );
+
+      expect(calls, 1);
+    });
+
+    test('开包失败只是「不是图片包」，不炸掉整次拖放', () async {
+      final Map<String, bool> result = await probeDroppedImageArchives(
+        <String>['/broken.zip'],
+        probe: (String path) async => throw const FileSystemException('nope'),
+      );
+
+      expect(result, <String, bool>{'/broken.zip': false},
+          reason: '损坏包应落回按扩展名的常规分类（.zip → 词典包），而不是抛出去');
+    });
+  });
+}

--- a/fushi/test/media/tags/tag_drop_test.dart
+++ b/fushi/test/media/tags/tag_drop_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/tags/tag_drop.dart';
+import 'package:fushi/utils.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 拖标签落库失败不再静默的守卫。
+///
+/// 五个调用点（书 / 字幕书 / 视频 / 书架合集 / 视频合集）此前各抄一遍
+/// 「查重 → 幂等提示 → 落库 → 成功提示」，且**都没有 try/catch**，又都以 unawaited
+/// Future 挂在 `onTagDropped` 这个 `void` 回调上。写失败时异常直接漂进 zone，用户
+/// 看到的是「拖了没反应」——而在这个交互里，「拖了没反应」恰恰又是**成功幂等**
+/// （标签本来就在）的样子。他会以为打上了，实际一个都没写进去。
+const BookTagRow _tag = BookTagRow(
+  id: 7,
+  name: 'fav',
+  colorValue: 0,
+  sortOrder: 0,
+  createdAt: 0,
+);
+
+void main() {
+  test('未打过 → 落库并返回 added，且不发任何提示', () async {
+    final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+    int writes = 0;
+
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: _tag,
+      isAlreadyTagged: () async => false,
+      addToDb: () async => writes += 1,
+      alreadyTaggedMessage: 'already',
+      notify: (String message, ToastSeverity severity) =>
+          told.add((message, severity)),
+    );
+
+    expect(outcome, TagAddOutcome.added);
+    expect(writes, 1);
+    // 成功提示归调用方（要 `mounted` 才能报），这里只确认没有多余提示。
+    expect(told, isEmpty);
+  });
+
+  test('已打过 → 不落库、给 warning 提示、返回 alreadyPresent', () async {
+    final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+    int writes = 0;
+
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: _tag,
+      isAlreadyTagged: () async => true,
+      addToDb: () async => writes += 1,
+      alreadyTaggedMessage: 'already',
+      notify: (String message, ToastSeverity severity) =>
+          told.add((message, severity)),
+    );
+
+    expect(outcome, TagAddOutcome.alreadyPresent);
+    expect(writes, 0, reason: '已存在时不该再写一次');
+    expect(told, <(String, ToastSeverity)>[('already', ToastSeverity.warning)]);
+  });
+
+  test('落库抛出 → 不外泄、给 error 提示、返回 failed', () async {
+    final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: _tag,
+      isAlreadyTagged: () async => false,
+      addToDb: () async => throw StateError('db locked'),
+      alreadyTaggedMessage: 'already',
+      notify: (String message, ToastSeverity severity) =>
+          told.add((message, severity)),
+    );
+
+    expect(outcome, TagAddOutcome.failed);
+    expect(told, hasLength(1));
+    expect(told.single.$2, ToastSeverity.error,
+        reason: '落库失败必须是 error 语义，不能与「已存在」的 warning 混同');
+  });
+
+  group('reorderTagsSafely', () {
+    test('写成功 → true，且不打扰用户（顺序当场变了就是反馈）', () async {
+      final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+
+      final bool ok = await reorderTagsSafely(
+        write: () async {},
+        notify: (String message, ToastSeverity severity) =>
+            told.add((message, severity)),
+      );
+
+      expect(ok, isTrue);
+      expect(told, isEmpty);
+    });
+
+    test('写失败 → false + error 提示，不外泄', () async {
+      final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+
+      final bool ok = await reorderTagsSafely(
+        write: () async => throw StateError('db locked'),
+        notify: (String message, ToastSeverity severity) =>
+            told.add((message, severity)),
+      );
+
+      expect(ok, isFalse, reason: '返回 false 才能让调用方跳过 invalidate，不把没落库的顺序当成已生效');
+      expect(told.single.$2, ToastSeverity.error);
+    });
+  });
+
+  test('查重本身抛出 → 一样归 failed 并提示，绝不当成「没打过」硬写', () async {
+    final List<(String, ToastSeverity)> told = <(String, ToastSeverity)>[];
+    int writes = 0;
+
+    final TagAddOutcome outcome = await addTagToTarget(
+      tag: _tag,
+      isAlreadyTagged: () async => throw StateError('read failed'),
+      addToDb: () async => writes += 1,
+      alreadyTaggedMessage: 'already',
+      notify: (String message, ToastSeverity severity) =>
+          told.add((message, severity)),
+    );
+
+    expect(outcome, TagAddOutcome.failed);
+    expect(writes, 0);
+    expect(told.single.$2, ToastSeverity.error);
+  });
+}

--- a/fushi/test/media/video/download/video_download_organizer_test.dart
+++ b/fushi/test/media/video/download/video_download_organizer_test.dart
@@ -6,20 +6,34 @@ import 'package:fushi/src/media/video/download/video_download_organizer.dart';
 import 'package:fushi/src/media/video/download/video_download_path_mapping.dart';
 import 'package:path/path.dart' as p;
 
+/// 本机侧根目录，按**当前平台**给。
+///
+/// [VideoDownloadPathMapping] 的本机侧走 `p.normalize(p.absolute(...))` + `p.join`
+/// （平台上下文），远端侧才统一 `/`。原来这条用例把本机根硬编码成 `C:\Media\Downloads`：
+/// Linux CI 上它不是绝对路径，`p.absolute` 会给它前置 CWD 变成
+/// `/…/cwd/C:\Media\Downloads`，拼出来的结果与期望值必然不等——「本机 Windows 绿、
+/// CI 必红」。本机路径按平台原生给才是这个类的真实用法，所以修的是用例的平台假设。
+final String _localRoot =
+    Platform.isWindows ? r'C:\Media\Downloads' : '/Media/Downloads';
+
 void main() {
   test('remote/local path mapping is bidirectional and prefix-safe', () {
     final VideoDownloadPathMapping mapping = VideoDownloadPathMapping(
       remoteRoot: '/srv/downloads/',
-      localRoot: r'C:\Media\Downloads',
+      localRoot: _localRoot,
       localCaseSensitive: false,
     );
 
     expect(
       mapping.remoteToLocal('/srv/downloads/Show/E01.mkv'),
-      p.normalize(r'C:\Media\Downloads\Show\E01.mkv'),
+      p.normalize(p.joinAll(<String>[_localRoot, 'Show', 'E01.mkv'])),
     );
+    // 大小写不敏感回程：把**根**整段转小写、目录段保持原样，两个平台都真的在考
+    // `localCaseSensitive: false`（Windows 上仍是原来那条 `c:\media\downloads\…`）。
     expect(
-      mapping.localToRemote(r'c:\media\downloads\Show\E01.mkv'),
+      mapping.localToRemote(
+        p.joinAll(<String>[_localRoot.toLowerCase(), 'Show', 'E01.mkv']),
+      ),
       '/srv/downloads/Show/E01.mkv',
     );
     expect(mapping.remoteToLocal('/srv/downloads-other/E01.mkv'), isNull);
@@ -34,8 +48,11 @@ void main() {
       if (await root.exists()) await root.delete(recursive: true);
     });
     final _FakeBackend backend = _FakeBackend(<TorrentFileEntry>[
+      // 种子内路径用 `/`：这是 qBittorrent `torrents/files` 真实返回的形态（与本机
+      // 平台无关）。原来写成反斜杠，只有 Windows 的 `p.basename` 认得，Linux 上取
+      // basename 会把整串当文件名——用例因此带上了不该有的平台依赖。
       const TorrentFileEntry(
-        name: r'Original\Show.S02E03.mkv',
+        name: 'Original/Show.S02E03.mkv',
         size: 100,
         progress: 1,
         index: 4,

--- a/fushi/test/media/video/metadata/video_source_metadata_indexer_test.dart
+++ b/fushi/test/media/video/metadata/video_source_metadata_indexer_test.dart
@@ -8,57 +8,108 @@ import 'package:fushi/src/media/video/metadata/video_source_metadata_indexer.dar
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
 
+/// 用**当前平台**的分隔符拼一条绝对路径。
+///
+/// [classifyLocalVideoExtra] 的目录名判据走 `p.split`（平台上下文）。原来这条用例
+/// 硬编码 `D:\Shows\...`：Windows 上 `p.split` 认得反斜杠、目录段能切出来所以全绿；
+/// Linux CI 上反斜杠只是普通字符，整串被当成**一个**路径段，`Trailers` / `迷你动画`
+/// 这类目录判据一条都命不中，stem 又变成 `d:\shows\title\trailers\official`，
+/// `trailer` 后面跟着 `s` 连兜底正则也不匹配 → 全部返回 null。典型的「本机 Windows
+/// 绿、CI 必红」。判据本身按平台分是对的（本地扫描拿到的就是平台原生路径），所以
+/// 修的是用例的平台假设，不是生产代码。
+String _nativePath(List<String> segments) => p.joinAll(<String>[
+      if (Platform.isWindows) r'D:\' else '/',
+      ...segments,
+    ]);
+
 void main() {
   test('Kodi local extra names are classified without matching normal episodes',
       () {
     expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\Trailers\official.mkv')?.kind,
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Shows', 'Title', 'Trailers', 'official.mkv']),
+      )?.kind,
       VideoMetadataExtraKind.trailer,
-    );
-    expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\Behind The Scenes\making-of.mkv')
-          ?.kind,
-      VideoMetadataExtraKind.behindTheScenes,
-    );
-    expect(
-      classifyLocalVideoExtra(r'D:\Movies\Film-trailer.mp4')?.kind,
-      VideoMetadataExtraKind.trailer,
-    );
-    expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\NCOP2.mkv')?.kind,
-      VideoMetadataExtraKind.clip,
-    );
-    expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\Title NCED.mkv')?.kind,
-      VideoMetadataExtraKind.clip,
-    );
-    expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\PV\[Group][Title][PV][01].mkv')
-          ?.kind,
-      VideoMetadataExtraKind.clip,
     );
     expect(
       classifyLocalVideoExtra(
-        r'D:\Shows\Title\NCOP&NCED\[Group][Title][NCOP].mkv',
+        _nativePath(<String>[
+          'Shows',
+          'Title',
+          'Behind The Scenes',
+          'making-of.mkv',
+        ]),
+      )?.kind,
+      VideoMetadataExtraKind.behindTheScenes,
+    );
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Movies', 'Film-trailer.mp4']),
+      )?.kind,
+      VideoMetadataExtraKind.trailer,
+    );
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Shows', 'Title', 'NCOP2.mkv']),
       )?.kind,
       VideoMetadataExtraKind.clip,
     );
     expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\menu\[Group][Title][01].mkv')
-          ?.kind,
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Shows', 'Title', 'Title NCED.mkv']),
+      )?.kind,
+      VideoMetadataExtraKind.clip,
+    );
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>[
+          'Shows',
+          'Title',
+          'PV',
+          '[Group][Title][PV][01].mkv',
+        ]),
+      )?.kind,
+      VideoMetadataExtraKind.clip,
+    );
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>[
+          'Shows',
+          'Title',
+          'NCOP&NCED',
+          '[Group][Title][NCOP].mkv',
+        ]),
+      )?.kind,
+      VideoMetadataExtraKind.clip,
+    );
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>[
+          'Shows',
+          'Title',
+          'menu',
+          '[Group][Title][01].mkv',
+        ]),
+      )?.kind,
       VideoMetadataExtraKind.extra,
     );
     expect(
-      classifyLocalVideoExtra(r'D:\Shows\Title\迷你动画\short-01.mkv')?.kind,
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Shows', 'Title', '迷你动画', 'short-01.mkv']),
+      )?.kind,
       VideoMetadataExtraKind.short,
     );
-    expect(classifyLocalVideoExtra(r'D:\Shows\Title\Title.S01E01.mkv'), isNull);
+    expect(
+      classifyLocalVideoExtra(
+        _nativePath(<String>['Shows', 'Title', 'Title.S01E01.mkv']),
+      ),
+      isNull,
+    );
   });
 
   test('existing source is backfilled into one idempotent provisional work',
       () async {
-    final FushiDatabase db =
-        FushiDatabase.forTesting(NativeDatabase.memory());
+    final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
     final Directory root =
         await Directory.systemTemp.createTemp('video-metadata-backfill-');
     addTearDown(() async {

--- a/fushi/test/pages/video_subtitle_fixes_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_fixes_guard_test.dart
@@ -170,7 +170,7 @@ void main() {
         reason: '播放页在上层时，视频库页不能继续弹 need-card-target SnackBar');
 
     final String shelfDrop = region(
-      'void _handleShelfDrop(',
+      'Future<void> _handleShelfDrop(',
       'Future<void> _openBookImportPrefilled(',
       source: shelfSrc,
     );

--- a/fushi/test/torrent/anime_download_service_test.dart
+++ b/fushi/test/torrent/anime_download_service_test.dart
@@ -1054,14 +1054,28 @@ void main() {
           <String, dynamic>{'name': 'Show 01.mkv', 'size': 1, 'progress': 0.2},
         ];
         final Completer<void> release = Completer<void>();
+        // importer 真的进场了的**确定性**信号。
+        //
+        // 原来这里赌 `Future.delayed(20ms)`：importNow 要先 loadAll、列种子、列文件
+        // 一串异步 IO 才走到 importer，本机 5~10 个 agent 并发跑测试时 20ms 经常不够，
+        // 这条用例就以「期望 1 个得 0 个」偶发变红——零代码改动的伪红。等一个 Completer
+        // 既不会早也不会晚，与机器负载无关。
+        final Completer<void> entered = Completer<void>();
         importerOverride = (AnimeDownloadPlan plan, List<String> videos) async {
+          if (!entered.isCompleted) entered.complete();
           await release.future;
           return const AnimeDownloadImportOutcome(collectionId: 42);
         };
         final AnimeDownloadService service = buildService();
         final Future<bool> first = service.importNow(_kHash);
         final Future<bool> second = service.importNow(_kHash);
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        // single-flight 的判据本身是同步的：第二次调用在 `_importNowInFlight` 里命中
+        // 同一个 operation，拿回的必须是**同一个** Future，而不是另起一轮。这条比数
+        // importCalls 更贴契约——per-plan 串行锁单独也能把并发 importer 压成 1 次，
+        // 光看「进场次数」区分不出「去重了」和「只是排队了」。
+        expect(identical(first, second), isTrue,
+            reason: '并发 importNow 必须返回同一个在途 Future，而不是排队跑第二轮');
+        await entered.future;
         expect(importCalls, hasLength(1));
         release.complete();
         expect(await Future.wait(<Future<bool>>[first, second]), <bool>[

--- a/packages/fushi_core/test/migration_book_key_test.dart
+++ b/packages/fushi_core/test/migration_book_key_test.dart
@@ -322,25 +322,30 @@ void main() {
         books.firstWhere((b) => b.bookKey == 'Book A (2)');
     expect(bookA2.extractDir, '/books/2');
 
-    // ── reader positions by bookKey ───────────────────────────────────
-    final p1 = await db.getReaderPosition('Book A');
+    // ── reader positions by book uid ──────────────────────────────────
+    // v16 把阅读数据重新键到 bookKey；v82 又把 reader_positions 的书键换成本机
+    // 稳定的 `EpubBooks.uid`（标题改名不丢位置）。所以这里查的是**书行的 uid**，
+    // 不再是 bookKey——两级 re-key 之后数据仍在，这才是本用例要守的「无损」。
+    final p1 = await db.getReaderPosition(bookA.uid);
     expect(p1, isNotNull);
     expect(p1!.normCharOffset, 5000);
-    final p2 = await db.getReaderPosition('Book A (2)');
+    final p2 = await db.getReaderPosition(bookA2.uid);
     expect(p2, isNotNull);
     expect(
         p2!.charOffset, -1); // BUG-162: v24 删 ttu_char_offset，char_offset 默认 -1
 
-    // ── bookmarks by bookKey ──────────────────────────────────────────
+    // ── bookmarks by book uid（v82 起 bookmarks 也改走 uid，同 reader_positions）─
     final bmA = await db
         .customSelect(
-          "SELECT COUNT(*) AS c FROM bookmarks WHERE book_key = 'Book A'",
+          'SELECT COUNT(*) AS c FROM bookmarks WHERE book_uid = ?',
+          variables: <Variable<Object>>[Variable<String>(bookA.uid)],
         )
         .getSingle();
     expect(bmA.read<int>('c'), 2);
     final bmA2 = await db
         .customSelect(
-          "SELECT COUNT(*) AS c FROM bookmarks WHERE book_key = 'Book A (2)'",
+          'SELECT COUNT(*) AS c FROM bookmarks WHERE book_uid = ?',
+          variables: <Variable<Object>>[Variable<String>(bookA2.uid)],
         )
         .getSingle();
     expect(bmA2.read<int>('c'), 1);
@@ -411,17 +416,18 @@ void main() {
 
     // ── FK cascade: deleting a book clears its reading data ───────────
     await db.deleteEpubBook('Book A');
-    expect(await db.getReaderPosition('Book A'), isNull);
+    expect(await db.getReaderPosition(bookA.uid), isNull);
     expect(await db.getAudiobookByBookKey('Book A'), isNull);
     expect(await db.getCuesForBook('Book A'), isEmpty);
     final bmAfter = await db
         .customSelect(
-          "SELECT COUNT(*) AS c FROM bookmarks WHERE book_key = 'Book A'",
+          'SELECT COUNT(*) AS c FROM bookmarks WHERE book_uid = ?',
+          variables: <Variable<Object>>[Variable<String>(bookA.uid)],
         )
         .getSingle();
     expect(bmAfter.read<int>('c'), 0);
     expect((await db.getTagsForBook('Book A')), isEmpty);
     // The other book is untouched.
-    expect(await db.getReaderPosition('Book A (2)'), isNotNull);
+    expect(await db.getReaderPosition(bookA2.uid), isNotNull);
   });
 }

--- a/packages/fushi_core/test/migration_partial_v16_shape_test.dart
+++ b/packages/fushi_core/test/migration_partial_v16_shape_test.dart
@@ -240,7 +240,9 @@ void main() {
         reason: 'legacy int id epub_books re-keyed to sanitized title');
 
     // ── reader_positions: ALREADY v16 -> untouched, original data kept ───
-    final pos = await db.getReaderPosition(kBookKey);
+    // v82 之后 reader_positions 的键是本机稳定的 `EpubBooks.uid`（不是 bookKey），
+    // 故按书行 uid 查；断言意图不变——已是 v16 形状的表不该被再动一次。
+    final pos = await db.getReaderPosition(books.single.uid);
     expect(pos, isNotNull);
     expect(pos!.normCharOffset, 4242,
         reason: 'already-v16 reader_positions skipped (no JOIN), data intact');
@@ -259,13 +261,13 @@ void main() {
         reason:
             'skipped v16 book_tag_mappings is a usable table post-migration');
 
-    // ── bookmarks: LEGACY ttu_book_id -> re-keyed to book_key ────────────
+    // ── bookmarks: LEGACY ttu_book_id -> re-keyed（v16 到 book_key，v82 到 uid）─
     final QueryRow bm = await db.customSelect(
-      "SELECT label FROM bookmarks WHERE book_key = ?",
-      variables: [Variable<String>(kBookKey)],
+      'SELECT label FROM bookmarks WHERE book_uid = ?',
+      variables: [Variable<String>(books.single.uid)],
     ).getSingle();
     expect(bm.read<String>('label'), 'bm1',
-        reason: 'legacy ttu_book_id bookmark re-keyed to book_key');
+        reason: 'legacy ttu_book_id bookmark re-keyed all the way to book_uid');
 
     // ── audiobooks + cues: LEGACY book_uid -> re-keyed to book_key ───────
     expect(await db.getAudiobookByBookKey(kBookKey), isNotNull,

--- a/packages/fushi_core/test/migration_sasayaki_values_v71_test.dart
+++ b/packages/fushi_core/test/migration_sasayaki_values_v71_test.dart
@@ -17,10 +17,15 @@ FushiDatabase _openMigratedFromV70() {
         // profile_settings -> profiles 外键形同虚设）。
         raw.execute('PRAGMA foreign_keys = ON');
 
+        // 列名必须与**真实 v70 的 audio_cues** 一致：这张表的书键叫 `book_key`
+        // （[AudioCues.bookKey]，至今未改名——改走 uid 的是 reader_positions /
+        // revealed_images 那一族，v82）。seed 写成 `book_uid` 会让迁移阶梯里的
+        // `_ensureIndexes()` 建 `idx_audio_cues_book_key ON audio_cues (book_key)`
+        // 时炸 "no such column"，红的是 seed 不是迁移。
         raw.execute('''
 CREATE TABLE audio_cues (
   id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  book_uid TEXT NOT NULL,
+  book_key TEXT NOT NULL,
   chapter_href TEXT NOT NULL,
   sentence_index INTEGER NOT NULL,
   text_fragment_id TEXT NOT NULL,
@@ -31,7 +36,7 @@ CREATE TABLE audio_cues (
 )''');
         raw.execute(
           "INSERT INTO audio_cues "
-          "(book_uid, chapter_href, sentence_index, text_fragment_id, cue_text, start_ms, end_ms, audio_file_index) "
+          "(book_key, chapter_href, sentence_index, text_fragment_id, cue_text, start_ms, end_ms, audio_file_index) "
           "VALUES "
           // ① 命中 cue：scheme 前缀改写，query 段不动。
           "('BookA', 'c1.xhtml', 0, 'sasayaki://s=1&ns=100&ne=200', 'hi', 0, 1000, 0),"

--- a/packages/fushi_core/test/migration_schema_v48_compat_test.dart
+++ b/packages/fushi_core/test/migration_schema_v48_compat_test.dart
@@ -84,9 +84,12 @@ void main() {
     // 迁移终点跟随当前代码的 schemaVersion（v48 时代写下，此后 develop 已继续升级）。
     expect(version.read<int>('user_version'), db.schemaVersion);
     expect(await _columnNames(db, 'epub_books'), contains('completed_at'));
+    // 断的是**迁移终点**（阶梯一路跑到当前 schemaVersion），不是 v48 当时的形状：
+    // v82 把 revealed_images 的书键从 title 派生的 `book_key` 改成本机稳定的
+    // `book_uid`（`EpubBooks.uid`，带数据搬迁），这里跟着改名走。
     expect(
       await _columnNames(db, 'revealed_images'),
-      containsAll(<String>['book_key', 'image_key', 'revealed_at']),
+      containsAll(<String>['book_uid', 'image_key', 'revealed_at']),
     );
   });
 
@@ -98,7 +101,7 @@ void main() {
     expect(await _columnNames(db, 'epub_books'), contains('completed_at'));
     expect(
       await _columnNames(db, 'revealed_images'),
-      containsAll(<String>['book_key', 'image_key', 'revealed_at']),
+      containsAll(<String>['book_uid', 'image_key', 'revealed_at']),
     );
     expect(
       await _indexNames(db),

--- a/packages/fushi_core/test/migration_sync_backend_type_v74_test.dart
+++ b/packages/fushi_core/test/migration_sync_backend_type_v74_test.dart
@@ -30,14 +30,32 @@ CREATE TABLE preferences (
         );
 
         raw.execute('''
+CREATE TABLE profiles (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)''');
+        raw.execute(
+          "INSERT INTO profiles (id, name, created_at, updated_at) "
+          "VALUES (1, 'Default', 1, 1)",
+        );
+        // profile_settings 必须按**真实**表形建（每 Profile 一行快照 + profile_id
+        // 外键）。原来 seed 写成裸 `(key, value)` 两列：迁移阶梯跑到
+        // `_ensureIndexes()` 建 `idx_profile_settings_profile ON
+        // profile_settings (profile_id)` 时炸 "no such column"，红的是 seed 不是迁移。
+        raw.execute('''
 CREATE TABLE profile_settings (
-  key TEXT NOT NULL PRIMARY KEY,
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  profile_id INTEGER NOT NULL REFERENCES profiles (id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  key TEXT NOT NULL,
   value TEXT NOT NULL
 )''');
         raw.execute(
-          'INSERT INTO profile_settings (key, value) VALUES '
+          'INSERT INTO profile_settings (profile_id, category, key, value) '
           // ③ 每 Profile 快照里的同一键，同样要改。
-          "('sync_backend_type', 's:hibikiServer')",
+          "VALUES (1, 'pref', 'sync_backend_type', 's:hibikiServer')",
         );
 
         raw.execute('PRAGMA user_version = 73');


### PR DESCRIPTION
## 背景

两批输入：① 一份「4 条 fushi/桥测试红」的报告；② 拖放族的 8 类未修入口 + fushi_core 6 条既存红 + 一处注释漂移。

先说结论纠正一条：**`video_drag_gesture` 那条不用改**——develop 最近两个提交（BUG-1506，`28ec267090` / `ddd702f39e`）已经把横滑 seek 守卫的锚点跟上新契约了，那份报告跑在合并之前。我在主 checkout 复现时这三条视频测试全绿，正是因为 develop 已经修过。

其余全部是真问题，且根因都不是「补丁式绕过」能盖住的。

## 一、拖放：失败静默消失（生产行为改动）

### 1. 一处咽喉，收全部 11 个文件拖入入口

各库页/对话框的 drop 路由函数挂在 desktop_drop 的 `void` 回调上，**全链路没有一个 try/catch**。处理器一抛异常就直接漂进 zone，用户看到的只有「拖了没反应」——而这个表象恰好又长得像「这类文件不支持」，他会得出完全错误的结论。

逐入口补 try/catch 等于把同一份补丁抄 11 遍，而且以后新增入口还会漏。改成收在 `FushiFileDropTarget`：

- `FileDropCallback` 从 `void` 改成 `FutureOr<void>` 并 `await` —— 只包同步栈的话，`async` 处理器抛的异常照样从 catch 底下漏走；
- catch 里走 error toast（新 key `drag_drop_failed`），并留可注入的 `onDropFailure` 缝供测试断言。

### 2. 书架落点不再在 drop 栈里同步解 zip

图片型 `.zip`（漫画）与 Yomitan 词典包同形，必须真读包才分得出 —— 判据本身没问题，问题是它**跑错了线程**：`MangaModule.isImageArchive` 同步解整个压缩包（`.epub` 分支还同步落一棵临时解压树），而它长在 desktop_drop 回调的同步栈上。拖个大包进书架，UI 线程就在那儿卡住不画帧。

新增 `image_archive_probe.dart`：先在后台 isolate 一次性判完，再把结果当同步谓词喂回 `classifyDroppedFiles`。分类函数因此保持纯函数不变，不需要为了「判据变异步」把整条分类/决策链改成异步。开包失败只归「不是图片包」，落回按扩展名的常规分类，不炸掉整次拖放。

### 3. 拖标签的 5 份「成功才提示、失败静默」

`_addTagToVideoBook` / `_addTagToVideoCollection` / `_addTagToBook` / `_addTagToSrtBook` / `_addTagToCollection` 各抄一遍「查重 → 幂等提示 → 落库 → 成功提示」，**五处都没有 try/catch**，又都以 unawaited Future 挂在 `onTagDropped` 这个 `void` 回调上。

这里比一般的「没反馈」更糟：**在这个交互里，「拖了没反应」恰好就是成功幂等（标签本来就在）的样子**。用户会以为打上了，实际一个都没写进去。

范式是现成的 —— `collection_drag.dart` 的 `addMediaRefToCollection` 早就把同一件事收口了（合集行头上并排挂着两个 `DragTarget`，落 `MediaRef` 走那边、落 `BookTagRow` 走这边）。新增 `tags/tag_drop.dart` 的 `addTagToTarget` 照抄那半边的分工：编排永不抛，调用方只按 outcome 决定要不要刷新 + 报成功（刷新要 `ref`、成功提示要 `mounted`，都属于 widget 层）。

顺带发现同族第三种写法：三个库页各一份**标签重排**，同样裸 `await db.reorderTags(...)`。失败时用户只看到「松手后顺序自己弹回去了」，没有任何解释 —— 收口到 `reorderTagsSafely`，返回 false 时调用方跳过 invalidate，不把没落库的顺序当成已生效。

## 二、测试红（无生产行为改动）

| 测试 | 真因 |
|---|---|
| `video_source_metadata_indexer` | 硬编码 `D:\Shows\...`。`classifyLocalVideoExtra` 走 `p.split`（平台上下文），Linux 上反斜杠只是普通字符，整串被当成**一个**路径段，目录判据一条都命不中，stem 变成 `d:\shows\title\trailers\official`，`trailer` 后跟着 `s` 连兜底正则也不匹配 → 全部 null |
| `video_download_organizer` | 硬编码 `C:\Media\Downloads`。Linux 上它不是绝对路径，`p.absolute` 前置 CWD → 拼出来必然不等。顺带把种子内路径从反斜杠改成 qBittorrent 真实返回的 `/` |
| `anime_download_service` single-flight | 靠 `Future.delayed(20ms)` 等 importer 进场，本机多 agent 并发时不够。改等 Completer；并补断 `identical(first, second)` —— per-plan 串行锁**单独也能**把并发进场压成 1 次，光数 importCalls 区分不出「去重了」和「只是排队了」 |
| fushi_core ×6 | 两处 seed DDL 写错真实表形（`audio_cues.book_uid` 应为 `book_key`；`profile_settings` 写成裸 `(key,value)`、缺 `profile_id` → 迁移阶梯跑到 `_ensureIndexes()` 建索引时炸 "no such column"）；四处断言没跟上 schema **v82「书身份改走 uid」**（`reader_positions` / `bookmarks` / `revealed_images` 的 `book_key` → `book_uid`，带数据搬迁）。**迁移逻辑本身无误** |

判据本身按平台分是对的（本地扫描拿到的就是平台原生路径），所以前两条修的是用例的平台假设，不是生产代码。

## 三、注释漂移

`controls_theme.part.dart` 的横滑 seek 注释还写着「按时长比例换算」，而那正是 BUG-1485 换掉的旧 fork 公式（每像素时间与总时长成正比 = 「一拽就起飞」的根因）。改指向 `VideoHorizontalSeekGesture` 的新模型（拖过整屏 = 固定一段时长，与总时长解耦），并明写「别照着旧句子推断当前行为」。

## 守卫与变异实测

新增 `drop_failure_visibility_test` / `tag_drop_test`，断言分两层，缺一不可：① 异常不许外泄（外泄 = 整次拖放消失）；② 失败**必须**被上报（只断①的话，把 catch 体写空同样能过 —— 那是把「静默消失」换成「静默吞掉」，用户处境一模一样）。

三次变异实测，均如期变红：

1. 去掉 `runDrop` 里的 `await` → 行为测试 + 源码守卫各自红；
2. 去掉失败上报 → 2 条红；
3. 把失败 severity 从 error 降成 warning → 2 条红。

另有两处既有源码守卫钉着 `void _handleShelfDrop(` 签名锚点，跟上新的 `Future<void>`。

## 验证

- `flutter analyze`（含 test）：**No issues found**
- `fushi`：`test/media` + `test/torrent` + `test/pages` + `test/i18n` + `test/tools` → **7995 tests 全绿**
- 目录枚举型守卫整批（新增了 lib/ 与 test/ 下的文件，会落进它们的扫描面）→ **137 + 364 全绿**
- `fushi_core` 全量 → **56 tests 全绿**（改前 6 红）

全部经 `dart run tool/flutter_test_failures.dart` 判绿（认 VERDICT 行 + 退出码，不用裸管道）。

## 未做 / 已知缺口

- 拖放族里 `DragTarget<VideoControlDragData>`（视频控件布局编辑）没动：那是纯内存布局操作，不落库，不属于同一类缺陷。
- 真机拖放未复测（本轮全部由自动化测试覆盖；`FushiFileDropTarget` 只在桌面端生效，headless 测试驱不了真实 OS 拖放事件，故走可注入缝 + 源码守卫两层）。

https://claude.ai/code/session_0175kHULxtRW1EV84fa89Y89
