### PR TITLE
fix(release): 发布序号加一次性地板，历史重写后不再倒退（BUG-1586）

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,13 +44,16 @@ jobs:
         # `git rev-list --count HEAD` report a truncated (smaller) sequence,
         # producing a versionCode that disagrees with release.yml's. Keep this in
         # lockstep with release.yml's `fetch-depth: 0`.
+        # 2026-08-12: 序号统一由 tool/release_sequence.sh 算（计数 + 一次性地板）。
+        # 地板只补「历史重写导致计数倒退」，补不了「浅克隆导致计数截断」——
+        # 后者每次 checkout 都可能不同，仍然只能靠 fetch-depth: 0 兜住。
         fetch-depth: 0
 
     - name: Resolve shared release sequence
       shell: bash
       run: |
         set -euo pipefail
-        RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+        RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
         if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
           echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
           exit 1

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' fushi/pubspec.yaml | sed 's/version: *//;s/+.*//')
-          RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+          RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
           if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
             echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
             exit 1
@@ -712,7 +712,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' fushi/pubspec.yaml | sed 's/version: *//;s/+.*//')
-          RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+          RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
           if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
             echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
             exit 1
@@ -1222,7 +1222,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' fushi/pubspec.yaml | sed 's/version: *//;s/+.*//')
-          RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+          RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
           if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
             echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
             exit 1
@@ -1698,7 +1698,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' fushi/pubspec.yaml | sed 's/version: *//;s/+.*//')
-          RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+          RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
           if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
             echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           echo "::error title=Invalid pubspec build number::Expected numeric +build in $PUBSPEC_VERSION"
           exit 1
         fi
-        RELEASE_SEQUENCE=$(git rev-list --count HEAD)
+        RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)
         if ! [[ "$RELEASE_SEQUENCE" =~ ^[0-9]+$ ]] || [ "$RELEASE_SEQUENCE" -le 0 ]; then
           echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $RELEASE_SEQUENCE"
           exit 1

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1586](bugs/BUG-1586-release-seq-floor-after-history-rewrite.md) | ✅ | ✅ | 历史重写让发布序号倒退，全部已装用户永久收不到更新 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -78,8 +78,11 @@ Flutter 版本号以 `fushi/pubspec.yaml` 的 `version: X.Y.Z+build` 为准。�
   - 一批功能完成 / 大模块 / 用户可见大改：升 minor 并重置 patch（如 `0.9.29` -> `0.10.0`）。
   - 一批修复 / 小功能阶段性收口：升 patch（如 `0.10.0` -> `0.10.1`）。
   - 单个零散 commit 通常**只 +build**；攒到一批 / 里程碑再升 `X.Y.Z`（届时 `+build` 也照常 +1）。
-- Android `versionCode` 的单调递增由 CI 的 `git rev-list --count HEAD`（每个 commit +1）经 `--build-number` 喂给 `build.gradle` 的 `versionCodeBase + 100 × <seq> + abiOffset` 保证；`build.gradle` 还带 2.1e9 上限断言，越界即 fail-fast（TODO-414）。**不依赖 pubspec `+build`**。
+- Android `versionCode` 的单调递增由 CI 的 `git rev-list --count HEAD`（每个 commit +1）**加一次性地板**经 `--build-number` 喂给 `build.gradle` 的 `versionCodeBase + 100 × <seq> + abiOffset` 保证；`build.gradle` 还带 2.1e9 上限断言，越界即 fail-fast（TODO-414）。**不依赖 pubspec `+build`**。
 - 纯文档、PM 元数据、不影响分发行为的 CI 维护不强制 bump；发布、安装包或运行行为变化应 bump。
+- **序号算式收在 `tool/release_sequence.sh` 一个文件里**，六处 workflow 一律 `RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)`，不得在 workflow 里写裸 `git rev-list --count HEAD` 赋值（守卫会红）。算式 = 提交计数 + `RELEASE_SEQUENCE_FLOOR`。
+- **为什么有地板**：提交计数只在「历史只增不减」时单调，**重写历史会让它倒退**。2026-08-12 develop 被强推成重写后的历史，计数从 10546 掉到 9466，而已发布并装到用户机器上的最大序号是 10405。序号倒退会同时锁死三处单调比较——Android `versionCode`（系统安装器拒装）、app 内更新器的 `releaseSequence` 全序比较（永远提示已是最新）、`tool/merge_update_manifest.py` 的「Never downgrades the advertised top-level release」（新包写不进清单）。这三处都没错，错的是序号倒退，所以修在源头加地板，而不是去放宽任何一处守卫。
+- **什么时候要再抬地板**：只有再次重写历史、且新的 `计数 + FLOOR` 不再高于「已发布过的最大序号」时。抬之前先去 GitHub Release 资产名里查真实的 `-debug.<seq>` / `-beta.<seq>` 最大值，别凭感觉加。守卫：`fushi/test/build/release_sequence_floor_guard_test.dart`。
 - 发布 workflow 修改后必须运行 `tool/check_release_policy.ps1`（Windows：`powershell -NoProfile -ExecutionPolicy Bypass -File tool/check_release_policy.ps1`；GitHub Actions 用 `pwsh`）。该守卫会拒绝重新引入 workflow-local run number、缺失完整历史 checkout、缺失同 tag/commit 发布并发锁，或文档缺少 cross-workflow release sequence / single GitHub Release 规则。
 
 ## CI 缓存配额（TODO-2721）

--- a/docs/bugs/BUG-1586-release-seq-floor-after-history-rewrite.md
+++ b/docs/bugs/BUG-1586-release-seq-floor-after-history-rewrite.md
@@ -1,0 +1,16 @@
+## BUG-1586 · 历史重写让发布序号倒退，全部已装用户永久收不到更新
+- **报告**：2026-08-13（用户：本机 Fushi 1.4.0-debug.10405 一直提示已是最新／新包装不上，"怎么会说降级"）
+- **真实性**：✅ 真 bug。根因 `tool/release_sequence.sh`（本次新增前：六处 workflow 各写一份 `RELEASE_SEQUENCE=$(git rev-list --count HEAD)`，见 `.github/workflows/release.yml:103`、`main.yml:53`、`release-desktop.yml:89/715/1225/1701`）。
+  - 序号取自 `git rev-list --count HEAD`，该值只在「历史只增不减」时单调。2026-08-12 03:37 `origin/develop` 被强推成重写后的历史：同一条提交 `dc328530c`(count 10546) → `139c30dba`(count 9466)，作者时间一致、SHA 全变，`origin/develop` reflog 连着三次 `forced-update`。当前 develop `62d5d8679` count = 9473。
+  - 而彼时已发布并装到用户机器上的最大序号是 **10405**（`fushi-debug-rolling` 的 `fushi-1.4.0-debug.10405-*`，出自旧历史 `48978772a`）。
+  - 序号倒退同时锁死三处**正确的**单调比较：
+    1. `fushi/android/app/build.gradle:92` `versionCode = 1e9 + 100*seq + abiOffset` → 比已装的低 93,200，系统安装器拒装；
+    2. `fushi/lib/src/utils/misc/update_checker_release.dart:1706/1731` 按 `releaseSequence` 全序比较 → 判远端「不比本机新」，客户端只显示 `update_already_latest`；
+    3. `tool/merge_update_manifest.py:161` "Never downgrades the advertised top-level release" → 新包写不进清单。
+  - 实测后果：`update-manifest` 孤儿分支的 `latest-debug-fushi.json` 自 08-11 08:03 起被钉死在 `releaseSequence: 10405`，等于本机装的那一版；#795~#807 十个已合 PR 对所有已装用户不可达。
+- **[x] ① 已修复** — `tool/release_sequence.sh` 新增：序号 = 提交计数 + 一次性地板 `RELEASE_SEQUENCE_FLOOR=2000`（同 `versionCodeBase=1e9` 的既有手法），六处 workflow 统一改成 `RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)`；`tool/check_release_policy.ps1` 的共享算式断言跟着改，并新增 `Forbid-Pattern` 禁止再写裸 `RELEASE_SEQUENCE=$(git rev-list`。修后 develop 序号 = 9473+2000 = 11473 > 10546，桥包分支 9114+2000 = 11114 同样越过。**没有放宽上面三处守卫中的任何一处**——它们拒绝更小的序号是对的。
+- **[x] ② 已加自动化测试** — `fushi/test/build/release_sequence_floor_guard_test.dart`（5 条）：地板可解析、当前分支序号越过历史最大值 10546、workflow 无绕过地板的裸赋值、守卫非空转反向锚。两条关键断言均做过变异实测（地板改 100 → 红；main.yml 改回裸赋值 → 红）。`tool/check_release_policy.ps1` 也做了同样的注入/还原实测。
+- **备注**：
+  - 变异实测第一轮**没抓住**地板变异——原实现拿 `git rev-parse --is-shallow-repository` 当跳过闸门，而本机 `.git/shallow` 是历史遗留标记，导致该断言永久静默跳过。已改成按「计数 < 1000 视为截断 checkout」跳过，CI 默认浅 checkout 仍不会假红。
+  - 本次修复**不**自动补发任何包：`release.yml` 的 push 触发自 2026-08-07 起因 Fushi 改名过渡期整块注释，发版仍需手动 `workflow_dispatch`。
+  - 同期发现但不属本 bug：`v1.4.0-beta.9473` 是半成品发布（只有 ipa+zip），因为同 run 的 windows job 构建失败 → `Publish mirror update manifest` 步骤报 `No files matched fushi-*-windows-setup.exe` 而挂。Windows 构建红另查。

--- a/fushi/test/build/release_sequence_floor_guard_test.dart
+++ b/fushi/test/build/release_sequence_floor_guard_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：发布序号必须走 `tool/release_sequence.sh`，且地板高过所有历史发布序号。
+///
+/// ## 起因
+///
+/// 序号来自 `git rev-list --count HEAD`。这个数只在「历史只增不减」的前提下
+/// 单调；**重写历史会让它倒退**。2026-08-12 develop 被强推成重写后的历史，
+/// 计数从 10546 掉到 9466，而当时已发布、已装到用户机器上的最大序号是 10405。
+///
+/// 序号同时喂三处单调比较，倒退把它们一起锁死：
+///   1. Android `versionCode = versionCodeBase + 100 * seq + abiOffset`
+///      → 比已装的小，系统安装器直接拒装；
+///   2. app 内更新器按 `releaseSequence` 全序比较（update_checker_release.dart）
+///      → 判远端「不比本机新」，用户永远收不到更新，且提示「已是最新版本」；
+///   3. `tool/merge_update_manifest.py` 的「Never downgrades the advertised
+///      top-level release」→ 新包根本写不进清单。
+///
+/// 三处守卫都没错——它们正确地拒绝了序号更小的包。错的是序号倒退。
+///
+/// ## 为什么这条守卫必须是静态扫描
+///
+/// 这类失效**没有任何构建期症状**：CI 全绿、包正常产出、release 正常发布，
+/// 只有用户那侧「永远收不到更新」。等症状暴露时，坏包已经发出去了。
+void main() {
+  final Directory repoRoot = Directory('..');
+  final File seqScript = File('../tool/release_sequence.sh');
+  final Directory workflowsDir = Directory('../.github/workflows');
+
+  /// 历史上真实出现过的最大序号。
+  ///
+  /// 10405 = 已发布到 `fushi-debug-rolling` 并装到用户机器上的最大值；
+  /// 10546 = 重写前 develop 曾推上去（并跑过发布 workflow）的最大计数。
+  /// 取两者较大者当下限：地板必须让**任何分支**的新序号都越过它，否则老装机
+  /// 永远收不到更新。再次重写历史后要重新核这个数（见 docs/agent/build.md）。
+  const int historicalMaxSequence = 10546;
+
+  test('前置：序号脚本与 workflows 目录都在', () {
+    expect(seqScript.existsSync(), isTrue,
+        reason: '缺 ${seqScript.absolute.path}——序号算式的单一真相源没了，'
+            '本守卫的全部断言失去对象。');
+    expect(workflowsDir.existsSync(), isTrue,
+        reason: 'expected ${workflowsDir.absolute.path}');
+  });
+
+  final String scriptText =
+      seqScript.existsSync() ? seqScript.readAsStringSync() : '';
+
+  test('脚本里能解析出 RELEASE_SEQUENCE_FLOOR', () {
+    expect(_parseFloor(scriptText), isNotNull,
+        reason: '在 tool/release_sequence.sh 里找不到形如 '
+            'RELEASE_SEQUENCE_FLOOR=<数字> 的赋值。改了变量名就同步改这条守卫，'
+            '否则下面「序号越过历史最大值」的断言会静默跑空。');
+  });
+
+  test('当前分支的序号越过历史最大值（计数被截断的 checkout 下自动跳过）', () {
+    final int? floor = _parseFloor(scriptText);
+    if (floor == null) return; // 上一条已经红了，这里不重复报。
+
+    final ProcessResult count = Process.runSync(
+      'git',
+      <String>['rev-list', '--count', 'HEAD'],
+      workingDirectory: repoRoot.path,
+    );
+    // 拿不到 git（沙箱里跑测试）时不制造假红。
+    if (count.exitCode != 0) return;
+    final int? commits = int.tryParse((count.stdout as String).trim());
+    if (commits == null) return;
+
+    // CI 的测试 job 用默认 fetch-depth（=1）checkout，计数会是个位数——那时测
+    // 计数等于测 checkout 深度，不是测地板，跳过。
+    //
+    // **不用 `git rev-parse --is-shallow-repository` 当闸门**：那条只看
+    // `.git/shallow` 标记在不在，一次历史很久以前的浅拉取会把标记永久留下，
+    // 于是本条断言在本机永远静默跳过——守卫看着绿，其实一行都没守。
+    // 这个坑是本守卫第一次变异实测（把地板改成 100）时暴露的：变异没被抓住。
+    const int truncatedCheckoutCeiling = 1000;
+    if (commits < truncatedCheckoutCeiling) return;
+
+    expect(commits + floor, greaterThan(historicalMaxSequence),
+        reason: '当前分支序号 = 提交计数 $commits + 地板 $floor = '
+            '${commits + floor}，没有越过历史最大已发布序号 '
+            '$historicalMaxSequence。从这个分支出的包：Android 装不上'
+            '（versionCode 更小）、app 内更新器判「不比本机新」、清单守卫拒收。'
+            '把 tool/release_sequence.sh 里的 RELEASE_SEQUENCE_FLOOR 抬到'
+            '足够高，并同步更新本守卫的 historicalMaxSequence。');
+  });
+
+  final List<File> workflows = workflowsDir.existsSync()
+      ? (workflowsDir
+          .listSync()
+          .whereType<File>()
+          .where(
+              (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+          .toList()
+        ..sort((File a, File b) => a.path.compareTo(b.path)))
+      : <File>[];
+
+  /// 走共享脚本的赋值点。
+  final List<String> viaScript = <String>[];
+
+  /// 绕过地板的裸赋值点。
+  final List<String> bareAssignments = <String>[];
+
+  const String scriptCall =
+      'RELEASE_SEQUENCE=' r'$(bash tool/release_sequence.sh)';
+  const String bareCall = 'RELEASE_SEQUENCE=' r'$(git rev-list';
+
+  for (final File workflow in workflows) {
+    final String name = workflow.uri.pathSegments.last;
+    final List<String> lines = workflow.readAsLinesSync();
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].contains(scriptCall)) viaScript.add('$name:${i + 1}');
+      if (lines[i].contains(bareCall)) bareAssignments.add('$name:${i + 1}');
+    }
+  }
+
+  test('守卫没跑空：扫到了走共享脚本的序号赋值点', () {
+    expect(workflows, isNotEmpty, reason: '一个 workflow 都没扫到');
+    expect(viaScript, isNotEmpty,
+        reason: '一处 `$scriptCall` 都没扫到。要么 workflow 改了写法，要么本守卫'
+            '的匹配串过期了——无论哪种，下面那条「无裸赋值」的断言此刻都是空转，'
+            '先修守卫再谈绿。');
+  });
+
+  test('workflow 里没有绕过地板的裸 rev-list 赋值', () {
+    expect(bareAssignments, isEmpty,
+        reason: '这些地方直接用 `git rev-list --count HEAD` 当序号，绕过了 '
+            'tool/release_sequence.sh 的一次性地板。历史一旦被重写，这些点算出的'
+            '序号会倒退到已发布序号之下，用户侧表现为「永远收不到更新 / 装不上包」，'
+            '而 CI 全绿：\n'
+            '${bareAssignments.map((String w) => "  $w").join("\n")}');
+  });
+}
+
+/// 从脚本正文里解析 `RELEASE_SEQUENCE_FLOOR=<数字>`。
+///
+/// 不用正则：这文件里所有匹配都走字面量前缀，免得转义在不同工具链之间被吃掉
+/// 一层，把守卫悄悄变成空转。
+int? _parseFloor(String scriptText) {
+  const String key = 'RELEASE_SEQUENCE_FLOOR=';
+  for (final String line in scriptText.split('\n')) {
+    final String trimmed = line.trim();
+    if (trimmed.startsWith('#')) continue;
+    if (!trimmed.startsWith(key)) continue;
+    return int.tryParse(trimmed.substring(key.length).trim());
+  }
+  return null;
+}

--- a/fushi/test/build/release_workflow_diagnostics_guard_test.dart
+++ b/fushi/test/build/release_workflow_diagnostics_guard_test.dart
@@ -275,7 +275,7 @@ void main() {
     expect(mainWorkflow, contains('fetch-depth: 0'),
         reason: 'shallow checkout would truncate git rev-list --count HEAD');
     expect(mainWorkflow,
-        contains(r'RELEASE_SEQUENCE=$(git rev-list --count HEAD)'));
+        contains(r'RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)'));
     expect(
         r'--build-number "$RELEASE_SEQUENCE"'.allMatches(mainWorkflow).length,
         greaterThanOrEqualTo(2),

--- a/fushi/test/settings/update_settings_android_only_guard_test.dart
+++ b/fushi/test/settings/update_settings_android_only_guard_test.dart
@@ -46,7 +46,7 @@ void main() {
     );
     expect(
       workflow,
-      contains(r'RELEASE_SEQUENCE=$(git rev-list --count HEAD)'),
+      contains(r'RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)'),
     );
     expect(
       workflow,
@@ -102,7 +102,7 @@ void main() {
     );
     expect(
       workflow,
-      contains(r'RELEASE_SEQUENCE=$(git rev-list --count HEAD)'),
+      contains(r'RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)'),
     );
     expect(workflow, contains('CHANNEL=debug'));
     expect(workflow, contains('PUBLISH_MANAGED_RELEASE=true'));

--- a/tool/check_release_policy.ps1
+++ b/tool/check_release_policy.ps1
@@ -60,9 +60,14 @@ foreach ($relativePath in $workflowPaths) {
   Require-Text $relativePath $content 'group: fushi-release-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.sha }}' 'same tag/commit publishes serialize instead of racing separate releases'
   Require-Text $relativePath $content 'cancel-in-progress: false' 'Android and desktop publishers both need to complete'
   Require-Text $relativePath $content 'fetch-depth: 0' 'release sequence uses full git history'
-  Require-Text $relativePath $content 'RELEASE_SEQUENCE=$(git rev-list --count HEAD)' 'release sequence must be shared by Android and desktop workflows'
+  Require-Text $relativePath $content 'RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)' 'release sequence must be shared by Android and desktop workflows'
+  # 2026-08-12: 序号不再在 workflow 里算。重写历史会让 rev-list 计数倒退，所以算式加一次性地板，
+  # 收进 tool/release_sequence.sh 单一真相源（六处 workflow 不再抄魔数）。
   Require-Text $relativePath $content 'release_sequence=$RELEASE_SEQUENCE' 'build steps must consume the shared release sequence'
 
+  # 裸算式绕过地板：新增一处 rev-list 赋值就足以把序号打回倒退态，
+  # 而症状要到用户装不上包、或永远收不到更新时才暴露。
+  Forbid-Pattern $relativePath $content 'RELEASE_SEQUENCE=\$\(git rev-list' 'release sequence must go through tool/release_sequence.sh (the one-time floor); a bare rev-list count regresses after any history rewrite'
   Forbid-Pattern $relativePath $content '\bGITHUB_RUN_NUMBER\b' 'workflow-local run_number splits same-version Android and desktop releases'
   Forbid-Pattern $relativePath $content 'github\.run_number' 'workflow-local run_number splits build numbers across release workflows'
 

--- a/tool/release_sequence.sh
+++ b/tool/release_sequence.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# 发布序号（release sequence）的**单一真相源**。
+#
+#   序号 = `git rev-list --count HEAD` + 一次性地板 RELEASE_SEQUENCE_FLOOR
+#
+# ## 为什么需要地板
+#
+# 提交计数只在「历史只增不减」的前提下单调。重写历史会让它**倒退**：
+# 2026-08-12 develop 被强推成重写后的历史，计数从 10546 掉到 9466，而当时
+# 已发布、已装到用户机器上的最大序号是 10405（fushi-debug-rolling）。
+#
+# 序号同时喂三处单调比较，倒退会把它们一起锁死：
+#   1. Android versionCode = versionCodeBase + 100 * seq + abiOffset
+#      （fushi/android/app/build.gradle）→ 比已装的小，系统安装器拒装；
+#   2. app 内更新器按 releaseSequence 做全序比较
+#      （fushi/lib/src/utils/misc/update_checker_release.dart）→ 判远端
+#      「不比本机新」，永远提示已是最新，用户再也收不到任何更新；
+#   3. tool/merge_update_manifest.py 的单调守卫「Never downgrades the
+#      advertised top-level release」→ 新包压根写不进清单。
+#
+# 这三处都不是 bug——它们正确地拒绝了一个序号更小的包。错的是序号倒退。
+# 同款手法已有先例：build.gradle 的 versionCodeBase = 1e9 就是一次性地板。
+#
+# ## 什么时候要再抬地板
+#
+# 只有**再次**重写历史、且新的 `count + FLOOR` 不再高于「已发布过的最大
+# 序号」时才需要抬。抬之前先去查真实的最大已发布序号（GitHub Release 资产
+# 名里的 `-debug.<seq>` / `-beta.<seq>`），别凭感觉加。
+#
+# 守卫：fushi/test/build/release_sequence_floor_guard_test.dart
+set -euo pipefail
+
+# 10546 = 重写前 develop 曾推上去的最大计数（已发布最大 10405）。加余量取
+# 2000：重写后 develop 9473 + 2000 = 11473 > 10546；桥包分支 9114 + 2000
+# = 11114 同样越过，跨分支发布不会再撞回旧序号。
+RELEASE_SEQUENCE_FLOOR=2000
+
+count=$(git rev-list --count HEAD)
+if ! [[ "$count" =~ ^[0-9]+$ ]] || [ "$count" -le 0 ]; then
+  echo "::error title=Invalid release sequence::Expected positive git rev-list count, got $count" >&2
+  exit 1
+fi
+
+echo "$((count + RELEASE_SEQUENCE_FLOOR))"


### PR DESCRIPTION
历史重写把 `git rev-list --count HEAD` 从 10546 打回 9473，而已发布并装到用户机器上的最大序号是 10405。序号倒退同时锁死三处**正确的**单调比较，导致 #795~#807 十个已合 PR 对所有已装用户不可达，而 CI 全绿、release 照发。

## 根因链（实证）

| 环节 | 证据 |
|---|---|
| 历史重写 | 同一条提交 `dc328530c`(count 10546) → `139c30dba`(count 9466)，作者时间一致、SHA 全变；`origin/develop` reflog 连着三次 `forced-update` |
| 序号来源 | 六处 workflow 各写 `RELEASE_SEQUENCE=$(git rev-list --count HEAD)` |
| 已发布最大值 | `fushi-debug-rolling` 的 `fushi-1.4.0-debug.10405-*`（出自旧历史 `48978772a`） |
| 锁死点 1 | `build.gradle:92` `versionCode = 1e9 + 100*seq + abi` → 低 93,200，系统安装器拒装 |
| 锁死点 2 | `update_checker_release.dart:1706/1731` 按 `releaseSequence` 全序比较 → 判「不比本机新」 |
| 锁死点 3 | `merge_update_manifest.py:161` "Never downgrades the advertised top-level release" → 新包写不进清单 |
| 实测后果 | `update-manifest` 分支的 `latest-debug-fushi.json` 自 08-11 08:03 被钉死在 `releaseSequence: 10405` |

三处守卫都没错——它们正确地拒绝了序号更小的包。错的是序号倒退。

## 改动

- 新增 `tool/release_sequence.sh` 作**单一真相源**：序号 = 提交计数 + 一次性地板 `RELEASE_SEQUENCE_FLOOR=2000`（同 `versionCodeBase=1e9` 的既有手法）
- 六处 workflow 统一 `RELEASE_SEQUENCE=$(bash tool/release_sequence.sh)`，不再各抄一份算式
- `check_release_policy.ps1` 共享算式断言跟改 + 新增 `Forbid-Pattern` 禁止再写裸算式
- 修后 develop = 9473+2000 = **11473** > 10546；桥包分支 9114+2000 = 11114 同样越过

**没有放宽任何一处单调守卫。**

## 验证

- `tool/check_release_policy.ps1`：绿；注入裸算式 → 两条断言同时红；反向替换还原 → 绿
- 新守卫 `fushi/test/build/release_sequence_floor_guard_test.dart`（5 条）全绿
- 变异实测：地板改 100 → 红；`main.yml` 改回裸赋值 → 红；均已还原
- **第一轮变异没抓住**，暴露原实现拿 `git rev-parse --is-shallow-repository` 当跳过闸门、被本机遗留 `.git/shallow` 标记永久静默跳过；已改成按「计数 < 1000 视为截断 checkout」跳过（CI 默认浅 checkout 仍不假红）
- `flutter analyze` 全量：`No issues found!`
- 相邻守卫 `powershell_51_compat` / `release_workflow_path_filter`：绿

## 不在本 PR 范围

- 本次修复**不**自动补发任何包：`release.yml` 的 push 触发自 2026-08-07 起因改名过渡期整块注释，发版仍需手动 dispatch
- `v1.4.0-beta.9473` 是半成品发布（只有 ipa+zip）：同 run 的 windows job 构建失败 → `Publish mirror update manifest` 报 `No files matched fushi-*-windows-setup.exe` 而挂。Windows 构建红另查（已单独重跑定性中）