### PR TITLE
fix(download): 排队等槽位不再谎报「torrent 已不在引擎中」（BUG-1587）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1587](bugs/BUG-1587-download-queued-reported-as-torrent-missing.md) | ✅ | ✅ | 排队等槽位的下载任务被误报成「torrent 已不在引擎中」 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/bugs/BUG-1587-download-queued-reported-as-torrent-missing.md
+++ b/docs/bugs/BUG-1587-download-queued-reported-as-torrent-missing.md
@@ -1,0 +1,14 @@
+## BUG-1587 · 排队等槽位的下载任务被误报成「torrent 已不在引擎中」
+- **报告**：2026-08-13（用户截图：任务停在 `0.0% · enqueue`，详情「网络」区却写「原下载后端在线，但该 torrent 已不在引擎中」。用户原话：「那句话不对，明明只是因为其他东西在下载」）
+- **真实性**：✅ 真 bug。根因链：
+  - `fushi/lib/src/media/video/download/video_download_pipeline_service.dart` `loadJobDetails()` 返回 `backend: liveSnapshot == null ? null : backend`——只要在 `backend.listTorrents()` 里没按 hash 找到快照，就把 backend 抹成 null；
+  - `fushi/lib/src/pages/implementations/downloads_page.dart:284` 据此算 `backendTaskMissing = details.backendOnline && details.backend == null`；
+  - `fushi/lib/src/pages/implementations/torrent_detail_dialog.dart:374` 把这个布尔量翻译成 `download_detail_task_missing`（「该 torrent 已不在引擎中」）。
+  - **三种完全不同的状态被折叠成同一个布尔量**：①还没交给下载器（`stage == enqueue`，排在别的下载后面等并发槽位）②交给过但引擎里没了（真丢失）③记录在案的后端连不上。其中①是**正常状态**，却走进了②的文案。截图里 `stage=enqueue` 且已有信息哈希，正是①。
+- **[x] ① 已修复** — 定性下沉到服务层（它持有 job 行，才知道 stage 与 backendTaskId），UI 不再自己猜：
+  - 新增 `VideoDownloadLiveDataAbsence{none, notHandedOff, missingFromBackend, backendOffline}` 与纯函数 `resolveLiveDataAbsence()`；判定顺序**先问「该不该已经在引擎里」再问「引擎答没答」**，反序即回归成误诊；
+  - `VideoDownloadJobDetails` 增 `liveDataAbsence` 字段，`loadJobDetails()` 填充；
+  - `downloads_page.dart` 改为透传该字段，`torrent_detail_dialog.dart` 按四态 switch 出文案；
+  - 新增 i18n `download_detail_task_queued`（17 语言经 `i18n_sync.dart --add` + `dart run slang`）：「排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。」
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/live_data_absence_test.dart`（5 条，直测纯函数四条分支 + 有快照）；`fushi/test/pages/torrent_detail_dialog_test.dart` 新增「排队态说排队且**不出现**丢失文案」（两条一起断言，只断言前者的话两句都显示也会绿）。变异实测：把判定顺序颠倒成先问引擎 → 单测与 widget 测试各红一条；反向替换还原 → 34 条全绿。
+- **备注**：本次只修「说错话」。用户同批还提的「没有自动重试」「没法设置每任务优先级」是相邻但独立的缺口——`VideoDownloadJobs.priority` 列已存在（`tables.dart:1983`，默认 0，`pipeline_service.dart:516` 已写入）但**无任何 UI 可设**；`retryJob` / 指数退避也已存在，缺的是「真丢失后自动重挂」这条路径。另开。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57222 (3366 per locale)
+/// Strings: 57239 (3367 per locale)
 ///
-/// Built on 2026-08-12 at 11:23 UTC
+/// Built on 2026-08-13 at 05:25 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4555,6 +4555,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -12326,6 +12328,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -20164,6 +20169,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -28018,6 +28026,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -35884,6 +35895,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -43678,6 +43692,9 @@ class _StringsId extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -51518,6 +51535,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -59172,6 +59192,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -66833,6 +66856,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -74653,6 +74679,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -82485,6 +82514,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -90303,6 +90335,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -98069,6 +98104,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -105866,6 +105904,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -113648,6 +113689,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 // Path: <root>
@@ -120864,6 +120908,9 @@ class _StringsZhCn extends _StringsEn {
       '选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。';
   @override
   String get remote_delete_audiobook_partial => '书已在对端删除，但它的有声书没能删掉';
+  @override
+  String get download_detail_task_queued =>
+      '排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。';
 }
 
 // Path: <root>
@@ -128441,6 +128488,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String get download_detail_task_queued =>
+      'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
 }
 
 /// Flat map(s) containing all translations.
@@ -135355,6 +135405,8 @@ extension on _StringsEn {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -142267,6 +142319,8 @@ extension on _StringsAr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -149201,6 +149255,8 @@ extension on _StringsDe {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -156134,6 +156190,8 @@ extension on _StringsEs {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -163073,6 +163131,8 @@ extension on _StringsFr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -169994,6 +170054,8 @@ extension on _StringsId {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -176929,6 +176991,8 @@ extension on _StringsIt {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -183826,6 +183890,8 @@ extension on _StringsJa {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -190727,6 +190793,8 @@ extension on _StringsKo {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -197656,6 +197724,8 @@ extension on _StringsNl {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -204582,6 +204652,8 @@ extension on _StringsPtBr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -211513,6 +211585,8 @@ extension on _StringsRu {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -218427,6 +218501,8 @@ extension on _StringsTh {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -225350,6 +225426,8 @@ extension on _StringsTr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -232269,6 +232347,8 @@ extension on _StringsVi {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }
@@ -239130,6 +239210,8 @@ extension on _StringsZhCn {
         return '选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。';
       case 'remote_delete_audiobook_partial':
         return '书已在对端删除，但它的有声书没能删掉';
+      case 'download_detail_task_queued':
+        return '排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。';
       default:
         return null;
     }
@@ -246022,6 +246104,8 @@ extension on _StringsZhHk {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'download_detail_task_queued':
+        return 'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "清除已存指纹并重新信任",
   "sync_pair_fingerprint_changed_body": "这条地址此前钉扎的是另一张证书。只有在你确知对方重装/重置过设备时才继续，否则连接可能正被中间人拦截。",
   "interconnect_upload_section_footer": "选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。",
-  "remote_delete_audiobook_partial": "书已在对端删除，但它的有声书没能删掉"
+  "remote_delete_audiobook_partial": "书已在对端删除，但它的有声书没能删掉",
+  "download_detail_task_queued": "排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "download_detail_task_queued": "Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data."
 }

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -82,6 +82,31 @@ class VideoDownloadBackendBinding {
   final List<VideoDownloadPathMapping> pathMappings;
 }
 
+/// 详情对话框拿不到**实时**数据时，究竟是为什么。
+///
+/// 这一层存在的理由：UI 侧原来只有 `backendOnline && backend == null` 一个
+/// 布尔量，于是把三种完全不同的状态折叠成同一句「该 torrent 已不在引擎中」。
+/// 其中最常见的一种根本不是异常——任务还排在队里等前面的下载让出槽位，
+/// 压根**还没被交给下载器**，却被报成「引擎里丢了」（用户报障：「明明只是
+/// 因为其他东西在下载」）。
+///
+/// 判据只有服务层拿得到（它持有 job 行，知道 stage 和有没有 backendTaskId），
+/// 所以由这里定性、UI 只负责渲染，杜绝 UI 二次猜测。
+enum VideoDownloadLiveDataAbsence {
+  /// 有实时数据，不缺。
+  none,
+
+  /// 还没交给下载器：任务仍在 `enqueue` 阶段（排队等槽位），或还没有拿到
+  /// 后端任务 id。**这是正常状态，不是故障**。
+  notHandedOff,
+
+  /// 交给过下载器，但现在引擎里找不到这个 hash——真丢了。
+  missingFromBackend,
+
+  /// 记录在案的那个后端此刻连不上（换机 / profile 变更 / 装包不全）。
+  backendOffline,
+}
+
 /// Details that remain useful even when the backend recorded by a durable job
 /// is no longer reachable. [backend] is only populated when that exact backend
 /// identity can be resolved; [snapshot] and [files] always have persisted
@@ -92,12 +117,37 @@ class VideoDownloadJobDetails {
     required this.files,
     this.backend,
     this.backendOnline = false,
+    this.liveDataAbsence = VideoDownloadLiveDataAbsence.none,
   });
 
   final TorrentBackend? backend;
   final bool backendOnline;
   final TorrentSnapshot snapshot;
   final List<TorrentFileEntry> files;
+
+  /// 没有实时数据的原因；[VideoDownloadLiveDataAbsence.none] 表示有。
+  final VideoDownloadLiveDataAbsence liveDataAbsence;
+}
+
+/// 定性「为什么没有实时数据」。纯函数，便于直接单测三条分支。
+///
+/// 顺序是**有意**的：先问「该不该在引擎里」，再问「引擎答没答」。反过来问就
+/// 会把排队中的任务判成丢失——那正是本函数要消灭的误诊。
+VideoDownloadLiveDataAbsence resolveLiveDataAbsence({
+  required VideoDownloadJobRow job,
+  required String torrentId,
+  required bool hasLiveSnapshot,
+  required bool backendOnline,
+}) {
+  if (hasLiveSnapshot) return VideoDownloadLiveDataAbsence.none;
+  // 还没有后端任务 id，或仍停在入队阶段 = 还没轮到它进下载器。前面的任务占着
+  // 并发槽时这条最常见，它是正常排队，不是任何形式的故障。
+  if (torrentId.isEmpty || job.stage == VideoDownloadJobStage.enqueue) {
+    return VideoDownloadLiveDataAbsence.notHandedOff;
+  }
+  return backendOnline
+      ? VideoDownloadLiveDataAbsence.missingFromBackend
+      : VideoDownloadLiveDataAbsence.backendOffline;
 }
 
 /// Builds the durable half of task details without requiring a running
@@ -831,6 +881,12 @@ class VideoDownloadPipelineService {
       backendOnline: backendOnline,
       snapshot: liveSnapshot ?? persistedDetails.snapshot,
       files: liveFiles ?? persistedDetails.files,
+      liveDataAbsence: resolveLiveDataAbsence(
+        job: job,
+        torrentId: torrentId,
+        hasLiveSnapshot: liveSnapshot != null,
+        backendOnline: backendOnline,
+      ),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -281,8 +281,7 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                                           ? job.resourceTitle!.trim()
                                           : job.title,
                                   backendOverride: details.backend,
-                                  backendTaskMissing: details.backendOnline &&
-                                      details.backend == null,
+                                  liveDataAbsence: details.liveDataAbsence,
                                   initialSnapshot: details.snapshot,
                                   initialFiles: details.files,
                                 ),

--- a/fushi/lib/src/pages/implementations/torrent_detail_dialog.dart
+++ b/fushi/lib/src/pages/implementations/torrent_detail_dialog.dart
@@ -7,6 +7,7 @@ import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
 import 'package:fushi/src/media/torrent/torrent_task_display.dart';
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/download_actions.dart';
 import 'package:fushi/utils.dart';
@@ -33,7 +34,7 @@ class TorrentTaskDetailDialog extends ConsumerStatefulWidget {
         torrentTitle = plan.torrentTitle,
         initialSnapshot = null,
         initialFiles = null,
-        backendTaskMissing = false,
+        liveDataAbsence = VideoDownloadLiveDataAbsence.none,
         resolveBackendFromAppModel = true;
 
   /// Durable download jobs use the same real backend detail surface without
@@ -45,7 +46,7 @@ class TorrentTaskDetailDialog extends ConsumerStatefulWidget {
     required this.backendOverride,
     required this.initialSnapshot,
     required this.initialFiles,
-    required this.backendTaskMissing,
+    required this.liveDataAbsence,
     super.key,
   }) : resolveBackendFromAppModel = false;
 
@@ -58,7 +59,9 @@ class TorrentTaskDetailDialog extends ConsumerStatefulWidget {
   final TorrentBackend? backendOverride;
   final TorrentSnapshot? initialSnapshot;
   final List<TorrentFileEntry>? initialFiles;
-  final bool backendTaskMissing;
+
+  /// 没有实时数据时的**定性结论**（由管线服务给出，UI 不再自己猜）。
+  final VideoDownloadLiveDataAbsence liveDataAbsence;
 
   /// Legacy plan dialogs may resolve the currently configured backend. Durable
   /// job dialogs must never do that because their persisted backend identity
@@ -371,11 +374,20 @@ class _TorrentTaskDetailDialogState
     return _buildEmptyNote(theme, _backendUnavailableMessage);
   }
 
-  String get _backendUnavailableMessage => widget.backendTaskMissing
-      ? t.download_detail_task_missing
-      : !widget.resolveBackendFromAppModel && _backend == null
-          ? t.download_detail_backend_offline
-          : t.download_detail_backend_unsupported;
+  String get _backendUnavailableMessage => switch (widget.liveDataAbsence) {
+        // 排队等槽位是正常状态，不能报成故障（用户报障：「明明只是因为其他
+        // 东西在下载」）。
+        VideoDownloadLiveDataAbsence.notHandedOff =>
+          t.download_detail_task_queued,
+        VideoDownloadLiveDataAbsence.missingFromBackend =>
+          t.download_detail_task_missing,
+        VideoDownloadLiveDataAbsence.backendOffline =>
+          t.download_detail_backend_offline,
+        VideoDownloadLiveDataAbsence.none =>
+          !widget.resolveBackendFromAppModel && _backend == null
+              ? t.download_detail_backend_offline
+              : t.download_detail_backend_unsupported,
+      };
 
   /// 四路数据共用的「没有数据时显示什么」——**唯一**会显示转圈的路径：
   /// 后端整体不可用 → 说明后端；还没有过任何结果 → 转圈；最近一次尝试

--- a/fushi/test/media/video/download/live_data_absence_test.dart
+++ b/fushi/test/media/video/download/live_data_absence_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 根因回归：`enqueue` 阶段（排在别的下载后面等槽位）的任务原本被判成
+/// 「该 torrent 已不在引擎中」。用户报障原话：「明明只是因为其他东西在下载」。
+///
+/// 判定顺序是关键——必须**先**问「它该不该已经在引擎里」，再问「引擎答没答」。
+/// 反过来问，排队中的任务就会落进「引擎里找不到 → 丢了」那条分支。
+VideoDownloadJobRow _job({
+  required String stage,
+  String? backendTaskId,
+  String? torrentHash,
+}) =>
+    VideoDownloadJobRow(
+      jobId: 'job-1',
+      resourceProvider: 'nyaa:default',
+      selectedResourceId: 'resource-1',
+      magnetUri: null,
+      resourceTitle: 'Some Release 1080p',
+      torrentHash: torrentHash,
+      metadataProvider: 'anilist',
+      externalId: 'media-1',
+      mediaKind: 'tv',
+      discoveryCategory: 'anime',
+      title: 'Some Show',
+      year: 2026,
+      season: 1,
+      coverUrl: null,
+      backendKind: 'embedded',
+      backendTaskId: backendTaskId,
+      backendProfileId: 'default',
+      fingerprint: 'embedded-test',
+      category: 'fushi-video',
+      targetSourceId: null,
+      collectionId: null,
+      organizationPolicy: 'library',
+      subtitlePolicy: 'bestEffort',
+      observedSavePath: null,
+      targetRelativeRoot: null,
+      lifecycle: VideoDownloadJobLifecycle.active,
+      stage: stage,
+      stageProgress: 0,
+      priority: 0,
+      attemptCount: 0,
+      maxAttempts: 3,
+      nextAttemptAt: null,
+      claimedBy: null,
+      claimExpiresAt: null,
+      lastError: null,
+      createdAt: 1,
+      updatedAt: 2,
+      completedAt: null,
+    );
+
+void main() {
+  group('resolveLiveDataAbsence', () {
+    test('有实时快照时不缺数据', () {
+      expect(
+        resolveLiveDataAbsence(
+          job: _job(stage: VideoDownloadJobStage.download),
+          torrentId: 'abc',
+          hasLiveSnapshot: true,
+          backendOnline: true,
+        ),
+        VideoDownloadLiveDataAbsence.none,
+      );
+    });
+
+    test('enqueue 阶段 = 还没交给下载器，即使已经有 hash 也不算丢失', () {
+      expect(
+        resolveLiveDataAbsence(
+          // 截图里的真实形态：已经有信息哈希，但仍停在 enqueue。
+          job: _job(
+            stage: VideoDownloadJobStage.enqueue,
+            torrentHash: 'abc',
+          ),
+          torrentId: 'abc',
+          hasLiveSnapshot: false,
+          backendOnline: true,
+        ),
+        VideoDownloadLiveDataAbsence.notHandedOff,
+        reason: '排队等槽位被判成 missingFromBackend，就是本次修的那条误诊。',
+      );
+    });
+
+    test('还没有后端任务 id 时也算还没交给下载器', () {
+      expect(
+        resolveLiveDataAbsence(
+          job: _job(stage: VideoDownloadJobStage.download),
+          torrentId: '',
+          hasLiveSnapshot: false,
+          backendOnline: true,
+        ),
+        VideoDownloadLiveDataAbsence.notHandedOff,
+      );
+    });
+
+    test('已过入队阶段 + 后端在线 + 引擎里没有 = 真丢失', () {
+      expect(
+        resolveLiveDataAbsence(
+          job: _job(
+            stage: VideoDownloadJobStage.download,
+            backendTaskId: 'abc',
+          ),
+          torrentId: 'abc',
+          hasLiveSnapshot: false,
+          backendOnline: true,
+        ),
+        VideoDownloadLiveDataAbsence.missingFromBackend,
+      );
+    });
+
+    test('后端连不上时报后端离线，不冒充丢失', () {
+      expect(
+        resolveLiveDataAbsence(
+          job: _job(
+            stage: VideoDownloadJobStage.download,
+            backendTaskId: 'abc',
+          ),
+          torrentId: 'abc',
+          hasLiveSnapshot: false,
+          backendOnline: false,
+        ),
+        VideoDownloadLiveDataAbsence.backendOffline,
+      );
+    });
+  });
+}

--- a/fushi/test/pages/torrent_detail_dialog_test.dart
+++ b/fushi/test/pages/torrent_detail_dialog_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
 
 const String _hash = 'aa11bb22cc33dd44ee55ff66aa77bb88cc99dd00';
@@ -259,7 +260,8 @@ Future<void> _dismiss(WidgetTester tester) async {
 
 Future<void> _pumpPersistedFallback(
   WidgetTester tester, {
-  bool backendTaskMissing = false,
+  VideoDownloadLiveDataAbsence liveDataAbsence =
+      VideoDownloadLiveDataAbsence.none,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -270,7 +272,7 @@ Future<void> _pumpPersistedFallback(
             title: 'Persisted Series',
             torrentTitle: 'Persisted release title',
             backendOverride: null,
-            backendTaskMissing: backendTaskMissing,
+            liveDataAbsence: liveDataAbsence,
             initialSnapshot: const TorrentSnapshot(
               hash: _hash,
               name: 'Persisted Series',
@@ -303,7 +305,10 @@ void main() {
   testWidgets('后端在线但任务已不存在时明确说明节点无法恢复', (
     WidgetTester tester,
   ) async {
-    await _pumpPersistedFallback(tester, backendTaskMissing: true);
+    await _pumpPersistedFallback(
+      tester,
+      liveDataAbsence: VideoDownloadLiveDataAbsence.missingFromBackend,
+    );
     final Finder missingNote =
         find.textContaining('this torrent is no longer present');
     await _scrollUntilFound(tester, missingNote);
@@ -312,6 +317,28 @@ void main() {
     expect(
       find.textContaining('Live peers and trackers cannot be recovered'),
       findsOneWidget,
+    );
+    await _dismiss(tester);
+  });
+
+  // BUG：排队等槽位的任务原来被报成「该 torrent 已不在引擎中」。用户报障原话
+  // 「明明只是因为其他东西在下载」。这条钉住：排队态必须说排队，且**绝不**
+  // 出现丢失文案——两条一起断言，只断言前者的话把两句都显示出来也会绿。
+  testWidgets('还没交给下载器（排队等槽位）时说排队，不谎报 torrent 丢失', (
+    WidgetTester tester,
+  ) async {
+    await _pumpPersistedFallback(
+      tester,
+      liveDataAbsence: VideoDownloadLiveDataAbsence.notHandedOff,
+    );
+    final Finder queuedNote =
+        find.textContaining('waiting for other downloads to free a slot');
+    await _scrollUntilFound(tester, queuedNote);
+    expect(queuedNote, findsOneWidget);
+    expect(
+      find.textContaining('this torrent is no longer present'),
+      findsNothing,
+      reason: '排队中的任务不是丢失，出现丢失文案就是回归到误诊。',
     );
     await _dismiss(tester);
   });


### PR DESCRIPTION
用户截图：任务停在 `0.0% · enqueue`，详情「网络」区却写「原下载后端在线，但该 torrent 已不在引擎中」。原话：**「那句话不对，明明只是因为其他东西在下载」**——是对的，那句话就是误诊。

## 根因

三种完全不同的状态被折叠成**一个布尔量**：

| 层 | 代码 |
|---|---|
| 服务 | `loadJobDetails()` 返回 `backend: liveSnapshot == null ? null : backend`——引擎列表里按 hash 找不到就把 backend 抹成 null |
| 页面 | `downloads_page.dart:284` `backendTaskMissing = details.backendOnline && details.backend == null` |
| 对话框 | `torrent_detail_dialog.dart:374` 把它翻译成「该 torrent 已不在引擎中」 |

被折叠的三态：① 还没交给下载器（`stage == enqueue`，排在别的下载后面等并发槽位）② 交给过但引擎里没了（真丢失）③ 记录在案的后端连不上。**① 是正常状态**，却走进了 ② 的文案。截图里 `stage=enqueue` 且已有信息哈希，正是 ①。

## 改法

定性下沉到服务层——只有它持有 job 行、知道 stage 与 backendTaskId；UI 不再自己猜：

- 新增 `VideoDownloadLiveDataAbsence{none, notHandedOff, missingFromBackend, backendOffline}` + 纯函数 `resolveLiveDataAbsence()`
- **判定顺序是关键**：先问「该不该已经在引擎里」，再问「引擎答没答」。反序就退回误诊
- `VideoDownloadJobDetails` 增 `liveDataAbsence`，`downloads_page` 透传，dialog 按四态 switch
- 新增 i18n `download_detail_task_queued`（17 语言走 `i18n_sync --add` + `dart run slang`）

## 验证

- `live_data_absence_test.dart` 5 条直测纯函数全部分支
- dialog widget 测试新增「排队态说排队 **且不出现**丢失文案」——两条一起断言，只断言前者的话两句都渲染也会绿
- **变异实测**：颠倒判定顺序（先问引擎）→ 单测与 widget 测试各红一条；反向替换还原 → 34 条全绿
- `flutter analyze` 全量：`No issues found!`

## 不在本 PR 范围

同批用户还提了「没有自动重试」「没法设置每任务优先级」。已确认底层**都在**：`VideoDownloadJobs.priority` 列存在（`tables.dart:1983`，默认 0，`pipeline_service.dart:516` 已写入）但**无任何 UI 可设**；`retryJob` / 订阅侧指数退避也在，缺的是「真丢失后自动重挂」这条路径。另开。