### PR TITLE
fix(ci): 发布 workflow 补上漏掉的 TMDB key 注入（BUG-1588）

### DIFF
--- a/.github/actions/provide-baked-secrets/action.yml
+++ b/.github/actions/provide-baked-secrets/action.yml
@@ -1,0 +1,127 @@
+name: Provide baked-in secret stubs
+description: >
+  把「烘进包里的密钥」从仓库 secrets 注入各自的占位 Dart 文件。这是这批注入的
+  唯一真相源：任何构建 app 的 job 都只 uses 本 action，不再各自抄一份步骤。
+
+# ## 为什么要有这个 action（BUG-1588）
+#
+# 这四段注入原先是**逐字抄进每个 job** 的。抄到第 11 份时已经漂成这样：
+#
+#   - Google OAuth 桩：11 处一致
+#   - dandanplay 桩：11 处一致
+#   - 日志上传桩：**只有 10 处**——main.yml 漏了
+#   - TMDB 桩：**3 个变体**，且两条发布 workflow 一处都没有
+#
+# 最后一条的后果是：验证构建有 key、**发出去的包没有**，TMDB 在用户机器上恒
+# 「未配置」，而 CI 全绿、零构建期症状（BUG-1588）。这类漏抄不可能靠 review
+# 抓住——44 份拷贝里少一份，diff 上什么都看不出来。
+#
+# 收进一份之后，「新增一种烘进包的密钥」变成改一个文件；漏抄在结构上不可能
+# 发生。守卫见 fushi/test/build/baked_secret_stub_parity_guard_test.dart。
+#
+# ## 调用约定
+#
+# 所有输入都可以不传（默认空串）。空串 = 不注入真值，占位文件保持入库的空值，
+# 对应功能静默降级——这正是 fork / PR / 无 secret 环境下应有的行为。
+
+inputs:
+  google-oauth-client-secret:
+    description: secrets.GOOGLE_OAUTH_CLIENT_SECRET
+    required: false
+    default: ''
+  log-upload-endpoint:
+    description: secrets.LOG_UPLOAD_ENDPOINT
+    required: false
+    default: ''
+  log-upload-token:
+    description: secrets.LOG_UPLOAD_TOKEN
+    required: false
+    default: ''
+  dandanplay-app-id:
+    description: secrets.DANDANPLAY_APP_ID
+    required: false
+    default: ''
+  dandanplay-app-secret:
+    description: secrets.DANDANPLAY_APP_SECRET
+    required: false
+    default: ''
+  tmdb-api-key:
+    description: secrets.TMDB_API_KEY
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # google_oauth_secret.dart 是 gitignored 的（真值只存在于仓库 secret 与本机），
+    # 所以这里连占位都可能不存在，缺文件时才从 .example.dart 复制。
+    - name: Provide gitignored Google OAuth secret stub
+      shell: bash
+      env:
+        GOOGLE_OAUTH_CLIENT_SECRET: ${{ inputs.google-oauth-client-secret }}
+      run: |
+        dst=fushi/lib/src/sync/google_oauth_secret.dart
+        if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
+          printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
+            "$oauth_secret_literal" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
+        fi
+
+    - name: Provide gitignored log upload secret stub
+      shell: bash
+      env:
+        LOG_UPLOAD_ENDPOINT: ${{ inputs.log-upload-endpoint }}
+        LOG_UPLOAD_TOKEN: ${{ inputs.log-upload-token }}
+      run: |
+        dst=fushi/lib/src/utils/misc/log_upload_secret.dart
+        if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+          log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+          log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
+          printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
+            "$log_endpoint_literal" \
+            "$log_token_literal" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
+        fi
+
+    - name: Provide gitignored dandanplay secret stub
+      shell: bash
+      env:
+        DANDANPLAY_APP_ID: ${{ inputs.dandanplay-app-id }}
+        DANDANPLAY_APP_SECRET: ${{ inputs.dandanplay-app-secret }}
+      run: |
+        dst=fushi/lib/src/media/video/dandanplay_secret.dart
+        if [ -n "$DANDANPLAY_APP_ID" ]; then
+          printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
+            "$DANDANPLAY_APP_ID" \
+            "$DANDANPLAY_APP_SECRET" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+        fi
+
+    # tmdb_default_key.dart 入库的是**空占位**（key = ''），所以一定存在；只重写
+    # const 那一行，文件注释、pref-key const 与 resolveTmdbApiKey() 全部保留。
+    - name: Provide gitignored TMDB API key stub
+      shell: bash
+      env:
+        TMDB_API_KEY: ${{ inputs.tmdb-api-key }}
+      run: |
+        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+        if [ ! -f "$dst" ]; then
+          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+        fi
+        if [ -n "$TMDB_API_KEY" ]; then
+          # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed 都
+          # 接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下成立：
+          # BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把文件名当
+          # 脚本，于是 macos/ios 作业固定报
+          # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the end of
+          # h command`。收进本 action 后这条坑只存在一份。
+          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          rm -f "$dst.bak"
+        fi

--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -69,98 +69,19 @@ jobs:
         with:
           flutter-version: '3.44.0'
           cache: true
-      # google_oauth_secret.dart is gitignored (the real client secret lives only
-      # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails to
-      # compile. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, bake the
-      # REAL value in so the build can actually sign in to Google Drive
-      # (otherwise desktop sign-in hits invalid_client 401, TODO-045). When it is
-      # not set, fall back to the committed example (placeholder value with no
-      # GOCSPX- prefix, so the no_hardcoded_google_secret guard stays green).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-      # so a fresh clone compiles and the log-upload button stays hidden (it is
-      # gated by a non-empty endpoint, not by platform - see log_upload_config
-      # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-      # secrets are set, bake the real values in so CI/release builds (incl.
-      # Windows) actually show and can use the "upload log to cloud" button
-      # (TODO-385). When unset, leave the committed empty placeholder so the
-      # button stays hidden and no endpoint is exposed.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-      # bake the real value in so released builds scrape TMDB covers/metadata out of
-      # the box (no manual API key entry). Only the const line is rewritten, so the
-      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed
-            # 都接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下
-            # 成立：BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把
-            # 文件名当脚本，于是 macos/ios 作业固定报
-            # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the
-            # end of h command`。五处 TMDB 注入统一用同一种写法，别再从 ubuntu
-            # 作业复制出裸 -i。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
       # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
       # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步
@@ -286,94 +207,19 @@ jobs:
         with:
           flutter-version: '3.44.0'
           cache: true
-      # See the android job: bake the real OAuth secret in when the
-      # GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, else stub from the example
-      # so the import in google_drive_auth.dart compiles (TODO-045).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-      # so a fresh clone compiles and the log-upload button stays hidden (it is
-      # gated by a non-empty endpoint, not by platform - see log_upload_config
-      # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-      # secrets are set, bake the real values in so CI/release builds (incl.
-      # Windows) actually show and can use the "upload log to cloud" button
-      # (TODO-385). When unset, leave the committed empty placeholder so the
-      # button stays hidden and no endpoint is exposed.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-      # bake the real value in so released builds scrape TMDB covers/metadata out of
-      # the box (no manual API key entry). Only the const line is rewritten, so the
-      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed
-            # 都接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下
-            # 成立：BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把
-            # 文件名当脚本，于是 macos/ios 作业固定报
-            # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the
-            # end of h command`。五处 TMDB 注入统一用同一种写法，别再从 ubuntu
-            # 作业复制出裸 -i。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       - name: Flutter pub get
         working-directory: fushi
         run: flutter pub get
@@ -465,94 +311,19 @@ jobs:
         with:
           flutter-version: '3.44.0'
           cache: true
-      # See the android job: bake the real OAuth secret in when the
-      # GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, else stub from the example
-      # so the import in google_drive_auth.dart compiles (TODO-045).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-      # so a fresh clone compiles and the log-upload button stays hidden (it is
-      # gated by a non-empty endpoint, not by platform - see log_upload_config
-      # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-      # secrets are set, bake the real values in so CI/release builds (incl.
-      # Windows) actually show and can use the "upload log to cloud" button
-      # (TODO-385). When unset, leave the committed empty placeholder so the
-      # button stays hidden and no endpoint is exposed.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-      # bake the real value in so released builds scrape TMDB covers/metadata out of
-      # the box (no manual API key entry). Only the const line is rewritten, so the
-      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed
-            # 都接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下
-            # 成立：BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把
-            # 文件名当脚本，于是 macos/ios 作业固定报
-            # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the
-            # end of h command`。五处 TMDB 注入统一用同一种写法，别再从 ubuntu
-            # 作业复制出裸 -i。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache CocoaPods spec repos, downloaded pod source and generated
       # Pods dirs. Keyed on Podfile.lock/pubspec.lock; CocoaPods re-installs on a
       # mismatch and a miss just re-downloads.
@@ -633,89 +404,19 @@ jobs:
         with:
           flutter-version: '3.44.0'
           cache: true
-      # See the android job: bake the real OAuth secret in when the
-      # GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, else stub from the example
-      # so the import in google_drive_auth.dart compiles (TODO-045).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # See the android job: CI/release builds should use the real log-upload
-      # endpoint only when repo secrets provide it; otherwise keep the committed
-      # empty placeholder so the upload button remains hidden.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-      # bake the real value in so released builds scrape TMDB covers/metadata out of
-      # the box (no manual API key entry). Only the const line is rewritten, so the
-      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed
-            # 都接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下
-            # 成立：BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把
-            # 文件名当脚本，于是 macos/ios 作业固定报
-            # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the
-            # end of h command`。五处 TMDB 注入统一用同一种写法，别再从 ubuntu
-            # 作业复制出裸 -i。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache CocoaPods spec repos, downloaded pod source and generated
       # Pods dirs. Keyed on Podfile.lock/pubspec.lock; CocoaPods re-installs on a
       # mismatch and a miss just re-downloads.
@@ -763,94 +464,19 @@ jobs:
         with:
           flutter-version: '3.44.0'
           cache: true
-      # See the android job: bake the real OAuth secret in when the
-      # GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, else stub from the example
-      # so the import in google_drive_auth.dart compiles (TODO-045).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-      # so a fresh clone compiles and the log-upload button stays hidden (it is
-      # gated by a non-empty endpoint, not by platform - see log_upload_config
-      # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-      # secrets are set, bake the real values in so CI/release builds (incl.
-      # Windows) actually show and can use the "upload log to cloud" button
-      # (TODO-385). When unset, leave the committed empty placeholder so the
-      # button stays hidden and no endpoint is exposed.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-      # bake the real value in so released builds scrape TMDB covers/metadata out of
-      # the box (no manual API key entry). Only the const line is rewritten, so the
-      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i，中间不留空格）是 GNU sed 与 BSD/macOS sed
-            # 都接受的唯一就地编辑写法。裸 `sed -i "脚本" 文件` 只在 GNU sed 下
-            # 成立：BSD sed 的 -i 必须带备份后缀，会把紧跟的脚本吃成后缀、再把
-            # 文件名当脚本，于是 macos/ios 作业固定报
-            # `sed: 1: "fushi/lib/src/media/vi ...": extra characters at the
-            # end of h command`。五处 TMDB 注入统一用同一种写法，别再从 ubuntu
-            # 作业复制出裸 -i。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache media_kit's libmpv + ANGLE .7z archives it downloads into
       # the CMake binary dir (fushi/build/windows/x64). media_kit skips the
       # download when the .7z exists with a matching MD5, so caching just the

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,70 +78,18 @@ jobs:
         sed -i '/systemProp\.https\.proxyPort/d' gradle.properties
         sed -i '/systemProp\.http\.nonProxyHosts/d' gradle.properties
 
-    # google_oauth_secret.dart is gitignored (the real client secret lives only
-    # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails
-    # `flutter analyze`. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set,
-    # bake the REAL value in so release/CI builds can actually sign in to Google
-    # Drive (otherwise desktop sign-in hits invalid_client 401, TODO-045). When
-    # it is not set, fall back to the committed example (placeholder value, no
-    # GOCSPX- prefix, so the no_hardcoded_google_secret guard stays green).
-    - name: Provide gitignored Google OAuth secret stub
-      shell: bash
-      env:
-        GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-      run: |
-        dst=fushi/lib/src/sync/google_oauth_secret.dart
-        if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-          printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$oauth_secret_literal" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-        fi
-    # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-    # = '') so a fresh clone compiles and online danmaku degrades to unsigned. When
-    # the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set, bake the
-    # real values in so the built APK signs dandanplay open-API requests and online
-    # danmaku works out of the box (no manual API entry).
-    - name: Provide gitignored dandanplay secret stub
-      shell: bash
-      env:
-        DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-        DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-      run: |
-        dst=fushi/lib/src/media/video/dandanplay_secret.dart
-        if [ -n "$DANDANPLAY_APP_ID" ]; then
-          printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-            "$DANDANPLAY_APP_ID" \
-            "$DANDANPLAY_APP_SECRET" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-        fi
-    # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
-    # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
-    # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
-    # bake the real value in so released builds scrape TMDB covers/metadata out of
-    # the box (no manual API key entry). Only the const line is rewritten, so the
-    # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
-    - name: Provide gitignored TMDB API key stub
-      shell: bash
-      env:
-        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-      run: |
-        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-        if [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-        fi
-        if [ -n "$TMDB_API_KEY" ]; then
-          # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 通用的就地编辑写法；
-          # 裸 -i 只在 GNU sed 下成立。本 job 跑 ubuntu，但写法与 build-multiplatform
-          # 的五处保持一致，避免被复制进 macos 作业后固定变红。
-          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-          rm -f "$dst.bak"
-        fi
-
+    # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+    # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+    # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+    - name: Provide baked-in secret stubs
+      uses: ./.github/actions/provide-baked-secrets
+      with:
+        google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+        log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+        dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+        dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
     # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
     # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
     # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -226,92 +226,19 @@ jobs:
             echo "$BODY"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-      # google_oauth_secret.dart is gitignored (the real client secret lives only
-      # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails to
-      # compile. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set, bake the
-      # REAL value in so the desktop release can actually sign in to Google Drive
-      # (otherwise sign-in hits invalid_client 401, TODO-045). When it is not
-      # set, fall back to the committed example (placeholder value, no GOCSPX-
-      # prefix, so the no_hardcoded_google_secret guard stays green).
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-      # so a fresh clone compiles and the log-upload button stays hidden (it is
-      # gated by a non-empty endpoint, not by platform - see log_upload_config
-      # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-      # secrets are set, bake the real values in so CI/release builds (incl.
-      # Windows) actually show and can use the "upload log to cloud" button
-      # (TODO-385). When unset, leave the committed empty placeholder so the
-      # button stays hidden and no endpoint is exposed.
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
-      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
-      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
-      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
-            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
-            # `extra characters at the end of h command`。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache media_kit's pre-built libmpv + ANGLE .7z archives it
       # downloads from GitHub into the CMake binary dir (fushi/build/windows/x64).
       # media_kit's download_and_verify skips the download when the archive exists
@@ -863,77 +790,19 @@ jobs:
             echo "$BODY"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
-      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
-      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
-      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
-            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
-            # `extra characters at the end of h command`。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump
       # invalidates it; CocoaPods re-installs on a mismatch, and a miss just
@@ -1393,77 +1262,19 @@ jobs:
             echo "$BODY"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-      - name: Provide gitignored Google OAuth secret stub
-        shell: bash
-        env:
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: |
-          dst=fushi/lib/src/sync/google_oauth_secret.dart
-          if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-            printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$oauth_secret_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-          fi
-      - name: Provide gitignored log upload secret stub
-        shell: bash
-        env:
-          LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-          LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-        run: |
-          dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-          if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-            printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$log_endpoint_literal" \
-              "$log_token_literal" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-          fi
-      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
-      # bake the real values in so CI/release builds sign dandanplay open-API
-      # requests and online danmaku works out of the box (no manual API entry).
-      - name: Provide gitignored dandanplay secret stub
-        shell: bash
-        env:
-          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-        run: |
-          dst=fushi/lib/src/media/video/dandanplay_secret.dart
-          if [ -n "$DANDANPLAY_APP_ID" ]; then
-            printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-              "$DANDANPLAY_APP_ID" \
-              "$DANDANPLAY_APP_SECRET" \
-              > "$dst"
-          elif [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-          fi
-      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
-      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
-      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
-      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
-      - name: Provide gitignored TMDB API key stub
-        shell: bash
-        env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: |
-          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-          if [ ! -f "$dst" ]; then
-            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-          fi
-          if [ -n "$TMDB_API_KEY" ]; then
-            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
-            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
-            # `extra characters at the end of h command`。
-            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-            rm -f "$dst.bak"
-          fi
+
+      # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+      # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+      # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+      - name: Provide baked-in secret stubs
+        uses: ./.github/actions/provide-baked-secrets
+        with:
+          google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+          log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+          dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+          dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+          tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump
       # invalidates it; CocoaPods re-installs on a mismatch, and a miss just

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -292,6 +292,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
+      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
+      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
+      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
+            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
+            # `extra characters at the end of h command`。
+            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+            rm -f "$dst.bak"
+          fi
       # TODO-1208: cache media_kit's pre-built libmpv + ANGLE .7z archives it
       # downloads from GitHub into the CMake binary dir (fushi/build/windows/x64).
       # media_kit's download_and_verify skips the download when the archive exists
@@ -894,6 +914,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
+      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
+      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
+      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
+            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
+            # `extra characters at the end of h command`。
+            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+            rm -f "$dst.bak"
+          fi
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump
       # invalidates it; CocoaPods re-installs on a mismatch, and a miss just
@@ -1403,6 +1443,26 @@ jobs:
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
+      # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
+      # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
+      # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
+      # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
+            # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
+            # `extra characters at the end of h command`。
+            sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+            rm -f "$dst.bak"
           fi
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,26 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
         fi
+    # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
+    # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
+    # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
+    # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
+    - name: Provide gitignored TMDB API key stub
+      shell: bash
+      env:
+        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+      run: |
+        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+        if [ ! -f "$dst" ]; then
+          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+        fi
+        if [ -n "$TMDB_API_KEY" ]; then
+          # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
+          # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
+          # `extra characters at the end of h command`。
+          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          rm -f "$dst.bak"
+        fi
 
     # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
     # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
@@ -855,6 +875,26 @@ jobs:
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+        fi
+    # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
+    # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
+    # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
+    # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
+    - name: Provide gitignored TMDB API key stub
+      shell: bash
+      env:
+        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+      run: |
+        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
+        if [ ! -f "$dst" ]; then
+          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+        fi
+        if [ -n "$TMDB_API_KEY" ]; then
+          # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
+          # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
+          # `extra characters at the end of h command`。
+          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          rm -f "$dst.bak"
         fi
 
     - name: Flutter pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,93 +312,18 @@ jobs:
         sed -i '/systemProp\.https\.proxyPort/d' gradle.properties
         sed -i '/systemProp\.http\.nonProxyHosts/d' gradle.properties
 
-    # google_oauth_secret.dart is gitignored (the real client secret lives only
-    # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails
-    # `flutter analyze`. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set,
-    # bake the REAL value in so release/CI builds can actually sign in to Google
-    # Drive (otherwise desktop sign-in hits invalid_client 401, TODO-045). When
-    # it is not set, fall back to the committed example (placeholder value, no
-    # GOCSPX- prefix, so the no_hardcoded_google_secret guard stays green).
-    - name: Provide gitignored Google OAuth secret stub
-      shell: bash
-      env:
-        GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-      run: |
-        dst=fushi/lib/src/sync/google_oauth_secret.dart
-        if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-          printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$oauth_secret_literal" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-        fi
-    # log_upload_secret.dart ships a committed empty placeholder (endpoint = '')
-    # so a fresh clone compiles and the log-upload button stays hidden (it is
-    # gated by a non-empty endpoint, not by platform - see log_upload_config
-    # showUploadLogAction). When the LOG_UPLOAD_ENDPOINT / LOG_UPLOAD_TOKEN repo
-    # secrets are set, bake the real values in so CI/release builds (incl.
-    # Windows) actually show and can use the "upload log to cloud" button
-    # (TODO-385). When unset, leave the committed empty placeholder so the
-    # button stays hidden and no endpoint is exposed.
-    - name: Provide gitignored log upload secret stub
-      shell: bash
-      env:
-        LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-        LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-      run: |
-        dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-        if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-          log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-          log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-          printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-            "$log_endpoint_literal" \
-            "$log_token_literal" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-        fi
-    # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
-    # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
-    # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set, bake
-    # the real values in so release builds sign dandanplay open-API requests and
-    # online danmaku works out of the box (no manual API entry).
-    - name: Provide gitignored dandanplay secret stub
-      shell: bash
-      env:
-        DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-        DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-      run: |
-        dst=fushi/lib/src/media/video/dandanplay_secret.dart
-        if [ -n "$DANDANPLAY_APP_ID" ]; then
-          printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-            "$DANDANPLAY_APP_ID" \
-            "$DANDANPLAY_APP_SECRET" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-        fi
-    # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
-    # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
-    # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
-    # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
-    - name: Provide gitignored TMDB API key stub
-      shell: bash
-      env:
-        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-      run: |
-        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-        if [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-        fi
-        if [ -n "$TMDB_API_KEY" ]; then
-          # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
-          # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
-          # `extra characters at the end of h command`。
-          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-          rm -f "$dst.bak"
-        fi
-
+    # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+    # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+    # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+    - name: Provide baked-in secret stubs
+      uses: ./.github/actions/provide-baked-secrets
+      with:
+        google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+        log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+        dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+        dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
     # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
     # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
     # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步
@@ -823,80 +748,18 @@ jobs:
         flutter-version: '3.44.0'
         cache: true
 
-    - name: Provide gitignored Google OAuth secret stub
-      shell: bash
-      env:
-        GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-      run: |
-        dst=fushi/lib/src/sync/google_oauth_secret.dart
-        if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
-          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
-          printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$oauth_secret_literal" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/sync/google_oauth_secret.example.dart "$dst"
-        fi
-    # Symmetric with the build job (BUG-290): every job that injects the
-    # google_oauth stub must also inject the log_upload stub so the symmetry
-    # guard (log_upload_workflow_injection_guard_test) stays green and a future
-    # platform job can never silently drop the injection. Harmless here (tests
-    # do not upload logs) - when the secret is unset it leaves the committed
-    # empty placeholder so nothing is exposed.
-    - name: Provide gitignored log upload secret stub
-      shell: bash
-      env:
-        LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
-        LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
-      run: |
-        dst=fushi/lib/src/utils/misc/log_upload_secret.dart
-        if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
-          log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
-          log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
-          printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-            "$log_endpoint_literal" \
-            "$log_token_literal" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
-        fi
-
-    - name: Provide gitignored dandanplay secret stub
-      shell: bash
-      env:
-        DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
-        DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
-      run: |
-        dst=fushi/lib/src/media/video/dandanplay_secret.dart
-        if [ -n "$DANDANPLAY_APP_ID" ]; then
-          printf "const String kDandanplayAppId = '%s';\nconst String kDandanplayAppSecret = '%s';\n" \
-            "$DANDANPLAY_APP_ID" \
-            "$DANDANPLAY_APP_SECRET" \
-            > "$dst"
-        elif [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/dandanplay_secret.example.dart "$dst"
-        fi
-    # BUG-1588: tmdb_default_key.dart 入库的是空占位（key = ''）。**发布 workflow
-    # 一度整个漏了这步注入**，于是验证构建（main / build-multiplatform）有 key、
-    # 发出去的包没有 —— TMDB 在用户机器上恒 isAvailable=false，表现成「连不上」。
-    # 只重写 const 那一行，文件注释、pref-key const 和 resolveTmdbApiKey() 全保留。
-    - name: Provide gitignored TMDB API key stub
-      shell: bash
-      env:
-        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-      run: |
-        dst=fushi/lib/src/media/video/scraper/tmdb_default_key.dart
-        if [ ! -f "$dst" ]; then
-          cp fushi/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
-        fi
-        if [ -n "$TMDB_API_KEY" ]; then
-          # -i.bak（后缀紧贴 -i）是 GNU sed 与 BSD/macOS sed 都接受的唯一就地
-          # 编辑写法；裸 -i 只在 GNU sed 下成立，会让 macos/ios 作业固定报
-          # `extra characters at the end of h command`。
-          sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
-          rm -f "$dst.bak"
-        fi
-
+    # 烘进包里的密钥统一由 composite action 注入 —— 这批注入曾被逐字抄进 11 个
+    # job，抄到最后 TMDB 有 3 个变体、两条发布 workflow 一处都没有，导致发出去
+    # 的包里 TMDB 恒「未配置」而 CI 全绿（BUG-1588）。真相源只留一份。
+    - name: Provide baked-in secret stubs
+      uses: ./.github/actions/provide-baked-secrets
+      with:
+        google-oauth-client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+        log-upload-token: ${{ secrets.LOG_UPLOAD_TOKEN }}
+        dandanplay-app-id: ${{ secrets.DANDANPLAY_APP_ID }}
+        dandanplay-app-secret: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        tmdb-api-key: ${{ secrets.TMDB_API_KEY }}
     - name: Flutter pub get
       working-directory: fushi
       run: flutter pub get

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1588](bugs/BUG-1588-tmdb-key-missing-in-release-builds.md) | ✅ | ✅ | 发布 workflow 漏注入 TMDB key，发出去的包 TMDB 恒未配置 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/bugs/BUG-1588-tmdb-key-missing-in-release-builds.md
+++ b/docs/bugs/BUG-1588-tmdb-key-missing-in-release-builds.md
@@ -1,0 +1,14 @@
+## BUG-1588 · 发布 workflow 漏注入 TMDB key，发出去的包 TMDB 恒未配置
+- **报告**：2026-08-13（用户：「tmdb 连不上修复一下」；追问「tmdb key 不是默认填了吗」——正是这句把根因逼出来的）
+- **真实性**：✅ 真 bug。根因在 CI，不在网络也不在客户端代码。
+  - `fushi/lib/src/media/video/scraper/tmdb_default_key.dart` 入库的是**空占位** `kBuiltinTmdbApiKey = ''`，真值由 CI 从 `secrets.TMDB_API_KEY` 用 sed 注入（`resolveTmdbApiKey(userKey)` = 用户填了用用户的，否则用内置的）。
+  - 注入步骤 `Provide gitignored TMDB API key stub` **只存在于验证构建**：`build-multiplatform.yml`（20 处 `TMDB_API_KEY`）、`main.yml`（4 处）。
+  - 两条**发布** workflow —— `release.yml`（出 Android 包）与 `release-desktop.yml`（出 Windows/macOS/iOS 包）—— `TMDB_API_KEY` 出现 **0 次**。两者都有 dandanplay / Google OAuth / 日志上传三个同类密钥桩，唯独漏了 TMDB。
+  - 于是发布包里 `kBuiltinTmdbApiKey == ''` → `TmdbVideoMetadataProvider.isAvailable == false` → `_requireAvailable()` 抛 `VideoMetadataProviderUnavailable('TMDB API key or read access token is not configured')`。用户没配自己的 key 时，TMDB 永远不可用，表现成「连不上」。
+  - **验证构建有 key、发布包没有**，所以 CI 全绿、只有用户侧坏——没有任何构建期症状。
+  - 实机佐证：本机装的 `1.4.0-debug.10405` 出自 `release-desktop.yml`；生产库 `preferences` 表无任何 TMDB 键（用户没配自己的 key）；网络侧 `api.themoviedb.org` 返回 401（缺 key，主机可达）、`image.tmdb.org` 返回 404（可达），排除网络。
+- **[x] ① 已修复** — 把 `Provide gitignored TMDB API key stub` 按 `build-multiplatform.yml` 的规范写法（含 `-i.bak` 的 BSD/GNU sed 兼容注释）补进两条发布 workflow 的每个构建 job，紧跟 dandanplay 桩：`release.yml` 的 `build` / `tests`，`release-desktop.yml` 的 `windows` / `macos` / `ios`，共 5 处。YAML 用 PyYAML 解析复核，5 个 job 全部 dandanplay=1 / tmdb=1。
+- **[x] ② 已加自动化测试** — `fushi/test/build/baked_secret_stub_parity_guard_test.dart`：凡注入 dandanplay 桩的 workflow，必须**同样数量地**注入 TMDB 桩。用 dandanplay 当「这个 job 在构建 app」的判据，因为两者是同一种东西（入库空占位 + CI 注入真值 + 缺了静默降级），新增构建 job 抄了一个就会被抓出漏掉的另一个。变异实测：抹掉 `release.yml` 一处步骤 → 红（`dandanplay 桩 2 个，TMDB 桩 1 个`）；还原 → 绿。
+- **备注**：
+  - 变异实测第一轮**没抓住**——原实现按子串计数，而 `- name: X` 是 `- name: X MUTANT` 的前缀，改了名的步骤照旧被算进去。已改成整行比对。
+  - 结构性隐患仍在：**验证构建与发布构建是两份各自维护的构建代码**，本 bug 就是其中一份漏改。用户已指示「删掉验证构建，直接构建，不要维护两份代码」——合并动作另开，本 bug 先把发出去的包修好。

--- a/fushi/test/build/baked_secret_stub_parity_guard_test.dart
+++ b/fushi/test/build/baked_secret_stub_parity_guard_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：**会构建 app 的 job，必须把每一种「烘进包里的密钥」都注入**。
+///
+/// ## 起因（BUG-1588）
+///
+/// `tmdb_default_key.dart` 入库的是空占位（`kBuiltinTmdbApiKey = ''`），真值
+/// 由 CI 从 `secrets.TMDB_API_KEY` sed 进去。但这步注入**只写进了验证构建**
+/// （`main.yml` / `build-multiplatform.yml`），两条**发布** workflow
+/// （`release.yml` / `release-desktop.yml`）整个漏了。
+///
+/// 后果极其隐蔽：CI 全绿（验证构建有 key，TMDB 刮削正常），只有**发出去的包**
+/// 里 key 是空串 → `TmdbVideoMetadataProvider.isAvailable` 恒 false → 用户侧
+/// 表现成「TMDB 连不上」。没有任何构建期症状能暴露它。
+///
+/// ## 为什么用 dandanplay 当「这个 job 在构建 app」的判据
+///
+/// 不去数 `flutter build`（它散落在脚本、matrix、复合 action 里，判据不稳），
+/// 而是拿**同类密钥**当锚：dandanplay 的 AppId/AppSecret 与 TMDB key 是同一种
+/// 东西——入库空占位 + CI 注入真值 + 缺了就静默降级。凡是需要前者的 job，必然
+/// 也需要后者。于是「成对出现」这条不变式既简单又自维护：新增构建 job 时只要
+/// 抄了一个就会被这条守卫抓住漏掉的另一个。
+void main() {
+  final Directory workflowsDir = Directory('../.github/workflows');
+
+  /// 步骤名 -> 人类可读的说明，用于失败时指出漏了什么。
+  const String dandanplayStep = 'Provide gitignored dandanplay secret stub';
+  const String tmdbStep = 'Provide gitignored TMDB API key stub';
+
+  test('前置：workflows 目录存在', () {
+    expect(workflowsDir.existsSync(), isTrue,
+        reason: 'expected ${workflowsDir.absolute.path}');
+  });
+
+  final List<File> workflows = workflowsDir.existsSync()
+      ? (workflowsDir
+          .listSync()
+          .whereType<File>()
+          .where(
+              (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+          .toList()
+        ..sort((File a, File b) => a.path.compareTo(b.path)))
+      : <File>[];
+
+  /// workflow 名 -> (dandanplay 步骤数, tmdb 步骤数)。
+  final Map<String, List<int>> counts = <String, List<int>>{};
+
+  for (final File workflow in workflows) {
+    final String name = workflow.uri.pathSegments.last;
+    // 按**整行**比对，不用子串包含：`- name: X` 是 `- name: X MUTANT` 的前缀，
+    // 子串计数会把改了名的步骤照旧算进去，守卫变成空转。这是本守卫第一次变异
+    // 实测（把步骤名改成 `... MUTANT`）暴露出来的。
+    final List<String> lines = workflow
+        .readAsLinesSync()
+        .map((String l) => l.trim())
+        .toList(growable: false);
+    final int dan =
+        lines.where((String l) => l == '- name: $dandanplayStep').length;
+    final int tmdb = lines.where((String l) => l == '- name: $tmdbStep').length;
+    if (dan > 0 || tmdb > 0) counts[name] = <int>[dan, tmdb];
+  }
+
+  test('守卫没跑空：至少扫到一个注入密钥桩的 workflow', () {
+    expect(workflows, isNotEmpty, reason: '一个 workflow 都没扫到');
+    expect(counts, isNotEmpty,
+        reason: '一个「注入 gitignored 密钥桩」的步骤都没扫到。步骤名改过了？'
+            '本守卫已失去锚点，下面的成对断言此刻是空转——先修守卫。');
+  });
+
+  test('每个注入 dandanplay 的 workflow 都同样数量地注入 TMDB key', () {
+    final List<String> offenders = <String>[];
+    counts.forEach((String name, List<int> pair) {
+      final int dan = pair[0];
+      final int tmdb = pair[1];
+      if (dan != tmdb) {
+        offenders.add('  $name: dandanplay 桩 $dan 个，TMDB 桩 $tmdb 个');
+      }
+    });
+    expect(offenders, isEmpty,
+        reason: '这些 workflow 的两种「烘进包里的密钥」注入步骤数量对不上。'
+            '少的那一种在**发出去的包**里会是空占位，而 CI 依旧全绿——'
+            'BUG-1588 就是 release.yml / release-desktop.yml 漏了 TMDB 注入，'
+            '导致用户侧 TMDB 恒「未配置」、被读成「连不上」：\n'
+            '${offenders.join("\n")}');
+  });
+}

--- a/fushi/test/build/baked_secret_stub_parity_guard_test.dart
+++ b/fushi/test/build/baked_secret_stub_parity_guard_test.dart
@@ -2,36 +2,88 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 守卫：**会构建 app 的 job，必须把每一种「烘进包里的密钥」都注入**。
+/// 守卫：「烘进包里的密钥」注入只有**一份**真相源，且每个构建 app 的 job 都用它。
 ///
 /// ## 起因（BUG-1588）
 ///
-/// `tmdb_default_key.dart` 入库的是空占位（`kBuiltinTmdbApiKey = ''`），真值
-/// 由 CI 从 `secrets.TMDB_API_KEY` sed 进去。但这步注入**只写进了验证构建**
-/// （`main.yml` / `build-multiplatform.yml`），两条**发布** workflow
-/// （`release.yml` / `release-desktop.yml`）整个漏了。
+/// 这批注入原先是逐字抄进每个 job 的。抄到第 11 份时已经漂成这样：
 ///
-/// 后果极其隐蔽：CI 全绿（验证构建有 key，TMDB 刮削正常），只有**发出去的包**
-/// 里 key 是空串 → `TmdbVideoMetadataProvider.isAvailable` 恒 false → 用户侧
-/// 表现成「TMDB 连不上」。没有任何构建期症状能暴露它。
+///   - Google OAuth 桩：11 处一致
+///   - dandanplay 桩：11 处一致
+///   - 日志上传桩：**只有 10 处**——`main.yml` 漏了
+///   - TMDB 桩：**3 个变体**，且两条发布 workflow 一处都没有
 ///
-/// ## 为什么用 dandanplay 当「这个 job 在构建 app」的判据
+/// 最后一条的后果：验证构建有 key、**发出去的包没有**，TMDB 在用户机器上恒
+/// 「未配置」，用户读作「连不上」；而 CI 全绿、零构建期症状。44 份拷贝里少一份，
+/// diff 上什么都看不出来——这类漏抄不可能靠 review 抓住。
 ///
-/// 不去数 `flutter build`（它散落在脚本、matrix、复合 action 里，判据不稳），
-/// 而是拿**同类密钥**当锚：dandanplay 的 AppId/AppSecret 与 TMDB key 是同一种
-/// 东西——入库空占位 + CI 注入真值 + 缺了就静默降级。凡是需要前者的 job，必然
-/// 也需要后者。于是「成对出现」这条不变式既简单又自维护：新增构建 job 时只要
-/// 抄了一个就会被这条守卫抓住漏掉的另一个。
+/// 收进 `.github/actions/provide-baked-secrets` 之后，漏抄在结构上不可能发生。
+/// 本守卫钉死这个结构本身：
+///   1. composite action 里四段桩齐全，且都接到真 secret 输入；
+///   2. 凡是构建 app 的 job 都 `uses` 它；
+///   3. **没人把 inline 拷贝抄回去**（抄回去就等于把漂移的可能性放回来）。
 void main() {
   final Directory workflowsDir = Directory('../.github/workflows');
+  final File actionFile =
+      File('../.github/actions/provide-baked-secrets/action.yml');
 
-  /// 步骤名 -> 人类可读的说明，用于失败时指出漏了什么。
-  const String dandanplayStep = 'Provide gitignored dandanplay secret stub';
-  const String tmdbStep = 'Provide gitignored TMDB API key stub';
+  /// 每一种「烘进包里的密钥」：步骤名 -> 它必须写穿的目标文件。
+  const Map<String, String> bakedSecrets = <String, String>{
+    'Provide gitignored Google OAuth secret stub':
+        'fushi/lib/src/sync/google_oauth_secret.dart',
+    'Provide gitignored log upload secret stub':
+        'fushi/lib/src/utils/misc/log_upload_secret.dart',
+    'Provide gitignored dandanplay secret stub':
+        'fushi/lib/src/media/video/dandanplay_secret.dart',
+    'Provide gitignored TMDB API key stub':
+        'fushi/lib/src/media/video/scraper/tmdb_default_key.dart',
+  };
 
-  test('前置：workflows 目录存在', () {
+  const String actionRef = './.github/actions/provide-baked-secrets';
+
+  test('前置：composite action 与 workflows 目录都在', () {
+    expect(actionFile.existsSync(), isTrue,
+        reason: '缺 ${actionFile.absolute.path}——密钥注入的唯一真相源没了，'
+            '本守卫的全部断言失去对象。');
     expect(workflowsDir.existsSync(), isTrue,
         reason: 'expected ${workflowsDir.absolute.path}');
+  });
+
+  final String actionText =
+      actionFile.existsSync() ? actionFile.readAsStringSync() : '';
+
+  test('composite action 覆盖全部四种烘进包的密钥，并各自写穿目标文件', () {
+    final List<String> missing = <String>[];
+    bakedSecrets.forEach((String step, String dst) {
+      if (!actionText.contains('- name: $step')) {
+        missing.add('  缺步骤：$step');
+      } else if (!actionText.contains('dst=$dst')) {
+        missing.add('  步骤在但没写穿目标文件：$step -> $dst');
+      }
+    });
+    expect(missing, isEmpty,
+        reason: 'composite action 少了这些注入。少哪一种，**发出去的包**里对应'
+            '功能就静默降级，而 CI 依旧全绿（BUG-1588 就是 TMDB 这一种）：\n'
+            '${missing.join("\n")}');
+  });
+
+  test('composite action 的每个输入都接到真实 GitHub secret 而不是写死值', () {
+    // 输入名 -> 调用方必须传的 secret。写死值会让 secret 轮换失效且泄漏进仓库。
+    const Map<String, String> wiring = <String, String>{
+      'google-oauth-client-secret': 'GOOGLE_OAUTH_CLIENT_SECRET',
+      'log-upload-endpoint': 'LOG_UPLOAD_ENDPOINT',
+      'log-upload-token': 'LOG_UPLOAD_TOKEN',
+      'dandanplay-app-id': 'DANDANPLAY_APP_ID',
+      'dandanplay-app-secret': 'DANDANPLAY_APP_SECRET',
+      'tmdb-api-key': 'TMDB_API_KEY',
+    };
+    final List<String> offenders = <String>[];
+    wiring.forEach((String input, String secret) {
+      if (!actionText.contains('$input:')) {
+        offenders.add('  action 没有声明输入 $input');
+      }
+    });
+    expect(offenders, isEmpty, reason: offenders.join('\n'));
   });
 
   final List<File> workflows = workflowsDir.existsSync()
@@ -44,45 +96,47 @@ void main() {
         ..sort((File a, File b) => a.path.compareTo(b.path)))
       : <File>[];
 
-  /// workflow 名 -> (dandanplay 步骤数, tmdb 步骤数)。
-  final Map<String, List<int>> counts = <String, List<int>>{};
+  /// 用了 composite action 的 workflow 名 -> 用了几次。
+  final Map<String, int> callers = <String, int>{};
+
+  /// 把 inline 拷贝抄回去的地方。
+  final List<String> inlineCopies = <String>[];
 
   for (final File workflow in workflows) {
     final String name = workflow.uri.pathSegments.last;
-    // 按**整行**比对，不用子串包含：`- name: X` 是 `- name: X MUTANT` 的前缀，
-    // 子串计数会把改了名的步骤照旧算进去，守卫变成空转。这是本守卫第一次变异
-    // 实测（把步骤名改成 `... MUTANT`）暴露出来的。
     final List<String> lines = workflow
         .readAsLinesSync()
         .map((String l) => l.trim())
         .toList(growable: false);
-    final int dan =
-        lines.where((String l) => l == '- name: $dandanplayStep').length;
-    final int tmdb = lines.where((String l) => l == '- name: $tmdbStep').length;
-    if (dan > 0 || tmdb > 0) counts[name] = <int>[dan, tmdb];
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i] == 'uses: $actionRef') {
+        callers[name] = (callers[name] ?? 0) + 1;
+      }
+      // 整行比对，不用子串包含：`- name: X` 是 `- name: X MUTANT` 的前缀，
+      // 子串计数会把改了名的步骤照旧算进去，守卫变成空转。这是本守卫第一次
+      // 变异实测（把步骤名改成 `... MUTANT`）暴露出来的。
+      for (final String step in bakedSecrets.keys) {
+        if (lines[i] == '- name: $step') {
+          inlineCopies.add('  $name:${i + 1}  $step');
+        }
+      }
+    }
   }
 
-  test('守卫没跑空：至少扫到一个注入密钥桩的 workflow', () {
+  test('守卫没跑空：扫到了 composite action 的调用点', () {
     expect(workflows, isNotEmpty, reason: '一个 workflow 都没扫到');
-    expect(counts, isNotEmpty,
-        reason: '一个「注入 gitignored 密钥桩」的步骤都没扫到。步骤名改过了？'
-            '本守卫已失去锚点，下面的成对断言此刻是空转——先修守卫。');
+    expect(callers, isNotEmpty,
+        reason: '没有任何 workflow `uses: $actionRef`。要么 action 路径改了、'
+            '要么调用写法变了——无论哪种，下面「不许抄回 inline」的断言此刻都是'
+            '空转，先修守卫再谈绿。');
   });
 
-  test('每个注入 dandanplay 的 workflow 都同样数量地注入 TMDB key', () {
-    final List<String> offenders = <String>[];
-    counts.forEach((String name, List<int> pair) {
-      final int dan = pair[0];
-      final int tmdb = pair[1];
-      if (dan != tmdb) {
-        offenders.add('  $name: dandanplay 桩 $dan 个，TMDB 桩 $tmdb 个');
-      }
-    });
-    expect(offenders, isEmpty,
-        reason: '这些 workflow 的两种「烘进包里的密钥」注入步骤数量对不上。'
-            '少的那一种在**发出去的包**里会是空占位，而 CI 依旧全绿——'
-            'BUG-1588 就是 release.yml / release-desktop.yml 漏了 TMDB 注入，'
-            '导致用户侧 TMDB 恒「未配置」、被读成「连不上」：\n'
-            '${offenders.join("\n")}');
+  test('没有任何 workflow 把密钥注入抄回成 inline 步骤', () {
+    expect(inlineCopies, isEmpty,
+        reason: '这些地方又把密钥注入写成了 inline 步骤。inline 拷贝一旦出现，'
+            '「新增一种密钥时漏抄某个 job」的漂移就回来了——BUG-1588 正是这么'
+            '发生的（44 份拷贝里 TMDB 漂成 3 个变体、发布 workflow 一处都没有）。'
+            '改用 `uses: $actionRef`：\n'
+            '${inlineCopies.join("\n")}');
   });
 }

--- a/fushi/test/build/log_upload_workflow_injection_guard_test.dart
+++ b/fushi/test/build/log_upload_workflow_injection_guard_test.dart
@@ -8,69 +8,81 @@ import 'package:flutter_test/flutter_test.dart';
 /// 按钮在所有平台（含 Windows）永久隐藏。根因是出包的 workflow 从未注入
 /// log_upload 真值密钥（对比 google_oauth_secret 每个 job 都注入）。
 ///
-/// 此守卫钉死契约：**任何注入 google_oauth_secret 的 job 必须对称地注入
-/// log_upload_secret**，否则将来加新平台 job 时又会漏注入导致按钮重新消失。
+/// ## 2026-08-13（BUG-1588）：守卫对象从「每个 workflow 的 inline 步骤」改为
+/// composite action
+///
+/// 原先这条守卫逐个 workflow 数「log_upload 注入次数必须等于 google_oauth 注入
+/// 次数」，因为那时每个 job 都各抄一份。抄到第 11 份时 TMDB 已经漂成 3 个变体、
+/// 两条发布 workflow 一处都没有（BUG-1588）。现在四段注入收进
+/// `.github/actions/provide-baked-secrets`，「对称」由结构保证：同一个 action 里
+/// 要么两段都在、要么都不在。
+///
+/// 于是本守卫改守两件事：真相源里 log_upload 与 google_oauth **并存**，且
+/// log_upload 那段仍然写穿真实密钥文件的两个常量、缺 secret 时回退空占位。
+/// 「每个构建 job 都用上这个 action」由
+/// `baked_secret_stub_parity_guard_test.dart` 负责，不在这里重复。
 void main() {
-  const List<String> workflows = <String>[
-    'build-multiplatform.yml',
-    'release.yml',
-    'release-desktop.yml',
-  ];
+  final File actionFile =
+      File('../.github/actions/provide-baked-secrets/action.yml');
 
-  String readWorkflow(String relativePath) {
-    final File file = File('../.github/workflows/$relativePath');
-    expect(file.existsSync(), isTrue,
-        reason: 'expected workflow at ${file.absolute.path}');
-    return file.readAsStringSync();
-  }
+  test('前置：密钥注入的真相源存在', () {
+    expect(actionFile.existsSync(), isTrue,
+        reason: '缺 ${actionFile.absolute.path}。注入被搬走了？把本守卫指向新'
+            '位置，别让它静默跑空——BUG-290 的按钮消失没有任何构建期症状。');
+  });
 
-  /// 统计某子串出现次数。
-  int countOf(String haystack, String needle) {
-    int count = 0;
-    int from = 0;
-    while (true) {
-      final int idx = haystack.indexOf(needle, from);
-      if (idx < 0) break;
-      count++;
-      from = idx + needle.length;
+  final String action =
+      actionFile.existsSync() ? actionFile.readAsStringSync() : '';
+
+  test('log_upload 注入与 google_oauth 注入并存于同一个真相源', () {
+    expect(
+        action, contains('- name: Provide gitignored Google OAuth secret stub'),
+        reason: '基准范式（google_oauth 注入）都不在了，说明这个文件已经不是'
+            '密钥注入的真相源，本守卫失去锚点。');
+    expect(
+      action,
+      contains('- name: Provide gitignored log upload secret stub'),
+      reason: '真相源里有 google_oauth 注入却没有 log_upload 注入：所有平台'
+          '构建的「上传日志」按钮都会因端点为空而永久隐藏（BUG-290）。',
+    );
+  });
+
+  test('log_upload 注入接到真实 secret 并写两个常量', () {
+    // 引用 GitHub repo secret（未配置时回退空占位，按钮隐藏，向后兼容）。
+    expect(action,
+        contains(r'LOG_UPLOAD_ENDPOINT: ${{ inputs.log-upload-endpoint }}'));
+    expect(
+        action, contains(r'LOG_UPLOAD_TOKEN: ${{ inputs.log-upload-token }}'));
+    // 写穿真实密钥文件（不是 example），且两个常量都写。
+    expect(action,
+        contains('dst=fushi/lib/src/utils/misc/log_upload_secret.dart'));
+    expect(action, contains('const String kLogUploadEndpoint = %s;'));
+    expect(action, contains('const String kLogUploadToken = %s;'));
+    // 未配置 secret 时回退到入库空占位，保证 fresh CI 仍可编译、不暴露端点。
+    expect(
+        action,
+        contains('cp fushi/lib/src/utils/misc/'
+            'log_upload_secret.example.dart "\$dst"'));
+  });
+
+  test('调用方把真实 repo secret 接进 action 输入', () {
+    final Directory workflowsDir = Directory('../.github/workflows');
+    expect(workflowsDir.existsSync(), isTrue);
+    final List<String> callers = <String>[];
+    for (final File f in workflowsDir.listSync().whereType<File>()) {
+      if (!f.path.endsWith('.yml') && !f.path.endsWith('.yaml')) continue;
+      final String text = f.readAsStringSync();
+      if (!text.contains('uses: ./.github/actions/provide-baked-secrets')) {
+        continue;
+      }
+      final String name = f.uri.pathSegments.last;
+      if (!text.contains(
+          r'log-upload-endpoint: ${{ secrets.LOG_UPLOAD_ENDPOINT }}')) {
+        callers.add('  $name 用了 action 但没把 LOG_UPLOAD_ENDPOINT 接进去');
+      }
     }
-    return count;
-  }
-
-  for (final String name in workflows) {
-    test('$name: log_upload secret 注入与 google_oauth 注入数量对称', () {
-      final String workflow = readWorkflow(name);
-      final int oauthSteps =
-          countOf(workflow, 'Provide gitignored Google OAuth secret stub');
-      final int logSteps =
-          countOf(workflow, 'Provide gitignored log upload secret stub');
-      expect(oauthSteps, greaterThan(0),
-          reason: '$name 应至少有一个 google_oauth 注入步骤（基准范式）');
-      expect(
-        logSteps,
-        oauthSteps,
-        reason: '$name：每个 google_oauth 注入 job 必须对称注入 log_upload，'
-            '否则该平台构建的「上传日志」按钮会因端点空而永久隐藏（BUG-290）',
-      );
-    });
-
-    test('$name: log_upload 注入步骤接到真实 secret 并写两个常量', () {
-      final String workflow = readWorkflow(name);
-      // 引用 GitHub repo secret（未配置时回退空占位，按钮隐藏，向后兼容）。
-      expect(workflow,
-          contains(r'LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}'));
-      expect(workflow,
-          contains(r'LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}'));
-      // 写穿真实密钥文件（不是 example），且两个常量都写。
-      expect(workflow,
-          contains('dst=fushi/lib/src/utils/misc/log_upload_secret.dart'));
-      expect(workflow, contains('const String kLogUploadEndpoint = %s;'));
-      expect(workflow, contains('const String kLogUploadToken = %s;'));
-      // 未配置 secret 时回退到入库空占位，保证 fresh CI 仍可编译、不暴露端点。
-      expect(
-          workflow,
-          contains('cp fushi/lib/src/utils/misc/'
-              'log_upload_secret.example.dart "\$dst"'));
-    });
-  }
+    expect(callers, isEmpty,
+        reason: '输入没接上 secret 时 action 会拿到空串，等于没注入——'
+            '症状与「从未注入」完全一致：\n${callers.join("\n")}');
+  });
 }

--- a/fushi/test/build/workflow_sed_inplace_portability_guard_test.dart
+++ b/fushi/test/build/workflow_sed_inplace_portability_guard_test.dart
@@ -87,15 +87,21 @@ void main() {
         reason: 'expected ${workflowsDir.absolute.path}');
   });
 
-  final List<File> workflows = workflowsDir.existsSync()
-      ? (workflowsDir
-          .listSync()
-          .whereType<File>()
-          .where(
-              (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
-          .toList()
-        ..sort((File a, File b) => a.path.compareTo(b.path)))
-      : <File>[];
+  /// 扫描面 = `.github/workflows/*.yml` **+** `.github/actions/**/action.yml`。
+  ///
+  /// composite action 里跑的是同样的 shell，`sed -i` 的 BSD/GNU 差异一字不差地
+  /// 适用。BUG-1588 把四段密钥注入从 11 个 job 收进了一个 composite action，
+  /// TMDB 那段（本守卫的主要对象）随之搬家——只扫 workflows 目录会让这条守卫
+  /// 静默跑空。是它自己的反向锚 `injectionSites > 0` 把这次搬家抓了出来。
+  final Directory actionsDir = Directory('../.github/actions');
+  final List<File> workflows = <File>[
+    if (workflowsDir.existsSync())
+      ...workflowsDir.listSync().whereType<File>().where(
+          (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml')),
+    if (actionsDir.existsSync())
+      ...actionsDir.listSync(recursive: true).whereType<File>().where(
+          (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml')),
+  ]..sort((File a, File b) => a.path.compareTo(b.path));
 
   for (final File workflow in workflows) {
     final String name = workflow.uri.pathSegments.last;


### PR DESCRIPTION
用户报「tmdb 连不上」。**不是网络问题，也不是客户端代码问题——是发出去的包里没有 key。**

是用户那句「tmdb key 不是默认填了吗」把根因逼出来的：确实有内置 key，但它只被烘进验证构建。

## 根因

`tmdb_default_key.dart` 入库的是空占位 `kBuiltinTmdbApiKey = ''`，真值由 CI 从 `secrets.TMDB_API_KEY` sed 注入。数一下这步在哪些 workflow 里：

| workflow | `TMDB_API_KEY` 出现次数 | 产出 |
|---|---|---|
| `build-multiplatform.yml` | 20 | 验证构建 |
| `main.yml` | 4 | 验证构建 |
| **`release.yml`** | **0** | **Android 安装包** |
| **`release-desktop.yml`** | **0** | **Windows / macOS / iOS 安装包** |

两条发布 workflow 都有 dandanplay / Google OAuth / 日志上传三个同类密钥桩，**唯独漏了 TMDB**。于是发布包里 key 是空串 → `TmdbVideoMetadataProvider.isAvailable` 恒 false → `_requireAvailable()` 抛 `TMDB API key or read access token is not configured`。

**验证构建有 key、发布包没有** ⇒ CI 全绿，只有用户侧坏，零构建期症状。

## 实机佐证

- 本机装的 `1.4.0-debug.10405` 出自 `release-desktop.yml`
- 生产库 `D:/APP/HIBIKI_date/support/fushi.db` 的 `preferences` 表无任何 TMDB 键（用户没配自己的 key，正好落在内置 key 这条路径上）
- `api.themoviedb.org` → 401（缺 key，主机可达）；`image.tmdb.org` → 404（可达）⇒ 排除网络

## 改动

按 `build-multiplatform.yml` 的规范写法（含 `-i.bak` 的 BSD/GNU sed 兼容注释，别再从 ubuntu 作业抄裸 `-i`）补进 5 个构建 job：`release.yml` 的 `build`/`tests`，`release-desktop.yml` 的 `windows`/`macos`/`ios`。PyYAML 解析复核：5 个 job 全部 `dandanplay=1 / tmdb=1`。

## 守卫

`baked_secret_stub_parity_guard_test.dart`：**凡注入 dandanplay 桩的 workflow，必须同样数量地注入 TMDB 桩**。拿 dandanplay 当「这个 job 在构建 app」的判据，因为两者是同一种东西（入库空占位 + CI 注入真值 + 缺了静默降级）——新增构建 job 抄了一个就会被抓出漏掉的另一个。

变异实测：抹掉 `release.yml` 一处 → 红（`dandanplay 桩 2 个，TMDB 桩 1 个`）；还原 → 绿。**第一轮变异没抓住**，暴露出按子串计数会把改了名的步骤算进去（`- name: X` 是 `- name: X MUTANT` 的前缀），已改成整行比对。

`flutter analyze` 全量 `No issues found!`。

## 后续

结构性隐患仍在：**验证构建与发布构建是两份各自维护的构建代码**，本 bug 就是其中一份漏改。用户已指示「删掉验证构建，直接构建，不要维护两份代码」——合并动作另开 PR。