### PR TITLE
fix(ci): Windows 发布构建加 -v 与失败日志 artifact，真错误不再被折叠（BUG-1589）

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -382,12 +382,32 @@ jobs:
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libtorrent:x64-windows
           if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent failed" }
           powershell -ExecutionPolicy Bypass -File native/fushi_torrent/build_windows_dll.ps1 -VcpkgRoot "$env:VCPKG_INSTALLATION_ROOT"
+      # BUG-1589：这一步在 develop 上固定红，而错误**看不见**——MSBuild 把自定义
+      # 生成步骤的真实报错折叠成 `Target dart_build failed` + `MSB8066`，日志里
+      # 只剩这两行。本机用 -v 跑同一条命令才拿到真正的 CMake/hook 报错。
+      #
+      # 注意验证构建（build-multiplatform.yml）跑的是 `--debug`，**不走 AOT**，
+      # 所以它绿不代表这条 release 路径绿——「CI 全绿」从来没覆盖过发布构建。
+      #
+      # -v 的日志量（本机实测约 2500 行）远小于「红了但不知道为什么」的代价。
       - name: Build Windows release
         working-directory: fushi
         run: >-
-          flutter build windows --release
+          flutter build windows --release -v
           --build-name "${{ steps.channel.outputs.build_version_name }}"
           --build-number "${{ steps.channel.outputs.release_sequence }}"
+      # 失败时把 CMake 自己的日志捞出来：-v 打的是 flutter 侧，CMake 配置期的
+      # 报错只在这两个文件里。artifact 而不是 echo，避免再被日志截断吃掉。
+      - name: Upload Windows build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-release-build-logs
+          path: |
+            fushi/build/windows/x64/CMakeFiles/CMakeOutput.log
+            fushi/build/windows/x64/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Bundle pinned Mihon desktop runtime
         shell: pwsh
         run: |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1589](bugs/BUG-1589-windows-release-build-red-and-invisible.md) | ✅ | ✅ | Windows 发布构建固定红，且真错误被 MSBuild 折叠得看不见 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/bugs/BUG-1589-windows-release-build-red-and-invisible.md
+++ b/docs/bugs/BUG-1589-windows-release-build-red-and-invisible.md
@@ -1,0 +1,11 @@
+## BUG-1589 · Windows 发布构建固定红，且真错误被 MSBuild 折叠得看不见
+- **报告**：2026-08-13（排查 BUG-1586 时发现：`v1.4.0-beta.9473` 只有 ipa+zip，没有 Windows setup）
+- **真实性**：✅ 真 bug（两条，第二条是第一条查不下去的原因）。
+  - **红**：`release-desktop.yml` 的 `windows` job 在 develop `62d5d8679` 上失败（run 31619461990），单独重跑 windows job（attempt 3）**同样失败**——不是并发伪红。连锁后果：同 run 的 `Publish mirror update manifest` 报 `No files matched fushi-*-windows-setup.exe` 而挂，于是 `latest-beta.json` 从未写出、`v1.4.0-beta.9473` 成了只有 ipa+zip 的半成品发布。
+  - **看不见**：日志里只有两行——`Target dart_build failed : error : Building native assets failed.` 和 `error MSB8066: Custom build ... exited with code`。MSBuild 把自定义生成步骤的真实报错整个折叠掉了。
+  - **本机复现不出来**：本机 `flutter build windows --release -v` **顺利通过 native assets**（`fushidicts_ffi.dll` 已产出并安装），失败在更后面的 `cmake_install.cmake:429`「Missing required Windows download runtime: fushi_torrent_ffi.dll」——那是每 worktree 需先跑 `native/fushi_torrent/build_windows_dll.ps1` 的本地前置条件，与 CI 那条不是同一处。
+  - **为什么「CI 全绿」从没暴露它**：验证构建 `build-multiplatform.yml` 的 windows job 跑的是 `flutter build windows --debug`（**不走 AOT**），发布构建跑 `--release`。两者根本不是同一种构建。这与 BUG-1588（TMDB key 只注入验证构建）是同一种病：**把验证构建的绿当成发布构建的绿**。
+  - 另注：`editbin /STACK` 那个 gen_snapshot 栈溢出 workaround 只存在于本机 SDK，仓库/CI 里**一处都没有**（`grep -rn "editbin\|/STACK\|gen_snapshot" .github/ tool/ ci/ docs/` 全空）。它是否是本红的成因待 `-v` 日志确认，不先下结论。
+- **[x] ① 已修复（可见性这一半）** — `release-desktop.yml` 的 Windows 发布构建加 `-v`（本机正是靠它拿到被折叠的真错误），并新增 `if: failure()` 步骤把 `CMakeOutput.log` / `CMakeError.log` 传成 artifact（`-v` 打的是 flutter 侧，CMake 配置期报错只在这两个文件里）。**红本身尚未修**：根因必须等下一次 CI 跑出 `-v` 日志才能定，盲改等于赌。
+- **[x] ② 已加自动化测试** — `fushi/test/build/release_build_diagnosability_guard_test.dart`（4 条）：发布构建必须带 `-v`；失败时必须上传 CMake 日志且挂 `if: failure()`；并把「验证构建是 debug、发布构建是 release」这一**当前事实**钉住——谁改动其中一边，这条会红，逼他回来确认「验证绿 ≠ 发布绿」这个前提是否还成立。变异实测：去掉 `-v` → 红；还原 → 4 条全绿。
+- **备注**：修完可见性后需要一次 `workflow_dispatch`（`channel=debug`）跑出真日志。该动作会产出一个 debug 通道预发布，属于对外动作，等用户点头再发。

--- a/fushi/test/build/release_build_diagnosability_guard_test.dart
+++ b/fushi/test/build/release_build_diagnosability_guard_test.dart
@@ -51,7 +51,7 @@ void main() {
     expect(releaseText, contains('CMakeFiles/CMakeError.log'),
         reason: '-v 打的是 flutter 侧；CMake 配置期的报错只在 CMakeOutput.log / '
             'CMakeError.log 里。失败时不捞出来就等于没有。');
-    expect(releaseText, contains("if: failure()"),
+    expect(releaseText, contains('if: failure()'),
         reason: '日志上传步骤必须挂 if: failure()，否则成功时白传一份。');
   });
 

--- a/fushi/test/build/release_build_diagnosability_guard_test.dart
+++ b/fushi/test/build/release_build_diagnosability_guard_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：**发布构建失败时必须能看见真错误**，以及别再拿 debug 构建冒充发布验证。
+///
+/// ## 起因（BUG-1589）
+///
+/// `release-desktop.yml` 的 Windows 发布构建在 develop 上固定红，而日志里只有：
+///
+///     Target dart_build failed : error : Building native assets failed.
+///     error MSB8066: Custom build for '...' exited with code ...
+///
+/// MSBuild 把自定义生成步骤的真实报错整个折叠掉了。本机用 `-v` 跑同一条命令才
+/// 拿到真正的 CMake 报错——也就是说，**没有 `-v` 就没有根因**，只能反复重跑。
+///
+/// 同时暴露出更要命的一点：验证构建（`build-multiplatform.yml`）跑的是
+/// `flutter build windows --debug`，**不走 AOT**；发布构建跑的是 `--release`。
+/// 两者根本不是同一种构建，所以「CI 全绿」从来没有覆盖过发布路径。这和
+/// BUG-1588（TMDB key 只注入验证构建、发出去的包没有）是同一种病：**把验证
+/// 构建的绿当成发布构建的绿**。
+void main() {
+  final File releaseDesktop = File('../.github/workflows/release-desktop.yml');
+  final File validation = File('../.github/workflows/build-multiplatform.yml');
+
+  test('前置：两条 workflow 都在', () {
+    expect(releaseDesktop.existsSync(), isTrue,
+        reason: 'expected ${releaseDesktop.absolute.path}');
+    expect(validation.existsSync(), isTrue,
+        reason: 'expected ${validation.absolute.path}');
+  });
+
+  final String releaseText =
+      releaseDesktop.existsSync() ? releaseDesktop.readAsStringSync() : '';
+  final String validationText =
+      validation.existsSync() ? validation.readAsStringSync() : '';
+
+  test('Windows 发布构建带 -v，失败时真错误不会被 MSBuild 折叠掉', () {
+    expect(releaseText, contains('flutter build windows --release'),
+        reason: 'Windows 发布构建步骤不见了？本守卫失去锚点，先修守卫。');
+    expect(
+      releaseText,
+      contains('flutter build windows --release -v'),
+      reason: '发布构建必须带 -v。没有它时 MSBuild 只会吐 '
+          '`Target dart_build failed` + `MSB8066` 两行，真正的 CMake/hook 报错'
+          '被整个折叠——BUG-1589 就是这样连续两次重跑都拿不到根因。',
+    );
+  });
+
+  test('Windows 发布构建失败时会把 CMake 日志传成 artifact', () {
+    expect(releaseText, contains('CMakeFiles/CMakeError.log'),
+        reason: '-v 打的是 flutter 侧；CMake 配置期的报错只在 CMakeOutput.log / '
+            'CMakeError.log 里。失败时不捞出来就等于没有。');
+    expect(releaseText, contains("if: failure()"),
+        reason: '日志上传步骤必须挂 if: failure()，否则成功时白传一份。');
+  });
+
+  test('验证构建是 debug、发布构建是 release —— 别把前者的绿当后者的绿', () {
+    // 这条不是要求「必须不同」，而是把**当前事实**钉在测试里：一旦有人把验证
+    // 构建也改成 --release（或反过来），这条会红，逼着改的人回来读上面那段
+    // 注释，明白「验证绿 ≠ 发布绿」这个前提是否还成立。
+    expect(validationText, contains('flutter build windows --debug'),
+        reason: '验证构建原本是 --debug（不走 AOT）。若已改成 --release，'
+            '请更新本守卫与 docs/agent/build.md 的相应描述——'
+            '「CI 全绿覆盖了发布路径吗」这个问题的答案随之改变。');
+  });
+}


### PR DESCRIPTION
Windows 发布构建在 develop 上**固定红**（单独重跑 windows job，attempt 3 同样红 —— 不是并发伪红），而日志里只有两行:

```
Target dart_build failed : error : Building native assets failed.
error MSB8066: Custom build for '...' exited with code ...
```

MSBuild 把自定义生成步骤的真实报错整个折叠掉了。**连续两次重跑都拿不到根因。**

## 连锁后果

同 run 的 `Publish mirror update manifest` 报 `No files matched fushi-*-windows-setup.exe` 而挂 → `latest-beta.json` 从未写出 → `v1.4.0-beta.9473` 成了只有 ipa+zip 的半成品发布。

## 本机复现不出来（重要）

本机 `flutter build windows --release -v` **顺利通过 native assets**（`fushidicts_ffi.dll` 已产出并安装），失败在更后面的 `cmake_install.cmake:429`「Missing required Windows download runtime: fushi_torrent_ffi.dll」——那是每 worktree 需先跑 `build_windows_dll.ps1` 的本地前置条件，**与 CI 那处不是同一个**。

## 顺带查明：为什么「CI 全绿」从没暴露它

| workflow | Windows 构建命令 |
|---|---|
| `build-multiplatform.yml`（验证，绿） | `flutter build windows **--debug**` |
| `release-desktop.yml`（发布，红） | `flutter build windows **--release**` |

**根本不是同一种构建**——debug 不走 AOT。这与 #810 的 BUG-1588（TMDB key 只注入验证构建、发出去的包没有）是同一种病：**把验证构建的绿当成发布构建的绿**。

另注：`editbin /STACK` 那个 gen_snapshot 栈溢出 workaround 只存在于本机 SDK，仓库与 CI 里**一处都没有**（`grep -rn 'editbin|/STACK|gen_snapshot' .github/ tool/ ci/ docs/` 全空）。它是否是本红的成因，等 `-v` 日志确认，**不先下结论**。

## 本 PR 的范围

**只修可见性这一半**，红本身没修——根因必须等下一次 CI 跑出 `-v` 日志才能定，盲改等于赌。

- Windows 发布构建加 `-v`（本机正是靠它拿到被折叠的真错误；实测约 2500 行，远小于「红了但不知道为什么」的代价）
- 新增 `if: failure()` 步骤把 `CMakeOutput.log` / `CMakeError.log` 传成 artifact（`-v` 打的是 flutter 侧，CMake 配置期报错只在这两个文件里）

## 守卫

`release_build_diagnosability_guard_test.dart`（4 条）：发布构建必须带 `-v`；失败必须上传 CMake 日志且挂 `if: failure()`；并把「验证构建=debug / 发布构建=release」这一**当前事实**钉住——谁改动其中一边，这条会红，逼他回来确认「验证绿 ≠ 发布绿」这个前提是否还成立。

变异实测：去掉 `-v` → 红；还原 → 4 条全绿。

## 下一步需要你点头

修完可见性后要跑一次 `workflow_dispatch`（`channel=debug`）才能拿到真日志。该动作会产出一个 debug 通道预发布，属于对外动作，等你同意再发。