### PR TITLE
feat(subscription): 候选列表按订阅生效单位聚合，不再一集一行（BUG-1590）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1590](bugs/BUG-1590-subscription-candidate-list-not-aggregated.md) | ✅ | ✅ | 订阅候选列表按发布逐条列，与订阅生效单位不一致 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1492 条。点号进各自文件。
+> 共 1493 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1591](bugs/BUG-1591-download-priority-has-no-write-entry.md) | ✅ | ✅ | priority 列参与排序却无写入口，排队退化成先来后到 |
 | [BUG-1590](bugs/BUG-1590-subscription-candidate-list-not-aggregated.md) | ✅ | ✅ | 订阅候选列表按发布逐条列，与订阅生效单位不一致 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |

--- a/docs/bugs/BUG-1590-subscription-candidate-list-not-aggregated.md
+++ b/docs/bugs/BUG-1590-subscription-candidate-list-not-aggregated.md
@@ -1,0 +1,11 @@
+## BUG-1590 · 订阅候选列表按发布逐条列，与订阅生效单位不一致
+- **报告**：2026-08-13（用户截图：订阅页搜 `Re:Zero kara Hajimeru Isekai Seikatsu 4th Season`，列表里是同一字幕组同一分辨率的 08/10/07/06/01/02/04… 一集一行。原话：「这里订阅的时候，重复的数据太多了，优化一下」）
+- **真实性**：✅ 真 bug（是设计缺陷不是渲染 bug）。根因 `fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart` 的结果列表 `itemCount: result.items.length`——**行单位是「一个发布」，而订阅的生效单位是「一条规则」**（页面自己写着「将追踪 Erai-raws · 1080p，有新的单集发布时自动加入下载」）。同一条规则命中十几集，列表就重复十几行，用户要在视觉噪声里找那条规则。
+- **[x] ① 已修复** — 新增纯函数 `groupVideoSubscriptionCandidates()`：**订阅模式下**把结果按订阅生效单位聚合成一行；下载模式保持一集一行（那时用户要挑的就是具体某个发布）。
+  - **分组键直接取 `deriveStrictVideoSubscriptionFilter()` 产出的 `filter.json`**，不另发明键。理由：那个函数就是「两个发布订起来是不是同一条」的**定义本身**。自己写「releaseGroup + resolution」看着等价，但 nyaa 还锁 `trusted`、torznab 还锁 source/codec/language，键漏一维就会把本该分开的两条规则合成一行——用户订到的和看到的不是一回事。用定义当键，这种漂移不可能发生。
+  - 代表条取做种最多者，并列时按发布时间、再按标题字典序——**全序**，同一份结果每次渲染同一行，列表不跳。
+  - 行序 = 各组首次出现序，聚合不改变用户已习惯的排序。
+  - 推不出 filter 的条目（版本证据不足、本就不能订阅）**不聚合**，各占一行照旧显示、提交时由既有校验拒绝；并成一坨只会让「为什么订不了」更难看懂。
+  - 聚合行补两项元数据：`video_subscription_group_release_count`（共 N 个发布，17 语言经 `i18n_sync --add` + `dart run slang`）与集数区间 `EP1-EP12`，否则用户看到一行会以为只订到一集。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_subscription_candidate_grouping_test.dart`（5 条）：多集聚合成一行且集数/最新时间/代表条正确；**`trusted` 不同必须分成两行**（正是「自己发明分组键」会合错的那一格）；分辨率/字幕组不同各自成行；不可订阅条目不聚合且排在后面；聚合稳定性（同一输入两次渲染结果一致、行序不跳）。变异实测：把分组键换成 `releaseGroup + resolution` → `trusted` 那条红；还原 → 5 条全绿。`test/pages` 全组 2781 条绿，`flutter analyze` 全量 No issues found。
+- **备注**：只改订阅模式的行单位，下载模式与提交/校验链路一字未动。

--- a/docs/bugs/BUG-1591-download-priority-has-no-write-entry.md
+++ b/docs/bugs/BUG-1591-download-priority-has-no-write-entry.md
@@ -1,0 +1,17 @@
+## BUG-1591 · priority 列参与排序却无写入口，排队退化成先来后到
+- **报告**：2026-08-13（用户：「下载，没有自动重试，没办法设置每个任务的优先权」）
+- **真实性**：✅ 真 bug（后半句）。❌ 前半句未复现——自动重试**已经有**，详见备注。
+  - `VideoDownloadJobs.priority`（`tables.dart:1983`，默认 0）**早就参与取任务排序**：`database_video_domain.part.dart` 三处 `OrderingTerm.desc(t.priority)`，外加专门的索引 `(lifecycle, next_attempt_at, priority DESC, created_at)`。
+  - 但**没有任何写入口**：它只在建任务时从 `request.priority` 带一次（`video_download_pipeline_service.dart:516`），而所有调用方都用默认值 0。DAO 层也没有任何 update 触及这一列。
+  - 结果：这一列恒为 0，`priority DESC` 恒为常量排序，实际排队退化成纯 `created_at` 先来后到。用户想让某个任务插队时无从下手。
+- **[x] ① 已修复** —
+  - DAO 新增 `setVideoDownloadJobPriority({jobId, priority, nowAt})`：只改 `priority` 与 `updatedAt`。优先级是排队意图，不该顺带动生命周期/阶段/重试预算——那些各有各的入口。
+  - 服务层新增 `VideoDownloadPipelineService.setJobPriority()`，写完立刻 `wake()`：优先级只在「下一次取任务」时生效，不唤醒的话用户会看到调了没反应直到下个轮询周期，观感上等于没生效。
+  - UI：任务卡新增优先级菜单（高 `1` / 普通 `0` / 低 `-1`），**绝对赋值而非加减**——加减实现下同一档点两次会漂。菜单只对 `active` / `needsAttention` 的任务显示：已完成/已取消的任务调了也不会被重新取走，露出来等于骗用户能插队。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_download_jobs_panel_test.dart` 新增 2 条：选「高」必须原样把 `1` 交给宿主（钉死绝对赋值语义）；已完成任务不给优先级入口。面板全组 18 条绿，`flutter analyze` 全量 No issues found。
+- **备注（前半句「没有自动重试」未复现）**：自动重试链路完整存在——
+  - `_observeDownload()` 发现内置引擎丢了任务时自动 `rewindVideoDownloadJobToEnqueue()` 重挂，并**消耗重试预算**（防止「永远重排、UI 上永远 active」）；
+  - `_advance()` 回到 download 阶段时 `resetAttempts: false`，不给反复丢任务的作业退还预算；
+  - 订阅侧有指数退避 `_retryDelay()`；另有用户显式 `retryJob()`。
+  - 非内置后端（外接 qBittorrent）故意不自动重加：外部服务器丢没丢任务不是本地能断言的。
+  - 用户之所以觉得「没有自动重试」，是 BUG-1587 那句误诊文案——排队等槽位的任务被写成「该 torrent 已不在引擎中」，看着就像卡死没人管。修完那句之后这个错觉自然消失。**故不新增第二套重试机制。**

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57239 (3367 per locale)
+/// Strings: 57307 (3371 per locale)
 ///
-/// Built on 2026-08-13 at 08:22 UTC
+/// Built on 2026-08-13 at 08:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4557,6 +4557,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Book deleted, but its audiobook could not be removed on the paired device';
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  String get download_task_priority => 'Queue priority';
+  String get download_task_priority_high => 'High';
+  String get download_task_priority_normal => 'Normal';
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -12331,6 +12335,14 @@ class _StringsAr extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -20172,6 +20184,14 @@ class _StringsDe extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -28029,6 +28049,14 @@ class _StringsEs extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -35898,6 +35926,14 @@ class _StringsFr extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -43695,6 +43731,14 @@ class _StringsId extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -51538,6 +51582,14 @@ class _StringsIt extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -59195,6 +59247,14 @@ class _StringsJa extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -66859,6 +66919,14 @@ class _StringsKo extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -74682,6 +74750,14 @@ class _StringsNl extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -82517,6 +82593,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -90338,6 +90422,14 @@ class _StringsRu extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -98107,6 +98199,14 @@ class _StringsTh extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -105907,6 +106007,14 @@ class _StringsTr extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -113692,6 +113800,14 @@ class _StringsVi extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 // Path: <root>
@@ -120911,6 +121027,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '共 ${count} 个发布';
+  @override
+  String get download_task_priority => '排队优先级';
+  @override
+  String get download_task_priority_high => '高';
+  @override
+  String get download_task_priority_normal => '普通';
+  @override
+  String get download_task_priority_low => '低';
 }
 
 // Path: <root>
@@ -128491,6 +128615,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
+  @override
+  String get download_task_priority => 'Queue priority';
+  @override
+  String get download_task_priority_high => 'High';
+  @override
+  String get download_task_priority_normal => 'Normal';
+  @override
+  String get download_task_priority_low => 'Low';
 }
 
 /// Flat map(s) containing all translations.
@@ -135407,6 +135539,14 @@ extension on _StringsEn {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -142321,6 +142461,14 @@ extension on _StringsAr {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -149257,6 +149405,14 @@ extension on _StringsDe {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -156192,6 +156348,14 @@ extension on _StringsEs {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -163133,6 +163297,14 @@ extension on _StringsFr {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -170056,6 +170228,14 @@ extension on _StringsId {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -176993,6 +177173,14 @@ extension on _StringsIt {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -183892,6 +184080,14 @@ extension on _StringsJa {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -190795,6 +190991,14 @@ extension on _StringsKo {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -197726,6 +197930,14 @@ extension on _StringsNl {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -204654,6 +204866,14 @@ extension on _StringsPtBr {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -211587,6 +211807,14 @@ extension on _StringsRu {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -218503,6 +218731,14 @@ extension on _StringsTh {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -225428,6 +225664,14 @@ extension on _StringsTr {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -232349,6 +232593,14 @@ extension on _StringsVi {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }
@@ -239212,6 +239464,14 @@ extension on _StringsZhCn {
         return '书已在对端删除，但它的有声书没能删掉';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '共 ${count} 个发布';
+      case 'download_task_priority':
+        return '排队优先级';
+      case 'download_task_priority_high':
+        return '高';
+      case 'download_task_priority_normal':
+        return '普通';
+      case 'download_task_priority_low':
+        return '低';
       default:
         return null;
     }
@@ -246106,6 +246366,14 @@ extension on _StringsZhHk {
         return 'Book deleted, but its audiobook could not be removed on the paired device';
       case 'video_subscription_group_release_count':
         return ({required Object count}) => '${count} releases';
+      case 'download_task_priority':
+        return 'Queue priority';
+      case 'download_task_priority_high':
+        return 'High';
+      case 'download_task_priority_normal':
+        return 'Normal';
+      case 'download_task_priority_low':
+        return 'Low';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57222 (3366 per locale)
+/// Strings: 57239 (3367 per locale)
 ///
-/// Built on 2026-08-12 at 11:23 UTC
+/// Built on 2026-08-13 at 08:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4555,6 +4555,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -12326,6 +12328,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -20164,6 +20169,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -28018,6 +28026,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -35884,6 +35895,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -43678,6 +43692,9 @@ class _StringsId extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -51518,6 +51535,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -59172,6 +59192,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -66833,6 +66856,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -74653,6 +74679,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -82485,6 +82514,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -90303,6 +90335,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -98069,6 +98104,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -105866,6 +105904,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -113648,6 +113689,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 // Path: <root>
@@ -120864,6 +120908,9 @@ class _StringsZhCn extends _StringsEn {
       '选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。';
   @override
   String get remote_delete_audiobook_partial => '书已在对端删除，但它的有声书没能删掉';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '共 ${count} 个发布';
 }
 
 // Path: <root>
@@ -128441,6 +128488,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get remote_delete_audiobook_partial =>
       'Book deleted, but its audiobook could not be removed on the paired device';
+  @override
+  String video_subscription_group_release_count({required Object count}) =>
+      '${count} releases';
 }
 
 /// Flat map(s) containing all translations.
@@ -135355,6 +135405,8 @@ extension on _StringsEn {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -142267,6 +142319,8 @@ extension on _StringsAr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -149201,6 +149255,8 @@ extension on _StringsDe {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -156134,6 +156190,8 @@ extension on _StringsEs {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -163073,6 +163131,8 @@ extension on _StringsFr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -169994,6 +170054,8 @@ extension on _StringsId {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -176929,6 +176991,8 @@ extension on _StringsIt {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -183826,6 +183890,8 @@ extension on _StringsJa {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -190727,6 +190793,8 @@ extension on _StringsKo {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -197656,6 +197724,8 @@ extension on _StringsNl {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -204582,6 +204652,8 @@ extension on _StringsPtBr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -211513,6 +211585,8 @@ extension on _StringsRu {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -218427,6 +218501,8 @@ extension on _StringsTh {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -225350,6 +225426,8 @@ extension on _StringsTr {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -232269,6 +232347,8 @@ extension on _StringsVi {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }
@@ -239130,6 +239210,8 @@ extension on _StringsZhCn {
         return '选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。';
       case 'remote_delete_audiobook_partial':
         return '书已在对端删除，但它的有声书没能删掉';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '共 ${count} 个发布';
       default:
         return null;
     }
@@ -246022,6 +246104,8 @@ extension on _StringsZhHk {
         return 'Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.';
       case 'remote_delete_audiobook_partial':
         return 'Book deleted, but its audiobook could not be removed on the paired device';
+      case 'video_subscription_group_release_count':
+        return ({required Object count}) => '${count} releases';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "清除已存指纹并重新信任",
   "sync_pair_fingerprint_changed_body": "这条地址此前钉扎的是另一张证书。只有在你确知对方重装/重置过设备时才继续，否则连接可能正被中间人拦截。",
   "interconnect_upload_section_footer": "选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。",
-  "remote_delete_audiobook_partial": "书已在对端删除，但它的有声书没能删掉"
+  "remote_delete_audiobook_partial": "书已在对端删除，但它的有声书没能删掉",
+  "video_subscription_group_release_count": "共 $count 个发布"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "这条地址此前钉扎的是另一张证书。只有在你确知对方重装/重置过设备时才继续，否则连接可能正被中间人拦截。",
   "interconnect_upload_section_footer": "选择本设备要把哪些内容上传给已连接的互联对端。与云备份的同名开关互不影响，且默认全部关闭。本组开关只在「启用互联」打开时生效：关掉互联，这里的上传全部停止。",
   "remote_delete_audiobook_partial": "书已在对端删除，但它的有声书没能删掉",
-  "video_subscription_group_release_count": "共 $count 个发布"
+  "video_subscription_group_release_count": "共 $count 个发布",
+  "download_task_priority": "排队优先级",
+  "download_task_priority_high": "高",
+  "download_task_priority_normal": "普通",
+  "download_task_priority_low": "低"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3364,5 +3364,6 @@
   "sync_pair_fingerprint_retrust": "Clear and trust again",
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
-  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device"
+  "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
+  "video_subscription_group_release_count": "$count releases"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3365,5 +3365,9 @@
   "sync_pair_fingerprint_changed_body": "This address was pinned to a different certificate before. Continue only if you know the peer reinstalled or reset it — otherwise someone may be intercepting the connection.",
   "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from the cloud backup switches and off by default. These switches only apply while Enable interconnect is on: turning interconnect off stops every upload here.",
   "remote_delete_audiobook_partial": "Book deleted, but its audiobook could not be removed on the paired device",
-  "video_subscription_group_release_count": "$count releases"
+  "video_subscription_group_release_count": "$count releases",
+  "download_task_priority": "Queue priority",
+  "download_task_priority_high": "High",
+  "download_task_priority_normal": "Normal",
+  "download_task_priority_low": "Low"
 }

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -593,6 +593,19 @@ class VideoDownloadPipelineService {
     return subtitleId;
   }
 
+  /// 用户显式调整排队优先级。数值越大越先被取走（DAO 侧 `priority DESC`）。
+  ///
+  /// 写完立刻 [wake]：优先级只在「下一次取任务」时才起作用，不唤醒的话用户会看到
+  /// 调了没反应，直到下一个轮询周期——那和没生效在观感上没区别。
+  Future<void> setJobPriority(String jobId, int priority) async {
+    await database.setVideoDownloadJobPriority(
+      jobId: jobId,
+      priority: priority,
+      nowAt: DateTime.now().millisecondsSinceEpoch,
+    );
+    wake();
+  }
+
   Future<void> retryJob(String jobId) async {
     final VideoDownloadJobRow? job = await database.getVideoDownloadJob(jobId);
     if (job == null) {

--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -288,6 +288,16 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                                 ),
                               );
                             },
+                            onSetPriority:
+                                (VideoDownloadJobRow job, int priority) async {
+                              final pipeline = ref
+                                  .read(appProvider)
+                                  .videoDownloadPipelineService;
+                              await pipeline?.setJobPriority(
+                                job.jobId,
+                                priority,
+                              );
+                            },
                             locationLoader: (VideoDownloadJobRow job) async {
                               final pipeline = ref
                                   .read(appProvider)

--- a/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
@@ -214,6 +214,131 @@ StrictVideoSubscriptionFilter? deriveStrictVideoSubscriptionFilter(
   );
 }
 
+/// 订阅候选列表里的一行：一条**可订阅的规则**，而不是一个发布。
+@immutable
+class VideoSubscriptionCandidateGroup {
+  const VideoSubscriptionCandidateGroup({
+    required this.representative,
+    required this.filter,
+    required this.memberCount,
+    required this.episodeNumbers,
+    required this.latestPublishedAt,
+  });
+
+  /// 用来推出订阅规则、也用来喂下游下载选择的那一条。同组任意一条推出的
+  /// filter 都相同（分组键就是它），选谁都不影响订阅本身。
+  final VideoResourceCandidate representative;
+
+  /// `null` 表示这一条没有足够的版本证据、根本不能建订阅（UI 照旧显示它并在
+  /// 提交时拒绝，不静默吞掉）。
+  final StrictVideoSubscriptionFilter? filter;
+
+  /// 这条规则在当前搜索结果里命中了几个发布。
+  final int memberCount;
+
+  /// 命中发布里能解析出的集数（升序、去重）；解析不出的不计入。
+  final List<int> episodeNumbers;
+
+  final DateTime? latestPublishedAt;
+}
+
+/// 把搜索结果按**订阅生效单位**聚合。
+///
+/// ## 为什么分组键是 `filter.json` 而不是「字幕组 × 分辨率」
+///
+/// 用户报障：订阅页搜一部番，列表里是同一个字幕组同一分辨率的十几集，一集一
+/// 行，「重复的数据太多了」。根子在于**列表的行单位与订阅的生效单位不一致**：
+/// 订阅追踪的是「Erai-raws · 1080p」这条规则，而列表按发布逐条列。
+///
+/// 于是分组键直接取 [deriveStrictVideoSubscriptionFilter] 的产物 `json`——它
+/// 就是「这两个发布订起来是不是同一条」的**定义本身**。自己另写一个
+/// 「releaseGroup + resolution」的键看着等价，但 nyaa 还锁 `trusted`、torznab
+/// 还锁 source/codec/language，键一旦漏掉其中一维，两条本该分开的规则会被合成
+/// 一行，用户订到的和看到的就不是一回事。用定义当键，这种漂移不可能发生。
+///
+/// 推不出 filter 的条目（版本证据不足）**不聚合**：它们各占一行，保持原样显示，
+/// 提交时由既有校验拒绝。把它们并成一坨只会让「为什么订不了」更难看懂。
+List<VideoSubscriptionCandidateGroup> groupVideoSubscriptionCandidates(
+  List<VideoResourceCandidate> candidates,
+) {
+  final Map<String, List<VideoResourceCandidate>> byFilter =
+      <String, List<VideoResourceCandidate>>{};
+  final Map<String, StrictVideoSubscriptionFilter> filters =
+      <String, StrictVideoSubscriptionFilter>{};
+  final List<VideoSubscriptionCandidateGroup> ungroupable =
+      <VideoSubscriptionCandidateGroup>[];
+  // 保持来源顺序：Map 的插入序即首次出现序，用户看到的排序不会因聚合而抖动。
+  final List<String> order = <String>[];
+
+  for (final VideoResourceCandidate candidate in candidates) {
+    final StrictVideoSubscriptionFilter? filter =
+        deriveStrictVideoSubscriptionFilter(candidate);
+    if (filter == null) {
+      ungroupable.add(
+        VideoSubscriptionCandidateGroup(
+          representative: candidate,
+          filter: null,
+          memberCount: 1,
+          episodeNumbers: const <int>[],
+          latestPublishedAt: candidate.publishedAt,
+        ),
+      );
+      continue;
+    }
+    if (!byFilter.containsKey(filter.json)) {
+      byFilter[filter.json] = <VideoResourceCandidate>[];
+      filters[filter.json] = filter;
+      order.add(filter.json);
+    }
+    byFilter[filter.json]!.add(candidate);
+  }
+
+  final List<VideoSubscriptionCandidateGroup> grouped =
+      <VideoSubscriptionCandidateGroup>[];
+  for (final String key in order) {
+    final List<VideoResourceCandidate> members = byFilter[key]!;
+    // 代表条：做种最多的那条（最可能拉得动）；并列时取最新发布，再并列取标题
+    // 字典序——**全序**，同一份搜索结果每次渲染都得到同一行，不会跳。
+    final List<VideoResourceCandidate> sorted =
+        List<VideoResourceCandidate>.of(members)
+          ..sort((VideoResourceCandidate a, VideoResourceCandidate b) {
+            final int bySeeders = b.seeders.compareTo(a.seeders);
+            if (bySeeders != 0) return bySeeders;
+            final DateTime? pa = a.publishedAt;
+            final DateTime? pb = b.publishedAt;
+            if (pa != null && pb != null) {
+              final int byDate = pb.compareTo(pa);
+              if (byDate != 0) return byDate;
+            } else if (pa != pb) {
+              return pa == null ? 1 : -1;
+            }
+            return a.title.compareTo(b.title);
+          });
+    final Set<int> episodes = <int>{};
+    DateTime? latest;
+    for (final VideoResourceCandidate member in members) {
+      final int? episode = episodeNumberFromReleaseTitle(member.title);
+      if (episode != null) episodes.add(episode);
+      final DateTime? published = member.publishedAt;
+      if (published != null && (latest == null || published.isAfter(latest))) {
+        latest = published;
+      }
+    }
+    grouped.add(
+      VideoSubscriptionCandidateGroup(
+        representative: sorted.first,
+        filter: filters[key],
+        memberCount: members.length,
+        episodeNumbers: (episodes.toList()..sort()),
+        latestPublishedAt: latest,
+      ),
+    );
+  }
+
+  // 可订阅的排前面：它们才是这个页面要用户挑的东西。
+  return <VideoSubscriptionCandidateGroup>[...grouped, ...ungroupable];
+}
+
 int? episodeNumberFromReleaseTitle(String title) {
   final RegExpMatch? seasonEpisode = RegExp(
     r'\bS\d{1,3}[ ._-]*E(\d{1,4})(?:v\d+)?\b',
@@ -980,11 +1105,18 @@ class _VideoResourceSearchSurfaceState
     if (result.items.isEmpty) {
       return Center(child: Text(t.video_discovery_empty));
     }
+    // 订阅模式下行单位 = 订阅生效单位（见 groupVideoSubscriptionCandidates 的
+    // 文档）；下载模式仍是一集一行，用户要挑的就是具体那一个发布。
+    final List<VideoSubscriptionCandidateGroup>? groups = widget.subscription
+        ? groupVideoSubscriptionCandidates(result.items)
+        : null;
     return ListView.builder(
       key: const ValueKey<String>('video-resource-results'),
-      itemCount: result.items.length,
+      itemCount: groups?.length ?? result.items.length,
       itemBuilder: (BuildContext context, int index) {
-        final VideoResourceCandidate candidate = result.items[index];
+        final VideoSubscriptionCandidateGroup? group = groups?[index];
+        final VideoResourceCandidate candidate =
+            group?.representative ?? result.items[index];
         final List<String> metadata = <String>[
           candidate.providerId,
           candidate.providerInstanceId,
@@ -1000,6 +1132,19 @@ class _VideoResourceSearchSurfaceState
           if (candidate.publishedAt case final DateTime published)
             _compactDate(published),
         ];
+        // 聚合行：把「这条规则覆盖了多少个发布 / 哪些集」说清楚，否则用户看到
+        // 一行会以为只订到一集。
+        if (group != null && group.memberCount > 1) {
+          metadata.add(
+            t.video_subscription_group_release_count(count: group.memberCount),
+          );
+          final List<int> episodes = group.episodeNumbers;
+          if (episodes.isNotEmpty) {
+            metadata.add(episodes.length == 1
+                ? 'EP${episodes.first}'
+                : 'EP${episodes.first}-${episodes.last}');
+          }
+        }
         return FushiListItem(
           key: ValueKey<String>('video-resource-${candidate.identityKey}'),
           title: Text(candidate.title),

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -59,6 +59,12 @@ final class DatabaseVideoDownloadJobsPanelStore
       database.watchVideoDownloadJobs();
 }
 
+/// 调整单个任务的排队优先级。数值越大越先被取走（DAO 侧 `priority DESC`）。
+typedef VideoDownloadJobPriorityAction = Future<void> Function(
+  VideoDownloadJobRow job,
+  int priority,
+);
+
 /// Compact task surface for schema-v78 durable video downloads.
 ///
 /// Retrying and cancelling are deliberately action ports rather than direct DB
@@ -72,6 +78,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
     this.onResume,
     this.onCancel,
     this.onOpenDetails,
+    this.onSetPriority,
     this.locationLoader,
     this.onDelete,
     this.pathRevealer = revealVideoDownloadPath,
@@ -88,6 +95,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
     VideoDownloadJobAction? onResume,
     VideoDownloadJobAction? onCancel,
     VideoDownloadJobAction? onOpenDetails,
+    VideoDownloadJobPriorityAction? onSetPriority,
     VideoDownloadJobLocationLoader? locationLoader,
     VideoDownloadJobDeleteAction? onDelete,
     VideoDownloadPathRevealer pathRevealer = revealVideoDownloadPath,
@@ -103,6 +111,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
         onResume: onResume,
         onCancel: onCancel,
         onOpenDetails: onOpenDetails,
+        onSetPriority: onSetPriority,
         locationLoader: locationLoader,
         onDelete: onDelete,
         pathRevealer: pathRevealer,
@@ -119,6 +128,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
   final VideoDownloadJobAction? onResume;
   final VideoDownloadJobAction? onCancel;
   final VideoDownloadJobAction? onOpenDetails;
+  final VideoDownloadJobPriorityAction? onSetPriority;
   final VideoDownloadJobLocationLoader? locationLoader;
   final VideoDownloadJobDeleteAction? onDelete;
   final VideoDownloadPathRevealer pathRevealer;
@@ -313,6 +323,13 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
               onOpenDetails: widget.onOpenDetails == null
                   ? null
                   : () => _runAction(job, widget.onOpenDetails!),
+              onSetPriority: widget.onSetPriority == null
+                  ? null
+                  : (int priority) => _runAction(
+                        job,
+                        (VideoDownloadJobRow row) =>
+                            widget.onSetPriority!(row, priority),
+                      ),
               // Mobile has no file-manager reveal contract; the action would
               // always fail, so it is not offered there.
               onOpenLocation: widget.locationLoader == null ||
@@ -482,6 +499,7 @@ class _VideoDownloadJobCard extends StatelessWidget {
     required this.onResume,
     required this.onCancel,
     required this.onOpenDetails,
+    required this.onSetPriority,
     required this.onOpenLocation,
     required this.onDelete,
     required this.lifecycleLabel,
@@ -497,6 +515,9 @@ class _VideoDownloadJobCard extends StatelessWidget {
   final VoidCallback? onResume;
   final VoidCallback? onCancel;
   final VoidCallback? onOpenDetails;
+
+  /// 传 null 表示宿主没接这个能力（例如只读的历史面板）。
+  final void Function(int priority)? onSetPriority;
   final VoidCallback? onOpenLocation;
   final VoidCallback? onDelete;
   final String Function(String lifecycle)? lifecycleLabel;
@@ -510,6 +531,20 @@ class _VideoDownloadJobCard extends StatelessWidget {
   bool get _canResume => job.lifecycle == VideoDownloadJobLifecycle.cancelled;
 
   bool get _canCancel => job.lifecycle == VideoDownloadJobLifecycle.active;
+
+  /// 优先级只对「还会被取走」的任务有意义。已完成 / 已取消的任务调了也不会重新
+  /// 排队，露出来只会让人以为能插队。
+  bool get _canSetPriority =>
+      job.lifecycle == VideoDownloadJobLifecycle.active ||
+      job.lifecycle == VideoDownloadJobLifecycle.needsAttention;
+
+  /// 数值 -> 档位名。非三档的历史值（理论上不会有，但 DB 不拦）按最接近的一档
+  /// 显示，不显示裸数字——用户看到 `优先级 · 7` 只会困惑。
+  static String _priorityLabel(int priority) {
+    if (priority > 0) return t.download_task_priority_high;
+    if (priority < 0) return t.download_task_priority_low;
+    return t.download_task_priority_normal;
+  }
 
   double get _progress =>
       snapshot?.progress.clamp(0, 1).toDouble() ??
@@ -649,6 +684,7 @@ class _VideoDownloadJobCard extends StatelessWidget {
               (_canCancel && onCancel != null) ||
               onOpenDetails != null ||
               onOpenLocation != null ||
+              onSetPriority != null ||
               onDelete != null) ...<Widget>[
             const SizedBox(height: 8),
             Align(
@@ -707,6 +743,43 @@ class _VideoDownloadJobCard extends StatelessWidget {
                             )
                           : const Icon(Icons.close, size: 18),
                       label: Text(t.cancel),
+                    ),
+                  // 优先级只对「还在排队/还没做完」的任务有意义：已完成或已取消
+                  // 的任务再调也不会被重新取走，给了只会让人以为能插队。
+                  if (onSetPriority != null && _canSetPriority)
+                    PopupMenuButton<int>(
+                      key: ValueKey<String>(
+                        'video-download-job-priority-${job.jobId}',
+                      ),
+                      enabled: !busy,
+                      tooltip: t.download_task_priority,
+                      initialValue: job.priority,
+                      onSelected: onSetPriority,
+                      itemBuilder: (BuildContext context) =>
+                          <PopupMenuEntry<int>>[
+                        PopupMenuItem<int>(
+                          value: 1,
+                          child: Text(t.download_task_priority_high),
+                        ),
+                        PopupMenuItem<int>(
+                          value: 0,
+                          child: Text(t.download_task_priority_normal),
+                        ),
+                        PopupMenuItem<int>(
+                          value: -1,
+                          child: Text(t.download_task_priority_low),
+                        ),
+                      ],
+                      child: OutlinedButton.icon(
+                        // 外层 PopupMenuButton 已接管点击；这里只借用按钮外观，
+                        // onPressed 必须为 null 才不会吞掉菜单的手势。
+                        onPressed: null,
+                        icon: const Icon(Icons.low_priority, size: 18),
+                        label: Text(
+                          '${t.download_task_priority} · '
+                          '${_priorityLabel(job.priority)}',
+                        ),
+                      ),
                     ),
                   if (onOpenLocation != null)
                     OutlinedButton.icon(

--- a/fushi/test/pages/video_download_jobs_panel_test.dart
+++ b/fushi/test/pages/video_download_jobs_panel_test.dart
@@ -687,4 +687,65 @@ void main() {
     expect(deleteCalls, <bool>[false, true, true]);
     expect(tester.takeException(), isNull);
   });
+
+  // 用户报障：「没办法设置每个任务的优先权」。priority 列和 DAO 侧的
+  // `priority DESC` 排序一直都在，缺的就是这个写入口。
+  testWidgets('优先级菜单把选中的档位原样交给宿主（绝对值，不是加减）', (WidgetTester tester) async {
+    final _MemoryJobsStore store = _MemoryJobsStore();
+    addTearDown(store.close);
+    final List<(String, int)> calls = <(String, int)>[];
+    await _pumpPanel(
+      tester,
+      panel: VideoDownloadJobsPanel(
+        store: store,
+        onSetPriority: (VideoDownloadJobRow job, int priority) async {
+          calls.add((job.jobId, priority));
+        },
+      ),
+    );
+    store.emit(<VideoDownloadJobRow>[
+      _job(id: 'active', title: 'Downloading show'),
+    ]);
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-download-job-priority-active')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.download_task_priority_high).last);
+    await tester.pumpAndSettle();
+
+    expect(calls, <(String, int)>[('active', 1)],
+        reason: '菜单选「高」必须原样传 1。用加减实现的话反复点会漂，'
+            '同一档点两次得到不同结果。');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('已完成的任务不给优先级入口（调了也不会被重新取走）', (WidgetTester tester) async {
+    final _MemoryJobsStore store = _MemoryJobsStore();
+    addTearDown(store.close);
+    await _pumpPanel(
+      tester,
+      panel: VideoDownloadJobsPanel(
+        store: store,
+        onSetPriority: (VideoDownloadJobRow job, int priority) async {},
+      ),
+    );
+    store.emit(<VideoDownloadJobRow>[
+      _job(
+        id: 'done',
+        title: 'Finished show',
+        lifecycle: VideoDownloadJobLifecycle.completed,
+        progress: 1,
+        completedAt: 10,
+      ),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('video-download-job-priority-done')),
+      findsNothing,
+      reason: '给一个不会再被取走的任务露出「优先级」，等于骗用户能插队。',
+    );
+  });
 }

--- a/fushi/test/pages/video_subscription_candidate_grouping_test.dart
+++ b/fushi/test/pages/video_subscription_candidate_grouping_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+import 'package:fushi/src/pages/implementations/video_discovery_acquisition_dialogs.dart';
+
+/// 用户报障：订阅页搜一部番，列表里是同一个字幕组同一分辨率的十几集，一集一
+/// 行，「重复的数据太多了」。根子是**列表行单位 ≠ 订阅生效单位**。
+///
+/// 这里钉死聚合语义，尤其是「分组键必须是 filter.json 本身」——自己另写一个
+/// 「releaseGroup + resolution」的键看着等价，但会漏掉 nyaa 的 trusted、
+/// torznab 的 source/codec/language，把本该分开的两条规则合成一行。
+class _Candidate extends VideoResourceCandidate {
+  _Candidate({
+    required super.title,
+    super.providerId = 'nyaa',
+    super.providerInstanceId = 'nyaa.si',
+    String? remoteId,
+    super.providerPriority = 0,
+    super.seeders = 0,
+    super.publishedAt,
+    super.resolution = '1080p',
+    super.releaseGroup = 'Erai-raws',
+    super.trusted = true,
+    super.category = '1_2',
+  }) : super(remoteId: remoteId ?? title);
+}
+
+void main() {
+  DateTime day(int d) => DateTime.utc(2026, 4, d);
+
+  test('同一字幕组同一分辨率的多集聚合成一行，集数区间正确', () {
+    final List<VideoSubscriptionCandidateGroup> groups =
+        groupVideoSubscriptionCandidates(<VideoResourceCandidate>[
+      _Candidate(
+          title: '[Erai-raws] Show - 01 [1080p]',
+          seeders: 10,
+          publishedAt: day(1)),
+      _Candidate(
+          title: '[Erai-raws] Show - 02 [1080p]',
+          seeders: 30,
+          publishedAt: day(2)),
+      _Candidate(
+          title: '[Erai-raws] Show - 04 [1080p]',
+          seeders: 20,
+          publishedAt: day(4)),
+    ]);
+
+    expect(groups, hasLength(1), reason: '三集同规则必须只占一行');
+    expect(groups.single.memberCount, 3);
+    expect(groups.single.episodeNumbers, <int>[1, 2, 4]);
+    expect(groups.single.latestPublishedAt, day(4));
+    expect(groups.single.representative.seeders, 30, reason: '代表条取做种最多的那条');
+  });
+
+  test('trusted 不同必须分成两行——这正是「自己发明分组键」会合错的地方', () {
+    final List<VideoSubscriptionCandidateGroup> groups =
+        groupVideoSubscriptionCandidates(<VideoResourceCandidate>[
+      _Candidate(title: '[Erai-raws] Show - 01 [1080p]', trusted: true),
+      _Candidate(title: '[Erai-raws] Show - 02 [1080p]', trusted: false),
+    ]);
+
+    expect(groups, hasLength(2),
+        reason: 'nyaa 的 filter 锁 trusted，两条订起来不是同一条规则；'
+            '按「releaseGroup + resolution」分组会错误合并。');
+  });
+
+  test('分辨率不同、字幕组不同各自成行', () {
+    final List<VideoSubscriptionCandidateGroup> groups =
+        groupVideoSubscriptionCandidates(<VideoResourceCandidate>[
+      _Candidate(
+          title: 'A - 01', resolution: '1080p', releaseGroup: 'Erai-raws'),
+      _Candidate(
+          title: 'B - 01', resolution: '720p', releaseGroup: 'Erai-raws'),
+      _Candidate(
+          title: 'C - 01', resolution: '1080p', releaseGroup: 'SubsPlease'),
+    ]);
+    expect(groups, hasLength(3));
+  });
+
+  test('推不出订阅规则的条目不聚合、各占一行，且排在可订阅的后面', () {
+    final List<VideoSubscriptionCandidateGroup> groups =
+        groupVideoSubscriptionCandidates(<VideoResourceCandidate>[
+      // nyaa 缺 releaseGroup -> deriveStrictVideoSubscriptionFilter 返回 null
+      _Candidate(title: 'raw upload 1', releaseGroup: null, resolution: null),
+      _Candidate(title: '[Erai-raws] Show - 01 [1080p]'),
+      _Candidate(title: 'raw upload 2', releaseGroup: null, resolution: null),
+    ]);
+
+    expect(groups, hasLength(3));
+    expect(groups.first.filter, isNotNull, reason: '可订阅的排前面');
+    expect(groups[1].filter, isNull);
+    expect(groups[2].filter, isNull);
+    expect(
+        groups.where((VideoSubscriptionCandidateGroup g) => g.filter == null),
+        hasLength(2),
+        reason: '两条不可订阅的必须各占一行，不能被并成一坨——'
+            '并起来只会让「为什么订不了」更难看懂');
+  });
+
+  test('聚合保持来源顺序，且代表条选择是全序（同一输入渲染两次结果一致）', () {
+    final List<VideoResourceCandidate> input = <VideoResourceCandidate>[
+      _Candidate(title: 'B - 01', releaseGroup: 'Bbb', seeders: 5),
+      _Candidate(title: 'A - 01', releaseGroup: 'Aaa', seeders: 5),
+      _Candidate(title: 'B - 02', releaseGroup: 'Bbb', seeders: 5),
+    ];
+    final List<VideoSubscriptionCandidateGroup> first =
+        groupVideoSubscriptionCandidates(input);
+    final List<VideoSubscriptionCandidateGroup> second =
+        groupVideoSubscriptionCandidates(input);
+
+    expect(first.map((VideoSubscriptionCandidateGroup g) => g.filter!.json),
+        second.map((VideoSubscriptionCandidateGroup g) => g.filter!.json));
+    expect(first.first.representative.releaseGroup, 'Bbb',
+        reason: '首次出现序决定行序，聚合不得让列表跳动');
+    // seeders 全并列时靠标题字典序定代表条，两次必须一致。
+    expect(first.first.representative.title, second.first.representative.title);
+  });
+}

--- a/fushi/test/pages/video_subscription_candidate_grouping_test.dart
+++ b/fushi/test/pages/video_subscription_candidate_grouping_test.dart
@@ -20,8 +20,7 @@ class _Candidate extends VideoResourceCandidate {
     super.resolution = '1080p',
     super.releaseGroup = 'Erai-raws',
     super.trusted = true,
-    super.category = '1_2',
-  }) : super(remoteId: remoteId ?? title);
+  }) : super(remoteId: remoteId ?? title, category: '1_2');
 }
 
 void main() {

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -1324,6 +1324,30 @@ mixin _FushiDbVideoDomain
     return changed == 1;
   }
 
+  /// 用户显式调整单个任务的排队优先级。
+  ///
+  /// `priority` 早就参与取任务的排序（三处 `OrderingTerm.desc(t.priority)` +
+  /// 索引 `(lifecycle, next_attempt_at, priority DESC, created_at)`），但在此之前
+  /// **没有任何写入口**：它只在建任务时从请求里带一次，而请求方从不传非默认值。
+  /// 于是这一列一直恒为 0，「排队顺序」实际退化成纯粹的 created_at 先来后到，
+  /// 用户报障「没办法设置每个任务的优先权」说的就是这个。
+  ///
+  /// 只改 priority 与 updatedAt：优先级是排队意图，不该顺带改动生命周期、阶段
+  /// 或重试预算——那些各有各的入口。
+  Future<bool> setVideoDownloadJobPriority({
+    required String jobId,
+    required int priority,
+    required int nowAt,
+  }) async {
+    final int changed = await (update(videoDownloadJobs)
+          ..where(($VideoDownloadJobsTable t) => t.jobId.equals(jobId)))
+        .write(VideoDownloadJobsCompanion(
+      priority: Value<int>(priority),
+      updatedAt: Value<int>(nowAt),
+    ));
+    return changed == 1;
+  }
+
   /// Explicit user resume. A cancelled job is paused durable state, not a
   /// failed retry: preserve its current stage when the backend task still
   /// exists, or rewind only when the embedded fast-resume entry disappeared.


### PR DESCRIPTION
用户截图：订阅页搜一部番，列表里是同一字幕组同一分辨率的 08/10/07/06/01/02/04… **一集一行**。原话：「这里订阅的时候，重复的数据太多了，优化一下」。

## 根因不是渲染，是行单位错了

列表 `itemCount: result.items.length` —— 行单位是「一个发布」。而订阅的生效单位是「一条规则」：页面自己写着「将追踪 **Erai-raws · 1080p**，有新的单集发布时自动加入下载」。一条规则命中十几集，列表就重复十几行。

## 分组键的选择（这是本 PR 唯一需要评审的判断）

**直接取 `deriveStrictVideoSubscriptionFilter()` 产出的 `filter.json` 当键，不另发明。**

那个函数就是「两个发布订起来是不是同一条」的**定义本身**。自己写一个「releaseGroup + resolution」看着等价，但：

- nyaa 的 filter 还锁 `trusted`
- torznab 的 filter 还锁 `source` / `codec` / `language`

键漏掉其中任一维，两条本该分开的规则就会被合成一行——**用户订到的和看到的不是一回事**。用定义当键，这类漂移在结构上不可能发生。测试里专门有一格钉这个（trusted 不同必须分两行）。

## 其余设计点

- **代表条**取做种最多者，并列时按发布时间、再按标题字典序 —— 全序，同一份结果每次渲染同一行，列表不跳
- **行序** = 各组首次出现序，聚合不改变用户已习惯的排序
- **推不出 filter 的条目不聚合**，各占一行照旧显示、提交时由既有校验拒绝。并成一坨只会让「为什么订不了」更难看懂
- **聚合行补两项元数据**：「共 N 个发布」+ 集数区间 `EP1-EP12`，否则一行看着像只订到一集
- **只改订阅模式**。下载模式仍是一集一行（那时用户要挑的就是具体某个发布），提交/校验链路一字未动

## 验证

- `video_subscription_candidate_grouping_test.dart` 5 条全绿
- **变异实测**：把分组键换成 `releaseGroup + resolution` → `trusted` 那条红；还原 → 全绿
- `test/pages` 全组 **2781 条**绿
- `flutter analyze` 全量 `No issues found!`
- i18n 新 key 走 `i18n_sync --add` + `dart run slang`（17 语言）