### PR TITLE
fix(video): 副字幕也能制卡——命中项带出所属 cue (BUG-1592)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1492 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1592](bugs/BUG-1592-secondary-subtitle-mining-black-cover.md) | ✅ | ✅ | 只开副字幕时制卡：无区间→封面抽片头黑帧 |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/bugs/BUG-1592-secondary-subtitle-mining-black-cover.md
+++ b/docs/bugs/BUG-1592-secondary-subtitle-mining-black-cover.md
@@ -1,0 +1,22 @@
+## BUG-1592 · 只开副字幕时制卡：无区间→封面抽片头黑帧
+- **报告**：2026-08-13（用户：「制卡黑屏」+ 卡片照片；随后澄清「副字幕的问题，我主字幕关掉的只开副字幕，副字幕是不是不能制卡。让副字幕也能制卡」）。用户包 `1.4.0-debug.10405`。
+- **真实性**：✅ **真 bug**（沿真实代码路径坐实）。用户照片里卡片图片是**一整块纯黑**：把该区域裁出来提亮（brightness +0.35 / contrast 2.2）后仍是纯黑、且带 Lapis 图片 CSS 的圆角，**没有破图图标、没有 alt 文本**——说明图片解码成功、像素本身就是黑的，不是 Anki 打不开 AVIF。另用随包 `third_party/ffmpeg-min/windows/ffmpeg.exe` 按 `buildFfmpegClipAnimatedArgs` 的真实参数（`libsvtav1 -preset 8 -crf 32 -pix_fmt yuv420p`）对 8bit H.264 与 10bit HEVC 源各跑一遍，产出 AVIF 均正常（YAVG≈126），**排除编码链黑图**。
+  根因链：
+  1. `fushi/lib/src/media/video/video_subtitle_overlay.dart` 的字幕命中项（`SubtitleCharHit` / `_SubtitleCharEntry`）只回传 `sentence` / `graphemeIndex` / `charRect`，**不带所属 cue**——尽管 entry 自己知道 `isSecondary`、且它就诞生在按 cue 渲染的循环里。
+  2. 于是页面侧 `video_fushi_page.dart:_handleSubtitleLookupTap` 不传 `overrideCue`，`lookup_favorite.part.dart:_lookupAt` 只好用 `resolveVideoLookupAnchorCue(currentCue: controller.currentCue, cues: controller.cues)` 去**主字幕流**按播放位置猜锚点。
+  3. 用户把主字幕关掉、只开副字幕 → `controller.cues` 恒空、`currentCue` 恒 null → `_lastLookupCue` 恒 null。
+  4. `video_fushi/lookup_mining.part.dart:_resolveVideoMiningRange` 三级兜底全落空 → 返回 `clipStartMs: 0, clipEndMs: 0`。
+  5. `mining/immersion_mining_engine.dart:_mineNow` 的封面阶梯：`tryGif()` 因 `req.hasRange` 为假直接 null（**静默、不记日志**），落到 `tryStartFrame()` → `extractVideoFrameViaFfmpeg(atSeconds: 0/1000 = 0.0)` → ffmpeg 抽视频**第 0 秒**的帧 = 片头黑帧。尺寸正确、像素全黑，即用户看到的「制卡黑屏」。句子音频同样因区间为 0 而空。
+  连带（同一根因的第二个症状）：`_setSentenceContextToDraft` 在 `controller.cues` 里 `indexOf(anchor)`，副字幕锚点恒 -1 → **上下 N 句上下文静默失效**；主副同开时点副字幕会**错锚到主字幕那句**（卡片句子是副字幕、音频/画面却截自主字幕那句的时间窗）。
+- **[x] ① 已修复** — 本提交。消除「猜锚点」这一整类特殊情况，而不是加「若副字幕则……」分支：
+  - `video_subtitle_overlay.dart`：`_SubtitleCharEntry` 携带所属 `AudioCue`；`SubtitleCharHit` 加第四元 `cue`；两个命中构造点（`_charHitTest` 点击/barrier 反查、`_charHitByEntryIndex` 手柄选词光标）与 `onCharTap` / `onCharHover` 回调一并带出 → **点哪条锚哪条**，主 / 副 / 重叠同一口径。
+  - `video_fushi_page.dart`：`_handleSubtitleLookupTap` / `_handleSubtitleHoverLookup` 收下 cue 并作 `overrideCue` 透传给 `_lookupAt`；三处命中消费点 + `subtitle_caret.part.dart` 的手柄确认路径同步透传。
+  - `video_player_controller.dart`：新增 `miningCues`（主流非空取主流，主流为空落副流）与 `cueStreamOwning(cue)`（按身份定位锚点所属流，都不含则回落 `miningCues`）。
+  - `lookup_favorite.part.dart` 的锚点兜底、`lookup_mining.part.dart` 的 `_resolveVideoMiningRange` 按位置兜底改走 `miningCues`（服务「没有命中项」的入口，如无查词直接制卡）；`_setSentenceContextToDraft` 改在 `cueStreamOwning(anchor)` 里取邻句。
+- **[x] ② 已加自动化测试** — 两支，均**变异实测**过（反向替换还原，未用 `git checkout --`）：
+  - `fushi/test/media/video/video_secondary_subtitle_mining_anchor_test.dart`（8 例）：只开副字幕时点副字幕 → 锚点 cue 时间窗是真实的 `12000..15000`（黑图根因的正反面）；主副同开时点副/点主各自不串层；`hitTester` 反查与手柄光标命中同样带 cue；`miningCues` / `cueStreamOwning` / 只开副字幕时 `resolveMiningCueForPosition` 非空。
+  - `fushi/test/pages/video_secondary_subtitle_anchor_wiring_guard_test.dart`（4 例）：源码断言页面把命中 cue 当 `overrideCue` 透传、兜底解析走 `miningCues`、上下文走 `cueStreamOwning`——widget 测试证明不了「页面转手用没用」，多收一个参数随手丢掉照样编译。
+  - 变异记录：① `miningCues => _cues` → 2 例红；② `cueStreamOwning` 恒返回主流 → 1 例红；③ `_charHitTest` 回退 `currentCue ?? e.cue` → **首轮全绿（守卫有洞）**，遂把 `hitTester` 用例改成主字幕同时在放（`currentCue` 非空）才能证伪，再测 → 红；④ 同款变异打在点击路径 `_charHitByEntryIndex` → 红；⑤ 摘掉 `overrideCue: cue` 透传 → 接线守卫红。全部还原后 12 例绿。
+- **备注**：
+  - 用户随卡片一起贴的另一条日志 `DictionaryMedia.cache 词典「大辞林　第四版」取不到媒体字节: daijirin2/可能-default.svg` **与本 bug 无关**，是词典媒体（外字/结构化内容图）没取到字节导致该条媒体退成 alt 文本，不影响封面。已单独排查到 `native/fushidicts/fushidicts_src/query.cpp:get_media_file_view`（对 `media.idx` 做二分），写入端 `importer.cpp:write_media_idx` 的 `std::ranges::sort` 与读取端比较器口径一致（都是 `char_traits<char>` 无符号字节序），未坐实为排序错；剩余候选是「该词典的 media 根本没导进去 / zip 条目名编码非 UTF-8」，需要用户那本词典才能定性——**未修，另立条目跟踪**。
+  - 未做真机复测（用户机器，本机没有该视频与该字幕组合）；本轮验证是 `flutter analyze` 全绿（含 test 目录）+ 上述 12 例守卫 + 相邻字幕/查词定向测试。

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -496,6 +496,25 @@ class VideoPlayerController extends ChangeNotifier
   /// TODO-1312：副字幕全量 cue（诊断 / 测试用）；空 = 无副字幕。
   List<AudioCue> get secondaryCues => _secondaryCues;
 
+  /// BUG-1592：制卡/上下文解析要用的「有效 cue 流」——主字幕流非空即主流，主流为空
+  /// （用户把主字幕关掉、只开副字幕）时落到副字幕流。
+  ///
+  /// 为什么需要它：制卡的区间锚点、上下 N 句上下文历来只认 [cues] 一条流。主字幕关闭时
+  /// 该流恒空 → 锚点 null → 制卡区间塌成 `0..0`：句子音频空、封面走 `atSeconds=0.0` 抽出
+  /// 片头黑帧（用户报「制卡黑屏」）。副字幕本就是同构的 cue 流（TODO-1312 起与主字幕独立
+  /// 求活动集、可逐字符查词），把「唯一的字幕流」这个隐含前提显式化即可，不加特例分支。
+  List<AudioCue> get miningCues => _cues.isNotEmpty ? _cues : _secondaryCues;
+
+  /// BUG-1592：[cue] 所属的那条流（按身份判定，主流优先）。两条流都不含它（列表面板的
+  /// 合成 cue / 已换集的陈旧 cue）时回 [miningCues]，保持「至少落在当前有效流上」。
+  List<AudioCue> cueStreamOwning(AudioCue cue) {
+    if (_cues.any((AudioCue c) => identical(c, cue))) return _cues;
+    if (_secondaryCues.any((AudioCue c) => identical(c, cue))) {
+      return _secondaryCues;
+    }
+    return miningCues;
+  }
+
   /// TODO-1312：副字幕当前活动集（overlay 副层渲染用，可查词）。
   List<AudioCue> get secondaryActiveCues => <AudioCue>[
         for (final int i in _activeSecondaryCueIndices)

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -16,9 +16,21 @@ import 'package:fushi/src/media/video/video_player_controller.dart';
 import 'package:fushi/src/media/video/video_subtitle_style.dart';
 import 'package:fushi_audio/fushi_audio.dart';
 
-/// 命中字幕某字符的结果：整条字幕、被点 grapheme 下标、该字符的全局屏幕矩形。
-/// 与 [VideoSubtitleOverlay.onCharTap] 的回调三元组同构。
-typedef SubtitleCharHit = ({String sentence, int graphemeIndex, Rect charRect});
+/// 命中字幕某字符的结果：整条字幕、被点 grapheme 下标、该字符的全局屏幕矩形、
+/// **该字符所属的那条 cue**。与 [VideoSubtitleOverlay.onCharTap] 的回调四元组同构。
+///
+/// BUG-1592：[cue] 是新增的第四元。此前命中只回传文本，页面侧只能拿 `sentence` 反过来
+/// 去**主字幕流**里按播放位置猜锚点 cue（[resolveVideoLookupAnchorCue]）——主字幕关掉、
+/// 只开副字幕时主流为空，锚点恒 null，制卡区间塌成 `0..0`：句子音频空、封面回退到
+/// `atSeconds=0.0` 抽出片头黑帧（用户报「制卡黑屏」）。命中项本来就诞生在「按 cue 渲染」
+/// 的循环里，把 cue 一并带出即消灭「猜锚点」这一整类特殊情况：点哪条锚哪条，主 / 副 /
+/// 重叠一视同仁（顺带修主副同开时点副字幕却锚到主字幕 cue 的错锚）。
+typedef SubtitleCharHit = ({
+  String sentence,
+  int graphemeIndex,
+  Rect charRect,
+  AudioCue cue,
+});
 
 /// 给上层（查词浮层的 dismiss barrier）按全局坐标反查「点到的是哪个字幕字符」用的
 /// 句柄。[VideoSubtitleOverlay] 在 build 时把自己的命中实现绑进来；上层持有同一个
@@ -316,8 +328,10 @@ class VideoSubtitleOverlay extends StatefulWidget {
   final VideoPlayerController controller;
 
   /// 点击字幕第 [graphemeIndex] 个字符时回调，[sentence] 为整条字幕文本，
-  /// [charRect] 为被点字符在全局坐标系下的矩形（弹窗定位用）。
-  final void Function(String sentence, int graphemeIndex, Rect charRect)?
+  /// [charRect] 为被点字符在全局坐标系下的矩形（弹窗定位用），[cue] 为该字符所属的
+  /// 那条 cue（BUG-1592：制卡区间/句子音频的锚点，主副字幕同一口径，见 [SubtitleCharHit]）。
+  final void Function(
+          String sentence, int graphemeIndex, Rect charRect, AudioCue cue)?
       onCharTap;
 
   /// 桌面 Shift-鼠标悬停查词（TODO-756a，与阅读器 `onShiftHover` 同语义）。按住 Shift 时鼠标
@@ -326,7 +340,8 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 查词行为一致、零重写。命中节流（8px 阈值 + 同一字符不重复触发）由本组件内部承载，避免每帧
   /// hover 都查词。非 Shift 悬停 / 模糊态 / 空句不触发（与点击不查词一致）。null（移动端 / 测试 /
   /// 无控制条场景）= 不挂 Shift-悬停通道，外观与历史一致。
-  final void Function(String sentence, int graphemeIndex, Rect charRect)?
+  final void Function(
+          String sentence, int graphemeIndex, Rect charRect, AudioCue cue)?
       onCharHover;
 
   /// TODO-756b：是否“鼠标悬停即自动查词”。true 时 [_handleShiftHover] 不再要求按住
@@ -653,6 +668,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       sentence: e.sentence,
       graphemeIndex: e.graphemeIndex,
       charRect: _globalRectOf(e.context),
+      cue: e.cue,
     );
   }
 
@@ -669,6 +685,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       sentence: e.sentence,
       graphemeIndex: e.graphemeIndex,
       charRect: r,
+      cue: e.cue,
     );
   }
 
@@ -707,7 +724,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 命中复用 [_charHitTest]（模糊态 / 空句返回 null → 不查词，与点击一致）。[PointerHoverEvent]
   /// 的 `position` 已是全局坐标，与 [_charHitTest] 的全局命中契约一致。
   void _handleShiftHover(PointerHoverEvent event) {
-    final void Function(String, int, Rect)? onCharHover = widget.onCharHover;
+    final void Function(String, int, Rect, AudioCue)? onCharHover =
+        widget.onCharHover;
     if (onCharHover == null) return;
     // TODO-756b：开了“悬停即查词”则纯悬停即触发，无需 Shift；否则退回 756a 的
     // Shift 门控。两路都共用同一节流锚与命中链路（onCharHover），仅门控判据不同。
@@ -733,7 +751,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     }
     _lastShiftHoverPos = event.position;
     _lastShiftHoverEntry = entryIndex;
-    onCharHover(e.sentence, e.graphemeIndex, _globalRectOf(e.context));
+    onCharHover(e.sentence, e.graphemeIndex, _globalRectOf(e.context), e.cue);
   }
 
   @override
@@ -1403,7 +1421,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
                   _pendingTapEntry = -1;
                   if (hit != null) {
                     widget.onCharTap!(
-                        hit.sentence, hit.graphemeIndex, hit.charRect);
+                        hit.sentence, hit.graphemeIndex, hit.charRect, hit.cue);
                   }
                 }
                 ..onTapCancel = () {
@@ -1517,6 +1535,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
               context: charContext,
               blurred: blurred,
               isSecondary: isSecondary,
+              cue: cue,
             ));
           }
           final Widget ch = _applyVerticalGlyphRotation(
@@ -2838,10 +2857,16 @@ class _SubtitleCharEntry {
     required this.context,
     required this.blurred,
     required this.isSecondary,
+    required this.cue,
   });
 
   /// 该字符所属的整条 cue 文本（查词 / 制卡取整句用）。
   final String sentence;
+
+  /// 该字符所属的那条 cue 本身（BUG-1592：制卡区间/句子音频的锚点）。[sentence] 是它的
+  /// 文本，但制卡还要它的 `startMs`/`endMs`——主字幕关闭、只开副字幕时页面侧无从从主流
+  /// 反推，必须由命中项直接带出。
+  final AudioCue cue;
 
   /// 该字符在其所属 cue 内的 grapheme 下标（从该位置起最长匹配取词）。
   final int graphemeIndex;

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart
@@ -60,10 +60,13 @@ extension _VideoLookupFavorite on _VideoFushiPageState {
     // 查词不传，回落 currentCue——它在字幕 gap / 末句后被清成 null（BUG-074 字幕条该消失），
     // 而查词往往就发生在字幕刚消失那一瞬，故 null 时按播放位置独立解析（TODO-104b / BUG-188，
     // 只读 controller，不复用被 gap 清空的 UI 状态）。
+    // BUG-1592：底部字幕 overlay 现在也透传 [overrideCue]（被点字符所属的那条 cue，主/副
+    // 同一口径），故这里的兜底只服务「没有命中项」的入口；按位置解析同样走有效流
+    // （主字幕流为空即副字幕流），否则只开副字幕时锚点恒 null → 制卡区间 `0..0`。
     _lastLookupCue = resolveVideoLookupAnchorCue(
       overrideCue: overrideCue,
       currentCue: controller.currentCue,
-      cues: controller.cues,
+      cues: controller.miningCues,
       positionMs: controller.positionMs ?? 0,
       delayMs: controller.delayMs,
     );

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -48,9 +48,13 @@ extension _VideoLookupMining on _VideoFushiPageState {
     );
   }
 
-  /// 以当前查词 cue（[_lastLookupCue]）为锚，在 [VideoPlayerController.cues]（按 startMs
-  /// 升序）里取它之前 [prevCount] 条、之后 [nextCount] 条作上下文，整体设进草稿（覆盖
-  /// 上次选择，不累积）。无 cue / 无控制器时清空上下文返回 0。
+  /// 以当前查词 cue（[_lastLookupCue]）为锚，在**锚点所属的那条字幕流**
+  /// （[VideoPlayerController.cueStreamOwning]，按 startMs 升序）里取它之前 [prevCount] 条、
+  /// 之后 [nextCount] 条作上下文，整体设进草稿（覆盖上次选择，不累积）。无 cue / 无控制器
+  /// 时清空上下文返回 0。
+  ///
+  /// BUG-1592：以前硬取主字幕流 [VideoPlayerController.cues]。副字幕上查词时锚点不在主流里，
+  /// `indexOf` 恒 -1 → 上下 N 句**静默失效**（用户只看到上下文没生效，没有任何报错）。
   Future<int> _setSentenceContextToDraft(int prevCount, int nextCount) async {
     final VideoPlayerController? controller = _controller;
     final AudioCue? anchor = _lastLookupCue;
@@ -58,7 +62,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
       _miningDraft.setContext();
       return _miningDraft.length;
     }
-    final List<AudioCue> cues = controller.cues;
+    final List<AudioCue> cues = controller.cueStreamOwning(anchor);
     final int idx = cues.indexOf(anchor);
     if (idx < 0) {
       _miningDraft.setContext();
@@ -144,10 +148,13 @@ extension _VideoLookupMining on _VideoFushiPageState {
     }
 
     // 查词窗口多句合一（TODO-270 E）。当前 cue 多段兜底（含 gap，BUG-188）。
+    // BUG-1592：按位置兜底走**有效流**（主字幕流为空即副字幕流）。命中项已带 cue 的入口
+    // （点击 / hover / 手柄光标 / 列表）走 [_lastLookupCue]，这条只服务「没有命中项」的
+    // 入口（如无查词直接制卡）——它以前硬认主流，主字幕关闭时恒 null → 区间 `0..0`。
     final AudioCue? cue = _lastLookupCue ??
         controller.currentCue ??
         resolveMiningCueForPosition(
-          cues: controller.cues,
+          cues: controller.miningCues,
           positionMs: controller.positionMs ?? 0,
           delayMs: controller.delayMs,
         );

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle_caret.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle_caret.part.dart
@@ -303,7 +303,8 @@ extension _VideoSubtitleCaret on _VideoFushiPageState {
         if (hit == null) return;
         // 与点击查词完全同链路（含沉浸门控）：弹窗渲染完成后
         // [onNestedPopupRendered] 会把光标 transfer 进弹窗。
-        _handleSubtitleLookupTap(hit.sentence, hit.graphemeIndex, hit.charRect);
+        _handleSubtitleLookupTap(
+            hit.sentence, hit.graphemeIndex, hit.charRect, hit.cue);
         return;
       case CaretAction.longPress:
       case CaretAction.jumpDictNext:

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1416,7 +1416,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         hitSubtitle: true,
       )) {
         _handleSubtitleHoverLookup(
-            hit.sentence, hit.graphemeIndex, hit.charRect);
+            hit.sentence, hit.graphemeIndex, hit.charRect, hit.cue);
       }
       return;
     }
@@ -3810,7 +3810,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
           topVisibleIndex: _topVisiblePopupIndex,
           hitSubtitle: true,
         )) {
-      _handleSubtitleHoverLookup(hit.sentence, hit.graphemeIndex, hit.charRect);
+      _handleSubtitleHoverLookup(
+          hit.sentence, hit.graphemeIndex, hit.charRect, hit.cue);
       return;
     }
     // BUG-879/881：画面字幕没命中，再反查**字幕列表侧栏**——barrier 全屏盖在推挤式侧栏上，
@@ -3843,6 +3844,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     String sentence,
     int graphemeIndex,
     Rect charRect,
+    AudioCue? cue,
   ) {
     if (sentence == _barrierHoverLastSentence &&
         graphemeIndex == _barrierHoverLastGrapheme) {
@@ -3850,7 +3852,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     }
     _barrierHoverLastSentence = sentence;
     _barrierHoverLastGrapheme = graphemeIndex;
-    _handleSubtitleLookupTap(sentence, graphemeIndex, charRect);
+    _handleSubtitleLookupTap(sentence, graphemeIndex, charRect, cue);
   }
 
   /// BUG-094: seed one persistent, hidden warm popup slot on open so its
@@ -3895,7 +3897,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       topVisibleIndex: _topVisiblePopupIndex,
       hitSubtitle: hit != null,
     )) {
-      _handleSubtitleLookupTap(hit!.sentence, hit.graphemeIndex, hit.charRect);
+      _handleSubtitleLookupTap(
+          hit!.sentence, hit.graphemeIndex, hit.charRect, hit.cue);
       return;
     }
     // BUG-874：底部字幕没命中，再反查**字幕列表侧栏**——barrier 全屏盖在推挤式侧栏之上、
@@ -3925,13 +3928,18 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _popNestedPopupAt(0);
   }
 
+  /// BUG-1592：[cue] 是被点字符**所属的那条 cue**，直接当查词/制卡锚点透传
+  /// （`overrideCue`）。此前不传，锚点靠 [resolveVideoLookupAnchorCue] 去主字幕流按播放
+  /// 位置猜——主字幕关掉只开副字幕时主流为空，锚点恒 null，制卡区间塌成 `0..0`（句子音频
+  /// 空 + 封面抽第 0 秒的片头黑帧）；主副同开时点副字幕还会错锚到主字幕那句。
   void _handleSubtitleLookupTap(
     String sentence,
     int graphemeIndex,
     Rect charRect,
+    AudioCue? cue,
   ) {
     if (!_immersiveAllowsLookup) return;
-    unawaited(_lookupAt(sentence, graphemeIndex, charRect));
+    unawaited(_lookupAt(sentence, graphemeIndex, charRect, overrideCue: cue));
   }
 
   void _popNestedPopupAt(int index) {

--- a/fushi/test/media/video/video_player_keyboard_static_test.dart
+++ b/fushi/test/media/video/video_player_keyboard_static_test.dart
@@ -466,12 +466,11 @@ void main() {
     });
 
     test('_handleSubtitleLookupTap gates lookup before _lookupAt', () {
+      // BUG-1592：形参表不再写死（新增第四个参数 `AudioCue? cue`——命中项带出的所属
+      // cue，作制卡锚点）。本守卫要锁的是**方法体内的顺序**（沉浸门控先于 _lookupAt），
+      // 不是签名长什么样，故按 `(...)` 整体匹配。
       final RegExpMatch? body = RegExp(
-        r'void _handleSubtitleLookupTap\(\n'
-        r'    String sentence,\n'
-        r'    int graphemeIndex,\n'
-        r'    Rect charRect,\n'
-        r'  \) \{(.*?)\n  \}',
+        r'void _handleSubtitleLookupTap\([^)]*\) \{(.*?)\n  \}',
         dotAll: true,
       ).firstMatch(page);
       expect(body, isNotNull,

--- a/fushi/test/media/video/video_secondary_subtitle_mining_anchor_test.dart
+++ b/fushi/test/media/video/video_secondary_subtitle_mining_anchor_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_overlay.dart';
+import 'package:fushi/src/pages/implementations/video_fushi_page.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+/// BUG-1592 守卫：**主字幕关掉、只开副字幕时也要能制卡**。
+///
+/// 病根链（用户报「制卡黑屏」，卡片图片是一整块纯黑）：
+///  1. 字幕命中项只回传文本（sentence / grapheme / rect），**不带所属 cue**；
+///  2. 页面侧只好用 [resolveVideoLookupAnchorCue] 去**主字幕流**按播放位置猜锚点 cue；
+///  3. 主字幕关闭时主流恒空 → 锚点恒 null → `_resolveVideoMiningRange` 返回 `0..0`；
+///  4. 区间非正 → 动图不抽、封面阶梯落到「字幕起点单帧」，而起点 = 0ms → ffmpeg 抽视频
+///     **第 0 秒**的帧 = 片头黑帧。尺寸正确、像素全黑，Anki 侧看就是「制卡黑屏」；句子
+///     音频同样因区间为 0 而空。
+///
+/// 修法是消除「猜锚点」这一整类特殊情况，而不是加「若副字幕则……」分支：命中项本来就
+/// 诞生在按 cue 渲染的循环里，把 cue 一并带出 → **点哪条锚哪条**，主 / 副 / 重叠同一
+/// 口径（顺带修主副同开时点副字幕却错锚到主字幕那句的旧错）。
+AudioCue _cue(String text, int startMs, int endMs) => AudioCue()
+  ..bookKey = 'b'
+  ..chapterHref = 'ch'
+  ..sentenceIndex = 0
+  ..textFragmentId = ''
+  ..text = text
+  ..startMs = startMs
+  ..endMs = endMs
+  ..audioFileIndex = 0;
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+  await tester.pump();
+}
+
+void main() {
+  group('BUG-1592 命中项带出所属 cue（制卡锚点）', () {
+    testWidgets('只开副字幕（主字幕流为空）：点副字幕字符 → 锚点 cue 是那条副字幕、时间窗非零',
+        (WidgetTester tester) async {
+      AudioCue? anchor;
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      // 用户把主字幕关掉：主流空，只有副字幕。
+      c.setCues(const <AudioCue>[]);
+      c.setSecondaryCues(<AudioCue>[_cue('いう', 12000, 15000)]);
+      c.debugUpdateCueForPosition(13000);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          onCharTap: (String s, int i, Rect _, AudioCue cue) => anchor = cue,
+        ),
+      );
+
+      await tester.tapAt(tester.getCenter(find.text('う').first));
+      await tester.pump();
+
+      expect(anchor, isNotNull, reason: '点副字幕必须回传锚点 cue，否则制卡无区间可用');
+      expect(anchor!.text, 'いう');
+      // 这两条就是黑图根因的正反面：区间必须是这条字幕的真实时间窗，不能塌成 0。
+      expect(anchor!.startMs, 12000);
+      expect(anchor!.endMs, 15000);
+    });
+
+    testWidgets('主副同开：点副字幕那条 → 锚点是副字幕 cue（不错锚到主字幕）',
+        (WidgetTester tester) async {
+      AudioCue? anchor;
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 5000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 1000, 4000)]);
+      c.debugUpdateCueForPosition(2000);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          onCharTap: (String s, int i, Rect _, AudioCue cue) => anchor = cue,
+        ),
+      );
+
+      await tester.tapAt(tester.getCenter(find.text('副').first));
+      await tester.pump();
+
+      expect(anchor?.text, '副');
+      expect(anchor?.startMs, 1000);
+      expect(anchor?.endMs, 4000);
+    });
+
+    testWidgets('主副同开：点主字幕那条 → 锚点仍是主字幕 cue（不串层）', (WidgetTester tester) async {
+      AudioCue? anchor;
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 5000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 1000, 4000)]);
+      c.debugUpdateCueForPosition(2000);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          onCharTap: (String s, int i, Rect _, AudioCue cue) => anchor = cue,
+        ),
+      );
+
+      await tester.tapAt(tester.getCenter(find.text('主').first));
+      await tester.pump();
+
+      expect(anchor?.text, '主');
+      expect(anchor?.startMs, 0);
+      expect(anchor?.endMs, 5000);
+    });
+
+    // 主字幕**同时在放**（`currentCue` 非空）才能证明命中项用的是「被点那条」而不是
+    // 「主字幕当前那条」——只开副字幕的用例里 `currentCue` 恒 null，两种实现都能过。
+    testWidgets('hitTester 反查（浮层 barrier 换词路径）带出被点那条 cue（主字幕同时在放）',
+        (WidgetTester tester) async {
+      final VideoSubtitleHitTester hitTester = VideoSubtitleHitTester();
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 7000, 9000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('か', 7000, 9000)]);
+      c.debugUpdateCueForPosition(8000);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(controller: c, hitTester: hitTester),
+      );
+
+      final SubtitleCharHit? hit =
+          hitTester.hitTest(tester.getCenter(find.text('か').first));
+      expect(hit, isNotNull);
+      expect(hit!.cue.text, 'か');
+      expect(hit.cue.startMs, 7000);
+      expect(hit.cue.endMs, 9000);
+    });
+
+    // 同上：主字幕在放时锚点仍须是光标停留那条（此处光标锚点默认落主字幕层首字符）。
+    testWidgets('选词光标（手柄查词）命中带出光标所在那条 cue', (WidgetTester tester) async {
+      final VideoSubtitleHitTester hitTester = VideoSubtitleHitTester();
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(const <AudioCue>[]);
+      c.setSecondaryCues(<AudioCue>[_cue('きく', 3000, 6000)]);
+      c.debugUpdateCueForPosition(4000);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(controller: c, hitTester: hitTester),
+      );
+
+      final int anchorEntry = hitTester.caretAnchorEntry();
+      expect(anchorEntry, greaterThanOrEqualTo(0));
+      final SubtitleCharHit? hit = hitTester.caretHitAt(anchorEntry);
+      expect(hit, isNotNull);
+      expect(hit!.cue.startMs, 3000);
+      expect(hit.cue.endMs, 6000);
+    });
+  });
+
+  group('BUG-1592 有效 cue 流（无命中项的制卡兜底 + 上下 N 句上下文）', () {
+    test('miningCues：主流非空取主流；主流为空（只开副字幕）落副流', () {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 1000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 1000)]);
+      expect(c.miningCues.single.text, '主');
+
+      c.setCues(const <AudioCue>[]);
+      expect(c.miningCues.single.text, '副',
+          reason: '主字幕关闭时制卡必须落到副字幕流，否则锚点恒 null → 区间 0..0 → 封面抽片头黑帧');
+    });
+
+    test('cueStreamOwning：按身份定位锚点所属流（上下 N 句上下文取邻句用）', () {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      final AudioCue main0 = _cue('主', 0, 1000);
+      final AudioCue sec0 = _cue('副0', 0, 1000);
+      final AudioCue sec1 = _cue('副1', 1000, 2000);
+      c.setCues(<AudioCue>[main0]);
+      c.setSecondaryCues(<AudioCue>[sec0, sec1]);
+
+      expect(identical(c.cueStreamOwning(main0), c.cues), isTrue);
+      // 副字幕锚点必须解析到副流；解析成主流会让 indexOf 恒 -1 → 上下 N 句静默失效。
+      expect(c.cueStreamOwning(sec1).map((AudioCue e) => e.text).toList(),
+          <String>['副0', '副1']);
+      // 两条流都不含（列表合成 cue / 换集后的陈旧 cue）→ 回落有效流，不返回空。
+      expect(c.cueStreamOwning(_cue('孤儿', 0, 1)).isNotEmpty, isTrue);
+    });
+
+    test('只开副字幕时按位置解析制卡 cue：非 null，且区间就是那条副字幕', () {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(const <AudioCue>[]);
+      c.setSecondaryCues(<AudioCue>[
+        _cue('一句', 10000, 12000),
+        _cue('二句', 12000, 14000),
+      ]);
+
+      final AudioCue? resolved = resolveMiningCueForPosition(
+        cues: c.miningCues,
+        positionMs: 13000,
+        delayMs: 0,
+      );
+      expect(resolved, isNotNull,
+          reason: '没有查词命中项的入口（直接制卡）也必须解析得到区间，否则回退第 0 秒黑帧');
+      expect(resolved!.startMs, 12000);
+      expect(resolved.endMs, 14000);
+    });
+  });
+}

--- a/fushi/test/media/video/video_subtitle_bilingual_marginv_overlap_test.dart
+++ b/fushi/test/media/video/video_subtitle_bilingual_marginv_overlap_test.dart
@@ -73,7 +73,7 @@ void main() {
             controller: c,
             respectAssStyle: true,
             hitTester: hitTester,
-            onCharTap: (_, __, ___) {},
+            onCharTap: (_, __, ___, ____) {},
           ),
         ),
       ),

--- a/fushi/test/media/video/video_subtitle_dual_bounce_test.dart
+++ b/fushi/test/media/video/video_subtitle_dual_bounce_test.dart
@@ -73,7 +73,7 @@ Future<void> _mount(
         child: VideoSubtitleOverlay(
           controller: c,
           respectAssStyle: true,
-          onCharTap: (_, __, ___) {},
+          onCharTap: (_, __, ___, ____) {},
         ),
       ),
     ),

--- a/fushi/test/media/video/video_subtitle_hover_lookup_test.dart
+++ b/fushi/test/media/video/video_subtitle_hover_lookup_test.dart
@@ -48,7 +48,7 @@ void main() {
         VideoSubtitleOverlay(
           controller: c,
           hoverAutoLookupEnabled: true,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -81,7 +81,7 @@ void main() {
         VideoSubtitleOverlay(
           controller: c,
           // hoverAutoLookupEnabled defaults to false.
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -107,7 +107,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -138,7 +138,7 @@ void main() {
         VideoSubtitleOverlay(
           controller: c,
           hoverAutoLookupEnabled: true,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );

--- a/fushi/test/media/video/video_subtitle_margin_break_test.dart
+++ b/fushi/test/media/video/video_subtitle_margin_break_test.dart
@@ -41,7 +41,7 @@ Future<void> _mount(WidgetTester tester, VideoPlayerController c) async {
         child: VideoSubtitleOverlay(
           controller: c,
           respectAssStyle: true,
-          onCharTap: (_, __, ___) {},
+          onCharTap: (_, __, ___, ____) {},
         ),
       ),
     ),

--- a/fushi/test/media/video/video_subtitle_multicue_test.dart
+++ b/fushi/test/media/video/video_subtitle_multicue_test.dart
@@ -120,7 +120,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharTap: (String s, int i, Rect _) {
+          onCharTap: (String s, int i, Rect _, AudioCue __) {
             tapped = s;
             tappedIndex = i;
           },
@@ -144,7 +144,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharTap: (String s, int i, Rect _) => tapped = s,
+          onCharTap: (String s, int i, Rect _, AudioCue __) => tapped = s,
         ),
       );
       await tester.tapAt(tester.getCenter(find.text('主').first));

--- a/fushi/test/media/video/video_subtitle_overlay_dual_snap_test.dart
+++ b/fushi/test/media/video/video_subtitle_overlay_dual_snap_test.dart
@@ -139,7 +139,7 @@ void main() {
           VideoSubtitleOverlay(
             controller: c,
             hitTester: hitTester,
-            onCharTap: (String s, int i, Rect r) {},
+            onCharTap: (String s, int i, Rect r, AudioCue c) {},
           ));
 
       // 甲 离场成占位：其原位置命中必须为 null（不可点、不可查词）。

--- a/fushi/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/fushi/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -37,7 +37,7 @@ void main() {
           controller: c,
           // BUG-903：\an 定位现属「尊重 .ass」语义（关=纯字幕模式恒底部堆叠）。
           respectAssStyle: true,
-          onCharTap: (String s, int i, Rect r) {
+          onCharTap: (String s, int i, Rect r, AudioCue cueArg) {
             tappedSentence = s;
             tappedIndex = i;
           },
@@ -473,7 +473,7 @@ void main() {
         body: VideoSubtitleOverlay(
           controller: c,
           respectAssStyle: true,
-          onCharTap: (String s, int i, Rect r) {
+          onCharTap: (String s, int i, Rect r, AudioCue cueArg) {
             tapped = s;
             idx = i;
           },

--- a/fushi/test/media/video/video_subtitle_overlay_test.dart
+++ b/fushi/test/media/video/video_subtitle_overlay_test.dart
@@ -476,7 +476,8 @@ void main() {
       final VideoPlayerController c = _controllerWithCue('テスト');
       await _pump(
         tester,
-        VideoSubtitleOverlay(controller: c, onCharTap: (_, __, ___) {}),
+        VideoSubtitleOverlay(
+            controller: c, onCharTap: (_, __, ___, AudioCue cueArg) {}),
       );
       final Iterable<GestureDetector> detectors =
           tester.widgetList<GestureDetector>(find.byType(GestureDetector));
@@ -509,7 +510,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharTap: (String s, int i, Rect _) {
+          onCharTap: (String s, int i, Rect _, AudioCue cueArg) {
             tappedSentence = s;
             tappedIndex = i;
           },

--- a/fushi/test/media/video/video_subtitle_shift_hover_lookup_test.dart
+++ b/fushi/test/media/video/video_subtitle_shift_hover_lookup_test.dart
@@ -49,7 +49,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -81,7 +81,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -106,7 +106,7 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -153,7 +153,7 @@ void main() {
         VideoSubtitleOverlay(
           controller: c,
           blurEnabled: true,
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );
@@ -183,7 +183,8 @@ void main() {
       final VideoPlayerController c2 = _controllerWithCue('A');
       await _pump(
         tester,
-        VideoSubtitleOverlay(controller: c2, onCharHover: (_, __, ___) {}),
+        VideoSubtitleOverlay(
+            controller: c2, onCharHover: (_, __, ___, AudioCue cueArg) {}),
       );
       final int withHover = find.byType(MouseRegion).evaluate().length;
 
@@ -200,9 +201,9 @@ void main() {
         tester,
         VideoSubtitleOverlay(
           controller: c,
-          onCharTap: (String s, int i, Rect r) =>
+          onCharTap: (String s, int i, Rect r, AudioCue cueArg) =>
               taps.add((sentence: s, graphemeIndex: i, charRect: r)),
-          onCharHover: (String s, int i, Rect r) =>
+          onCharHover: (String s, int i, Rect r, AudioCue cueArg) =>
               hovers.add((sentence: s, graphemeIndex: i, charRect: r)),
         ),
       );

--- a/fushi/test/pages/video_secondary_subtitle_anchor_wiring_guard_test.dart
+++ b/fushi/test/pages/video_secondary_subtitle_anchor_wiring_guard_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1592 接线守卫：字幕命中项带出的 cue **必须**一路走到查词/制卡锚点。
+///
+/// widget 测试（`test/media/video/video_secondary_subtitle_mining_anchor_test.dart`）能证明
+/// overlay 把「被点那条 cue」回传给了页面，但证明不了页面**转手把它当锚点用**——`onCharTap`
+/// 多收一个参数、随手丢掉也照样编译通过。而丢掉的后果正是本 bug 的原状：主字幕关掉、只开
+/// 副字幕时锚点恒 null → 制卡区间塌成 `0..0` → 句子音频空 + 封面抽视频第 0 秒的片头黑帧
+/// （用户报「制卡黑屏」）。故在此对这几行接线做源码断言。
+void main() {
+  String read(String rel) {
+    final File f = File(rel);
+    expect(f.existsSync(), isTrue, reason: '缺文件: $rel');
+    return f.readAsStringSync();
+  }
+
+  test('_handleSubtitleLookupTap 必须把命中 cue 作为 overrideCue 透传给 _lookupAt', () {
+    final String page =
+        read('lib/src/pages/implementations/video_fushi_page.dart');
+    final int start = page.indexOf('void _handleSubtitleLookupTap(');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = page.indexOf('\n  }', start);
+    expect(end, greaterThan(start));
+    final String body = page.substring(start, end);
+
+    expect(body.contains('AudioCue? cue'), isTrue,
+        reason: '点击查词入口必须收下命中项带出的所属 cue');
+    expect(body.contains('overrideCue: cue'), isTrue,
+        reason: '收下了却不作为 overrideCue 透传 = 锚点仍去主字幕流猜 → 只开副字幕时制卡区间 0..0');
+  });
+
+  test('hover 查词入口同样透传命中 cue（与点击同一条链路）', () {
+    final String page =
+        read('lib/src/pages/implementations/video_fushi_page.dart');
+    final int start = page.indexOf('void _handleSubtitleHoverLookup(');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = page.indexOf('\n  }', start);
+    final String body = page.substring(start, end);
+
+    expect(body.contains('AudioCue? cue'), isTrue);
+    expect(
+        RegExp(r'_handleSubtitleLookupTap\([^;]*cue\)').hasMatch(body), isTrue,
+        reason: 'hover 换词丢掉 cue 会让 Shift-悬停查词制出的卡回到黑帧');
+  });
+
+  test('查词锚点兜底解析走有效流 miningCues（主流为空即副流），不再硬认主字幕流', () {
+    final String favorite = read(
+        'lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart');
+    expect(favorite.contains('cues: controller.miningCues'), isTrue,
+        reason: '硬认 controller.cues 会让只开副字幕时按位置解析恒 null');
+    expect(favorite.contains('cues: controller.cues'), isFalse,
+        reason: '不得回潮到只认主字幕流');
+  });
+
+  test('制卡区间与上下 N 句上下文都按有效流/锚点所属流取', () {
+    final String mining = read(
+        'lib/src/pages/implementations/video_fushi/lookup_mining.part.dart');
+    expect(mining.contains('cues: controller.miningCues'), isTrue,
+        reason: '_resolveVideoMiningRange 的按位置兜底必须走有效流');
+    expect(mining.contains('controller.cueStreamOwning(anchor)'), isTrue,
+        reason: '上下 N 句必须在锚点所属的那条流里取邻句，否则副字幕锚点 indexOf 恒 -1 静默失效');
+  });
+}

--- a/fushi/test/widgets/video_subtitle_lookup_seek_priority_test.dart
+++ b/fushi/test/widgets/video_subtitle_lookup_seek_priority_test.dart
@@ -34,7 +34,8 @@ void main() {
   Future<void> pumpOverlayOverSeekListener(
     WidgetTester tester, {
     required VideoPlayerController controller,
-    required void Function(String sentence, int graphemeIndex, Rect rect)
+    required void Function(
+            String sentence, int graphemeIndex, Rect rect, AudioCue cue)
         onCharTap,
     required VoidCallback onSeekPointerUp,
   }) async {
@@ -73,7 +74,8 @@ void main() {
     await pumpOverlayOverSeekListener(
       tester,
       controller: c,
-      onCharTap: (String s, int i, Rect r) => tappedSentence = s,
+      onCharTap: (String s, int i, Rect r, AudioCue cueArg) =>
+          tappedSentence = s,
       onSeekPointerUp: () => seekPointerUps++,
     );
 
@@ -99,7 +101,8 @@ void main() {
     await pumpOverlayOverSeekListener(
       tester,
       controller: c,
-      onCharTap: (String s, int i, Rect r) => tappedSentence = s,
+      onCharTap: (String s, int i, Rect r, AudioCue cueArg) =>
+          tappedSentence = s,
       onSeekPointerUp: () => seekPointerUps++,
     );
 

--- a/fushi/test/widgets/video_subtitle_overlay_down_snap_test.dart
+++ b/fushi/test/widgets/video_subtitle_overlay_down_snap_test.dart
@@ -36,7 +36,7 @@ void main() {
       // 放大避让位移，确保 up 落点显著偏离 down 命中字符（验证锁 down 不依赖 up 反查）。
       controlsBottomReserve: 400,
       bottomPadding: 10,
-      onCharTap: (String s, int i, Rect rect) {
+      onCharTap: (String s, int i, Rect rect, AudioCue cueArg) {
         tappedSentence = s;
         tappedIndex = i;
       },

--- a/fushi/test/widgets/video_subtitle_overlay_fallthrough_test.dart
+++ b/fushi/test/widgets/video_subtitle_overlay_fallthrough_test.dart
@@ -28,7 +28,8 @@ void main() {
   Future<void> pumpOverlayOverCounter(
     WidgetTester tester, {
     required VideoPlayerController controller,
-    required void Function(String sentence, int graphemeIndex, Rect rect)
+    required void Function(
+            String sentence, int graphemeIndex, Rect rect, AudioCue cue)
         onCharTap,
     required VoidCallback onUnderlyingTap,
   }) async {
@@ -65,7 +66,8 @@ void main() {
     await pumpOverlayOverCounter(
       tester,
       controller: c,
-      onCharTap: (String s, int i, Rect r) => tappedSentence = s,
+      onCharTap: (String s, int i, Rect r, AudioCue cueArg) =>
+          tappedSentence = s,
       onUnderlyingTap: () => underlyingTaps++,
     );
 
@@ -91,7 +93,8 @@ void main() {
     await pumpOverlayOverCounter(
       tester,
       controller: c,
-      onCharTap: (String s, int i, Rect r) => tappedSentence = s,
+      onCharTap: (String s, int i, Rect r, AudioCue cueArg) =>
+          tappedSentence = s,
       onUnderlyingTap: () => underlyingTaps++,
     );
 

--- a/fushi/test/widgets/video_subtitle_overlay_test.dart
+++ b/fushi/test/widgets/video_subtitle_overlay_test.dart
@@ -28,7 +28,7 @@ void main() {
     Rect? tappedRect;
     await tester.pumpWidget(buildTestApp(VideoSubtitleOverlay(
       controller: c,
-      onCharTap: (String s, int i, Rect rect) {
+      onCharTap: (String s, int i, Rect rect, AudioCue cueArg) {
         tappedSentence = s;
         tappedIndex = i;
         tappedRect = rect;


### PR DESCRIPTION
## 用户报告
「制卡黑屏」+ 卡片照片（图片字段一整块纯黑）；澄清为**主字幕关掉、只开副字幕**时制卡。

## 根因
不是编码链黑图（随包 `ffmpeg-min` 按 `buildFfmpegClipAnimatedArgs` 真实参数对 8bit H.264 / 10bit HEVC 源各跑一遍 AVIF，产出正常 YAVG≈126；照片黑框提亮后无破图图标、无 alt，说明像素本身就是黑的）。

链路：
1. `SubtitleCharHit` / `_SubtitleCharEntry` 只回传文本，**不带所属 cue**；
2. 页面只好用 `resolveVideoLookupAnchorCue` 去**主字幕流**按播放位置猜锚点；
3. 主字幕关闭 → `controller.cues` 恒空、`currentCue` 恒 null → `_lastLookupCue` 恒 null；
4. `_resolveVideoMiningRange` 返回 `0..0`；
5. 封面阶梯：`tryGif()` 因无区间静默返回 null → `tryStartFrame(atSeconds: 0.0)` → ffmpeg 抽视频**第 0 秒**=片头黑帧。句子音频同样为空。

连带：副字幕锚点在主流里 `indexOf` 恒 -1 → 上下 N 句上下文静默失效；主副同开时点副字幕**错锚**到主字幕那句。

## 修法
消除「猜锚点」这一整类特殊情况，不加副字幕分支——命中项本就诞生在按 cue 渲染的循环里，把 cue 一并带出即可：**点哪条锚哪条**。

- `video_subtitle_overlay.dart`：entry 携带 `AudioCue`，`SubtitleCharHit` 加第四元 `cue`，两个命中构造点 + `onCharTap`/`onCharHover` 带出。
- `video_fushi_page.dart` / `subtitle_caret.part.dart`：收下并作 `overrideCue` 透传。
- `video_player_controller.dart`：`miningCues`（主流空落副流）+ `cueStreamOwning`（按身份定位所属流）。
- `lookup_favorite` / `lookup_mining`：按位置兜底与上下文改走上面两者。

## 验证
- `flutter analyze`（含 test）零问题。
- 新增 12 例守卫（8 widget/单测 + 4 接线源码守卫），**全部变异实测**；其中一轮变异首次全绿暴露守卫有洞（用例没开主字幕，`currentCue` 恒 null 两种实现都能过），补强为「主字幕同时在放」后被杀掉。
- 相邻域定向 `dart run tool/flutter_test_failures.dart`：**2991 例全绿**。
- 未做真机复测（用户机器，本机无该视频/字幕组合）。

BUG 档：`docs/bugs/BUG-1592-secondary-subtitle-mining-black-cover.md`

⚠️ 另：用户同贴的 `DictionaryMedia.cache 取不到媒体字节: daijirin2/可能-default.svg` 与本 bug 无关（词典外字退成 alt，不影响封面），已排到 `query.cpp:get_media_file_view` 的 media.idx 二分，写读两端比较器口径一致、未坐实排序错，剩余候选需用户那本词典才能定性——**未修**。

https://claude.ai/code/session_012ESUV6BfxKpEPems8h8VWb