### PR TITLE
fix(gal): 制卡语音每句都被削掉句首 (BUG-1593/1594)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1491 条。点号进各自文件。
+> 共 1493 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1594](bugs/BUG-1594-ring-probe-readonly-map-crash.md) | ✅ | ✅ | ring_probe 只读映射下枚举文本槽必崩（Interlocked 写只读页） |
+| [BUG-1593](bugs/BUG-1593-gal-utterance-head-clipped.md) | ✅ | ✅ | galgame 制卡语音每句都少一截开头（提交时刻 vs 播放时刻） |
 | [BUG-1585](bugs/BUG-1585-golden-cross-platform-raster-false-red.md) | ✅ | ✅ | golden 基准图跨平台光栅必红：非 Windows 开发机全量套件恒 33 条伪红 |
 | [BUG-1584](bugs/BUG-1584-ios-archive-strip-drops-ffi-exports.md) | ✅ | ✅ | iOS archive 的 STRIP_STYLE=all 抹掉 fushidicts FFI 导出符号，上架包启动即 Initialisation failed |
 | [BUG-1583](bugs/BUG-1583-manga-ocr-test-platform-gate.md) | ✅ | ✅ | manga OCR 编排测试硬读 Platform，macOS/iOS 宿主上结构性必红 |

--- a/docs/bugs/BUG-1593-gal-utterance-head-clipped.md
+++ b/docs/bugs/BUG-1593-gal-utterance-head-clipped.md
@@ -1,0 +1,52 @@
+## BUG-1593 · galgame 制卡语音每句都少一截开头（提交时刻 vs 播放时刻）
+- **报告**：2026-08-13（用户：制卡截取的音频都会漏掉前面 2s 左右的内容；游戏 `C:\Users\wrds\Downloads\Compressed\ceshi\恋爱成双`）
+- **真实性**：✅ 真 bug，已在用户原始路径复现并量化。根因 `fushi/windows/runner/voice_hook_reader.cpp:1060`（原 `if (d < -200 || d > forward_ms) continue;`）。
+- **[x] ① 已修复** — `native/galgame_hook/include/voice_hook_utterance_window.h`（新增，唯一实现）+ `fushi/windows/runner/voice_hook_reader.cpp`（`GrabUtterance` 改用它算下界）+ `native/galgame_hook/tools/ring_probe.cpp`（诊断工具共用同一份，避免排障被带偏）
+- **[x] ② 已加自动化测试** — `native/galgame_hook/tests/utterance_window_test.cpp`（CTest 目标 `fushi_utterance_window_test`），fixture 全部是真机 dump 出来的时间轴；已做变异实测：把判据改成恒假，6 条断言里 4 条转红。
+- **备注**：见下文。
+
+### 台账（真实路径）
+
+| 项 | 值 |
+|---|---|
+| 游戏 | フタマタ恋愛（恋爱成双 / 劈腿之恋）Ver1.00，KiriKiri2 / KiriKiriZ（`*.xp3` + `*.cf` + `plugin/`） |
+| exe | `フタマタ恋愛.exe`，x86（machine 0x014C），SHA-256 `07A2A3D6AA665E3E2C4958FBF9FECFD93A5C9BAAC797813A152736B1EDBA3245` |
+| 启动 | 用户原始入口：Locale Emulator（`フタマタ恋愛.exe.le.config`，ja-JP）。复现时用 `voice_hook/x86/fushi_voice_injector.exe --launch <exe> --japanese-locale --hold` |
+| 进程 | injector 报 `LAUNCH pid=189452 arch=x86`、`profile=futamata-renai-jp`、`OK hooked ... hooked=1` |
+| 文本链 | LunaHook / `ExtKAGParser.dll` 线程，`text_hooked=1` `luna_active=1` |
+| 音频链 | DirectSound（每句语音**新建**一个 secondary buffer，source_ptr 每句都变），`48000/1/16`；另有一条长期存在的混音输出源 `48000/2/16` |
+| 阶段 | `process_found → helper_ready → ipc_ready → text_ready → pcm_ready → paired` 全通过；结论建立在 paired 这一层，不涉及 `e2e_verified`，`engine-support.yaml` 不动 |
+
+### 根因链
+
+1. `VoiceClip::timestamp_ms` 是 hook 在音频回调里打的 **`GetTickCount64()` 提交时刻**（`native/galgame_hook/hook/dll_main.cpp:417`），不是这段 PCM 被听到的时刻。契约头里那句注释「该 clip 播放时刻」是错的，误导了下游所有判据。
+2. 流式引擎必然**按缓冲深度提前提交**。KiriKiri 每句语音新建一个 DirectSound buffer，`Play` 之前把整个缓冲一次性灌满：实测**同一个 tick** 内连着写 `96000B`（1000ms 静音底）+ `4×12000B`（500ms 人声）= **1500ms 音频**。
+3. 这一整块的提交时刻比 LunaHook 的文本时刻早 **219ms**（多句实测稳定 203–219ms）。
+4. `GrabUtterance` 的窗口下界是写死的 `ts-200`。**219 > 200**，于是那 1500ms 整块**每一句**都出界被丢掉——不是偶发，是确定性地每句都少开头。
+5. Dart 侧的增长收敛 `_settleLineUtterance`（BUG-1109）与封口 grab（BUG-1475）都只往**后**补，用的还是同一个 ts 和同一个下界，句首丢了就永远回不来。
+
+### 修法
+
+窗口下界不再是常量，改判「这段是不是被引擎**提前灌进去**的」：区间 `[j, i0)` 承载的音频时长若显著快于它被写入的墙钟跨度（`audio > 1.25 * wall`），说明引擎在按缓冲深度提前提交，这段属于本句开头，下界回退到那里；上限 `kUtteranceMaxBackMs = 6000`。
+
+- **实时写入的混音 / BGM 源 `audio ≈ wall`（实测偏差 <10%），判据不成立，下界原样退回 `ts-200`——取音逐字节等价于旧行为。**
+- 判据**不能**逐对比较相邻 clip 间隔：`GetTickCount64` 只有 ~15ms 粒度，同一游戏相邻两句量到的「突发块 → 流式段」间隔一边 62ms 一边 63ms。本修复第一版就是逐对阈值，实测在这点噪声上把一半句子漏掉了；第二版用累计队列模型，又在长流式源上失控（多吞 11750ms BGM）。两次都是真机对照跑出来的，不是推理。
+
+### 真机验证（同一会话，仓库最终实现直接 include 进只读探针对跑）
+
+| 台词 | 现行 | 修正后（裸 / 去静音） | 找回人声 |
+|---|---|---|---|
+| 「忘れもしないさ、あれは俺に初めての彼女が…」 | 5625ms | 7125 / 6001ms | +376ms |
+| 「結愛が彼女紹介してって言うから…」 | 3500ms | 5000 / 3875ms | +375ms |
+| 「彼女いっぱい作って遊んでる…」 | 3500ms | 5000 / 3875ms | +375ms |
+| 「理由なんて考えず愛しまくればいい…」 | 3500ms | 5000 / 3873ms | +373ms |
+| 「刺すんじゃなくて切り落とせば良かったのに」 | 3500ms | 5000 / 3888ms | +388ms |
+| 旁白句（无角色语音，选到混音源）×3 | 6250ms | 6250ms | **0（逐字节不变）** |
+
+丢掉的整块恒为 1500ms，其中 1000ms 是缓冲静音底（本来就会被去首尾静音吃掉），**可听的句首损失约 0.4s**——用户报的「2s 左右」是主观量级，实际丢的是每句开头一个词。
+
+### 未解决 / 后续
+
+- 无角色语音的旁白句（主角独白）会被能量选源判据选到混音输出源，取到的是 BGM。本次不动，另立条目。
+- `VoiceClip::timestamp_ms` 的注释「该 clip 播放时刻」与实现不符，已在新头文件里把语义写清；契约头那行注释留待与 hook 侧一起改，避免本次 PR 动 IPC 契约。
+- 相关：[BUG-1594](BUG-1594-ring-probe-readonly-map-crash.md)（排查本 bug 时撞到的诊断工具崩溃）。

--- a/docs/bugs/BUG-1594-ring-probe-readonly-map-crash.md
+++ b/docs/bugs/BUG-1594-ring-probe-readonly-map-crash.md
@@ -1,0 +1,21 @@
+## BUG-1594 · ring_probe 只读映射下枚举文本槽必崩（Interlocked 写只读页）
+- **报告**：2026-08-13（排查 [BUG-1593](BUG-1593-gal-utterance-head-clipped.md) 时撞到）
+- **真实性**：✅ 真 bug。根因 `native/galgame_hook/tools/ring_probe.cpp:745`（原 `mapping_access = select_text_thread ? READ|WRITE : FILE_MAP_READ`）。
+- **[x] ① 已修复** — `native/galgame_hook/tools/ring_probe.cpp`：映射一律 `FILE_MAP_READ | FILE_MAP_WRITE`（host 侧 `voice_hook_reader.cpp:644` 一直是这么开的，只有这个诊断工具漏了）。
+- **[x] ② 已加自动化测试** — 无法做成自动化断言：崩溃只在「真实共享内存 + 已有文本道」这两个前提同时成立时发生，构造它等于把 injector 与 hook 全跑起来，不是可落地的单测层。改为在代码里把「为什么只读不够」写死成注释，并在 [BUG-1593](BUG-1593-gal-utterance-head-clipped.md) 的真机流程里覆盖。
+- **备注**：见下文。
+
+### 根因链
+
+1. `ring_probe` 自称只读，映射按 `FILE_MAP_READ` 开（文件头注释也强调「**只读**，不注入、不写共享内存」）。
+2. 但文本槽枚举走契约头的 `CollectTextSlotsBySeq`（`include/voice_hook_ipc.h:601`），它按跨进程发布纪律用 `AtomicLoadPreview64(&slot->lane_seq)` 读道内序号。
+3. `AtomicLoadPreview64` 的实现是 `InterlockedCompareExchange64(p, 0, 0)`（`include/thread_preview_ipc.h:61`）——即便比较值与期望值相同，它仍是一条**带 lock 前缀的读改写**指令，对只读页发起写访问。
+4. 于是只要目标进程已经写过任何一条文本行（`text_lane_count > 0`），`ring_probe <pid>` / `--dump-text` / `--dump-text-events` 一律 **0xC0000005** 直接挂掉，而且是在打印完 header 之后立刻挂，看起来像「共享内存坏了」。
+
+### 复现与验证
+
+排查 BUG-1593 时自己写的只读探针踩到同一条路径：header 行正常打印，随后进程以 `-1073741819`（0xC0000005）退出；把映射从 `FILE_MAP_READ` 换成 `FILE_MAP_READ | FILE_MAP_WRITE` 后同一份代码立刻正常枚举出 15 条文本槽。失败与修复走的是同一个共享头、同一个调用点。
+
+### 为什么不改 `AtomicLoadPreview64`
+
+把 64 位读换成 x64 上的普通对齐读确实能从更根上消除「读操作写页面」，但那个头文件同时被注入进游戏进程的 hook DLL 使用（x86 上 64 位裸读会撕裂），改它就是在音频回调的热路径上动内存序语义。收益是让一个诊断工具能开只读映射，风险是动跨进程发布纪律——不划算。放宽这个工具的映射权限不改变「它一个字节都不写」这个事实。

--- a/fushi/windows/runner/voice_hook_reader.cpp
+++ b/fushi/windows/runner/voice_hook_reader.cpp
@@ -22,6 +22,7 @@
 // 直接退回整机混音。副本已删除，改为直接 include 真相源——两侧编同一组常量与同一份结构布局，
 // 版本漂移在结构上不再可能（守卫见 test/mining/gal_ipc_contract_single_source_test.dart）。
 #include "../../../native/galgame_hook/include/voice_hook_ipc.h"
+#include "../../../native/galgame_hook/include/voice_hook_utterance_window.h"
 
 // galgame 一键制卡 C 阶段 —— 引擎-hook 共享内存读侧实现。见 voice_hook_reader.h。
 // 纯 Win32 文件映射，无 COM、无异常（runner 以 _HAS_EXCEPTIONS=0 编译，全程句柄/契约校验）。
@@ -1035,11 +1036,17 @@ VoiceHookStatus VoiceHookReader::GrabUtterance(
     // any_energy=false（非 16-bit）：无法能量选源，退化为拼所有源（filter_by_src 保持 false）。
   }
 
-  // 拼接选定源在 [ts-200, ts+forward_ms] 的段；静音判据用该源峰值能量的 8%。
+  // 拼接选定源在 [下界, ts+forward_ms] 的段；静音判据用该源峰值能量的 8%。
   //
   // BUG-1475：forward_ms 缺省仍是 6000（旧行为逐字等价）。调用方给出 end_ts_ms
   // （下一句的时间戳）时收窄到那里——封口 grab 要拿回已进环、时间戳**严格早于**
   // 下一句的那点尾巴，同时保住 BUG-1109「不把下一句的段拼进上一句」的不变量。
+  //
+  // BUG-1593：下界**不再**是写死的 ts-200。clip 的时间戳是**提交**时刻不是播放时刻，
+  // 流式引擎按缓冲深度提前提交（KiriKiri 每句新建 DirectSound buffer 并一次性灌满整个
+  // 缓冲，实测比文本 hook 早 219ms 灌进 1500ms 音频），固定 200ms 回看会把整句的开头
+  // 整块丢掉。判据见 voice_hook_utterance_window.h：只对「明显快于实时写入」的段回退，
+  // 实时写入的混音 / BGM 源逐字节维持旧行为。
   int64_t forward_ms = 6000;
   if (end_ts_ms != 0 && end_ts_ms > ts_ms) {
     forward_ms = std::min<int64_t>(
@@ -1048,6 +1055,26 @@ VoiceHookStatus VoiceHookReader::GrabUtterance(
     // 下一句时间戳不晚于本句：拿不到任何合法的前向窗口，退化为只取本句时刻附近。
     forward_ms = 0;
   }
+  // 选定源的段（按提交顺序）喂给下界推算：valid 本身就是 seq 升序。
+  std::vector<fushi_voice_hook::UtteranceClipTiming> timings;
+  timings.reserve(valid.size());
+  for (const auto* c : valid) {
+    if (filter_by_src && c->source_ptr != sel_src) {
+      continue;
+    }
+    const uint32_t block = c->channels * (c->bits_per_sample / 8);
+    const int64_t dur =
+        (block == 0 || c->sample_rate == 0)
+            ? 0
+            : static_cast<int64_t>(static_cast<int64_t>(c->byte_len) * 1000 /
+                                   (static_cast<int64_t>(block) *
+                                    static_cast<int64_t>(c->sample_rate)));
+    timings.push_back(fushi_voice_hook::UtteranceClipTiming{
+        static_cast<int64_t>(c->timestamp_ms), dur});
+  }
+  const int64_t lower_ts = fushi_voice_hook::UtteranceLowerBoundMs(
+      timings.data(), timings.size(), static_cast<int64_t>(ts_ms));
+
   std::vector<uint8_t> pcm;
   const fushi_voice_hook::VoiceClip* fmt = nullptr;
   double peak = 1.0;
@@ -1057,7 +1084,7 @@ VoiceHookStatus VoiceHookReader::GrabUtterance(
     }
     const int64_t d = static_cast<int64_t>(c->timestamp_ms) -
                       static_cast<int64_t>(ts_ms);
-    if (d < -200 || d > forward_ms) {
+    if (static_cast<int64_t>(c->timestamp_ms) < lower_ts || d > forward_ms) {
       continue;
     }
     const double e = ClipEnergy16Locked(h, ring, c);

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -93,6 +93,12 @@ target_include_directories(fushi_resource_audio_ready_test PRIVATE "include")
 target_compile_definitions(fushi_resource_audio_ready_test PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
 add_test(NAME fushi_resource_audio_ready_test COMMAND fushi_resource_audio_ready_test)
 
+add_executable(fushi_utterance_window_test
+  "tests/utterance_window_test.cpp"
+)
+target_include_directories(fushi_utterance_window_test PRIVATE "include")
+add_test(NAME fushi_utterance_window_test COMMAND fushi_utterance_window_test)
+
 add_executable(fushi_voice_resource_filename_test
   "tests/voice_resource_filename_test.cpp"
 )

--- a/native/galgame_hook/include/voice_hook_utterance_window.h
+++ b/native/galgame_hook/include/voice_hook_utterance_window.h
@@ -1,0 +1,78 @@
+#ifndef FUSHI_VOICE_HOOK_UTTERANCE_WINDOW_H_
+#define FUSHI_VOICE_HOOK_UTTERANCE_WINDOW_H_
+
+#include <cstddef>
+#include <cstdint>
+
+// 整句语音拼接窗口的**下界**推算（BUG-1593）。
+//
+// 为什么需要它：`VoiceClip::timestamp_ms` 是 hook 在 XAudio2/DirectSound 回调里打的**提交**
+// 时刻，不是这段 PCM 被听到的时刻。流式引擎必然按缓冲深度提前提交，两者相差「提交时该源还
+// 没播完的积压」。KiriKiri 每句语音新建一个 DirectSound secondary buffer，Play 之前把整个
+// 缓冲一次性灌满——实测フタマタ恋愛：96000B 静音底（1000ms）+ 4×12000B 人声（500ms）共
+// 1500ms 音频**落在同一个 tick**，而这一整块的提交时刻比文本 hook 早 **219ms**。窗口下界
+// 若是写死的 `ts-200ms`，这一整块必然整体出界，于是**每一句**都被削掉开头（BUG-1593）。
+//
+// 判据为什么不能逐对比较相邻 clip 的间隔：`GetTickCount64` 只有 ~15ms 粒度，同一游戏相邻
+// 两句量到的「突发块到流式段」的间隔一边 62ms 一边 63ms，任何逐对阈值都会在这点噪声上
+// 二选一地翻车（本修复第一版实测就是这么漏掉一半句子的）。
+//
+// 改用**聚合**判据：区间 `[j, i0)` 承载的音频时长若显著快于它被写入的墙钟跨度
+// （`audio > 1.25 * wall`），说明引擎正在提前灌入，这段属于本句开头。实时写入的混音 / BGM
+// 源 `audio ≈ wall`（实测偏差 <10%），判据不成立，下界原样退回 `text_ts - back_ms` ——
+// 对这类源的取音**逐字节等价于旧行为**（真机实测差异 0 字节）。1.25 这个倍率把「提前灌入」
+// （实测超出 20 倍以上）和「实时写入」（实测 <1.1 倍）分得很开，不在噪声量级上。
+namespace fushi_voice_hook {
+
+// 文本时刻之前仍算作本句的固定回看量（旧行为的唯一常量，保持不变）。
+constexpr int64_t kUtteranceBackMs = 200;
+// 下界最多回看多远：与前向窗口同量级，兜住「选到长流式源」时的失控回溯。
+constexpr int64_t kUtteranceMaxBackMs = 6000;
+
+struct UtteranceClipTiming {
+  int64_t timestamp_ms;  // 提交时刻（VoiceClip::timestamp_ms）
+  int64_t duration_ms;   // 该段承载的音频时长
+};
+
+// [clips, clips+count) 必须是**选定语音源**的段、按提交顺序（seq 升序）。
+// 返回值是提交时间轴上的下界：调用方保留 `timestamp_ms >= 返回值` 的段。
+// 恒有 `返回值 <= text_ts_ms - back_ms`，即只可能比旧行为多收、不可能少收。
+inline int64_t UtteranceLowerBoundMs(const UtteranceClipTiming* clips,
+                                     size_t count, int64_t text_ts_ms,
+                                     int64_t back_ms = kUtteranceBackMs,
+                                     int64_t max_back_ms = kUtteranceMaxBackMs) {
+  const int64_t base = text_ts_ms - back_ms;
+  if (clips == nullptr || count == 0) {
+    return base;
+  }
+  size_t i0 = count;
+  for (size_t k = 0; k < count; ++k) {
+    if (clips[k].timestamp_ms >= base) {
+      i0 = k;
+      break;
+    }
+  }
+  // i0 == 0：最早的段已经在窗口里，没有开头可捡。
+  // i0 == count：边界之后一段都没有，本来就取不到这句，扩下界没有意义。
+  if (i0 == 0 || i0 == count) {
+    return base;
+  }
+  int64_t lower = base;
+  int64_t audio = 0;
+  for (size_t j = i0; j-- > 0;) {
+    audio += clips[j].duration_ms;
+    if (text_ts_ms - clips[j].timestamp_ms > max_back_ms) {
+      break;
+    }
+    const int64_t wall =
+        clips[i0].timestamp_ms - clips[j].timestamp_ms;
+    if (audio * 4 > wall * 5) {
+      lower = clips[j].timestamp_ms;  // 取满足条件的**最早**那个 j
+    }
+  }
+  return lower < base ? lower : base;
+}
+
+}  // namespace fushi_voice_hook
+
+#endif  // FUSHI_VOICE_HOOK_UTTERANCE_WINDOW_H_

--- a/native/galgame_hook/tests/utterance_window_test.cpp
+++ b/native/galgame_hook/tests/utterance_window_test.cpp
@@ -1,0 +1,135 @@
+// BUG-1593：整句语音窗口下界的不变量测试。
+//
+// fixture 全部是**真机采到的**时间轴（フタマタ恋愛 / KiriKiriZ，x86，2026-08-13，
+// injector 早注入 pid=189452，只读探针从共享内存 dump 出的 VoiceClip 索引），不是编的：
+// 每句语音一个新建的 DirectSound buffer，Play 前把整个缓冲一次灌满（1000ms 静音底 +
+// 4×125ms 人声，全落在同一个 tick），提交时刻比文本 hook 早 219ms。
+//
+// 不用 assert：本目录的测试目标没有关掉 NDEBUG，Release 配置下 assert 会被整条编掉，
+// 那样的「测试」永远绿。这里用显式检查 + 非零退出码。
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "voice_hook_utterance_window.h"
+
+using fushi_voice_hook::UtteranceClipTiming;
+using fushi_voice_hook::UtteranceLowerBoundMs;
+
+namespace {
+
+int g_failures = 0;
+
+void Expect(bool ok, const char* what, int64_t got, int64_t want) {
+  if (ok) {
+    return;
+  }
+  ++g_failures;
+  printf("FAIL %s: got %lld want %lld\n", what, static_cast<long long>(got),
+         static_cast<long long>(want));
+}
+
+void ExpectEq(int64_t got, int64_t want, const char* what) {
+  Expect(got == want, what, got, want);
+}
+
+// 真机时间轴：一句语音（新建 buffer）。第一段是整缓冲灌入，随后 125ms 一段流式补。
+std::vector<UtteranceClipTiming> RealUtterance(int64_t t0) {
+  return {
+      {t0, 1000},      {t0, 125},       {t0, 125},       {t0, 125},
+      {t0, 125},       {t0 + 62, 125},  {t0 + 109, 125}, {t0 + 172, 125},
+      {t0 + 234, 125}, {t0 + 297, 125}, {t0 + 359, 125}, {t0 + 422, 125},
+      {t0 + 484, 125}, {t0 + 547, 125}, {t0 + 609, 125}, {t0 + 672, 125},
+  };
+}
+
+}  // namespace
+
+int main() {
+  // ① 真机主用例：文本时刻比整块灌入晚 219ms —— 旧的固定 -200ms 下界会把这 1500ms
+  //    整块丢掉；下界必须回退到灌入时刻本身。
+  {
+    const int64_t t0 = 519155031;
+    const int64_t text_ts = t0 + 219;  // 真机实测 519155250
+    const auto clips = RealUtterance(t0);
+    ExpectEq(UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts), t0,
+             "fill-ahead burst recovered");
+  }
+
+  // ② 上一版判据翻车的边缘用例：突发块与其后第一段流式段之间是 63ms（另一句是
+  //    62ms），逐对阈值会在 GetTickCount64 的 15ms 粒度噪声上二选一。聚合判据必须
+  //    对两者都成立。
+  for (const int64_t first_gap : {62, 63}) {
+    const int64_t t0 = 519148640;
+    const int64_t text_ts = t0 + 219;
+    std::vector<UtteranceClipTiming> clips{
+        {t0, 1000},   {t0, 125},
+        {t0, 125},    {t0, 125},
+        {t0, 125},    {t0 + first_gap, 125},
+        {t0 + first_gap + 47, 125}, {t0 + first_gap + 109, 125},
+        {t0 + first_gap + 172, 125}, {t0 + first_gap + 234, 125},
+    };
+    ExpectEq(UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts), t0,
+             first_gap == 62 ? "burst boundary gap=62" : "burst boundary gap=63");
+  }
+
+  // ③ 实时写入的混音 / BGM 源：125ms 音频约每 120ms 写一次，判据不成立，下界必须
+  //    原样是 ts-200（对这类源逐字节等价于旧行为——真机实测差异 0 字节）。
+  {
+    const int64_t t0 = 519000000;
+    std::vector<UtteranceClipTiming> clips;
+    for (int i = 0; i < 200; ++i) {
+      clips.push_back({t0 + i * 120, 125});
+    }
+    const int64_t text_ts = t0 + 100 * 120;
+    ExpectEq(UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts),
+             text_ts - fushi_voice_hook::kUtteranceBackMs,
+             "realtime stream unchanged");
+  }
+
+  // ④ 上一句的段不许被拼进来：两句之间隔着 3.4s 空档（真机实测值），下界只能停在
+  //    本句的灌入块，不能穿到上一句。
+  {
+    const int64_t prev_t0 = 519148640;
+    const int64_t t0 = prev_t0 + 6391;  // 真机：519155031
+    std::vector<UtteranceClipTiming> clips = RealUtterance(prev_t0);
+    for (const auto& c : RealUtterance(t0)) {
+      clips.push_back(c);
+    }
+    const int64_t text_ts = t0 + 219;
+    ExpectEq(UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts), t0,
+             "previous utterance not spliced");
+  }
+
+  // ⑤ 回看上限：即便判据一路成立，也不许超过 kUtteranceMaxBackMs。
+  {
+    const int64_t t0 = 519000000;
+    std::vector<UtteranceClipTiming> clips;
+    for (int i = 0; i < 400; ++i) {
+      clips.push_back({t0 + i * 30, 1000});  // 30ms 写一次 1000ms：一路都是提前灌入
+    }
+    const int64_t text_ts = t0 + 399 * 30;
+    const int64_t lower =
+        UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts);
+    Expect(text_ts - lower <= fushi_voice_hook::kUtteranceMaxBackMs,
+           "max back cap", text_ts - lower, fushi_voice_hook::kUtteranceMaxBackMs);
+  }
+
+  // ⑥ 边界：空输入 / 全部段都已在窗口内 —— 下界恒为 ts-200，且永不晚于 ts-200。
+  {
+    const int64_t text_ts = 1000000;
+    ExpectEq(UtteranceLowerBoundMs(nullptr, 0, text_ts),
+             text_ts - fushi_voice_hook::kUtteranceBackMs, "empty input");
+    std::vector<UtteranceClipTiming> clips{
+        {text_ts - 100, 125}, {text_ts - 20, 125}, {text_ts + 60, 125}};
+    ExpectEq(UtteranceLowerBoundMs(clips.data(), clips.size(), text_ts),
+             text_ts - fushi_voice_hook::kUtteranceBackMs, "all inside window");
+  }
+
+  if (g_failures != 0) {
+    printf("utterance_window_test: %d failure(s)\n", g_failures);
+    return 1;
+  }
+  printf("utterance_window_test: ok\n");
+  return 0;
+}

--- a/native/galgame_hook/tools/ring_probe.cpp
+++ b/native/galgame_hook/tools/ring_probe.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "voice_hook_ipc.h"
+#include "voice_hook_utterance_window.h"
 
 // galgame 一键制卡 C 阶段 —— 环形缓冲诊断读取器（x64 独立小工具）。
 //
@@ -365,7 +366,28 @@ bool DumpUtterance(const SharedHeader* h, const uint8_t* ring, uint64_t ts,
       voice_src = kv.first;
     }
   }
-  // 拼接语音源在 [ts-200, ts+6000] 的段；静音判据用该源峰值能量的 8%。
+  // 拼接语音源在 [下界, ts+6000] 的段；静音判据用该源峰值能量的 8%。下界与 host 的
+  // GrabUtterance 共用同一份实现（BUG-1593）：clip 时间戳是**提交**时刻，流式引擎按缓冲
+  // 深度提前灌入，固定 200ms 回看会整块丢掉句首。诊断工具必须和真实取音判据一致，否则
+  // 拿它排障只会把人带偏。
+  std::vector<fushi_voice_hook::UtteranceClipTiming> timings;
+  for (const auto* c : valid) {
+    if (any_energy && c->source_ptr != voice_src) {
+      continue;
+    }
+    const uint32_t block = c->channels * (c->bits_per_sample / 8);
+    const int64_t dur =
+        (block == 0 || c->sample_rate == 0)
+            ? 0
+            : static_cast<int64_t>(static_cast<int64_t>(c->byte_len) * 1000 /
+                                   (static_cast<int64_t>(block) *
+                                    static_cast<int64_t>(c->sample_rate)));
+    timings.push_back(fushi_voice_hook::UtteranceClipTiming{
+        static_cast<int64_t>(c->timestamp_ms), dur});
+  }
+  const int64_t lower_ts = fushi_voice_hook::UtteranceLowerBoundMs(
+      timings.data(), timings.size(), static_cast<int64_t>(ts));
+
   std::vector<uint8_t> pcm;
   const fushi_voice_hook::VoiceClip* fmt = nullptr;
   double peak = 1.0;
@@ -375,7 +397,7 @@ bool DumpUtterance(const SharedHeader* h, const uint8_t* ring, uint64_t ts,
     }
     const int64_t d = static_cast<int64_t>(c->timestamp_ms) -
                       static_cast<int64_t>(ts);
-    if (d < -200 || d > 6000) {
+    if (static_cast<int64_t>(c->timestamp_ms) < lower_ts || d > 6000) {
       continue;
     }
     const double e = ClipEnergy16(h, ring, c);
@@ -719,8 +741,12 @@ int main(int argc, char** argv) {
       argc >= 4 && strcmp(argv[2], "--select-text-thread") == 0;
 
   const std::wstring shm = SharedMemoryName(pid);
-  const DWORD mapping_access =
-      select_text_thread ? FILE_MAP_READ | FILE_MAP_WRITE : FILE_MAP_READ;
+  // BUG-1594：映射必须带 FILE_MAP_WRITE，哪怕本工具一个字节都不写。文本槽枚举走契约头的
+  // CollectTextSlotsBySeq，它按跨进程发布纪律用 AtomicLoadPreview64 读 lane_seq，而那是
+  // InterlockedCompareExchange64——一条**带锁的读改写**指令，落到只读页上就是 0xC0000005。
+  // 于是「有文本行之后跑 ring_probe <pid>」必崩（本仓 host 侧一直用 READ|WRITE，只有这个
+  // 诊断工具漏了）。权限放宽不改变「本工具只读不写」这个事实。
+  const DWORD mapping_access = FILE_MAP_READ | FILE_MAP_WRITE;
   HANDLE mapping = OpenFileMappingW(mapping_access, FALSE, shm.c_str());
   if (mapping == nullptr) {
     fprintf(stderr,


### PR DESCRIPTION
用户报：「制卡截取的音频都会漏掉前面 2s 左右的内容」（游戏：恋爱成双 / フタマタ恋愛，KiriKiriZ）。

## 根因

`VoiceClip::timestamp_ms` 是 hook 在音频回调里打的**提交**时刻，不是这段 PCM 被听到的时刻（契约头那句「该 clip 播放时刻」的注释是错的）。流式引擎必然按缓冲深度提前提交：KiriKiri 每句语音新建一个 DirectSound secondary buffer，`Play` 之前把整个缓冲一次性灌满——真机实测**同一个 tick** 内连写 `96000B`(1000ms 静音底) + `4×12000B`(500ms 人声) = **1500ms 音频**，这一整块的提交时刻比 LunaHook 的文本时刻早 **219ms**。

`GrabUtterance` 的窗口下界是写死的 `ts-200`。**219 > 200**，于是这 1500ms 整块**每一句**都出界被丢掉——确定性的，不是偶发。Dart 侧的增长收敛（BUG-1109）和封口 grab（BUG-1475）都只往后补，句首丢了永远回不来。

## 修法

下界不再是常量，改判「这段是不是被引擎**提前灌进去**的」：区间 `[j, i0)` 承载的音频时长若显著快于它被写入的墙钟跨度（`audio > 1.25 * wall`），说明引擎在提前提交，下界回退到那里；上限 6000ms。

- **实时写入的混音 / BGM 源 `audio ≈ wall`，判据不成立，逐字节等价于旧行为。**
- 判据**不能**逐对比较相邻 clip 间隔：`GetTickCount64` 只有 ~15ms 粒度，同一游戏相邻两句量到的边界一边 62ms 一边 63ms。第一版逐对阈值实测漏掉一半句子；第二版累计队列模型在长流式源上失控（多吞 11750ms BGM）。两次都是真机对照跑出来才发现的。
- 实现只有一份（`voice_hook_utterance_window.h`），host 的 `GrabUtterance` 与诊断工具 `ring_probe` 共用——诊断工具和真实取音判据不一致比没有更糟。

顺带修 `ring_probe` 的只读映射崩溃（BUG-1594）：文本槽枚举走 `AtomicLoadPreview64` = `InterlockedCompareExchange64`，那是带 lock 的读改写，落到 `FILE_MAP_READ` 页上就是 0xC0000005。目标进程一有文本行，`ring_probe <pid>` 必崩。

## 验证

真机（injector 早注入 `pid=189452`，仓库最终实现直接 include 进只读探针对跑）：

| 台词 | 现行 | 修正后（去静音） | 找回 |
|---|---|---|---|
| 「忘れもしないさ、あれは俺に…」 | 5625ms | 6001ms | +376ms |
| 「結愛が彼女紹介してって…」 | 3500ms | 3875ms | +375ms |
| 「彼女いっぱい作って遊んでる…」 | 3500ms | 3875ms | +375ms |
| 「理由なんて考えず愛しまくれば…」 | 3500ms | 3873ms | +373ms |
| 「刺すんじゃなくて切り落とせば…」 | 3500ms | 3888ms | +388ms |
| 旁白句（选到混音源）×3 | 6250ms | 6250ms | **0（逐字节不变）** |

- 新增 CTest `fushi_utterance_window_test`，fixture 全部是真机 dump 出来的时间轴（含那条 62/63ms 边缘用例）；**变异实测**：判据改恒假 → 6 条断言转红 4 条，还原后恢复绿。
- `voice_hook_reader.cpp` / `ring_probe.cpp` 单文件 `/W4` 编译 0 error、0 新增 warning。
- `flutter analyze` 全量 No issues；`test/mining` 990 tests passed（`flutter_test_failures.dart` 判绿）。
- native 守卫：`generate_engine_support.py --check`、`generate_luna_profiles.py --check`、`galhook.py check`（结构/证据/workflow 共 31 条）全通过。

## 未做

- 无角色语音的旁白句会被能量选源判据选到混音输出源、取到 BGM。本次不动，已在 BUG-1593 记为后续。
- 不改 `engine-support.yaml`：本次证据链停在 `paired`，没有走完 `e2e_verified`。

https://claude.ai/code/session_01YDUoCJn3fKcFVnVxFBcGGK
