### PR TITLE
feat(video): 主副字幕分开调轴——副轨独立 delay 两层持久化（TODO-2837，schema v86）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57307 (3371 per locale)
+/// Strings: 57409 (3377 per locale)
 ///
-/// Built on 2026-08-13 at 08:43 UTC
+/// Built on 2026-08-13 at 11:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4563,6 +4563,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_priority_high => 'High';
   String get download_task_priority_normal => 'Normal';
   String get download_task_priority_low => 'Low';
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -12337,6 +12345,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -12347,6 +12356,19 @@ class _StringsAr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -20188,6 +20210,7 @@ class _StringsDe extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -20198,6 +20221,19 @@ class _StringsDe extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -28055,6 +28091,7 @@ class _StringsEs extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -28065,6 +28102,19 @@ class _StringsEs extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -35934,6 +35984,7 @@ class _StringsFr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -35944,6 +35995,19 @@ class _StringsFr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -43741,6 +43805,7 @@ class _StringsId extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -43751,6 +43816,19 @@ class _StringsId extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -51594,6 +51672,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -51604,6 +51683,19 @@ class _StringsIt extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -59261,6 +59353,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -59271,6 +59364,19 @@ class _StringsJa extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -66935,6 +67041,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -66945,6 +67052,19 @@ class _StringsKo extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -74768,6 +74888,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -74778,6 +74899,19 @@ class _StringsNl extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -82613,6 +82747,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -82623,6 +82758,19 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -90444,6 +90592,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -90454,6 +90603,19 @@ class _StringsRu extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -98223,6 +98385,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -98233,6 +98396,19 @@ class _StringsTh extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -106033,6 +106209,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -106043,6 +106220,19 @@ class _StringsTr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -113828,6 +114018,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -113838,6 +114029,19 @@ class _StringsVi extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 // Path: <root>
@@ -121057,6 +121261,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       '排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '共 ${count} 个发布';
   @override
@@ -121067,6 +121272,17 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_priority_normal => '普通';
   @override
   String get download_task_priority_low => '低';
+  @override
+  String get video_setting_secondary_av_delay => '副字幕调轴';
+  @override
+  String get video_setting_secondary_av_delay_hint => '副字幕独立偏移；未单独设置时跟随主字幕调轴。';
+  @override
+  String get video_setting_secondary_delay_follow => '跟随主字幕';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      '副字幕同步：${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd => '副字幕同步：跟随主字幕';
 }
 
 // Path: <root>
@@ -128647,6 +128863,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -128657,6 +128874,19 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_secondary_av_delay => 'Secondary subtitle sync';
+  @override
+  String get video_setting_secondary_av_delay_hint =>
+      'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+  @override
+  String get video_setting_secondary_delay_follow => 'Follow primary';
+  @override
+  String video_subtitle_secondary_delay_osd({required Object ms}) =>
+      'Secondary subtitle sync: ${ms} ms';
+  @override
+  String get video_subtitle_secondary_delay_follow_osd =>
+      'Secondary subtitle sync: follow primary';
 }
 
 /// Flat map(s) containing all translations.
@@ -135583,6 +135813,16 @@ extension on _StringsEn {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -142507,6 +142747,16 @@ extension on _StringsAr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -149453,6 +149703,16 @@ extension on _StringsDe {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -156398,6 +156658,16 @@ extension on _StringsEs {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -163349,6 +163619,16 @@ extension on _StringsFr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -170282,6 +170562,16 @@ extension on _StringsId {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -177229,6 +177519,16 @@ extension on _StringsIt {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -184138,6 +184438,16 @@ extension on _StringsJa {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -191051,6 +191361,16 @@ extension on _StringsKo {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -197992,6 +198312,16 @@ extension on _StringsNl {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -204930,6 +205260,16 @@ extension on _StringsPtBr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -211873,6 +212213,16 @@ extension on _StringsRu {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -218799,6 +219149,16 @@ extension on _StringsTh {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -225734,6 +226094,16 @@ extension on _StringsTr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -232665,6 +233035,16 @@ extension on _StringsVi {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }
@@ -239538,6 +239918,16 @@ extension on _StringsZhCn {
         return '普通';
       case 'download_task_priority_low':
         return '低';
+      case 'video_setting_secondary_av_delay':
+        return '副字幕调轴';
+      case 'video_setting_secondary_av_delay_hint':
+        return '副字幕独立偏移；未单独设置时跟随主字幕调轴。';
+      case 'video_setting_secondary_delay_follow':
+        return '跟随主字幕';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => '副字幕同步：${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return '副字幕同步：跟随主字幕';
       default:
         return null;
     }
@@ -246442,6 +246832,16 @@ extension on _StringsZhHk {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_secondary_av_delay':
+        return 'Secondary subtitle sync';
+      case 'video_setting_secondary_av_delay_hint':
+        return 'Adjust the secondary subtitle offset independently. It follows the primary offset until set here.';
+      case 'video_setting_secondary_delay_follow':
+        return 'Follow primary';
+      case 'video_subtitle_secondary_delay_osd':
+        return ({required Object ms}) => 'Secondary subtitle sync: ${ms} ms';
+      case 'video_subtitle_secondary_delay_follow_osd':
+        return 'Secondary subtitle sync: follow primary';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "排队优先级",
   "download_task_priority_high": "高",
   "download_task_priority_normal": "普通",
-  "download_task_priority_low": "低"
+  "download_task_priority_low": "低",
+  "video_setting_secondary_av_delay": "副字幕调轴",
+  "video_setting_secondary_av_delay_hint": "副字幕独立偏移；未单独设置时跟随主字幕调轴。",
+  "video_setting_secondary_delay_follow": "跟随主字幕",
+  "video_subtitle_secondary_delay_osd": "副字幕同步：$ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "副字幕同步：跟随主字幕"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_secondary_av_delay": "Secondary subtitle sync",
+  "video_setting_secondary_av_delay_hint": "Adjust the secondary subtitle offset independently. It follows the primary offset until set here.",
+  "video_setting_secondary_delay_follow": "Follow primary",
+  "video_subtitle_secondary_delay_osd": "Secondary subtitle sync: $ms ms",
+  "video_subtitle_secondary_delay_follow_osd": "Secondary subtitle sync: follow primary"
 }

--- a/fushi/lib/src/media/video/series_playback_prefs.dart
+++ b/fushi/lib/src/media/video/series_playback_prefs.dart
@@ -24,3 +24,12 @@ String? effectiveSeriesAudioTrackId(
 /// 系列级非 null 优先，否则回退 per-book。
 int effectiveSeriesDelayMs(int? collectionValue, int perBookValue) =>
     collectionValue ?? perBookValue;
+
+/// 解析生效的**副字幕**独立调轴（毫秒，schema v86，TODO-2837 主副字幕分开调轴）。
+/// [collectionValue] 系列（合集）级副轨调轴（`MediaCollections.secondarySubtitleDelayMs`）；
+/// [perBookValue] 本集自己行的 `VideoBooks.secondaryDelayMs`。两列都 nullable：
+/// 系列级非 null 优先，否则回退 per-book；**两者皆 null → null = 副字幕跟随主字幕
+/// 调轴**（v86 前「主副共用一个 offset」的行为，Never break userspace）。与
+/// [effectiveSeriesDelayMs] 同一优先级语义，仅回退终点不同（null=跟随而非 0）。
+int? effectiveSeriesSecondaryDelayMs(int? collectionValue, int? perBookValue) =>
+    collectionValue ?? perBookValue;

--- a/fushi/lib/src/media/video/video_book_repository.dart
+++ b/fushi/lib/src/media/video/video_book_repository.dart
@@ -642,6 +642,11 @@ class VideoBookRepository {
   Future<void> updateDelayMs(String bookUid, int delayMs) =>
       _db.updateVideoBookDelayMs(bookUid, delayMs);
 
+  /// 更新副字幕独立调轴（毫秒，schema v86，TODO-2837）。[secondaryDelayMs] 为
+  /// null = 清除独立值（副字幕回到跟随主字幕 [updateDelayMs] 的值）。
+  Future<void> updateSecondaryDelayMs(String bookUid, int? secondaryDelayMs) =>
+      _db.updateVideoBookSecondaryDelayMs(bookUid, secondaryDelayMs);
+
   /// 更新用户选中的字幕源（外挂存绝对路径；内嵌存 `embedded:<n>`；用户显式关闭存
   /// `off:` 哨兵 `SubtitleSource.offSentinel`，TODO-818；null=无偏好/从未选过，按
   /// 「自动选默认」恢复，与「显式关闭」区分，勿混用）。
@@ -679,6 +684,14 @@ class VideoBookRepository {
     int? delayMs,
   ) =>
       _db.updateMediaCollectionSubtitleDelayMs(collectionId, delayMs);
+
+  /// 更新系列（合集）级**副字幕**独立调轴（毫秒，schema v86，TODO-2837，同系列
+  /// 副轨调轴记忆）。null=清除（加载回退各集 per-book；两层都 null = 跟随主字幕）。
+  Future<void> updateCollectionSecondarySubtitleDelayMs(
+    int collectionId,
+    int? delayMs,
+  ) =>
+      _db.updateMediaCollectionSecondarySubtitleDelayMs(collectionId, delayMs);
 
   /// 更新视频封面图绝对路径（书架/视频库长按菜单手动设置封面）。
   Future<void> updateCover(String bookUid, String coverPath) =>

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -297,6 +297,12 @@ class VideoPlayerController extends ChangeNotifier
   /// 音画延迟（毫秒）：正值表示"视频比文字先播"，查 cue 时把位置往回拨。
   int _delayMs = 0;
 
+  /// 副字幕独立调轴（毫秒，TODO-2837 主副字幕分开调轴）。**null = 未单独设置 =
+  /// 跟随 [_delayMs]**（与历史「主副共用一个 offset」行为一致）；非 null = 副字幕
+  /// cue 流按此值独立求活动集（主副字幕轴不同源时各调各的）。副字幕恒为 Dart 文本
+  /// cue 流（无图形轨形态），不涉及 libmpv `sub-delay`。
+  int? _secondaryDelayMs;
+
   /// 当前字幕是否走 libmpv 画面渲染的**图形内封轨**（PGS/DVD 等位图，
   /// [selectEmbeddedGraphicTrack]）。图形字幕没有文本 cue，[_delayMs] 的 Dart 侧 cue
   /// 偏移对它无效，调轴必须下发到 libmpv `sub-delay`（BUG-301）。
@@ -929,6 +935,54 @@ class VideoPlayerController extends ChangeNotifier
     _secondaryCues = <AudioCue>[];
     _activeSecondaryCueIndices = const <int>[];
     notifyListeners();
+  }
+
+  /// 设置副字幕独立调轴（毫秒，TODO-2837）。null = 清除独立值、回到跟随主字幕
+  /// [_delayMs]；非 null clamp 到 ±600000（与 [setDelayMs] 同界）。
+  ///
+  /// 与 [setDelayMs] 的 BUG-373 同理：改完**立即按当前位置重算活动集并通知**，
+  /// 暂停定格微调也即时反馈、不等 125ms tick。副字幕恒为 Dart 文本 cue 流，无
+  /// libmpv `sub-delay` 参与（图形轨只存在于主字幕），故无需碰 player。
+  void setSecondaryDelayMs(int? delayMs) {
+    _secondaryDelayMs = delayMs?.clamp(-600000, 600000);
+    final int? pos = positionMs;
+    if (pos == null) return;
+    _syncCueForPosition(pos, persistPosition: false);
+  }
+
+  /// 副字幕独立调轴原始值；null = 跟随主字幕（未单独设置）。
+  int? get secondaryDelayMs => _secondaryDelayMs;
+
+  /// 副字幕**生效**调轴（毫秒）：独立值优先，未设置时跟随主字幕 [_delayMs]。
+  /// 副字幕活动集求解 / 制卡逆变换 / 片段字幕导出的共享真相源。
+  int get effectiveSecondaryDelayMs => _secondaryDelayMs ?? _delayMs;
+
+  /// [miningCues]（BUG-1592 有效 cue 流）对应的生效调轴：主流非空用主轨
+  /// [_delayMs]，主流为空落副字幕流时用 [effectiveSecondaryDelayMs]。制卡按位置
+  /// 解析锚点 / 裁剪逆变换必须与该流的 cue 命中同一根时间轴（TODO-2837）。
+  int get miningDelayMs =>
+      _cues.isNotEmpty ? _delayMs : effectiveSecondaryDelayMs;
+
+  /// [cue] 所属流的生效调轴（按身份判定，镜像 [cueStreamOwning]）：主流 cue 用
+  /// [_delayMs]、副流 cue 用 [effectiveSecondaryDelayMs]；两条流都不含它（列表
+  /// 面板的合成 cue / 已换集的陈旧 cue）时回 [miningDelayMs]（与
+  /// [cueStreamOwning] 的兜底同一口径）。
+  int delayMsForCue(AudioCue cue) {
+    if (_cues.any((AudioCue c) => identical(c, cue))) return _delayMs;
+    if (_secondaryCues.any((AudioCue c) => identical(c, cue))) {
+      return effectiveSecondaryDelayMs;
+    }
+    return miningDelayMs;
+  }
+
+  /// [cue] 所属流的**调轴校正后等效位置**（毫秒；未 [load] / 无位置时 null）。
+  /// 字幕 overlay 的 ASS 动画（`\fad`/`\move`/`\t`）求「cue 内已播放时长」用——
+  /// 副字幕独立调轴后主副两条流的等效时间轴可以不同，按 cue 分流取轴
+  /// （TODO-2837；主轨等价于旧 [effectivePositionMs]）。
+  int? effectivePositionMsForCue(AudioCue cue) {
+    final int? pos = positionMs;
+    if (pos == null) return null;
+    return effectiveSubtitlePositionMs(pos, delayMsForCue(cue));
   }
 
   /// 设置音画延迟（毫秒），clamp 到 ±600000（±10 分钟）。
@@ -1622,13 +1676,16 @@ class VideoPlayerController extends ChangeNotifier
     }
     final int effectiveMs = effectiveSubtitlePositionMs(posMs, _delayMs);
 
-    // TODO-1312：副字幕活动集（与主字幕独立、同一 effective 位置各自求；空副字幕恒空集）。
+    // TODO-1312：副字幕活动集（与主字幕独立求；空副字幕恒空集）。TODO-2837：副字幕
+    // 用**自己的生效调轴**（[effectiveSecondaryDelayMs]，未单独设置时 == _delayMs，
+    // 等价旧「同一 effective 位置」行为）求活动集——主副字幕轴不同源时各调各的。
     // 无论主字幕有无都要更新（副字幕可在无主字幕时单独显示），故放在主 cues 空判之前。
     final List<int> nextSecondary = _secondaryCues.isEmpty
         ? const <int>[]
         : JsonAlignmentParser.findActiveCueIndices(
             cues: _secondaryCues,
-            positionMs: effectiveMs,
+            positionMs:
+                effectiveSubtitlePositionMs(posMs, effectiveSecondaryDelayMs),
             // 渲染集半开区间：相邻对白边界不产生「幻影重叠」→ 堆叠不弹跳（见
             // [JsonAlignmentParser.findActiveCueIndices] 的 endInclusive 说明）。
             endInclusive: false);

--- a/fushi/lib/src/media/video/video_quick_settings_host.dart
+++ b/fushi/lib/src/media/video/video_quick_settings_host.dart
@@ -28,6 +28,9 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
     required this.isTouchControls,
     required this.delayMs,
     required this.onSetDelay,
+    this.secondaryDelayMs,
+    this.onSetSecondaryDelay,
+    this.hasSecondarySubtitle,
     this.onAutoAlign,
     this.subtitleWaveformCues = const <AudioCue>[],
     this.videoDurationMs = 0,
@@ -85,6 +88,19 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
   // ── 字幕调轴（A/V 延迟，per-media DB 持久化，仅播放中有意义）──────────────
   final int Function() delayMs;
   final Future<void> Function(int delayMs) onSetDelay;
+
+  /// TODO-2837：副字幕独立调轴当前值（null = 跟随主字幕）。三件套（本值 /
+  /// [onSetSecondaryDelay] / [hasSecondarySubtitle]）齐备且副字幕轨激活时，
+  /// 调轴行才显示副轨独立一段；不齐（全局设置页等无播放器上下文）自然隐藏。
+  final int? Function()? secondaryDelayMs;
+
+  /// TODO-2837：设置副字幕独立调轴（null = 重置为跟随主字幕）。
+  final Future<void> Function(int? delayMs)? onSetSecondaryDelay;
+
+  /// TODO-2837：副字幕轨当前是否激活（cue 流非空）。活值 getter——面板内切换
+  /// 副字幕轨后经 [subtitlePositionListenable]（controller）的通知即时显隐。
+  final bool Function()? hasSecondarySubtitle;
+
   final Future<int?> Function()? onAutoAlign;
   final List<AudioCue> subtitleWaveformCues;
   final int videoDurationMs;

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -1658,7 +1658,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     double? rot = markup.rotationDeg ??
         ((styleAngle != null && styleAngle != 0) ? styleAngle : null);
     // \t(\frz) 旋转动画：从基线折叠到目标（逐帧，_syncFadeTicker 驱动）。
-    final int? posMs = widget.controller.effectivePositionMs;
+    // TODO-2837：等效位置按 cue 所属流取轴（副字幕独立调轴后主副轴可不同）。
+    final int? posMs = widget.controller.effectivePositionMsForCue(cue);
     final int elapsed = (posMs ?? cue.startMs) - cue.startMs;
     final int durMs = cue.endMs - cue.startMs;
     for (final SubtitleTransition tr in markup.transitions) {
@@ -1731,8 +1732,9 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
 
   /// 本条 cue 的 `\fad`/`\fade` 不透明度（0..1）。无位置信息（未 load）时恒 1（不淡）。
   /// elapsed = 音画延迟校正后的等效位置 − cue 起点；duration = cue 时长。
+  /// TODO-2837：等效位置按 cue 所属流取轴（副字幕独立调轴后主副轴可不同）。
   double _fadeOpacityFor(SubtitleFade fade, AudioCue cue) {
-    final int? pos = widget.controller.effectivePositionMs;
+    final int? pos = widget.controller.effectivePositionMsForCue(cue);
     if (pos == null) return 1.0;
     return fade.opacityAt(pos - cue.startMs, cue.endMs - cue.startMs);
   }
@@ -1759,7 +1761,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   Widget _buildSubtitleChar(
       String char, int i, SubtitleMarkup? markup, AudioCue cue) {
     // \t 动画 / 卡拉 OK 需要 cue 内已播放时长（逐帧重算由 _syncFadeTicker 驱动）。
-    final int? posMs = widget.controller.effectivePositionMs;
+    // TODO-2837：等效位置按 cue 所属流取轴（副字幕独立调轴后主副轴可不同）。
+    final int? posMs = widget.controller.effectivePositionMsForCue(cue);
     final int elapsedMs = (posMs ?? cue.startMs) - cue.startMs;
     final int durMs = cue.endMs - cue.startMs;
     final TextStyle fillStyle =
@@ -2424,7 +2427,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // build 里对带 move 的活动 cue 启动，故每帧重算。
     final SubtitleMove? move = widget.respectAssStyle ? markup?.move : null;
     if (pf == null && move != null && cue != null) {
-      final int? posMs = widget.controller.effectivePositionMs;
+      // TODO-2837：等效位置按 cue 所属流取轴（副字幕独立调轴后主副轴可不同）。
+      final int? posMs = widget.controller.effectivePositionMsForCue(cue);
       final int elapsed = (posMs ?? cue.startMs) - cue.startMs;
       pf = move.posAt(elapsed, cue.endMs - cue.startMs);
     }

--- a/fushi/lib/src/media/video/video_subtitle_sync_row.dart
+++ b/fushi/lib/src/media/video/video_subtitle_sync_row.dart
@@ -57,10 +57,34 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
   /// 一键自动对轴进行中（TODO-701）：按钮显示 spinner 并禁用，防重入。
   bool _autoAligning = false;
 
+  // ── 副字幕独立调轴（TODO-2837）────────────────────────────────────────────
+  // 本地权威镜像：null = 跟随主字幕（[_delayMs]）；非 null = 副轨独立偏移。
+  // 仅副字幕轨激活（host.hasSecondarySubtitle）时渲染本段，避免死 UI。
+  late int? _secondaryDelayMs = widget.host.secondaryDelayMs?.call();
+
+  /// 拖动副轨滑条时的临时预览值（仅本地回显，松手才提交）；null = 未在拖动。
+  int? _secondaryDragMs;
+
+  /// 副轨数值输入框控制器（未单独设置时回显主轨生效值）。
+  late final TextEditingController _secondaryDelayController =
+      TextEditingController(text: '${_secondaryDelayMs ?? _delayMs}');
+
+  /// 副轨数值输入框「边键入边生效」去抖（与主轨同款，BUG-918 范式）。
+  late final SubtitleDelayInputDebounce _secondaryDelayInput =
+      SubtitleDelayInputDebounce(
+    controller: _secondaryDelayController,
+    isMounted: () => mounted,
+    currentDelayMs: () => _secondaryDelayMs ?? _delayMs,
+    commit: (int delayMs, {bool syncField = true}) =>
+        _commitSecondaryDelay(delayMs, syncField: syncField),
+  );
+
   @override
   void dispose() {
     _delayInput.dispose();
     _delayController.dispose();
+    _secondaryDelayInput.dispose();
+    _secondaryDelayController.dispose();
     super.dispose();
   }
 
@@ -77,6 +101,24 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
       _delayController.text = '$clamped';
     }
     await widget.host.onSetDelay(clamped);
+  }
+
+  /// 副轨调轴权威提交（TODO-2837）：滑条 / ± 按钮 / 数值输入 / 「跟随主字幕」重置
+  /// 四处共享。[next] 为 null = 重置为跟随主字幕；非 null clamp 后经
+  /// [VideoQuickSettingsHost.onSetSecondaryDelay] 落盘 + 实时生效。
+  Future<void> _commitSecondaryDelay(int? next, {bool syncField = true}) async {
+    final Future<void> Function(int? delayMs)? onSet =
+        widget.host.onSetSecondaryDelay;
+    if (onSet == null) return;
+    final int? clamped =
+        next?.clamp(-_subtitleSyncClampMs, _subtitleSyncClampMs);
+    if (syncField) _secondaryDelayInput.cancelPending();
+    setState(() => _secondaryDelayMs = clamped);
+    final String fieldText = '${clamped ?? _delayMs}';
+    if (syncField && _secondaryDelayController.text != fieldText) {
+      _secondaryDelayController.text = fieldText;
+    }
+    await onSet(clamped);
   }
 
   /// TODO-701 阶段1：触发一键自动对轴。回调内部抽音频能量包络、与字幕 cue 互相关求整体
@@ -251,8 +293,150 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
               currentPositionMs: host.currentSubtitlePositionMs,
             ),
           ],
+          // TODO-2837：副字幕独立调轴段。仅副字幕轨激活时渲染（无副字幕不加死 UI）；
+          // 激活态是活值（面板内切换副字幕轨即变），经 controller（
+          // subtitlePositionListenable）的通知即时显隐。
+          if (host.onSetSecondaryDelay != null &&
+              host.secondaryDelayMs != null) ...<Widget>[
+            if (host.subtitlePositionListenable != null)
+              ListenableBuilder(
+                listenable: host.subtitlePositionListenable!,
+                builder: (BuildContext ctx, Widget? _) =>
+                    _buildSecondarySection(ctx),
+              )
+            else
+              _buildSecondarySection(context),
+          ],
         ],
       ),
+    );
+  }
+
+  /// 副字幕独立调轴段（TODO-2837）：标题 + 滑条 + ±50/±1000 微调 + 数值输入 +
+  /// 「跟随主字幕」重置。未单独设置（null=跟随）时滑条/数值回显主轨生效值、数值
+  /// 染次要色；显式设置后染主色并出现重置按钮。副字幕轨未激活时整段收起。
+  Widget _buildSecondarySection(BuildContext context) {
+    if (!(widget.host.hasSecondarySubtitle?.call() ?? false)) {
+      return const SizedBox.shrink();
+    }
+    final ThemeData theme = Theme.of(context);
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final bool following =
+        _secondaryDelayMs == null && _secondaryDragMs == null;
+    final int shownMs = _secondaryDragMs ?? _secondaryDelayMs ?? _delayMs;
+    final String label = following
+        ? t.video_setting_secondary_delay_follow
+        : '${shownMs >= 0 ? '+' : ''}$shownMs ms';
+    final double sliderValue = shownMs
+        .clamp(-_subtitleSyncSliderRangeMs, _subtitleSyncSliderRangeMs)
+        .toDouble();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        SizedBox(height: tokens.spacing.gap),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                t.video_setting_secondary_av_delay,
+                style: theme.textTheme.titleSmall,
+              ),
+            ),
+            // 显式设置过才给「跟随主字幕」重置入口（跟随态本身无可重置）。
+            if (_secondaryDelayMs != null)
+              TextButton(
+                onPressed: () => _commitSecondaryDelay(null),
+                child: Text(t.video_setting_secondary_delay_follow),
+              ),
+          ],
+        ),
+        Text(
+          t.video_setting_secondary_av_delay_hint,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+        adaptiveSlider(
+          context: context,
+          value: sliderValue,
+          min: -_subtitleSyncSliderRangeMs.toDouble(),
+          max: _subtitleSyncSliderRangeMs.toDouble(),
+          divisions: _subtitleSyncSliderRangeMs ~/ 50, // 50ms 一档
+          label: label,
+          onChanged: (double v) => setState(() => _secondaryDragMs = v.round()),
+          onChangeEnd: (double v) {
+            setState(() => _secondaryDragMs = null);
+            _commitSecondaryDelay(v.round());
+          },
+        ),
+        SizedBox(height: tokens.spacing.gap / 2),
+        Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: tokens.spacing.gap / 2,
+          runSpacing: tokens.spacing.gap / 2,
+          children: <Widget>[
+            FushiIconButton(
+              icon: Icons.keyboard_double_arrow_left,
+              tooltip: '-1000ms',
+              padding: EdgeInsets.all(tokens.spacing.gap / 2),
+              // 跟随态微调以主轨生效值为基准起步（首次微调 = 主轨值 ± 步进）。
+              onTap: () =>
+                  _commitSecondaryDelay((_secondaryDelayMs ?? _delayMs) - 1000),
+            ),
+            FushiIconButton(
+              icon: Icons.chevron_left,
+              tooltip: '-50ms',
+              padding: EdgeInsets.all(tokens.spacing.gap / 2),
+              onTap: () =>
+                  _commitSecondaryDelay((_secondaryDelayMs ?? _delayMs) - 50),
+            ),
+            FushiFocusable(
+              onTap: shownMs == 0 && !following
+                  ? null
+                  : () => _commitSecondaryDelay(0),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 84, maxWidth: 160),
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: following
+                        ? theme.colorScheme.onSurfaceVariant
+                        : theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+            FushiIconButton(
+              icon: Icons.chevron_right,
+              tooltip: '+50ms',
+              padding: EdgeInsets.all(tokens.spacing.gap / 2),
+              onTap: () =>
+                  _commitSecondaryDelay((_secondaryDelayMs ?? _delayMs) + 50),
+            ),
+            FushiIconButton(
+              icon: Icons.keyboard_double_arrow_right,
+              tooltip: '+1000ms',
+              padding: EdgeInsets.all(tokens.spacing.gap / 2),
+              onTap: () =>
+                  _commitSecondaryDelay((_secondaryDelayMs ?? _delayMs) + 1000),
+            ),
+          ],
+        ),
+        SizedBox(height: tokens.spacing.gap / 2),
+        AdaptiveSettingsTextField(
+          controller: _secondaryDelayController,
+          labelText: t.video_setting_subtitle_sync_input,
+          keyboardType: const TextInputType.numberWithOptions(signed: true),
+          textInputAction: TextInputAction.done,
+          onChanged: _secondaryDelayInput.onChanged,
+          onSubmitted: _secondaryDelayInput.onSubmitted,
+        ),
+      ],
     );
   }
 }

--- a/fushi/lib/src/pages/implementations/video_fushi/clip_export.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/clip_export.part.dart
@@ -182,18 +182,19 @@ extension _VideoClipExport on _VideoFushiPageState {
     required int startMs,
     required int endMs,
   }) {
-    final int delayMs = controller.delayMs;
     final String? primary = buildClipSrtContent(
       cues: controller.cues,
       startMs: startMs,
       endMs: endMs,
-      delayMs: delayMs,
+      delayMs: controller.delayMs,
     );
     final String? secondary = buildClipSrtContent(
       cues: controller.secondaryCues,
       startMs: startMs,
       endMs: endMs,
-      delayMs: delayMs,
+      // TODO-2837：主副字幕分开调轴后，副轨 SRT 按副轨生效轴换算（未单独设置时
+      // == 主轨，行为与旧版一致），导出的字幕才等于屏幕上看到的那条。
+      delayMs: controller.effectiveSecondaryDelayMs,
     );
     return <String>[
       if (primary != null) primary,

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart
@@ -68,7 +68,9 @@ extension _VideoLookupFavorite on _VideoFushiPageState {
       currentCue: controller.currentCue,
       cues: controller.miningCues,
       positionMs: controller.positionMs ?? 0,
-      delayMs: controller.delayMs,
+      // TODO-2837：按位置兜底与有效流的 cue 命中同一根轴（主流空落副流时用副轨
+      // 生效轴，副轨独立调轴后才不会锚错句）。
+      delayMs: controller.miningDelayMs,
     );
     await pushNestedPopup(
       query: term,

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -137,10 +137,14 @@ extension _VideoLookupMining on _VideoFushiPageState {
     if (selectedCue != null) {
       // 字幕列表多选（独立入口）：单段区间就是合成 cue 的时间窗，文本即其 join。
       // TODO-680 / BUG-392：cue 时间是字幕文件坐标，裁音频/封面前逆变换回播放器轴
-      // （+ delayMs），否则字幕调轴后裁的位置整体偏移 delayMs。
+      // （+ delayMs），否则字幕调轴后裁的位置整体偏移 delayMs。TODO-2837：主副
+      // 字幕分开调轴后，逆变换必须用**该 cue 所属流**的生效轴（delayMsForCue；
+      // 列表多选的合成 cue 不属任一流 → 回落有效流 miningDelayMs）。
       return (
-        clipStartMs: miningClipTimeMs(selectedCue.startMs, controller.delayMs),
-        clipEndMs: miningClipTimeMs(selectedCue.endMs, controller.delayMs),
+        clipStartMs: miningClipTimeMs(
+            selectedCue.startMs, controller.delayMsForCue(selectedCue)),
+        clipEndMs: miningClipTimeMs(
+            selectedCue.endMs, controller.delayMsForCue(selectedCue)),
         sentence: selectedCue.text,
         cueSentence: selectedCue.text,
         usedSelectedCue: true,
@@ -156,7 +160,9 @@ extension _VideoLookupMining on _VideoFushiPageState {
         resolveMiningCueForPosition(
           cues: controller.miningCues,
           positionMs: controller.positionMs ?? 0,
-          delayMs: controller.delayMs,
+          // TODO-2837：按位置解析必须与有效流的 cue 命中同一根轴（主流空落副流
+          // 时用副轨生效轴，否则副轨独立调轴后锚错句）。
+          delayMs: controller.miningDelayMs,
         );
     // 草稿全部句 + 当前查词句合成 sentence（草稿空 → 单句 _lastLookupSentence trim）。
     final String mergedSentence = _miningDraft.composeText(_lastLookupSentence);
@@ -172,12 +178,15 @@ extension _VideoLookupMining on _VideoFushiPageState {
     );
     // TODO-680 / BUG-392：mergedRange / cue 的 startMs/endMs 都是字幕文件坐标，裁
     // 音频/封面前逆变换回播放器轴（+ delayMs），与字幕显示用的 effectiveSubtitlePositionMs
-    // 方向相反，保证裁的就是用户实际听到/看到的那段。
+    // 方向相反，保证裁的就是用户实际听到/看到的那段。TODO-2837：主副分开调轴后
+    // 按锚定 cue 所属流取轴（查副字幕词制卡时用副轨生效轴；无 cue 回落有效流轴）。
+    final int clipDelayMs =
+        cue == null ? controller.miningDelayMs : controller.delayMsForCue(cue);
     return (
       clipStartMs: miningClipTimeMs(
-          mergedRange?.startMs ?? cue?.startMs ?? 0, controller.delayMs),
-      clipEndMs: miningClipTimeMs(
-          mergedRange?.endMs ?? cue?.endMs ?? 0, controller.delayMs),
+          mergedRange?.startMs ?? cue?.startMs ?? 0, clipDelayMs),
+      clipEndMs:
+          miningClipTimeMs(mergedRange?.endMs ?? cue?.endMs ?? 0, clipDelayMs),
       // 多句时 cueSentence 用合并文本与 sentence 一致；草稿空时退回单 cue 文本作 fallback。
       cueSentence: _miningDraft.isEmpty ? cue?.text : mergedSentence,
       sentence: mergedSentence,

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -1289,6 +1289,9 @@ extension _VideoSubtitle on _VideoFushiPageState {
   /// 新 delayMs，可单测）；本方法只做胶水：取 controller 实时 cues/positionMs 与当前
   /// `_delayMs`，拿到新延迟后走既有权威写穿 [_setDelayMs]（clamp + 落盘 + OSD + 即时重算）。
   /// 无 controller / 无 cue / 位置未就绪 / 已是首末句无相邻 cue 时 no-op（不弹窗、不改延迟）。
+  ///
+  /// TODO-2837：本对齐（连同波形对轴 / 自动对轴）**只作用于主字幕轨**；副字幕的
+  /// asbplayer 式/波形对齐是后续工作，本轮副轨只有快速设置面板的独立调轴段。
   void _snapSubtitleDelayToCue({required bool next}) {
     final VideoPlayerController? controller = _controller;
     if (controller == null) return;

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1696,6 +1696,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 音画延迟（毫秒）：字幕 cue 同步偏移，跨重启保留；换集复用同一值。
   int _delayMs = 0;
 
+  /// 副字幕独立调轴（毫秒，TODO-2837 主副字幕分开调轴）：null = 未单独设置 =
+  /// 跟随 [_delayMs]（v86 前「主副共用一个 offset」行为）；非 null = 副轨独立偏移
+  /// （主副字幕轴不同源时各调各的）。两层持久化镜像 [_delayMs]（per-book
+  /// `VideoBooks.secondaryDelayMs` + 合集级 `MediaCollections.secondarySubtitleDelayMs`），
+  /// 换集复用同一值。远端播放恒 null（host 不下发副轨偏移，副字幕也不参与远端流）。
+  int? _secondaryDelayMs;
+
   /// 播放倍速：用户在设置面板调，跨重启保留；换集复用同一值（速度记忆）。
   double _playbackSpeed = 1.0;
   double? _longPressPreviousSpeed;
@@ -2051,6 +2058,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _currentSecondarySubtitleSource = row.secondarySubtitleSource;
     _currentAudioTrackId = row.audioTrackId;
     _delayMs = row.delayMs;
+    // TODO-2837：副字幕独立调轴（null = 跟随主字幕）。
+    _secondaryDelayMs = row.secondaryDelayMs;
     _playbackSpeed = _readPersistedSpeed();
     _playbackVolume = _readPersistedVolume();
     _subtitleStyle = VideoSubtitleStyle.decode(appModel.videoSubtitleStyle);
@@ -2073,6 +2082,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _currentAudioTrackId =
           effectiveSeriesAudioTrackId(col?.audioTrackId, row.audioTrackId);
       _delayMs = effectiveSeriesDelayMs(col?.subtitleDelayMs, row.delayMs);
+      // TODO-2837：副轨调轴同款系列级优先（两层都 null = 跟随主字幕）。
+      _secondaryDelayMs = effectiveSeriesSecondaryDelayMs(
+          col?.secondarySubtitleDelayMs, row.secondaryDelayMs);
       final List<MediaCollectionItemRow> members =
           await widget.repo.getCollectionItems(collectionId);
       // v68 Jellyfin 对齐：剧集面板要 ①集级刮削集名 ②合集横图回退链 ③看完/在看
@@ -2133,6 +2145,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // BUG-996：远端播放跟随 host 下发的字幕时序偏移（此前恒 0，字幕调轴不同步）。
     // 通道已就绪——_applyLoad 里 controller.setDelayMs(_delayMs) 会应用它。
     _delayMs = info.delayMs;
+    // TODO-2837：远端无副字幕流，副轨独立调轴恒复位为「跟随主字幕」。
+    _secondaryDelayMs = null;
     _playbackSpeed = _readPersistedSpeed();
     _playbackVolume = _readPersistedVolume();
     _subtitleStyle = VideoSubtitleStyle.decode(appModel.videoSubtitleStyle);
@@ -2933,6 +2947,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     }
     // 应用持久化的音画延迟（换集复用同一值；load 不重置 delay）。
     controller.setDelayMs(_delayMs);
+    // TODO-2837：副字幕独立调轴同步应用（null = 跟随主字幕，controller 侧回退）。
+    controller.setSecondaryDelayMs(_secondaryDelayMs);
     controller.setPauseAtSubtitleEnd(_asbConfig.pauseAtSubtitleEnd);
     // TODO-559: 远端断点保存——远端无 DB 行，按 bookUid 落 prefs（原为 null 不存）。
     controller.onPositionWrite =
@@ -4420,7 +4436,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       }),
       // 字幕对轴/匹配（用户请求）：Shift+A 一键弹波形对轴放大视图；z/x 整体平移字幕延迟
       // ±_kSubtitleDelayNudgeMs（走 _setDelayMs 写穿 delayMs 落盘 + OSD）。都过沉浸门控，
-      // 与顶部快速设置面板同源、零第二套状态。
+      // 与顶部快速设置面板同源、零第二套状态。TODO-2837：z/x 保持只调**主字幕轨**；
+      // 副字幕独立调轴本轮只走快速设置面板（_setSecondaryDelayMs），不占新键位——
+      // 加副轨微调快捷键前须查 docs/agent/shortcuts-inventory.md 撞键并走注册表新动作。
       openSubtitleAlign: () => _runWhenImmersiveAllowsShortcuts(
         () => unawaited(_openSubtitleWaveformAlign()),
       ),
@@ -5787,6 +5805,44 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     if (mounted) setState(() {});
   }
 
+  /// 设置**副字幕**独立调轴（毫秒，TODO-2837）：null = 清除独立值、回到跟随主字幕
+  /// [_delayMs]。即时调 controller（副字幕活动集立即按新轴重算）+ 两层持久化镜像
+  /// [_setDelayMs]（合集内写系列级、否则写 per-book）+ 左上角 OSD 即时反馈。
+  ///
+  /// 「重置为跟随」在合集内**两层都清**（系列级 + 本集 per-book）：决议是
+  /// `系列级 ?? per-book`，只清系列级会让本集在单集时代留下的旧独立值复活——
+  /// 「跟随」的语义是两层皆 null，一次写干净，不留特例。
+  Future<void> _setSecondaryDelayMs(int? delayMs) async {
+    final int? clamped = delayMs?.clamp(-600000, 600000);
+    if (clamped == _secondaryDelayMs) return;
+    _secondaryDelayMs = clamped;
+    _controller?.setSecondaryDelayMs(clamped);
+    if (clamped == null) {
+      _showOsd(
+        t.video_subtitle_secondary_delay_follow_osd,
+        icon: Icons.sync_outlined,
+      );
+    } else {
+      final String signed = clamped >= 0 ? '+$clamped' : '$clamped';
+      _showOsd(
+        t.video_subtitle_secondary_delay_osd(ms: signed),
+        icon: Icons.sync_outlined,
+      );
+    }
+    final int? collectionId = widget.playlistCollectionId;
+    if (collectionId != null) {
+      await widget.repo
+          .updateCollectionSecondarySubtitleDelayMs(collectionId, clamped);
+      if (clamped == null) {
+        // 重置为跟随：连本集 per-book 旧值一起清（见 doc，消除回退复活特例）。
+        await widget.repo.updateSecondaryDelayMs(widget.bookUid, null);
+      }
+    } else {
+      await widget.repo.updateSecondaryDelayMs(widget.bookUid, clamped);
+    }
+    if (mounted) setState(() {});
+  }
+
   /// TODO-099: 进入视频页时锁横屏（移动端）。只锁本页，不动全 app
   /// 默认方向策略（保护竖排小说能竖屏）；退出由 [_restoreOrientationOnExit] 还原。
   /// 桌面门控 no-op（桌面窗口不走设备方向）。
@@ -6150,6 +6206,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       danmakuStyle: () => _danmakuStyle,
       controlLayout: () => _controlLayout,
       onSetDelay: _setDelayMs,
+      // TODO-2837：副字幕独立调轴（null = 跟随主字幕）。行只在副字幕轨激活
+      // （secondaryCues 非空）时显示——hasSecondarySubtitle 是活值 getter，
+      // 面板内切换副字幕轨后经 controller 通知即时显隐。
+      secondaryDelayMs: () => _secondaryDelayMs,
+      onSetSecondaryDelay: _setSecondaryDelayMs,
+      hasSecondarySubtitle: () =>
+          _controller?.secondaryCues.isNotEmpty ?? false,
       // TODO-701 阶段1：仅当当前有字幕 cue + 视频本地路径时给自动对轴按钮（否则
       // 无可对齐对象/无音频源），否则置 null 让面板不显示该按钮。
       onAutoAlign: (_controller?.cues.isNotEmpty ?? false) &&

--- a/fushi/test/database/collection_relations_test.dart
+++ b/fushi/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final FushiDatabase db = await openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/fushi/test/database/migration_test.dart
+++ b/fushi/test/database/migration_test.dart
@@ -1078,7 +1078,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 paired peers 表). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 85,
+      expect(db.schemaVersion, 86,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1155,7 +1155,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 85,
+      expect(db.schemaVersion, 86,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1313,7 +1313,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 85,
+      expect(db.schemaVersion, 86,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1364,7 +1364,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
     });
 
     test(
@@ -1373,7 +1373,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 85,
+      expect(db.schemaVersion, 86,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1407,7 +1407,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 85,
+      expect(db.schemaVersion, 86,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1447,7 +1447,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1478,7 +1478,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1512,7 +1512,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1524,7 +1524,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1560,7 +1560,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 85);
+      expect(db.schemaVersion, 86);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/fushi/test/database/migration_v40_collections_test.dart
+++ b/fushi/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
   });
 }

--- a/fushi/test/database/migration_v51_pdf_format_test.dart
+++ b/fushi/test/database/migration_v51_pdf_format_test.dart
@@ -109,6 +109,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
   });
 }

--- a/fushi/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/fushi/test/database/migration_v53_manga_reading_mode_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
   });
 }

--- a/fushi/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/fushi/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
   });
 }

--- a/fushi/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/fushi/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v57_naming_unification_test.dart
+++ b/fushi/test/database/migration_v57_naming_unification_test.dart
@@ -191,7 +191,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v60_reading_pages_test.dart
+++ b/fushi/test/database/migration_v60_reading_pages_test.dart
@@ -59,7 +59,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 86, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/fushi/test/database/migration_v61_collection_cover_path_test.dart
+++ b/fushi/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 85);
-    expect(db.schemaVersion, 85);
+    expect(version.read<int>('user_version'), 86);
+    expect(db.schemaVersion, 86);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -287,7 +287,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 85);
+    expect(version.read<int>('user_version'), 86);
   });
 
   test(
@@ -318,7 +318,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 85);
+      expect(probe.select('PRAGMA user_version').first.values.first, 86);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,7 +105,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
     expect(await _userVersion(db), db.schemaVersion);
 
     // v63 真跑了：两处废弃偏好都没了。

--- a/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
+++ b/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
@@ -77,7 +77,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v75 给 galgames 加 japanese_locale_mode（每游戏转区档位）');
 
     final List<QueryRow> columns =

--- a/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
+++ b/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
@@ -86,7 +86,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v76 给 lookup_mining_counters 的 book_key 进唯一键');
 
     final List<LookupMiningCounterRow> rows =

--- a/fushi/test/database/migration_v79_tag_assignments_test.dart
+++ b/fushi/test/database/migration_v79_tag_assignments_test.dart
@@ -114,7 +114,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
 
     final List<TagAssignmentRow> rows = await db.getAllTagAssignments();
     expect(rows, hasLength(5), reason: '5 张表各 1 行有效映射（孤儿 srt 行丢弃）');

--- a/fushi/test/database/migration_v80_media_open_history_test.dart
+++ b/fushi/test/database/migration_v80_media_open_history_test.dart
@@ -61,7 +61,7 @@ CREATE TABLE media_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85);
+    expect(db.schemaVersion, 86);
 
     final rows = await db.getAllMediaOpenHistory();
     expect(rows, hasLength(2), reason: '迁移零丢行');

--- a/fushi/test/database/migration_v82_subtable_uid_test.dart
+++ b/fushi/test/database/migration_v82_subtable_uid_test.dart
@@ -131,7 +131,7 @@ CREATE TABLE revealed_images (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85, reason: 'v82 = 四子表书键切 uid');
+    expect(db.schemaVersion, 86, reason: 'v82 = 四子表书键切 uid');
 
     // ── reader_positions：跨书族，epub 命中换 uid，SRT 照抄 ──
     expect(await count(db, 'reader_positions'), 2, reason: '迁移零丢行');

--- a/fushi/test/database/migration_v83_entrykey_uid_test.dart
+++ b/fushi/test/database/migration_v83_entrykey_uid_test.dart
@@ -128,7 +128,7 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 85,
+    expect(db.schemaVersion, 86,
         reason: 'v83 = shelf_entries / media_collection_items epub 键切 uid');
 
     // ── shelf_entries：epub 命中换 uid、透传照抄、非 epub 照抄、零丢行 ──

--- a/fushi/test/database/migration_v84_preferences_updated_at_test.dart
+++ b/fushi/test/database/migration_v84_preferences_updated_at_test.dart
@@ -53,8 +53,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 85);
-    expect(db.schemaVersion, 85);
+    expect(version.read<int>('user_version'), 86);
+    expect(db.schemaVersion, 86);
 
     // 存量行零丢失——改名是用户数据，迁移丢一行就是丢一个书名。
     expect(await db.getPref(_overrideKey), 's:母设备改的名');

--- a/fushi/test/database/migration_v85_video_last_played_at_test.dart
+++ b/fushi/test/database/migration_v85_video_last_played_at_test.dart
@@ -94,8 +94,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 85);
-    expect(db.schemaVersion, 85);
+    expect(version.read<int>('user_version'), 86);
+    expect(db.schemaVersion, 86);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(4), reason: '迁移丢一行就是丢一部视频的观看记录');

--- a/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
+++ b/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
@@ -1,0 +1,151 @@
+import 'package:drift/drift.dart' show QueryRow;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// v86（TODO-2837 主副字幕分开调轴）：`video_books` 加 `secondary_delay_ms`、
+/// `media_collections` 加 `secondary_subtitle_delay_ms`，给副字幕一套独立于主
+/// 字幕的两层调轴（镜像 v52 的 delay_ms / subtitle_delay_ms 结构）。
+///
+/// 本文件守两件事：
+///  1. **加列无损**：存量视频行 / 合集行一条不丢、既有调轴值逐列不变。
+///  2. **跟随语义**：升级后两列全 NULL = 副字幕继续跟随主字幕调轴——v86 前
+///     「主副共用一个 offset」的行为逐字节保留（Never break userspace），任何
+///     非 NULL 回填都是在替用户做没做过的决定。
+void _seedV85(dynamic rawDb) {
+  // v85 形状的 video_books：**没有** secondary_delay_ms。列集照抄升级前真实形状
+  // （v84 形状 + v85 的 last_played_at），多写少写都会让这条迁移在测试里走上一条
+  // 生产不存在的路径。
+  rawDb.execute('''
+CREATE TABLE video_books (
+  book_uid TEXT NOT NULL,
+  title TEXT NOT NULL,
+  video_path TEXT NOT NULL,
+  subtitle_source TEXT NULL,
+  secondary_subtitle_source TEXT NULL,
+  subtitle_format TEXT NULL,
+  embedded_subtitle_track INTEGER NULL,
+  cover_path TEXT NULL,
+  last_position_ms INTEGER NOT NULL DEFAULT 0,
+  last_played_at INTEGER NULL,
+  imported_at INTEGER NULL,
+  playlist_json TEXT NULL,
+  current_episode INTEGER NOT NULL DEFAULT 0,
+  audio_track_id TEXT NULL,
+  delay_ms INTEGER NOT NULL DEFAULT 0,
+  completed_at INTEGER NULL,
+  source_id INTEGER NULL,
+  stream_spec_json TEXT NULL,
+  PRIMARY KEY (book_uid)
+)
+''');
+  // v85 形状的 media_collections：**没有** secondary_subtitle_delay_ms。
+  rawDb.execute('''
+CREATE TABLE media_collections (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  collection_type TEXT NOT NULL DEFAULT 'collection',
+  cover_source TEXT NULL,
+  cover_path TEXT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  order_updated_at INTEGER NOT NULL DEFAULT 0,
+  anilist_id INTEGER NULL,
+  audio_track_id TEXT NULL,
+  subtitle_delay_ms INTEGER NULL
+)
+''');
+  // ep0 调过主轨（+800）、ep1 没调过：升级后两行的主轨值必须原样保留。
+  rawDb.execute(
+    'INSERT INTO video_books (book_uid, title, video_path, delay_ms) '
+    "VALUES ('video/ep0', '第 1 集', '/abs/ep0.mkv', 800), "
+    "('video/ep1', '第 2 集', '/abs/ep1.mkv', 0)",
+  );
+  // 合集级调过主轨（-450）：升级后系列级主轨值必须原样保留。
+  rawDb.execute(
+    'INSERT INTO media_collections (name, created_at, subtitle_delay_ms) '
+    "VALUES ('某番剧', 1700000000, -450)",
+  );
+  rawDb.execute('PRAGMA user_version = 85');
+}
+
+Future<int?> _colInt(FushiDatabase db, String sql) async {
+  final QueryRow row = await db.customSelect(sql).getSingle();
+  return row.readNullable<int>(row.data.keys.single);
+}
+
+void main() {
+  FushiDatabase openUpgraded() {
+    final FushiDatabase db =
+        FushiDatabase.forTesting(NativeDatabase.memory(setup: _seedV85));
+    addTearDown(db.close);
+    return db;
+  }
+
+  test('v85 -> v86：加列无损，存量行与既有主轨调轴逐列不变', () async {
+    final FushiDatabase db = openUpgraded();
+
+    final QueryRow version =
+        await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 86);
+    expect(db.schemaVersion, 86);
+
+    final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
+    expect(rows, hasLength(2), reason: '迁移丢一行就是丢一部视频的记录');
+    final VideoBookRow ep0 =
+        rows.firstWhere((VideoBookRow r) => r.bookUid == 'video/ep0');
+    expect(ep0.delayMs, 800, reason: '主轨调轴值不许被迁移动到');
+
+    final List<MediaCollectionRow> cols =
+        await db.select(db.mediaCollections).get();
+    expect(cols, hasLength(1));
+    expect(cols.single.subtitleDelayMs, -450, reason: '系列级主轨调轴值不许被迁移动到');
+  });
+
+  test('跟随语义：升级后两层副轨列全 NULL = 副字幕继续跟随主字幕（行为不变）', () async {
+    final FushiDatabase db = openUpgraded();
+    expect(
+      await _colInt(db,
+          "SELECT secondary_delay_ms FROM video_books WHERE book_uid = 'video/ep0'"),
+      isNull,
+      reason: '主轨调过（+800）的行也不回填副轨——NULL=跟随，本就等价旧「主副共用」行为',
+    );
+    expect(
+      await _colInt(db,
+          "SELECT secondary_delay_ms FROM video_books WHERE book_uid = 'video/ep1'"),
+      isNull,
+    );
+    expect(
+      await _colInt(
+          db, 'SELECT secondary_subtitle_delay_ms FROM media_collections'),
+      isNull,
+    );
+  });
+
+  test('升级后新写入照常（per-book 与合集级两层写入口）', () async {
+    final FushiDatabase db = openUpgraded();
+    await db.updateVideoBookSecondaryDelayMs('video/ep0', -250);
+    expect(
+      await _colInt(db,
+          "SELECT secondary_delay_ms FROM video_books WHERE book_uid = 'video/ep0'"),
+      -250,
+    );
+    // 重置为跟随：写回 NULL（不是 0——0 是显式独立值）。
+    await db.updateVideoBookSecondaryDelayMs('video/ep0', null);
+    expect(
+      await _colInt(db,
+          "SELECT secondary_delay_ms FROM video_books WHERE book_uid = 'video/ep0'"),
+      isNull,
+    );
+
+    final List<MediaCollectionRow> cols =
+        await db.select(db.mediaCollections).get();
+    await db.updateMediaCollectionSecondarySubtitleDelayMs(
+        cols.single.id, 1200);
+    expect(
+      await _colInt(
+          db, 'SELECT secondary_subtitle_delay_ms FROM media_collections'),
+      1200,
+    );
+  });
+}

--- a/fushi/test/media/video/series_playback_prefs_test.dart
+++ b/fushi/test/media/video/series_playback_prefs_test.dart
@@ -44,4 +44,32 @@ void main() {
       expect(effectiveSeriesDelayMs(-1200, 0), -1200);
     });
   });
+
+  // TODO-2837（schema v86）：副字幕独立调轴的两层决议。与主轨同一优先级语义，
+  // 仅回退终点不同：两层皆 null → null = 跟随主字幕（v86 前行为）。
+  group('effectiveSeriesSecondaryDelayMs — 同系列副字幕调轴记忆', () {
+    test('系列级非 null 时优先于 per-book', () {
+      expect(effectiveSeriesSecondaryDelayMs(1500, 300), 1500);
+    });
+
+    test('系列级显式 0 优先（区别于「系列没设过」的 null）', () {
+      expect(effectiveSeriesSecondaryDelayMs(0, 800), 0);
+    });
+
+    test('系列级为 null 时回退 per-book', () {
+      expect(effectiveSeriesSecondaryDelayMs(null, 800), 800);
+    });
+
+    test('per-book 显式 0 是独立值，不塌成跟随', () {
+      expect(effectiveSeriesSecondaryDelayMs(null, 0), 0);
+    });
+
+    test('两层皆 null → null = 副字幕跟随主字幕调轴（升级后行为不变的关键）', () {
+      expect(effectiveSeriesSecondaryDelayMs(null, null), isNull);
+    });
+
+    test('负值正确透传', () {
+      expect(effectiveSeriesSecondaryDelayMs(-1200, null), -1200);
+    });
+  });
 }

--- a/fushi/test/media/video/video_player_controller_test.dart
+++ b/fushi/test/media/video/video_player_controller_test.dart
@@ -106,6 +106,120 @@ void main() {
     });
   });
 
+  // TODO-2837：主副字幕分开调轴。副轨 null = 跟随主轨（v86 前行为逐字节保留）；
+  // 非 null = 主副各自求活动集，互不影响。
+  group('VideoPlayerController secondary delay (TODO-2837)', () {
+    test('未单独设置（null）：副字幕跟随主轨 delay（历史行为不变）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 0, 1000)]);
+      c.setSecondaryCues([_cue(10, 0, 1000)]);
+      c.setDelayMs(600);
+      expect(c.secondaryDelayMs, isNull);
+      expect(c.effectiveSecondaryDelayMs, 600, reason: '跟随主轨');
+      // 1500-600=900：主副同轴同时命中。
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCueIndex, 0);
+      expect(c.secondaryActiveCues.map((AudioCue x) => x.text), ['line10']);
+    });
+
+    test('独立设置后主副各自求活动集（轴不同源各调各的）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 0, 1000)]);
+      c.setSecondaryCues([_cue(10, 2000, 3000)]);
+      // 副轨独立 -1500：位置 500 → 主 effective 500 命中 cue0；
+      // 副 effective 500-(-1500)=2000 命中副轨 cue。
+      c.setSecondaryDelayMs(-1500);
+      expect(c.effectiveSecondaryDelayMs, -1500);
+      c.debugUpdateCueForPosition(500);
+      expect(c.currentCueIndex, 0);
+      expect(c.secondaryActiveCues.map((AudioCue x) => x.text), ['line10']);
+    });
+
+    test('显式 0 独立于主轨（改主轨不再牵动副轨）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 0, 1000)]);
+      c.setSecondaryCues([_cue(10, 0, 1000)]);
+      c.setSecondaryDelayMs(0); // 显式 0，区别于「跟随」的 null
+      c.setDelayMs(600);
+      expect(c.effectiveSecondaryDelayMs, 0);
+      // 位置 1500：主 effective 900 命中；副 effective 1500 已出窗（不跟随平移）。
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCueIndex, 0);
+      expect(c.secondaryActiveCues, isEmpty);
+    });
+
+    test('传 null 重置为跟随主轨', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 0, 1000)]);
+      c.setSecondaryCues([_cue(10, 0, 1000)]);
+      c.setSecondaryDelayMs(250);
+      c.setSecondaryDelayMs(null);
+      c.setDelayMs(600);
+      expect(c.secondaryDelayMs, isNull);
+      expect(c.effectiveSecondaryDelayMs, 600);
+      c.debugUpdateCueForPosition(1500);
+      expect(c.secondaryActiveCues.map((AudioCue x) => x.text), ['line10']);
+    });
+
+    test('setSecondaryDelayMs 立即按当前位置重算（BUG-373 同理，不等 tick）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setSecondaryCues([_cue(10, 2000, 3000)]);
+      c.debugSetPositionForTesting(500);
+      expect(c.secondaryActiveCues, isEmpty);
+      c.setSecondaryDelayMs(-1500); // effective 500+1500=2000 → 应即时命中
+      expect(c.secondaryActiveCues.map((AudioCue x) => x.text), ['line10']);
+    });
+
+    test('clamp 到 ±600000（与主轨同界）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setSecondaryDelayMs(900000);
+      expect(c.secondaryDelayMs, 600000);
+      c.setSecondaryDelayMs(-900000);
+      expect(c.secondaryDelayMs, -600000);
+    });
+
+    test('delayMsForCue / miningDelayMs 按流分轴（制卡逆变换真相源）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      final AudioCue main0 = _cue(0, 0, 1000);
+      final AudioCue sec0 = _cue(10, 0, 1000);
+      c.setCues([main0]);
+      c.setSecondaryCues([sec0]);
+      c.setDelayMs(600);
+      c.setSecondaryDelayMs(-200);
+      // setCues/setSecondaryCues 内部会拷贝列表但保留元素身份，按身份取回。
+      final AudioCue mainCue = c.cues.single;
+      final AudioCue secCue = c.secondaryCues.single;
+      expect(c.delayMsForCue(mainCue), 600);
+      expect(c.delayMsForCue(secCue), -200);
+      // 主流非空 → miningDelayMs 用主轨；陌生 cue 兜底同口径。
+      expect(c.miningDelayMs, 600);
+      expect(c.delayMsForCue(_cue(99, 0, 1)), 600);
+      // 主流清空（只开副字幕，BUG-1592 形态）→ 有效流轴切到副轨生效值。
+      c.setCues(const <AudioCue>[]);
+      expect(c.miningDelayMs, -200);
+      expect(c.delayMsForCue(_cue(99, 0, 1)), -200);
+    });
+
+    test('effectivePositionMsForCue 按 cue 所属流取轴（overlay ASS 动画用）', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 0, 1000)]);
+      c.setSecondaryCues([_cue(10, 0, 1000)]);
+      c.setDelayMs(600);
+      c.setSecondaryDelayMs(100);
+      c.debugSetPositionForTesting(1500);
+      expect(c.effectivePositionMsForCue(c.cues.single), 900);
+      expect(c.effectivePositionMsForCue(c.secondaryCues.single), 1400);
+    });
+  });
+
   group('VideoPlayerController completed stream auto-advance hook', () {
     test('completed=false is ignored; completed=true fires once per load', () {
       final c = VideoPlayerController();

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -514,7 +514,7 @@ class FushiDatabase extends _$FushiDatabase
   final bool _isMainProcess;
 
   @override
-  int get schemaVersion => 85;
+  int get schemaVersion => 86;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2473,6 +2473,26 @@ class FushiDatabase extends _$FushiDatabase
                 SELECT 1 FROM video_watch_statistics w
                 WHERE w.book_uid = video_books.book_uid
                   AND w.last_modified > 0)''');
+            }
+          }
+          if (from < 86) {
+            // v86（TODO-2837 主副字幕分开调轴）：video_books 加 secondary_delay_ms、
+            // media_collections 加 secondary_subtitle_delay_ms，给副字幕一套独立于
+            // 主字幕的两层调轴（per-book + 系列级，镜像 v52 的 delay_ms /
+            // subtitle_delay_ms 结构）。无损迁移：两列 nullable 无 default → 旧库
+            // 既有行全 NULL = 副字幕继续跟随主字幕调轴（v86 前主副共用一个 offset
+            // 的行为逐字节保留，Never break userspace）；用户单独调过副轨后才落
+            // 非 NULL 值。守卫幂等（fresh DB 已由 onCreate 建好，重复升级
+            // _columnExists 短路 no-op）。
+            if (await _tableExists('video_books') &&
+                !await _columnExists('video_books', 'secondary_delay_ms')) {
+              await m.addColumn(videoBooks, videoBooks.secondaryDelayMs);
+            }
+            if (await _tableExists('media_collections') &&
+                !await _columnExists(
+                    'media_collections', 'secondary_subtitle_delay_ms')) {
+              await m.addColumn(
+                  mediaCollections, mediaCollections.secondarySubtitleDelayMs);
             }
           }
         },

--- a/packages/fushi_core/lib/src/database/database.g.dart
+++ b/packages/fushi_core/lib/src/database/database.g.dart
@@ -8674,6 +8674,12 @@ class $VideoBooksTable extends VideoBooks
       type: DriftSqlType.int,
       requiredDuringInsert: false,
       defaultValue: const Constant(0));
+  static const VerificationMeta _secondaryDelayMsMeta =
+      const VerificationMeta('secondaryDelayMs');
+  @override
+  late final GeneratedColumn<int> secondaryDelayMs = GeneratedColumn<int>(
+      'secondary_delay_ms', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _completedAtMeta =
       const VerificationMeta('completedAt');
   @override
@@ -8712,6 +8718,7 @@ class $VideoBooksTable extends VideoBooks
         currentEpisode,
         audioTrackId,
         delayMs,
+        secondaryDelayMs,
         completedAt,
         sourceId,
         streamSpecJson
@@ -8813,6 +8820,12 @@ class $VideoBooksTable extends VideoBooks
       context.handle(_delayMsMeta,
           delayMs.isAcceptableOrUnknown(data['delay_ms']!, _delayMsMeta));
     }
+    if (data.containsKey('secondary_delay_ms')) {
+      context.handle(
+          _secondaryDelayMsMeta,
+          secondaryDelayMs.isAcceptableOrUnknown(
+              data['secondary_delay_ms']!, _secondaryDelayMsMeta));
+    }
     if (data.containsKey('completed_at')) {
       context.handle(
           _completedAtMeta,
@@ -8869,6 +8882,8 @@ class $VideoBooksTable extends VideoBooks
           .read(DriftSqlType.string, data['${effectivePrefix}audio_track_id']),
       delayMs: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}delay_ms'])!,
+      secondaryDelayMs: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}secondary_delay_ms']),
       completedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}completed_at']),
       sourceId: attachedDatabase.typeMapping
@@ -8892,7 +8907,8 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
 
   /// 副字幕源（TODO-857 视频双字幕 Path A）：与 [subtitleSource] 同款四态编码
   /// （外挂存绝对路径；内嵌存 `embedded:<n>`；关闭存 `off:`；无副字幕存 null）。
-  /// 副字幕由 libmpv `secondary-sid` 自渲染，不进 Dart cue 流，不可查词。
+  /// TODO-1312 起副字幕走独立 Dart cue 流（Flutter overlay 副层渲染，可逐字符
+  /// 查词），**不再**由 libmpv `secondary-sid` 自渲染；持久化编码沿用不变。
   final String? secondarySubtitleSource;
   final String? subtitleFormat;
   final int? embeddedSubtitleTrack;
@@ -8933,6 +8949,13 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
   /// 跨重启保留；多集播放列表换集时复用同一值（手动校准一次全片受用）。
   final int delayMs;
 
+  /// 副字幕独立调轴（毫秒，schema v86，TODO-2837 主副字幕分开调轴）。**nullable**
+  /// （区别于 [delayMs] 的 withDefault(0)）：NULL = 未单独设置 = 副字幕跟随
+  /// [delayMs]（与 v86 前「主副共用一个 offset」逐字节一致，Never break
+  /// userspace——旧库升级后全 NULL，行为零变化）；非 NULL = 副字幕独立于主字幕
+  /// 调轴（主副字幕轴不同源时各调各的）。含义与 [delayMs] 同向（正值=字幕延后）。
+  final int? secondaryDelayMs;
+
   /// 视频首次播放进度 ≥ 90% 的时间戳（完成标记）；null = 未完成。统计去重计数用。
   final DateTime? completedAt;
 
@@ -8963,6 +8986,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
       required this.currentEpisode,
       this.audioTrackId,
       required this.delayMs,
+      this.secondaryDelayMs,
       this.completedAt,
       this.sourceId,
       this.streamSpecJson});
@@ -9003,6 +9027,9 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
       map['audio_track_id'] = Variable<String>(audioTrackId);
     }
     map['delay_ms'] = Variable<int>(delayMs);
+    if (!nullToAbsent || secondaryDelayMs != null) {
+      map['secondary_delay_ms'] = Variable<int>(secondaryDelayMs);
+    }
     if (!nullToAbsent || completedAt != null) {
       map['completed_at'] = Variable<DateTime>(completedAt);
     }
@@ -9050,6 +9077,9 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
           ? const Value.absent()
           : Value(audioTrackId),
       delayMs: Value(delayMs),
+      secondaryDelayMs: secondaryDelayMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(secondaryDelayMs),
       completedAt: completedAt == null && nullToAbsent
           ? const Value.absent()
           : Value(completedAt),
@@ -9083,6 +9113,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
       currentEpisode: serializer.fromJson<int>(json['currentEpisode']),
       audioTrackId: serializer.fromJson<String?>(json['audioTrackId']),
       delayMs: serializer.fromJson<int>(json['delayMs']),
+      secondaryDelayMs: serializer.fromJson<int?>(json['secondaryDelayMs']),
       completedAt: serializer.fromJson<DateTime?>(json['completedAt']),
       sourceId: serializer.fromJson<int?>(json['sourceId']),
       streamSpecJson: serializer.fromJson<String?>(json['streamSpecJson']),
@@ -9108,6 +9139,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
       'currentEpisode': serializer.toJson<int>(currentEpisode),
       'audioTrackId': serializer.toJson<String?>(audioTrackId),
       'delayMs': serializer.toJson<int>(delayMs),
+      'secondaryDelayMs': serializer.toJson<int?>(secondaryDelayMs),
       'completedAt': serializer.toJson<DateTime?>(completedAt),
       'sourceId': serializer.toJson<int?>(sourceId),
       'streamSpecJson': serializer.toJson<String?>(streamSpecJson),
@@ -9130,6 +9162,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
           int? currentEpisode,
           Value<String?> audioTrackId = const Value.absent(),
           int? delayMs,
+          Value<int?> secondaryDelayMs = const Value.absent(),
           Value<DateTime?> completedAt = const Value.absent(),
           Value<int?> sourceId = const Value.absent(),
           Value<String?> streamSpecJson = const Value.absent()}) =>
@@ -9158,6 +9191,9 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
         audioTrackId:
             audioTrackId.present ? audioTrackId.value : this.audioTrackId,
         delayMs: delayMs ?? this.delayMs,
+        secondaryDelayMs: secondaryDelayMs.present
+            ? secondaryDelayMs.value
+            : this.secondaryDelayMs,
         completedAt: completedAt.present ? completedAt.value : this.completedAt,
         sourceId: sourceId.present ? sourceId.value : this.sourceId,
         streamSpecJson:
@@ -9199,6 +9235,9 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
           ? data.audioTrackId.value
           : this.audioTrackId,
       delayMs: data.delayMs.present ? data.delayMs.value : this.delayMs,
+      secondaryDelayMs: data.secondaryDelayMs.present
+          ? data.secondaryDelayMs.value
+          : this.secondaryDelayMs,
       completedAt:
           data.completedAt.present ? data.completedAt.value : this.completedAt,
       sourceId: data.sourceId.present ? data.sourceId.value : this.sourceId,
@@ -9226,6 +9265,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
           ..write('currentEpisode: $currentEpisode, ')
           ..write('audioTrackId: $audioTrackId, ')
           ..write('delayMs: $delayMs, ')
+          ..write('secondaryDelayMs: $secondaryDelayMs, ')
           ..write('completedAt: $completedAt, ')
           ..write('sourceId: $sourceId, ')
           ..write('streamSpecJson: $streamSpecJson')
@@ -9250,6 +9290,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
       currentEpisode,
       audioTrackId,
       delayMs,
+      secondaryDelayMs,
       completedAt,
       sourceId,
       streamSpecJson);
@@ -9272,6 +9313,7 @@ class VideoBookRow extends DataClass implements Insertable<VideoBookRow> {
           other.currentEpisode == this.currentEpisode &&
           other.audioTrackId == this.audioTrackId &&
           other.delayMs == this.delayMs &&
+          other.secondaryDelayMs == this.secondaryDelayMs &&
           other.completedAt == this.completedAt &&
           other.sourceId == this.sourceId &&
           other.streamSpecJson == this.streamSpecJson);
@@ -9293,6 +9335,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
   final Value<int> currentEpisode;
   final Value<String?> audioTrackId;
   final Value<int> delayMs;
+  final Value<int?> secondaryDelayMs;
   final Value<DateTime?> completedAt;
   final Value<int?> sourceId;
   final Value<String?> streamSpecJson;
@@ -9313,6 +9356,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
     this.currentEpisode = const Value.absent(),
     this.audioTrackId = const Value.absent(),
     this.delayMs = const Value.absent(),
+    this.secondaryDelayMs = const Value.absent(),
     this.completedAt = const Value.absent(),
     this.sourceId = const Value.absent(),
     this.streamSpecJson = const Value.absent(),
@@ -9334,6 +9378,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
     this.currentEpisode = const Value.absent(),
     this.audioTrackId = const Value.absent(),
     this.delayMs = const Value.absent(),
+    this.secondaryDelayMs = const Value.absent(),
     this.completedAt = const Value.absent(),
     this.sourceId = const Value.absent(),
     this.streamSpecJson = const Value.absent(),
@@ -9357,6 +9402,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
     Expression<int>? currentEpisode,
     Expression<String>? audioTrackId,
     Expression<int>? delayMs,
+    Expression<int>? secondaryDelayMs,
     Expression<DateTime>? completedAt,
     Expression<int>? sourceId,
     Expression<String>? streamSpecJson,
@@ -9380,6 +9426,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
       if (currentEpisode != null) 'current_episode': currentEpisode,
       if (audioTrackId != null) 'audio_track_id': audioTrackId,
       if (delayMs != null) 'delay_ms': delayMs,
+      if (secondaryDelayMs != null) 'secondary_delay_ms': secondaryDelayMs,
       if (completedAt != null) 'completed_at': completedAt,
       if (sourceId != null) 'source_id': sourceId,
       if (streamSpecJson != null) 'stream_spec_json': streamSpecJson,
@@ -9403,6 +9450,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
       Value<int>? currentEpisode,
       Value<String?>? audioTrackId,
       Value<int>? delayMs,
+      Value<int?>? secondaryDelayMs,
       Value<DateTime?>? completedAt,
       Value<int?>? sourceId,
       Value<String?>? streamSpecJson,
@@ -9425,6 +9473,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
       currentEpisode: currentEpisode ?? this.currentEpisode,
       audioTrackId: audioTrackId ?? this.audioTrackId,
       delayMs: delayMs ?? this.delayMs,
+      secondaryDelayMs: secondaryDelayMs ?? this.secondaryDelayMs,
       completedAt: completedAt ?? this.completedAt,
       sourceId: sourceId ?? this.sourceId,
       streamSpecJson: streamSpecJson ?? this.streamSpecJson,
@@ -9482,6 +9531,9 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
     if (delayMs.present) {
       map['delay_ms'] = Variable<int>(delayMs.value);
     }
+    if (secondaryDelayMs.present) {
+      map['secondary_delay_ms'] = Variable<int>(secondaryDelayMs.value);
+    }
     if (completedAt.present) {
       map['completed_at'] = Variable<DateTime>(completedAt.value);
     }
@@ -9515,6 +9567,7 @@ class VideoBooksCompanion extends UpdateCompanion<VideoBookRow> {
           ..write('currentEpisode: $currentEpisode, ')
           ..write('audioTrackId: $audioTrackId, ')
           ..write('delayMs: $delayMs, ')
+          ..write('secondaryDelayMs: $secondaryDelayMs, ')
           ..write('completedAt: $completedAt, ')
           ..write('sourceId: $sourceId, ')
           ..write('streamSpecJson: $streamSpecJson, ')
@@ -12332,6 +12385,12 @@ class $MediaCollectionsTable extends MediaCollections
   late final GeneratedColumn<int> subtitleDelayMs = GeneratedColumn<int>(
       'subtitle_delay_ms', aliasedName, true,
       type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _secondarySubtitleDelayMsMeta =
+      const VerificationMeta('secondarySubtitleDelayMs');
+  @override
+  late final GeneratedColumn<int> secondarySubtitleDelayMs =
+      GeneratedColumn<int>('secondary_subtitle_delay_ms', aliasedName, true,
+          type: DriftSqlType.int, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -12344,7 +12403,8 @@ class $MediaCollectionsTable extends MediaCollections
         orderUpdatedAt,
         anilistId,
         audioTrackId,
-        subtitleDelayMs
+        subtitleDelayMs,
+        secondarySubtitleDelayMs
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -12413,6 +12473,13 @@ class $MediaCollectionsTable extends MediaCollections
           subtitleDelayMs.isAcceptableOrUnknown(
               data['subtitle_delay_ms']!, _subtitleDelayMsMeta));
     }
+    if (data.containsKey('secondary_subtitle_delay_ms')) {
+      context.handle(
+          _secondarySubtitleDelayMsMeta,
+          secondarySubtitleDelayMs.isAcceptableOrUnknown(
+              data['secondary_subtitle_delay_ms']!,
+              _secondarySubtitleDelayMsMeta));
+    }
     return context;
   }
 
@@ -12444,6 +12511,9 @@ class $MediaCollectionsTable extends MediaCollections
           .read(DriftSqlType.string, data['${effectivePrefix}audio_track_id']),
       subtitleDelayMs: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}subtitle_delay_ms']),
+      secondarySubtitleDelayMs: attachedDatabase.typeMapping.read(
+          DriftSqlType.int,
+          data['${effectivePrefix}secondary_subtitle_delay_ms']),
     );
   }
 
@@ -12520,6 +12590,13 @@ class MediaCollectionRow extends DataClass
   /// 与「显式调成 0」区分，避免 0 哨兵歧义。无损迁移：nullable 无 default → 旧库既有行全
   /// NULL = 行为与旧版一致（Never break userspace）。
   final int? subtitleDelayMs;
+
+  /// 系列级**副字幕**独立调轴（毫秒，schema v86，TODO-2837）。与 [subtitleDelayMs]
+  /// 同款「系列共享」语义：合集内任一集调副轨轴即写这里，任一集加载优先读这里
+  /// （回退各集自己行的 [VideoBooks.secondaryDelayMs]）。两层都 NULL = 副字幕跟随
+  /// 主字幕调轴（v86 前行为）。无损迁移：nullable 无 default → 旧库既有行全 NULL =
+  /// 行为与旧版一致（Never break userspace）。
+  final int? secondarySubtitleDelayMs;
   const MediaCollectionRow(
       {required this.id,
       required this.name,
@@ -12531,7 +12608,8 @@ class MediaCollectionRow extends DataClass
       required this.orderUpdatedAt,
       this.anilistId,
       this.audioTrackId,
-      this.subtitleDelayMs});
+      this.subtitleDelayMs,
+      this.secondarySubtitleDelayMs});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -12555,6 +12633,10 @@ class MediaCollectionRow extends DataClass
     }
     if (!nullToAbsent || subtitleDelayMs != null) {
       map['subtitle_delay_ms'] = Variable<int>(subtitleDelayMs);
+    }
+    if (!nullToAbsent || secondarySubtitleDelayMs != null) {
+      map['secondary_subtitle_delay_ms'] =
+          Variable<int>(secondarySubtitleDelayMs);
     }
     return map;
   }
@@ -12582,6 +12664,9 @@ class MediaCollectionRow extends DataClass
       subtitleDelayMs: subtitleDelayMs == null && nullToAbsent
           ? const Value.absent()
           : Value(subtitleDelayMs),
+      secondarySubtitleDelayMs: secondarySubtitleDelayMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(secondarySubtitleDelayMs),
     );
   }
 
@@ -12600,6 +12685,8 @@ class MediaCollectionRow extends DataClass
       anilistId: serializer.fromJson<int?>(json['anilistId']),
       audioTrackId: serializer.fromJson<String?>(json['audioTrackId']),
       subtitleDelayMs: serializer.fromJson<int?>(json['subtitleDelayMs']),
+      secondarySubtitleDelayMs:
+          serializer.fromJson<int?>(json['secondarySubtitleDelayMs']),
     );
   }
   @override
@@ -12617,6 +12704,8 @@ class MediaCollectionRow extends DataClass
       'anilistId': serializer.toJson<int?>(anilistId),
       'audioTrackId': serializer.toJson<String?>(audioTrackId),
       'subtitleDelayMs': serializer.toJson<int?>(subtitleDelayMs),
+      'secondarySubtitleDelayMs':
+          serializer.toJson<int?>(secondarySubtitleDelayMs),
     };
   }
 
@@ -12631,7 +12720,8 @@ class MediaCollectionRow extends DataClass
           int? orderUpdatedAt,
           Value<int?> anilistId = const Value.absent(),
           Value<String?> audioTrackId = const Value.absent(),
-          Value<int?> subtitleDelayMs = const Value.absent()}) =>
+          Value<int?> subtitleDelayMs = const Value.absent(),
+          Value<int?> secondarySubtitleDelayMs = const Value.absent()}) =>
       MediaCollectionRow(
         id: id ?? this.id,
         name: name ?? this.name,
@@ -12647,6 +12737,9 @@ class MediaCollectionRow extends DataClass
         subtitleDelayMs: subtitleDelayMs.present
             ? subtitleDelayMs.value
             : this.subtitleDelayMs,
+        secondarySubtitleDelayMs: secondarySubtitleDelayMs.present
+            ? secondarySubtitleDelayMs.value
+            : this.secondarySubtitleDelayMs,
       );
   MediaCollectionRow copyWithCompanion(MediaCollectionsCompanion data) {
     return MediaCollectionRow(
@@ -12670,6 +12763,9 @@ class MediaCollectionRow extends DataClass
       subtitleDelayMs: data.subtitleDelayMs.present
           ? data.subtitleDelayMs.value
           : this.subtitleDelayMs,
+      secondarySubtitleDelayMs: data.secondarySubtitleDelayMs.present
+          ? data.secondarySubtitleDelayMs.value
+          : this.secondarySubtitleDelayMs,
     );
   }
 
@@ -12686,7 +12782,8 @@ class MediaCollectionRow extends DataClass
           ..write('orderUpdatedAt: $orderUpdatedAt, ')
           ..write('anilistId: $anilistId, ')
           ..write('audioTrackId: $audioTrackId, ')
-          ..write('subtitleDelayMs: $subtitleDelayMs')
+          ..write('subtitleDelayMs: $subtitleDelayMs, ')
+          ..write('secondarySubtitleDelayMs: $secondarySubtitleDelayMs')
           ..write(')'))
         .toString();
   }
@@ -12703,7 +12800,8 @@ class MediaCollectionRow extends DataClass
       orderUpdatedAt,
       anilistId,
       audioTrackId,
-      subtitleDelayMs);
+      subtitleDelayMs,
+      secondarySubtitleDelayMs);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -12718,7 +12816,8 @@ class MediaCollectionRow extends DataClass
           other.orderUpdatedAt == this.orderUpdatedAt &&
           other.anilistId == this.anilistId &&
           other.audioTrackId == this.audioTrackId &&
-          other.subtitleDelayMs == this.subtitleDelayMs);
+          other.subtitleDelayMs == this.subtitleDelayMs &&
+          other.secondarySubtitleDelayMs == this.secondarySubtitleDelayMs);
 }
 
 class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
@@ -12733,6 +12832,7 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
   final Value<int?> anilistId;
   final Value<String?> audioTrackId;
   final Value<int?> subtitleDelayMs;
+  final Value<int?> secondarySubtitleDelayMs;
   const MediaCollectionsCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
@@ -12745,6 +12845,7 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
     this.anilistId = const Value.absent(),
     this.audioTrackId = const Value.absent(),
     this.subtitleDelayMs = const Value.absent(),
+    this.secondarySubtitleDelayMs = const Value.absent(),
   });
   MediaCollectionsCompanion.insert({
     this.id = const Value.absent(),
@@ -12758,6 +12859,7 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
     this.anilistId = const Value.absent(),
     this.audioTrackId = const Value.absent(),
     this.subtitleDelayMs = const Value.absent(),
+    this.secondarySubtitleDelayMs = const Value.absent(),
   })  : name = Value(name),
         createdAt = Value(createdAt);
   static Insertable<MediaCollectionRow> custom({
@@ -12772,6 +12874,7 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
     Expression<int>? anilistId,
     Expression<String>? audioTrackId,
     Expression<int>? subtitleDelayMs,
+    Expression<int>? secondarySubtitleDelayMs,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -12785,6 +12888,8 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
       if (anilistId != null) 'anilist_id': anilistId,
       if (audioTrackId != null) 'audio_track_id': audioTrackId,
       if (subtitleDelayMs != null) 'subtitle_delay_ms': subtitleDelayMs,
+      if (secondarySubtitleDelayMs != null)
+        'secondary_subtitle_delay_ms': secondarySubtitleDelayMs,
     });
   }
 
@@ -12799,7 +12904,8 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
       Value<int>? orderUpdatedAt,
       Value<int?>? anilistId,
       Value<String?>? audioTrackId,
-      Value<int?>? subtitleDelayMs}) {
+      Value<int?>? subtitleDelayMs,
+      Value<int?>? secondarySubtitleDelayMs}) {
     return MediaCollectionsCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
@@ -12812,6 +12918,8 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
       anilistId: anilistId ?? this.anilistId,
       audioTrackId: audioTrackId ?? this.audioTrackId,
       subtitleDelayMs: subtitleDelayMs ?? this.subtitleDelayMs,
+      secondarySubtitleDelayMs:
+          secondarySubtitleDelayMs ?? this.secondarySubtitleDelayMs,
     );
   }
 
@@ -12851,6 +12959,10 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
     if (subtitleDelayMs.present) {
       map['subtitle_delay_ms'] = Variable<int>(subtitleDelayMs.value);
     }
+    if (secondarySubtitleDelayMs.present) {
+      map['secondary_subtitle_delay_ms'] =
+          Variable<int>(secondarySubtitleDelayMs.value);
+    }
     return map;
   }
 
@@ -12867,7 +12979,8 @@ class MediaCollectionsCompanion extends UpdateCompanion<MediaCollectionRow> {
           ..write('orderUpdatedAt: $orderUpdatedAt, ')
           ..write('anilistId: $anilistId, ')
           ..write('audioTrackId: $audioTrackId, ')
-          ..write('subtitleDelayMs: $subtitleDelayMs')
+          ..write('subtitleDelayMs: $subtitleDelayMs, ')
+          ..write('secondarySubtitleDelayMs: $secondarySubtitleDelayMs')
           ..write(')'))
         .toString();
   }
@@ -45124,6 +45237,7 @@ typedef $$VideoBooksTableCreateCompanionBuilder = VideoBooksCompanion Function({
   Value<int> currentEpisode,
   Value<String?> audioTrackId,
   Value<int> delayMs,
+  Value<int?> secondaryDelayMs,
   Value<DateTime?> completedAt,
   Value<int?> sourceId,
   Value<String?> streamSpecJson,
@@ -45145,6 +45259,7 @@ typedef $$VideoBooksTableUpdateCompanionBuilder = VideoBooksCompanion Function({
   Value<int> currentEpisode,
   Value<String?> audioTrackId,
   Value<int> delayMs,
+  Value<int?> secondaryDelayMs,
   Value<DateTime?> completedAt,
   Value<int?> sourceId,
   Value<String?> streamSpecJson,
@@ -45317,6 +45432,10 @@ class $$VideoBooksTableFilterComposer
 
   ColumnFilters<int> get delayMs => $composableBuilder(
       column: $table.delayMs, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get secondaryDelayMs => $composableBuilder(
+      column: $table.secondaryDelayMs,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get completedAt => $composableBuilder(
       column: $table.completedAt, builder: (column) => ColumnFilters(column));
@@ -45516,6 +45635,10 @@ class $$VideoBooksTableOrderingComposer
   ColumnOrderings<int> get delayMs => $composableBuilder(
       column: $table.delayMs, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get secondaryDelayMs => $composableBuilder(
+      column: $table.secondaryDelayMs,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get completedAt => $composableBuilder(
       column: $table.completedAt, builder: (column) => ColumnOrderings(column));
 
@@ -45597,6 +45720,9 @@ class $$VideoBooksTableAnnotationComposer
 
   GeneratedColumn<int> get delayMs =>
       $composableBuilder(column: $table.delayMs, builder: (column) => column);
+
+  GeneratedColumn<int> get secondaryDelayMs => $composableBuilder(
+      column: $table.secondaryDelayMs, builder: (column) => column);
 
   GeneratedColumn<DateTime> get completedAt => $composableBuilder(
       column: $table.completedAt, builder: (column) => column);
@@ -45779,6 +45905,7 @@ class $$VideoBooksTableTableManager extends RootTableManager<
             Value<int> currentEpisode = const Value.absent(),
             Value<String?> audioTrackId = const Value.absent(),
             Value<int> delayMs = const Value.absent(),
+            Value<int?> secondaryDelayMs = const Value.absent(),
             Value<DateTime?> completedAt = const Value.absent(),
             Value<int?> sourceId = const Value.absent(),
             Value<String?> streamSpecJson = const Value.absent(),
@@ -45800,6 +45927,7 @@ class $$VideoBooksTableTableManager extends RootTableManager<
             currentEpisode: currentEpisode,
             audioTrackId: audioTrackId,
             delayMs: delayMs,
+            secondaryDelayMs: secondaryDelayMs,
             completedAt: completedAt,
             sourceId: sourceId,
             streamSpecJson: streamSpecJson,
@@ -45821,6 +45949,7 @@ class $$VideoBooksTableTableManager extends RootTableManager<
             Value<int> currentEpisode = const Value.absent(),
             Value<String?> audioTrackId = const Value.absent(),
             Value<int> delayMs = const Value.absent(),
+            Value<int?> secondaryDelayMs = const Value.absent(),
             Value<DateTime?> completedAt = const Value.absent(),
             Value<int?> sourceId = const Value.absent(),
             Value<String?> streamSpecJson = const Value.absent(),
@@ -45842,6 +45971,7 @@ class $$VideoBooksTableTableManager extends RootTableManager<
             currentEpisode: currentEpisode,
             audioTrackId: audioTrackId,
             delayMs: delayMs,
+            secondaryDelayMs: secondaryDelayMs,
             completedAt: completedAt,
             sourceId: sourceId,
             streamSpecJson: streamSpecJson,
@@ -47569,6 +47699,7 @@ typedef $$MediaCollectionsTableCreateCompanionBuilder
   Value<int?> anilistId,
   Value<String?> audioTrackId,
   Value<int?> subtitleDelayMs,
+  Value<int?> secondarySubtitleDelayMs,
 });
 typedef $$MediaCollectionsTableUpdateCompanionBuilder
     = MediaCollectionsCompanion Function({
@@ -47583,6 +47714,7 @@ typedef $$MediaCollectionsTableUpdateCompanionBuilder
   Value<int?> anilistId,
   Value<String?> audioTrackId,
   Value<int?> subtitleDelayMs,
+  Value<int?> secondarySubtitleDelayMs,
 });
 
 final class $$MediaCollectionsTableReferences extends BaseReferences<
@@ -47740,6 +47872,10 @@ class $$MediaCollectionsTableFilterComposer
 
   ColumnFilters<int> get subtitleDelayMs => $composableBuilder(
       column: $table.subtitleDelayMs,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get secondarySubtitleDelayMs => $composableBuilder(
+      column: $table.secondarySubtitleDelayMs,
       builder: (column) => ColumnFilters(column));
 
   Expression<bool> mediaCollectionItemsRefs(
@@ -47919,6 +48055,10 @@ class $$MediaCollectionsTableOrderingComposer
   ColumnOrderings<int> get subtitleDelayMs => $composableBuilder(
       column: $table.subtitleDelayMs,
       builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get secondarySubtitleDelayMs => $composableBuilder(
+      column: $table.secondarySubtitleDelayMs,
+      builder: (column) => ColumnOrderings(column));
 }
 
 class $$MediaCollectionsTableAnnotationComposer
@@ -47962,6 +48102,9 @@ class $$MediaCollectionsTableAnnotationComposer
 
   GeneratedColumn<int> get subtitleDelayMs => $composableBuilder(
       column: $table.subtitleDelayMs, builder: (column) => column);
+
+  GeneratedColumn<int> get secondarySubtitleDelayMs => $composableBuilder(
+      column: $table.secondarySubtitleDelayMs, builder: (column) => column);
 
   Expression<T> mediaCollectionItemsRefs<T extends Object>(
       Expression<T> Function($$MediaCollectionItemsTableAnnotationComposer a)
@@ -48140,6 +48283,7 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
             Value<int?> anilistId = const Value.absent(),
             Value<String?> audioTrackId = const Value.absent(),
             Value<int?> subtitleDelayMs = const Value.absent(),
+            Value<int?> secondarySubtitleDelayMs = const Value.absent(),
           }) =>
               MediaCollectionsCompanion(
             id: id,
@@ -48153,6 +48297,7 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
             anilistId: anilistId,
             audioTrackId: audioTrackId,
             subtitleDelayMs: subtitleDelayMs,
+            secondarySubtitleDelayMs: secondarySubtitleDelayMs,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -48166,6 +48311,7 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
             Value<int?> anilistId = const Value.absent(),
             Value<String?> audioTrackId = const Value.absent(),
             Value<int?> subtitleDelayMs = const Value.absent(),
+            Value<int?> secondarySubtitleDelayMs = const Value.absent(),
           }) =>
               MediaCollectionsCompanion.insert(
             id: id,
@@ -48179,6 +48325,7 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
             anilistId: anilistId,
             audioTrackId: audioTrackId,
             subtitleDelayMs: subtitleDelayMs,
+            secondarySubtitleDelayMs: secondarySubtitleDelayMs,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (

--- a/packages/fushi_core/lib/src/database/database_library.part.dart
+++ b/packages/fushi_core/lib/src/database/database_library.part.dart
@@ -446,6 +446,16 @@ mixin _FushiDbLibrary on _$FushiDatabase, _FushiDbTagsSync {
         MediaCollectionsCompanion(subtitleDelayMs: Value<int?>(delayMs)),
       );
 
+  /// 更新系列（合集）级**副字幕**独立调轴（毫秒，schema v86，TODO-2837，同系列
+  /// 副轨调轴记忆）。[delayMs] 为 null 时清除（加载回退各集 per-book；两层都
+  /// null = 副字幕跟随主字幕调轴）。
+  Future<void> updateMediaCollectionSecondarySubtitleDelayMs(
+          int id, int? delayMs) =>
+      (update(mediaCollections)..where((t) => t.id.equals(id))).write(
+        MediaCollectionsCompanion(
+            secondarySubtitleDelayMs: Value<int?>(delayMs)),
+      );
+
   /// 新建合集，返回自增 id。sortOrder 默认排末尾（现有最大 +1，空表 0）。同事务清
   /// 同自然键的合集级删除墓碑（重建 = 撤销删除，仿插书清书墓碑 [insertEpubBook]
   /// 一律；不清成员墓碑——成员重加走 [addToCollection] 逐键清）。

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -1974,6 +1974,13 @@ mixin _FushiDbVideoDomain
       (update(videoBooks)..where((t) => t.bookUid.equals(bookUid)))
           .write(VideoBooksCompanion(delayMs: Value(delayMs)));
 
+  /// 更新副字幕独立调轴（毫秒，schema v86，TODO-2837）。[secondaryDelayMs] 为
+  /// null = 清除独立值（副字幕回到跟随主字幕 [VideoBooks.delayMs]）。
+  Future<void> updateVideoBookSecondaryDelayMs(
+          String bookUid, int? secondaryDelayMs) =>
+      (update(videoBooks)..where((t) => t.bookUid.equals(bookUid))).write(
+          VideoBooksCompanion(secondaryDelayMs: Value<int?>(secondaryDelayMs)));
+
   /// 更新用户选中的字幕源（外挂存路径；内嵌存 `embedded:<n>`；关闭存 null）。
   Future<void> updateVideoBookSubtitleSource(
           String bookUid, String? subtitleSource) =>

--- a/packages/fushi_core/lib/src/database/tables.dart
+++ b/packages/fushi_core/lib/src/database/tables.dart
@@ -558,7 +558,8 @@ class VideoBooks extends Table {
 
   /// 副字幕源（TODO-857 视频双字幕 Path A）：与 [subtitleSource] 同款四态编码
   /// （外挂存绝对路径；内嵌存 `embedded:<n>`；关闭存 `off:`；无副字幕存 null）。
-  /// 副字幕由 libmpv `secondary-sid` 自渲染，不进 Dart cue 流，不可查词。
+  /// TODO-1312 起副字幕走独立 Dart cue 流（Flutter overlay 副层渲染，可逐字符
+  /// 查词），**不再**由 libmpv `secondary-sid` 自渲染；持久化编码沿用不变。
   TextColumn get secondarySubtitleSource => text().nullable()();
   TextColumn get subtitleFormat => text().nullable()();
   IntColumn get embeddedSubtitleTrack => integer().nullable()();
@@ -598,6 +599,13 @@ class VideoBooks extends Table {
   /// 音画延迟（毫秒）：正值=画面先于文字，查 cue 时把位置往回拨，让字幕与画面对齐。
   /// 跨重启保留；多集播放列表换集时复用同一值（手动校准一次全片受用）。
   IntColumn get delayMs => integer().withDefault(const Constant(0))();
+
+  /// 副字幕独立调轴（毫秒，schema v86，TODO-2837 主副字幕分开调轴）。**nullable**
+  /// （区别于 [delayMs] 的 withDefault(0)）：NULL = 未单独设置 = 副字幕跟随
+  /// [delayMs]（与 v86 前「主副共用一个 offset」逐字节一致，Never break
+  /// userspace——旧库升级后全 NULL，行为零变化）；非 NULL = 副字幕独立于主字幕
+  /// 调轴（主副字幕轴不同源时各调各的）。含义与 [delayMs] 同向（正值=字幕延后）。
+  IntColumn get secondaryDelayMs => integer().nullable()();
 
   /// 视频首次播放进度 ≥ 90% 的时间戳（完成标记）；null = 未完成。统计去重计数用。
   DateTimeColumn get completedAt => dateTime().nullable()();
@@ -930,6 +938,13 @@ class MediaCollections extends Table {
   /// 与「显式调成 0」区分，避免 0 哨兵歧义。无损迁移：nullable 无 default → 旧库既有行全
   /// NULL = 行为与旧版一致（Never break userspace）。
   IntColumn get subtitleDelayMs => integer().nullable()();
+
+  /// 系列级**副字幕**独立调轴（毫秒，schema v86，TODO-2837）。与 [subtitleDelayMs]
+  /// 同款「系列共享」语义：合集内任一集调副轨轴即写这里，任一集加载优先读这里
+  /// （回退各集自己行的 [VideoBooks.secondaryDelayMs]）。两层都 NULL = 副字幕跟随
+  /// 主字幕调轴（v86 前行为）。无损迁移：nullable 无 default → 旧库既有行全 NULL =
+  /// 行为与旧版一致（Never break userspace）。
+  IntColumn get secondarySubtitleDelayMs => integer().nullable()();
 }
 
 // ── media_collection_items (合集成员引用 = Jellyfin LinkedChildren) ────


### PR DESCRIPTION
## TODO-2837 主副字幕分开调轴（副轨独立 delay 两层持久化）

用户诉求：副字幕和主字幕能分开调轴（日文主字幕对轴、中文副字幕轴不同源时各调各的）。

### 数据结构取舍（核心决策）

副轨「未单独设置」表示为 **nullable = 跟随主轨**，而不是独立 0 值 + 迁移回填：

- `VideoBooks.secondaryDelayMs`（nullable int）+ `MediaCollections.secondarySubtitleDelayMs`（nullable int），schema **v85→v86**（任务书写的 v62 早已过时，开工实测 develop 已到 v85）。
- **NULL = 跟随主轨**：与 v86 前「主副共用一个 `_delayMs`」的行为逐字节一致。旧库升级后两列全 NULL，主轨 delay≠0 的用户其副字幕继续被同一值平移——**迁移零回填、零特殊情况**（Never break userspace）。若选「独立 0 值」则必须迁移时把副轨初始化为现存主轨值，且从此两值漂移；nullable 方案把「跟随」表达成数据结构本身，消除该特例。
- 决议纯函数 `effectiveSeriesSecondaryDelayMs(collection, perBook) = collection ?? perBook`，两层皆 NULL → NULL = 跟随；镜像 v52 主轨 `effectiveSeriesDelayMs` 的系列级优先语义。
- 写分派镜像主轨：合集内写系列级、否则写 per-book。**「重置为跟随」在合集内两层都清**——决议是 `系列 ?? per-book`，只清系列级会让本集单集时代的旧独立值复活。

### Controller

- `_secondaryDelayMs`（int?，null=跟随）；副字幕活动集用 `effectiveSecondaryDelayMs = _secondaryDelayMs ?? _delayMs` 独立求解；主轨逻辑零改动。
- `setSecondaryDelayMs` 改完立即按当前位置重算（BUG-373 同理，不等 125ms tick）；副字幕恒为 Dart 文本 cue 流，无 libmpv `sub-delay` 参与。
- 新增按流分轴 API：`miningDelayMs`（BUG-1592 有效流的轴）、`delayMsForCue`（按 cue 身份取所属流的轴）、`effectivePositionMsForCue`（overlay ASS 动画用）。

### 制卡/查词链路（沿真实代码路径查过）

制卡裁剪逆变换 `miningClipTimeMs` 原来硬用主轨 delay。副轨独立调轴后，**锚定 cue 属于副字幕流时（查副字幕词制卡、主字幕关闭只开副字幕）必须用副轨生效轴**，否则裁出的音频/封面整体偏移两轨差值。已改：

- `lookup_mining.part.dart` 三处 → `delayMsForCue(cue)` / `miningDelayMs`；
- `lookup_favorite.part.dart` 按位置兜底 → `miningDelayMs`；
- `clip_export.part.dart` 副轨 SRT 导出 → `effectiveSecondaryDelayMs`；
- `video_subtitle_overlay.dart` 四处 ASS 动画（`\fad`/`\move`/`\t`/卡拉OK）等效位置 → `effectivePositionMsForCue(cue)`。

未单独设置时以上全部退化为主轨值，与旧行为逐字节一致。

### UI

- `VideoSubtitleSyncRow` 内新增副轨独立段：滑条（±10s）+ ±50/±1000 微调 + 数值输入（去抖复用 `SubtitleDelayInputDebounce`）+ 「跟随主字幕」重置按钮；跟随态回显主轨生效值、染次要色。
- **仅副字幕轨激活（cue 流非空）时渲染**（不加死 UI）；激活态经 controller 通知（`subtitlePositionListenable`）即时显隐，面板内切换副字幕轨立即生效。
- 副轨 UI 收在 `VideoSubtitleSyncRow` 内部，**没有碰** TODO-2838 并行线的 `settings_schema_video.dart` / `video_subtitle_style` / overlay 样式。
- 新 i18n key 5 个（`i18n_sync --add` + `dart run slang`）。

### 快捷键取舍

z/x 保持只调主轨。副轨微调**本轮不加新键位**：本仓快捷键是注册表驱动（可改键），加副轨动作需要 `ShortcutAction` 新枚举 + registry schema 迁移 + 设置页分组 + 盘点文档更新，且修饰键组合撞键面大；副轨调轴是低频校准操作，面板入口足够。已在代码注释标明后续加键的前置条件。波形对轴/asbplayer 对齐同样保持只对齐主轨（注释已标注副轨对齐为后续工作）。

### 兼容性

- 旧库升级：两列 NULL → 行为不变（迁移测试专门锁死「主轨调过 +800 的行也不回填副轨」）。
- 远端播放：host 不下发副轨偏移，`_secondaryDelayMs` 恒 null（跟随），与现状一致。
- 本 PR bump `schemaVersion=86` 并把 22 个迁移测试的「当前版本」等值断言 85→86；**与其它并发 schema bump 线会撞号，rebase 后需重核**。

### 测试证据（本机全绿）

- `flutter analyze`（fushi 全量，warning 当致命）：**No issues found**；`dart analyze packages/fushi_core`：绿。
- 定向 `flutter test test/media/video + 6 个 database/pages 目标 --no-pub`：**2560 passed，exit 0**。
- 全量 `flutter test test/database --no-pub`：**603 passed，exit 0**（首轮揪出 v63 测试一处非标准写法的 85 字面量断言，已改）。
- 新增测试：
  - `migration_v86_secondary_subtitle_delay_test.dart`：v85→v86 加列无损 + 升级后两层全 NULL（跟随语义=行为不变）+ 两层写入口回归；
  - `video_player_controller_test.dart` 新组 8 例：跟随/独立/显式0/重置/即时重算/clamp/`delayMsForCue`/`effectivePositionMsForCue`；
  - `series_playback_prefs_test.dart` 新组 6 例：副轨两层决议。

全量套件由 PR CI 兜底（Build Release APK 的 Run unit tests）。

https://claude.ai/code/session_01QxNTaiYQB8vnoFBiX3CaqQ
