### PR TITLE
feat(library): 统一四模块入库入口——「来源」视图改「导入」+快速导入区

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57324 (3372 per locale)
+/// Strings: 57460 (3380 per locale)
 ///
-/// Built on 2026-08-13 at 11:34 UTC
+/// Built on 2026-08-13 at 12:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3672,7 +3672,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String media_source_count_manga({required Object n}) => '${n} volumes';
   String get library_view_shelf => 'Shelf';
   String get library_view_browse => 'Browse';
-  String get library_view_sources => 'Sources';
   String get library_view_media => 'Library';
   String get scrape_failure_detail_show => 'Show details';
   String get scrape_failure_detail_hide => 'Hide details';
@@ -4563,6 +4562,17 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_priority_high => 'High';
   String get download_task_priority_normal => 'Normal';
   String get download_task_priority_low => 'Low';
+  String get library_view_import => 'Import';
+  String get quick_import_title => 'Quick import';
+  String get media_source_section_title => 'Library sources';
+  String get book_import_folder => 'Import folder';
+  String get book_import_folder_as_source => 'Add as library source';
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  String get book_import_folder_once => 'Import once only';
+  String get library_empty_go_import => 'Go to import';
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -10816,8 +10826,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -12348,6 +12356,26 @@ class _StringsAr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -18668,8 +18696,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -20200,6 +20226,26 @@ class _StringsDe extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -26536,8 +26582,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -28068,6 +28112,26 @@ class _StringsEs extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -34416,8 +34480,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -35948,6 +36010,26 @@ class _StringsFr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -42224,8 +42306,6 @@ class _StringsId extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -43756,6 +43836,26 @@ class _StringsId extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -50078,8 +50178,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -51610,6 +51708,26 @@ class _StringsIt extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -57746,8 +57864,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -59278,6 +59394,26 @@ class _StringsJa extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -65421,8 +65557,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -66953,6 +67087,26 @@ class _StringsKo extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -73255,8 +73409,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -74787,6 +74939,26 @@ class _StringsNl extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -81101,8 +81273,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -82633,6 +82803,26 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -88933,8 +89123,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -90465,6 +90653,26 @@ class _StringsRu extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -96713,8 +96921,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -98245,6 +98451,26 @@ class _StringsTh extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -104524,8 +104750,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -106056,6 +106280,26 @@ class _StringsTr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -112320,8 +112564,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -113852,6 +114094,26 @@ class _StringsVi extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 // Path: <root>
@@ -119674,8 +119936,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get library_view_browse => '浏览';
   @override
-  String get library_view_sources => '来源';
-  @override
   String get library_view_media => '媒体库';
   @override
   String get scrape_failure_detail_show => '显示详情';
@@ -121082,6 +121342,24 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_priority_normal => '普通';
   @override
   String get download_task_priority_low => '低';
+  @override
+  String get library_view_import => '导入';
+  @override
+  String get quick_import_title => '快速导入';
+  @override
+  String get media_source_section_title => '常驻来源';
+  @override
+  String get book_import_folder => '导入文件夹';
+  @override
+  String get book_import_folder_as_source => '设为常驻来源';
+  @override
+  String get book_import_folder_as_source_hint => '以后自动扫描此文件夹里的新书';
+  @override
+  String get book_import_folder_once => '仅导入这一次';
+  @override
+  String get library_empty_go_import => '去导入';
+  @override
+  String get game_import_drop_hint => '也可以把 .exe 文件直接拖进游戏库添加';
 }
 
 // Path: <root>
@@ -127142,8 +127420,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get library_view_browse => 'Browse';
   @override
-  String get library_view_sources => 'Sources';
-  @override
   String get library_view_media => 'Library';
   @override
   String get scrape_failure_detail_show => 'Show details';
@@ -128673,6 +128949,26 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get library_view_import => 'Import';
+  @override
+  String get quick_import_title => 'Quick import';
+  @override
+  String get media_source_section_title => 'Library sources';
+  @override
+  String get book_import_folder => 'Import folder';
+  @override
+  String get book_import_folder_as_source => 'Add as library source';
+  @override
+  String get book_import_folder_as_source_hint =>
+      'Keep scanning this folder for new books';
+  @override
+  String get book_import_folder_once => 'Import once only';
+  @override
+  String get library_empty_go_import => 'Go to import';
+  @override
+  String get game_import_drop_hint =>
+      'You can also drag .exe files into the game library';
 }
 
 /// Flat map(s) containing all translations.
@@ -134267,8 +134563,6 @@ extension on _StringsEn {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -135599,6 +135893,24 @@ extension on _StringsEn {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -141191,8 +141503,6 @@ extension on _StringsAr {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -142523,6 +142833,24 @@ extension on _StringsAr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -148137,8 +148465,6 @@ extension on _StringsDe {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -149469,6 +149795,24 @@ extension on _StringsDe {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -155082,8 +155426,6 @@ extension on _StringsEs {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -156414,6 +156756,24 @@ extension on _StringsEs {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -162033,8 +162393,6 @@ extension on _StringsFr {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -163365,6 +163723,24 @@ extension on _StringsFr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -168966,8 +169342,6 @@ extension on _StringsId {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -170298,6 +170672,24 @@ extension on _StringsId {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -175913,8 +176305,6 @@ extension on _StringsIt {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -177245,6 +177635,24 @@ extension on _StringsIt {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -182822,8 +183230,6 @@ extension on _StringsJa {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -184154,6 +184560,24 @@ extension on _StringsJa {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -189735,8 +190159,6 @@ extension on _StringsKo {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -191067,6 +191489,24 @@ extension on _StringsKo {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -196676,8 +197116,6 @@ extension on _StringsNl {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -198008,6 +198446,24 @@ extension on _StringsNl {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -203614,8 +204070,6 @@ extension on _StringsPtBr {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -204946,6 +205400,24 @@ extension on _StringsPtBr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -210557,8 +211029,6 @@ extension on _StringsRu {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -211889,6 +212359,24 @@ extension on _StringsRu {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -217483,8 +217971,6 @@ extension on _StringsTh {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -218815,6 +219301,24 @@ extension on _StringsTh {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -224418,8 +224922,6 @@ extension on _StringsTr {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -225750,6 +226252,24 @@ extension on _StringsTr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -231349,8 +231869,6 @@ extension on _StringsVi {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -232681,6 +233199,24 @@ extension on _StringsVi {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }
@@ -238232,8 +238768,6 @@ extension on _StringsZhCn {
         return '书架';
       case 'library_view_browse':
         return '浏览';
-      case 'library_view_sources':
-        return '来源';
       case 'library_view_media':
         return '媒体库';
       case 'scrape_failure_detail_show':
@@ -239554,6 +240088,24 @@ extension on _StringsZhCn {
         return '普通';
       case 'download_task_priority_low':
         return '低';
+      case 'library_view_import':
+        return '导入';
+      case 'quick_import_title':
+        return '快速导入';
+      case 'media_source_section_title':
+        return '常驻来源';
+      case 'book_import_folder':
+        return '导入文件夹';
+      case 'book_import_folder_as_source':
+        return '设为常驻来源';
+      case 'book_import_folder_as_source_hint':
+        return '以后自动扫描此文件夹里的新书';
+      case 'book_import_folder_once':
+        return '仅导入这一次';
+      case 'library_empty_go_import':
+        return '去导入';
+      case 'game_import_drop_hint':
+        return '也可以把 .exe 文件直接拖进游戏库添加';
       default:
         return null;
     }
@@ -245126,8 +245678,6 @@ extension on _StringsZhHk {
         return 'Shelf';
       case 'library_view_browse':
         return 'Browse';
-      case 'library_view_sources':
-        return 'Sources';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -246458,6 +247008,24 @@ extension on _StringsZhHk {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'library_view_import':
+        return 'Import';
+      case 'quick_import_title':
+        return 'Quick import';
+      case 'media_source_section_title':
+        return 'Library sources';
+      case 'book_import_folder':
+        return 'Import folder';
+      case 'book_import_folder_as_source':
+        return 'Add as library source';
+      case 'book_import_folder_as_source_hint':
+        return 'Keep scanning this folder for new books';
+      case 'book_import_folder_once':
+        return 'Import once only';
+      case 'library_empty_go_import':
+        return 'Go to import';
+      case 'game_import_drop_hint':
+        return 'You can also drag .exe files into the game library';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n 卷",
   "library_view_shelf": "书架",
   "library_view_browse": "浏览",
-  "library_view_sources": "来源",
   "library_view_media": "媒体库",
   "scrape_failure_detail_show": "显示详情",
   "scrape_failure_detail_hide": "隐藏详情",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "排队优先级",
   "download_task_priority_high": "高",
   "download_task_priority_normal": "普通",
-  "download_task_priority_low": "低"
+  "download_task_priority_low": "低",
+  "library_view_import": "导入",
+  "quick_import_title": "快速导入",
+  "media_source_section_title": "常驻来源",
+  "book_import_folder": "导入文件夹",
+  "book_import_folder_as_source": "设为常驻来源",
+  "book_import_folder_as_source_hint": "以后自动扫描此文件夹里的新书",
+  "book_import_folder_once": "仅导入这一次",
+  "library_empty_go_import": "去导入",
+  "game_import_drop_hint": "也可以把 .exe 文件直接拖进游戏库添加"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2729,7 +2729,6 @@
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
   "library_view_browse": "Browse",
-  "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3370,5 +3369,14 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "library_view_import": "Import",
+  "quick_import_title": "Quick import",
+  "media_source_section_title": "Library sources",
+  "book_import_folder": "Import folder",
+  "book_import_folder_as_source": "Add as library source",
+  "book_import_folder_as_source_hint": "Keep scanning this folder for new books",
+  "book_import_folder_once": "Import once only",
+  "library_empty_go_import": "Go to import",
+  "game_import_drop_hint": "You can also drag .exe files into the game library"
 }

--- a/fushi/lib/src/media/import/quick_import_section.dart
+++ b/fushi/lib/src/media/import/quick_import_section.dart
@@ -1,0 +1,59 @@
+import 'dart:async' show unawaited;
+
+import 'package:flutter/material.dart';
+
+import 'package:fushi/utils.dart';
+
+/// 「快速导入」区的一个入口按钮声明。
+class QuickImportAction {
+  const QuickImportAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.enabled = true,
+  });
+
+  final IconData icon;
+  final String label;
+  final Future<void> Function() onTap;
+  final bool enabled;
+}
+
+/// 库页「导入」视图顶部的快速导入区：区标题 + 一排入口按钮。
+///
+/// 四个媒体域（书 / 漫画 / 视频 / 游戏）同构复用——版式完全一致，只是按钮多少
+/// 不同（各域只声明自己真正有的入口，与 `MediaLibraryShell`「不放空壳 tab」同一
+/// 哲学）。单件导入入口从各库页页头 / FAB 收敛到这里后，「要进内容 → 去导入」
+/// 是全 app 唯一心智模型；批量常驻入口（扫描根）由同一页下方的来源列表承接，
+/// 两种入库方式在同一屏幕上下文里自然互相解释。
+class QuickImportSection extends StatelessWidget {
+  const QuickImportSection({required this.actions, super.key});
+
+  final List<QuickImportAction> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(t.quick_import_title, style: theme.textTheme.titleLarge),
+        SizedBox(height: tokens.spacing.gap),
+        Wrap(
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            for (final QuickImportAction action in actions)
+              FilledButton.tonalIcon(
+                onPressed:
+                    action.enabled ? () => unawaited(action.onTap()) : null,
+                icon: Icon(action.icon, size: 18),
+                label: Text(action.label),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/manga_library_page.dart
+++ b/fushi/lib/src/media/manga/manga_library_page.dart
@@ -50,7 +50,7 @@ class MangaLibraryPage extends StatelessWidget {
         ),
         MediaLibraryViewSpec(
           kind: MediaLibraryViewKind.sources,
-          label: t.library_view_sources,
+          label: t.library_view_import,
           builder: (BuildContext context, Widget navigation) =>
               MangaSourcesPage(navigation: navigation),
         ),

--- a/fushi/lib/src/media/manga/manga_sources_page.dart
+++ b/fushi/lib/src/media/manga/manga_sources_page.dart
@@ -4,6 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/src/media/import/quick_import_section.dart';
+import 'package:fushi/src/media/manga/manga_import_dialog.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_extensions_page.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
@@ -71,6 +75,20 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
 
   void _changed() {
     if (mounted) setState(() {});
+  }
+
+  /// 单卷 / 单文件漫画导入：与旧漫画库页头按钮同一个对话框（目录 / `.mokuro` /
+  /// `.cbz` / 图片包 + OCR 向导）。落库成功后失效书架 provider 刷新漫画库。
+  Future<void> _importManga() async {
+    final FushiDatabase db = ref.read(appProvider).database;
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => MangaImportDialog(db: db),
+    );
+    if (imported == true && mounted) {
+      ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+      ref.invalidate(srtBooksProvider);
+    }
   }
 
   Future<void> _clearSourceData(MangaOnlineSourceRow source) async {
@@ -196,6 +214,18 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: <Widget>[
+                            // 快速导入区：单卷 / 单文件入口（与书 / 视频「导入」
+                            // 视图同构同位；对话框内含文件 / 文件夹 / OCR 向导）。
+                            QuickImportSection(
+                              actions: <QuickImportAction>[
+                                QuickImportAction(
+                                  icon: Icons.auto_stories_outlined,
+                                  label: t.manga_import_action,
+                                  onTap: _importManga,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 28),
                             _sectionTitle(t.media_source_local_roots),
                             const SizedBox(height: 8),
                             MediaSourcesView(

--- a/fushi/lib/src/mining/galgame_add_flow.dart
+++ b/fushi/lib/src/mining/galgame_add_flow.dart
@@ -1,0 +1,57 @@
+import 'dart:async' show unawaited;
+
+import 'package:file_picker/file_picker.dart';
+
+import 'package:fushi/src/mining/galgame_cover_resolver.dart';
+import 'package:fushi/src/mining/galgame_library.dart';
+import 'package:fushi/src/mining/galgame_repository.dart';
+import 'package:fushi/utils.dart';
+
+/// 「添加游戏」共用动作：文件选择器选一个 `.exe` → 查重 → 落库 → 后台补封面。
+///
+/// 两个消费方：游戏库页（独立使用时的 FAB / 空态兜底）与游戏「导入」视图的快速
+/// 导入区。落库经 [GalgameRepository]（ChangeNotifier）广播，游戏库页监听仓储
+/// 自动刷新，调用方无须再手动刷列表。
+///
+/// 封面补齐与库页 `_autoCover(silent: true)` 同语义：添加即返回（卡片先用占位
+/// 图出现），目录封面图 / exe 图标解析在后台跑完回填，失败静默。
+Future<void> addGameViaFilePicker(GalgameRepository repo) async {
+  // 「导入」视图可能先于游戏库打开，仓储此刻未必载入过；查重需要全量列表。
+  await repo.load();
+  final FilePickerResult? picked = await FilePicker.platform.pickFiles(
+    type: FileType.custom,
+    allowedExtensions: <String>['exe'],
+  );
+  final String? exe = (picked != null && picked.files.isNotEmpty)
+      ? picked.files.first.path
+      : null;
+  if (exe == null || exe.isEmpty) {
+    return; // 用户取消
+  }
+  if (filterOutDuplicateGameExes(repo.games, <String>[exe]).isEmpty) {
+    FushiToast.show(
+      msg: t.game_already_added,
+      severity: ToastSeverity.warning,
+    );
+    return; // 已在库里：不重复添加
+  }
+  final GalgameEntry entry = newGalgameEntryFromExe(exe);
+  await repo.addAll(<GalgameEntry>[entry]);
+  unawaited(_autoCoverSilently(repo, entry));
+}
+
+/// 后台补封面（静默版）：目录封面图 → exe 内嵌图标；期间条目被删则空操作。
+Future<void> _autoCoverSilently(
+  GalgameRepository repo,
+  GalgameEntry game,
+) async {
+  final ResolvedGameCover? resolved = await autoResolveGameCover(
+    gameId: game.id,
+    gameName: game.displayName,
+    exePath: game.exePath,
+    workdir: game.workdir,
+  );
+  if (resolved == null) return;
+  if (repo.byId(game.id) == null) return;
+  await repo.setCoverPath(game.id, resolved.path);
+}

--- a/fushi/lib/src/pages/implementations/game_shared.dart
+++ b/fushi/lib/src/pages/implementations/game_shared.dart
@@ -12,8 +12,16 @@ import 'package:fushi/utils.dart';
 /// 直接上屏（camelCase 英文暴露给 17 语言用户）。
 
 /// 游戏页子区。[dashboard] 是游戏模块的默认首屏（游戏首页/仪表盘），排在最前，
-/// 库/工作台/诊断顺延——枚举顺序即 [HomeGamePage] 的 IndexedStack 索引顺序。
-enum GameSection { dashboard, library, monitor, diagnostics, settings }
+/// 库/工作台/诊断顺延——枚举顺序即 [HomeGamePage] 的 IndexedStack 索引顺序
+/// （[importGames] 后补，只能追加在尾部，显示顺序由 [GameSectionTabs] 决定）。
+enum GameSection {
+  dashboard,
+  library,
+  monitor,
+  diagnostics,
+  settings,
+  importGames
+}
 
 /// App 级游戏页子区导航。默认停在游戏首页（[GameSection.dashboard]）；原生 Hook
 /// 浮窗可在主窗最小化时请求回到捕获工作台（写 [GameSection.monitor]）。
@@ -150,10 +158,13 @@ class GameSectionTabs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 「导入」紧挨「设置」之前——与书 / 漫画 / 视频库页的分段顺序一致
+    // （三者的「导入」视图都在「设置」前一位），肌肉记忆全 app 同构。
     const List<GameSection> values = <GameSection>[
       GameSection.dashboard,
       GameSection.library,
       GameSection.monitor,
+      GameSection.importGames,
       GameSection.settings,
     ];
     void select(GameSection section) {
@@ -164,6 +175,9 @@ class GameSectionTabs extends StatelessWidget {
           return;
         case GameSection.library:
           onSelectLibrary();
+          return;
+        case GameSection.importGames:
+          gameSectionNotifier.value = GameSection.importGames;
           return;
         case GameSection.monitor:
           onSelectMonitor();
@@ -197,6 +211,12 @@ class GameSectionTabs extends StatelessWidget {
           ButtonSegment<GameSection>(
             value: GameSection.monitor,
             label: Text(t.game_capture_workbench),
+          ),
+          // 「导入」段与书 / 漫画 / 视频库页的「导入」视图同名同位（2026-08-13
+          // 入库入口统一定案）：游戏的单件入口（选 exe）收敛在这里，不再用 FAB。
+          ButtonSegment<GameSection>(
+            value: GameSection.importGames,
+            label: Text(t.library_view_import),
           ),
           ButtonSegment<GameSection>(
             value: GameSection.settings,

--- a/fushi/lib/src/pages/implementations/games_library_page.dart
+++ b/fushi/lib/src/pages/implementations/games_library_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -35,7 +34,10 @@ import 'package:fushi/src/mining/galgame_scrape_controller.dart';
 import 'package:fushi/src/mining/metadata/galgame_metadata_draft.dart';
 import 'package:fushi/src/mining/magpie_upscaling.dart';
 import 'package:fushi/src/mining/magpie_upscaling_prompt.dart';
+import 'package:fushi/src/mining/galgame_add_flow.dart';
 import 'package:fushi/src/pages/implementations/galgame_detail_page.dart';
+import 'package:fushi/src/pages/implementations/game_shared.dart'
+    show GameSection, gameSectionNotifier;
 import 'package:fushi/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:fushi/src/pages/implementations/media_item_dialog_page.dart'
     show DialogDangerAction, DialogQuickAction, MediaItemDialogFrame;
@@ -108,11 +110,15 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   @override
   void initState() {
     super.initState();
+    // 仓储是 ChangeNotifier：监听它，游戏从任何入口落库（「导入」视图快速导入、
+    // 详情页编辑等）本页都能自动刷新，不再依赖「写操作都发生在本页」的隐含假设。
+    _repo.addListener(_refresh);
     unawaited(_reload());
   }
 
   @override
   void dispose() {
+    _repo.removeListener(_refresh);
     _searchController.dispose();
     super.dispose();
   }
@@ -160,33 +166,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   List<GalgameEntry> _visibleFor(Set<String>? allowedIds) =>
       applyGalgameLibraryView(_games, _view, allowedIds: allowedIds);
 
-  /// 添加游戏：文件选择器选一个 `.exe`，以文件名去扩展名作默认名，追加进列表。
-  ///
-  /// 落库后**不等封面**就返回（卡片先用默认占位图出现），封面解析在后台跑完再回填：
-  /// 目录扫描 + exe 图标解析是磁盘/CPU 活，让它阻塞「添加」这一步会让 UI 无谓地卡住。
-  Future<void> _addGame() async {
-    final FilePickerResult? picked = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: <String>['exe'],
-    );
-    final String? exe = (picked != null && picked.files.isNotEmpty)
-        ? picked.files.first.path
-        : null;
-    if (exe == null || exe.isEmpty) {
-      return; // 用户取消
-    }
-    if (filterOutDuplicateGameExes(_games, <String>[exe]).isEmpty) {
-      FushiToast.show(
-        msg: t.game_already_added,
-        severity: ToastSeverity.warning,
-      );
-      return; // 已在库里：不重复添加
-    }
-    final GalgameEntry entry = newGalgameEntryFromExe(exe);
-    await _repo.addAll(<GalgameEntry>[entry]);
-    _refresh();
-    unawaited(_autoCover(entry, silent: true));
-  }
+  /// 添加游戏（独立使用时的兜底入口）：委托给共享动作 [addGameViaFilePicker]
+  /// （选 exe → 查重 → 落库 → 后台补封面），与「导入」视图快速导入区同一条路。
+  /// 本页经仓储监听自动刷新。
+  Future<void> _addGame() => addGameViaFilePicker(_repo);
 
   /// 拖入文件导入：筛出新的 `.exe` 批量添加，toast 汇报数量；每条落库后走
   /// 与「添加游戏」同一套 [_autoCover] 后台补齐封面（#370 目录级联 + exe 图标）。
@@ -687,24 +670,21 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         ],
       ),
     );
-    final Widget addButton = FloatingActionButton.extended(
-      onPressed: _addGame,
-      icon: const Icon(Icons.add),
-      label: Text(t.game_add),
-    );
+    // 嵌在游戏 tab 里（生产路径）：单件入口已统一收敛到「导入」分段（与书 /
+    // 漫画 / 视频库页同位，2026-08-13 定案），不再摆 FAB。独立 push 时够不到
+    // 分段导航，保留 FAB 兜底。
     if (widget.embedded) {
-      return Stack(
-        children: <Widget>[
-          Positioned.fill(child: body),
-          Positioned(right: 16, bottom: 16, child: addButton),
-        ],
-      );
+      return body;
     }
     return Scaffold(
       appBar: AppBar(
         title: Text(t.games),
       ),
-      floatingActionButton: addButton,
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _addGame,
+        icon: const Icon(Icons.add),
+        label: Text(t.game_add),
+      ),
       body: body,
     );
   }
@@ -1020,11 +1000,20 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
                 ),
           ),
           const SizedBox(height: 16),
-          FilledButton.icon(
-            onPressed: _addGame,
-            icon: const Icon(Icons.add),
-            label: Text(t.game_add),
-          ),
+          // 嵌壳时空态引导去「导入」分段（唯一入库位置）；独立使用时直接选 exe。
+          if (widget.embedded)
+            FilledButton.icon(
+              onPressed: () =>
+                  gameSectionNotifier.value = GameSection.importGames,
+              icon: const Icon(Icons.library_add_outlined),
+              label: Text(t.library_empty_go_import),
+            )
+          else
+            FilledButton.icon(
+              onPressed: _addGame,
+              icon: const Icon(Icons.add),
+              label: Text(t.game_add),
+            ),
         ],
       ),
     );

--- a/fushi/lib/src/pages/implementations/home_game_page.dart
+++ b/fushi/lib/src/pages/implementations/home_game_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi/models.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/media/import/quick_import_section.dart';
 import 'package:fushi/src/mining/gal_hook_session_controller.dart';
+import 'package:fushi/src/mining/galgame_add_flow.dart';
 import 'package:fushi/src/pages/implementations/galgame_home_page.dart';
 import 'package:fushi/src/pages/implementations/game_diagnostics_page.dart';
 import 'package:fushi/src/pages/implementations/game_shared.dart';
@@ -63,6 +67,7 @@ class HomeGamePage extends StatefulWidget {
   static const Key monitorKey = ValueKey<String>('game-monitor');
   static const Key diagnosticsKey = ValueKey<String>('game-diagnostics');
   static const Key settingsKey = ValueKey<String>('game-settings');
+  static const Key importKey = ValueKey<String>('game-import');
 
   /// 库页顶部会话状态带（原两张总览大卡的收敛替身），整条可点进入捕获工作台。
   static const Key captureStatusKey = ValueKey<String>('game-capture-status');
@@ -178,6 +183,72 @@ class _HomeGamePageState extends State<HomeGamePage> {
                       navigation: navigation,
                     );
               },
+            ),
+          ),
+          KeyedSubtree(
+            key: HomeGamePage.importKey,
+            child: _buildImport(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 游戏「导入」视图：与书 / 漫画 / 视频库页的「导入」视图同构同位（快速导入
+  /// 区收纳单件入口；游戏暂无扫描根概念，故本页只有快速导入一区）。
+  Widget _buildImport(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final ThemeData theme = Theme.of(context);
+    return DesktopContentLayout(
+      kind: DesktopContentKind.readerShelf,
+      child: Column(
+        children: <Widget>[
+          FushiPageHeader.customTitle(
+            title: GameSectionTabs(
+              selected: GameSection.importGames,
+              focusIdPrefix: 'game-import-tab',
+              onSelectDashboard: _showDashboard,
+              onSelectLibrary: _showLibrary,
+              onSelectMonitor: _showMonitor,
+              onSelectSettings: _showSettings,
+            ),
+            actions: const <Widget>[],
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Builder(
+                    builder: (BuildContext context) {
+                      return QuickImportSection(
+                        actions: <QuickImportAction>[
+                          QuickImportAction(
+                            icon: Icons.videogame_asset_outlined,
+                            label: t.game_add,
+                            // IndexedStack 急切构建全部子区，本视图在无
+                            // ProviderScope 的 widget 测试里也会被 build——
+                            // 容器只在点按时解析，构建期零 provider 依赖。
+                            onTap: () => addGameViaFilePicker(
+                              ProviderScope.containerOf(context, listen: false)
+                                  .read(appProvider)
+                                  .galgameRepo,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    t.game_import_drop_hint,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/fushi/lib/src/pages/implementations/home_reader_page.dart
+++ b/fushi/lib/src/pages/implementations/home_reader_page.dart
@@ -41,7 +41,7 @@ class _HomeReaderPageState extends BaseTabPageState<HomeReaderPage> {
         ),
         MediaLibraryViewSpec(
           kind: MediaLibraryViewKind.sources,
-          label: t.library_view_sources,
+          label: t.library_view_import,
           builder: (BuildContext context, Widget navigation) =>
               MediaSourcesPage(mediaKind: 'book', navigation: navigation),
         ),

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -4962,7 +4962,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     ref.invalidate(allTagsProvider);
   }
 
-  /// 空库只提示从「来源」添加文件夹；常规单视频 CTA 已移除。
+  /// 空库引导去「导入」视图（快速导入 + 来源扫描根都在那）；与书 / 漫画 / 游戏
+  /// 空态同一句引导词，全 app 只教一个入库位置。
   Widget _buildEmpty() {
     return FushiPlaceholderMessage(
       icon: Icons.movie_outlined,
@@ -4971,8 +4972,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           ? null
           : FilledButton.icon(
               onPressed: widget.onOpenSources,
-              icon: const Icon(Icons.create_new_folder_outlined),
-              label: Text(t.media_source_add),
+              icon: const Icon(Icons.library_add_outlined),
+              label: Text(t.library_empty_go_import),
             ),
     );
   }

--- a/fushi/lib/src/pages/implementations/media_library_shell.dart
+++ b/fushi/lib/src/pages/implementations/media_library_shell.dart
@@ -40,6 +40,30 @@ class MediaLibraryViewSpec {
   final Widget Function(BuildContext context, Widget navigation) builder;
 }
 
+/// 向壳内子树暴露「切到某个视图」的能力（[InheritedWidget]，不改 builder 签名）。
+///
+/// 动因：库页空态的引导按钮要能把用户带到「导入」视图（[MediaLibraryViewKind.sources]），
+/// 而空态 widget 埋在书架页深处——层层回调穿透会让三个库页壳的构造签名全部膨胀。
+/// 子树用 [maybeOf] 取到后调 [select]；不在壳内（书架被独立 push）时拿到 null，
+/// 调用方自行回退（如直接开导入对话框）。
+class MediaLibraryShellScope extends InheritedWidget {
+  const MediaLibraryShellScope({
+    required this.select,
+    required super.child,
+    super.key,
+  });
+
+  /// 切到指定视图；壳没有该视图时静默忽略。
+  final void Function(MediaLibraryViewKind kind) select;
+
+  static MediaLibraryShellScope? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<MediaLibraryShellScope>();
+
+  @override
+  bool updateShouldNotify(MediaLibraryShellScope oldWidget) =>
+      select != oldWidget.select;
+}
+
 /// 库页视图导航壳：在一个顶层 tab 内切换 [MediaLibraryViewSpec] 声明的若干视图。
 ///
 /// 设计要点：
@@ -99,24 +123,30 @@ class _MediaLibraryShellState extends State<MediaLibraryShell> {
   Widget build(BuildContext context) {
     final List<MediaLibraryViewSpec> views = widget.views;
     if (views.length < 2) {
-      return views.first.builder(context, const SizedBox.shrink());
+      return MediaLibraryShellScope(
+        select: _select,
+        child: views.first.builder(context, const SizedBox.shrink()),
+      );
     }
     final Widget navigation = _buildNavigation(views);
-    return Stack(
-      children: <Widget>[
-        for (int i = 0; i < views.length; i++)
-          if (_visited.contains(i))
-            Offstage(
-              offstage: i != _currentIndex,
-              child: TickerMode(
-                enabled: i == _currentIndex,
-                child: views[i].builder(
-                  context,
-                  i == _currentIndex ? navigation : const SizedBox.shrink(),
+    return MediaLibraryShellScope(
+      select: _select,
+      child: Stack(
+        children: <Widget>[
+          for (int i = 0; i < views.length; i++)
+            if (_visited.contains(i))
+              Offstage(
+                offstage: i != _currentIndex,
+                child: TickerMode(
+                  enabled: i == _currentIndex,
+                  child: views[i].builder(
+                    context,
+                    i == _currentIndex ? navigation : const SizedBox.shrink(),
+                  ),
                 ),
               ),
-            ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/media_sources_page.dart
+++ b/fushi/lib/src/pages/implementations/media_sources_page.dart
@@ -1,16 +1,35 @@
-import 'package:flutter/material.dart';
+import 'dart:async' show unawaited;
 
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+import 'package:fushi/media.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/media/audiobook/book_import_dialog.dart';
+import 'package:fushi/src/media/import/quick_import_section.dart';
 import 'package:fushi/src/media/source_library/source_library_row.dart';
 import 'package:fushi/src/media/source_library/source_library_scanner.dart';
 import 'package:fushi/src/media/video/metadata/video_source_scrape_task.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_import_dialog.dart';
 import 'package:fushi/src/pages/implementations/media_sources_view.dart';
 import 'package:fushi/utils.dart';
 
-/// 库页三视图里的「来源」视图：本地扫描根 + 网络来源的管理页。
+/// 库页导航壳里的「导入」视图：**本域内容入库的唯一入口页**。
 ///
-/// 与 [MediaSourcesDialog] 共用同一个内容体 [MediaSourcesView]，差别只在 chrome：
-/// 对话框把「添加来源」放页脚，页面把它放页头动作区（与书架的导入按钮同位）。
-class MediaSourcesPage extends StatefulWidget {
+/// 自上而下两区：
+/// 1. 快速导入（[QuickImportSection]）——单件 / 一次性入口：书 = 导入文件 +
+///    导入文件夹（二选一：设为常驻来源 / 仅导入一次）；视频 = 导入视频（对话框
+///    内含文件 / 文件夹 / 播放列表 / 网络流）。
+/// 2. 常驻来源（[MediaSourcesView]）——本地扫描根 + 网络来源的管理列表。
+///
+/// 此前单件导入按钮散在各库页页头（书 / 漫画在页头、视频已删、游戏在 FAB），
+/// 五个模块五种入口；现在统一收敛到「导入」视图同一位置（2026-08-13 用户定案）。
+/// 与 [MediaSourcesDialog] 共用同一个来源列表内容体 [MediaSourcesView]，对话框
+/// 语境（旧兼容路径）不带快速导入区、逐像素不变。
+class MediaSourcesPage extends ConsumerStatefulWidget {
   const MediaSourcesPage({
     required this.mediaKind,
     super.key,
@@ -47,16 +66,22 @@ class MediaSourcesPage extends StatefulWidget {
   /// 视频后台刮削任务面板；即使当前有任务运行也必须可进入查看或取消。
   final VoidCallback? onOpenScrapeTasks;
 
-  /// 来源扫描完成后通知保活的媒体库重读合集、排序和封面。
+  /// 来源扫描 / 快速导入完成后通知保活的媒体库重读合集、排序和封面。
   final VoidCallback? onLibraryChanged;
 
   @override
-  State<MediaSourcesPage> createState() => _MediaSourcesPageState();
+  ConsumerState<MediaSourcesPage> createState() => _MediaSourcesPageState();
 }
 
-class _MediaSourcesPageState extends State<MediaSourcesPage> {
+/// 书籍「导入文件夹」的两个去向：设为常驻来源 / 仅导入这一次。
+enum _FolderImportChoice { asSource, once }
+
+class _MediaSourcesPageState extends ConsumerState<MediaSourcesPage> {
   final GlobalKey<MediaSourcesViewState> _viewKey =
       GlobalKey<MediaSourcesViewState>();
+
+  /// BUG-513 同款纪律：AppModel 在 initState 捕获，async gap 之后不再 `ref.read`。
+  late final AppModel _appModel = ref.read(appProvider);
 
   @override
   void initState() {
@@ -85,6 +110,7 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
   @override
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final List<QuickImportAction> quickActions = _quickImportActions();
     // 与书架 / 视频 / 词典三个库页同构：DesktopContentLayout + FushiPageHeader
     // 大标题 + FushiIconButton 动作，外层 Scaffold 由 HomePage 提供。
     return DesktopContentLayout(
@@ -100,19 +126,149 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
             // 贴真实边缘（padding 在 SingleChildScrollView 里，不在它外面）。
             child: SingleChildScrollView(
               padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
-              child: MediaSourcesView(
-                key: _viewKey,
-                mediaKind: widget.mediaKind,
-                onScrapeSource: widget.onScrapeSource,
-                onVideoScanCompleted: widget.onVideoScanCompleted,
-                scrapeTaskController: widget.scrapeTaskController,
-                onLibraryChanged: widget.onLibraryChanged,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  if (quickActions.isNotEmpty) ...<Widget>[
+                    QuickImportSection(actions: quickActions),
+                    const SizedBox(height: 28),
+                    Text(
+                      t.media_source_section_title,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                  MediaSourcesView(
+                    key: _viewKey,
+                    mediaKind: widget.mediaKind,
+                    onScrapeSource: widget.onScrapeSource,
+                    onVideoScanCompleted: widget.onVideoScanCompleted,
+                    scrapeTaskController: widget.scrapeTaskController,
+                    onLibraryChanged: widget.onLibraryChanged,
+                  ),
+                ],
               ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  /// 本域的快速导入入口（各域只声明真正有的入口）。
+  ///
+  /// 'manga' 走 [MangaSourcesPage] 自己的快速导入区，不经过本页；对话框语境
+  /// （[MediaSourcesDialog]）直接用 [MediaSourcesView]，也不经过本页。
+  List<QuickImportAction> _quickImportActions() {
+    return switch (widget.mediaKind) {
+      'book' => <QuickImportAction>[
+          QuickImportAction(
+            icon: Icons.upload_file_outlined,
+            label: t.srt_import,
+            onTap: _importBookFile,
+          ),
+          QuickImportAction(
+            icon: Icons.drive_folder_upload_outlined,
+            label: t.book_import_folder,
+            onTap: _importBookFolder,
+          ),
+        ],
+      'video' => <QuickImportAction>[
+          QuickImportAction(
+            icon: Icons.movie_outlined,
+            label: t.video_import_action,
+            onTap: _importVideo,
+          ),
+        ],
+      _ => const <QuickImportAction>[],
+    };
+  }
+
+  /// 单本书导入：与旧书架页头按钮同一个对话框（EPUB/PDF/文本/字幕/有声书对齐）。
+  Future<void> _importBookFile() async {
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => BookImportDialog(
+        repo: SrtBookRepository(_appModel.database),
+        audiobookRepo: AudiobookRepository(_appModel.database),
+        db: _appModel.database,
+      ),
+    );
+    if (imported == true) _invalidateBookProviders();
+  }
+
+  /// 书籍「导入文件夹」：二选一——设为常驻来源（Komga 式，长期自动扫描）或
+  /// 仅导入这一次（同一条扫描管线，扫完不留扫描根）。
+  Future<void> _importBookFolder() async {
+    final _FolderImportChoice? choice =
+        await showAppDialog<_FolderImportChoice>(
+      context: context,
+      builder: (BuildContext ctx) => SimpleDialog(
+        title: Text(t.book_import_folder),
+        children: <Widget>[
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx, _FolderImportChoice.asSource),
+            child: Row(
+              children: <Widget>[
+                const Icon(Icons.create_new_folder_outlined),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(t.book_import_folder_as_source),
+                      Text(
+                        t.book_import_folder_as_source_hint,
+                        style: Theme.of(ctx).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx, _FolderImportChoice.once),
+            child: Row(
+              children: <Widget>[
+                const Icon(Icons.file_download_outlined),
+                const SizedBox(width: 16),
+                Expanded(child: Text(t.book_import_folder_once)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || choice == null) return;
+    switch (choice) {
+      case _FolderImportChoice.asSource:
+        await _viewKey.currentState?.addLocalFolder();
+      case _FolderImportChoice.once:
+        await _viewKey.currentState?.importLocalFolderOnce();
+    }
+    if (mounted) _invalidateBookProviders();
+  }
+
+  /// 单个视频 / 播放列表 / 网络流导入：复用 [VideoImportDialog]（原页头入口
+  /// 迁到来源视图后的唯一常规入口，对话框弹出即含文件 / 文件夹 / 链接三形态）。
+  Future<void> _importVideo() async {
+    final String? bookUid = await showAppDialog<String>(
+      context: context,
+      builder: (_) => VideoImportDialog(
+        repo: VideoBookRepository(_appModel.database),
+      ),
+    );
+    if (bookUid != null && mounted) widget.onLibraryChanged?.call();
+  }
+
+  /// 书架 provider 失效（快速导入落库后书架 / 漫画库立即刷新）。
+  void _invalidateBookProviders() {
+    if (!mounted) return;
+    ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+    ref.invalidate(srtBooksProvider);
+    widget.onLibraryChanged?.call();
   }
 
   Widget _buildHeader() {
@@ -125,7 +281,7 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
         icon: Icons.create_new_folder_outlined,
         enabled: !busy,
         onTap: () {
-          if (!busy) _viewKey.currentState?.addSource();
+          if (!busy) unawaited(_viewKey.currentState?.addSource());
         },
       ),
       if (widget.mediaKind == 'video' && widget.onScrapeAll != null)
@@ -135,7 +291,7 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
           icon: Icons.manage_search_outlined,
           enabled: !busy,
           onTap: () {
-            if (!busy) widget.onScrapeAll!();
+            if (!busy) unawaited(widget.onScrapeAll!());
           },
         ),
       if (widget.mediaKind == 'video' && widget.onOpenScrapeTasks != null)

--- a/fushi/lib/src/pages/implementations/media_sources_view.dart
+++ b/fushi/lib/src/pages/implementations/media_sources_view.dart
@@ -633,7 +633,7 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     // 视频来源只有本地文件夹这一种合法入口，直接选择并立即登记/扫描，避免再弹一层
     // 只有一个选项的对话框。书籍仍保留本地/网络选择，漫画 UX 保持不变。
     if (widget.mediaKind == 'video') {
-      await _addLocalFolder();
+      await addLocalFolder();
       return;
     }
     final _AddSourceChoice? choice = await showAppDialog<_AddSourceChoice>(
@@ -683,13 +683,17 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     if (!mounted || choice == null) return;
     switch (choice) {
       case _AddSourceChoice.local:
-        await _addLocalFolder();
+        await addLocalFolder();
       case _AddSourceChoice.network:
         await _addNetworkSource();
     }
   }
 
-  Future<void> _addLocalFolder() async {
+  /// 添加本地文件夹为常驻来源（选目录 → 去重 → 落库 → 立即扫描）。
+  ///
+  /// 公开：除 [addSource] 的本地分支外，「导入」视图快速导入区的「导入文件夹 →
+  /// 设为常驻来源」也直接调它，跳过对话框里那层本地/网络二选一。
+  Future<void> addLocalFolder() async {
     // 扫描根是**长期存储并反复复扫**的路径，必须是 `dart:io` 真读得动的绝对路径：
     // 安卓上裸 `getDirectoryPath()` 只是把 tree URI 拼成路径串（映射不出 volume 时
     // 还会退化成 `/`），而 SAF 授的是 URI 权限不是路径权限——没有全文件访问，扫描
@@ -726,6 +730,80 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     // 插入后立即扫描新行（拿回带 scanResult 的最新行刷新统计）。
     final SourceLibraryRow? fresh = await _db.getMediaSourceById(newId);
     if (fresh != null) await _rescan(fresh);
+  }
+
+  /// 「导入文件夹（仅此一次）」：与常驻来源共用**同一条**扫描-导入管线，但登记的
+  /// 来源行只作为这一次扫描的载体，扫完即删——已导入媒体保留（FK setNull 把
+  /// sourceId 归 NULL，等价于手动单件导入），不留下常驻扫描根。
+  ///
+  /// 这样一次性批量导入不需要第二套导入实现：导入管线只有 scanner 一份，
+  /// 去重（[DuplicatePolicy.skip]）、字幕/音频 sidecar 关联等行为与来源扫描
+  /// 逐字一致。
+  Future<void> importLocalFolderOnce() async {
+    if (isBusy) return;
+    final String? picked = await pickRealDirectoryPath(
+      context: context,
+      appModel: _appModel,
+      dialogTitle: t.book_import_folder,
+    );
+    if (!mounted || picked == null || picked.isEmpty) return;
+
+    final String norm = normalizeSourceRootPath(picked, transport: 'local');
+    // 该根已是常驻来源：不再造同根的一次性影子，直接重扫那一行。
+    final List<SourceLibraryRow> existing = _rows ?? const <SourceLibraryRow>[];
+    for (final SourceLibraryRow row in existing) {
+      if (row.transport == 'local' && row.rootPath == norm) {
+        await _rescan(row);
+        return;
+      }
+    }
+
+    final VoidCallback? onLibraryChanged = widget.onLibraryChanged;
+    final int tempId = await _db.insertMediaSource(
+      MediaSourcesCompanion(
+        label: Value(defaultLabelFromRoot(norm, transport: 'local')),
+        mediaKind: Value(widget.mediaKind),
+        transport: const Value('local'),
+        rootPath: Value(norm),
+        recursive: const Value(true),
+        sortOrder: Value(_nextSortOrder()),
+        createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+      ),
+    );
+    final SourceLibraryRow? temp = await _db.getMediaSourceById(tempId);
+    if (temp == null) return;
+    SourceScanSummary? summary;
+    // 临时行不进 _rows（中途不 _load），但计入 _scanning 让 isBusy 生效，
+    // 与常驻来源扫描共享同一套忙态与重入保护。
+    setState(() => _scanning.add(tempId));
+    try {
+      summary = await SourceLibraryScanner(_db).scan(temp);
+    } finally {
+      await _db.deleteMediaSource(tempId);
+      if (mounted) {
+        setState(() => _scanning.remove(tempId));
+        // summary == null 只发生在 scan 意外抛出（scanner 常规失败会把错误写进
+        // summary.error）；此时不播成功，让异常沿 unawaited 链路进错误日志。
+        if (summary != null) {
+          final String? error = summary.error;
+          if (error != null) {
+            FushiToast.show(msg: error, severity: ToastSeverity.error);
+          } else {
+            FushiToast.show(
+              msg: switch (widget.mediaKind) {
+                'book' =>
+                  t.media_source_count_book(n: summary.importedMediaCount),
+                'manga' =>
+                  t.media_source_count_manga(n: summary.importedMediaCount),
+                _ => t.media_source_count_video(n: summary.importedMediaCount),
+              },
+              severity: ToastSeverity.success,
+            );
+          }
+        }
+      }
+      onLibraryChanged?.call();
+    }
   }
 
   /// 添加网络来源：弹连接表单（SFTP/FTP）→ 落库连接参数 + 单独存凭据 → 立即扫描。

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -30,6 +30,7 @@ import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_feature_flags.dart';
 import 'package:fushi/src/media/video/video_import_dialog.dart';
 import 'package:fushi/src/pages/implementations/book_drag_target.dart';
+import 'package:fushi/src/pages/implementations/media_library_shell.dart';
 import 'package:fushi/src/pages/implementations/collection_name_dialog.dart';
 import 'package:fushi/src/pages/implementations/tag_filter_bar.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -657,26 +658,27 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
 
   Widget _buildPageHeader() {
     final List<Widget> actions = <Widget>[
-      // 宽窗（非 compact）时动作展开成「图标+文字」药丸（与视频 tab 页头一致，
-      // 用户 mockup：导入书籍 / 来源 / 合集 / 阅读统计带文字外显）；窄窗回落纯图标。
-      // 漫画库和书架是同一页面的两种壳，但导入的是两种载体，故按钮指向两个不同
-      // 的对话框——不再是「同一个框换个 label」。
-      if (_mangaOnly)
-        MangaFushiSource.instance.buildMangaImportButton(
-          context: context,
-          ref: ref,
-          appModel: appModel,
-          focusId: kShelfImportFocusId,
-          label: t.manga_import_action,
-        )
-      else
-        mediaSource.buildBookImportButton(
-          context: context,
-          ref: ref,
-          appModel: appModel,
-          focusId: kShelfImportFocusId,
-          label: t.srt_import,
-        ),
+      // 单件导入入口已统一收敛到库页「导入」视图的快速导入区（书 / 漫画 / 视频 /
+      // 游戏四域同位，2026-08-13 定案）；页头只在书架被**独立使用**（无导航壳、
+      // 够不到「导入」视图）时保留导入按钮兜底。漫画和书籍载体不同，兜底按钮
+      // 仍指向两个不同的对话框。
+      if (_pageWidget.navigation == null)
+        if (_mangaOnly)
+          MangaFushiSource.instance.buildMangaImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+            focusId: kShelfImportFocusId,
+            label: t.manga_import_action,
+          )
+        else
+          mediaSource.buildBookImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+            focusId: kShelfImportFocusId,
+            label: t.srt_import,
+          ),
       _headerAction(
         tooltip: t.scrape_all,
         icon: Icons.manage_search_outlined,
@@ -1955,6 +1957,10 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   @override
   Widget buildPlaceholder() {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    // 在库页导航壳里：空态引导去「导入」视图（快速导入 + 常驻来源都在那），教会
+    // 用户唯一入库位置；独立使用（无壳）时回退为直接开导入对话框。
+    final MediaLibraryShellScope? shell =
+        MediaLibraryShellScope.maybeOf(context);
 
     return Center(
       child: Column(
@@ -1965,27 +1971,34 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
             message: t.reader_no_books_added,
           ),
           SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),
-          FilledButton.icon(
-            icon: const Icon(Icons.library_add_outlined, size: 18),
-            label: Text(_mangaOnly ? t.manga_import_action : t.srt_import),
-            onPressed: () async {
-              // 空态按钮与页头按钮指向同一个对话框：漫画库开漫画框，书架开书籍框。
-              final bool? imported = await showAppDialog<bool>(
-                context: context,
-                builder: (_) => _mangaOnly
-                    ? MangaImportDialog(db: appModel.database)
-                    : BookImportDialog(
-                        repo: SrtBookRepository(appModel.database),
-                        audiobookRepo: AudiobookRepository(appModel.database),
-                        db: appModel.database,
-                      ),
-              );
-              if (imported == true) {
-                ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
-                ref.invalidate(srtBooksProvider);
-              }
-            },
-          ),
+          if (shell != null)
+            FilledButton.icon(
+              icon: const Icon(Icons.library_add_outlined, size: 18),
+              label: Text(t.library_empty_go_import),
+              onPressed: () => shell.select(MediaLibraryViewKind.sources),
+            )
+          else
+            FilledButton.icon(
+              icon: const Icon(Icons.library_add_outlined, size: 18),
+              label: Text(_mangaOnly ? t.manga_import_action : t.srt_import),
+              onPressed: () async {
+                // 空态兜底与页头兜底指向同一个对话框：漫画库开漫画框，书架开书籍框。
+                final bool? imported = await showAppDialog<bool>(
+                  context: context,
+                  builder: (_) => _mangaOnly
+                      ? MangaImportDialog(db: appModel.database)
+                      : BookImportDialog(
+                          repo: SrtBookRepository(appModel.database),
+                          audiobookRepo: AudiobookRepository(appModel.database),
+                          db: appModel.database,
+                        ),
+                );
+                if (imported == true) {
+                  ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+                  ref.invalidate(srtBooksProvider);
+                }
+              },
+            ),
         ],
       ),
     );

--- a/fushi/lib/src/pages/implementations/video_library_shell.dart
+++ b/fushi/lib/src/pages/implementations/video_library_shell.dart
@@ -133,7 +133,7 @@ class _VideoLibraryShellState extends State<VideoLibraryShell> {
           ),
           ButtonSegment<VideoLibrarySection>(
             value: VideoLibrarySection.sources,
-            label: Text(t.library_view_sources),
+            label: Text(t.library_view_import),
           ),
           ButtonSegment<VideoLibrarySection>(
             value: VideoLibrarySection.settings,

--- a/fushi/test/pages/home_game_page_test.dart
+++ b/fushi/test/pages/home_game_page_test.dart
@@ -177,6 +177,19 @@ void main() {
     expect(controller.primaryFocusIsManagedTarget, isTrue);
     await driver.adjust(steps: 1);
 
+    // 2026-08-13 入库入口统一：捕获工作台与设置之间插入「导入」分段（与书 /
+    // 漫画 / 视频库页的「导入在设置前一位」同构）。
+    expect(find.byKey(HomeGamePage.importKey), findsOneWidget);
+    expect(
+      controller.requestById(
+        const FushiFocusId('game-import-tab-sections'),
+      ),
+      isTrue,
+      reason: '切到导入页后，新的稳定分段 ID 必须可聚焦',
+    );
+    await tester.pump();
+    await driver.adjust(steps: 1);
+
     expect(find.byKey(HomeGamePage.settingsKey), findsOneWidget);
     expect(find.text('game-settings'), findsOneWidget);
     expect(find.text(t.game_diagnostics), findsNothing,

--- a/fushi/test/pages/video_header_button_order_guard_test.dart
+++ b/fushi/test/pages/video_header_button_order_guard_test.dart
@@ -95,7 +95,7 @@ void main() {
     expect(collectionsIdx, lessThan(statsIdx), reason: '视频收藏夹按钮应在统计之前');
   });
 
-  test('视频空库只提供前往来源的目录 CTA，不提供单视频导入', () {
+  test('视频空库只提供前往「导入」视图的 CTA，不提供单视频导入', () {
     final String body = methodBody(
       videoSrc.readAsStringSync(),
       'Widget _buildEmpty()',
@@ -104,8 +104,9 @@ void main() {
     expect(body, isNot(contains('home_video_empty_import')));
     expect(body, isNot(contains('t.video_import_action')));
     expect(body, contains('widget.onOpenSources'));
-    expect(body, contains('t.media_source_add'));
-    expect(body, contains('Icons.create_new_folder_outlined'));
+    // 2026-08-13 入库入口统一：空态引导词与书 / 漫画 / 游戏一致（去导入）。
+    expect(body, contains('t.library_empty_go_import'));
+    expect(body, contains('Icons.library_add_outlined'));
   });
 
   test('播放器顶栏片段导出按钮紧挨截图按钮', () {

--- a/fushi/test/pages/video_library_series_structure_guard_test.dart
+++ b/fushi/test/pages/video_library_series_structure_guard_test.dart
@@ -22,7 +22,8 @@ void main() {
     expect(shell, contains('t.nav_home'));
     expect(shell, contains('t.series'));
     expect(shell, contains('t.video_library_all_videos'));
-    expect(shell, contains('t.library_view_sources'));
+    // 2026-08-13 入库入口统一：来源分段改名「导入」（library_view_import）。
+    expect(shell, contains('t.library_view_import'));
     expect(shell, contains('Offstage('));
     expect(shell, contains('HomeVideoPage('));
     expect(shell, contains('MediaSourcesPage('));

--- a/fushi/test/tools/file_picker_discipline_guard_test.dart
+++ b/fushi/test/tools/file_picker_discipline_guard_test.dart
@@ -79,7 +79,8 @@ const Map<String, String> kFilePickerAllowlist = <String, String>{
   'lib/src/media/manga/mihon/mihon_extensions_page.dart':
       'Mihon 扩展 APK：选中即 readAsBytes 拷进 app 存储的 tmp/extension-<sha>.apk.part 再校验安装，原路径不入库',
   // (a) 长期引用，但**仅 Windows** 路径可达，安卓那条腿根本跑不到：
-  'lib/src/pages/implementations/games_library_page.dart':
+  // （2026-08-13 选 exe 逻辑从 games_library_page 收敛到共享动作 galgame_add_flow）
+  'lib/src/mining/galgame_add_flow.dart':
       'galgame exe：Windows 专属（见 galgame SOP），安卓无此入口',
   'lib/src/pages/implementations/texthooker_page.dart':
       'galgame exe / LunaHook tsv：Windows 专属（见 galgame SOP）',


### PR DESCRIPTION
## 背景

2026-08-13 群聊定案（方案 A）：五个模块五种导入入口（书/漫画在页头、视频已删按钮、游戏在 FAB、dashboard 无入口）是用户「改完不知道怎么导入」的根因。定案：**「来源」tab 改名「导入」，单件导入入口全部收进去**，书和漫画保持独立库页不聚合。

## 改动

**统一后的结构（四域同构）**：「导入」视图上区 = 快速导入（单件/一次性入口），下区 = 常驻来源（扫描根）；分段顺序统一为「导入」在「设置」前一位。

- 新增 `QuickImportSection`（`media/import/quick_import_section.dart`）四域复用
- **书**：导入文件（原 BookImportDialog）+ **新增导入文件夹二选一**——「设为常驻来源」/「仅导入这一次」（后者复用同一条 SourceLibraryScanner 管线：插临时来源行→扫描→删行，媒体保留 FK setNull，零第二套导入实现）
- **漫画**：MangaSourcesPage 顶部快速导入区（原 MangaImportDialog，含文件/文件夹/OCR 向导）
- **视频**：恢复单件导入常规入口（VideoImportDialog 收进导入视图；此前 UI 上无任何常规按钮能打开它）
- **游戏**：GameSection 新增 `importGames` 分段（选 exe），FAB 收敛；选 exe 逻辑抽出 `galgame_add_flow.dart` 共享；游戏库页改为监听 GalgameRepository（ChangeNotifier）自动刷新
- 书/漫画页头导入按钮仅独立使用（无导航壳）时兜底保留；四域空态统一「去导入」引导（新增 `MediaLibraryShellScope` InheritedWidget，不膨胀 builder 签名）
- i18n：`library_view_sources` → `library_view_import`（导入）等 9 键增删，全程 i18n_sync + slang
- 守卫同步：页头顺序守卫、视频空态 CTA 守卫、游戏分段焦点遍历测试（覆盖新分段）、file_picker 豁免清单迁移

## 验证

- `flutter analyze` 全量零问题（rebase 到 develop `9ff27d76d0` 后复跑）
- 定向 + 守卫批：test/tools 整批 + i18n 完整性 + 游戏/漫画/视频/书架相关 widget 与守卫测试，408 条全绿
- rebase 时 i18n 与 #809/#812 的冲突用「develop 版 + i18n_sync 重放」解，未手改 json

## 已知取舍

- 漫画「选文件夹」保持在对话框内（单卷语义），未做书籍式二选一：漫画文件夹有「一卷页图」与「多卷扫描根」两义，且对话框负责卷标题；两条路已在同一页上下相邻
- 游戏暂无扫描根（SourceLibraryKind 无 game），导入视图只有快速导入一区，附拖拽提示

https://claude.ai/code/session_014WqPPby7otTBh1Gz9QJPpR