### PR TITLE
feat(video): 主字幕顶部锚定 + 位置上限400 + 拖拽可视化调整字幕位置（TODO-2838）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57307 (3371 per locale)
+/// Strings: 57409 (3377 per locale)
 ///
-/// Built on 2026-08-13 at 08:43 UTC
+/// Built on 2026-08-13 at 11:51 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4563,6 +4563,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_priority_high => 'High';
   String get download_task_priority_normal => 'Normal';
   String get download_task_priority_low => 'Low';
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  String get video_subtitle_anchor_top => 'Top';
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -12337,6 +12343,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -12347,6 +12354,17 @@ class _StringsAr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -20188,6 +20206,7 @@ class _StringsDe extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -20198,6 +20217,17 @@ class _StringsDe extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -28055,6 +28085,7 @@ class _StringsEs extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -28065,6 +28096,17 @@ class _StringsEs extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -35934,6 +35976,7 @@ class _StringsFr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -35944,6 +35987,17 @@ class _StringsFr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -43741,6 +43795,7 @@ class _StringsId extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -43751,6 +43806,17 @@ class _StringsId extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -51594,6 +51660,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -51604,6 +51671,17 @@ class _StringsIt extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -59261,6 +59339,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -59271,6 +59350,17 @@ class _StringsJa extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -66935,6 +67025,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -66945,6 +67036,17 @@ class _StringsKo extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -74768,6 +74870,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -74778,6 +74881,17 @@ class _StringsNl extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -82613,6 +82727,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -82623,6 +82738,17 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -90444,6 +90570,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -90454,6 +90581,17 @@ class _StringsRu extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -98223,6 +98361,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -98233,6 +98372,17 @@ class _StringsTh extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -106033,6 +106183,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -106043,6 +106194,17 @@ class _StringsTr extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -113828,6 +113990,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -113838,6 +114001,17 @@ class _StringsVi extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 // Path: <root>
@@ -121057,6 +121231,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       '排队中：正在等其他下载让出槽位。任务还没交给下载器，所以暂时没有实时节点和 Tracker 数据。';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '共 ${count} 个发布';
   @override
@@ -121067,6 +121242,16 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_priority_normal => '普通';
   @override
   String get download_task_priority_low => '低';
+  @override
+  String get video_setting_subtitle_anchor => '主字幕锚定';
+  @override
+  String get video_subtitle_anchor_bottom => '底部';
+  @override
+  String get video_subtitle_anchor_top => '顶部';
+  @override
+  String get video_setting_subtitle_drag_adjust => '拖拽调整位置';
+  @override
+  String get video_subtitle_drag_adjust_hint => '上下拖动字幕调整位置';
 }
 
 // Path: <root>
@@ -128647,6 +128832,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get download_detail_task_queued =>
       'Queued: waiting for other downloads to free a slot. This task has not been handed to the downloader yet, so there is no live peer or tracker data.';
+  @override
   String video_subscription_group_release_count({required Object count}) =>
       '${count} releases';
   @override
@@ -128657,6 +128843,17 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_priority_normal => 'Normal';
   @override
   String get download_task_priority_low => 'Low';
+  @override
+  String get video_setting_subtitle_anchor => 'Main subtitle anchor';
+  @override
+  String get video_subtitle_anchor_bottom => 'Bottom';
+  @override
+  String get video_subtitle_anchor_top => 'Top';
+  @override
+  String get video_setting_subtitle_drag_adjust => 'Drag to adjust position';
+  @override
+  String get video_subtitle_drag_adjust_hint =>
+      'Drag a subtitle up or down to reposition it';
 }
 
 /// Flat map(s) containing all translations.
@@ -135583,6 +135780,16 @@ extension on _StringsEn {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -142507,6 +142714,16 @@ extension on _StringsAr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -149453,6 +149670,16 @@ extension on _StringsDe {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -156398,6 +156625,16 @@ extension on _StringsEs {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -163349,6 +163586,16 @@ extension on _StringsFr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -170282,6 +170529,16 @@ extension on _StringsId {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -177229,6 +177486,16 @@ extension on _StringsIt {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -184138,6 +184405,16 @@ extension on _StringsJa {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -191051,6 +191328,16 @@ extension on _StringsKo {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -197992,6 +198279,16 @@ extension on _StringsNl {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -204930,6 +205227,16 @@ extension on _StringsPtBr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -211873,6 +212180,16 @@ extension on _StringsRu {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -218799,6 +219116,16 @@ extension on _StringsTh {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -225734,6 +226061,16 @@ extension on _StringsTr {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -232665,6 +233002,16 @@ extension on _StringsVi {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }
@@ -239538,6 +239885,16 @@ extension on _StringsZhCn {
         return '普通';
       case 'download_task_priority_low':
         return '低';
+      case 'video_setting_subtitle_anchor':
+        return '主字幕锚定';
+      case 'video_subtitle_anchor_bottom':
+        return '底部';
+      case 'video_subtitle_anchor_top':
+        return '顶部';
+      case 'video_setting_subtitle_drag_adjust':
+        return '拖拽调整位置';
+      case 'video_subtitle_drag_adjust_hint':
+        return '上下拖动字幕调整位置';
       default:
         return null;
     }
@@ -246442,6 +246799,16 @@ extension on _StringsZhHk {
         return 'Normal';
       case 'download_task_priority_low':
         return 'Low';
+      case 'video_setting_subtitle_anchor':
+        return 'Main subtitle anchor';
+      case 'video_subtitle_anchor_bottom':
+        return 'Bottom';
+      case 'video_subtitle_anchor_top':
+        return 'Top';
+      case 'video_setting_subtitle_drag_adjust':
+        return 'Drag to adjust position';
+      case 'video_subtitle_drag_adjust_hint':
+        return 'Drag a subtitle up or down to reposition it';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "排队优先级",
   "download_task_priority_high": "高",
   "download_task_priority_normal": "普通",
-  "download_task_priority_low": "低"
+  "download_task_priority_low": "低",
+  "video_setting_subtitle_anchor": "主字幕锚定",
+  "video_subtitle_anchor_bottom": "底部",
+  "video_subtitle_anchor_top": "顶部",
+  "video_setting_subtitle_drag_adjust": "拖拽调整位置",
+  "video_subtitle_drag_adjust_hint": "上下拖动字幕调整位置"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3370,5 +3370,10 @@
   "download_task_priority": "Queue priority",
   "download_task_priority_high": "High",
   "download_task_priority_normal": "Normal",
-  "download_task_priority_low": "Low"
+  "download_task_priority_low": "Low",
+  "video_setting_subtitle_anchor": "Main subtitle anchor",
+  "video_subtitle_anchor_bottom": "Bottom",
+  "video_subtitle_anchor_top": "Top",
+  "video_setting_subtitle_drag_adjust": "Drag to adjust position",
+  "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it"
 }

--- a/fushi/lib/src/media/video/video_quick_settings_host.dart
+++ b/fushi/lib/src/media/video/video_quick_settings_host.dart
@@ -47,6 +47,7 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
     required this.subtitleStyle,
     required this.onSubtitleStylePreview,
     required this.onSubtitleStyleCommit,
+    this.onEnterSubtitleDragAdjust,
     this.onRespectAssStyleChanged,
     required this.onAsbConfigChanged,
     required this.onMpvConfigChanged,
@@ -112,6 +113,11 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
   final VideoSubtitleStyle Function() subtitleStyle;
   final void Function(VideoSubtitleStyle style) onSubtitleStylePreview;
   final Future<void> Function(VideoSubtitleStyle style) onSubtitleStyleCommit;
+
+  /// 进入「拖拽调整字幕位置」模式（TODO-2838）：页面关设置侧栏 + 打开拖拽模式，
+  /// 字幕 overlay 显示可拖指示、竖直拖动写回位置偏好。null = 面板不显示该入口
+  /// （全局设置页 / 无播放器场景）。
+  final VoidCallback? onEnterSubtitleDragAdjust;
   final Future<void> Function(bool value)? onRespectAssStyleChanged;
 
   // ── 手势/播放行为 JSON pref（页面持久化 + 即时生效）──────────────────────

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -317,6 +317,10 @@ class VideoSubtitleOverlay extends StatefulWidget {
     this.backgroundOpacity = 0,
     this.bottomPadding = 75,
     this.secondaryBottomPadding,
+    this.mainAnchor = SubtitleLayerVAnchor.bottom,
+    this.secondaryAnchor,
+    this.dragAdjustEnabled = false,
+    this.onDragAdjustEnd,
     this.controlsVisible,
     this.controlsBottomReserve = kVideoControlsBottomReserve,
     this.controlsTopReserve = kVideoControlsTopReserve,
@@ -423,6 +427,30 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 恒用 [bottomPadding]，两层不再互相牵动（此前共用一个字段，调主字幕位置会把副字幕
   /// 一起挪走）。控制条 / 顶栏避让照旧对各自基线取下限（max），语义不变。
   final double? secondaryBottomPadding;
+
+  /// 主字幕层的用户垂直锚定（TODO-2838，[VideoSubtitleStyle.mainAnchor]）。
+  /// [SubtitleLayerVAnchor.bottom]（默认）= 历史底部基线路径；[SubtitleLayerVAnchor.top]
+  /// 时主字幕强制置顶、[bottomPadding] 语义变为离顶距离（镜像副字幕 forceTop 路径）。
+  /// 与 ASS 自带位置的优先级见 [resolveLayerForcedAnchor]。
+  final SubtitleLayerVAnchor mainAnchor;
+
+  /// 副字幕层的用户垂直锚定（[VideoSubtitleStyle.secondaryAnchor]）。null = 自动取主层
+  /// 对侧（主底 → 副顶，历史行为）；非 null = 用户拖拽落点显式指定。
+  final SubtitleLayerVAnchor? secondaryAnchor;
+
+  /// 「拖拽调整字幕位置」模式（TODO-2838）。为 true 时：字幕盒显示可拖边框指示、竖直
+  /// 拖动实时预览位置（落点在上半屏 = 顶锚 + 离顶距离、下半屏 = 底锚 + 离底距离），
+  /// 松手经 [onDragAdjustEnd] 回报；模式内**不再**触发查词点击 / Shift-悬停查词 / 听力
+  /// 沉浸显形（指针面整体让给拖拽），退出后全部恢复。默认 false = 外观与交互零变化。
+  final bool dragAdjustEnabled;
+
+  /// 拖拽调整松手回调：[isSecondary] 层、落点解析出的 [anchor] 与距锚定边的 [padding]
+  /// （已 clamp 0..400）。页面侧据此写回 [VideoSubtitleStyle] 并持久化（主副各自独立）。
+  final void Function({
+    required bool isSecondary,
+    required SubtitleLayerVAnchor anchor,
+    required double padding,
+  })? onDragAdjustEnd;
 
   /// media_kit 控制条当前是否可见（TODO-129/161）。非 null 时驱动字幕动态避让：可见时
   /// 字幕底部 padding 取 `max([bottomPadding], [controlsBottomReserve])`（字幕底缘骑到
@@ -558,6 +586,20 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 副字幕模糊态的独立显形标志（TODO-1382）：主/副字幕各有自己的 reveal，悬停/点击
   /// 副字幕层只显形副字幕、不误显形主字幕（两层可同时开模糊）。
   bool _secondaryRevealed = false;
+
+  /// 拖拽调整模式的**逐层实时预览**（TODO-2838）：非 null 时该层的用户锚定/基线以本值
+  /// 为准（覆盖 widget 传入的持久化值），拖动中逐帧更新、松手经
+  /// [VideoSubtitleOverlay.onDragAdjustEnd] 提交后**保留**（避免「预览清了、新 style 还
+  /// 没传回来」的一帧回跳），[didUpdateWidget] 检测到拖拽模式关闭时统一清除。
+  ({SubtitleLayerVAnchor anchor, double padding})? _dragPreviewMain;
+  ({SubtitleLayerVAnchor anchor, double padding})? _dragPreviewSecondary;
+
+  /// 当前一次拖拽的起始几何（pan start 采样）：被抓字幕盒的全局顶缘 / 盒高 / 指针起始
+  /// 全局 y。update 时用「盒顶 + 指针位移」重算盒位置，与手指严格同步（不是把盒中心
+  /// 吸到指针上——抓哪儿跟哪儿）。
+  double _dragBoxTopGlobal = 0;
+  double _dragBoxHeight = 0;
+  double _dragStartPointerY = 0;
 
   /// `\fad`/`\fade` 淡入淡出逐帧刷新驱动（TODO-1373）：活动集里有带 fade 的 cue（且开
   /// respectAssStyle）时启动，每帧 setState 重读 [VideoPlayerController.effectivePositionMs]
@@ -802,6 +844,12 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     if (!widget.blurEnabled && _revealed) _revealed = false;
     if (!widget.secondaryBlurEnabled && _secondaryRevealed) {
       _secondaryRevealed = false;
+    }
+    // 退出拖拽调整模式：清掉逐层预览，位置回归 widget 传入的持久化值（提交过的拖拽
+    // 已写进 style，两者一致；未提交的中途退出则丢弃预览=取消语义）。
+    if (!widget.dragAdjustEnabled && oldWidget.dragAdjustEnabled) {
+      _dragPreviewMain = null;
+      _dragPreviewSecondary = null;
     }
   }
 
@@ -1307,13 +1355,18 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     final SubtitlePos? ownPos = ownMarkup?.posFraction;
     final SubtitleAnchor? ownAnchor = ownMarkup?.anchor;
     final bool ownNonBottom = ownPos != null ||
-        ownMarkup?.move != null || // \move 自带绝对位置，不被强制置顶（TODO-1374）
+        ownMarkup?.move != null || // \move 自带绝对位置，不被强制锚定（TODO-1374）
         (ownAnchor != null && ownAnchor.vertical != SubtitleVAlign.bottom);
-    final bool forceTop = isSecondary && !ownNonBottom;
-    final SubtitleMarkup? posMarkup = forceTop ? null : ownMarkup;
+    // TODO-2838：锚定解析收敛成统一函数（[resolveLayerForcedAnchor]）——用户锚定（含
+    // 拖拽预览）、副字幕自动对侧、ASS 自带位置的优先级都在那一处，此处不再叠 if。
+    // 旧 `forceTop = isSecondary && !ownNonBottom` 是它在「主恒底锚」时代的特例投影。
+    final SubtitleLayerVAnchor? forcedAnchor = _layerForcedAnchor(
+        isSecondary: isSecondary, ownNonBottom: ownNonBottom);
+    final bool forceTop = forcedAnchor == SubtitleLayerVAnchor.top;
+    final SubtitleMarkup? posMarkup = forcedAnchor != null ? null : ownMarkup;
     // 本组生效的竖直锚：决定堆叠增长方向（槽位远端在哪一侧）。
-    final SubtitleVAlign effectiveV = forceTop
-        ? SubtitleVAlign.top
+    final SubtitleVAlign effectiveV = forcedAnchor != null
+        ? (forceTop ? SubtitleVAlign.top : SubtitleVAlign.bottom)
         : (ownAnchor?.vertical ?? SubtitleVAlign.bottom);
 
     // TODO-1372/BUG-698：组内跨帧稳定槽位（锚点侧在前，不变量见 [_groupSlots]）。Column
@@ -1400,6 +1453,12 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     required bool isSecondary,
     required bool blurred,
   }) {
+    // 拖拽调整模式（TODO-2838）：该层指针面整体让给拖拽——不挂查词点击 / glyph 吸收 /
+    // 模糊显形 / hover 通道（模式内字幕保持清晰便于对位），套可拖指示边框 + 竖直拖动。
+    // 模式关闭（didUpdateWidget 清预览）后走下方原路径，查词 / 悬停 / 模糊全部恢复。
+    if (widget.dragAdjustEnabled) {
+      return _wrapDragAdjust(content, isSecondary: isSecondary);
+    }
     if (widget.onCharTap != null) {
       content = RawGestureDetector(
         behavior: HitTestBehavior.translucent,
@@ -1493,6 +1552,87 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         _lastShiftHoverEntry = -1;
       },
       child: content,
+    );
+  }
+
+  /// 拖拽调整模式下一组字幕盒的交互包装（TODO-2838）：可拖指示边框（foregroundDecoration
+  /// 画在字幕之上、不改布局几何）+ 竖直 pan 手势。抓哪儿跟哪儿：pan start 采样被抓盒的
+  /// 全局顶缘与指针 y，update 用指针位移平移盒位置，经 [resolveDragAdjustDrop] 解析成
+  /// 锚定边 + 距边 padding 写进该层预览（[_dragPreviewMain]/[_dragPreviewSecondary]），
+  /// 松手经 [VideoSubtitleOverlay.onDragAdjustEnd] 提交（主副各自独立）。
+  /// [HitTestBehavior.opaque]：模式内盒面点击不再下探 media_kit（不误唤控制条显隐）。
+  Widget _wrapDragAdjust(Widget content, {required bool isSecondary}) {
+    return Builder(
+      builder: (BuildContext boxContext) {
+        final Color accent = Theme.of(boxContext).colorScheme.primary;
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onPanStart: (DragStartDetails d) =>
+              _handleDragAdjustStart(d, boxContext, isSecondary: isSecondary),
+          onPanUpdate: (DragUpdateDetails d) =>
+              _handleDragAdjustUpdate(d, isSecondary: isSecondary),
+          onPanEnd: (DragEndDetails d) =>
+              _handleDragAdjustEnd(isSecondary: isSecondary),
+          onPanCancel: () => _handleDragAdjustEnd(isSecondary: isSecondary),
+          child: Container(
+            foregroundDecoration: BoxDecoration(
+              border: Border.all(color: accent, width: 2),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: content,
+          ),
+        );
+      },
+    );
+  }
+
+  /// pan start：采样被抓字幕盒的全局顶缘 / 盒高与指针起始 y（[_wrapDragAdjust] 注释）。
+  void _handleDragAdjustStart(DragStartDetails d, BuildContext boxContext,
+      {required bool isSecondary}) {
+    final RenderObject? ro = boxContext.findRenderObject();
+    if (ro is! RenderBox || !ro.hasSize) return;
+    _dragBoxTopGlobal = ro.localToGlobal(Offset.zero).dy;
+    _dragBoxHeight = ro.size.height;
+    _dragStartPointerY = d.globalPosition.dy;
+  }
+
+  /// pan update：盒顶 = 起始盒顶 + 指针位移，折成 overlay 局部坐标后经
+  /// [resolveDragAdjustDrop] 解析锚定边 + padding，写该层预览实时跟手。
+  void _handleDragAdjustUpdate(DragUpdateDetails d,
+      {required bool isSecondary}) {
+    if (_dragBoxHeight <= 0) return; // start 未采样成功（无 RenderBox）
+    final RenderObject? overlayRo = context.findRenderObject();
+    if (overlayRo is! RenderBox || !overlayRo.hasSize) return;
+    final double overlayTop = overlayRo.localToGlobal(Offset.zero).dy;
+    final double boxTop = _dragBoxTopGlobal +
+        (d.globalPosition.dy - _dragStartPointerY) -
+        overlayTop;
+    final ({SubtitleLayerVAnchor anchor, double padding}) preview =
+        resolveDragAdjustDrop(
+      boxTop: boxTop,
+      boxHeight: _dragBoxHeight,
+      containerHeight: overlayRo.size.height,
+    );
+    setState(() {
+      if (isSecondary) {
+        _dragPreviewSecondary = preview;
+      } else {
+        _dragPreviewMain = preview;
+      }
+    });
+  }
+
+  /// pan end / cancel：把该层预览经 [VideoSubtitleOverlay.onDragAdjustEnd] 提交给页面
+  /// 写回 style 偏好。预览**保留**（与提交值一致，避免 style 回传前的一帧回跳），退出
+  /// 模式时由 [didUpdateWidget] 统一清除。
+  void _handleDragAdjustEnd({required bool isSecondary}) {
+    final ({SubtitleLayerVAnchor anchor, double padding})? preview =
+        _dragPreviewFor(isSecondary);
+    if (preview == null) return;
+    widget.onDragAdjustEnd?.call(
+      isSecondary: isSecondary,
+      anchor: preview.anchor,
+      padding: preview.padding,
     );
   }
 
@@ -2467,10 +2607,48 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 单独调过（[VideoSubtitleOverlay.secondaryBottomPadding] 非 null）时用自己的值、否则
   /// 跟随主字幕（历史行为）。位置计算全部经此取值，不再有第二处直读 `widget.bottomPadding`
   /// 的层无关分支——这正是「调主字幕位置把副字幕一起挪走」的根因。
-  double _layerBaseline(bool isSecondary) =>
-      isSecondary && widget.secondaryBottomPadding != null
-          ? widget.secondaryBottomPadding!
-          : widget.bottomPadding;
+  /// 拖拽调整模式内（TODO-2838）该层的拖拽预览值优先——预览与提交同一条消费路径，
+  /// 「预览即所得」。
+  double _layerBaseline(bool isSecondary) {
+    final ({SubtitleLayerVAnchor anchor, double padding})? preview =
+        _dragPreviewFor(isSecondary);
+    if (preview != null) return preview.padding;
+    return isSecondary && widget.secondaryBottomPadding != null
+        ? widget.secondaryBottomPadding!
+        : widget.bottomPadding;
+  }
+
+  /// 该层的拖拽预览态（TODO-2838）；null = 无预览（用 widget 持久化值）。
+  ({SubtitleLayerVAnchor anchor, double padding})? _dragPreviewFor(
+          bool isSecondary) =>
+      isSecondary ? _dragPreviewSecondary : _dragPreviewMain;
+
+  /// 该层的**用户显式锚定**输入（喂给 [resolveLayerForcedAnchor] 的 `userAnchor`）：
+  /// 拖拽预览优先；否则主层只有选了顶部才算显式（底部 = 历史默认、不构成对 ASS 位置的
+  /// 覆盖），副层直接透传（null = 自动对侧）。
+  SubtitleLayerVAnchor? _layerUserAnchor(bool isSecondary) {
+    final ({SubtitleLayerVAnchor anchor, double padding})? preview =
+        _dragPreviewFor(isSecondary);
+    if (preview != null) return preview.anchor;
+    if (isSecondary) return widget.secondaryAnchor;
+    return widget.mainAnchor == SubtitleLayerVAnchor.top
+        ? SubtitleLayerVAnchor.top
+        : null;
+  }
+
+  /// 该层对一组 cue 的**强制锚定边**（统一锚定解析的实例入口，TODO-2838）：
+  /// null = 不强制（遵 cue 自带 ASS 位置 / 主层历史底部路径）。纯逻辑在
+  /// [resolveLayerForcedAnchor]（可单测），此处只是把 widget 状态折成其输入。
+  SubtitleLayerVAnchor? _layerForcedAnchor(
+          {required bool isSecondary, required bool ownNonBottom}) =>
+      resolveLayerForcedAnchor(
+        isSecondary: isSecondary,
+        userAnchor: _layerUserAnchor(isSecondary),
+        // 副层自动对侧要跟的是主层**当前生效**的锚定：拖拽主字幕的预览期也实时对侧，
+        // 预览与提交后行为一致。
+        mainUserAnchor: _dragPreviewMain?.anchor ?? widget.mainAnchor,
+        ownNonBottom: ownNonBottom,
+      );
 
   /// 顶部锚点用顶部 padding、中部不加、底部按 [controlsVisible] 取避让下限。
   ///
@@ -2683,6 +2861,29 @@ bool isBaselineBucketMarginV({
   required double? rawMarginV,
 }) =>
     rawMarginV == null || rawMarginV <= 0 || rawMarginV <= userBase;
+
+/// 拖拽调整落点解析（TODO-2838，纯函数）：给定字幕盒当前顶缘（overlay 局部坐标）、盒高
+/// 与 overlay 高度，返回锚定边 + 距锚定边的 padding。
+///
+/// 盒**中心**落在上半屏 = 顶锚 + 离顶距离（盒顶到顶边），下半屏 = 底锚 + 离底距离
+/// （盒底到底边）——锚定自动跟随落点，消除「先选锚再拖」的两步特例。两分支在屏幕中线
+/// 处数值连续（盒中心恰在中线时顶距 == 底距），拖过中线不跳变。padding 夹进
+/// [0, [kVideoSubtitleMaxPadding]]，与滑条 / 持久化同一上限；controls reserve 避让在
+/// 渲染侧照旧对结果取下限（[_paddingFor]），本函数不参与。
+@visibleForTesting
+({SubtitleLayerVAnchor anchor, double padding}) resolveDragAdjustDrop({
+  required double boxTop,
+  required double boxHeight,
+  required double containerHeight,
+}) {
+  final double center = boxTop + boxHeight / 2;
+  final bool top = center < containerHeight / 2;
+  final double raw = top ? boxTop : containerHeight - (boxTop + boxHeight);
+  return (
+    anchor: top ? SubtitleLayerVAnchor.top : SubtitleLayerVAnchor.bottom,
+    padding: raw.clamp(0.0, kVideoSubtitleMaxPadding).toDouble(),
+  );
+}
 
 /// ASS/GDI 字体名是否声明了**竖排书写**（`@` 前缀约定，BUG-1331）。
 ///

--- a/fushi/lib/src/media/video/video_subtitle_style.dart
+++ b/fushi/lib/src/media/video/video_subtitle_style.dart
@@ -199,6 +199,52 @@ double subtitleScreenScaleFactor(
   return raw.clamp(minFactor, maxFactor).toDouble();
 }
 
+/// 字幕层的**用户垂直锚定**（TODO-2838）：决定该层 padding 基线量的是「离底距离」
+/// （[bottom]，历史默认）还是「离顶距离」（[top]）。
+///
+/// 此前顶部锚定只来自两处非用户源：ASS `\an`/`\pos` 标记（respectAssStyle 开时）与
+/// 纯 SRT 副字幕的自动置顶。用户想把**主字幕**放到画面顶部（动画字幕常在上 1/6 处）
+/// 没有任何入口。本枚举把「锚定边」提升成用户可选的一等状态：顶锚时
+/// [VideoSubtitleStyle.bottomPadding]（持久化名冻结）语义 = 离顶距离，镜像副字幕
+/// forceTop 的既有消费方式（`_paddingFor` 顶分支），不新造第二个距离字段。
+enum SubtitleLayerVAnchor { bottom, top }
+
+/// 字幕垂直位置（距锚定边的距离）的统一上限（逻辑像素，TODO-2838）：持久化 clamp、
+/// 设置滑条 max、拖拽落点 clamp 三处同一真相源。历史上滑条上限 240 < 存储上限 400，
+/// 用户想把字幕放到画面上 1/6 够不着；统一拉到 400（存储上限本就允许）。
+const double kVideoSubtitleMaxPadding = 400;
+
+/// 统一「层锚定解析」纯函数（TODO-2838）：返回该层要**强制**的垂直锚定边；null =
+/// 不强制（遵 cue 自带 ASS 位置，或主层历史底部基线路径）。
+///
+/// 优先级（高 → 低）：
+/// 1. cue 自带非底位置（`\pos` / `\move` / 非底 `\an`，[ownNonBottom]）——它只在
+///    「尊重 .ass 自带样式」开启时才存在（纯字幕模式 markup 恒空），代表作者明示的
+///    定位意图；用户已显式选择尊重 ASS，则各遵其位。**默认纯字幕模式下 markup 恒空，
+///    用户锚定事实上最高优先**。若让用户锚定越过 ASS 位置，多组异位 cue（\pos 招牌 +
+///    对白）会被折到同一顶部盒互相叠印——锚定是「层默认位置」，不是「压平一切」。
+/// 2. 用户显式锚定 [userAnchor]：主层只有选了顶部才算显式（底部即历史默认）；副层
+///    任何非 null 值（拖拽落点写入）都算显式。
+/// 3. 副字幕自动锚定：无显式选择时取主层锚定的**对侧**（[mainUserAnchor] 底 → 副顶，
+///    历史行为；主顶 → 副底）。双层各占一边，消除「主字幕顶锚后与自动置顶的副字幕
+///    同点叠印」的新特例——对侧规则让碰撞在结构上不可能。
+/// 4. 主层默认：null（不强制，底部基线路径，历史像素级不变）。
+SubtitleLayerVAnchor? resolveLayerForcedAnchor({
+  required bool isSecondary,
+  required SubtitleLayerVAnchor? userAnchor,
+  required SubtitleLayerVAnchor mainUserAnchor,
+  required bool ownNonBottom,
+}) {
+  if (ownNonBottom) return null;
+  if (userAnchor != null) return userAnchor;
+  if (isSecondary) {
+    return mainUserAnchor == SubtitleLayerVAnchor.top
+        ? SubtitleLayerVAnchor.bottom
+        : SubtitleLayerVAnchor.top;
+  }
+  return null;
+}
+
 /// 字幕背景盒的**默认底色**（TODO-1059 方案A）：固定半透明黑，而非跟随
 /// `ColorScheme.surface`。
 ///
@@ -237,6 +283,8 @@ class VideoSubtitleStyle {
     required this.backgroundOpacity,
     required this.bottomPadding,
     this.secondaryBottomPadding,
+    this.mainAnchor = SubtitleLayerVAnchor.bottom,
+    this.secondaryAnchor,
   });
 
   static const int defaultFontWeight = 700;
@@ -308,6 +356,17 @@ class VideoSubtitleStyle {
   /// 位置（Never break userspace：老用户外观像素级不变）。
   final double? secondaryBottomPadding;
 
+  /// 主字幕层的用户垂直锚定（TODO-2838）。默认 [SubtitleLayerVAnchor.bottom] =
+  /// 历史行为（底距基线）；[SubtitleLayerVAnchor.top] 时 [bottomPadding] 语义变为
+  /// **离顶距离**（镜像副字幕 forceTop 的既有消费路径）。旧 JSON 无本字段 → 底锚，
+  /// 零迁移零破坏。
+  final SubtitleLayerVAnchor mainAnchor;
+
+  /// 副字幕层的用户垂直锚定（TODO-2838）。null = 自动（历史行为：取主层锚定的对侧，
+  /// 主底 → 副顶）；非 null = 用户显式选择（播放器内拖拽落点写入），从此不再自动跟随。
+  /// 锚定解析优先级见 [resolveLayerForcedAnchor]。
+  final SubtitleLayerVAnchor? secondaryAnchor;
+
   VideoSubtitleStyle copyWith({
     double? fontSize,
     Color? textColor,
@@ -320,6 +379,11 @@ class VideoSubtitleStyle {
     // null = 不改（保持当前值，含「仍跟随主字幕」的 null 态）。设置面板拖动副字幕位置
     // 时才传具体值；无「改回跟随」的入口，故不需要 backgroundColor 那样的 reset 标志。
     double? secondaryBottomPadding,
+    // null = 不改。锚定选择器 / 拖拽落点才传具体值。
+    SubtitleLayerVAnchor? mainAnchor,
+    // null = 不改（保持当前值，含「仍自动对侧」的 null 态）。仅拖拽副字幕落点写入；
+    // 无「改回自动」的入口，与 secondaryBottomPadding 同款单向语义。
+    SubtitleLayerVAnchor? secondaryAnchor,
     // [backgroundColor] 与 null 语义冲突：`null` 既是「不改」又是「显式清空跟随默认黑」。
     // 用显式 [resetBackgroundColor] 标志区分——true 时把 [backgroundColor] 强制清成 null
     // （回到 [kDefaultSubtitleBackgroundColor] 固定默认），供设置面板「默认（黑）」选项用。
@@ -338,6 +402,8 @@ class VideoSubtitleStyle {
       bottomPadding: bottomPadding ?? this.bottomPadding,
       secondaryBottomPadding:
           secondaryBottomPadding ?? this.secondaryBottomPadding,
+      mainAnchor: mainAnchor ?? this.mainAnchor,
+      secondaryAnchor: secondaryAnchor ?? this.secondaryAnchor,
     );
   }
 
@@ -374,6 +440,10 @@ class VideoSubtitleStyle {
         'bottomPadding': s.bottomPadding,
         // null（从未单独调过副字幕位置）也照写：decode 侧 null → 继续跟随主字幕。
         'secondaryBottomPadding': s.secondaryBottomPadding,
+        // 锚定（TODO-2838）：主层枚举名字符串（'bottom'/'top'）；副层 null（自动
+        // 对侧）也照写，decode 侧 null → 继续自动。
+        'mainAnchor': s.mainAnchor.name,
+        'secondaryAnchor': s.secondaryAnchor?.name,
       });
 
   static VideoSubtitleStyle decode(String? json) {
@@ -431,20 +501,32 @@ class VideoSubtitleStyle {
           d['backgroundOpacity'],
           defaults.backgroundOpacity,
         ).clamp(0.0, 1.0),
-        bottomPadding:
-            num2d(d['bottomPadding'], defaults.bottomPadding).clamp(0, 400),
+        bottomPadding: num2d(d['bottomPadding'], defaults.bottomPadding)
+            .clamp(0, kVideoSubtitleMaxPadding),
         // 缺字段（旧数据）/ 非数字 → null = 副字幕继续跟随主字幕位置（旧外观不变）。
         secondaryBottomPadding: d['secondaryBottomPadding'] is num
             ? (d['secondaryBottomPadding'] as num)
                 .toDouble()
-                .clamp(0, 400)
+                .clamp(0, kVideoSubtitleMaxPadding)
                 .toDouble()
             : null,
+        // 锚定（TODO-2838）：缺字段（旧数据）/ 未知值 → 主层底锚、副层自动（对侧），
+        // 旧外观像素级不变。
+        mainAnchor:
+            _decodeAnchor(d['mainAnchor']) ?? SubtitleLayerVAnchor.bottom,
+        secondaryAnchor: _decodeAnchor(d['secondaryAnchor']),
       );
     } catch (_) {
       return defaults;
     }
   }
+
+  /// JSON 里的锚定字符串 → 枚举；未知/非字符串返回 null（调用方决定回退语义）。
+  static SubtitleLayerVAnchor? _decodeAnchor(Object? v) => switch (v) {
+        'top' => SubtitleLayerVAnchor.top,
+        'bottom' => SubtitleLayerVAnchor.bottom,
+        _ => null,
+      };
 
   static double _normalizeUiScale(double uiScale) {
     return FushiAppUiScale.normalize(uiScale);

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -394,6 +394,12 @@ extension _VideoLayout on _VideoFushiPageState {
                           // 主字幕位置滑杆不再把副字幕一起挪走。
                           secondaryBottomPadding:
                               _subtitleStyle.secondaryBottomPadding,
+                          // TODO-2838：主/副字幕用户垂直锚定（底/顶）+ 拖拽调整模式。
+                          // 拖拽松手把落点锚定 + 距边距离写回 style 偏好并持久化。
+                          mainAnchor: _subtitleStyle.mainAnchor,
+                          secondaryAnchor: _subtitleStyle.secondaryAnchor,
+                          dragAdjustEnabled: _subtitleDragAdjustActive,
+                          onDragAdjustEnd: _handleSubtitleDragAdjustEnd,
                           // 控制条可见性驱动动态避让（TODO-129）：进度条出现时字幕底缘对
                           // 进度条上缘取下限（max，非加法——BUG-226 防顶飞）、隐藏落回。全屏
                           // 复用同一 builder + ValueNotifier，故窗口与全屏都跟随（BUG-120 同源）。
@@ -424,6 +430,9 @@ extension _VideoLayout on _VideoFushiPageState {
                       // IgnorePointer；隐藏态零尺寸）。挂在 auto-advance 之后、
                       // level HUD 之前，与其它 chrome overlay 同源。
                       _buildBlackFlickerNoticeOverlay(),
+                      // TODO-2838：拖拽调整字幕位置模式的顶部横幅（提示 + 「完成」退出）。
+                      // 非模式态零尺寸。
+                      _buildSubtitleDragAdjustBanner(),
                       _buildLevelHudOverlay(),
                       _buildVideoSideActionRail(controller),
                       _buildVideoSidePanelOverlay(controller),
@@ -884,6 +893,77 @@ extension _VideoLayout on _VideoFushiPageState {
                 },
               );
             },
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── 拖拽调整字幕位置（TODO-2838）─────────────────────────────────────────
+
+  /// 进入拖拽调整模式（设置面板「拖拽调整位置」入口，经
+  /// [VideoQuickSettingsHost.onEnterSubtitleDragAdjust] 调到这里）：先关设置侧栏
+  /// （面板盖着画面没法拖），再打开模式让字幕 overlay 切换到拖拽指针面。
+  void _enterSubtitleDragAdjust() {
+    _hideVideoSidePanel();
+    _rebuild(() => _subtitleDragAdjustActive = true);
+  }
+
+  /// 拖拽松手回调（[VideoSubtitleOverlay.onDragAdjustEnd]）：把落点解析出的锚定边 +
+  /// 距边距离写回 [_subtitleStyle] 对应层的字段并持久化（复用 [_persistSubtitleStyle]
+  /// 的「更新页面快照 + 落 pref + setState」全链路）。主副各自独立：拖主字幕写
+  /// mainAnchor/bottomPadding，拖副字幕写 secondaryAnchor/secondaryBottomPadding。
+  void _handleSubtitleDragAdjustEnd({
+    required bool isSecondary,
+    required SubtitleLayerVAnchor anchor,
+    required double padding,
+  }) {
+    final VideoSubtitleStyle next = isSecondary
+        ? _subtitleStyle.copyWith(
+            secondaryAnchor: anchor,
+            secondaryBottomPadding: padding,
+          )
+        : _subtitleStyle.copyWith(
+            mainAnchor: anchor,
+            bottomPadding: padding,
+          );
+    unawaited(_persistSubtitleStyle(next));
+  }
+
+  /// 拖拽调整模式的顶部横幅：提示文案 + 「完成」按钮退出。非模式态返回零尺寸盒。
+  /// 挂在 chrome 层（OSD 之后），不参与字幕 overlay 的指针面。圆角走
+  /// [FushiBorderRadius] 共享 token、面色用非分档 surfaceContainer（MD3 守卫纪律）。
+  Widget _buildSubtitleDragAdjustBanner() {
+    if (!_subtitleDragAdjustActive) return const SizedBox.shrink();
+    final ColorScheme cs = _videoChromeColorScheme(context);
+    final TextStyle? labelStyle =
+        Theme.of(context).textTheme.labelLarge?.copyWith(color: cs.onSurface);
+    return SafeArea(
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.only(top: 12),
+          child: Material(
+            color: cs.surfaceContainer.withValues(alpha: 0.92),
+            borderRadius: FushiBorderRadius.dialog,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Icon(Icons.open_with_outlined, size: 18, color: cs.primary),
+                  const SizedBox(width: 8),
+                  Text(t.video_subtitle_drag_adjust_hint, style: labelStyle),
+                  const SizedBox(width: 12),
+                  FilledButton(
+                    key: const Key('video-subtitle-drag-adjust-done'),
+                    onPressed: () =>
+                        _rebuild(() => _subtitleDragAdjustActive = false),
+                    child: Text(t.dialog_done),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1721,6 +1721,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
 
   /// 当前字幕外观（全局偏好快照；设置面板改动后刷新）。
   VideoSubtitleStyle _subtitleStyle = VideoSubtitleStyle.defaults;
+
+  /// 「拖拽调整字幕位置」模式开关（TODO-2838）：设置面板入口进入、画面顶部横幅
+  /// 「完成」退出。开启时字幕 overlay 让出查词指针面、改挂竖直拖拽（见
+  /// [VideoSubtitleOverlay.dragAdjustEnabled]），松手经 [_handleSubtitleDragAdjustEnd]
+  /// 写回 [_subtitleStyle] 并持久化。
+  bool _subtitleDragAdjustActive = false;
   VideoAsbplayerConfig _asbConfig = VideoAsbplayerConfig.defaults;
 
   /// Live 9-slot control button layout (TODO-274/312 phase 2). This is loaded
@@ -6208,6 +6214,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         if (mounted) setState(() => _subtitleStyle = s);
       },
       onSubtitleStyleCommit: _persistSubtitleStyle,
+      // TODO-2838：进入「拖拽调整字幕位置」模式（关设置侧栏 + 开拖拽，见 layout.part）。
+      onEnterSubtitleDragAdjust: _enterSubtitleDragAdjust,
       // TODO-1105：尊重 .ass 自带样式切换回调（持久化 + 重建让 overlay 即时生效）。
       onRespectAssStyleChanged: _setVideoRespectAssStyle,
       // 着色器/mpv 配置面板内嵌（不弹独立对话框）：着色器勾选 → 持久化启用集 +

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -1003,6 +1003,43 @@ SettingsDestination buildVideoDestination() {
               );
             },
           ),
+          // 主字幕垂直锚定（TODO-2838）：底部（默认，历史行为）/ 顶部。顶锚时下面的
+          // 「垂直位置」量纲变为**离顶距离**（镜像副字幕置顶的既有消费路径）；ASS 自带
+          // 位置（respectAssStyle 开）仍各遵其位，优先级见 resolveLayerForcedAnchor。
+          SettingsSegmentedItem<String>(
+            id: 'video.subtitle.anchor',
+            title: t.video_setting_subtitle_anchor,
+            icon: Icons.vertical_align_top_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.subtitle,
+              order: 138,
+              section: t.video_setting_subtitle_appearance,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: SubtitleLayerVAnchor.bottom.name,
+                label: t.video_subtitle_anchor_bottom,
+                icon: Icons.vertical_align_bottom_outlined,
+              ),
+              SettingsSegmentOption<String>(
+                value: SubtitleLayerVAnchor.top.name,
+                label: t.video_subtitle_anchor_top,
+                icon: Icons.vertical_align_top_outlined,
+              ),
+            ],
+            selected: (SettingsContext settingsContext) =>
+                currentVideoSubtitleStyle(settingsContext).mainAnchor.name,
+            onChanged: (SettingsContext settingsContext, String v) async {
+              await commitVideoSubtitleStyle(
+                settingsContext,
+                (VideoSubtitleStyle s) => s.copyWith(
+                  mainAnchor: v == SubtitleLayerVAnchor.top.name
+                      ? SubtitleLayerVAnchor.top
+                      : SubtitleLayerVAnchor.bottom,
+                ),
+              );
+            },
+          ),
           SettingsSliderItem(
             id: 'video.subtitle.position',
             title: t.video_setting_subtitle_position,
@@ -1013,12 +1050,14 @@ SettingsDestination buildVideoDestination() {
               section: t.video_setting_subtitle_appearance,
             ),
             min: 0,
-            max: 240,
-            divisions: 24,
+            // TODO-2838：上限 240 → 400（kVideoSubtitleMaxPadding，与存储 clamp 同源）。
+            // 旧上限让字幕最高只能到画面下 1/3，用户想放到上 1/6 够不着。
+            max: kVideoSubtitleMaxPadding,
+            divisions: 40,
             value: (SettingsContext settingsContext) =>
                 currentVideoSubtitleStyle(settingsContext)
                     .bottomPadding
-                    .clamp(0, 240),
+                    .clamp(0, kVideoSubtitleMaxPadding),
             onChanged: (SettingsContext settingsContext, double v) {
               previewVideoSubtitleStyle(
                 settingsContext,
@@ -1046,13 +1085,14 @@ SettingsDestination buildVideoDestination() {
               section: t.video_setting_subtitle_appearance,
             ),
             min: 0,
-            max: 240,
-            divisions: 24,
+            // TODO-2838：与主字幕位置同步拉高上限（kVideoSubtitleMaxPadding）。
+            max: kVideoSubtitleMaxPadding,
+            divisions: 40,
             value: (SettingsContext settingsContext) {
               final VideoSubtitleStyle s =
                   currentVideoSubtitleStyle(settingsContext);
               return (s.secondaryBottomPadding ?? s.bottomPadding)
-                  .clamp(0, 240);
+                  .clamp(0, kVideoSubtitleMaxPadding);
             },
             onChanged: (SettingsContext settingsContext, double v) {
               previewVideoSubtitleStyle(
@@ -1065,6 +1105,29 @@ SettingsDestination buildVideoDestination() {
                 settingsContext,
                 (VideoSubtitleStyle s) => s.copyWith(secondaryBottomPadding: v),
               );
+            },
+          ),
+          // 拖拽调整字幕位置入口（TODO-2838）：进入播放器内可视化拖拽模式——字幕盒
+          // 显示可拖边框、竖直拖动实时预览、落点自动定锚（上半屏顶锚/下半屏底锚）、
+          // 松手写回偏好。仅播放中有意义（要有真字幕 overlay 可拖），全局设置页隐藏；
+          // 入口放位置滑条旁而非长按字幕：字级查词已占用字幕的 tap 指针面（BUG-553/838
+          // 竞技场纪律），再叠长按手势会与查词/显形抢竞技场，按钮进入零冲突。
+          SettingsActionItem(
+            id: 'video.subtitle.drag_adjust',
+            title: t.video_setting_subtitle_drag_adjust,
+            subtitle: t.video_subtitle_drag_adjust_hint,
+            icon: Icons.open_with_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.subtitle,
+              order: 148,
+              section: t.video_setting_subtitle_appearance,
+            ),
+            visible: (SettingsContext c) =>
+                videoQuickSettingsHostOf(c)?.onEnterSubtitleDragAdjust != null,
+            onTap: (SettingsContext settingsContext) async {
+              videoQuickSettingsHostOf(settingsContext)
+                  ?.onEnterSubtitleDragAdjust
+                  ?.call();
             },
           ),
           // ── Jimaku（在线字幕源）───────────────────────────────────────────

--- a/fushi/test/media/video/video_subtitle_anchor_drag_test.dart
+++ b/fushi/test/media/video/video_subtitle_anchor_drag_test.dart
@@ -1,0 +1,415 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_overlay.dart';
+import 'package:fushi/src/media/video/video_subtitle_style.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+/// TODO-2838：视频字幕垂直位置增强——主字幕顶部锚定 + 位置上限 400 + 拖拽可视化调整。
+///
+/// 分五层验证：
+///  ① 统一锚定解析纯函数 [resolveLayerForcedAnchor]：用户锚定 / ASS 自带位置 / 副字幕
+///     自动对侧的优先级。
+///  ② 拖拽落点解析纯函数 [resolveDragAdjustDrop]：上/下半屏定锚、中线连续、clamp 0..400。
+///  ③ [VideoSubtitleStyle] 持久化：锚定字段 round-trip + 旧 blob（无字段）向后兼容。
+///  ④ overlay 真几何：主字幕顶锚渲染在顶部（padding = 离顶距离）、控制条可见时避让
+///     top reserve；主顶锚时副字幕自动落到底部（对侧规则）。
+///  ⑤ 拖拽模式交互：模式内 tap 不再触发查词、拖拽松手回报锚定 + 距离、退出后查词恢复。
+AudioCue _cue(String text, {int startMs = 0, int endMs = 5000}) => AudioCue()
+  ..bookKey = 'b'
+  ..chapterHref = 'ch'
+  ..sentenceIndex = 0
+  ..textFragmentId = '#s1'
+  ..text = text
+  ..startMs = startMs
+  ..endMs = endMs
+  ..audioFileIndex = 0;
+
+VideoPlayerController _controllerWithCue(String text) {
+  final VideoPlayerController c = VideoPlayerController();
+  c.setCues(<AudioCue>[_cue(text)]);
+  c.debugUpdateCueForPosition(100);
+  return c;
+}
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+  await tester.pump();
+}
+
+void main() {
+  group('① resolveLayerForcedAnchor 统一锚定解析', () {
+    test('主层默认（底锚、无 ASS 位置）→ null（历史底部基线路径）', () {
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: false,
+          userAnchor: null,
+          mainUserAnchor: SubtitleLayerVAnchor.bottom,
+          ownNonBottom: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('主层用户顶锚（无 ASS 位置）→ 强制顶', () {
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: false,
+          userAnchor: SubtitleLayerVAnchor.top,
+          mainUserAnchor: SubtitleLayerVAnchor.top,
+          ownNonBottom: false,
+        ),
+        SubtitleLayerVAnchor.top,
+      );
+    });
+
+    test('ASS 自带非底位置优先于用户锚定（respectAssStyle 开时各遵其位）', () {
+      // 尊重 ASS 模式下 \pos/\an 招牌若被用户锚定压平到同一顶部盒会互相叠印，
+      // 故自带位置组不强制。纯字幕模式 markup 恒空、用户锚定事实上最高优先。
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: false,
+          userAnchor: SubtitleLayerVAnchor.top,
+          mainUserAnchor: SubtitleLayerVAnchor.top,
+          ownNonBottom: true,
+        ),
+        isNull,
+      );
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: true,
+          userAnchor: SubtitleLayerVAnchor.bottom,
+          mainUserAnchor: SubtitleLayerVAnchor.bottom,
+          ownNonBottom: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('副层自动（null）：取主层对侧——主底→副顶（历史），主顶→副底（防同点叠印）', () {
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: true,
+          userAnchor: null,
+          mainUserAnchor: SubtitleLayerVAnchor.bottom,
+          ownNonBottom: false,
+        ),
+        SubtitleLayerVAnchor.top,
+        reason: '主底锚时副字幕自动置顶 = 历史行为',
+      );
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: true,
+          userAnchor: null,
+          mainUserAnchor: SubtitleLayerVAnchor.top,
+          ownNonBottom: false,
+        ),
+        SubtitleLayerVAnchor.bottom,
+        reason: '主顶锚时副字幕自动落底，双层各占一边不叠印',
+      );
+    });
+
+    test('副层显式锚定直接生效（拖拽落点写入后不再自动对侧）', () {
+      expect(
+        resolveLayerForcedAnchor(
+          isSecondary: true,
+          userAnchor: SubtitleLayerVAnchor.bottom,
+          mainUserAnchor: SubtitleLayerVAnchor.bottom,
+          ownNonBottom: false,
+        ),
+        SubtitleLayerVAnchor.bottom,
+      );
+    });
+  });
+
+  group('② resolveDragAdjustDrop 拖拽落点解析', () {
+    test('盒中心在上半屏 → 顶锚 + 离顶距离（盒顶到顶边）', () {
+      final ({SubtitleLayerVAnchor anchor, double padding}) r =
+          resolveDragAdjustDrop(
+              boxTop: 100, boxHeight: 40, containerHeight: 600);
+      expect(r.anchor, SubtitleLayerVAnchor.top);
+      expect(r.padding, 100);
+    });
+
+    test('盒中心在下半屏 → 底锚 + 离底距离（盒底到底边）', () {
+      final ({SubtitleLayerVAnchor anchor, double padding}) r =
+          resolveDragAdjustDrop(
+              boxTop: 500, boxHeight: 40, containerHeight: 600);
+      expect(r.anchor, SubtitleLayerVAnchor.bottom);
+      expect(r.padding, 600 - 500 - 40);
+    });
+
+    test('屏幕中线连续：盒中心恰在中线时顶距 == 底距（拖过中线不跳变）', () {
+      // 盒中心 = 300（= 600/2），boxTop = 280，boxH = 40：
+      // 顶距 = 280，底距 = 600 - 280 - 40 = 280。两分支数值相等。
+      final ({SubtitleLayerVAnchor anchor, double padding}) atMid =
+          resolveDragAdjustDrop(
+              boxTop: 280, boxHeight: 40, containerHeight: 600);
+      expect(atMid.padding, 280);
+      // 中线上方一像素 → 顶锚；下方一像素 → 底锚；padding 差 1（连续）。
+      final ({SubtitleLayerVAnchor anchor, double padding}) above =
+          resolveDragAdjustDrop(
+              boxTop: 279, boxHeight: 40, containerHeight: 600);
+      final ({SubtitleLayerVAnchor anchor, double padding}) below =
+          resolveDragAdjustDrop(
+              boxTop: 281, boxHeight: 40, containerHeight: 600);
+      expect(above.anchor, SubtitleLayerVAnchor.top);
+      expect(above.padding, 279);
+      expect(below.anchor, SubtitleLayerVAnchor.bottom);
+      expect(below.padding, 279);
+    });
+
+    test('clamp 进 [0, kVideoSubtitleMaxPadding]：拖出屏 → 0，超上限 → 400', () {
+      expect(
+        resolveDragAdjustDrop(boxTop: -50, boxHeight: 40, containerHeight: 600)
+            .padding,
+        0,
+      );
+      expect(
+        resolveDragAdjustDrop(
+                boxTop: 1500, boxHeight: 40, containerHeight: 2000)
+            .padding,
+        kVideoSubtitleMaxPadding,
+        reason: '底锚离底 460 超上限，夹到 400',
+      );
+    });
+  });
+
+  group('③ VideoSubtitleStyle 锚定持久化', () {
+    test('round-trip：mainAnchor=top + secondaryAnchor=bottom 编解码不变', () {
+      final VideoSubtitleStyle s = VideoSubtitleStyle.defaults.copyWith(
+        mainAnchor: SubtitleLayerVAnchor.top,
+        secondaryAnchor: SubtitleLayerVAnchor.bottom,
+        bottomPadding: 320,
+      );
+      final VideoSubtitleStyle back =
+          VideoSubtitleStyle.decode(VideoSubtitleStyle.encode(s));
+      expect(back.mainAnchor, SubtitleLayerVAnchor.top);
+      expect(back.secondaryAnchor, SubtitleLayerVAnchor.bottom);
+      expect(back.bottomPadding, 320);
+    });
+
+    test('旧 blob（无锚定字段）→ 主底锚 / 副自动（向后兼容，零迁移）', () {
+      const String legacy =
+          '{"_v":2,"fontSize":36,"bottomPadding":75,"backgroundOpacity":0}';
+      final VideoSubtitleStyle s = VideoSubtitleStyle.decode(legacy);
+      expect(s.mainAnchor, SubtitleLayerVAnchor.bottom);
+      expect(s.secondaryAnchor, isNull);
+    });
+
+    test('未知锚定值 → 回退默认（主底锚 / 副自动），不炸不钉死', () {
+      const String weird =
+          '{"_v":2,"fontSize":36,"bottomPadding":75,"backgroundOpacity":0,'
+          '"mainAnchor":"middle","secondaryAnchor":42}';
+      final VideoSubtitleStyle s = VideoSubtitleStyle.decode(weird);
+      expect(s.mainAnchor, SubtitleLayerVAnchor.bottom);
+      expect(s.secondaryAnchor, isNull);
+    });
+
+    test('bottomPadding 解码上限 = kVideoSubtitleMaxPadding（400），不再是 240', () {
+      const String high =
+          '{"_v":2,"fontSize":36,"bottomPadding":399,"backgroundOpacity":0}';
+      expect(VideoSubtitleStyle.decode(high).bottomPadding, 399);
+      const String over =
+          '{"_v":2,"fontSize":36,"bottomPadding":9999,"backgroundOpacity":0}';
+      expect(VideoSubtitleStyle.decode(over).bottomPadding,
+          kVideoSubtitleMaxPadding);
+    });
+  });
+
+  group('④ overlay 真几何：主字幕顶锚', () {
+    // 字幕盒自身的垂直内 padding（EdgeInsets.symmetric(vertical: 6) 的顶部 6px）。
+    const double kBoxPadTop = 6;
+
+    double gapFromTop(WidgetTester tester, String text) {
+      final Rect overlayRect =
+          tester.getRect(find.byType(VideoSubtitleOverlay));
+      final Rect charRect = tester.getRect(find.text(text).first);
+      return charRect.top - overlayRect.top;
+    }
+
+    double gapFromBottom(WidgetTester tester, String text) {
+      final Rect overlayRect =
+          tester.getRect(find.byType(VideoSubtitleOverlay));
+      final Rect charRect = tester.getRect(find.text(text).first);
+      return overlayRect.bottom - charRect.bottom;
+    }
+
+    testWidgets('mainAnchor=top：主字幕渲染在顶部，bottomPadding 语义 = 离顶距离',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('A');
+      addTearDown(c.dispose);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          bottomPadding: 50,
+          mainAnchor: SubtitleLayerVAnchor.top,
+        ),
+      );
+      expect(gapFromTop(tester, 'A'), closeTo(50 + kBoxPadTop, 0.5),
+          reason: '顶锚时主字幕顶缘离顶 = 用户位置（+盒内 padding），镜像副字幕置顶路径');
+    });
+
+    testWidgets('mainAnchor=top + 控制条可见：避让 controlsTopReserve（取下限）',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('A');
+      addTearDown(c.dispose);
+      final ValueNotifier<bool> visible = ValueNotifier<bool>(false);
+      addTearDown(visible.dispose);
+      const double kTopReserve = 300;
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          bottomPadding: 12,
+          mainAnchor: SubtitleLayerVAnchor.top,
+          controlsVisible: visible,
+          controlsTopReserve: kTopReserve,
+        ),
+      );
+
+      double maxAnimatedTop() => tester
+          .widgetList<AnimatedPadding>(find.byType(AnimatedPadding))
+          .map((AnimatedPadding p) => p.padding.resolve(TextDirection.ltr).top)
+          .fold<double>(0, (double a, double b) => b > a ? b : a);
+
+      expect(maxAnimatedTop(), 12, reason: '控制条隐藏：贴用户基线');
+      visible.value = true;
+      await tester.pump();
+      expect(maxAnimatedTop(), kTopReserve,
+          reason: '控制条可见：顶锚主字幕下移到顶栏下方（BUG-1069 同契约）');
+    });
+
+    testWidgets('mainAnchor=top 时副字幕自动落底（对侧规则，不与主字幕同点叠印）',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主')]);
+      c.setSecondaryCues(<AudioCue>[_cue('副')]);
+      c.debugUpdateCueForPosition(100);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          bottomPadding: 50,
+          secondaryBottomPadding: 80,
+          mainAnchor: SubtitleLayerVAnchor.top,
+        ),
+      );
+      expect(gapFromTop(tester, '主'), closeTo(50 + kBoxPadTop, 0.5),
+          reason: '主字幕在顶');
+      expect(gapFromBottom(tester, '副'), closeTo(80 + kBoxPadTop, 0.5),
+          reason: '副字幕自动对侧落底，吃自己的基线');
+    });
+
+    testWidgets('默认（mainAnchor=bottom）外观与历史像素级一致（零破坏守卫）',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('A');
+      addTearDown(c.dispose);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(controller: c, bottomPadding: 75),
+      );
+      expect(gapFromBottom(tester, 'A'), closeTo(75 + kBoxPadTop, 0.5),
+          reason: '不传锚定 = 历史底部基线');
+    });
+  });
+
+  group('⑤ 拖拽调整模式', () {
+    testWidgets('模式内 tap 字幕不再触发查词；退出后恢复', (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('テスト');
+      addTearDown(c.dispose);
+      int taps = 0;
+      Widget overlay({required bool dragMode}) => VideoSubtitleOverlay(
+            controller: c,
+            dragAdjustEnabled: dragMode,
+            onCharTap: (String s, int i, Rect r, AudioCue cue) => taps++,
+            onDragAdjustEnd: (
+                {required bool isSecondary,
+                required SubtitleLayerVAnchor anchor,
+                required double padding}) {},
+          );
+
+      await _pump(tester, overlay(dragMode: true));
+      await tester.tapAt(tester.getCenter(find.text('ス').first));
+      await tester.pump();
+      expect(taps, 0, reason: '拖拽模式内指针面让给拖拽，点字不查词');
+
+      // 退出模式：同一棵树换参重建（State 保留），查词恢复。
+      await tester.pumpWidget(
+          MaterialApp(home: Scaffold(body: overlay(dragMode: false))));
+      await tester.pump();
+      await tester.tapAt(tester.getCenter(find.text('ス').first));
+      await tester.pump();
+      expect(taps, 1, reason: '退出拖拽模式后查词手势恢复');
+    });
+
+    testWidgets('竖直拖到顶部：实时预览 + 松手回报 top 锚 + clamp 后距离',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('テスト');
+      addTearDown(c.dispose);
+      bool? endIsSecondary;
+      SubtitleLayerVAnchor? endAnchor;
+      double? endPadding;
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          bottomPadding: 75,
+          dragAdjustEnabled: true,
+          onDragAdjustEnd: (
+              {required bool isSecondary,
+              required SubtitleLayerVAnchor anchor,
+              required double padding}) {
+            endIsSecondary = isSecondary;
+            endAnchor = anchor;
+            endPadding = padding;
+          },
+        ),
+      );
+
+      // 从字幕中心一路拖到屏幕外上方：盒顶 < 0 → clamp 0 → 顶锚贴顶。
+      final Offset start = tester.getCenter(find.text('ス').first);
+      final TestGesture g = await tester.startGesture(start);
+      await g.moveBy(const Offset(0, -1000));
+      await tester.pump();
+      await g.up();
+      await tester.pump();
+
+      expect(endIsSecondary, isFalse);
+      expect(endAnchor, SubtitleLayerVAnchor.top);
+      expect(endPadding, 0, reason: '拖出顶边 clamp 到 0（贴顶）');
+
+      // 预览已生效：字幕盒贴顶渲染（离顶 = 0 + 盒内 padding 6）。
+      final Rect overlayRect =
+          tester.getRect(find.byType(VideoSubtitleOverlay));
+      final Rect charRect = tester.getRect(find.text('テ').first);
+      expect(charRect.top - overlayRect.top, closeTo(6, 0.5),
+          reason: '松手后预览保留在落点（顶锚 0 + 盒内 6px）');
+    });
+
+    testWidgets('拖拽模式内字幕盒显示可拖指示边框', (WidgetTester tester) async {
+      final VideoPlayerController c = _controllerWithCue('A');
+      addTearDown(c.dispose);
+      await _pump(
+        tester,
+        VideoSubtitleOverlay(
+          controller: c,
+          dragAdjustEnabled: true,
+          onDragAdjustEnd: (
+              {required bool isSecondary,
+              required SubtitleLayerVAnchor anchor,
+              required double padding}) {},
+        ),
+      );
+      final bool hasBorder = tester
+          .widgetList<Container>(find.byType(Container))
+          .any((Container w) {
+        final Decoration? d = w.foregroundDecoration;
+        return d is BoxDecoration && d.border != null;
+      });
+      expect(hasBorder, isTrue, reason: '模式内字幕盒需有可拖指示（边框）');
+    });
+  });
+}

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -318,6 +318,13 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'video/Background opacity': 'test/media/video/video_subtitle_style_test.dart',
   'video/Vertical position':
       'test/media/video/video_subtitle_style_test.dart + test/pages/video_subtitle_push_up_guard_test.dart',
+  // TODO-2838：主字幕垂直锚定（底/顶）。写 videoSubtitleStyle blob（changed=true），
+  // 生效点在 VideoSubtitleOverlay 的统一锚定解析（resolveLayerForcedAnchor →
+  // _positionCueGroup 强制置顶 + padding 语义变离顶距离），本 harness 的 video 分组
+  // 无适用探针（与主/副字幕位置滑杆同理）。由专项测试咬住：解析纯函数优先级 /
+  // overlay 顶锚真几何 / top reserve 避让 / 持久化 round-trip + 旧 blob 兼容。
+  'video/Main subtitle anchor':
+      'test/media/video/video_subtitle_anchor_drag_test.dart',
   // PR#610「主/副字幕垂直位置分开调节」新增的副字幕位置滑杆（与上面主字幕
   // 'Vertical position' 同量纲、各自独立）。写 prefsRepo（changed=true），生效点在
   // VideoSubtitleOverlay 副字幕层的真几何（_layerBaseline），需真播放器 + media_kit，
@@ -556,8 +563,7 @@ void main() {
     final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
-    final ReaderSettings? prevReaderSettings =
-        ReaderFushiSource.readerSettings;
+    final ReaderSettings? prevReaderSettings = ReaderFushiSource.readerSettings;
     final ReaderSettings readerSettings = ReaderSettings(db);
     await readerSettings.refreshFromDb();
     ReaderFushiSource.readerSettings = readerSettings;


### PR DESCRIPTION
## 用户诉求
用户看的动画字幕在画面顶部（约上 1/6），希望：① 主字幕能放到最上面；② 垂直位置上限拉高；③ 字幕位置能拖拽可视化调整。

## 实现

### 1. 主字幕锚定选项（顶锚成为正常情况，不是特例）
- `VideoSubtitleStyle` 新增 `mainAnchor`（默认 `bottom` = 零破坏）与 `secondaryAnchor`（null = 自动）。JSON blob 向后兼容：旧数据缺字段 → 主底锚 / 副自动，未知值回退默认，零迁移。
- **锚定解析收敛成一个纯函数** `resolveLayerForcedAnchor`（video_subtitle_style.dart），旧 `forceTop = isSecondary && !ownNonBottom` 是它在「主恒底锚」时代的特例投影。优先级：
  1. **cue 自带非底位置**（\pos/\move/非底 \an，仅 respectAssStyle 开时 markup 非空）——各遵其位；
  2. **用户显式锚定**（主层选顶 / 副层拖拽写入的任何值）；
  3. **副字幕自动 = 主层对侧**（主底→副顶 = 历史行为；主顶→副底，消除「主顶锚后与自动置顶副字幕同点叠印」——对侧规则让碰撞在结构上不可能）；
  4. 主层默认 = 不强制（历史底部基线，像素级不变）。
- **与任务书字面优先级（用户锚定 > ASS 标记）的偏差说明**：默认纯字幕模式（respectAssStyle 关）markup 恒空，用户锚定**事实上最高优先**；只在用户显式开了「尊重 .ass 自带样式」时 ASS 位置才赢——若让用户锚定越过 \pos/\an，多组异位 cue（招牌+对白）会被压平到同一顶部盒互相叠印。锚定语义是「层默认位置」，不是「压平一切」。
- 顶锚时 `bottomPadding`（持久化名冻结）语义 = 离顶距离，逐字复用副字幕 forceTop 的 `_paddingFor` 顶分支与 `controlsTopReserve` 避让（BUG-1069 同契约），不新造第二个距离字段、不加新分支。

### 2. 上限 240 → 400
- 新常量 `kVideoSubtitleMaxPadding = 400`：设置滑条 max（主副两条，divisions 24→40）、存储 decode clamp、拖拽落点 clamp 三处同一真相源。

### 3. 播放器内拖拽可视化调整
- **入口方案评估**：选「快速设置面板位置滑条旁的 SettingsActionItem」而非长按字幕。理由：字级查词已占用字幕的 tap 指针面（BUG-553 竞技场门控 + BUG-838 glyph 吸收），叠加长按识别器会与查词/模糊显形抢竞技场且无可见 affordance；面板按钮零手势冲突、可发现性好。入口仅播放中可见（`videoQuickSettingsHostOf(c)?.onEnterSubtitleDragAdjust != null` 门控），进入时自动收起设置侧栏。
- 模式内：字幕盒 `foregroundDecoration` 边框指示（不改布局几何）；竖直 pan「抓哪儿跟哪儿」实时预览；落点解析纯函数 `resolveDragAdjustDrop`——盒中心上半屏 = 顶锚+离顶距离、下半屏 = 底锚+离底距离（锚定自动跟随落点，消除「先选锚再拖」两步特例；两分支在中线数值连续，拖过中线不跳变）；松手写回 style 偏好（主副各自独立），预览保留到退出模式（避免 style 回传前一帧回跳）。
- 模式内查词 tap / Shift-悬停 / 模糊显形整体让位（`_wrapInteractive` 单一早退分支），顶部横幅「完成」退出后全部恢复。controls reserve 避让在渲染侧照旧取下限，不受拖拽影响。
- 已知取舍：模式内字幕保持清晰（便于对位）；无字幕在屏时无盒可拖（需等当前句出现）；键盘/手柄用户暂只能走滑条+锚定选择器（横幅按钮是指针面）。

### 测试证据（本地全绿，flutter analyze 0 issue）
- 新增 `test/media/video/video_subtitle_anchor_drag_test.dart`（20 条，五层）：锚定解析纯函数优先级 / 拖拽落点解析（定锚、中线连续、clamp）/ style round-trip + 旧 blob 兼容 + 未知值回退 / overlay 顶锚真几何 + top reserve 避让 + 副字幕自动对侧 + 默认外观零破坏守卫 / 拖拽模式（模式内 tap 不查词、拖到顶 clamp 0 + 预览落位、退出后查词恢复、边框指示存在）。
- 相邻回归：`video_subtitle_overlay(±markup/dual_snap/pos_dodge/top_reserve/secondary_position/style/bg/text_color)`、`video_subtitle_push_up_guard`、`video_quick_settings_sheet`、`video_topbar_safe_inset_guard`、`settings_schema_coverage`（新锚定项已登记）、`md3_design_system_static`（横幅走 FushiBorderRadius token + 非分档 surfaceContainer）、`test/i18n` 全绿。
- i18n：5 个新 key 走 `i18n_sync --add` + `dart run slang` + `dart format` 生成文件。

## 与并行线 TODO-2837 的冲突面
未触碰 video_player_controller / tables.dart / video_subtitle_sync_row / subtitle.part.dart。`video_fushi_page.dart` 仅 3 处最小改动（1 字段 + 1 host 接线行 + 字段注释），其余页面侧逻辑全在 layout.part.dart。

https://claude.ai/code/session_01QxNTaiYQB8vnoFBiX3CaqQ