### PR TITLE
feat(header): 手机顶栏显示不全——拥挤时动作收⋯菜单 + 下载页门头统一

### DIFF
--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+
 import 'package:fushi/src/media/manga/manga_module.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_tasks_section.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
@@ -163,6 +165,71 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     );
   }
 
+  /// 统一门头：分段条（资源 / 任务 / 订阅 / 设置）作页头主位 + 页头动作，与其余
+  /// 顶层库页同构。分段条选中态跟随 [TabController]（横滑切页后高亮同步），点段
+  /// 走 animateTo；独立 push 进来（无 home 壳）时在 leading 位保留返回按钮——
+  /// 旧 AppBar 的自动返回键由这里承接。
+  Widget _buildHeader(BuildContext tabContext) {
+    final TabController tabController = DefaultTabController.of(tabContext);
+    final bool canPop = Navigator.of(context).canPop();
+    return AnimatedBuilder(
+      animation: tabController,
+      builder: (BuildContext context, _) {
+        final int index = tabController.index;
+        void select(int value) {
+          if (value != tabController.index) tabController.animateTo(value);
+        }
+
+        return FushiPageHeader.customTitle(
+          leading: canPop
+              ? FushiIconButton(
+                  icon: Icons.arrow_back,
+                  tooltip: t.back,
+                  onTap: () => Navigator.of(context).maybePop(),
+                )
+              : null,
+          title: FushiAdjustableSegmented<int>(
+            values: const <int>[0, 1, 2, 3],
+            selected: index,
+            onChanged: select,
+            focusIdPrefix: 'downloads-tab',
+            focusId: const FushiFocusId('downloads-tab-sections'),
+            child: FushiSegmentedStrip<int>(
+              segments: <ButtonSegment<int>>[
+                ButtonSegment<int>(
+                  value: 0,
+                  label: Text(t.download_resources_tab),
+                ),
+                ButtonSegment<int>(value: 1, label: Text(t.download_tasks_tab)),
+                ButtonSegment<int>(
+                  value: 2,
+                  label: Text(t.download_subscriptions_tab),
+                ),
+                ButtonSegment<int>(value: 3, label: Text(t.settings)),
+              ],
+              selected: index,
+              onChanged: select,
+            ),
+          ),
+          actions: <Widget>[
+            FushiIconButton(
+              icon: Icons.calendar_month_outlined,
+              tooltip: t.download_airing_calendar_title,
+              label: t.download_airing_calendar_title,
+              onTap: () => _openAiringCalendar(tabContext),
+            ),
+            FushiIconButton(
+              icon: Icons.menu_book_outlined,
+              tooltip: t.manga_online_catalog_title,
+              label: t.manga_online_catalog_title,
+              onTap: _openMangaCatalog,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppModel appModel = ref.watch(appProvider);
@@ -185,173 +252,175 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
             // 「下载任务被输入框挤上去」）。关掉 inset 让键盘只覆盖下半部结果/任务区（打字时
             // 本就不看），顶部输入框保持可见、布局不反流。
             resizeToAvoidBottomInset: false,
-            appBar: AppBar(
-              title: Text(t.nav_downloads),
-              bottom: TabBar(
-                // BUG-1184：三个 tab 均分宽度时，窄屏 + 大字号下较长的 tab 名
-                // （英文 Subscriptions）会被裁。可滚动 tab 条按内容取宽，装不下
-                // 就横向滚动而不是裁字。
-                isScrollable: true,
-                tabAlignment: TabAlignment.center,
-                tabs: <Widget>[
-                  Tab(text: t.download_resources_tab),
-                  Tab(text: t.download_tasks_tab),
-                  Tab(text: t.download_subscriptions_tab),
-                  Tab(text: t.settings),
-                ],
-              ),
-              actions: <Widget>[
-                IconButton(
-                  tooltip: t.download_airing_calendar_title,
-                  icon: const Icon(Icons.calendar_month_outlined),
-                  onPressed: () => _openAiringCalendar(tabContext),
-                ),
-                IconButton(
-                  tooltip: t.manga_online_catalog_title,
-                  icon: const Icon(Icons.menu_book_outlined),
-                  onPressed: _openMangaCatalog,
-                ),
-              ],
-            ),
-            body: TabBarView(
-              children: <Widget>[
-                _buildResourceTab(tabContext),
-                // 任务 tab：漫画目录卷下载队列（有任务才占位）+ torrent 任务，
-                // 统一下载中心的同屏任务视图。
-                //
-                // 「同屏只留一份空态」由**旧计划列表**按需折叠实现（BUG-1512）：
-                // 新版任务面板常驻并自带空态与实时指标，旧 AnimeDownloadDialog
-                // 只在真有旧任务时按比例分高度，没有就整块收成 0 高。
-                LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    final double legacyHeight =
-                        (constraints.maxHeight * 0.38).clamp(180, 360);
-                    return Column(
+            // 统一门头（2026-08-13）：与书 / 漫画 / 视频 / 游戏库页同一范式——
+            // FushiPageHeader.customTitle（左对齐分段条）+ FushiIconButton 动作，
+            // 替代旧 AppBar + 居中 TabBar 的独有形态（本页此前是全 app 唯一还在
+            // 用 AppBar 门头的顶层 tab）。分段条与 TabBarView 由同一个
+            // TabController 驱动，横滑切页不受影响；旧 TabBar 的「窄屏可滚不裁
+            // 字」（BUG-1184）由 FushiSegmentedStrip 的同一契约承接。作为 home
+            // tab 时外层已有 SafeArea，这里的 SafeArea 兜的是独立 push 进来
+            // （设置/对话框入口）失去 AppBar 后的状态栏避让，双层无副作用。
+            body: SafeArea(
+              bottom: false,
+              child: Column(
+                children: <Widget>[
+                  if (!isCupertinoPlatform(context)) _buildHeader(tabContext),
+                  Expanded(
+                    child: TabBarView(
                       children: <Widget>[
-                        const MokuroMoeTasksSection(),
-                        Expanded(
-                          child: VideoDownloadJobsPanel.database(
-                            database: ref.read(appProvider).database,
-                            metricsLoader: ref
-                                .read(appProvider)
-                                .videoDownloadPipelineService
-                                ?.loadTaskSnapshots,
-                            onRetry: (VideoDownloadJobRow job) async {
-                              await ref
-                                  .read(appProvider)
-                                  .videoDownloadPipelineService
-                                  ?.retryJob(job.jobId);
-                            },
-                            onResume: (VideoDownloadJobRow job) async {
-                              await ref
-                                  .read(appProvider)
-                                  .videoDownloadPipelineService
-                                  ?.resumeJob(job.jobId);
-                            },
-                            onCancel: (VideoDownloadJobRow job) async {
-                              await ref
-                                  .read(appProvider)
-                                  .videoDownloadPipelineService
-                                  ?.cancelJob(job.jobId);
-                            },
-                            onOpenDetails: (VideoDownloadJobRow job) async {
-                              final appModel = ref.read(appProvider);
-                              final pipeline =
-                                  appModel.videoDownloadPipelineService;
-                              final details = pipeline != null
-                                  ? await pipeline.loadJobDetails(job.jobId)
-                                  : buildPersistedVideoDownloadJobDetails(
-                                      job,
-                                      await appModel.database
-                                          .getVideoDownloadJobFiles(job.jobId),
-                                    );
-                              if (!context.mounted) return;
-                              final String torrentId =
-                                  (job.backendTaskId ?? job.torrentHash ?? '')
-                                      .trim();
-                              await showAppDialog<void>(
-                                context: context,
-                                builder: (BuildContext dialogContext) =>
-                                    TorrentTaskDetailDialog.task(
-                                  torrentId: torrentId,
-                                  title: job.title,
-                                  torrentTitle:
-                                      job.resourceTitle?.trim().isNotEmpty ==
-                                              true
-                                          ? job.resourceTitle!.trim()
-                                          : job.title,
-                                  backendOverride: details.backend,
-                                  liveDataAbsence: details.liveDataAbsence,
-                                  initialSnapshot: details.snapshot,
-                                  initialFiles: details.files,
+                        _buildResourceTab(tabContext),
+                        // 任务 tab：漫画目录卷下载队列（有任务才占位）+ torrent 任务，
+                        // 统一下载中心的同屏任务视图。
+                        //
+                        // 「同屏只留一份空态」由**旧计划列表**按需折叠实现（BUG-1512）：
+                        // 新版任务面板常驻并自带空态与实时指标，旧 AnimeDownloadDialog
+                        // 只在真有旧任务时按比例分高度，没有就整块收成 0 高。
+                        LayoutBuilder(
+                          builder: (BuildContext context,
+                              BoxConstraints constraints) {
+                            final double legacyHeight =
+                                (constraints.maxHeight * 0.38).clamp(180, 360);
+                            return Column(
+                              children: <Widget>[
+                                const MokuroMoeTasksSection(),
+                                Expanded(
+                                  child: VideoDownloadJobsPanel.database(
+                                    database: ref.read(appProvider).database,
+                                    metricsLoader: ref
+                                        .read(appProvider)
+                                        .videoDownloadPipelineService
+                                        ?.loadTaskSnapshots,
+                                    onRetry: (VideoDownloadJobRow job) async {
+                                      await ref
+                                          .read(appProvider)
+                                          .videoDownloadPipelineService
+                                          ?.retryJob(job.jobId);
+                                    },
+                                    onResume: (VideoDownloadJobRow job) async {
+                                      await ref
+                                          .read(appProvider)
+                                          .videoDownloadPipelineService
+                                          ?.resumeJob(job.jobId);
+                                    },
+                                    onCancel: (VideoDownloadJobRow job) async {
+                                      await ref
+                                          .read(appProvider)
+                                          .videoDownloadPipelineService
+                                          ?.cancelJob(job.jobId);
+                                    },
+                                    onOpenDetails:
+                                        (VideoDownloadJobRow job) async {
+                                      final appModel = ref.read(appProvider);
+                                      final pipeline =
+                                          appModel.videoDownloadPipelineService;
+                                      final details = pipeline != null
+                                          ? await pipeline
+                                              .loadJobDetails(job.jobId)
+                                          : buildPersistedVideoDownloadJobDetails(
+                                              job,
+                                              await appModel.database
+                                                  .getVideoDownloadJobFiles(
+                                                      job.jobId),
+                                            );
+                                      if (!context.mounted) return;
+                                      final String torrentId =
+                                          (job.backendTaskId ??
+                                                  job.torrentHash ??
+                                                  '')
+                                              .trim();
+                                      await showAppDialog<void>(
+                                        context: context,
+                                        builder: (BuildContext dialogContext) =>
+                                            TorrentTaskDetailDialog.task(
+                                          torrentId: torrentId,
+                                          title: job.title,
+                                          torrentTitle: job.resourceTitle
+                                                      ?.trim()
+                                                      .isNotEmpty ==
+                                                  true
+                                              ? job.resourceTitle!.trim()
+                                              : job.title,
+                                          backendOverride: details.backend,
+                                          liveDataAbsence:
+                                              details.liveDataAbsence,
+                                          initialSnapshot: details.snapshot,
+                                          initialFiles: details.files,
+                                        ),
+                                      );
+                                    },
+                                    onSetPriority: (VideoDownloadJobRow job,
+                                        int priority) async {
+                                      final pipeline = ref
+                                          .read(appProvider)
+                                          .videoDownloadPipelineService;
+                                      await pipeline?.setJobPriority(
+                                        job.jobId,
+                                        priority,
+                                      );
+                                    },
+                                    locationLoader:
+                                        (VideoDownloadJobRow job) async {
+                                      final pipeline = ref
+                                          .read(appProvider)
+                                          .videoDownloadPipelineService;
+                                      return pipeline == null
+                                          ? null
+                                          : await pipeline
+                                              .resolveJobLocation(job.jobId);
+                                    },
+                                    onDelete: (job,
+                                        {required bool deleteFiles}) async {
+                                      final appModel = ref.read(appProvider);
+                                      final pipeline =
+                                          appModel.videoDownloadPipelineService;
+                                      if (pipeline != null) {
+                                        await pipeline.deleteJob(
+                                          job.jobId,
+                                          deleteFiles: deleteFiles,
+                                        );
+                                      } else {
+                                        await deletePersistedVideoDownloadJob(
+                                          database: appModel.database,
+                                          job: job,
+                                          deleteFiles: deleteFiles,
+                                        );
+                                      }
+                                    },
+                                  ),
                                 ),
-                              );
-                            },
-                            onSetPriority:
-                                (VideoDownloadJobRow job, int priority) async {
-                              final pipeline = ref
-                                  .read(appProvider)
-                                  .videoDownloadPipelineService;
-                              await pipeline?.setJobPriority(
-                                job.jobId,
-                                priority,
-                              );
-                            },
-                            locationLoader: (VideoDownloadJobRow job) async {
-                              final pipeline = ref
-                                  .read(appProvider)
-                                  .videoDownloadPipelineService;
-                              return pipeline == null
-                                  ? null
-                                  : await pipeline
-                                      .resolveJobLocation(job.jobId);
-                            },
-                            onDelete: (job, {required bool deleteFiles}) async {
-                              final appModel = ref.read(appProvider);
-                              final pipeline =
-                                  appModel.videoDownloadPipelineService;
-                              if (pipeline != null) {
-                                await pipeline.deleteJob(
-                                  job.jobId,
-                                  deleteFiles: deleteFiles,
-                                );
-                              } else {
-                                await deletePersistedVideoDownloadJob(
-                                  database: appModel.database,
-                                  job: job,
-                                  deleteFiles: deleteFiles,
-                                );
-                              }
-                            },
-                          ),
+                                SizedBox(
+                                  height:
+                                      _hasLegacyAnimeTasks ? legacyHeight : 0,
+                                  child: Offstage(
+                                    offstage: !_hasLegacyAnimeTasks,
+                                    child: AnimeDownloadDialog(
+                                      embedded: true,
+                                      tasksOnly: true,
+                                      showTasks: false,
+                                      onTaskPresenceChanged:
+                                          _setLegacyAnimeTaskPresence,
+                                      onOpenSettings: () =>
+                                          DefaultTabController.of(
+                                        tabContext,
+                                      ).animateTo(3),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            );
+                          },
                         ),
-                        SizedBox(
-                          height: _hasLegacyAnimeTasks ? legacyHeight : 0,
-                          child: Offstage(
-                            offstage: !_hasLegacyAnimeTasks,
-                            child: AnimeDownloadDialog(
-                              embedded: true,
-                              tasksOnly: true,
-                              showTasks: false,
-                              onTaskPresenceChanged:
-                                  _setLegacyAnimeTaskPresence,
-                              onOpenSettings: () => DefaultTabController.of(
-                                tabContext,
-                              ).animateTo(3),
-                            ),
-                          ),
+                        const VideoDownloadSubscriptionsPanel(),
+                        ListView(
+                          children: const <Widget>[
+                            TorrentSettingsSection(constrainWidth: false),
+                          ],
                         ),
                       ],
-                    );
-                  },
-                ),
-                const VideoDownloadSubscriptionsPanel(),
-                ListView(
-                  children: const <Widget>[
-                    TorrentSettingsSection(constrainWidth: false),
-                  ],
-                ),
-              ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ));

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -1838,7 +1838,11 @@ class FushiPageHeader extends StatelessWidget {
             tokens: tokens,
             leading: leading,
             title: resolvedTitle,
-            actions: actions.isEmpty ? null : _buildActionRow(tokens),
+            actionItems: actions,
+            // 只有 customTitle（标题位是分段导航等自报宽度的组件）才启用
+            // 「左边摆不下就把动作收进 ⋯ 菜单」；纯文字标题自身可省略号收缩，
+            // 维持既有行为。
+            collapseWhenCramped: titleWidget != null,
             centerVertically: titleWidget != null,
           ),
           if (bottom != null)
@@ -1850,19 +1854,34 @@ class FushiPageHeader extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildActionRow(FushiDesignTokens tokens) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        for (int index = 0; index < actions.length; index++) ...<Widget>[
-          if (index > 0) SizedBox(width: tokens.spacing.gap / 2),
-          actions[index],
-        ],
-      ],
-    );
-  }
+/// 页头下发给标题位组件的「自报自然宽」通道。
+///
+/// 动因（2026-08-13 手机顶栏显示不全）：页头一行同时放分段导航（标题位）和一排
+/// 动作按钮，两边都想要宽度；窄屏上动作区按自然宽优先拿，分段条被挤到只剩一小截。
+/// 「动作何时该收进 ⋯ 菜单」的正确判据是**标题位的自然宽 + 动作自然宽 > 行宽**，
+/// 而标题位是任意 widget，页头无法自行估宽——由标题位里的分段条（自然宽是纯
+/// build 期可算量）经本作用域上报。没有上报（纯文字标题等）就永不收纳。
+///
+/// 上报发生在子组件 build 期，回调内部经 post-frame 才 setState，且同值去重——
+/// 估宽只依赖标签/字号/缩放，不依赖布局结果，不会形成布局反馈振荡。
+class FushiHeaderCrampScope extends InheritedWidget {
+  const FushiHeaderCrampScope({
+    required this.reportTitleNaturalWidth,
+    required super.child,
+    super.key,
+  });
+
+  /// 标题位组件在 build 期上报自己的自然宽（逻辑像素）。
+  final void Function(double width) reportTitleNaturalWidth;
+
+  /// 静态查找（不建立依赖：回调每次 build 重建，依赖会造成无谓的子树重建）。
+  static FushiHeaderCrampScope? maybeOf(BuildContext context) =>
+      context.getInheritedWidgetOfExactType<FushiHeaderCrampScope>();
+
+  @override
+  bool updateShouldNotify(FushiHeaderCrampScope oldWidget) => false;
 }
 
 /// TODO-1126 / BUG-541: [FushiPageHeader] 的标题 + 动作行。
@@ -1881,29 +1900,144 @@ class FushiPageHeader extends StatelessWidget {
 /// [SingleChildScrollView] 收缩 + 可横滚兜底，消除 RenderFlex overflow，滚动起始边在
 /// 左、最左侧动作（回归态被裁的 [Icons.add]）默认可见。三个 home tab（视频/书架/词典）
 /// 页头均无 leading + actions 并存，故不必为 leading 额外预留。
-class _FushiPageHeaderRow extends StatelessWidget {
+class _FushiPageHeaderRow extends StatefulWidget {
   const _FushiPageHeaderRow({
     required this.tokens,
     required this.title,
     required this.leading,
-    required this.actions,
+    required this.actionItems,
+    required this.collapseWhenCramped,
     required this.centerVertically,
   });
 
   final FushiDesignTokens tokens;
   final Widget title;
   final Widget? leading;
-  final Widget? actions;
+  final List<Widget> actionItems;
+
+  /// true（customTitle 模式）时，若标题位上报的自然宽 + 动作自然宽超过行宽，
+  /// 把可收纳的动作（[FushiIconButton]）折进一个 ⋯ 菜单，把宽度还给标题位。
+  final bool collapseWhenCramped;
   final bool centerVertically;
+
+  @override
+  State<_FushiPageHeaderRow> createState() => _FushiPageHeaderRowState();
+}
+
+class _FushiPageHeaderRowState extends State<_FushiPageHeaderRow> {
+  FushiDesignTokens get tokens => widget.tokens;
+
+  /// 标题位（经 [FushiHeaderCrampScope]）最近一次上报的自然宽；null = 从未上报
+  /// （纯文字标题等），永不收纳。
+  double? _titleNaturalWidth;
+
+  void _onTitleWidthReported(double width) {
+    if (_titleNaturalWidth == width) return;
+    // 上报发生在子组件 build 期，不能同帧 setState；post-frame 再落。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _titleNaturalWidth == width) return;
+      setState(() => _titleNaturalWidth = width);
+    });
+  }
+
+  /// 动作区自然宽估算（图标形态）：[FushiIconButton] = 图标 + 内边距；其它
+  /// widget 给一个按钮级的保守值。只在非展开标签（<840）的窄行场景使用。
+  double _estimateActionsWidth(List<Widget> items) {
+    double total = 0;
+    for (int index = 0; index < items.length; index++) {
+      if (index > 0) total += tokens.spacing.gap / 2;
+      final Widget item = items[index];
+      if (item is FushiIconButton) {
+        final double icon = item.size ?? 24.0;
+        final EdgeInsets padding =
+            item.padding ?? EdgeInsets.all(tokens.spacing.gap);
+        total += icon + padding.horizontal;
+      } else {
+        total += 48.0;
+      }
+    }
+    return total;
+  }
+
+  Widget _buildActionRow(List<Widget> items) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        for (int index = 0; index < items.length; index++) ...<Widget>[
+          if (index > 0) SizedBox(width: tokens.spacing.gap / 2),
+          items[index],
+        ],
+      ],
+    );
+  }
+
+  /// ⋯ 溢出按钮：菜单项由被收纳的 [FushiIconButton] 的图标 + 文案（label 优先、
+  /// 回退 tooltip）就地派生，动作行为共享同一个 onTap，不复制第二份实现。
+  Widget _buildOverflowMenuButton(List<FushiIconButton> collapsed) {
+    return Builder(
+      builder: (BuildContext anchorContext) => FushiIconButton(
+        icon: Icons.more_vert,
+        tooltip: t.common_more_actions,
+        onTap: () => _showOverflowMenu(anchorContext, collapsed),
+      ),
+    );
+  }
+
+  Future<void> _showOverflowMenu(
+    BuildContext anchorContext,
+    List<FushiIconButton> collapsed,
+  ) async {
+    final RenderBox button = anchorContext.findRenderObject()! as RenderBox;
+    final RenderBox overlay = Navigator.of(anchorContext)
+        .overlay!
+        .context
+        .findRenderObject()! as RenderBox;
+    final RelativeRect position = RelativeRect.fromRect(
+      Rect.fromPoints(
+        button.localToGlobal(Offset.zero, ancestor: overlay),
+        button.localToGlobal(
+          button.size.bottomRight(Offset.zero),
+          ancestor: overlay,
+        ),
+      ),
+      Offset.zero & overlay.size,
+    );
+    final FushiIconButton? choice = await showMenu<FushiIconButton>(
+      context: anchorContext,
+      position: position,
+      items: <PopupMenuEntry<FushiIconButton>>[
+        for (final FushiIconButton action in collapsed)
+          PopupMenuItem<FushiIconButton>(
+            value: action,
+            enabled: action.enabled && action.onTap != null,
+            child: Row(
+              children: <Widget>[
+                Icon(action.icon, size: 20),
+                const SizedBox(width: 12),
+                Expanded(child: Text(action.label ?? action.tooltip)),
+              ],
+            ),
+          ),
+      ],
+    );
+    await choice?.onTap?.call();
+  }
 
   @override
   Widget build(BuildContext context) {
     final double leadingGap = tokens.spacing.gap + 4;
     final double actionsGap = tokens.spacing.gap;
+    final Widget? leading = widget.leading;
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final Widget titleChild = Expanded(child: title);
+        final Widget titleChild = Expanded(
+          child: FushiHeaderCrampScope(
+            reportTitleNaturalWidth: _onTitleWidthReported,
+            child: widget.title,
+          ),
+        );
 
         final List<Widget> children = <Widget>[];
         if (leading != null) {
@@ -1918,7 +2052,7 @@ class _FushiPageHeaderRow extends StatelessWidget {
           );
         }
         children.add(titleChild);
-        if (actions != null) {
+        if (widget.actionItems.isNotEmpty) {
           // 动作区可用宽上界：整行宽减去动作前 gap，**再减去留给标题的保底宽**。
           // leading（含右 gap）作为非弹性子项另行占位，不计入此上界——它在 Row 里已被
           // 独立扣除；这里只需保证「gap + 动作区」不超过整行宽即可避免 overflow。
@@ -1949,6 +2083,33 @@ class _FushiPageHeaderRow extends StatelessWidget {
                     FushiAppUiScale.of(context),
                   ) ==
                   WindowSizeClass.expanded;
+
+          // 2026-08-13 手机顶栏显示不全：标题位是分段导航时（customTitle），
+          // 「标题自然宽 + 动作自然宽」超过行宽才把可收纳动作折进 ⋯ 菜单——
+          // 摆得下就一个不收（用户定案：仅在左边位置不够时才变）。宽窗药丸
+          // 形态（expandLabels）永不收纳。可收纳 <2 个时收了也省不出宽度，
+          // 维持原样让滚动兜底。
+          List<Widget> resolvedItems = widget.actionItems;
+          if (widget.collapseWhenCramped &&
+              !expandLabels &&
+              _titleNaturalWidth != null &&
+              constraints.maxWidth.isFinite) {
+            final double needed = _titleNaturalWidth! +
+                actionsGap +
+                _estimateActionsWidth(widget.actionItems);
+            final List<FushiIconButton> collapsible = widget.actionItems
+                .whereType<FushiIconButton>()
+                .where((FushiIconButton b) => b.onTap != null)
+                .toList(growable: false);
+            if (needed > constraints.maxWidth && collapsible.length >= 2) {
+              resolvedItems = <Widget>[
+                for (final Widget item in widget.actionItems)
+                  if (item is! FushiIconButton || item.onTap == null) item,
+                _buildOverflowMenuButton(collapsible),
+              ];
+            }
+          }
+
           children
             ..add(SizedBox(width: actionsGap))
             ..add(
@@ -1960,7 +2121,7 @@ class _FushiPageHeaderRow extends StatelessWidget {
                     physics: const ClampingScrollPhysics(),
                     child: FushiHeaderLabelScope(
                       expandLabels: expandLabels,
-                      child: actions!,
+                      child: _buildActionRow(resolvedItems),
                     ),
                   ),
                 ),
@@ -1969,7 +2130,7 @@ class _FushiPageHeaderRow extends StatelessWidget {
         }
 
         return Row(
-          crossAxisAlignment: centerVertically
+          crossAxisAlignment: widget.centerVertically
               ? CrossAxisAlignment.center
               : CrossAxisAlignment.start,
           children: children,

--- a/fushi/lib/src/utils/components/settings_shared.dart
+++ b/fushi/lib/src/utils/components/settings_shared.dart
@@ -1,3 +1,4 @@
+import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -1118,26 +1119,144 @@ class FushiSegmentedStrip<T extends Object> extends StatelessWidget {
       style: style,
     );
 
+    // 分段条自然宽是纯 build 期可算量（只依赖标签/字号/缩放，不依赖布局）。
+    // 先算出来：页头（[FushiHeaderCrampScope]）用它判定「左边是否摆得下」，
+    // LayoutBuilder 里再用同一个值决定滚动兜底。
+    final double estimated = estimateSegmentedStripWidth(
+      segmentLabels: segmentLabels,
+      fontSize: fontSize,
+      textScaleFactor: textScale,
+    );
+    FushiHeaderCrampScope.maybeOf(context)?.reportTitleNaturalWidth(estimated);
+    final int selectedIndex =
+        segments.indexWhere((ButtonSegment<T> s) => s.value == selected);
+
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double available = constraints.maxWidth;
-        final double estimated = estimateSegmentedStripWidth(
-          segmentLabels: segmentLabels,
-          fontSize: fontSize,
-          textScaleFactor: textScale,
-        );
         final bool fits = available.isFinite && estimated <= available;
         if (fits) return Align(alignment: alignment, child: strip);
         // 与上面 [_SegmentedStripHost] 同一契约：装不下就横向滚动，且桌面端要能用
         // 鼠标左键拖着滚（默认 dragDevices 不含 mouse，否则只有滚轮能动）。段内
         // 只有点击目标、没有横拖手势，不存在竞技场之争。
+        // 滚动兜底带两侧渐隐 + 选中段自动滚入可视区（可发现性：此前被截断的
+        // 尾部分段没有任何「还有更多」的提示，用户以为 tab 没了）。
         return HorizontalDragScrollable(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: strip,
+          child: _SegmentedStripScroller(
+            strip: strip,
+            segmentLabels: segmentLabels,
+            selectedIndex: selectedIndex,
+            fontSize: fontSize,
+            textScale: textScale,
           ),
         );
       },
+    );
+  }
+}
+
+/// 分段条溢出滚动器：横向滚动 + 两侧渐隐边缘 + 选中段自动滚入可视区。
+///
+/// 渐隐边缘明示「这排还有更多段」——此前的硬截断没有任何提示，手机窄屏上用户
+/// 以为尾部 tab 不存在。选中段偏移用与 [estimateSegmentedStripWidth] 同一套
+/// 每段估宽累加（纯 build 期可算，不需要真实测量），误差被余量吸收。
+class _SegmentedStripScroller extends StatefulWidget {
+  const _SegmentedStripScroller({
+    required this.strip,
+    required this.segmentLabels,
+    required this.selectedIndex,
+    required this.fontSize,
+    required this.textScale,
+  });
+
+  final Widget strip;
+  final List<String?> segmentLabels;
+  final int selectedIndex;
+  final double fontSize;
+  final double textScale;
+
+  @override
+  State<_SegmentedStripScroller> createState() =>
+      _SegmentedStripScrollerState();
+}
+
+class _SegmentedStripScrollerState extends State<_SegmentedStripScroller> {
+  final ScrollController _controller = ScrollController();
+
+  /// 让相邻段露出一截的余量：既是视觉提示（还有前/后段），也抵消估宽误差。
+  static const double _kRevealMargin = 24.0;
+
+  @override
+  void initState() {
+    super.initState();
+    // 首帧后定位（jump 不动画）：打开页面时选中段就在可视区内。
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _ensureSelectedVisible(animate: false),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _SegmentedStripScroller oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedIndex != widget.selectedIndex) {
+      _ensureSelectedVisible(animate: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  double _segmentWidth(String? label) {
+    final double content = (label == null || label.isEmpty)
+        ? _kSegmentIconOnlyWidth
+        : label.characters.length *
+            widget.fontSize *
+            widget.textScale *
+            _kSegmentGlyphWidthFactor;
+    return content + _kSegmentHorizontalChrome;
+  }
+
+  void _ensureSelectedVisible({required bool animate}) {
+    if (!mounted || !_controller.hasClients) return;
+    final int index = widget.selectedIndex;
+    if (index < 0 || index >= widget.segmentLabels.length) return;
+    double start = 0;
+    for (int i = 0; i < index; i++) {
+      start += _segmentWidth(widget.segmentLabels[i]);
+    }
+    final double end = start + _segmentWidth(widget.segmentLabels[index]);
+    final ScrollPosition position = _controller.position;
+    final double viewport = position.viewportDimension;
+    double? target;
+    if (start - _kRevealMargin < position.pixels) {
+      target = start - _kRevealMargin;
+    } else if (end + _kRevealMargin > position.pixels + viewport) {
+      target = end + _kRevealMargin - viewport;
+    }
+    if (target == null) return;
+    final double clamped = target.clamp(0.0, position.maxScrollExtent);
+    if (animate) {
+      _controller.animateTo(
+        clamped,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+      );
+    } else {
+      _controller.jumpTo(clamped);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadingEdgeScrollView.fromSingleChildScrollView(
+      child: SingleChildScrollView(
+        controller: _controller,
+        scrollDirection: Axis.horizontal,
+        child: widget.strip,
+      ),
     );
   }
 }

--- a/fushi/pubspec.lock
+++ b/fushi/pubspec.lock
@@ -520,7 +520,7 @@ packages:
     source: hosted
     version: "2.2.0"
   fading_edge_scrollview:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../third_party/fading_edge_scrollview"
       relative: true

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   dynamic_color: ^1.7.0
   external_app_launcher: ^4.0.3
   external_path: ^2.2.0
+  # 分段条溢出滚动的渐隐边缘（vendored，见 dependency_overrides）。
+  fading_edge_scrollview: ^3.0.0
   file_picker: ^8.0.0
   float_column: ^4.0.3
   # Cross-platform game controllers (GameInput / GameController / evdev).

--- a/fushi/test/pages/downloads_header_unified_guard_test.dart
+++ b/fushi/test/pages/downloads_header_unified_guard_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 门头统一守卫（2026-08-13 用户定案）：下载页此前是全 app 唯一还在用
+/// `AppBar + 居中 TabBar` 门头的顶层 tab，与书 / 漫画 / 视频 / 游戏库页的
+/// `FushiPageHeader.customTitle`（左对齐分段条 + FushiIconButton 动作）不一致。
+/// 本守卫钉死统一后的形态不被回退。
+///
+/// 注释与三引号语料先经 [maskCommentsAndScriptLines] 掩掉：源文件的说明注释里
+/// 会提到旧 AppBar 与新范式的名字，裸 contains 会两个方向都误判。
+void main() {
+  test('下载页门头走 FushiPageHeader.customTitle 分段条范式，不再用 AppBar', () {
+    final File f = File('lib/src/pages/implementations/downloads_page.dart');
+    expect(f.existsSync(), isTrue,
+        reason: '找不到 downloads_page.dart（路径变了要同步本守卫）');
+    final String code = maskCommentsAndScriptLines(f.readAsStringSync());
+
+    expect(code, contains('FushiPageHeader.customTitle'),
+        reason: '下载页门头必须与其余顶层库页同范式（分段条作页头主位）');
+    expect(code, contains('FushiSegmentedStrip<int>'),
+        reason: '子页导航必须是统一的分段条组件（可滚不裁字契约由它承接）');
+    expect(code, isNot(contains('appBar: AppBar(')),
+        reason: '不得回退到独有的 AppBar 门头（与其它库页不一致）');
+    expect(code, isNot(contains('bottom: TabBar(')),
+        reason: '不得回退到 AppBar 内嵌居中 TabBar 的旧形态');
+  });
+}

--- a/fushi/test/widgets/fushi_page_header_cramped_collapse_test.dart
+++ b/fushi/test/widgets/fushi_page_header_cramped_collapse_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/components/settings_shared.dart';
+import 'package:fushi/utils.dart';
+
+/// 2026-08-13 手机顶栏显示不全：页头（customTitle 分段导航形态）在「分段条自然宽
+/// + 动作自然宽 > 行宽」时把可收纳动作折进 ⋯ 菜单，把宽度还给分段条；摆得下时
+/// 一个都不收（用户定案：仅在左边位置不够时才变）。
+void main() {
+  Widget host({
+    required double width,
+    required List<Widget> actions,
+    int segmentCount = 6,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: width,
+            child: FushiPageHeader.customTitle(
+              title: FushiSegmentedStrip<int>(
+                segments: <ButtonSegment<int>>[
+                  for (int i = 0; i < segmentCount; i++)
+                    ButtonSegment<int>(value: i, label: Text('分段$i')),
+                ],
+                selected: 0,
+                onChanged: (_) {},
+              ),
+              actions: actions,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> buildActions(List<String> tapped) => <Widget>[
+        for (int i = 0; i < 4; i++)
+          FushiIconButton(
+            icon: Icons.star_border,
+            tooltip: 'action-$i',
+            onTap: () => tapped.add('action-$i'),
+          ),
+      ];
+
+  testWidgets('窄行放不下：动作收进 ⋯ 菜单，菜单项可触发原动作', (WidgetTester tester) async {
+    final List<String> tapped = <String>[];
+    await tester.pumpWidget(host(width: 360, actions: buildActions(tapped)));
+    // 分段条 build 期上报自然宽 → 页头 post-frame setState 收纳，需再泵一帧。
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byIcon(Icons.more_vert), findsOneWidget,
+        reason: '360dp 行宽放不下 6 段 + 4 动作，必须出现 ⋯ 溢出按钮');
+    expect(find.byIcon(Icons.star_border), findsNothing,
+        reason: '被收纳的动作不应再以图标形态占页头宽度');
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(find.text('action-2'), findsOneWidget,
+        reason: '菜单项以动作的 tooltip 文案呈现');
+    await tester.tap(find.text('action-2'));
+    await tester.pumpAndSettle();
+    expect(tapped, <String>['action-2'], reason: '菜单项必须触发原动作的 onTap');
+  });
+
+  testWidgets('行宽足够：一个动作都不收，无 ⋯ 按钮', (WidgetTester tester) async {
+    final List<String> tapped = <String>[];
+    await tester.pumpWidget(host(width: 760, actions: buildActions(tapped)));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byIcon(Icons.more_vert), findsNothing,
+        reason: '放得下时不收纳（仅在左边位置不够时才变）');
+    expect(find.byIcon(Icons.star_border), findsNWidgets(4));
+  });
+
+  testWidgets('纯文字标题（非 customTitle 分段形态）永不收纳', (WidgetTester tester) async {
+    final List<String> tapped = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: FushiPageHeader(
+                title: '一个很长很长很长很长很长很长的页面标题',
+                actions: buildActions(tapped),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byIcon(Icons.more_vert), findsNothing,
+        reason: '文字标题自身可省略号收缩，维持既有行为');
+    expect(find.byIcon(Icons.star_border), findsNWidgets(4));
+  });
+}

--- a/fushi/test/widgets/segmented_strip_overflow_scroll_test.dart
+++ b/fushi/test/widgets/segmented_strip_overflow_scroll_test.dart
@@ -1,0 +1,59 @@
+import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/components/settings_shared.dart';
+
+/// 分段条溢出滚动的可发现性补强（2026-08-13 手机顶栏显示不全）：
+/// 装不下时的横向滚动必须带渐隐边缘（明示还有更多段），且选中段自动滚入可视区
+/// （打开即可见选中段、程序切段后不停留在看不见选中段的位置）。
+void main() {
+  Widget host({required int selected, ValueChanged<int>? onChanged}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 160,
+            child: FushiSegmentedStrip<int>(
+              segments: <ButtonSegment<int>>[
+                for (int i = 0; i < 8; i++)
+                  ButtonSegment<int>(value: i, label: Text('分段$i')),
+              ],
+              selected: selected,
+              onChanged: onChanged ?? (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  ScrollController controllerOf(WidgetTester tester) {
+    final SingleChildScrollView scrollView = tester.widget<SingleChildScrollView>(
+      find.descendant(
+        of: find.byType(FadingEdgeScrollView),
+        matching: find.byType(SingleChildScrollView),
+      ),
+    );
+    return scrollView.controller!;
+  }
+
+  testWidgets('装不下时滚动兜底带渐隐边缘', (WidgetTester tester) async {
+    await tester.pumpWidget(host(selected: 0));
+    await tester.pump();
+    expect(find.byType(FadingEdgeScrollView), findsOneWidget,
+        reason: '截断的分段条必须有「还有更多」的渐隐提示');
+  });
+
+  testWidgets('打开时选中段自动滚入可视区；切回首段滚回起点', (WidgetTester tester) async {
+    await tester.pumpWidget(host(selected: 7));
+    // 首帧 post-frame jumpTo 定位。
+    await tester.pump();
+    expect(controllerOf(tester).offset, greaterThan(0),
+        reason: '选中尾段时不应停在起点（选中段在可视区外）');
+
+    await tester.pumpWidget(host(selected: 0));
+    await tester.pumpAndSettle();
+    expect(controllerOf(tester).offset, 0,
+        reason: '切回首段应动画滚回起点让它可见');
+  });
+}


### PR DESCRIPTION
## 背景（2026-08-13 用户反馈）

1. **手机顶栏显示不全**：页头一行同时放分段导航（视频 6 段）与一排动作按钮，窄屏上动作区按自然宽优先拿，分段条被挤到只剩一小截；滚动兜底无任何可发现性提示。用户定案方案 C 加约束：**仅在左边位置不够时**才把动作收进 ⋯，够放就一个不收。
2. **下载页门头不统一**：下载页是全 app 唯一还用 `AppBar + 居中 TabBar` 门头的顶层 tab。

## 改动

**commit 1 — 页头拥挤收纳 + 分段条滚动补强**
- 新增 `FushiHeaderCrampScope`：分段条 build 期上报自然宽（纯 build 期可算，无布局反馈振荡），页头以「标题自然宽 + 动作自然宽 > 行宽」**精确判定**拥挤，才把可收纳动作（FushiIconButton）折进 ⋯ 菜单；菜单项就地派生自按钮的图标+文案，共享同一 onTap。纯文字标题页头、宽窗药丸形态、可收纳 <2 个时均维持现状
- `FushiSegmentedStrip` 溢出滚动加渐隐边缘（vendored fading_edge_scrollview，已补 pubspec 声明）+ 选中段自动滚入可视区

**commit 2 — 下载页门头统一**
- `AppBar+TabBar` → `FushiPageHeader.customTitle`（分段条：资源/任务/订阅/设置）+ FushiIconButton 动作，与书/漫画/视频/游戏库页同构；TabController 复用（横滑切页高亮同步）；独立 push 入口 leading 位保留返回键；`resizeToAvoidBottomInset:false`（BUG-1003）与全宽守卫不动

## 验证

- `flutter analyze` 全量零问题
- 新增 3 个测试文件：页头收纳三态（收/不收/纯文字不收）、滚动渐隐+选中定位、下载页门头源码守卫（`maskCommentsAndScriptLines` 防注释假绿，**变异实测**：改坏源文件守卫即红、逆向还原零残留）
- `test/widgets` + `test/tools` 全批 + 下载/页头/游戏/壳相关页测试：除 1 条**develop 基底自带**的红（`video_chrome_colors_test` 的「无游离字面 alpha」，`layout.part.dart:947` 的 `alpha: 0.92`，来自刚合入的视频字幕 PR #819，与本 PR 无关、需视频侧修）外全绿

## 关联

- 与 PR #818（导入入口统一）独立：本 PR 基于最新 develop，两者无文件冲突（#818 改库页/导入域，本 PR 改共享页头组件+下载页）；游戏 5 段、书漫视频的「导入」分段在 #818 合入后同样受益于本收纳逻辑

https://claude.ai/code/session_014WqPPby7otTBh1Gz9QJPpR