### PR TITLE
feat(interconnect): Lapis 可视化配置经互联作用于主机 Anki，手机端可用

### DIFF
--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -254,7 +254,8 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   // ── Lapis 样式客制化（备份/恢复/应用见 LapisTemplateService）──────────
 
   /// 当前后端能否读写已存在 note type 的模板（AnkiConnect true；AnkiDroid /
-  /// AnkiMobile false，设置页据此隐藏 Lapis 样式区）。
+  /// AnkiMobile false，设置页据此隐藏 Lapis 样式区）。开启「制卡到已配对设备」
+  /// 时恒 true——模板读写经互联作用于主机端 Anki，手机端因此也能可视化配置。
   bool get supportsNoteTypeEditing => _repository.supportsNoteTypeEditing;
 
   /// 与当前仓库绑定的模板服务（无状态，随用随建）。

--- a/fushi/lib/src/anki/remote_mining_anki_repository.dart
+++ b/fushi/lib/src/anki/remote_mining_anki_repository.dart
@@ -25,6 +25,11 @@ typedef RemoteMiningAuthReporter = void Function(String message);
 /// （[fetchConfiguration]/[createDeck]/[createNoteType]）委派给包装的本地仓库 [_local]，
 /// 以便设置页在开关开启时仍能正常配置本地 Anki（供开关关闭时使用）。
 ///
+/// **Lapis 模板读写例外**（[readNoteTypeDefinition]/[updateNoteTypeStyling]/
+/// [updateNoteTypeTemplates]）：跟随制卡落点经互联作用于**主机端**卡型——卡落在
+/// 主机上，样式客制化就必须改主机的模板；这同时让手机端（AnkiDroid 无模板 API）
+/// 第一次拥有可视化配置 Lapis 的通道。
+///
 /// 覆盖/查看类方法（[updateMinedNote]/[findOverwriteTargetNoteId]/[findMatchingNotes]/
 /// [noteFields]/[openNoteInAnki]）保留基类降级默认（不委派本地——那会在远端制卡时错误地
 /// 操作**本机** Anki 的卡片；远端 note id 本就为 null，本会话覆写第三态不激活，与 AnkiDroid
@@ -272,23 +277,33 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
   Future<bool> createNoteType(AnkiNoteTypeTemplate template) =>
       _local.createNoteType(template);
 
-  // Lapis 模板读写也是配置类：委派本地仓库（设置页在「制卡到已配对设备」
-  // 开启时仍配置/备份/客制化本机 Anki 的模板，与 createNoteType 同语义）。
+  // ---- Lapis 模板读写：跟随制卡落点，经互联作用于**主机端**卡型 ----
+  //
+  // 开关开启时卡片落在已配对主机的 Anki 上，样式客制化/备份/恢复必须作用于
+  // 同一个 Anki——委派本地会在手机上把整个 Lapis 区隐藏（AnkiDroid 无模板
+  // API，这正是「可视化配置 Lapis 不支持手机端」的根因），在桌面上则改到
+  // 一个根本不落卡的本机 Anki。这也是手机端唯一的模板编辑通道（平台边界：
+  // AnkiDroid / AnkiMobile 均无改已存在模板的 API）。
+  //
+  // 主机版本过旧（无 `/api/anki/note-type/*` 端点）时：读返回 null（UI 按
+  // 「未找到 Lapis」提示），写返回 false（服务层转「后端不支持」失败）；
+  // 主机不可达/token 被拒由 client 抛出，原样透传给 UI 显示。
+
   @override
-  bool get supportsNoteTypeEditing => _local.supportsNoteTypeEditing;
+  bool get supportsNoteTypeEditing => true;
 
   @override
   Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(String modelName) =>
-      _local.readNoteTypeDefinition(modelName);
+      _client.readNoteTypeDefinition(modelName);
 
   @override
   Future<bool> updateNoteTypeStyling(String modelName, String css) =>
-      _local.updateNoteTypeStyling(modelName, css);
+      _client.updateNoteTypeStyling(modelName, css);
 
   @override
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) =>
-      _local.updateNoteTypeTemplates(modelName, templates);
+      _client.updateNoteTypeTemplates(modelName, templates);
 
   // 媒体去重同为配置/维护类：作用于本机 Anki，委派本地仓库。
   @override

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6625,6 +6625,38 @@ class _AppModelRemoteLookupService
     }
   }
 
+  // ── 互联 Lapis 客制化：客户端（手机等）经互联读写本机 Anki 的 note type。
+  // 与 mineForwarded 同语义地用**本机**平台仓库（主机自己的 AnkiConnect），
+  // 后端不支持时按 BaseAnkiRepository 的降级契约回 null/false（不抛）。
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    final BaseAnkiRepository repo =
+        _appModel.platformServices.createAnkiRepository();
+    if (!repo.supportsNoteTypeEditing) return null;
+    return repo.readNoteTypeDefinition(modelName);
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    final BaseAnkiRepository repo =
+        _appModel.platformServices.createAnkiRepository();
+    if (!repo.supportsNoteTypeEditing) return false;
+    return repo.updateNoteTypeStyling(modelName, css);
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  ) async {
+    final BaseAnkiRepository repo =
+        _appModel.platformServices.createAnkiRepository();
+    if (!repo.supportsNoteTypeEditing) return false;
+    return repo.updateNoteTypeTemplates(modelName, templates);
+  }
+
   @override
   Future<bool> isDuplicate({
     required String expression,

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -123,8 +123,9 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           ],
         ),
         // Lapis 样式客制化：备份 / 恢复 / 字号缩放 / 自定义 CSS / 应用。
-        // 仅后端支持读写已存在 note type 时显示（AnkiConnect）；AnkiDroid /
-        // AnkiMobile 平台 API 改不了已存在模板（平台边界），整区隐藏。
+        // 仅后端支持读写已存在 note type 时显示（AnkiConnect；开启「制卡到
+        // 已配对设备」时经互联作用于主机端 Anki，手机上因此也显示）；纯本地
+        // AnkiDroid / AnkiMobile 平台 API 改不了已存在模板（平台边界），整区隐藏。
         if (vm.supportsNoteTypeEditing)
           AdaptiveSettingsSection(
             title: t.anki_lapis_section,
@@ -673,17 +674,24 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
     AnkiSettings settings,
     AnkiViewModel vm,
   ) async {
-    // 字段映射编辑只在真的选了卡型时给出：字段名来自当前卡型，编辑器据此
-    // 自我门控（卡型里没有的字段一律不显示）。
-    final List<String> noteTypeFields =
+    // 字段映射编辑只在真的选了本地卡型时给出：映射写回本地设置、供本地制卡
+    // 渲染用，编辑器据此自我门控（卡型里没有的字段一律不显示）。
+    final List<String> localNoteTypeFields =
         settings.selectedNoteType?.fields ?? const <String>[];
     // 预览基线取用户 Anki 里现有的 Lapis CSS（剥掉 Hibiki 托管区段），编辑器里
     // 看到的才是他自己那张卡。读不到就退回内置副本——只影响预览观感，不影响写入。
+    // 「制卡到已配对设备」开启时这条读取走互联，返回的是**主机端**的 Lapis。
     String? baseCss;
+    List<String> noteTypeFields = localNoteTypeFields;
     try {
       final AnkiNoteTypeDefinition? def = await vm.lapisTemplateService
           .readNoteTypeDefinitionForPreview(LapisNoteType.modelName);
-      if (def != null) baseCss = stripLapisUserSection(def.css);
+      if (def != null) {
+        baseCss = stripLapisUserSection(def.css);
+        // 手机端 + 互联：本地没配 Anki 卡型时，自定义区域的字段候选取样式将
+        // 落地的那个卡型（主机端 Lapis）——否则区域区永远停在「先选卡型」。
+        if (noteTypeFields.isEmpty) noteTypeFields = def.fields;
+      }
     } catch (e) {
       debugPrint('Lapis 预览基线读取失败，退回内置副本: $e');
     }
@@ -699,7 +707,9 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           initialFieldMappings: settings.fieldMappings,
           initialBlocks: settings.lapisCustomBlocks,
           baseCss: baseCss,
-          pickHandlebar: noteTypeFields.isEmpty
+          // 映射编辑仍按**本地**卡型门控：远端字段候选只服务区域摆放，映射
+          // 本身是本地制卡配置，本地没选卡型就没有可写的映射目标。
+          pickHandlebar: localNoteTypeFields.isEmpty
               ? null
               : (String field, String currentValue) =>
                   _pickHandlebar(field, currentValue),

--- a/fushi/lib/src/sync/fushi_remote_api_handlers.dart
+++ b/fushi/lib/src/sync/fushi_remote_api_handlers.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
 import 'package:fushi/src/sync/forwarded_mine_payload.dart';
@@ -171,4 +172,62 @@ Future<Map<String, dynamic>> buildRemoteDuplicateResponse(
   final bool duplicate =
       await mining.isDuplicate(expression: expression, reading: reading);
   return <String, dynamic>{'duplicate': duplicate};
+}
+
+/// `POST /api/anki/note-type/read` 的响应体。互联 Lapis 客制化：手机端（AnkiDroid /
+/// AnkiMobile 没有改已存在模板的平台 API）经互联读主机端 note type 完整定义，供可视化
+/// 编辑器拿真实基线、备份与漂移判定。[body] 需含 `modelName`（非空），缺失/类型错抛
+/// [FormatException]（调用方转 400）。主机后端不支持模板读写或模型不存在时 `noteType`
+/// 为 null（客户端按「未找到」提示）。
+Future<Map<String, dynamic>> buildAnkiNoteTypeReadResponse(
+  Map<String, dynamic> body, {
+  required FushiRemoteMiningService mining,
+}) async {
+  final AnkiNoteTypeDefinition? def =
+      await mining.readNoteTypeDefinition(_requiredModelName(body));
+  return <String, dynamic>{'noteType': def?.toJson()};
+}
+
+/// `POST /api/anki/note-type/styling` 的响应体。覆写主机端 note type 的 styling。
+/// [body] 需含 `modelName` 与 `css`（均为字符串，css 可为空串），缺失/类型错抛
+/// [FormatException]。`ok=false` = 主机后端不支持模板写入。
+Future<Map<String, dynamic>> buildAnkiNoteTypeStylingResponse(
+  Map<String, dynamic> body, {
+  required FushiRemoteMiningService mining,
+}) async {
+  final String modelName = _requiredModelName(body);
+  final Object? css = body['css'];
+  if (css is! String) throw const FormatException('Missing css');
+  return <String, dynamic>{
+    'ok': await mining.updateNoteTypeStyling(modelName, css),
+  };
+}
+
+/// `POST /api/anki/note-type/templates` 的响应体。覆写主机端 note type 的全部卡模板
+/// （客户端「从备份恢复」/写 Lapis 背面模板用）。[body] 需含 `modelName` 与
+/// `templates`（`[{name, front, back}]`），缺失/类型错抛 [FormatException]。
+/// `ok=false` = 主机后端不支持模板写入。
+Future<Map<String, dynamic>> buildAnkiNoteTypeTemplatesResponse(
+  Map<String, dynamic> body, {
+  required FushiRemoteMiningService mining,
+}) async {
+  final String modelName = _requiredModelName(body);
+  final Object? rawTemplates = body['templates'];
+  if (rawTemplates is! List) throw const FormatException('Missing templates');
+  final List<AnkiCardTemplate> templates = <AnkiCardTemplate>[];
+  for (final Object? entry in rawTemplates) {
+    if (entry is! Map) throw const FormatException('Malformed templates');
+    templates.add(AnkiCardTemplate.fromJson(Map<String, dynamic>.from(entry)));
+  }
+  return <String, dynamic>{
+    'ok': await mining.updateNoteTypeTemplates(modelName, templates),
+  };
+}
+
+String _requiredModelName(Map<String, dynamic> body) {
+  final String modelName = body['modelName']?.toString() ?? '';
+  if (modelName.trim().isEmpty) {
+    throw const FormatException('Missing modelName');
+  }
+  return modelName;
 }

--- a/fushi/lib/src/sync/fushi_remote_lookup_service.dart
+++ b/fushi/lib/src/sync/fushi_remote_lookup_service.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
 import 'package:fushi/src/sync/forwarded_mine_payload.dart';
@@ -115,6 +116,26 @@ abstract class FushiRemoteMiningService {
     required String expression,
     required String reading,
   });
+
+  // ── 互联 Lapis 客制化：主机端 note type 模板读写 ──────────────────────
+  //
+  // 手机端（AnkiDroid / AnkiMobile）没有改已存在模板的平台 API；开启「制卡到
+  // 已配对设备」时卡片落在主机的 Anki 上，Lapis 样式客制化因此必须经互联作用
+  // 于**主机端**卡型。三个方法与 `BaseAnkiRepository` 同名同契约，实现方直接
+  // 委派主机本地 Anki 仓库。
+
+  /// 读主机端 [modelName] 的完整定义（字段/卡模板/CSS）。主机后端不支持模板
+  /// 读写或模型不存在返回 `null`；主机 Anki 不可达照抛（调用方转成失败响应）。
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(String modelName);
+
+  /// 覆写主机端 [modelName] 的 styling。返回 `false` = 主机后端不支持。
+  Future<bool> updateNoteTypeStyling(String modelName, String css);
+
+  /// 覆写主机端 [modelName] 的全部卡模板。返回 `false` = 主机后端不支持。
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  );
 }
 
 /// 把一次查词结果写入 Hibiki 查词历史（无 UI 副作用）。浏览器扩展 record 用。

--- a/fushi/lib/src/sync/fushi_remote_mining_client.dart
+++ b/fushi/lib/src/sync/fushi_remote_mining_client.dart
@@ -2,6 +2,7 @@ import 'package:fushi/src/sync/forwarded_mine_payload.dart';
 import 'package:fushi/src/sync/interconnect_post_transport.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 import 'package:http/http.dart' as http;
 
 /// BUG-1185：远端查重的三态结果。查重是「用户据此决定要不要再制一张卡」的信息，
@@ -34,6 +35,25 @@ abstract class RemoteMineSender {
     required String expression,
     required String reading,
   });
+
+  // ── 互联 Lapis 客制化：主机端 note type 模板读写 ──────────────────────
+  // 三个方法与 `BaseAnkiRepository` 同名同契约（RemoteMiningAnkiRepository 直接
+  // 转发），区别只在错误语义：token 被拒抛 [SyncAuthError]；全部候选传输层不可达
+  // 抛 [StateError]（客制化是显式用户操作，必须报「设备不可达」而不是谎报
+  // 「模型不存在/不支持」）。
+
+  /// 读主机端 [modelName] 的完整定义。主机后端不支持、模型不存在或主机版本
+  /// 过旧（无此端点）返回 null。
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(String modelName);
+
+  /// 覆写主机端 [modelName] 的 styling。false = 主机不支持/版本过旧。
+  Future<bool> updateNoteTypeStyling(String modelName, String css);
+
+  /// 覆写主机端 [modelName] 的全部卡模板。false = 主机不支持/版本过旧。
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  );
 }
 
 /// 互联「制卡到服务端」的客户端发送器。传输走共享的 [InterconnectPostTransport]
@@ -47,6 +67,7 @@ class FushiRemoteMiningClient implements RemoteMineSender {
     http.Client Function(String expectedFingerprint)? pinnedClientFactory,
     Duration mineTimeout = const Duration(seconds: 60),
     Duration duplicateTimeout = const Duration(seconds: 5),
+    Duration noteTypeTimeout = const Duration(seconds: 15),
   })  : _repo = repo,
         _transport = InterconnectPostTransport(
           repo: repo,
@@ -54,12 +75,17 @@ class FushiRemoteMiningClient implements RemoteMineSender {
           pinnedClientFactory: pinnedClientFactory,
         ),
         _mineTimeout = mineTimeout,
-        _duplicateTimeout = duplicateTimeout;
+        _duplicateTimeout = duplicateTimeout,
+        _noteTypeTimeout = noteTypeTimeout;
 
   final SyncRepository _repo;
   final InterconnectPostTransport _transport;
   final Duration _mineTimeout;
   final Duration _duplicateTimeout;
+
+  /// Lapis 模板读写的超时：请求体是纯文本（CSS/模板最多几百 KB），LAN 上比制卡
+  /// （媒体字节几 MB）快得多，但仍留出比查重宽裕的窗口。
+  final Duration _noteTypeTimeout;
 
   /// 是否已配置可达的已配对主机（enabled 候选 + token）。用于设置页/开关判断能否远端制卡。
   Future<bool> hasTarget() async {
@@ -109,6 +135,65 @@ class FushiRemoteMiningClient implements RemoteMineSender {
     } catch (_) {
       return RemoteDuplicateCheck.notDuplicate;
     }
+  }
+
+  /// 主机端 Lapis note type 读取。null 的三种来源统一表示「主机侧没有可用定义」：
+  /// 主机后端不支持模板读写 / 模型不存在 / 主机版本过旧（404，无此端点）。
+  /// 全部候选传输层不可达抛 [StateError]——客制化是显式用户操作，「设备不可达」
+  /// 必须原样报给用户，压成 null 会被 UI 误报成「Lapis 卡型不存在」。
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    final Map<String, dynamic>? json = await _postNoteType(
+      path: '/api/anki/note-type/read',
+      body: <String, dynamic>{'modelName': modelName},
+    );
+    final Object? noteType = json?['noteType'];
+    if (noteType is! Map) return null;
+    return AnkiNoteTypeDefinition.fromJson(Map<String, dynamic>.from(noteType));
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    final Map<String, dynamic>? json = await _postNoteType(
+      path: '/api/anki/note-type/styling',
+      body: <String, dynamic>{'modelName': modelName, 'css': css},
+    );
+    return json?['ok'] == true;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  ) async {
+    final Map<String, dynamic>? json = await _postNoteType(
+      path: '/api/anki/note-type/templates',
+      body: <String, dynamic>{
+        'modelName': modelName,
+        'templates': templates.map((AnkiCardTemplate t) => t.toJson()).toList(),
+      },
+    );
+    return json?['ok'] == true;
+  }
+
+  /// note type 端点与制卡侧 [_post] 的唯一差别：消费 `allUnreachable`，把
+  /// 「配对主机全部不可达」升格成异常（见 [readNoteTypeDefinition]）。
+  Future<Map<String, dynamic>?> _postNoteType({
+    required String path,
+    required Map<String, dynamic> body,
+  }) async {
+    final InterconnectPostOutcome outcome = await _transport.post(
+      path: path,
+      body: body,
+      timeout: _noteTypeTimeout,
+      authErrorMessage: 'Fushi server rejected remote mining token',
+    );
+    if (outcome.json == null && outcome.allUnreachable) {
+      throw StateError(
+          'No paired device is reachable for Lapis template editing.');
+    }
+    return outcome.json;
   }
 
   /// 制卡侧不消费 `allUnreachable`（没有失败冷却机制），只取响应体——「全不可达」

--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -549,6 +549,10 @@ class FushiSyncServer {
       if (method != 'POST') return shelf.Response(405);
       return _handleMineForward(request);
     }
+    if (reqPath.startsWith('/api/anki/note-type/')) {
+      if (method != 'POST') return shelf.Response(405);
+      return _handleAnkiNoteType(request, reqPath);
+    }
     if (reqPath == '/api/media/dictionary') {
       if (method != 'GET' && method != 'HEAD') return shelf.Response(405);
       return _handleDictionaryMedia(request, method == 'HEAD');
@@ -1188,6 +1192,38 @@ class FushiSyncServer {
       return _jsonResponse(await buildForwardedMineResponse(body, mining: svc));
     } on FormatException {
       return shelf.Response(400, body: 'Missing rawPayloadJson');
+    }
+  }
+
+  /// 互联 Lapis 客制化：客户端（手机 AnkiDroid 等无模板 API 的平台）经互联读写本机
+  /// Anki 的 note type（读定义 / 写 styling / 写卡模板）。契约与 YomitanApiServer 共享
+  /// （buildAnkiNoteType*Response，单一真相源）。未注入挖词 service → 404（旧版客户端
+  /// 不会打这些端点，旧版主机对新客户端返回 404 → 客户端按「后端不支持」降级）；
+  /// modelName/css/templates 缺失或类型错 → 400。
+  Future<shelf.Response> _handleAnkiNoteType(
+    shelf.Request request,
+    String path,
+  ) async {
+    final FushiRemoteMiningService? svc = _miningService;
+    if (svc == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await _readJsonObject(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      switch (path) {
+        case '/api/anki/note-type/read':
+          return _jsonResponse(
+              await buildAnkiNoteTypeReadResponse(body, mining: svc));
+        case '/api/anki/note-type/styling':
+          return _jsonResponse(
+              await buildAnkiNoteTypeStylingResponse(body, mining: svc));
+        case '/api/anki/note-type/templates':
+          return _jsonResponse(
+              await buildAnkiNoteTypeTemplatesResponse(body, mining: svc));
+        default:
+          return shelf.Response.notFound('Unknown endpoint');
+      }
+    } on FormatException catch (e) {
+      return shelf.Response(400, body: e.message);
     }
   }
 

--- a/fushi/lib/src/sync/yomitan_api_server.dart
+++ b/fushi/lib/src/sync/yomitan_api_server.dart
@@ -250,6 +250,10 @@ class YomitanApiServer {
         return _handleMine(request);
       case '/api/mine/forward':
         return _handleMineForward(request);
+      case '/api/anki/note-type/read':
+      case '/api/anki/note-type/styling':
+      case '/api/anki/note-type/templates':
+        return _handleAnkiNoteType(request, path);
       case '/api/duplicate':
         return _handleDuplicate(request);
       case '/api/extension/popup-size':
@@ -377,6 +381,34 @@ class YomitanApiServer {
       return _json(await buildForwardedMineResponse(body, mining: mining));
     } on FormatException {
       return shelf.Response(400, body: 'Missing rawPayloadJson');
+    }
+  }
+
+  /// 互联 Lapis 客制化端点（与 FushiSyncServer 共享契约 buildAnkiNoteType*Response）。
+  /// 手机端经互联读写主机 Anki 的 note type。未注入挖词 service → 404；
+  /// modelName/css/templates 缺失或类型错 → 400。
+  Future<shelf.Response> _handleAnkiNoteType(
+    shelf.Request request,
+    String path,
+  ) async {
+    final FushiRemoteMiningService? mining = _mining;
+    if (mining == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await _readJson(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      switch (path) {
+        case '/api/anki/note-type/read':
+          return _json(
+              await buildAnkiNoteTypeReadResponse(body, mining: mining));
+        case '/api/anki/note-type/styling':
+          return _json(
+              await buildAnkiNoteTypeStylingResponse(body, mining: mining));
+        default:
+          return _json(
+              await buildAnkiNoteTypeTemplatesResponse(body, mining: mining));
+      }
+    } on FormatException catch (e) {
+      return shelf.Response(400, body: e.message);
     }
   }
 

--- a/fushi/test/anki/remote_mining_anki_repository_test.dart
+++ b/fushi/test/anki/remote_mining_anki_repository_test.dart
@@ -33,6 +33,34 @@ class _FakeSender implements RemoteMineSender {
     dupCalls.add(<String>[expression, reading]);
     return dupResult;
   }
+
+  // 互联 Lapis 客制化：note type 读写捕获。
+  AnkiNoteTypeDefinition? noteTypeDef;
+  bool noteTypeWriteOk = true;
+  final List<String> noteTypeReads = <String>[];
+  final List<(String, String)> stylingWrites = <(String, String)>[];
+  final List<(String, List<AnkiCardTemplate>)> templateWrites =
+      <(String, List<AnkiCardTemplate>)>[];
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    noteTypeReads.add(modelName);
+    return noteTypeDef;
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    stylingWrites.add((modelName, css));
+    return noteTypeWriteOk;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+      String modelName, List<AnkiCardTemplate> templates) async {
+    templateWrites.add((modelName, templates));
+    return noteTypeWriteOk;
+  }
 }
 
 /// 假本地仓库：远端模式下 mineEntry/isDuplicate 绝不该落到它身上（落了就抛，验证不误操作本机）。
@@ -65,6 +93,21 @@ class _FakeLocal extends BaseAnkiRepository {
     createdDecks.add(name);
     return true;
   }
+
+  // Lapis 模板读写跟随制卡落点走互联：远端模式下绝不该落到本地仓库。
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      throw StateError('local readNoteTypeDefinition must NOT run');
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async =>
+      throw StateError('local updateNoteTypeStyling must NOT run');
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
+      throw StateError('local updateNoteTypeTemplates must NOT run');
 }
 
 /// BUG-1549：带可配置本地设置的假本地仓库（配置类委派合法，制卡类仍禁止落地）。
@@ -284,6 +327,56 @@ void main() {
           rawPayloadJson: '{}',
           context: const AnkiMiningContext(sentence: ''));
       expect(up.result, MineResult.error);
+    });
+
+    // Lapis 模板读写跟随制卡落点：卡落在主机上，样式客制化就必须改主机的模板。
+    // 这也是手机端（AnkiDroid 无模板 API）唯一的可视化配置通道。
+    group('Lapis note type 读写经互联作用于主机端', () {
+      test('supportsNoteTypeEditing 恒 true（本地 AnkiDroid false 也不遮蔽）', () {
+        final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+            local: _FakeLocal(), client: _FakeSender(null));
+        // _FakeLocal 继承基类默认 false；远端模式下不再看本地能力。
+        expect(repo.supportsNoteTypeEditing, isTrue);
+      });
+
+      test('readNoteTypeDefinition 转发远端、不触本地', () async {
+        final _FakeSender sender = _FakeSender(null)
+          ..noteTypeDef = const AnkiNoteTypeDefinition(
+            name: 'Lapis',
+            fields: <String>['Expression'],
+            templates: <AnkiCardTemplate>[],
+            css: '.card {}',
+          );
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+        final AnkiNoteTypeDefinition? def =
+            await repo.readNoteTypeDefinition('Lapis');
+        expect(def?.name, 'Lapis');
+        expect(sender.noteTypeReads.single, 'Lapis');
+      });
+
+      test('updateNoteTypeStyling / updateNoteTypeTemplates 转发远端', () async {
+        final _FakeSender sender = _FakeSender(null);
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+        expect(await repo.updateNoteTypeStyling('Lapis', '.card {}'), isTrue);
+        expect(sender.stylingWrites.single, ('Lapis', '.card {}'));
+        expect(
+          await repo.updateNoteTypeTemplates('Lapis', const <AnkiCardTemplate>[
+            AnkiCardTemplate(name: 'Card', front: 'F', back: 'B'),
+          ]),
+          isTrue,
+        );
+        expect(sender.templateWrites.single.$1, 'Lapis');
+        expect(sender.templateWrites.single.$2.single.back, 'B');
+      });
+
+      test('主机版本过旧/不支持 → 写返回 false（不谎报成功）', () async {
+        final _FakeSender sender = _FakeSender(null)..noteTypeWriteOk = false;
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+        expect(await repo.updateNoteTypeStyling('Lapis', ''), isFalse);
+      });
     });
   });
 }

--- a/fushi/test/sync/anki_note_type_response_test.dart
+++ b/fushi/test/sync/anki_note_type_response_test.dart
@@ -1,0 +1,180 @@
+// 互联 Lapis 客制化：`/api/anki/note-type/*` 三个端点的共享 handler 契约。
+// 手机端（AnkiDroid / AnkiMobile 无改已存在模板的平台 API）经互联读写主机端
+// Anki 的 note type，可视化配置 Lapis 因此第一次在手机上可用。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/sync/forwarded_mine_payload.dart';
+import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
+import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
+import 'package:fushi/src/sync/immersion_mine_payload.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+class _FakeMining implements FushiRemoteMiningService {
+  AnkiNoteTypeDefinition? noteTypeDef;
+  bool writeOk = true;
+  final List<String> reads = <String>[];
+  final List<(String, String)> stylingWrites = <(String, String)>[];
+  final List<(String, List<AnkiCardTemplate>)> templateWrites =
+      <(String, List<AnkiCardTemplate>)>[];
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    reads.add(modelName);
+    return noteTypeDef;
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    stylingWrites.add((modelName, css));
+    return writeOk;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+      String modelName, List<AnkiCardTemplate> templates) async {
+    templateWrites.add((modelName, templates));
+    return writeOk;
+  }
+
+  @override
+  Future<RemoteMineResult> mineEntry(
+          {required Map<String, String> fields,
+          required String sentence}) async =>
+      const RemoteMineResult(result: 'success');
+
+  @override
+  Future<RemoteMineResult> mineImmersion(ImmersionMinePayload payload) async =>
+      const RemoteMineResult(result: 'success');
+
+  @override
+  Future<RemoteMineResult> mineForwarded(ForwardedMinePayload payload) async =>
+      const RemoteMineResult(result: 'success');
+
+  @override
+  Future<bool> isDuplicate(
+          {required String expression, required String reading}) async =>
+      false;
+}
+
+void main() {
+  group('buildAnkiNoteTypeReadResponse', () {
+    test('回传完整定义 JSON（wire 形状与 AnkiNoteTypeDefinition.toJson 一致）', () async {
+      final _FakeMining m = _FakeMining()
+        ..noteTypeDef = const AnkiNoteTypeDefinition(
+          name: 'Lapis',
+          fields: <String>['Expression', 'Sentence'],
+          templates: <AnkiCardTemplate>[
+            AnkiCardTemplate(name: 'Card', front: 'F', back: 'B'),
+          ],
+          css: '.card { color: red; }',
+        );
+      final Map<String, dynamic> resp = await buildAnkiNoteTypeReadResponse(
+        <String, dynamic>{'modelName': 'Lapis'},
+        mining: m,
+      );
+      expect(m.reads.single, 'Lapis');
+      final Map<String, dynamic> noteType =
+          resp['noteType'] as Map<String, dynamic>;
+      // 回传体必须能被客户端 AnkiNoteTypeDefinition.fromJson 原样读回。
+      final AnkiNoteTypeDefinition roundTrip =
+          AnkiNoteTypeDefinition.fromJson(noteType);
+      expect(roundTrip.name, 'Lapis');
+      expect(roundTrip.fields, <String>['Expression', 'Sentence']);
+      expect(roundTrip.templates.single.back, 'B');
+      expect(roundTrip.css, '.card { color: red; }');
+    });
+
+    test('模型不存在/后端不支持 → noteType 为 null（不是错误）', () async {
+      final Map<String, dynamic> resp = await buildAnkiNoteTypeReadResponse(
+        <String, dynamic>{'modelName': 'Lapis'},
+        mining: _FakeMining(),
+      );
+      expect(resp.containsKey('noteType'), isTrue);
+      expect(resp['noteType'], isNull);
+    });
+
+    test('modelName 缺失 → FormatException（调用方转 400）', () {
+      expect(
+        () => buildAnkiNoteTypeReadResponse(<String, dynamic>{},
+            mining: _FakeMining()),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('buildAnkiNoteTypeStylingResponse', () {
+    test('写穿 + 回 ok', () async {
+      final _FakeMining m = _FakeMining();
+      final Map<String, dynamic> resp = await buildAnkiNoteTypeStylingResponse(
+        <String, dynamic>{'modelName': 'Lapis', 'css': '.card {}'},
+        mining: m,
+      );
+      expect(resp['ok'], isTrue);
+      expect(m.stylingWrites.single, ('Lapis', '.card {}'));
+    });
+
+    test('空串 css 合法（清空 styling 是有效操作）', () async {
+      final _FakeMining m = _FakeMining();
+      final Map<String, dynamic> resp = await buildAnkiNoteTypeStylingResponse(
+        <String, dynamic>{'modelName': 'Lapis', 'css': ''},
+        mining: m,
+      );
+      expect(resp['ok'], isTrue);
+      expect(m.stylingWrites.single, ('Lapis', ''));
+    });
+
+    test('css 缺失 → FormatException；后端不支持 → ok=false', () async {
+      expect(
+        () => buildAnkiNoteTypeStylingResponse(
+            <String, dynamic>{'modelName': 'Lapis'},
+            mining: _FakeMining()),
+        throwsFormatException,
+      );
+      final Map<String, dynamic> resp = await buildAnkiNoteTypeStylingResponse(
+        <String, dynamic>{'modelName': 'Lapis', 'css': 'x'},
+        mining: _FakeMining()..writeOk = false,
+      );
+      expect(resp['ok'], isFalse);
+    });
+  });
+
+  group('buildAnkiNoteTypeTemplatesResponse', () {
+    test('解析 templates 列表并写穿', () async {
+      final _FakeMining m = _FakeMining();
+      final Map<String, dynamic> resp =
+          await buildAnkiNoteTypeTemplatesResponse(
+        <String, dynamic>{
+          'modelName': 'Lapis',
+          'templates': <dynamic>[
+            <String, dynamic>{'name': 'Card', 'front': 'F', 'back': 'B2'},
+          ],
+        },
+        mining: m,
+      );
+      expect(resp['ok'], isTrue);
+      expect(m.templateWrites.single.$1, 'Lapis');
+      expect(m.templateWrites.single.$2.single.name, 'Card');
+      expect(m.templateWrites.single.$2.single.back, 'B2');
+    });
+
+    test('templates 缺失/元素类型错 → FormatException', () {
+      expect(
+        () => buildAnkiNoteTypeTemplatesResponse(
+            <String, dynamic>{'modelName': 'Lapis'},
+            mining: _FakeMining()),
+        throwsFormatException,
+      );
+      expect(
+        () => buildAnkiNoteTypeTemplatesResponse(
+          <String, dynamic>{
+            'modelName': 'Lapis',
+            'templates': <dynamic>['not a map'],
+          },
+          mining: _FakeMining(),
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/fushi/test/sync/forwarded_mine_response_test.dart
+++ b/fushi/test/sync/forwarded_mine_response_test.dart
@@ -4,12 +4,27 @@ import 'package:fushi/src/sync/forwarded_mine_payload.dart';
 import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 
 /// 假挖词 service：捕获转发来的 payload，回预设结果。
 class _FakeMining implements FushiRemoteMiningService {
   ForwardedMinePayload? forwarded;
   RemoteMineResult result =
       const RemoteMineResult(result: 'success', message: 'ok');
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      null;
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async =>
+      false;
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
+      false;
 
   @override
   Future<RemoteMineResult> mineForwarded(ForwardedMinePayload payload) async {
@@ -53,8 +68,8 @@ void main() {
 
     test('rawPayloadJson 缺失 → FormatException（调用方转 400）', () {
       expect(
-        () => buildForwardedMineResponse(
-            <String, dynamic>{'sentence': 'x'}, mining: _FakeMining()),
+        () => buildForwardedMineResponse(<String, dynamic>{'sentence': 'x'},
+            mining: _FakeMining()),
         throwsFormatException,
       );
     });

--- a/fushi/test/sync/fushi_remote_mining_client_note_type_test.dart
+++ b/fushi/test/sync/fushi_remote_mining_client_note_type_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/fushi_remote_mining_client.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// 互联 Lapis 客制化：`FushiRemoteMiningClient` 的 note type 读写语义。
+/// 关键区分（可视化配置是显式用户操作，错误必须各归各位）：
+/// - 旧版主机（404，无 `/api/anki/note-type/*` 端点）→ 读 null / 写 false，
+///   按「后端不支持」降级，不报错；
+/// - 主机全部不可达（传输层失败）→ 抛 [StateError]，绝不压成 null 被 UI
+///   误报成「Lapis 卡型不存在」；
+/// - token 被拒（401）→ 抛 [SyncAuthError]，用户须重新配对。
+FushiDatabase _testDb() {
+  return FushiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+}
+
+Future<SyncRepository> _repo(FushiDatabase db) async {
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setFushiClientUrls(
+      const <FushiClientUrl>[FushiClientUrl(url: 'http://host:8765')]);
+  await repo.setFushiClientToken('tok');
+  return repo;
+}
+
+Future<FushiRemoteMiningClient> _client(
+  FushiDatabase db,
+  http.Response Function(http.Request request) respond,
+) async {
+  return FushiRemoteMiningClient(
+    repo: await _repo(db),
+    httpClient: MockClient((http.Request request) async => respond(request)),
+  );
+}
+
+http.Response _json(Map<String, dynamic> body) => http.Response.bytes(
+      utf8.encode(jsonEncode(body)),
+      200,
+      headers: const <String, String>{
+        'content-type': 'application/json; charset=utf-8',
+      },
+    );
+
+void main() {
+  test('read：主机回传定义 → 反序列化成 AnkiNoteTypeDefinition', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    http.Request? seen;
+    final FushiRemoteMiningClient client = await _client(db, (http.Request r) {
+      seen = r;
+      return _json(<String, dynamic>{
+        'noteType': const AnkiNoteTypeDefinition(
+          name: 'Lapis',
+          fields: <String>['Expression'],
+          templates: <AnkiCardTemplate>[
+            AnkiCardTemplate(name: 'Card', front: 'F', back: 'B'),
+          ],
+          css: '.card {}',
+        ).toJson(),
+      });
+    });
+    final AnkiNoteTypeDefinition? def =
+        await client.readNoteTypeDefinition('Lapis');
+    expect(seen!.url.path, '/api/anki/note-type/read');
+    expect(jsonDecode(seen!.body), <String, dynamic>{'modelName': 'Lapis'});
+    expect(def?.name, 'Lapis');
+    expect(def?.templates.single.back, 'B');
+  });
+
+  test('read：主机可达但无该模型（noteType null）→ null', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    final FushiRemoteMiningClient client = await _client(
+        db, (http.Request _) => _json(<String, dynamic>{'noteType': null}));
+    expect(await client.readNoteTypeDefinition('Lapis'), isNull);
+  });
+
+  test('read：旧版主机（404，无端点）→ null（按后端不支持降级）', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    final FushiRemoteMiningClient client =
+        await _client(db, (http.Request _) => http.Response('nope', 404));
+    expect(await client.readNoteTypeDefinition('Lapis'), isNull);
+  });
+
+  test('read：主机全部不可达 → 抛 StateError（不冒充「模型不存在」）', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    final FushiRemoteMiningClient client = FushiRemoteMiningClient(
+      repo: await _repo(db),
+      httpClient: MockClient(
+          (http.Request _) async => throw http.ClientException('boom')),
+    );
+    expect(
+      () => client.readNoteTypeDefinition('Lapis'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('read：token 被拒（401）→ 抛 SyncAuthError', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    final FushiRemoteMiningClient client =
+        await _client(db, (http.Request _) => http.Response('nope', 401));
+    expect(
+      () => client.readNoteTypeDefinition('Lapis'),
+      throwsA(isA<SyncAuthError>()),
+    );
+  });
+
+  test('styling：写穿 ok=true；旧版主机 404 → false', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    http.Request? seen;
+    final FushiRemoteMiningClient okClient =
+        await _client(db, (http.Request r) {
+      seen = r;
+      return _json(<String, dynamic>{'ok': true});
+    });
+    expect(await okClient.updateNoteTypeStyling('Lapis', '.card {}'), isTrue);
+    expect(seen!.url.path, '/api/anki/note-type/styling');
+    expect(jsonDecode(seen!.body),
+        <String, dynamic>{'modelName': 'Lapis', 'css': '.card {}'});
+
+    final FushiRemoteMiningClient oldHost =
+        await _client(db, (http.Request _) => http.Response('nope', 404));
+    expect(await oldHost.updateNoteTypeStyling('Lapis', '.card {}'), isFalse);
+  });
+
+  test('templates：模板列表序列化进请求体', () async {
+    final FushiDatabase db = _testDb();
+    addTearDown(db.close);
+    http.Request? seen;
+    final FushiRemoteMiningClient client = await _client(db, (http.Request r) {
+      seen = r;
+      return _json(<String, dynamic>{'ok': true});
+    });
+    expect(
+      await client.updateNoteTypeTemplates('Lapis', const <AnkiCardTemplate>[
+        AnkiCardTemplate(name: 'Card', front: 'F', back: 'B2'),
+      ]),
+      isTrue,
+    );
+    expect(seen!.url.path, '/api/anki/note-type/templates');
+    final Map<String, dynamic> body =
+        jsonDecode(seen!.body) as Map<String, dynamic>;
+    expect(body['modelName'], 'Lapis');
+    expect((body['templates'] as List).single,
+        <String, dynamic>{'name': 'Card', 'front': 'F', 'back': 'B2'});
+  });
+}

--- a/fushi/test/sync/fushi_remote_mining_service_test.dart
+++ b/fushi/test/sync/fushi_remote_mining_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/sync/forwarded_mine_payload.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 
 void main() {
   test('FushiRemoteMiningService is an abstract contract with mineEntry', () {
@@ -30,5 +31,19 @@ class _FakeMining implements FushiRemoteMiningService {
     required String expression,
     required String reading,
   }) async =>
+      false;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      null;
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async =>
+      false;
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
       false;
 }

--- a/fushi/test/sync/fushi_sync_server_mine_test.dart
+++ b/fushi/test/sync/fushi_sync_server_mine_test.dart
@@ -5,6 +5,7 @@ import 'package:fushi/src/sync/fushi_sync_server.dart';
 import 'package:fushi/src/sync/forwarded_mine_payload.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 
 class _FakeMining implements FushiRemoteMiningService {
   Map<String, String>? lastFields;
@@ -43,6 +44,33 @@ class _FakeMining implements FushiRemoteMiningService {
     lastDupExpression = expression;
     lastDupReading = reading;
     return dupResult;
+  }
+
+  // 互联 Lapis 客制化端点的捕获（/api/anki/note-type/*）。
+  AnkiNoteTypeDefinition? noteTypeDef;
+  bool noteTypeWriteOk = true;
+  String? lastNoteTypeRead;
+  (String, String)? lastStylingWrite;
+  (String, List<AnkiCardTemplate>)? lastTemplatesWrite;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    lastNoteTypeRead = modelName;
+    return noteTypeDef;
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    lastStylingWrite = (modelName, css);
+    return noteTypeWriteOk;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+      String modelName, List<AnkiCardTemplate> templates) async {
+    lastTemplatesWrite = (modelName, templates);
+    return noteTypeWriteOk;
   }
 }
 
@@ -174,6 +202,109 @@ void main() {
     final r = await c.post('127.0.0.1', server.port, '/api/duplicate');
     r.headers.contentType = ContentType.json;
     r.write('{"expression":"猫"}');
+    final resp = await r.close();
+    expect(resp.statusCode, 401);
+    await server.stop();
+  });
+
+  // ── 互联 Lapis 客制化端点（手机端经互联读写主机 Anki 的 note type）────────
+
+  test('POST /api/anki/note-type/read returns host definition', () async {
+    final mining = _FakeMining()
+      ..noteTypeDef = const AnkiNoteTypeDefinition(
+        name: 'Lapis',
+        fields: <String>['Expression', 'Sentence'],
+        templates: <AnkiCardTemplate>[
+          AnkiCardTemplate(name: 'Card', front: 'F', back: 'B'),
+        ],
+        css: '.card {}',
+      );
+    final server = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk').path,
+        port: 0,
+        token: 'tok',
+        miningService: mining);
+    await server.start();
+    final resp = await _post(
+        server.port, '/api/anki/note-type/read', {'modelName': 'Lapis'}, 'tok');
+    expect(resp.statusCode, 200);
+    final out = jsonDecode(await resp.transform(utf8.decoder).join());
+    expect(mining.lastNoteTypeRead, 'Lapis');
+    expect(out['noteType']['name'], 'Lapis');
+    expect(out['noteType']['css'], '.card {}');
+    expect(out['noteType']['fields'], ['Expression', 'Sentence']);
+    await server.stop();
+  });
+
+  test('POST /api/anki/note-type/styling writes through and echoes ok',
+      () async {
+    final mining = _FakeMining();
+    final server = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk').path,
+        port: 0,
+        token: 'tok',
+        miningService: mining);
+    await server.start();
+    final resp = await _post(server.port, '/api/anki/note-type/styling',
+        {'modelName': 'Lapis', 'css': '.card { color: red; }'}, 'tok');
+    expect(resp.statusCode, 200);
+    final out = jsonDecode(await resp.transform(utf8.decoder).join());
+    expect(out['ok'], true);
+    expect(mining.lastStylingWrite, ('Lapis', '.card { color: red; }'));
+    await server.stop();
+  });
+
+  test('POST /api/anki/note-type/templates writes through', () async {
+    final mining = _FakeMining();
+    final server = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk').path,
+        port: 0,
+        token: 'tok',
+        miningService: mining);
+    await server.start();
+    final resp = await _post(
+        server.port,
+        '/api/anki/note-type/templates',
+        {
+          'modelName': 'Lapis',
+          'templates': [
+            {'name': 'Card', 'front': 'F', 'back': 'B2'},
+          ],
+        },
+        'tok');
+    expect(resp.statusCode, 200);
+    final out = jsonDecode(await resp.transform(utf8.decoder).join());
+    expect(out['ok'], true);
+    expect(mining.lastTemplatesWrite?.$1, 'Lapis');
+    expect(mining.lastTemplatesWrite?.$2.single.back, 'B2');
+    await server.stop();
+  });
+
+  test('POST /api/anki/note-type/read with missing modelName is 400', () async {
+    final server = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk').path,
+        port: 0,
+        token: 'tok',
+        miningService: _FakeMining());
+    await server.start();
+    final resp =
+        await _post(server.port, '/api/anki/note-type/read', {}, 'tok');
+    expect(resp.statusCode, 400);
+    await server.stop();
+  });
+
+  test('POST /api/anki/note-type/read without auth is 401', () async {
+    final server = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk').path,
+        port: 0,
+        token: 'tok',
+        miningService: _FakeMining());
+    await server.start();
+    final c = HttpClient();
+    final r =
+        await c.post('127.0.0.1', server.port, '/api/anki/note-type/read');
+    r.headers.contentType = ContentType.json;
+    r.write('{"modelName":"Lapis"}');
     final resp = await r.close();
     expect(resp.statusCode, 401);
     await server.stop();

--- a/fushi/test/sync/remote_mine_response_diagnostics_test.dart
+++ b/fushi/test/sync/remote_mine_response_diagnostics_test.dart
@@ -3,6 +3,7 @@ import 'package:fushi/src/sync/forwarded_mine_payload.dart';
 import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 
 /// TODO-1303 契约守卫：`/api/mine` 响应体现在除 `result` 外，还摊开诊断
 /// `message`（失败原因 / 音频落空警告）与 `detail`（技术细节）——浏览器扩展 content.js
@@ -32,6 +33,20 @@ class _DiagMining implements FushiRemoteMiningService {
     required String expression,
     required String reading,
   }) async =>
+      false;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      null;
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async =>
+      false;
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
       false;
 }
 

--- a/fushi/test/sync/yomitan_api_server_extension_endpoints_test.dart
+++ b/fushi/test/sync/yomitan_api_server_extension_endpoints_test.dart
@@ -14,6 +14,7 @@ import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
 import 'package:fushi/src/sync/yomitan_api_server.dart';
 import 'package:fushi/src/sync/yomitan_tokenize_adapter.dart';
+import 'package:fushi_anki/fushi_anki.dart';
 
 class _FakeLookup
     implements FushiRemoteLookupService, FushiRemotePopupLookupService {
@@ -99,6 +100,29 @@ class _FakeMining implements FushiRemoteMiningService {
     lastDupReading = reading;
     return dupResult;
   }
+
+  // 互联 Lapis 客制化端点的捕获（/api/anki/note-type/*）。
+  AnkiNoteTypeDefinition? noteTypeDef;
+  String? lastNoteTypeRead;
+  (String, String)? lastStylingWrite;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+      String modelName) async {
+    lastNoteTypeRead = modelName;
+    return noteTypeDef;
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    lastStylingWrite = (modelName, css);
+    return true;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
+      true;
 }
 
 String _basic(String token) =>


### PR DESCRIPTION
## 问题

用户报告：fushi 互联下可视化配置 Lapis 有问题，且可视化配置 Lapis 要支持手机端。

根因：「制卡到已配对设备」开启时卡片落在**主机**的 Anki 上，但 `RemoteMiningAnkiRepository` 把 Lapis 卡型读写（`readNoteTypeDefinition` / `updateNoteTypeStyling` / `updateNoteTypeTemplates`）委派给了**本地**仓库——

- 手机端本地是 AnkiDroid（平台无改已存在模板的 API）→ `supportsNoteTypeEditing=false` → 设置页整个 Lapis 样式区被隐藏，可视化配置在手机上完全不可用；
- 桌面端则把样式改到一个根本不落卡的本机 Anki，与制卡落点脱节。

## 修复（样式跟随制卡落点）

- **互联协议**：新增 `POST /api/anki/note-type/read|styling|templates` 三端点，`FushiSyncServer` 与 `YomitanApiServer` 共享 `buildAnkiNoteType*Response` handler（与 `/api/mine/forward` 同模式，单一真相源），走既有 token 鉴权 middleware。
- **主机侧**：`FushiRemoteMiningService` 扩展同名三方法，`_AppModelRemoteLookupService` 委派本机平台 Anki 仓库（与 `mineForwarded` 同语义）；主机后端不支持时按基类降级契约回 null/false。
- **客户端**：`RemoteMineSender`/`FushiRemoteMiningClient` 新增三方法，传输复用 `InterconnectPostTransport`（候选 fallback / 证书钉扎 / 401 语义）。错误分层：旧版主机（404 无端点）→ 读 null / 写 false（按「后端不支持」降级）；主机全部不可达 → 抛 `StateError`（不冒充「模型不存在」）；token 被拒 → `SyncAuthError`。
- **仓库包装**：`RemoteMiningAnkiRepository` 模板读写改为转发主机，`supportsNoteTypeEditing` 恒 true → 手机上 Lapis 区（可视化编辑器/应用/备份/恢复/出厂恢复）全部可用，作用于主机端卡型；备份 JSON 照旧落本机 `backups/lapis/`。
- **设置页**：本地没配 Anki 卡型时，可视化编辑器自定义区域的字段候选回退到远端 Lapis 定义的字段；字段映射编辑仍按本地卡型门控（映射是本地制卡渲染配置）。

可视化编辑器页面本身已是响应式布局（<820px 上下堆叠），预览走 InAppWebView，Android 可直接使用，无需另改。

## 兼容性

- 旧客户端不打新端点，行为不变；旧主机对新客户端返回 404，客户端按「后端不支持」降级，不误报。
- 开关关闭（纯本地）路径零改动；`/api/mine*`、`/api/duplicate` 契约未动。

## 验证

- `flutter analyze` 全量零问题。
- 定向 `flutter test`（互联端点 HTTP 层 + handler 契约 + 客户端三态语义 + 仓库转发 + 全部既有 anki/Lapis 测试）297 通过、退出码 0。
- 新增测试：`anki_note_type_response_test.dart`（handler 契约 + wire 往返）、`fushi_remote_mining_client_note_type_test.dart`（404/不可达/401 语义）、`fushi_sync_server_mine_test.dart` 增互联端点端到端 5 例、`remote_mining_anki_repository_test.dart` 增转发/不触本地 4 例。

https://claude.ai/code/session_013C5iywkHYWJ93aNSEeZHRb