### PR TITLE
fix(sync): 合集与退出书的通道循环补逐通道隔离，云盘坏不再连累互联 (BUG-1604)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1503 条。点号进各自文件。
+> 共 1504 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1604](bugs/BUG-1604-sync-channel-isolation-remaining-loops.md) | ✅ | ✅ | 合集同步与退出书同步的通道循环仍无逐通道隔离：云通道抛异常，互联通道整轮不跑 |
 | [BUG-1603](bugs/BUG-1603-srt-subtitle-shadow-directional-offset.md) | ✅ | ✅ | SRT 字幕柔和投影方向性偏下，真机上观感为阴影错位 |
 | [BUG-1596](bugs/BUG-1596-release-sequence-workdir.md) | ✅ | ✅ | release.yml 序号脚本在 working-directory: fushi 下解析成不存在路径，恢复自动发布首跑 exit 127 |
 | [BUG-1595](bugs/BUG-1595-dict-update-not-replacing.md) | ✅ | ✅ | 词典更新入口遇新包标题变化仍判新增两版并存 |

--- a/docs/bugs/BUG-1604-sync-channel-isolation-remaining-loops.md
+++ b/docs/bugs/BUG-1604-sync-channel-isolation-remaining-loops.md
@@ -1,0 +1,36 @@
+## BUG-1604 · 合集同步与退出书同步的通道循环仍无逐通道隔离：云通道抛异常，互联通道整轮不跑
+- **报告**：2026-08-14（用户报「互联所有地方都有点问题」，TODO-2803 互联体检第⑤条的遗留部分）
+- **真实性**：✅ 真 bug。BUG-1552 只修了四条通道循环里的一条（app-open sweep），
+  BUG-1573 补了第二条（`runManualFullSync`），另外两条原样存活：
+  - `fushi/lib/src/sync/sync_auto_trigger.dart:847`（改前）`_runCollectionsSync` 的
+    `for (final SyncChannel channel in await enabledSyncChannelBackends(repo))` 循环体
+    **无逐通道 try**，只有 `:879` 外层一个 `catch (e) { developer.log(...) }`。
+  - `fushi/lib/src/sync/sync_auto_trigger.dart:949`（改前）`_runAutoSync` 的 per-book
+    通道循环同形，只有 `:994` 外层 catch。
+  - 云备份通道**恒排第一**（`enabledSyncChannelBackends`）。触发：Google Drive 令牌
+    失效 / WebDAV 或 FTP 不可达 → `backend.restoreAuth(repo)` 或
+    `orchestrator.runCollectionsOnly()` / `manager.syncBook()` 抛裸 `SocketException`
+    → 异常冒出 for → **局域网互联通道这一轮根本不执行**。
+  - 附带记账缺陷：per-book 循环的 `channelsRun++` 在 `syncBook` **之前**，抛异常的通道
+    也被计成「跑过」。
+- **症状预测**：设置页 UI 承诺「互联与云备份并存、互不干扰」，实际云盘一坏互联跟着哑。
+  合集维度：手机上新建的合集在桌面一直不出现（合集是双端都在改的维度，漏一轮即不一致）。
+  退出书维度：对端续读位置停在旧处——而退出书是「读到哪」最主要的写入时机。两处的失败
+  原因都指向云盘，用户不会想到互联被连累，于是表现为弥散的「互联所有地方都有点问题」。
+- **[x] ① 已修复** — 两条循环各加逐通道 try/catch，与 app-open sweep 同一范式：一条通道
+  抛异常只记它自己的账（`developer.log` 带 name/stack + `interconnect=` 身份），其余通道
+  照跑；`anyChannelFailed` 让最终 `reason` 如实报 `failed` 而不是把部分失败伪装成
+  `completed`；per-book 的 `channelsRun++` 移到 `syncBook` 成功之后。
+  提交：见本条 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/sync_channel_isolation_test.dart`（4 例）。
+  **顺带还掉 BUG-1552 ② 的欠账**：该条当时写明「未加测试，待补——给通道列表抽一个可注入
+  的测试缝后，用『第一条通道 throw、断言第二条仍被调用』做守卫」，正因为缝没抽，同一个
+  结构缺陷才在另外两条循环里存活至今。本次新增
+  `sync_auto_trigger.dart` 的 `debugSyncChannelsOverride`（`@visibleForTesting`，生产恒
+  null）+ `runAutoSyncForBookForTest` 可 await 入口，注入假通道后即可守。
+  断言落在「第二条通道的 `restoreAuth` 有没有被调到」——它精确等价于「循环有没有被第一条
+  通道的异常掐断」，且无需拉起 orchestrator/SyncManager。
+  **变异实测**：在两个 catch 末尾各插一句 `rethrow` 还原缺陷，两条守卫精确变红
+  （`Expected: true, Actual: <false>`）；撤销探针后复绿，探针零残留。
+- **备注**：TODO-2803 审计的六条实锤中，①③④⑥ 与②已由 BUG-1576/1578/1579/1580/1566 在
+  2026-08-12 修掉，第⑤条的这两条循环是最后的遗留。四条通道循环至此全部具备逐通道隔离。

--- a/fushi/lib/src/sync/sync_auto_trigger.dart
+++ b/fushi/lib/src/sync/sync_auto_trigger.dart
@@ -179,11 +179,26 @@ class SyncChannelAuthError implements Exception {
   String toString() => 'SyncChannelAuthError(${channel.type.name}): $error';
 }
 
+/// BUG-1604 测试缝：注入本轮要跑的通道列表，绕开 [resolveSyncBackend] 返回的真实
+/// 单例后端。生产恒为 null（走下面的真实枚举）。
+///
+/// 为什么必须有这个缝：本文件里「一条通道抛异常，其余通道照跑」是**循环结构**的
+/// 不变式，只能用「第一条通道 throw，断言第二条仍被调用」来守。而真实通道来自六个
+/// 后端工厂 + 全套编排依赖，单测层拉不起来——BUG-1552 当初修了 sweep 那条循环却
+/// 把测试记成欠账（「待补：抽一个可注入的通道列表测试缝」），于是同一个结构缺陷在
+/// 另外两条循环里原样存活到 BUG-1604。缝补上，四条循环才都守得住。
+@visibleForTesting
+Future<List<SyncChannel>> Function(SyncRepository repo)?
+    debugSyncChannelsOverride;
+
 /// 不再 `@visibleForTesting`：`hasDeletionPropagationChannel` 是生产消费方——
 /// 「本机有没有可用于删除传播的通道」必须复用同一份通道枚举，各处重抄必漂。
 Future<List<SyncChannel>> enabledSyncChannelBackends(
   SyncRepository repo,
 ) async {
+  final Future<List<SyncChannel>> Function(SyncRepository repo)? override =
+      debugSyncChannelsOverride;
+  if (override != null) return override(repo);
   final SyncBackendType cloudType = await repo.getBackendType();
   final SyncBackend cloud = resolveSyncBackend(cloudType);
   // isInterconnect 由后端身份决定，不由「它排在云通道那一格」决定：备份后端被选成
@@ -407,6 +422,21 @@ Future<void> runAutoSyncAllForTest({
       localAudioEntries: localAudioEntries,
       onLocalAudioImported:
           onLocalAudioImported ?? (LocalAudioPackageContents _) async {},
+    );
+
+/// BUG-1604 测试入口：以可 await 的方式跑一次退出书 per-book 同步（生产入口
+/// [triggerAutoSyncOnMediaClosed] 把它注册进 [BookExitSyncScope] 且不回传 future）。
+@visibleForTesting
+Future<void> runAutoSyncForBookForTest({
+  required FushiDatabase db,
+  required String mediaIdentifier,
+  SyncReportCallback? onReport,
+}) =>
+    _runAutoSync(
+      db: db,
+      mediaIdentifier: mediaIdentifier,
+      messenger: null,
+      onReport: onReport,
     );
 
 const _syncCooldownMs = 5 * 60 * 1000;
@@ -844,37 +874,60 @@ Future<void> _runCollectionsSync({required FushiDatabase db}) async {
         reason = SyncOutcomeReason.autoDisabled;
         return;
       }
+      // BUG-1604：**逐通道**隔离异常，与 app-open sweep 同一范式。这个 for 原来
+      // 整体裸奔，只有外层一个 `catch (e) { developer.log(...) }`——云通道恒排第一
+      // （见 enabledSyncChannelBackends），它的 `restoreAuth` 探测不到 WebDAV/FTP、
+      // 或 `runCollectionsOnly` 抛裸 SocketException，异常直接终止整个 for，互联
+      // 通道的合集同步这一轮**根本不执行**。合集是双端都在改的维度，漏跑一轮就是
+      // 「我在手机上建的合集，桌面上一直不出现」。
+      bool anyChannelFailed = false;
       for (final SyncChannel channel
           in await enabledSyncChannelBackends(repo)) {
-        final SyncBackend backend = channel.backend;
-        await backend.restoreAuth(repo);
-        if (!await backend.isAuthenticated) continue;
-        final SyncOrchestrator orchestrator = SyncOrchestrator(
-          db: db,
-          backend: backend,
-          // 合集维度不触碰词典/音频/临时目录；systemTemp 仅为满足构造器形参，
-          // runCollectionsOnly 保证不落任何文件。
-          dictionaryResourceRoot: Directory.systemTemp,
-          audioDatabaseRoot: Directory.systemTemp,
-          tempDir: Directory.systemTemp,
-          deviceId: await repo.getOrCreateDeviceId(),
-          syncStats: false,
-          syncAudioBookPosition: false,
-          syncContent: false,
-          syncAudioBookFiles: false,
-          syncVideoFiles: false,
-          syncDictionary: false,
-          syncLocalAudio: false,
-          localAudioEntries: const <LocalAudioDbEntry>[],
-          onLocalAudioImported: (LocalAudioPackageContents _) async {},
-        );
-        final SyncRunReport report = await orchestrator.runCollectionsOnly();
-        channelsRun++;
-        logSyncReportErrors(report);
+        try {
+          final SyncBackend backend = channel.backend;
+          await backend.restoreAuth(repo);
+          if (!await backend.isAuthenticated) continue;
+          final SyncOrchestrator orchestrator = SyncOrchestrator(
+            db: db,
+            backend: backend,
+            // 合集维度不触碰词典/音频/临时目录；systemTemp 仅为满足构造器形参，
+            // runCollectionsOnly 保证不落任何文件。
+            dictionaryResourceRoot: Directory.systemTemp,
+            audioDatabaseRoot: Directory.systemTemp,
+            tempDir: Directory.systemTemp,
+            deviceId: await repo.getOrCreateDeviceId(),
+            syncStats: false,
+            syncAudioBookPosition: false,
+            syncContent: false,
+            syncAudioBookFiles: false,
+            syncVideoFiles: false,
+            syncDictionary: false,
+            syncLocalAudio: false,
+            localAudioEntries: const <LocalAudioDbEntry>[],
+            onLocalAudioImported: (LocalAudioPackageContents _) async {},
+          );
+          final SyncRunReport report = await orchestrator.runCollectionsOnly();
+          channelsRun++;
+          logSyncReportErrors(report);
+        } catch (e, stack) {
+          anyChannelFailed = true;
+          developer.log(
+            'Collections sync channel failed '
+            '(interconnect=${channel.isInterconnect})',
+            error: e,
+            stackTrace: stack,
+            name: 'SyncAutoTrigger',
+          );
+        }
       }
-      reason = channelsRun > 0
-          ? SyncOutcomeReason.completed
-          : SyncOutcomeReason.noChannels;
+      // 部分失败如实报 failed，不伪装成 completed（与 sweep 同一记账口径）。
+      if (anyChannelFailed) {
+        reason = SyncOutcomeReason.failed;
+      } else {
+        reason = channelsRun > 0
+            ? SyncOutcomeReason.completed
+            : SyncOutcomeReason.noChannels;
+      }
     });
   } catch (e) {
     developer.log(
@@ -946,50 +999,73 @@ Future<void> _runAutoSync({
 
       // option B 双通道：退出书时对每条启用的通道（云备份 + 互联）各跑一次 per-book
       // 同步，互不排斥。每条通道各自认证成功才跑；未配置的通道 continue 跳过。
+      //
+      // BUG-1604：**逐通道**隔离异常，与 app-open sweep 同一范式。这个 for 原来也是
+      // 整体裸奔（只有外层一个 catch）——云通道的 `restoreAuth` / `syncBook` 一抛，
+      // 互联通道的书进度与内容推送整轮被跳过。退出书是「读到哪」最主要的写入时机，
+      // 漏跑一轮就是对端续读位置停在旧处，而失败原因指向云盘，用户不会想到互联被连累。
+      bool anyChannelFailed = false;
       for (final SyncChannel channel
           in await enabledSyncChannelBackends(repo)) {
         final SyncBackend backend = channel.backend;
-        await backend.restoreAuth(repo);
-        if (!await backend.isAuthenticated) continue;
+        try {
+          await backend.restoreAuth(repo);
+          if (!await backend.isAuthenticated) continue;
 
-        channelsRun++;
-        final manager = SyncManager(db: db, backend: backend);
-        final result = await manager.syncBook(
-          book: book,
-          syncStats: syncStats,
-          statsSyncMode: StatisticsSyncMode.merge,
-          syncAudioBook: syncAudioBook,
-          syncContent:
-              channel.isInterconnect ? interconnectSyncContent : syncContent,
-        );
+          final manager = SyncManager(db: db, backend: backend);
+          final result = await manager.syncBook(
+            book: book,
+            syncStats: syncStats,
+            statsSyncMode: StatisticsSyncMode.merge,
+            syncAudioBook: syncAudioBook,
+            syncContent:
+                channel.isInterconnect ? interconnectSyncContent : syncContent,
+          );
+          // 计数放在 syncBook **之后**：抛异常的通道不算「跑过」，否则
+          // channelsRun>0 会把一条都没成功的轮次记成 completed（与 sweep 一致）。
+          channelsRun++;
 
-        // TODO-132 诉求B：退出书同步静默——不再弹 imported/exported「同步成功」
-        // SnackBar（打断用户、让用户误以为「必须等同步成功条才能离开」=卡手）。
-        // 同步是 fire-and-forget 后台动作，成功无需打断式提示；真正需要用户介入的
-        // **冲突**仍经下方 onReport → presentAutoConflicts 弹对话框（不是 SnackBar）。
-        // messenger 参数保留（签名兼容，背景/app-open 路径本就传 null）。
+          // TODO-132 诉求B：退出书同步静默——不再弹 imported/exported「同步成功」
+          // SnackBar（打断用户、让用户误以为「必须等同步成功条才能离开」=卡手）。
+          // 同步是 fire-and-forget 后台动作，成功无需打断式提示；真正需要用户介入的
+          // **冲突**仍经下方 onReport → presentAutoConflicts 弹对话框（不是 SnackBar）。
+          // messenger 参数保留（签名兼容，背景/app-open 路径本就传 null）。
 
-        // Surface a genuine fork to the caller as a one-conflict report so the
-        // book-exit flow can prompt resolution. The single-book path runs
-        // SyncManager.syncBook (not the orchestrator), so build the report here
-        // from the conflict fields SyncManager fills on SyncResult.conflict.
-        if (onReport != null) {
-          final SyncRunReport report = SyncRunReport();
-          if (result.direction == SyncResult.conflict) {
-            report.conflicts.add(SyncConflict(
-              assetKey: result.conflictAssetKey!,
-              dimension: result.conflictDimension!,
-              title: result.title,
-              localVersion: result.conflictLocalVersion,
-              remoteVersion: result.conflictRemoteVersion,
-            ));
+          // Surface a genuine fork to the caller as a one-conflict report so the
+          // book-exit flow can prompt resolution. The single-book path runs
+          // SyncManager.syncBook (not the orchestrator), so build the report here
+          // from the conflict fields SyncManager fills on SyncResult.conflict.
+          if (onReport != null) {
+            final SyncRunReport report = SyncRunReport();
+            if (result.direction == SyncResult.conflict) {
+              report.conflicts.add(SyncConflict(
+                assetKey: result.conflictAssetKey!,
+                dimension: result.conflictDimension!,
+                title: result.title,
+                localVersion: result.conflictLocalVersion,
+                remoteVersion: result.conflictRemoteVersion,
+              ));
+            }
+            onReport(report, backend);
           }
-          onReport(report, backend);
+        } catch (e, stack) {
+          anyChannelFailed = true;
+          developer.log(
+            'Book-exit sync channel failed '
+            '(interconnect=${channel.isInterconnect})',
+            error: e,
+            stackTrace: stack,
+            name: 'SyncAutoTrigger',
+          );
         }
       }
-      reason = channelsRun > 0
-          ? SyncOutcomeReason.completed
-          : SyncOutcomeReason.noChannels;
+      if (anyChannelFailed) {
+        reason = SyncOutcomeReason.failed;
+      } else {
+        reason = channelsRun > 0
+            ? SyncOutcomeReason.completed
+            : SyncOutcomeReason.noChannels;
+      }
     });
   } catch (e) {
     developer.log(

--- a/fushi/test/sync/sync_channel_isolation_test.dart
+++ b/fushi/test/sync/sync_channel_isolation_test.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/sync_auto_trigger.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// BUG-1604 守卫：双通道的**循环结构**不变式——「一条通道抛异常，其余通道照跑」。
+///
+/// UI 承诺「互联与云备份并存、互不干扰」。云通道恒排第一（见
+/// [enabledSyncChannelBackends]），所以只要通道循环没有逐通道 try，云盘一坏（令牌
+/// 失效 / WebDAV 不可达 / 裸 SocketException）就会终止整个 for，局域网互联通道这一
+/// 轮根本不执行——用户看到的是弥散的「互联所有地方都有点问题」。
+///
+/// 这类缺陷只能用「第一条通道 throw、断言第二条仍被调用」来守，而真实通道来自六个
+/// 后端工厂 + 全套编排依赖，单测层拉不起来。BUG-1552 当初因此把测试记成欠账，同一个
+/// 结构缺陷于是在另外两条循环里原样存活。[debugSyncChannelsOverride] 就是补上的那个
+/// 缝：注入假通道，四条循环从此都守得住。
+///
+/// **断言落在 `restoreAuth` 被调用与否上**：它是每条通道进入实际工作前的第一步，
+/// 「第二条通道的 restoreAuth 有没有被调到」精确等价于「循环有没有被第一条通道的
+/// 异常掐断」，且不需要拉起 orchestrator/SyncManager。第二条通道让
+/// `isAuthenticated` 返回 false，循环体在构造编排器之前就 continue。
+FushiDatabase _memDb() =>
+    FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+/// 假后端：记录 restoreAuth 是否被调用；[throwOnRestore] 时抛裸异常模拟
+/// 「云盘不可达」。其余成员一律未实现——被碰到就是测试假设错了，直接炸。
+class _ProbeBackend implements SyncBackend {
+  _ProbeBackend({this.throwOnRestore = false});
+
+  final bool throwOnRestore;
+  bool restoreAuthCalled = false;
+
+  @override
+  Future<bool> restoreAuth(SyncRepository repo) async {
+    restoreAuthCalled = true;
+    if (throwOnRestore) {
+      // 裸 SocketException：审计里 WebDavOps 抛的就是它（不是 SyncBackendError），
+      // 用它才能守住「任何异常都被隔离」而不是只守住某个自家异常类型。
+      throw const SocketException('backend unreachable');
+    }
+    return true;
+  }
+
+  /// 第二条通道恒返回 false：循环体据此 continue，不必构造真编排器。
+  @override
+  Future<bool> get isAuthenticated async => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('unexpected ${invocation.memberName}');
+}
+
+/// 造一对通道：云通道（会抛）+ 互联通道（应当仍被跑到）。
+({_ProbeBackend cloud, _ProbeBackend interconnect}) _probePair() => (
+      cloud: _ProbeBackend(throwOnRestore: true),
+      interconnect: _ProbeBackend(),
+    );
+
+List<SyncChannel> _channels(
+        ({_ProbeBackend cloud, _ProbeBackend interconnect}) p) =>
+    <SyncChannel>[
+      SyncChannel(p.cloud, type: SyncBackendType.webDav, isInterconnect: false),
+      SyncChannel(p.interconnect,
+          type: SyncBackendType.fushiServer, isInterconnect: true),
+    ];
+
+void main() {
+  tearDown(() => debugSyncChannelsOverride = null);
+
+  test('测试缝默认关闭：生产枚举不受影响', () async {
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+    // 未设 override 时走真实枚举：只配了云备份默认值 → 至少解析出一条通道，
+    // 且绝不是本测试的假后端。
+    final List<SyncChannel> real = await enabledSyncChannelBackends(repo);
+    expect(real, isNotEmpty);
+    expect(real.first.backend, isNot(isA<_ProbeBackend>()));
+  });
+
+  group('BUG-1604 合集同步：云通道抛异常不得掐断互联通道', () {
+    test('第一条通道 restoreAuth 抛 SocketException，第二条仍被跑到', () async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+      await repo.setAutoSyncEnabled(true);
+
+      final ({_ProbeBackend cloud, _ProbeBackend interconnect}) p =
+          _probePair();
+      debugSyncChannelsOverride = (SyncRepository _) async => _channels(p);
+
+      await runCollectionsSyncNow(db: db);
+
+      expect(p.cloud.restoreAuthCalled, isTrue, reason: '第一条通道本就该被跑到');
+      expect(
+        p.interconnect.restoreAuthCalled,
+        isTrue,
+        reason: '修复前：云通道的异常终止整个 for，互联通道这一轮根本不执行',
+      );
+    });
+
+    test('自动同步关闭时一条通道都不跑（不误伤既有短路）', () async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+      await repo.setAutoSyncEnabled(false);
+
+      final ({_ProbeBackend cloud, _ProbeBackend interconnect}) p =
+          _probePair();
+      debugSyncChannelsOverride = (SyncRepository _) async => _channels(p);
+
+      await runCollectionsSyncNow(db: db);
+
+      expect(p.cloud.restoreAuthCalled, isFalse);
+      expect(p.interconnect.restoreAuthCalled, isFalse);
+    });
+  });
+
+  group('BUG-1604 退出书同步：云通道抛异常不得掐断互联通道', () {
+    test('第一条通道 restoreAuth 抛 SocketException，第二条仍被跑到', () async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+      await repo.setAutoSyncEnabled(true);
+      // per-book 路径要先取到书，取不到会在进入通道循环前就以 nothingToSync 收尾。
+      const String bookKey = 'bug1604book';
+      await db.insertEpubBook(EpubBooksCompanion.insert(
+        bookKey: bookKey,
+        title: 'BUG-1604 fixture',
+        epubPath: '/tmp/$bookKey/original.epub',
+        extractDir: '/tmp/$bookKey',
+        chapterCount: 1,
+        chaptersJson: '["c"]',
+        importedAt: 0,
+      ));
+
+      final ({_ProbeBackend cloud, _ProbeBackend interconnect}) p =
+          _probePair();
+      debugSyncChannelsOverride = (SyncRepository _) async => _channels(p);
+
+      // 前缀必须是 fushi://book/：入口用 `_bookKeyPattern` + parseBookKey 双重
+      // 校验，别的前缀会在取书之前就 return，测试会假绿。
+      await runAutoSyncForBookForTest(
+        db: db,
+        mediaIdentifier: 'fushi://book/$bookKey',
+      );
+
+      expect(p.cloud.restoreAuthCalled, isTrue, reason: '第一条通道本就该被跑到');
+      expect(
+        p.interconnect.restoreAuthCalled,
+        isTrue,
+        reason: '修复前：云通道的异常终止整个 for，互联通道的书进度整轮被跳过',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 背景

用户报「互联所有地方都有点问题」。看板 TODO-2803 的只读审计（2026-08-11）列了六条实锤，统一根因是「互联从互斥 backendType 解耦成与云并存的第二通道时，单例状态没按通道拆维度」。

先对着 `origin/develop` 逐条复核了这六条的现状：**①②③④⑥ 已在 2026-08-12 由 BUG-1576/1578/1579/1580/1566 系统性修掉**（folder 缓存按通道分槽、`SyncChannelAuthError` 带通道身份、合集/墓碑基线拆维度、词典删除与比较入口改遍历通道）。**只剩第⑤条「通道零异常隔离」的两条循环是真实遗留**，本 PR 修的就是它。

## 根因

四条通道循环里，BUG-1552 只修了 app-open sweep 一条，BUG-1573 补了 `runManualFullSync`，另外两条原样裸奔：

| 位置 | 状态（改前） |
|---|---|
| `sync_auto_trigger.dart:847` `_runCollectionsSync` | 循环体无 try，只有 `:879` 外层 catch |
| `sync_auto_trigger.dart:949` `_runAutoSync` per-book | 循环体无 try，只有 `:994` 外层 catch |

云备份通道**恒排第一**（`enabledSyncChannelBackends`）。Google Drive 令牌失效 / WebDAV / FTP 不可达时，`backend.restoreAuth(repo)` 或 `orchestrator.runCollectionsOnly()` / `manager.syncBook()` 抛裸 `SocketException` → 异常冒出 for → **互联通道这一轮根本不执行**。

设置页 UI 承诺「互联与云备份并存、互不干扰」，实际是云盘一坏互联跟着哑：合集维度上手机新建的合集在桌面一直不出现；退出书维度上对端续读位置停在旧处（退出书是「读到哪」最主要的写入时机）。两处失败原因都指向云盘，用户不会想到互联被连累——这正是「所有地方都有点问题」这种弥散症状的来源。

附带：per-book 的 `channelsRun++` 在 `syncBook` **之前**，抛异常的通道也被计成「跑过」。

## 修复

- 两条循环各加逐通道 try/catch，与 app-open sweep 同一范式：一条通道抛异常只记它自己的账（`developer.log` 带 name/stack + `interconnect=` 身份），其余通道照跑。
- `anyChannelFailed` 让最终 `reason` 如实报 `failed`，不把部分失败伪装成 `completed`。
- per-book 的 `channelsRun++` 移到 `syncBook` 成功之后。

## 顺带还掉 BUG-1552 的测试欠账

BUG-1552 当年写明「测试未加，**待补**：给通道列表抽一个可注入的测试缝后，用『第一条通道 throw、断言第二条仍被调用』做守卫」。正因为这个缝没抽，同一个结构缺陷才在另外两条循环里存活至今。本 PR 把缝补上：

- `debugSyncChannelsOverride`（`@visibleForTesting`，生产恒 null，与本文件已有的 `debugMarkSweepInProgress` 同一 idiom）
- `runAutoSyncForBookForTest`（可 await 的 per-book 入口，对应已有的 `runAutoSyncAllForTest`）

断言落在「第二条通道的 `restoreAuth` 有没有被调到」——它精确等价于「循环有没有被第一条通道的异常掐断」，且无需拉起 orchestrator/SyncManager（这正是当年判定「代价远超收益」的那部分）。

## 验证

- `flutter analyze` 全量（含 test）零问题。
- `flutter test test/sync test/tools --no-pub`：**2469 条全过，退出码 0**。
- 新增 `fushi/test/sync/sync_channel_isolation_test.dart`（4 例）。
- **变异实测**：在两个 catch 末尾各插一句 `rethrow` 还原缺陷，两条守卫精确变红（`Expected: true, Actual: <false>`）；用反向替换撤销探针后复绿，`grep MUTATION-PROBE` / `grep rethrow` 均零残留。

https://claude.ai/code/session_013C5iywkHYWJ93aNSEeZHRb