### PR TITLE
fix(av): 消掉 Windows 更新路径上的 LOLBin 行为特征（卡巴 PDM:Trojan.Win32.Generic 误报）

### DIFF
--- a/fushi/lib/src/platform/desktop/windows_process_query.dart
+++ b/fushi/lib/src/platform/desktop/windows_process_query.dart
@@ -1,0 +1,488 @@
+/// Windows 进程 / 注册表查询：**直接调 Win32 API，不生成子进程**。
+///
+/// ## 为什么存在（真实事故）
+///
+/// 卡巴斯基 Endpoint Security 的行为检测（PDM）把运行中的 hibiki.exe 判成
+/// `PDM:Trojan.Win32.Generic`（威胁级别「高」，对象类型「进程」，直接结束进程）。
+/// 没有任何文件特征命中——是**动作链**打分过阈：
+///
+///   未签名进程 → 联网拉 PE 落盘 → 生成 powershell 子进程枚举全机进程/模块
+///   → 生成 reg.exe 读注册表 → 生成分离子进程静默执行刚下载的 PE → 自身退出
+///
+/// 这条链里「进程生成 powershell/reg 去问系统要信息」这几环是**可以完全消掉**的：
+/// 同样的信息用 Win32 API 直接读，既不产生子进程、也不经过 LOLBin。本模块就是那层。
+///
+/// 换掉的调用（全部曾是 `Process.run`）：
+/// - `powershell -Command "Get-CimInstance Win32_Process ..."` ×2（更新器诊断）
+/// - `powershell -Command "(Get-Process -Id N).Path"` ×1（端口占用者）
+/// - `tasklist /FI "PID eq N"` ×1（端口占用者进程名）
+/// - `reg query ...` ×3（安装位置 ×2、系统代理 ×1）
+///
+/// ## 为什么比 tasklist / Get-CimInstance 更轻
+///
+/// 那两者取一次信息就把**全机每个进程**的元数据都拉一遍。本模块把「枚举」和
+/// 「取完整路径」拆成两步：[enumerateWindowsProcesses] 只读快照里的 PID + image 名
+/// （不 `OpenProcess` 任何进程），调用方按名字/PID 过滤完，再对**命中的少数几个**
+/// 调 [windowsProcessImagePath]。全机 `OpenProcess` 从此不在正常路径上发生。
+///
+/// ## 为什么是裸 FFI 而不是 package:win32
+///
+/// win32 在本仓只是**传递依赖**，直接 import 会触发 `depend_on_referenced_packages`
+/// （CI 把 warning 当致命）。仓库既有的 `galgame_play_tracker.dart` /
+/// `desktop_foreground_guard.dart` / `selection_capture_ffi.dart` 都是这个范式。
+///
+/// 非 Windows 平台全部返回空/null，调用方无需自己 gate。
+library;
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart';
+
+/// 一个进程的最小身份。[path] 为 null 表示没取到（权限不足 / 进程已退出 /
+/// 调用方压根没要求解析路径——见 [enumerateWindowsProcesses] 的惰性契约）。
+@immutable
+class WindowsProcessEntry {
+  const WindowsProcessEntry({
+    required this.pid,
+    required this.name,
+    this.path,
+  });
+
+  final int pid;
+
+  /// image 名（`PROCESSENTRY32W.szExeFile`），如 `fushi.exe`。
+  final String name;
+
+  /// exe 完整路径，取不到为 null。
+  final String? path;
+
+  WindowsProcessEntry withPath(String? resolved) => WindowsProcessEntry(
+        pid: pid,
+        name: name,
+        path: resolved ?? path,
+      );
+
+  @override
+  String toString() => 'WindowsProcessEntry(pid: $pid, name: $name, '
+      'path: ${path ?? '<unresolved>'})';
+}
+
+/// 注册表根键。
+enum WindowsRegistryRoot {
+  currentUser(0x80000001),
+  localMachine(0x80000002);
+
+  const WindowsRegistryRoot(this.handle);
+
+  final int handle;
+}
+
+// ── 公开 API ─────────────────────────────────────────────────────────────────
+
+/// 枚举全机进程，**只取 PID + image 名**（不 `OpenProcess`，不解析路径）。
+///
+/// 路径按需单独取（[windowsProcessImagePath]）——这是本模块相对 `tasklist` /
+/// `Get-CimInstance` 的核心差别：不为了拿几个进程的路径而访问全机每个进程。
+List<WindowsProcessEntry> enumerateWindowsProcesses() {
+  if (!Platform.isWindows) return const <WindowsProcessEntry>[];
+  return _Win32.instance?.enumerateProcesses() ?? const <WindowsProcessEntry>[];
+}
+
+/// 取指定 PID 的 exe 完整路径；取不到返回 null。
+String? windowsProcessImagePath(int pid) {
+  if (!Platform.isWindows || pid <= 0) return null;
+  return _Win32.instance?.processImagePath(pid);
+}
+
+/// 取指定 PID 的进程身份（含路径）；进程不存在返回 null。
+WindowsProcessEntry? windowsProcessById(int pid) {
+  if (!Platform.isWindows || pid <= 0) return null;
+  for (final WindowsProcessEntry entry in enumerateWindowsProcesses()) {
+    if (entry.pid == pid) {
+      return entry.withPath(windowsProcessImagePath(pid));
+    }
+  }
+  return null;
+}
+
+/// 按 image 名（大小写不敏感）筛进程，并为命中项解析完整路径。
+///
+/// 先筛后解析：只对命中的少数进程 `OpenProcess`。
+List<WindowsProcessEntry> windowsProcessesByNames(Set<String> imageNames) {
+  if (!Platform.isWindows || imageNames.isEmpty) {
+    return const <WindowsProcessEntry>[];
+  }
+  final Set<String> wanted =
+      imageNames.map((String name) => name.toLowerCase()).toSet();
+  return <WindowsProcessEntry>[
+    for (final WindowsProcessEntry entry in enumerateWindowsProcesses())
+      if (wanted.contains(entry.name.toLowerCase()))
+        entry.withPath(windowsProcessImagePath(entry.pid)),
+  ];
+}
+
+/// 批量取若干 PID 的身份（含路径）。只枚举一次快照。
+Map<int, WindowsProcessEntry> windowsProcessesByIds(Iterable<int> pids) {
+  final Set<int> wanted = pids.where((int pid) => pid > 0).toSet();
+  if (!Platform.isWindows || wanted.isEmpty) {
+    return const <int, WindowsProcessEntry>{};
+  }
+  return <int, WindowsProcessEntry>{
+    for (final WindowsProcessEntry entry in enumerateWindowsProcesses())
+      if (wanted.contains(entry.pid))
+        entry.pid: entry.withPath(windowsProcessImagePath(entry.pid)),
+  };
+}
+
+/// 读注册表字符串值（`REG_SZ` / `REG_EXPAND_SZ`）；不存在或类型不符返回 null。
+String? readWindowsRegistryString(
+  WindowsRegistryRoot root,
+  String subKey,
+  String valueName,
+) {
+  if (!Platform.isWindows) return null;
+  return _Win32.instance?.readRegistryString(root, subKey, valueName);
+}
+
+/// 读注册表 DWORD 值（`REG_DWORD`）；不存在或类型不符返回 null。
+int? readWindowsRegistryDword(
+  WindowsRegistryRoot root,
+  String subKey,
+  String valueName,
+) {
+  if (!Platform.isWindows) return null;
+  return _Win32.instance?.readRegistryDword(root, subKey, valueName);
+}
+
+// ── Win32 绑定 ───────────────────────────────────────────────────────────────
+
+/// 惰性单例：只在真 Windows 上 `DynamicLibrary.open`，失败则整体退化成 null
+/// （调用方拿到空结果，与「查不到」同义，绝不抛到业务层）。
+class _Win32 {
+  _Win32._()
+      : _openProcess =
+            _kernel32.lookupFunction<_OpenProcessNative, _OpenProcessDart>(
+                'OpenProcess'),
+        _queryFullProcessImageName = _kernel32.lookupFunction<
+            _QueryFullProcessImageNameNative,
+            _QueryFullProcessImageNameDart>('QueryFullProcessImageNameW'),
+        _createToolhelp32Snapshot = _kernel32.lookupFunction<
+            _CreateToolhelp32SnapshotNative,
+            _CreateToolhelp32SnapshotDart>('CreateToolhelp32Snapshot'),
+        _process32First =
+            _kernel32.lookupFunction<_Process32Native, _Process32Dart>(
+                'Process32FirstW'),
+        _process32Next = _kernel32
+            .lookupFunction<_Process32Native, _Process32Dart>('Process32NextW'),
+        _closeHandle =
+            _kernel32.lookupFunction<_CloseHandleNative, _CloseHandleDart>(
+                'CloseHandle'),
+        _regOpenKeyEx =
+            _advapi32.lookupFunction<_RegOpenKeyExNative, _RegOpenKeyExDart>(
+                'RegOpenKeyExW'),
+        _regQueryValueEx = _advapi32.lookupFunction<_RegQueryValueExNative,
+            _RegQueryValueExDart>('RegQueryValueExW'),
+        _regCloseKey =
+            _advapi32.lookupFunction<_RegCloseKeyNative, _RegCloseKeyDart>(
+                'RegCloseKey');
+
+  static _Win32? _cached;
+  static bool _initialised = false;
+
+  static _Win32? get instance {
+    if (_initialised) return _cached;
+    _initialised = true;
+    try {
+      _cached = _Win32._();
+    } on Object catch (e) {
+      debugPrint('[WindowsProcessQuery] Win32 bind failed: $e');
+      _cached = null;
+    }
+    return _cached;
+  }
+
+  static final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+  static final DynamicLibrary _advapi32 = DynamicLibrary.open('advapi32.dll');
+
+  static const int _processQueryLimitedInformation = 0x1000;
+  static const int _th32csSnapProcess = 0x00000002;
+  static const int _invalidHandleValue = -1;
+  static const int _imagePathBufferLength = 32768;
+  static const int _errorSuccess = 0;
+  static const int _keyRead = 0x20019;
+  static const int _regSz = 1;
+  static const int _regExpandSz = 2;
+  static const int _regDword = 4;
+
+  final _OpenProcessDart _openProcess;
+  final _QueryFullProcessImageNameDart _queryFullProcessImageName;
+  final _CreateToolhelp32SnapshotDart _createToolhelp32Snapshot;
+  final _Process32Dart _process32First;
+  final _Process32Dart _process32Next;
+  final _CloseHandleDart _closeHandle;
+  final _RegOpenKeyExDart _regOpenKeyEx;
+  final _RegQueryValueExDart _regQueryValueEx;
+  final _RegCloseKeyDart _regCloseKey;
+
+  List<WindowsProcessEntry> enumerateProcesses() {
+    final List<WindowsProcessEntry> result = <WindowsProcessEntry>[];
+    int snapshot = _invalidHandleValue;
+    Pointer<_ProcessEntry32W>? entry;
+    try {
+      snapshot = _createToolhelp32Snapshot(_th32csSnapProcess, 0);
+      if (snapshot == _invalidHandleValue || snapshot == 0) return result;
+      entry = calloc<_ProcessEntry32W>();
+      entry.ref.dwSize = sizeOf<_ProcessEntry32W>();
+      int ok = _process32First(snapshot, entry);
+      while (ok != 0) {
+        final int pid = entry.ref.th32ProcessID;
+        if (pid > 0) {
+          result.add(
+            WindowsProcessEntry(
+              pid: pid,
+              name: _exeNameFrom(entry.ref.szExeFile),
+            ),
+          );
+        }
+        ok = _process32Next(snapshot, entry);
+      }
+      return result;
+    } on Object {
+      return result;
+    } finally {
+      if (entry != null) calloc.free(entry);
+      if (snapshot != _invalidHandleValue && snapshot != 0) {
+        _closeHandle(snapshot);
+      }
+    }
+  }
+
+  /// `szExeFile` 是定长 260 的 UTF-16 数组，读到 NUL 为止。
+  String _exeNameFrom(Array<Uint16> raw) {
+    final StringBuffer buffer = StringBuffer();
+    for (int i = 0; i < 260; i++) {
+      final int unit = raw[i];
+      if (unit == 0) break;
+      buffer.writeCharCode(unit);
+    }
+    return buffer.toString();
+  }
+
+  String? processImagePath(int pid) {
+    try {
+      final int handle = _openProcess(_processQueryLimitedInformation, 0, pid);
+      if (handle == 0) return null;
+      final Pointer<Utf16> path = calloc<Uint16>(_imagePathBufferLength).cast();
+      final Pointer<Uint32> length = calloc<Uint32>()
+        ..value = _imagePathBufferLength;
+      try {
+        final int ok = _queryFullProcessImageName(handle, 0, path, length);
+        if (ok == 0 || length.value == 0) return null;
+        return path.toDartString(length: length.value);
+      } finally {
+        calloc.free(length);
+        calloc.free(path);
+        _closeHandle(handle);
+      }
+    } on Object {
+      return null;
+    }
+  }
+
+  /// 打开子键 → 读值 → 关键。失败一律 null（与「没有这个值」同义）。
+  T? _withRegistryValue<T>(
+    WindowsRegistryRoot root,
+    String subKey,
+    String valueName,
+    T? Function(int type, Pointer<Uint8> data, int bytes) read,
+  ) {
+    final Pointer<Utf16> subKeyPtr = subKey.toNativeUtf16();
+    final Pointer<Utf16> valuePtr = valueName.toNativeUtf16();
+    final Pointer<IntPtr> keyHandle = calloc<IntPtr>();
+    try {
+      if (_regOpenKeyEx(root.handle, subKeyPtr, 0, _keyRead, keyHandle) !=
+          _errorSuccess) {
+        return null;
+      }
+      final int key = keyHandle.value;
+      final Pointer<Uint32> type = calloc<Uint32>();
+      final Pointer<Uint32> size = calloc<Uint32>();
+      try {
+        // 第一次调用只问长度（data == nullptr）。
+        if (_regQueryValueEx(key, valuePtr, nullptr, type, nullptr, size) !=
+            _errorSuccess) {
+          return null;
+        }
+        if (size.value == 0) return null;
+        final Pointer<Uint8> data = calloc<Uint8>(size.value);
+        try {
+          if (_regQueryValueEx(key, valuePtr, nullptr, type, data, size) !=
+              _errorSuccess) {
+            return null;
+          }
+          return read(type.value, data, size.value);
+        } finally {
+          calloc.free(data);
+        }
+      } finally {
+        calloc.free(size);
+        calloc.free(type);
+        _regCloseKey(key);
+      }
+    } on Object {
+      return null;
+    } finally {
+      calloc.free(keyHandle);
+      calloc.free(valuePtr);
+      calloc.free(subKeyPtr);
+    }
+  }
+
+  String? readRegistryString(
+    WindowsRegistryRoot root,
+    String subKey,
+    String valueName,
+  ) =>
+      _withRegistryValue<String>(root, subKey, valueName,
+          (int type, Pointer<Uint8> data, int bytes) {
+        if (type != _regSz && type != _regExpandSz) return null;
+        // 字节数 → UTF-16 码元数；注册表字符串可能带也可能不带结尾 NUL。
+        final int units = bytes ~/ 2;
+        final Pointer<Uint16> units16 = data.cast<Uint16>();
+        final StringBuffer buffer = StringBuffer();
+        for (int i = 0; i < units; i++) {
+          final int unit = units16[i];
+          if (unit == 0) break;
+          buffer.writeCharCode(unit);
+        }
+        final String value = buffer.toString();
+        return value.isEmpty ? null : value;
+      });
+
+  int? readRegistryDword(
+    WindowsRegistryRoot root,
+    String subKey,
+    String valueName,
+  ) =>
+      _withRegistryValue<int>(root, subKey, valueName,
+          (int type, Pointer<Uint8> data, int bytes) {
+        if (type != _regDword || bytes < 4) return null;
+        return data.cast<Uint32>().value;
+      });
+}
+
+/// `PROCESSENTRY32W`。`dwSize` 必须等于 `sizeOf<_ProcessEntry32W>()`，字段顺序与
+/// 对齐（`th32DefaultHeapID` 是 `ULONG_PTR` → [IntPtr]）不能动。
+final class _ProcessEntry32W extends Struct {
+  @Uint32()
+  external int dwSize;
+
+  @Uint32()
+  external int cntUsage;
+
+  @Uint32()
+  external int th32ProcessID;
+
+  @IntPtr()
+  external int th32DefaultHeapID;
+
+  @Uint32()
+  external int th32ModuleID;
+
+  @Uint32()
+  external int cntThreads;
+
+  @Uint32()
+  external int th32ParentProcessID;
+
+  @Int32()
+  external int pcPriClassBase;
+
+  @Uint32()
+  external int dwFlags;
+
+  @Array(260)
+  external Array<Uint16> szExeFile;
+}
+
+typedef _OpenProcessNative = IntPtr Function(
+  Uint32 desiredAccess,
+  Int32 inheritHandle,
+  Uint32 processId,
+);
+typedef _OpenProcessDart = int Function(
+  int desiredAccess,
+  int inheritHandle,
+  int processId,
+);
+
+typedef _QueryFullProcessImageNameNative = Int32 Function(
+  IntPtr process,
+  Uint32 flags,
+  Pointer<Utf16> exeName,
+  Pointer<Uint32> size,
+);
+typedef _QueryFullProcessImageNameDart = int Function(
+  int process,
+  int flags,
+  Pointer<Utf16> exeName,
+  Pointer<Uint32> size,
+);
+
+typedef _CreateToolhelp32SnapshotNative = IntPtr Function(
+  Uint32 flags,
+  Uint32 processId,
+);
+typedef _CreateToolhelp32SnapshotDart = int Function(
+  int flags,
+  int processId,
+);
+
+typedef _Process32Native = Int32 Function(
+  IntPtr snapshot,
+  Pointer<_ProcessEntry32W> entry,
+);
+typedef _Process32Dart = int Function(
+  int snapshot,
+  Pointer<_ProcessEntry32W> entry,
+);
+
+typedef _CloseHandleNative = Int32 Function(IntPtr handle);
+typedef _CloseHandleDart = int Function(int handle);
+
+typedef _RegOpenKeyExNative = Int32 Function(
+  IntPtr key,
+  Pointer<Utf16> subKey,
+  Uint32 options,
+  Uint32 desired,
+  Pointer<IntPtr> result,
+);
+typedef _RegOpenKeyExDart = int Function(
+  int key,
+  Pointer<Utf16> subKey,
+  int options,
+  int desired,
+  Pointer<IntPtr> result,
+);
+
+typedef _RegQueryValueExNative = Int32 Function(
+  IntPtr key,
+  Pointer<Utf16> valueName,
+  Pointer<Uint32> reserved,
+  Pointer<Uint32> type,
+  Pointer<Uint8> data,
+  Pointer<Uint32> size,
+);
+typedef _RegQueryValueExDart = int Function(
+  int key,
+  Pointer<Utf16> valueName,
+  Pointer<Uint32> reserved,
+  Pointer<Uint32> type,
+  Pointer<Uint8> data,
+  Pointer<Uint32> size,
+);
+
+typedef _RegCloseKeyNative = Int32 Function(IntPtr key);
+typedef _RegCloseKeyDart = int Function(int key);

--- a/fushi/lib/src/platform/desktop/windows_process_query.dart
+++ b/fushi/lib/src/platform/desktop/windows_process_query.dart
@@ -136,6 +136,25 @@ Map<int, WindowsProcessEntry> windowsProcessesByIds(Iterable<int> pids) {
   };
 }
 
+/// 谁正占用着 [filePath] 这个**具体文件**（Restart Manager）。
+///
+/// 取代 `tasklist /M <dll名>`。两者的差别不只是「有没有子进程」，语义也更准：
+/// - `tasklist /M libmpv-2.dll` 匹配的是**任意路径**下同名 DLL 的加载者，要扫全机
+///   每个进程的模块表，再由调用方按 exe 路径过滤回来；
+/// - Restart Manager 直接问系统「谁持有这个路径的文件」，不枚举任何无关进程。
+///
+/// 而我们真正要判的就是后者——「安装器能不能换掉这个文件」。这也正是 MSI / Inno
+/// 等安装器判占用时用的 API，属于安装场景里最正常不过的调用。
+///
+/// 文件不存在 / 无人占用 / 会话建不起来 → 空列表（与「没有占用者」同义）。
+List<WindowsProcessEntry> windowsProcessesHoldingFile(String filePath) {
+  if (!Platform.isWindows || filePath.isEmpty) {
+    return const <WindowsProcessEntry>[];
+  }
+  return _Win32.instance?.processesHoldingFile(filePath) ??
+      const <WindowsProcessEntry>[];
+}
+
 /// 读注册表字符串值（`REG_SZ` / `REG_EXPAND_SZ`）；不存在或类型不符返回 null。
 String? readWindowsRegistryString(
   WindowsRegistryRoot root,
@@ -186,7 +205,17 @@ class _Win32 {
             _RegQueryValueExDart>('RegQueryValueExW'),
         _regCloseKey =
             _advapi32.lookupFunction<_RegCloseKeyNative, _RegCloseKeyDart>(
-                'RegCloseKey');
+                'RegCloseKey'),
+        _rmStartSession = _rstrtmgr.lookupFunction<_RmStartSessionNative,
+            _RmStartSessionDart>('RmStartSession'),
+        _rmRegisterResources = _rstrtmgr.lookupFunction<
+            _RmRegisterResourcesNative,
+            _RmRegisterResourcesDart>('RmRegisterResources'),
+        _rmGetList = _rstrtmgr
+            .lookupFunction<_RmGetListNative, _RmGetListDart>('RmGetList'),
+        _rmEndSession =
+            _rstrtmgr.lookupFunction<_RmEndSessionNative, _RmEndSessionDart>(
+                'RmEndSession');
 
   static _Win32? _cached;
   static bool _initialised = false;
@@ -205,6 +234,7 @@ class _Win32 {
 
   static final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
   static final DynamicLibrary _advapi32 = DynamicLibrary.open('advapi32.dll');
+  static final DynamicLibrary _rstrtmgr = DynamicLibrary.open('rstrtmgr.dll');
 
   static const int _processQueryLimitedInformation = 0x1000;
   static const int _th32csSnapProcess = 0x00000002;
@@ -225,6 +255,109 @@ class _Win32 {
   final _RegOpenKeyExDart _regOpenKeyEx;
   final _RegQueryValueExDart _regQueryValueEx;
   final _RegCloseKeyDart _regCloseKey;
+  final _RmStartSessionDart _rmStartSession;
+  final _RmRegisterResourcesDart _rmRegisterResources;
+  final _RmGetListDart _rmGetList;
+  final _RmEndSessionDart _rmEndSession;
+
+  /// `RmGetList` 一次要到的最多进程数。占用同一个文件的进程通常是个位数；
+  /// 上限只为给缓冲区封顶，超出部分丢弃（诊断用途，不需要绝对完整）。
+  static const int _rmMaxProcessInfo = 64;
+
+  /// `CCH_RM_SESSION_KEY + 1`（会话键是 GUID 串，32 字符 + NUL）。
+  static const int _rmSessionKeyLength = 33;
+
+  static const int _errorMoreData = 234;
+
+  List<WindowsProcessEntry> processesHoldingFile(String filePath) {
+    final Pointer<Uint32> session = calloc<Uint32>();
+    // RmStartSession 要求调用方提供已清零的 CCH_RM_SESSION_KEY+1 缓冲区。
+    final Pointer<Uint16> sessionKey = calloc<Uint16>(_rmSessionKeyLength);
+    bool started = false;
+    try {
+      if (_rmStartSession(session, 0, sessionKey.cast<Utf16>()) !=
+          _errorSuccess) {
+        return const <WindowsProcessEntry>[];
+      }
+      started = true;
+
+      final Pointer<Utf16> path = filePath.toNativeUtf16();
+      final Pointer<Pointer<Utf16>> files = calloc<Pointer<Utf16>>();
+      try {
+        files[0] = path;
+        if (_rmRegisterResources(
+              session.value,
+              1,
+              files,
+              0,
+              nullptr,
+              0,
+              nullptr,
+            ) !=
+            _errorSuccess) {
+          return const <WindowsProcessEntry>[];
+        }
+      } finally {
+        calloc.free(files);
+        calloc.free(path);
+      }
+
+      final Pointer<Uint32> needed = calloc<Uint32>();
+      final Pointer<Uint32> count = calloc<Uint32>()..value = _rmMaxProcessInfo;
+      final Pointer<_RmProcessInfo> infos =
+          calloc<_RmProcessInfo>(_rmMaxProcessInfo);
+      final Pointer<Uint32> reasons = calloc<Uint32>();
+      try {
+        final int rc = _rmGetList(session.value, needed, count, infos, reasons);
+        // ERROR_MORE_DATA：占用者多于缓冲区容量，已填满的部分仍然有效。
+        if (rc != _errorSuccess && rc != _errorMoreData) {
+          return const <WindowsProcessEntry>[];
+        }
+        final int filled =
+            count.value > _rmMaxProcessInfo ? _rmMaxProcessInfo : count.value;
+        final List<WindowsProcessEntry> result = <WindowsProcessEntry>[];
+        for (int i = 0; i < filled; i++) {
+          final int holderPid = infos[i].Process.dwProcessId;
+          if (holderPid <= 0) continue;
+          // strAppName 是 RM 给的显示名，未必等于 image 名；image 名/路径统一
+          // 用我们自己的 Win32 查询补齐，保证与其它入口同源同格式。
+          final String? imagePath = processImagePath(holderPid);
+          result.add(
+            WindowsProcessEntry(
+              pid: holderPid,
+              name: imagePath == null
+                  ? _appNameFrom(infos[i].strAppName)
+                  : imagePath.split(r'\').last,
+              path: imagePath,
+            ),
+          );
+        }
+        return result;
+      } finally {
+        calloc.free(reasons);
+        calloc.free(infos);
+        calloc.free(count);
+        calloc.free(needed);
+      }
+    } on Object {
+      return const <WindowsProcessEntry>[];
+    } finally {
+      if (started) _rmEndSession(session.value);
+      calloc.free(sessionKey);
+      calloc.free(session);
+    }
+  }
+
+  /// `strAppName` 是定长 256 的 UTF-16 数组，读到 NUL 为止。
+  String _appNameFrom(Array<Uint16> raw) {
+    final StringBuffer buffer = StringBuffer();
+    for (int i = 0; i < 256; i++) {
+      final int unit = raw[i];
+      if (unit == 0) break;
+      buffer.writeCharCode(unit);
+    }
+    return buffer.toString();
+  }
 
   List<WindowsProcessEntry> enumerateProcesses() {
     final List<WindowsProcessEntry> result = <WindowsProcessEntry>[];
@@ -486,3 +619,93 @@ typedef _RegQueryValueExDart = int Function(
 
 typedef _RegCloseKeyNative = Int32 Function(IntPtr key);
 typedef _RegCloseKeyDart = int Function(int key);
+
+// ── Restart Manager（rstrtmgr.dll）─────────────────────────────────────────────
+
+/// `RM_UNIQUE_PROCESS`：PID + 进程启动时刻（`FILETIME` 拆成两个 DWORD）。
+/// 启动时刻用于消歧 PID 复用，我们只读 PID。
+final class _RmUniqueProcess extends Struct {
+  @Uint32()
+  external int dwProcessId;
+
+  @Uint32()
+  external int startTimeLow;
+
+  @Uint32()
+  external int startTimeHigh;
+}
+
+/// `RM_PROCESS_INFO`。字段顺序与定长数组尺寸不能动：
+/// `CCH_RM_MAX_APP_NAME + 1` = 256、`CCH_RM_MAX_SVC_NAME + 1` = 64。
+/// 写错不会报错，只会读出乱码 PID —— 由 `windows_process_query_test.dart`
+/// 拿「当前进程必然持有自己的 exe 文件」这条已知真值挡住。
+final class _RmProcessInfo extends Struct {
+  // ignore: non_constant_identifier_names — 与 Win32 结构体字段同名，便于对照文档
+  external _RmUniqueProcess Process;
+
+  @Array(256)
+  external Array<Uint16> strAppName;
+
+  @Array(64)
+  external Array<Uint16> strServiceShortName;
+
+  @Int32()
+  external int applicationType;
+
+  @Uint32()
+  external int appStatus;
+
+  @Uint32()
+  external int tsSessionId;
+
+  @Int32()
+  external int bRestartable;
+}
+
+typedef _RmStartSessionNative = Int32 Function(
+  Pointer<Uint32> sessionHandle,
+  Uint32 sessionFlags,
+  Pointer<Utf16> sessionKey,
+);
+typedef _RmStartSessionDart = int Function(
+  Pointer<Uint32> sessionHandle,
+  int sessionFlags,
+  Pointer<Utf16> sessionKey,
+);
+
+typedef _RmRegisterResourcesNative = Int32 Function(
+  Uint32 sessionHandle,
+  Uint32 nFiles,
+  Pointer<Pointer<Utf16>> rgsFileNames,
+  Uint32 nApplications,
+  Pointer<_RmUniqueProcess> rgApplications,
+  Uint32 nServices,
+  Pointer<Pointer<Utf16>> rgsServiceNames,
+);
+typedef _RmRegisterResourcesDart = int Function(
+  int sessionHandle,
+  int nFiles,
+  Pointer<Pointer<Utf16>> rgsFileNames,
+  int nApplications,
+  Pointer<_RmUniqueProcess> rgApplications,
+  int nServices,
+  Pointer<Pointer<Utf16>> rgsServiceNames,
+);
+
+typedef _RmGetListNative = Int32 Function(
+  Uint32 sessionHandle,
+  Pointer<Uint32> procInfoNeeded,
+  Pointer<Uint32> procInfo,
+  Pointer<_RmProcessInfo> affectedApps,
+  Pointer<Uint32> rebootReasons,
+);
+typedef _RmGetListDart = int Function(
+  int sessionHandle,
+  Pointer<Uint32> procInfoNeeded,
+  Pointer<Uint32> procInfo,
+  Pointer<_RmProcessInfo> affectedApps,
+  Pointer<Uint32> rebootReasons,
+);
+
+typedef _RmEndSessionNative = Int32 Function(Uint32 sessionHandle);
+typedef _RmEndSessionDart = int Function(int sessionHandle);

--- a/fushi/lib/src/sync/port_process_terminator.dart
+++ b/fushi/lib/src/sync/port_process_terminator.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:fushi/src/platform/desktop/windows_process_query.dart';
+
 /// 监听某端口的进程信息（用于「端口被占用 → 一键结束占用进程」）。
 class PortListenerInfo {
   const PortListenerInfo({
@@ -120,12 +122,9 @@ class PortProcessTerminator {
     final String fallback = 'PID $targetPid';
     try {
       if (Platform.isWindows) {
-        final ProcessResult result = await Process.run(
-          'tasklist',
-          <String>['/FI', 'PID eq $targetPid', '/FO', 'CSV', '/NH'],
-        );
-        if (result.exitCode != 0) return fallback;
-        return parseTasklistProcessName('${result.stdout}') ?? fallback;
+        // Win32 快照，不生成 tasklist 子进程（AV 行为检测把
+        // 「进程 spawn LOLBin 查进程表」算高权重信号，见 windows_process_query.dart）。
+        return windowsProcessById(targetPid)?.name ?? fallback;
       }
       final ProcessResult result =
           await Process.run('ps', <String>['-p', '$targetPid', '-o', 'comm=']);
@@ -144,15 +143,8 @@ class PortProcessTerminator {
   static Future<String?> _executablePath(int targetPid) async {
     try {
       if (Platform.isWindows) {
-        final ProcessResult result = await Process.run('powershell', <String>[
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          '(Get-Process -Id $targetPid -ErrorAction SilentlyContinue).Path',
-        ]);
-        if (result.exitCode != 0) return null;
-        final String out = '${result.stdout}'.trim();
-        return out.isEmpty ? null : out;
+        // 同上：`QueryFullProcessImageNameW` 直接取，不生成 powershell 子进程。
+        return windowsProcessImagePath(targetPid);
       }
       if (Platform.isLinux) {
         // /proc/<pid>/exe 是指向真实可执行文件的符号链接。

--- a/fushi/lib/src/utils/misc/platform_updater.dart
+++ b/fushi/lib/src/utils/misc/platform_updater.dart
@@ -994,7 +994,7 @@ Future<List<WindowsProcessInfo>> queryWindowsFushiProcesses() async {
   try {
     final ProcessResult result = await Process.run(
       'powershell',
-      <String>['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', command],
+      <String>['-NoProfile', '-NonInteractive', '-Command', command],
     );
     if (result.exitCode != 0) return const <WindowsProcessInfo>[];
     return parseWindowsProcessJson(
@@ -1047,7 +1047,7 @@ Future<Map<int, WindowsProcessInfo>> queryWindowsProcessInfoForPids(
   try {
     final ProcessResult result = await Process.run(
       'powershell',
-      <String>['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', command],
+      <String>['-NoProfile', '-NonInteractive', '-Command', command],
     );
     if (result.exitCode != 0) return const <int, WindowsProcessInfo>{};
     final List<WindowsProcessInfo> processes = parseWindowsProcessJson(

--- a/fushi/lib/src/utils/misc/platform_updater.dart
+++ b/fushi/lib/src/utils/misc/platform_updater.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
@@ -790,34 +789,20 @@ class WindowsInstaller {
   static List<WindowsProcessInfo> _blockingWindowsInstallProcesses(
     WindowsInstallerDiagnostics diagnostics,
   ) {
-    final String? targetInstallDir = diagnostics.targetInstallDir;
     final Map<int, WindowsProcessInfo> blockers = <int, WindowsProcessInfo>{};
     for (final WindowsProcessInfo process
         in diagnostics.runningFushiProcesses) {
       blockers[process.pid] = process;
     }
+    // libmpvModuleHolders 现在由 Restart Manager 按**目标目录里那个文件**给出
+    // （见 [queryWindowsLibmpvModuleHolders]），每一个都已经是货真价实的占用者，
+    // 无需再按 exe 路径 / 进程名过滤——旧的那层过滤是为了把 `tasklist /M` 的
+    // 全机同名 DLL 结果收窄回来，同时也把「exe 在别处却持有我们这份 libmpv」
+    // 的外部进程一并漏掉了。特殊情况就此消失。
     for (final WindowsProcessInfo process in diagnostics.libmpvModuleHolders) {
-      if (_processIsInTargetInstallDir(process, targetInstallDir) ||
-          (process.name ?? '').toLowerCase() == 'fushi.exe' ||
-          (process.name ?? '').toLowerCase() == 'hibiki.exe') {
-        blockers[process.pid] = process;
-      }
+      blockers[process.pid] = process;
     }
     return blockers.values.toList(growable: false);
-  }
-
-  static bool _processIsInTargetInstallDir(
-    WindowsProcessInfo process,
-    String? targetInstallDir,
-  ) {
-    final String? processPath = process.path;
-    if (targetInstallDir == null ||
-        targetInstallDir.isEmpty ||
-        processPath == null ||
-        processPath.isEmpty) {
-      return false;
-    }
-    return _windowsPathEquals(File(processPath).parent.path, targetInstallDir);
   }
 
   static Future<void> _markLaunchFailed(
@@ -865,7 +850,7 @@ Future<WindowsInstallerDiagnostics> collectWindowsInstallerDiagnostics({
               currentProcessId == null || process.pid != currentProcessId)
           .toList(growable: false);
   final List<WindowsProcessInfo> libmpvModuleHolders =
-      (await queryWindowsLibmpvModuleHolders())
+      (await queryWindowsLibmpvModuleHolders(targetInstallDir))
           .where((WindowsProcessInfo process) =>
               currentProcessId == null || process.pid != currentProcessId)
           .toList(growable: false);
@@ -1018,28 +1003,33 @@ Future<List<WindowsProcessInfo>> queryWindowsFushiProcesses() async {
   }
 }
 
-Future<List<WindowsProcessInfo>> queryWindowsLibmpvModuleHolders() async {
-  if (!Platform.isWindows) return const <WindowsProcessInfo>[];
+/// 目标安装目录里那个 `libmpv-2.dll` 现在被谁占着。
+///
+/// 原实现是 `tasklist /M libmpv-2.dll`：扫**全机每个进程的模块表**找同名 DLL，
+/// 再由 [WindowsInstaller._blockingWindowsInstallProcesses] 按 exe 路径过滤回来。
+/// 那是本次 AV 行为检测告警里权重最高的剩余动作（全机模块枚举），而且**答非所问**
+/// ——它按 DLL 名匹配任意路径下的副本，却漏掉「exe 在别处、但正持有我们这一份
+/// libmpv 的外部进程」，而那恰恰是硬中止分支要拦的情况（漏了的后果就是放行安装、
+/// 然后 Inno 在拷贝阶段 `DeleteFile code 5` 失败，即 BUG-1459 的症状）。
+///
+/// 改用 Restart Manager 直接问「谁持有这个路径的文件」：不枚举无关进程，且返回的
+/// 每一个都是货真价实的占用者，无需再按路径过滤。这也是安装器判占用的标准做法。
+Future<List<WindowsProcessInfo>> queryWindowsLibmpvModuleHolders(
+  String targetInstallDir,
+) async {
+  if (!Platform.isWindows || targetInstallDir.isEmpty) {
+    return const <WindowsProcessInfo>[];
+  }
   try {
-    final ProcessResult result = await Process.run(
-      'tasklist',
-      <String>['/M', 'libmpv-2.dll', '/FO', 'CSV', '/NH'],
-    );
-    if (result.exitCode != 0) return const <WindowsProcessInfo>[];
-    final List<WindowsProcessInfo> holders = parseWindowsTasklistModuleHolders(
-      result.stdout is String ? result.stdout as String : '',
-    );
-    final Map<int, WindowsProcessInfo> hydrated =
-        await queryWindowsProcessInfoForPids(
-      holders.map((WindowsProcessInfo process) => process.pid),
-    );
-    return holders.map((WindowsProcessInfo process) {
-      final WindowsProcessInfo? info = hydrated[process.pid];
-      return process.copyWith(
-        name: info?.name,
-        path: info?.path,
-      );
-    }).toList(growable: false);
+    final String libmpv =
+        '$targetInstallDir${Platform.pathSeparator}libmpv-2.dll';
+    return windowsProcessesHoldingFile(libmpv)
+        .map((WindowsProcessEntry entry) => WindowsProcessInfo(
+              pid: entry.pid,
+              name: entry.name,
+              path: entry.path,
+            ))
+        .toList(growable: false);
   } catch (_) {
     return const <WindowsProcessInfo>[];
   }
@@ -1067,25 +1057,6 @@ Future<Map<int, WindowsProcessInfo>> queryWindowsProcessInfoForPids(
   }
 }
 
-List<WindowsProcessInfo> parseWindowsTasklistModuleHolders(String output) {
-  final List<WindowsProcessInfo> holders = <WindowsProcessInfo>[];
-  for (final String rawLine in const LineSplitter().convert(output)) {
-    final String line = rawLine.trim();
-    if (line.isEmpty || line.startsWith('INFO:')) continue;
-    final List<String> fields = _parseCsvLine(line);
-    if (fields.length < 2) continue;
-    final int? parsedPid = int.tryParse(fields[1].replaceAll(',', '').trim());
-    if (parsedPid == null) continue;
-    holders.add(
-      WindowsProcessInfo(
-        pid: parsedPid,
-        name: fields[0].trim(),
-      ),
-    );
-  }
-  return holders;
-}
-
 List<WindowsDetectedInstallLocation> _dedupeInstallLocations(
   Iterable<WindowsDetectedInstallLocation> locations,
 ) {
@@ -1108,32 +1079,6 @@ String _stripDisplayIconSuffix(String value) {
     if (closing > 0) path = path.substring(1, closing);
   }
   return path.replaceFirst(RegExp(r',\d+$'), '').trim();
-}
-
-List<String> _parseCsvLine(String line) {
-  final List<String> fields = <String>[];
-  final StringBuffer current = StringBuffer();
-  bool inQuotes = false;
-  for (int i = 0; i < line.length; i++) {
-    final String char = line[i];
-    if (char == '"') {
-      if (inQuotes && i + 1 < line.length && line[i + 1] == '"') {
-        current.write('"');
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-      continue;
-    }
-    if (char == ',' && !inQuotes) {
-      fields.add(current.toString());
-      current.clear();
-      continue;
-    }
-    current.write(char);
-  }
-  fields.add(current.toString());
-  return fields;
 }
 
 bool _windowsPathEquals(String a, String b) {

--- a/fushi/lib/src/utils/misc/platform_updater.dart
+++ b/fushi/lib/src/utils/misc/platform_updater.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 
 import 'package:fushi/src/platform/desktop/windows_native_pre_exit.dart';
+import 'package:fushi/src/platform/desktop/windows_process_query.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/src/utils/misc/mac_update_handoff.dart';
 import 'package:fushi/src/utils/misc/update_handoff.dart';
@@ -887,22 +888,30 @@ Future<List<WindowsDetectedInstallLocation>>
     queryWindowsRegisteredInstallLocations() async {
   if (!Platform.isWindows) return const <WindowsDetectedInstallLocation>[];
   const String appId = r'{8F2C1A3E-7B4D-4E9A-9C21-0A1B2C3D4E5F}_is1';
-  const List<String> keys = <String>[
-    r'HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\' + appId,
-    r'HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\' + appId,
+  const String uninstallSubKey =
+      r'Software\Microsoft\Windows\CurrentVersion\Uninstall\' + appId;
+  const List<(WindowsRegistryRoot, String)> keys =
+      <(WindowsRegistryRoot, String)>[
+    (WindowsRegistryRoot.currentUser, uninstallSubKey),
+    (WindowsRegistryRoot.localMachine, uninstallSubKey),
   ];
   final List<WindowsDetectedInstallLocation> result =
       <WindowsDetectedInstallLocation>[];
-  for (final String key in keys) {
+  for (final (WindowsRegistryRoot root, String subKey) in keys) {
     try {
-      final ProcessResult query = await Process.run(
-        'reg',
-        <String>['query', key],
-      );
-      if (query.exitCode != 0) continue;
       result.addAll(
-        parseWindowsRegistryInstallLocations(
-          query.stdout is String ? query.stdout as String : '',
+        windowsRegistryInstallLocations(
+          installLocation: readWindowsRegistryString(
+                root,
+                subKey,
+                'InstallLocation',
+              ) ??
+              readWindowsRegistryString(
+                root,
+                subKey,
+                'Inno Setup: App Path',
+              ),
+          displayIcon: readWindowsRegistryString(root, subKey, 'DisplayIcon'),
         ),
       );
     } catch (_) {
@@ -912,14 +921,16 @@ Future<List<WindowsDetectedInstallLocation>>
   return _dedupeInstallLocations(result);
 }
 
-List<WindowsDetectedInstallLocation> parseWindowsRegistryInstallLocations(
-  String output,
-) {
+/// **纯函数**：把已读出的注册表值折成安装位置列表。
+///
+/// 取值方式（原先是 `reg query` 子进程，现在是 `RegQueryValueExW`）与折算规则
+/// 分离，规则这层因此始终可单测，不依赖 Windows。
+List<WindowsDetectedInstallLocation> windowsRegistryInstallLocations({
+  required String? installLocation,
+  required String? displayIcon,
+}) {
   final List<WindowsDetectedInstallLocation> result =
       <WindowsDetectedInstallLocation>[];
-  final String? installLocation =
-      _registryValueAfterType(output, 'InstallLocation') ??
-          _registryValueAfterType(output, 'Inno Setup: App Path');
   if (installLocation != null && installLocation.isNotEmpty) {
     result.add(
       WindowsDetectedInstallLocation(
@@ -929,7 +940,6 @@ List<WindowsDetectedInstallLocation> parseWindowsRegistryInstallLocations(
     );
   }
 
-  final String? displayIcon = _registryValueAfterType(output, 'DisplayIcon');
   if (displayIcon != null && displayIcon.isNotEmpty) {
     final String path = _stripDisplayIconSuffix(displayIcon);
     // fushi.exe 是改名后的主 exe；\hibiki.exe 保留识别旧版注册表残留安装。
@@ -986,20 +996,23 @@ String? windowsInstallPathMismatchWarning({
       '$details';
 }
 
+/// 我们自己的 image 名（含改名前的旧包，老安装仍在跑 hibiki.exe）。
+const Set<String> kFushiImageNames = <String>{'fushi.exe', 'hibiki.exe'};
+
+/// 走 Win32 快照，**不生成 powershell 子进程**（AV 行为检测把
+/// 「进程 spawn powershell 查全机进程」算成高权重恶意信号，见
+/// `windows_process_query.dart` 文件头）。语义与原 `Get-CimInstance
+/// Win32_Process -Filter "Name = 'fushi.exe' OR Name = 'hibiki.exe'"` 等价。
 Future<List<WindowsProcessInfo>> queryWindowsFushiProcesses() async {
   if (!Platform.isWindows) return const <WindowsProcessInfo>[];
-  const String command =
-      "Get-CimInstance Win32_Process -Filter \"Name = 'fushi.exe' OR Name = 'hibiki.exe'\" | "
-      'Select-Object ProcessId,Name,ExecutablePath | ConvertTo-Json -Compress';
   try {
-    final ProcessResult result = await Process.run(
-      'powershell',
-      <String>['-NoProfile', '-NonInteractive', '-Command', command],
-    );
-    if (result.exitCode != 0) return const <WindowsProcessInfo>[];
-    return parseWindowsProcessJson(
-      result.stdout is String ? result.stdout as String : '',
-    );
+    return windowsProcessesByNames(kFushiImageNames)
+        .map((WindowsProcessEntry entry) => WindowsProcessInfo(
+              pid: entry.pid,
+              name: entry.name,
+              path: entry.path,
+            ))
+        .toList(growable: false);
   } catch (_) {
     return const <WindowsProcessInfo>[];
   }
@@ -1032,6 +1045,8 @@ Future<List<WindowsProcessInfo>> queryWindowsLibmpvModuleHolders() async {
   }
 }
 
+/// 走 Win32 快照，**不生成 powershell 子进程**（理由同
+/// [queryWindowsFushiProcesses]）。
 Future<Map<int, WindowsProcessInfo>> queryWindowsProcessInfoForPids(
   Iterable<int> pids,
 ) async {
@@ -1040,49 +1055,15 @@ Future<Map<int, WindowsProcessInfo>> queryWindowsProcessInfoForPids(
   if (!Platform.isWindows || uniquePids.isEmpty) {
     return const <int, WindowsProcessInfo>{};
   }
-  final String filter =
-      uniquePids.map((int pid) => 'ProcessId = $pid').join(' OR ');
-  final String command = 'Get-CimInstance Win32_Process -Filter "$filter" | '
-      'Select-Object ProcessId,Name,ExecutablePath | ConvertTo-Json -Compress';
   try {
-    final ProcessResult result = await Process.run(
-      'powershell',
-      <String>['-NoProfile', '-NonInteractive', '-Command', command],
+    return windowsProcessesByIds(uniquePids).map(
+      (int pid, WindowsProcessEntry entry) => MapEntry<int, WindowsProcessInfo>(
+        pid,
+        WindowsProcessInfo(pid: entry.pid, name: entry.name, path: entry.path),
+      ),
     );
-    if (result.exitCode != 0) return const <int, WindowsProcessInfo>{};
-    final List<WindowsProcessInfo> processes = parseWindowsProcessJson(
-      result.stdout is String ? result.stdout as String : '',
-    );
-    return <int, WindowsProcessInfo>{
-      for (final WindowsProcessInfo process in processes) process.pid: process,
-    };
   } catch (_) {
     return const <int, WindowsProcessInfo>{};
-  }
-}
-
-List<WindowsProcessInfo> parseWindowsProcessJson(String output) {
-  if (output.trim().isEmpty) return const <WindowsProcessInfo>[];
-  try {
-    final Object? decoded = jsonDecode(output);
-    final List<dynamic> rows = decoded is List
-        ? decoded
-        : decoded is Map<String, dynamic>
-            ? <dynamic>[decoded]
-            : const <dynamic>[];
-    return rows
-        .whereType<Map<String, dynamic>>()
-        .map((Map<String, dynamic> row) {
-          return WindowsProcessInfo(
-            pid: _objectToInt(row['ProcessId']) ?? 0,
-            name: row['Name'] as String?,
-            path: row['ExecutablePath'] as String?,
-          );
-        })
-        .where((WindowsProcessInfo process) => process.pid > 0)
-        .toList(growable: false);
-  } catch (_) {
-    return const <WindowsProcessInfo>[];
   }
 }
 
@@ -1118,18 +1099,6 @@ List<WindowsDetectedInstallLocation> _dedupeInstallLocations(
     result.add(location);
   }
   return result;
-}
-
-String? _registryValueAfterType(String output, String valueName) {
-  for (final String rawLine in const LineSplitter().convert(output)) {
-    final String line = rawLine.trim();
-    if (!line.startsWith(valueName)) continue;
-    final RegExpMatch? match =
-        RegExp(r'^' + RegExp.escape(valueName) + r'\s+REG_\w+\s+(.+)$')
-            .firstMatch(line);
-    if (match != null) return match.group(1)!.trim();
-  }
-  return null;
 }
 
 String _stripDisplayIconSuffix(String value) {
@@ -1177,13 +1146,6 @@ String _normalizeWindowsPath(String path) {
       .replaceAll('/', r'\')
       .replaceFirst(RegExp(r'\\+$'), '')
       .toLowerCase();
-}
-
-int? _objectToInt(Object? value) {
-  if (value is int) return value;
-  if (value is num) return value.toInt();
-  if (value is String) return int.tryParse(value.trim());
-  return null;
 }
 
 Future<void> ensureWindowsInstallTargetWritable(Directory installDir) async {

--- a/fushi/lib/src/utils/net/app_proxy.dart
+++ b/fushi/lib/src/utils/net/app_proxy.dart
@@ -31,6 +31,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:fushi/src/platform/desktop/windows_process_query.dart';
 
 /// 进程级「用户手填代理」读取器——[applyAppProxy] 不显式传 `userProxy` 时的取值来源。
 ///
@@ -347,20 +348,18 @@ Future<Map<String, String>> resolveWindowsSystemProxyEnvironment() async {
   if (!Platform.isWindows) return const <String, String>{};
   try {
     const String key =
-        r'HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings';
-    final ProcessResult enableResult = await Process.run(
-      'reg',
-      <String>['query', key, '/v', 'ProxyEnable'],
-    );
-    final ProcessResult serverResult = await Process.run(
-      'reg',
-      <String>['query', key, '/v', 'ProxyServer'],
-    );
+        r'Software\Microsoft\Windows\CurrentVersion\Internet Settings';
     return parseWindowsRegistryProxy(
-      proxyEnableOutput:
-          enableResult.stdout is String ? enableResult.stdout as String : '',
-      proxyServerOutput:
-          serverResult.stdout is String ? serverResult.stdout as String : '',
+      proxyEnable: readWindowsRegistryDword(
+        WindowsRegistryRoot.currentUser,
+        key,
+        'ProxyEnable',
+      ),
+      proxyServer: readWindowsRegistryString(
+        WindowsRegistryRoot.currentUser,
+        key,
+        'ProxyServer',
+      ),
     );
   } catch (e) {
     // 读不到注册表（权限/环境异常）就当没有系统代理，回退直连——best-effort。
@@ -382,38 +381,19 @@ Future<Map<String, String>> resolveWindowsSystemProxyEnvironment() async {
 /// 以连续空白分隔；值本身可能含 `=`/`;`/`:` 但不含空白，故按「类型标记 REG_* 之后」取值）。
 @visibleForTesting
 Map<String, String> parseWindowsRegistryProxy({
-  required String proxyEnableOutput,
-  required String proxyServerOutput,
+  required int? proxyEnable,
+  required String? proxyServer,
 }) {
-  final String? enableValue =
-      _registryValueAfterType(proxyEnableOutput, 'ProxyEnable');
-  // ProxyEnable 是 REG_DWORD，值形如 `0x1`/`0x0`。非 0x1 视为未启用。
-  if (enableValue == null || enableValue.toLowerCase() != '0x1') {
-    return const <String, String>{};
-  }
-  final String? serverValue =
-      _registryValueAfterType(proxyServerOutput, 'ProxyServer');
-  if (serverValue == null || serverValue.isEmpty) {
+  // ProxyEnable 是 REG_DWORD；非 1 视为未启用。
+  if (proxyEnable != 1) return const <String, String>{};
+  if (proxyServer == null || proxyServer.isEmpty) {
     return const <String, String>{};
   }
 
-  final String? https = _proxyForScheme(serverValue, 'https');
+  final String? https = _proxyForScheme(proxyServer, 'https');
   final String? http =
-      _proxyForScheme(serverValue, 'http') ?? _globalProxy(serverValue);
+      _proxyForScheme(proxyServer, 'http') ?? _globalProxy(proxyServer);
   return _buildProxyEnv(https: https, http: http);
-}
-
-/// 从单条 `reg query` 输出里取出指定值名后、`REG_<TYPE>` 标记之后的那段值。
-/// 匹配行必须含 `valueName`，再按空白切出最后一段作为值。无匹配返回 null。
-String? _registryValueAfterType(String output, String valueName) {
-  for (final String rawLine in const LineSplitter().convert(output)) {
-    final String line = rawLine.trim();
-    if (!line.startsWith(valueName)) continue;
-    final RegExpMatch? m =
-        RegExp(r'^' + valueName + r'\s+REG_\w+\s+(.+)$').firstMatch(line);
-    if (m != null) return m.group(1)!.trim();
-  }
-  return null;
 }
 
 /// 从分协议代理串（`http=h:p;https=h:p`）里取指定 scheme 的 `host:port`；全局串

--- a/fushi/test/platform/windows_process_query_test.dart
+++ b/fushi/test/platform/windows_process_query_test.dart
@@ -1,0 +1,225 @@
+// `windows_process_query.dart` 的真实系统验证。
+//
+// 这层是裸 FFI：`PROCESSENTRY32W` 的字段顺序/对齐写错、`dwSize` 填错、注册表值
+// 类型判断写错，**都不会抛异常**，只会安静地返回空列表或 null——而空结果在业务
+// 侧与「机器上确实没有」同义，永远不会有人发现。所以这份测试的核心是**拿当前
+// 进程和系统必然存在的注册表值当已知真值去对**，而不是「调用没崩就算过」。
+//
+// 只在 Windows 上有意义；其它平台断言「一律返回空/null」这条契约。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/platform/desktop/windows_process_query.dart';
+
+/// 当前进程 exe 的 basename，如 `flutter_tester.exe`。
+String _ownExeName() =>
+    Platform.resolvedExecutable.replaceAll('/', r'\').split(r'\').last;
+
+void main() {
+  group('非 Windows 平台契约', () {
+    test('全部返回空/null，调用方无需自己 gate', () {
+      if (Platform.isWindows) return;
+      expect(enumerateWindowsProcesses(), isEmpty);
+      expect(windowsProcessImagePath(1), isNull);
+      expect(windowsProcessById(1), isNull);
+      expect(windowsProcessesByNames(<String>{'x.exe'}), isEmpty);
+      expect(windowsProcessesByIds(<int>[1]), isEmpty);
+      expect(
+        readWindowsRegistryString(
+            WindowsRegistryRoot.localMachine, 'SOFTWARE', 'X'),
+        isNull,
+      );
+      expect(
+        readWindowsRegistryDword(
+            WindowsRegistryRoot.localMachine, 'SOFTWARE', 'X'),
+        isNull,
+      );
+    });
+  });
+
+  group('进程枚举（真实系统）', () {
+    test('枚举到的进程数是合理量级，且必然包含当前进程', () {
+      final List<WindowsProcessEntry> all = enumerateWindowsProcesses();
+
+      // 量级哨兵：任何活着的 Windows 至少有几十个进程。扫出个位数
+      // ≈ 结构体布局错了导致遍历提前中断，这正是要挡的静默失败。
+      expect(
+        all.length,
+        greaterThan(20),
+        reason: '只枚举到 ${all.length} 个进程——PROCESSENTRY32W 布局或 dwSize 可能写错了',
+      );
+
+      final Iterable<WindowsProcessEntry> self =
+          all.where((WindowsProcessEntry e) => e.pid == pid);
+      expect(self, hasLength(1),
+          reason: '当前进程 PID $pid 必须出现在快照里（实际 ${self.length} 条）');
+    });
+
+    test('当前进程的 image 名与 resolvedExecutable 的 basename 一致', () {
+      final WindowsProcessEntry? me = enumerateWindowsProcesses()
+          .where((WindowsProcessEntry e) => e.pid == pid)
+          .firstOrNull;
+      expect(me, isNotNull);
+      expect(
+        me!.name.toLowerCase(),
+        _ownExeName().toLowerCase(),
+        reason: 'szExeFile 解码错了（定长 260 UTF-16 数组，读到 NUL 为止）',
+      );
+    });
+
+    test('枚举阶段不解析路径（惰性契约——这正是比 tasklist 轻的地方）', () {
+      // 全部 entry 的 path 都应为 null：枚举只读快照，不 OpenProcess 任何进程。
+      final List<WindowsProcessEntry> all = enumerateWindowsProcesses();
+      expect(
+        all.every((WindowsProcessEntry e) => e.path == null),
+        isTrue,
+        reason: '枚举阶段不得解析路径，否则等于对全机每个进程 OpenProcess',
+      );
+    });
+  });
+
+  group('路径解析（真实系统）', () {
+    test('当前进程路径等于 Platform.resolvedExecutable', () {
+      final String? path = windowsProcessImagePath(pid);
+      expect(path, isNotNull, reason: 'QueryFullProcessImageNameW 对自己必然成功');
+      expect(
+        path!.toLowerCase().replaceAll('/', r'\'),
+        Platform.resolvedExecutable.toLowerCase().replaceAll('/', r'\'),
+      );
+    });
+
+    test('不存在的 PID 返回 null 而不是抛异常', () {
+      // 0 与负数被公开 API 直接挡掉；这里用一个几乎不可能存在的高位 PID。
+      expect(windowsProcessImagePath(0x7FFFFFF0), isNull);
+      expect(windowsProcessImagePath(0), isNull);
+      expect(windowsProcessImagePath(-1), isNull);
+    });
+  });
+
+  group('按名字 / 按 PID 查询（真实系统）', () {
+    test('按 image 名（大小写不敏感）能查到自己，且带完整路径', () {
+      final String own = _ownExeName();
+      for (final String probe in <String>[
+        own,
+        own.toUpperCase(),
+        own.toLowerCase(),
+      ]) {
+        final List<WindowsProcessEntry> found =
+            windowsProcessesByNames(<String>{probe});
+        expect(
+            found.where((WindowsProcessEntry e) => e.pid == pid), hasLength(1),
+            reason: '用 "$probe" 查不到当前进程');
+        final WindowsProcessEntry me =
+            found.firstWhere((WindowsProcessEntry e) => e.pid == pid);
+        expect(me.path, isNotNull, reason: '命中项必须已解析路径');
+      }
+    });
+
+    test('按 PID 批量查询：命中自己、忽略不存在的、带路径', () {
+      final Map<int, WindowsProcessEntry> found =
+          windowsProcessesByIds(<int>[pid, 0x7FFFFFF0, 0, -5]);
+      expect(found.keys, contains(pid));
+      expect(found[pid]!.path, isNotNull);
+      expect(found.keys, isNot(contains(0)));
+      expect(found.keys, isNot(contains(-5)));
+    });
+
+    test('windowsProcessById 返回带路径的身份', () {
+      final WindowsProcessEntry? me = windowsProcessById(pid);
+      expect(me, isNotNull);
+      expect(me!.name.toLowerCase(), _ownExeName().toLowerCase());
+      expect(me.path, isNotNull);
+    });
+
+    test('空名字集合 / 空 PID 集合返回空，不做无谓枚举', () {
+      expect(windowsProcessesByNames(<String>{}), isEmpty);
+      expect(windowsProcessesByIds(<int>[]), isEmpty);
+    });
+  });
+
+  group('注册表读取（真实系统）', () {
+    const String ntCurrentVersion =
+        r'SOFTWARE\Microsoft\Windows NT\CurrentVersion';
+
+    test('读 REG_SZ：ProductName 在任何 Windows 上都存在且非空', () {
+      final String? product = readWindowsRegistryString(
+        WindowsRegistryRoot.localMachine,
+        ntCurrentVersion,
+        'ProductName',
+      );
+      expect(product, isNotNull, reason: 'HKLM 下 ProductName 必然存在');
+      expect(product, isNotEmpty);
+      expect(product!.toLowerCase(), contains('windows'));
+    });
+
+    test('读 REG_DWORD：CurrentMajorVersionNumber 是合理的版本号', () {
+      final int? major = readWindowsRegistryDword(
+        WindowsRegistryRoot.localMachine,
+        ntCurrentVersion,
+        'CurrentMajorVersionNumber',
+      );
+      // Win10/11 都写 10；给个宽区间，只要不是 0 或垃圾值。
+      expect(major, isNotNull, reason: 'Win10+ 必然有这个值');
+      expect(major, inInclusiveRange(6, 99),
+          reason: '读出 $major——DWORD 解码或类型判断写错了');
+    });
+
+    test('类型不符返回 null（拿 DWORD 读法读字符串值，反之亦然）', () {
+      expect(
+        readWindowsRegistryDword(
+          WindowsRegistryRoot.localMachine,
+          ntCurrentVersion,
+          'ProductName', // 实为 REG_SZ
+        ),
+        isNull,
+      );
+      expect(
+        readWindowsRegistryString(
+          WindowsRegistryRoot.localMachine,
+          ntCurrentVersion,
+          'CurrentMajorVersionNumber', // 实为 REG_DWORD
+        ),
+        isNull,
+      );
+    });
+
+    test('不存在的键 / 值返回 null 而不是抛异常', () {
+      expect(
+        readWindowsRegistryString(
+          WindowsRegistryRoot.localMachine,
+          r'SOFTWARE\Fushi\NoSuchKey\Ever',
+          'Whatever',
+        ),
+        isNull,
+      );
+      expect(
+        readWindowsRegistryString(
+          WindowsRegistryRoot.localMachine,
+          ntCurrentVersion,
+          'NoSuchValueEver',
+        ),
+        isNull,
+      );
+      expect(
+        readWindowsRegistryDword(
+          WindowsRegistryRoot.currentUser,
+          r'Software\Fushi\NoSuchKey\Ever',
+          'Whatever',
+        ),
+        isNull,
+      );
+    });
+
+    test('HKCU 根也能读（系统代理设置就在这个根下）', () {
+      // Internet Settings 键在任何有网络栈的 Windows 上都存在。
+      // 值可能不存在（没开系统代理），但读键本身不该炸。
+      final int? proxyEnable = readWindowsRegistryDword(
+        WindowsRegistryRoot.currentUser,
+        r'Software\Microsoft\Windows\CurrentVersion\Internet Settings',
+        'ProxyEnable',
+      );
+      expect(proxyEnable, anyOf(isNull, isA<int>()));
+    });
+  });
+}

--- a/fushi/test/platform/windows_process_query_test.dart
+++ b/fushi/test/platform/windows_process_query_test.dart
@@ -25,6 +25,7 @@ void main() {
       expect(windowsProcessById(1), isNull);
       expect(windowsProcessesByNames(<String>{'x.exe'}), isEmpty);
       expect(windowsProcessesByIds(<int>[1]), isEmpty);
+      expect(windowsProcessesHoldingFile('/tmp/x'), isEmpty);
       expect(
         readWindowsRegistryString(
             WindowsRegistryRoot.localMachine, 'SOFTWARE', 'X'),
@@ -135,6 +136,53 @@ void main() {
     test('空名字集合 / 空 PID 集合返回空，不做无谓枚举', () {
       expect(windowsProcessesByNames(<String>{}), isEmpty);
       expect(windowsProcessesByIds(<int>[]), isEmpty);
+    });
+  });
+
+  group('文件占用者查询 / Restart Manager（真实系统）', () {
+    test('当前进程必然被报为自己 exe 文件的占用者', () {
+      // 这是本组的核心断言：RM_PROCESS_INFO 的字段顺序 / 定长数组尺寸写错，
+      // 不会抛异常，只会读出垃圾 PID 或空列表。运行中的进程一定持有自己的
+      // image 文件，是唯一不依赖环境的已知真值。
+      final List<WindowsProcessEntry> holders =
+          windowsProcessesHoldingFile(Platform.resolvedExecutable);
+      expect(
+        holders.map((WindowsProcessEntry e) => e.pid),
+        contains(pid),
+        reason: 'RM 没把当前进程报成自己 exe 的占用者——'
+            'RM_PROCESS_INFO 布局（256/64 定长数组）可能写错了，实际拿到 $holders',
+      );
+    });
+
+    test('报出的占用者带正确的 image 名与路径', () {
+      final WindowsProcessEntry me =
+          windowsProcessesHoldingFile(Platform.resolvedExecutable)
+              .firstWhere((WindowsProcessEntry e) => e.pid == pid);
+      expect(me.name.toLowerCase(), _ownExeName().toLowerCase());
+      expect(
+        me.path!.toLowerCase().replaceAll('/', r'\'),
+        Platform.resolvedExecutable.toLowerCase().replaceAll('/', r'\'),
+      );
+    });
+
+    test('无人占用的普通文件 → 空列表', () {
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('fushi_rm_probe_');
+      try {
+        final File idle = File('${tmp.path}\\idle.bin')
+          ..writeAsBytesSync(<int>[1, 2, 3]);
+        expect(windowsProcessesHoldingFile(idle.path), isEmpty);
+      } finally {
+        tmp.deleteSync(recursive: true);
+      }
+    });
+
+    test('不存在的文件 / 空路径 → 空列表，不抛异常', () {
+      expect(
+        windowsProcessesHoldingFile(r'C:\NoSuchDir\NoSuchFile.dll'),
+        isEmpty,
+      );
+      expect(windowsProcessesHoldingFile(''), isEmpty);
     });
   });
 

--- a/fushi/test/tools/no_powershell_execution_policy_guard_test.dart
+++ b/fushi/test/tools/no_powershell_execution_policy_guard_test.dart
@@ -1,0 +1,112 @@
+// 守卫：随 app 出货的代码里，不得再给 powershell 传执行策略绕过参数。
+//
+// 背景（真实事故）：卡巴斯基 Endpoint Security 的**行为检测**（PDM）把运行中的
+// hibiki.exe 判成 `PDM:Trojan.Win32.Generic`（威胁级别「高」，对象类型「进程」，
+// 直接结束进程）。没有任何文件特征命中——纯粹是动作链打分过阈：
+//
+//   未签名进程 → 联网拉 PE 落盘 → 生成 powershell 子进程枚举全机进程/模块
+//   → 读注册表 → 生成分离子进程静默执行刚下载的 PE → 自身退出
+//
+// 「进程生成 powershell 且带执行策略绕过」是各家 EDR/AV 规则库里的标准高危项
+// （LOLBin 滥用），在上面那条链里是权重最高的单点信号之一。
+//
+// 关键事实：这个参数在我们这几处**本来就是空写**。执行策略只约束 `.ps1` 脚本
+// 文件的加载，对 `-Command` 传入的内联字符串完全不生效。实测（Windows
+// PowerShell 5.1）：即使显式传最严的 Restricted，内联 -Command 照常执行。
+// 所以删掉它零功能损失，纯粹是把一个高权重 AV 信号白送出去。
+//
+// 因此本守卫的判据是「出货代码里不得出现该参数」，而不是「不许用 powershell」——
+// 用 powershell 取信息本身还有合法用途，白送信号没有。
+//
+// 扫描面**只含随 app 出货的代码**（fushi/lib + fushi/windows）。开发期脚本
+// （tool/*.ps1 及调用它们的文档命令）不在此列：那些不进用户机器，且用 -File
+// 跑真实 .ps1 时该参数是**有效且必要**的。
+//
+// 纯 dart:io，不依赖 Flutter 运行时。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import '../helpers/scan_scale.dart';
+
+/// 从当前 cwd 向上找含 docs/BUGS.md 的仓库根。
+Directory _repoRoot() {
+  Directory dir = Directory.current;
+  for (int i = 0; i < 6; i++) {
+    if (File('${dir.path}/docs/BUGS.md').existsSync()) return dir;
+    final Directory parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail('找不到含 docs/BUGS.md 的仓库根（从 ${Directory.current.path} 向上）');
+}
+
+/// 随 app 出货的代码根。**不含** tool/ 与 .github/：那些是开发期/CI 脚本。
+const List<String> _shippedRoots = <String>[
+  'fushi/lib',
+  'fushi/windows',
+];
+
+/// 只看文本源码；二进制与生成物跳过。
+bool _isTextSource(String path) {
+  const List<String> exts = <String>[
+    '.dart',
+    '.iss',
+    '.cpp',
+    '.h',
+    '.cc',
+    '.ps1',
+    '.bat',
+    '.cmd',
+  ];
+  final String lower = path.toLowerCase();
+  return exts.any(lower.endsWith);
+}
+
+/// 针（拆开拼装）：避免本守卫文件自身被未来扩大的扫描面匹配到。
+const String _needle = '-Execution${'Policy'}';
+
+void main() {
+  test('出货代码不得给 powershell 传执行策略绕过参数（AV 行为检测高权重信号）', () {
+    final Directory root = _repoRoot();
+    final List<String> offenders = <String>[];
+    int scanned = 0;
+
+    for (final String rel in _shippedRoots) {
+      final Directory dir = Directory('${root.path}/$rel');
+      if (!dir.existsSync()) {
+        fail('扫描根不存在：$rel —— 守卫的路径常量过期了，先修守卫');
+      }
+      for (final FileSystemEntity entity in dir.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!_isTextSource(entity.path)) continue;
+        scanned++;
+        final String text = entity.readAsStringSync();
+        if (!text.contains(_needle)) continue;
+        for (final String line in text.split('\n')) {
+          if (line.contains(_needle)) {
+            offenders.add('${entity.path}: ${line.trim()}');
+          }
+        }
+      }
+    }
+
+    expectScanScale(
+      scanned,
+      what: '出货代码（fushi/lib + fushi/windows）里的文本源文件',
+      atLeast: 800,
+      measured: 1085,
+    );
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: '这些出货代码给 powershell 传了执行策略绕过参数：\n'
+          '${offenders.join('\n')}\n\n'
+          '它对 `-Command` 内联字符串**本来就不生效**（执行策略只管 .ps1 文件加载），'
+          '却是 AV/EDR 行为检测里的高权重信号——卡巴 PDM 已因此把 app 进程判成木马并结束。\n'
+          '删掉即可；要传参就用 `-NoProfile -NonInteractive`。\n'
+          '若确实需要跑真实 .ps1 脚本文件，把脚本挪到 tool/（开发期，不随 app 出货）。',
+    );
+  });
+}

--- a/fushi/test/utils/misc/platform_updater_test.dart
+++ b/fushi/test/utils/misc/platform_updater_test.dart
@@ -226,8 +226,7 @@ void main() {
       final Iterable<String> logArgs =
           args.where((String arg) => arg.startsWith('/LOG='));
       expect(logArgs, hasLength(1));
-      expect(
-          logArgs.single, contains('fushi-0.4.2-windows-setup.install.log'));
+      expect(logArgs.single, contains('fushi-0.4.2-windows-setup.install.log'));
     });
 
     test('pins the installer target to the current executable directory', () {
@@ -510,21 +509,23 @@ void main() {
       expect(failures.single.path, r'C:\Program Files\Hibiki\libmpv-2.dll');
     });
 
-    test('parses tasklist module holders without terminating them', () {
-      final List<WindowsProcessInfo> holders =
-          parseWindowsTasklistModuleHolders(
-        [
-          '"hibiki.exe","4321","Console","1","120,000 K"',
-          '"mpv-helper.exe","8765","Console","1","80,000 K"',
-        ].join('\n'),
-      );
-
-      expect(holders.map((WindowsProcessInfo p) => p.pid), <int>[4321, 8765]);
+    // 原用例还断言了 `tasklist /M` 的 CSV 解析。占用者查询已改走 Restart Manager
+    // （直接问系统「谁持有目标目录里那个 libmpv-2.dll」，不再扫全机模块表，见
+    // `windows_process_query.dart`），那个解析器随之删除，用例也不再有对象。
+    // 但同一个用例里搭着的**不变式**依然要守：更新器只观察占用者，永不杀进程。
+    test('更新器只观察占用者，永不终结任何进程', () {
       final String source =
           File('lib/src/utils/misc/platform_updater.dart').readAsStringSync();
       expect(source, isNot(contains('kill')));
       expect(source, isNot(contains('taskkill')));
       expect(source, isNot(contains('TerminateProcess')));
+      // 占用者查询本身也不得越权：RM 只做只读查询，不注册 restart/shutdown。
+      final String query =
+          File('lib/src/platform/desktop/windows_process_query.dart')
+              .readAsStringSync();
+      expect(query, isNot(contains('RmShutdown')));
+      expect(query, isNot(contains('RmRestart')));
+      expect(query, isNot(contains('TerminateProcess')));
     });
   });
 

--- a/fushi/test/utils/misc/update_checker_proxy_test.dart
+++ b/fushi/test/utils/misc/update_checker_proxy_test.dart
@@ -5,26 +5,17 @@ import 'package:flutter_test/flutter_test.dart';
 // 出口，而 part 没法被外部 import）。测试跟着搬 import，断言逐字不变。
 import 'package:fushi/src/utils/net/app_proxy.dart';
 
-/// 构造一条 `reg query ... /v ProxyEnable` 的典型输出。
-String _regEnable(String value) {
-  const String key =
-      r'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings';
-  return '\r\n$key\r\n    ProxyEnable    REG_DWORD    $value\r\n';
-}
-
-/// 构造一条 `reg query ... /v ProxyServer` 的典型输出。
-String _regServer(String value) {
-  const String key =
-      r'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings';
-  return '\r\n$key\r\n    ProxyServer    REG_SZ    $value\r\n';
-}
-
 void main() {
-  group('parseWindowsRegistryProxy（解析 Windows 系统代理注册表输出，纯函数）', () {
+  // 取值方式已从 `reg query` 子进程换成 `RegQueryValueExW`（AV 行为检测把
+  // 「进程 spawn reg/powershell 问系统要信息」算高权重信号，见
+  // `windows_process_query.dart` 文件头）。于是本纯函数的入参从「reg 的 stdout
+  // 文本」变成「已读出的 DWORD / 字符串值」——注册表输出的**文本解析**不再由我们
+  // 做，那几条用例随之消失；折算规则（启用判据 / 分协议串取段）这层断言逐字不变。
+  group('parseWindowsRegistryProxy（把已读出的注册表值折成代理 env，纯函数）', () {
     test('系统代理启用 + 全局 host:port → 填 https_proxy/http_proxy', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer('127.0.0.1:34151'),
+        proxyEnable: 1,
+        proxyServer: '127.0.0.1:34151',
       );
       expect(env['https_proxy'], '127.0.0.1:34151');
       expect(env['http_proxy'], '127.0.0.1:34151');
@@ -32,34 +23,33 @@ void main() {
 
     test('系统代理未启用（0x0）→ 空 map（不补代理，回退直连）', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x0'),
-        proxyServerOutput: _regServer('127.0.0.1:34151'),
+        proxyEnable: 0,
+        proxyServer: '127.0.0.1:34151',
       );
       expect(env, isEmpty);
     });
 
     test('ProxyEnable 缺失 → 空 map', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: 'ERROR: registry value not found.',
-        proxyServerOutput: _regServer('127.0.0.1:34151'),
+        proxyEnable: null,
+        proxyServer: '127.0.0.1:34151',
       );
       expect(env, isEmpty);
     });
 
     test('启用但 ProxyServer 缺失/为空 → 空 map', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: 'ERROR: registry value not found.',
+        proxyEnable: 1,
+        proxyServer: null,
       );
       expect(env, isEmpty);
     });
 
     test('分协议串（http=/https=）分别取对应段', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer(
-          'http=127.0.0.1:7890;https=127.0.0.1:7891;ftp=127.0.0.1:7892',
-        ),
+        proxyEnable: 1,
+        proxyServer:
+            'http=127.0.0.1:7890;https=127.0.0.1:7891;ftp=127.0.0.1:7892',
       );
       expect(env['https_proxy'], '127.0.0.1:7891');
       expect(env['http_proxy'], '127.0.0.1:7890');
@@ -67,8 +57,8 @@ void main() {
 
     test('分协议串只给 https → http_proxy 回退到 https 段', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer('https=127.0.0.1:7891'),
+        proxyEnable: 1,
+        proxyServer: 'https=127.0.0.1:7891',
       );
       expect(env['https_proxy'], '127.0.0.1:7891');
       expect(env['http_proxy'], '127.0.0.1:7891');
@@ -76,25 +66,39 @@ void main() {
 
     test('分协议串只给 http → https_proxy 回退到 http 段', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer('http=127.0.0.1:7890'),
+        proxyEnable: 1,
+        proxyServer: 'http=127.0.0.1:7890',
       );
       expect(env['http_proxy'], '127.0.0.1:7890');
       expect(env['https_proxy'], '127.0.0.1:7890');
     });
 
-    test('ProxyEnable 大小写不敏感（0X1）仍视为启用', () {
-      final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0X1'),
-        proxyServerOutput: _regServer('127.0.0.1:34151'),
+    test('ProxyEnable 为 1 以外的任何值都视为未启用（fail-closed）', () {
+      // 原用例断言的是「0X1 大小写不敏感」——那是 reg 输出的**文本**形态问题，
+      // 换成 REG_DWORD 直读后不复存在。真正要钉的判据是「只有 1 算启用」。
+      for (final int? enable in <int?>[0, 2, -1, null]) {
+        expect(
+          parseWindowsRegistryProxy(
+            proxyEnable: enable,
+            proxyServer: '127.0.0.1:34151',
+          ),
+          isEmpty,
+          reason: 'ProxyEnable=$enable 不应被当成已启用',
+        );
+      }
+      expect(
+        parseWindowsRegistryProxy(
+          proxyEnable: 1,
+          proxyServer: '127.0.0.1:34151',
+        )['https_proxy'],
+        '127.0.0.1:34151',
       );
-      expect(env['https_proxy'], '127.0.0.1:34151');
     });
 
     test('解析结果可直接喂给 HttpClient.findProxyFromEnvironment 得到 PROXY 指令', () {
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer('127.0.0.1:34151'),
+        proxyEnable: 1,
+        proxyServer: '127.0.0.1:34151',
       );
       // 不实际建连，只验证生成的 environment 能被 findProxyFromEnvironment 识别为代理。
       final String directive = HttpClient.findProxyFromEnvironment(
@@ -411,8 +415,8 @@ void main() {
       final String? normalized = normalizeUserProxyHostPort('127.0.0.1:7890');
       expect(normalized, '127.0.0.1:7890');
       final Map<String, String> env = parseWindowsRegistryProxy(
-        proxyEnableOutput: _regEnable('0x1'),
-        proxyServerOutput: _regServer(normalized!),
+        proxyEnable: 1,
+        proxyServer: normalized!,
       );
       final String directive = HttpClient.findProxyFromEnvironment(
         Uri.parse('https://api.github.com/repos/x/y/releases/latest'),

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -220,7 +220,7 @@ var
 begin
   EscapedDir := Dir;
   StringChangeEx(EscapedDir, '''', '''''', True);
-  Cmd := '-NoProfile -ExecutionPolicy Bypass -Command "$d = ''' + EscapedDir + '''; ' +
+  Cmd := '-NoProfile -NonInteractive -Command "$d = ''' + EscapedDir + '''; ' +
     'if (-not $d.EndsWith(''\'')) { $d += ''\'' }; ' +
     'Get-Process | Where-Object { $_.Path -and $_.Path.StartsWith($d, [System.StringComparison]::OrdinalIgnoreCase) } | ' +
     'Stop-Process -Force -ErrorAction SilentlyContinue"';


### PR DESCRIPTION
## 背景

用户在 Kaspersky Endpoint Security 下更新到 1.4 后，主程序被**行为检测**（PDM，Proactive Defense Module）报 `PDM:Trojan.Win32.Generic`，位置 `...\fushi\fushi.exe`。

PDM 不看文件内容，只看进程运行时行为——所以用户单独下载安装包做静态扫描是干净的，两者不矛盾。

真正触发的是「点一次应用内更新」时，`fushi.exe` 在数秒内连续发出的一串 LOLBin 调用，叠加成典型恶意链（侦察 → 下载器 → 落盘执行 → 断开进程链 → 静默安装 → 强杀进程 → 自替换）：

| 行为 | 原位置 |
|---|---|
| `reg query HKLM\...\Uninstall\...` 注册表侦察 | `platform_updater.dart:899` |
| `tasklist /M libmpv-2.dll` 全机模块枚举 | `platform_updater.dart:1012` |
| `powershell -ExecutionPolicy Bypass -Command` ×2 | `platform_updater.dart:997`、`1050` |
| `powershell -ExecutionPolicy Bypass ... Get-Process \| Stop-Process -Force` | `fushi.iss:223` |

其中 `-ExecutionPolicy Bypass` 是纯粹白送的行为分：执行策略只约束 `.ps1` 脚本文件加载，对 `-Command` 内联命令根本不生效，这几处跑的都是 `Get-CimInstance` / `Get-Process`，不加载任何脚本。

1.4 才爆的放大器是**信誉归零**——改名后 `fushi.exe` 是全新 image 名 + 全新哈希，KSN 云信誉零记录，行为评分阈值随之下降。（Windows 产物一贯无代码签名，非本次新增；`WINDOWS_CERT_BASE64` 从未配置，历次发布 `Sign installer (optional)` 全部 skipped。）

## 本 PR 做了什么

- `f28958e3a7` 摘掉出货代码里的 powershell 执行策略绕过参数，附源码扫描守卫 `no_powershell_execution_policy_guard_test.dart`
- `84712de7bb` 进程/注册表查询改走 Win32 API，消掉 6 处 LOLBin 子进程生成（新增 `windows_process_query.dart` + 测试，顺带清了 `port_process_terminator.dart` / `app_proxy.dart`）
- `8e37051d58` 占用者查询改走 Restart Manager，干掉更新路径上的全机模块枚举

## 遗留

代码签名（`WINDOWS_CERT_BASE64` + 把签名范围从「只签 installer」扩到 `fushi.exe` / `fushi_update_launcher.exe` / 随包 helper）不在本 PR 范围，是唯一能根治信誉问题的手段，需单独立项。

https://claude.ai/code/session_01GQqYFirezR3NSYMWyMsYbn