### PR TITLE
fix(video): Windows hwdec 值域排除 CUDA 后端，根治 nvdec 起播闪退（BUG-1639）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1511 条。点号进各自文件。
+> 共 1512 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1639](bugs/BUG-1639-hwdec-nvdec-cuda-crash.md) | ✅ | ✅ | Windows+NVIDIA 起播闪退：hwdec=auto-safe 在 GL 渲染路径下必然回退 nvdec(CUDA)，nvcuda64 空指针整进程崩（BUG-1545 未根治） |
 | [BUG-1613](bugs/BUG-1613-apple-coreml-ep-detector-empty.md) | ✅ | ✅ | Apple CoreML EP 上 int8 检测模型静默返回空结果且更慢 |
 | [BUG-1610](bugs/BUG-1610-bangumi-search-rating-null.md) | ✅ | ✅ | Bangumi 搜索候选评分恒空：映射器读扁平 score，真实响应只有嵌套 rating.score |
 | [BUG-1609](bugs/BUG-1609-global-lookup-card-right-corners-square.md) | ✅ | ✅ | app 外全局查词卡片右上/右下圆角变方角 |

--- a/docs/bugs/BUG-1639-hwdec-nvdec-cuda-crash.md
+++ b/docs/bugs/BUG-1639-hwdec-nvdec-cuda-crash.md
@@ -1,0 +1,86 @@
+## BUG-1639 · Windows+NVIDIA 起播闪退：hwdec=auto-safe 在 GL 渲染路径下必然回退 nvdec(CUDA)，nvcuda64 空指针整进程崩（BUG-1545 未根治）
+- **报告**：2026-08-14（用户：打开 K-ON 就闪退——与 BUG-1545 同一句报告，装了含 BUG-1545 修复的构建后仍复发）
+- **真实性**：✅ 真 bug，根因 `fushi/lib/src/media/video/video_mpv_config.dart` 的平台 hwdec 解析（原 `resolveAndroidHwdec`）在 Windows 上原样透传 `auto-safe`，而 `auto-safe` 的 mpv 白名单里 `nvdec` 就是 CUDA
+- **[x] ① 已修复** — `resolveAndroidHwdec` → `resolvePlatformHwdec`，Windows 上把 `auto-safe`/`auto-copy` 解析成不含 CUDA 的显式候选（`d3d11va,d3d11va-copy` / `d3d11va-copy`），`no` 透传；两个调用点（`VideoController` 构造与 `buildMpvProperties`）同源取值
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_hwdec_controller_config_guard_test.dart` 新增 BUG-1639 组 6 条（值域不含 nvdec/cuda、两档语义、常量自校验、no 透传、非 Windows 零变化、端到端 `buildMpvProperties`）；已做变异实测两轮（常量掺 `nvdec` → 3 条转红；Windows 分支退化成透传 → 2 条转红，均退出码 1）
+- **备注**：本条是 BUG-1545 的**未尽根因**，不是重复条目——1545 修的是「谁下发」，本条修的是「下发什么值」
+
+### 崩溃证据（本机真实 minidump）
+
+`C:\Users\wrds\AppData\Local\CrashDumps\fushi.exe.160512.dmp`（2026-08-14 16:14，进程版本 `2.0.0.11553`，
+该构建产于 08-14 05:51，**已包含** BUG-1545 的修复 commit `538c2e847e`（08-11 22:26））：
+
+```
+ExceptionCode: c0000005 (Access violation), AV.Dereference=NullClassPtr, AV.Fault=Read
+nvcuda64!cuProfilerStop+0x136d8f:  mov rbx,qword ptr [rax+8]   ds:0000000000000008   (rax=0)
+
+libmpv_2!mpv_create+0x1ae                        <- mpv 核心线程入口
+libmpv_2!mpv_stream_cb_add_ro+0x24c60            <- 播放循环
+libmpv_2!mpv_stream_cb_add_ro+0x59e68 / +0x5a389 / +0x5ad45
+libmpv_2!mpv_render_context_get_info+0x84930
+libmpv_2!sixel_output_set_encode_policy+0x563743 <- cuda hwdec 初始化
+nvcuda64!cuCtxCreate_v2+0x25  ->  nvcuda64!cuCtxCreate+0x10b  ->  空指针解引用
+```
+
+与 BUG-1545 记录的三份 08-11 dump 栈形状完全一致 → **同一条崩溃路径在修复后复发**。
+
+### 根因：修掉了「谁下发」，没修掉「下发什么」
+
+BUG-1545 的结论是「media_kit 把 `configuration.hwdec == null` 兜底成 `auto`，抢在 app 策略之前下发，
+`auto` 含非 copy 的 `cuda`/`nvdec`」，修法是把 app 策略 `auto-safe` 随 `VideoControllerConfiguration`
+传进去。**但 `auto-safe` 通往的是同一个 CUDA 后端**：
+
+1. media_kit 的 `NativeVideoController` 在 Windows 走**纹理渲染**（libmpv render API + ANGLE/OpenGL），
+   libmpv 拿不到宿主的 D3D11 device；
+2. 于是 hwdec 探测里 `d3d11va`（需 D3D11 interop）**必然**失败：`[vd] Could not create device.`；
+3. mpv 的 `auto-safe` 白名单里紧跟其后的是 `nvdec`——它是 CUDA API（cuvid）的封装，
+   NVIDIA 机器上必然被选中：`[vo/gpu] Loading hwdec driver 'cuda'` → `Using hardware decoding (nvdec)`；
+4. 进而 `cuInit()` / `cuCtxCreate_v2()` 在 `nvcuda64.dll` 内部空指针解引用 → 整进程 `0xC0000005`。
+
+### 本机确定性复现（ctypes 直驱安装目录的 libmpv，非推断）
+
+用 `D:\APP\Hibiki\libmpv-2.dll` + 本次崩溃的片源（`D:\video\K-ON!\Season 01\K-ON! - S01E01.mkv`，
+HEVC **Main 10** / yuv420p10le / 1080p / Opus / ASS）在 **GL 上下文**（`gpu-context=win`，对齐 app 的
+GL 纹理渲染而非 d3d11 直渲）下逐档实测：
+
+| 下发的 hwdec | libmpv 实际选择 | 是否触碰 CUDA |
+|---|---|---|
+| `auto-safe`（app 默认，也是用户当前设置） | `Using hardware decoding (nvdec)` | 是，崩溃路径 |
+| `auto-copy` | `Using hardware decoding (d3d11va-copy)` | 否（但无 d3d11va 的机器会落 `cuda-copy`） |
+| `d3d11va-copy` | `Using hardware decoding (d3d11va-copy)` | 否 |
+| `d3d11va,d3d11va-copy` | `d3d11va` 失败 → `Using hardware decoding (d3d11va-copy)` | 否 |
+
+注：同一档 `auto-safe` 在 `vo=gpu` **d3d11 直渲**上下文下选的是 d3d11va、不碰 CUDA——所以「用 mpv.exe
+播同一个文件不崩」不能证伪本条，渲染上下文才是分叉点。
+
+### 关于「只有 K-ON 崩」
+
+与 BUG-1545 的结论一致：不是 K-ON 专属，也不是标题里的 `!`、不是每集新建 Player。
+本机 27 个番剧目录里 hevc/yuv420p10le 有 14 个。K-ON 是最大的合集（59 集 / 3 季），
+打开它时主 isolate 负载最重，最容易走到会崩的那条初始化路径；修掉值域后与合集大小无关。
+
+### 修复
+
+`resolveAndroidHwdec` → `resolvePlatformHwdec(hwdec, {isAndroid, isWindows})`：一个函数决定「实际下发值」，
+平台是它的输入（原来 Android 一个特例函数，Windows 再加一个就是两个特例）。Windows 分支：
+
+- `auto-safe` → `d3d11va,d3d11va-copy`（`kWindowsAutoHwdec`）：先试 interop 直渲（media_kit 将来能共享
+  D3D11 device 就直接受益），失败静默回落 copy-back；
+- `auto-copy` → `d3d11va-copy`（`kWindowsCopyHwdec`）：用户显式要 copy-back，只给 copy 变体；
+- `no` 原样透传。
+
+`d3d11va` 是 Windows 8+ 通用硬解（Intel/AMD/NVIDIA 全支持），两档都失败时 libmpv 自行回落软解，不会无画面。
+Android 分支行为一字未改（`auto-safe`/`auto` → `auto-copy`，BUG-465 不回归）；macOS/Linux/iOS 原样透传。
+
+### 影响范围与验证缺口
+
+- 影响：Windows + NVIDIA 用户起播视频时的整进程闪退（无 Dart 异常，`ErrorLogService` 捕不到）。
+- 已验证：`flutter analyze` 零问题；定向 + 相邻 `test/media/video/` 全域 2572 通过（退出码 0）；
+  守卫两轮变异实测；libmpv 层逐档实测见上表。
+- **未验证**：真机复测「装上含本修复的构建后打开 K-ON 起播不再闪退」需要新出一版 Windows 包再走一遍原始路径。
+  libmpv 层已确定性证明修复后的值域不会加载 `nvcuda64.dll`，但 app 内端到端仍待下一版验收。
+
+### 用户侧即时缓解（无需等新版）
+
+设置 → 视频 → 硬件解码 改成「自动（复制）」：本机实测该档在同一 GL 路径下选 `d3d11va-copy`，不碰 CUDA。
+或改成「关闭」走软解（10-bit 1080p HEVC 软解在该机 CPU 上完全够）。

--- a/docs/bugs/BUG-1639-hwdec-nvdec-cuda-crash.md
+++ b/docs/bugs/BUG-1639-hwdec-nvdec-cuda-crash.md
@@ -53,6 +53,38 @@ GL 纹理渲染而非 d3d11 直渲）下逐档实测：
 注：同一档 `auto-safe` 在 `vo=gpu` **d3d11 直渲**上下文下选的是 d3d11va、不碰 CUDA——所以「用 mpv.exe
 播同一个文件不崩」不能证伪本条，渲染上下文才是分叉点。
 
+### 为什么不去「适配 CUDA」而是把它排除（实测，非取舍偏好）
+
+app 的真实渲染路径是 media_kit 的 **ANGLE + render API**（`third_party/media_kit_video/windows/`：
+`angle_surface_manager.cc:283` `eglCreateContext` 建 EGL/GLES context，`video_output.cc:56`
+以 `MPV_RENDER_PARAM_API_TYPE = MPV_RENDER_API_TYPE_OPENGL` 交给 `mpv_render_context_create`）。
+在**同构的 ANGLE 上下文**（`gpu-context=angle`，非前表的 WGL）下逐档实测：
+
+| hwdec | ANGLE 下的结果 |
+|---|---|
+| `nvdec`（零拷贝 CUDA interop） | `cu->cuGLGetDevices(...) failed -> CUDA_ERROR_OPERATING_SYSTEM` → `[vo/gpu/cuda] CUDA hwdec only works with OpenGL or Vulkan backends.` → `Loading failed` → 回落 |
+| `d3d11va`（零拷贝 D3D11 interop） | `d3d11va` 与 `d3d11-egl` 两个 interop driver 均 `Loading failed` |
+| `nvdec-copy`（CUDA copy-back） | ✅ `Using hardware decoding (nvdec-copy)`，正常播放 |
+| `d3d11va-copy`（D3D11 copy-back） | ✅ `Using hardware decoding (d3d11va-copy)`，正常播放 |
+
+三条结论：
+
+1. **零拷贝 CUDA 在当前架构下不可达**——ANGLE 是「GLES-over-D3D11」，不是 NVIDIA 的真 OpenGL，
+   `cuGLGetDevices` 认不了它，**mpv 自己就会拒绝启用 CUDA interop**。要让它生效需把 Flutter Windows
+   的渲染后端换成真 OpenGL 或 Vulkan（等于重写 media_kit Windows 渲染层），不属于「适配」范畴。
+2. **copy-back 的 CUDA（`nvdec-copy`）技术上可用，但相对 `d3d11va-copy` 零收益**：两者都用 GPU 硬件
+   解码单元、都把帧拷回内存，NVIDIA 上 D3D11VA 底层调的就是同一块 NVDEC 硬件；区别只是前者要多走
+   一遍 `cuInit()` / `cuCtxCreate_v2()`——正是本条崩溃的那步。**排除 CUDA 不等于放弃硬解。**
+3. **未解**：单实例复现时 `cuInit` 能成功（走到 `cuGLGetDevices` 才失败），而 app 里连
+   `cuInit`/`cuCtxCreate` 都崩。崩溃 dump 里进程并存 **14 个 libmpv 实例**（14 个 `mpv_wait_event`
+   事件循环）与 3 个 nvcuda64 线程，怀疑与之相关但未复现。这不影响修复结论：`d3d11va-copy`
+   根本不加载 `nvcuda64.dll`，整条路径被消除。
+
+**顺带记录一个真实的优化机会（非本条崩溃）**：`d3d11va` 零拷贝在这条路径下同样失败（连 `d3d11-egl`
+interop 都没加载起来），意味着当前每帧都在做 GPU→内存→GPU 往返。根因方向是 media_kit 建 ANGLE
+context 时没把底层 D3D11 device 经 EGL 扩展暴露给 mpv。修好它可省掉这次往返，属于性能优化，
+未在本条处理。
+
 ### 关于「只有 K-ON 崩」
 
 与 BUG-1545 的结论一致：不是 K-ON 专属，也不是标题里的 `!`、不是每集新建 Player。

--- a/fushi/lib/src/media/video/video_mpv_config.dart
+++ b/fushi/lib/src/media/video/video_mpv_config.dart
@@ -351,6 +351,19 @@ Map<String, String> parseMpvConf(String text) {
 /// GL 上下文 + 本次崩溃的 10-bit HEVC 片源）：`Using hardware decoding (d3d11va-copy)`，
 /// 全程不加载 `nvcuda64.dll`。
 ///
+/// **这不是「为了避崩而牺牲硬解」——终点本来就是同一个。** 在 media_kit 真实用的 ANGLE
+/// 上下文下实测：`nvdec` 的零拷贝 CUDA interop 会被 **mpv 自己拒绝**
+/// （`cuGLGetDevices` 失败 → `CUDA hwdec only works with OpenGL or Vulkan backends`），
+/// 因为 ANGLE 是 GLES-over-D3D11、不是 NVIDIA 的真 OpenGL；mpv 随后照样回落到
+/// `d3d11va-copy`。也就是说 CUDA 分支**从来没能真正用上零拷贝**，它只是在回落之前先跑
+/// 一趟 `cuInit()` / `cuCtxCreate_v2()`——而那趟在本机 app 进程里会栽进驱动空指针。
+/// 本修复只是把同一个终点提前，不再路过雷区；解码依然是 GPU 硬解（NVIDIA 上 D3D11VA
+/// 底层调的就是同一块 NVDEC 硬件）。
+///
+/// 反过来说，真要拿到零拷贝就得让 `d3d11va`（非 copy）的 interop 在这条路径上成立
+/// ——那是 media_kit 建 ANGLE context 时把底层 D3D11 device 经 EGL 扩展暴露给 mpv 的活，
+/// 属于性能优化，与本崩溃无关（详见 `docs/bugs/BUG-1639-*.md` 末节）。
+///
 /// 非 Android / 非 Windows（macOS / Linux / iOS）原样透传，零行为变化。
 ///
 /// [isAndroid] / [isWindows] 默认取 `Platform.isAndroid` / `Platform.isWindows`，

--- a/fushi/lib/src/media/video/video_mpv_config.dart
+++ b/fushi/lib/src/media/video/video_mpv_config.dart
@@ -324,16 +324,66 @@ Map<String, String> parseMpvConf(String text) {
 /// 故 Android 上把会落到 surface-直渲的 `auto-safe` / `auto` 一律改写成 `auto-copy`；
 /// `no`（软解）与 `auto-copy`（已是 copy）原样透传。这是**对齐 media_kit 的纹理渲染模型**
 /// 的根因修复，对**所有** Android 设备一致（都走同一 texture 渲染器），不是给 realme 8
-/// 打特例；非 Android（桌面 / iOS）原样透传，零行为变化。
+/// 打特例。
 ///
-/// [isAndroid] 默认取 `Platform.isAndroid`，注入仅为单测。
-String resolveAndroidHwdec(String hwdec, {bool? isAndroid}) {
+/// **根治 Windows + NVIDIA 起播整进程闪退（BUG-1639；BUG-1545 的未尽根因）。**
+/// 同一条「渲染模型 ↔ 硬解后端必须匹配」的推理在 Windows 桌面端同样成立，只是失配的
+/// 那一端换成了 CUDA：media_kit 的 `NativeVideoController` 在 Windows 也走**纹理渲染**
+/// （libmpv render API + ANGLE/OpenGL），libmpv 拿不到宿主的 D3D11 device，于是
+/// `d3d11va`（需 D3D11 interop）在 hwdec 探测里必然 `Could not create device` 失败。
+/// 而 mpv 的 `auto-safe` 白名单里**紧跟其后的就是 `nvdec`——它是 CUDA API 的封装**，
+/// 于是 NVIDIA 机器上必然回退到它：`Loading hwdec driver 'cuda'` →
+/// `cuInit()` / `cuCtxCreate_v2()` → `nvcuda64.dll` 内部空指针解引用 → 整个进程
+/// `0xC0000005` 闪退（本机 minidump 四份栈完全一致，详见 `docs/bugs/BUG-1639-*.md`）。
+///
+/// BUG-1545 当时只把 media_kit 抢跑下发的裸 `auto` 换成了用户策略 `auto-safe`，**但
+/// `auto-safe` 通往的是同一个 CUDA 后端**，故崩溃复发。真正的修复是让 Windows 下发的
+/// hwdec **值域里根本不含 CUDA 系后端**（`nvdec` / `cuda` 及其 copy 变体），而不是继续
+/// 在「哪个 auto」之间挑：
+/// - `auto-safe` → `d3d11va,d3d11va-copy`：先试 interop 直渲（将来 media_kit 若能共享
+///   D3D11 device 就直接受益），失败静默回落 copy-back；
+/// - `auto-copy` → `d3d11va-copy`：用户显式要 copy-back，只给 copy 变体（保留两档语义
+///   差异，且不像裸 `auto-copy` 那样在无 d3d11va 的机器上落到 `cuda-copy`）；
+/// - `no`（软解）原样透传。
+///
+/// `d3d11va` 是 Windows 8+ 的通用硬解（Intel / AMD / NVIDIA 全支持），两档都失败时
+/// libmpv 自行回落软解，不会无画面。本机实测（`hwdec=d3d11va,d3d11va-copy` +
+/// GL 上下文 + 本次崩溃的 10-bit HEVC 片源）：`Using hardware decoding (d3d11va-copy)`，
+/// 全程不加载 `nvcuda64.dll`。
+///
+/// 非 Android / 非 Windows（macOS / Linux / iOS）原样透传，零行为变化。
+///
+/// [isAndroid] / [isWindows] 默认取 `Platform.isAndroid` / `Platform.isWindows`，
+/// 注入仅为单测。
+String resolvePlatformHwdec(String hwdec, {bool? isAndroid, bool? isWindows}) {
   final bool android = isAndroid ?? Platform.isAndroid;
-  if (!android) return hwdec;
-  // Android 纹理渲染下，surface-直渲的 auto-safe/auto 会 surface-null，统一改 copy 变体。
-  if (hwdec == 'auto-safe' || hwdec == 'auto') return 'auto-copy';
-  return hwdec; // no（软解）/ auto-copy（已 copy）/ 其它显式值透传。
+  if (android) {
+    // Android 纹理渲染下，surface-直渲的 auto-safe/auto 会 surface-null，统一改 copy 变体。
+    if (hwdec == 'auto-safe' || hwdec == 'auto') return 'auto-copy';
+    return hwdec; // no（软解）/ auto-copy（已 copy）/ 其它显式值透传。
+  }
+  final bool windows = isWindows ?? Platform.isWindows;
+  if (windows) {
+    // Windows GL 纹理渲染下，任何 auto* 都会经 d3d11va 失败回退到 nvdec(CUDA) → 驱动崩。
+    // 显式给不含 CUDA 的候选列表，让 CUDA 后端从值域里消失（BUG-1639）。
+    if (hwdec == 'no') return 'no';
+    if (hwdec == 'auto-copy') return kWindowsCopyHwdec;
+    return kWindowsAutoHwdec; // auto-safe / auto / 其它 auto 变体。
+  }
+  return hwdec;
 }
+
+/// Windows 下 `auto-safe`（默认档）实际下发的 hwdec 候选列表——**不含任何 CUDA 系后端**。
+///
+/// 先 `d3d11va`（interop 直渲，media_kit 当前拿不到 D3D11 device 故会失败）再
+/// `d3d11va-copy`（copy-back，实测可用）。见 [resolvePlatformHwdec] 的 BUG-1639 说明。
+const String kWindowsAutoHwdec = 'd3d11va,d3d11va-copy';
+
+/// Windows 下 `auto-copy`（用户显式要 copy-back）实际下发的 hwdec 值。
+///
+/// 只给 copy 变体，且不含 CUDA 系后端（裸 `auto-copy` 在无 d3d11va 的机器上会落到
+/// `cuda-copy`，同样调 `cuInit()`）。见 [resolvePlatformHwdec] 的 BUG-1639 说明。
+const String kWindowsCopyHwdec = 'd3d11va-copy';
 
 /// 把 [highQuality] 偏好按平台解析成「实际下发给 libmpv 的 scale 缩放链」属性 map。纯函数。
 ///
@@ -345,7 +395,7 @@ String resolveAndroidHwdec(String hwdec, {bool? isAndroid}) {
 ///
 /// 故移动端（Android/iOS）即便 highQuality 开，也把 EWA polar 链回落成轻量的**可分离**
 /// `spline36`（远比 EWA polar 便宜、又明显优于 mpv 默认 bilinear，保留「高画质开关」在移动端的
-/// 可感质量差异）；桌面 GPU 扛得住，保持 `ewa_lanczossharp` 原样不降级。这与 [resolveAndroidHwdec]
+/// 可感质量差异）；桌面 GPU 扛得住，保持 `ewa_lanczossharp` 原样不降级。这与 [resolvePlatformHwdec]
 /// 同范式：只改移动端**实际下发**的滤镜，不改用户可见的 highQuality 开关语义（用户仍可手动开，
 /// 移动端下发的是轻量链、自担闪烁风险）。对齐 Windows 端把 `sigmoid-upscaling` 默认关修闪的同类
 /// 「中端 GPU 扛不住高画质渲染链」降级思路。highQuality 关时两端一致回落 mpv 默认 bilinear
@@ -421,7 +471,7 @@ const String _standardChannelLayouts = '7.1,5.1,stereo';
 /// `android_video_controller/real.dart`）。10-bit 帧（`yuv420p10` 等）需 16-bit 纹理格式，
 /// Mali-G76 的 GL ES 驱动为该格式分配/上传时 `OUT_OF_MEMORY` → 帧上不了屏（blank），偶发
 /// 成功 vs 失败交替 → 闪烁。软解（`hwdec=no`）与 copy 硬解（`auto-copy`）两条路的**公共下游**
-/// 都是这段 10-bit GL 上屏，故 [resolveAndroidHwdec] 的 hwdec 改写救不了它——必须在 VO 之前把
+/// 都是这段 10-bit GL 上屏，故 [resolvePlatformHwdec] 的 hwdec 改写救不了它——必须在 VO 之前把
 /// 帧降到 8-bit。
 ///
 /// 修复=Android 上无条件下发 `vf=format=yuv420p`，让 libmpv 在滤镜链里把 10-bit 帧转成
@@ -430,7 +480,7 @@ const String _standardChannelLayouts = '7.1,5.1,stereo';
 /// 故对全部 Android 设备一致下发（GL 路径本就不该见 10-bit），不是给 realme 8 打特例。
 ///
 /// **仅 Android**：桌面 GL 扛得住 10-bit，iOS 走另一套渲染（Metal），均不下发（原样透传，
-/// 零行为变化）。与 [resolveAndroidHwdec] / [resolveScaleProperties] 同范式——只改 Android
+/// 零行为变化）。与 [resolvePlatformHwdec] / [resolveScaleProperties] 同范式——只改 Android
 /// **实际下发**的属性，不引入用户可见开关（高级用户仍可经 [VideoMpvConfig.rawConf] 的 `vf`
 /// 覆盖，raw 最后合并优先）。
 ///
@@ -443,10 +493,12 @@ Map<String, String> resolveAndroidPixelFormatProperties({bool? isAndroid}) {
 }
 
 Map<String, String> buildMpvProperties(VideoMpvConfig config,
-    {bool? isAndroid, bool? isMobile}) {
+    {bool? isAndroid, bool? isMobile, bool? isWindows}) {
   final Map<String, String> out = <String, String>{};
-  // 解码：Android 纹理渲染下把 surface-直渲的 auto-safe 改写成 copy 变体（BUG-465）。
-  out['hwdec'] = resolveAndroidHwdec(config.hwdec, isAndroid: isAndroid);
+  // 解码：Android 纹理渲染下把 surface-直渲的 auto-safe 改写成 copy 变体（BUG-465）；
+  // Windows GL 纹理渲染下把 auto* 改写成不含 CUDA 的 d3d11va 列表（BUG-1639）。
+  out['hwdec'] = resolvePlatformHwdec(config.hwdec,
+      isAndroid: isAndroid, isWindows: isWindows);
   // Android 10-bit → 8-bit 降位：VO 前 vf=format=yuv420p 绕开 Mali GL 16-bit 纹理 OOM
   // （TODO-1196 / BUG-465 根因）；桌面/iOS 不下发。见 [resolveAndroidPixelFormatProperties]。
   out.addAll(resolveAndroidPixelFormatProperties(isAndroid: isAndroid));

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -1188,12 +1188,18 @@ class VideoPlayerController extends ChangeNotifier
       // `cuCtxCreate_v2()`，在 nvcuda64.dll 内部空指针解引用，**整个进程 0xC0000005
       // 闪退**（三份 minidump 栈完全一致）。传 configuration 让策略在**第一次属性
       // 下发**就生效，`auto` 再也不会到达 libmpv——消除时间窗本身，而不是事后覆盖。
-      // 与 [buildMpvProperties] 用同一个 [resolveAndroidHwdec] 解析，两处取值恒一致
+      // 与 [buildMpvProperties] 用同一个 [resolvePlatformHwdec] 解析，两处取值恒一致
       // （Android 仍是 copy 变体，BUG-465 不回归）。
+      //
+      // BUG-1639：**光把 `auto` 换成 `auto-safe` 并不够** —— `auto-safe` 的白名单里
+      // `nvdec` 就是 CUDA，而 Windows 上 media_kit 同样走 GL 纹理渲染、`d3d11va`
+      // interop 必然建不出 device，于是必然回退到它，同一条 `cuCtxCreate_v2` 崩溃复发。
+      // 故 [resolvePlatformHwdec] 现在在 Windows 下发不含 CUDA 的 `d3d11va` 候选列表，
+      // 让 CUDA 后端从值域里消失（详见该函数注释与 `docs/bugs/BUG-1639-*.md`）。
       _videoController = VideoController(
         player,
         configuration: VideoControllerConfiguration(
-          hwdec: resolveAndroidHwdec(mpvConfig.hwdec),
+          hwdec: resolvePlatformHwdec(mpvConfig.hwdec),
         ),
       );
       // TODO-1212：登记文件句柄释放（幂等，只在首次建 Player 时登记一次）。

--- a/fushi/test/media/video/video_hwdec_controller_config_guard_test.dart
+++ b/fushi/test/media/video/video_hwdec_controller_config_guard_test.dart
@@ -49,14 +49,15 @@ void main() {
           reason: 'VideoController 必须显式传 VideoControllerConfiguration');
     });
 
-    test('configuration 的 hwdec 必须来自 app 策略（resolveAndroidHwdec + mpvConfig）',
+    test('configuration 的 hwdec 必须来自 app 策略（resolvePlatformHwdec + mpvConfig）',
         () {
       expect(
-        RegExp(r'hwdec:\s*resolveAndroidHwdec\(\s*mpvConfig\.hwdec\s*\)')
+        RegExp(r'hwdec:\s*resolvePlatformHwdec\(\s*mpvConfig\.hwdec\s*\)')
             .hasMatch(src),
         isTrue,
-        reason: 'hwdec 必须由本次 load 的 mpvConfig 经 resolveAndroidHwdec 解析，'
-            '与 buildMpvProperties 取值一致（Android 仍为 copy 变体，BUG-465 不回归）',
+        reason: 'hwdec 必须由本次 load 的 mpvConfig 经 resolvePlatformHwdec 解析，'
+            '与 buildMpvProperties 取值一致（Android 仍为 copy 变体 BUG-465 不回归；'
+            'Windows 为不含 CUDA 的 d3d11va 列表 BUG-1639）',
       );
     });
 
@@ -94,18 +95,107 @@ void main() {
       expect(VideoMpvConfig.defaults.hwdec, 'auto-safe');
     });
 
-    test('resolveAndroidHwdec 对任何合法值都不产出裸 auto', () {
+    test('resolvePlatformHwdec 对任何合法值都不产出裸 auto', () {
       for (final String v in <String>['no', 'auto-safe', 'auto-copy']) {
         for (final bool android in <bool>[true, false]) {
-          expect(resolveAndroidHwdec(v, isAndroid: android), isNot('auto'),
-              reason: 'hwdec=$v (android=$android) 解析后不得是裸 auto');
+          for (final bool windows in <bool>[true, false]) {
+            expect(
+                resolvePlatformHwdec(v, isAndroid: android, isWindows: windows),
+                isNot('auto'),
+                reason:
+                    'hwdec=$v (android=$android, windows=$windows) 解析后不得是裸 auto');
+          }
         }
       }
     });
 
     test('Android 仍改写成 copy 变体（BUG-465 不回归）', () {
-      expect(resolveAndroidHwdec('auto-safe', isAndroid: true), 'auto-copy');
-      expect(resolveAndroidHwdec('auto-safe', isAndroid: false), 'auto-safe');
+      expect(
+          resolvePlatformHwdec('auto-safe', isAndroid: true, isWindows: false),
+          'auto-copy');
+      expect(
+          resolvePlatformHwdec('auto-safe', isAndroid: false, isWindows: false),
+          'auto-safe');
+    });
+  });
+
+  /// 守卫（BUG-1639）：**Windows 下发的 hwdec 值域里不得出现任何 CUDA 系后端**。
+  ///
+  /// BUG-1545 修掉了「media_kit 抢跑下发裸 `auto`」的时间窗，但把值换成用户策略
+  /// `auto-safe` 之后崩溃复发——因为 `auto-safe` 的白名单里 `nvdec` 就是 CUDA API 的
+  /// 封装。Windows 上 media_kit 同样走 GL(ANGLE) 纹理渲染，libmpv 拿不到宿主 D3D11
+  /// device，`d3d11va` interop 在 hwdec 探测里必然 `Could not create device`，于是
+  /// NVIDIA 机器必然回退 `nvdec` → `Loading hwdec driver 'cuda'` → `cuInit()` /
+  /// `cuCtxCreate_v2()` → `nvcuda64.dll` 空指针 → 整进程 0xC0000005。
+  ///
+  /// 本机 libmpv 实测（GL 上下文 + 10-bit HEVC 片源）：
+  /// `auto-safe` → `Using hardware decoding (nvdec)`（崩溃路径）；
+  /// `d3d11va,d3d11va-copy` → `Using hardware decoding (d3d11va-copy)`（不碰 nvcuda64）。
+  group('Windows 下发的 hwdec 不得含 CUDA 系后端 (BUG-1639)', () {
+    /// CUDA 系后端名（`nvdec` / `cuda` 及其 copy 变体）——出现任何一个都会走 `cuInit()`。
+    const List<String> cudaBackends = <String>['nvdec', 'cuda'];
+
+    test('任何合法 hwdec 在 Windows 解析后都不含 nvdec / cuda', () {
+      for (final String v in <String>['no', 'auto-safe', 'auto-copy']) {
+        final String resolved =
+            resolvePlatformHwdec(v, isAndroid: false, isWindows: true);
+        for (final String backend in cudaBackends) {
+          expect(resolved.contains(backend), isFalse,
+              reason: 'hwdec=$v 在 Windows 解析成 "$resolved"，含 CUDA 后端 '
+                  '"$backend" → cuInit()/cuCtxCreate_v2() → nvcuda64 空指针整进程闪退');
+        }
+      }
+    });
+
+    test('Windows 下 auto* 解析成显式 d3d11va 候选（保留两档语义差异）', () {
+      expect(
+          resolvePlatformHwdec('auto-safe', isAndroid: false, isWindows: true),
+          kWindowsAutoHwdec,
+          reason: 'auto-safe：先试 interop 直渲，失败静默回落 copy-back');
+      expect(
+          resolvePlatformHwdec('auto-copy', isAndroid: false, isWindows: true),
+          kWindowsCopyHwdec,
+          reason: 'auto-copy：用户显式要 copy-back，只给 copy 变体');
+    });
+
+    test('两个 Windows 常量本身也不含 CUDA 后端', () {
+      for (final String value in <String>[
+        kWindowsAutoHwdec,
+        kWindowsCopyHwdec
+      ]) {
+        for (final String backend in cudaBackends) {
+          expect(value.contains(backend), isFalse,
+              reason: 'Windows hwdec 常量 "$value" 不得含 CUDA 后端 "$backend"');
+        }
+        expect(value.contains('d3d11va'), isTrue,
+            reason: 'Windows 硬解走 d3d11va（Win8+ 通用，Intel/AMD/NVIDIA 全支持）');
+      }
+    });
+
+    test('Windows 下软解 no 原样透传（用户显式关硬解不被改写）', () {
+      expect(
+          resolvePlatformHwdec('no', isAndroid: false, isWindows: true), 'no');
+    });
+
+    test('非 Windows 桌面（macOS / Linux）原样透传，零行为变化', () {
+      for (final String v in <String>['no', 'auto-safe', 'auto-copy']) {
+        expect(resolvePlatformHwdec(v, isAndroid: false, isWindows: false), v,
+            reason: '非 Android / 非 Windows 平台不改写 hwdec');
+      }
+    });
+
+    test('buildMpvProperties 下发的 hwdec 在 Windows 同样不含 CUDA', () {
+      final Map<String, String> props = buildMpvProperties(
+        VideoMpvConfig.defaults,
+        isAndroid: false,
+        isMobile: false,
+        isWindows: true,
+      );
+      expect(props['hwdec'], kWindowsAutoHwdec,
+          reason: 'controller 构造与 buildMpvProperties 两处取值必须恒一致');
+      for (final String backend in cudaBackends) {
+        expect(props['hwdec']!.contains(backend), isFalse);
+      }
     });
   });
 }

--- a/fushi/test/media/video/video_mpv_config_test.dart
+++ b/fushi/test/media/video/video_mpv_config_test.dart
@@ -30,9 +30,10 @@ keep-open=yes
 
   group('buildMpvProperties', () {
     test('defaults enable conservative built-in image enhancement', () {
-      // isAndroid:false 钉非 Android：hwdec 透传 auto-safe（Android 改写见 resolveAndroidHwdec 组）。
-      final Map<String, String> m =
-          buildMpvProperties(VideoMpvConfig.defaults, isAndroid: false);
+      // isAndroid/isWindows:false 钉非 Android 非 Windows：hwdec 透传 auto-safe
+      // （Android 改写见 resolvePlatformHwdec 组；Windows 改写见 BUG-1639 守卫）。
+      final Map<String, String> m = buildMpvProperties(VideoMpvConfig.defaults,
+          isAndroid: false, isWindows: false);
       expect(m['hwdec'], 'auto-safe');
       expect(VideoMpvConfig.defaults.highQuality, isTrue);
       expect(VideoMpvConfig.decode('').highQuality, isTrue);
@@ -107,10 +108,11 @@ keep-open=yes
       });
     });
 
-    test('hwdec value passes through (non-Android)', () {
+    test('hwdec value passes through (non-Android, non-Windows)', () {
       final Map<String, String> m = buildMpvProperties(
           VideoMpvConfig.defaults.copyWith(hwdec: 'auto-safe'),
-          isAndroid: false);
+          isAndroid: false,
+          isWindows: false);
       expect(m['hwdec'], 'auto-safe');
     });
 
@@ -163,27 +165,33 @@ keep-open=yes
     });
   });
 
-  group('resolveAndroidHwdec (BUG-465 Android HEVC surface-null)', () {
+  group('resolvePlatformHwdec (BUG-465 Android HEVC surface-null)', () {
     // 根因：media_kit Android 纹理渲染（vo=gpu/gpu-context=android，无直渲 surface），
     // 而 auto-safe/auto 在 Android 选 surface-直渲 mediacodec → Both surface and
     // native_window are NULL。修复=Android 改写成 copy 变体。
     test('Android: auto-safe -> auto-copy', () {
-      expect(resolveAndroidHwdec('auto-safe', isAndroid: true), 'auto-copy');
+      expect(resolvePlatformHwdec('auto-safe', isAndroid: true), 'auto-copy');
     });
     test('Android: auto -> auto-copy', () {
-      expect(resolveAndroidHwdec('auto', isAndroid: true), 'auto-copy');
+      expect(resolvePlatformHwdec('auto', isAndroid: true), 'auto-copy');
     });
     test('Android: no (software) passes through', () {
-      expect(resolveAndroidHwdec('no', isAndroid: true), 'no');
+      expect(resolvePlatformHwdec('no', isAndroid: true), 'no');
     });
     test('Android: auto-copy (already copy) passes through', () {
-      expect(resolveAndroidHwdec('auto-copy', isAndroid: true), 'auto-copy');
+      expect(resolvePlatformHwdec('auto-copy', isAndroid: true), 'auto-copy');
     });
     test('non-Android: every value passes through unchanged', () {
-      expect(resolveAndroidHwdec('auto-safe', isAndroid: false), 'auto-safe');
-      expect(resolveAndroidHwdec('auto', isAndroid: false), 'auto');
-      expect(resolveAndroidHwdec('no', isAndroid: false), 'no');
-      expect(resolveAndroidHwdec('auto-copy', isAndroid: false), 'auto-copy');
+      expect(
+          resolvePlatformHwdec('auto-safe', isAndroid: false, isWindows: false),
+          'auto-safe');
+      expect(resolvePlatformHwdec('auto', isAndroid: false, isWindows: false),
+          'auto');
+      expect(
+          resolvePlatformHwdec('no', isAndroid: false, isWindows: false), 'no');
+      expect(
+          resolvePlatformHwdec('auto-copy', isAndroid: false, isWindows: false),
+          'auto-copy');
     });
     test('buildMpvProperties on Android downs auto-safe to copy variant', () {
       // 守卫：下发到 libmpv 的 hwdec 在 Android 必为 copy 变体，不被回退成 surface-直渲。


### PR DESCRIPTION
## 用户报告

「打开 K-ON 就闪退」——与 BUG-1545 同一句报告。用户装的 `2.0.0-debug.11553`（08-14 05:51 构建）**已包含** BUG-1545 的修复 `538c2e847e`，但 08-14 16:14 又崩了同一条栈。

## 根因：BUG-1545 修掉了「谁下发」，没修掉「下发什么值」

BUG-1545 的修法是把 app 策略 `auto-safe` 随 `VideoControllerConfiguration` 传进 `VideoController`，消除 media_kit 兜底裸 `auto` 的时间窗。**但 `auto-safe` 通往的是同一个 CUDA 后端**：

1. media_kit 在 Windows 走纹理渲染（libmpv render API + ANGLE/OpenGL），libmpv 拿不到宿主 D3D11 device；
2. hwdec 探测里 `d3d11va`（需 interop）必然失败：`[vd] Could not create device.`；
3. `auto-safe` 白名单里紧跟其后的 `nvdec` 是 CUDA API 封装，NVIDIA 机器必然选中：`Loading hwdec driver 'cuda'` → `Using hardware decoding (nvdec)`；
4. `cuInit()` / `cuCtxCreate_v2()` 在 `nvcuda64.dll` 内部空指针解引用 → 整进程 `0xC0000005`。

minidump（`fushi.exe.160512.dmp`，`AV.Dereference=NullClassPtr`）栈自底向上：`libmpv_2!mpv_create` → 播放循环 → cuda hwdec 初始化 → `nvcuda64!cuCtxCreate_v2+0x25` → 空指针。与 BUG-1545 记录的三份 08-11 dump 形状完全一致。

## 本机确定性复现（ctypes 直驱安装目录的 libmpv）

`D:\APP\Hibiki\libmpv-2.dll` + 崩溃片源（HEVC Main 10 / 1080p），**GL 上下文**（对齐 app 渲染路径）：

| 下发的 hwdec | libmpv 实际选择 | 触碰 CUDA |
|---|---|---|
| `auto-safe`（默认，用户当前设置） | `Using hardware decoding (nvdec)` | 是（崩溃路径） |
| `auto-copy` | `d3d11va-copy` | 否（但无 d3d11va 的机器会落 `cuda-copy`） |
| `d3d11va-copy` | `d3d11va-copy` | 否 |
| `d3d11va,d3d11va-copy` | `d3d11va` 失败 → `d3d11va-copy` | 否 |

同一档 `auto-safe` 在 d3d11 **直渲**上下文下选的是 d3d11va、不碰 CUDA——所以「mpv.exe 播同一文件不崩」不能证伪本条，渲染上下文才是分叉点。

## 修复

`resolveAndroidHwdec` → `resolvePlatformHwdec(hwdec, {isAndroid, isWindows})`：一个函数决定「实际下发值」，平台是它的输入（否则 Android 一个特例函数、Windows 再加一个就是两个特例）。Windows 分支下发**值域里不含 CUDA 系后端**：

- `auto-safe` → `d3d11va,d3d11va-copy`：先试 interop 直渲（media_kit 将来能共享 D3D11 device 就直接受益），失败静默回落 copy-back；
- `auto-copy` → `d3d11va-copy`：用户显式要 copy-back，只给 copy 变体；
- `no` 原样透传。

`d3d11va` 是 Win8+ 通用硬解（Intel/AMD/NVIDIA 全支持），两档都失败时 libmpv 自行回落软解，不会无画面。Android 分支行为一字未改（BUG-465 不回归），macOS/Linux/iOS 原样透传。

## 验证

- `flutter analyze`（含 test）：No issues found
- `test/media/video/` 全域：**2572 通过**，退出码 0（走 `tool/flutter_test_failures.dart`）
- 新守卫 6 条（BUG-1639 组）已**两轮变异实测**：常量掺 `nvdec` → 3 条转红；Windows 分支退化成透传 → 2 条转红，均退出码 1
- **未验证**：app 内端到端真机复测需要出一版新 Windows 包再走原始路径；libmpv 层已确定性证明修复后的值域不加载 `nvcuda64.dll`

## 用户侧即时缓解（无需等新版）

设置 → 视频 → 硬件解码 改成「自动（复制）」（实测该档在同一 GL 路径下选 `d3d11va-copy`，不碰 CUDA），或改「关闭」走软解。

详见 `docs/bugs/BUG-1639-hwdec-nvdec-cuda-crash.md`。

https://claude.ai/code/session_011TjBZkKgmbXWpn5qBC2Lj6
