### PR TITLE
fix(anki): 跳转 Anki 时把窗口真正带到前台（BUG-1641）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1511 条。点号进各自文件。
+> 共 1512 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1641](bugs/BUG-1641-anki-open-not-foreground.md) | ✅ | ✅ | 制卡后「在 Anki 中打开」只闪任务栏，Anki 不到前台 |
 | [BUG-1613](bugs/BUG-1613-apple-coreml-ep-detector-empty.md) | ✅ | ✅ | Apple CoreML EP 上 int8 检测模型静默返回空结果且更慢 |
 | [BUG-1610](bugs/BUG-1610-bangumi-search-rating-null.md) | ✅ | ✅ | Bangumi 搜索候选评分恒空：映射器读扁平 score，真实响应只有嵌套 rating.score |
 | [BUG-1609](bugs/BUG-1609-global-lookup-card-right-corners-square.md) | ✅ | ✅ | app 外全局查词卡片右上/右下圆角变方角 |

--- a/docs/bugs/BUG-1641-anki-open-not-foreground.md
+++ b/docs/bugs/BUG-1641-anki-open-not-foreground.md
@@ -1,0 +1,27 @@
+## BUG-1641 · 制卡后「在 Anki 中打开」只闪任务栏，Anki 不到前台
+- **报告**：2026-08-14（用户：）
+- **真实性**：✅ 真 bug — 根因 `packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart:1141`（`openNoteInAnki` 只发 `guiBrowse`，没有在 Hibiki 侧解开 Windows 前台锁定）
+
+  用户观察把根因直接框死成两半：Anki 的「浏览」窗口**没开**时点跳转能弹出来，**已在后台开着**时只闪任务栏图标。
+  对应 AnkiConnect `guiBrowse` → `aqt.dialogs.open('Browser')` 的两条路径：
+  - 未开 → 新建窗口，新窗口首次 show 仍能进前台；
+  - 已开 → 复用路径，只对一个**已存在**的窗口 `raise_()` + `activateWindow()`。Windows 的前台锁定规则里，
+    非前台进程调 `SetForegroundWindow` 不会置前，而是被降级成「闪任务栏按钮」——正是用户看到的现象。
+
+  有权解开这个锁的只有**当时的前台进程**，也就是用户刚点下按钮的 Hibiki 自己，所以修复只能落在 Hibiki 侧，
+  Anki/AnkiConnect 那边无论怎么调都绕不过去。
+- **[x] ① 已修复** — `packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart`（新增 `AnkiDesktopForeground`）
+  + `ankiconnect_repository.dart` 的 `openNoteInAnki` 前后各夹一步：
+  1. 发 `guiBrowse` **前**按 Z 序找到 `anki.exe` 的 pid，`AllowSetForegroundWindow(ankiPid)` **定向**让渡前台权限
+     （不用 `ASFW_ANY` 放开给任意进程），让 Anki 自己的 activate 直接生效，两条路径一并覆盖；
+  2. 发完**后**兜底：前台仍不属于 Anki 时，取它 Z 序最顶的可见顶层窗口（Anki 刚 `raise_()` 过「浏览」，
+     Z 序里就是它），`IsIconic` 则 `ShowWindow(SW_RESTORE)`，再 `SetForegroundWindow`；带 3 次上限的正向确认循环。
+
+  只在 AnkiConnect host 是 loopback 时生效（远端 Anki 在别的机器上，激活本机窗口无意义）；非 Windows 与
+  FFI 加载失败全 fail-soft 退回原行为，绝不让制卡链路因此报错。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/anki_desktop_foreground_test.dart`（6 例）：钉「让渡在 guiBrowse 前 /
+  兜底在其后」的调用时间线、前台已归 Anki 时不再强拉、非 loopback 完全不碰本机窗口、找不到 Anki 时降级、
+  重试次数上限、后端抛错不影响返回值。已做变异实测：去掉 loopback 门、把兜底挪到 `guiBrowse` 之前，两次都被测试抓红。
+- **备注**：Win32 调用面由 `AnkiDesktopForegroundBackend` 抽象隔离，测试环境注入替身；真实 `_WindowsAnkiForeground`
+  用 `GetTopWindow` + `GW_HWNDNEXT` 遍历（等价 `EnumWindows` 且天然按 Z 序，省掉一次性的 `NativeCallable` 回调）。
+  AnkiDroid / AnkiMobile 后端不走这条路径，不受影响。

--- a/fushi/test/anki/anki_desktop_foreground_test.dart
+++ b/fushi/test/anki/anki_desktop_foreground_test.dart
@@ -1,0 +1,211 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// 「在 Anki 中打开」后 Anki 只闪任务栏、不跳到前台的修复守卫。
+///
+/// 现象分两半（用户实测）：Anki 的「浏览」窗口没开时能跳出来；已在后台开着时只闪。
+/// 原因是后者走 Anki 内部「raise 一个已存在窗口」的路径，被 Windows 前台锁定降级
+/// 成闪任务栏。解锁权只属于当时的前台进程（Hibiki），所以 [AnkiConnectRepository]
+/// 必须在 guiBrowse **前**把前台权限让渡给 Anki 进程、**后**再兜底强拉一次。
+///
+/// 这里钉的是编排（顺序 / loopback 门 / fail-soft），真实 Win32 调用由
+/// [AnkiDesktopForegroundBackend] 替身隔离——测试环境没有 Anki 窗口可激活。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    AnkiDesktopForeground.raiseRetryInterval = Duration.zero;
+  });
+
+  tearDown(() {
+    AnkiDesktopForeground.debugBackend = null;
+    AnkiDesktopForeground.raiseRetryInterval =
+        const Duration(milliseconds: 120);
+  });
+
+  /// 把 HTTP 侧的 action 与前台调用记进**同一条**时间线，才能钉住先后顺序。
+  MockClient clientRecording(List<String> events) {
+    return MockClient((http.Request req) async {
+      final Map<String, dynamic> body =
+          jsonDecode(req.body) as Map<String, dynamic>;
+      events.add('http:${body['action']}');
+      return http.Response(jsonEncode({'result': null, 'error': null}), 200);
+    });
+  }
+
+  test('本机 Anki：先让渡前台权限，再发 guiBrowse，最后兜底强拉', () async {
+    final List<String> events = <String>[];
+    final _FakeForegroundBackend backend = _FakeForegroundBackend(
+      events: events,
+      ankiPid: 4321,
+      // 让渡没生效（Anki 没能自己上来），兜底这一路必须走到。
+      foregroundPidSequence: <int?>[null, 4321],
+    );
+    AnkiDesktopForeground.debugBackend = backend;
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(client: clientRecording(events)),
+    );
+
+    final bool ok = await repo.openNoteInAnki(305);
+
+    expect(ok, isTrue);
+    expect(events, <String>[
+      'find',
+      'allow:4321',
+      'http:guiBrowse',
+      'foreground?',
+      'raise:4321',
+      'foreground?',
+    ]);
+  });
+
+  test('让渡已生效（前台已归 Anki）时不再强拉窗口', () async {
+    final List<String> events = <String>[];
+    AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+      events: events,
+      ankiPid: 4321,
+      foregroundPidSequence: <int?>[4321],
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(client: clientRecording(events)),
+    );
+
+    await repo.openNoteInAnki(305);
+
+    expect(
+        events, <String>['find', 'allow:4321', 'http:guiBrowse', 'foreground?'],
+        reason: 'Anki 自己已经上来了，再 SetForegroundWindow 只会抢焦点');
+  });
+
+  test('远端 AnkiConnect（非 loopback）完全不碰本机窗口', () async {
+    final List<String> events = <String>[];
+    AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+      events: events,
+      ankiPid: 4321,
+      foregroundPidSequence: <int?>[null],
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(
+        client: clientRecording(events),
+        host: '192.168.1.34',
+      ),
+    );
+
+    final bool ok = await repo.openNoteInAnki(305);
+
+    expect(ok, isTrue);
+    expect(events, <String>['http:guiBrowse'],
+        reason: '另一台机器上的 Anki，激活本机窗口毫无意义');
+  });
+
+  test('本机找不到 Anki 窗口时降级为纯 guiBrowse（不抛、不空转重试）', () async {
+    final List<String> events = <String>[];
+    AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+      events: events,
+      ankiPid: null,
+      foregroundPidSequence: <int?>[null],
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(client: clientRecording(events)),
+    );
+
+    final bool ok = await repo.openNoteInAnki(305);
+
+    expect(ok, isTrue);
+    expect(events, <String>['find', 'http:guiBrowse']);
+  });
+
+  test('窗口一次没拉上来时重试，且总次数有上限', () async {
+    final List<String> events = <String>[];
+    AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+      events: events,
+      ankiPid: 4321,
+      foregroundPidSequence: <int?>[null],
+      raiseSucceeds: false,
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(client: clientRecording(events)),
+    );
+
+    await repo.openNoteInAnki(305);
+
+    expect(events.where((String e) => e == 'raise:4321').length, 3,
+        reason: '重试上限，避免前台被别的程序占住时无限循环');
+  });
+
+  test('前台激活抛错不得影响「在 Anki 中打开」的结果', () async {
+    AnkiDesktopForeground.debugBackend = _ThrowingForegroundBackend();
+    final AnkiConnectRepository repo = AnkiConnectRepository(
+      service: AnkiConnectService(client: clientRecording(<String>[])),
+    );
+
+    expect(await repo.openNoteInAnki(305), isTrue);
+  });
+}
+
+/// 记录调用时间线的 Win32 替身。
+class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
+  _FakeForegroundBackend({
+    required this.events,
+    required this.ankiPid,
+    required List<int?> foregroundPidSequence,
+    this.raiseSucceeds = true,
+  }) : _foregroundPidSequence = foregroundPidSequence;
+
+  final List<String> events;
+  final int? ankiPid;
+  final bool raiseSucceeds;
+
+  /// 依次返回的「当前前台进程」；用完后保持最后一个值。
+  final List<int?> _foregroundPidSequence;
+  int _foregroundReads = 0;
+
+  @override
+  int? findAnkiProcessId() {
+    events.add('find');
+    return ankiPid;
+  }
+
+  @override
+  bool allowSetForegroundWindow(int pid) {
+    events.add('allow:$pid');
+    return true;
+  }
+
+  @override
+  bool isForegroundOwnedByProcess(int pid) {
+    events.add('foreground?');
+    final int index = _foregroundReads < _foregroundPidSequence.length
+        ? _foregroundReads
+        : _foregroundPidSequence.length - 1;
+    _foregroundReads++;
+    return _foregroundPidSequence[index] == pid;
+  }
+
+  @override
+  bool raiseTopWindowOfProcess(int pid) {
+    events.add('raise:$pid');
+    return raiseSucceeds;
+  }
+}
+
+class _ThrowingForegroundBackend implements AnkiDesktopForegroundBackend {
+  @override
+  int? findAnkiProcessId() => throw StateError('user32 unavailable');
+
+  @override
+  bool allowSetForegroundWindow(int pid) =>
+      throw StateError('user32 unavailable');
+
+  @override
+  bool isForegroundOwnedByProcess(int pid) =>
+      throw StateError('user32 unavailable');
+
+  @override
+  bool raiseTopWindowOfProcess(int pid) =>
+      throw StateError('user32 unavailable');
+}

--- a/packages/fushi_anki/lib/fushi_anki.dart
+++ b/packages/fushi_anki/lib/fushi_anki.dart
@@ -13,5 +13,6 @@ export 'src/lapis_note_type.dart';
 export 'src/lapis_style_preview.dart';
 export 'src/lapis_styling.dart';
 export 'src/ankidroid/anki_repository.dart';
+export 'src/ankiconnect/anki_desktop_foreground.dart';
 export 'src/ankiconnect/ankiconnect_repository.dart';
 export 'src/ankiconnect/ankiconnect_service.dart';

--- a/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
@@ -1,0 +1,329 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart';
+
+/// 「在 Anki 中打开」时把 Anki 窗口真正带到前台（Windows）。
+///
+/// 根因：AnkiConnect 的 `guiBrowse` 只能让 **Anki 自己** 调 `activateWindow()`。
+/// 而 Windows 的前台锁定规则里，非前台进程调 `SetForegroundWindow` 会被降级成
+/// 「闪任务栏按钮」，于是用户观察到的现象正好分成两半：
+///   - Anki 的「浏览」窗口**尚未打开**：`aqt.dialogs.open('Browser')` 走新建窗口
+///     路径，新窗口首次显示仍能进前台 → Anki 跳出来，看着是好的；
+///   - 「浏览」窗口**已在后台开着**：走复用路径，只是 raise + activate 一个**已
+///     存在**的窗口 → 被前台锁定拒绝，只剩任务栏闪烁。
+///
+/// 有权解开这个锁的只有当时的前台进程，也就是用户刚点下按钮的 Hibiki 自己，所以
+/// 修复必须落在这一侧，分两步：
+///   1. 发 `guiBrowse` **前**用 [grantForegroundToAnki] 把前台权限**定向**让渡给
+///      Anki 进程（`AllowSetForegroundWindow(ankiPid)`；不用 `ASFW_ANY` 放开给
+///      任意进程），Anki 自己的 activate 就直接生效，两种情况一并覆盖；
+///   2. 发完后用 [raiseAnkiWindow] 兜底：前台仍不属于 Anki 时，按 Z 序取它最顶的
+///      可见顶层窗口（Anki 刚 `raise_()` 过「浏览」，Z 序里就是它），必要时先从
+///      最小化恢复，再 `SetForegroundWindow`。
+///
+/// 全程 fail-soft：找不到 Anki 窗口、非 Windows、FFI 加载失败都退回「什么都不做」，
+/// 与修复前的行为一致，绝不让制卡链路因此报错。
+abstract final class AnkiDesktopForeground {
+  /// 单测替身：注入后完全取代真实 Win32 后端（含平台判断）。
+  @visibleForTesting
+  static AnkiDesktopForegroundBackend? debugBackend;
+
+  /// 兜底重试的间隔。Anki 是 Qt 应用，`guiBrowse` 的 HTTP 响应回来时窗口激活可能
+  /// 还差一轮事件循环，所以这里做**正向确认**循环（判据明确：前台归 Anki 即返回），
+  /// 而不是盲等一个固定时长。
+  @visibleForTesting
+  static Duration raiseRetryInterval = const Duration(milliseconds: 120);
+
+  static const int _raiseAttempts = 3;
+
+  static AnkiDesktopForegroundBackend? get _backend {
+    final AnkiDesktopForegroundBackend? override = debugBackend;
+    if (override != null) return override;
+    if (!Platform.isWindows) return null;
+    try {
+      return _WindowsAnkiForeground.instance;
+    } on Object {
+      return null;
+    }
+  }
+
+  /// 把前台权限让渡给本机 Anki 进程，返回它的 pid（找不到/不适用时 null）。
+  ///
+  /// 返回值交给 [raiseAnkiWindow]，避免在这里存跨调用的可变全局状态。
+  static int? grantForegroundToAnki() {
+    final AnkiDesktopForegroundBackend? backend = _backend;
+    if (backend == null) return null;
+    try {
+      final int? pid = backend.findAnkiProcessId();
+      if (pid == null) return null;
+      backend.allowSetForegroundWindow(pid);
+      return pid;
+    } on Object {
+      return null;
+    }
+  }
+
+  /// 兜底把 [ankiPid] 的顶层窗口拉到前台；前台已经归它时立即返回。
+  static Future<void> raiseAnkiWindow(int? ankiPid) async {
+    if (ankiPid == null) return;
+    final AnkiDesktopForegroundBackend? backend = _backend;
+    if (backend == null) return;
+    for (int attempt = 0; attempt < _raiseAttempts; attempt++) {
+      try {
+        if (backend.isForegroundOwnedByProcess(ankiPid)) return;
+        if (backend.raiseTopWindowOfProcess(ankiPid) &&
+            backend.isForegroundOwnedByProcess(ankiPid)) {
+          return;
+        }
+      } on Object {
+        return;
+      }
+      if (attempt < _raiseAttempts - 1) {
+        await Future<void>.delayed(raiseRetryInterval);
+      }
+    }
+  }
+}
+
+/// [AnkiDesktopForeground] 依赖的平台原语，抽出来是为了让编排逻辑可单测（真实实现
+/// 全是 Win32 调用，测试环境里跑不了）。
+abstract interface class AnkiDesktopForegroundBackend {
+  /// 本机正在运行的 Anki 桌面端进程 id；没找到返回 null。
+  int? findAnkiProcessId();
+
+  /// `AllowSetForegroundWindow`：把本进程的前台权限让渡给 [pid]。
+  bool allowSetForegroundWindow(int pid);
+
+  /// 当前前台窗口是否属于 [pid]。
+  bool isForegroundOwnedByProcess(int pid);
+
+  /// 按 Z 序取 [pid] 最顶的可见顶层窗口，必要时从最小化恢复，再置前台。
+  bool raiseTopWindowOfProcess(int pid);
+}
+
+final class _WindowsAnkiForeground implements AnkiDesktopForegroundBackend {
+  _WindowsAnkiForeground._()
+      : _getTopWindow =
+            _user32.lookupFunction<_GetTopWindowNative, _GetTopWindowDart>(
+                'GetTopWindow'),
+        _getWindow = _user32
+            .lookupFunction<_GetWindowNative, _GetWindowDart>('GetWindow'),
+        _isWindowVisible = _user32.lookupFunction<_IsWindowVisibleNative,
+            _IsWindowVisibleDart>('IsWindowVisible'),
+        _getWindowTextLength = _user32.lookupFunction<
+            _GetWindowTextLengthNative,
+            _GetWindowTextLengthDart>('GetWindowTextLengthW'),
+        _getWindowThreadProcessId = _user32.lookupFunction<
+            _GetWindowThreadProcessIdNative,
+            _GetWindowThreadProcessIdDart>('GetWindowThreadProcessId'),
+        _getForegroundWindow = _user32.lookupFunction<
+            _GetForegroundWindowNative,
+            _GetForegroundWindowDart>('GetForegroundWindow'),
+        _setForegroundWindow = _user32.lookupFunction<
+            _SetForegroundWindowNative,
+            _SetForegroundWindowDart>('SetForegroundWindow'),
+        _allowSetForegroundWindow = _user32.lookupFunction<
+            _AllowSetForegroundWindowNative,
+            _AllowSetForegroundWindowDart>('AllowSetForegroundWindow'),
+        _isIconic =
+            _user32.lookupFunction<_IsIconicNative, _IsIconicDart>('IsIconic'),
+        _showWindow = _user32
+            .lookupFunction<_ShowWindowNative, _ShowWindowDart>('ShowWindow'),
+        _openProcess =
+            _kernel32.lookupFunction<_OpenProcessNative, _OpenProcessDart>(
+                'OpenProcess'),
+        _queryFullProcessImageName = _kernel32.lookupFunction<
+            _QueryFullProcessImageNameNative,
+            _QueryFullProcessImageNameDart>('QueryFullProcessImageNameW'),
+        _closeHandle =
+            _kernel32.lookupFunction<_CloseHandleNative, _CloseHandleDart>(
+                'CloseHandle');
+
+  static final DynamicLibrary _user32 = DynamicLibrary.open('user32.dll');
+  static final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+  static final _WindowsAnkiForeground instance = _WindowsAnkiForeground._();
+
+  final _GetTopWindowDart _getTopWindow;
+  final _GetWindowDart _getWindow;
+  final _IsWindowVisibleDart _isWindowVisible;
+  final _GetWindowTextLengthDart _getWindowTextLength;
+  final _GetWindowThreadProcessIdDart _getWindowThreadProcessId;
+  final _GetForegroundWindowDart _getForegroundWindow;
+  final _SetForegroundWindowDart _setForegroundWindow;
+  final _AllowSetForegroundWindowDart _allowSetForegroundWindow;
+  final _IsIconicDart _isIconic;
+  final _ShowWindowDart _showWindow;
+  final _OpenProcessDart _openProcess;
+  final _QueryFullProcessImageNameDart _queryFullProcessImageName;
+  final _CloseHandleDart _closeHandle;
+
+  static const int _gwHwndNext = 2;
+  static const int _swRestore = 9;
+  static const int _processQueryLimitedInformation = 0x1000;
+  static const int _imagePathBufferLength = 32768;
+
+  /// 顶层窗口链的遍历上限；纯粹是防御异常的 Z 序环，正常桌面远达不到。
+  static const int _enumerationGuard = 4096;
+
+  @override
+  int? findAnkiProcessId() {
+    final Map<int, bool> ankiByPid = <int, bool>{};
+    int? found;
+    _forEachTopLevelWindow((int hwnd, int pid) {
+      final bool isAnki = ankiByPid.putIfAbsent(pid, () => _isAnkiProcess(pid));
+      if (!isAnki) return true;
+      found = pid;
+      return false;
+    });
+    return found;
+  }
+
+  @override
+  bool allowSetForegroundWindow(int pid) => _allowSetForegroundWindow(pid) != 0;
+
+  @override
+  bool isForegroundOwnedByProcess(int pid) {
+    final int hwnd = _getForegroundWindow();
+    if (hwnd == 0) return false;
+    return _windowProcessId(hwnd) == pid;
+  }
+
+  @override
+  bool raiseTopWindowOfProcess(int pid) {
+    int target = 0;
+    _forEachTopLevelWindow((int hwnd, int windowPid) {
+      if (windowPid != pid) return true;
+      target = hwnd;
+      return false;
+    });
+    if (target == 0) return false;
+    // 最小化的窗口 IsWindowVisible 仍为真，所以恢复要单独判 IsIconic。
+    if (_isIconic(target) != 0) {
+      _showWindow(target, _swRestore);
+    }
+    return _setForegroundWindow(target) != 0;
+  }
+
+  /// 按 Z 序（最顶在前）遍历「可见且有标题」的顶层窗口；[visit] 返回 false 即停。
+  ///
+  /// 用 GetTopWindow + GW_HWNDNEXT 而不是 EnumWindows：等价、天然按 Z 序，且不需要
+  /// 为一次性查询建 [NativeCallable] 回调。
+  void _forEachTopLevelWindow(bool Function(int hwnd, int pid) visit) {
+    int hwnd = _getTopWindow(0);
+    int guard = 0;
+    while (hwnd != 0 && guard++ < _enumerationGuard) {
+      if (_isWindowVisible(hwnd) != 0 && _getWindowTextLength(hwnd) > 0) {
+        final int? pid = _windowProcessId(hwnd);
+        if (pid != null && !visit(hwnd, pid)) return;
+      }
+      hwnd = _getWindow(hwnd, _gwHwndNext);
+    }
+  }
+
+  int? _windowProcessId(int hwnd) {
+    final Pointer<Uint32> pid = calloc<Uint32>();
+    try {
+      _getWindowThreadProcessId(hwnd, pid);
+      return pid.value == 0 ? null : pid.value;
+    } finally {
+      calloc.free(pid);
+    }
+  }
+
+  bool _isAnkiProcess(int pid) {
+    final String? imagePath = _processImagePath(pid);
+    if (imagePath == null) return false;
+    return _basenameLower(imagePath) == 'anki.exe';
+  }
+
+  String? _processImagePath(int pid) {
+    final int handle = _openProcess(_processQueryLimitedInformation, 0, pid);
+    if (handle == 0) return null;
+    final Pointer<Utf16> path = calloc<Uint16>(_imagePathBufferLength).cast();
+    final Pointer<Uint32> length = calloc<Uint32>()
+      ..value = _imagePathBufferLength;
+    try {
+      final int ok = _queryFullProcessImageName(handle, 0, path, length);
+      if (ok == 0 || length.value == 0) return null;
+      return path.toDartString(length: length.value);
+    } finally {
+      calloc.free(length);
+      calloc.free(path);
+      _closeHandle(handle);
+    }
+  }
+
+  static String _basenameLower(String path) {
+    final String normalized = path.replaceAll('\\', '/');
+    final int slash = normalized.lastIndexOf('/');
+    final String basename =
+        slash >= 0 ? normalized.substring(slash + 1) : normalized;
+    return basename.toLowerCase();
+  }
+}
+
+typedef _GetTopWindowNative = IntPtr Function(IntPtr hWnd);
+typedef _GetTopWindowDart = int Function(int hWnd);
+
+typedef _GetWindowNative = IntPtr Function(IntPtr hWnd, Uint32 cmd);
+typedef _GetWindowDart = int Function(int hWnd, int cmd);
+
+typedef _IsWindowVisibleNative = Int32 Function(IntPtr hWnd);
+typedef _IsWindowVisibleDart = int Function(int hWnd);
+
+typedef _GetWindowTextLengthNative = Int32 Function(IntPtr hWnd);
+typedef _GetWindowTextLengthDart = int Function(int hWnd);
+
+typedef _GetWindowThreadProcessIdNative = Uint32 Function(
+  IntPtr hWnd,
+  Pointer<Uint32> processId,
+);
+typedef _GetWindowThreadProcessIdDart = int Function(
+  int hWnd,
+  Pointer<Uint32> processId,
+);
+
+typedef _GetForegroundWindowNative = IntPtr Function();
+typedef _GetForegroundWindowDart = int Function();
+
+typedef _SetForegroundWindowNative = Int32 Function(IntPtr hWnd);
+typedef _SetForegroundWindowDart = int Function(int hWnd);
+
+typedef _AllowSetForegroundWindowNative = Int32 Function(Uint32 processId);
+typedef _AllowSetForegroundWindowDart = int Function(int processId);
+
+typedef _IsIconicNative = Int32 Function(IntPtr hWnd);
+typedef _IsIconicDart = int Function(int hWnd);
+
+typedef _ShowWindowNative = Int32 Function(IntPtr hWnd, Int32 cmdShow);
+typedef _ShowWindowDart = int Function(int hWnd, int cmdShow);
+
+typedef _OpenProcessNative = IntPtr Function(
+  Uint32 desiredAccess,
+  Int32 inheritHandle,
+  Uint32 processId,
+);
+typedef _OpenProcessDart = int Function(
+  int desiredAccess,
+  int inheritHandle,
+  int processId,
+);
+
+typedef _QueryFullProcessImageNameNative = Int32 Function(
+  IntPtr process,
+  Uint32 flags,
+  Pointer<Utf16> exeName,
+  Pointer<Uint32> size,
+);
+typedef _QueryFullProcessImageNameDart = int Function(
+  int process,
+  int flags,
+  Pointer<Utf16> exeName,
+  Pointer<Uint32> size,
+);
+
+typedef _CloseHandleNative = Int32 Function(IntPtr handle);
+typedef _CloseHandleDart = int Function(int handle);

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -15,6 +15,7 @@ import '../anki_note_type_definition.dart';
 import '../base_anki_repository.dart';
 import '../lapis_note_type.dart';
 import '../lapis_styling.dart';
+import 'anki_desktop_foreground.dart';
 import 'ankiconnect_service.dart';
 
 const int _uint32Mask = 0xffffffff;
@@ -1137,11 +1138,23 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   }
 
   // TODO-1007/1008：在 Anki 桌面端打开浏览器并选中该 note（guiBrowse(nid:<id>)）。
+  //
+  // 光发 guiBrowse 不够：Anki 若已经在后台开着「浏览」窗口，它内部只是 raise 一个
+  // **已存在**的窗口，会被 Windows 前台锁定降级成「闪任务栏」而不真正跳出来。解锁
+  // 权握在此刻的前台进程（用户刚点按钮的 Hibiki）手里，所以在这里前后各夹一步
+  // 让渡/兜底，机制详见 [AnkiDesktopForeground]。
+  //
+  // 只对本机 Anki 生效：host 非 loopback 时说的是另一台机器上的 AnkiConnect，
+  // 去激活本机窗口毫无意义。
   @override
   Future<bool> openNoteInAnki(int noteId) async {
     try {
       final service = await _getService();
+      final int? ankiPid = ankiConnectHostIsLoopback(service.host)
+          ? AnkiDesktopForeground.grantForegroundToAnki()
+          : null;
       await service.guiBrowse(noteId);
+      await AnkiDesktopForeground.raiseAnkiWindow(ankiPid);
       return true;
     } catch (e, stack) {
       debugPrint('AnkiConnectRepository.openNoteInAnki: $e');

--- a/packages/fushi_anki/pubspec.yaml
+++ b/packages/fushi_anki/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
     sdk: flutter
   collection: any
   crypto: ^3.0.0
+  # Windows 前台激活（AnkiDesktopForeground）要用 calloc/Utf16 做 Win32 FFI。
+  ffi: ^2.1.3
   shared_preferences: ^2.2.2
   http: ^1.1.0
 


### PR DESCRIPTION
## 问题

制卡后点「在 Anki 中打开」，Anki 常常不跳到前台，只有任务栏图标在闪，得手动去任务栏点一下。

用户实测把根因框死成两半：
- Anki 的「浏览」窗口**没打开**时 → 能正常跳出来；
- 「浏览」窗口**已在后台开着**时 → 只闪任务栏。

## 根因

`AnkiConnectRepository.openNoteInAnki` 只发了 `guiBrowse`，没有任何一侧去解 Windows 的前台锁定。

`guiBrowse` → `aqt.dialogs.open('Browser')` 正好有两条路径，与上面两种表现一一对应：
- 未开 → **新建**窗口，新窗口首次 show 仍能进前台；
- 已开 → **复用**路径，只对一个已存在的窗口 `raise_()` + `activateWindow()`。Windows 的前台锁定规则里，
  非前台进程调 `SetForegroundWindow` 不会置前，而是被降级成「闪任务栏按钮」。

有权解开这个锁的只有**当时的前台进程**，也就是用户刚点下按钮的 Hibiki 自己 —— Anki/AnkiConnect
那侧无论怎么改都绕不过去，所以修复只能落在这里。

## 改法

新增 `AnkiDesktopForeground`（`packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart`），
在 `openNoteInAnki` 的 `guiBrowse` 前后各夹一步：

1. **发之前**：按 Z 序找到 `anki.exe` 的 pid，`AllowSetForegroundWindow(ankiPid)` **定向**让渡前台权限
   （不用 `ASFW_ANY` 放开给任意进程）。Anki 自己那句 `activateWindow()` 于是直接生效，两条路径一并覆盖。
2. **发之后兜底**：前台仍不属于 Anki 时，取它 Z 序最顶的可见顶层窗口（刚被 `raise_()` 过的「浏览」就在那），
   `IsIconic` 则 `ShowWindow(SW_RESTORE)`，再 `SetForegroundWindow`。3 次上限的正向确认循环，
   判据是「前台已归 Anki」，不是盲等固定时长。

边界：
- 只在 AnkiConnect host 是 **loopback** 时生效 —— 远端 Anki 在别的机器上，激活本机窗口毫无意义；
- 非 Windows、user32 加载失败、找不到 Anki 窗口全部 **fail-soft** 退回原行为，绝不让制卡链路报错；
- AnkiDroid / AnkiMobile 后端不走这条路径，不受影响。

实现上用 `GetTopWindow` + `GW_HWNDNEXT` 遍历顶层窗口：等价 `EnumWindows` 且天然按 Z 序，
省掉一次性查询要建 `NativeCallable` 回调。Win32 调用面由 `AnkiDesktopForegroundBackend` 抽象隔离，
测试注入替身。

## 验证

- `flutter analyze`（含 test 目录）：No issues found
- `dart run tool/flutter_test_failures.dart --no-pub`：**PASSED — 18962 tests ran, all tests passed**
- `test/anki` 全目录：245 通过
- 新增 `fushi/test/anki/anki_desktop_foreground_test.dart`（6 例）：钉调用时间线（让渡在 `guiBrowse` 前 /
  兜底在其后）、前台已归 Anki 时不再强拉、非 loopback 完全不碰本机窗口、找不到 Anki 时降级、
  重试上限、后端抛错不影响返回值
- **变异实测**：去掉 loopback 门、把兜底挪到 `guiBrowse` 之前，两次都被测试抓红（不是假绿守卫）

## 未覆盖

真实 Windows 上「Anki 开着浏览窗口 → 点跳转 → 窗口真的置前」这一步是 Win32 行为，单测覆盖不到
（测试环境没有 Anki 窗口）。需要装了 Anki 的 Windows 机器上跑一次实机确认。

BUG-1641
