### PR TITLE
feat(gal): hook 台词浮窗改桌面歌词式渲染（描边+投影+透明底板）

### DIFF
--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -79,7 +79,12 @@ class GalHookTextOverlayController extends ChangeNotifier {
 
   static const String _rectPreferenceKey = 'gal_hook_text_window_rect';
   static const String _opacityPreferenceKey = 'gal_hook_text_window_bg_opacity';
-  static const double _defaultOpacity = 0.88;
+
+  /// 桌面歌词式重写：native 侧 hook 模式文字已自带描边 + 投影，可读性不再依赖
+  /// 底板，默认背景与音乐播放器桌面歌词一致——全透明。存过偏好的用户保持原值
+  /// （never break userspace）；`◐` 一键切底板时恢复到 [_defaultRestoreOpacity]。
+  static const double _defaultOpacity = 0.0;
+  static const double _defaultRestoreOpacity = 0.6;
 
   /// BUG-1095：台词字号的持久化 key。与 [_rectPreferenceKey]（窗口几何）严格分开——
   /// 这两件事以前被 native 的「字号 = 基准 × 窗高比例」耦成一件，正是「放不下拖高
@@ -124,7 +129,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
   /// 浮窗被关掉时仍要能判出换行并让游戏内卡片消场。
   String? _ingameLatestLineId;
   double _opacity = _defaultOpacity;
-  double _lastNonZeroOpacity = _defaultOpacity;
+  double _lastNonZeroOpacity = _defaultRestoreOpacity;
   double _fontSize = kGalHookTextFontSize;
   GalHookTextWindowRect? _savedRect;
 
@@ -452,8 +457,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
       _lastNonZeroOpacity = _opacity;
       _opacity = 0;
     } else {
-      _opacity =
-          _lastNonZeroOpacity > 0 ? _lastNonZeroOpacity : _defaultOpacity;
+      _opacity = _lastNonZeroOpacity > 0
+          ? _lastNonZeroOpacity
+          : _defaultRestoreOpacity;
     }
     final AppModel? model = _appModel;
     if (model != null) {

--- a/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
+++ b/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
@@ -1,0 +1,96 @@
+// 源码守卫：gal hook 台词浮窗的「桌面歌词式」文字渲染（描边 + 投影 + 透明底板）。
+//
+// 浮窗是 runner 自有的 Win32 分层窗（Direct2D + DirectWrite 直绘），C++ 无法在
+// Dart 测试里执行，故在源码层锁死这次重写赖以成立的结构性前提：
+//   ① 描边/投影遍复用**同一个** text_layout_ 做偏移多遍绘制——不是自定义
+//      IDWriteTextRenderer、不是第二份排版。一旦分叉，CharIndexAt 点字 index、
+//      折行、滚动、注音四处几何就会各走各的（overlay_ruby_render_guard_test 已
+//      禁 IDWriteTextRenderer，这里锁「多遍偏移」这条正路本身）。
+//   ② 描边只在 hook 模式生效：有声书歌词条 / 剪贴板文字窗逐像素不变
+//      （never break userspace）。
+//   ③ 最终填充遍仍是滚动守卫锚定的那次原点绘制（text_rect_.left, text_origin_y）。
+//   ④ Dart 侧默认背景全透明（可读性由描边承担），且 ◐ 一键底板的恢复值非零
+//      ——否则 toggle 会在 0 ↔ 0 之间死循环。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String window =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+  final String controller =
+      File('lib/src/lookup/gal_hook_text_overlay_controller.dart')
+          .readAsStringSync();
+
+  test('① 描边/投影是同一 text_layout_ 的偏移多遍绘制', () {
+    expect(
+      window.contains('kLyricOutlineRadiusDip'),
+      isTrue,
+      reason: '描边半径常量必须存在，否则桌面歌词渲染根本没接上',
+    );
+    expect(
+      window.contains('kLyricShadowOffsetDip'),
+      isTrue,
+      reason: '投影偏移常量必须存在',
+    );
+    // 描边环必须把 text_layout_ 自己再画一遍（同一几何），而不是另建排版。
+    expect(
+      RegExp(r'for \(const D2D1_POINT_2F& off : ring\)[\s\S]{0,300}?'
+              r'text_layout_\.Get\(\), lyric_outline\.Get\(\)')
+          .hasMatch(window),
+      isTrue,
+      reason: '描边遍必须复用 text_layout_（与点字/滚动/高亮同一份几何）',
+    );
+  });
+
+  test('② 描边只在 hook 模式生效，其余浮窗逐像素不变', () {
+    // 主文本门与注音门分别锁：两处同形门若只锁其一，另一处被拆掉时守卫不响。
+    expect(
+      RegExp(r'if \(hook_text_mode_ && lyric_outline != nullptr &&\s*'
+              r'lyric_shadow != nullptr\)')
+          .hasMatch(window),
+      isTrue,
+      reason: '主文本描边/投影遍必须被 hook_text_mode_ 门住；'
+          '歌词条 / 剪贴板窗不许被改观感',
+    );
+    expect(
+      RegExp(r'if \(hook_text_mode_ && lyric_outline != nullptr\) \{')
+          .hasMatch(window),
+      isTrue,
+      reason: '注音描边遍必须被 hook_text_mode_ 门住',
+    );
+    expect(
+      RegExp(r'hook_text_mode_\s*\?\s*DWRITE_FONT_WEIGHT_SEMI_BOLD'
+              r'\s*:\s*DWRITE_FONT_WEIGHT_NORMAL')
+          .hasMatch(window),
+      isTrue,
+      reason: '半粗字重同样只允许在 hook 模式启用',
+    );
+  });
+
+  test('③ 最终填充遍仍是原点那次绘制（滚动守卫的锚点）', () {
+    expect(
+      RegExp(r'D2D1::Point2F\(text_rect_\.left, text_origin_y\), '
+              r'text_layout_\.Get\(\),\s*brush\.Get\(\)')
+          .hasMatch(window),
+      isTrue,
+      reason: '填充遍必须保持在 (text_rect_.left, text_origin_y) 原点、用正文画刷',
+    );
+  });
+
+  test('④ Dart 默认底板全透明，◐ 恢复值非零', () {
+    expect(
+      controller.contains('_defaultOpacity = 0.0'),
+      isTrue,
+      reason: '桌面歌词式默认无底板；可读性由 native 描边承担',
+    );
+    final RegExp restore = RegExp(r'_defaultRestoreOpacity = (\d+(?:\.\d+)?);');
+    final Match? m = restore.firstMatch(controller);
+    expect(m, isNotNull, reason: '◐ 的恢复常量必须存在');
+    expect(
+      double.parse(m!.group(1)!),
+      greaterThan(0),
+      reason: '恢复值为 0 会让 ◐ 在 0 ↔ 0 之间空转',
+    );
+  });
+}

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -53,6 +53,19 @@ constexpr float kDragThresholdDip = 6.0f;
 // 注音高度，假名与基准字之间因此有一条细缝，不会贴在一起。
 constexpr float kRubyFontScale = 0.45f;
 constexpr float kRubyLineGapScale = 1.25f;
+// 桌面歌词式文字渲染（仅 hook 台词浮窗）：文字自带「投影 + 描边」，可读性不再
+// 依赖底板，于是背景可以像音乐播放器桌面歌词一样默认全透明。
+//
+// 描边不走自定义 DirectWrite 文本渲染器（overlay_ruby_render_guard 明确禁止
+// ——它会让绘制路径与 CharIndexAt / 高亮 / 滚动共用的那份 text_layout_ 几何
+// 分叉），而是把**同一个**
+// text_layout_ 按 8 个方向偏移多画几遍：几何天然逐像素一致，点字 index、折行、
+// 滚动、注音全部不动。8 遍 + 阴影 + 填充共 10 次 DrawTextLayout，只在文本 /
+// 悬停 / 拖动变化时重绘，代价可忽略。
+constexpr float kLyricOutlineRadiusDip = 1.6f;
+constexpr float kLyricShadowOffsetDip = 2.0f;
+constexpr uint32_t kLyricOutlineColor = 0xE0000000;  // 88% 黑描边
+constexpr uint32_t kLyricShadowColor = 0x59000000;   // 35% 黑投影
 // Base logical font size the lyric text was authored at; the rendered font
 // scales with the bar height so growing the bar enlarges the text too.
 constexpr float kBaseStripHeightForFontDip = 96.0f;
@@ -1140,9 +1153,14 @@ void FloatingLyricWindow::Render() {
   const float ruby_gap_px = ruby_font_px * kRubyLineGapScale;
   const bool has_ruby = !ruby_spans_.empty();
 
+  // 桌面歌词字重：hook 模式半粗（描边字太细会被描边吃掉笔画）；歌词条 / 剪贴板
+  // 窗保持 NORMAL，逐像素不变。
+  const DWRITE_FONT_WEIGHT text_weight = hook_text_mode_
+                                             ? DWRITE_FONT_WEIGHT_SEMI_BOLD
+                                             : DWRITE_FONT_WEIGHT_NORMAL;
   if (text_format_ == nullptr) {
     dwrite_factory_->CreateTextFormat(
-        L"Yu Gothic UI", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
+        L"Yu Gothic UI", nullptr, text_weight,
         DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         static_cast<float>(ScaleForDpi(scaled_font)),
         L"", text_format_.GetAddressOf());
@@ -1161,7 +1179,7 @@ void FloatingLyricWindow::Render() {
   // PushAxisAlignedClip 把一切文字绘制框在 text_rect_ 里，绝不会画到控件带上）。
   if (has_ruby && ruby_format_ == nullptr) {
     dwrite_factory_->CreateTextFormat(
-        L"Yu Gothic UI", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
+        L"Yu Gothic UI", nullptr, text_weight,
         DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, ruby_font_px,
         L"", ruby_format_.GetAddressOf());
     if (ruby_format_ != nullptr) {
@@ -1321,6 +1339,37 @@ void FloatingLyricWindow::Render() {
           }
         }
       }
+      // 桌面歌词式描边（仅 hook 模式）：同一 text_layout_ 先按 8 向偏移画描边、
+      // 再画投影，最后回到原点画填充。所有遍都在上面的 text_clip 之内。
+      // hook 的 UpdateText 恒传 current_line_start=-1，不存在 per-range dim
+      // drawing effect，因此描边遍不会被 SetDrawingEffect 换色。
+      Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> lyric_outline;
+      Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> lyric_shadow;
+      if (hook_text_mode_) {
+        render_target_->CreateSolidColorBrush(
+            ColorFromArgb(kLyricOutlineColor), lyric_outline.GetAddressOf());
+        render_target_->CreateSolidColorBrush(
+            ColorFromArgb(kLyricShadowColor), lyric_shadow.GetAddressOf());
+      }
+      if (hook_text_mode_ && lyric_outline != nullptr &&
+          lyric_shadow != nullptr) {
+        const float shadow_off = ScaleForDpi(kLyricShadowOffsetDip);
+        render_target_->DrawTextLayout(
+            D2D1::Point2F(text_rect_.left + shadow_off * 0.5f,
+                          text_origin_y + shadow_off),
+            text_layout_.Get(), lyric_shadow.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE);
+        const float r = ScaleForDpi(kLyricOutlineRadiusDip);
+        const float d = r * 0.7071f;
+        const D2D1_POINT_2F ring[8] = {
+            {r, 0.0f},  {-r, 0.0f}, {0.0f, r},  {0.0f, -r},
+            {d, d},     {d, -d},    {-d, d},    {-d, -d}};
+        for (const D2D1_POINT_2F& off : ring) {
+          render_target_->DrawTextLayout(
+              D2D1::Point2F(text_rect_.left + off.x, text_origin_y + off.y),
+              text_layout_.Get(), lyric_outline.Get(),
+              D2D1_DRAW_TEXT_OPTIONS_NONE);
+        }
+      }
       render_target_->DrawTextLayout(
           D2D1::Point2F(text_rect_.left, text_origin_y), text_layout_.Get(),
           brush.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE);
@@ -1354,6 +1403,23 @@ void FloatingLyricWindow::Render() {
               text_rect_.left + box.left, text_origin_y + box.top,
               text_rect_.left + box.left + box.width,
               text_origin_y + box.top + ruby_gap_px);
+          // 注音的桌面歌词描边：字小，半径收到 0.75 倍、不画投影。
+          if (hook_text_mode_ && lyric_outline != nullptr) {
+            const float rr = ScaleForDpi(kLyricOutlineRadiusDip * 0.75f);
+            const float rd = rr * 0.7071f;
+            const D2D1_POINT_2F ruby_ring[8] = {
+                {rr, 0.0f}, {-rr, 0.0f}, {0.0f, rr},  {0.0f, -rr},
+                {rd, rd},   {rd, -rd},   {-rd, rd},   {-rd, -rd}};
+            for (const D2D1_POINT_2F& off : ruby_ring) {
+              const D2D1_RECT_F shifted = D2D1::RectF(
+                  ruby_rect.left + off.x, ruby_rect.top + off.y,
+                  ruby_rect.right + off.x, ruby_rect.bottom + off.y);
+              render_target_->DrawTextW(
+                  span.ruby.c_str(), static_cast<UINT32>(span.ruby.size()),
+                  ruby_format_.Get(), shifted, lyric_outline.Get(),
+                  D2D1_DRAW_TEXT_OPTIONS_NONE);
+            }
+          }
           render_target_->DrawTextW(
               span.ruby.c_str(), static_cast<UINT32>(span.ruby.size()),
               ruby_format_.Get(), ruby_rect, brush.Get(),


### PR DESCRIPTION
## 改了什么

游戏 hook 文本浮窗按用户要求重写为**音乐播放器桌面歌词样式**：

- **native**（`floating_lyric_window.cpp`，仅 `hook_text_mode_`）：
  - 文字自带 35% 黑投影 + 8 向 1.6dip 黑描边 + 半粗字重（Yu Gothic UI Semibold），可读性不再依赖底板；
  - 注音（振假名）同样描边（0.75 倍半径、无投影）；
  - 描边是**同一个** `text_layout_` 的偏移多遍绘制，不引入自定义 DirectWrite 文本渲染器——CharIndexAt 点字查词、折行、滚动、高亮、注音几何逐字节不变（overlay_ruby_render_guard 明确禁 renderer，本 PR 顺着它的约束走）。
- **Dart**（`gal_hook_text_overlay_controller.dart`）：默认背景透明度 0.88 → **0（全透明，桌面歌词无底板）**；`◐` 一键底板恢复到 0.6。存过偏好的用户保持原值（never break userspace）。
- **守卫**：新增 `test/build/gal_overlay_lyric_style_guard_test.dart` 锁四条结构前提，已做变异实测（3 处变异全部打红后还原）。

## 不变

- 有声书悬浮歌词条、剪贴板文字窗逐像素不变（描边/字重全部被 `hook_text_mode_` 门住）。
- 拖动/缩放/滚动/悬停查词/穿透/工具条逻辑零改动；透明底板的可点性由既有 BUG-1046 alpha 地板保证。

## 验证

- 定向 33 测试全绿（新守卫 + font_decoupled/scroll/ruby 三守卫 + controller/channel/voice 测试）。
- 全量 `flutter analyze` No issues。
- `floating_lyric_window.cpp` 以 /W4 /WX /utf-8 单独 cl 编译通过。
- 缺口：未在真机游戏会话里目视新样式（描边/投影观感），合并前建议开一局游戏看一眼。

https://claude.ai/code/session_019uYsQGjPditdLa5UiGsLJH