### PR TITLE
fix(settings): 取消设置页宽屏 960px 强制限宽（BUG-1643）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1511 条。点号进各自文件。
+> 共 1512 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1643](bugs/BUG-1643-settings-width-cap.md) | ✅ | ✅ | 设置页宽屏被 960px 强制限宽 |
 | [BUG-1613](bugs/BUG-1613-apple-coreml-ep-detector-empty.md) | ✅ | ✅ | Apple CoreML EP 上 int8 检测模型静默返回空结果且更慢 |
 | [BUG-1610](bugs/BUG-1610-bangumi-search-rating-null.md) | ✅ | ✅ | Bangumi 搜索候选评分恒空：映射器读扁平 score，真实响应只有嵌套 rating.score |
 | [BUG-1609](bugs/BUG-1609-global-lookup-card-right-corners-square.md) | ✅ | ✅ | app 外全局查词卡片右上/右下圆角变方角 |

--- a/docs/bugs/BUG-1643-settings-width-cap.md
+++ b/docs/bugs/BUG-1643-settings-width-cap.md
@@ -1,0 +1,22 @@
+## BUG-1643 · 设置页宽屏被 960px 强制限宽
+- **报告**：2026-08-14（用户：设置页有莫名奇妙的宽度限制，要求删掉）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/misc/platform_utils.dart:230`（修前）——
+  `desktopContentMaxWidth()` 对 `DesktopContentKind.settings` 在 medium/expanded 返回 `960`，
+  `DesktopContentLayout` 据此把正文塞进 `Center` + `ConstrainedBox`，宽屏下居中锁窄。
+  受影响的实际页面是走该布局的设置正文：各库页内嵌的设置标签页
+  `ModuleSettingsView`（`fushi/lib/src/pages/implementations/module_settings_view.dart:51`，
+  小说 / 视频 / 漫画 / 游戏库页都用它）与设置主页窄屏单列分支
+  （`fushi/lib/src/settings/settings_home_page.dart:98`）。
+  这是同一族「莫名宽度上限」的最后一处残留：书架 1280 与查词 1040 早已按用户实报改成 `null`，
+  设置主页的宽屏主从分支也早已按用户拍板不限宽（`settings_home_page._buildWideLayout` 注释：
+  4K 窗口右侧空 2400px），唯独这条 960 还在，导致同一 app 内设置详情两种宽度自相矛盾。
+- **[x] ① 已修复** — `DesktopContentKind.settings => null`，走 full-bleed 分支；
+  `desktopContentPadding` 保持 16/24px 侧向留白（正文是文字流，不贴边）。
+- **[x] ② 已加自动化测试** — `fushi/test/utils/platform_utils_settings_width_test.dart`
+  （medium/expanded 均须为 `null` + 留白仍为 24）；同步更新既有契约
+  `fushi/test/utils/misc/platform_layout_test.dart`、
+  `fushi/test/pages/popup_layout_width_columns_test.dart`、
+  `fushi/test/pages/settings_wide_left_aligned_test.dart`。
+  变异实测：把 `null` 改回 `960` → 守卫红（exit 1，2 个失败）；还原 → 绿（5 tests passed）。
+- **备注**：阅读器内的设置**弹窗**（`FushiSettingsDialogPage` 的 `kFushiSettingsDialogMaxWidth` = 900）
+  是弹窗尺寸、且是 BUG-1546 按用户要求从 560 放宽来的，不在本次范围内，未动。

--- a/fushi/lib/src/utils/misc/platform_utils.dart
+++ b/fushi/lib/src/utils/misc/platform_utils.dart
@@ -227,7 +227,15 @@ double? desktopContentMaxWidth(
     // --dict-columns 与更长释义）。嵌套查词弹窗渲染在根 Overlay、独立走
     // popupMaxWidth，不受此项影响。
     DesktopContentKind.dictionary => null,
-    DesktopContentKind.settings => 960,
+    // 取消设置页（含各库页内嵌的 [ModuleSettingsView] 设置标签页）在宽屏上的
+    // 960px 强制内容宽上限——这是书架（1280）/ 查词（1040）同款「莫名奇妙的宽度
+    // 限制」的最后一处残留：设置详情本身就是填满 pane 的列表流（设置主页的宽屏
+    // 主从布局早已按用户拍板不限宽，见 settings_home_page._buildWideLayout 注释），
+    // 唯独走 [DesktopContentLayout] 的这一支还把正文居中锁在 960，4K 窗口下两侧
+    // 各留 700+px 空白、且与同一 app 内不限宽的设置详情自相矛盾。
+    // 返回 null 走 full-bleed 分支，仍由 [desktopContentPadding] 保留 16/24px
+    // 侧向留白（正文不贴边）。
+    DesktopContentKind.settings => null,
   };
 }
 

--- a/fushi/test/pages/popup_layout_width_columns_test.dart
+++ b/fushi/test/pages/popup_layout_width_columns_test.dart
@@ -40,10 +40,12 @@ void main() {
         isNull,
         reason: '书架/视频库宽屏应占满（用户实报莫名宽度上限）',
       );
+      // 设置页同样取消上限（用户实报「设置页有莫名奇妙的宽度限制」）。
       expect(
         desktopContentMaxWidth(
             WindowSizeClass.expanded, DesktopContentKind.settings),
-        960,
+        isNull,
+        reason: '设置正文宽屏应占满，不再被 960 锁窄',
       );
     });
 

--- a/fushi/test/pages/settings_wide_left_aligned_test.dart
+++ b/fushi/test/pages/settings_wide_left_aligned_test.dart
@@ -37,9 +37,8 @@ void main() {
   });
 
   testWidgets(
-      'REGRESSION DOC: wrapping in centered DesktopContentLayout '
-      'pushes the nav pane off the left (why we do NOT wrap the wide branch)',
-      (tester) async {
+      'REGRESSION DOC: wrapping in DesktopContentLayout still pads the nav '
+      'pane off the left (why we do NOT wrap the wide branch)', (tester) async {
     await useWideSurface(tester);
     await tester.pumpWidget(_fullBleed(
       DesktopContentLayout(
@@ -49,7 +48,11 @@ void main() {
     ));
     await tester.pump();
     final Rect nav = tester.getRect(find.byKey(navKey));
-    // 1500 宽被居中限到 960 → 左缘明显 > 0(这正是我们要避免的旧行为)。
-    expect(nav.left, greaterThan(100.0));
+    // 设置正文的 960 居中限宽已取消(用户实报「设置页有莫名奇妙的宽度限制」),
+    // 但 DesktopContentLayout 仍给文字流留 24px 侧向留白 —— 导航面板依旧不贴
+    // 左缘,所以宽屏主从分支仍然不能套这一层。
+    expect(nav.width, greaterThan(0));
+    expect(nav.left, closeTo(24.0, 0.5),
+        reason: '限宽取消后只剩侧向留白,但仍非 0 —— 宽屏分支不套 DesktopContentLayout');
   });
 }

--- a/fushi/test/utils/misc/platform_layout_test.dart
+++ b/fushi/test/utils/misc/platform_layout_test.dart
@@ -106,15 +106,16 @@ void main() {
       );
     });
 
-    test('uses wider settings content on Windows-sized expanded layouts', () {
+    test('settings content is full-bleed on wide desktop', () {
+      // 取消了设置正文在宽屏上的 960px 强制内容宽上限（用户实报「设置页有莫名
+      // 奇妙的宽度限制」），权威契约见
+      // test/utils/platform_utils_settings_width_test.dart。
       expect(
         desktopContentMaxWidth(
           WindowSizeClass.expanded,
           DesktopContentKind.settings,
         ),
-        // MD3 list-detail: widened 760 -> 960 so the detail pane breathes after
-        // the 280px nav pane (Phase 1 ④).
-        960,
+        isNull,
       );
     });
 

--- a/fushi/test/utils/platform_utils_settings_width_test.dart
+++ b/fushi/test/utils/platform_utils_settings_width_test.dart
@@ -1,15 +1,22 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/misc/platform_utils.dart';
 
+/// 设置页内容宽守卫：宽屏不再有强制内容宽上限（用户实报「设置页有莫名奇妙的宽度
+/// 限制」）。此前 medium / expanded 返回 960，把走 [DesktopContentLayout] 的设置
+/// 正文（各库页内嵌的设置标签页 `ModuleSettingsView`）居中锁在窄栏。
 void main() {
-  test('settings detail pane is widened for desktop balance (760 -> 960)', () {
-    expect(
-      desktopContentMaxWidth(
-        WindowSizeClass.expanded,
-        DesktopContentKind.settings,
-      ),
-      960,
-    );
+  test('settings content has no width cap on wide desktop', () {
+    for (final WindowSizeClass sizeClass in <WindowSizeClass>[
+      WindowSizeClass.medium,
+      WindowSizeClass.expanded,
+    ]) {
+      expect(
+        desktopContentMaxWidth(sizeClass, DesktopContentKind.settings),
+        isNull,
+        reason: '$sizeClass 下设置正文应占满（仅留侧向留白），不得再被 960 锁窄',
+      );
+    }
   });
 
   test('compact returns null (no cap) for settings', () {
@@ -19,6 +26,16 @@ void main() {
         DesktopContentKind.settings,
       ),
       isNull,
+    );
+  });
+
+  test('settings keeps its side padding so text does not touch the edge', () {
+    expect(
+      desktopContentPadding(
+        WindowSizeClass.expanded,
+        DesktopContentKind.settings,
+      ),
+      const EdgeInsets.symmetric(horizontal: 24),
     );
   });
 }


### PR DESCRIPTION
## 问题

用户实报「设置页有莫名奇妙的宽度限制」。

根因：`fushi/lib/src/utils/misc/platform_utils.dart` 的 `desktopContentMaxWidth()` 对 `DesktopContentKind.settings` 在 medium/expanded 返回 `960`，`DesktopContentLayout` 据此把正文塞进 `Center` + `ConstrainedBox`，宽屏下居中锁窄。

受影响的实际页面：
- `ModuleSettingsView`（各库页内嵌的设置标签页——小说 / 视频 / 漫画 / 游戏库页都用它）
- 设置主页的窄屏单列分支

这是同族「莫名宽度上限」的最后一处残留：书架 1280 与查词 1040 早已按用户实报改成 `null`，设置主页的宽屏主从分支也早已按用户拍板不限宽（`settings_home_page._buildWideLayout` 注释记着 4K 窗口右侧空 2400px 的实机反馈），唯独这条 960 还在，导致同一 app 内设置详情两种宽度自相矛盾。

## 改动

- `DesktopContentKind.settings => null`，走 full-bleed 分支。
- `desktopContentPadding` 不动：仍保留 16/24px 侧向留白（设置正文是文字流，不贴边）。

## 验证

- 新增守卫 `test/utils/platform_utils_settings_width_test.dart`（medium/expanded 均须为 `null` + 留白仍为 24）。
- 同步更新三处既有契约：`test/utils/misc/platform_layout_test.dart`、`test/pages/popup_layout_width_columns_test.dart`、`test/pages/settings_wide_left_aligned_test.dart`（后者原本把 960 居中当「反面教材」断言 `left > 100`，限宽取消后改断言只剩 24px 留白——宽屏主从分支仍然不能套这一层）。
- 变异实测：把 `null` 改回 `960` → 守卫红（exit 1，2 个失败）；反向替换还原 → 绿（5 tests passed）。
- `flutter analyze` 全量（含 test）：No issues found。
- 定向测试 71 tests passed；目录枚举型守卫整批 250 tests passed（= 当前基线）。

BUG 记录：`docs/bugs/BUG-1643-settings-width-cap.md`

https://claude.ai/code/session_01Prbav2epdsc3KrAVKHLbpf