### PR TITLE
fix(video): 恢复 Windows d3d11va 零拷贝 interop（ANGLE 设备共享 + libmpv 升级）（BUG-1644）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1511 条。点号进各自文件。
+> 共 1512 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |
 | [BUG-1613](bugs/BUG-1613-apple-coreml-ep-detector-empty.md) | ✅ | ✅ | Apple CoreML EP 上 int8 检测模型静默返回空结果且更慢 |
 | [BUG-1610](bugs/BUG-1610-bangumi-search-rating-null.md) | ✅ | ✅ | Bangumi 搜索候选评分恒空：映射器读扁平 score，真实响应只有嵌套 rating.score |
 | [BUG-1609](bugs/BUG-1609-global-lookup-card-right-corners-square.md) | ✅ | ✅ | app 外全局查词卡片右上/右下圆角变方角 |

--- a/docs/bugs/BUG-1644-d3d11va-zero-copy-interop.md
+++ b/docs/bugs/BUG-1644-d3d11va-zero-copy-interop.md
@@ -1,0 +1,74 @@
+## BUG-1644 · Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了
+- **报告**：2026-08-14（用户：「d3d11va 的零拷贝 interop（现在连 d3d11-egl 都没加载起来，每帧白走一次 GPU→内存→GPU）。那是 media_kit 建 ANGLE context 时没把 D3D11 device 暴露给 mpv」）
+- **真实性**：✅ 真 bug。根因 `third_party/media_kit_video/windows/angle_surface_manager.cc:CreateEGLDisplay`（补前）——`EGLDisplay` 建自 `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, …)`，ANGLE 因此自建一个**隐藏的** `ID3D11Device`，与 `CreateD3DTexture` 里 media_kit 自己那个（`D3D11CreateDevice(..., flags = 0)`）互不相干。
+- **[x] ① 已修复** — 改成 mpv `context_angle.c` 的做法：进程内唯一一个 `ID3D11Device`（`BGRA_SUPPORT | VIDEO_SUPPORT` + `SetMultithreadProtected(TRUE)`），用 `eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, dev)` + `eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, …)` 交给 ANGLE；失败原样退回上游四级 fallback 链。详见 `third_party/media_kit_video/PATCHES.md` 的 BUG-1644 段。
+- **[x] ② 已加自动化测试** — `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`（7 条源码扫描守卫，含「fallback 链必须还在」与「共享 device 不得逐实例 Release」）；变异实测 6 条全部转红（含「断言字面量只出现在注释里不算数」一条，守卫内置 `stripComments`）。
+- **备注**：与 BUG-1639 是同一条链路的**上下游**，不是重复条目——1639 修的是「Windows 上 `auto-safe` 会选到 CUDA/nvdec 导致 `nvcuda64` 空指针崩」，落点是把 hwdec 值域收敛到 `d3d11va,d3d11va-copy`；本条修的是「收敛之后 `d3d11va` 为什么还是失败、只能落 `d3d11va-copy`」。
+
+### 根因链（对着 mpv 源码逐段核过）
+
+mpv 的 `d3d11-egl` interop（`video/out/opengl/hwdec_d3d11egl.c` 的 `init()`）**只有一条**途径拿到解码用的
+D3D11 设备——从**当前 EGLDisplay** 反查：
+
+```c
+p_eglQueryDisplayAttribEXT(egl_display, EGL_DEVICE_EXT, &device);
+p_eglQueryDeviceAttribEXT((EGLDeviceEXT)device, EGL_D3D11_DEVICE_ANGLE, &d3d_device);
+p->d3d11_device = (ID3D11Device *)d3d_device;
+...
+p->hwctx = (struct mp_hwdec_ctx){ .av_device_ref = d3d11_wrap_device_ref(p->d3d11_device), ... };
+if (!p->hwctx.av_device_ref) { MP_VERBOSE(hw, "Failed to create hwdevice_ctx\n"); return -1; }
+```
+
+也就是说：**谁建的 display，谁的 device 就是解码设备**。上游 media_kit 让 ANGLE 自建 device，于是：
+
+1. mpv 拿到的是 ANGLE 的隐藏 device，而它是 ANGLE 用自己的 flags 建的，**没有**
+   `D3D11_CREATE_DEVICE_VIDEO_SUPPORT`，也没人给它 `SetMultithreadProtected`；
+2. `d3d11_wrap_device_ref()` 走 FFmpeg 的 `d3d11va_device_init()`，那里对设备 QI `ID3D11VideoDevice`、
+   对 immediate context QI `ID3D11VideoContext`；没有 video flag 的设备可能两者之一失败
+   （本机实测：WARP 上 `QI ID3D11VideoDevice` = `E_NOINTERFACE 0x80004002`）；
+3. `init()` 于是 `return -1`，而且是**静默**的（`goto fail` 前的分支都不打日志），mpv 日志里只看得到
+   `Loading hwdec driver 'd3d11-egl'` 后面什么都没有；
+4. `d3d11va`（零拷贝）因此不可用，`hwdec` 落到 `d3d11va-copy`——每帧解码结果从 GPU 读回系统内存再上传。
+
+### 复现证据（本机，独立 C++ 探针 + 真 libmpv）
+
+探针原样复刻 media_kit 的 ANGLE 初始化后创建真的 `mpv_render_context`，`hwdec=auto-safe` 播真片源：
+
+```
+=== mode=legacy driver=WARP videoSupport=0 clientVersion=ES2 hwdec=auto-safe ===
+[env] ANGLE ID3D11Device = 00000229B4D2E3C0 (ours = 00000229B4D85C10) -> DIFFERENT device
+[env] QI ID3D11VideoDevice (ffmpeg d3d11va_device_init): hr=0x80004002 FAILED
+[mpv:libmpv_render] Loading hwdec driver 'd3d11-egl'      <- 之后无任何输出 = 静默失败
+[RESULT] mode=legacy WARP video=0 es2 hwdec-req=auto-safe -> hwdec-current=d3d11va-copy
+```
+
+同一探针切到本补丁的路径（`eglCreateDeviceANGLE` + `EGL_PLATFORM_DEVICE_EXT`）：
+
+```
+=== mode=interop driver=WARP videoSupport=0 clientVersion=ES2 hwdec=auto-safe ===
+[env] ANGLE ID3D11Device = 0000016C2A914FA0 (ours = 0000016C2A914FA0) -> SAME device
+[env] QI ID3D10Multithread: hr=0x00000000 protected=1
+```
+
+即：**ANGLE 确实接受了我们的设备**，多线程保护保留，共享句柄 pbuffer 与 mpv 渲染均正常。
+（这一轮是 WARP，因为 WARP 拒绝 `VIDEO_SUPPORT` 标志，所以 QI 仍失败、`hwdec-current` 仍是
+`d3d11va-copy`——它验证的是**接线**，不是最终 hwdec 值。）
+
+BUG-1639 用另一条独立路径（ctypes 直驱安装目录的 libmpv、GL 上下文）得到一致结论：
+`d3d11va,d3d11va-copy` → 「`d3d11va` 失败 → `Using hardware decoding (d3d11va-copy)`」。
+
+### 未闭环项（真机门）
+
+「NVIDIA 真硬件 + ANGLE D3D11 display 下 `hwdec-current` 从 `d3d11va-copy` 变成 `d3d11va`」这一条
+**尚未取到**：本机当前 `D3D11CreateDevice(D3D_DRIVER_TYPE_HARDWARE)` 对三块 5090 适配器一律返回
+`E_OUTOFMEMORY 0x8007000E`（`nvidia-smi` 显示 67 个 GPU 客户端进程、显存却还剩 25GB，属驱动并发 D3D
+上下文打满），ANGLE 的 D3D11 display 随之 `EGL_NOT_INITIALIZED` 退到 D3D9。探针与一键复跑脚本见
+`docs/agent/` 未收录的临时目录，命令：
+
+```
+angle_probe.exe legacy  hw novideo es2 <video> auto-safe   # 期望 hwdec-current=d3d11va-copy
+angle_probe.exe interop hw video   es2 <video> auto-safe   # 期望 hwdec-current=d3d11va
+```
+
+GPU 空闲时跑这两条即可闭环；`VideoOutput` 现在也会在启动日志里直接打
+`libmpv d3d11-egl zero-copy interop: available/unavailable`。

--- a/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
+++ b/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
@@ -1,0 +1,209 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1644 source-scan guard: the vendored `media_kit_video` Windows ANGLE
+/// surface manager must keep rendering on **our** Direct3D 11 device.
+///
+/// Root cause: upstream `ANGLESurfaceManager` builds its `EGLDisplay` with
+/// `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, …)`,
+/// which makes ANGLE create a hidden `ID3D11Device` of its own — separate from
+/// the device media_kit created for the shared textures. libmpv's `d3d11-egl`
+/// hardware decoding interop can only reach the device that is reachable
+/// through the display (`EGL_DEVICE_EXT` → `EGL_D3D11_DEVICE_ANGLE`), i.e.
+/// ANGLE's hidden one, which was never created with
+/// `D3D11_CREATE_DEVICE_VIDEO_SUPPORT`. FFmpeg's `d3d11va_device_init` then
+/// fails its `ID3D11VideoDevice` / `ID3D11VideoContext` QueryInterface, the
+/// interop bails silently, and `hwdec=d3d11va` degrades to `d3d11va-copy`:
+/// every decoded frame round-trips GPU → system memory → GPU.
+///
+/// Fix (mirrors mpv's own `context_angle.c`): create one process-wide device
+/// with the video + BGRA flags, mark it multithread protected, and hand it to
+/// ANGLE via `eglCreateDeviceANGLE` + `eglGetPlatformDisplayEXT(
+/// EGL_PLATFORM_DEVICE_EXT, …)`. This test guards the *patch* — a future
+/// re-vendor of media_kit_video that drops it silently reintroduces the
+/// per-frame readback. See `third_party/media_kit_video/PATCHES.md`.
+void main() {
+  // Tests run with CWD = `fushi/`; vendored packages live at the workspace root.
+  const String managerSourcePath =
+      '../third_party/media_kit_video/windows/angle_surface_manager.cc';
+  const String managerHeaderPath =
+      '../third_party/media_kit_video/windows/angle_surface_manager.h';
+  const String videoOutputPath =
+      '../third_party/media_kit_video/windows/video_output.cc';
+
+  /// Strips `//` line comments and `/* */` block comments so a guarded token
+  /// that only survives inside prose (a comment describing the removed code)
+  /// can never satisfy an assertion.
+  String stripComments(String source) {
+    final StringBuffer out = StringBuffer();
+    bool inLine = false;
+    bool inBlock = false;
+    for (int i = 0; i < source.length; i++) {
+      final String c = source[i];
+      final String next = i + 1 < source.length ? source[i + 1] : '';
+      if (inLine) {
+        if (c == '\n') {
+          inLine = false;
+          out.write(c);
+        }
+        continue;
+      }
+      if (inBlock) {
+        if (c == '*' && next == '/') {
+          inBlock = false;
+          i++;
+        }
+        continue;
+      }
+      if (c == '/' && next == '/') {
+        inLine = true;
+        i++;
+        continue;
+      }
+      if (c == '/' && next == '*') {
+        inBlock = true;
+        i++;
+        continue;
+      }
+      out.write(c);
+    }
+    return out.toString();
+  }
+
+  late String managerCode;
+  late String headerCode;
+  late String videoOutputCode;
+
+  setUp(() {
+    managerCode = stripComments(File(managerSourcePath).readAsStringSync());
+    headerCode = stripComments(File(managerHeaderPath).readAsStringSync());
+    videoOutputCode = stripComments(File(videoOutputPath).readAsStringSync());
+  });
+
+  test('vendored media_kit_video override is wired in pubspec', () {
+    final String pubspec = File('pubspec.yaml').readAsStringSync();
+    final RegExp override = RegExp(
+      r'media_kit_video:\s*\n\s*path:\s*\.\./third_party/media_kit_video',
+    );
+    expect(
+      override.hasMatch(pubspec),
+      isTrue,
+      reason: 'dependency_overrides must point media_kit_video at '
+          '../third_party/media_kit_video (BUG-1644). Without it the pub.dev '
+          'package returns and Windows hardware decoding drops back to '
+          'd3d11va-copy.',
+    );
+  });
+
+  group('BUG-1644: ANGLE is bound to media_kit\'s own Direct3D 11 device', () {
+    test('the EGLDisplay is created from our device, not EGL_DEFAULT_DISPLAY',
+        () {
+      expect(
+        managerCode.contains('eglCreateDeviceANGLE'),
+        isTrue,
+        reason: 'angle_surface_manager.cc must wrap its ID3D11Device with '
+            'eglCreateDeviceANGLE; without it mpv can only see ANGLE\'s '
+            'hidden device and d3d11va falls back to d3d11va-copy.',
+      );
+      expect(
+        managerCode.contains('EGL_D3D11_DEVICE_ANGLE'),
+        isTrue,
+        reason: 'eglCreateDeviceANGLE must be called with '
+            'EGL_D3D11_DEVICE_ANGLE so ANGLE adopts a D3D11 device.',
+      );
+      expect(
+        managerCode.contains('EGL_PLATFORM_DEVICE_EXT'),
+        isTrue,
+        reason: 'the display must come from '
+            'eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, ...); the '
+            'EGL_PLATFORM_ANGLE_ANGLE/EGL_DEFAULT_DISPLAY form makes ANGLE '
+            'create its own device.',
+      );
+    });
+
+    test('the shared device asks for video + BGRA support', () {
+      expect(
+        managerCode.contains('D3D11_CREATE_DEVICE_VIDEO_SUPPORT'),
+        isTrue,
+        reason: 'FFmpeg\'s d3d11va_device_init QueryInterfaces for '
+            'ID3D11VideoDevice/ID3D11VideoContext; a device created without '
+            'D3D11_CREATE_DEVICE_VIDEO_SUPPORT can refuse them and the '
+            'd3d11-egl interop then bails silently.',
+      );
+      expect(
+        managerCode.contains('D3D11_CREATE_DEVICE_BGRA_SUPPORT'),
+        isTrue,
+        reason: 'ANGLE requires BGRA support on the device it renders with.',
+      );
+    });
+
+    test('the shared device is marked multithread protected', () {
+      expect(
+        managerCode.contains('SetMultithreadProtected(TRUE)'),
+        isTrue,
+        reason: 'libmpv decodes on its own threads while Flutter\'s raster '
+            'thread reads the shared texture; the device must be thread safe '
+            'before it is handed to ANGLE.',
+      );
+    });
+
+    test('the legacy EGL_DEFAULT_DISPLAY chain survives as a fallback', () {
+      for (final String attributes in <String>[
+        'kD3D11DisplayAttributes',
+        'kD3D11_9_3DisplayAttributes',
+        'kD3D9DisplayAttributes',
+        'kWrapDisplayAttributes',
+      ]) {
+        expect(
+          managerCode.contains(attributes),
+          isTrue,
+          reason: 'the upstream $attributes fallback must stay reachable so '
+              'machines that cannot take the device-backed display keep '
+              'working exactly like pub.dev (BUG-1644 must not regress '
+              'playback on old drivers).',
+        );
+      }
+    });
+
+    test('the process-wide device is not released per instance', () {
+      final int cleanUp = managerCode.indexOf('void ANGLESurfaceManager::CleanUp');
+      expect(cleanUp, isNonNegative,
+          reason: 'expected a CleanUp definition in angle_surface_manager.cc');
+      final int nextFunction =
+          managerCode.indexOf('\nbool ANGLESurfaceManager::', cleanUp);
+      final String body = managerCode.substring(
+          cleanUp, nextFunction < 0 ? managerCode.length : nextFunction);
+      expect(
+        body.contains('d3d_11_device_->Release()'),
+        isFalse,
+        reason: 'the device is shared by every ANGLESurfaceManager now; '
+            'releasing it per instance frees it under the surviving '
+            'VideoOutputs. CleanUp must delegate to ReleaseSharedResources() '
+            'on the last instance instead.',
+      );
+      expect(
+        body.contains('ReleaseSharedResources()'),
+        isTrue,
+        reason: 'the last instance must tear the shared display & device down '
+            'through ReleaseSharedResources().',
+      );
+    });
+
+    test('the interop outcome is observable', () {
+      expect(
+        headerCode.contains('uses_shared_d3d11_device'),
+        isTrue,
+        reason: 'ANGLESurfaceManager must expose whether ANGLE actually runs '
+            'on the shared device, otherwise a silent fallback to '
+            'd3d11va-copy is undiagnosable in the field.',
+      );
+      expect(
+        videoOutputCode.contains('uses_shared_d3d11_device'),
+        isTrue,
+        reason: 'VideoOutput must log the interop state next to '
+            '"Using H/W rendering.".',
+      );
+    });
+  });
+}

--- a/third_party/media_kit_video/PATCHES.md
+++ b/third_party/media_kit_video/PATCHES.md
@@ -445,3 +445,61 @@ drag gesture at all, so mouse / keyboard seeking is untouched.
 
 Source-guard test: `fushi/test/pages/video_horizontal_seek_test.dart`
 (group `BUG-1485: 横滑 seek 换算模型接线守卫`).
+
+## BUG-1644: ANGLE must render on our Direct3D 11 device (`d3d11va` zero-copy)
+
+`windows/angle_surface_manager.{h,cc}` and one log line in `windows/video_output.cc`.
+
+Upstream `ANGLESurfaceManager` creates **two unrelated** Direct3D 11 devices:
+
+- one per `ANGLESurfaceManager` instance, via `D3D11CreateDevice(..., flags = 0)`,
+  used only to allocate the two shared BGRA textures Flutter samples;
+- one *hidden* device that ANGLE creates for itself, because the `EGLDisplay`
+  comes from `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+  EGL_DEFAULT_DISPLAY, ...)`.
+
+libmpv's `d3d11-egl` hardware-decoding interop
+(`mpv/video/out/opengl/hwdec_d3d11egl.c`) has exactly one way to find the device
+it must decode into: it reads it back out of the *current* display with
+`eglQueryDisplayAttribEXT(EGL_DEVICE_EXT)` →
+`eglQueryDeviceAttribEXT(EGL_D3D11_DEVICE_ANGLE)`. So it can only ever see
+ANGLE's hidden device — a device nobody created with
+`D3D11_CREATE_DEVICE_VIDEO_SUPPORT` and nobody marked thread safe. It then hands
+that device to FFmpeg (`d3d11_wrap_device_ref` → `d3d11va_device_init`), which
+`QueryInterface`s for `ID3D11VideoDevice` **and** `ID3D11VideoContext`; a device
+created without the video flag can fail either QI (measured: `E_NOINTERFACE` for
+`ID3D11VideoDevice` on WARP). `init()` then returns `-1` *silently*, mpv logs
+only `Loading hwdec driver 'd3d11-egl'` with no follow-up, and `--hwdec=d3d11va`
+degrades to `d3d11va-copy`: every decoded frame is read back to system memory
+and re-uploaded to the GPU. Independently observed in `docs/bugs/BUG-1639`
+("`d3d11va` 失败 → `Using hardware decoding (d3d11va-copy)`").
+
+The patch does what mpv's own `--gpu-context=angle` does
+(`mpv/video/out/opengl/context_angle.c`, `d3d11_device_create`):
+
+- **one** process-wide `ID3D11Device` (`shared_d3d_11_device_`) replaces the
+  per-instance ones, created with
+  `D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT` and
+  marked `ID3D10Multithread::SetMultithreadProtected(TRUE)` (libmpv decodes on
+  its own threads while Flutter's raster thread reads the shared texture);
+- the `EGLDisplay` is created **on that device** with
+  `eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, device)` +
+  `eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, ...)`, so
+  `EGL_D3D11_DEVICE_ANGLE` resolves to our device and the interop adopts it;
+- `CleanUp(true)` no longer `Release`s the device per instance (that would free
+  it under the surviving `VideoOutput`s) — the last instance calls
+  `ReleaseSharedResources()`, which terminates the display, releases the
+  `EGLDeviceEXT` and only then the device.
+
+Every new step is guarded: if the device rejects the flags they are dropped one
+by one, and if `eglCreateDeviceANGLE` / the device-backed display is
+unavailable the original
+`EGL_PLATFORM_ANGLE_ANGLE`/`EGL_DEFAULT_DISPLAY` four-candidate fallback chain
+(D3D11 → D3D11 9_3 → D3D9 → wrap) runs verbatim, so machines that cannot take
+the new path behave exactly like pub.dev.
+
+`ANGLESurfaceManager::uses_shared_d3d11_device()` makes the outcome observable;
+`VideoOutput` logs `libmpv d3d11-egl zero-copy interop: available/unavailable`
+next to its existing `Using H/W rendering.` line.
+
+Source-guard test: `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`.

--- a/third_party/media_kit_video/windows/angle_surface_manager.cc
+++ b/third_party/media_kit_video/windows/angle_surface_manager.cc
@@ -24,6 +24,13 @@
 
 int ANGLESurfaceManager::instance_count_ = 0;
 
+ID3D11Device* ANGLESurfaceManager::shared_d3d_11_device_ = nullptr;
+ID3D11DeviceContext* ANGLESurfaceManager::shared_d3d_11_device_context_ =
+    nullptr;
+EGLDeviceEXT ANGLESurfaceManager::shared_egl_device_ = EGL_NO_DEVICE_EXT;
+EGLDisplay ANGLESurfaceManager::shared_display_ = EGL_NO_DISPLAY;
+bool ANGLESurfaceManager::shared_display_uses_our_device_ = false;
+
 ANGLESurfaceManager::ANGLESurfaceManager(int32_t width, int32_t height)
     : width_(width), height_(height) {
   mutex_ = ::CreateMutex(NULL, FALSE, NULL);
@@ -111,19 +118,17 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
       eglDestroySurface(display_, surface_);
       surface_ = EGL_NO_SURFACE;
     }
+    // HIBIKI FORK: the |EGLDisplay| & the Direct3D device are process wide now
+    // (see |shared_d3d_11_device_|), so only the last instance may tear them
+    // down. |d3d_11_device_| / |d3d_11_device_context_| are non-owning aliases
+    // and are merely forgotten here; upstream |Release|d them per instance,
+    // which would now free the device out from under the surviving instances.
     if (instance_count_ == 1) {
-      eglTerminate(display_);
+      ReleaseSharedResources();
     }
     display_ = EGL_NO_DISPLAY;
-    // Release D3D device & context if the instance is being destroyed.
-    if (d3d_11_device_context_) {
-      d3d_11_device_context_->Release();
-      d3d_11_device_context_ = nullptr;
-    }
-    if (d3d_11_device_) {
-      d3d_11_device_->Release();
-      d3d_11_device_ = nullptr;
-    }
+    d3d_11_device_context_ = nullptr;
+    d3d_11_device_ = nullptr;
   } else {
     // Clear context & destroy existing |surface_|.
     eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, context_);
@@ -143,52 +148,99 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
   }
 }
 
-bool ANGLESurfaceManager::CreateD3DTexture() {
-  if (d3d_11_device_ == nullptr) {
-    // NOTE: Not enabling Feature Level 12. It crashes directly on Windows 7.
-    const auto feature_levels = {
-        D3D_FEATURE_LEVEL_11_0,
-        D3D_FEATURE_LEVEL_10_1,
-        D3D_FEATURE_LEVEL_10_0,
-        D3D_FEATURE_LEVEL_9_3,
-    };
+bool ANGLESurfaceManager::EnsureSharedD3D11Device() {
+  if (shared_d3d_11_device_ != nullptr) {
+    return true;
+  }
 
-    IDXGIAdapter* adapter = nullptr;
-    D3D_DRIVER_TYPE driver_type = D3D_DRIVER_TYPE_UNKNOWN;
+  // NOTE: Not enabling Feature Level 12. It crashes directly on Windows 7.
+  const D3D_FEATURE_LEVEL feature_levels[] = {
+      D3D_FEATURE_LEVEL_11_0,
+      D3D_FEATURE_LEVEL_10_1,
+      D3D_FEATURE_LEVEL_10_0,
+      D3D_FEATURE_LEVEL_9_3,
+  };
 
-    // NOTE: Automatically selecting adapter on Windows 10 RTM or greater.
-    if (Utils::IsWindows10RTMOrGreater()) {
-      adapter = NULL;
-      driver_type = D3D_DRIVER_TYPE_HARDWARE;
-    } else {
-      IDXGIFactory* dxgi = nullptr;
-      ::CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&dxgi);
-      // As far as my experience goes, this is the safest approach. Passing NULL
-      // (so-called default) seems to cause issues on Windows 7 or maybe some
-      // older graphics drivers. First adapter is the default.
-      // D3D_DRIVER_TYPE_UNKNOWN| must be passed with manual adapter selection.
-      dxgi->EnumAdapters(0, &adapter);
-      dxgi->Release();
+  IDXGIAdapter* adapter = nullptr;
+  D3D_DRIVER_TYPE driver_type = D3D_DRIVER_TYPE_UNKNOWN;
+
+  // NOTE: Automatically selecting adapter on Windows 10 RTM or greater.
+  if (Utils::IsWindows10RTMOrGreater()) {
+    adapter = NULL;
+    driver_type = D3D_DRIVER_TYPE_HARDWARE;
+  } else {
+    IDXGIFactory* dxgi = nullptr;
+    ::CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&dxgi);
+    // As far as my experience goes, this is the safest approach. Passing NULL
+    // (so-called default) seems to cause issues on Windows 7 or maybe some
+    // older graphics drivers. First adapter is the default.
+    // D3D_DRIVER_TYPE_UNKNOWN| must be passed with manual adapter selection.
+    dxgi->EnumAdapters(0, &adapter);
+    dxgi->Release();
+  }
+
+  // HIBIKI FORK: |D3D11_CREATE_DEVICE_VIDEO_SUPPORT| is what makes this device
+  // usable as libmpv's hardware decoding device: FFmpeg's D3D11VA device init
+  // does a QueryInterface for |ID3D11VideoDevice|, which drivers may refuse on
+  // a device created without the flag (measured: E_NOINTERFACE on WARP).
+  // |D3D11_CREATE_DEVICE_BGRA_SUPPORT| is what ANGLE wants. Both are dropped
+  // one by one if the driver rejects them, so a machine that cannot do either
+  // still gets exactly the device upstream would have created.
+  const UINT device_flag_candidates[] = {
+      D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
+      D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+      0,
+  };
+  HRESULT hr = E_FAIL;
+  for (UINT device_flags : device_flag_candidates) {
+    hr = ::D3D11CreateDevice(adapter, driver_type, 0, device_flags,
+                             feature_levels,
+                             ARRAYSIZE(feature_levels),
+                             D3D11_SDK_VERSION, &shared_d3d_11_device_, 0,
+                             &shared_d3d_11_device_context_);
+    if (SUCCEEDED(hr)) {
+      std::cout << "media_kit: ANGLESurfaceManager: Direct3D device flags: 0x"
+                << std::hex << device_flags << std::dec << std::endl;
+      break;
     }
+  }
+  if (adapter != nullptr) {
+    adapter->Release();
+  }
+  CHECK_HRESULT("D3D11CreateDevice");
 
-    auto hr = ::D3D11CreateDevice(
-        adapter, driver_type, 0, 0, feature_levels.begin(),
-        static_cast<UINT>(feature_levels.size()), D3D11_SDK_VERSION,
-        &d3d_11_device_, 0, &d3d_11_device_context_);
-    CHECK_HRESULT("D3D11CreateDevice");
+  // The device is touched by libmpv's decoder threads, media_kit's render
+  // thread pool & Flutter's raster thread at the same time. libmpv turns this
+  // on itself once its interop adopts the device, but ANGLE and the Flutter
+  // texture already share it before that happens.
+  Microsoft::WRL::ComPtr<ID3D10Multithread> multithread;
+  if (SUCCEEDED(shared_d3d_11_device_->QueryInterface(
+          __uuidof(ID3D10Multithread), (void**)&multithread)) &&
+      multithread != nullptr) {
+    multithread->SetMultithreadProtected(TRUE);
   }
 
   Microsoft::WRL::ComPtr<IDXGIDevice> dxgi_device = nullptr;
-  auto dxgi_device_success = d3d_11_device_->QueryInterface(
+  auto dxgi_device_success = shared_d3d_11_device_->QueryInterface(
       __uuidof(IDXGIDevice), (void**)&dxgi_device);
   if (SUCCEEDED(dxgi_device_success) && dxgi_device != nullptr) {
     dxgi_device->SetGPUThreadPriority(5);  // Must be in interval [-7, 7].
   }
 
-  auto level = d3d_11_device_->GetFeatureLevel();
+  auto level = shared_d3d_11_device_->GetFeatureLevel();
   std::cout << "media_kit: ANGLESurfaceManager: Direct3D Feature Level: "
             << (((unsigned)level) >> 12) << "_"
             << ((((unsigned)level) >> 8) & 0xf) << std::endl;
+  return true;
+}
+
+bool ANGLESurfaceManager::CreateD3DTexture() {
+  if (!EnsureSharedD3D11Device()) {
+    return false;
+  }
+  d3d_11_device_ = shared_d3d_11_device_;
+  d3d_11_device_context_ = shared_d3d_11_device_context_;
+
   auto d3d11_texture2D_desc = D3D11_TEXTURE2D_DESC{0};
   d3d11_texture2D_desc.Width = width_;
   d3d11_texture2D_desc.Height = height_;
@@ -236,36 +288,109 @@ bool ANGLESurfaceManager::CreateD3DTexture() {
   return true;
 }
 
-bool ANGLESurfaceManager::CreateEGLDisplay() {
-  if (display_ == EGL_NO_DISPLAY) {
-    auto eglGetPlatformDisplayEXT =
-        reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
-            eglGetProcAddress("eglGetPlatformDisplayEXT"));
-    if (eglGetPlatformDisplayEXT) {
-      display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                          EGL_DEFAULT_DISPLAY,
-                                          kD3D11DisplayAttributes);
-      if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-        display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                            EGL_DEFAULT_DISPLAY,
-                                            kD3D11_9_3DisplayAttributes);
-        if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-          display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                              EGL_DEFAULT_DISPLAY,
-                                              kD3D9DisplayAttributes);
-          if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-            display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                                EGL_DEFAULT_DISPLAY,
-                                                kWrapDisplayAttributes);
-            if (eglInitialize(display_, 0, 0) == EGL_FALSE) {
-              FAIL("eglGetPlatformDisplayEXT");
-            }
-          }
+bool ANGLESurfaceManager::EnsureSharedEGLDisplay() {
+  if (shared_display_ != EGL_NO_DISPLAY) {
+    return true;
+  }
+
+  auto eglGetPlatformDisplayEXT =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+          eglGetProcAddress("eglGetPlatformDisplayEXT"));
+  if (!eglGetPlatformDisplayEXT) {
+    FAIL("eglGetProcAddress");
+  }
+
+  // HIBIKI FORK: preferred path - run ANGLE on the device we created instead of
+  // letting it create a hidden one. libmpv's `d3d11-egl` interop reads its
+  // decoding device back out of the display
+  // (`EGL_DEVICE_EXT` -> `EGL_D3D11_DEVICE_ANGLE`), so this is the only way to
+  // decide which device decodes: with ANGLE's hidden device, `d3d11va` falls
+  // back to `d3d11va-copy`, i.e. every frame is read back to system memory and
+  // re-uploaded. This mirrors what mpv's own `--gpu-context=angle` does.
+  auto eglCreateDeviceANGLE = reinterpret_cast<PFNEGLCREATEDEVICEANGLEPROC>(
+      eglGetProcAddress("eglCreateDeviceANGLE"));
+  if (shared_d3d_11_device_ != nullptr && eglCreateDeviceANGLE != nullptr) {
+    shared_egl_device_ = eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE,
+                                              shared_d3d_11_device_, nullptr);
+    if (shared_egl_device_ != EGL_NO_DEVICE_EXT) {
+      auto display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT,
+                                              shared_egl_device_, nullptr);
+      if (display != EGL_NO_DISPLAY && eglInitialize(display, 0, 0)) {
+        shared_display_ = display;
+        shared_display_uses_our_device_ = true;
+        std::cout << "media_kit: ANGLESurfaceManager: ANGLE bound to the "
+                     "shared Direct3D 11 device (libmpv d3d11-egl zero-copy "
+                     "interop available)."
+                  << std::endl;
+        return true;
+      }
+      auto eglReleaseDeviceANGLE =
+          reinterpret_cast<PFNEGLRELEASEDEVICEANGLEPROC>(
+              eglGetProcAddress("eglReleaseDeviceANGLE"));
+      if (eglReleaseDeviceANGLE) {
+        eglReleaseDeviceANGLE(shared_egl_device_);
+      }
+      shared_egl_device_ = EGL_NO_DEVICE_EXT;
+    }
+    std::cout << "media_kit: ANGLESurfaceManager: Could not bind ANGLE to the "
+                 "shared Direct3D 11 device; falling back to ANGLE's own "
+                 "device (hardware decoding will copy through system memory)."
+              << std::endl;
+  }
+
+  shared_display_ = eglGetPlatformDisplayEXT(
+      EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, kD3D11DisplayAttributes);
+  if (eglInitialize(shared_display_, 0, 0) == EGL_FALSE) {
+    shared_display_ =
+        eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY,
+                                 kD3D11_9_3DisplayAttributes);
+    if (eglInitialize(shared_display_, 0, 0) == EGL_FALSE) {
+      shared_display_ = eglGetPlatformDisplayEXT(
+          EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, kD3D9DisplayAttributes);
+      if (eglInitialize(shared_display_, 0, 0) == EGL_FALSE) {
+        shared_display_ =
+            eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+                                     EGL_DEFAULT_DISPLAY, kWrapDisplayAttributes);
+        if (eglInitialize(shared_display_, 0, 0) == EGL_FALSE) {
+          shared_display_ = EGL_NO_DISPLAY;
+          FAIL("eglGetPlatformDisplayEXT");
         }
       }
-    } else {
-      FAIL("eglGetProcAddress");
     }
+  }
+  return true;
+}
+
+void ANGLESurfaceManager::ReleaseSharedResources() {
+  if (shared_display_ != EGL_NO_DISPLAY) {
+    eglTerminate(shared_display_);
+    shared_display_ = EGL_NO_DISPLAY;
+  }
+  if (shared_egl_device_ != EGL_NO_DEVICE_EXT) {
+    auto eglReleaseDeviceANGLE = reinterpret_cast<PFNEGLRELEASEDEVICEANGLEPROC>(
+        eglGetProcAddress("eglReleaseDeviceANGLE"));
+    if (eglReleaseDeviceANGLE) {
+      eglReleaseDeviceANGLE(shared_egl_device_);
+    }
+    shared_egl_device_ = EGL_NO_DEVICE_EXT;
+  }
+  shared_display_uses_our_device_ = false;
+  if (shared_d3d_11_device_context_ != nullptr) {
+    shared_d3d_11_device_context_->Release();
+    shared_d3d_11_device_context_ = nullptr;
+  }
+  if (shared_d3d_11_device_ != nullptr) {
+    shared_d3d_11_device_->Release();
+    shared_d3d_11_device_ = nullptr;
+  }
+}
+
+bool ANGLESurfaceManager::CreateEGLDisplay() {
+  if (display_ == EGL_NO_DISPLAY) {
+    if (!EnsureSharedEGLDisplay()) {
+      return false;
+    }
+    display_ = shared_display_;
   }
   return true;
 }

--- a/third_party/media_kit_video/windows/angle_surface_manager.h
+++ b/third_party/media_kit_video/windows/angle_surface_manager.h
@@ -11,6 +11,7 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <EGL/eglext_angle.h>
 #include <EGL/eglplatform.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
@@ -53,6 +54,14 @@ class ANGLESurfaceManager {
 
   void MakeCurrent(bool value);
 
+  // Whether ANGLE renders on the Direct3D 11 device this class created (see
+  // |shared_d3d_11_device_|). When false, libmpv can only reach ANGLE's own
+  // hidden device and therefore falls back from `d3d11va` to `d3d11va-copy`,
+  // reading every decoded frame back through system memory.
+  static bool uses_shared_d3d11_device() {
+    return shared_display_uses_our_device_;
+  }
+
  private:
   void SwapBuffers();
 
@@ -66,6 +75,20 @@ class ANGLESurfaceManager {
 
   bool CreateAndBindEGLSurface();
 
+  // Creates (once per process) the Direct3D 11 device every |ANGLESurfaceManager|
+  // draws into. See |ANGLESurfaceManager::shared_d3d_11_device_|.
+  static bool EnsureSharedD3D11Device();
+
+  // Creates (once per process) the |EGLDisplay|. Prefers an ANGLE display that
+  // runs on |shared_d3d_11_device_| so libmpv's `d3d11-egl` hardware decoding
+  // interop can adopt the very same device; falls back to letting ANGLE create
+  // its own hidden device.
+  static bool EnsureSharedEGLDisplay();
+
+  // Destroys the process wide device & display. Only called by the last living
+  // |ANGLESurfaceManager|.
+  static void ReleaseSharedResources();
+
   int32_t width_ = 1;
   int32_t height_ = 1;
   HANDLE internal_handle_ = nullptr;
@@ -73,7 +96,8 @@ class ANGLESurfaceManager {
 
   // Sync |Draw| & |Read| calls.
   HANDLE mutex_ = nullptr;
-  // D3D 11
+  // D3D 11. Non-owning aliases of |shared_d3d_11_device_| &
+  // |shared_d3d_11_device_context_|; never |Release|d per instance.
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;
   Microsoft::WRL::ComPtr<ID3D11Texture2D> internal_d3d_11_texture_2D_;
@@ -129,6 +153,26 @@ class ANGLESurfaceManager {
 
   // Number of active instances of ANGLESurfaceManager.
   static int32_t instance_count_;
+
+  // HIBIKI FORK: process wide Direct3D 11 device.
+  //
+  // Upstream created one |ID3D11Device| per |ANGLESurfaceManager| *and* let
+  // ANGLE create yet another, hidden one (|EGL_DEFAULT_DISPLAY|). libmpv's
+  // `d3d11-egl` hardware decoding interop resolves its decoding device through
+  // `EGL_DEVICE_EXT` -> `EGL_D3D11_DEVICE_ANGLE`, i.e. it can only ever see
+  // ANGLE's hidden device: one nobody created with
+  // |D3D11_CREATE_DEVICE_VIDEO_SUPPORT| and nobody marked thread safe. Sharing
+  // a single device that we create with the right flags and then handing it to
+  // ANGLE puts decoder, renderer & presentation on one device.
+  static ID3D11Device* shared_d3d_11_device_;
+  static ID3D11DeviceContext* shared_d3d_11_device_context_;
+  // ANGLE handle wrapping |shared_d3d_11_device_|; |EGL_NO_DEVICE_EXT| when the
+  // interop path was not taken.
+  static EGLDeviceEXT shared_egl_device_;
+  // The one |EGLDisplay| every instance renders on.
+  static EGLDisplay shared_display_;
+  // Whether ANGLE actually runs on |shared_d3d_11_device_|.
+  static bool shared_display_uses_our_device_;
 };
 
 #endif  // ANGLE_SURFACE_MANAGER_H_

--- a/third_party/media_kit_video/windows/video_output.cc
+++ b/third_party/media_kit_video/windows/video_output.cc
@@ -73,6 +73,16 @@ VideoOutput::VideoOutput(int64_t handle,
           is_hardware_acceleration_enabled = true;
           std::cout << "media_kit: VideoOutput: Using H/W rendering."
                     << std::endl;
+          // HIBIKI FORK: makes it observable whether libmpv can decode straight
+          // into the same Direct3D 11 device ANGLE renders with (`d3d11va`) or
+          // has to round-trip every frame through system memory
+          // (`d3d11va-copy`). See |ANGLESurfaceManager::EnsureSharedEGLDisplay|.
+          std::cout << "media_kit: VideoOutput: libmpv d3d11-egl zero-copy "
+                       "interop: "
+                    << (ANGLESurfaceManager::uses_shared_d3d11_device()
+                            ? "available"
+                            : "unavailable")
+                    << std::endl;
         }
       } catch (...) {
         // Do nothing.


### PR DESCRIPTION
## 问题

Windows 视频硬解实际走 `d3d11va-copy`——每帧解码结果从 GPU 读回系统内存再上传。mpv 日志里只有一句 `Loading hwdec driver 'd3d11-egl'`，后面**一行原因都没有**。

## 根因（两条，缺一条都到不了零拷贝）

### A. ANGLE 用自己的隐藏 D3D11 device

上游 `ANGLESurfaceManager` 里有**两个互不相干**的 D3D11 设备：每个 `ANGLESurfaceManager` 各建一个（`D3D11CreateDevice(..., flags = 0)`）只用来分配 Flutter 采样的共享 BGRA 纹理；ANGLE 因为 `EGLDisplay` 来自 `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, …)` **自己再偷偷建一个**（`Renderer11.cpp` 的 `callD3D11CreateDevice` 里 flags 写死 `debug ? D3D11_CREATE_DEVICE_DEBUG : 0`）。

而 mpv 的 `hwdec_d3d11egl::init()` 只能从当前 display 反查设备（`EGL_DEVICE_EXT` → `EGL_D3D11_DEVICE_ANGLE`）——**谁建的 display，谁的 device 就是解码设备**。ffmpeg 的 `d3d11va_device_init()` 随后对它 QI `ID3D11VideoDevice` / `ID3D11VideoContext`，这是 **D3D11 运行时级**的门：不带 `D3D11_CREATE_DEVICE_VIDEO_SUPPORT` 建的设备返回 `E_NOINTERFACE`（WARP 实测）。

> 订正一处：最初的提交说明称该 QI「必然失败」。**真机实测不成立**——RTX 5090 上对 ANGLE 那个不带 flag 的设备 QI `ID3D11VideoDevice` 返回 `hr=0x00000000`。所以根因 A 在这台机器上不是卡点，修它是为了在「flag 真的起作用」的适配器上也正确，并顺带去掉重复设备与跨设备共享纹理一跳。

### B. vendored libmpv 太旧（本机真正的卡点）

`init()` 在**看设备之前**先查 `EGL_EXT_device_query`。pin 的 `mpv-dev-x86_64-20260704-git-33111f3212` 早于上游 `1d15686142`（2026-07-31, *"hwdec_d3d11egl: fix EGL_EXT_device_query availability check"*），只在 EGL **display** 扩展串里找它，而 ANGLE 按规范放在 **client** 串里 → 静默 `return -1`。上游提交信息原话：*"The display string check always failed, silently disabling native d3d11va interop."*

实测（legacy 与 device-backed 两种 display、WARP 与 RTX 5090 都一样）：

```
EGL_EXT_device_query on display string : no    <- 旧 libmpv 只认这个
EGL_EXT_device_query on client  string : YES
```

## 改动

1. **`angle_surface_manager.{h,cc}`**（commit 1）：进程内**唯一**一个 `ID3D11Device`（`BGRA_SUPPORT | VIDEO_SUPPORT` + `ID3D10Multithread::SetMultithreadProtected(TRUE)`）取代逐实例设备，经 `eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, dev)` + `eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, …)` 交给 ANGLE（与 mpv 自己的 `--gpu-context=angle` 同款）。`CleanUp(true)` 不再逐实例 `Release` 设备，由最后一个实例走 `ReleaseSharedResources()`。
2. **vendored libmpv 升级**（commit 2）：`20260704-git-33111f3212` → `20260813-git-7b8915bc1d`（相对修复提交 ahead 5 / behind 0）。sha256 对 zhongfly `sha256.txt` 核过、镜像到 `vendor-libmpv`；CMake 更新 name/URL/MD5 并写明「不得早于 2026-07-31」的下限与原因。
3. **可观测性**：`VideoOutput` 在既有 `Using H/W rendering.` 旁多打一行 `libmpv d3d11-egl zero-copy interop: available/unavailable`。

**向后兼容**：设备 flag 被驱动拒绝时逐个降级；`eglCreateDeviceANGLE` / device-backed display 不可用时原样退回上游四级 fallback 链（D3D11 → D3D11 9_3 → D3D9 → wrap），行为与 pub.dev 一致。

## 证据

独立 C++ 探针原样复刻 media_kit 的 ANGLE 初始化 + 真 `mpv_render_context` + 真片源。

接线（WARP，`interop` 模式）：
```
ANGLE-owned ID3D11Device : 000002AA9B172850
our    ID3D11Device      : 000002AA9B172850  (SAME - shared with mpv)
QI ID3D10Multithread     : PASS protected=1
```

A/B（同一探针、同一 WARP、只换 libmpv DLL）：
```
旧: Loading hwdec driver 'd3d11-egl' -> Loading failed.                    (无原因)
新: Loading hwdec driver 'd3d11-egl'
    -> d3d11-egl: Failed to create hwdevice_ctx                            (已过 device_query 门)
    -> Loading failed.                                                     (WARP 无 video device)
```

真 NVIDIA 硬件那轮：`display ext EGL_EXT_device_query = no` / `client = YES`、`QI ID3D11VideoDevice hr=0x00000000 OK`。

## 验证

- 新 DLL 保 TrueHD/MLP/eac3/dts/h264/hevc/av1 + render API（`mpv v0.41.0-923-g7b8915bc1`，BUG-073 不变式）。
- 干净 `flutter build windows --debug` 成功：`√ Built build\windows\x64\runner\Debug\fushi.exe`，真实退出码 0；打包出的 `libmpv-2.dll` 即新版。
- `flutter analyze` 全量 `No issues found!`；`test/third_party` 64 条、`test/media/video` 2566 条全绿；`bug.dart check` 通过。
- 守卫 `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart` 共 8 条，全部做过变异实测（含「断言字面量只出现在注释里不算数」；libmpv 那条另做三次变异：日期回退 / `-lgpl` 变体 / 指向未提交归档）。

## 未闭环（合并前建议本地跑一次）

「真硬件上 `hwdec-current` 由 `d3d11va-copy` 变成 `d3d11va`」这一条**尚未取到**：本机任何新进程都建不出硬件 D3D11/D3D12 设备（三块 RTX 5090 适配器一律 `E_OUTOFMEMORY 0x8007000E`，WARP / Basic Render Driver / D3D9Ex 正常；显存 6.4G/32G、提交内存充足、驱动 2026-05-05 已开机 7 天，是 1014 进程 / 68 个 GPU 客户端把 WDDM 侧资源打满）。新 libmpv 自己也照出同一条件：`[vd] Failed to create D3D11 Device: 内存资源不足 (0x8007000e)`。

关掉几个占 GPU 的窗口后跑一次 Windows 构建，看启动日志里 `libmpv d3d11-egl zero-copy interop:` 那行，并确认播放中 `hwdec-current` 为 `d3d11va` 即闭环。

关联：BUG-1639（另一条分支，尚未并入 develop）修的是「Windows 上 `auto-safe` 会选到 CUDA/nvdec 导致 `nvcuda64` 空指针崩」；本 PR 修的是「`d3d11va` 为什么起不来、只能落 `d3d11va-copy`」。

https://claude.ai/code/session_01Sn5id8JzPN6NNfemwvRADg
