### PR TITLE
fix(video): 升级 vendored libmpv 越过 EGL_EXT_device_query 门，补齐 d3d11va 零拷贝（BUG-1644，接 #835）

### DIFF
--- a/docs/bugs/BUG-1644-d3d11va-zero-copy-interop.md
+++ b/docs/bugs/BUG-1644-d3d11va-zero-copy-interop.md
@@ -1,9 +1,14 @@
 ## BUG-1644 · Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了
 - **报告**：2026-08-14（用户：「d3d11va 的零拷贝 interop（现在连 d3d11-egl 都没加载起来，每帧白走一次 GPU→内存→GPU）。那是 media_kit 建 ANGLE context 时没把 D3D11 device 暴露给 mpv」）
 - **真实性**：✅ 真 bug。根因 `third_party/media_kit_video/windows/angle_surface_manager.cc:CreateEGLDisplay`（补前）——`EGLDisplay` 建自 `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, …)`，ANGLE 因此自建一个**隐藏的** `ID3D11Device`，与 `CreateD3DTexture` 里 media_kit 自己那个（`D3D11CreateDevice(..., flags = 0)`）互不相干。
-- **[x] ① 已修复** — 改成 mpv `context_angle.c` 的做法：进程内唯一一个 `ID3D11Device`（`BGRA_SUPPORT | VIDEO_SUPPORT` + `SetMultithreadProtected(TRUE)`），用 `eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, dev)` + `eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, …)` 交给 ANGLE；失败原样退回上游四级 fallback 链。详见 `third_party/media_kit_video/PATCHES.md` 的 BUG-1644 段。
-- **[x] ② 已加自动化测试** — `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`（7 条源码扫描守卫，含「fallback 链必须还在」与「共享 device 不得逐实例 Release」）；变异实测 6 条全部转红（含「断言字面量只出现在注释里不算数」一条，守卫内置 `stripComments`）。
-- **备注**：与 BUG-1639 是同一条链路的**上下游**，不是重复条目——1639 修的是「Windows 上 `auto-safe` 会选到 CUDA/nvdec 导致 `nvcuda64` 空指针崩」，落点是把 hwdec 值域收敛到 `d3d11va,d3d11va-copy`；本条修的是「收敛之后 `d3d11va` 为什么还是失败、只能落 `d3d11va-copy`」。
+- **根因有两条，缺一条都到不了零拷贝**：
+  - **根因 A（设备）**：ANGLE 自建隐藏 `ID3D11Device`，media_kit 无法把自己的设备交给 mpv。
+  - **根因 B（libmpv 版本）**：vendored 的 `mpv-dev-x86_64-20260704-git-33111f3212` 早于 mpv `1d15686142`（2026-07-31，`hwdec_d3d11egl: fix EGL_EXT_device_query availability check`）。旧版只在 EGL **display** 扩展串里找 `EGL_EXT_device_query`，而 ANGLE 按规范把它放在 **client** 串里 → `init()` 在**看设备之前**就静默 `return -1`。这条与设备无关，换成 device-backed display 也照样卡住（实测两种 display 都是 `display: no / client: YES`）。
+- **[x] ① 已修复** — 两条一起修：
+  - A：改成 mpv `context_angle.c` 的做法：进程内唯一一个 `ID3D11Device`（`BGRA_SUPPORT | VIDEO_SUPPORT` + `SetMultithreadProtected(TRUE)`），用 `eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE, dev)` + `eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, …)` 交给 ANGLE；失败原样退回上游四级 fallback 链。详见 `third_party/media_kit_video/PATCHES.md` 的 BUG-1644 段。
+  - B：vendored libmpv 升到 `mpv-dev-x86_64-20260813-git-7b8915bc1d`（相对修复提交 ahead 5 / behind 0），并在 `third_party/media_kit_libs_windows_video/windows/CMakeLists.txt` 写死「不得早于 2026-07-31」的下限说明。
+- **[x] ② 已加自动化测试** — `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`（8 条源码扫描守卫，含「fallback 链必须还在」「共享 device 不得逐实例 Release」「libmpv pin 不得早于 2026-07-31 且必须是已提交的非 `-lgpl`/`-v3` 构建」）；变异实测全部转红（含「断言字面量只出现在注释里不算数」一条，守卫内置 `stripComments`；libmpv 那条另做三次变异——日期回退 / 换 `-lgpl` 变体 / 指向未提交归档，各自命中不同断言）。
+- **备注**：与 BUG-1639（另一条分支，**尚未并入 develop**）是同一条链路的**上下游**，不是重复条目——1639 修的是「Windows 上 `auto-safe` 会选到 CUDA/nvdec 导致 `nvcuda64` 空指针崩」，落点是把 hwdec 值域收敛到 `d3d11va,d3d11va-copy`；本条修的是「收敛之后 `d3d11va` 为什么还是失败、只能落 `d3d11va-copy`」。
 
 ### 根因链（对着 mpv 源码逐段核过）
 
@@ -21,13 +26,19 @@ if (!p->hwctx.av_device_ref) { MP_VERBOSE(hw, "Failed to create hwdevice_ctx\n")
 
 也就是说：**谁建的 display，谁的 device 就是解码设备**。上游 media_kit 让 ANGLE 自建 device，于是：
 
-1. mpv 拿到的是 ANGLE 的隐藏 device，而它是 ANGLE 用自己的 flags 建的，**没有**
+1. mpv 拿到的是 ANGLE 的隐藏 device，而它是 ANGLE 用自己的 flags 建的（ANGLE `Renderer11.cpp`
+   `callD3D11CreateDevice` 里写死 `debug ? D3D11_CREATE_DEVICE_DEBUG : 0`），**没有**
    `D3D11_CREATE_DEVICE_VIDEO_SUPPORT`，也没人给它 `SetMultithreadProtected`；
 2. `d3d11_wrap_device_ref()` 走 FFmpeg 的 `d3d11va_device_init()`，那里对设备 QI `ID3D11VideoDevice`、
-   对 immediate context QI `ID3D11VideoContext`；没有 video flag 的设备可能两者之一失败
-   （本机实测：WARP 上 `QI ID3D11VideoDevice` = `E_NOINTERFACE 0x80004002`）；
-3. `init()` 于是 `return -1`，而且是**静默**的（`goto fail` 前的分支都不打日志），mpv 日志里只看得到
-   `Loading hwdec driver 'd3d11-egl'` 后面什么都没有；
+   对 immediate context QI `ID3D11VideoContext`。这个 QI 是 **D3D11 运行时级**的门而不是驱动的门：
+   不带 video flag 建的设备返回 `E_NOINTERFACE 0x80004002`（WARP 实测）。**但代价随适配器而异——本机
+   RTX 5090 上，对 ANGLE 那个不带 flag 的设备 QI `ID3D11VideoDevice` 反而 `hr=0x00000000` 成功**，
+   所以在这台机器上根因 A 并不是卡点，修它是为了在「flag 真的起作用」的适配器上也正确；
+3. **真正卡住本机的是更早一步**：`init()` 在看设备之前先查 `EGL_EXT_device_query`，而 pinned 的
+   libmpv（2026-07-04）只查 **display** 扩展串，ANGLE 把它放在 **client** 串 → 静默 `return -1`。
+   这就是 mpv 日志里 `Loading hwdec driver 'd3d11-egl'` 之后**一行原因都没有**的来源；upstream 在
+   `1d15686142`（2026-07-31）修掉，提交信息原话即 "The display string check always failed, silently
+   disabling native d3d11va interop."；
 4. `d3d11va`（零拷贝）因此不可用，`hwdec` 落到 `d3d11va-copy`——每帧解码结果从 GPU 读回系统内存再上传。
 
 ### 复现证据（本机，独立 C++ 探针 + 真 libmpv）
@@ -54,21 +65,56 @@ if (!p->hwctx.av_device_ref) { MP_VERBOSE(hw, "Failed to create hwdevice_ctx\n")
 （这一轮是 WARP，因为 WARP 拒绝 `VIDEO_SUPPORT` 标志，所以 QI 仍失败、`hwdec-current` 仍是
 `d3d11va-copy`——它验证的是**接线**，不是最终 hwdec 值。）
 
+真 NVIDIA 硬件那一轮（GPU 还能建设备时抓到的）证明根因 A 在本机不是卡点：
+
+```
+[env] GL_RENDERER = ANGLE (NVIDIA, NVIDIA GeForce RTX 5090 Direct3D11 vs_5_0 ps_5_0, D3D11-32.0.15.9649)
+[env] display ext EGL_EXT_device_query                          no      <- 卡在这里
+[env] client  ext EGL_EXT_device_query                          YES
+[env] ANGLE ID3D11Device = 0000025126012860 (ours = 000002516C676360) -> DIFFERENT device
+[env] QI ID3D11VideoDevice (ffmpeg d3d11va_device_init): hr=0x00000000 OK   <- N 卡上并不失败
+```
+
+### 根因 B 的 A/B 证据（同一探针、同一 WARP、只换 libmpv DLL）
+
+旧 pin `mpv-dev-x86_64-20260704-git-33111f3212`：
+
+```
+[   0.004][v][libmpv_render] Loading hwdec driver 'd3d11-egl'
+[   0.004][v][libmpv_render] Loading failed.                      <- 静默，无任何原因
+```
+
+新 pin `mpv-dev-x86_64-20260813-git-7b8915bc1d`：
+
+```
+[   0.005][v][libmpv_render] Loading hwdec driver 'd3d11-egl'
+[   0.005][v][libmpv_render/d3d11-egl] Failed to create hwdevice_ctx   <- 已越过 device_query 门
+[   0.005][v][libmpv_render] Loading failed.
+```
+
+新版已经推进到「用设备建 hwdevice_ctx」这一步；WARP 上仍失败是因为 Basic Render Driver 根本没有
+`ID3D11VideoDevice`（同轮实测 `D3D11CreateDevice(WARP, VIDEO_SUPPORT)` = `DXGI_ERROR_UNSUPPORTED
+0x887A0004`），而真 N 卡上该 QI 已实测成功。
+
 BUG-1639 用另一条独立路径（ctypes 直驱安装目录的 libmpv、GL 上下文）得到一致结论：
 `d3d11va,d3d11va-copy` → 「`d3d11va` 失败 → `Using hardware decoding (d3d11va-copy)`」。
 
 ### 未闭环项（真机门）
 
-「NVIDIA 真硬件 + ANGLE D3D11 display 下 `hwdec-current` 从 `d3d11va-copy` 变成 `d3d11va`」这一条
-**尚未取到**：本机当前 `D3D11CreateDevice(D3D_DRIVER_TYPE_HARDWARE)` 对三块 5090 适配器一律返回
-`E_OUTOFMEMORY 0x8007000E`（`nvidia-smi` 显示 67 个 GPU 客户端进程、显存却还剩 25GB，属驱动并发 D3D
-上下文打满），ANGLE 的 D3D11 display 随之 `EGL_NOT_INITIALIZED` 退到 D3D9。探针与一键复跑脚本见
-`docs/agent/` 未收录的临时目录，命令：
+「NVIDIA 真硬件 + 新 libmpv + device-backed display 下 `hwdec-current` 从 `d3d11va-copy` 变成
+`d3d11va`」这一条**尚未取到**：本机 `D3D11CreateDevice(D3D_DRIVER_TYPE_HARDWARE)` 对三块 5090 适配器
+一律返回 `E_OUTOFMEMORY 0x8007000E`（`D3D12CreateDevice` 同样失败，WARP / Basic Render Driver /
+D3D9Ex 正常；显存 6.4G/32G、提交内存充足、驱动 2026-05-05 已开机 7 天，是 1014 个进程 / 68 个 GPU
+客户端把 WDDM 侧资源打满），ANGLE 的 D3D11 display 随之 `EGL_NOT_INITIALIZED` 退到 D3D9。新 libmpv
+自己也照出了同一条件：`[vd] Failed to create D3D11 Device: 内存资源不足 (0x8007000e)`。
+
+GPU 恢复后跑这两条即可闭环（探针在临时目录，未入库）：
 
 ```
-angle_probe.exe legacy  hw novideo es2 <video> auto-safe   # 期望 hwdec-current=d3d11va-copy
-angle_probe.exe interop hw video   es2 <video> auto-safe   # 期望 hwdec-current=d3d11va
+angle_probe.exe legacy  es2 auto-safe <video>   # 期望 hwdec-current=d3d11va-copy
+angle_probe.exe interop es2 auto-safe <video>   # 期望 hwdec-current=d3d11va
 ```
 
-GPU 空闲时跑这两条即可闭环；`VideoOutput` 现在也会在启动日志里直接打
-`libmpv d3d11-egl zero-copy interop: available/unavailable`。
+也可以直接看 app：`VideoOutput` 现在在启动日志里打
+`libmpv d3d11-egl zero-copy interop: available/unavailable`，播放中 `hwdec-current` 应为 `d3d11va`
+而非 `d3d11va-copy`。

--- a/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
+++ b/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
@@ -13,8 +13,10 @@ import 'package:flutter_test/flutter_test.dart';
 /// through the display (`EGL_DEVICE_EXT` → `EGL_D3D11_DEVICE_ANGLE`), i.e.
 /// ANGLE's hidden one, which was never created with
 /// `D3D11_CREATE_DEVICE_VIDEO_SUPPORT`. FFmpeg's `d3d11va_device_init` then
-/// fails its `ID3D11VideoDevice` / `ID3D11VideoContext` QueryInterface, the
-/// interop bails silently, and `hwdec=d3d11va` degrades to `d3d11va-copy`:
+/// QueryInterfaces it for `ID3D11VideoDevice` / `ID3D11VideoContext`, which the
+/// D3D11 runtime refuses on a device built without that flag (`E_NOINTERFACE`,
+/// measured on WARP; a GeForce RTX 5090 happened to allow it). Where it is
+/// refused the interop bails and `hwdec=d3d11va` degrades to `d3d11va-copy`:
 /// every decoded frame round-trips GPU → system memory → GPU.
 ///
 /// Fix (mirrors mpv's own `context_angle.c`): create one process-wide device
@@ -23,6 +25,13 @@ import 'package:flutter_test/flutter_test.dart';
 /// EGL_PLATFORM_DEVICE_EXT, …)`. This test guards the *patch* — a future
 /// re-vendor of media_kit_video that drops it silently reintroduces the
 /// per-frame readback. See `third_party/media_kit_video/PATCHES.md`.
+///
+/// The patch has a second half that lives outside this package: libmpv itself
+/// must be new enough to accept ANGLE at all (mpv `1d15686142`, 2026-07-31 —
+/// older builds look for `EGL_EXT_device_query` in the EGL display extension
+/// string while ANGLE publishes it in the client string, so the interop is
+/// silently off no matter which device the display carries). The last test
+/// below guards that pin.
 void main() {
   // Tests run with CWD = `fushi/`; vendored packages live at the workspace root.
   const String managerSourcePath =
@@ -167,7 +176,8 @@ void main() {
     });
 
     test('the process-wide device is not released per instance', () {
-      final int cleanUp = managerCode.indexOf('void ANGLESurfaceManager::CleanUp');
+      final int cleanUp =
+          managerCode.indexOf('void ANGLESurfaceManager::CleanUp');
       expect(cleanUp, isNonNegative,
           reason: 'expected a CleanUp definition in angle_surface_manager.cc');
       final int nextFunction =
@@ -187,6 +197,62 @@ void main() {
         isTrue,
         reason: 'the last instance must tear the shared display & device down '
             'through ReleaseSharedResources().',
+      );
+    });
+
+    test('the vendored libmpv is new enough to accept ANGLE', () {
+      const String cmakePath =
+          '../third_party/media_kit_libs_windows_video/windows/CMakeLists.txt';
+      const String vendoredDir =
+          '../third_party/media_kit_libs_windows_video/vendored';
+
+      // CMake comments are `#` to end of line; a commented-out pin must not
+      // satisfy this guard.
+      final String cmake = File(cmakePath).readAsLinesSync().map((String line) {
+        final int hash = line.indexOf('#');
+        return hash < 0 ? line : line.substring(0, hash);
+      }).join('\n');
+
+      final RegExpMatch? pin =
+          RegExp(r'set\(LIBMPV\s+"([^"]+)"\)').firstMatch(cmake);
+      expect(pin, isNotNull,
+          reason: 'expected a set(LIBMPV "...") pin in $cmakePath');
+      final String archive = pin!.group(1)!;
+
+      expect(
+        File('$vendoredDir/$archive').existsSync(),
+        isTrue,
+        reason: 'the pinned libmpv archive $archive must be committed under '
+            '$vendoredDir (TODO-1172: nothing is downloaded at build time).',
+      );
+
+      final RegExpMatch? stamp =
+          RegExp(r'^mpv-dev-x86_64-(\d{8})-git-').firstMatch(archive);
+      expect(
+        stamp,
+        isNotNull,
+        reason: 'the pin must be a plain `mpv-dev-x86_64-<date>-git-<sha>.7z` '
+            'build: `-lgpl` drops TrueHD (re-opens BUG-073) and `-v3` needs '
+            'Haswell+ (crashes on older CPUs). Got: $archive',
+      );
+
+      // mpv 1d15686142 (2026-07-31) "hwdec_d3d11egl: fix EGL_EXT_device_query
+      // availability check". Before it, libmpv looked for EGL_EXT_device_query
+      // in the EGL *display* extension string while ANGLE publishes it in the
+      // *client* string, so hwdec_d3d11egl::init() returned -1 before ever
+      // reading the D3D11 device -- native d3d11va interop silently off and
+      // every frame round-tripping GPU -> system memory -> GPU. Handing ANGLE
+      // our own device (the rest of BUG-1644) cannot help while this gate
+      // fails, so the pin must not regress behind the fix.
+      const int minimumBuildDate = 20260731;
+      final int buildDate = int.parse(stamp!.group(1)!);
+      expect(
+        buildDate,
+        greaterThanOrEqualTo(minimumBuildDate),
+        reason: 'libmpv pin $archive predates mpv 1d15686142 '
+            '($minimumBuildDate), which fixes the EGL_EXT_device_query check '
+            'that gates d3d11-egl on ANGLE. Bumping backwards past it silently '
+            'restores d3d11va-copy (BUG-1644).',
       );
     });
 

--- a/third_party/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/third_party/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -101,16 +101,29 @@ get_filename_component(
 # (GPL full FFmpeg with TrueHD): NOT `-lgpl` (drops TrueHD -> re-opens BUG-073),
 # NOT `-v3` (needs Haswell+, crashes on older CPUs); `gh release upload
 # vendor-libmpv <file> --repo hajisensai/hibiki`; then update the name/URL/MD5
-# below. sha256 of this pin (verified against zhongfly sha256.txt AND re-verified
-# from the mirror before the swap):
-# 2651a618ba6906ac869a87f669c4db157ef3b9d566eb946362fadafcd2e253c1
-set(LIBMPV "mpv-dev-x86_64-20260704-git-33111f3212.7z")
+# below. sha256 of this pin (verified against zhongfly sha256.txt before the
+# swap):
+# e105420c358b71233a0a8530d570ca9993132f92e2d3cb23c4cd1c084c9c6120
+#
+# MINIMUM VERSION (BUG-1644): this pin must stay at or after mpv upstream
+# 1d15686142fd5d53c954aab7526cedab05ef9dc3 (2026-07-31, "hwdec_d3d11egl: fix
+# EGL_EXT_device_query availability check"), i.e. a zhongfly build dated
+# 2026-07-31 or later. Older libmpv checks `EGL_EXT_device_query` against the
+# EGL *display* extension string only, while ANGLE (since ANGLE 56663dbfa780)
+# lists it in the *client* string - so `hwdec_d3d11egl::init()` returns -1
+# before it ever looks at the D3D11 device, silently disabling native d3d11va
+# interop and forcing `d3d11va-copy` (every decoded frame read back to system
+# memory and re-uploaded). Measured on the previous 20260704 pin: mpv logged
+# `Loading hwdec driver 'd3d11-egl'` -> `Loading failed.` with no reason; on
+# this pin the same probe reaches `d3d11-egl: Failed to create hwdevice_ctx`,
+# i.e. past that gate. Do NOT bump backwards past 2026-07-31.
+set(LIBMPV "mpv-dev-x86_64-20260813-git-7b8915bc1d.7z")
 
 # Provenance of the vendored libmpv archive (TODO-1172: no longer downloaded
 # at build time). URL is the permanent mirror (hajisensai/hibiki release),
 # kept so the origin stays auditable; the committed .7z is the source of truth.
 set(LIBMPV_URL "https://github.com/hajisensai/hibiki/releases/download/vendor-libmpv/${LIBMPV}")
-set(LIBMPV_MD5 "89702937368b0181cbce41c30e811c76")
+set(LIBMPV_MD5 "be118f0492bc99d17467e9419a0f948f")
 
 # Vendored archive (committed) + build-dir extraction target (TODO-1172).
 set(LIBMPV_ARCHIVE "${VENDORED_DIR}/${LIBMPV}")

--- a/third_party/media_kit_video/PATCHES.md
+++ b/third_party/media_kit_video/PATCHES.md
@@ -464,15 +464,32 @@ it must decode into: it reads it back out of the *current* display with
 `eglQueryDisplayAttribEXT(EGL_DEVICE_EXT)` →
 `eglQueryDeviceAttribEXT(EGL_D3D11_DEVICE_ANGLE)`. So it can only ever see
 ANGLE's hidden device — a device nobody created with
-`D3D11_CREATE_DEVICE_VIDEO_SUPPORT` and nobody marked thread safe. It then hands
-that device to FFmpeg (`d3d11_wrap_device_ref` → `d3d11va_device_init`), which
-`QueryInterface`s for `ID3D11VideoDevice` **and** `ID3D11VideoContext`; a device
-created without the video flag can fail either QI (measured: `E_NOINTERFACE` for
-`ID3D11VideoDevice` on WARP). `init()` then returns `-1` *silently*, mpv logs
-only `Loading hwdec driver 'd3d11-egl'` with no follow-up, and `--hwdec=d3d11va`
+`D3D11_CREATE_DEVICE_VIDEO_SUPPORT` and nobody marked thread safe (ANGLE hard
+codes `debug ? D3D11_CREATE_DEVICE_DEBUG : 0`, see ANGLE `Renderer11.cpp`
+`callD3D11CreateDevice`). It then hands that device to FFmpeg
+(`d3d11_wrap_device_ref` → `d3d11va_device_init`), which `QueryInterface`s for
+`ID3D11VideoDevice` **and** `ID3D11VideoContext`. That QI is gated by the flag
+at the D3D11 *runtime* level, not by the driver: a device created without
+`D3D11_CREATE_DEVICE_VIDEO_SUPPORT` returns `E_NOINTERFACE 0x80004002`
+(measured on WARP). How much that costs depends on the adapter — measured on a
+GeForce RTX 5090 the QI on ANGLE's flag-less device still succeeded — so this
+half of the patch is about being correct everywhere rather than about one
+machine. When the QI does fail, `init()` returns `-1` and `--hwdec=d3d11va`
 degrades to `d3d11va-copy`: every decoded frame is read back to system memory
 and re-uploaded to the GPU. Independently observed in `docs/bugs/BUG-1639`
+(a separate branch, not merged into `develop` yet)
 ("`d3d11va` 失败 → `Using hardware decoding (d3d11va-copy)`").
+
+**This patch alone is not sufficient.** `hwdec_d3d11egl::init()` checks
+`EGL_EXT_device_query` *before* it ever looks at the device, and libmpv older
+than mpv `1d15686142` (2026-07-31) looks for it in the EGL **display**
+extension string while ANGLE publishes it in the **client** string — so `init()`
+returns `-1` with no log line at all, whichever device the display carries
+(measured: `display: no` / `client: YES` on both the upstream
+`EGL_DEFAULT_DISPLAY` and this patch's `EGL_PLATFORM_DEVICE_EXT` display).
+`third_party/media_kit_libs_windows_video/windows/CMakeLists.txt` therefore
+pins libmpv at or after that fix and documents the floor; the guard test below
+enforces it.
 
 The patch does what mpv's own `--gpu-context=angle` does
 (`mpv/video/out/opengl/context_angle.c`, `d3d11_device_create`):


### PR DESCRIPTION
**接 #835（已合并）的后半。** #835 让 ANGLE 跑在 media_kit 自己的 D3D11 device 上，但那**不足以**恢复零拷贝——本 PR 补上真正卡住本机的那一环，并订正 #835 里一处被真机实测推翻的说法。

## 为什么 #835 还不够

mpv 的 `hwdec_d3d11egl::init()` 在**看设备之前**先查 `EGL_EXT_device_query`。vendored 的 `mpv-dev-x86_64-20260704-git-33111f3212` 早于上游修复 `1d15686142`（2026-07-31, *"hwdec_d3d11egl: fix EGL_EXT_device_query availability check"*），只在 EGL **display** 扩展串里找它；而 ANGLE 按规范把它放在 **client** 串里 → `init()` 静默 `return -1`，interop 永远加载不起来，`hwdec` 落到 `d3d11va-copy`（每帧 GPU→内存→GPU）。上游提交信息原话：*"The display string check always failed, silently disabling native d3d11va interop."*

实测：legacy 与 #835 的 device-backed 两种 display、WARP 与 RTX 5090 两种适配器，结果都一样——

```
EGL_EXT_device_query on display string : no    <- 旧 libmpv 只认这个
EGL_EXT_device_query on client  string : YES
```

所以换 display 类型绕不开它，只能升 libmpv。

## A/B 证据（同一探针、同一 WARP、只换 libmpv DLL）

```
旧 pin: Loading hwdec driver 'd3d11-egl' -> Loading failed.                 (无任何原因)
新 pin: Loading hwdec driver 'd3d11-egl'
        -> d3d11-egl: Failed to create hwdevice_ctx                         (已越过 device_query 门)
        -> Loading failed.                                                  (WARP 无 video device，预期内)
```

新版已推进到「用设备建 hwdevice_ctx」这一步；WARP 上仍失败是因为 Basic Render Driver 根本没有 `ID3D11VideoDevice`（同轮实测 `D3D11CreateDevice(WARP, VIDEO_SUPPORT)` = `DXGI_ERROR_UNSUPPORTED`），而真 N 卡上该 QI 已实测成功。

## 改动

1. **vendored libmpv 升级**：`20260704-git-33111f3212` → `20260813-git-7b8915bc1d`（相对修复提交 ahead 5 / behind 0）。sha256 对 zhongfly `sha256.txt` 核过、已镜像到 `hajisensai/hibiki` 的 `vendor-libmpv` release；CMake 更新 name/URL/MD5，并写明「不得早于 2026-07-31」的下限与原因。
2. **守卫加第 8 条**：pin 必须已提交、必须是非 `-lgpl`/`-v3` 的 `mpv-dev-x86_64` 构建、日期不得早于 `20260731`。
3. **订正文档**：#835 的说明称 ffmpeg 的 `QI ID3D11VideoDevice` 必然失败。**真机实测不成立**——RTX 5090 上对 ANGLE 那个不带 flag 的设备该 QI 返回 `hr=0x00000000`；`E_NOINTERFACE` 只在 WARP 复现。改写为：`D3D11_CREATE_DEVICE_VIDEO_SUPPORT` 是 **D3D11 运行时级**的门、代价随适配器而异，所以 #835 那半是为「flag 真的起作用」的适配器而修（并顺带去掉重复设备与跨设备共享纹理一跳），不是本机的卡点。BUG-1644、`PATCHES.md`、CMake 注释三处同步。

## 验证

- 新 DLL 保 TrueHD/MLP/eac3/dts/h264/hevc/av1 + render API（`mpv v0.41.0-923-g7b8915bc1`，BUG-073 不变式）。
- 干净 `flutter build windows --debug` 成功：`√ Built build\windows\x64\runner\Debug\fushi.exe`，真实退出码 0（非管道退出码）；打包出的 `libmpv-2.dll` 即新版（118,971,392 字节）。
- `flutter analyze` 全量 `No issues found!`；`test/third_party` 64 条、`test/media/video` 2566 条全绿；`bug.dart check` 通过。
- 新守卫做了三次变异实测：日期回退 / 换 `-lgpl` 变体 / 指向未提交归档，各自命中不同断言，还原后重新全绿。

## 未闭环（合并前建议本地跑一次）

「真硬件上 `hwdec-current` 由 `d3d11va-copy` 变成 `d3d11va`」这一条**尚未取到**：本机任何新进程都建不出硬件 D3D11/D3D12 设备（三块 RTX 5090 适配器一律 `E_OUTOFMEMORY 0x8007000E`，WARP / Basic Render Driver / D3D9Ex 正常；显存 6.4G/32G、提交内存充足、驱动 2026-05-05 已开机 7 天，是 1014 进程 / 68 个 GPU 客户端把 WDDM 侧资源打满）。新 libmpv 自己也照出同一条件：`[vd] Failed to create D3D11 Device: 内存资源不足 (0x8007000e)`。

关掉几个占 GPU 的窗口后跑一次 Windows 构建，看启动日志里 `libmpv d3d11-egl zero-copy interop:` 那行（#835 加的），并确认播放中 `hwdec-current` 为 `d3d11va` 即闭环。

https://claude.ai/code/session_01Sn5id8JzPN6NNfemwvRADg
