### PR TITLE
fix(video): 视频顶栏按钮优先于名称分宽，标题不再霸占 1/3

### DIFF
--- a/fushi/lib/src/media/video/video_top_bar_slots.dart
+++ b/fushi/lib/src/media/video/video_top_bar_slots.dart
@@ -1,0 +1,98 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+/// 视频内顶栏的三槽标识（左按钮组 / 标题 / 右按钮组），见 [VideoTopBarSlots]。
+enum VideoTopBarSlotId { left, title, right }
+
+/// 视频内顶栏三槽布局：**按钮按需拿宽、标题吃剩余**。
+///
+/// 根因（2026-08 修复）：顶栏原来直接是 media_kit fork 的一条 `Row`，左按钮组 / 标题 /
+/// 右按钮组各自挂一个 `Flexible(flex: 1)`。`Flex` 把可用宽按 flex 因子**平分**成三份，
+/// 而 `FlexFit.loose` 的子项用不完的份额**不会回流**给别人 —— 于是右上角按钮组无论窗口
+/// 多宽都只拿得到 1/3 顶栏宽，多出来的按钮被裁进组内横滚区（用户看到的「视频名称把
+/// 按钮挡住、要横滑才点得到」）。标题项被关掉时旧代码还返回 `Spacer()`（= `FlexFit.tight`），
+/// 空白中段照样霸占那 1/3，所以「把名称删掉、中间明明是空的」也救不回按钮。
+///
+/// 这里换成显式优先级：先满足左槽（返回键等，必达），再满足右槽（功能键），最后把
+/// **真正剩下的**宽度交给标题。按钮永远完整可见；标题窄了靠 `maxLines: 1` + ellipsis
+/// 优雅截断——即「按钮比名称重要」。两侧按钮组自身仍是可横滚的（页面侧用 `shrinkWrap`
+/// ListView 包裹），极窄窗按钮总宽超过整条顶栏时依旧可达、不会被裁没。
+///
+/// 三槽都必须传：不显示的槽传零尺寸占位（如 `SizedBox.shrink()`），它就不占宽。
+class VideoTopBarSlots extends StatelessWidget {
+  const VideoTopBarSlots({
+    required this.left,
+    required this.title,
+    required this.right,
+    super.key,
+  });
+
+  /// 左按钮组（返回键等）：第一优先，按内容固有宽足额分配。
+  final Widget left;
+
+  /// 标题：最后布局，只吃两侧按钮组用剩的宽。
+  final Widget title;
+
+  /// 右按钮组（功能键）：第二优先，在左槽之后按内容固有宽足额分配。
+  final Widget right;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomMultiChildLayout(
+      delegate: VideoTopBarSlotsDelegate(),
+      children: <Widget>[
+        LayoutId(id: VideoTopBarSlotId.left, child: left),
+        LayoutId(id: VideoTopBarSlotId.right, child: right),
+        LayoutId(id: VideoTopBarSlotId.title, child: title),
+      ],
+    );
+  }
+}
+
+/// [VideoTopBarSlots] 的排布委托：**布局顺序即优先级**（左按钮 → 右按钮 → 标题吃剩余）。
+class VideoTopBarSlotsDelegate extends MultiChildLayoutDelegate {
+  @override
+  void performLayout(Size size) {
+    final double height = size.height;
+    double consumed = 0;
+    double leftWidth = 0;
+    if (hasChild(VideoTopBarSlotId.left)) {
+      final Size s = layoutChild(
+        VideoTopBarSlotId.left,
+        BoxConstraints.loose(Size(size.width, height)),
+      );
+      leftWidth = s.width;
+      consumed += s.width;
+      positionChild(VideoTopBarSlotId.left, Offset(0, (height - s.height) / 2));
+    }
+    if (hasChild(VideoTopBarSlotId.right)) {
+      final Size s = layoutChild(
+        VideoTopBarSlotId.right,
+        BoxConstraints.loose(
+          Size(math.max(0.0, size.width - consumed), height),
+        ),
+      );
+      consumed += s.width;
+      positionChild(
+        VideoTopBarSlotId.right,
+        Offset(size.width - s.width, (height - s.height) / 2),
+      );
+    }
+    if (hasChild(VideoTopBarSlotId.title)) {
+      final Size s = layoutChild(
+        VideoTopBarSlotId.title,
+        BoxConstraints.loose(
+          Size(math.max(0.0, size.width - consumed), height),
+        ),
+      );
+      positionChild(
+        VideoTopBarSlotId.title,
+        Offset(leftWidth, (height - s.height) / 2),
+      );
+    }
+  }
+
+  @override
+  bool shouldRelayout(VideoTopBarSlotsDelegate oldDelegate) => false;
+}

--- a/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
@@ -99,18 +99,26 @@ extension _VideoControlsTheme on _VideoFushiPageState {
       // 视频内顶栏（替代被删的 Scaffold AppBar，BUG-102）：左右按钮和标题均从用户布局
       // slot 渲染；标题仍监听 _titleNotifier。
       topButtonBar: <Widget>[
-        _topBarSlotGroup(
-          VideoControlSlot.topLeft,
-          controller,
-          layout: layout,
-          desktop: true,
-        ),
-        _topBarTitle(),
-        _topBarSlotGroup(
-          VideoControlSlot.topRight,
-          controller,
-          layout: layout,
-          desktop: true,
+        // 整条顶栏交给 [VideoTopBarSlots] 统一分宽（按钮按需优先、标题吃剩余），与底栏
+        // 用单个 [Expanded] 承接 [_centeredBottomControlBar] 同一套路。不能再把三段
+        // 直接摊成 fork 那条 Row 的 flex child——那会被 Flex 平分成 1/3，右上角按钮
+        // 永远拿不到自己需要的宽。
+        Expanded(
+          child: VideoTopBarSlots(
+            left: _topBarSlotGroup(
+              VideoControlSlot.topLeft,
+              controller,
+              layout: layout,
+              desktop: true,
+            ),
+            title: _topBarTitle(),
+            right: _topBarSlotGroup(
+              VideoControlSlot.topRight,
+              controller,
+              layout: layout,
+              desktop: true,
+            ),
+          ),
         ),
       ],
       bottomButtonBar: <Widget>[
@@ -266,18 +274,24 @@ extension _VideoControlsTheme on _VideoFushiPageState {
       // 视频内顶栏（替代被删的 Scaffold AppBar，BUG-102）：左右按钮和标题均从用户布局
       // slot 渲染；标题仍监听 _titleNotifier。
       topButtonBar: <Widget>[
-        _topBarSlotGroup(
-          VideoControlSlot.topLeft,
-          controller,
-          layout: layout,
-          desktop: false,
-        ),
-        _topBarTitle(),
-        _topBarSlotGroup(
-          VideoControlSlot.topRight,
-          controller,
-          layout: layout,
-          desktop: false,
+        // 与桌面同源：整条顶栏交给 [VideoTopBarSlots] 分宽（按钮按需优先、标题吃剩余），
+        // 不再让三段各占 fork 顶栏 Row 的 1/3 flex 份额。
+        Expanded(
+          child: VideoTopBarSlots(
+            left: _topBarSlotGroup(
+              VideoControlSlot.topLeft,
+              controller,
+              layout: layout,
+              desktop: false,
+            ),
+            title: _topBarTitle(),
+            right: _topBarSlotGroup(
+              VideoControlSlot.topRight,
+              controller,
+              layout: layout,
+              desktop: false,
+            ),
+          ),
         ),
       ],
       bottomButtonBar: <Widget>[

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -40,6 +40,7 @@ import 'package:fushi/src/media/video/stream_video_launch.dart';
 import 'package:fushi/src/media/video/subtitle_embedded_fonts.dart';
 import 'package:fushi/src/media/video/video_episode_start_policy.dart';
 import 'package:fushi/src/media/video/video_import_dialog.dart';
+import 'package:fushi/src/media/video/video_top_bar_slots.dart';
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
 import 'package:fushi/src/media/video/url_stream_video.dart';
 import 'package:fushi/src/media/video/youtube_source_resolver.dart'
@@ -5000,20 +5001,22 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     if (!_controlLayout.itemsIn(VideoControlSlot.topCenter).contains(
           VideoControlItem.title,
         )) {
-      return const Spacer();
+      // 标题项没配置：交回零宽占位，整条顶栏宽都归两侧按钮组。绝不能返回 Spacer
+      // （= Expanded/FlexFit.tight）——那会让「空的中段」硬占一份顶栏宽，用户把标题
+      // 关掉后中间明明是空白、右上角按钮却照旧被挤进滚动区裁掉（本轮修复的现象）。
+      return const SizedBox.shrink();
     }
-    return Flexible(
-      // TODO-642：标题用 Flexible(loose) 而非 Expanded(=FlexFit.tight)。tight 会强迫
-      // 标题填满它分到的那 1/3 顶栏宽，把左右按钮组（同为 Flexible loose）挤进窄滚动
-      // 区，导致右上角按钮被裁/要横滑才看得到。loose 让标题只占自身需要的宽、把剩余
-      // 空间优先让给按钮组；标题已有 maxLines:1 + ellipsis，窄窗时优雅截断不溢出。
-      fit: FlexFit.loose,
-      // 标题走 ValueListenableBuilder（BUG-120）：全屏路由不随页面 setState 重建，
-      // 监听 _titleNotifier 才能在全屏换集后刷新标题。Align 固定标题起点：
-      // topRight 清空时不靠右侧空白占位撑布局，已有按钮未清空时仍保持原有 Row 顺序。
-      child: _topBarTitleText(
-        alignment: AlignmentDirectional.centerStart,
-      ),
+    // TODO-642 → 本轮：标题不再参与 Row 的 flex 分配（旧实现是 Flexible(loose)，与
+    // 左右按钮组各占 flex:1 → Flex 把整宽**平分**成三份，loose 用不完的空间又不回流，
+    // 所以右侧按钮组无论如何最多只拿 1/3 顶栏宽、多出来的按钮被裁进横滚区）。改由
+    // [_TopBarSlots] 按「按钮按需优先、标题吃剩余」的固定优先级分宽：按钮永远完整可见，
+    // 标题只在剩余宽里显示、靠 maxLines:1 + ellipsis 优雅截断。
+    //
+    // 标题走 ValueListenableBuilder（BUG-120）：全屏路由不随页面 setState 重建，
+    // 监听 _titleNotifier 才能在全屏换集后刷新标题。Align 固定标题起点：
+    // topRight 清空时不靠右侧空白占位撑布局，已有按钮未清空时仍保持原有顺序。
+    return _topBarTitleText(
+      alignment: AlignmentDirectional.centerStart,
     );
   }
 
@@ -5314,17 +5317,23 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       );
     }
 
-    return Flexible(
-      fit: FlexFit.loose,
-      child: Align(
-        alignment: slot == VideoControlSlot.topRight
-            ? Alignment.centerRight
-            : Alignment.centerLeft,
-        child: HorizontalDragScrollable(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            reverse: slot == VideoControlSlot.topRight,
-            child: Row(
+    // 按钮组按**内容固有宽**收缩（`widthFactor: 1` + `shrinkWrap: true`），不再撑满
+    // 分到的那份宽：这样 [_TopBarSlots] 才能先把两侧按钮要的宽度足额给出去、把真正
+    // 剩下的宽度交给标题。用 ListView 而不是 SingleChildScrollView，正是因为后者的
+    // viewport 在主轴上恒撑满约束（拿不到内容宽），窄窗仍靠横滚兜底按钮可达性。
+    return Align(
+      alignment: slot == VideoControlSlot.topRight
+          ? Alignment.centerRight
+          : Alignment.centerLeft,
+      widthFactor: 1,
+      child: HorizontalDragScrollable(
+        child: ListView(
+          scrollDirection: Axis.horizontal,
+          shrinkWrap: true,
+          padding: EdgeInsets.zero,
+          reverse: slot == VideoControlSlot.topRight,
+          children: <Widget>[
+            Row(
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: slot == VideoControlSlot.topRight
                   ? MainAxisAlignment.end
@@ -5337,7 +5346,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
                     buttonFor(item),
               ],
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/fushi/test/pages/video_mobile_controls_guard_test.dart
+++ b/fushi/test/pages/video_mobile_controls_guard_test.dart
@@ -52,9 +52,21 @@ void main() {
     );
     expect(group.contains('Alignment.centerRight'), isTrue,
         reason: 'topRight must stay aligned as one group at the right edge');
-    expect(group.contains('SingleChildScrollView('), isTrue,
+    // 组内仍必须能横滚（窄窗按钮不被裁没），但**不能**再用 SingleChildScrollView：
+    // 它的 viewport 在主轴上恒撑满约束，顶栏拿不到按钮组的内容固有宽，也就没法把
+    // 「按钮用剩的」宽度交给标题（见 VideoTopBarSlots）。改用 shrinkWrap 横向 ListView：
+    // 内容少时按内容宽收缩、内容多时照旧滚动。
+    expect(group.contains('scrollDirection: Axis.horizontal'), isTrue,
         reason:
             'topRight group must scroll horizontally instead of overflowing');
+    expect(group.contains('shrinkWrap: true'), isTrue,
+        reason:
+            'topRight group must shrink-wrap to its content width so the top bar '
+            'can hand the leftover width to the title');
+    expect(group.contains('SingleChildScrollView('), isFalse,
+        reason:
+            'SingleChildScrollView always fills the main axis — it would hide the '
+            'group content width and re-break the button/title width priority');
     expect(group.contains('reverse: slot == VideoControlSlot.topRight'), isTrue,
         reason: 'topRight scroll origin should keep the end buttons reachable');
     expect(group.contains('MainAxisAlignment.end'), isTrue,

--- a/fushi/test/pages/video_top_bar_slots_test.dart
+++ b/fushi/test/pages/video_top_bar_slots_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_top_bar_slots.dart';
+
+/// 视频内顶栏三槽布局（[VideoTopBarSlots]）的行为守卫。
+///
+/// 原缺陷：顶栏是 media_kit fork 的一条 `Row`，左按钮组 / 标题 / 右按钮组各挂
+/// `Flexible(flex: 1)` → `Flex` 把宽**平分**三份、`loose` 用不完的份额又不回流，
+/// 右上角按钮组最多只拿到 1/3 顶栏宽，多出来的按钮被裁进横滚区；标题项关掉时旧代码
+/// 返回 `Spacer()`，空白中段照旧霸占 1/3（「名称删空了、中间是空的，按钮还是被挡」）。
+///
+/// 现在按优先级分宽：左按钮 → 右按钮 → 标题吃剩余。下面每条都用**真实布局尺寸**断言，
+/// 不是源码扫描。
+void main() {
+  const Key leftKey = Key('slot-left');
+  const Key titleKey = Key('slot-title');
+  const Key rightKey = Key('slot-right');
+
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    required double barWidth,
+    required double leftWidth,
+    required double rightWidth,
+    Widget? title,
+    double height = 48,
+  }) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: barWidth,
+            height: height,
+            child: VideoTopBarSlots(
+              left: SizedBox(key: leftKey, width: leftWidth, height: height),
+              title: title ??
+                  SizedBox(key: titleKey, width: barWidth, height: height),
+              right: SizedBox(key: rightKey, width: rightWidth, height: height),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('顶栏三槽：按钮按需拿宽、标题吃剩余', () {
+    testWidgets('右按钮组能拿到远超 1/3 顶栏宽的自身所需宽度', (WidgetTester tester) async {
+      // 600 宽顶栏、右组需要 400（= 2/3）。旧的三等分 Flex 只会给 200。
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftWidth: 60,
+        rightWidth: 400,
+      );
+
+      expect(tester.getSize(find.byKey(rightKey)).width, 400,
+          reason: '右按钮组必须足额拿到自身需要的宽，不被平分成 1/3（200）');
+      expect(tester.getSize(find.byKey(leftKey)).width, 60);
+      // 标题只吃剩余：600 - 60 - 400 = 140。
+      expect(tester.getSize(find.byKey(titleKey)).width, 140,
+          reason: '标题只拿两侧按钮用剩的宽');
+    });
+
+    testWidgets('右按钮组贴右边缘、左按钮组贴左边缘、标题接在左组之后', (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftWidth: 60,
+        rightWidth: 400,
+      );
+
+      expect(tester.getTopLeft(find.byKey(leftKey)).dx, 0);
+      expect(tester.getTopLeft(find.byKey(titleKey)).dx, 60);
+      expect(tester.getTopRight(find.byKey(rightKey)).dx, 600,
+          reason: 'topRight 组必须右对齐到顶栏右边缘');
+    });
+
+    testWidgets('标题槽为空时整条宽度都归按钮，不留霸占中段的空白占位', (WidgetTester tester) async {
+      // 用户场景：把视频名称删空 / 关掉标题项 → 中段是空的，按钮不该再被挤。
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftWidth: 60,
+        rightWidth: 520,
+        title: const SizedBox.shrink(key: titleKey),
+      );
+
+      expect(tester.getSize(find.byKey(rightKey)).width, 520,
+          reason: '标题空了，右按钮组应能吃到 60 之外的全部宽');
+      expect(tester.getSize(find.byKey(titleKey)).width, 0);
+      expect(tester.getTopRight(find.byKey(rightKey)).dx, 600);
+    });
+
+    testWidgets('超长标题不得挤压按钮：按钮先拿够，标题被压成剩余宽', (WidgetTester tester) async {
+      // 标题子树自身想要 10000 宽（模拟超长片名），仍只能拿剩余的 140。
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftWidth: 60,
+        rightWidth: 400,
+        title: const SizedBox(key: titleKey, width: 10000, height: 48),
+      );
+
+      expect(tester.getSize(find.byKey(rightKey)).width, 400);
+      expect(tester.getSize(find.byKey(titleKey)).width, 140,
+          reason: '标题被剩余宽钳住（按钮优先于名称）');
+      expect(tester.takeException(), isNull, reason: '超长标题不得造成溢出');
+    });
+
+    testWidgets('极窄顶栏：左组优先满足，右组吃掉剩下的全部，标题归零且不溢出', (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        barWidth: 300,
+        leftWidth: 60,
+        rightWidth: 400,
+      );
+
+      expect(tester.getSize(find.byKey(leftKey)).width, 60);
+      expect(tester.getSize(find.byKey(rightKey)).width, 240,
+          reason: '右组被钳到剩余的 240（组内自带横滚兜底可达性）');
+      expect(tester.getSize(find.byKey(titleKey)).width, 0);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('槽内子项垂直居中', (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftWidth: 60,
+        rightWidth: 100,
+        title: const SizedBox(key: titleKey, width: 100, height: 20),
+        height: 48,
+      );
+
+      expect(tester.getTopLeft(find.byKey(titleKey)).dy, (48 - 20) / 2);
+    });
+  });
+}

--- a/fushi/test/pages/video_topbar_guards_test.dart
+++ b/fushi/test/pages/video_topbar_guards_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
 
+import '../helpers/source_guard.dart';
 import 'video_fushi_page_source_corpus.dart';
 
 /// video_topbar 组合并守卫（守卫审计合并产物；断言零丢弃）：
@@ -79,11 +80,14 @@ void main() {
           reason: '标题 helper 内部仍应监听 _titleNotifier（BUG-120）');
     });
 
-    test('标题用 Flexible(loose) 让宽给按钮，不用 Expanded 抢固定 1/3（TODO-642）', () {
-      // 根因：_topBarTitle() 曾用 Expanded（= Flexible(FlexFit.tight)），强迫标题填满
-      // 它分到的那段顶栏宽，把左右按钮组挤进窄横向滚动区（右上角按钮被裁 / 要横滑）。
-      // 修复改成 Flexible(fit: FlexFit.loose)：标题只占自身需要的宽、剩余空间优先让给
-      // 按钮组；标题已有 maxLines:1 + ellipsis，窄窗优雅截断。本守卫钉住该让位语义。
+    test('标题彻底退出顶栏 flex 分配，按钮先拿宽、标题吃剩余（TODO-642 续）', () {
+      // 根因（两轮）：①_topBarTitle() 最早用 Expanded（= FlexFit.tight）强占顶栏宽；
+      // ②改成 Flexible(loose) 后仍在 Flex 里——Flex 按 flex 因子**平分**可用宽，loose
+      // 用不完的份额又不回流，于是「左组 / 标题 / 右组」各锁死 1/3：右上角按钮再多也只有
+      // 1/3 宽、超出的被裁进横滚区；标题项关掉时旧代码返回 Spacer()（tight），空白中段
+      // 照样霸占 1/3（用户现象：「名称删空了、中间是空的，按钮还是被挡」）。
+      // 现在整条顶栏交给 VideoTopBarSlots 按优先级分宽（左按钮 → 右按钮 → 标题吃剩余），
+      // 布局行为本身由 test/pages/video_top_bar_slots_test.dart 用真实尺寸断言。
       final int titleStart = src.indexOf('Widget _topBarTitle()');
       expect(titleStart, greaterThanOrEqualTo(0),
           reason: '应存在 _topBarTitle() helper');
@@ -91,11 +95,25 @@ void main() {
           src.indexOf('Widget _topBarInlineTitle(', titleStart);
       expect(titleEnd, greaterThan(titleStart),
           reason: '_topBarTitle() 方法体应正常闭合在 _topBarInlineTitle 之前');
-      final String titleBody = src.substring(titleStart, titleEnd);
-      expect(titleBody.contains('fit: FlexFit.loose'), isTrue,
-          reason: 'TODO-642：标题须用 Flexible(fit: FlexFit.loose) 把宽让给按钮');
+      // 只看代码：方法体注释里必然复述 `Flexible(` / `Spacer()` 这些被禁写法的历史，
+      // 带着注释扫会把「解释为什么禁用」误判成「还在用」。掩码走共享原语（块注释/行尾
+      // 注释都能盖住，且不移动下标）。
+      final String titleBody =
+          maskComments(src.substring(titleStart, titleEnd));
+      expect(titleBody.contains('return const SizedBox.shrink();'), isTrue,
+          reason: '标题项没配置时须交回零宽占位，整条顶栏宽都归按钮');
+      expect(titleBody.contains('Spacer()'), isFalse,
+          reason: 'Spacer(=FlexFit.tight) 会让空白中段继续霸占一份顶栏宽');
       expect(titleBody.contains('return Expanded('), isFalse,
-          reason: 'TODO-642：标题不能再用 Expanded（FlexFit.tight 会抢固定 1/3 顶栏宽）');
+          reason: '标题不能用 Expanded（FlexFit.tight 会抢固定 1/3 顶栏宽）');
+      expect(titleBody.contains('Flexible('), isFalse,
+          reason: '标题不能再参与顶栏 Flex 平分（loose 也会锁死在 1/3）');
+      // 两套 controls 主题都必须把三槽交给同一个优先级布局。
+      expect(
+          'VideoTopBarSlots('.allMatches(src).length, greaterThanOrEqualTo(2),
+          reason: '桌面与移动顶栏都应经 VideoTopBarSlots 分宽');
+      expect(RegExp(r'title:\s*_topBarTitle\(\)').hasMatch(src), isTrue,
+          reason: '标题应作为 VideoTopBarSlots 的 title 槽传入');
       // 标题截断兜底仍在（窄窗让位后靠 ellipsis 优雅收尾）。
       final int textStart = src.indexOf('Widget _topBarTitleText(');
       expect(textStart, greaterThanOrEqualTo(0));


### PR DESCRIPTION
## 用户报的现象

> 视频里面，视频的名称部分，不要把按钮挡住，明明我把视频名称删掉了，他是空的。而且应该按钮比名称更重要才对

## 根因

视频内顶栏是 media_kit fork 的一条 `Row`，左按钮组 / 标题 / 右按钮组各挂一个 `Flexible(flex: 1)`。

- `Flex` 把可用宽按 flex 因子**平分**成三份；
- `FlexFit.loose` 的子项用不完的份额**不会回流**给别人。

于是右上角按钮组无论窗口多宽都只拿得到 **1/3 顶栏宽**，超出的按钮被裁进组内横滚区 —— 就是「名称把按钮挡住、要横滑才点得到」。

而标题项没配置时 `_topBarTitle()` 返回的是 `Spacer()`（= `FlexFit.tight`），空白中段照旧硬占那 1/3 —— 所以「把视频名称删空、中间明明是空的，按钮还是被挡」。

## 修法

- 新增 `VideoTopBarSlots`（`CustomMultiChildLayout`）：**布局顺序即优先级** —— 左按钮组 → 右按钮组 → 标题吃剩余。按钮永远完整可见，标题窄了走 `maxLines: 1` + ellipsis。
- `_topBarSlotGroup` 改为按内容固有宽收缩（`Align(widthFactor: 1)` + `shrinkWrap` 横向 `ListView`），顶栏才能拿到按钮组的真实宽度。窄窗仍可横滚，按钮不被裁没。不能再用 `SingleChildScrollView`：它的 viewport 恒撑满主轴，会把内容宽藏起来。
- `_topBarTitle` 无标题项时返回 `SizedBox.shrink()`，不再用 `Spacer` 占位。
- 桌面 / 移动两套 controls 主题的 `topButtonBar` 统一收成单个 `Expanded` 承接三槽布局，与底栏 `_centeredBottomControlBar` 同一套路。

## 测试

- 新增 `test/pages/video_top_bar_slots_test.dart`：6 条**真实布局尺寸**断言（右组拿满 400 而不是平分的 200、标题吃剩余、标题空时宽度全归按钮、超长标题不挤按钮、极窄窗不溢出、垂直居中）。
- **变异实测**：把右槽约束改回 `size.width / 3` 后，4 条相关断言转红；还原后 sha256 与变异前一致。
- 同步更新两条既有守卫（旧的 `Flexible(loose)` / `SingleChildScrollView` 字面断言 → 新语义），注释剥离改用 `helpers/source_guard.dart` 的 `maskComments`（`source_guard_adoption_test` 要求）。

## 验证

- `flutter analyze` 全量（含 test）：**0 issue**
- `test/pages` + `test/media/video`：**5368 条通过**
- 目录枚举型守卫 35 条批次：通过

## 本分支之外的既有红（origin/develop 上已存在，未在本 PR 处理）

1. `test/tools/book_format_discipline_guard_test.dart` → `test/sync/fushi_library_host_service_books_test.dart:229` 用了裸字面量 `format: const Value('manga')`，应改为 `BookFormat.manga.dbValue`。已确认 `origin/develop` 上就是这样。
2. `test/pages/reader_remote_interconnect_test.dart` 的「BUG-1181: 漫画书架实例从不拉远端书」稳定红，报 `Bad state: Can't re-open a database after closing it`。该文件与 `origin/develop` 完全一致、与本次顶栏改动无因果关系（单独跑该用例同样红）。

https://claude.ai/code/session_01LoTxj6GfD5DrAeQFPoM72G
