### PR TITLE
fix(gal): keep Naninovel subtitles across scene changes

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1527 条。点号进各自文件。
+> 共 1528 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1646](bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md) | ✅ | 🚧 | 魔法少女的魔女审判切换场景后字幕线程断开 |
 | [BUG-1645](bugs/BUG-1645-nested-latin-lookup.md) | ✅ | ✅ | 嵌套查词查不了英语单词（跨节点粘连成拉丁串） |
 | [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |
 | [BUG-1643](bugs/BUG-1643-settings-width-cap.md) | ✅ | ✅ | 设置页宽屏被 960px 强制限宽 |

--- a/docs/bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md
+++ b/docs/bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md
@@ -1,0 +1,6 @@
+## BUG-1646 · 魔法少女的魔女审判切换场景后字幕线程断开
+- **报告**：2026-08-14（用户：本地实机反馈）
+- **真实性**：✅ 真 bug。`native/galgame_hook/hook/adapters/unity_adapter.inc:329` 原先把 Naninovel 的临时 `RevealableText` 组件指针混入线程 ID；载入其他场景后组件被重建，已选线程停在旧指针，新字幕进入另一候选线程。
+- **[x] ① 已修复** — `native/galgame_hook/hook/adapters/unity_adapter.inc:284` 为已知场景稳定的 Naninovel 对话源使用引擎级线程身份，同时继续把真实组件地址保留在事件元数据中。Fresh build 还暴露 Unity 6 在 HookWorker 调用 `il2cpp_class_get_method_from_name` 会进入 Boehm GC；`native/galgame_hook/hook/adapters/unity_adapter.inc:714` 改为枚举已发布的方法元数据，避免启动 GC 崩溃。
+- **[ ] ② 未加自动化测试** — 用户明确要求本轮跳过所有测试；未运行或新增自动化测试，以真实 Windows 游戏的 Release 多场景回放作为当前验证门。
+- **备注**：旧 DLL 实机复现为已选线程计数停在 8，而新场景组件另起候选并收到 2 条。修复后 RelWithDebInfo 同一选择跨三场景从 4→8→14；最终 Release 同一选择跨场景从 5→10，组件元数据地址变化但无需重选，并继续出现 `game_resource` 音频。游戏 1.1.2，Unity 6000.0.48f1；证据账本位于 `.codex-test/manosaba-multiscene-evidence.json`，未保存截图或台词正文。

--- a/native/galgame_hook/hook/adapters/unity_adapter.inc
+++ b/native/galgame_hook/hook/adapters/unity_adapter.inc
@@ -280,7 +280,8 @@ void PublishUnityText(uint64_t thread_id, void* text_component,
 }
 
 void RecordUnityTmpText(void* text_component, void* string_object,
-                        const char* hook_name, const wchar_t* hook_code) {
+                        const char* hook_name, const wchar_t* hook_code,
+                        bool stable_across_components = false) {
   if (string_object == nullptr || g_il2cpp_string_chars == nullptr ||
       g_il2cpp_string_length == nullptr) {
     return;
@@ -314,8 +315,18 @@ void RecordUnityTmpText(void* text_component, void* string_object,
     }
   }
   if (length == 0 || meaningful == 0 || (!has_cjk && meaningful < 2)) return;
+  // Most Unity text components are independent UI fields, so their object
+  // identity must remain part of the selectable thread. Naninovel recreates
+  // its main RevealableText component when loading/switching scenes, though:
+  // using that transient pointer as the thread id silently strands the user's
+  // selection on the old scene. Keep the real component in event metadata,
+  // but give known scene-stable dialogue sources an engine-level identity.
+  const uint64_t component_identity =
+      stable_across_components
+          ? 0
+          : reinterpret_cast<uint64_t>(text_component);
   const uint64_t thread_id = fushi_voice_hook::NativeTextThreadIdFrom(
-      reinterpret_cast<uint64_t>(text_component), hook_code, hook_name);
+      component_identity, hook_code, hook_name);
   PublishUnityText(thread_id, text_component, clean, length, true, hook_name,
                    hook_code);
 }
@@ -653,7 +664,7 @@ void Detour_NaninovelRevealableSetText(void* self, void* text,
                                        const void* method) {
   g_orig_NaninovelRevealableSetText(self, text, method);
   RecordUnityTmpText(self, text, "Naninovel RevealableText",
-                     L"Naninovel.UI.RevealableText.set_Text");
+                     L"Naninovel.UI.RevealableText.set_Text", true);
 }
 
 void* Il2CppMethodPointer(const void* method) {
@@ -694,6 +705,27 @@ const void* FindIl2CppMethod(void* klass, const char* method_name,
     const char* name = g_il2cpp_method_get_name(method);
     if (name != nullptr && strcmp(name, method_name) == 0 &&
         Il2CppMethodHasParams(method, expected, count)) {
+      return method;
+    }
+  }
+  return nullptr;
+}
+
+const void* FindIl2CppMethodByParamCount(void* klass,
+                                         const char* method_name,
+                                         uint32_t count) {
+  if (klass == nullptr || method_name == nullptr ||
+      g_il2cpp_class_get_methods == nullptr ||
+      g_il2cpp_method_get_name == nullptr ||
+      g_il2cpp_method_get_param_count == nullptr) {
+    return nullptr;
+  }
+  void* iterator = nullptr;
+  while (const void* method =
+             g_il2cpp_class_get_methods(klass, &iterator)) {
+    const char* name = g_il2cpp_method_get_name(method);
+    if (name != nullptr && strcmp(name, method_name) == 0 &&
+        g_il2cpp_method_get_param_count(method) == count) {
       return method;
     }
   }
@@ -773,8 +805,6 @@ bool TryHookUnityIl2CppAudio() {
       GetProcAddress(game, "il2cpp_assembly_get_image"));
   const auto class_from_name = reinterpret_cast<Il2CppClassFromName>(
       GetProcAddress(game, "il2cpp_class_from_name"));
-  const auto class_get_method = reinterpret_cast<Il2CppClassGetMethodFromName>(
-      GetProcAddress(game, "il2cpp_class_get_method_from_name"));
   const auto get_corlib = reinterpret_cast<Il2CppGetCorlib>(
       GetProcAddress(game, "il2cpp_get_corlib"));
   g_il2cpp_runtime_invoke = reinterpret_cast<Il2CppRuntimeInvoke>(
@@ -876,13 +906,13 @@ bool TryHookUnityIl2CppAudio() {
 
   bool resource_methods_ready = false;
   bool pcm_helpers_ready = false;
-  if (class_get_method != nullptr && g_il2cpp_runtime_invoke != nullptr &&
+  if (g_il2cpp_runtime_invoke != nullptr &&
       source_class != nullptr && clip_class != nullptr &&
       object_class != nullptr) {
     g_unity_source_get_clip =
-        class_get_method(source_class, "get_clip", 0);
+        FindIl2CppMethodByParamCount(source_class, "get_clip", 0);
     g_unity_object_get_name =
-        class_get_method(object_class, "get_name", 0);
+        FindIl2CppMethodByParamCount(object_class, "get_name", 0);
     resource_methods_ready =
         g_unity_source_get_clip != nullptr &&
         g_unity_object_get_name != nullptr;
@@ -896,12 +926,13 @@ bool TryHookUnityIl2CppAudio() {
         corlib == nullptr ? nullptr
                           : class_from_name(corlib, "System", "Single");
     g_unity_clip_get_samples =
-        class_get_method(clip_class, "get_samples", 0);
+        FindIl2CppMethodByParamCount(clip_class, "get_samples", 0);
     g_unity_clip_get_channels =
-        class_get_method(clip_class, "get_channels", 0);
+        FindIl2CppMethodByParamCount(clip_class, "get_channels", 0);
     g_unity_clip_get_frequency =
-        class_get_method(clip_class, "get_frequency", 0);
-    g_unity_clip_get_data = class_get_method(clip_class, "GetData", 2);
+        FindIl2CppMethodByParamCount(clip_class, "get_frequency", 0);
+    g_unity_clip_get_data =
+        FindIl2CppMethodByParamCount(clip_class, "GetData", 2);
     pcm_helpers_ready =
         g_system_single_class != nullptr && g_il2cpp_array_new != nullptr &&
         g_il2cpp_object_unbox != nullptr &&
@@ -995,18 +1026,28 @@ bool TryHookUnityIl2CppAudio() {
   if (!resource_methods_ready) return false;
 
   bool any = audio_ready;
-  const void* play = class_get_method(source_class, "Play", 0);
-  const void* one_shot_1 = class_get_method(source_class, "PlayOneShot", 1);
-  const void* one_shot_2 = class_get_method(source_class, "PlayOneShot", 2);
-  const void* set_clip = class_get_method(source_class, "set_clip", 1);
+  // Unity 6's il2cpp_class_get_method_from_name may enter Boehm GC even for
+  // metadata lookup and abort when called from our native HookWorker. Enumerate
+  // the already-published method metadata instead; this is also what the text
+  // hook discovery above uses successfully.
+  const void* play =
+      FindIl2CppMethodByParamCount(source_class, "Play", 0);
+  const void* one_shot_1 =
+      FindIl2CppMethodByParamCount(source_class, "PlayOneShot", 1);
+  const void* one_shot_2 =
+      FindIl2CppMethodByParamCount(source_class, "PlayOneShot", 2);
+  const void* set_clip =
+      FindIl2CppMethodByParamCount(source_class, "set_clip", 1);
   const void* play_scheduled =
-      class_get_method(source_class, "PlayScheduled", 1);
-  const void* play_delayed = class_get_method(source_class, "PlayDelayed", 1);
-  const void* play_helper = class_get_method(source_class, "PlayHelper", 2);
+      FindIl2CppMethodByParamCount(source_class, "PlayScheduled", 1);
+  const void* play_delayed =
+      FindIl2CppMethodByParamCount(source_class, "PlayDelayed", 1);
+  const void* play_helper =
+      FindIl2CppMethodByParamCount(source_class, "PlayHelper", 2);
   const void* one_shot_helper =
-      class_get_method(source_class, "PlayOneShotHelper", 3);
+      FindIl2CppMethodByParamCount(source_class, "PlayOneShotHelper", 3);
   const void* play_delayed_helper =
-      class_get_method(source_class, "PlayDelayedHelper", 2);
+      FindIl2CppMethodByParamCount(source_class, "PlayDelayedHelper", 2);
   if (g_header != nullptr &&
       (play != nullptr || one_shot_1 != nullptr ||
        one_shot_2 != nullptr || set_clip != nullptr ||


### PR DESCRIPTION
## What changed

- Give Naninovel `RevealableText` an engine-stable text lane identity while retaining the real component pointer in event metadata.
- Replace worker-thread `il2cpp_class_get_method_from_name` calls with published metadata enumeration by method name and parameter count.
- Add BUG-1646 with the reproduced root cause and Windows runtime evidence.

## Why

Naninovel recreates its dialogue component when a save or scene is loaded. The component pointer was part of the selectable thread ID, so the user's selected lane remained attached to the old scene and new subtitles appeared in a different candidate lane.

A fresh Unity 6 build also exposed that `il2cpp_class_get_method_from_name` can enter Boehm GC from the native HookWorker and abort the game with `Fatal error in GC`. Enumerating already-published metadata avoids that unsafe lookup path.

## User impact

In *Magical Girl Witch Trials* 1.1.2, the selected Naninovel subtitle lane now continues across scene changes without requiring reselection, and game-resource audio observation remains available.

## Validation

- Windows x64 RelWithDebInfo runtime: one selected lane continued `4 -> 8 -> 14` across three distinct saves/scenes while component metadata changed each time.
- Windows x64 Release runtime: one selected lane continued `5 -> 10` across a scene change; game-resource audio events remained present.
- Windows x64 and x86 Release distribution builds completed successfully.
- x64 archive SHA-256: `44227352e41b0a55569d0809aa5fec318a0609103a54229a611b7f50a7fee0d3`
- x86 archive SHA-256: `d9ff0cefd818a8dc84eaa2c756b861193b010167f8aebf3de9a2afc043c8530b`
- Automated tests were intentionally skipped for this iteration per the requested fast manual-validation workflow.
