### PR TITLE
fix(tracking): BUG-1647 Bangumi 同步失败后退避到期自动重试

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1528 条。点号进各自文件。
+> 共 1529 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1647](bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md) | ✅ | ✅ | Bangumi 同步失败后卡在退避窗口且无自动重试，只能手动同步 |
 | [BUG-1646](bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md) | ✅ | 🚧 | 魔法少女的魔女审判切换场景后字幕线程断开 |
 | [BUG-1645](bugs/BUG-1645-nested-latin-lookup.md) | ✅ | ✅ | 嵌套查词查不了英语单词（跨节点粘连成拉丁串） |
 | [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |

--- a/docs/bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md
+++ b/docs/bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md
@@ -1,0 +1,6 @@
+## BUG-1647 · Bangumi 同步失败后卡在退避窗口且无自动重试，只能手动同步
+- **报告**：2026-08-14（用户：Bangumi 同步一直要手动同步才生效）
+- **真实性**：✅ 真 bug。自动同步全仓只有两个触发点：启动一次（`fushi/lib/src/models/app_model.dart:2236` 的 `syncNow()`）+ 完成事件当下一次（`media_tracking_service.dart` `_enqueueAndSync`）。发送失败的行被 `MediaTrackingRepository.markFailed`（`media_tracking_repository.dart:1043`）推进 30s..6h 指数退避后，`dueUpdates`（同文件 :970）按 `nextAttemptAt` 把它过滤掉，而**没有任何定时器在退避到期时再拉一轮**：失败行只能等下一个完成事件碰巧到来且恰好已出窗口，否则永远要靠设置页/首页「立即同步」（`force=true` → `retryAllNow` 清退避）。看完一集那一刻网络抖一下，该集就再也不会自动同步——与用户症状完全同形。
+- **[x] ① 已修复** — `MediaTrackingService` 每轮同步收尾时查 outbox 最早 `nextAttemptAt`（新增 `MediaTrackingRepository.earliestNextAttemptAt()`），挂一只 `Timer` 到点自动 `syncNow()`；下一轮同步开始即作废旧定时器，未配置令牌/零待办不挂。顺带覆盖单轮 20 条上限的积压续跑（剩余行 `nextAttemptAt=0` → 最小 5s 延迟续一轮）。`AppModel` 两处重建服务实例前先 `dispose()` 取消旧定时器。提交：（待填）
+- **[x] ② 已加自动化测试** — `fushi/test/media/tracking/media_tracking_service_test.dart`「退避到期自动重试（BUG-1647）」组 3 例：失败后按 ~30s 退避安排重试且到期触发即重发成功；下一轮同步取消旧定时器、零待办不再安排；未配置令牌不安排。定时器工厂可注入（`TrackingRetryTimerFactory`），断言确定性。
+- **备注**：不动 schema、不动 i18n。手动「立即同步」语义不变（仍是唯一会 `retryAllNow` 清退避的入口）；自动重试只是让退避表到期后真的有人来发。

--- a/docs/bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md
+++ b/docs/bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md
@@ -1,6 +1,6 @@
 ## BUG-1647 · Bangumi 同步失败后卡在退避窗口且无自动重试，只能手动同步
 - **报告**：2026-08-14（用户：Bangumi 同步一直要手动同步才生效）
 - **真实性**：✅ 真 bug。自动同步全仓只有两个触发点：启动一次（`fushi/lib/src/models/app_model.dart:2236` 的 `syncNow()`）+ 完成事件当下一次（`media_tracking_service.dart` `_enqueueAndSync`）。发送失败的行被 `MediaTrackingRepository.markFailed`（`media_tracking_repository.dart:1043`）推进 30s..6h 指数退避后，`dueUpdates`（同文件 :970）按 `nextAttemptAt` 把它过滤掉，而**没有任何定时器在退避到期时再拉一轮**：失败行只能等下一个完成事件碰巧到来且恰好已出窗口，否则永远要靠设置页/首页「立即同步」（`force=true` → `retryAllNow` 清退避）。看完一集那一刻网络抖一下，该集就再也不会自动同步——与用户症状完全同形。
-- **[x] ① 已修复** — `MediaTrackingService` 每轮同步收尾时查 outbox 最早 `nextAttemptAt`（新增 `MediaTrackingRepository.earliestNextAttemptAt()`），挂一只 `Timer` 到点自动 `syncNow()`；下一轮同步开始即作废旧定时器，未配置令牌/零待办不挂。顺带覆盖单轮 20 条上限的积压续跑（剩余行 `nextAttemptAt=0` → 最小 5s 延迟续一轮）。`AppModel` 两处重建服务实例前先 `dispose()` 取消旧定时器。提交：（待填）
+- **[x] ① 已修复** — `MediaTrackingService` 每轮同步收尾时查 outbox 最早 `nextAttemptAt`（新增 `MediaTrackingRepository.earliestNextAttemptAt()`），挂一只 `Timer` 到点自动 `syncNow()`；下一轮同步开始即作废旧定时器，未配置令牌/零待办不挂。顺带覆盖单轮 20 条上限的积压续跑（剩余行 `nextAttemptAt=0` → 最小 5s 延迟续一轮）。`AppModel` 两处重建服务实例前先 `dispose()` 取消旧定时器。提交：66815efe5（PR #843）
 - **[x] ② 已加自动化测试** — `fushi/test/media/tracking/media_tracking_service_test.dart`「退避到期自动重试（BUG-1647）」组 3 例：失败后按 ~30s 退避安排重试且到期触发即重发成功；下一轮同步取消旧定时器、零待办不再安排；未配置令牌不安排。定时器工厂可注入（`TrackingRetryTimerFactory`），断言确定性。
 - **备注**：不动 schema、不动 i18n。手动「立即同步」语义不变（仍是唯一会 `retryAllNow` 清退避的入口）；自动重试只是让退避表到期后真的有人来发。

--- a/fushi/lib/src/media/tracking/media_tracking_repository.dart
+++ b/fushi/lib/src/media/tracking/media_tracking_repository.dart
@@ -1070,4 +1070,16 @@ class MediaTrackingRepository {
           nextAttemptAt: Value<int>(0),
         ),
       );
+
+  /// 待同步行中最早的下次尝试时刻（毫秒）；outbox 为空时返回 null。
+  ///
+  /// 服务发送侧用它在每轮同步收尾时安排退避到期的自动重试（BUG-1647）。
+  Future<int?> earliestNextAttemptAt() async {
+    final Expression<int> earliest =
+        _db.mediaTrackingOutbox.nextAttemptAt.min();
+    final TypedResult? row = await (_db.selectOnly(_db.mediaTrackingOutbox)
+          ..addColumns(<Expression<Object>>[earliest]))
+        .getSingleOrNull();
+    return row?.read(earliest);
+  }
 }

--- a/fushi/lib/src/media/tracking/media_tracking_service.dart
+++ b/fushi/lib/src/media/tracking/media_tracking_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:fushi/src/media/collections/collection_season_groups.dart'
@@ -38,6 +39,13 @@ const String kGameTrackingReconcileWatermarkPref =
     'media_tracking_game_reconcile_watermark_v1';
 
 typedef BangumiApiFactory = BangumiTrackingApi Function(String accessToken);
+
+/// 退避重试定时器工厂（BUG-1647）；生产用真 [Timer]，测试注入假实现以便
+/// 确定性地断言「安排了多久后重试」并手动触发到期回调。
+typedef TrackingRetryTimerFactory = Timer Function(
+  Duration delay,
+  void Function() callback,
+);
 
 class MediaTrackingSyncResult {
   const MediaTrackingSyncResult({
@@ -278,17 +286,25 @@ class MediaTrackingService {
     required PreferencesRepository preferences,
     required String userAgent,
     BangumiApiFactory? apiFactory,
+    TrackingRetryTimerFactory? retryTimerFactory,
   })  : _repository = repository,
         _preferences = preferences,
         _apiFactory = apiFactory ??
             ((String token) => BangumiApiClient(
                   accessToken: token,
                   userAgent: userAgent,
-                ));
+                )),
+        _retryTimerFactory = retryTimerFactory ??
+            ((Duration delay, void Function() callback) =>
+                Timer(delay, callback));
 
   final MediaTrackingRepository _repository;
   final PreferencesRepository _preferences;
   final BangumiApiFactory _apiFactory;
+  final TrackingRetryTimerFactory _retryTimerFactory;
+
+  /// BUG-1647：退避到期后的自动重试定时器；同一时刻至多一只。
+  Timer? _retryTimer;
 
   Future<MediaTrackingSyncResult>? _syncInFlight;
   bool _syncAgainRequested = false;
@@ -1034,13 +1050,57 @@ class MediaTrackingService {
   Future<MediaTrackingSyncResult> _syncUntilSettled({
     required bool force,
   }) async {
+    // 本轮同步会重新计算下一次重试时刻，旧定时器作废。
+    _retryTimer?.cancel();
+    _retryTimer = null;
     MediaTrackingSyncResult result = await _reconcileAndSync(force: force);
     while (_syncAgainRequested) {
       _syncAgainRequested = false;
       result = await _reconcileAndSync(force: false);
     }
     await _persistSyncOutcome(result);
+    await _scheduleBackoffRetry();
     return result;
+  }
+
+  /// BUG-1647：退避到期后自动重试。
+  ///
+  /// 自动同步原本只有两个触发点——启动一次 + 完成事件当下一次。发送失败的行被
+  /// [MediaTrackingRepository.markFailed] 推进 30s..6h 的指数退避后，若没有任何
+  /// 定时器在到期时再拉一轮，`dueUpdates` 会一直把它过滤掉：失败行只能等下一个
+  /// 完成事件碰巧到来（且恰好已出退避窗口），否则永远要靠手动「立即同步」。
+  /// 这里在每轮同步收尾时查 outbox 里最早的 `nextAttemptAt`，挂一只定时器到点
+  /// 自动 [syncNow]，把「退避」从死路修成真正的重试计划。顺带覆盖单轮发送上限
+  /// （20 条/轮）导致的积压：剩余行 `nextAttemptAt` 为 0，会以最小延迟续跑。
+  Future<void> _scheduleBackoffRetry() async {
+    if (!isConfigured) return;
+    final int? earliest;
+    try {
+      earliest = await _repository.earliestNextAttemptAt();
+    } catch (error, stackTrace) {
+      ErrorLogService.instance.log(
+        'MediaTrackingService.scheduleRetry',
+        error,
+        stackTrace,
+      );
+      return;
+    }
+    if (earliest == null) return;
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    // 已到期（或从未尝试）的行也至少等一小段再跑，避免与刚结束的这一轮竞争成热循环。
+    final Duration delay =
+        Duration(milliseconds: math.max(earliest - now, 5000));
+    _retryTimer = _retryTimerFactory(delay, () {
+      _retryTimer = null;
+      unawaited(syncNow());
+    });
+  }
+
+  /// 取消挂起的重试定时器。生产进程里服务与 app 同寿命；换库/换进程重建实例前
+  /// 必须先调这里，否则旧定时器会拿着旧 repository 继续同步。
+  void dispose() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
   }
 
   /// 把本轮同步结果落成可见状态。未配置令牌时不写「上次同步」（那一轮什么都没发，

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2228,6 +2228,9 @@ class AppModel with ChangeNotifier {
       // （localhost:8765，也可能是局域网另一台机）绝不经过它。
       installAnkiRemoteMediaHttpClientFactory();
       _applyMemoryPolicy();
+      // BUG-1647：lazy getter 可能已提前建过实例；替换前先取消其重试定时器，
+      // 否则旧定时器会拿着旧 repository 继续同步。
+      _mediaTrackingService?.dispose();
       _mediaTrackingService = MediaTrackingService(
         repository: MediaTrackingRepository(_database),
         preferences: prefsRepo,
@@ -2565,6 +2568,8 @@ class AppModel with ChangeNotifier {
       _prefsRepo = PreferencesRepository(_database);
       await prefsRepo.loadFromDb();
       prefsRepo.addListener(notifyListeners);
+      // BUG-1647：同主进程路径，替换前取消旧实例可能挂起的重试定时器。
+      _mediaTrackingService?.dispose();
       _mediaTrackingService = MediaTrackingService(
         repository: MediaTrackingRepository(_database),
         preferences: prefsRepo,

--- a/fushi/test/media/tracking/media_tracking_service_test.dart
+++ b/fushi/test/media/tracking/media_tracking_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -113,6 +115,24 @@ class _FakeBangumiApi implements BangumiTrackingApi {
   void close() {}
 }
 
+/// 可手动触发的假重试定时器（BUG-1647），用于确定性断言退避重试的调度。
+class _FakeRetryTimer implements Timer {
+  _FakeRetryTimer(this.delay, this.callback);
+
+  final Duration delay;
+  final void Function() callback;
+  bool cancelled = false;
+
+  @override
+  void cancel() => cancelled = true;
+
+  @override
+  bool get isActive => !cancelled;
+
+  @override
+  int get tick => 0;
+}
+
 void main() {
   late FushiDatabase db;
   late PreferencesRepository preferences;
@@ -136,6 +156,9 @@ void main() {
   });
 
   tearDown(() async {
+    // BUG-1647：同步失败会挂真实的退避重试定时器；不取消的话它会在库关闭后
+    // 触发并在已关闭的 db 上跑同步，把无关测试炸成随机红。
+    service.dispose();
     preferences.dispose();
     await db.close();
   });
@@ -707,6 +730,102 @@ void main() {
 
     expect(result.failed, 1);
     expect(await repository.pendingCount(), 1);
+  });
+
+  group('退避到期自动重试（BUG-1647）', () {
+    late List<_FakeRetryTimer> scheduled;
+    late MediaTrackingService retryService;
+
+    setUp(() {
+      scheduled = <_FakeRetryTimer>[];
+      retryService = MediaTrackingService(
+        repository: repository,
+        preferences: preferences,
+        userAgent: 'test-agent',
+        apiFactory: (_) => api,
+        retryTimerFactory: (Duration delay, void Function() callback) {
+          final _FakeRetryTimer timer = _FakeRetryTimer(delay, callback);
+          scheduled.add(timer);
+          return timer;
+        },
+      );
+    });
+
+    tearDown(() {
+      retryService.dispose();
+    });
+
+    Future<void> enqueueOneBookUpdate() async {
+      await repository.saveMapping(
+        mediaType: TrackingMediaType.book,
+        mediaKey: 'book',
+        mediaTitle: 'Book',
+        kind: TrackingKind.manga,
+        subjectId: 7,
+        subjectName: 'Remote book',
+        progressMode: TrackingProgressMode.volume,
+        progressOffset: 0,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.book,
+        mediaKey: 'book',
+        localProgress: 1,
+        completed: false,
+      );
+    }
+
+    test('发送失败后按退避安排自动重试，到期触发即重发成功', () async {
+      await enqueueOneBookUpdate();
+      api.error = const BangumiApiException(
+        statusCode: 503,
+        message: 'temporarily unavailable',
+      );
+
+      final MediaTrackingSyncResult failedRound = await retryService.syncNow();
+
+      expect(failedRound.failed, 1);
+      expect(scheduled, hasLength(1), reason: '失败后必须安排退避重试，否则只能手动同步');
+      final _FakeRetryTimer timer = scheduled.single;
+      // 首次失败退避 30s：安排的延迟应逼近它（调度与落库间的耗时只会更短）。
+      expect(timer.delay.inMilliseconds, lessThanOrEqualTo(30000));
+      expect(timer.delay.inMilliseconds, greaterThan(20000));
+
+      // 模拟退避窗口走完：把行重置为到期，再触发定时器回调。
+      api.error = null;
+      await repository.retryAllNow();
+      timer.callback();
+      // 回调里的 syncNow 已在飞行中，这里拿到同一个 future 等它收尾。
+      await retryService.syncNow();
+
+      expect(await repository.pendingCount(), 0, reason: '到期重试应把失败行真正发出去');
+      expect(api.creates, isNotEmpty);
+    });
+
+    test('下一轮同步开始时取消旧定时器，零待办不再安排新的', () async {
+      await enqueueOneBookUpdate();
+      api.error = const BangumiApiException(
+        statusCode: 500,
+        message: 'boom',
+      );
+      await retryService.syncNow();
+      expect(scheduled, hasLength(1));
+
+      api.error = null;
+      await retryService.syncNow(force: true);
+
+      expect(scheduled.single.cancelled, isTrue, reason: '重新同步后旧定时器必须作废');
+      expect(scheduled, hasLength(1), reason: 'outbox 清空后不该再挂新定时器');
+      expect(await repository.pendingCount(), 0);
+    });
+
+    test('未配置令牌时不安排重试定时器', () async {
+      await preferences.setPref(kBangumiAccessTokenPref, '');
+      await enqueueOneBookUpdate();
+
+      await retryService.syncNow();
+
+      expect(scheduled, isEmpty);
+    });
   });
 
   test('video completion reuses scraped Bangumi subject and creates mapping',


### PR DESCRIPTION
## 症状
用户报「bangumi 同步一直要手动同步」：看完一集后进度不会自动出现在 Bangumi，只有设置页/首页点「立即同步」才生效。

## 根因（BUG-1647）
自动同步全仓只有两个触发点：启动一次（`app_model.dart` init 里的 `syncNow()`）+ 完成事件当下一次（`_enqueueAndSync`）。发送失败的行被 `markFailed` 推进 30s..6h 指数退避后，`dueUpdates` 按 `nextAttemptAt` 过滤把它跳过，而**没有任何定时器在退避到期时再拉一轮**。看完那一刻网络抖一下，该行就永远卡在退避里，只有手动「立即同步」（`force=true` → `retryAllNow`）能救。

## 修复
- `MediaTrackingService`：每轮同步收尾查 outbox 最早 `nextAttemptAt`（新增 `MediaTrackingRepository.earliestNextAttemptAt()`），挂 `Timer` 到点自动 `syncNow()`；下一轮同步开始即作废旧定时器；未配置令牌/零待办不挂；已到期行 clamp 最小 5s 防热循环。顺带覆盖单轮 20 条发送上限的积压续跑（剩余行 `nextAttemptAt=0`）。
- `AppModel`：两处重建服务实例前先 `dispose()` 取消旧定时器（防旧定时器拿旧 repository 继续同步）。
- 定时器工厂 `TrackingRetryTimerFactory` 可注入；测试 tearDown 统一 `dispose()` 防真定时器在关库后触发炸无关测试。

不动 schema、不动 i18n；手动「立即同步」语义不变（仍是唯一清退避的入口）。

## 验证
- `flutter analyze` 全量绿（No issues found）。
- `flutter test test/media/tracking --no-pub` 75 项全绿，含新增 3 项（失败后 ~30s 安排重试且到期触发即重发成功 / 下一轮取消旧定时器且零待办不再挂 / 未配置令牌不挂）。
- 变异实测：删掉 `_scheduleBackoffRetry()` 调用 → 新测试 2 红；还原后 sha256 与变异前逐字节一致。
- `dart run tool/bug.dart check`：BUG-1647 号唯一。

https://claude.ai/code/session_01JgipfpDU5KKiyEq1Byo9Vs