### PR TITLE
feat(video): 字幕默认字重 700→400 与 mpv 对齐

### DIFF
--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -400,7 +400,7 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 字幕文字颜色（外观设置）。
   final Color? textColor;
 
-  /// 字幕字重（CSS numeric weight 100..900；asbplayer 默认 700）。
+  /// 字幕字重（CSS numeric weight 100..900；默认 400 常规，与 mpv `--sub-bold=no` 对齐）。
   final int fontWeight;
 
   /// 字幕阴影颜色。
@@ -2186,7 +2186,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     final double assFontScale = respect ? _assFontScale(markup) : 1.0;
     final double? cueFontPx = respect ? cue?.fontSizePx : null;
     // 字重：cueStyle 存在即以 ASS 为准——`Bold=0`（fansub 对白的常态）必须渲染
-    // **常规字重**，不得回退用户统一字重（视频页默认 700）。否则所有 ASS 字幕被
+    // **常规字重**，不得回退用户统一字重（历史默认 700，现默认 400 与 mpv 对齐，但
+    // 用户仍可显式调粗）。否则所有 ASS 字幕被
     // 合成假粗体（Fontname 多半未安装 → 回退字体再被 fake-bold），笔画变粗变宽、
     // 细描边被吞，观感与 mpv（同缺字体但按 Bold=0 常规渲染）差异巨大——用户报
     // 「字号/描边没尊重 ASS」的真凶。无 cueStyle（非 ASS / 样式失配）才用统一字重。

--- a/fushi/lib/src/media/video/video_subtitle_style.dart
+++ b/fushi/lib/src/media/video/video_subtitle_style.dart
@@ -287,7 +287,16 @@ class VideoSubtitleStyle {
     this.secondaryAnchor,
   });
 
-  static const int defaultFontWeight = 700;
+  /// 默认字重 400（常规），与 mpv 默认（`--sub-bold=no` → Regular）对齐：同一字体
+  /// SRT/无样式表字幕在 fushi 与 mpv 里不再一边粗体一边常规（用户报「字重差异大」）。
+  /// ASS 有 cueStyle 时字重恒以 ASS 为准（Bold 标志/命名面字重，BUG-819），本默认值
+  /// 只管非 ASS / 样式失配路径。历史默认曾是 700，v1 迁移锚点见 [_v1LegacyFontWeight]。
+  static const int defaultFontWeight = 400;
+
+  /// v1 持久化时代硬编码的默认字重（700）。仅供 [decode] 把 v1 存的该值迁移成 null
+  /// （跟随缩放/新默认）用；与当前 [defaultFontWeight] 解耦，与
+  /// [_v1LegacyShadowThickness] 同一模式——改默认不破坏旧数据迁移语义。
+  static const int _v1LegacyFontWeight = 700;
 
   /// 默认阴影/投影**半径**（模糊强度），抄 Niratan（mac 原生日语沉浸 app）字幕默认的
   /// `shadowRadius = 3`（其设置滑杆范围 0..10）。BUG-323 时代这里是 5px「硬描边粗细」；
@@ -301,7 +310,7 @@ class VideoSubtitleStyle {
   /// 同为 3，语义不同（此值是历史迁移锚点），后续改默认也不破坏旧数据迁移。
   static const double _v1LegacyShadowThickness = 3;
 
-  /// High-contrast caption defaults (TODO-051): 36px bold WHITE text with a soft
+  /// High-contrast caption defaults (TODO-051): 36px WHITE text with a soft
   /// translucent-BLACK drop shadow, no box. Fixed white/black instead of theme
   /// colors so subtitles stay legible on any video and don't wash out on
   /// low-contrast themes. [fontWeight]/[shadowThickness] stay null to follow the
@@ -466,7 +475,10 @@ class VideoSubtitleStyle {
       int? readFontWeight(Object? v) {
         if (v is! num) return null;
         final int normalized = normalizeWeight(v);
-        return version < 2 && normalized == defaultFontWeight
+        // v1 数据存的是当时硬编码默认字重（700）=「跟随默认」，迁移成 null。对照 v1
+        // 时代字面量而非当前 [defaultFontWeight]（已改 400，mpv 对齐）：否则老用户的
+        // 未调整值会被钉死成显式 700、永远吃不到新默认（同 shadowThickness 的教训）。
+        return version < 2 && normalized == _v1LegacyFontWeight
             ? null
             : normalized;
       }

--- a/fushi/test/media/video/video_subtitle_blur_border_semantics_test.dart
+++ b/fushi/test/media/video/video_subtitle_blur_border_semantics_test.dart
@@ -127,7 +127,7 @@ void main() {
         home: Scaffold(
           body: VideoSubtitleOverlay(
             controller: c,
-            fontWeight: 700, // 用户统一字重=粗体（视频页默认）
+            fontWeight: 700, // 用户显式统一字重=粗体（默认已是 400，此处特意调粗测渗透）
             respectAssStyle: respect,
           ),
         ),

--- a/fushi/test/media/video/video_subtitle_style_test.dart
+++ b/fushi/test/media/video/video_subtitle_style_test.dart
@@ -17,7 +17,10 @@ void main() {
       const Color(0xE6000000),
     );
     expect(s.fontWeight, isNull);
-    expect(s.resolveFontWeight(1.0), 700);
+    // 默认字重 400 常规，与 mpv 默认（--sub-bold=no）对齐；ASS cueStyle 路径的字重
+    // 恒随 ASS（BUG-819），本默认只管 SRT/无样式表路径。
+    expect(VideoSubtitleStyle.defaultFontWeight, 400);
+    expect(s.resolveFontWeight(1.0), 400);
     // 阴影半径改回 Niratan 默认 3（柔和投影模糊半径，不再是 5px 硬描边）。
     expect(s.shadowThickness, isNull);
     expect(VideoSubtitleStyle.defaultShadowThickness, 3);
@@ -32,9 +35,9 @@ void main() {
   test('unconfigured weight and shadow follow app UI scale', () {
     const VideoSubtitleStyle s = VideoSubtitleStyle.defaults;
 
-    expect(s.resolveFontWeight(2.0), 900);
+    expect(s.resolveFontWeight(2.0), 800); // 400 * 2.0
     expect(s.resolveShadowThickness(2.0), 6); // 3 * 2.0
-    expect(s.resolveFontWeight(0.5), 400);
+    expect(s.resolveFontWeight(0.5), 200); // 400 * 0.5
     expect(s.resolveShadowThickness(0.5), 1.5); // 3 * 0.5
   });
 
@@ -161,7 +164,9 @@ void main() {
 
     expect(s.fontWeight, isNull);
     expect(s.shadowThickness, isNull);
-    expect(s.resolveFontWeight(1.0), 700);
+    // v1 的 700 是历史迁移锚点（_v1LegacyFontWeight）；折叠成 null 后 resolve 出的是
+    // **当前**默认 400（mpv 对齐）——「跟随默认」的老用户随新默认走，而非钉死旧值。
+    expect(s.resolveFontWeight(1.0), 400);
     expect(s.resolveShadowThickness(1.0), 3); // Niratan 默认半径。
   });
 


### PR DESCRIPTION
## 背景
用户对比同一字体在 fushi 与 MPV 的字幕渲染，发现观感差异大，定位为字重：mpv 默认 `--sub-bold=no` 渲染常规体（400），fushi 统一字幕默认却是 700 粗体。

## 改动
- `VideoSubtitleStyle.defaultFontWeight` 700 → 400，与 mpv 默认对齐。ASS 有 cueStyle 时字重本就恒随 ASS（BUG-819），本默认只影响 SRT/无样式表/尊重关闭路径。
- v1 持久化迁移锚点解耦成 `_v1LegacyFontWeight = 700` 字面量（复用 `_v1LegacyShadowThickness` 既有模式）：v1 老数据存的 700=「跟随默认」仍折叠成 null、随新默认 400 走；v2 显式设置值（含显式 700）原样保留。
- 过时注释与测试断言同步更新。

## 验证
- `flutter analyze` 全量绿（exit 0）
- 定向 `test/media/video`：46+13 条全绿；一条 suite 装载失败为并发伪红（单跑全绿）

https://claude.ai/code/session_01FU4eXoUF2hisi3mevHUjoM