### PR TITLE
fix(sync): 同步拉回更远进度后首页「继续」/书架不刷新须重启（BUG-1650）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1531 条。点号进各自文件。
+> 共 1532 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1650](bugs/BUG-1650-sync-pulled-progress-stale-until-restart.md) | ✅ | ✅ | 同步拉回更远进度后首页继续与书架不刷新须重启 |
 | [BUG-1649](bugs/BUG-1649-manga-folder-epub-import.md) | ✅ | ✅ | 漫画页选文件夹导入：目录内是 epub 卷时报 Manga image folder has no pages |
 | [BUG-1648](bugs/BUG-1648-embedded-torrent-idle-discovery.md) | ✅ | ✅ | 已完成任务恢复后 DHT 常驻导致网关周期性高延迟 |
 | [BUG-1647](bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md) | ✅ | ✅ | Bangumi 同步失败后卡在退避窗口且无自动重试，只能手动同步 |

--- a/docs/bugs/BUG-1650-sync-pulled-progress-stale-until-restart.md
+++ b/docs/bugs/BUG-1650-sync-pulled-progress-stale-until-restart.md
@@ -1,0 +1,14 @@
+## BUG-1650 · 同步拉回更远进度后首页继续与书架不刷新须重启
+- **报告**：2026-08-14（用户：every time you sync and the remote progress is further than local, you have to restart the app for the progress to actually reflect in the "continue reading"）
+- **真实性**：✅ 真 bug，三处断链共同作用（首页「继续」的书侧数据全部派生自 `reader_positions`，而同步回灌只写这张表）：
+  1. `FushiDatabase.watchDashboardDataChanges()`（首页自动刷新的表级信号，`database_statistics.part.dart`）表集不含 `reader_positions` → 同步写回后首页不重载；
+  2. 书数据的三个缓存 provider（`fushiBooksProvider`（`MediaItem.position` 派生自 reader_positions）/ `bookLastReadAtProvider`，`reader_fushi_source.dart`）只在**关书**（`onSourceExit`）与**导入**时失效——同步这条写入路径没有任何失效点；
+  3. BUG-686 让书进度拉回触发 `ReaderMediaType.refreshTab()`，但书架页的 `_reloadShelfMapsOnTabRefresh` 只重载合集折叠映射、不失效上述 provider——信号修了、消费端一直没接上。
+  重启「能好」正是因为 provider 冷重建时才重新读库。
+- **[x] ① 已修复** —（本分支提交）响应式根修，一条通道覆盖所有写入点（本机关书 / 互联 sweep / 云同步 / 下载回填）：
+  - `watchDashboardDataChanges()` 表集加入 `readerPositions`；
+  - 首页 `_scheduleReload` 防抖回调里同点失效 `fushiBooksProvider` + `bookLastReadAtProvider`（书架从未打开也能刷新；频度由写入端 debounce + 400ms 防抖兜住）；
+  - 书架 `_reloadShelfMapsOnTabRefresh` 同点失效两 provider（进度条 / 最近阅读排序同步后立即正确）。
+  视频侧无此断链：首页 `_videos` 走 `videoBooks` 表级信号（本就在表集里），sweep 写 `updateVideoBookPosition` 即触发。
+- **[x] ② 已加自动化测试** — `fushi/test/database/activity_events_test.dart`（`watchDashboardDataChanges` 在 `upsertReaderPosition` 时 emit——根通道守卫，同组既有 activity/统计/视频改名用例同款）。页面侧 invalidate 是两行胶水，由根通道测试覆盖。
+- **备注**：视频**库页**（home_video_page）监听的是 `watchVideoBookUids().distinct`（纯列更新不触发），同步写回断点后要切回 tab 才刷新——症状轻（tab 激活即刷），未在本条处理，记为后续观察项。

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -543,7 +543,15 @@ class _HomeDashboardPageState
   void _scheduleReload() {
     _reloadDebounce?.cancel();
     _reloadDebounce = Timer(const Duration(milliseconds: 400), () {
-      if (mounted) unawaited(_loadDashboardData());
+      if (!mounted) return;
+      // 「继续」的书侧数据来自缓存 provider（书列表/最近阅读时刻均派生自
+      // reader_positions），它们此前只在关书/导入时失效——互联/云同步把更远的
+      // 对端进度写回后首页拿不到新值、要重启才生效。表级变更信号（现已含
+      // readerPositions）到达时一并失效，让下面的重载 + build 的 ref.watch 读到
+      // 新进度。频度由写入端自身的 debounce + 本 400ms 防抖兜住。
+      ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+      ref.invalidate(bookLastReadAtProvider);
+      unawaited(_loadDashboardData());
     });
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -439,6 +439,12 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 落到这里重载 _shelfMapsFuture，让新同步进来的合集成员立即成组。
   void _reloadShelfMapsOnTabRefresh() {
     if (!mounted) return;
+    // 同步拉回对端更远的阅读进度（localBookProgressPulled>0 同样走 refreshTab）
+    // 时，书列表 / 最近阅读时刻 provider 的缓存也必须失效——否则书架进度条与
+    // 「最近阅读」排序停在旧值，要下拉刷新或重启才对（BUG-686 只修了触发信号，
+    // 消费端一直没接上这两个缓存）。
+    ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+    ref.invalidate(bookLastReadAtProvider);
     setState(() {
       _shelfMapsFuture = _loadShelfMaps();
     });

--- a/fushi/test/database/activity_events_test.dart
+++ b/fushi/test/database/activity_events_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -255,6 +256,24 @@ void main() {
         charsRead: 10,
         timeMs: 1000,
       );
+      await emitted;
+    });
+
+    test(
+        'watchDashboardDataChanges 在写入阅读位置（reader_positions）时也 emit '
+        '（同步回灌对端更远进度后首页「继续」自动刷新的根通道——此前不在表集里，'
+        '要重启 app 才生效）', () async {
+      final db = await _openDb();
+      final Future<void> emitted = db.watchDashboardDataChanges().first.timeout(
+            const Duration(seconds: 3),
+          );
+      await db.upsertReaderPosition(ReaderPositionsCompanion(
+        bookUid: const Value('uid-progress-sync'),
+        sectionIndex: const Value(3),
+        normCharOffset: const Value(4200),
+        charOffset: const Value(88),
+        updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      ));
       await emitted;
     });
 

--- a/packages/fushi_core/lib/src/database/database_statistics.part.dart
+++ b/packages/fushi_core/lib/src/database/database_statistics.part.dart
@@ -602,6 +602,11 @@ mixin _FushiDbStatistics
             readingStatistics,
             videoWatchStatistics,
             videoBooks,
+            // 阅读位置是首页「继续」的数据源（MediaItem.position 与最近阅读时刻
+            // 均派生自它）。此前不在表集里：互联/云同步把更远的对端进度写回
+            // reader_positions 后，首页「继续」不刷新、要重启 app 才生效——
+            // 同步回灌与本机关书是同一张表的写入，理应同一条失效通道。
+            readerPositions,
           ]),
         ).listen((_) {
           if (!controller.isClosed) controller.add(null);


### PR DESCRIPTION
## 问题（BUG-1650）

用户报告：互联/云同步把对端更远的阅读进度拉回本机后，首页「继续阅读」和书架**不刷新，必须重启 app 才生效**。

## 根因（三处断链，首页「继续」的书侧数据全部派生自 `reader_positions`，而同步回灌只写这张表）

1. `FushiDatabase.watchDashboardDataChanges()`（首页自动刷新的表级信号）表集**不含 `reader_positions`** → 同步写回后首页不重载；
2. 书数据缓存 provider（`fushiBooksProvider`（`MediaItem.position` 派生自 reader_positions）/ `bookLastReadAtProvider`）只在**关书**与**导入**时失效——同步这条写入路径没有任何失效点；
3. BUG-686 修了触发信号（书进度拉回 → `ReaderMediaType.refreshTab()`），但书架页 `_reloadShelfMapsOnTabRefresh` 只重载合集折叠映射、从不失效上述 provider——信号修了、消费端一直没接上。

重启「能好」正是因为 provider 冷重建时才重新读库。

## 修复（响应式根修，一条通道覆盖本机关书 / 互联 sweep / 云同步 / 下载回填全部写入点）

- `watchDashboardDataChanges()` 表集加入 `readerPositions`（`packages/fushi_core/.../database_statistics.part.dart`）；
- 首页 `_scheduleReload` 400ms 防抖回调里同点失效 `fushiBooksProvider` + `bookLastReadAtProvider`（书架从未打开也能刷新）；
- 书架 `_reloadShelfMapsOnTabRefresh` 同点失效两 provider（进度条 / 最近阅读排序同步后立即正确）。

视频侧无此断链：首页 `_videos` 走 `videoBooks` 表级信号（本就在表集里），sweep 写 `updateVideoBookPosition` 即触发。

## 测试

- 新增守卫：`fushi/test/database/activity_events_test.dart` —— `watchDashboardDataChanges` 在 `upsertReaderPosition` 时 emit（根通道守卫，同组既有 activity / 统计 / 视频改名用例同款）。
- `flutter analyze` 绿（fushi + fushi_core）；定向合跑 `test/database` + `home_dashboard_page_test` + `interconnect_dashboard_feed_test` 651 项全绿。

## 备注

- 本 commit 原是 #830 分支上合并后追加的提交（`08315be685`），按「合并后追加 push 永不进 develop」规则 cherry-pick 到本干净分支重新开 PR。
- 后续观察项（已记录在 BUG-1650 备注）：视频**库页**（home_video_page）监听 `watchVideoBookUids().distinct`（纯列更新不触发），同步写回断点后要切回 tab 才刷新——症状轻，未在本条处理。

https://claude.ai/code/session_01DEMru6DwoQx9us6n83TzMw
