### PR TITLE
fix(test): 修 develop 单测门红——#840 新测试用裸字符串比较 format

### DIFF
--- a/fushi/test/media/manga/manga_folder_batch_test.dart
+++ b/fushi/test/media/manga/manga_folder_batch_test.dart
@@ -113,7 +113,11 @@ void main() {
         books.map((EpubBookRow b) => b.title).toList()..sort(),
         <String>['銀河英雄伝説 01', '銀河英雄伝説 02'],
       );
-      expect(books.every((EpubBookRow b) => b.format == 'manga'), isTrue);
+      expect(
+        books.every((EpubBookRow b) =>
+            BookFormat.parseOrEpub(b.format) == BookFormat.manga),
+        isTrue,
+      );
     });
 
     test('一卷坏包不中断整批：其余卷照样进库', () async {


### PR DESCRIPTION
fix(test): 修 develop 单测门红——#840 新测试用裸字符串比较 format

`book_format_discipline_guard_test.dart` 是目录枚举型守卫，用 listSync(recursive)
扫 lib/ + test/ 全树。PR #840 新增的 manga_folder_batch_test.dart 落进它的扫描面，
第 116 行 `b.format == 'manga'` 命中「不得用裸字符串比较 format」规则，
develop head c26830a3 的 Build Release APK -> tests 因此红（19052 test，1 error）。

改成 `BookFormat.parseOrEpub(b.format) == BookFormat.manga`：断言语义不变
（仍然要求两卷都是 manga），但走枚举而不是裸字面量，未知/拼错的 format 值
在这里不再被静默当成「不等于 manga」而是先归一化。

验证：
- 目录枚举型守卫整批 36 个 test 文件，250 tests 全绿（137 + 113，exit 0）
- manga_folder_batch_test + import_carrier_test 38 tests 绿
- flutter analyze（含 test）No issues
