### PR TITLE
fix(test): 修 develop 单测门红——#845 改默认字重漏了快捷设置面板的预览断言

### DIFF
--- a/fushi/test/media/video/video_subtitle_style_test.dart
+++ b/fushi/test/media/video/video_subtitle_style_test.dart
@@ -41,6 +41,24 @@ void main() {
     expect(s.resolveShadowThickness(0.5), 1.5); // 3 * 0.5
   });
 
+  test('extreme UI scale still lands inside CSS weight / shadow bounds', () {
+    // UI scale 先被 FushiAppUiScale.normalize 钳到 [0.3, 3.0]，再参与缩放。
+    // 这份覆盖原先只由 video_quick_settings_sheet_test 在旧默认 700 下偶然盖住
+    // （700 * 2 = 1400 → 上限 900）；默认改 400 后那里不再饱和，故在此显式钉死。
+    const VideoSubtitleStyle s = VideoSubtitleStyle.defaults;
+
+    // 字重上限 900 仍够得着：scale 3.0 → 400 * 3 = 1200 → 钳到 900。
+    expect(s.resolveFontWeight(3.0), 900);
+    expect(s.resolveFontWeight(99.0), 900, reason: 'scale 先被归一化到 3.0');
+    // 下限侧：scale 归一化到 0.3 → 400 * 0.3 = 120 → 按 100 步进舍入到 100。
+    expect(s.resolveFontWeight(0.01), 100);
+    // 阴影：归一化后最大 3 * 3.0 = 9，够不到滑杆上限 12——这是值域设计的结论，
+    // 不是断言写松了；若哪天 maxScale 或默认半径变大，这条会先红。
+    expect(s.resolveShadowThickness(3.0), 9);
+    expect(s.resolveShadowThickness(99.0), 9, reason: 'scale 先被归一化到 3.0');
+    expect(s.resolveShadowThickness(0.01), closeTo(0.9, 1e-9));
+  });
+
   test('null color still means follow the active theme (legacy data)', () {
     // 旧数据（TODO-051 前默认）持久化时颜色为 null = 跟随主题；resolve 仍回退主题色。
     const VideoSubtitleStyle s = VideoSubtitleStyle(

--- a/fushi/test/pages/video_quick_settings_sheet_test.dart
+++ b/fushi/test/pages/video_quick_settings_sheet_test.dart
@@ -552,7 +552,10 @@ void main() {
         t.video_setting_subtitle_font_weight,
       ),
     );
-    expect(fontWeightRow.value, 900);
+    // 默认字重 400（PR#845 与 mpv `--sub-bold=no` 对齐）；UI scale 2.0 下预览
+    // = 400 * 2 = 800。旧值 900 是「700 * 2 = 1400 被上限钳位」的饱和结果，
+    // 顺带盖住了钳位；钳位覆盖已移到单元层 video_subtitle_style_test.dart。
+    expect(fontWeightRow.value, 800);
 
     final Iterable<AdaptiveSettingsSliderRow> sliders =
         tester.widgetList<AdaptiveSettingsSliderRow>(


### PR DESCRIPTION
fix(test): 修 develop 单测门红——#845 改默认字重漏了快捷设置面板的预览断言

PR #845 把 VideoSubtitleStyle.defaultFontWeight 从 700 改成 400（与 mpv
`--sub-bold=no` 对齐），同批更新了 video_subtitle_style_test，但漏了
test/pages/video_quick_settings_sheet_test.dart 的
`subtitle default weight and shadow preview use app UI scale`：
它在 uiScale=2.0 下断言字重步进行的值是 900。

那个 900 不是「默认字重」，是**上限钳位的饱和值**——旧默认 700 * 2 = 1400，被
resolveFontWeight 的 `rounded > 900` 钳回 900。默认改 400 后 400 * 2 = 800，
不再饱和，断言随之红（develop head 5e2763c9 的 Build Release APK -> tests，
19053 test 里 1 个 error）。

两处改动：
1. sheet 测试期望值 900 -> 800，并写清 800 的来历与旧值为何是饱和值。
2. 旧值顺带盖住了字重上限钳位，改成 800 就把这份覆盖丢了。故在单元层
   video_subtitle_style_test.dart 补一条显式用例，钉死「UI scale 先被
   FushiAppUiScale.normalize 钳到 [0.3, 3.0]，再缩放，结果落在 CSS 字重
   100..900 与阴影滑杆 0..12 内」：
   - scale 3.0 -> 400*3=1200 -> 上限 900（钳位仍够得着）
   - scale 99.0 -> 归一化 3.0 -> 900
   - scale 0.01 -> 归一化 0.3 -> 120 -> 按 100 步进舍入到 100
   - 阴影归一化后最大 3*3.0=9，够不到滑杆上限 12——这是值域设计的结论，
     maxScale 或默认半径变大时这条会先红。

未动任何 lib/ 代码：#845 的实现是对的，红的是没跟上的测试期望。

变异实测（两条断言都真能抓到回归，源码均按唯一锚点反向替换还原并比对 sha256 一致）：
- 把 resolveFontWeight 上限 900 -> 9000：新用例红（Expected 900 / Actual 1200）
- 把字重步进行的 resolveFontWeight(videoSubtitleUiScale(ctx)) -> resolveFontWeight(1.0)：
  sheet 用例红（Expected 800 / Actual 400.0），证明它仍在钉「预览用 app UI scale」

验证：
- 定向 test/pages/video_quick_settings_sheet_test + 字幕样式 + test/settings/ 共 486 tests 绿，exit 0
- 目录枚举型守卫整批 36 文件 250 tests 绿，exit 0
- flutter analyze（含 test）No issues，exit 0
