### PR TITLE
fix(video): interop surface 失败改退回上游 EGL display，别把画质增强/超分一起丢掉（BUG-1657）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1512 条。点号进各自文件。
+> 共 1513 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1657](bugs/BUG-1657-angle-surface-fallback-loses-shaders.md) | ✅ | ✅ | 画质增强/超分静默失效：ANGLE device-backed display 之后任一步失败即掉软件渲染，而 SW 路径下 glsl-shaders 完全不生效 |
 | [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |
 | [BUG-1613](bugs/BUG-1613-apple-coreml-ep-detector-empty.md) | ✅ | ✅ | Apple CoreML EP 上 int8 检测模型静默返回空结果且更慢 |
 | [BUG-1610](bugs/BUG-1610-bangumi-search-rating-null.md) | ✅ | ✅ | Bangumi 搜索候选评分恒空：映射器读扁平 score，真实响应只有嵌套 rating.score |

--- a/docs/bugs/BUG-1657-angle-surface-fallback-loses-shaders.md
+++ b/docs/bugs/BUG-1657-angle-surface-fallback-loses-shaders.md
@@ -1,0 +1,59 @@
+## BUG-1657 · 画质增强/超分静默失效：ANGLE device-backed display 之后任一步失败即掉软件渲染，而 SW 路径下 glsl-shaders 完全不生效
+- **报告**：2026-08-15（用户：「我感觉画质增强，也就是超分好像不生效了」）
+- **真实性**：✅ 真 bug（健壮性缺陷 + 可观测性缺失）。根因两层，见下。
+- **[x] ① 已修复** — ① `third_party/media_kit_video/windows/angle_surface_manager.cc:Create()` 在 `CreateAndBindEGLSurface()` 失败时先调 `RetryOnUpstreamEGLDisplay()`：拆掉 device-backed display、latch `shared_interop_display_disabled_`、在上游 `EGL_DEFAULT_DISPLAY` 链上重建 context/surface；只有它也失败才抛异常。② `video_output.cc` 在 S/W 回落分支多打一行，明说 `glsl-shaders & scale filters are INERT`。
+- **[x] ② 已加自动化测试** — `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart` 新增 2 条（`Create()` 必须走 retry 且必须 latch；S/W 分支必须打出 INERT 警告），共 10 条；两条各做变异实测转红，文件按 sha256 逐字节还原。
+
+### 为什么「掉软件渲染」等于「超分没了」
+
+media_kit 的 `VideoOutput` 在 `ANGLESurfaceManager` 抛异常时回落到
+`MPV_RENDER_PARAM_API_TYPE = MPV_RENDER_API_TYPE_SW`（`video_output.cc:100`）。那条路**不是
+`vo=gpu`**，libmpv 的 `glsl-shaders`（Anime4K 等超分）与 `scale`/`cscale`（画质增强下发的
+`ewa_lanczossharp`）都不会被应用，而且**不报任何错**——用户只看到「开了跟没开一样」。
+
+实测（同一份 libmpv、同一套用户实际启用的 7 个 Anime4K shader、同一个片源，只换渲染 API）：
+
+| 渲染路径 | 生成着色器里 `conv2d` 引用数 |
+|---|---|
+| OpenGL / ANGLE（`vo=gpu`） | **2016**（Anime4K 完整进管线） |
+| `MPV_RENDER_API_TYPE_SW`（media_kit 软件回落） | **0**（user shader 完全不生效） |
+
+判据说明：mpv **不会**把 `//!DESC` 写进生成的着色器或日志，所以「日志里 grep 不到 Anime4K」
+不能作为未加载的证据（第一次排查就在这里误判过一次）。可靠标记是 `//!SAVE` 产生的中间纹理名
+（这里是 `conv2d*`），它会真实出现在生成的 GLSL/HLSL 里。
+
+### 根因 A：BUG-1644 引入的新 display 没有下游回退
+
+BUG-1644 让 ANGLE 跑在我们自建的 D3D11 device 上（`eglCreateDeviceANGLE` +
+`eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, …)`）。`EnsureSharedEGLDisplay()` 只在
+**创建该 display 本身**失败时退回上游四级链；但 config / context / `eglCreatePbufferFromClientBuffer`
+是在**之后**做的，任何一步失败都会让 `Create()` 直接抛异常 → 整个 `VideoOutput` 掉进软件渲染。
+也就是说：一个只影响「零拷贝」的问题，被放大成了「丢掉整条 GPU 渲染管线（连带画质增强）」。
+device-backed display 上的 pbuffer 路径此前只在 WARP 上验过，真 N 卡未验证（见 BUG-1644 未闭环项），
+所以这个放大风险是真实存在的。
+
+修法：失败时保留硬件渲染、只放弃零拷贝——回到上游 display 重建一次。仅对**首个**实例执行
+（`instance_count_ == 0`），避免把别的 `VideoOutput` 正在用的共享 display 拆掉。
+
+### 根因 B：软件回落没有任何可观测信号
+
+回落只打 `Using S/W rendering.`，没说代价。现在补一行明确写出 `glsl-shaders & scale filters
+are INERT`，下次同类报告可一眼定位。
+
+### 本次报告的现场结论
+
+用户设置侧完全正常：`video_mpv_config.highQuality = true`，`video_shaders_enabled` 7 个且文件
+都在 `D:\APP\HIBIKI_date\documents\mpv_shaders\`；下发链路也正常（探针实测 7 条
+`change-list glsl-shaders append` 全部返回 0，`glsl-shaders` 属性确实带上 7 个路径）。
+
+但**本机当时处于「新进程建不出硬件 D3D11 设备」的状态**（三块 5090 适配器一律
+`E_OUTOFMEMORY 0x8007000E`，D3D12 同样失败，只有 WARP / Basic Render Driver / D3D9Ex 可用；
+详见 BUG-1644 未闭环项与 `reference_no_hw_d3d11_device_when_gpu_clients_saturated`）。在该状态下
+`EnsureSharedD3D11Device()` 必然失败 → `Create()` 抛异常 → 软件渲染 → 超分整体失效。
+**这一条与 BUG-1644 无关，改动前后都会发生**；根因 A 是在此之上新增的、独立的放大路径。
+
+### 未闭环
+
+「真 N 卡上 device-backed display 的 pbuffer 是否可用」仍未验证（GPU 不可用）。若它其实不可用，
+本条的 retry 正好把后果从「丢 GPU 管线」降级为「只丢零拷贝」；若可用，则 retry 永不触发，零代价。
+GPU 恢复后按 BUG-1644 的命令跑一次探针即可同时闭环两条。

--- a/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
+++ b/fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart
@@ -256,6 +256,46 @@ void main() {
       );
     });
 
+    test('a failed interop surface retries on ANGLE\'s own display', () {
+      // BUG-1657: the device-backed display is new; if the surface cannot be
+      // built on it, VideoOutput's software renderer takes over, and
+      // MPV_RENDER_API_TYPE_SW has no vo=gpu pipeline, so every glsl-shader
+      // (Anime4K / upscalers) and the scale/cscale filters silently stop
+      // applying. Hardware rendering must be retried on the upstream display
+      // first; losing zero-copy is far cheaper than losing the GPU pipeline.
+      final int create =
+          managerCode.indexOf('void ANGLESurfaceManager::Create()');
+      expect(create, isNonNegative,
+          reason: 'expected a Create() definition in angle_surface_manager.cc');
+      final int nextFunction =
+          managerCode.indexOf('\nvoid ANGLESurfaceManager::CleanUp', create);
+      final String body = managerCode.substring(
+          create, nextFunction < 0 ? managerCode.length : nextFunction);
+      expect(
+        body.contains('RetryOnUpstreamEGLDisplay()'),
+        isTrue,
+        reason: 'Create() must retry on the upstream EGL display when the '
+            'surface fails, instead of throwing straight into the software '
+            'renderer (where glsl-shaders are inert).',
+      );
+      expect(
+        managerCode.contains('shared_interop_display_disabled_'),
+        isTrue,
+        reason: 'once the device-backed display proves unusable it must be '
+            'latched off, otherwise every later instance rebuilds it.',
+      );
+    });
+
+    test('the software downgrade says that shaders stop applying', () {
+      expect(
+        videoOutputCode.contains('glsl-shaders & scale filters are INERT'),
+        isTrue,
+        reason: 'S/W rendering silently disables 画质增强 / super-resolution; '
+            'the log must say so or the next report is undiagnosable '
+            '(BUG-1657).',
+      );
+    });
+
     test('the interop outcome is observable', () {
       expect(
         headerCode.contains('uses_shared_d3d11_device'),

--- a/third_party/media_kit_video/PATCHES.md
+++ b/third_party/media_kit_video/PATCHES.md
@@ -520,3 +520,46 @@ the new path behave exactly like pub.dev.
 next to its existing `Using H/W rendering.` line.
 
 Source-guard test: `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`.
+
+## BUG-1657: a failed interop surface must not cost the whole GPU pipeline
+
+`windows/angle_surface_manager.{h,cc}` and one log line in `windows/video_output.cc`.
+
+BUG-1644 added a new display type (`EGL_PLATFORM_DEVICE_EXT` on our own D3D11
+device). `EnsureSharedEGLDisplay()` falls back to the upstream
+`EGL_DEFAULT_DISPLAY` chain only when creating *that display* fails, but the
+config, the context and the `eglCreatePbufferFromClientBuffer` all happen
+afterwards, and any of those failing threw straight out of `Create()`, which
+drops the whole `VideoOutput` into `MPV_RENDER_API_TYPE_SW`.
+
+That downgrade is far more expensive than it looks: the software path is not
+`vo=gpu`, so libmpv's `glsl-shaders` (Anime4K & other upscalers) and the
+`scale`/`cscale` filters stop applying **silently**. Measured with one user's
+real shader set, same libmpv, same clip, changing only the render API: the
+generated shaders contain 2016 `conv2d` references on the GL path and **zero**
+on the S/W path. The user-visible symptom is just "super-resolution stopped
+working", with nothing in any log.
+
+Note on evidence: mpv never emits a user shader's `//!DESC` text into the
+generated shader or the log, so "the log does not mention Anime4K" proves
+nothing. The reliable marker is the intermediate texture names a shader
+declares with `//!SAVE` (`conv2d*` here), which do appear in the generated
+GLSL/HLSL.
+
+The patch:
+
+- `Create()` calls `RetryOnUpstreamEGLDisplay()` when `CreateAndBindEGLSurface()`
+  fails. It terminates the device-backed display, releases the `EGLDeviceEXT`,
+  latches `shared_interop_display_disabled_` so neither this nor a later
+  instance rebuilds it, and rebuilds context + surface on the upstream display.
+  Only then, if that also fails, does it throw. Guarded by `instance_count_ == 0`
+  so a shared display another `VideoOutput` is already rendering on is never
+  torn down.
+- `VideoOutput` logs, next to `Using S/W rendering.`, that
+  `libmpv glsl-shaders & scale filters are INERT`, so the next such report is
+  diagnosable from the log alone.
+
+Net effect: a problem that only affects zero-copy now costs only zero-copy,
+instead of costing hardware rendering and every shader with it.
+
+Source-guard test: `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart`.

--- a/third_party/media_kit_video/windows/angle_surface_manager.cc
+++ b/third_party/media_kit_video/windows/angle_surface_manager.cc
@@ -30,6 +30,7 @@ ID3D11DeviceContext* ANGLESurfaceManager::shared_d3d_11_device_context_ =
 EGLDeviceEXT ANGLESurfaceManager::shared_egl_device_ = EGL_NO_DEVICE_EXT;
 EGLDisplay ANGLESurfaceManager::shared_display_ = EGL_NO_DISPLAY;
 bool ANGLESurfaceManager::shared_display_uses_our_device_ = false;
+bool ANGLESurfaceManager::shared_interop_display_disabled_ = false;
 
 ANGLESurfaceManager::ANGLESurfaceManager(int32_t width, int32_t height)
     : width_(width), height_(height) {
@@ -96,8 +97,21 @@ void ANGLESurfaceManager::Create() {
     return;
   }
   if (!CreateAndBindEGLSurface()) {
-    throw std::runtime_error("Unable to create ANGLE EGL surface.");
-    return;
+    // HIBIKI FORK (BUG-1657): BUG-1644 introduced a *new* display type
+    // (EGL_PLATFORM_DEVICE_EXT on our own device). |EnsureSharedEGLDisplay|
+    // only falls back to the upstream EGL_DEFAULT_DISPLAY chain when creating
+    // that display fails; anything failing *after* it (config, context,
+    // pbuffer-from-share-handle) used to land straight in |VideoOutput|'s
+    // software renderer. That is a silent, expensive downgrade: the S/W path
+    // renders with MPV_RENDER_API_TYPE_SW, which is not vo=gpu, so libmpv's
+    // `glsl-shaders` (Anime4K & friends) and the `scale`/`cscale` filters stop
+    // applying entirely -- measured: the very same shader set inlines 2016
+    // `conv2d` references into the generated shaders on the GL path and zero on
+    // the S/W path. Retry once on the well-trodden upstream display before
+    // giving up on hardware rendering.
+    if (!RetryOnUpstreamEGLDisplay()) {
+      throw std::runtime_error("Unable to create ANGLE EGL surface.");
+    }
   }
   if (internal_handle_ == nullptr || handle_ == nullptr) {
     throw std::runtime_error("Unable to retrieve Direct3D shared HANDLE.");
@@ -309,7 +323,8 @@ bool ANGLESurfaceManager::EnsureSharedEGLDisplay() {
   // re-uploaded. This mirrors what mpv's own `--gpu-context=angle` does.
   auto eglCreateDeviceANGLE = reinterpret_cast<PFNEGLCREATEDEVICEANGLEPROC>(
       eglGetProcAddress("eglCreateDeviceANGLE"));
-  if (shared_d3d_11_device_ != nullptr && eglCreateDeviceANGLE != nullptr) {
+  if (shared_d3d_11_device_ != nullptr && eglCreateDeviceANGLE != nullptr &&
+      !shared_interop_display_disabled_) {
     shared_egl_device_ = eglCreateDeviceANGLE(EGL_D3D11_DEVICE_ANGLE,
                                               shared_d3d_11_device_, nullptr);
     if (shared_egl_device_ != EGL_NO_DEVICE_EXT) {
@@ -383,6 +398,45 @@ void ANGLESurfaceManager::ReleaseSharedResources() {
     shared_d3d_11_device_->Release();
     shared_d3d_11_device_ = nullptr;
   }
+}
+
+bool ANGLESurfaceManager::RetryOnUpstreamEGLDisplay() {
+  // Only meaningful when the device-backed display is what we are on, and only
+  // safe for the very first instance: |instance_count_| is bumped after the
+  // constructor returns, so 0 means nobody else is rendering on the shared
+  // display we are about to terminate.
+  if (!shared_display_uses_our_device_ || instance_count_ != 0) {
+    return false;
+  }
+  std::cout << "media_kit: ANGLESurfaceManager: EGL surface creation failed on "
+               "the shared Direct3D 11 device; retrying on ANGLE's own display "
+               "(hardware rendering kept, zero-copy interop given up)."
+            << std::endl;
+
+  // The context/surface belong to the display we are terminating; eglTerminate
+  // destroys them, so just forget the handles instead of double-destroying.
+  context_ = EGL_NO_CONTEXT;
+  surface_ = EGL_NO_SURFACE;
+  display_ = EGL_NO_DISPLAY;
+  if (shared_display_ != EGL_NO_DISPLAY) {
+    eglTerminate(shared_display_);
+    shared_display_ = EGL_NO_DISPLAY;
+  }
+  if (shared_egl_device_ != EGL_NO_DEVICE_EXT) {
+    auto eglReleaseDeviceANGLE = reinterpret_cast<PFNEGLRELEASEDEVICEANGLEPROC>(
+        eglGetProcAddress("eglReleaseDeviceANGLE"));
+    if (eglReleaseDeviceANGLE) {
+      eglReleaseDeviceANGLE(shared_egl_device_);
+    }
+    shared_egl_device_ = EGL_NO_DEVICE_EXT;
+  }
+  shared_display_uses_our_device_ = false;
+  // Make |EnsureSharedEGLDisplay| skip the device-backed attempt from now on,
+  // otherwise this instance (and every later one) would rebuild the display
+  // that just proved unusable.
+  shared_interop_display_disabled_ = true;
+
+  return CreateEGLDisplay() && CreateAndBindEGLSurface();
 }
 
 bool ANGLESurfaceManager::CreateEGLDisplay() {

--- a/third_party/media_kit_video/windows/angle_surface_manager.h
+++ b/third_party/media_kit_video/windows/angle_surface_manager.h
@@ -89,6 +89,13 @@ class ANGLESurfaceManager {
   // |ANGLESurfaceManager|.
   static void ReleaseSharedResources();
 
+  // BUG-1657: tears the device-backed display down and rebuilds the surface on
+  // ANGLE's own display, so a failure downstream of the interop display costs
+  // the zero-copy interop instead of costing hardware rendering (and with it,
+  // silently, every `glsl-shaders` / `scale` filter). Returns false when the
+  // retry is not applicable or also failed.
+  bool RetryOnUpstreamEGLDisplay();
+
   int32_t width_ = 1;
   int32_t height_ = 1;
   HANDLE internal_handle_ = nullptr;
@@ -173,6 +180,9 @@ class ANGLESurfaceManager {
   static EGLDisplay shared_display_;
   // Whether ANGLE actually runs on |shared_d3d_11_device_|.
   static bool shared_display_uses_our_device_;
+  // Set once the device-backed display has proven unusable (BUG-1657), so it is
+  // not rebuilt for this or any later instance.
+  static bool shared_interop_display_disabled_;
 };
 
 #endif  // ANGLE_SURFACE_MANAGER_H_

--- a/third_party/media_kit_video/windows/video_output.cc
+++ b/third_party/media_kit_video/windows/video_output.cc
@@ -92,6 +92,13 @@ VideoOutput::VideoOutput(int64_t handle,
     }
     if (!is_hardware_acceleration_enabled) {
       std::cout << "media_kit: VideoOutput: Using S/W rendering." << std::endl;
+      // HIBIKI FORK (BUG-1657): make the real cost of this downgrade visible.
+      // MPV_RENDER_API_TYPE_SW is not vo=gpu, so libmpv's `glsl-shaders`
+      // (Anime4K / upscalers) and the `scale`/`cscale` filters silently stop
+      // applying -- users see "画质增强 stopped working" with no other symptom.
+      std::cout << "media_kit: VideoOutput: S/W rendering has no vo=gpu "
+                   "pipeline: libmpv glsl-shaders & scale filters are INERT."
+                << std::endl;
       // Allocate a "large enough" buffer ahead of time.
       pixel_buffer_ =
           std::make_unique<uint8_t[]>(SW_RENDERING_PIXEL_BUFFER_SIZE);


### PR DESCRIPTION
用户报告：「画质增强，也就是超分好像不生效了」。

## 定性（实测，不是推断）

**「超分不生效」等价于 media_kit 掉进了软件渲染。** 同一份 libmpv、用户实际启用的那 7 个 Anime4K、同一片源，只换渲染 API：

| 渲染路径 | 生成着色器里 `conv2d` 引用数 |
|---|---|
| OpenGL / ANGLE（正常 `vo=gpu`） | **2016**（Anime4K 完整进管线） |
| `MPV_RENDER_API_TYPE_SW`（media_kit 软件回落） | **0**（user shader 完全失效） |

软件回落那条路不是 `vo=gpu`，libmpv 的 `glsl-shaders`（超分）与 `scale`/`cscale`（画质增强下发的 `ewa_lanczossharp`）会**一起静默失效**，而且不报任何错。

已排除：设置侧 `highQuality: true`、7 个 shader 全启用且文件都在；下发链路正常（7 条 `change-list glsl-shaders append` 全返回 0，`glsl-shaders` 属性确实带上 7 个路径）；这些 shader 均不含 `//!COMPUTE`。

> 排查中的一处自我更正（已写进台账）：mpv **不会**把 user shader 的 `//!DESC` 写进生成的着色器或日志，所以「日志里 grep 不到 Anime4K」不能作为未加载的证据——我第一轮据此误判过一次。可靠标记是 `//!SAVE` 声明的中间纹理名（这里是 `conv2d*`），它会真实出现在生成的 GLSL/HLSL 中。

## 根因 A（本 PR 修的）：新 display 缺下游回退，把小问题放大成大问题

#835 让 ANGLE 跑在我们自建的 D3D11 device 上。`EnsureSharedEGLDisplay()` 只在**创建该 display 本身**失败时退回上游 `EGL_DEFAULT_DISPLAY` 四级链；而 config / context / `eglCreatePbufferFromClientBuffer` 都在**之后**，任何一步失败都会让 `Create()` 直接抛异常 → 整个 `VideoOutput` 掉进软件渲染。

也就是：**一个只该影响「零拷贝」的问题，被放大成「丢掉整条 GPU 渲染管线，连带画质增强」**。而 device-backed display 上的 pbuffer 路径此前只在 WARP 验证过、真 N 卡未验证（#835 的未闭环项），所以这个放大风险是真实的。

改法：`CreateAndBindEGLSurface()` 失败时先调 `RetryOnUpstreamEGLDisplay()`——拆掉 device-backed display、释放 `EGLDeviceEXT`、latch `shared_interop_display_disabled_`（避免本实例与后续实例反复重建已证明不可用的 display）、在上游 display 上重建 context + surface；只有它也失败才抛异常。用 `instance_count_ == 0` 兜住，绝不拆别的 `VideoOutput` 正在渲染的共享 display。

**净效果**：只影响零拷贝的问题现在只损失零拷贝，不再连带损失硬件渲染和所有 shader。

## 根因 B（可观测性）

软件回落此前只打 `Using S/W rendering.`，不说代价。现补一行明写 `libmpv glsl-shaders & scale filters are INERT`，下次同类报告可从日志直接定位。

## 验证

- `/W4 /WX`（项目真实标志）下 `angle_surface_manager.cc` / `video_output.cc` 均编过。
- 干净 `flutter build windows --debug` 成功：`√ Built build\windows\x64\runner\Debug\fushi.exe`，真实退出码 0；新日志字符串已确认存在于产物 `media_kit_video_plugin.dll`。
- `flutter analyze` 全量 `No issues found!`。
- 守卫 `fushi/test/third_party/media_kit_video_angle_interop_guard_test.dart` 由 8 条增至 10 条，两条新守卫各做变异实测转红（去掉 retry 调用 / 改掉 INERT 文案），两个源文件按 sha256 逐字节还原后重新全绿。

## 关于本次现场

用户机器当时处于「新进程建不出硬件 D3D11 设备」的状态（三块 RTX 5090 一律 `E_OUTOFMEMORY 0x8007000E`，D3D12 同样失败，只有 WARP / Basic Render Driver / D3D9Ex 可用，68 个 GPU 客户端进程）。在该状态下 `EnsureSharedD3D11Device()` 必然失败 → 软件渲染 → 超分失效，**这一条与 #835 无关、改动前后都会发生**；根因 A 是在此之上新增的、独立的放大路径。两者都值得修，但用户当下的现象主要由前者触发，减少占 GPU 的进程后重启即可恢复。

详见 `docs/bugs/BUG-1657-angle-surface-fallback-loses-shaders.md`。

https://claude.ai/code/session_01Sn5id8JzPN6NNfemwvRADg
