### PR TITLE
feat(torrent): Android 内置 libtorrent 下载引擎（手机内置下载）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,6 +357,56 @@ jobs:
         chmod +x ci/apply-patches.sh
         bash ci/apply-patches.sh
 
+    # 内置 libtorrent 引擎的 Android .so：vcpkg 交叉编 libtorrent + bridge，产物落
+    # native/fushi_torrent/prebuilt/android/arm64-v8a/，由 fushi/android/app/
+    # build.gradle 的 jniLibs copy-if-present 随包。
+    #
+    # 范围决策：**只编 arm64-v8a**（2026 年真机几乎全是 arm64）。armeabi-v7a /
+    # x86_64 的 split APK 与 fat debug APK 在这些 ABI 上没有 .so，运行期
+    # EmbeddedTorrentHost.open 返回 null → 自动回退外接 qb（与 Windows 缺 DLL
+    # 同一条路径），不是静默破坏。要补其它 ABI 时给脚本追加 ABI 参数即可。
+    #
+    # 缓存姿势照抄 build-multiplatform.yml 的 Windows vcpkg 步骤（TODO-2668）：
+    # key 带 runner ImageVersion（镜像决定 vcpkg 修订与工具链 = 决定 ABI hash，
+    # 常量 key 会让另一镜像永远冷编且命中即不回存）；distfile 目录第二层兜
+    # 「新镜像上线那一次必然冷编」的高危外网取件。
+    - name: Resolve vcpkg cache identity
+      id: vcpkg_cache_id
+      if: ${{ steps.channel.outputs.build_debug_apk == 'true' || steps.channel.outputs.build_debug_channel_apk == 'true' || steps.channel.outputs.build_split_release_apk == 'true' }}
+      shell: bash
+      run: |
+        image="${ImageVersion:-unknown-image}"
+        image="$(echo "$image" | tr -c '0-9A-Za-z._-' '-')"
+        echo "vcpkg cache identity (runner ImageVersion): $image"
+        echo "image=$image" >> "$GITHUB_OUTPUT"
+    - name: Cache vcpkg source distfiles (libtorrent android)
+      if: ${{ steps.channel.outputs.build_debug_apk == 'true' || steps.channel.outputs.build_debug_channel_apk == 'true' || steps.channel.outputs.build_split_release_apk == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ runner.temp }}/vcpkg-downloads
+          !${{ runner.temp }}/vcpkg-downloads/tools
+        key: ${{ runner.os }}-vcpkg-downloads-libtorrent-android-v1-${{ steps.vcpkg_cache_id.outputs.image }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-downloads-libtorrent-android-v1-
+    - name: Cache vcpkg binary archives (libtorrent android)
+      if: ${{ steps.channel.outputs.build_debug_apk == 'true' || steps.channel.outputs.build_debug_channel_apk == 'true' || steps.channel.outputs.build_split_release_apk == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/vcpkg/archives
+        key: ${{ runner.os }}-vcpkg-libtorrent-arm64-android-v1-${{ steps.vcpkg_cache_id.outputs.image }}
+    - name: Build embedded libtorrent Android .so (vcpkg)
+      if: ${{ steps.channel.outputs.build_debug_apk == 'true' || steps.channel.outputs.build_debug_channel_apk == 'true' || steps.channel.outputs.build_split_release_apk == 'true' }}
+      timeout-minutes: 90
+      shell: bash
+      env:
+        VCPKG_DOWNLOADS: ${{ runner.temp }}/vcpkg-downloads
+      run: |
+        set -euo pipefail
+        chmod +x native/fushi_torrent/build_android_so.sh
+        bash native/fushi_torrent/build_android_so.sh \
+          "$VCPKG_INSTALLATION_ROOT" "$ANDROID_NDK_LATEST_HOME" arm64-v8a
+
     # TODO-fast-release: analyze/unit/package tests no longer gate this build job.
     # They ran here as sequential steps BEFORE `flutter build apk`, so a slow or
     # red suite delayed (and could block) the debug-channel APK the user is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@
 
 - Flutter 版本分两处：本地钉 `.fvmrc` = `3.41.6`（pubspec `flutter: "^3.41.6"`），CI workflows 用 `3.44.0`；Dart SDK 约束 `>=3.5.0 <4.0.0`。最低 Android API 24，`compileSdk 36` / `targetSdk 35`。
 - 状态管理 Riverpod；音频 just_audio（桌面经 just_audio_media_kit）；录音 record 6.0.0；视频播放走 **media_kit**（third_party vendored 全套）+ youtube_explode_dart。
-- torrent 走内部包 `packages/fushi_torrent`（libtorrent 2.x C ABI FFI，native 在 `native/fushi_torrent/`；Windows 预编译 DLL 随包，缺失时回退外接 qBittorrent）。
+- torrent 走内部包 `packages/fushi_torrent`（libtorrent 2.x C ABI FFI，native 在 `native/fushi_torrent/`；Windows 预编译 DLL / Android arm64 `.so` 随包，缺失时回退外接 qBittorrent；iOS 无内置引擎）。
 - 主存储是 Drift SQLite（`FushiDatabase`，schema v62），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
 - EPUB 阅读器走 reader_fushi 实现（见仓库地图）。`reader_ttu` key、`setTtu*` 方法、`ttu_*` i18n 只是旧数据兼容残留，不代表还有 TTU 阅读器；没有迁移方案别随手改这些持久化 key。（旧文档提过的 `ttuBookId` 列在当前 schema 已不存在，只活在迁移阶梯里。）
 - 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer` / `TtuIdbReader` / `assets/ttu-ebook-reader` 均已删除）；只剩上述命名残留作旧数据兼容。阅读器渲染/交互问题按 reader_fushi 路径修，不要去上游 ttu fork 仓库改。
@@ -141,7 +141,7 @@
 | `packages/gamepads_windows/` | Dart+C++ | gamepads Windows vendored fork（BUG-116 崩溃修复，path override） | — |
 | `packages/gamepads_android_stub/` | Dart | `gamepads_android` no-op stub（防启动 ClassCastException，path override） | — |
 | `native/fushidicts/` | C++ | 词典查询/导入引擎（上游深度 fork；`fushidicts_external/` 为 vendored 第三方）；FFI/JNI 编入 app | [UPSTREAM.md](native/fushidicts/UPSTREAM.md) |
-| `native/fushi_torrent/` | C++ | libtorrent 2.x C ABI bridge；FFI，Windows 预编译 DLL 随包 | [README.md](native/fushi_torrent/README.md) |
+| `native/fushi_torrent/` | C++ | libtorrent 2.x C ABI bridge；FFI，Windows 预编译 DLL / Android arm64 `.so` 随包 | [README.md](native/fushi_torrent/README.md) |
 | `services/log-backend/log-collector/` | Go | 报错日志接收端（自有服务器 + EdgeOne 版）；独立部署（原 `server/`，改名消与同步层 `fushi_sync_server.dart`/`SyncBackendType.hibikiServer` 的三义撞词） | [README.md](services/log-backend/log-collector/README.md) |
 | `services/log-backend/cf-worker/` | JS | 报错日志接收端（Cloudflare Worker + D1 版，与 Go 版择一）；独立部署 | [README.md](services/log-backend/cf-worker/README.md) |
 | `tools/browser-extension/` | JS | 浏览器查词扩展（根级 `tools/`，非 `tool/`） | — |

--- a/fushi/CLAUDE.md
+++ b/fushi/CLAUDE.md
@@ -133,7 +133,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 ### 11. torrent 下载 (`lib/src/media/torrent/`)
 
 - `embedded_torrent_backend.dart` -- 内置引擎的 `TorrentBackend` 实现；同目录含番剧下载/nyaa/qBittorrent 客户端。
-- 引擎在 `packages/fushi_torrent`（Dart FFI）+ `native/fushi_torrent`（libtorrent C ABI）；DLL 缺失时回退外接 qBittorrent（`qb_torrent_backend.dart`）。
+- 引擎在 `packages/fushi_torrent`（Dart FFI）+ `native/fushi_torrent`（libtorrent C ABI）；桌面 + Android 可用，原生库（Windows DLL / Android `.so`）缺失时回退外接 qBittorrent（`qb_torrent_backend.dart`）。
 
 ### 12. galgame 制卡 (`lib/src/lookup/` + `lib/src/mining/`)
 

--- a/fushi/android/app/build.gradle
+++ b/fushi/android/app/build.gradle
@@ -137,6 +137,12 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         main.java.srcDirs += mihonSourceOutput
+        // 内置 libtorrent 引擎（copy-if-present，与 Windows runner 同姿态）：
+        // native/fushi_torrent/build_android_so.{ps1,sh} 产出的
+        // prebuilt/android/<abi>/libfushi_torrent_ffi.so 存在则随包；目录缺失时
+        // Gradle 静默跳过，app 运行期 EmbeddedTorrentHost.open 因 .so 缺失返回
+        // null → 自动回退外接 qBittorrent。构建本身不依赖 vcpkg/NDK 交叉编译。
+        main.jniLibs.srcDirs += '../../../native/fushi_torrent/prebuilt/android'
     }
 
     defaultConfig {

--- a/fushi/integration_test/embedded_torrent_engine_smoke_test.dart
+++ b/fushi/integration_test/embedded_torrent_engine_smoke_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_torrent/fushi_torrent.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// 设备冒烟：证明随包的内置 libtorrent 引擎在 Android 上**真能加载并干活**——
+/// `libfushi_torrent_ffi.so` 经 jniLibs 随包（vcpkg android triplet 静态链
+/// libtorrent/boost/openssl），按名 `DynamicLibrary.open` 命中 nativeLibraryDir。
+/// 三层递进：加载 → 版本串（C ABI 往返）→ 建 session + make_torrent（真实
+/// libtorrent 逻辑跑通，非仅符号存在）。
+///
+/// 在真机/模拟器跑（构建机需先跑 native/fushi_torrent/build_android_so 产出
+/// 对应 ABI 的 .so，缺 .so 时本用例会明确失败——那正是「包不完整」的信号）：
+///   flutter test integration_test/embedded_torrent_engine_smoke_test.dart -d <id>
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('libfushi_torrent_ffi.so 可加载且 libtorrent 版本可读', (tester) async {
+    final EmbeddedTorrentEngine engine = EmbeddedTorrentEngine.open();
+    final String version = engine.libtorrentVersion();
+    expect(version, isNotEmpty, reason: 'ht_libtorrent_version 必须返回版本串');
+    expect(version, startsWith('2.'),
+        reason: '选型钉 libtorrent 2.x，实际: $version');
+  });
+
+  testWidgets('session 建得起来且 make_torrent 真跑通', (tester) async {
+    final EmbeddedTorrentEngine engine = EmbeddedTorrentEngine.open();
+    final Directory tmp = await getTemporaryDirectory();
+    final Directory dir = await Directory(
+      '${tmp.path}/embedded_torrent_smoke',
+    ).create(recursive: true);
+    final File content = File('${dir.path}/payload.bin');
+    await content.writeAsBytes(List<int>.generate(4096, (int i) => i % 251));
+    final String outTorrent = '${dir.path}/payload.torrent';
+    try {
+      final FtAddResult made = engine.makeTorrent(
+        contentPath: content.path,
+        outTorrentPath: outTorrent,
+      );
+      expect(made.ok, isTrue, reason: 'make_torrent 失败: ${made.error}');
+      expect(File(outTorrent).existsSync(), isTrue);
+
+      // 回环监听 session：能建、能拿到系统分配端口、能销毁，即证明
+      // boost.asio / openssl 静态链路在设备上完好。
+      final EmbeddedTorrentSession? session = EmbeddedTorrentSession.open(
+        engine,
+        listenInterfaces: '127.0.0.1:0',
+      );
+      expect(session, isNotNull, reason: 'session 创建失败');
+      expect(session!.listenPort, greaterThan(0));
+      session.close();
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 57732 (3396 per locale)
 ///
-/// Built on 2026-08-14 at 15:35 UTC
+/// Built on 2026-08-14 at 19:19 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3240,8 +3240,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_setting_torrent_active_seeds => 'Max active seeds';
   String get video_setting_torrent_anonymous => 'Anonymous mode';
   String get video_setting_torrent_antileech => 'Enable anti-leech';
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop only)';
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
   String get video_setting_torrent_ban_relative_cheat =>
@@ -3633,8 +3631,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Subtitles: pending until download completes';
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   String get stat_source_breakdown => 'By source';
   String stat_format_pages({required Object n}) => '${n} pages';
   String anime_download_subs_season_mismatch({required Object season}) =>
@@ -4602,6 +4598,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'No subtitle lines found in that file';
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -10119,9 +10118,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -10787,9 +10783,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -12450,6 +12443,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -18029,9 +18027,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -18702,9 +18697,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -20365,6 +20357,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -25958,9 +25955,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -26633,9 +26627,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -28296,6 +28287,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -33900,9 +33896,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -34576,9 +34569,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -36239,6 +36229,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -41777,9 +41772,6 @@ class _StringsId extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -42447,9 +42439,6 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -44110,6 +44099,11 @@ class _StringsId extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -49690,9 +49684,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -50364,9 +50355,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -52027,6 +52015,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -57438,9 +57431,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -58095,9 +58085,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -59758,6 +59745,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -65173,9 +65165,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -65833,9 +65822,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -67496,6 +67482,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -73058,9 +73049,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -73730,9 +73718,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -75393,6 +75378,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -80966,9 +80956,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -81639,9 +81626,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -83302,6 +83286,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -88861,9 +88850,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -89534,9 +89520,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -91197,6 +91180,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -96709,9 +96697,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -97377,9 +97362,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -99040,6 +99022,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -104581,9 +104568,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -105251,9 +105235,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -106914,6 +106895,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -112441,9 +112427,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -113110,9 +113093,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -114773,6 +114753,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 // Path: <root>
@@ -119923,8 +119908,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => '启用反吸血';
   @override
-  String get video_setting_torrent_backend_embedded => '内置引擎（仅桌面）';
-  @override
   String get video_setting_torrent_backend_qb => '外接 qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => '封禁进度作弊';
@@ -120531,9 +120514,6 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_subs_pending => '字幕：待下载完成后配对';
   @override
   String get anime_download_subs_unmatched => '字幕：未匹配到（可手动补）';
-  @override
-  String get download_backend_desktop_only_note =>
-      '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
   @override
   String get stat_source_breakdown => '各来源';
   @override
@@ -122058,6 +122038,11 @@ class _StringsZhCn extends _StringsEn {
   String get srt_book_reimport_no_cues => '该字幕文件解析不出任何字幕行';
   @override
   String get srt_book_reimport_body_rebuilt => '正文已重建，请重新打开本书';
+  @override
+  String get video_setting_torrent_backend_embedded => '内置引擎';
+  @override
+  String get download_backend_unsupported_note =>
+      '本平台无内置引擎，下载使用外接 qBittorrent。';
 }
 
 // Path: <root>
@@ -127398,9 +127383,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_setting_torrent_antileech => 'Enable anti-leech';
   @override
-  String get video_setting_torrent_backend_embedded =>
-      'Built-in engine (desktop only)';
-  @override
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   @override
   String get video_setting_torrent_ban_progress_cheat => 'Ban progress cheat';
@@ -128050,9 +128032,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
-  @override
-  String get download_backend_desktop_only_note =>
-      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   @override
   String get stat_source_breakdown => 'By source';
   @override
@@ -129712,6 +129691,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get video_setting_torrent_backend_embedded => 'Built-in engine';
+  @override
+  String get download_backend_unsupported_note =>
+      'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
 }
 
 /// Flat map(s) containing all translations.
@@ -134673,8 +134657,6 @@ extension on _StringsEn {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop only)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -135249,8 +135231,6 @@ extension on _StringsEn {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -136691,6 +136671,10 @@ extension on _StringsEn {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -141649,8 +141633,6 @@ extension on _StringsAr {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -142226,8 +142208,6 @@ extension on _StringsAr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -143668,6 +143648,10 @@ extension on _StringsAr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -148648,8 +148632,6 @@ extension on _StringsDe {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -149225,8 +149207,6 @@ extension on _StringsDe {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -150667,6 +150647,10 @@ extension on _StringsDe {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -155647,8 +155631,6 @@ extension on _StringsEs {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -156223,8 +156205,6 @@ extension on _StringsEs {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -157665,6 +157645,10 @@ extension on _StringsEs {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -162651,8 +162635,6 @@ extension on _StringsFr {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -163227,8 +163209,6 @@ extension on _StringsFr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -164669,6 +164649,10 @@ extension on _StringsFr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -169636,8 +169620,6 @@ extension on _StringsId {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -170213,8 +170195,6 @@ extension on _StringsId {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -171655,6 +171635,10 @@ extension on _StringsId {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -176636,8 +176620,6 @@ extension on _StringsIt {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -177213,8 +177195,6 @@ extension on _StringsIt {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -178655,6 +178635,10 @@ extension on _StringsIt {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -183600,8 +183584,6 @@ extension on _StringsJa {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -184175,8 +184157,6 @@ extension on _StringsJa {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -185617,6 +185597,10 @@ extension on _StringsJa {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -190565,8 +190549,6 @@ extension on _StringsKo {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -191141,8 +191123,6 @@ extension on _StringsKo {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -192583,6 +192563,10 @@ extension on _StringsKo {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -197558,8 +197542,6 @@ extension on _StringsNl {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -198135,8 +198117,6 @@ extension on _StringsNl {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -199577,6 +199557,10 @@ extension on _StringsNl {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -204550,8 +204534,6 @@ extension on _StringsPtBr {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -205126,8 +205108,6 @@ extension on _StringsPtBr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -206568,6 +206548,10 @@ extension on _StringsPtBr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -211546,8 +211530,6 @@ extension on _StringsRu {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -212122,8 +212104,6 @@ extension on _StringsRu {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -213564,6 +213544,10 @@ extension on _StringsRu {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -218524,8 +218508,6 @@ extension on _StringsTh {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -219101,8 +219083,6 @@ extension on _StringsTh {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -220543,6 +220523,10 @@ extension on _StringsTh {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -225513,8 +225497,6 @@ extension on _StringsTr {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -226089,8 +226071,6 @@ extension on _StringsTr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -227531,6 +227511,10 @@ extension on _StringsTr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -232497,8 +232481,6 @@ extension on _StringsVi {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -233073,8 +233055,6 @@ extension on _StringsVi {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -234515,6 +234495,10 @@ extension on _StringsVi {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }
@@ -239438,8 +239422,6 @@ extension on _StringsZhCn {
         return '匿名模式';
       case 'video_setting_torrent_antileech':
         return '启用反吸血';
-      case 'video_setting_torrent_backend_embedded':
-        return '内置引擎（仅桌面）';
       case 'video_setting_torrent_backend_qb':
         return '外接 qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -240009,8 +239991,6 @@ extension on _StringsZhCn {
         return '字幕：待下载完成后配对';
       case 'anime_download_subs_unmatched':
         return '字幕：未匹配到（可手动补）';
-      case 'download_backend_desktop_only_note':
-        return '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
       case 'stat_source_breakdown':
         return '各来源';
       case 'stat_format_pages':
@@ -241441,6 +241421,10 @@ extension on _StringsZhCn {
         return '该字幕文件解析不出任何字幕行';
       case 'srt_book_reimport_body_rebuilt':
         return '正文已重建，请重新打开本书';
+      case 'video_setting_torrent_backend_embedded':
+        return '内置引擎';
+      case 'download_backend_unsupported_note':
+        return '本平台无内置引擎，下载使用外接 qBittorrent。';
       default:
         return null;
     }
@@ -246382,8 +246366,6 @@ extension on _StringsZhHk {
         return 'Anonymous mode';
       case 'video_setting_torrent_antileech':
         return 'Enable anti-leech';
-      case 'video_setting_torrent_backend_embedded':
-        return 'Built-in engine (desktop only)';
       case 'video_setting_torrent_backend_qb':
         return 'External qBittorrent';
       case 'video_setting_torrent_ban_progress_cheat':
@@ -246956,8 +246938,6 @@ extension on _StringsZhHk {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
-      case 'download_backend_desktop_only_note':
-        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       case 'stat_source_breakdown':
         return 'By source';
       case 'stat_format_pages':
@@ -248398,6 +248378,10 @@ extension on _StringsZhHk {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine';
+      case 'download_backend_unsupported_note':
+        return 'The built-in engine is not available on this platform. Downloads use external qBittorrent.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop only)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "最大活跃做种数",
   "video_setting_torrent_anonymous": "匿名模式",
   "video_setting_torrent_antileech": "启用反吸血",
-  "video_setting_torrent_backend_embedded": "内置引擎（仅桌面）",
   "video_setting_torrent_backend_qb": "外接 qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "封禁进度作弊",
   "video_setting_torrent_ban_relative_cheat": "封禁相对进度作弊",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
   "anime_download_subs_pending": "字幕：待下载完成后配对",
   "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）",
-  "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。",
   "stat_source_breakdown": "各来源",
   "stat_format_pages": "$n 页",
   "anime_download_subs_season_mismatch": "没有字幕条目对得上该种子的第 $season 季，已不自动选中。要用的话请手动选一条。",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "重新导入",
   "srt_book_reimport_subtitle_hint": "替换字幕会用新字幕重建这本书的正文。",
   "srt_book_reimport_no_cues": "该字幕文件解析不出任何字幕行",
-  "srt_book_reimport_body_rebuilt": "正文已重建，请重新打开本书"
+  "srt_book_reimport_body_rebuilt": "正文已重建，请重新打开本书",
+  "video_setting_torrent_backend_embedded": "内置引擎",
+  "download_backend_unsupported_note": "本平台无内置引擎，下载使用外接 qBittorrent。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2425,7 +2425,6 @@
   "video_setting_torrent_active_seeds": "Max active seeds",
   "video_setting_torrent_anonymous": "Anonymous mode",
   "video_setting_torrent_antileech": "Enable anti-leech",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop only)",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_ban_progress_cheat": "Ban progress cheat",
   "video_setting_torrent_ban_relative_cheat": "Ban relative progress cheat",
@@ -2701,7 +2700,6 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
   "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
@@ -3394,5 +3392,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "video_setting_torrent_backend_embedded": "Built-in engine",
+  "download_backend_unsupported_note": "The built-in engine is not available on this platform. Downloads use external qBittorrent."
 }

--- a/fushi/lib/src/media/torrent/anime_download_config.dart
+++ b/fushi/lib/src/media/torrent/anime_download_config.dart
@@ -53,11 +53,11 @@ class QbConnectionConfig {
   /// 后端标识：外接 qBittorrent WebUI。
   static const String backendQbittorrent = 'qbittorrent';
 
-  /// 后端标识：内置 libtorrent 引擎（桌面；见 EmbeddedTorrentHost）。
+  /// 后端标识：内置 libtorrent 引擎（见 EmbeddedTorrentHost）。
   static const String backendEmbedded = 'embedded';
 
-  /// 后端标识：自动（默认，开箱即用）——桌面用内置引擎、移动端外接 qb。
-  /// 用户没显式选过后端时的值。
+  /// 后端标识：自动（默认，开箱即用）——有内置引擎的平台用内置引擎、
+  /// 其余平台外接 qb。用户没显式选过后端时的值。
   static const String backendAuto = 'auto';
 
   /// 下载后端（[backendAuto] / [backendQbittorrent] / [backendEmbedded]）。
@@ -67,18 +67,23 @@ class QbConnectionConfig {
 
   /// 把配置值解析成**本平台真实可用**的后端。
   ///
-  /// [isDesktop] = 本平台是否具备内置引擎（调用方传 `_supportsEmbeddedTorrent()`）。
+  /// [embeddedSupported] = 本平台是否具备内置引擎（调用方传
+  /// `_supportsEmbeddedTorrent()`；桌面 + Android 为 true，iOS 为 false——
+  /// iOS 从不构建也从不打包内置引擎产物）。
   ///
   /// BUG-1207：这里过去只规约 [backendAuto]，显式的 [backendEmbedded] 一律原样
-  /// 放行——于是移动端（Android/iOS 从不构建也从不打包 `libfushi_torrent_ffi.so`：
-  /// `native/fushi_torrent/CMakeLists.txt` 只有 WIN32/APPLE 分支，
-  /// `fushi/android/app/build.gradle` 的 externalNativeBuild 只含 fushidicts）
-  /// 会解析出一个根本不存在的后端：`EmbeddedTorrentHost.open` 吞掉 `ArgumentError`
-  /// 返回 null，`_torrentBackendFor` 静默造一个 `QbTorrentBackend`，而设置页仍显示
+  /// 放行——于是无内置引擎的平台会解析出一个根本不存在的后端：
+  /// `EmbeddedTorrentHost.open` 吞掉 `ArgumentError` 返回 null，
+  /// `_torrentBackendFor` 静默造一个 `QbTorrentBackend`，而设置页仍显示
   /// 「内置引擎」选中、并把只有内置引擎才读的下载目录暴露给用户改（改了不被任何人
   /// 采用）。规约收在这一处，下游 UI 分支与运行时后端选择的特殊情况一并消失。
-  String resolveBackend({required bool isDesktop}) {
-    if (!isDesktop) return backendQbittorrent;
+  ///
+  /// 注意 Android 的 `.so` 是 copy-if-present 随包（构建机没跑
+  /// `build_android_so` 时 APK 里没有它）：那种残缺包里 [embeddedSupported]
+  /// 仍是 true、解析结果是 embedded，但宿主 open 失败后运行时仍会按上述 null
+  /// 路径回退 qb——行为与 Windows 缺 DLL 完全一致，不是新特例。
+  String resolveBackend({required bool embeddedSupported}) {
+    if (!embeddedSupported) return backendQbittorrent;
     if (backend == backendAuto) return backendEmbedded;
     return backend;
   }

--- a/fushi/lib/src/media/torrent/anime_download_service.dart
+++ b/fushi/lib/src/media/torrent/anime_download_service.dart
@@ -336,12 +336,12 @@ class AnimeDownloadService {
   static Duration resolvePollInterval({
     required QbConnectionConfig? config,
     required bool hasActiveDownloads,
-    required bool isDesktop,
+    required bool embeddedSupported,
     required Duration idle,
     Duration active = activeInterval,
   }) {
     final bool embedded = config != null &&
-        config.resolveBackend(isDesktop: isDesktop) ==
+        config.resolveBackend(embeddedSupported: embeddedSupported) ==
             QbConnectionConfig.backendEmbedded;
     return embedded && hasActiveDownloads ? active : idle;
   }
@@ -352,7 +352,7 @@ class AnimeDownloadService {
     final Duration want = resolvePollInterval(
       config: _configProvider(),
       hasActiveDownloads: downloadProgress.value.isNotEmpty,
-      isDesktop: _isDesktop(),
+      embeddedSupported: _supportsEmbeddedTorrent(),
       idle: interval,
     );
     if (want == _currentPeriod) return;
@@ -360,8 +360,12 @@ class AnimeDownloadService {
     _startTimer(want);
   }
 
-  static bool _isDesktop() =>
-      Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+  /// 与 AppModel._supportsEmbeddedTorrent 同一判据：桌面 + Android。
+  static bool _supportsEmbeddedTorrent() =>
+      Platform.isWindows ||
+      Platform.isLinux ||
+      Platform.isMacOS ||
+      Platform.isAndroid;
 
   /// 轮询一次（可单独调用；测试用）。内置防重入：上一 tick 未完成则跳过。
   /// 整体容错：网络/文件系统异常静默跳过，下轮再试。

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3524,7 +3524,7 @@ class AppModel with ChangeNotifier {
         AnimeDownloadPlanStore(baseDir: baseDir);
     _animeDownloadPlanStore = store;
 
-    // 内置引擎宿主：仅桌面（Android/iOS 阶段4/5 再定）。默认下载根就在计划目录旁的
+    // 内置引擎宿主：桌面 + Android（iOS 无内置引擎）。默认下载根就在计划目录旁的
     // `content/` 子目录（分类再往下分）；TODO-1961 起用户可在设置里改成任意目录。
     //
     // BUG-1053：这里**只记路径，不建 session**。真正的 libtorrent session 会绑
@@ -3676,7 +3676,7 @@ class AppModel with ChangeNotifier {
     QbConnectionConfig config,
   ) async {
     final String resolved =
-        config.resolveBackend(isDesktop: _supportsEmbeddedTorrent());
+        config.resolveBackend(embeddedSupported: _supportsEmbeddedTorrent());
     final String installationId =
         await prefsRepo.ensureVideoDownloadEmbeddedInstallationId();
     return buildVideoDownloadBackendIdentity(
@@ -3711,7 +3711,7 @@ class AppModel with ChangeNotifier {
 
   TorrentBackend? _createExactTorrentBackend(QbConnectionConfig config) {
     final String resolved =
-        config.resolveBackend(isDesktop: _supportsEmbeddedTorrent());
+        config.resolveBackend(embeddedSupported: _supportsEmbeddedTorrent());
     if (resolved == QbConnectionConfig.backendEmbedded) {
       final EmbeddedTorrentHost? host = _ensureEmbeddedTorrentHost();
       return host?.backendView();
@@ -4022,7 +4022,7 @@ class AppModel with ChangeNotifier {
   /// 外接 qBittorrent（默认 / 内置不可用时的回退）。
   TorrentBackend _torrentBackendFor(QbConnectionConfig config) {
     final String backend =
-        config.resolveBackend(isDesktop: _supportsEmbeddedTorrent());
+        config.resolveBackend(embeddedSupported: _supportsEmbeddedTorrent());
     // BUG-1053：到这里才是「真的要用下载后端」，session 在此懒建（幂等）。
     final EmbeddedTorrentHost? host =
         backend == QbConnectionConfig.backendEmbedded
@@ -4038,9 +4038,13 @@ class AppModel with ChangeNotifier {
     ));
   }
 
-  /// 内置 libtorrent 支持的平台：桌面（Windows 先行；mac/Linux 阶段4）。
+  /// 内置 libtorrent 支持的平台：桌面 + Android（`libfushi_torrent_ffi.so`
+  /// 经 jniLibs 随包）。iOS 不支持：从不构建也从不打包内置引擎产物。
   bool _supportsEmbeddedTorrent() =>
-      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+      Platform.isWindows ||
+      Platform.isMacOS ||
+      Platform.isLinux ||
+      Platform.isAndroid;
 
   /// 每系列记住的 Jimaku 字幕语言偏好（TODO-674）。
   Map<String, String> get jimakuPreferredLanguages =>

--- a/fushi/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/torrent_settings_section.dart
@@ -25,7 +25,7 @@ const double kTorrentSettingsContentMaxWidth = 560;
 class TorrentSettingsSection extends ConsumerStatefulWidget {
   const TorrentSettingsSection({
     super.key,
-    this.desktopOverride,
+    this.embeddedSupportedOverride,
     this.constrainWidth = true,
   });
 
@@ -42,7 +42,7 @@ class TorrentSettingsSection extends ConsumerStatefulWidget {
   /// null = 用真实 `dart:io` 平台判断。照搬 `book_import_dialog.dart` 的
   /// `ocrEntryDesktopOverride` 范式——`Platform` 不可 override，不给注入口就
   /// 只能退回源码扫描守卫，测不到真实渲染行为。
-  final bool? desktopOverride;
+  final bool? embeddedSupportedOverride;
 
   @override
   ConsumerState<TorrentSettingsSection> createState() =>
@@ -51,9 +51,14 @@ class TorrentSettingsSection extends ConsumerStatefulWidget {
 
 class _TorrentSettingsSectionState
     extends ConsumerState<TorrentSettingsSection> {
-  bool get _isDesktop =>
-      widget.desktopOverride ??
-      (Platform.isWindows || Platform.isMacOS || Platform.isLinux);
+  /// 本平台是否具备内置引擎（桌面 + Android；与
+  /// `AppModel._supportsEmbeddedTorrent` 同一判据）。
+  bool get _supportsEmbedded =>
+      widget.embeddedSupportedOverride ??
+      (Platform.isWindows ||
+          Platform.isMacOS ||
+          Platform.isLinux ||
+          Platform.isAndroid);
 
   QbConnectionConfig get _config =>
       effectiveTorrentConfig(ref.read(appProvider).qbConnectionConfig);
@@ -331,7 +336,8 @@ class _TorrentSettingsSectionState
     final AppModel appModel = ref.watch(appProvider);
     final DownloadNetworkProxyConfig proxy =
         appModel.downloadNetworkProxyConfig;
-    final String backend = c.resolveBackend(isDesktop: _isDesktop);
+    final String backend =
+        c.resolveBackend(embeddedSupported: _supportsEmbedded);
     final bool isQb = backend == QbConnectionConfig.backendQbittorrent;
     final bool isEmbedded = backend == QbConnectionConfig.backendEmbedded;
 
@@ -384,13 +390,13 @@ class _TorrentSettingsSectionState
           ),
         const Divider(height: 24),
 
-        // 后端二选一。标签是 `qBittorrent` / `Built-in engine (desktop only)` 这类
+        // 后端二选一。标签是 `External qBittorrent` / `Built-in engine` 这类
         // 不可断行的长词，窄屏裸 SegmentedButton 会直接裁字（BUG-1184）。
         //
-        // BUG-1207：移动端根本没有内置引擎的 .so，选择器只放一个够不着的档位——
-        // 选中后 resolveBackend 会把它规约回 qb，段选状态原地弹回，比没有选项更糟。
-        // 故非桌面不渲染选择器，改为一行说明交代本平台只有外接 qb。
-        if (_isDesktop) ...<Widget>[
+        // BUG-1207：无内置引擎的平台（现在只剩 iOS）不渲染选择器——选择器里放一个
+        // 够不着的档位，选中后 resolveBackend 会把它规约回 qb，段选状态原地弹回，
+        // 比没有选项更糟。改为一行说明交代本平台只有外接 qb。
+        if (_supportsEmbedded) ...<Widget>[
           FushiSegmentedStrip<String>(
             segments: <ButtonSegment<String>>[
               ButtonSegment<String>(
@@ -410,7 +416,7 @@ class _TorrentSettingsSectionState
           Padding(
             padding: const EdgeInsets.fromLTRB(2, 0, 2, 4),
             child: Text(
-              t.download_backend_desktop_only_note,
+              t.download_backend_unsupported_note,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/fushi/test/media/torrent/anime_download_config_backend_test.dart
+++ b/fushi/test/media/torrent/anime_download_config_backend_test.dart
@@ -7,31 +7,31 @@ void main() {
   test('backend defaults to auto (resolves per platform)', () {
     const QbConnectionConfig config = QbConnectionConfig();
     expect(config.backend, QbConnectionConfig.backendAuto);
-    // 桌面 → 内置引擎（开箱即用）；移动端 → 外接 qb。
-    expect(config.resolveBackend(isDesktop: true),
+    // 有内置引擎（桌面/Android）→ 内置引擎（开箱即用）；无（iOS）→ 外接 qb。
+    expect(config.resolveBackend(embeddedSupported: true),
         QbConnectionConfig.backendEmbedded);
-    expect(config.resolveBackend(isDesktop: false),
+    expect(config.resolveBackend(embeddedSupported: false),
         QbConnectionConfig.backendQbittorrent);
   });
 
   test('显式 backend 按平台能力规约：无内置引擎的平台连 embedded 也降级 qb (BUG-1207)', () {
     // 契约变更（原断言「explicit backends resolve to themselves regardless of
-    // platform」）：移动端从不构建也从不打包 libfushi_torrent_ffi.so，原样放行
-    // embedded 只会让设置页谎报「正在用内置引擎」、并暴露一个没有任何人读取的
-    // 下载目录，运行时再静默回退外接 qb。
+    // platform」）：无内置引擎的平台（现在只剩 iOS）从不构建也从不打包
+    // libfushi_torrent_ffi.so，原样放行 embedded 只会让设置页谎报「正在用内置
+    // 引擎」、并暴露一个没有任何人读取的下载目录，运行时再静默回退外接 qb。
     // 存储层不受影响——backend 字段仍原样存 embedded（见下面的 round-trip 用例），
-    // 规约只发生在 resolveBackend 这一处，桌面重新可用时旧配置自动复原。
+    // 规约只发生在 resolveBackend 这一处，平台重新可用时旧配置自动复原。
     const QbConnectionConfig emb =
         QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
-    expect(emb.resolveBackend(isDesktop: false),
+    expect(emb.resolveBackend(embeddedSupported: false),
         QbConnectionConfig.backendQbittorrent);
-    expect(emb.resolveBackend(isDesktop: true),
+    expect(emb.resolveBackend(embeddedSupported: true),
         QbConnectionConfig.backendEmbedded);
     const QbConnectionConfig qb =
         QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
-    expect(qb.resolveBackend(isDesktop: true),
+    expect(qb.resolveBackend(embeddedSupported: true),
         QbConnectionConfig.backendQbittorrent);
-    expect(qb.resolveBackend(isDesktop: false),
+    expect(qb.resolveBackend(embeddedSupported: false),
         QbConnectionConfig.backendQbittorrent);
   });
 

--- a/fushi/test/pages/torrent_settings_android_backend_gating_test.dart
+++ b/fushi/test/pages/torrent_settings_android_backend_gating_test.dart
@@ -14,16 +14,14 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../helpers/test_platform_services.dart';
 
-/// BUG-1207：移动端不存在内置 torrent 引擎的原生产物——
-/// `native/fushi_torrent/CMakeLists.txt` 只有 WIN32 / APPLE 分支，
-/// `fushi/android/app/build.gradle` 的 externalNativeBuild 只构建 fushidicts，
-/// 全仓也没有任何 `libfushi_torrent_ffi.so`。可下载设置页照样把「内置引擎」
-/// 画出来让用户选中，选中后还暴露一个**只有内置引擎才读**的下载目录。
-/// 实际运行时 `EmbeddedTorrentHost.open` 吞掉 `ArgumentError` 返回 null，
+/// BUG-1207：无内置引擎的平台（Android 支持后只剩 iOS——它从不构建也从不
+/// 打包 `libfushi_torrent_ffi.so`）不得把「内置引擎」画出来让用户选中：
+/// 选中后还会暴露一个**只有内置引擎才读**的下载目录，而实际运行时
+/// `EmbeddedTorrentHost.open` 吞掉 `ArgumentError` 返回 null，
 /// `_torrentBackendFor` 静默造一个 `QbTorrentBackend` —— 用户以为自己在用
 /// 内置引擎、以为改的下载目录生效了，两件事都不成立。
 ///
-/// 本守卫断言的是**真实渲染行为**（不是「某字符串存在」）：非桌面平台下
+/// 本守卫断言的是**真实渲染行为**（不是「某字符串存在」）：无内置引擎平台下
 /// 后端选择器与下载目录必须整块不出现，且必须真的落到外接 qb 分支。
 class _TestAppModel extends AppModel {
   _TestAppModel(this._config) : super(testPlatformServices());
@@ -55,7 +53,7 @@ const QbConnectionConfig _explicitEmbedded = QbConnectionConfig(
   backend: QbConnectionConfig.backendEmbedded,
 );
 
-Widget _harness({required bool desktop}) {
+Widget _harness({required bool embeddedSupported}) {
   final FushiDatabase db = FushiDatabase.forTesting(
     DatabaseConnection(NativeDatabase.memory()),
   );
@@ -90,7 +88,8 @@ Widget _harness({required bool desktop}) {
         body: SizedBox(
           width: 900,
           child: SingleChildScrollView(
-            child: TorrentSettingsSection(desktopOverride: desktop),
+            child: TorrentSettingsSection(
+                embeddedSupportedOverride: embeddedSupported),
           ),
         ),
       ),
@@ -102,25 +101,25 @@ void main() {
   group('resolveBackend 按平台能力规约（BUG-1207 根因层）', () {
     test('无内置引擎的平台：显式 embedded 也必须解析成外接 qb', () {
       expect(
-        _explicitEmbedded.resolveBackend(isDesktop: false),
+        _explicitEmbedded.resolveBackend(embeddedSupported: false),
         QbConnectionConfig.backendQbittorrent,
-        reason: '移动端没有 libfushi_torrent_ffi.so，解析出 embedded 只会静默回退',
+        reason: 'iOS 没有 libfushi_torrent_ffi.so，解析出 embedded 只会静默回退',
       );
     });
 
     test('有内置引擎的平台：显式 embedded 原样保留', () {
       expect(
-        _explicitEmbedded.resolveBackend(isDesktop: true),
+        _explicitEmbedded.resolveBackend(embeddedSupported: true),
         QbConnectionConfig.backendEmbedded,
       );
     });
 
-    test('auto 的既有行为不变（桌面 embedded / 移动 qb）', () {
+    test('auto 的既有行为不变（有引擎 embedded / 无引擎 qb）', () {
       const QbConnectionConfig auto = QbConnectionConfig();
       expect(auto.backend, QbConnectionConfig.backendAuto);
-      expect(auto.resolveBackend(isDesktop: true),
+      expect(auto.resolveBackend(embeddedSupported: true),
           QbConnectionConfig.backendEmbedded);
-      expect(auto.resolveBackend(isDesktop: false),
+      expect(auto.resolveBackend(embeddedSupported: false),
           QbConnectionConfig.backendQbittorrent);
     });
 
@@ -128,57 +127,58 @@ void main() {
       const QbConnectionConfig qb = QbConnectionConfig(
         backend: QbConnectionConfig.backendQbittorrent,
       );
-      expect(qb.resolveBackend(isDesktop: true),
+      expect(qb.resolveBackend(embeddedSupported: true),
           QbConnectionConfig.backendQbittorrent);
-      expect(qb.resolveBackend(isDesktop: false),
+      expect(qb.resolveBackend(embeddedSupported: false),
           QbConnectionConfig.backendQbittorrent);
     });
   });
 
-  testWidgets('非桌面：后端选择器与下载目录整块不渲染，落到外接 qb 分支', (WidgetTester tester) async {
+  testWidgets('无内置引擎平台：后端选择器与下载目录整块不渲染，落到外接 qb 分支',
+      (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1200, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
 
-    await tester.pumpWidget(_harness(desktop: false));
+    await tester.pumpWidget(_harness(embeddedSupported: false));
     await tester.pumpAndSettle();
 
     // ① 后端二选一整个控件不存在——用户点不到一个够不着的档位。
     //    （代理模式那条 strip 是 FushiSegmentedStrip<DownloadNetworkProxyMode>，
     //     泛型不同，不会被这个 finder 命中。）
     expect(find.byType(FushiSegmentedStrip<String>), findsNothing,
-        reason: '移动端没有第二个可用后端，选择器必须整块不渲染');
+        reason: '本平台没有第二个可用后端，选择器必须整块不渲染');
     expect(find.text(t.video_setting_torrent_backend_embedded), findsNothing,
         reason: '「内置引擎」在本平台不存在，不得出现在界面上');
 
     // ② 死设置消失：下载目录只被内置引擎读取，外接 qb 的落盘目录 qb 自己管。
     expect(find.text(t.download_save_root_title), findsNothing,
-        reason: '下载目录在移动端改了不被任何人采用，不得暴露给用户');
+        reason: '下载目录在无引擎平台改了不被任何人采用，不得暴露给用户');
     expect(find.text(t.download_save_root_change), findsNothing);
 
     // ③ 真的落到 qb 分支（不是整段都没渲染出来的假绿）。
     expect(find.text(t.video_setting_qb_url), findsOneWidget,
-        reason: '移动端唯一可用后端是外接 qBittorrent，其连接字段必须在');
+        reason: '本平台唯一可用后端是外接 qBittorrent，其连接字段必须在');
     expect(find.text(t.download_test_connection), findsOneWidget);
 
     // ④ 交代原因，别让用户以为选项丢了。
-    expect(find.text(t.download_backend_desktop_only_note), findsOneWidget);
+    expect(find.text(t.download_backend_unsupported_note), findsOneWidget);
   });
 
-  testWidgets('桌面：同一份显式 embedded 配置仍给出选择器与下载目录（不误伤）',
+  testWidgets('有内置引擎平台：同一份显式 embedded 配置仍给出选择器与下载目录（不误伤）',
       (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1200, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
 
-    await tester.pumpWidget(_harness(desktop: true));
+    await tester.pumpWidget(_harness(embeddedSupported: true));
     await tester.pumpAndSettle();
 
     expect(find.byType(FushiSegmentedStrip<String>), findsOneWidget);
     expect(find.text(t.video_setting_torrent_backend_embedded), findsOneWidget);
     expect(find.text(t.download_save_root_title), findsOneWidget,
-        reason: '桌面内置引擎真会读这个目录，必须保留');
-    expect(find.text(t.download_backend_desktop_only_note), findsNothing);
+        reason: '内置引擎真会读这个目录，必须保留');
+    expect(find.text(t.download_backend_unsupported_note), findsNothing);
     expect(find.text(t.video_setting_qb_url), findsNothing,
         reason: '内置引擎分支不渲染 qb 连接字段');
   });

--- a/fushi/test/torrent/anime_download_service_progress_test.dart
+++ b/fushi/test/torrent/anime_download_service_progress_test.dart
@@ -219,7 +219,7 @@ void main() {
       AnimeDownloadService.resolvePollInterval(
         config: embedded,
         hasActiveDownloads: true,
-        isDesktop: true,
+        embeddedSupported: true,
         idle: idle,
       ),
       AnimeDownloadService.activeInterval,
@@ -229,7 +229,7 @@ void main() {
       AnimeDownloadService.resolvePollInterval(
         config: embedded,
         hasActiveDownloads: false,
-        isDesktop: true,
+        embeddedSupported: true,
         idle: idle,
       ),
       idle,
@@ -240,7 +240,7 @@ void main() {
       AnimeDownloadService.resolvePollInterval(
         config: _kConfig,
         hasActiveDownloads: true,
-        isDesktop: true,
+        embeddedSupported: true,
         idle: idle,
       ),
       idle,
@@ -250,7 +250,7 @@ void main() {
       AnimeDownloadService.resolvePollInterval(
         config: null,
         hasActiveDownloads: true,
-        isDesktop: true,
+        embeddedSupported: true,
         idle: idle,
       ),
       idle,

--- a/native/fushi_torrent/.gitignore
+++ b/native/fushi_torrent/.gitignore
@@ -1,5 +1,6 @@
 # CMake / standalone build artifacts — never commit.
 build/
+build-android-*/
 
 # Vendored prebuilt runtime DLLs（由 build_windows_dll.ps1 产出，~11MB）——
 # 不入库（repo 不放二进制），由构建/发布流程各自现产或从 release 拉取。

--- a/native/fushi_torrent/CMakeLists.txt
+++ b/native/fushi_torrent/CMakeLists.txt
@@ -48,3 +48,13 @@ if(APPLE)
       BUILD_WITH_INSTALL_NAME_DIR TRUE
   )
 endif()
+
+# Android：产物名走默认 lib 前缀（libfushi_torrent_ffi.so，Dart 侧
+# defaultLibraryNames 按此名 DynamicLibrary.open）。依赖（libtorrent/boost/
+# openssl）由 vcpkg android triplet 提供**静态归档**，全部链进这一个 .so ——
+# jniLibs 里只随包一个文件，没有 Windows 那套同目录依赖预载问题。
+if(ANDROID)
+  # Android 15+ 的 16KB page size 设备要求 ELF segment 按 16KB 对齐；NDK r28
+  # 起是默认，r27 及以下需显式给。恒设无害（4KB 设备兼容 16KB 对齐产物）。
+  target_link_options(fushi_torrent_ffi PRIVATE "-Wl,-z,max-page-size=16384")
+endif()

--- a/native/fushi_torrent/README.md
+++ b/native/fushi_torrent/README.md
@@ -231,11 +231,38 @@ libtorrent 2.x **无 WebSocket/WebRTC/WebTorrent tracker 能力**（头文件里
 种子（Nyaa）用标准 `udp://`/`http://` tracker + DHT，不依赖 wss——所以这
 不是"用户用不了"的短板。真实下载走标准 tracker + DHT 即可。
 
+## 阶段5 — Android .so 随包（jniLibs copy-if-present）
+
+与 Windows 阶段4 同一套「vendored 预编译」决策，产物形态更简单：vcpkg 的
+android triplet 默认**静态链接**，libtorrent/boost/openssl 全部链进单个
+`libfushi_torrent_ffi.so`，没有 Windows 那 4 个运行时 DLL 的收拢/预载问题。
+
+1. **产出**：`build_android_so.ps1`（本机 Windows）/ `build_android_so.sh`
+   （CI Linux）——vcpkg 装 `libtorrent:<triplet>`（arm64-v8a→arm64-android 等），
+   cmake 用 vcpkg 工具链 chainload NDK 工具链（`ANDROID_PLATFORM=android-24`
+   对齐 minSdk，`ANDROID_STL=c++_shared` 对齐 app 内 fushidicts，16KB page
+   对齐见 CMakeLists），产物 strip 后落 `prebuilt/android/<abi>/`。
+2. **随包**：`fushi/android/app/build.gradle` 把 `prebuilt/android` 加进
+   `jniLibs.srcDirs`——目录存在则随包，不存在则 Gradle 静默跳过。因此
+   `flutter build apk` **不依赖 vcpkg/NDK 交叉编译**：没跑过产出脚本的机器
+   照常构建，只是运行期 `EmbeddedTorrentHost.open` 因 `.so` 缺失返回 null
+   → 自动回退外接 qb（与 Windows 缺 DLL 完全同一条路径）。
+3. **加载**：`EmbeddedTorrentEngine._openByPlatformDefault` 按
+   `libfushi_torrent_ffi.so` 名 `DynamicLibrary.open`，命中 app 的
+   nativeLibraryDir，无需路径解析。
+4. **CI**：`release.yml` 出 APK 前跑 `build_android_so.sh`，**只编 arm64-v8a**
+   （真机主力）；armeabi-v7a / x86_64 包按上述回退路径落外接 qb，不是静默破坏。
+   vcpkg 二进制/distfile 双层缓存姿势照抄 build-multiplatform.yml（TODO-2668）。
+
+平台门控随之放开：`AppModel._supportsEmbeddedTorrent()` = 桌面 + Android；
+`resolveBackend(embeddedSupported:)`（原 `isDesktop`，参数已正名）只在 iOS
+规约回 qb。
+
 ## 尚未做（多平台 + 真机）
 
-- **多平台**（Android/macOS/Linux）：同样走 vendored 预编译 + 各 runner
-  CMake 的 copy-if-present，但需对应工具链编 libtorrent（Android NDK /
-  Xcode / gcc），未在本机验证，另起 job。
+- **macOS/Linux**：同样走 vendored 预编译 + 各 runner CMake 的
+  copy-if-present，但需对应工具链编 libtorrent（Xcode / gcc），未在本机
+  验证，另起 job。
 - http(s) .torrent URL 下载（内置引擎侧 magnet-only；Nyaa 链路产 magnet）。
 - 反吸血的真实吸血 peer 触发（PCB 进度作弊需伪造进度的 peer；本地 rig 的
   做种者诚实，自动化只验 ip_filter 执行力 + peer_info 导出 + sweep 不误封，

--- a/native/fushi_torrent/README.md
+++ b/native/fushi_torrent/README.md
@@ -238,10 +238,16 @@ android triplet 默认**静态链接**，libtorrent/boost/openssl 全部链进�
 `libfushi_torrent_ffi.so`，没有 Windows 那 4 个运行时 DLL 的收拢/预载问题。
 
 1. **产出**：`build_android_so.ps1`（本机 Windows）/ `build_android_so.sh`
-   （CI Linux）——vcpkg 装 `libtorrent:<triplet>`（arm64-v8a→arm64-android 等），
-   cmake 用 vcpkg 工具链 chainload NDK 工具链（`ANDROID_PLATFORM=android-24`
-   对齐 minSdk，`ANDROID_STL=c++_shared` 对齐 app 内 fushidicts，16KB page
-   对齐见 CMakeLists），产物 strip 后落 `prebuilt/android/<abi>/`。
+   （CI Linux）——vcpkg 装 `libtorrent:<triplet>`（arm64-v8a→arm64-android 等，
+   **必须带 `--overlay-triplets=vcpkg-triplets/`**：vcpkg 自带 android triplet
+   钉 API 28，boost.asio 会引用 API 28 才进 libc 的 `aligned_alloc`，bridge 按
+   android-24 链接直接 undefined symbol——依赖与 bridge 必须同一 API level，
+   overlay 统一钉 24），cmake 用 vcpkg 工具链 chainload NDK 工具链
+   （`ANDROID_PLATFORM=android-24` 对齐 minSdk，`ANDROID_STL=c++_shared` 对齐
+   app 内 fushidicts，16KB page 对齐见 CMakeLists），产物 strip 后落
+   `prebuilt/android/<abi>/`。已在 Android 模拟器（API 34 x86_64）实测：
+   `fushi/integration_test/embedded_torrent_engine_smoke_test.dart` 两用例全过
+   （加载 + 版本串 + session + make_torrent）。
 2. **随包**：`fushi/android/app/build.gradle` 把 `prebuilt/android` 加进
    `jniLibs.srcDirs`——目录存在则随包，不存在则 Gradle 静默跳过。因此
    `flutter build apk` **不依赖 vcpkg/NDK 交叉编译**：没跑过产出脚本的机器

--- a/native/fushi_torrent/build_android_so.ps1
+++ b/native/fushi_torrent/build_android_so.ps1
@@ -60,8 +60,12 @@ foreach ($abi in $Abis) {
     $triplet = $tripletByAbi[$abi]
     if ($null -eq $triplet) { throw "unknown ABI: $abi（支持 $($tripletByAbi.Keys -join ', ')）" }
 
-    Write-Host "==> vcpkg install libtorrent:$triplet"
-    & $vcpkgExe install "libtorrent:$triplet"
+    Write-Host "==> vcpkg install libtorrent:$triplet (overlay: API 24)"
+    # overlay triplet 把依赖钉到 API 24（对齐 app minSdk）：vcpkg 自带 android
+    # triplet 钉 28，boost.asio 会引用 API 28 才有的 aligned_alloc，bridge 按
+    # android-24 链接直接 undefined symbol（详见 vcpkg-triplets/ 内注释）。
+    $overlay = Join-Path $scriptDir "vcpkg-triplets"
+    & $vcpkgExe install "libtorrent:$triplet" "--overlay-triplets=$overlay"
     if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent:$triplet failed" }
 
     $buildDir = Join-Path $scriptDir "build-android-$abi"

--- a/native/fushi_torrent/build_android_so.ps1
+++ b/native/fushi_torrent/build_android_so.ps1
@@ -1,0 +1,104 @@
+﻿# 构建内置 libtorrent 引擎的 Android .so 并落到 prebuilt/android/<abi>/ 供
+# fushi/android 的 jniLibs copy-if-present 随包（见 fushi/android/app/build.gradle）。
+#
+# 与 Windows 版（build_windows_dll.ps1）同一套「vendored 预编译」决策，但产物形态
+# 不同：vcpkg 的 android triplet 是静态链接，libtorrent/boost/openssl 全部链进
+# 单个 libfushi_torrent_ffi.so，不存在 Windows 那 4 个运行时 DLL 的收拢问题。
+#
+# 用法（vcpkg 首次编 libtorrent:<triplet> 约 30~60min/架构，之后走二进制缓存）：
+#   pwsh -File native/fushi_torrent/build_android_so.ps1 `
+#       -VcpkgRoot D:\APP\vcpkg -NdkRoot D:\android_sdk\ndk\27.0.12077973
+#   # 默认只编 arm64-v8a（真机主力）；模拟器验证再加 x86_64：
+#   pwsh -File ... -Abis arm64-v8a,x86_64
+# 产物：native/fushi_torrent/prebuilt/android/<abi>/libfushi_torrent_ffi.so
+# （git 忽略，不入库——repo 不放二进制，构建/发布流程各自现产。）
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$VcpkgRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$NdkRoot,
+
+    [string[]]$Abis = @("arm64-v8a"),
+
+    [string]$Config = "Release",
+
+    # ninja 所在目录（Android SDK 的 cmake 包自带；PATH 里已有 ninja 可不传）。
+    [string]$NinjaDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# ABI -> vcpkg 社区 triplet（armeabi-v7a 用 neon 变体：minSdk 24 的设备全部带 NEON）。
+$tripletByAbi = @{
+    "arm64-v8a"   = "arm64-android"
+    "armeabi-v7a" = "arm-neon-android"
+    "x86_64"      = "x64-android"
+    "x86"         = "x86-android"
+}
+
+$vcpkgExe = Join-Path $VcpkgRoot "vcpkg.exe"
+if (-not (Test-Path $vcpkgExe)) { throw "vcpkg not found: $vcpkgExe" }
+$androidToolchain = Join-Path $NdkRoot "build\cmake\android.toolchain.cmake"
+if (-not (Test-Path $androidToolchain)) {
+    throw "NDK cmake toolchain not found: $androidToolchain (传 -NdkRoot <NDK 根目录>)"
+}
+$vcpkgToolchain = Join-Path $VcpkgRoot "scripts\buildsystems\vcpkg.cmake"
+
+if ($NinjaDir -ne "") { $env:PATH = "$NinjaDir;$env:PATH" }
+if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) {
+    throw "ninja not on PATH（Android SDK 的 cmake 目录自带，传 -NinjaDir <dir>）"
+}
+
+# vcpkg 的 android toolchain 从 ANDROID_NDK_HOME 找编译器。
+$env:ANDROID_NDK_HOME = $NdkRoot
+
+foreach ($abi in $Abis) {
+    $triplet = $tripletByAbi[$abi]
+    if ($null -eq $triplet) { throw "unknown ABI: $abi（支持 $($tripletByAbi.Keys -join ', ')）" }
+
+    Write-Host "==> vcpkg install libtorrent:$triplet"
+    & $vcpkgExe install "libtorrent:$triplet"
+    if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent:$triplet failed" }
+
+    $buildDir = Join-Path $scriptDir "build-android-$abi"
+    Write-Host "==> CMake configure ($abi / $triplet)"
+    # vcpkg 工具链在前（find_package 解析到 triplet 的静态归档），chainload NDK
+    # 工具链拿交叉编译器。ANDROID_PLATFORM 对齐 app minSdkVersion 24。
+    # ANDROID_STL=c++_shared 与 app 内 fushidicts 一致（libc++_shared.so 已随包）。
+    cmake -G Ninja -B $buildDir -S $scriptDir `
+        "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" `
+        "-DVCPKG_TARGET_TRIPLET=$triplet" `
+        "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$androidToolchain" `
+        "-DANDROID_ABI=$abi" `
+        "-DANDROID_PLATFORM=android-24" `
+        "-DANDROID_STL=c++_shared" `
+        "-DCMAKE_BUILD_TYPE=$Config"
+    if ($LASTEXITCODE -ne 0) { throw "cmake configure failed ($abi)" }
+
+    Write-Host "==> CMake build ($abi)"
+    cmake --build $buildDir
+    if ($LASTEXITCODE -ne 0) { throw "cmake build failed ($abi)" }
+
+    $so = Join-Path $buildDir "libfushi_torrent_ffi.so"
+    if (-not (Test-Path $so)) { throw "构建产物缺失: $so" }
+
+    $outDir = Join-Path $scriptDir "prebuilt\android\$abi"
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    Copy-Item $so (Join-Path $outDir "libfushi_torrent_ffi.so") -Force
+
+    # 静态链 boost/libtorrent 的未 strip 产物有几十 MB 调试符号；随包必 strip。
+    $strip = Join-Path $NdkRoot "toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-strip.exe"
+    if (Test-Path $strip) {
+        & $strip --strip-unneeded (Join-Path $outDir "libfushi_torrent_ffi.so")
+        if ($LASTEXITCODE -ne 0) { throw "llvm-strip failed ($abi)" }
+    } else {
+        Write-Warning "llvm-strip not found at $strip — 产物未 strip（APK 会显著变大）"
+    }
+
+    $size = (Get-Item (Join-Path $outDir "libfushi_torrent_ffi.so")).Length
+    Write-Host ("==> OK {0}: {1:N1} MB -> {2}" -f $abi, ($size / 1MB), $outDir)
+}

--- a/native/fushi_torrent/build_android_so.sh
+++ b/native/fushi_torrent/build_android_so.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# CI（Linux）版 Android .so 构建：与 build_android_so.ps1 完全同一套流程/产物布局，
+# 供 release.yml 在 flutter build apk 前调用。详细决策注释见 .ps1 版与 README。
+#
+# 用法: build_android_so.sh <vcpkg-root> <ndk-root> [abi ...]
+#   abi 缺省 arm64-v8a。产物: prebuilt/android/<abi>/libfushi_torrent_ffi.so
+set -euo pipefail
+
+VCPKG_ROOT="${1:?usage: build_android_so.sh <vcpkg-root> <ndk-root> [abi ...]}"
+NDK_ROOT="${2:?usage: build_android_so.sh <vcpkg-root> <ndk-root> [abi ...]}"
+shift 2
+ABIS=("${@:-arm64-v8a}")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+triplet_for_abi() {
+  case "$1" in
+    arm64-v8a)   echo arm64-android ;;
+    armeabi-v7a) echo arm-neon-android ;;
+    x86_64)      echo x64-android ;;
+    x86)         echo x86-android ;;
+    *) echo "unknown ABI: $1" >&2; return 1 ;;
+  esac
+}
+
+export ANDROID_NDK_HOME="$NDK_ROOT"
+ANDROID_TOOLCHAIN="$NDK_ROOT/build/cmake/android.toolchain.cmake"
+VCPKG_TOOLCHAIN="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+[[ -f "$ANDROID_TOOLCHAIN" ]] || { echo "NDK toolchain missing: $ANDROID_TOOLCHAIN" >&2; exit 1; }
+
+for abi in "${ABIS[@]}"; do
+  triplet="$(triplet_for_abi "$abi")"
+  echo "==> vcpkg install libtorrent:$triplet"
+  "$VCPKG_ROOT/vcpkg" install "libtorrent:$triplet"
+
+  build_dir="$SCRIPT_DIR/build-android-$abi"
+  echo "==> cmake configure ($abi / $triplet)"
+  cmake -G Ninja -B "$build_dir" -S "$SCRIPT_DIR" \
+    "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_TOOLCHAIN" \
+    "-DVCPKG_TARGET_TRIPLET=$triplet" \
+    "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$ANDROID_TOOLCHAIN" \
+    "-DANDROID_ABI=$abi" \
+    "-DANDROID_PLATFORM=android-24" \
+    "-DANDROID_STL=c++_shared" \
+    "-DCMAKE_BUILD_TYPE=Release"
+  cmake --build "$build_dir"
+
+  so="$build_dir/libfushi_torrent_ffi.so"
+  [[ -f "$so" ]] || { echo "missing artifact: $so" >&2; exit 1; }
+
+  out_dir="$SCRIPT_DIR/prebuilt/android/$abi"
+  mkdir -p "$out_dir"
+  cp -f "$so" "$out_dir/libfushi_torrent_ffi.so"
+
+  strip_bin="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
+  if [[ -x "$strip_bin" ]]; then
+    "$strip_bin" --strip-unneeded "$out_dir/libfushi_torrent_ffi.so"
+  else
+    echo "WARN: llvm-strip not found ($strip_bin) — artifact not stripped" >&2
+  fi
+  ls -lh "$out_dir/libfushi_torrent_ffi.so"
+done

--- a/native/fushi_torrent/build_android_so.sh
+++ b/native/fushi_torrent/build_android_so.sh
@@ -30,8 +30,9 @@ VCPKG_TOOLCHAIN="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
 
 for abi in "${ABIS[@]}"; do
   triplet="$(triplet_for_abi "$abi")"
-  echo "==> vcpkg install libtorrent:$triplet"
-  "$VCPKG_ROOT/vcpkg" install "libtorrent:$triplet"
+  echo "==> vcpkg install libtorrent:$triplet (overlay: API 24)"
+  # overlay triplet 钉 API 24 对齐 minSdk（原因见 vcpkg-triplets/ 内注释）。
+  "$VCPKG_ROOT/vcpkg" install "libtorrent:$triplet"     "--overlay-triplets=$SCRIPT_DIR/vcpkg-triplets"
 
   build_dir="$SCRIPT_DIR/build-android-$abi"
   echo "==> cmake configure ($abi / $triplet)"

--- a/native/fushi_torrent/vcpkg-triplets/arm-neon-android.cmake
+++ b/native/fushi_torrent/vcpkg-triplets/arm-neon-android.cmake
@@ -1,0 +1,8 @@
+# Overlay triplet：API level 钉 24（原因见 arm64-android.cmake 注释）。
+set(VCPKG_TARGET_ARCHITECTURE arm)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Android)
+set(VCPKG_CMAKE_SYSTEM_VERSION 24)
+set(VCPKG_MAKE_BUILD_TRIPLET "--host=armv7a-linux-androideabi")
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DANDROID_ABI=armeabi-v7a -DANDROID_ARM_NEON=ON)

--- a/native/fushi_torrent/vcpkg-triplets/arm64-android.cmake
+++ b/native/fushi_torrent/vcpkg-triplets/arm64-android.cmake
@@ -1,0 +1,11 @@
+# Overlay triplet：与 vcpkg 自带 arm64-android 唯一区别是 API level 钉 24。
+# 自带 triplet 钉 VCPKG_CMAKE_SYSTEM_VERSION 28，boost.asio 会引用 API 28 才进
+# libc 的 aligned_alloc；bridge 按 app minSdk 24 链接时 undefined symbol，
+# 且即便链过了也会在 API 24~27 设备上 dlopen 失败。依赖与 bridge 必须同一 API。
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Android)
+set(VCPKG_CMAKE_SYSTEM_VERSION 24)
+set(VCPKG_MAKE_BUILD_TRIPLET "--host=aarch64-linux-android")
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DANDROID_ABI=arm64-v8a)

--- a/native/fushi_torrent/vcpkg-triplets/x64-android.cmake
+++ b/native/fushi_torrent/vcpkg-triplets/x64-android.cmake
@@ -1,0 +1,8 @@
+# Overlay triplet：API level 钉 24（原因见 arm64-android.cmake 注释）。
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Android)
+set(VCPKG_CMAKE_SYSTEM_VERSION 24)
+set(VCPKG_MAKE_BUILD_TRIPLET "--host=x86_64-linux-android")
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DANDROID_ABI=x86_64)

--- a/native/fushi_torrent/vcpkg-triplets/x86-android.cmake
+++ b/native/fushi_torrent/vcpkg-triplets/x86-android.cmake
@@ -1,0 +1,8 @@
+# Overlay triplet：API level 钉 24（原因见 arm64-android.cmake 注释）。
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Android)
+set(VCPKG_CMAKE_SYSTEM_VERSION 24)
+set(VCPKG_MAKE_BUILD_TRIPLET "--host=i686-linux-android")
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DANDROID_ABI=x86)


### PR DESCRIPTION
## 目标

手机（Android）支持内置 torrent 下载，不再强制依赖外接 qBittorrent。这是 native/fushi_torrent README 里早已定调的「多平台另起 job」的 Android 篇。

## 方案（沿用 Windows 阶段4 的 vendored 预编译决策）

- **native**：`build_android_so.{ps1,sh}` 用 vcpkg android triplet 交叉编 libtorrent 2.0.11（静态链 boost 1.91 / openssl 3.6.3 → 单个 `libfushi_torrent_ffi.so`，~12MB/ABI）。**overlay triplet 把依赖钉到 API 24 对齐 minSdk**——vcpkg 自带 triplet 钉 API 28，boost.asio 会引用 API 28 才进 libc 的 `aligned_alloc`，bridge 按 android-24 链接直接 undefined symbol。CMake 补 16KB page 对齐（Android 15+ 设备要求）。
- **打包**：Gradle `jniLibs` copy-if-present——`prebuilt/android/<abi>/` 存在则随包，缺失照常构建、运行期 `EmbeddedTorrentHost.open` 返回 null 自动回退外接 qb（与 Windows 缺 DLL 完全同一条路径，零特例）。
- **Dart**：`_supportsEmbeddedTorrent()` 放开 Android；`resolveBackend(isDesktop:)` 参数正名 `embeddedSupported`（Android 支持后旧名撒谎）；设置页在 Android 渲染后端选择器，BUG-1207 门控收缩为仅 iOS。
- **i18n**：内置引擎标签去「仅桌面」；`download_backend_desktop_only_note` → `download_backend_unsupported_note`（i18n_sync 重建 17 语言）。
- **CI**：release.yml 出 APK 前编 arm64-v8a .so（vcpkg 二进制/distfile 双层缓存照抄 build-multiplatform.yml 姿势）。**范围决策：只编 arm64-v8a**；armeabi-v7a/x86_64 包按回退路径落外接 qb，不是静默破坏。

## 验证

- `flutter analyze` 全量零问题；torrent 域 + 设置页定向测试 496 全过（含更新后的 BUG-1207 门控 widget 测试）。
- **模拟器实测**（API 34 x86_64，新增 `integration_test/embedded_torrent_engine_smoke_test.dart`）：两用例全过——.so 按名加载 + libtorrent 版本串 2.x；回环 session 创建、拿到监听端口、`make_torrent` 真实产出 .torrent。
- APK 解包核验：`lib/arm64-v8a/` 与 `lib/x86_64/` 均含 `libfushi_torrent_ffi.so`，armeabi-v7a 无（copy-if-present 预期）。
- 本机产物 readelf 核验：51 个 `ht_*` C ABI 导出齐全，依赖仅 libc/libm/libdl/libc++_shared。

## 行为变化说明

Android 上 `backend=auto`（默认）现在解析为内置引擎（此前恒外接 qb）——与桌面当年引入内置引擎时的迁移行为一致；显式选过 qb 的配置不受影响（decode 兼容逻辑未动）。

## 已知边界

- CI 首次跑该步骤为冷编（~30-60 分钟），之后走缓存（~3 分钟）。
- iOS 仍无内置引擎（从不构建也从不打包），设置页显示平台说明文案。
- 下载仅在 app 存活期间进行（无前台服务），与现有 qb 轮询行为一致，后续可另起任务。

https://claude.ai/code/session_01FU4eXoUF2hisi3mevHUjoM