### PR TITLE
fix(lookup): inline-block 的振假名单元不是渲染断点，别把带 ruby 的词切成一个字（BUG-1659）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1533 条。点号进各自文件。
+> 共 1534 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1659](bugs/BUG-1659-inline-level-box-scan-boundary.md) | ✅ | ✅ | 查词浮窗 glossary 里带振假名的词只能查到第一个汉字 |
 | [BUG-1655](bugs/BUG-1655-ruby-double-scale.md) | ✅ | ✅ | 查词浮窗振假名显示过小（疑双重 0.5em 缩放） |
 | [BUG-1650](bugs/BUG-1650-sync-pulled-progress-stale-until-restart.md) | ✅ | ✅ | 同步拉回更远进度后首页继续与书架不刷新须重启 |
 | [BUG-1649](bugs/BUG-1649-manga-folder-epub-import.md) | ✅ | ✅ | 漫画页选文件夹导入：目录内是 epub 卷时报 Manga image folder has no pages |

--- a/docs/bugs/BUG-1659-inline-level-box-scan-boundary.md
+++ b/docs/bugs/BUG-1659-inline-level-box-scan-boundary.md
@@ -1,0 +1,33 @@
+## BUG-1659 · 查词浮窗 glossary 里带振假名的词只能查到第一个汉字
+- **报告**：2026-08-15（用户：CI 巡检发现，非用户报告）
+- **真实性**：✅ 真 bug（`fushi/assets/popup/selection.js:36` 的 `isInlineBox`，
+  由 BUG-1645 的 `b705e79816` 引入）。
+  症状两条，同一个根因：
+  1. **真实浏览器**：查词浮窗 glossary 里任何带振假名的词，跨节点续扫扫到第一个
+     ruby 单元就断 —— 「打ち合わせ」只取到「打」。popup.css:964
+     `.ruby-unit { display: inline-block }`（postProcessRuby 给每个振假名基字包一
+     个单元盒），而 `isInlineBox` 只认 `display === 'inline'`，把 inline-block 判成
+     了渲染断点。
+  2. **CI**：`test/js/popup_ruby_selection.test.mjs` 的
+     「mixed kanji/kana lookup skips ruby-reserve layout text」在 develop 上恒红
+     （`'打' !== '打ち合わせ'`）。这条走的是另一条路径 —— jsdom 默认样式表只给块级
+     元素赋 display，fixture 里 span/ruby 的 computed display 全是空串，
+     `isInlineBox` 的兜底只挡了 style 对象为空、没挡 display 为空串。
+- **为什么 push 门没拦住**：跑这条 JS 测试的是 `main.yml`（Build Android APK），
+  TODO-1208 之后**只在 pull_request 触发**。于是它红在 develop 上没人看见，却把
+  当时每一个 PR 的 `build` 检查一起拖红（#850 / #851 实测）。
+- **[x] ① 已修复** — `isInlineBox` 改为按「inline-level 盒」这个概念判定：
+  `display.startsWith('inline') || display === 'contents' ||
+  display.startsWith('ruby')`，并补 `if (!display) return true` 让空 display 落回
+  既有的「拿不到样式就沿用旧续扫行为」兜底。三份 selection.js 镜像同步（逐字节
+  sha256 一致）。教训是判据不要枚举概念的某个子集 —— inline-flex / inline-grid /
+  inline-table 当初也一起漏了。
+- **[x] ② 已加自动化测试** — `fushi/test/lookup/nested_latin_lookup_bug1645_test.js`
+  场景 E（`.ruby-unit` = `inline-block` 必须继续续扫）与场景 F（空 display 不得判成
+  断点）。挑这份 harness 是因为它的 fake DOM 由测试显式指定 `display`，能钉住
+  **真实浏览器**的值；`popup_ruby_selection.test.mjs` 受 jsdom 默认样式表所限只能
+  盖到场景 F，盖不住 inline-block。变异实测：判据缩回 `=== 'inline'` → 场景 E 红成
+  `'打' !== '打ち合わせ'`；摘掉空 display 兜底 → 场景 F 红成 `'打ち' !== '打ち合わせ'`。
+- **备注**：BUG-1645 的四个原场景（相邻释义断开 / compact `::after` 分隔符断开 /
+  行内拆词仍能拼回 / 日语不回归）全部不受影响 —— 它们用的是 `list-item` 与
+  `inline`，与本次放宽的 inline-level 集合不相交。

--- a/fushi/assets/browser_extension/vendor/selection.js
+++ b/fushi/assets/browser_extension/vendor/selection.js
@@ -30,14 +30,24 @@ window.fushiSelection = {
         return /^[\s　]$/.test(char) || this.scanDelimiters.includes(char);
     },
 
-    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/inline-block
-    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。拿不到样式时返回 true
-    // （保持旧的跨节点续扫行为，不引入新的失败模式）。
+    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/flex/grid
+    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。
+    //
+    // BUG-1659：判据必须是「inline-level 盒」这个概念本身，不是它的某个枚举
+    // 子集。原先写死 `display === 'inline'`，把 inline-block / inline-flex /
+    // inline-grid / inline-table 这些同样排在同一行上的盒子一律当成了断点。
+    // 而 popup.css 的 `.ruby-unit` 正是 `display: inline-block`（每个振假名单元一
+    // 个），于是查词浮窗 glossary 里任何带振假名的词扫到第一个 ruby 单元就断：
+    // 「打ち合わせ」只剩下「打」。
+    //
+    // 拿不到样式（或拿不到 display）时返回 true，保持旧的跨节点续扫行为，
+    // 不引入新的失败模式。
     isInlineBox(element) {
         const style = window.getComputedStyle?.(element);
         if (!style) return true;
         const display = style.display;
-        return display === 'inline' || display === 'contents' ||
+        if (!display) return true;
+        return display.startsWith('inline') || display === 'contents' ||
             display.startsWith('ruby');
     },
 

--- a/fushi/assets/popup/selection.js
+++ b/fushi/assets/popup/selection.js
@@ -30,14 +30,24 @@ window.fushiSelection = {
         return /^[\s　]$/.test(char) || this.scanDelimiters.includes(char);
     },
 
-    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/inline-block
-    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。拿不到样式时返回 true
-    // （保持旧的跨节点续扫行为，不引入新的失败模式）。
+    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/flex/grid
+    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。
+    //
+    // BUG-1659：判据必须是「inline-level 盒」这个概念本身，不是它的某个枚举
+    // 子集。原先写死 `display === 'inline'`，把 inline-block / inline-flex /
+    // inline-grid / inline-table 这些同样排在同一行上的盒子一律当成了断点。
+    // 而 popup.css 的 `.ruby-unit` 正是 `display: inline-block`（每个振假名单元一
+    // 个），于是查词浮窗 glossary 里任何带振假名的词扫到第一个 ruby 单元就断：
+    // 「打ち合わせ」只剩下「打」。
+    //
+    // 拿不到样式（或拿不到 display）时返回 true，保持旧的跨节点续扫行为，
+    // 不引入新的失败模式。
     isInlineBox(element) {
         const style = window.getComputedStyle?.(element);
         if (!style) return true;
         const display = style.display;
-        return display === 'inline' || display === 'contents' ||
+        if (!display) return true;
+        return display.startsWith('inline') || display === 'contents' ||
             display.startsWith('ruby');
     },
 

--- a/fushi/test/lookup/nested_latin_lookup_bug1645_test.js
+++ b/fushi/test/lookup/nested_latin_lookup_bug1645_test.js
@@ -15,6 +15,10 @@
 // 判据必须是渲染盒而不是「两侧都是字母就断」，否则 `<b>ac</b>rid` 这种行内标记
 // 拆开的单词会被误断（场景 C 守这条）。
 //
+// BUG-1659（同一函数的后续回归）：`isInlineBox` 手工枚举 inline 盒，漏掉了
+// inline-block（popup.css 的 `.ruby-unit` 正是它）与「computed display 为空串」
+// 两种情况，两者都被误判成渲染断点 —— 见下方场景 E / F。
+//
 // 运行：node fushi/test/lookup/nested_latin_lookup_bug1645_test.js
 // 由同名 .dart wrapper 通过 Process.run('node', ...) 驱动（无 node 时 skip）。
 
@@ -232,6 +236,64 @@ function run() {
     });
     const text = ctx.sandbox.window.fushiSelection.selectFromPosition(ctx.hit, 0, 20);
     assert.strictEqual(text, '打ち合わせ', '[ja-inline] 日语跨行内节点续扫不得回归');
+  }
+
+  // 场景 E（BUG-1659 根因守卫）：振假名单元是 `display: inline-block`。
+  // popup.css `.ruby-unit { display: inline-block }`（每个振假名单元一个盒），
+  // 而 inline-block 是 **inline-level** 盒 —— 它和相邻文字排在同一行上，两侧
+  // 文字完全可能是同一个词。BUG-1645 的 isInlineBox 手工枚举成
+  // `display === 'inline'`，把它连同 inline-flex / inline-grid / inline-table
+  // 一起当成了渲染断点，于是查词浮窗 glossary 里任何带振假名的词扫到第一个
+  // ruby 单元就断：「打ち合わせ」只剩下「打」。
+  //
+  // 注意 test/js/popup_ruby_selection.test.mjs 盖不住这条：jsdom 的默认样式表
+  // 只给块级元素赋 display，fixture 里 span/ruby 的 computed display 全是空串，
+  // 那条测试踩到的是「空 display」路径（场景 F），不是 inline-block。
+  {
+    const ctx = buildContext((body) => {
+      const content = makeElement('div', { className: 'glossary-content', display: 'block' });
+      const ruby = makeElement('ruby', { display: 'ruby' });
+      const unit = makeElement('span', { className: 'ruby-unit', display: 'inline-block' });
+      const baseText = makeText('打', unit);
+      unit.childNodes = [baseText];
+      const tail = makeElement('span', { display: 'inline' });
+      const tailText = makeText('ち合わせ', tail);
+      tail.childNodes = [tailText];
+      appendChildren(ruby, [unit]);
+      appendChildren(content, [ruby, tail]);
+      appendChildren(body, [content]);
+      return { hit: baseText };
+    });
+    const text = ctx.sandbox.window.fushiSelection.selectFromPosition(ctx.hit, 0, 20);
+    assert.strictEqual(
+      text,
+      '打ち合わせ',
+      '[inline-block] 振假名单元(.ruby-unit)是 inline-level 盒，不得当成渲染断点',
+    );
+  }
+
+  // 场景 F（BUG-1659）：computed display 取不到值（空串）时不得当成断点。
+  // isInlineBox 的既有兜底是「拿不到样式时返回 true」，但只挡了 style 对象本身
+  // 为空的情况；样式对象在、display 是空串时会一路落到 `=== 'inline'` 全部不中，
+  // 反而判成断点。jsdom / 精简沙箱 / 未附加到文档的节点都会走到这条路径。
+  {
+    const ctx = buildContext((body) => {
+      const paragraph = makeElement('p', { display: 'block' });
+      const span = makeElement('span', { display: '' });
+      const spanText = makeText('打ち', span);
+      span.childNodes = [spanText];
+      const tailText = makeText('合わせ', paragraph);
+      appendChildren(paragraph, [span]);
+      paragraph.childNodes = [span, tailText];
+      appendChildren(body, [paragraph]);
+      return { hit: spanText };
+    });
+    const text = ctx.sandbox.window.fushiSelection.selectFromPosition(ctx.hit, 0, 20);
+    assert.strictEqual(
+      text,
+      '打ち合わせ',
+      '[empty-display] 拿不到 display 时必须沿用旧的续扫行为，不得判成断点',
+    );
   }
 
   console.log('all assertions passed');

--- a/tools/browser-extension/vendor/selection.js
+++ b/tools/browser-extension/vendor/selection.js
@@ -30,14 +30,24 @@ window.fushiSelection = {
         return /^[\s　]$/.test(char) || this.scanDelimiters.includes(char);
     },
 
-    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/inline-block
-    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。拿不到样式时返回 true
-    // （保持旧的跨节点续扫行为，不引入新的失败模式）。
+    // BUG-1645：元素是否「同一行内连排」的 inline 盒。块级/列表项/表格单元/flex/grid
+    // 在用户眼里就是换行或分栏，两侧文字不可能是同一个词。
+    //
+    // BUG-1659：判据必须是「inline-level 盒」这个概念本身，不是它的某个枚举
+    // 子集。原先写死 `display === 'inline'`，把 inline-block / inline-flex /
+    // inline-grid / inline-table 这些同样排在同一行上的盒子一律当成了断点。
+    // 而 popup.css 的 `.ruby-unit` 正是 `display: inline-block`（每个振假名单元一
+    // 个），于是查词浮窗 glossary 里任何带振假名的词扫到第一个 ruby 单元就断：
+    // 「打ち合わせ」只剩下「打」。
+    //
+    // 拿不到样式（或拿不到 display）时返回 true，保持旧的跨节点续扫行为，
+    // 不引入新的失败模式。
     isInlineBox(element) {
         const style = window.getComputedStyle?.(element);
         if (!style) return true;
         const display = style.display;
-        return display === 'inline' || display === 'contents' ||
+        if (!display) return true;
+        return display.startsWith('inline') || display === 'contents' ||
             display.startsWith('ruby');
     },
 


### PR DESCRIPTION
fix(lookup): inline-block 的振假名单元不是渲染断点，别把带 ruby 的词切成一个字（BUG-1659）

develop 上 `test/js/popup_ruby_selection.test.mjs` 的「mixed kanji/kana lookup
skips ruby-reserve layout text」恒红（`'打' !== '打ち合わせ'`）。跑这条 JS 测试的
`main.yml` 在 TODO-1208 之后只在 pull_request 触发，所以它红在 develop 上没人
看见，却把当时每一个 PR 的 `build` 检查一起拖红（#850 / #851 实测）。

根因在 BUG-1645（b705e79816）新增的 `isInlineBox`：它把「同一行内连排」这个概念
写成了 `display === 'inline'` 这一个枚举值。两条真实后果：

1. **真实浏览器**：popup.css:964 `.ruby-unit { display: inline-block }`
   （postProcessRuby 给每个振假名基字包一个单元盒）。inline-block 是 inline-level
   盒，和相邻文字排在同一行上，可是它被判成了渲染断点 —— 于是查词浮窗 glossary 里
   任何带振假名的词，跨节点续扫扫到第一个 ruby 单元就停，「打ち合わせ」只取到「打」。
   inline-flex / inline-grid / inline-table 当初也一起漏了。
2. **CI**：jsdom 的默认样式表只给块级元素赋 display，fixture 里 span/ruby 的
   computed display 全是空串；`isInlineBox` 的兜底只挡了 style 对象为空、没挡
   display 为空串，于是每个 span 都成了断点。

修法是让判据回到概念本身，而不是概念的某个子集：
    display.startsWith('inline') || display === 'contents' || display.startsWith('ruby')
并补 `if (!display) return true`，让空 display 落回既有的「拿不到样式就沿用旧的
跨节点续扫行为」兜底。三份 selection.js 镜像同步，逐字节 sha256 一致。

BUG-1645 的四个原场景不受影响：它们用的是 `list-item` 与 `inline`，与这次放宽的
inline-level 集合不相交。

测试加在 `fushi/test/lookup/nested_latin_lookup_bug1645_test.js`（它的 fake DOM 由
测试显式指定 display，能钉住**真实浏览器**的值；`popup_ruby_selection.test.mjs` 受
jsdom 默认样式表所限只盖得到空 display 那条路径，盖不住 inline-block）：
- 场景 E：`.ruby-unit` = `inline-block` 时必须继续续扫
- 场景 F：空 display 不得判成断点

变异实测（源码按唯一锚点反向替换还原，sha256 与变异前逐字节一致）：
- 判据缩回 `=== 'inline'` → 场景 E 红成 `'打' !== '打ち合わせ'`
- 摘掉空 display 兜底 → 场景 F 红成 `'打ち' !== '打ち合わせ'`

验证：
- test/js 全部 20 tests 绿（含原先那条红的）
- tools/browser-extension 全部 210 tests 绿
- nested_latin_lookup_bug1645_test.js 六个场景绿
- flutter analyze（含 test）No issues，exit 0

Claude-Session: https://claude.ai/code/session_01WCUeqCBNeQqdoUeyPyaM1L
