### PR TITLE
chore: .mailmap 归一 W1ght 的双身份

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,3 +3,4 @@ Arianne Orpilla <arianneorpilla@protonmail.com> <artisanlro@mbp.localdomain>
 wrds <2598142880@qq.com> <pm@hibiki.local>
 wrds <2598142880@qq.com> <qqbotxiaoxiao@gmail.com>
 wrds <2598142880@qq.com> <vw6cnhd9f7@privaterelay.appleid.com>
+shishamo <63065966+W1ght@users.noreply.github.com> <506997957@qq.com>


### PR DESCRIPTION
W1ght（shishamo）在 develop 上的 commit 身份分裂：263 个用 `506997957@qq.com`（不挂 GitHub 账号）、4 个用 `63065966+W1ght@users.noreply.github.com`。加一行 .mailmap 把前者归一到后者，`git shortlog -sne` 里 267 个 commit 合并为一个作者条目。

验证：`git check-mailmap "shishamo <506997957@qq.com>"` → `shishamo <63065966+W1ght@users.noreply.github.com>`。

注：.mailmap 只影响 git 侧作者统计（shortlog/log/blame）；GitHub 网页上按邮箱→账号的归属不吃 .mailmap，QQ 邮箱那批要在网页上也算到 W1ght 头上，需要他本人在 GitHub 账号设置里添加该邮箱。