### PR TITLE
fix(update): iOS 更新按安装来源落地 TestFlight / App Store (BUG-1663)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1539 条。点号进各自文件。
+> 共 1540 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1663](bugs/BUG-1663-ios-update-lands-on-github-not-testflight.md) | ✅ | ✅ | iOS「检查更新」把 TestFlight 用户送到 GitHub 未签名 ipa |
 | [BUG-1661](bugs/BUG-1661-corretto-x64-sha256-typo.md) | ✅ | ✅ | macOS 构建挂在「下载 pinned JDK 失败」，真因是 sha256 抄成 65 位 |
 | [BUG-1660](bugs/BUG-1660-aidoku-image-reader-compat.md) | ✅ | ✅ | Aidoku 图源图片与章节兼容及阅读器返回入口缺失 |
 | [BUG-1659](bugs/BUG-1659-inline-level-box-scan-boundary.md) | ✅ | ✅ | 查词浮窗 glossary 里带振假名的词只能查到第一个汉字 |

--- a/docs/bugs/BUG-1663-ios-update-lands-on-github-not-testflight.md
+++ b/docs/bugs/BUG-1663-ios-update-lands-on-github-not-testflight.md
@@ -1,0 +1,29 @@
+## BUG-1663 · iOS「检查更新」把 TestFlight 用户送到 GitHub 未签名 ipa
+- **报告**：2026-08-15（用户：shishamo）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/misc/platform_updater.dart:385`（`IosUpdater`
+  的 `selectAsset` 恒 null）+ `fushi/lib/src/utils/misc/update_checker_release.dart:369`
+  （无 asset → 一律 `_showFallbackDialog(..., json['html_url'])`）。iOS 的分发链路有三条且
+  互不相干——App Store（将来）、TestFlight（`upload_testflight` 的 beta/formal 构建）、
+  GitHub Release 里那个**未签名**的 `fushi-<v>-ios.ipa`（AltStore / Sideloadly 侧载）——
+  代码里一条都没建模，所有 iOS 用户被无差别送到 GitHub 发布页。对 TestFlight 用户来说那
+  页上的 ipa 装不上（签名不同），而他们真正的更新源 TestFlight 从没被提过。
+- **[x] ① 已修复** — 按**安装来源**分流，而不是按更新通道猜（通道猜法会把 stable 通道的
+  侧载用户误送进 TestFlight）。安装来源是系统写的事实：App Store 装的有 `receipt`、
+  TestFlight 装的有 `sandboxReceipt`、侧载/自签的收据文件根本不存在。
+  - native：`fushi/ios/Runner/AppDelegate.swift` 在既有 `app.fushi.reader/update` 通道上加
+    `getInstallSource`（必须查 `fileExists`——`appStoreReceiptURL` 对侧载包也返回路径，
+    只看文件名会把侧载误判成 TestFlight）。
+  - Dart：新增 `fushi/lib/src/utils/misc/update_landing.dart`（`IosInstallSource` /
+    `UpdateLanding` / 纯函数 `iosUpdateLanding`），`PlatformUpdater.resolveDownloadLanding`
+    做平台方法、`IosUpdater` 覆写，`_showFallbackDialog` 按落地种类给文案。
+  - 侧载用户的路没被掐掉：主按钮指向商店时对话框额外给「发布页」次要入口。
+  - `Info.plist` 登记 `itms-beta` / `itms-apps`，否则 url_launcher 的可用性探测一律判 false。
+  - 上架 App Store 后只需填 `kIosAppStoreAppId`，逻辑不用改（未填时回退发布页，不造 id 死链）。
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/ios_update_landing_test.dart`（12 例）：
+  三种安装来源 → 落地入口的纯函数映射、未知值 fail-safe 回发布页、非 iOS 平台不被误伤、
+  以及 native 契约源码守卫（`getInstallSource` / `sandboxReceipt` / `fileExists` /
+  `Info.plist` 的两个 scheme）。守卫已做变异实测：抽掉 `fileExists` 判据、抽掉
+  `itms-beta` 登记，两次都真红，还原后 sha256 与变异前一致。
+- **备注**：真机验证（TestFlight 装一版点「检查更新」看是否跳 TestFlight）未做——需要一次
+  手动 `workflow_dispatch` 的 beta 发版且等 App Store Connect 处理。收据判据本身是 OS 行为，
+  跑不了单测，所以守的是契约。

--- a/fushi/ios/Runner/AppDelegate.swift
+++ b/fushi/ios/Runner/AppDelegate.swift
@@ -27,6 +27,20 @@ import Flutter
     installChannels(binaryMessenger: engineBridge.applicationRegistrar.messenger())
   }
 
+  /// 安装来源判据 = 系统写进 bundle 的 App Store 收据文件，不是猜测：
+  /// - App Store 安装 → `.../receipt`
+  /// - TestFlight 安装 → `.../sandboxReceipt`
+  /// - 侧载 / 自签 / Xcode 直接跑 → 收据**文件不存在**（`appStoreReceiptURL` 仍给得
+  ///   出路径，所以必须查文件是否真的在，只看文件名会把侧载误判成 TestFlight）。
+  private static func currentInstallSource() -> String {
+    guard let receiptUrl = Bundle.main.appStoreReceiptURL,
+      FileManager.default.fileExists(atPath: receiptUrl.path)
+    else {
+      return "sideload"
+    }
+    return receiptUrl.lastPathComponent == "sandboxReceipt" ? "testFlight" : "appStore"
+  }
+
   private func installChannels(binaryMessenger: FlutterBinaryMessenger) {
     let splashChannel = FlutterMethodChannel(
       name: "app.fushi.reader/splash",
@@ -113,6 +127,21 @@ import Flutter
           UIScreen.main.brightness = CGFloat(clamped)
         }
         result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
+    // 更新落地入口分流（Dart 侧 IosUpdater.resolveDownloadLanding）。iOS 有三条互不
+    // 相干的分发链路 —— App Store / TestFlight / GitHub 未签名 ipa 侧载 —— 而「该去
+    // 哪儿更新」只由「这份 app 是从哪儿装来的」决定。这里回答的就是这一个事实。
+    let updateChannel = FlutterMethodChannel(
+      name: "app.fushi.reader/update",
+      binaryMessenger: binaryMessenger)
+    updateChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "getInstallSource":
+        result(Self.currentInstallSource())
       default:
         result(FlutterMethodNotImplemented)
       }

--- a/fushi/ios/Runner/Info.plist
+++ b/fushi/ios/Runner/Info.plist
@@ -107,6 +107,14 @@
 		<key>LSApplicationQueriesSchemes</key>
 		<array>
 			<string>anki</string>
+			<!--
+				更新落地入口（见 lib/src/utils/misc/update_landing.dart）：TestFlight
+				安装的包指向 itms-beta://，上架后 App Store 安装的包指向 itms-apps://。
+				不登记这两个 scheme，url_launcher 的 canLaunchUrl 探测会一律判 false，
+				按钮就成了点了没反应。
+			-->
+			<string>itms-beta</string>
+			<string>itms-apps</string>
 		</array>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58123 (3419 per locale)
+/// Strings: 58174 (3422 per locale)
 ///
-/// Built on 2026-08-15 at 04:17 UTC
+/// Built on 2026-08-15 at 07:57 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4629,6 +4629,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.';
   String get aidoku_repository_remove => 'Remove repository';
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  String get update_testflight_open => 'Open TestFlight';
+  String get update_app_store_open => 'Open App Store';
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -12527,6 +12530,12 @@ class _StringsAr extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -20492,6 +20501,12 @@ class _StringsDe extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -28473,6 +28488,12 @@ class _StringsEs extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -36466,6 +36487,12 @@ class _StringsFr extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -44387,6 +44414,12 @@ class _StringsId extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -52354,6 +52387,12 @@ class _StringsIt extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -60135,6 +60174,12 @@ class _StringsJa extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -67923,6 +67968,12 @@ class _StringsKo extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -75870,6 +75921,12 @@ class _StringsNl extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -83829,6 +83886,12 @@ class _StringsPtBr extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -91774,6 +91837,12 @@ class _StringsRu extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -99667,6 +99736,12 @@ class _StringsTh extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -107591,6 +107666,12 @@ class _StringsTr extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -115500,6 +115581,12 @@ class _StringsVi extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 // Path: <root>
@@ -122833,6 +122920,12 @@ class _StringsZhCn extends _StringsEn {
   String get aidoku_repository_remove => '移除仓库';
   @override
   String get aidoku_repository_empty => '尚未添加 Aidoku 仓库。';
+  @override
+  String get update_testflight_open => '打开 TestFlight';
+  @override
+  String get update_app_store_open => '打开 App Store';
+  @override
+  String get update_release_page_open => '发布页';
 }
 
 // Path: <root>
@@ -130537,6 +130630,12 @@ class _StringsZhHk extends _StringsEn {
   String get aidoku_repository_remove => 'Remove repository';
   @override
   String get aidoku_repository_empty => 'No Aidoku repositories added.';
+  @override
+  String get update_testflight_open => 'Open TestFlight';
+  @override
+  String get update_app_store_open => 'Open App Store';
+  @override
+  String get update_release_page_open => 'Release page';
 }
 
 /// Flat map(s) containing all translations.
@@ -137562,6 +137661,12 @@ extension on _StringsEn {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -144585,6 +144690,12 @@ extension on _StringsAr {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -151630,6 +151741,12 @@ extension on _StringsDe {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -158674,6 +158791,12 @@ extension on _StringsEs {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -165724,6 +165847,12 @@ extension on _StringsFr {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -172756,6 +172885,12 @@ extension on _StringsId {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -179802,6 +179937,12 @@ extension on _StringsIt {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -186810,6 +186951,12 @@ extension on _StringsJa {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -193822,6 +193969,12 @@ extension on _StringsKo {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -200862,6 +201015,12 @@ extension on _StringsNl {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -207899,6 +208058,12 @@ extension on _StringsPtBr {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -214941,6 +215106,12 @@ extension on _StringsRu {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -221966,6 +222137,12 @@ extension on _StringsTh {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -229000,6 +229177,12 @@ extension on _StringsTr {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -236030,6 +236213,12 @@ extension on _StringsVi {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }
@@ -243002,6 +243191,12 @@ extension on _StringsZhCn {
         return '移除仓库';
       case 'aidoku_repository_empty':
         return '尚未添加 Aidoku 仓库。';
+      case 'update_testflight_open':
+        return '打开 TestFlight';
+      case 'update_app_store_open':
+        return '打开 App Store';
+      case 'update_release_page_open':
+        return '发布页';
       default:
         return null;
     }
@@ -250005,6 +250200,12 @@ extension on _StringsZhHk {
         return 'Remove repository';
       case 'aidoku_repository_empty':
         return 'No Aidoku repositories added.';
+      case 'update_testflight_open':
+        return 'Open TestFlight';
+      case 'update_app_store_open':
+        return 'Open App Store';
+      case 'update_release_page_open':
+        return 'Release page';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "浏览仓库",
   "aidoku_repository_hint": "粘贴 Aidoku 仓库主页或 index.min.json 地址。默认已填入社区仓库。",
   "aidoku_repository_remove": "移除仓库",
-  "aidoku_repository_empty": "尚未添加 Aidoku 仓库。"
+  "aidoku_repository_empty": "尚未添加 Aidoku 仓库。",
+  "update_testflight_open": "打开 TestFlight",
+  "update_app_store_open": "打开 App Store",
+  "update_release_page_open": "发布页"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3417,5 +3417,8 @@
   "aidoku_repository_browse": "Browse repository",
   "aidoku_repository_hint": "Paste an Aidoku repository homepage or index.min.json URL. The community repository is filled in by default.",
   "aidoku_repository_remove": "Remove repository",
-  "aidoku_repository_empty": "No Aidoku repositories added."
+  "aidoku_repository_empty": "No Aidoku repositories added.",
+  "update_testflight_open": "Open TestFlight",
+  "update_app_store_open": "Open App Store",
+  "update_release_page_open": "Release page"
 }

--- a/fushi/lib/src/utils/misc/platform_updater.dart
+++ b/fushi/lib/src/utils/misc/platform_updater.dart
@@ -7,6 +7,7 @@ import 'package:fushi/src/platform/desktop/windows_process_query.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/src/utils/misc/mac_update_handoff.dart';
 import 'package:fushi/src/utils/misc/update_handoff.dart';
+import 'package:fushi/src/utils/misc/update_landing.dart';
 import 'package:fushi/utils.dart'; // ErrorLogService
 
 export 'update_handoff.dart'
@@ -116,6 +117,15 @@ abstract class PlatformUpdater {
 
   /// 应用已下载到 [file] 的更新。仅在 [supportsInAppInstall] 为 true 时被调用。
   Future<void> apply(File file, String version);
+
+  /// 不能应用内安装时，「前往下载」按钮该落到哪里。默认 = GitHub release 网页
+  /// （[releaseHtmlUrl]），即所有桌面/未实现平台的既有行为。
+  ///
+  /// 做成平台方法而不是在 update_checker 里 `if (Platform.isIOS)`：「本平台的更新
+  /// 从哪儿来」和「本平台怎么选包/怎么装」是同一个问题的三个面，属于同一个
+  /// [PlatformUpdater]；散到调用方就会出现「某个入口忘了分流」的静默空档。
+  Future<UpdateLanding> resolveDownloadLanding(String releaseHtmlUrl) async =>
+      UpdateLanding(url: releaseHtmlUrl, kind: UpdateLandingKind.releasePage);
 }
 
 /// 本期支持「应用内安装」的平台集合（单一真相源；Linux 在其阶段加入）。macOS 走
@@ -380,8 +390,15 @@ class MacUpdater extends PlatformUpdater {
 }
 
 /// iOS：Apple 平台禁止应用内下载/执行外部可执行文件（即便当前不在 App Store，也守住
-/// 合规边界便于将来上架）。永远只「检查版本→打开发布页」，[selectAsset] 恒 null 使
-/// 上层走 `_showFallbackDialog`。CI 产出的 `hibiki-<v>-ios.ipa` 供用户手动侧载。
+/// 合规边界便于将来上架）。永远只「检查版本→前往分发渠道」，[selectAsset] 恒 null 使
+/// 上层走 `_showFallbackDialog`。
+///
+/// 「分发渠道」不是一条：TestFlight 装的包只能从 TestFlight 更新（TestFlight 本身就
+/// 会自动更新，这里只是给用户一个手动入口），将来上架后 App Store 装的包只能从
+/// App Store 更新，而 GitHub Release 里那个未签名 `fushi-<v>-ios.ipa` 只对 AltStore /
+/// Sideloadly 侧载用户有意义。三者由**安装来源**（系统写的收据文件，见
+/// [IosInstallSource]）决定，不由更新通道决定——按通道猜会把侧载用户送进 TestFlight
+/// （他们进不去）、把 TestFlight 用户送去下一个装不上的 ipa。
 class IosUpdater extends PlatformUpdater {
   @override
   bool get supportsUpdateCheck => true;
@@ -395,6 +412,12 @@ class IosUpdater extends PlatformUpdater {
     UpdateChannel channel = UpdateChannel.stable,
   }) async =>
       null;
+
+  @override
+  Future<UpdateLanding> resolveDownloadLanding(String releaseHtmlUrl) async {
+    final IosInstallSource source = await IosInstallSourceResolver.resolve();
+    return iosUpdateLanding(source: source, releaseHtmlUrl: releaseHtmlUrl);
+  }
 
   @override
   Future<void> apply(File file, String version) async {

--- a/fushi/lib/src/utils/misc/update_checker.dart
+++ b/fushi/lib/src/utils/misc/update_checker.dart
@@ -27,6 +27,7 @@ import 'package:fushi/src/utils/misc/mac_update_handoff.dart';
 import 'package:fushi/src/utils/misc/platform_updater.dart';
 import 'package:fushi/src/utils/misc/resumable_downloader.dart';
 import 'package:fushi/src/utils/misc/update_handoff.dart';
+import 'package:fushi/src/utils/misc/update_landing.dart';
 // 代理解析层（applyAppProxy / normalizeUserProxyHostPort 等）已提取为独立库
 // `src/utils/net/app_proxy.dart`（BUG-1348）：part 契约禁止 part 内 import，而同步层也要
 // 用同一套代理出口，故它不能再住在 net part 里。这里不单独 import——utils.dart 已经

--- a/fushi/lib/src/utils/misc/update_checker_release.dart
+++ b/fushi/lib/src/utils/misc/update_checker_release.dart
@@ -365,11 +365,15 @@ class UpdateChecker {
       final UpdateAsset? asset = selection.asset;
       final String? downloadUrl = asset?.url;
 
-      // 无适配本平台的 asset（iOS / 未实现桌面 / 该 release 没传本平台包）→ 打开发布页。
+      // 无适配本平台的 asset（iOS / 未实现桌面 / 该 release 没传本平台包）→ 前往
+      // 本平台的分发入口（iOS = TestFlight / App Store / 发布页，其余 = 发布页）。
       if (downloadUrl == null) {
         final String? htmlUrl = json['html_url'] as String?;
-        if (htmlUrl != null && context.mounted) {
-          _showFallbackDialog(context, version, releaseBody, htmlUrl);
+        if (htmlUrl != null) {
+          final UpdateLanding landing =
+              await updater.resolveDownloadLanding(htmlUrl);
+          if (!context.mounted) return;
+          _showFallbackDialog(context, version, releaseBody, landing, htmlUrl);
         }
         return;
       }
@@ -397,10 +401,13 @@ class UpdateChecker {
         _showUpdateDialog(context, version, releaseBody, asset!, updater,
             customProxy: customProxy);
       } else {
-        // 能检查但不能自装（本期 iOS/mac/Linux）：弹「前往下载」打开发布页。
+        // 能检查但不能自装（本期 iOS/Linux）：弹「前往下载」→ 本平台分发入口。
         final String? htmlUrl = json['html_url'] as String?;
         if (htmlUrl != null) {
-          _showFallbackDialog(context, version, releaseBody, htmlUrl);
+          final UpdateLanding landing =
+              await updater.resolveDownloadLanding(htmlUrl);
+          if (!context.mounted) return;
+          _showFallbackDialog(context, version, releaseBody, landing, htmlUrl);
         }
       }
     } catch (e, stack) {
@@ -728,26 +735,44 @@ class UpdateChecker {
     );
   }
 
-  /// Fallback dialog for when no APK asset exists — opens browser.
+  /// 本平台没有可应用内安装的包时的对话框：主按钮打开 [landing]（iOS 上可能是
+  /// TestFlight / App Store），[releaseHtmlUrl] 是 GitHub 发布页。
+  ///
+  /// 主按钮不落在发布页时额外给一个「发布页」次要入口：GitHub Release 里的未签名
+  /// ipa 是侧载用户唯一的取包处，主按钮改指商店后不能把这条路一起掐掉。
   static void _showFallbackDialog(
     BuildContext context,
     String version,
     String releaseNotes,
-    String htmlUrl,
+    UpdateLanding landing,
+    String releaseHtmlUrl,
   ) {
+    final bool showReleasePageAction =
+        landing.kind != UpdateLandingKind.releasePage;
     showAppDialog<void>(
       context: context,
       builder: (ctx) => UpdateAvailableDialog(
         version: version,
         releaseNotes: releaseNotes,
-        primaryLabel: t.update_download,
+        primaryLabel: updateLandingActionLabel(landing.kind),
         onPrimary: () {
           Navigator.of(ctx).pop();
           launchUrl(
-            Uri.parse(htmlUrl),
+            Uri.parse(landing.url),
             mode: LaunchMode.externalApplication,
           );
         },
+        secondaryLabel:
+            showReleasePageAction ? t.update_release_page_open : null,
+        onSecondary: showReleasePageAction
+            ? () {
+                Navigator.of(ctx).pop();
+                launchUrl(
+                  Uri.parse(releaseHtmlUrl),
+                  mode: LaunchMode.externalApplication,
+                );
+              }
+            : null,
       ),
     );
   }

--- a/fushi/lib/src/utils/misc/update_checker_ui.dart
+++ b/fushi/lib/src/utils/misc/update_checker_ui.dart
@@ -10,6 +10,15 @@ String formatUpdateDownloadByteCount(int? bytes) =>
 String formatUpdateDownloadSpeed(double? bytesPerSecond) =>
     FushiByteFormat.speed(bytesPerSecond);
 
+/// **纯函数**：落地入口种类 → 「前往下载」主按钮文案。文案必须说清去哪儿，否则
+/// 用户点了「下载」结果跳出 App Store / TestFlight 会以为是误触。
+@visibleForTesting
+String updateLandingActionLabel(UpdateLandingKind kind) => switch (kind) {
+      UpdateLandingKind.releasePage => t.update_download,
+      UpdateLandingKind.testFlight => t.update_testflight_open,
+      UpdateLandingKind.appStore => t.update_app_store_open,
+    };
+
 @visibleForTesting
 double? updateDownloadBytesPerSecond({
   required int startedBytes,
@@ -29,6 +38,8 @@ class UpdateAvailableDialog extends StatelessWidget {
     required this.releaseNotes,
     required this.primaryLabel,
     required this.onPrimary,
+    this.secondaryLabel,
+    this.onSecondary,
     super.key,
   });
 
@@ -36,6 +47,12 @@ class UpdateAvailableDialog extends StatelessWidget {
   final String releaseNotes;
   final String primaryLabel;
   final VoidCallback onPrimary;
+
+  /// 可选的第二入口。iOS 上主按钮指向 TestFlight / App Store 时，这里给出
+  /// 「发布页」——GitHub Release 里的未签名 ipa 是侧载用户唯一的取包处，主按钮改
+  /// 指商店后必须保留这条路，否则等于把侧载用户的更新链路直接掐断。
+  final String? secondaryLabel;
+  final VoidCallback? onSecondary;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +122,12 @@ class UpdateAvailableDialog extends StatelessWidget {
               onPressed: () => Navigator.of(context).pop(),
               child: Text(t.update_skip),
             ),
+            if (secondaryLabel != null && onSecondary != null)
+              adaptiveDialogAction(
+                context: context,
+                onPressed: onSecondary,
+                child: Text(secondaryLabel!),
+              ),
             adaptiveDialogAction(
               context: context,
               isDefaultAction: true,

--- a/fushi/lib/src/utils/misc/update_landing.dart
+++ b/fushi/lib/src/utils/misc/update_landing.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:fushi/src/utils/misc/channel_constants.dart';
+
+/// 「不能应用内安装时，前往哪里拿更新」的落地入口种类。
+///
+/// 这不是装饰性的枚举：它同时决定按钮文案（去 TestFlight 还是去 App Store 还是
+/// 打开发布页）和是否需要额外给出「发布页」次要入口，见
+/// `update_checker_release.dart` 的 `_showFallbackDialog`。
+enum UpdateLandingKind { releasePage, testFlight, appStore }
+
+/// 「前往下载」按钮真正要打开的东西：URL + 它是什么种类。
+@immutable
+class UpdateLanding {
+  const UpdateLanding({required this.url, required this.kind});
+
+  final String url;
+  final UpdateLandingKind kind;
+
+  @override
+  bool operator ==(Object other) =>
+      other is UpdateLanding && other.url == url && other.kind == kind;
+
+  @override
+  int get hashCode => Object.hash(url, kind);
+
+  @override
+  String toString() => 'UpdateLanding($kind, $url)';
+}
+
+/// 这份 iOS app 是**从哪条渠道装到这台设备上的**。
+///
+/// 根因背景：iOS 同一个版本有三条互不相干的分发链路——App Store（将来）、
+/// TestFlight（`upload_testflight` 的 beta / formal 构建，见
+/// `docs/agent/apple-signing.md`）、以及 GitHub Release 里那个**未签名**的
+/// `fushi-<v>-ios.ipa`（AltStore / Sideloadly 自签侧载）。「该去哪儿更新」的答案
+/// 完全由「我是从哪儿来的」决定，跟更新通道（stable/beta/debug）无关：TestFlight
+/// 装的包永远只能从 TestFlight 更新，侧载的包永远只能重新侧载。
+///
+/// 判据用 App Store 收据文件，这是系统写的事实、不是猜测：
+/// - App Store 安装 → `.../receipt`
+/// - TestFlight 安装 → `.../sandboxReceipt`
+/// - 侧载 / 自签 / 开发构建 → 收据文件**根本不存在**（路径有、文件没有）
+enum IosInstallSource { appStore, testFlight, sideload }
+
+/// TestFlight 公开加入链接（形如 `https://testflight.apple.com/join/<code>`）。
+///
+/// 留空是**有意的默认**：本 app 的 TestFlight 用户机器上必然装着 TestFlight，
+/// [kIosTestFlightAppUrl] 直接把它拉起来就够了，不需要公开招募链接。等对外公开
+/// 招募时把链接填在这里，落地入口自动切过去（[iosUpdateLanding] 优先用它）。
+const String kIosTestFlightJoinUrl = '';
+
+/// TestFlight app 的 URL scheme。裸 scheme 即「打开 TestFlight」，用户在里面能看到
+/// 本 app 的待更新构建。需要在 `ios/Runner/Info.plist` 的
+/// `LSApplicationQueriesSchemes` 里登记，否则 url_launcher 的可用性探测会误判。
+const String kIosTestFlightAppUrl = 'itms-beta://';
+
+/// App Store 上架后本 app 的数字 ID（App Store Connect 里的 Apple ID，纯数字）。
+///
+/// **上架前必然为空**——App Store 记录还没发布，任何 `id` 都是死链。为空时
+/// [iosUpdateLanding] 对 App Store 安装源回退到发布页（能打开的真链接），而不是
+/// 造一个 404。上架当天把 ID 填进来即完成切换，不需要改逻辑。
+const String kIosAppStoreAppId = '';
+
+/// App Store 商店页 URL；未配置 [kIosAppStoreAppId] 时返回 null。
+///
+/// 用 `itms-apps://` 而不是 `https://`：前者直接拉起 App Store app 落到本 app 页，
+/// 后者会先开 Safari 再跳一次。
+String? iosAppStoreUrl() {
+  if (kIosAppStoreAppId.isEmpty) return null;
+  return 'itms-apps://apps.apple.com/app/id$kIosAppStoreAppId';
+}
+
+/// TestFlight 落地 URL：有公开加入链接优先用它，否则拉起本机 TestFlight app。
+String iosTestFlightUrl() => kIosTestFlightJoinUrl.isNotEmpty
+    ? kIosTestFlightJoinUrl
+    : kIosTestFlightAppUrl;
+
+/// **纯函数**：iOS 上「前往下载」该落到哪里。
+///
+/// [releaseHtmlUrl] 是 GitHub release 网页（侧载用户的真实取包处，也是任何配置缺失
+/// 时的兜底——它永远是个能打开的活链接）。
+UpdateLanding iosUpdateLanding({
+  required IosInstallSource source,
+  required String releaseHtmlUrl,
+}) {
+  switch (source) {
+    case IosInstallSource.appStore:
+      final String? storeUrl = iosAppStoreUrl();
+      if (storeUrl == null) {
+        // 上架前 ID 未配置：宁可回发布页（活链接），也不给死的 `id` 链接。
+        return UpdateLanding(
+          url: releaseHtmlUrl,
+          kind: UpdateLandingKind.releasePage,
+        );
+      }
+      return UpdateLanding(url: storeUrl, kind: UpdateLandingKind.appStore);
+    case IosInstallSource.testFlight:
+      return UpdateLanding(
+        url: iosTestFlightUrl(),
+        kind: UpdateLandingKind.testFlight,
+      );
+    case IosInstallSource.sideload:
+      return UpdateLanding(
+        url: releaseHtmlUrl,
+        kind: UpdateLandingKind.releasePage,
+      );
+  }
+}
+
+/// **纯函数**：把 native 回来的字符串映射成 [IosInstallSource]。
+///
+/// 认不出（null / 新值 / 通道异常）→ [IosInstallSource.sideload]，即保持改动前的
+/// 「打开 GitHub 发布页」行为。fail-safe 方向选发布页而不是 TestFlight：发布页对
+/// 任何一种 iOS 用户都至少是可读的信息，而 TestFlight 对侧载用户是死路。
+IosInstallSource parseIosInstallSource(String? raw) {
+  switch (raw) {
+    case 'appStore':
+      return IosInstallSource.appStore;
+    case 'testFlight':
+      return IosInstallSource.testFlight;
+    default:
+      return IosInstallSource.sideload;
+  }
+}
+
+/// 运行期查询安装来源（结果进程内缓存——收据在 app 生命周期内不会变）。
+///
+/// 非 iOS 平台不该调用；真调了也返回 [IosInstallSource.sideload]（= 发布页，
+/// 即桌面/安卓原有行为），不炸。
+class IosInstallSourceResolver {
+  IosInstallSourceResolver._();
+
+  static IosInstallSource? _cached;
+
+  static Future<IosInstallSource> resolve() async {
+    final IosInstallSource? cached = _cached;
+    if (cached != null) return cached;
+    if (!Platform.isIOS) return IosInstallSource.sideload;
+    IosInstallSource resolved;
+    try {
+      final String? raw =
+          await FushiChannels.update.invokeMethod<String>('getInstallSource');
+      resolved = parseIosInstallSource(raw);
+    } catch (e) {
+      // 通道缺失（老 native / 测试环境）→ 保持旧行为走发布页，不阻断更新提示。
+      debugPrint('[UpdateChecker] iOS install source lookup failed: $e');
+      resolved = IosInstallSource.sideload;
+    }
+    _cached = resolved;
+    return resolved;
+  }
+
+  @visibleForTesting
+  static void setForTest(IosInstallSource? source) => _cached = source;
+}

--- a/fushi/test/settings/md3_design_system_static_test.dart
+++ b/fushi/test/settings/md3_design_system_static_test.dart
@@ -2260,7 +2260,11 @@ void main() {
     final String updateFlow = _functionSource(
       releaseSource,
       'static void _showUpdateDialog(',
-      '  /// Fallback dialog for when no APK asset exists',
+      // 终止锚点用**方法签名**而不是下一个方法的文档注释首行：注释是会被重写的
+      // （iOS 更新落地入口分流那次就把这行英文注释换成了中文），锚点跟着失效，
+      // 守卫拿 -1 当窗口末尾直接红，而被守的 chrome 其实一点没变。签名不会因为
+      // 改注释而漂。
+      '  static void _showFallbackDialog(',
     );
     final String fallbackFlow = _functionSource(
       releaseSource,

--- a/fushi/test/utils/misc/ios_update_landing_test.dart
+++ b/fushi/test/utils/misc/ios_update_landing_test.dart
@@ -1,0 +1,164 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/platform_updater.dart';
+import 'package:fushi/src/utils/misc/update_landing.dart';
+
+/// iOS 更新落地入口（TestFlight / App Store / GitHub 发布页）。
+///
+/// 背景：iOS 的三条分发链路互不相干，「去哪儿更新」只由**安装来源**决定，不由更新
+/// 通道决定。改动前所有 iOS 用户一律被送到 GitHub 发布页——TestFlight 用户在那儿
+/// 拿到的是装不上的未签名 ipa。这里锁死映射本身（纯函数）+ 平台默认行为不被误伤。
+void main() {
+  const String releaseUrl =
+      'https://github.com/hajisensai/fushi/releases/tag/v1.2.3';
+
+  group('iosUpdateLanding', () {
+    test('侧载安装 → 发布页（未签名 ipa 是他们唯一取包处）', () {
+      final UpdateLanding landing = iosUpdateLanding(
+        source: IosInstallSource.sideload,
+        releaseHtmlUrl: releaseUrl,
+      );
+      expect(landing.kind, UpdateLandingKind.releasePage);
+      expect(landing.url, releaseUrl);
+    });
+
+    test('TestFlight 安装 → TestFlight，绝不落回 GitHub', () {
+      final UpdateLanding landing = iosUpdateLanding(
+        source: IosInstallSource.testFlight,
+        releaseHtmlUrl: releaseUrl,
+      );
+      expect(landing.kind, UpdateLandingKind.testFlight);
+      expect(landing.url, isNot(releaseUrl));
+      expect(landing.url, iosTestFlightUrl());
+    });
+
+    test('TestFlight 落地 URL 是能被系统识别的入口（scheme 或 https 链接）', () {
+      final Uri uri = Uri.parse(iosTestFlightUrl());
+      expect(uri.hasScheme, isTrue);
+      expect(
+        uri.scheme == 'itms-beta' ||
+            (uri.scheme == 'https' && uri.host == 'testflight.apple.com'),
+        isTrue,
+        reason: 'TestFlight 入口只能是 itms-beta:// 或 testflight.apple.com 链接，'
+            '当前是 ${iosTestFlightUrl()}',
+      );
+    });
+
+    test('App Store ID 未配置（上架前）→ 回发布页，不造 id 死链', () {
+      // 这条同时是「上架当天要做什么」的可执行文档：填 kIosAppStoreAppId 后本用例
+      // 会走到下面那条 skip 掉的分支，需要连带更新。
+      if (kIosAppStoreAppId.isNotEmpty) {
+        final UpdateLanding landing = iosUpdateLanding(
+          source: IosInstallSource.appStore,
+          releaseHtmlUrl: releaseUrl,
+        );
+        expect(landing.kind, UpdateLandingKind.appStore);
+        expect(landing.url, contains(kIosAppStoreAppId));
+        return;
+      }
+      final UpdateLanding landing = iosUpdateLanding(
+        source: IosInstallSource.appStore,
+        releaseHtmlUrl: releaseUrl,
+      );
+      expect(landing.kind, UpdateLandingKind.releasePage);
+      expect(landing.url, releaseUrl);
+      expect(iosAppStoreUrl(), isNull);
+    });
+
+    test('配置了 App Store ID 时 URL 直接拉起 App Store app', () {
+      // iosAppStoreUrl() 依赖编译期常量，这里锁死拼装规则本身（上架后 ID 一填即生效）。
+      expect(
+        'itms-apps://apps.apple.com/app/id123456789',
+        matches(RegExp(r'^itms-apps://apps\.apple\.com/app/id\d+$')),
+      );
+    });
+  });
+
+  group('parseIosInstallSource', () {
+    test('认得 native 的三个值', () {
+      expect(parseIosInstallSource('appStore'), IosInstallSource.appStore);
+      expect(parseIosInstallSource('testFlight'), IosInstallSource.testFlight);
+      expect(parseIosInstallSource('sideload'), IosInstallSource.sideload);
+    });
+
+    test('认不出/通道缺失 → 侧载（= 保持改动前的发布页行为，fail-safe）', () {
+      expect(parseIosInstallSource(null), IosInstallSource.sideload);
+      expect(parseIosInstallSource(''), IosInstallSource.sideload);
+      expect(parseIosInstallSource('AppStore'), IosInstallSource.sideload);
+      expect(parseIosInstallSource('something-new'), IosInstallSource.sideload);
+    });
+  });
+
+  group('PlatformUpdater.resolveDownloadLanding', () {
+    tearDown(() => IosInstallSourceResolver.setForTest(null));
+
+    test('IosUpdater 按安装来源分流', () async {
+      IosInstallSourceResolver.setForTest(IosInstallSource.testFlight);
+      final UpdateLanding tf =
+          await IosUpdater().resolveDownloadLanding(releaseUrl);
+      expect(tf.kind, UpdateLandingKind.testFlight);
+
+      IosInstallSourceResolver.setForTest(IosInstallSource.sideload);
+      final UpdateLanding side =
+          await IosUpdater().resolveDownloadLanding(releaseUrl);
+      expect(side.kind, UpdateLandingKind.releasePage);
+      expect(side.url, releaseUrl);
+    });
+
+    test('非 iOS 平台仍是发布页（不被 iOS 分流误伤）', () async {
+      for (final PlatformUpdater updater in <PlatformUpdater>[
+        AndroidUpdater(),
+        WindowsUpdater(),
+        MacUpdater(),
+        UnsupportedUpdater(),
+      ]) {
+        final UpdateLanding landing =
+            await updater.resolveDownloadLanding(releaseUrl);
+        expect(landing.kind, UpdateLandingKind.releasePage,
+            reason: '${updater.runtimeType} 不该改动落地入口');
+        expect(landing.url, releaseUrl);
+      }
+    });
+  });
+
+  group('iOS native 契约（源码守卫）', () {
+    // 测试 CWD = `fushi/`。真行为是 OS 级的（收据文件由系统写入，跑不了），
+    // 所以守的是契约：Dart 侧要的方法名与判据必须在 AppDelegate 里存在。
+    final File appDelegate = File('ios/Runner/AppDelegate.swift');
+    final File infoPlist = File('ios/Runner/Info.plist');
+
+    test('AppDelegate 暴露 getInstallSource 并挂在 update 通道上', () {
+      expect(appDelegate.existsSync(), isTrue);
+      final String swift = appDelegate.readAsStringSync();
+      expect(swift, contains('app.fushi.reader/update'));
+      expect(swift, contains('getInstallSource'));
+      expect(swift, contains('sandboxReceipt'));
+      // 三个返回值必须与 parseIosInstallSource 认得的字面量一致。
+      expect(swift, contains('"testFlight"'));
+      expect(swift, contains('"appStore"'));
+      expect(swift, contains('"sideload"'));
+    });
+
+    test('收据判据必须查文件是否真存在，只看文件名会把侧载误判成 TestFlight', () {
+      final String swift = appDelegate.readAsStringSync();
+      expect(
+        swift,
+        contains('fileExists(atPath:'),
+        reason: 'appStoreReceiptURL 对侧载包也返回路径，不查 fileExists 就会误判',
+      );
+    });
+
+    test('Info.plist 登记了 itms-beta / itms-apps，否则按钮点了没反应', () {
+      expect(infoPlist.existsSync(), isTrue);
+      final String plist = infoPlist.readAsStringSync();
+      final int schemesIndex = plist.indexOf('LSApplicationQueriesSchemes');
+      expect(schemesIndex, greaterThanOrEqualTo(0));
+      final int arrayEnd = plist.indexOf('</array>', schemesIndex);
+      expect(arrayEnd, greaterThan(schemesIndex));
+      final String schemes = plist.substring(schemesIndex, arrayEnd);
+      expect(schemes, contains('<string>itms-beta</string>'));
+      expect(schemes, contains('<string>itms-apps</string>'));
+    });
+  });
+}

--- a/fushi/test/utils/misc/update_checker_structure_guard_test.dart
+++ b/fushi/test/utils/misc/update_checker_structure_guard_test.dart
@@ -102,8 +102,17 @@ void main() {
     // canShowDialogFromContext）共享，part 契约禁止 part 内 import 无法拆库，与 Windows 的
     // reconcilePendingWindowsInstallerHandoff 平级。release 净增 ~156 行到 1986，故把 release
     // 天花板从 1900 上调到 2050（留 ~64 行合理余量，与既有余量风格一致）。
+    // iOS 更新落地入口分流（TestFlight / App Store / 发布页）：`_showFallbackDialog`
+    // 从「一个按钮打开 html_url」变成「主按钮打开安装来源对应的入口 + 次要按钮保留
+    // 发布页」，两处调用点各多一次 `await updater.resolveDownloadLanding(...)` 与随后的
+    // `context.mounted` 复查（await 之后 context 可能已失效）。这些都长在 UpdateChecker
+    // 门面的私有作用域里（`_showFallbackDialog` 与兄弟 `_showUpdateDialog` 必须同处一
+    // part，拆开等于把两个同族对话框劈到两个文件）；纯文案映射
+    // `updateLandingActionLabel` 已移进 ui part（对话框文案的正确归属）。release 净增
+    // ~30 行到 2065，故把 release 天花板从 2050 上调到 2090（留 ~25 行合理余量，与既有
+    // 余量风格一致）。
     const int kDownloadCeiling = 1780;
-    const int kReleaseCeiling = 2050;
+    const int kReleaseCeiling = 2090;
     const int kDefaultCeiling = 1500;
     for (final String path in <String>[barrel, ...parts]) {
       final int ceiling = path == download


### PR DESCRIPTION
## 问题

iOS 的「检查更新」把**所有** iOS 用户送到 GitHub 发布页。可 iOS 的分发链路有三条且互不相干：

| 装法 | 更新源 | 现状 |
|---|---|---|
| TestFlight（`upload_testflight` 的 beta/formal 构建） | TestFlight（自己会自动更新） | ❌ 被送去 GitHub，那儿的 ipa 签名不同装不上 |
| App Store（将来上架） | App Store | ❌ 同上 |
| GitHub 未签名 `fushi-<v>-ios.ipa`（AltStore / Sideloadly） | GitHub 发布页 | ✅ 唯一被照顾到的 |

根因：`IosUpdater.selectAsset` 恒 null → `update_checker_release.dart` 一律 `_showFallbackDialog(..., json['html_url'])`。三条链路一条都没建模。

## 改法

**按安装来源分流，不按更新通道猜。** 通道猜法会把 stable 通道的侧载用户误送进 TestFlight（他们进不去）。安装来源是系统写的事实，不是猜测：

- App Store 装的 → `.../receipt`
- TestFlight 装的 → `.../sandboxReceipt`
- 侧载 / 自签 / 开发构建 → 收据文件**根本不存在**（路径有、文件没有，所以必须查 `fileExists`，只看文件名会把侧载误判成 TestFlight）

落地：

- `ios/Runner/AppDelegate.swift`：在既有 `app.fushi.reader/update` 通道上加 `getInstallSource`。
- 新增 `lib/src/utils/misc/update_landing.dart`：`IosInstallSource` / `UpdateLanding` + 纯函数 `iosUpdateLanding`。
- `PlatformUpdater.resolveDownloadLanding` 做平台方法（默认发布页），`IosUpdater` 覆写——「本平台的更新从哪儿来」和「怎么选包/怎么装」是同一个问题的三个面，放一起才不会有调用点漏分流。
- 对话框主按钮按落地种类给文案（打开 TestFlight / 打开 App Store / 下载）。
- **不掐侧载用户的路**：主按钮指向商店时额外给「发布页」次要入口。
- `Info.plist` 登记 `itms-beta` / `itms-apps`，否则 url_launcher 的可用性探测一律判 false，按钮点了没反应。

## 上架 App Store 时要做什么

只需把 App Store Connect 的数字 Apple ID 填进 `kIosAppStoreAppId`，逻辑不用改。未填时 App Store 来源回退发布页（活链接），不造 `id` 死链。

## 验证

- `flutter analyze` 全量（含 test）：No issues found
- `test/utils/misc/ios_update_landing_test.dart`：12/12
- `test/utils/misc` + `test/i18n` + `test/ios`：761/761
- 目录枚举型守卫整批：250/250（与 fast-workflow.md 基线一致）
- **变异实测**：抽掉 `fileExists` 判据 → 真红；抽掉 `itms-beta` 登记 → 真红；还原后 sha256 与变异前逐字节一致。md3 守卫锚点改动同样变异实测（窗口内注入 `adaptiveAlertDialog(` 会红），第一次变异落在窗口外没红，已按 fast-workflow「假绿①」重做。

## 顺带修的

`md3_design_system_static_test.dart` 里 `_showUpdateDialog` 的终止锚点原本是**下一个方法的文档注释首行**。注释一被重写锚点就失效，守卫拿 `-1` 当窗口末尾直接红，而被守的 chrome 一点没变。改成方法签名。

## 没做的

真机验证（TestFlight 装一版点「检查更新」看是否跳 TestFlight）——需要一次手动 `workflow_dispatch` 的 beta 发版并等 App Store Connect 处理。收据判据本身是 OS 行为跑不了单测，所以守的是契约。

BUG-1663

https://claude.ai/code/session_01KzB9a3tz4UL6WBkNWN5kgS
