### PR TITLE
fix: 英语制卡词头还原原形 (BUG-1665) + 卡片交叉引用链接跳回 fushi (BUG-1666)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1540 条。点号进各自文件。
+> 共 1541 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1666](bugs/BUG-1666-anki-card-crossref-links-localhost.md) | ✅ | ✅ | 制卡后卡片释义交叉引用链接跳向127本地地址 |
 | [BUG-1665](bugs/BUG-1665-english-mining-term-not-lemma.md) | ✅ | ✅ | 英语查词制卡词头不还原原形（MDX 重定向别名词条盖过原形） |
 | [BUG-1661](bugs/BUG-1661-corretto-x64-sha256-typo.md) | ✅ | ✅ | macOS 构建挂在「下载 pinned JDK 失败」，真因是 sha256 抄成 65 位 |
 | [BUG-1660](bugs/BUG-1660-aidoku-image-reader-compat.md) | ✅ | ✅ | Aidoku 图源图片与章节兼容及阅读器返回入口缺失 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1539 条。点号进各自文件。
+> 共 1540 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1665](bugs/BUG-1665-english-mining-term-not-lemma.md) | ✅ | ✅ | 英语查词制卡词头不还原原形（MDX 重定向别名词条盖过原形） |
 | [BUG-1661](bugs/BUG-1661-corretto-x64-sha256-typo.md) | ✅ | ✅ | macOS 构建挂在「下载 pinned JDK 失败」，真因是 sha256 抄成 65 位 |
 | [BUG-1660](bugs/BUG-1660-aidoku-image-reader-compat.md) | ✅ | ✅ | Aidoku 图源图片与章节兼容及阅读器返回入口缺失 |
 | [BUG-1659](bugs/BUG-1659-inline-level-box-scan-boundary.md) | ✅ | ✅ | 查词浮窗 glossary 里带振假名的词只能查到第一个汉字 |

--- a/docs/bugs/BUG-1665-english-mining-term-not-lemma.md
+++ b/docs/bugs/BUG-1665-english-mining-term-not-lemma.md
@@ -1,0 +1,9 @@
+## BUG-1665 · 英语查词制卡词头不还原原形（MDX 重定向别名词条盖过原形）
+- **报告**：2026-08-15（用户：查 "belongs" 命中 OALDPEX 的 belong 词条，但弹窗词头/制卡 Term 仍是 "belongs"；Yomitan 会还原成原形 belong）
+- **真实性**：✅ 真 bug。根因链：
+  - `native/fushidicts/fushidicts_src/mdx/mdx_reader.cpp:563` —— MDX `@@@LINK=belong` 重定向解析时只把**目标释义字节**复制到别名词条，词头仍是 "belongs"，于是导入库里 "belongs" 成了释义与 "belong" 逐字节相同的完整词条。
+  - `native/fushidicts/fushidicts_src/lookup.cpp`（排序比较器 trace_len 升序）—— 查 "belongs" 同时命中「别名精确词条（0 次变形）」和「经 en 变形还原出的 belong 原形词条（1 次变形）」，别名恒排前，弹窗词头与制卡 payload 的 `expression` 就是变形面 "belongs"。
+  - 英语变形规则本身没问题（`fushi/assets/transforms/en.json` 有 3rd-pers-s 等规则），仅命中排序被别名词条截胡。
+- **[x] ① 已修复** — `native/fushidicts/fushidicts_src/lookup.cpp`：导入器按哈希去重相同释义、同库内别名与原形共享**同一压缩 blob**（`importer.cpp process_simple_entries`），这是逐字节精确的重定向判据。lookup 去重后：同一 surface 下，未变形精确命中的每条 glossary 若其 blob 同时支撑「真变形后 expression==deinflected 的原形命中」则删除；删空的结果整条移除。按 glossary 粒度处理，另一部词典对同一变形面的**真实独立词条**保留；无变形规则可达的拼写别名（colour→color）不受影响；已导入词典即刻生效、无需重导。（提交：见本分支）
+- **[x] ② 已加自动化测试** — `native/fushidicts/tests/mdx_redirect_lemma_lookup_test.cpp`（注册于 `tests/CMakeLists.txt`，ctest 全套 20/20 绿）：①别名塌缩进原形且 matched/deinflected 正确；②释义不同的真实屈折词条保留且仍排第一；③无规则拼写别名不受影响；④跨词典按 glossary 粒度只删复制来的那份。已做变异实测：将修复条件短路成恒真，仅本测试红（19 绿 1 红），还原后 20/20 绿。
+- **备注**：制卡 payload 的 `expression` 取自弹窗分组词头（`popup_json.cpp` 按 expression 分组 → `popup.js buildMinePayload`），lookup 层收敛后无需动 JS/Dart。词形还原后单词音频/查重也统一按原形。

--- a/docs/bugs/BUG-1666-anki-card-crossref-links-localhost.md
+++ b/docs/bugs/BUG-1666-anki-card-crossref-links-localhost.md
@@ -1,0 +1,15 @@
+## BUG-1666 · 制卡后卡片释义交叉引用链接跳向127本地地址
+- **报告**：2026-08-15（用户：制卡后卡片某字段里的链接——词典释义里指向另一个单词的交叉引用——点开跳向 `http://127.0.0.1:<端口>` 等本地 IP；希望改成跳回 fushi 查词）
+- **真实性**：✅ 真 bug。根因链：
+  - 导出制卡 HTML 的两个构建器（`fushi/assets/popup/popup.js` `constructGlossaryHtml` / `constructSingleGlossaryHtml`）原样保留词典 HTML 里的交叉引用锚点（MDX `entry://词`、相对路径 `/belong_1`）。弹窗内这类点击被 `handleGlossaryAnchorClick`（BUG-767）拦截并按可见词头重查，但卡片上没有拦截器。
+  - Anki 桌面与 AnkiDroid 的卡片 WebView 以各自**本地媒体服务器**（`http://127.0.0.1:<随机端口>`）为 base URL，相对/未知链接被解析到 127 的死页。
+  - 顺带发现深链消费端残留：Android `:popup` 词典窗的 `extractProcessText`（`PopupDictFlutterActivity.kt` / 失活回退 `PopupDictActivity.kt`）只认 `hibiki://lookup`，而 manifest 注册的 scheme 是 `fushi`——`fushi://lookup?word=…` 会开出**空弹窗**。
+- **[x] ① 已修复** —
+  - `popup.js` 新增 `rewriteExportedGlossaryAnchors`（两个导出构建器序列化前调用）：内部交叉引用 → `fushi://lookup?word=<可见词头>`（trim + percent-encode）；`http(s)://` 外链保留；`#` 片段保留；`sound:`/`image:`/`dictmedia:`（字节未随卡导出）与无文本锚点去 href。三镜像已同步（assets/popup、assets/browser_extension/vendor、tools/browser-extension/vendor）。
+  - Android：两个 Kotlin activity 的 scheme 判定改为接受 `fushi`（兼容保留 `hibiki`），深链在手机上直接开 `:popup` 词典窗查词。
+  - Windows：`fushi/windows/installer/fushi.iss` 注册 HKCU `Software\Classes\fushi` URL 协议 → `fushi.exe "%1"`；Dart 新增 `lib/src/lookup/lookup_deep_link.dart::lookupWordFromDeepLink`，冷启动 `main(args)` 与单实例 WM_COPYDATA 转交（复用外部视频通道 `_handleExternalVideoChannel`，深链分支先于视频白名单）两条路都汇到 `DesktopLookupService.triggerLookup`（explicit 起源、越过去重；C++ 侧已前置主窗，零 C++ 改动）。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/exported_glossary_anchor_deeplink_test.dart`：
+  - 行为级：node 真执行 `rewriteExportedGlossaryAnchors`（7 场景：entry://、相对路径、非 ASCII 编码、外链保留、# 保留、sound:// 去 href、空文本去 href）+ 源级断言两个导出构建器都调用它；
+  - `lookupWordFromDeepLink` 纯函数单测（fushi/hibiki scheme、percent 解码、拒绝 auth/视频路径/空词）；
+  - Kotlin 源级守卫：两个 activity 必须接受 `fushi` scheme。
+- **备注**：仅安装包用户获得 Windows 协议注册；debug/绿色版需手动导入注册表（同 iss 键值）。macOS/Linux 未注册协议（用户平台为 Windows+Android）。卡片上历史旧卡的链接不会自愈（HTML 已烤进卡片），重制卡后生效。

--- a/fushi/android/app/src/main/java/app/fushi/reader/PopupDictActivity.kt
+++ b/fushi/android/app/src/main/java/app/fushi/reader/PopupDictActivity.kt
@@ -590,7 +590,8 @@ class PopupDictActivity : Activity() {
         intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()?.let { return it }
         intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()?.let { return it }
         intent.data?.let { uri ->
-            if (uri.scheme == "hibiki" && uri.host == "lookup") {
+            // BUG-1666: manifest 注册的 scheme 是 "fushi"；"hibiki" 为改名前残留，兼容保留。
+            if ((uri.scheme == "fushi" || uri.scheme == "hibiki") && uri.host == "lookup") {
                 uri.getQueryParameter("word")?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
             }
         }

--- a/fushi/android/app/src/main/java/app/fushi/reader/PopupDictFlutterActivity.kt
+++ b/fushi/android/app/src/main/java/app/fushi/reader/PopupDictFlutterActivity.kt
@@ -127,7 +127,11 @@ class PopupDictFlutterActivity : FlutterActivity() {
         intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()?.let { return it }
         intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()?.let { return it }
         intent.data?.let { uri ->
-            if (uri.scheme == "hibiki" && uri.host == "lookup") {
+            // BUG-1666: the manifest registers scheme "fushi" for this VIEW
+            // intent-filter; "hibiki" is the pre-rename residue kept for any
+            // legacy link still in the wild. Matching only "hibiki" meant a
+            // fushi://lookup?word=… deep link opened an EMPTY popup.
+            if ((uri.scheme == "fushi" || uri.scheme == "hibiki") && uri.host == "lookup") {
                 uri.getQueryParameter("word")?.trim()?.takeIf { it.isNotEmpty() }
                     ?.let { return it }
             }

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -773,6 +773,36 @@ const COMPACT_GLOSSARIES_ANKI = `.yomitan-glossary ul[data-sc-content="glossary"
 .yomitan-glossary ul[data-sc-content="glossary"] > li, .yomitan-glossary .glossary-list > li { display: inline; }
 .yomitan-glossary ul[data-sc-content="glossary"], .yomitan-glossary .glossary-list { display: inline; list-style: none; padding-left: 0px; }`;
 
+// BUG-1666: exported glossary HTML used to keep the dictionary's raw
+// cross-reference anchors (`entry://词` / relative hrefs). Anki desktop and
+// AnkiDroid render cards in a WebView whose base URL is their local media
+// server (http://127.0.0.1:<random port>), so tapping such a link on a card
+// navigated to a dead localhost page. Inside the popup these clicks are
+// intercepted and re-looked-up by the anchor's visible headword
+// (handleGlossaryAnchorClick, BUG-767); a card has no interceptor, so bake the
+// same semantic into the exported bytes: internal cross references become
+// fushi://lookup?word=<visible text> deep links (Android :popup dict window /
+// Windows single-instance handoff open them as a lookup), real external
+// http(s) links are kept, `#` fragments stay (they never leave the card), and
+// dictionary media anchors (sound:// etc., whose bytes are not exported) lose
+// their href instead of pointing nowhere.
+function rewriteExportedGlossaryAnchors(root) {
+    root.querySelectorAll('a[href]').forEach((anchor) => {
+        const href = (anchor.getAttribute('href') || '').trim();
+        if (/^https?:\/\//i.test(href) || href.startsWith('#')) {
+            return;
+        }
+        const word = /^(?:sound|image|dictmedia):/i.test(href)
+            ? ''
+            : (anchor.textContent || '').trim();
+        if (!word) {
+            anchor.removeAttribute('href');
+            return;
+        }
+        anchor.setAttribute('href', `fushi://lookup?word=${encodeURIComponent(word)}`);
+    });
+}
+
 // the following two should roughly match the glossary format of yomitan and keep compatibility with notetypes like lapis
 // 23.01.2026: this still has some differences
 // 24.01.2026: should be a bit closer now
@@ -854,6 +884,7 @@ function constructSingleGlossaryHtml(entryIndex) {
         const currentTags = JSON.stringify(posTags);
         const filteredTags = parsedTags.filter(tag => !isPartOfSpeech(tag) || !(prevTags !== null && prevTags === currentTags));
         const tags = filteredTags.length > 0 ? filteredTags.join(', ') : '';
+        rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
         if (dictChanged) {
@@ -918,6 +949,7 @@ function constructGlossaryHtml(entryIndex) {
             label = tags ? `(${tags})` : ''
         }
         
+        rewriteExportedGlossaryAnchors(tempDiv);
         glossaryItems += `<li data-dictionary="${dictName}"><i>${label}</i> <span>${applyTableStyles(tempDiv.innerHTML)}</span></li>`;
         prevTags = currentTags;
         

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -773,6 +773,36 @@ const COMPACT_GLOSSARIES_ANKI = `.yomitan-glossary ul[data-sc-content="glossary"
 .yomitan-glossary ul[data-sc-content="glossary"] > li, .yomitan-glossary .glossary-list > li { display: inline; }
 .yomitan-glossary ul[data-sc-content="glossary"], .yomitan-glossary .glossary-list { display: inline; list-style: none; padding-left: 0px; }`;
 
+// BUG-1666: exported glossary HTML used to keep the dictionary's raw
+// cross-reference anchors (`entry://词` / relative hrefs). Anki desktop and
+// AnkiDroid render cards in a WebView whose base URL is their local media
+// server (http://127.0.0.1:<random port>), so tapping such a link on a card
+// navigated to a dead localhost page. Inside the popup these clicks are
+// intercepted and re-looked-up by the anchor's visible headword
+// (handleGlossaryAnchorClick, BUG-767); a card has no interceptor, so bake the
+// same semantic into the exported bytes: internal cross references become
+// fushi://lookup?word=<visible text> deep links (Android :popup dict window /
+// Windows single-instance handoff open them as a lookup), real external
+// http(s) links are kept, `#` fragments stay (they never leave the card), and
+// dictionary media anchors (sound:// etc., whose bytes are not exported) lose
+// their href instead of pointing nowhere.
+function rewriteExportedGlossaryAnchors(root) {
+    root.querySelectorAll('a[href]').forEach((anchor) => {
+        const href = (anchor.getAttribute('href') || '').trim();
+        if (/^https?:\/\//i.test(href) || href.startsWith('#')) {
+            return;
+        }
+        const word = /^(?:sound|image|dictmedia):/i.test(href)
+            ? ''
+            : (anchor.textContent || '').trim();
+        if (!word) {
+            anchor.removeAttribute('href');
+            return;
+        }
+        anchor.setAttribute('href', `fushi://lookup?word=${encodeURIComponent(word)}`);
+    });
+}
+
 // the following two should roughly match the glossary format of yomitan and keep compatibility with notetypes like lapis
 // 23.01.2026: this still has some differences
 // 24.01.2026: should be a bit closer now
@@ -854,6 +884,7 @@ function constructSingleGlossaryHtml(entryIndex) {
         const currentTags = JSON.stringify(posTags);
         const filteredTags = parsedTags.filter(tag => !isPartOfSpeech(tag) || !(prevTags !== null && prevTags === currentTags));
         const tags = filteredTags.length > 0 ? filteredTags.join(', ') : '';
+        rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
         if (dictChanged) {
@@ -918,6 +949,7 @@ function constructGlossaryHtml(entryIndex) {
             label = tags ? `(${tags})` : ''
         }
         
+        rewriteExportedGlossaryAnchors(tempDiv);
         glossaryItems += `<li data-dictionary="${dictName}"><i>${label}</i> <span>${applyTableStyles(tempDiv.innerHTML)}</span></li>`;
         prevTags = currentTags;
         

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -41,6 +41,7 @@ import 'package:fushi/src/lookup/clipboard_panel_controller.dart';
 import 'package:fushi/src/lookup/clipboard_text_overlay_controller.dart';
 import 'package:fushi/src/lookup/desktop_lookup_dispatcher.dart';
 import 'package:fushi/src/lookup/global_lookup_log.dart';
+import 'package:fushi/src/lookup/lookup_deep_link.dart';
 import 'package:fushi/src/lookup/global_lookup_controller.dart';
 import 'package:fushi/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:fushi/src/startup/desktop_window_placement.dart';
@@ -81,6 +82,11 @@ Color? _savedSplashColor;
 /// 把视频路径传进 `main(List<String> args)`；这里暂存，待 app 初始化完成后由
 /// [_FushiReaderAppState] 打开播放页并加入书架。null 表示本次启动不是外部打开视频。
 String? _pendingExternalVideoPath;
+
+/// BUG-1666：桌面端 `fushi://lookup?word=<词>` 深链（Anki 卡片上的词典交叉引用）
+/// 冷启动时从 `main(args)` 暂存待查词；app 初始化完成后由 [_FushiReaderAppState]
+/// 经 [DesktopLookupService.triggerLookup] 排队查词。null = 本次启动非深链查词。
+String? _pendingLookupDeepLinkWord;
 
 /// Single source of truth for the status/navigation bar overlay style.
 ///
@@ -129,6 +135,15 @@ void main([List<String> args = const <String>[]]) {
     final String? videoArg = firstExternalVideoArg(args);
     if (videoArg != null && File(videoArg).existsSync()) {
       _pendingExternalVideoPath = videoArg;
+    }
+    // BUG-1666：系统协议注册把 `fushi://lookup?word=<词>` 交给 `fushi.exe "%1"`，
+    // 冷启动时该 URL 就在 argv 里；与视频路径互斥判定（URL 不会命中视频白名单）。
+    for (final String arg in args) {
+      final String? word = lookupWordFromDeepLink(arg);
+      if (word != null) {
+        _pendingLookupDeepLinkWord = word;
+        break;
+      }
     }
   }
 
@@ -544,6 +559,9 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
 
   /// 守卫：确保外部打开的视频只被打开一次（[build] 可能多次重建）。
   bool _externalVideoHandled = false;
+
+  /// BUG-1666：同上——`fushi://lookup` 深链查词只触发一次。
+  bool _lookupDeepLinkHandled = false;
 
   /// TODO-904 P0 回归：Windows 单实例守卫下，第二实例（文件关联 / 拖到 exe / CLI
   /// `hibiki.exe "%1"`）不会自己起窗口，而是把视频路径经 WM_COPYDATA 转交首实例
@@ -978,6 +996,21 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
     if (raw is! String) return null;
     final String videoPath = raw;
     if (videoPath.isEmpty) return null;
+    // BUG-1666：单实例转交的是「候选 argv 字符串」，不只视频路径——Anki 卡片上的
+    // `fushi://lookup?word=<词>` 协议启动第二实例后经同一 WM_COPYDATA 通道到这里。
+    // 深链先于视频白名单分流：查词请求交 DesktopLookupService（explicit 起源，
+    // 越过去重；C++ 侧已前置主窗）；未初始化完成则暂存，交 build 首启分支接手。
+    final String? lookupWord = lookupWordFromDeepLink(videoPath);
+    if (lookupWord != null) {
+      if (!appModel.isInitialised) {
+        _pendingLookupDeepLinkWord = lookupWord;
+        _lookupDeepLinkHandled = false;
+        if (mounted) setState(() {});
+        return null;
+      }
+      DesktopLookupService.instance.triggerLookup(lookupWord);
+      return null;
+    }
     if (!isSupportedVideoFile(videoPath)) return null;
     if (!File(videoPath).existsSync()) return null;
 
@@ -1540,6 +1573,17 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
       _pendingExternalVideoPath = null;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         unawaited(_openExternalVideo(videoPath));
+      });
+    }
+
+    // BUG-1666：同上，冷启动带 `fushi://lookup?word=<词>` 深链时，初始化完成后
+    // 排队一次显式查词（消费侧按用户的剪贴板落点配置路由到主窗 tab / 面板 / 瞬态卡）。
+    if (!_lookupDeepLinkHandled && _pendingLookupDeepLinkWord != null) {
+      _lookupDeepLinkHandled = true;
+      final String word = _pendingLookupDeepLinkWord!;
+      _pendingLookupDeepLinkWord = null;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        DesktopLookupService.instance.triggerLookup(word);
       });
     }
 

--- a/fushi/lib/src/lookup/lookup_deep_link.dart
+++ b/fushi/lib/src/lookup/lookup_deep_link.dart
@@ -1,0 +1,24 @@
+/// BUG-1666：`fushi://lookup?word=<词>` 深链解析。
+///
+/// 产生端是制卡导出的释义 HTML（popup.js `rewriteExportedGlossaryAnchors` 把词典
+/// 内部交叉引用改写成本深链），消费端分平台：
+///  - Android：manifest 给 `:popup` 词典窗注册了 `fushi://lookup` 的 VIEW
+///    intent-filter（Kotlin `extractProcessText` 解析同一 `word` 参数）；
+///  - Windows：系统协议注册（安装包 HKCU `Software\Classes\fushi`）把链接交给
+///    `fushi.exe "%1"`——冷启动走 Dart `main(args)`，热启动走单实例 WM_COPYDATA
+///    转交（与外部视频同一条 `app.fushi/external_video` 通道，见
+///    [docs/agent/external-video-open.md]），两条路都汇到本解析器。
+///
+/// `hibiki` scheme 是改名前残留，兼容保留（与 Kotlin 侧一致）。
+String? lookupWordFromDeepLink(String url) {
+  final String trimmed = url.trim();
+  if (trimmed.isEmpty) return null;
+  final Uri? uri = Uri.tryParse(trimmed);
+  if (uri == null) return null;
+  final String scheme = uri.scheme.toLowerCase();
+  if (scheme != 'fushi' && scheme != 'hibiki') return null;
+  if (uri.host.toLowerCase() != 'lookup') return null;
+  final String? word = uri.queryParameters['word']?.trim();
+  if (word == null || word.isEmpty) return null;
+  return word;
+}

--- a/fushi/test/anki/exported_glossary_anchor_deeplink_test.dart
+++ b/fushi/test/anki/exported_glossary_anchor_deeplink_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/lookup/lookup_deep_link.dart';
+
+/// BUG-1666：制卡后卡片上「词典释义里指向另一个单词」的链接点开跳向
+/// `http://127.0.0.1:<端口>`（Anki 桌面/AnkiDroid 的本地媒体服务器 base URL 把
+/// 释义里保留的 `entry://` / 相对路径交叉引用解析成了死本地页）。
+///
+/// 修复分三段，三层守护对应：
+/// ① 行为级——node 真执行 popup.js 的 `rewriteExportedGlossaryAnchors`，断言
+///    entry://、相对路径改写成 `fushi://lookup?word=<词>` 深链、外链/`#` 保留、
+///    sound:// 与无文本锚点去 href；并源级断言两个导出构建器
+///    （constructGlossaryHtml / constructSingleGlossaryHtml）都在序列化前调用它。
+///    无 node 时 skip。
+/// ② 三镜像逐字节一致由 `browser_extension_popup_parity_guard_test.dart` 守。
+/// ③ 深链消费端——`lookupWordFromDeepLink` 纯函数（Windows 冷启动 argv /
+///    单实例 WM_COPYDATA 转交两条路共用）在本文件直接单测；Android 端同参数由
+///    Kotlin `extractProcessText` 解析（scheme 须含 "fushi"，见源级守卫）。
+void main() {
+  test(
+    'BUG-1666: exported glossary cross-references become fushi://lookup deep '
+    'links (executes popup.js via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+            'node not found on PATH; skipping JS behavior execution');
+        return;
+      }
+
+      final File jsTest =
+          File('test/anki/exported_glossary_anchor_deeplink_test.js');
+      expect(jsTest.existsSync(), isTrue,
+          reason: 'behavior harness ${jsTest.path} must exist');
+
+      final ProcessResult result = await Process.run(
+        nodeExe,
+        <String>[jsTest.path],
+        workingDirectory: Directory.current.path,
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'BUG-1666 exported anchor deep-link behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(result.stdout.toString(), contains('all assertions passed'),
+          reason: 'behavior harness must reach its success marker');
+    },
+  );
+
+  group('lookupWordFromDeepLink', () {
+    test('parses fushi://lookup?word=… (percent-decoded, trimmed)', () {
+      expect(lookupWordFromDeepLink('fushi://lookup?word=belong'), 'belong');
+      expect(
+        lookupWordFromDeepLink(
+            'fushi://lookup?word=%E9%A3%9F%E3%81%B9%E3%82%8B'),
+        '食べる',
+      );
+      expect(lookupWordFromDeepLink(' fushi://lookup?word=%20belong%20 '),
+          'belong');
+    });
+
+    test('accepts the legacy hibiki scheme', () {
+      expect(lookupWordFromDeepLink('hibiki://lookup?word=belong'), 'belong');
+    });
+
+    test('rejects non-lookup URLs and empty words', () {
+      expect(lookupWordFromDeepLink('fushi://auth/onedrive?code=x'), isNull);
+      expect(lookupWordFromDeepLink('fushi://lookup'), isNull);
+      expect(lookupWordFromDeepLink('fushi://lookup?word='), isNull);
+      expect(lookupWordFromDeepLink('fushi://lookup?word=%20'), isNull);
+      expect(
+          lookupWordFromDeepLink('https://example.com/?word=belong'), isNull);
+      expect(lookupWordFromDeepLink(r'D:\video\ep01.mkv'), isNull);
+      expect(lookupWordFromDeepLink(''), isNull);
+    });
+  });
+
+  test(
+      'Android :popup activities accept the fushi scheme for lookup deep links '
+      '(source guard)', () {
+    const List<String> activities = <String>[
+      'android/app/src/main/java/app/fushi/reader/PopupDictFlutterActivity.kt',
+      'android/app/src/main/java/app/fushi/reader/PopupDictActivity.kt',
+    ];
+    for (final String path in activities) {
+      final File file = File(path);
+      expect(file.existsSync(), isTrue, reason: '$path must exist');
+      final String source = file.readAsStringSync();
+      // 断言字面量写进注释，变异测试时能定位：manifest 注册的 scheme 是
+      // "fushi"，Kotlin 侧曾只认 "hibiki"（改名残留）导致深链开出空弹窗。
+      expect(source, contains('uri.scheme == "fushi"'),
+          reason: '$path must accept the fushi scheme (manifest registers it)');
+    }
+  });
+}
+
+String? _resolveNode() {
+  final String exe = Platform.isWindows ? 'node.exe' : 'node';
+  final String pathEnv = Platform.environment['PATH'] ?? '';
+  final String separator = Platform.isWindows ? ';' : ':';
+  for (final String dir in pathEnv.split(separator)) {
+    if (dir.isEmpty) continue;
+    final File candidate = File('$dir${Platform.pathSeparator}$exe');
+    if (candidate.existsSync()) return candidate.path;
+  }
+  return null;
+}

--- a/fushi/test/anki/exported_glossary_anchor_deeplink_test.js
+++ b/fushi/test/anki/exported_glossary_anchor_deeplink_test.js
@@ -1,0 +1,123 @@
+// BUG-1666 行为守卫：制卡导出的释义 HTML 里，词典内部交叉引用锚点必须改写成
+// fushi://lookup?word=<可见词头> 深链，而不是保留 entry:// / 相对路径原样。
+//
+// 症状：Anki（桌面 + AnkiDroid）用本地媒体服务器（http://127.0.0.1:<随机端口>）
+// 作卡片 WebView 的 base URL，释义里指向「另一个单词」的相对链接点下去就解析成
+// 127.0.0.1 的死页。弹窗内这类点击被 handleGlossaryAnchorClick（BUG-767）拦截并按
+// 可见词头重查；卡片上没有拦截器，只能把同一语义烤进导出字节。
+//
+// 判据（rewriteExportedGlossaryAnchors，popup.js）：
+//   - entry:// 与相对路径 → fushi://lookup?word=<encodeURIComponent(textContent)>
+//   - http(s):// 外链保留
+//   - # 片段保留（不离开卡片，无 127 危害）
+//   - sound:/image:/dictmedia:（字节未导出）→ 去掉 href
+//   - 无可见文本的内部锚点 → 去掉 href
+//
+// 运行：node fushi/test/anki/exported_glossary_anchor_deeplink_test.js
+// 由同名 .dart wrapper 通过 Process.run('node', ...) 驱动（无 node 时 skip）。
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const popupSrc = fs.readFileSync(
+  path.resolve(__dirname, '..', '..', 'assets', 'popup', 'popup.js'),
+  'utf8',
+);
+
+// ---- 提取被测函数（不执行整个 popup.js：它依赖真实 DOM/window） ------------
+const fnMatch = popupSrc.match(
+  /function rewriteExportedGlossaryAnchors\(root\) \{[\s\S]*?\n\}/,
+);
+assert.ok(fnMatch, 'popup.js must define rewriteExportedGlossaryAnchors(root)');
+
+const context = { console };
+vm.createContext(context);
+vm.runInContext(`${fnMatch[0]}; this.__fn = rewriteExportedGlossaryAnchors;`, context);
+const rewriteExportedGlossaryAnchors = context.__fn;
+
+// ---- 两个导出构建器都必须在序列化前调用它（调用点源级判据） ----------------
+const callSites = popupSrc.match(/rewriteExportedGlossaryAnchors\(tempDiv\);/g) || [];
+assert.ok(
+  callSites.length >= 2,
+  `both export builders (constructGlossaryHtml / constructSingleGlossaryHtml) must call ` +
+  `rewriteExportedGlossaryAnchors(tempDiv); found ${callSites.length} call site(s)`,
+);
+
+// ---- 最小 fake DOM：只需 querySelectorAll('a[href]') + 锚点三方法 ----------
+function makeAnchor(href, text) {
+  const attrs = { href };
+  return {
+    textContent: text,
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    setAttribute: (name, value) => { attrs[name] = value; },
+    removeAttribute: (name) => { delete attrs[name]; },
+    get href() { return attrs.href; },
+    hasHref() { return 'href' in attrs; },
+  };
+}
+
+function makeRoot(anchors) {
+  return {
+    querySelectorAll: (selector) => {
+      assert.strictEqual(selector, 'a[href]');
+      return anchors;
+    },
+  };
+}
+
+// 场景 A：MDX entry:// 交叉引用 → fushi 深链（按可见词头，percent-encode）。
+{
+  const a = makeAnchor('entry://belong', 'belong');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.href, 'fushi://lookup?word=belong', 'entry:// must become a fushi deep link');
+}
+
+// 场景 B：相对路径（Anki 卡片里会解析到 127.0.0.1 本地服务器）→ fushi 深链。
+{
+  const a = makeAnchor('/belong_1', 'belong');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.href, 'fushi://lookup?word=belong', 'relative href must become a fushi deep link');
+}
+
+// 场景 C：可见词头含非 ASCII / 空白 → encodeURIComponent + trim。
+{
+  const a = makeAnchor('entry://食べる（たべる）', ' 食べる ');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(
+    a.href,
+    `fushi://lookup?word=${encodeURIComponent('食べる')}`,
+    'visible headword must be trimmed and percent-encoded',
+  );
+}
+
+// 场景 D：真外链保留原样。
+{
+  const a = makeAnchor('https://example.com/belong', 'belong');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.href, 'https://example.com/belong', 'external http(s) links must be kept');
+}
+
+// 场景 E：# 片段保留（卡内跳转无 127 危害）。
+{
+  const a = makeAnchor('#idiom-1', 'Idioms');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.href, '#idiom-1', '# fragments must be kept');
+}
+
+// 场景 F：sound:// 发音锚点（音频字节未随卡导出）→ 去 href，不指向任何死地址。
+{
+  const a = makeAnchor('sound://media/belong.mp3', '🔊');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.hasHref(), false, 'sound:// anchors must lose their href');
+}
+
+// 场景 G：无可见文本的内部锚点（图标图等）→ 去 href。
+{
+  const a = makeAnchor('entry://belong', '  ');
+  rewriteExportedGlossaryAnchors(makeRoot([a]));
+  assert.strictEqual(a.hasHref(), false, 'internal anchors without visible text must lose their href');
+}
+
+console.log('all assertions passed');

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -85,6 +85,15 @@ Name: "{userdesktop}\Fushi"; Filename: "{app}\fushi.exe"; Tasks: desktopicon; Ch
 ; Fushi 应用 ProgId：双击/「打开方式」时以 fushi.exe "<文件>" 启动。
 ; "%1" 即视频绝对路径，被 runner 经 set_dart_entrypoint_arguments 传给 Dart
 ; main(args)（见 lib/main.dart + windows/runner/utils.cpp::GetCommandLineArguments）。
+; BUG-1666：fushi:// URL 协议（Anki 卡片上的词典交叉引用 fushi://lookup?word=<词>）。
+; 点击后系统以 fushi.exe "<完整URL>" 启动：冷启动走 Dart main(args)，app 已开则由
+; 单实例守卫经 WM_COPYDATA 转交首实例（与外部视频同一条链路），Dart 侧
+; lookupWordFromDeepLink 解析后排队显式查词。无条件注册（不挂 videoassoc 任务）。
+Root: HKCU; Subkey: "Software\Classes\fushi"; ValueType: string; ValueData: "URL:Fushi Lookup"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\fushi"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCU; Subkey: "Software\Classes\fushi\DefaultIcon"; ValueType: string; ValueData: "{app}\fushi.exe,0"
+Root: HKCU; Subkey: "Software\Classes\fushi\shell\open\command"; ValueType: string; ValueData: """{app}\fushi.exe"" ""%1"""
+
 Root: HKCU; Subkey: "Software\Classes\Fushi.Video"; ValueType: string; ValueData: "Fushi 视频"; Flags: uninsdeletekey; Tasks: videoassoc
 Root: HKCU; Subkey: "Software\Classes\Fushi.Video\DefaultIcon"; ValueType: string; ValueData: "{app}\fushi.exe,0"; Tasks: videoassoc
 Root: HKCU; Subkey: "Software\Classes\Fushi.Video\shell\open\command"; ValueType: string; ValueData: """{app}\fushi.exe"" ""%1"""; Tasks: videoassoc

--- a/native/fushidicts/fushidicts_src/lookup.cpp
+++ b/native/fushidicts/fushidicts_src/lookup.cpp
@@ -82,6 +82,42 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
 
   auto results = result_map | std::views::values | std::views::as_rvalue | std::ranges::to<std::vector>();
 
+  // BUG-1665: MDX/StarDict importers resolve redirects (@@@LINK= / .syn) by
+  // copying the target's definition under the inflected key, so "belongs"
+  // carries belong's bytes as its own entry. A lookup of "belongs" then
+  // surfaces BOTH that alias exact hit and the deinflected lemma hit, and the
+  // alias (0 transforms) sorts first — the popup header and the mined Anki
+  // term become the inflected surface form instead of the lemma (Yomitan
+  // mines the lemma). The importer dedupes identical definitions by hash into
+  // ONE compressed blob, so within a dict an alias glossary and its lemma
+  // glossary share the same blob pointer — a byte-exact redirect detector
+  // that needs no re-import of already-imported dictionaries. For each
+  // surface form, drop from the untransformed exact hit every glossary whose
+  // blob also backs a lemma hit (a real transform whose result is the entry's
+  // own expression) of the same surface; drop the result once empty. Spelling
+  // variants (colour → color) have no deinflection rule and are untouched; a
+  // dictionary with a genuinely distinct inflected entry keeps it (different
+  // blob).
+  auto same_blob = [](const GlossaryEntry& x, const GlossaryEntry& y) {
+    return x.compressed_data == y.compressed_data && x.compressed_size == y.compressed_size &&
+           x.dict_name == y.dict_name;
+  };
+  for (auto& r : results) {
+    // Only an untransformed direct expression hit can be a redirect alias.
+    if (!r.trace.empty() || r.term.expression != r.deinflected) {
+      continue;
+    }
+    for (const auto& lemma : results) {
+      if (&lemma == &r || lemma.matched != r.matched) continue;
+      if (lemma.trace.empty() || lemma.term.expression != lemma.deinflected) continue;
+      std::erase_if(r.term.glossaries, [&](const GlossaryEntry& g) {
+        return std::ranges::any_of(lemma.term.glossaries,
+                                   [&](const GlossaryEntry& lg) { return same_blob(g, lg); });
+      });
+    }
+  }
+  std::erase_if(results, [](const LookupResult& r) { return r.term.glossaries.empty(); });
+
   // BUG-1304: frequency enrichment happens ONCE here, on the deduplicated set,
   // instead of inside every query_raw() call above (which runs once per
   // scan-candidate x text-variant x deinflection -- ~69 times per user lookup,

--- a/native/fushidicts/tests/CMakeLists.txt
+++ b/native/fushidicts/tests/CMakeLists.txt
@@ -80,6 +80,10 @@ add_fushi_test(ipa_import_query_test ipa_import_query_test.cpp)
 # Simple dicts (MDX/StarDict/DSL) store rules="*" so filter_by_pos keeps them
 # for inflected-form lookups; pins pos_to_conditions("*")==~0 + the stored rule.
 add_fushi_test(simple_dict_deinflection_test simple_dict_deinflection_test.cpp)
+# BUG-1665: an MDX @@@LINK= redirect entry (definition bytes copied from its
+# lemma at import) must collapse into the lemma at lookup time, so the popup
+# header / mined Anki term is the dictionary form, not the inflected surface.
+add_fushi_test(mdx_redirect_lemma_lookup_test mdx_redirect_lemma_lookup_test.cpp)
 
 # --- TODO-892: malformed-DEFLATE / null-decompressor / breadcrumb guards ---
 # zip_malformed_deflate_test includes <libdeflate.h> (to forge a real deflate

--- a/native/fushidicts/tests/mdx_redirect_lemma_lookup_test.cpp
+++ b/native/fushidicts/tests/mdx_redirect_lemma_lookup_test.cpp
@@ -1,0 +1,219 @@
+// BUG-1665 guard: an MDX @@@LINK= redirect entry must not out-rank its lemma.
+//
+// mdx_reader resolves @@@LINK=target by COPYING the target's definition bytes
+// under the redirect key, so an imported OALD-style dictionary carries
+// "belongs" as a full entry whose definition is byte-identical to "belong"'s.
+// Lookup("belongs") then surfaced BOTH the alias exact hit (0 transforms) and
+// the deinflected lemma hit (1 transform); the comparator ranks fewer
+// transforms first, so the popup header — and the mined Anki term — became the
+// inflected surface form instead of the lemma (Yomitan mines the lemma).
+//
+// The fix lives in Lookup::lookup(): the importer dedupes identical
+// definitions by hash into ONE compressed blob, so within a dict the alias
+// glossary and its lemma glossary share the same blob pointer. For each
+// surface form, every glossary on the untransformed exact hit whose blob also
+// backs a lemma hit of the same surface is dropped (per-glossary, so a second
+// dictionary's REAL inflected entry on the same result survives), and a result
+// stripped of every glossary is removed entirely. Already-imported
+// dictionaries are healed with no re-import.
+//
+// Cases pinned here:
+//   1) redirect alias collapses into the lemma (only "belong" survives);
+//   2) a genuinely distinct inflected entry (different definition bytes) is
+//      kept and still ranks first;
+//   3) a spelling-variant redirect with no deinflection rule (colour->color)
+//      is untouched;
+//   4) per-glossary granularity: dictA redirects "belongs" while dictB defines
+//      "belongs" for real -> the "belongs" result keeps ONLY dictB's glossary.
+//
+// Usage: mdx_redirect_lemma_lookup_test  (no args) -> exit 0 PASS.
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "fushidicts/deinflector.hpp"
+#include "fushidicts/importer.hpp"
+#include "fushidicts/lookup.hpp"
+#include "fushidicts/query.hpp"
+#include "zip_fixture.hpp"
+
+namespace {
+
+int g_fail = 0;
+
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_fail;
+}
+
+// Minimal English-like descriptor: verb condition + third-person "s" ->
+// "" suffix transform (the same shape as assets/transforms/en.json).
+const std::string kEnTransforms =
+    "{\"language\":\"en\",\"conditions\":{"
+    "\"v\":{\"name\":\"Verb\",\"isDictionaryForm\":true,\"subConditions\":[]}"
+    "},\"transforms\":{\"3ps\":{\"name\":\"3ps\",\"description\":\"\",\"rules\":["
+    "{\"type\":\"suffix\",\"fromSuffix\":\"s\",\"toSuffix\":\"\","
+    "\"conditionsIn\":[\"v\"],\"conditionsOut\":[\"v\"]}]}}}";
+
+std::string dump_results(const std::vector<LookupResult>& results) {
+  std::string s;
+  for (const LookupResult& r : results) {
+    s += "[" + r.term.expression + " glossaries=" + std::to_string(r.term.glossaries.size()) + "] ";
+  }
+  return s;
+}
+
+// Writes a simple dict (the storage MDX/StarDict/DSL imports share) and
+// returns its on-disk path, or "" on failure.
+std::string write_dict(const char* title, const std::vector<SimpleEntry>& entries) {
+  const std::string out_dir = fushi_test::temp_dir() + "/fushi_redirect_lemma_out";
+  ImportResult r = dictionary_importer::write_simple_dict(title, entries, out_dir);
+  if (!r.success) {
+    std::fprintf(stderr, "FAIL write_simple_dict(%s): %s\n", title,
+                 r.errors.empty() ? "(no error)" : r.errors.front().c_str());
+    ++g_fail;
+    return "";
+  }
+  return out_dir + "/" + r.title;
+}
+
+// 1) The redirect alias collapses into the lemma: only "belong" survives, and
+//    it records the inflected surface as `matched`.
+void case_alias_collapses_into_lemma() {
+  const std::string dict = write_dict(
+      "RedirectDict", {{"belong", "to be in the right place"},
+                       {"belongs", "to be in the right place"}});  // resolved @@@LINK copy
+  if (dict.empty()) return;
+
+  DictionaryQuery q;
+  q.add_term_dict(dict);
+  Deinflector d;
+  d.load_transforms_json(kEnTransforms);
+  Lookup lk(q, d);
+
+  std::vector<LookupResult> results = lk.lookup("belongs", 16);
+  bool has_lemma = false;
+  bool has_alias = false;
+  for (const LookupResult& r : results) {
+    if (r.term.expression == "belong") {
+      has_lemma = true;
+      if (r.matched != "belongs") fail("alias-collapse: lemma result must keep matched=belongs");
+      if (r.deinflected != "belong") fail("alias-collapse: lemma result must record deinflected=belong");
+    }
+    if (r.term.expression == "belongs") has_alias = true;
+  }
+  if (!has_lemma) fail("alias-collapse: lemma entry 'belong' missing from results");
+  if (has_alias) fail("alias-collapse: redirect alias 'belongs' must be dropped");
+  if (!results.empty() && results.front().term.expression != "belong") {
+    std::fprintf(stderr, "FAIL alias-collapse: first result must be the lemma; got %s\n",
+                 dump_results(results).c_str());
+    ++g_fail;
+  }
+}
+
+// 2) A genuinely distinct inflected entry (different definition bytes -> its
+//    own blob) is NOT a redirect and must survive, still ranked first.
+void case_distinct_inflected_entry_kept() {
+  const std::string dict = write_dict(
+      "DistinctDict", {{"lead", "to guide"}, {"leads", "plural of lead (metal strips)"}});
+  if (dict.empty()) return;
+
+  DictionaryQuery q;
+  q.add_term_dict(dict);
+  Deinflector d;
+  d.load_transforms_json(kEnTransforms);
+  Lookup lk(q, d);
+
+  std::vector<LookupResult> results = lk.lookup("leads", 16);
+  bool has_exact = false;
+  bool has_lemma = false;
+  for (const LookupResult& r : results) {
+    if (r.term.expression == "leads") has_exact = true;
+    if (r.term.expression == "lead") has_lemma = true;
+  }
+  if (!has_exact) fail("distinct: real inflected entry 'leads' must be kept");
+  if (!has_lemma) fail("distinct: lemma 'lead' must still be found via deinflection");
+  if (!results.empty() && results.front().term.expression != "leads") {
+    std::fprintf(stderr, "FAIL distinct: exact entry must still rank first; got %s\n",
+                 dump_results(results).c_str());
+    ++g_fail;
+  }
+}
+
+// 3) Spelling-variant redirect (colour -> color): no deinflection rule reaches
+//    "color", so there is no lemma hit and the alias MUST keep working.
+void case_spelling_variant_untouched() {
+  const std::string dict =
+      write_dict("VariantDict", {{"color", "a hue"}, {"colour", "a hue"}});  // resolved @@@LINK copy
+  if (dict.empty()) return;
+
+  DictionaryQuery q;
+  q.add_term_dict(dict);
+  Deinflector d;
+  d.load_transforms_json(kEnTransforms);
+  Lookup lk(q, d);
+
+  std::vector<LookupResult> results = lk.lookup("colour", 16);
+  bool has_variant = false;
+  for (const LookupResult& r : results) {
+    if (r.term.expression == "colour") has_variant = true;
+  }
+  if (!has_variant) fail("variant: 'colour' redirect entry must still be found");
+}
+
+// 4) Per-glossary granularity across dictionaries: dictA redirects "belongs"
+//    to belong's bytes, dictB defines "belongs" in its own right. The merged
+//    "belongs" result must lose ONLY dictA's copied glossary.
+void case_cross_dict_keeps_real_glossary() {
+  const std::string dict_a = write_dict(
+      "CrossRedirectDict", {{"belong", "to be in the right place"},
+                            {"belongs", "to be in the right place"}});
+  const std::string dict_b =
+      write_dict("CrossRealDict", {{"belongs", "third-person entry of its own"}});
+  if (dict_a.empty() || dict_b.empty()) return;
+
+  DictionaryQuery q;
+  q.add_term_dict(dict_a);
+  q.add_term_dict(dict_b);
+  Deinflector d;
+  d.load_transforms_json(kEnTransforms);
+  Lookup lk(q, d);
+
+  std::vector<LookupResult> results = lk.lookup("belongs", 16);
+  const LookupResult* exact = nullptr;
+  const LookupResult* lemma = nullptr;
+  for (const LookupResult& r : results) {
+    if (r.term.expression == "belongs") exact = &r;
+    if (r.term.expression == "belong") lemma = &r;
+  }
+  if (lemma == nullptr) fail("cross-dict: lemma 'belong' missing");
+  if (exact == nullptr) {
+    fail("cross-dict: 'belongs' with a real dictB glossary must survive");
+  } else {
+    if (exact->term.glossaries.size() != 1) {
+      std::fprintf(stderr, "FAIL cross-dict: 'belongs' must keep exactly dictB's glossary, got %zu\n",
+                   exact->term.glossaries.size());
+      ++g_fail;
+    } else if (exact->term.glossaries.front().dict_name != "CrossRealDict") {
+      std::fprintf(stderr, "FAIL cross-dict: surviving glossary must be CrossRealDict's, got %s\n",
+                   exact->term.glossaries.front().dict_name.c_str());
+      ++g_fail;
+    }
+  }
+}
+
+}  // namespace
+
+int main() {
+  case_alias_collapses_into_lemma();
+  case_distinct_inflected_entry_kept();
+  case_spelling_variant_untouched();
+  case_cross_dict_keeps_real_glossary();
+
+  if (g_fail) {
+    std::fprintf(stderr, "%d FAIL\n", g_fail);
+    return 1;
+  }
+  std::printf("PASS\n");
+  return 0;
+}

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -773,6 +773,36 @@ const COMPACT_GLOSSARIES_ANKI = `.yomitan-glossary ul[data-sc-content="glossary"
 .yomitan-glossary ul[data-sc-content="glossary"] > li, .yomitan-glossary .glossary-list > li { display: inline; }
 .yomitan-glossary ul[data-sc-content="glossary"], .yomitan-glossary .glossary-list { display: inline; list-style: none; padding-left: 0px; }`;
 
+// BUG-1666: exported glossary HTML used to keep the dictionary's raw
+// cross-reference anchors (`entry://词` / relative hrefs). Anki desktop and
+// AnkiDroid render cards in a WebView whose base URL is their local media
+// server (http://127.0.0.1:<random port>), so tapping such a link on a card
+// navigated to a dead localhost page. Inside the popup these clicks are
+// intercepted and re-looked-up by the anchor's visible headword
+// (handleGlossaryAnchorClick, BUG-767); a card has no interceptor, so bake the
+// same semantic into the exported bytes: internal cross references become
+// fushi://lookup?word=<visible text> deep links (Android :popup dict window /
+// Windows single-instance handoff open them as a lookup), real external
+// http(s) links are kept, `#` fragments stay (they never leave the card), and
+// dictionary media anchors (sound:// etc., whose bytes are not exported) lose
+// their href instead of pointing nowhere.
+function rewriteExportedGlossaryAnchors(root) {
+    root.querySelectorAll('a[href]').forEach((anchor) => {
+        const href = (anchor.getAttribute('href') || '').trim();
+        if (/^https?:\/\//i.test(href) || href.startsWith('#')) {
+            return;
+        }
+        const word = /^(?:sound|image|dictmedia):/i.test(href)
+            ? ''
+            : (anchor.textContent || '').trim();
+        if (!word) {
+            anchor.removeAttribute('href');
+            return;
+        }
+        anchor.setAttribute('href', `fushi://lookup?word=${encodeURIComponent(word)}`);
+    });
+}
+
 // the following two should roughly match the glossary format of yomitan and keep compatibility with notetypes like lapis
 // 23.01.2026: this still has some differences
 // 24.01.2026: should be a bit closer now
@@ -854,6 +884,7 @@ function constructSingleGlossaryHtml(entryIndex) {
         const currentTags = JSON.stringify(posTags);
         const filteredTags = parsedTags.filter(tag => !isPartOfSpeech(tag) || !(prevTags !== null && prevTags === currentTags));
         const tags = filteredTags.length > 0 ? filteredTags.join(', ') : '';
+        rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
         if (dictChanged) {
@@ -918,6 +949,7 @@ function constructGlossaryHtml(entryIndex) {
             label = tags ? `(${tags})` : ''
         }
         
+        rewriteExportedGlossaryAnchors(tempDiv);
         glossaryItems += `<li data-dictionary="${dictName}"><i>${label}</i> <span>${applyTableStyles(tempDiv.innerHTML)}</span></li>`;
         prevTags = currentTags;
         


### PR DESCRIPTION
## 两条用户报修

### BUG-1665 · 英语查词制卡词头不还原原形
- 根因：MDX `@@@LINK=belong` 重定向在导入时只复制目标释义字节、词头仍是 `belongs`（`mdx_reader.cpp:563`）；查询时别名精确命中（0 次变形）排在 en 变形还原出的原形词条（1 次变形）之前，弹窗词头与制卡 Term 都是变形面。
- 修复（lookup 层，**已导入词典无需重导**）：导入器按哈希对相同释义去重、别名与原形共享同一压缩 blob——这是逐字节精确的重定向判据。`Lookup::lookup` 去重后按 glossary 粒度删除「blob 同时支撑同 surface 原形命中」的精确命中释义，删空整条移除。拼写别名（colour→color，无变形规则）不受影响；真实独立屈折词条（释义不同 → 不同 blob）保留。
- 测试：`native/fushidicts/tests/mdx_redirect_lemma_lookup_test.cpp`（4 场景，已注册 ctest；全套 20/20 绿，变异实测仅新测试红）。

### BUG-1666 · 制卡后卡片释义交叉引用链接跳向 127 本地地址
- 根因：导出制卡 HTML 原样保留词典交叉引用锚点（`entry://` / 相对路径）；Anki 桌面/AnkiDroid 卡片 WebView 以本地媒体服务器 `http://127.0.0.1:<端口>` 为 base，点「另一个单词」跳到死本地页。弹窗内有 BUG-767 拦截、卡片上没有。
- 修复：
  - popup.js 新增 `rewriteExportedGlossaryAnchors`（两个导出构建器序列化前调用）：内部交叉引用 → `fushi://lookup?word=<可见词头>`；http(s)/# 保留；sound: 等去 href。三镜像同步。
  - Android：`extractProcessText` 改名残留只认 `hibiki` scheme（manifest 注册的是 `fushi`，深链开出空弹窗）→ 接受 fushi（兼容保留 hibiki）。点卡片链接直接开 :popup 词典窗查词。
  - Windows：安装包注册 HKCU `fushi:` URL 协议；冷启动 argv 与单实例 WM_COPYDATA 转交（复用外部视频通道，零 C++ 改动）都经 `lookupWordFromDeepLink` 汇到 `DesktopLookupService.triggerLookup`。
- 测试：node 行为测试（7 场景 + 调用点扫描）、`lookupWordFromDeepLink` 单测、Kotlin scheme 源级守卫——均变异实测。

## 验证
- native ctest 20/20 绿（含新测试）；变异实测红→还原绿。
- `flutter analyze` 全量 No issues。
- 定向 `flutter_test_failures.dart`：**VERDICT: PASSED - 34 tests ran**（新测试 + popup 三镜像 parity + external_video + 单实例守卫）。
- 未做：真机 E2E（重制英语卡验证词头/链接）、Windows 安装包协议注册实测、gradle 编译（仅 .kt 条件微改）。历史旧卡 HTML 已烤死不自愈，重制卡后生效。

https://claude.ai/code/session_01EWijpQVknjKe6qRgcPA1XG