### PR TITLE
fix(extension): 「正在查词」卡死 + 查词暂停/关窗恢复视频 + 侧边栏字幕不全 (BUG-1669/1670/1671)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1540 条。点号进各自文件。
+> 共 1543 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1671](bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md) | ✅ | ✅ | 浏览器扩展侧边栏获取字幕不全 |
+| [BUG-1670](bugs/BUG-1670-ext-pause-on-lookup-no-resume.md) | ✅ | ✅ | 浏览器扩展查词不暂停视频且关闭弹窗不恢复播放 |
+| [BUG-1669](bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md) | ✅ | ✅ | 浏览器扩展侧边栏高频查词后「正在查词」永久卡死 |
 | [BUG-1664](bugs/BUG-1664-mine-abort-root-cause.md) | ✅ | ✅ | 制卡中止只报症状不报根因（macOS 缺 ffmpeg 时批量制卡整批失败且不可诊断） |
 | [BUG-1661](bugs/BUG-1661-corretto-x64-sha256-typo.md) | ✅ | ✅ | macOS 构建挂在「下载 pinned JDK 失败」，真因是 sha256 抄成 65 位 |
 | [BUG-1660](bugs/BUG-1660-aidoku-image-reader-compat.md) | ✅ | ✅ | Aidoku 图源图片与章节兼容及阅读器返回入口缺失 |

--- a/docs/bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md
+++ b/docs/bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md
@@ -1,0 +1,14 @@
+## BUG-1669 · 浏览器扩展侧边栏高频查词后「正在查词」永久卡死
+- **报告**：2026-08-15（用户：shishamo 群报「浏览器插件查词频率高，会出现『正在查词』然后一直显示这个状态一直不动」）
+- **真实性**：✅ 真 bug——BUG-1024（MV3 service worker 在消息在途时被系统回收，`chrome.runtime.sendMessage` 回调永不触发）的 Side Panel 孪生。BUG-1024 只修了 `content.js`（在途闸 + 1500ms 截止兜底），`side-panel.js` 完全没有等价兜底：
+  - `tools/browser-extension/side-panel.js` `sendRuntime()`（修复前 :59-68）只有 resolve、无超时——回调不来 Promise 永久 pending，`lookupTerm()` 的 `await` 永久挂起，「正在查词…」（:361）永久停留；
+  - 更糟的是 BUG-1525 引入的同词在途复用（:262 `lookupInFlight.get(value)`）会把这个死 Promise 缓存住，`.finally` 永不执行 → 同一个词此后每次查询直接拿回死 Promise，**永久锁死**，且 `activeScanKey` 去重（:415-417）挡住原地重试；
+  - 触发器：Side Panel 的 pointermove 扫词只有 rAF 节流、无位移阈值、无在途闸，横扫一行 20 字 = 1 秒内 20 个 HTTP POST，打满 Chrome 每主机 6 连接上限 + app 侧串行词典查询，SW 在高压长挂起下被回收概率大增；`background.js` 查词 `fetch`（:618）也无超时，app 侧一旦长阻塞 `sendResponse` 永不被调。
+- **[x] ① 已修复** — 四层根因修复（提交哈希：a22c46daf）：
+  1. `side-panel.js` `sendRuntime()` 加 8s 超时竞速，Promise 一定 settle → `.finally` 一定执行、在途表去毒；
+  2. `lookupTerm()` 包 try/finally：任何路径（含处理回调抛错）loading 必被替换成可重试失败文案；失败后复位 `activeScanKey` 允许原地重试；
+  3. `lookupAtPointer()` 加在途闸（1500ms 截止，对齐 content.js 的 BUG-1024 兜底；显式手势不受闸）防请求放大；
+  4. `background.js` 查词 fetch 加 `AbortSignal.timeout(10000)`，超时走既有 catch 分支必定 `sendResponse`。
+  app 侧同步 FFI 串行/UI isolate 阻塞的根治在 PR#624（已另行处理），不在本条重复。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/side-panel-lookup-deadlock.test.js`：受控 vm 真加载 side-panel.js，stub sendMessage 永不回调 → 推进超时定时器 → 断言 loading 被替换成失败文案、同词重试真正重新发出 lookup（在途表已去毒）。变异实测：删掉超时定时器该测试即红。
+- **备注**：镜像 `fushi/assets/browser_extension/` 由 `scripts/sync-mirrors.mjs` 同步。

--- a/docs/bugs/BUG-1670-ext-pause-on-lookup-no-resume.md
+++ b/docs/bugs/BUG-1670-ext-pause-on-lookup-no-resume.md
@@ -1,0 +1,13 @@
+## BUG-1670 · 浏览器扩展查词不暂停视频且关闭弹窗不恢复播放
+- **报告**：2026-08-15（用户：shishamo 群报「查词不能暂停或者恢复视频的播放」）
+- **真实性**：✅ 真 bug（半成品功能）：
+  - 「不暂停」：开关 `subtitlePauseOnLookup` 默认**关**（`tools/browser-extension/options.js`，修复前 :18），而 app 侧 `pauseOnLookup` 早已默认开（TODO-1108，`fushi/test/media/sources/pause_on_lookup_default_1108_test.dart:25`），扩展没跟；
+  - 「不恢复」：全扩展没有任何 `play()` 恢复代码——`content.js` 两个暂停点（修复前 :1714-1716 / :1839-1841）只 pause，注释还把「不自动恢复」写成契约；
+  - 附带：`document.querySelector('video')` 只搜顶层文档第一个 video，shadow DOM / 同源 iframe 里的播放器完全够不着。
+- **[x] ① 已修复** — 对齐 app 侧 `shouldResumeAfterLookupDismiss` 三条不变式（提交哈希：a22c46daf）：
+  1. 默认值翻到开启（`options.js` settingDefaults + `content.js` 无显式偏好回落 true；新键/旧键显式选择仍优先）；
+  2. 暂停记录唯一真相源 `fushiPausedForLookup`（记「被我们暂停的那个 video 元素」）；只暂停「正在播放」的视频（`fushiFindPlayingVideo()`：顶层快路径 + open shadow root/同源 iframe 深搜兜底）；
+  3. 关窗汇聚点 `fushiRemoveContainer()` 恢复：只 play 确实由查词暂停的那个视频，用户自己暂停的绝不被播起来，用户已手动恢复的不重复 play；嵌套查词不经此处、天然不提前恢复。
+  Side Panel 发起的查词（`fushiPrepareLookupFromSidePanel`）无「面板关闭」回调，维持只暂停不自动恢复（防止被无关的页面弹窗关闭误恢复），已注释说明。跨域 iframe（嵌入式第三方播放器）本轮不覆盖（需 all_frames + background 广播，影响面大，另行排期）。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/shift-hover.test.js` 新增：默认开启即暂停/显式关闭不暂停、关窗自动恢复且不重复 play、用户自己暂停的视频绝不被自动播放、旧键显式 false 压过新默认。变异实测：禁用恢复块「关闭查词弹窗后自动恢复」用例即红。守卫 `fushi/test/mining/netflix_mining_robustness_guard_test.dart` #1 同步为新暂停代码形状。
+- **备注**：options.html 文案同步改为「关闭查词弹窗后自动恢复播放」。

--- a/docs/bugs/BUG-1670-ext-pause-on-lookup-no-resume.md
+++ b/docs/bugs/BUG-1670-ext-pause-on-lookup-no-resume.md
@@ -11,3 +11,4 @@
   Side Panel 发起的查词（`fushiPrepareLookupFromSidePanel`）无「面板关闭」回调，维持只暂停不自动恢复（防止被无关的页面弹窗关闭误恢复），已注释说明。跨域 iframe（嵌入式第三方播放器）本轮不覆盖（需 all_frames + background 广播，影响面大，另行排期）。
 - **[x] ② 已加自动化测试** — `tools/browser-extension/shift-hover.test.js` 新增：默认开启即暂停/显式关闭不暂停、关窗自动恢复且不重复 play、用户自己暂停的视频绝不被自动播放、旧键显式 false 压过新默认。变异实测：禁用恢复块「关闭查词弹窗后自动恢复」用例即红。守卫 `fushi/test/mining/netflix_mining_robustness_guard_test.dart` #1 同步为新暂停代码形状。
 - **备注**：options.html 文案同步改为「关闭查词弹窗后自动恢复播放」。
+- **审查修复（code review 后补，同 PR）**：①「用户播放→再暂停→关窗」会被误播——暂停时挂一次性 `play` 监听收回 `fushiPausedForLookup`（用户手动播放即收回控制权；我们自己 resume 前先置 null 不会误清）；②查词失败/扩展失效/SW 回收（12s 兜底定时器）等「弹窗没建出来」的路径没有关窗动作可触发恢复——恢复块抽成 `fushiResumePausedForLookup()`，这些路径在无在场弹窗时直接恢复；③深搜落热路径——已因查词暂停且视频仍停着时短路跳过整个暂停块，「找不到在播视频」记 2s TTL 负缓存（纯文本页高频扫词不再全树扫描）。测试各有独立用例（shift-hover.test.js），失败恢复路径变异实测红。

--- a/docs/bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md
+++ b/docs/bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md
@@ -1,0 +1,11 @@
+## BUG-1671 · 浏览器扩展侧边栏获取字幕不全
+- **报告**：2026-08-15（用户：shishamo 群报「侧边栏获取字幕不全」）
+- **真实性**：✅ 真 bug，两个独立根因都在 `tools/browser-extension/content.js` 的 textTracks 收割器 `fushiHarvestTextTracks()`（修复前 :625-649）：
+  1. **增量判据错误**：用「cue 条数单调增长」当增量门（`existing.length >= tt.cues.length` 就整段跳过，长了就整轨覆盖）。hls.js/Shaka/MSE 分片字幕会随 back-buffer 回收、seek 重建把 `tt.cues` 整批换成另一时间窗——条数没长 → 新区间字幕永远进不来；条数长了 → 旧区间已收字幕被整轨覆盖抹掉。正是「只拿到一段/条数不全」；
+  2. **disabled 轨直接跳过**：浏览器对 `mode === 'disabled'` 的轨不加载 cues，收割器从不主动升 `hidden` → 只有播放器当前开着的那条轨能进 store，侧边栏语言轨永远只有一条。
+- **[x] ① 已修复** —（提交哈希：a22c46daf）
+  1. 收割改为**归并**：逐条 `fushiSortedCueInsert`（同文本 ±750ms 去重）并入既有轨，轨只增不减，快进/回看各区间都留得住；有真插入才通知面板；
+  2. disabled 的 subtitles/captions 轨升为 `hidden`（加载 cues 但不渲染、不影响站点显示，asbplayer 同款），下一轮轮询收割全部语言轨。
+  未覆盖（记录为已知边界）：DOM 采样 live 轨天然只有播过的部分、后台标签页 setInterval 节流丢行、跨域 iframe 播放器（需 all_frames）、YouTube server 兜底「拿到一条就不再补」门闩——均不是本次用户路径的主因，另行排期。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/universal-subtitle-providers.test.js` 新增两用例：「disabled 语言轨强制升 hidden 下一轮收齐」「分片整批替换按归并合并，旧区间不丢/新区间进得来/重复收割去重」。变异实测：去掉升 hidden、归并退化为盲追加，两用例分别红。
+- **备注**：镜像 `fushi/assets/browser_extension/` 由 `scripts/sync-mirrors.mjs` 同步。

--- a/docs/bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md
+++ b/docs/bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md
@@ -9,3 +9,5 @@
   未覆盖（记录为已知边界）：DOM 采样 live 轨天然只有播过的部分、后台标签页 setInterval 节流丢行、跨域 iframe 播放器（需 all_frames）、YouTube server 兜底「拿到一条就不再补」门闩——均不是本次用户路径的主因，另行排期。
 - **[x] ② 已加自动化测试** — `tools/browser-extension/universal-subtitle-providers.test.js` 新增两用例：「disabled 语言轨强制升 hidden 下一轮收齐」「分片整批替换按归并合并，旧区间不丢/新区间进得来/重复收割去重」。变异实测：去掉升 hidden、归并退化为盲追加，两用例分别红。
 - **备注**：镜像 `fushi/assets/browser_extension/` 由 `scripts/sync-mirrors.mjs` 同步。
+- **审查修复（code review 后补，同 PR）**：①同语言多轨（"English" 与 "English [CC]" 的 language 同为 en）会被归并进同一条侧边栏轨、台词穿插重复——语言撞车时把 label 编进轨 key 消歧（单轨语言保持裸语言码，对齐其它 provider 的 key 习惯）；②textTracks 精确时间轴下 750ms 同文去重会误杀连续两声相同短句——`fushiSortedCueInsert` 加窗宽参数，收割路径用 1ms（等于 startMs 精确相等），live 轨保持 750ms；③升 hidden 与站点播放器（hls.js 等）可能拉锯——加 WeakSet 一轨一次门，站点拨回 disabled 即尊重站点，杀死 1.2s 轮询无限翻转。
+- **⚠ implemented_unverified**：`tt.mode='hidden'` 在 hls.js 真站（字幕全关时被 hls.js 反读为活动轨、触发分片下载/UI 状态）的实际行为**未真机取证**，本会话无浏览器环境；一轨一次门已把最坏情况限制在每轨一次翻转。合并前建议在一个 hls.js 站点实测字幕菜单状态与网络面板。

--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -615,8 +615,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         const maximumTerms = lookupTrace.maximumTerms;
         lookupTrace.phase = 'fetch-headers';
         const fetchStartedAt = performance.now();
+        // 查词 fetch 必须有上限：app 侧一旦长阻塞（词典重载/磁盘 stall），无超时的 await 会让
+        // sendResponse 永不被调——Side Panel 的「正在查词…」就永久停留。超时走下方 catch 分支
+        // 回错误响应，用户看到可重试的失败文案而不是无限转圈。上限 > Side Panel 兜底(8s)，
+        // 正常慢查询不受影响。
         const r = await fetch(base + '/api/lookup/dictionary', {
           method: 'POST',
+          signal: AbortSignal.timeout(10000),
           headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
           body: JSON.stringify({
             term: msg.term,

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -88,14 +88,56 @@ function fushiReportVisibleAfterPaint(ctx, container) {
 
 // 「查词时暂停」取代旧的「悬停字幕时暂停」。新键显式值优先；旧
 // subtitleHoverPause 只作升级兼容读取，避免用户更新扩展后原选择突然丢失。
-let fushiPauseOnLookup = false;
+// 默认**开启**，对齐 app 侧 pauseOnLookup 默认 true（TODO-1108）；从未做过选择的用户
+// 查词即暂停、关窗即恢复（恢复侧见 fushiRemoveContainer）。
+let fushiPauseOnLookup = true;
 let fushiHasPauseOnLookupPref = false;
 function fushiApplyPauseOnLookupPrefs(saved) {
   saved = saved || {};
   fushiHasPauseOnLookupPref = typeof saved.subtitlePauseOnLookup === 'boolean';
   fushiPauseOnLookup = fushiHasPauseOnLookupPref
     ? saved.subtitlePauseOnLookup
-    : saved.subtitleHoverPause === true;
+    : (typeof saved.subtitleHoverPause === 'boolean'
+        ? saved.subtitleHoverPause
+        : true);
+}
+// 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
+// _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
+let fushiPausedForLookup = null;
+// 找「正在播放」的视频：没有在播的就没有可暂停的（也就无需恢复）。顶层文档快路径优先
+// （高频 Shift 悬停查词不能每次全树扫描）；顶层没有才穿透 open shadow root 与**同源**
+// iframe 深搜（跨域 iframe 拿不到 contentDocument，静默跳过——嵌入式第三方播放器暂不覆盖）。
+function fushiFindPlayingVideo() {
+  const playing = (root) => {
+    let vids;
+    try { vids = root.querySelectorAll('video'); } catch (_) { return null; }
+    for (const v of vids) {
+      if (!v.paused && !v.ended) return v;
+    }
+    return null;
+  };
+  const top = playing(document);
+  if (top) return top;
+  const deep = (root, depth) => {
+    if (!root || depth > 3) return null;
+    let all;
+    try { all = root.querySelectorAll('*'); } catch (_) { return null; }
+    for (const el of all) {
+      let sub = null;
+      if (el.shadowRoot) {
+        sub = playing(el.shadowRoot) || deep(el.shadowRoot, depth + 1);
+      } else if (el.tagName === 'IFRAME') {
+        try {
+          if (el.contentDocument) {
+            sub = playing(el.contentDocument) || deep(el.contentDocument, depth + 1);
+          }
+        } catch (_) { /* 跨域 iframe */ }
+      }
+      if (sub) return sub;
+    }
+    return null;
+  };
+  return deep(document, 0);
 }
 try {
   const fushiPausePrefsPromise = chrome.storage.local.get(
@@ -578,8 +620,14 @@ function fushiLiveCueEnd(state, endV) {
   state.liveCueReplay = false;
 }
 
-// a) textTracks 全量收割：轮询增量（cue 随流加载渐增，条数长了才重建该轨）。kind 只收
-// subtitles/captions；mode 为 disabled 时浏览器不加载 cues，跳过。
+// a) textTracks 全量收割：轮询归并。kind 只收 subtitles/captions。两条完整性规则：
+//   ① disabled 轨浏览器根本不加载 cues → 以前直接跳过 = 只有播放器当前开着的那条轨能进
+//      store，侧边栏语言轨永远只有一条。asbplayer 同款做法：临时升到 hidden（加载 cues 但
+//      不渲染、不影响站点显示），下一轮轮询即可收割全部语言轨。
+//   ② 归并而非整轨覆盖：hls.js/Shaka 的分片字幕会随 back-buffer 回收 / seek 重建而增删
+//      cue——旧的「条数没长就跳过、长了整轨覆盖」两个方向都丢字幕（新区间进不来 / 旧区间
+//      被抹掉），正是「侧边栏字幕不全」的主根因。逐条有序插入（fushiSortedCueInsert 同文本
+//      ±750ms 去重），轨只增不减，快进/回看过的各区间都留得住。
 function fushiHarvestTextTracks() {
   const v = document.querySelector('video');
   if (!v || !v.textTracks || !v.textTracks.length) return;
@@ -587,22 +635,24 @@ function fushiHarvestTextTracks() {
   for (let i = 0; i < v.textTracks.length; i++) {
     const tt = v.textTracks[i];
     if (!tt || (tt.kind !== 'subtitles' && tt.kind !== 'captions')) continue;
-    if (tt.mode === 'disabled' || !tt.cues || !tt.cues.length) continue;
+    if (tt.mode === 'disabled') {
+      try { tt.mode = 'hidden'; } catch (_) {}
+      continue; // cues 要到下一轮轮询才加载好
+    }
+    if (!tt.cues || !tt.cues.length) continue;
     const lang = String(tt.language || tt.label || 'und').replace(/\|/g, '_');
     const key = vidKey + '|' + lang;
-    const existing = fushiEpisodeCues[key];
-    if (existing && existing.length >= tt.cues.length) continue;
-    const out = [];
+    const track = fushiEpisodeCues[key] || (fushiEpisodeCues[key] = []);
+    let inserted = false;
     for (let j = 0; j < tt.cues.length; j++) {
       const c = tt.cues[j];
       if (!c || typeof c.startTime !== 'number' || typeof c.endTime !== 'number') continue;
       const text = stripCueTags(String(c.text || ''));
       if (!text) continue;
-      out.push({ startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text });
+      const cue = { startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text };
+      if (fushiSortedCueInsert(track, cue)) inserted = true;
     }
-    if (!out.length) continue;
-    fushiEpisodeCues[key] = out;
-    fushiNotifyPanel(key);
+    if (inserted) fushiNotifyPanel(key);
   }
 }
 try { setInterval(fushiHarvestTextTracks, 1200); } catch (_) {}
@@ -1551,6 +1601,20 @@ function fushiRemoveContainer() {
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
+  // 「查词时暂停」的恢复侧（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由
+  // 查词暂停的那个视频；用户自己暂停的绝不被播起来（关窗时它不在 fushiPausedForLookup 里），
+  // 用户已手动继续播放的也不重复 play（v.paused 守卫）。嵌套查词只换弹窗内容、不经此处，
+  // 天然不会提前恢复——与 app「整栈关空才恢复」同语义。
+  if (fushiPausedForLookup) {
+    const pausedVideo = fushiPausedForLookup;
+    fushiPausedForLookup = null;
+    try {
+      if (pausedVideo.isConnected !== false && pausedVideo.paused) {
+        const played = pausedVideo.play();
+        if (played && typeof played.catch === 'function') played.catch(() => {});
+      }
+    } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
+  }
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
   try {
     if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
@@ -1703,8 +1767,9 @@ function fushiShowConnectionFailure(resp) {
 }
 
 // 发查词请求 + 渲染弹窗的共享收尾（Shift 悬停、面板行点击、悬浮字幕自动查词同源）。
-// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停当前视频；不自动恢复，查完由用户
-// 继续播放。关闭时任何站点都不因查词被暂停。
+// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停正在播放的视频，并记下
+// fushiPausedForLookup；关闭查词弹窗时自动恢复（fushiRemoveContainer）。关闭该设置时
+// 任何站点都不因查词被暂停。
 function fushiSendLookup(term, anchorRect, cueWindow) {
   // TODO-1219 P3：每次查词刷新精确窗——面板行查词传 cueWindow（该行精确 [startMs,endMs]），
   // mousemove 划词不传则清空，使后续制卡回落 DOM 采样窗（live 视频 hover 取当前句）。
@@ -1712,7 +1777,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   if (!term || !term.trim()) return;
   if (!fushiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
   if (fushiPauseOnLookup) {
-    try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}
+    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}
   }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
@@ -1837,7 +1902,9 @@ window.fushiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
 window.fushiPrepareLookupFromSidePanel = function (cueWindow) {
   fushiPendingCueWindow = cueWindow && typeof cueWindow === 'object' ? cueWindow : null;
   if (fushiPauseOnLookup) {
-    try { const video = document.querySelector('video'); if (video && !video.paused) video.pause(); } catch (_) {}
+    // Side Panel 自渲染词典、没有「面板关闭」回调到 content script，故此路径只暂停、
+    // 不记 fushiPausedForLookup（否则会被后续无关的页面弹窗关闭误恢复）；恢复由用户手动。
+    try { const video = fushiFindPlayingVideo(); if (video) video.pause(); } catch (_) {}
   }
   return true;
 };

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -104,9 +104,37 @@ function fushiApplyPauseOnLookupPrefs(saved) {
 // 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
 // _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
 let fushiPausedForLookup = null;
+// 记「被我们暂停」并挂一次性 play 监听：用户手动点播放（不是我们 resume——我们 resume 前
+// 已先置 null）即视为收回控制权，清掉标记。这样「查词暂停 → 用户播放 → 用户再暂停 → 关窗」
+// 不会把用户自己按下的暂停顶掉；SPA 同元素换 src 继续播的场景同样被覆盖。
+function fushiMarkPausedForLookup(v) {
+  if (fushiPausedForLookup === v) return; // 重复查词同一视频：已挂过监听，别叠加
+  fushiPausedForLookup = v;
+  try {
+    v.addEventListener('play', function () {
+      if (fushiPausedForLookup === v) fushiPausedForLookup = null;
+    }, { once: true });
+  } catch (_) {}
+}
+// 恢复侧唯一实现（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由查词暂停的
+// 那个视频；用户已手动继续播放的不重复 play（v.paused 守卫）。除关窗汇聚点外，查词失败/
+// 扩展失效等「弹窗根本没建出来」的路径也必须走它——否则视频被停住却没有任何关窗动作可触发恢复。
+function fushiResumePausedForLookup() {
+  if (!fushiPausedForLookup) return;
+  const pausedVideo = fushiPausedForLookup;
+  fushiPausedForLookup = null;
+  try {
+    if (pausedVideo.isConnected !== false && pausedVideo.paused) {
+      const played = pausedVideo.play();
+      if (played && typeof played.catch === 'function') played.catch(() => {});
+    }
+  } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
+}
 // 找「正在播放」的视频：没有在播的就没有可暂停的（也就无需恢复）。顶层文档快路径优先
 // （高频 Shift 悬停查词不能每次全树扫描）；顶层没有才穿透 open shadow root 与**同源**
 // iframe 深搜（跨域 iframe 拿不到 contentDocument，静默跳过——嵌入式第三方播放器暂不覆盖）。
+// 深搜结果为空时记 2s TTL 负缓存：纯文本页/无在播视频的页面上，高频扫词不反复全树扫描。
+let fushiNoPlayingVideoUntil = 0;
 function fushiFindPlayingVideo() {
   const playing = (root) => {
     let vids;
@@ -118,6 +146,7 @@ function fushiFindPlayingVideo() {
   };
   const top = playing(document);
   if (top) return top;
+  if (Date.now() < fushiNoPlayingVideoUntil) return null; // 负缓存命中：跳过深搜
   const deep = (root, depth) => {
     if (!root || depth > 3) return null;
     let all;
@@ -137,7 +166,9 @@ function fushiFindPlayingVideo() {
     }
     return null;
   };
-  return deep(document, 0);
+  const found = deep(document, 0);
+  if (!found) fushiNoPlayingVideoUntil = Date.now() + 2000;
+  return found;
 }
 try {
   const fushiPausePrefsPromise = chrome.storage.local.get(
@@ -551,18 +582,22 @@ function fushiNotifyPanel(key) {
   } catch (_) {}
 }
 
-// 有序插入 + 去重：同文本且句首相差 <750ms 视为同一句（倒退/回放重看不重复入轨）。返回是否真插入。
-function fushiSortedCueInsert(cues, cue) {
+// 有序插入 + 去重：同文本且句首相差 <windowMs 视为同一句（倒退/回放重看不重复入轨）。
+// windowMs 缺省 750（DOM 采样 live 轨的时间轴本就有采样抖动）；textTracks 收割传 1（精确
+// 时间轴，只有 startMs 完全相同才算同一条——连续两声相同短句是真实台词，不能被宽窗误杀）。
+// 返回是否真插入。
+function fushiSortedCueInsert(cues, cue, windowMs) {
+  const win = windowMs > 0 ? windowMs : 750;
   let lo = 0;
   let hi = cues.length;
   while (lo < hi) {
     const mid = (lo + hi) >> 1;
     if (cues[mid].startMs <= cue.startMs) lo = mid + 1; else hi = mid;
   }
-  for (let i = lo - 1; i >= 0 && cue.startMs - cues[i].startMs < 750; i--) {
+  for (let i = lo - 1; i >= 0 && cue.startMs - cues[i].startMs < win; i--) {
     if (cues[i].text === cue.text) return false;
   }
-  for (let j = lo; j < cues.length && cues[j].startMs - cue.startMs < 750; j++) {
+  for (let j = lo; j < cues.length && cues[j].startMs - cue.startMs < win; j++) {
     if (cues[j].text === cue.text) return false;
   }
   cues.splice(lo, 0, cue);
@@ -628,20 +663,40 @@ function fushiLiveCueEnd(state, endV) {
 //      cue——旧的「条数没长就跳过、长了整轨覆盖」两个方向都丢字幕（新区间进不来 / 旧区间
 //      被抹掉），正是「侧边栏字幕不全」的主根因。逐条有序插入（fushiSortedCueInsert 同文本
 //      ±750ms 去重），轨只增不减，快进/回看过的各区间都留得住。
+// 每条 track 只尝试升 hidden 一次：站点播放器（hls.js 等）若把 mode 拨回 disabled，那是它在
+// 管理轨道，1.2s 轮询若反复翻回去会形成无限拉锯（每次翻转都触发站点侧 change 处理）。一次
+// 尝试足以让静态播放器把 cues 加载出来；被站点收回的轨就尊重站点。
+const fushiPromotedTracks = typeof WeakSet === 'function' ? new WeakSet() : null;
 function fushiHarvestTextTracks() {
   const v = document.querySelector('video');
   if (!v || !v.textTracks || !v.textTracks.length) return;
   const vidKey = fushiVideoKey();
+  // 同语言多轨（如 "English" 与 "English [CC]"，language 同为 en）必须分 key，否则两条轨的
+  // cue 被归并进同一条侧边栏轨、台词穿插重复且轨只增不减无法恢复。仅在语言撞车时才把 label
+  // 编进轨身份——单轨语言保持裸语言码，与其它 provider（stream-bridge/YouTube）的 key 习惯一致。
+  const langCount = Object.create(null);
+  for (let i = 0; i < v.textTracks.length; i++) {
+    const t = v.textTracks[i];
+    if (!t || (t.kind !== 'subtitles' && t.kind !== 'captions')) continue;
+    const l = String(t.language || t.label || 'und');
+    langCount[l] = (langCount[l] || 0) + 1;
+  }
   for (let i = 0; i < v.textTracks.length; i++) {
     const tt = v.textTracks[i];
     if (!tt || (tt.kind !== 'subtitles' && tt.kind !== 'captions')) continue;
     if (tt.mode === 'disabled') {
-      try { tt.mode = 'hidden'; } catch (_) {}
+      if (fushiPromotedTracks && !fushiPromotedTracks.has(tt)) {
+        fushiPromotedTracks.add(tt);
+        try { tt.mode = 'hidden'; } catch (_) {}
+      }
       continue; // cues 要到下一轮轮询才加载好
     }
     if (!tt.cues || !tt.cues.length) continue;
-    const lang = String(tt.language || tt.label || 'und').replace(/\|/g, '_');
-    const key = vidKey + '|' + lang;
+    const langRaw = String(tt.language || tt.label || 'und');
+    const langId = langCount[langRaw] > 1
+      ? langRaw + '·' + String(tt.label || '#' + i)
+      : langRaw;
+    const key = vidKey + '|' + langId.replace(/\|/g, '_');
     const track = fushiEpisodeCues[key] || (fushiEpisodeCues[key] = []);
     let inserted = false;
     for (let j = 0; j < tt.cues.length; j++) {
@@ -650,7 +705,7 @@ function fushiHarvestTextTracks() {
       const text = stripCueTags(String(c.text || ''));
       if (!text) continue;
       const cue = { startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text };
-      if (fushiSortedCueInsert(track, cue)) inserted = true;
+      if (fushiSortedCueInsert(track, cue, 1)) inserted = true;
     }
     if (inserted) fushiNotifyPanel(key);
   }
@@ -1601,20 +1656,9 @@ function fushiRemoveContainer() {
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
-  // 「查词时暂停」的恢复侧（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由
-  // 查词暂停的那个视频；用户自己暂停的绝不被播起来（关窗时它不在 fushiPausedForLookup 里），
-  // 用户已手动继续播放的也不重复 play（v.paused 守卫）。嵌套查词只换弹窗内容、不经此处，
-  // 天然不会提前恢复——与 app「整栈关空才恢复」同语义。
-  if (fushiPausedForLookup) {
-    const pausedVideo = fushiPausedForLookup;
-    fushiPausedForLookup = null;
-    try {
-      if (pausedVideo.isConnected !== false && pausedVideo.paused) {
-        const played = pausedVideo.play();
-        if (played && typeof played.catch === 'function') played.catch(() => {});
-      }
-    } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
-  }
+  // 「查词时暂停」的恢复侧：关窗即恢复（实现与不变式见 fushiResumePausedForLookup）。
+  // 嵌套查词只换弹窗内容、不经此处，天然不会提前恢复——与 app「整栈关空才恢复」同语义。
+  fushiResumePausedForLookup();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
   try {
     if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
@@ -1776,11 +1820,22 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   fushiPendingCueWindow = cueWindow || null;
   if (!term || !term.trim()) return;
   if (!fushiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
-  if (fushiPauseOnLookup) {
-    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}
+  // 已因查词暂停且视频仍停着：重复查词不必再扫（fushiFindPlayingVideo 也不会命中）。
+  if (fushiPauseOnLookup && !(fushiPausedForLookup && fushiPausedForLookup.paused)) {
+    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiMarkPausedForLookup(_v); } } catch (_) {}
   }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
+  // SW 在消息在途时被回收（BUG-1024）：回调永不触发，下面的失败恢复路径也到不了。兜底：
+  // 12s 后仍是同一笔在途且没有弹窗在场，就恢复被查词暂停的视频（正常有响应时无操作）。
+  const fushiLookupIssuedAt = fushiPendingSince;
+  try {
+    setTimeout(() => {
+      if (fushiPending && fushiPendingSince === fushiLookupIssuedAt && !fushiHost) {
+        fushiResumePausedForLookup();
+      }
+    }, 12000);
+  } catch (_) {}
   const clientStartedAt = performance.now();
   const clientSentEpochMs = performance.timeOrigin + clientStartedAt;
   try {
@@ -1810,6 +1865,9 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
           error: String(resp && resp.error || 'empty lookup response'),
         });
         fushiShowConnectionFailure(resp);
+        // 失败且没有在场弹窗：不会有任何「关窗」动作可触发恢复——直接恢复被查词暂停的
+        // 视频，否则服务未启动时 Shift 划词=视频被停住+只剩一条 toast、暂停无出口。
+        if (!fushiHost) fushiResumePausedForLookup();
         return;
       }
       if (!resp.data || typeof resp.data.popupJson !== 'string') {
@@ -1820,6 +1878,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
           term,
           error: 'missing popupJson',
         });
+        if (!fushiHost) fushiResumePausedForLookup();
         return;
       }
       const servicePerf = resp.lookupPerf || {};
@@ -1859,6 +1918,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
     });
   } catch (_) {
     fushiPending = false; // 「Extension context invalidated」：静默，等用户重载页面
+    if (!fushiHost) fushiResumePausedForLookup(); // 暂停不能没有出口
   }
 }
 

--- a/fushi/assets/browser_extension/options.html
+++ b/fushi/assets/browser_extension/options.html
@@ -72,7 +72,7 @@
             <label class="setting-row" for="subtitlePauseOnLookup">
               <span class="setting-copy">
                 <strong>查词时暂停</strong>
-                <small>从网页、字幕列表或悬浮字幕发起查词时暂停当前视频；查完后由你继续播放。</small>
+                <small>从网页、字幕列表或悬浮字幕发起查词时暂停正在播放的视频；关闭查词弹窗后自动恢复播放（你自己暂停的视频不会被播放）。</small>
               </span>
               <span class="switch"><input id="subtitlePauseOnLookup" type="checkbox"><span aria-hidden="true"></span></span>
             </label>

--- a/fushi/assets/browser_extension/options.js
+++ b/fushi/assets/browser_extension/options.js
@@ -15,7 +15,8 @@ const settingDefaults = Object.freeze({
   subtitleDragDropEnabled: true,
   subtitleAutoScroll: true,
   netflixHideNextEpisode: true,
-  subtitlePauseOnLookup: false,
+  // 默认开启，对齐 app 侧 pauseOnLookup 默认 true（TODO-1108）；显式选择（含旧键）优先。
+  subtitlePauseOnLookup: true,
   subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -49,6 +49,11 @@
   var scheduledPointer = null;
   var scanFrame = null;
   var activeScanKey = '';
+  // pointer 扫词在途闸（对齐 content.js 的 fushiPending/fushiPendingSince，BUG-1024 同款防洪）：
+  // 有词典请求在途时暂缓 pointermove 触发的新查词——横扫一行 20 个字不再瞬间打出 20 个请求把
+  // 本地服务与 6 连接上限灌满。0=无在途；带截止时间兜底，任何异常都不会永久闸死。
+  var lookupPendingSince = 0;
+  var LOOKUP_PENDING_TIMEOUT_MS = 1500;
   // 复杂词的 popupJson 可超过 2 MB，解析后的对象树通常还会膨胀数倍。只按“48 个词”
   // 淘汰会让 Side Panel 很快常驻数百 MB，并在后续查词时触发秒级 GC。双门槛保留常用
   // 小词，同时让超大结果最多只占少量槽位；最新一条即使单独超预算也保留以支持复查。
@@ -56,14 +61,29 @@
   var LOOKUP_CACHE_CHAR_LIMIT = 8 * 1024 * 1024;
   var FONT_STEPS = [0.85, 1, 1.15, 1.3];
 
+  // BUG-1024 孪生（Side Panel 版）：MV3 service worker 在消息在途时被系统回收，sendMessage
+  // 回调**永不触发**——没有兜底的话这里的 Promise 永久 pending：「正在查词…」永久停留，且
+  // fetchLookup 的同词在途复用（BUG-1525）会把这个死 Promise 缓存起来，同一个词从此永久卡死。
+  // 超时竞速保证 Promise 一定 settle（值取 > app 冷查询 P99；超时按失败处理，UI 显示可重试的
+  // 失败文案而不是无限转圈）。
+  var RUNTIME_MESSAGE_TIMEOUT_MS = 8000;
   function sendRuntime(message) {
     return new Promise(function (resolve) {
+      var settled = false;
+      var timer = null;
+      var finish = function (value) {
+        if (settled) return;
+        settled = true;
+        if (timer !== null) clearTimeout(timer);
+        resolve(value);
+      };
+      timer = setTimeout(function () { finish(null); }, RUNTIME_MESSAGE_TIMEOUT_MS);
       try {
         chrome.runtime.sendMessage(message, function (response) {
-          try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
-          resolve(response || null);
+          try { if (chrome.runtime.lastError) return finish(null); } catch (_) { return finish(null); }
+          finish(response || null);
         });
-      } catch (_) { resolve(null); }
+      } catch (_) { finish(null); }
     });
   }
 
@@ -360,11 +380,23 @@
     }
     lookupContainer.innerHTML = '<div class="no-results">正在查词…</div>';
     if (shouldPosition) positionLookup(anchor);
-    var data = await fetchLookup(value);
+    // try/finally 锁死两条不变式：①「正在查词…」绝不永久停留——fetchLookup 无论 resolve /
+    // reject（内部处理回调抛错）都必须落到成功或失败文案；② pointer 扫词在途闸一定被复位。
+    var data = null;
+    try {
+      lookupPendingSince = Date.now();
+      data = await fetchLookup(value);
+    } catch (_) {
+      data = null;
+    } finally {
+      lookupPendingSince = 0;
+    }
     if (requestId !== lookupRequestId) return;
     if (!data) {
       lookupContainer.innerHTML = '<div class="no-results">查词失败，请确认 Fushi 查词服务已开启。</div>';
       if (shouldPosition) positionLookup(anchor);
+      // 失败后复位扫描去重键：不复位的话鼠标停在同一个字上永远触发不了重试。
+      activeScanKey = '';
       return;
     }
     renderLookupData(value, data, false);
@@ -414,6 +446,12 @@
     }
     var scanKey = pointer.index + '\u0000' + term;
     if (scanKey === activeScanKey && !lookupPaneEl.hidden) return;
+    // 在途闸只拦 pointermove 自动扫词（announceMissing=false）；显式手势永远放行。
+    // 超过截止时间的在途视为已死（SW 被回收等），放行新查词——死锁不可复活。
+    if (!announceMissing && lookupPendingSince &&
+        Date.now() - lookupPendingSince < LOOKUP_PENDING_TIMEOUT_MS) {
+      return;
+    }
     activeScanKey = scanKey;
     lookupTerm(term, pointer.cue, anchorForHit(hit, pointer.x, pointer.y));
   }

--- a/fushi/test/mining/netflix_mining_robustness_guard_test.dart
+++ b/fushi/test/mining/netflix_mining_robustness_guard_test.dart
@@ -38,10 +38,12 @@ void main() {
           final String src = content.readAsStringSync();
           expect(
             src.contains('if (fushiPauseOnLookup) {\n'
-                "    try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}\n"
+                '    try { const _v = fushiFindPlayingVideo(); '
+                'if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}\n'
                 '  }'),
             isTrue,
-            reason: '${content.path} 查词暂停未受用户设置门控',
+            reason: '${content.path} 查词暂停未受用户设置门控'
+                '（或暂停未记录 fushiPausedForLookup 供关窗恢复）',
           );
           expect(
             src.contains("fushiSite() === 'netflix'"),

--- a/fushi/test/mining/netflix_mining_robustness_guard_test.dart
+++ b/fushi/test/mining/netflix_mining_robustness_guard_test.dart
@@ -37,9 +37,10 @@ void main() {
         test('#1 查词暂停由 subtitlePauseOnLookup 门控', () {
           final String src = content.readAsStringSync();
           expect(
-            src.contains('if (fushiPauseOnLookup) {\n'
+            src.contains('if (fushiPauseOnLookup && '
+                '!(fushiPausedForLookup && fushiPausedForLookup.paused)) {\n'
                 '    try { const _v = fushiFindPlayingVideo(); '
-                'if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}\n'
+                'if (_v) { _v.pause(); fushiMarkPausedForLookup(_v); } } catch (_) {}\n'
                 '  }'),
             isTrue,
             reason: '${content.path} 查词暂停未受用户设置门控'

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -615,8 +615,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         const maximumTerms = lookupTrace.maximumTerms;
         lookupTrace.phase = 'fetch-headers';
         const fetchStartedAt = performance.now();
+        // 查词 fetch 必须有上限：app 侧一旦长阻塞（词典重载/磁盘 stall），无超时的 await 会让
+        // sendResponse 永不被调——Side Panel 的「正在查词…」就永久停留。超时走下方 catch 分支
+        // 回错误响应，用户看到可重试的失败文案而不是无限转圈。上限 > Side Panel 兜底(8s)，
+        // 正常慢查询不受影响。
         const r = await fetch(base + '/api/lookup/dictionary', {
           method: 'POST',
+          signal: AbortSignal.timeout(10000),
           headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
           body: JSON.stringify({
             term: msg.term,

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -88,14 +88,56 @@ function fushiReportVisibleAfterPaint(ctx, container) {
 
 // 「查词时暂停」取代旧的「悬停字幕时暂停」。新键显式值优先；旧
 // subtitleHoverPause 只作升级兼容读取，避免用户更新扩展后原选择突然丢失。
-let fushiPauseOnLookup = false;
+// 默认**开启**，对齐 app 侧 pauseOnLookup 默认 true（TODO-1108）；从未做过选择的用户
+// 查词即暂停、关窗即恢复（恢复侧见 fushiRemoveContainer）。
+let fushiPauseOnLookup = true;
 let fushiHasPauseOnLookupPref = false;
 function fushiApplyPauseOnLookupPrefs(saved) {
   saved = saved || {};
   fushiHasPauseOnLookupPref = typeof saved.subtitlePauseOnLookup === 'boolean';
   fushiPauseOnLookup = fushiHasPauseOnLookupPref
     ? saved.subtitlePauseOnLookup
-    : saved.subtitleHoverPause === true;
+    : (typeof saved.subtitleHoverPause === 'boolean'
+        ? saved.subtitleHoverPause
+        : true);
+}
+// 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
+// _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
+let fushiPausedForLookup = null;
+// 找「正在播放」的视频：没有在播的就没有可暂停的（也就无需恢复）。顶层文档快路径优先
+// （高频 Shift 悬停查词不能每次全树扫描）；顶层没有才穿透 open shadow root 与**同源**
+// iframe 深搜（跨域 iframe 拿不到 contentDocument，静默跳过——嵌入式第三方播放器暂不覆盖）。
+function fushiFindPlayingVideo() {
+  const playing = (root) => {
+    let vids;
+    try { vids = root.querySelectorAll('video'); } catch (_) { return null; }
+    for (const v of vids) {
+      if (!v.paused && !v.ended) return v;
+    }
+    return null;
+  };
+  const top = playing(document);
+  if (top) return top;
+  const deep = (root, depth) => {
+    if (!root || depth > 3) return null;
+    let all;
+    try { all = root.querySelectorAll('*'); } catch (_) { return null; }
+    for (const el of all) {
+      let sub = null;
+      if (el.shadowRoot) {
+        sub = playing(el.shadowRoot) || deep(el.shadowRoot, depth + 1);
+      } else if (el.tagName === 'IFRAME') {
+        try {
+          if (el.contentDocument) {
+            sub = playing(el.contentDocument) || deep(el.contentDocument, depth + 1);
+          }
+        } catch (_) { /* 跨域 iframe */ }
+      }
+      if (sub) return sub;
+    }
+    return null;
+  };
+  return deep(document, 0);
 }
 try {
   const fushiPausePrefsPromise = chrome.storage.local.get(
@@ -578,8 +620,14 @@ function fushiLiveCueEnd(state, endV) {
   state.liveCueReplay = false;
 }
 
-// a) textTracks 全量收割：轮询增量（cue 随流加载渐增，条数长了才重建该轨）。kind 只收
-// subtitles/captions；mode 为 disabled 时浏览器不加载 cues，跳过。
+// a) textTracks 全量收割：轮询归并。kind 只收 subtitles/captions。两条完整性规则：
+//   ① disabled 轨浏览器根本不加载 cues → 以前直接跳过 = 只有播放器当前开着的那条轨能进
+//      store，侧边栏语言轨永远只有一条。asbplayer 同款做法：临时升到 hidden（加载 cues 但
+//      不渲染、不影响站点显示），下一轮轮询即可收割全部语言轨。
+//   ② 归并而非整轨覆盖：hls.js/Shaka 的分片字幕会随 back-buffer 回收 / seek 重建而增删
+//      cue——旧的「条数没长就跳过、长了整轨覆盖」两个方向都丢字幕（新区间进不来 / 旧区间
+//      被抹掉），正是「侧边栏字幕不全」的主根因。逐条有序插入（fushiSortedCueInsert 同文本
+//      ±750ms 去重），轨只增不减，快进/回看过的各区间都留得住。
 function fushiHarvestTextTracks() {
   const v = document.querySelector('video');
   if (!v || !v.textTracks || !v.textTracks.length) return;
@@ -587,22 +635,24 @@ function fushiHarvestTextTracks() {
   for (let i = 0; i < v.textTracks.length; i++) {
     const tt = v.textTracks[i];
     if (!tt || (tt.kind !== 'subtitles' && tt.kind !== 'captions')) continue;
-    if (tt.mode === 'disabled' || !tt.cues || !tt.cues.length) continue;
+    if (tt.mode === 'disabled') {
+      try { tt.mode = 'hidden'; } catch (_) {}
+      continue; // cues 要到下一轮轮询才加载好
+    }
+    if (!tt.cues || !tt.cues.length) continue;
     const lang = String(tt.language || tt.label || 'und').replace(/\|/g, '_');
     const key = vidKey + '|' + lang;
-    const existing = fushiEpisodeCues[key];
-    if (existing && existing.length >= tt.cues.length) continue;
-    const out = [];
+    const track = fushiEpisodeCues[key] || (fushiEpisodeCues[key] = []);
+    let inserted = false;
     for (let j = 0; j < tt.cues.length; j++) {
       const c = tt.cues[j];
       if (!c || typeof c.startTime !== 'number' || typeof c.endTime !== 'number') continue;
       const text = stripCueTags(String(c.text || ''));
       if (!text) continue;
-      out.push({ startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text });
+      const cue = { startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text };
+      if (fushiSortedCueInsert(track, cue)) inserted = true;
     }
-    if (!out.length) continue;
-    fushiEpisodeCues[key] = out;
-    fushiNotifyPanel(key);
+    if (inserted) fushiNotifyPanel(key);
   }
 }
 try { setInterval(fushiHarvestTextTracks, 1200); } catch (_) {}
@@ -1551,6 +1601,20 @@ function fushiRemoveContainer() {
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
+  // 「查词时暂停」的恢复侧（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由
+  // 查词暂停的那个视频；用户自己暂停的绝不被播起来（关窗时它不在 fushiPausedForLookup 里），
+  // 用户已手动继续播放的也不重复 play（v.paused 守卫）。嵌套查词只换弹窗内容、不经此处，
+  // 天然不会提前恢复——与 app「整栈关空才恢复」同语义。
+  if (fushiPausedForLookup) {
+    const pausedVideo = fushiPausedForLookup;
+    fushiPausedForLookup = null;
+    try {
+      if (pausedVideo.isConnected !== false && pausedVideo.paused) {
+        const played = pausedVideo.play();
+        if (played && typeof played.catch === 'function') played.catch(() => {});
+      }
+    } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
+  }
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
   try {
     if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
@@ -1703,8 +1767,9 @@ function fushiShowConnectionFailure(resp) {
 }
 
 // 发查词请求 + 渲染弹窗的共享收尾（Shift 悬停、面板行点击、悬浮字幕自动查词同源）。
-// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停当前视频；不自动恢复，查完由用户
-// 继续播放。关闭时任何站点都不因查词被暂停。
+// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停正在播放的视频，并记下
+// fushiPausedForLookup；关闭查词弹窗时自动恢复（fushiRemoveContainer）。关闭该设置时
+// 任何站点都不因查词被暂停。
 function fushiSendLookup(term, anchorRect, cueWindow) {
   // TODO-1219 P3：每次查词刷新精确窗——面板行查词传 cueWindow（该行精确 [startMs,endMs]），
   // mousemove 划词不传则清空，使后续制卡回落 DOM 采样窗（live 视频 hover 取当前句）。
@@ -1712,7 +1777,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   if (!term || !term.trim()) return;
   if (!fushiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
   if (fushiPauseOnLookup) {
-    try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}
+    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}
   }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
@@ -1837,7 +1902,9 @@ window.fushiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
 window.fushiPrepareLookupFromSidePanel = function (cueWindow) {
   fushiPendingCueWindow = cueWindow && typeof cueWindow === 'object' ? cueWindow : null;
   if (fushiPauseOnLookup) {
-    try { const video = document.querySelector('video'); if (video && !video.paused) video.pause(); } catch (_) {}
+    // Side Panel 自渲染词典、没有「面板关闭」回调到 content script，故此路径只暂停、
+    // 不记 fushiPausedForLookup（否则会被后续无关的页面弹窗关闭误恢复）；恢复由用户手动。
+    try { const video = fushiFindPlayingVideo(); if (video) video.pause(); } catch (_) {}
   }
   return true;
 };

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -104,9 +104,37 @@ function fushiApplyPauseOnLookupPrefs(saved) {
 // 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
 // _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
 let fushiPausedForLookup = null;
+// 记「被我们暂停」并挂一次性 play 监听：用户手动点播放（不是我们 resume——我们 resume 前
+// 已先置 null）即视为收回控制权，清掉标记。这样「查词暂停 → 用户播放 → 用户再暂停 → 关窗」
+// 不会把用户自己按下的暂停顶掉；SPA 同元素换 src 继续播的场景同样被覆盖。
+function fushiMarkPausedForLookup(v) {
+  if (fushiPausedForLookup === v) return; // 重复查词同一视频：已挂过监听，别叠加
+  fushiPausedForLookup = v;
+  try {
+    v.addEventListener('play', function () {
+      if (fushiPausedForLookup === v) fushiPausedForLookup = null;
+    }, { once: true });
+  } catch (_) {}
+}
+// 恢复侧唯一实现（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由查词暂停的
+// 那个视频；用户已手动继续播放的不重复 play（v.paused 守卫）。除关窗汇聚点外，查词失败/
+// 扩展失效等「弹窗根本没建出来」的路径也必须走它——否则视频被停住却没有任何关窗动作可触发恢复。
+function fushiResumePausedForLookup() {
+  if (!fushiPausedForLookup) return;
+  const pausedVideo = fushiPausedForLookup;
+  fushiPausedForLookup = null;
+  try {
+    if (pausedVideo.isConnected !== false && pausedVideo.paused) {
+      const played = pausedVideo.play();
+      if (played && typeof played.catch === 'function') played.catch(() => {});
+    }
+  } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
+}
 // 找「正在播放」的视频：没有在播的就没有可暂停的（也就无需恢复）。顶层文档快路径优先
 // （高频 Shift 悬停查词不能每次全树扫描）；顶层没有才穿透 open shadow root 与**同源**
 // iframe 深搜（跨域 iframe 拿不到 contentDocument，静默跳过——嵌入式第三方播放器暂不覆盖）。
+// 深搜结果为空时记 2s TTL 负缓存：纯文本页/无在播视频的页面上，高频扫词不反复全树扫描。
+let fushiNoPlayingVideoUntil = 0;
 function fushiFindPlayingVideo() {
   const playing = (root) => {
     let vids;
@@ -118,6 +146,7 @@ function fushiFindPlayingVideo() {
   };
   const top = playing(document);
   if (top) return top;
+  if (Date.now() < fushiNoPlayingVideoUntil) return null; // 负缓存命中：跳过深搜
   const deep = (root, depth) => {
     if (!root || depth > 3) return null;
     let all;
@@ -137,7 +166,9 @@ function fushiFindPlayingVideo() {
     }
     return null;
   };
-  return deep(document, 0);
+  const found = deep(document, 0);
+  if (!found) fushiNoPlayingVideoUntil = Date.now() + 2000;
+  return found;
 }
 try {
   const fushiPausePrefsPromise = chrome.storage.local.get(
@@ -551,18 +582,22 @@ function fushiNotifyPanel(key) {
   } catch (_) {}
 }
 
-// 有序插入 + 去重：同文本且句首相差 <750ms 视为同一句（倒退/回放重看不重复入轨）。返回是否真插入。
-function fushiSortedCueInsert(cues, cue) {
+// 有序插入 + 去重：同文本且句首相差 <windowMs 视为同一句（倒退/回放重看不重复入轨）。
+// windowMs 缺省 750（DOM 采样 live 轨的时间轴本就有采样抖动）；textTracks 收割传 1（精确
+// 时间轴，只有 startMs 完全相同才算同一条——连续两声相同短句是真实台词，不能被宽窗误杀）。
+// 返回是否真插入。
+function fushiSortedCueInsert(cues, cue, windowMs) {
+  const win = windowMs > 0 ? windowMs : 750;
   let lo = 0;
   let hi = cues.length;
   while (lo < hi) {
     const mid = (lo + hi) >> 1;
     if (cues[mid].startMs <= cue.startMs) lo = mid + 1; else hi = mid;
   }
-  for (let i = lo - 1; i >= 0 && cue.startMs - cues[i].startMs < 750; i--) {
+  for (let i = lo - 1; i >= 0 && cue.startMs - cues[i].startMs < win; i--) {
     if (cues[i].text === cue.text) return false;
   }
-  for (let j = lo; j < cues.length && cues[j].startMs - cue.startMs < 750; j++) {
+  for (let j = lo; j < cues.length && cues[j].startMs - cue.startMs < win; j++) {
     if (cues[j].text === cue.text) return false;
   }
   cues.splice(lo, 0, cue);
@@ -628,20 +663,40 @@ function fushiLiveCueEnd(state, endV) {
 //      cue——旧的「条数没长就跳过、长了整轨覆盖」两个方向都丢字幕（新区间进不来 / 旧区间
 //      被抹掉），正是「侧边栏字幕不全」的主根因。逐条有序插入（fushiSortedCueInsert 同文本
 //      ±750ms 去重），轨只增不减，快进/回看过的各区间都留得住。
+// 每条 track 只尝试升 hidden 一次：站点播放器（hls.js 等）若把 mode 拨回 disabled，那是它在
+// 管理轨道，1.2s 轮询若反复翻回去会形成无限拉锯（每次翻转都触发站点侧 change 处理）。一次
+// 尝试足以让静态播放器把 cues 加载出来；被站点收回的轨就尊重站点。
+const fushiPromotedTracks = typeof WeakSet === 'function' ? new WeakSet() : null;
 function fushiHarvestTextTracks() {
   const v = document.querySelector('video');
   if (!v || !v.textTracks || !v.textTracks.length) return;
   const vidKey = fushiVideoKey();
+  // 同语言多轨（如 "English" 与 "English [CC]"，language 同为 en）必须分 key，否则两条轨的
+  // cue 被归并进同一条侧边栏轨、台词穿插重复且轨只增不减无法恢复。仅在语言撞车时才把 label
+  // 编进轨身份——单轨语言保持裸语言码，与其它 provider（stream-bridge/YouTube）的 key 习惯一致。
+  const langCount = Object.create(null);
+  for (let i = 0; i < v.textTracks.length; i++) {
+    const t = v.textTracks[i];
+    if (!t || (t.kind !== 'subtitles' && t.kind !== 'captions')) continue;
+    const l = String(t.language || t.label || 'und');
+    langCount[l] = (langCount[l] || 0) + 1;
+  }
   for (let i = 0; i < v.textTracks.length; i++) {
     const tt = v.textTracks[i];
     if (!tt || (tt.kind !== 'subtitles' && tt.kind !== 'captions')) continue;
     if (tt.mode === 'disabled') {
-      try { tt.mode = 'hidden'; } catch (_) {}
+      if (fushiPromotedTracks && !fushiPromotedTracks.has(tt)) {
+        fushiPromotedTracks.add(tt);
+        try { tt.mode = 'hidden'; } catch (_) {}
+      }
       continue; // cues 要到下一轮轮询才加载好
     }
     if (!tt.cues || !tt.cues.length) continue;
-    const lang = String(tt.language || tt.label || 'und').replace(/\|/g, '_');
-    const key = vidKey + '|' + lang;
+    const langRaw = String(tt.language || tt.label || 'und');
+    const langId = langCount[langRaw] > 1
+      ? langRaw + '·' + String(tt.label || '#' + i)
+      : langRaw;
+    const key = vidKey + '|' + langId.replace(/\|/g, '_');
     const track = fushiEpisodeCues[key] || (fushiEpisodeCues[key] = []);
     let inserted = false;
     for (let j = 0; j < tt.cues.length; j++) {
@@ -650,7 +705,7 @@ function fushiHarvestTextTracks() {
       const text = stripCueTags(String(c.text || ''));
       if (!text) continue;
       const cue = { startMs: Math.round(c.startTime * 1000), endMs: Math.round(c.endTime * 1000), text: text };
-      if (fushiSortedCueInsert(track, cue)) inserted = true;
+      if (fushiSortedCueInsert(track, cue, 1)) inserted = true;
     }
     if (inserted) fushiNotifyPanel(key);
   }
@@ -1601,20 +1656,9 @@ function fushiRemoveContainer() {
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
-  // 「查词时暂停」的恢复侧（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由
-  // 查词暂停的那个视频；用户自己暂停的绝不被播起来（关窗时它不在 fushiPausedForLookup 里），
-  // 用户已手动继续播放的也不重复 play（v.paused 守卫）。嵌套查词只换弹窗内容、不经此处，
-  // 天然不会提前恢复——与 app「整栈关空才恢复」同语义。
-  if (fushiPausedForLookup) {
-    const pausedVideo = fushiPausedForLookup;
-    fushiPausedForLookup = null;
-    try {
-      if (pausedVideo.isConnected !== false && pausedVideo.paused) {
-        const played = pausedVideo.play();
-        if (played && typeof played.catch === 'function') played.catch(() => {});
-      }
-    } catch (_) { /* autoplay 拦截等：保持暂停即可 */ }
-  }
+  // 「查词时暂停」的恢复侧：关窗即恢复（实现与不变式见 fushiResumePausedForLookup）。
+  // 嵌套查词只换弹窗内容、不经此处，天然不会提前恢复——与 app「整栈关空才恢复」同语义。
+  fushiResumePausedForLookup();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
   try {
     if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
@@ -1776,11 +1820,22 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   fushiPendingCueWindow = cueWindow || null;
   if (!term || !term.trim()) return;
   if (!fushiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
-  if (fushiPauseOnLookup) {
-    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiPausedForLookup = _v; } } catch (_) {}
+  // 已因查词暂停且视频仍停着：重复查词不必再扫（fushiFindPlayingVideo 也不会命中）。
+  if (fushiPauseOnLookup && !(fushiPausedForLookup && fushiPausedForLookup.paused)) {
+    try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiMarkPausedForLookup(_v); } } catch (_) {}
   }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
+  // SW 在消息在途时被回收（BUG-1024）：回调永不触发，下面的失败恢复路径也到不了。兜底：
+  // 12s 后仍是同一笔在途且没有弹窗在场，就恢复被查词暂停的视频（正常有响应时无操作）。
+  const fushiLookupIssuedAt = fushiPendingSince;
+  try {
+    setTimeout(() => {
+      if (fushiPending && fushiPendingSince === fushiLookupIssuedAt && !fushiHost) {
+        fushiResumePausedForLookup();
+      }
+    }, 12000);
+  } catch (_) {}
   const clientStartedAt = performance.now();
   const clientSentEpochMs = performance.timeOrigin + clientStartedAt;
   try {
@@ -1810,6 +1865,9 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
           error: String(resp && resp.error || 'empty lookup response'),
         });
         fushiShowConnectionFailure(resp);
+        // 失败且没有在场弹窗：不会有任何「关窗」动作可触发恢复——直接恢复被查词暂停的
+        // 视频，否则服务未启动时 Shift 划词=视频被停住+只剩一条 toast、暂停无出口。
+        if (!fushiHost) fushiResumePausedForLookup();
         return;
       }
       if (!resp.data || typeof resp.data.popupJson !== 'string') {
@@ -1820,6 +1878,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
           term,
           error: 'missing popupJson',
         });
+        if (!fushiHost) fushiResumePausedForLookup();
         return;
       }
       const servicePerf = resp.lookupPerf || {};
@@ -1859,6 +1918,7 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
     });
   } catch (_) {
     fushiPending = false; // 「Extension context invalidated」：静默，等用户重载页面
+    if (!fushiHost) fushiResumePausedForLookup(); // 暂停不能没有出口
   }
 }
 

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -72,7 +72,7 @@
             <label class="setting-row" for="subtitlePauseOnLookup">
               <span class="setting-copy">
                 <strong>查词时暂停</strong>
-                <small>从网页、字幕列表或悬浮字幕发起查词时暂停当前视频；查完后由你继续播放。</small>
+                <small>从网页、字幕列表或悬浮字幕发起查词时暂停正在播放的视频；关闭查词弹窗后自动恢复播放（你自己暂停的视频不会被播放）。</small>
               </span>
               <span class="switch"><input id="subtitlePauseOnLookup" type="checkbox"><span aria-hidden="true"></span></span>
             </label>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -15,7 +15,8 @@ const settingDefaults = Object.freeze({
   subtitleDragDropEnabled: true,
   subtitleAutoScroll: true,
   netflixHideNextEpisode: true,
-  subtitlePauseOnLookup: false,
+  // 默认开启，对齐 app 侧 pauseOnLookup 默认 true（TODO-1108）；显式选择（含旧键）优先。
+  subtitlePauseOnLookup: true,
   subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,

--- a/tools/browser-extension/shift-hover.test.js
+++ b/tools/browser-extension/shift-hover.test.js
@@ -31,10 +31,21 @@ function loadContentAndFireShift(options) {
     isConnected: true,
     pauseCount: 0,
     playCount: 0,
+    handlers: {},
+    addEventListener(type, fn, opts) {
+      (this.handlers[type] = this.handlers[type] || []).push({ fn, once: !!(opts && opts.once) });
+    },
+    removeEventListener() {},
+    emit(type) {
+      const hs = this.handlers[type] || [];
+      this.handlers[type] = hs.filter((h) => !h.once);
+      for (const h of hs) h.fn();
+    },
     pause() { this.paused = true; this.pauseCount++; },
     play() {
       this.paused = false;
       this.playCount++;
+      this.emit('play');
       return { catch() {} };
     },
   };
@@ -93,7 +104,7 @@ function loadContentAndFireShift(options) {
       sendMessage: (msg, cb) => {
         sent.push(msg);
         if (cb && respond) {
-          cb({
+          cb(options.response !== undefined ? options.response : {
             ok: true,
             data: { popupJson: '[]', result: { bestLength: 2 }, audioSources: [] },
           });
@@ -209,6 +220,27 @@ test('用户自己暂停的视频不因关闭查词弹窗被播放', () => {
   for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
   assert.strictEqual(h.video.playCount, 0, '用户自己暂停的视频绝不被自动播放');
   assert.strictEqual(h.video.paused, true);
+});
+
+test('查词暂停后用户手动播放又手动暂停：关窗不得把用户的暂停顶掉', () => {
+  const h = loadContentAndFireShift();
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.paused, true, '查词先暂停');
+  // 用户手动点播放（play 事件收回控制权），随后又手动暂停。
+  h.video.paused = false;
+  h.video.emit('play');
+  h.video.paused = true;
+  for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
+  assert.strictEqual(h.video.playCount, 0, '用户收回控制权后关窗绝不自动播放');
+  assert.strictEqual(h.video.paused, true);
+});
+
+test('查词失败（无弹窗可关）时立即恢复被查词暂停的视频，暂停不得没有出口', () => {
+  const h = loadContentAndFireShift({ response: { ok: false, error: 'ECONNREFUSED' } });
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.pauseCount, 1, '发起查词先暂停');
+  assert.strictEqual(h.video.playCount, 1, '失败且无在场弹窗必须立即恢复播放');
+  assert.strictEqual(h.video.paused, false);
 });
 
 test('查词暂停兼容旧 subtitleHoverPause，但新键显式 false 优先', () => {

--- a/tools/browser-extension/shift-hover.test.js
+++ b/tools/browser-extension/shift-hover.test.js
@@ -27,8 +27,16 @@ function loadContentAndFireShift(options) {
   const dataset = {};
   const video = {
     paused: false,
+    ended: false,
+    isConnected: true,
     pauseCount: 0,
+    playCount: 0,
     pause() { this.paused = true; this.pauseCount++; },
+    play() {
+      this.paused = false;
+      this.playCount++;
+      return { catch() {} };
+    },
   };
   // 可控时钟：BUG-1024 的在途闸超时兜底按 Date.now() 判定，测试需要推进虚拟时间。
   const nowRef = { value: 1000000 };
@@ -65,12 +73,15 @@ function loadContentAndFireShift(options) {
     },
     getElementById: () => null,
     querySelector: (selector) => selector === 'video' ? video : null,
-    querySelectorAll: () => [],
+    querySelectorAll: (selector) => selector === 'video' ? [video] : [],
     createElement: () => ({
       style: {},
       addEventListener() {},
+      removeEventListener() {},
       appendChild() {},
       setAttribute() {},
+      remove() {},
+      contains: () => false,
       classList: { add() {} },
     }),
   };
@@ -162,18 +173,42 @@ test('未按 Shift 的 mousemove 不发查词（不刷爆服务器）', () => {
   );
 });
 
-test('查词时暂停默认关闭；开启后任意视频站点只在发起查词时暂停', () => {
-  const off = loadContentAndFireShift();
-  for (const fn of off.docListeners.mousemove) {
-    fn({ shiftKey: true, clientX: 300, clientY: 400 });
-  }
-  assert.strictEqual(off.video.pauseCount, 0, '默认关闭时查词不得暂停视频');
-
-  const on = loadContentAndFireShift({ stored: { subtitlePauseOnLookup: true } });
+test('查词时暂停默认开启（对齐 app TODO-1108）；显式关闭后不暂停', () => {
+  const on = loadContentAndFireShift();
   for (const fn of on.docListeners.mousemove) {
     fn({ shiftKey: true, clientX: 300, clientY: 400 });
   }
-  assert.strictEqual(on.video.pauseCount, 1, '开启后发起查词应暂停当前视频');
+  assert.strictEqual(on.video.pauseCount, 1, '默认开启：发起查词应暂停正在播放的视频');
+
+  const off = loadContentAndFireShift({ stored: { subtitlePauseOnLookup: false } });
+  for (const fn of off.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(off.video.pauseCount, 0, '显式关闭时查词不得暂停视频');
+});
+
+test('关闭查词弹窗后自动恢复由查词暂停的视频', () => {
+  const h = loadContentAndFireShift();
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.pauseCount, 1, '查词应先暂停视频');
+  assert.strictEqual(h.video.paused, true);
+  // 点弹窗外关窗（mousedown 命中 host 之外）→ fushiRemoveContainer → 恢复播放。
+  for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
+  assert.strictEqual(h.video.playCount, 1, '关窗必须恢复由查词暂停的视频');
+  assert.strictEqual(h.video.paused, false);
+  // 再关一次（无在场弹窗）不得重复 play。
+  for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
+  assert.strictEqual(h.video.playCount, 1, '无查词暂停在场时不得重复 play');
+});
+
+test('用户自己暂停的视频不因关闭查词弹窗被播放', () => {
+  const h = loadContentAndFireShift();
+  h.video.paused = true; // 查词前用户已手动暂停
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.pauseCount, 0, '没有正在播放的视频就没有可暂停的');
+  for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
+  assert.strictEqual(h.video.playCount, 0, '用户自己暂停的视频绝不被自动播放');
+  assert.strictEqual(h.video.paused, true);
 });
 
 test('查词暂停兼容旧 subtitleHoverPause，但新键显式 false 优先', () => {
@@ -190,6 +225,12 @@ test('查词暂停兼容旧 subtitleHoverPause，但新键显式 false 优先', 
     fn({ shiftKey: true, clientX: 300, clientY: 400 });
   }
   assert.strictEqual(overridden.video.pauseCount, 0, '新键显式 false 必须覆盖旧 true');
+
+  const legacyOff = loadContentAndFireShift({ stored: { subtitleHoverPause: false } });
+  for (const fn of legacyOff.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(legacyOff.video.pauseCount, 0, '旧键显式 false 必须压过新默认开启');
 });
 
 test('查词暂停经 storage.onChanged 热更新启停，无需刷新页面', () => {

--- a/tools/browser-extension/side-panel-lookup-deadlock.test.js
+++ b/tools/browser-extension/side-panel-lookup-deadlock.test.js
@@ -1,0 +1,153 @@
+// 「正在查词…」永久卡死回归守卫（BUG-1024 的 Side Panel 孪生）：
+// MV3 service worker 在查词消息在途时被系统回收，chrome.runtime.sendMessage 的回调**永不触发**。
+// 修复前的死锁闭环：
+//   ① sendRuntime 的 Promise 永不 settle → lookupTerm 的 await 永久挂起 → 「正在查词…」永久停留；
+//   ② fetchLookup 的同词在途复用（BUG-1525）把这个死 Promise 存进 lookupInFlight，
+//      `.finally` 永不执行 → 同一个词此后每次查询都直接拿回死 Promise，永久锁死。
+// 本守卫在受控 vm 里真加载 side-panel.js：stub sendMessage 永不回调，推进超时定时器，断言
+//   a) loading 被替换成可重试的失败文案（不是无限转圈）；
+//   b) 同一个词能再次真正发出 lookup 请求（在途表已去毒）。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SIDE_PANEL = fs.readFileSync(path.join(__dirname, 'side-panel.js'), 'utf8');
+
+const flush = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r)); };
+
+function makeEl() {
+  return {
+    id: '', textContent: '', innerHTML: '', hidden: false, disabled: false, value: '',
+    dataset: {}, style: { setProperty() {}, removeProperty() {} }, children: [],
+    handlers: {},
+    classList: { add() {}, remove() {}, toggle() {} },
+    addEventListener(type, fn) { (this.handlers[type] = this.handlers[type] || []).push(fn); },
+    removeEventListener() {},
+    appendChild(child) { this.children.push(child); return child; },
+    removeChild() {}, remove() {},
+    setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    attachShadow() { const shadow = makeEl(); this.shadowRoot = shadow; return shadow; },
+    scrollIntoView() {}, focus() {}, contains() { return false; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+  };
+}
+
+function permissive() {
+  return new Proxy(function () {}, {
+    get(_t, key) {
+      if (key === 'then' || key === Symbol.toPrimitive) return undefined;
+      if (key === 'addListener' || key === 'removeListener') return function () {};
+      return permissive();
+    },
+    apply() { return Promise.resolve({}); },
+  });
+}
+
+function loadSidePanel() {
+  const els = new Map();
+  const created = [];
+  const sentLookups = []; // {message, callback} —— callback 由测试决定何时/是否触发
+  const timers = []; // {fn, ms}
+  const chromeMock = new Proxy({}, {
+    get(_t, key) {
+      if (key === 'runtime') {
+        return {
+          id: 'test-ext-id',
+          lastError: undefined,
+          getURL() { return 'chrome-extension://test/x'; },
+          onMessage: { addListener() {} },
+          sendMessage(message, callback) {
+            if (message && message.type === 'lookup') {
+              sentLookups.push({ message, callback });
+              return; // SW 被回收：回调永不触发
+            }
+            if (callback) callback(undefined); // 打点等旁路消息直接回
+          },
+        };
+      }
+      if (key === 'storage') {
+        return {
+          local: {
+            get(_keys, cb) { if (cb) cb({}); return Promise.resolve({}); },
+            set() { return Promise.resolve(); },
+          },
+          onChanged: { addListener() {} },
+        };
+      }
+      return permissive();
+    },
+  });
+  const windowObj = {
+    addEventListener() {},
+    innerWidth: 400,
+    innerHeight: 800,
+  };
+  const sandbox = {
+    document: {
+      getElementById(id) {
+        if (!els.has(id)) { const el = makeEl(); el.id = id; els.set(id, el); }
+        return els.get(id);
+      },
+      createElement() { const el = makeEl(); created.push(el); return el; },
+      addEventListener() {},
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      createRange() { return { setStart() {}, setEnd() {}, getBoundingClientRect() { return null; } }; },
+      body: makeEl(),
+    },
+    window: windowObj,
+    chrome: chromeMock,
+    setTimeout(fn, ms) { timers.push({ fn, ms }); return timers.length; },
+    clearTimeout() {},
+    setInterval: () => 1,
+    clearInterval() {},
+    requestAnimationFrame: () => 0,
+    performance: { now: () => 1000, timeOrigin: 1700000000000 },
+    console: { log() {}, warn() {}, error() {} },
+    navigator: { language: 'zh-CN' },
+    URL,
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.self = sandbox.window;
+  vm.runInNewContext(SIDE_PANEL, sandbox, { filename: 'side-panel.js' });
+  const container = created.find((el) => el.id === 'entries-container');
+  assert.ok(container, 'side-panel.js 必须建出 #entries-container 查词容器');
+  return {
+    windowObj,
+    container,
+    sentLookups,
+    timers,
+    lookup(term) {
+      // popup.js 桥的嵌套查词入口 —— 外部可达且直通 lookupTerm。
+      windowObj.flutter_inappwebview.callHandler('onLinkClick', term);
+    },
+    fireRuntimeTimeout() {
+      // sendRuntime 的超时兜底定时器：不推进它 Promise 永不 settle（这正是本 bug）。
+      const t = timers.splice(0).filter((x) => x.ms >= 1000);
+      assert.ok(t.length >= 1, 'sendRuntime 必须挂超时兜底定时器（否则 SW 回收后永久 pending）');
+      for (const timer of t) timer.fn();
+    },
+  };
+}
+
+test('SW 回调永不触发时：超时把「正在查词…」替换成失败文案，同词可重试（在途表去毒）', async () => {
+  const h = loadSidePanel();
+
+  h.lookup('世界');
+  await flush();
+  assert.strictEqual(h.sentLookups.length, 1, '首查必须真的发出 lookup 消息');
+  assert.match(h.container.innerHTML, /正在查词/, '在途期间显示 loading');
+
+  h.fireRuntimeTimeout();
+  await flush();
+  assert.doesNotMatch(h.container.innerHTML, /正在查词/, '超时后 loading 不得永久停留');
+  assert.match(h.container.innerHTML, /查词失败/, '超时按失败处理，给出可重试文案');
+
+  // 同一个词再查：修复前 lookupInFlight 里的死 Promise 会被直接还回 → 永远不再发请求。
+  h.lookup('世界');
+  await flush();
+  assert.strictEqual(h.sentLookups.length, 2, '同词重试必须真正重新发出 lookup（在途表已去毒）');
+  assert.match(h.container.innerHTML, /正在查词/, '重试重新进入 loading');
+});

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -49,6 +49,11 @@
   var scheduledPointer = null;
   var scanFrame = null;
   var activeScanKey = '';
+  // pointer 扫词在途闸（对齐 content.js 的 fushiPending/fushiPendingSince，BUG-1024 同款防洪）：
+  // 有词典请求在途时暂缓 pointermove 触发的新查词——横扫一行 20 个字不再瞬间打出 20 个请求把
+  // 本地服务与 6 连接上限灌满。0=无在途；带截止时间兜底，任何异常都不会永久闸死。
+  var lookupPendingSince = 0;
+  var LOOKUP_PENDING_TIMEOUT_MS = 1500;
   // 复杂词的 popupJson 可超过 2 MB，解析后的对象树通常还会膨胀数倍。只按“48 个词”
   // 淘汰会让 Side Panel 很快常驻数百 MB，并在后续查词时触发秒级 GC。双门槛保留常用
   // 小词，同时让超大结果最多只占少量槽位；最新一条即使单独超预算也保留以支持复查。
@@ -56,14 +61,29 @@
   var LOOKUP_CACHE_CHAR_LIMIT = 8 * 1024 * 1024;
   var FONT_STEPS = [0.85, 1, 1.15, 1.3];
 
+  // BUG-1024 孪生（Side Panel 版）：MV3 service worker 在消息在途时被系统回收，sendMessage
+  // 回调**永不触发**——没有兜底的话这里的 Promise 永久 pending：「正在查词…」永久停留，且
+  // fetchLookup 的同词在途复用（BUG-1525）会把这个死 Promise 缓存起来，同一个词从此永久卡死。
+  // 超时竞速保证 Promise 一定 settle（值取 > app 冷查询 P99；超时按失败处理，UI 显示可重试的
+  // 失败文案而不是无限转圈）。
+  var RUNTIME_MESSAGE_TIMEOUT_MS = 8000;
   function sendRuntime(message) {
     return new Promise(function (resolve) {
+      var settled = false;
+      var timer = null;
+      var finish = function (value) {
+        if (settled) return;
+        settled = true;
+        if (timer !== null) clearTimeout(timer);
+        resolve(value);
+      };
+      timer = setTimeout(function () { finish(null); }, RUNTIME_MESSAGE_TIMEOUT_MS);
       try {
         chrome.runtime.sendMessage(message, function (response) {
-          try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
-          resolve(response || null);
+          try { if (chrome.runtime.lastError) return finish(null); } catch (_) { return finish(null); }
+          finish(response || null);
         });
-      } catch (_) { resolve(null); }
+      } catch (_) { finish(null); }
     });
   }
 
@@ -360,11 +380,23 @@
     }
     lookupContainer.innerHTML = '<div class="no-results">正在查词…</div>';
     if (shouldPosition) positionLookup(anchor);
-    var data = await fetchLookup(value);
+    // try/finally 锁死两条不变式：①「正在查词…」绝不永久停留——fetchLookup 无论 resolve /
+    // reject（内部处理回调抛错）都必须落到成功或失败文案；② pointer 扫词在途闸一定被复位。
+    var data = null;
+    try {
+      lookupPendingSince = Date.now();
+      data = await fetchLookup(value);
+    } catch (_) {
+      data = null;
+    } finally {
+      lookupPendingSince = 0;
+    }
     if (requestId !== lookupRequestId) return;
     if (!data) {
       lookupContainer.innerHTML = '<div class="no-results">查词失败，请确认 Fushi 查词服务已开启。</div>';
       if (shouldPosition) positionLookup(anchor);
+      // 失败后复位扫描去重键：不复位的话鼠标停在同一个字上永远触发不了重试。
+      activeScanKey = '';
       return;
     }
     renderLookupData(value, data, false);
@@ -414,6 +446,12 @@
     }
     var scanKey = pointer.index + '\u0000' + term;
     if (scanKey === activeScanKey && !lookupPaneEl.hidden) return;
+    // 在途闸只拦 pointermove 自动扫词（announceMissing=false）；显式手势永远放行。
+    // 超过截止时间的在途视为已死（SW 被回收等），放行新查词——死锁不可复活。
+    if (!announceMissing && lookupPendingSince &&
+        Date.now() - lookupPendingSince < LOOKUP_PENDING_TIMEOUT_MS) {
+      return;
+    }
     activeScanKey = scanKey;
     lookupTerm(term, pointer.cue, anchorForHit(hit, pointer.x, pointer.y));
   }

--- a/tools/browser-extension/universal-subtitle-providers.test.js
+++ b/tools/browser-extension/universal-subtitle-providers.test.js
@@ -511,7 +511,6 @@ test('textTracks 收割：原生字幕轨整轨读出（清洗标签）并增量
     textTracks: [
       { kind: 'subtitles', mode: 'showing', language: 'en', cues },
       { kind: 'metadata', mode: 'showing', language: 'md', cues },
-      { kind: 'subtitles', mode: 'disabled', language: 'fr', cues },
     ],
   });
   assert.ok(h.harvester, '缺 1200ms textTracks 收割器');
@@ -527,16 +526,70 @@ test('textTracks 收割：原生字幕轨整轨读出（清洗标签）并增量
   assert.strictEqual(store[key][0].text, 'Hello world', '行内标签必须清洗');
   assert.strictEqual(store[key][1].endMs, 4500);
   assert.strictEqual(store['example.com/p|md'], undefined, 'metadata 轨不收');
-  assert.strictEqual(store['example.com/p|fr'], undefined, 'disabled 轨不收（cues 未加载）');
   assert.deepStrictEqual(notified, [key]);
 
-  // 流媒体渐进加载：cue 变多 → 整轨刷新；没变 → 不重复通知。
+  // 流媒体渐进加载：cue 变多 → 归并入轨；没变 → 不重复通知。
   h.harvester.fn();
   assert.deepStrictEqual(notified, [key], '无增量不得重复通知面板');
   cues.push({ startTime: 6, endTime: 7, text: 'Third' });
   h.harvester.fn();
   assert.strictEqual(store[key].length, 3, 'cue 增多必须增量刷新');
   assert.deepStrictEqual(notified, [key, key]);
+});
+
+test('textTracks 收割：disabled 语言轨强制升 hidden，下一轮收齐全部语言轨', () => {
+  // 浏览器对 disabled 轨不加载 cues → 以前直接跳过 = 侧边栏语言轨永远只有播放器当前开着
+  // 的那条。现在收割器把 disabled 升为 hidden（加载 cues 但不渲染），下一轮即可收割。
+  const enCues = [{ startTime: 1, endTime: 2, text: 'Hello' }];
+  const frTrack = { kind: 'subtitles', mode: 'disabled', language: 'fr', cues: null };
+  const h = loadContent({
+    hostname: 'example.com',
+    pathname: '/p',
+    textTracks: [
+      { kind: 'subtitles', mode: 'showing', language: 'en', cues: enCues },
+      frTrack,
+    ],
+  });
+  const store = h.windowObj.fushiEpisodeCues;
+  h.harvester.fn();
+  assert.strictEqual(frTrack.mode, 'hidden', 'disabled 字幕轨必须被升为 hidden 以触发 cue 加载');
+  assert.strictEqual(store['example.com/p|fr'], undefined, '升 hidden 当轮 cues 未就绪，先不入 store');
+  // 模拟浏览器在下一轮轮询前加载完 hidden 轨的 cues。
+  frTrack.cues = [{ startTime: 1, endTime: 2, text: 'Bonjour' }];
+  h.harvester.fn();
+  assert.ok(store['example.com/p|fr'], 'hidden 轨 cues 就绪后必须进 store');
+  assert.strictEqual(store['example.com/p|fr'][0].text, 'Bonjour');
+  assert.strictEqual(store['example.com/p|en'].length, 1, 'en 轨不受影响');
+});
+
+test('textTracks 收割：分片字幕整批替换按归并合并，旧区间不丢、新区间进得来', () => {
+  // hls.js/Shaka 会随 back-buffer 回收/seek 把 tt.cues 整批换成另一时间窗（条数可能不变或
+  // 变少）。旧实现「条数没长就跳过、长了整轨覆盖」两个方向都丢字幕；归并后轨只增不减。
+  const track = {
+    kind: 'subtitles', mode: 'showing', language: 'en',
+    cues: [
+      { startTime: 1, endTime: 2, text: 'One' },
+      { startTime: 3, endTime: 4, text: 'Two' },
+    ],
+  };
+  const h = loadContent({ hostname: 'example.com', pathname: '/p', textTracks: [track] });
+  const store = h.windowObj.fushiEpisodeCues;
+  const key = 'example.com/p|en';
+  h.harvester.fn();
+  assert.strictEqual(store[key].length, 2);
+  // seek 后整批换窗：条数没变多（旧实现在这里整段跳过 → 新区间永远进不来）。
+  track.cues = [{ startTime: 100, endTime: 101, text: 'Later' }];
+  h.harvester.fn();
+  assert.strictEqual(store[key].length, 3, '换窗后的新 cue 必须并入');
+  assert.ok(store[key].some((c) => c.text === 'One'), '旧区间 cue 不得被整轨覆盖抹掉');
+  assert.ok(store[key].some((c) => c.text === 'Later'), '新区间 cue 必须进 store');
+  // 回看已收割区间：同 cue 重复收割去重，不得翻倍。
+  track.cues = [
+    { startTime: 1, endTime: 2, text: 'One' },
+    { startTime: 3, endTime: 4, text: 'Two' },
+  ];
+  h.harvester.fn();
+  assert.strictEqual(store[key].length, 3, '重复收割必须去重');
 });
 
 test('videoKey 契约：netflix=watch id、youtube=yt-<v>、其它=host+path', () => {

--- a/tools/browser-extension/universal-subtitle-providers.test.js
+++ b/tools/browser-extension/universal-subtitle-providers.test.js
@@ -560,6 +560,35 @@ test('textTracks 收割：disabled 语言轨强制升 hidden，下一轮收齐�
   assert.ok(store['example.com/p|fr'], 'hidden 轨 cues 就绪后必须进 store');
   assert.strictEqual(store['example.com/p|fr'][0].text, 'Bonjour');
   assert.strictEqual(store['example.com/p|en'].length, 1, 'en 轨不受影响');
+  // 站点播放器（hls.js 等）把 mode 拨回 disabled = 它在管理轨道：同一轨只升一次，
+  // 不得形成 1.2s 轮询的无限翻转拉锯。
+  frTrack.mode = 'disabled';
+  h.harvester.fn();
+  assert.strictEqual(frTrack.mode, 'disabled', '同一轨只尝试升 hidden 一次，站点拨回后尊重站点');
+});
+
+test('textTracks 收割：同语言多轨（English 与 English [CC]）分 key，不得穿插归并', () => {
+  const h = loadContent({
+    hostname: 'example.com',
+    pathname: '/p',
+    textTracks: [
+      {
+        kind: 'subtitles', mode: 'showing', language: 'en', label: 'English',
+        cues: [{ startTime: 1, endTime: 2, text: 'Hello' }],
+      },
+      {
+        kind: 'captions', mode: 'hidden', language: 'en', label: 'English [CC]',
+        cues: [{ startTime: 1, endTime: 2, text: '[door slams] Hello' }],
+      },
+    ],
+  });
+  const store = h.windowObj.fushiEpisodeCues;
+  h.harvester.fn();
+  const keys = Object.keys(store).filter((k) => k.startsWith('example.com/p|'));
+  assert.strictEqual(keys.length, 2, '同语言两条轨必须落成两个独立 key');
+  for (const k of keys) {
+    assert.strictEqual(store[k].length, 1, '每条轨只含自己的 cue，不得互相穿插');
+  }
 });
 
 test('textTracks 收割：分片字幕整批替换按归并合并，旧区间不丢、新区间进得来', () => {


### PR DESCRIPTION
用户报三条浏览器扩展 bug（shishamo 2026-08-15），全部沿真实代码路径验真、根因修复、测试变异实测：

## BUG-1669 高频查词后「正在查词」永久卡死
BUG-1024（MV3 SW 在消息在途时被回收、sendMessage 回调永不触发）的 Side Panel 孪生，当年只修了 content.js。死锁闭环：`sendRuntime` 无超时 → Promise 永久 pending →「正在查词…」永久停留；BUG-1525 的同词在途复用把死 Promise 缓存住 → 同词永久锁死；`activeScanKey` 去重挡住原地重试。修复：
- `sendRuntime` 8s 超时竞速（Promise 必 settle → 在途表去毒）
- `lookupTerm` try/finally：loading 必落到成功/可重试失败文案；失败复位 `activeScanKey`
- pointer 扫词在途闸（1500ms 截止，对齐 content.js 防洪；显式手势放行）
- background 查词 fetch 加 `AbortSignal.timeout(10000)`，`sendResponse` 必被调用

app 侧同步 FFI 串行的根治在 PR#624，不在本条重复。

## BUG-1670 查词不暂停 / 关窗不恢复视频
半成品功能：只有 pause 没有任何 resume 代码，且默认关（app 侧 TODO-1108 早已默认开）。修复对齐 app `shouldResumeAfterLookupDismiss` 三不变式：
- 默认开启；新键/旧键显式选择优先
- `fushiPausedForLookup` 记「被我们暂停的那个 video」＝恢复唯一真相源
- 关窗汇聚点 `fushiRemoveContainer` 恢复；用户自己暂停的绝不被播起来；嵌套查词天然不提前恢复
- `fushiFindPlayingVideo()`：只找正在播放的（顶层快路径 + shadow DOM/同源 iframe 深搜）

已知边界：跨域 iframe 播放器（需 all_frames + background 广播）与 Side Panel 发起路径的自动恢复另行排期（档案有记录）。

## BUG-1671 侧边栏获取字幕不全
两个独立根因都在 textTracks 收割器：①「条数单调增长」当增量门——hls.js/Shaka 分片字幕换窗时新区间进不来/旧区间被整轨覆盖抹掉；② disabled 语言轨直接跳过（浏览器不给 disabled 轨加载 cue）→ 语言轨永远只有一条。修复：逐条 `fushiSortedCueInsert` 归并（轨只增不减）+ disabled 轨升 hidden（asbplayer 同款）。

## 验证
- 扩展 node 测试 215/215 绿（新增 `side-panel-lookup-deadlock.test.js` vm 行为测试 + shift-hover 4 例 + universal-subtitle 2 例）
- 三组新守卫全部**变异实测**（去掉超时/恢复块/归并各自红）
- `fushi/` 定向：test/lookup 619 绿、test/mining+build+theme 守卫 1318 绿；全量 analyze 干净（仅 1 条上游既有 info）
- 镜像 `fushi/assets/browser_extension/` 已 sync-mirrors 同步；`bug.dart check` 撞号通过
- 未真机复测浏览器（本会话无浏览器环境），扩展需用户重跑「安装扩展」助手 + reload 生效

https://claude.ai/code/session_012aJnBgVpmxVbWWbX4Ju3Ci