### PR TITLE
fix(ci): 修 dart analyze 恒红——制卡守卫锚点首段改单引号

### DIFF
--- a/fushi/test/pages/video_mining_context_guard_test.dart
+++ b/fushi/test/pages/video_mining_context_guard_test.dart
@@ -219,7 +219,7 @@ void main() {
     // 退回常量即红。
     expect(
         engineNorm,
-        contains("aborted: true, abortReason: "
+        contains('aborted: true, abortReason: '
             "_withRootCause('required audio missing'"),
         reason: '缺音频中止走 aborted 信号回 shell，且必须带出根因（不得退回常量）。');
     // shell：res.aborted → 用户可见 OSD（复用现有 i18n card_export_failed_detail）。


### PR DESCRIPTION
## 问题

`develop` 上 **Build Android APK / Run dart analyze 恒红**，把所有开着的 PR 的 build check 一起带红（实测 #857 / #858 的 build FAILURE 与它们自身改动无关，报错行完全相同）：

```
info • Unnecessary use of double quotes. Try using single quotes unless the string
       contains single quotes • test/pages/video_mining_context_guard_test.dart:222:18
       • prefer_single_quotes
1 issue found.
##[error]Process completed with exit code 1.
```

根因：CI 用的是 `dart analyze`（默认 `--fatal-infos`，任何 issue 都 exit 1），而本地 `flutter analyze` 对 info 退出码仍是 0——所以 e20d2eee04（BUG-1664 守卫）在本地看着是绿的，进 CI 就恒红。

## 改法

`contains(...)` 的**第一段**字符串不含单引号，触发 `prefer_single_quotes`；第二段含 `'required audio missing'`，用双引号是合法的。只把第一段改成单引号：

```dart
contains('aborted: true, abortReason: '
    "_withRootCause('required audio missing'"),
```

**断言字面量内容一字未改**，守卫判据不变。

## 验证

- `flutter analyze`（全量含 test）：0 issue
- 目录枚举型守卫整批 + 相关定向测试：`FLUTTER TEST VERDICT: PASSED - 282 tests ran`

https://claude.ai/code/session_019uH8Lg6niHdRQGHpCRVA2b