### PR TITLE
fix(test): 修 PR#856 合入后 develop 全量单测 4 条红（守卫锚点 + 测试替身缺口）

### DIFF
--- a/fushi/test/startup/data_root_unavailable_escape_guard_test.dart
+++ b/fushi/test/startup/data_root_unavailable_escape_guard_test.dart
@@ -29,13 +29,20 @@ void main() {
   test('main.dart：dataRootUnavailable 逃生屏在裸 loading 分支之前，且接双按钮 (BUG-815)', () {
     final String src = read('lib/main.dart');
 
-    final int escapeIdx = src.indexOf('appModel.dataRootUnavailable');
+    // BUG-1666 起 main.dart 在 build 之外也有 `if (!appModel.isInitialised)`
+    // （深链在未初始化时暂存词的分支），裸 indexOf 会锚到那一处，让整个守卫窗口错位。
+    // 判据本就只关心根 widget build 内的分支顺序，所以一律从 build 起点往后找。
+    final int buildIdx = src.indexOf('Widget build(BuildContext context)');
+    expect(buildIdx, greaterThan(0), reason: 'main.dart 必须有根 widget 的 build');
+
+    final int escapeIdx = src.indexOf('appModel.dataRootUnavailable', buildIdx);
     expect(escapeIdx, greaterThanOrEqualTo(0),
         reason: 'main.dart 必须检查 appModel.dataRootUnavailable 显逃生屏');
 
     // 裸 loading 分支（!appModel.isInitialised）。逃生屏必须在它之前，否则慢启动会先落到
     // loading/空态而看不到逃生屏。
-    final int loadingIdx = src.indexOf('if (!appModel.isInitialised)');
+    final int loadingIdx =
+        src.indexOf('if (!appModel.isInitialised)', buildIdx);
     expect(loadingIdx, greaterThan(escapeIdx),
         reason: 'dataRootUnavailable 逃生屏必须在裸 loading 分支之前渲染');
 

--- a/fushi/test/storage/data_root_migration_view_test.dart
+++ b/fushi/test/storage/data_root_migration_view_test.dart
@@ -122,8 +122,15 @@ void main() {
 
     test('main.dart：迁移遮罩分支在裸 loading 分支之前', () {
       final String src = readSource('lib/main.dart').readAsStringSync();
-      final int migrateIdx = src.indexOf('appModel.dataRootMigrationActive');
-      final int loadingIdx = src.indexOf('if (!appModel.isInitialised)');
+      // BUG-1666 起 main.dart 在 build 之外也有 `if (!appModel.isInitialised)`
+      // （深链未初始化时暂存词的分支），裸 indexOf 会锚错窗口；判据只关心根 widget
+      // build 内的分支顺序，所以从 build 起点往后找。
+      final int buildIdx = src.indexOf('Widget build(BuildContext context)');
+      expect(buildIdx, greaterThan(0), reason: 'main.dart 必须有根 widget 的 build');
+      final int migrateIdx =
+          src.indexOf('appModel.dataRootMigrationActive', buildIdx);
+      final int loadingIdx =
+          src.indexOf('if (!appModel.isInitialised)', buildIdx);
       expect(migrateIdx, greaterThan(0), reason: '根 widget 必须有迁移遮罩分支');
       expect(loadingIdx, greaterThan(0));
       expect(migrateIdx, lessThan(loadingIdx),

--- a/fushi/test/sync/backup_import_overlay_test.dart
+++ b/fushi/test/sync/backup_import_overlay_test.dart
@@ -251,8 +251,15 @@ void main() {
 
     test('main.dart：备份导入遮罩分支在裸 loading 分支之前，且渲染专用视图', () {
       final String src = readSource('lib/main.dart').readAsStringSync();
-      final int backupIdx = src.indexOf('appModel.backupImportActive');
-      final int loadingIdx = src.indexOf('if (!appModel.isInitialised)');
+      // BUG-1666 起 main.dart 在 build 之外也有 `if (!appModel.isInitialised)`
+      // （深链未初始化时暂存词的分支），裸 indexOf 会锚错窗口；判据只关心根 widget
+      // build 内的分支顺序，所以从 build 起点往后找。
+      final int buildIdx = src.indexOf('Widget build(BuildContext context)');
+      expect(buildIdx, greaterThan(0), reason: 'main.dart 必须有根 widget 的 build');
+      final int backupIdx =
+          src.indexOf('appModel.backupImportActive', buildIdx);
+      final int loadingIdx =
+          src.indexOf('if (!appModel.isInitialised)', buildIdx);
       expect(backupIdx, greaterThan(0), reason: '根 widget 必须有备份导入遮罩分支');
       expect(loadingIdx, greaterThan(0));
       expect(backupIdx, lessThan(loadingIdx),

--- a/fushi/test/utils/misc/popup_asset_behavior_test.js
+++ b/fushi/test/utils/misc/popup_asset_behavior_test.js
@@ -147,6 +147,18 @@ class FakeElement {
     return Object.prototype.hasOwnProperty.call(this.attributes, name);
   }
 
+  // BUG-1666: rewriteExportedGlossaryAnchors 走导出制卡路径，读/删锚点的 href。
+  // 真 DOM 上 getAttribute 缺属性时返回 null（不是 undefined），照此实现。
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+  }
+
   addEventListener(type, handler) {
     if (!this.listeners[type]) {
       this.listeners[type] = [];
@@ -205,6 +217,35 @@ class FakeElement {
       return null;
     };
     return visit(this);
+  }
+
+  // BUG-1666: 与 querySelector 同一套最小选择器语法，另加「属性存在」判据，
+  // 因为 rewriteExportedGlossaryAnchors 用的是 'a[href]'。真 DOM 返回 NodeList，
+  // 生产代码只对它 .forEach，所以这里返回数组即可。
+  querySelectorAll(selector) {
+    const parsed = selector.match(/^([a-zA-Z]+)?(?:\.([\w-]+))?(?:\[([\w-]+)\])?$/);
+    if (!parsed || (!parsed[1] && !parsed[2] && !parsed[3])) {
+      return [];
+    }
+    const wantTag = parsed[1] ? parsed[1].toUpperCase() : null;
+    const wantClass = parsed[2] || null;
+    const wantAttr = parsed[3] || null;
+    const matches = (el) =>
+      (wantTag === null || el.tagName === wantTag) &&
+      (wantClass === null || (!!el.classList && el.classList.contains(wantClass))) &&
+      (wantAttr === null ||
+        (typeof el.hasAttribute === 'function' && el.hasAttribute(wantAttr)));
+    const found = [];
+    const visit = (el) => {
+      for (const child of el.children ?? []) {
+        if (matches(child)) {
+          found.push(child);
+        }
+        visit(child);
+      }
+    };
+    visit(this);
+    return found;
   }
 
   closest(selector) {


### PR DESCRIPTION
PR#856 合入后，`develop` 上 **Build Release APK / Run unit tests 恒红 4 条**（#857、#858 合并后的 run 上是同样这 4 条，说明它们自身没引入新红）。两个独立根因，**都不是生产代码错**。

## ① 三条 main.dart 源码守卫的锚点被同形 token 抢走

BUG-1666 在 `_handleExternalVideoChannel` 里新增了一处 `if (!appModel.isInitialised)`（深链在未初始化时暂存待查词）。它在 build **之前**，于是三条守卫的裸 `src.indexOf('if (!appModel.isInitialised)')` 全部锚到这一处（偏移 41108），而真正的裸 loading 分支在 build 里（1538 行）：

| 守卫 | 断言 | 实际 |
|---|---|---|
| 逃生屏 (BUG-815) | loadingIdx > escapeIdx(53996) | 41108 ❌ |
| 导入遮罩 (TODO-1151) | backupIdx(47676) < loadingIdx | 41108 ❌ |
| 迁移遮罩 (TODO-959) | migrateIdx(47632) < loadingIdx | 41108 ❌ |

**build 里的分支顺序一点没变**（逃生屏 1332 行 < 裸 loading 1538 行），是判据取错了窗口。三条守卫本就只关心根 widget build 内的相对顺序，所以一律改成先定位唯一的 `Widget build(BuildContext context)`、再从该偏移往后找——**比原判据更精确**，且不受 build 之外新增同形代码影响。

## ② popup 测试替身 FakeElement 缺三个方法

BUG-1666 新增的 `rewriteExportedGlossaryAnchors` 走导出制卡路径，用了 `querySelectorAll('a[href]')` / `getAttribute` / `removeAttribute`，而 `popup_asset_behavior_test.js` 的 `FakeElement` 三个都没有：

```
TypeError: root.querySelectorAll is not a function
    at rewriteExportedGlossaryAnchors (fushi/assets/popup/popup.js:790)
    at constructGlossaryHtml → buildMinePayload → mineEntry
```

真 WebView 里 `document.createElement('div')` 返回真 Element，**生产路径没问题**；缺的是测试替身。按真 DOM 语义补齐：`getAttribute` 缺属性返回 `null`（不是 undefined）；`querySelectorAll` 复用 `querySelector` 的最小选择器语法并加「属性存在」判据，返回数组以支持生产代码的 `.forEach`。

> 没有给生产代码加 `if (typeof root.querySelectorAll !== 'function') return` 之类的防御——那会在真的传错 root 时静默跳过锚点重写，把 BUG-1666 悄悄退回去而无人发现。

## 验证

- 4 条红全部转绿：`FLUTTER TEST VERDICT: PASSED - 30 tests ran`
- 5 个使用 `FakeElement` 的测试全绿（28 tests），确认补齐没破坏既有用法
- **变异实测**：把锚点还原成裸 `indexOf` → 真红（2 tests 真执行，行为红非编译红）；还原后源文件 sha256 与基线**逐字节一致**
- `FakeElement` 新方法做了隔离语义验证（12 条断言：嵌套可达、属性选择器只命中带该属性者、缺属性返回 null、removeAttribute 后不再命中、class 选择器未被破坏）
- 全量套件本地跑在进行中，CI 的 Run unit tests 为准

https://claude.ai/code/session_019uH8Lg6niHdRQGHpCRVA2b