### PR TITLE
fix(anki): 可视化编辑「布局」区首个下拉框标签不再被裁 (BUG-1677)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1549 条。点号进各自文件。
+> 共 1550 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1677](bugs/BUG-1677-expansiontile-outline-label-clipped.md) | ✅ | ✅ | 折叠区首个下拉框的浮动标签被展开动画的 ClipRect 削掉上半截 |
 | [BUG-1671](bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md) | ✅ | ✅ | 浏览器扩展侧边栏获取字幕不全 |
 | [BUG-1670](bugs/BUG-1670-ext-pause-on-lookup-no-resume.md) | ✅ | ✅ | 浏览器扩展查词不暂停视频且关闭弹窗不恢复播放 |
 | [BUG-1669](bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md) | ✅ | ✅ | 浏览器扩展侧边栏高频查词后「正在查词」永久卡死 |

--- a/docs/bugs/BUG-1677-expansiontile-outline-label-clipped.md
+++ b/docs/bugs/BUG-1677-expansiontile-outline-label-clipped.md
@@ -1,0 +1,16 @@
+## BUG-1677 · 折叠区首个下拉框的浮动标签被展开动画的 ClipRect 削掉上半截
+- **报告**：2026-08-16（用户：截图 Anki「可视化编辑」右侧面板，「布局」展开区第一项「例句位置」的标签只剩下半截）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/anki/lapis_style_editor_page.dart:1155`（`_buildLayoutSection` 的 `childrenPadding` 只给了 `bottom`，top = 0）。
+
+  机制是两个 Material 行为叠加：
+  1. outline 边框的输入框在 label 浮起时，把 label **竖直居中压在顶边框线上**——`_RenderDecoration` 的 `floatingY = -labelHeight × 0.75 ÷ 2 + 边框宽 ÷ 2`，即约半个字高画在自身 RenderBox **外面**（widget 测试实测 5.5px = 16 × 0.75 ÷ 2 − 1 ÷ 2）。
+  2. `ExpansionTile` 用 `ClipRect + Align(heightFactor)` 做展开动画，裁剪线正压在**第一个子控件的顶边**。
+
+  「布局」区的第一个子控件恰好是 `_buildLayoutPicker` 生成的 `DropdownMenu`（`expandedInsets: EdgeInsets.zero`，且有 `initialSelection` 所以 label 一开始就是浮起状态），于是溢出的那半截落在裁剪线外被削掉。同区第二、三个下拉框（图片位置 / 音频按钮）前面有 `SizedBox(height: gap)`，溢出落在兄弟控件的空白上，所以只有第一个出问题。
+
+  **排查范围**：全 app 输入框默认 outline（`theme_notifier.dart:1039` 的 `inputDecorationTheme`），所以这是个通用形状。仓库里另有 8 个文件用 `ExpansionTile`，逐处核过首个子控件：本页其余 4 处分别是 chips / slider / `FushiListItem` / 只有 `hintText`（无浮动 label）的 `TextField`，都不产生浮动标签溢出；唯一另一个「首项是带 `labelText` 的输入框」是 `anime_download_dialog.dart:1276` 的「通用下载」区，写了 widget 测试**实测**——`dense: true` + `isDense: true` 让它即使 top=0 也还有 4px 余量、不裁，**不是**同一 bug，故未改动、也未留下一条恒绿的守卫。
+
+- **[x] ① 已修复** — `_buildLayoutSection` 的 `childrenPadding` 补 `top: tokens.spacing.gap`（8px > 实测溢出 5.5px），与本页其它下拉框之间「留一个 gap」的既有节奏一致；顺带把标签与折叠区标题挤在一起的观感也修了。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/lapis_visual_editor_label_clip_test.dart`：装载真实页面 → 展开「布局」→ 量标签相对**最近裁剪祖先**的顶部溢出，要求 ≤ 0。变异实测：把 `top` 改回 0 时报 `5.5px 露在裁剪线之外` 判红，还原后文件 sha256 与变异前完全一致。
+  - 顺带把 `lapis_style_editor_harness.dart` 拆出 `pumpEditor`（只装载不保存），几何类用例不再被「保存按钮此刻可不可点」绑架；`openEditorAndSave` 改为复用它，行为不变。
+- **备注**：这类几何 bug 不能用 `findsOneWidget` 守——被裁的控件照样 find 得到，必须量矩形。

--- a/fushi/lib/src/anki/lapis_style_editor_page.dart
+++ b/fushi/lib/src/anki/lapis_style_editor_page.dart
@@ -1154,7 +1154,14 @@ class _LapisStyleEditorPageState extends State<LapisStyleEditorPage> {
   /// （见 [LapisVisualLayout]）——空值 = 不覆写 = 保持出厂布局。
   Widget _buildLayoutSection(FushiDesignTokens tokens) => ExpansionTile(
         tilePadding: EdgeInsets.zero,
-        childrenPadding: EdgeInsets.only(bottom: tokens.spacing.gap),
+        // top 不能是 0：outline 输入框的浮动 label 竖直居中压在顶边框线上，约半个
+        // 字高（实测 5.5px）画在自身 RenderBox **外面**，而 ExpansionTile 用
+        // ClipRect + Align(heightFactor) 做展开动画，裁剪线正压在第一个子控件顶
+        // 边——首个 `_buildLayoutPicker` 的「例句位置」会被削掉上半截（BUG-1677）。
+        childrenPadding: EdgeInsets.only(
+          top: tokens.spacing.gap,
+          bottom: tokens.spacing.gap,
+        ),
         leading: const Icon(Icons.dashboard_customize_outlined),
         title: Text(t.anki_lapis_visual_layout),
         subtitle: Text(t.anki_lapis_visual_layout_hint),

--- a/fushi/test/anki/lapis_style_editor_harness.dart
+++ b/fushi/test/anki/lapis_style_editor_harness.dart
@@ -28,16 +28,24 @@ Future<void> toggleBold(WidgetTester tester) async {
   await tester.pumpAndSettle();
 }
 
-Future<LapisVisualEditorResult?> openEditorAndSave(
+/// [pumpEditor] 的句柄：[popped] 在页面被 pop 后完成。
+class EditorSession {
+  const EditorSession(this.popped);
+
+  final Future<void> popped;
+}
+
+/// 只装载页面、不保存：给几何/布局类用例用（它们不需要弹回结果，也不该被
+/// 「保存按钮此刻是否可点」绑架）。
+Future<EditorSession> pumpEditor(
   WidgetTester tester, {
   required String initialCustomCss,
   List<String> noteTypeFields = const <String>[],
   Map<String, String> initialFieldMappings = const <String, String>{},
   List<LapisCustomBlock> initialBlocks = const <LapisCustomBlock>[],
   LapisHandlebarPicker? pickHandlebar,
-  Future<void> Function(WidgetTester tester)? interact,
+  void Function(LapisVisualEditorResult? result)? onResult,
 }) async {
-  LapisVisualEditorResult? result;
   late BuildContext hostContext;
   await tester.pumpWidget(
     MaterialApp(
@@ -65,14 +73,36 @@ Future<LapisVisualEditorResult?> openEditorAndSave(
     ),
   )
       .then((LapisVisualEditorResult? value) {
-    result = value;
+    onResult?.call(value);
   });
   await tester.pumpAndSettle();
+  return EditorSession(pushed);
+}
+
+Future<LapisVisualEditorResult?> openEditorAndSave(
+  WidgetTester tester, {
+  required String initialCustomCss,
+  List<String> noteTypeFields = const <String>[],
+  Map<String, String> initialFieldMappings = const <String, String>{},
+  List<LapisCustomBlock> initialBlocks = const <LapisCustomBlock>[],
+  LapisHandlebarPicker? pickHandlebar,
+  Future<void> Function(WidgetTester tester)? interact,
+}) async {
+  LapisVisualEditorResult? result;
+  final EditorSession session = await pumpEditor(
+    tester,
+    initialCustomCss: initialCustomCss,
+    noteTypeFields: noteTypeFields,
+    initialFieldMappings: initialFieldMappings,
+    initialBlocks: initialBlocks,
+    pickHandlebar: pickHandlebar,
+    onResult: (LapisVisualEditorResult? value) => result = value,
+  );
 
   await (interact ?? toggleBold)(tester);
 
   await tester.tap(find.byIcon(Icons.save_outlined));
   await tester.pumpAndSettle();
-  await pushed;
+  await session.popped;
   return result;
 }

--- a/fushi/test/anki/lapis_visual_editor_label_clip_test.dart
+++ b/fushi/test/anki/lapis_visual_editor_label_clip_test.dart
@@ -1,0 +1,43 @@
+// 「布局」折叠区里第一个下拉框的浮动标签不能被 [ExpansionTile] 的 ClipRect 裁掉。
+//
+// Material 的 outline 输入框把浮动 label 画在自身 RenderBox **上方**（label 竖直
+// 居中压在顶边框线上，约半个字高露在框外）；[ExpansionTile] 又用 ClipRect +
+// Align(heightFactor) 做展开动画，裁剪线正压在第一个子控件的顶边。两者叠在一起，
+// 折叠区里第一个下拉框的标签就被削掉上半截（BUG-1677）。
+//
+// 这类几何断言不能只 `findsOneWidget`——被裁的标签照样 find 得到。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/utils.dart';
+
+import 'lapis_style_editor_harness.dart';
+
+/// [inner] 顶部越过它**最近的裁剪祖先**上边界的高度；>0 = 被裁掉这么多。
+double _topOverflowIntoClip(WidgetTester tester, Finder inner) {
+  final Finder clip =
+      find.ancestor(of: inner, matching: find.byType(ClipRect)).first;
+  return tester.getRect(clip).top - tester.getRect(inner).top;
+}
+
+void main() {
+  testWidgets('布局折叠区第一个下拉框的标签完整可见，没被展开动画的 ClipRect 裁掉',
+      (WidgetTester tester) async {
+    useWideWindow(tester);
+    await pumpEditor(tester, initialCustomCss: '');
+
+    await tester.tap(find.text(t.anki_lapis_visual_layout));
+    await tester.pumpAndSettle();
+
+    // 下拉框有 initialSelection（「默认」），label 一开始就是浮起状态。
+    final Finder label = find.text(t.anki_lapis_visual_layout_sentence);
+    expect(label, findsOneWidget);
+
+    // 修复前实测溢出 5.5px（= 标签高 16 × 浮动缩放 0.75 ÷ 2 − 边框 1 ÷ 2）。
+    final double overflow = _topOverflowIntoClip(tester, label);
+    expect(
+      overflow,
+      lessThanOrEqualTo(0.0),
+      reason: '「例句位置」标签有 ${overflow}px 露在裁剪线之外，会被削掉上半截',
+    );
+  });
+}


### PR DESCRIPTION
用户截图：Anki「可视化编辑」右侧面板，「布局」展开区第一项「例句位置」的标签只剩下半截。

## 根因

两个 Material 行为叠加：

1. outline 边框的输入框在 label 浮起时，把 label **竖直居中压在顶边框线上**——`floatingY = -labelHeight × 0.75 ÷ 2 + 边框宽 ÷ 2`，约半个字高画在自身 RenderBox **外面**（widget 测试实测 5.5px）。
2. `ExpansionTile` 用 `ClipRect + Align(heightFactor)` 做展开动画，裁剪线正压在**第一个子控件的顶边**。

`_buildLayoutSection` 的 `childrenPadding` 只给了 `bottom`，而它的第一个子控件恰好是带 `initialSelection`（label 一开始就浮起）的 `DropdownMenu`，溢出那半截落在裁剪线外被削掉。同区第二、三个下拉框前面有 `SizedBox(height: gap)`，所以只有第一个出问题。

## 修复

`childrenPadding` 补 `top: tokens.spacing.gap`（8px > 实测溢出 5.5px），与本页其它下拉框之间「留一个 gap」的既有节奏一致。

## 排查范围

全 app 输入框默认 outline，所以这是通用形状。逐处核过仓库另外 8 个用 `ExpansionTile` 的文件的首个子控件：唯一另一个「首项是带 labelText 的输入框」是 `anime_download_dialog.dart` 的「通用下载」区，写了 widget 测试**实测** `dense`+`isDense` 让它即使 top=0 也还有 4px 余量、不裁，**不是**同一 bug，未改动、也未留恒绿守卫。

## 测试

- 新增 `fushi/test/anki/lapis_visual_editor_label_clip_test.dart`：量标签相对**最近裁剪祖先**的顶部溢出要求 ≤ 0（被裁的控件照样 `find` 得到，`findsOneWidget` 守不住）。
- 变异实测：`top` 改回 0 判红「5.5px 露在裁剪线之外」，还原后文件 sha256 与变异前完全一致。
- `lapis_style_editor_harness` 拆出 `pumpEditor`（只装载不保存），几何类用例不再被「保存按钮此刻可不可点」绑架；`openEditorAndSave` 复用它，行为不变。

## 验证

- `flutter analyze`（含 test）：No issues found
- `flutter test test/anki test/settings/md3_design_system_static_test.dart`：314 绿，退出码 0
- 目录枚举型守卫整批：`FLUTTER TEST VERDICT: PASSED - 250 tests ran`（与文档基线 250 一致）

https://claude.ai/code/session_01YHYuBnjCPJaBuAr7pH2dzp