### PR TITLE
fix(anki): 手机上打通 Lapis 样式区与媒体存储优化 (BUG-1680/1681/1682)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1549 条。点号进各自文件。
+> 共 1552 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1682](bugs/BUG-1682-remote-mining-media-dedup-delegates-local.md) | ✅ | ✅ | 制卡到已配对设备时媒体去重委派本地仓库，手机上整区隐藏 |
+| [BUG-1681](bugs/BUG-1681-ankiconnect-remote-media-dedup-phantom-section.md) | ✅ | ✅ | 手机连局域网 AnkiConnect 时显示一个必然不可用的媒体存储优化区 |
+| [BUG-1680](bugs/BUG-1680-ankidroid-note-type-editing.md) | ✅ | ✅ | AnkiDroid 能改已存在 note type，Lapis 样式区却在手机上整区隐藏 |
 | [BUG-1671](bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md) | ✅ | ✅ | 浏览器扩展侧边栏获取字幕不全 |
 | [BUG-1670](bugs/BUG-1670-ext-pause-on-lookup-no-resume.md) | ✅ | ✅ | 浏览器扩展查词不暂停视频且关闭弹窗不恢复播放 |
 | [BUG-1669](bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md) | ✅ | ✅ | 浏览器扩展侧边栏高频查词后「正在查词」永久卡死 |

--- a/docs/bugs/BUG-1680-ankidroid-note-type-editing.md
+++ b/docs/bugs/BUG-1680-ankidroid-note-type-editing.md
@@ -1,0 +1,10 @@
+## BUG-1680 · AnkiDroid 能改已存在 note type，Lapis 样式区却在手机上整区隐藏
+- **报告**：2026-08-16（用户：手机看不到 lapis 卡片样式）
+- **真实性**：✅ 真 bug（建立在错误的平台前提上）。根因 `packages/fushi_anki/lib/src/base_anki_repository.dart:222` 的默认 `supportsNoteTypeEditing => false` + `AnkiRepository`（AnkiDroid）从不覆写它，设置页 `fushi/lib/src/pages/implementations/anki_settings_page.dart:142` 据此把整个 Lapis 样式区隐藏。
+
+  代码注释把这写成「平台边界，非本仓可修」，但那是错的：AnkiDroid 上游 `CardContentProvider.update()` 的 `models/<mid>` 分支支持写 `FlashCardsContract.Model.CSS`，`models/<mid>/templates/<ord>` 分支支持写 `CardTemplate.QUESTION_FORMAT` / `ANSWER_FORMAT`；被明确拒绝的只有改字段名（`"Field names cannot be changed via provider"`），而 Lapis 样式客制化一个字段名都不改。`fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java` 只实现了 `createNoteType`，从没实现读/改——「我们没实现」被记成了「平台做不到」。
+
+  真正的平台边界是 iOS 的 `AnkiMobileRepository`（只有加卡的 URL scheme），它仍然降级。
+- **[x] ① 已修复** — `AnkiChannelHandler.java` 新增 `readNoteType` / `updateNoteTypeStyling` / `updateNoteTypeTemplates` 三个 method（走 ContentProvider；模板按**名字**而不是 ord 匹配——ord 是位置，用户重排模板之后按位置写回会把正面写进另一张卡）；`packages/fushi_anki/lib/src/ankidroid/anki_repository.dart` 覆写 `supportsNoteTypeEditing => true` 与三个读写方法。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/ankidroid_note_type_editing_test.dart`：MethodChannel 行为测试（读解析 / 写 payload / 空列表不打桥 / 桥返回 false 不谎报成功）+ Java 桥源码扫描守卫（三个 case 分支、写入用的是 provider 真正认的列、不把字段名塞进 ContentValues）。守卫已变异实测：把 `case "readNoteType":` 改名后测试转红，还原后文件 sha256 与变异前一致。
+- **备注**：与 BUG-1681 / BUG-1682 同批（同一条「手机上两块 Anki 维护功能看不到」的用户报告）。真机验证仍缺：需要在装了 AnkiDroid 的 Android 机上跑一次「改字号 → 应用样式到 Anki → 卡片真的变了」。

--- a/docs/bugs/BUG-1681-ankiconnect-remote-media-dedup-phantom-section.md
+++ b/docs/bugs/BUG-1681-ankiconnect-remote-media-dedup-phantom-section.md
@@ -1,0 +1,8 @@
+## BUG-1681 · 手机连局域网 AnkiConnect 时显示一个必然不可用的媒体存储优化区
+- **报告**：2026-08-16（用户：手机看不到 anki 媒体存储优化 —— 顺着这条报告查出来的相邻缺陷）
+- **真实性**：✅ 真 bug。根因 `packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart` 把 `supportsMediaMaintenance` 硬编码 `true`，而实现（同文件 `runMediaDedup`）是 `getMediaDirPath()` 拿到路径后用 `dart:io` **直读本机文件**。
+
+  同一个仓库类既服务「桌面本机 Anki」也服务「手机开了『改用 AnkiConnect』连局域网里的桌面 Anki」。后者拿到的是**那台机器**的路径，本机不存在，`runMediaDedup` 走 `existsSync()` 判否返回 null，设置页只能弹一句 `anki_dedup_unavailable`。也就是：区块显示得出来、点得动、必然不可用。静态的「后端类型支持」被当成了「此刻能不能用」。
+- **[x] ① 已修复** — 加一层真实探测 `BaseAnkiRepository.probeMediaMaintenance()`（默认 = 静态能力，不做 I/O；AnkiConnect 覆写为 `_localMediaDir() != null`，与 `runMediaDedup` 共用同一份判据）。`AnkiViewModel.probeMediaMaintenance()` 把结论落进 `AnkiUiState.mediaMaintenanceAvailable`，设置页门控改成 `uiState.mediaMaintenanceAvailable ?? vm.supportsMediaMaintenance`。**后端不可达时保持「未知」**而不是记成「不支持」——否则桌面用户只要在 Anki 没开的时候进过一次设置页，整区就消失了。探测只在设置页 `initState` 发起（一次网络往返，不塞进 vm 构造，避免制卡路径顺带发请求）。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/media_maintenance_probe_test.dart`：三态（后端类型不支持 → 不发起探测直接 false / 探到 false / 探到 true）+ 不可达保持 null + 设置页门控源码扫描守卫。守卫已变异实测：门控退回裸 `if (vm.supportsMediaMaintenance)` 时测试转红，还原后文件 sha256 与变异前一致。
+- **备注**：与 BUG-1680 / BUG-1682 同批。

--- a/docs/bugs/BUG-1682-remote-mining-media-dedup-delegates-local.md
+++ b/docs/bugs/BUG-1682-remote-mining-media-dedup-delegates-local.md
@@ -1,0 +1,12 @@
+## BUG-1682 · 制卡到已配对设备时媒体去重委派本地仓库，手机上整区隐藏
+- **报告**：2026-08-16（用户：手机看不到 anki 媒体存储优化）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/anki/remote_mining_anki_repository.dart` 的 `supportsMediaMaintenance => _local.supportsMediaMaintenance`（连同 `runMediaDedup` 也委派 `_local`）。
+
+  开了「制卡到已配对设备」时卡片落在**主机**的 Anki 上，重复媒体也堆在主机的 `collection.media` 里，客户端本机连那个目录都没有。委派本地的后果：Android 上本地是 AnkiDroid（`supportsMediaMaintenance` 恒 false），于是明明主机能去重，手机上整区隐藏；而同一屏上方的 note type 编辑（`supportsNoteTypeEditing => true`）**已经**走远端。同一个「制卡到已配对设备」模式下，两个维护动作指向两台不同的机器，自相矛盾。
+
+  把「配置类方法一律委派本地」这条规则套到了不该套的地方——去重不是配置，是对媒体库的实际改写，必须跟随卡片落点。
+- **[x] ① 已修复** — `RemoteMiningAnkiRepository` 的 `supportsMediaMaintenance` 恒 `true`，`probeMediaMaintenance` / `runMediaDedup` 转发远端；新增主机端点 `POST /api/anki/media/dedup/probe` 与 `/run`（`fushi/lib/src/sync/fushi_remote_api_handlers.dart` + `fushi_sync_server.dart`），主机侧经**自己的** `AnkiMediaDedupRunner` 执行，审计 journal 与「上次去重时刻」落在真正发生删除的那台机器上。`AnkiMediaDedupReport` / `MediaDedupDeletion` 补 `fromJson`（派生值 `duplicatesRemoved` / `bytesSaved` 从 `deletions` 重算，不从 wire 上读）。
+
+  诚实降级：进度与取消跨不过这一次 HTTP 往返，因此新增 `supportsMediaMaintenanceProgress`（本地 true / 远端 false），进度弹窗据此**不画**取消按钮——一个点了没反应的取消按钮比没有更糟，用户会以为已经停了。远端 `dryRun` 缺省是 `true`（真删的决定权在客户端用户手里，缺字段的旧客户端绝不能被解读成「删吧」）。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/remote_mining_anki_repository_test.dart` 新增「媒体存储优化经互联作用于主机端」组（恒 true 不被本地遮蔽 / 探测问主机 / 转发带 dryRun / 不支持进度取消 / 主机不支持返回 null 不谎报「没有重复」）；`fushi/test/sync/anki_media_dedup_response_test.dart` 守主机端点契约（缺 dryRun → 干跑、类型错 → FormatException、报告可完整序列化还原）。
+- **备注**：与 BUG-1680 / BUG-1681 同批。真机验证仍缺：需要手机 + 桌面主机各一台跑一次端到端。

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
@@ -88,6 +88,10 @@ public class AnkiChannelHandler {
                 final String deckName = call.argument("deckName");
                 final Number noteIdArg = call.argument("noteId");
                 final Map<String, String> fieldValues = call.argument("fieldValues");
+                // Lapis 样式客制化：模板列表（每项 name/front/back），见
+                // readNoteType / updateNoteTypeTemplates。
+                final ArrayList<Map<String, String>> noteTypeTemplates =
+                    call.argument("templates");
 
                 switch (call.method) {
                     case "addNote":
@@ -271,6 +275,54 @@ public class AnkiChannelHandler {
                                 result.success(null);
                             } catch (Exception e) {
                                 result.error("CREATE_MODEL_FAILED",
+                                    e.getMessage(), null);
+                            }
+                        }
+                        break;
+                    // ── 已存在 note type 的读/改（Lapis 样式客制化）──────────
+                    // 早期版本据「AnkiDroid 改不了已存在 note type」隐藏整个
+                    // Lapis 样式区，那个前提是错的：CardContentProvider.update()
+                    // 的 models/<mid> 分支支持写 Model.CSS，models/<mid>/
+                    // templates/<ord> 分支支持写 QUESTION_FORMAT/ANSWER_FORMAT。
+                    // 真正被 provider 拒绝的只有改字段名（"Field names cannot be
+                    // changed via provider"），而样式客制化一个字段名都不改。
+                    case "readNoteType":
+                        if (noteTypeName == null) {
+                            result.error("MISSING_ARG",
+                                "noteTypeName is required", null);
+                        } else if (requirePermission(result)) {
+                            try {
+                                result.success(readNoteType(noteTypeName));
+                            } catch (Exception e) {
+                                result.error(providerErrorCode(e),
+                                    e.getMessage(), null);
+                            }
+                        }
+                        break;
+                    case "updateNoteTypeStyling":
+                        if (noteTypeName == null || css == null) {
+                            result.error("MISSING_ARG",
+                                "noteTypeName and css are required", null);
+                        } else if (requirePermission(result)) {
+                            try {
+                                result.success(
+                                    updateNoteTypeStyling(noteTypeName, css));
+                            } catch (Exception e) {
+                                result.error(providerErrorCode(e),
+                                    e.getMessage(), null);
+                            }
+                        }
+                        break;
+                    case "updateNoteTypeTemplates":
+                        if (noteTypeName == null || noteTypeTemplates == null) {
+                            result.error("MISSING_ARG",
+                                "noteTypeName and templates are required", null);
+                        } else if (requirePermission(result)) {
+                            try {
+                                result.success(updateNoteTypeTemplates(
+                                    noteTypeName, noteTypeTemplates));
+                            } catch (Exception e) {
+                                result.error(providerErrorCode(e),
                                     e.getMessage(), null);
                             }
                         }
@@ -662,5 +714,138 @@ public class AnkiChannelHandler {
             null,
             null
         );
+    }
+
+    /** `content://com.ichi2.anki.flashcards/models/<mid>`。 */
+    private static Uri noteTypeUri(long mid) {
+        return Uri.withAppendedPath(
+            FlashCardsContract.Model.CONTENT_URI, Long.toString(mid));
+    }
+
+    /** `content://com.ichi2.anki.flashcards/models/<mid>/templates`。 */
+    private static Uri noteTypeTemplatesUri(long mid) {
+        return Uri.withAppendedPath(noteTypeUri(mid), "templates");
+    }
+
+    /**
+     * 读一个已存在 note type 的完整定义（字段顺序 / 卡模板 / CSS），供 Lapis
+     * 备份与漂移判定。note type 不存在返回 {@code null}（Dart 侧照契约转
+     * 「未找到」，不是错误）。
+     *
+     * <p>字段名列表由 provider 用 {@code Utils.joinFields} 以 0x1f 连接成一个
+     * 字符串返回（{@link FlashCardsContract.Model#FIELD_NAMES}），这里拆回列表。
+     */
+    @Nullable
+    private Map<String, Object> readNoteType(String name) {
+        final Long mid = ankiDroid.findModelIdByName(name, 1);
+        if (mid == null) return null;
+        final ContentResolver resolver = context.getContentResolver();
+        final Map<String, Object> out = new LinkedHashMap<>();
+        try (Cursor cursor = resolver.query(
+                noteTypeUri(mid),
+                new String[] {
+                    FlashCardsContract.Model.NAME,
+                    FlashCardsContract.Model.FIELD_NAMES,
+                    FlashCardsContract.Model.CSS,
+                },
+                null, null, null)) {
+            if (cursor == null || !cursor.moveToFirst()) return null;
+            out.put("name", emptyIfNull(cursor.getString(0)));
+            out.put("fields", splitFieldNames(cursor.getString(1)));
+            out.put("css", emptyIfNull(cursor.getString(2)));
+        }
+        out.put("templates", readNoteTypeTemplates(resolver, mid));
+        return out;
+    }
+
+    /**
+     * 读一个 note type 的全部卡模板，按 provider 给出的 ord 升序。
+     * 每项含 {@code ord}（0 基，写回时就是 URI 末段）、{@code name}、
+     * {@code front}、{@code back}。
+     */
+    private List<Map<String, Object>> readNoteTypeTemplates(
+            ContentResolver resolver, long mid) {
+        final List<Map<String, Object>> templates = new ArrayList<>();
+        try (Cursor cursor = resolver.query(
+                noteTypeTemplatesUri(mid),
+                new String[] {
+                    FlashCardsContract.CardTemplate.ORD,
+                    FlashCardsContract.CardTemplate.NAME,
+                    FlashCardsContract.CardTemplate.QUESTION_FORMAT,
+                    FlashCardsContract.CardTemplate.ANSWER_FORMAT,
+                },
+                null, null, null)) {
+            if (cursor == null) return templates;
+            while (cursor.moveToNext()) {
+                final Map<String, Object> tmpl = new LinkedHashMap<>();
+                tmpl.put("ord", cursor.getInt(0));
+                tmpl.put("name", emptyIfNull(cursor.getString(1)));
+                tmpl.put("front", emptyIfNull(cursor.getString(2)));
+                tmpl.put("back", emptyIfNull(cursor.getString(3)));
+                templates.add(tmpl);
+            }
+        }
+        return templates;
+    }
+
+    /**
+     * 覆写已存在 note type 的 styling（CSS）。note type 不存在或 provider 没
+     * 认下这次改动返回 {@code false}；provider 抛错照抛（调用方转错误码）。
+     */
+    private boolean updateNoteTypeStyling(String name, String newCss) {
+        final Long mid = ankiDroid.findModelIdByName(name, 1);
+        if (mid == null) return false;
+        final ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Model.CSS, newCss);
+        return context.getContentResolver()
+            .update(noteTypeUri(mid), values, null, null) > 0;
+    }
+
+    /**
+     * 覆写已存在 note type 的卡模板正/反面，**按模板名匹配**。
+     *
+     * <p>provider 的写入 URI 用的是 ord（0 基下标），但备份文件里只有模板名
+     * ——ord 是位置，模板被用户重排之后按位置写回就会把正面写进另一张卡。
+     * 所以这里先读一遍现有模板建立「名 → ord」，只写名字对得上的那些；备份里
+     * 有、当前 note type 里没有的模板名直接跳过（provider 不支持增删模板）。
+     *
+     * @return 是否至少有一张模板被真正改写。
+     */
+    private boolean updateNoteTypeTemplates(
+            String name, List<Map<String, String>> templates) {
+        final Long mid = ankiDroid.findModelIdByName(name, 1);
+        if (mid == null) return false;
+        final ContentResolver resolver = context.getContentResolver();
+        final Map<String, Integer> ordByName = new LinkedHashMap<>();
+        for (Map<String, Object> existing : readNoteTypeTemplates(resolver, mid)) {
+            ordByName.put((String) existing.get("name"),
+                (Integer) existing.get("ord"));
+        }
+        boolean changed = false;
+        for (Map<String, String> tmpl : templates) {
+            final Integer ord = ordByName.get(tmpl.get("name"));
+            if (ord == null) continue;
+            final ContentValues values = new ContentValues();
+            values.put(FlashCardsContract.CardTemplate.QUESTION_FORMAT,
+                emptyIfNull(tmpl.get("front")));
+            values.put(FlashCardsContract.CardTemplate.ANSWER_FORMAT,
+                emptyIfNull(tmpl.get("back")));
+            final Uri uri = Uri.withAppendedPath(
+                noteTypeTemplatesUri(mid), Integer.toString(ord));
+            if (resolver.update(uri, values, null, null) > 0) changed = true;
+        }
+        return changed;
+    }
+
+    /** provider 的字段名串（0x1f 连接）→ 列表；空串 = 无字段。 */
+    private static ArrayList<String> splitFieldNames(@Nullable String joined) {
+        final ArrayList<String> fields = new ArrayList<>();
+        if (joined == null || joined.isEmpty()) return fields;
+        fields.addAll(Arrays.asList(joined.split("\u001f", -1)));
+        return fields;
+    }
+
+    private static String emptyIfNull(@Nullable String value) {
+        return value == null ? "" : value;
     }
 }

--- a/fushi/lib/src/anki/anki_media_dedup_dialogs.dart
+++ b/fushi/lib/src/anki/anki_media_dedup_dialogs.dart
@@ -50,16 +50,20 @@ Future<AnkiMediaDedupReport?> runAnkiMediaDedupWithProgress(
             ),
           ),
           actions: [
-            ValueListenableBuilder<bool>(
-              valueListenable: cancelRequested,
-              builder: (BuildContext context, bool requested, Widget? child) =>
-                  TextButton(
-                onPressed:
-                    requested ? null : () => cancelRequested.value = true,
-                child:
-                    Text(requested ? t.anki_dedup_cancelling : t.dialog_cancel),
+            // 后端不支持中途叫停（整轮在主机进程里跑）时**不画**取消按钮：
+            // 一个点了没反应的取消按钮比没有更糟，用户会以为已经停了。
+            if (runner.supportsProgress)
+              ValueListenableBuilder<bool>(
+                valueListenable: cancelRequested,
+                builder:
+                    (BuildContext context, bool requested, Widget? child) =>
+                        TextButton(
+                  onPressed:
+                      requested ? null : () => cancelRequested.value = true,
+                  child: Text(
+                      requested ? t.anki_dedup_cancelling : t.dialog_cancel),
+                ),
               ),
-            ),
           ],
         ),
       );

--- a/fushi/lib/src/anki/anki_media_dedup_runner.dart
+++ b/fushi/lib/src/anki/anki_media_dedup_runner.dart
@@ -75,6 +75,11 @@ class AnkiMediaDedupRunner {
     return dir;
   }
 
+  /// 传给 [runNow] 的 `onProgress` / `shouldCancel` 是不是真会被调用（互联
+  /// 「制卡到已配对设备」把整轮推给主机跑，两者都跨不过那次 HTTP 往返）。
+  /// 进度弹窗据此画不确定进度条并隐藏取消按钮。
+  bool get supportsProgress => _repository.supportsMediaMaintenanceProgress;
+
   /// 跑一轮去重。[dryRun] = 只扫描规划、不改动任何东西（不写 journal、不更新
   /// 时间戳），产出的 `AnkiMediaDedupReport.deletions` 就是给用户看的删除清单。
   /// [onProgress] / [shouldCancel] 直通仓库层（BUG-1263：分钟级长任务必须有

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -14,10 +14,15 @@ class AnkiUiState {
     this.settings = const AnkiSettings(),
     this.isFetching = false,
     this.errorMessage,
+    this.mediaMaintenanceAvailable,
   });
   final AnkiSettings settings;
   final bool isFetching;
   final String? errorMessage;
+
+  /// 媒体去重此刻真能不能用；null = 还没探测出结论（没探过 / 后端不可达）。
+  /// 设置页用它做区块门控，未知时回落到后端静态能力。
+  final bool? mediaMaintenanceAvailable;
 
   List<AnkiDeck> get availableDecks => settings.availableDecks;
   List<AnkiNoteType> get availableNoteTypes => settings.availableNoteTypes;
@@ -29,11 +34,16 @@ class AnkiUiState {
     bool? isFetching,
     String? errorMessage,
     bool clearError = false,
+    bool? mediaMaintenanceAvailable,
+    bool clearMediaMaintenanceAvailable = false,
   }) =>
       AnkiUiState(
         settings: settings ?? this.settings,
         isFetching: isFetching ?? this.isFetching,
         errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+        mediaMaintenanceAvailable: clearMediaMaintenanceAvailable
+            ? null
+            : (mediaMaintenanceAvailable ?? this.mediaMaintenanceAvailable),
       );
 }
 
@@ -293,8 +303,27 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
 
   // ── 媒体存储优化（字节级去重）──────────────────────────────────────
 
-  /// 当前后端能否做媒体去重（AnkiConnect 且与 Anki 同机；设置页据此隐藏区块）。
+  /// 当前后端**类型**能否做媒体去重。这是静态能力，说不了「媒体目录这台机器
+  /// 读得到」——那个由 [probeMediaMaintenance] 探测，设置页两者一起判。
   bool get supportsMediaMaintenance => _repository.supportsMediaMaintenance;
+
+  /// 探测媒体去重此刻真能不能用，结论落进 [AnkiUiState.mediaMaintenanceAvailable]。
+  ///
+  /// 后端不可达（Anki 没开 / 局域网断了）时保持「未知」，绝不把它记成
+  /// 「不支持」——那会让桌面用户下次打开设置页发现整区消失。
+  Future<void> probeMediaMaintenance() async {
+    if (!_repository.supportsMediaMaintenance) {
+      state = state.copyWith(mediaMaintenanceAvailable: false);
+      return;
+    }
+    try {
+      final bool available = await _repository.probeMediaMaintenance();
+      state = state.copyWith(mediaMaintenanceAvailable: available);
+    } catch (e, stack) {
+      debugPrint('AnkiViewModel.probeMediaMaintenance: $e\n$stack');
+      state = state.copyWith(clearMediaMaintenanceAvailable: true);
+    }
+  }
 
   /// 与当前仓库绑定的去重编排器（无状态，随用随建）。
   AnkiMediaDedupRunner get mediaDedupRunner =>

--- a/fushi/lib/src/anki/remote_mining_anki_repository.dart
+++ b/fushi/lib/src/anki/remote_mining_anki_repository.dart
@@ -305,9 +305,26 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
           String modelName, List<AnkiCardTemplate> templates) =>
       _client.updateNoteTypeTemplates(modelName, templates);
 
-  // 媒体去重同为配置/维护类：作用于本机 Anki，委派本地仓库。
+  // ── 媒体存储优化：作用于**主机端** collection.media ────────────────────
+  //
+  // 这里曾委派本地仓库（`_local.supportsMediaMaintenance`），那是把「配置类
+  // 方法一律委派本地」的规则套错了地方：卡片落在主机的 Anki 上，重复媒体也
+  // 堆在主机的 collection.media 里，客户端本机连那个目录都没有。委派本地的
+  // 后果是——Android 上本地是 AnkiDroid（恒 false），于是明明主机能去重，
+  // 手机上整区隐藏；而 note type 编辑（就在上面几行）却已经走远端。同一个
+  // 「制卡到已配对设备」模式下两个维护动作指向两台不同机器，是自相矛盾的。
+  //
+  // 与 note type 编辑同构：能力与执行都在主机侧。
+
   @override
-  bool get supportsMediaMaintenance => _local.supportsMediaMaintenance;
+  bool get supportsMediaMaintenance => true;
+
+  /// 整轮去重在主机进程里跑，进度与取消跨不过这一次 HTTP 往返。
+  @override
+  bool get supportsMediaMaintenanceProgress => false;
+
+  @override
+  Future<bool> probeMediaMaintenance() => _client.probeMediaMaintenance();
 
   @override
   Future<AnkiMediaDedupReport?> runMediaDedup({
@@ -315,11 +332,11 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
     Future<void> Function(Map<String, dynamic> entry)? onJournal,
     AnkiMediaDedupOnProgress? onProgress,
     bool Function()? shouldCancel,
-  }) =>
-      _local.runMediaDedup(
-        dryRun: dryRun,
-        onJournal: onJournal,
-        onProgress: onProgress,
-        shouldCancel: shouldCancel,
-      );
+  }) {
+    // onJournal 有意不接：改写/删除都发生在主机，审计日志也该落在主机（主机
+    // 侧经自己的 AnkiMediaDedupRunner 落 journal）。把主机的删除记进客户端的
+    // 日志目录只会造出一份「本机什么都没删」的假账。
+    // onProgress / shouldCancel 同理跨不过来，见 supportsMediaMaintenanceProgress。
+    return _client.runMediaDedup(dryRun: dryRun);
+  }
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -35,6 +35,7 @@ import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi/src/profile/profile_repository.dart';
 import 'package:fushi/src/pages/implementations/popup_dictionary_page.dart';
 import 'package:fushi_anki/fushi_anki.dart';
+import 'package:fushi/src/anki/anki_media_dedup_runner.dart';
 import 'package:fushi/src/media/floating_dict_channel.dart';
 import 'package:fushi/src/models/app_font_loader.dart';
 import 'package:fushi/src/models/app_ui_font_chain.dart';
@@ -6707,6 +6708,27 @@ class _AppModelRemoteLookupService
         _appModel.platformServices.createAnkiRepository();
     if (!repo.supportsNoteTypeEditing) return false;
     return repo.updateNoteTypeTemplates(modelName, templates);
+  }
+
+  // ── 互联媒体存储优化：客户端（手机）经互联对本机 collection.media 去重。
+  // 与上面同语义地用**本机**平台仓库；后端不支持时按 BaseAnkiRepository 的
+  // 降级契约回 false/null（不抛）。
+
+  @override
+  Future<bool> probeMediaMaintenance() async {
+    final BaseAnkiRepository repo =
+        _appModel.platformServices.createAnkiRepository();
+    return repo.probeMediaMaintenance();
+  }
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async {
+    final BaseAnkiRepository repo =
+        _appModel.platformServices.createAnkiRepository();
+    if (!repo.supportsMediaMaintenance) return null;
+    // 走本机 runner 而不是裸 repo：改写与删除真实发生在**这台机器**上，
+    // 审计 journal 与「上次去重时刻」就该落在这里。客户端只发起、只看结果。
+    return AnkiMediaDedupRunner(repo).runNow(dryRun: dryRun);
   }
 
   @override

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -56,11 +56,24 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   bool _ankiBackendBusy = false;
 
   /// 本平台的原生 Anki 后端是否受限、因而提供「改用 AnkiConnect」这个开关。
-  /// 与 [PlatformServices.offersMobileAnkiConnectChoice] 同义：Android 的
-  /// AnkiDroid 与 iOS 的 AnkiMobile 都改不了已存在的 note type；桌面本来就走
-  /// AnkiConnect，没有这条支路。
+  /// 与 [PlatformServices.offersMobileAnkiConnectChoice] 同义：iOS 的 AnkiMobile
+  /// 只有加卡的 URL scheme，Android 的 AnkiDroid 走 Content Provider（能改模板，
+  /// 但读不到 collection.media，做不了媒体去重）；桌面本来就走 AnkiConnect，
+  /// 没有这条支路。
   static final bool _isMobileAnkiPlatform =
       Platform.isAndroid || Platform.isIOS;
+
+  @override
+  void initState() {
+    super.initState();
+    // 媒体去重区的门控要的是「此刻真能不能用」，不是后端类型（手机连局域网
+    // 桌面 Anki 时后端类型说支持、媒体目录本机却不存在）。探测要一次网络往返，
+    // 只在真正需要这个结论的设置页发起，不塞进 vm 构造。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(ankiViewModelProvider.notifier).probeMediaMaintenance();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -204,11 +217,16 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
             ],
           ),
         // 媒体存储优化：字节级去重（只删字节相同的多余副本，绝不重编码）。
-        // 需要与 Anki 同机（本机可直读 collection.media），后端不支持时整区隐藏。
+        // 需要与 Anki 同机（本机可直读 collection.media）。门控读探测结论
+        // （[AnkiViewModel.probeMediaMaintenance]）而不是后端静态能力：手机连
+        // 局域网里的桌面 Anki 时后端类型也是 AnkiConnect，但媒体目录在那台
+        // 机器上，显示出来只会是个点了说「不可用」的死区块。探测还没有结论
+        // （没探完 / Anki 没开）时回落静态能力，不让「Anki 暂时没开」把桌面
+        // 用户的整区弄消失。
         // 用户拍板方案 A：默认不跑；自动处理是一个**默认关**的开关，打开之后
         // 也只是自动干跑并提示，真删仍要用户确认——除非再显式打开「自动直接
         // 删除」。手动触发同样先看干跑清单再确认。
-        if (vm.supportsMediaMaintenance)
+        if (uiState.mediaMaintenanceAvailable ?? vm.supportsMediaMaintenance)
           AdaptiveSettingsSection(
             title: t.anki_dedup_section,
             children: [

--- a/fushi/lib/src/sync/fushi_remote_api_handlers.dart
+++ b/fushi/lib/src/sync/fushi_remote_api_handlers.dart
@@ -224,6 +224,32 @@ Future<Map<String, dynamic>> buildAnkiNoteTypeTemplatesResponse(
   };
 }
 
+/// `POST /api/anki/media/dedup/probe` 的响应体。主机端此刻能不能做媒体去重
+/// （客户端据此决定显不显示「媒体存储优化」区）。主机 Anki 不可达照抛（调用方
+/// 转成失败响应，客户端保持「未知」而不是记成「不支持」）。
+Future<Map<String, dynamic>> buildAnkiMediaDedupProbeResponse({
+  required FushiRemoteMiningService mining,
+}) async {
+  return <String, dynamic>{'available': await mining.probeMediaMaintenance()};
+}
+
+/// `POST /api/anki/media/dedup/run` 的响应体。在主机端跑一轮媒体去重。
+/// [body] 可含 `dryRun`（bool，缺省 true——**默认不动文件**：这条链路上真删的
+/// 决定权在客户端用户手里，缺字段的旧客户端/坏请求绝不能被解读成「删吧」）。
+/// `report` 为 null = 主机后端不支持。
+Future<Map<String, dynamic>> buildAnkiMediaDedupRunResponse(
+  Map<String, dynamic> body, {
+  required FushiRemoteMiningService mining,
+}) async {
+  final Object? rawDryRun = body['dryRun'];
+  if (rawDryRun != null && rawDryRun is! bool) {
+    throw const FormatException('Malformed dryRun');
+  }
+  final AnkiMediaDedupReport? report =
+      await mining.runMediaDedup(dryRun: (rawDryRun as bool?) ?? true);
+  return <String, dynamic>{'report': report?.toJson()};
+}
+
 String _requiredModelName(Map<String, dynamic> body) {
   final String modelName = body['modelName']?.toString() ?? '';
   if (modelName.trim().isEmpty) {

--- a/fushi/lib/src/sync/fushi_remote_lookup_service.dart
+++ b/fushi/lib/src/sync/fushi_remote_lookup_service.dart
@@ -119,10 +119,11 @@ abstract class FushiRemoteMiningService {
 
   // ── 互联 Lapis 客制化：主机端 note type 模板读写 ──────────────────────
   //
-  // 手机端（AnkiDroid / AnkiMobile）没有改已存在模板的平台 API；开启「制卡到
-  // 已配对设备」时卡片落在主机的 Anki 上，Lapis 样式客制化因此必须经互联作用
-  // 于**主机端**卡型。三个方法与 `BaseAnkiRepository` 同名同契约，实现方直接
-  // 委派主机本地 Anki 仓库。
+  // 开启「制卡到已配对设备」时卡片落在**主机**的 Anki 上，改客户端本机卡型
+  // 毫无意义——Lapis 样式客制化因此必须经互联作用于主机端卡型。三个方法与
+  // `BaseAnkiRepository` 同名同契约，实现方直接委派主机本地 Anki 仓库。
+  // （客户端本机能不能改模板是另一回事：AnkiDroid 经 Content Provider 可以，
+  // iOS 的 AnkiMobile 只有加卡的 URL scheme，不行。）
 
   /// 读主机端 [modelName] 的完整定义（字段/卡模板/CSS）。主机后端不支持模板
   /// 读写或模型不存在返回 `null`；主机 Anki 不可达照抛（调用方转成失败响应）。
@@ -136,6 +137,23 @@ abstract class FushiRemoteMiningService {
     String modelName,
     List<AnkiCardTemplate> templates,
   );
+
+  // ── 互联媒体存储优化：主机端 collection.media 字节级去重 ────────────────
+  //
+  // 卡片落在主机的 Anki 上，媒体副本也堆在**主机**的 collection.media 里；
+  // 客户端（手机）本机根本没有那个目录。去重因此与上面的模板读写同类：能力与
+  // 执行都在主机侧，客户端只发起、只看结果。
+
+  /// 主机端此刻能不能做媒体去重（= 主机本地 Anki 仓库的
+  /// `probeMediaMaintenance`）。主机 Anki 不可达照抛。
+  Future<bool> probeMediaMaintenance();
+
+  /// 在主机端跑一轮媒体去重。返回 `null` = 主机后端不支持。
+  ///
+  /// **不带进度与取消**：这条链路是一次 HTTP 往返，进度回调与取消判据都在
+  /// 主机进程内，跨不过来。客户端据此隐藏取消按钮（见
+  /// `AnkiMediaDedupRunner.supportsCancel`），绝不摆一个点了没用的按钮。
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun});
 }
 
 /// 把一次查词结果写入 Hibiki 查词历史（无 UI 副作用）。浏览器扩展 record 用。

--- a/fushi/lib/src/sync/fushi_remote_mining_client.dart
+++ b/fushi/lib/src/sync/fushi_remote_mining_client.dart
@@ -54,6 +54,15 @@ abstract class RemoteMineSender {
     String modelName,
     List<AnkiCardTemplate> templates,
   );
+
+  // ── 互联媒体存储优化：主机端 collection.media 字节级去重 ────────────────
+
+  /// 主机端此刻能不能做媒体去重。false = 主机不支持/版本过旧（无此端点）。
+  /// 全部候选不可达抛 [StateError]（同上：不可达 ≠ 不支持）。
+  Future<bool> probeMediaMaintenance();
+
+  /// 在主机端跑一轮去重。null = 主机不支持/版本过旧。
+  Future<AnkiMediaDedupReport?> runMediaDedup({required bool dryRun});
 }
 
 /// 互联「制卡到服务端」的客户端发送器。传输走共享的 [InterconnectPostTransport]
@@ -68,6 +77,7 @@ class FushiRemoteMiningClient implements RemoteMineSender {
     Duration mineTimeout = const Duration(seconds: 60),
     Duration duplicateTimeout = const Duration(seconds: 5),
     Duration noteTypeTimeout = const Duration(seconds: 15),
+    Duration mediaDedupTimeout = const Duration(minutes: 30),
   })  : _repo = repo,
         _transport = InterconnectPostTransport(
           repo: repo,
@@ -76,7 +86,8 @@ class FushiRemoteMiningClient implements RemoteMineSender {
         ),
         _mineTimeout = mineTimeout,
         _duplicateTimeout = duplicateTimeout,
-        _noteTypeTimeout = noteTypeTimeout;
+        _noteTypeTimeout = noteTypeTimeout,
+        _mediaDedupTimeout = mediaDedupTimeout;
 
   final SyncRepository _repo;
   final InterconnectPostTransport _transport;
@@ -86,6 +97,11 @@ class FushiRemoteMiningClient implements RemoteMineSender {
   /// Lapis 模板读写的超时：请求体是纯文本（CSS/模板最多几百 KB），LAN 上比制卡
   /// （媒体字节几 MB）快得多，但仍留出比查重宽裕的窗口。
   final Duration _noteTypeTimeout;
+
+  /// 媒体去重的超时：主机端要扫全库 collection.media（几万文件）并对同尺寸候选
+  /// 逐字节比对，分钟级是常态。这是**一次**长请求，不是心跳——超时短了会把正常
+  /// 运行截断成「主机不可达」，而客户端此时无从知道主机那边删到哪了。
+  final Duration _mediaDedupTimeout;
 
   /// 是否已配置可达的已配对主机（enabled 候选 + token）。用于设置页/开关判断能否远端制卡。
   Future<bool> hasTarget() async {
@@ -177,16 +193,40 @@ class FushiRemoteMiningClient implements RemoteMineSender {
     return json?['ok'] == true;
   }
 
+  @override
+  Future<bool> probeMediaMaintenance() async {
+    final Map<String, dynamic>? json = await _postNoteType(
+      path: '/api/anki/media/dedup/probe',
+      body: const <String, dynamic>{},
+    );
+    return json?['available'] == true;
+  }
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({required bool dryRun}) async {
+    final Map<String, dynamic>? json = await _postNoteType(
+      path: '/api/anki/media/dedup/run',
+      body: <String, dynamic>{'dryRun': dryRun},
+      // 去重要扫全库媒体 + 逐字节比对，几万个文件时分钟级；套用模板读写的
+      // 15 秒会把一次正常运行截成「主机不可达」。
+      timeout: _mediaDedupTimeout,
+    );
+    final Object? report = json?['report'];
+    if (report is! Map) return null;
+    return AnkiMediaDedupReport.fromJson(Map<String, dynamic>.from(report));
+  }
+
   /// note type 端点与制卡侧 [_post] 的唯一差别：消费 `allUnreachable`，把
   /// 「配对主机全部不可达」升格成异常（见 [readNoteTypeDefinition]）。
   Future<Map<String, dynamic>?> _postNoteType({
     required String path,
     required Map<String, dynamic> body,
+    Duration? timeout,
   }) async {
     final InterconnectPostOutcome outcome = await _transport.post(
       path: path,
       body: body,
-      timeout: _noteTypeTimeout,
+      timeout: timeout ?? _noteTypeTimeout,
       authErrorMessage: 'Fushi server rejected remote mining token',
     );
     if (outcome.json == null && outcome.allUnreachable) {

--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -553,6 +553,10 @@ class FushiSyncServer {
       if (method != 'POST') return shelf.Response(405);
       return _handleAnkiNoteType(request, reqPath);
     }
+    if (reqPath.startsWith('/api/anki/media/dedup/')) {
+      if (method != 'POST') return shelf.Response(405);
+      return _handleAnkiMediaDedup(request, reqPath);
+    }
     if (reqPath == '/api/media/dictionary') {
       if (method != 'GET' && method != 'HEAD') return shelf.Response(405);
       return _handleDictionaryMedia(request, method == 'HEAD');
@@ -1219,6 +1223,34 @@ class FushiSyncServer {
         case '/api/anki/note-type/templates':
           return _jsonResponse(
               await buildAnkiNoteTypeTemplatesResponse(body, mining: svc));
+        default:
+          return shelf.Response.notFound('Unknown endpoint');
+      }
+    } on FormatException catch (e) {
+      return shelf.Response(400, body: e.message);
+    }
+  }
+
+  /// 互联媒体存储优化：客户端（手机）经互联对**主机端** collection.media 做字节级
+  /// 去重——卡片落在主机的 Anki 上，重复媒体也堆在主机，客户端本机根本没有那个
+  /// 目录。未注入挖词 service → 404（旧版主机对新客户端同样 404 → 客户端按
+  /// 「不支持」隐藏区块）；dryRun 类型错 → 400。
+  Future<shelf.Response> _handleAnkiMediaDedup(
+    shelf.Request request,
+    String path,
+  ) async {
+    final FushiRemoteMiningService? svc = _miningService;
+    if (svc == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await _readJsonObject(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      switch (path) {
+        case '/api/anki/media/dedup/probe':
+          return _jsonResponse(
+              await buildAnkiMediaDedupProbeResponse(mining: svc));
+        case '/api/anki/media/dedup/run':
+          return _jsonResponse(
+              await buildAnkiMediaDedupRunResponse(body, mining: svc));
         default:
           return shelf.Response.notFound('Unknown endpoint');
       }

--- a/fushi/test/anki/ankidroid_note_type_editing_test.dart
+++ b/fushi/test/anki/ankidroid_note_type_editing_test.dart
@@ -1,0 +1,174 @@
+/// BUG-1680：AnkiDroid 后端的 note type 模板读写（Lapis 样式客制化）。
+///
+/// 长期以来 Android 上整个 Lapis 样式区是隐藏的，依据是「AnkiDroid Content
+/// Provider 改不了已存在的 note type」。那个前提是错的：AnkiDroid 的
+/// CardContentProvider.update() 的 `models/<mid>` 分支支持写 `Model.CSS`，
+/// `models/<mid>/templates/<ord>` 分支支持写 QUESTION_FORMAT / ANSWER_FORMAT；
+/// 被拒绝的只有改字段名，而样式客制化一个字段名都不改。
+///
+/// 这里同时守两层：Dart 侧经 MethodChannel 的读写契约（行为测试），以及 Java
+/// 桥确实实现了那三个方法、且用的是 provider 真正认的那几个列（源码扫描——
+/// 本仓没有跑 JVM 的测试宿主，这是 Java 侧最强的可落地层）。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+const MethodChannel _channel = MethodChannel('app.fushi.reader/anki');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> calls;
+  late Map<String, Object?> responses;
+
+  setUp(() {
+    calls = <MethodCall>[];
+    responses = <String, Object?>{};
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (MethodCall call) async {
+      calls.add(call);
+      return responses[call.method];
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  });
+
+  group('AnkiRepository note type 模板读写', () {
+    test('声明支持编辑已存在 note type（Lapis 样式区据此显示）', () {
+      expect(AnkiRepository().supportsNoteTypeEditing, isTrue);
+    });
+
+    test('readNoteTypeDefinition 解析字段/模板/CSS', () async {
+      responses['readNoteType'] = <Object?, Object?>{
+        'name': 'Lapis',
+        'fields': <Object?>['Word', 'Sentence'],
+        'css': '.card { color: red; }',
+        'templates': <Object?>[
+          <Object?, Object?>{
+            'ord': 0,
+            'name': 'Card 1',
+            'front': '{{Word}}',
+            'back': '{{Sentence}}',
+          },
+        ],
+      };
+
+      final AnkiNoteTypeDefinition? def =
+          await AnkiRepository().readNoteTypeDefinition('Lapis');
+
+      expect(def, isNotNull);
+      expect(def!.name, 'Lapis');
+      expect(def.fields, <String>['Word', 'Sentence']);
+      expect(def.css, '.card { color: red; }');
+      expect(def.templates, hasLength(1));
+      expect(def.templates.single.name, 'Card 1');
+      expect(def.templates.single.front, '{{Word}}');
+      expect(def.templates.single.back, '{{Sentence}}');
+      expect(
+        calls.map((MethodCall c) => c.method),
+        containsAllInOrder(
+            <String>['requestAnkidroidPermissions', 'readNoteType']),
+      );
+      expect(
+        calls.last.arguments,
+        containsPair('noteTypeName', 'Lapis'),
+      );
+    });
+
+    test('readNoteTypeDefinition：note type 不存在返回 null（不是错误）', () async {
+      responses['readNoteType'] = null;
+      expect(await AnkiRepository().readNoteTypeDefinition('Lapis'), isNull);
+    });
+
+    test('updateNoteTypeStyling 把 CSS 发过去并透传结果', () async {
+      responses['updateNoteTypeStyling'] = true;
+      final bool ok =
+          await AnkiRepository().updateNoteTypeStyling('Lapis', 'body{}');
+      expect(ok, isTrue);
+      final MethodCall call = calls
+          .firstWhere((MethodCall c) => c.method == 'updateNoteTypeStyling');
+      expect(call.arguments, containsPair('noteTypeName', 'Lapis'));
+      expect(call.arguments, containsPair('css', 'body{}'));
+    });
+
+    test('updateNoteTypeStyling：桥返回 false（provider 没认下改动）不谎报成功', () async {
+      responses['updateNoteTypeStyling'] = false;
+      expect(
+        await AnkiRepository().updateNoteTypeStyling('Lapis', 'body{}'),
+        isFalse,
+      );
+    });
+
+    test('updateNoteTypeTemplates 按模板名发送正/反面', () async {
+      responses['updateNoteTypeTemplates'] = true;
+      final bool ok = await AnkiRepository().updateNoteTypeTemplates(
+        'Lapis',
+        const <AnkiCardTemplate>[
+          AnkiCardTemplate(name: 'Card 1', front: 'F', back: 'B'),
+        ],
+      );
+      expect(ok, isTrue);
+      final MethodCall call = calls
+          .firstWhere((MethodCall c) => c.method == 'updateNoteTypeTemplates');
+      final List<Object?> sent =
+          (call.arguments as Map)['templates'] as List<Object?>;
+      expect(sent, hasLength(1));
+      expect(sent.single, <String, String>{
+        'name': 'Card 1',
+        'front': 'F',
+        'back': 'B',
+      });
+    });
+
+    test('updateNoteTypeTemplates：空列表不打桥（没有可写的东西）', () async {
+      expect(
+        await AnkiRepository().updateNoteTypeTemplates(
+          'Lapis',
+          const <AnkiCardTemplate>[],
+        ),
+        isFalse,
+      );
+      expect(calls, isEmpty);
+    });
+  });
+
+  group('Java 桥实现（源码扫描守卫）', () {
+    late String java;
+
+    setUpAll(() {
+      java = File(
+        'android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java',
+      ).readAsStringSync();
+    });
+
+    test('三个 method 都有 case 分支', () {
+      expect(java, contains('case "readNoteType":'));
+      expect(java, contains('case "updateNoteTypeStyling":'));
+      expect(java, contains('case "updateNoteTypeTemplates":'));
+    });
+
+    test('写入用的是 provider 真正认的那几个列', () {
+      // provider 的 models/<mid> 分支只认 Model.CSS 这一个与样式有关的键；
+      // templates/<ord> 分支认 QUESTION_FORMAT / ANSWER_FORMAT。换成别的列名
+      // 会被静默忽略（update 返回 0），表现成「点了应用样式什么都没变」。
+      expect(java, contains('FlashCardsContract.Model.CSS'));
+      expect(java, contains('FlashCardsContract.CardTemplate.QUESTION_FORMAT'));
+      expect(java, contains('FlashCardsContract.CardTemplate.ANSWER_FORMAT'));
+    });
+
+    test('不把字段名塞进 ContentValues（provider 明确拒绝，整次 update 会抛）', () {
+      // provider: "Field names cannot be changed via provider"。读 FIELD_NAMES
+      // 是合法的（readNoteType 就在读），写不是——判据只能是「有没有 put 进
+      // ContentValues」，不能是「文件里出没出现过这个常量」。
+      expect(
+          java, isNot(contains('.put(FlashCardsContract.Model.FIELD_NAMES')));
+    });
+  });
+}

--- a/fushi/test/anki/media_maintenance_probe_test.dart
+++ b/fushi/test/anki/media_maintenance_probe_test.dart
@@ -1,0 +1,142 @@
+/// BUG-1681：媒体存储优化区的门控必须是「此刻真能不能用」，不是后端类型。
+///
+/// `AnkiConnectRepository.supportsMediaMaintenance` 恒 true——它说的是「这个
+/// 后端**类型**实现了去重」。但去重要本机直读 collection.media：手机连局域网
+/// 里的桌面 Anki 时后端类型也是 AnkiConnect，`getMediaDirPath` 返回的却是那台
+/// 机器的路径，本机根本不存在。于是设置页显示一个点了只会说「不可用」的区块。
+///
+/// 修法是加一层真实探测（[BaseAnkiRepository.probeMediaMaintenance]），并让
+/// 「后端不可达」保持**未知**而不是被记成「不支持」——否则桌面用户只要在 Anki
+/// 没开的时候进过一次设置页，整区就消失了。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+class _ProbeRepo extends BaseAnkiRepository {
+  _ProbeRepo({
+    required this.staticSupport,
+    this.probeResult,
+    this.probeThrows = false,
+  });
+
+  /// 后端**类型**是否实现了去重（= 旧门控用的那个值）。
+  final bool staticSupport;
+
+  /// 探测结论。
+  final bool? probeResult;
+
+  /// 探测时后端不可达。
+  final bool probeThrows;
+
+  int probeCalls = 0;
+
+  @override
+  bool get supportsMediaMaintenance => staticSupport;
+
+  @override
+  Future<bool> probeMediaMaintenance() async {
+    probeCalls++;
+    if (probeThrows) throw const SocketException('host unreachable');
+    return probeResult ?? staticSupport;
+  }
+
+  @override
+  Future<AnkiSettings> loadSettings() async => const AnkiSettings();
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async {}
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('unused');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BaseAnkiRepository.probeMediaMaintenance 默认契约', () {
+    test('默认实现 = 静态能力，不做任何 I/O', () async {
+      final _ProbeRepo off = _ProbeRepo(staticSupport: false);
+      expect(await off.probeMediaMaintenance(), isFalse);
+    });
+
+    test('默认支持进度与取消（本进程内跑的后端）', () {
+      expect(
+        _ProbeRepo(staticSupport: true).supportsMediaMaintenanceProgress,
+        isTrue,
+      );
+    });
+  });
+
+  group('AnkiViewModel 的探测结论', () {
+    test('后端类型就不支持：直接记 false，连探测都不发起', () async {
+      final _ProbeRepo repo = _ProbeRepo(staticSupport: false);
+      final AnkiViewModel vm = AnkiViewModel(repo);
+      await vm.probeMediaMaintenance();
+      expect(vm.debugState.mediaMaintenanceAvailable, isFalse);
+      expect(repo.probeCalls, 0);
+    });
+
+    test('后端类型支持但媒体目录本机没有（手机连局域网桌面）：记 false', () async {
+      final _ProbeRepo repo =
+          _ProbeRepo(staticSupport: true, probeResult: false);
+      final AnkiViewModel vm = AnkiViewModel(repo);
+      await vm.probeMediaMaintenance();
+      expect(vm.debugState.mediaMaintenanceAvailable, isFalse);
+      expect(repo.probeCalls, 1);
+    });
+
+    test('本机可读：记 true', () async {
+      final _ProbeRepo repo =
+          _ProbeRepo(staticSupport: true, probeResult: true);
+      final AnkiViewModel vm = AnkiViewModel(repo);
+      await vm.probeMediaMaintenance();
+      expect(vm.debugState.mediaMaintenanceAvailable, isTrue);
+    });
+
+    test('后端不可达（Anki 没开）：保持未知，绝不记成不支持', () async {
+      final _ProbeRepo repo =
+          _ProbeRepo(staticSupport: true, probeThrows: true);
+      final AnkiViewModel vm = AnkiViewModel(repo);
+      await vm.probeMediaMaintenance();
+      // null = 未知；设置页据此回落静态能力，区块照常显示（点了会报连接错误）。
+      expect(vm.debugState.mediaMaintenanceAvailable, isNull);
+    });
+  });
+
+  group('设置页门控（源码扫描守卫）', () {
+    test('媒体存储优化区读探测结论，未知时才回落静态能力', () {
+      final String page = File(
+        'lib/src/pages/implementations/anki_settings_page.dart',
+      ).readAsStringSync();
+      // 断言的字面量：`uiState.mediaMaintenanceAvailable ?? vm.supportsMediaMaintenance`
+      // 退回裸 `if (vm.supportsMediaMaintenance)` 就是本 bug 的原状。
+      expect(
+        page,
+        contains('uiState.mediaMaintenanceAvailable ?? '
+            'vm.supportsMediaMaintenance'),
+      );
+      expect(page, contains('probeMediaMaintenance()'));
+    });
+  });
+}

--- a/fushi/test/anki/remote_mining_anki_repository_test.dart
+++ b/fushi/test/anki/remote_mining_anki_repository_test.dart
@@ -61,6 +61,20 @@ class _FakeSender implements RemoteMineSender {
     templateWrites.add((modelName, templates));
     return noteTypeWriteOk;
   }
+
+  // 互联媒体存储优化：主机端去重捕获。
+  bool mediaMaintenanceAvailable = true;
+  AnkiMediaDedupReport? dedupReport;
+  final List<bool> dedupRuns = <bool>[];
+
+  @override
+  Future<bool> probeMediaMaintenance() async => mediaMaintenanceAvailable;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({required bool dryRun}) async {
+    dedupRuns.add(dryRun);
+    return dedupReport;
+  }
 }
 
 /// 假本地仓库：远端模式下 mineEntry/isDuplicate 绝不该落到它身上（落了就抛，验证不误操作本机）。
@@ -376,6 +390,69 @@ void main() {
         final RemoteMiningAnkiRepository repo =
             RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
         expect(await repo.updateNoteTypeStyling('Lapis', ''), isFalse);
+      });
+    });
+
+    // BUG-1682：媒体去重曾委派本地仓库（`_local.supportsMediaMaintenance`）。
+    // 卡落在主机上、重复媒体也堆在主机的 collection.media 里，客户端本机连那个
+    // 目录都没有；委派本地的后果是 Android（本地 AnkiDroid 恒 false）上整区隐藏，
+    // 而同一屏上的 note type 编辑却已经走远端——两个维护动作指向两台机器。
+    group('媒体存储优化经互联作用于主机端', () {
+      test('supportsMediaMaintenance 恒 true（本地 AnkiDroid false 也不遮蔽）', () {
+        final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+            local: _FakeLocal(), client: _FakeSender(null));
+        expect(_FakeLocal().supportsMediaMaintenance, isFalse);
+        expect(repo.supportsMediaMaintenance, isTrue);
+      });
+
+      test('probeMediaMaintenance 问的是主机，不是本地', () async {
+        final _FakeSender sender = _FakeSender(null)
+          ..mediaMaintenanceAvailable = true;
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+        expect(await repo.probeMediaMaintenance(), isTrue);
+
+        sender.mediaMaintenanceAvailable = false;
+        expect(await repo.probeMediaMaintenance(), isFalse);
+      });
+
+      test('runMediaDedup 转发远端并带上 dryRun', () async {
+        final _FakeSender sender = _FakeSender(null)
+          ..dedupReport = const AnkiMediaDedupReport(
+            dryRun: true,
+            groupCount: 2,
+            deletions: <MediaDedupDeletion>[
+              MediaDedupDeletion(
+                  filename: 'a.jpg', canonical: 'b.jpg', bytes: 10),
+            ],
+            notesRewritten: 0,
+            modelsRewritten: 0,
+            skipped: 0,
+          );
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+
+        final AnkiMediaDedupReport? plan =
+            await repo.runMediaDedup(dryRun: true);
+        expect(plan?.groupCount, 2);
+        expect(plan?.duplicatesRemoved, 1);
+        await repo.runMediaDedup(dryRun: false);
+        expect(sender.dedupRuns, <bool>[true, false]);
+      });
+
+      test('进度与取消跨不过 HTTP 往返：明说不支持，UI 据此不画取消按钮', () {
+        final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+            local: _FakeLocal(), client: _FakeSender(null));
+        expect(repo.supportsMediaMaintenanceProgress, isFalse);
+        // 本地后端在同一进程里跑，两者都真会被调用。
+        expect(_FakeLocal().supportsMediaMaintenanceProgress, isTrue);
+      });
+
+      test('主机不支持 → 返回 null（不谎报「没有重复」）', () async {
+        final _FakeSender sender = _FakeSender(null)..dedupReport = null;
+        final RemoteMiningAnkiRepository repo =
+            RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
+        expect(await repo.runMediaDedup(dryRun: true), isNull);
       });
     });
   });

--- a/fushi/test/sync/anki_media_dedup_response_test.dart
+++ b/fushi/test/sync/anki_media_dedup_response_test.dart
@@ -1,0 +1,123 @@
+/// BUG-1682：互联媒体存储优化的主机端端点契约。
+///
+/// 客户端（手机）经互联对**主机端** collection.media 去重。这里守两条要害：
+///   1. `dryRun` 缺省必须是 **true**——真删的决定权在客户端用户手里，缺字段的
+///      旧客户端或坏请求绝不能被解读成「删吧」；
+///   2. 主机后端不支持时 `report` 为 null，不能编造一个「没有重复」的空报告。
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
+import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+class _FakeMining implements FushiRemoteMiningService {
+  bool available = true;
+  AnkiMediaDedupReport? report;
+  final List<bool> runs = <bool>[];
+
+  @override
+  Future<bool> probeMediaMaintenance() async => available;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async {
+    runs.add(dryRun);
+    return report;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} must not run');
+}
+
+const AnkiMediaDedupReport _plan = AnkiMediaDedupReport(
+  dryRun: true,
+  groupCount: 1,
+  deletions: <MediaDedupDeletion>[
+    MediaDedupDeletion(filename: 'dupe.jpg', canonical: 'keep.jpg', bytes: 42),
+  ],
+  notesRewritten: 3,
+  modelsRewritten: 1,
+  skipped: 2,
+);
+
+void main() {
+  group('POST /api/anki/media/dedup/probe', () {
+    test('把主机端探测结论原样报回', () async {
+      final _FakeMining mining = _FakeMining()..available = true;
+      expect(
+        await buildAnkiMediaDedupProbeResponse(mining: mining),
+        <String, dynamic>{'available': true},
+      );
+
+      mining.available = false;
+      expect(
+        await buildAnkiMediaDedupProbeResponse(mining: mining),
+        <String, dynamic>{'available': false},
+      );
+    });
+  });
+
+  group('POST /api/anki/media/dedup/run', () {
+    test('缺 dryRun 字段 → 干跑（安全默认，一个文件都不动）', () async {
+      final _FakeMining mining = _FakeMining()..report = _plan;
+      await buildAnkiMediaDedupRunResponse(
+        <String, dynamic>{},
+        mining: mining,
+      );
+      expect(mining.runs, <bool>[true]);
+    });
+
+    test('dryRun=false 才真跑', () async {
+      final _FakeMining mining = _FakeMining()..report = _plan;
+      await buildAnkiMediaDedupRunResponse(
+        <String, dynamic>{'dryRun': false},
+        mining: mining,
+      );
+      expect(mining.runs, <bool>[false]);
+    });
+
+    test('dryRun 类型错 → FormatException（调用方转 400），绝不当成 false', () async {
+      final _FakeMining mining = _FakeMining()..report = _plan;
+      await expectLater(
+        buildAnkiMediaDedupRunResponse(
+          <String, dynamic>{'dryRun': 'false'},
+          mining: mining,
+        ),
+        throwsA(isA<FormatException>()),
+      );
+      expect(mining.runs, isEmpty);
+    });
+
+    test('报告可完整序列化并还原（客户端要拿它画删除清单）', () async {
+      final _FakeMining mining = _FakeMining()..report = _plan;
+      final Map<String, dynamic> body = await buildAnkiMediaDedupRunResponse(
+        <String, dynamic>{'dryRun': true},
+        mining: mining,
+      );
+      final AnkiMediaDedupReport back = AnkiMediaDedupReport.fromJson(
+        Map<String, dynamic>.from(body['report'] as Map),
+      );
+      expect(back.dryRun, isTrue);
+      expect(back.groupCount, 1);
+      expect(back.notesRewritten, 3);
+      expect(back.modelsRewritten, 1);
+      expect(back.skipped, 2);
+      expect(back.cancelled, isFalse);
+      expect(back.deletions.single.filename, 'dupe.jpg');
+      expect(back.deletions.single.canonical, 'keep.jpg');
+      // 派生值从 deletions 重算，不从 wire 上读——两份数字迟早对不上。
+      expect(back.duplicatesRemoved, 1);
+      expect(back.bytesSaved, 42);
+    });
+
+    test('主机后端不支持 → report 为 null，不编造空报告', () async {
+      final _FakeMining mining = _FakeMining()..report = null;
+      final Map<String, dynamic> body = await buildAnkiMediaDedupRunResponse(
+        <String, dynamic>{'dryRun': true},
+        mining: mining,
+      );
+      expect(body['report'], isNull);
+    });
+  });
+}

--- a/fushi/test/sync/anki_note_type_response_test.dart
+++ b/fushi/test/sync/anki_note_type_response_test.dart
@@ -38,6 +38,13 @@ class _FakeMining implements FushiRemoteMiningService {
   }
 
   @override
+  Future<bool> probeMediaMaintenance() async => false;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async =>
+      null;
+
+  @override
   Future<RemoteMineResult> mineEntry(
           {required Map<String, String> fields,
           required String sentence}) async =>

--- a/fushi/test/sync/forwarded_mine_response_test.dart
+++ b/fushi/test/sync/forwarded_mine_response_test.dart
@@ -27,6 +27,13 @@ class _FakeMining implements FushiRemoteMiningService {
       false;
 
   @override
+  Future<bool> probeMediaMaintenance() async => false;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async =>
+      null;
+
+  @override
   Future<RemoteMineResult> mineForwarded(ForwardedMinePayload payload) async {
     forwarded = payload;
     return result;

--- a/fushi/test/sync/fushi_remote_mining_service_test.dart
+++ b/fushi/test/sync/fushi_remote_mining_service_test.dart
@@ -46,4 +46,11 @@ class _FakeMining implements FushiRemoteMiningService {
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) async =>
       false;
+
+  @override
+  Future<bool> probeMediaMaintenance() async => false;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async =>
+      null;
 }

--- a/fushi/test/sync/fushi_sync_server_mine_test.dart
+++ b/fushi/test/sync/fushi_sync_server_mine_test.dart
@@ -72,6 +72,20 @@ class _FakeMining implements FushiRemoteMiningService {
     lastTemplatesWrite = (modelName, templates);
     return noteTypeWriteOk;
   }
+
+  /// 媒体去重：本 fake 只需满足契约，端点行为由 dedup 专用测试覆盖。
+  bool mediaMaintenanceAvailable = false;
+  AnkiMediaDedupReport? dedupReport;
+  final List<bool> dedupRuns = <bool>[];
+
+  @override
+  Future<bool> probeMediaMaintenance() async => mediaMaintenanceAvailable;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async {
+    dedupRuns.add(dryRun);
+    return dedupReport;
+  }
 }
 
 Future<HttpClientResponse> _post(

--- a/fushi/test/sync/remote_mine_response_diagnostics_test.dart
+++ b/fushi/test/sync/remote_mine_response_diagnostics_test.dart
@@ -48,6 +48,13 @@ class _DiagMining implements FushiRemoteMiningService {
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) async =>
       false;
+
+  @override
+  Future<bool> probeMediaMaintenance() async => false;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async =>
+      null;
 }
 
 Map<String, dynamic> _entryBody() => <String, dynamic>{

--- a/fushi/test/sync/yomitan_api_server_extension_endpoints_test.dart
+++ b/fushi/test/sync/yomitan_api_server_extension_endpoints_test.dart
@@ -123,6 +123,13 @@ class _FakeMining implements FushiRemoteMiningService {
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) async =>
       true;
+
+  @override
+  Future<bool> probeMediaMaintenance() async => false;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({bool dryRun = true}) async =>
+      null;
 }
 
 String _basic(String token) =>

--- a/packages/fushi_anki/lib/src/anki_media_dedup.dart
+++ b/packages/fushi_anki/lib/src/anki_media_dedup.dart
@@ -41,6 +41,13 @@ class MediaDedupDeletion {
   /// [filename] 占用的字节数（= 释放的空间）。
   final int bytes;
 
+  factory MediaDedupDeletion.fromJson(Map<String, dynamic> json) =>
+      MediaDedupDeletion(
+        filename: json['filename']?.toString() ?? '',
+        canonical: json['canonical']?.toString() ?? '',
+        bytes: (json['bytes'] as num?)?.toInt() ?? 0,
+      );
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'filename': filename,
         'canonical': canonical,
@@ -243,6 +250,23 @@ class AnkiMediaDedupReport {
   /// true = 用户中途取消，数字只统计取消前已完成的部分；已做的改写/删除
   /// 保留（引用永远先改指保留份，任何时刻停下都不会出现悬空引用）。
   final bool cancelled;
+
+  /// 从 [toJson] 的产物还原（互联「制卡到已配对设备」时主机端跑完把报告发回
+  /// 客户端）。`duplicatesRemoved` / `bytesSaved` 是 [deletions] 的派生值，
+  /// 这里**不读**它们——两份数字各自还原迟早对不上，派生值只该有一个来源。
+  factory AnkiMediaDedupReport.fromJson(Map<String, dynamic> json) =>
+      AnkiMediaDedupReport(
+        dryRun: json['dryRun'] == true,
+        groupCount: (json['groupCount'] as num?)?.toInt() ?? 0,
+        deletions: ((json['deletions'] as List?) ?? const <dynamic>[])
+            .map((dynamic e) =>
+                MediaDedupDeletion.fromJson(Map<String, dynamic>.from(e as Map)))
+            .toList(growable: false),
+        notesRewritten: (json['notesRewritten'] as num?)?.toInt() ?? 0,
+        modelsRewritten: (json['modelsRewritten'] as num?)?.toInt() ?? 0,
+        skipped: (json['skipped'] as num?)?.toInt() ?? 0,
+        cancelled: json['cancelled'] == true,
+      );
 
   /// 实际删除（[dryRun] 时 = 将会删除）的多余副本数。
   int get duplicatesRemoved => deletions.length;

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1228,6 +1228,23 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   @override
   bool get supportsMediaMaintenance => true;
 
+  /// AnkiConnect 报的媒体目录，**本机确实存在时**才返回，否则 null。
+  ///
+  /// 同一个仓库类既服务「桌面本机 Anki」也服务「手机连局域网里的桌面 Anki」，
+  /// 后者拿到的是那台机器的路径，本机不存在。判据只写这一份：能力探测
+  /// （[probeMediaMaintenance]，UI 据此决定显不显示）与真跑（[runMediaDedup]）
+  /// 各写一遍必然漂开，而漂开的表现就是「显示了一个点了只说不可用的区块」。
+  Future<Directory?> _localMediaDir() async {
+    final AnkiConnectService service = await _getService();
+    final String mediaPath = await service.getMediaDirPath();
+    if (mediaPath.isEmpty) return null;
+    final Directory dir = Directory(mediaPath);
+    return dir.existsSync() ? dir : null;
+  }
+
+  @override
+  Future<bool> probeMediaMaintenance() async => (await _localMediaDir()) != null;
+
   /// 媒体目录里的一个文件（媒体目录是扁平的，文件名即相对路径）。
   File _mediaFile(Directory mediaDir, String name) =>
       File('${mediaDir.path}${Platform.pathSeparator}$name');
@@ -1679,11 +1696,10 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     bool Function()? shouldCancel,
   }) async {
     final AnkiConnectService service = await _getService();
-    final String mediaPath = await service.getMediaDirPath();
-    final Directory mediaDir = Directory(mediaPath);
-    // AnkiConnect 在远程主机上时拿到的路径本机不存在——按不支持处理，绝不
-    // 盲扫错误目录。
-    if (!mediaDir.existsSync()) return null;
+    final Directory? mediaDir = await _localMediaDir();
+    // 媒体目录本机不存在（AnkiConnect 在另一台机器上）= 不支持，绝不盲扫。
+    // 判据与 [probeMediaMaintenance] 共用 [_localMediaDir]，不在这里再写一遍。
+    if (mediaDir == null) return null;
 
     bool cancelled = false;
     bool checkCancel() =>

--- a/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../anki_models.dart';
+import '../anki_note_type_definition.dart';
 import '../anki_remote_media_http.dart';
 import '../base_anki_repository.dart';
 import '../ankiconnect/ankiconnect_repository.dart';
@@ -572,6 +573,84 @@ class AnkiRepository extends BaseAnkiRepository {
       'css': template.css,
     });
     return true;
+  }
+
+  // ── note type 模板读写（Lapis 客制化/备份/自动迁移）────────────────────
+  //
+  // 长期以来这里默认降级（基类的 false），依据是「AnkiDroid Content Provider
+  // 改不了已存在的 note type」。那个前提是错的：AnkiDroid 的
+  // CardContentProvider.update() 在 `models/<mid>` 分支支持写 `Model.CSS`，
+  // 在 `models/<mid>/templates/<ord>` 分支支持写 QUESTION_FORMAT /
+  // ANSWER_FORMAT；被明确拒绝的只有改字段名（"Field names cannot be changed
+  // via provider"），而 Lapis 样式客制化一个字段名都不改。真正的平台边界是
+  // iOS 的 AnkiMobile（只有加卡的 URL scheme），那边仍然降级。
+
+  @override
+  bool get supportsNoteTypeEditing => true;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+    String modelName,
+  ) async {
+    await _channel.invokeMethod('requestAnkidroidPermissions');
+    final Map? raw = await _channel.invokeMethod(
+      'readNoteType',
+      <String, dynamic>{'noteTypeName': modelName},
+    ) as Map?;
+    if (raw == null) return null;
+    final List<dynamic> templates =
+        (raw['templates'] as List?) ?? const <dynamic>[];
+    return AnkiNoteTypeDefinition(
+      name: raw['name']?.toString() ?? modelName,
+      fields: ((raw['fields'] as List?) ?? const <dynamic>[])
+          .map((dynamic e) => e?.toString() ?? '')
+          .toList(growable: false),
+      // ord 只在写回时用于定位（Java 侧按模板名反查），backend 无关的
+      // AnkiCardTemplate 不带它——备份文件里存位置号毫无意义，模板被重排
+      // 之后按位置写回就会把正面写进另一张卡。
+      templates: templates.map((dynamic e) {
+        final Map tmpl = e as Map;
+        return AnkiCardTemplate(
+          name: tmpl['name']?.toString() ?? '',
+          front: tmpl['front']?.toString() ?? '',
+          back: tmpl['back']?.toString() ?? '',
+        );
+      }).toList(growable: false),
+      css: raw['css']?.toString() ?? '',
+    );
+  }
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    await _channel.invokeMethod('requestAnkidroidPermissions');
+    final bool? ok = await _channel.invokeMethod(
+      'updateNoteTypeStyling',
+      <String, dynamic>{'noteTypeName': modelName, 'css': css},
+    ) as bool?;
+    return ok ?? false;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  ) async {
+    if (templates.isEmpty) return false;
+    await _channel.invokeMethod('requestAnkidroidPermissions');
+    final bool? ok = await _channel.invokeMethod(
+      'updateNoteTypeTemplates',
+      <String, dynamic>{
+        'noteTypeName': modelName,
+        'templates': templates
+            .map((AnkiCardTemplate t) => <String, String>{
+                  'name': t.name,
+                  'front': t.front,
+                  'back': t.back,
+                })
+            .toList(growable: false),
+      },
+    ) as bool?;
+    return ok ?? false;
   }
 
   @override

--- a/packages/fushi_anki/lib/src/base_anki_repository.dart
+++ b/packages/fushi_anki/lib/src/base_anki_repository.dart
@@ -256,6 +256,26 @@ abstract class BaseAnkiRepository {
   /// 写卡路径的能力，与本功能无关。
   bool get supportsMediaMaintenance => false;
 
+  /// 本后端**此刻真能不能**做媒体去重。
+  ///
+  /// [supportsMediaMaintenance] 只说「这个后端类型实现了去重」，说不了「媒体
+  /// 目录这台机器读得到」——AnkiConnect 是同一个类，桌面上跑是本机直读，手机
+  /// 连局域网里的桌面 Anki 也是同一个类，但 `getMediaDirPath` 返回的是**那台
+  /// 机器**的路径，本机根本不存在。用静态能力当门控的后果是手机上显示一个
+  /// 点了只会说「不可用」的区块。
+  ///
+  /// 默认实现 = 静态能力（不做任何 I/O）；需要探测的后端覆写。后端不可达时
+  /// **照抛**——调用方据此保持「未知」，不要把「Anki 没开」误判成「不支持」。
+  Future<bool> probeMediaMaintenance() async => supportsMediaMaintenance;
+
+  /// [runMediaDedup] 的 `onProgress` / `shouldCancel` 是不是真的会被调用。
+  ///
+  /// 本进程内跑的后端恒 true。互联「制卡到已配对设备」把整轮去重推给主机跑，
+  /// 一次 HTTP 往返里没有回传进度的通道、也没有中途叫停的通道——那种后端返回
+  /// false，UI 据此画不确定进度条并**隐藏取消按钮**。摆一个点了没反应的取消
+  /// 按钮比没有取消按钮更糟：用户会以为已经停了。
+  bool get supportsMediaMaintenanceProgress => true;
+
   /// 跑一轮媒体字节级去重：找出字节完全相同的文件组 → 把笔记字段与卡模板/
   /// styling 里的引用统一改指保留份 → 复核引用清干净后删除多余副本。
   /// **绝不重编码任何文件**。[dryRun] = 只扫描规划，不改动。[onJournal] 在


### PR DESCRIPTION
用户报告：**手机看不到 lapis 卡片样式和 anki 媒体存储优化**。查下来是三处独立的「能力判据写错」，不是功能缺失。

## BUG-1680 · AnkiDroid 的 note type 读写

基类默认 `supportsNoteTypeEditing => false`，注释写「AnkiDroid Content Provider 改不了已存在 note type，平台边界，非本仓可修」。**这个前提是错的**：上游 `CardContentProvider.update()` 的 `models/<mid>` 分支支持写 `Model.CSS`，`models/<mid>/templates/<ord>` 分支支持写 `QUESTION_FORMAT` / `ANSWER_FORMAT`；被明确拒绝的只有改字段名（`"Field names cannot be changed via provider"`），而 Lapis 样式客制化一个字段名都不改。我们只是从没实现读/改，把「没实现」记成了「平台做不到」。

- `AnkiChannelHandler.java` 补 `readNoteType` / `updateNoteTypeStyling` / `updateNoteTypeTemplates`
- 模板按**名字**匹配而不是 ord——ord 是位置，用户重排模板后按位置写回会把正面写进另一张卡
- iOS 的 AnkiMobile（只有加卡 URL scheme）才是真平台边界，仍降级

## BUG-1681 · 媒体去重的显示判据

`AnkiConnectRepository.supportsMediaMaintenance` 硬编码 `true`，但实现要本机直读 `collection.media`。手机开「改用 AnkiConnect」连局域网桌面 Anki 时后端类型也是 AnkiConnect，路径却在那台机器上——区块显示得出来、点得动、必然不可用。

- 新增 `probeMediaMaintenance()` 真实探测，与 `runMediaDedup` 共用同一份判据
- 门控改成 `uiState.mediaMaintenanceAvailable ?? vm.supportsMediaMaintenance`
- 后端不可达保持「未知」，不让「Anki 没开」把桌面用户整区弄消失

## BUG-1682 · 制卡到已配对设备时的委派

去重委派了本地仓库，而卡片和重复媒体都在主机上。Android 本地是 AnkiDroid（恒 false）于是整区隐藏，**同屏上方的 note type 编辑却已经走远端**——两个维护动作指向两台机器。

- 改为跟随卡片落点：新增 `POST /api/anki/media/dedup/probe` 与 `/run`
- 主机侧经自己的 `AnkiMediaDedupRunner` 执行，journal 与「上次去重时刻」落在真正发生删除的机器上
- 进度与取消跨不过一次 HTTP 往返 → 新增 `supportsMediaMaintenanceProgress`，弹窗据此**隐藏取消按钮**（点了没反应的取消比没有更糟）
- 远端 `dryRun` 缺省 `true`：真删的决定权在客户端用户手里

## 验证

- `flutter analyze` — `fushi` 与 `fushi_anki` 两个包均零问题（注意：在 `fushi/` 下跑不覆盖 path 依赖包，两边都要跑）
- `dart run tool/flutter_test_failures.dart --no-pub` 分四批跑完全量：2563 + 6598 + 5468 + 3995 = **18624 条全绿**（含目录枚举型守卫所在的 `test/tools`）
- `flutter build apk --debug` 成功 — Java 改动真能编译
- 两个源码扫描守卫已**变异实测**：改坏后转红，还原后文件 sha256 与基线逐字节一致

## 仍缺（不阻塞合并，但别当已验）

- Android + AnkiDroid 真机跑一次「改字号 → 应用样式到 Anki → 卡片真的变了」
- 手机 + 桌面主机各一台，远端去重端到端

https://claude.ai/code/session_01GeYLeJXQXB9MzywMNE2Psq
