### PR TITLE
feat(anki): 由 Fushi 代装 AnkiConnect 插件（Windows）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58310 (3430 per locale)
+/// Strings: 58429 (3437 per locale)
 ///
-/// Built on 2026-08-15 at 13:16 UTC
+/// Built on 2026-08-16 at 04:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4643,6 +4643,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get update_testflight_open => 'Open TestFlight';
   String get update_app_store_open => 'Open App Store';
   String get update_release_page_open => 'Release page';
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -12566,6 +12579,26 @@ class _StringsAr extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -20556,6 +20589,26 @@ class _StringsDe extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -28562,6 +28615,26 @@ class _StringsEs extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -36580,6 +36653,26 @@ class _StringsFr extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -44526,6 +44619,26 @@ class _StringsId extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -52518,6 +52631,26 @@ class _StringsIt extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -60324,6 +60457,26 @@ class _StringsJa extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -68137,6 +68290,26 @@ class _StringsKo extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -76109,6 +76282,26 @@ class _StringsNl extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -84093,6 +84286,26 @@ class _StringsPtBr extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -92063,6 +92276,26 @@ class _StringsRu extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -99981,6 +100214,26 @@ class _StringsTh extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -107930,6 +108183,26 @@ class _StringsTr extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -115864,6 +116137,26 @@ class _StringsVi extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 // Path: <root>
@@ -123220,6 +123513,25 @@ class _StringsZhCn extends _StringsEn {
   String get update_app_store_open => '打开 App Store';
   @override
   String get update_release_page_open => '发布页';
+  @override
+  String get anki_connect_addon_install => '安装 AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      '从 AnkiWeb 下载 AnkiConnect 并交给正在运行的 Anki。Anki 会弹窗请你确认，之后按它的提示重启。';
+  @override
+  String get anki_connect_addon_handed =>
+      '已把 AnkiConnect 交给 Anki。请在 Anki 弹出的确认框中同意，然后按 Anki 的提示重启。';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      '没有检测到正在运行的 Anki。请先启动 Anki 桌面版再试。';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      '无法从 AnkiWeb 下载 AnkiConnect：${error}';
+  @override
+  String get anki_connect_addon_invalid => 'AnkiWeb 返回的内容不是可用的插件包。';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      '无法把插件交给 Anki：${error}';
 }
 
 // Path: <root>
@@ -130949,6 +131261,26 @@ class _StringsZhHk extends _StringsEn {
   String get update_app_store_open => 'Open App Store';
   @override
   String get update_release_page_open => 'Release page';
+  @override
+  String get anki_connect_addon_install => 'Install AnkiConnect';
+  @override
+  String get anki_connect_addon_install_hint =>
+      'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+  @override
+  String get anki_connect_addon_handed =>
+      'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+  @override
+  String get anki_connect_addon_anki_not_running =>
+      'No running Anki found. Start Anki desktop first, then try again.';
+  @override
+  String anki_connect_addon_download_failed({required Object error}) =>
+      'Could not download AnkiConnect from AnkiWeb: ${error}';
+  @override
+  String get anki_connect_addon_invalid =>
+      'AnkiWeb returned something that is not a usable add-on package.';
+  @override
+  String anki_connect_addon_launch_failed({required Object error}) =>
+      'Could not hand the add-on to Anki: ${error}';
 }
 
 /// Flat map(s) containing all translations.
@@ -137996,6 +138328,22 @@ extension on _StringsEn {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -145041,6 +145389,22 @@ extension on _StringsAr {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -152108,6 +152472,22 @@ extension on _StringsDe {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -159174,6 +159554,22 @@ extension on _StringsEs {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -166246,6 +166642,22 @@ extension on _StringsFr {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -173300,6 +173712,22 @@ extension on _StringsId {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -180368,6 +180796,22 @@ extension on _StringsIt {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -187398,6 +187842,22 @@ extension on _StringsJa {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -194432,6 +194892,22 @@ extension on _StringsKo {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -201494,6 +201970,22 @@ extension on _StringsNl {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -208553,6 +209045,22 @@ extension on _StringsPtBr {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -215617,6 +216125,22 @@ extension on _StringsRu {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -222664,6 +223188,22 @@ extension on _StringsTh {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -229720,6 +230260,22 @@ extension on _StringsTr {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -236772,6 +237328,22 @@ extension on _StringsVi {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }
@@ -243766,6 +244338,21 @@ extension on _StringsZhCn {
         return '打开 App Store';
       case 'update_release_page_open':
         return '发布页';
+      case 'anki_connect_addon_install':
+        return '安装 AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return '从 AnkiWeb 下载 AnkiConnect 并交给正在运行的 Anki。Anki 会弹窗请你确认，之后按它的提示重启。';
+      case 'anki_connect_addon_handed':
+        return '已把 AnkiConnect 交给 Anki。请在 Anki 弹出的确认框中同意，然后按 Anki 的提示重启。';
+      case 'anki_connect_addon_anki_not_running':
+        return '没有检测到正在运行的 Anki。请先启动 Anki 桌面版再试。';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            '无法从 AnkiWeb 下载 AnkiConnect：${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb 返回的内容不是可用的插件包。';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) => '无法把插件交给 Anki：${error}';
       default:
         return null;
     }
@@ -250791,6 +251378,22 @@ extension on _StringsZhHk {
         return 'Open App Store';
       case 'update_release_page_open':
         return 'Release page';
+      case 'anki_connect_addon_install':
+        return 'Install AnkiConnect';
+      case 'anki_connect_addon_install_hint':
+        return 'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
+      case 'anki_connect_addon_handed':
+        return 'Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.';
+      case 'anki_connect_addon_anki_not_running':
+        return 'No running Anki found. Start Anki desktop first, then try again.';
+      case 'anki_connect_addon_download_failed':
+        return ({required Object error}) =>
+            'Could not download AnkiConnect from AnkiWeb: ${error}';
+      case 'anki_connect_addon_invalid':
+        return 'AnkiWeb returned something that is not a usable add-on package.';
+      case 'anki_connect_addon_launch_failed':
+        return ({required Object error}) =>
+            'Could not hand the add-on to Anki: ${error}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "刮削资料与封面",
   "update_testflight_open": "打开 TestFlight",
   "update_app_store_open": "打开 App Store",
-  "update_release_page_open": "发布页"
+  "update_release_page_open": "发布页",
+  "anki_connect_addon_install": "安装 AnkiConnect",
+  "anki_connect_addon_install_hint": "从 AnkiWeb 下载 AnkiConnect 并交给正在运行的 Anki。Anki 会弹窗请你确认，之后按它的提示重启。",
+  "anki_connect_addon_handed": "已把 AnkiConnect 交给 Anki。请在 Anki 弹出的确认框中同意，然后按 Anki 的提示重启。",
+  "anki_connect_addon_anki_not_running": "没有检测到正在运行的 Anki。请先启动 Anki 桌面版再试。",
+  "anki_connect_addon_download_failed": "无法从 AnkiWeb 下载 AnkiConnect：$error",
+  "anki_connect_addon_invalid": "AnkiWeb 返回的内容不是可用的插件包。",
+  "anki_connect_addon_launch_failed": "无法把插件交给 Anki：$error"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3428,5 +3428,12 @@
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
-  "update_release_page_open": "Release page"
+  "update_release_page_open": "Release page",
+  "anki_connect_addon_install": "Install AnkiConnect",
+  "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
+  "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
+  "anki_connect_addon_anki_not_running": "No running Anki found. Start Anki desktop first, then try again.",
+  "anki_connect_addon_download_failed": "Could not download AnkiConnect from AnkiWeb: $error",
+  "anki_connect_addon_invalid": "AnkiWeb returned something that is not a usable add-on package.",
+  "anki_connect_addon_launch_failed": "Could not hand the add-on to Anki: $error"
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2237,6 +2237,9 @@ class AppModel with ChangeNotifier {
       // 同样反向 import 不了 applyAppProxy。只接**远程媒体**这一条，AnkiConnect 自身
       // （localhost:8765，也可能是局域网另一台机）绝不经过它。
       installAnkiRemoteMediaHttpClientFactory();
+      // 「代装 AnkiConnect」从 ankiweb.net 下插件包，同样是公网出站、同样住在
+      // fushi_anki 包里。与上面一条彼此独立：一个抓发音，一个下插件。
+      installAnkiAddonDownloadHttpClientFactory();
       _applyMemoryPolicy();
       // BUG-1647：lazy getter 可能已提前建过实例；替换前先取消其重试定时器，
       // 否则旧定时器会拿着旧 repository 继续同步。

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -48,6 +48,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   /// type，互斥防重入。
   bool _lapisBusy = false;
 
+  /// 「代装 AnkiConnect」进行中。与 [_lapisBusy] 分开：两者操作对象不同
+  /// （一个是 Anki 的插件目录，一个是 note type），互不阻塞。
+  bool _addonInstallBusy = false;
+
   /// 媒体去重在途标记（扫描/执行互斥防重入）。
   bool _dedupBusy = false;
 
@@ -61,6 +65,16 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   /// AnkiConnect，没有这条支路。
   static final bool _isMobileAnkiPlatform =
       Platform.isAndroid || Platform.isIOS;
+
+  /// 是否提供「代装 AnkiConnect」入口。
+  ///
+  /// 只有 Windows：代装依赖从**正在运行的 Anki 进程**读出它自己的 exe 路径，
+  /// 而这套进程枚举目前只有 Win32 实现（见 `AnkiDesktopForeground`）。
+  ///
+  /// 这里刻意**不**把「Anki 此刻在不在跑」也作为显示条件：藏起来用户根本发现
+  /// 不了这个功能，更不会知道前提是先开 Anki。入口常显、点下去再探测并如实
+  /// 告知「请先启动 Anki」，比静默消失有用。顺带也避免了每帧去枚举顶层窗口。
+  static final bool _supportsAddonInstall = Platform.isWindows;
 
   @override
   Widget build(BuildContext context) {
@@ -133,6 +147,25 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
               // 必须当场处置（见 [_updateAnkiConnectApiKey]）。
               onChanged: _updateAnkiConnectApiKey,
             ),
+            // 没有 AnkiConnect，上面这三个字段填得再对也连不上——而装它原本要
+            // 手动走 工具 → 插件 → 获取插件 → 输编号 → 重启。这一行把那套流程
+            // 收成一次点击：下载 + 交给 Anki，剩下的确认与重启由 Anki 自己主持。
+            if (_supportsAddonInstall)
+              AdaptiveSettingsRow(
+                icon: Icons.extension_outlined,
+                showIcon: true,
+                title: t.anki_connect_addon_install,
+                subtitle: t.anki_connect_addon_install_hint,
+                trailing: _addonInstallBusy
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child:
+                            adaptiveIndicator(context: context, strokeWidth: 2),
+                      )
+                    : null,
+                onTap: _addonInstallBusy ? null : _installAnkiConnectAddon,
+              ),
           ],
         ),
         // Lapis 样式客制化：备份 / 恢复 / 字号缩放 / 自定义 CSS / 应用。
@@ -867,6 +900,40 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       ));
     } finally {
       if (mounted) setState(() => _lapisBusy = false);
+    }
+  }
+
+  /// 下载 AnkiConnect 并交给正在运行的 Anki 安装。
+  ///
+  /// 措辞上刻意不说「已安装」：装不装由用户在 Anki 自己弹的确认框里决定，之后
+  /// 还要重启 Anki 才生效，Fushi 两件事都无从得知。能证明插件真的到位的只有
+  /// 之后 AnkiConnect 能应答，那属于连接探活，不是这里该声称的。
+  Future<void> _installAnkiConnectAddon() async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _addonInstallBusy = true);
+    try {
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+      messenger.showSnackBar(
+        SnackBar(content: Text(_addonInstallMessage(result))),
+      );
+    } finally {
+      if (mounted) setState(() => _addonInstallBusy = false);
+    }
+  }
+
+  String _addonInstallMessage(AnkiAddonInstallResult result) {
+    switch (result.status) {
+      case AnkiAddonInstallStatus.handedToAnki:
+        return t.anki_connect_addon_handed;
+      case AnkiAddonInstallStatus.ankiNotRunning:
+        return t.anki_connect_addon_anki_not_running;
+      case AnkiAddonInstallStatus.downloadFailed:
+        return t.anki_connect_addon_download_failed(error: result.detail ?? '');
+      case AnkiAddonInstallStatus.invalidPackage:
+        return t.anki_connect_addon_invalid;
+      case AnkiAddonInstallStatus.launchFailed:
+        return t.anki_connect_addon_launch_failed(error: result.detail ?? '');
     }
   }
 

--- a/fushi/lib/src/utils/net/anki_addon_download_http.dart
+++ b/fushi/lib/src/utils/net/anki_addon_download_http.dart
@@ -1,0 +1,24 @@
+/// 把 `fushi_anki` 的「代装 AnkiConnect 插件」下载链路接到全应用代理出口（app 侧接线）。
+///
+/// 与 `anki_remote_media_http.dart`（BUG-1498）、`dictionary_dio.dart`（BUG-1493）同范式：
+/// 包内只留一个进程级工厂钩子，代理解析层住在 app 侧，由本文件把两边接上。
+///
+/// 这条链路打的是公网 `ankiweb.net`，**必须**能走代理：装 AnkiConnect 是接入 Anki 的第一
+/// 步，这一步下不下来，后面整条制卡链路都无从谈起。与之相对，[AnkiConnectService] 自己那
+/// 条打 `localhost:8765` 的链路绝不接代理（见 `outbound_http_discipline_guard_test.dart`
+/// 的登记表）—— 同一个包里两条出站，方向正好相反，别接混。
+library;
+
+import 'package:http/http.dart' as http;
+
+import 'package:fushi_anki/fushi_anki.dart';
+
+import 'package:fushi/src/utils/net/app_http.dart';
+
+/// 把插件下载的 client 工厂接到应用代理出口。幂等，可重复调用。
+void installAnkiAddonDownloadHttpClientFactory() {
+  ankiAddonDownloadHttpClientFactory = createProxiedAnkiAddonDownloadClient;
+}
+
+/// 建一个走应用代理的 [http.Client]。插件包只有几十 KB，沿用默认的连接超时即可。
+http.Client createProxiedAnkiAddonDownloadClient() => createAppHttpIoClient();

--- a/fushi/lib/utils.dart
+++ b/fushi/lib/utils.dart
@@ -50,6 +50,7 @@ export 'src/utils/net/app_proxy.dart';
 export 'src/utils/net/app_http.dart';
 export 'src/utils/net/dictionary_dio.dart';
 export 'src/utils/net/anki_remote_media_http.dart';
+export 'src/utils/net/anki_addon_download_http.dart';
 export 'src/utils/misc/update_check_cache.dart';
 export 'src/utils/misc/fushi_toast.dart';
 export 'src/utils/misc/webview_asset_url.dart';

--- a/fushi/test/anki/anki_desktop_foreground_test.dart
+++ b/fushi/test/anki/anki_desktop_foreground_test.dart
@@ -145,6 +145,47 @@ void main() {
 
     expect(await repo.openNoteInAnki(305), isTrue);
   });
+
+  /// 代装 AnkiConnect 要拿 `anki.exe` 的路径。刻意只认**正在运行的进程**报出来
+  /// 的路径，而不去注册表或默认安装目录里猜：绿色版、自定义安装位置、多版本
+  /// 共存都会让猜测失准，而进程自己报的永远是真在跑的那一个。
+  group('findRunningAnkiExecutable', () {
+    test('取正在运行的 Anki 进程自己报出的完整路径', () {
+      final List<String> events = <String>[];
+      AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+        events: events,
+        ankiPid: 4321,
+        foregroundPidSequence: <int?>[4321],
+        ankiExecutablePath: r'C:\Program Files\Anki\anki.exe',
+      );
+
+      expect(
+        AnkiDesktopForeground.findRunningAnkiExecutable(),
+        r'C:\Program Files\Anki\anki.exe',
+      );
+      expect(events, <String>['find', 'imagePath:4321']);
+    });
+
+    test('Anki 没在运行时返回 null，不去别处猜路径', () {
+      final List<String> events = <String>[];
+      AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+        events: events,
+        ankiPid: null,
+        foregroundPidSequence: <int?>[null],
+        ankiExecutablePath: r'C:\Program Files\Anki\anki.exe',
+      );
+
+      expect(AnkiDesktopForeground.findRunningAnkiExecutable(), isNull);
+      // 没有 pid 就不该再去问路径。
+      expect(events, <String>['find']);
+    });
+
+    test('Win32 不可用时 fail-soft 返回 null，不把异常抛给调用方', () {
+      AnkiDesktopForeground.debugBackend = _ThrowingForegroundBackend();
+
+      expect(AnkiDesktopForeground.findRunningAnkiExecutable(), isNull);
+    });
+  });
 }
 
 /// 记录调用时间线的 Win32 替身。
@@ -154,11 +195,13 @@ class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
     required this.ankiPid,
     required List<int?> foregroundPidSequence,
     this.raiseSucceeds = true,
+    this.ankiExecutablePath,
   }) : _foregroundPidSequence = foregroundPidSequence;
 
   final List<String> events;
   final int? ankiPid;
   final bool raiseSucceeds;
+  final String? ankiExecutablePath;
 
   /// 依次返回的「当前前台进程」；用完后保持最后一个值。
   final List<int?> _foregroundPidSequence;
@@ -191,6 +234,12 @@ class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
     events.add('raise:$pid');
     return raiseSucceeds;
   }
+
+  @override
+  String? processImagePath(int pid) {
+    events.add('imagePath:$pid');
+    return ankiExecutablePath;
+  }
 }
 
 class _ThrowingForegroundBackend implements AnkiDesktopForegroundBackend {
@@ -208,4 +257,7 @@ class _ThrowingForegroundBackend implements AnkiDesktopForegroundBackend {
   @override
   bool raiseTopWindowOfProcess(int pid) =>
       throw StateError('user32 unavailable');
+
+  @override
+  String? processImagePath(int pid) => throw StateError('user32 unavailable');
 }

--- a/fushi/test/tools/outbound_http_discipline_guard_test.dart
+++ b/fushi/test/tools/outbound_http_discipline_guard_test.dart
@@ -73,6 +73,11 @@ const Map<String, String> kOutboundAssemblyPoints = <String, String>{
       '更新包下载：同上，逐镜像建 client + applyAppProxy',
   'packages/fushi_anki/lib/src/anki_remote_media_http.dart':
       '制卡远程媒体的包内工厂钩子（BUG-1498）：未接线时回退裸 HttpClient，行为与接线前等价',
+  'packages/fushi_anki/lib/src/ankiconnect/ankiconnect_installer.dart':
+      '代装 AnkiConnect 时从 ankiweb.net 下插件包的包内工厂钩子（同 BUG-1498 范式）：'
+          'app 侧经 installAnkiAddonDownloadHttpClientFactory 接线，未接线时回退裸 '
+          'http.Client()。注意与同包 ankiconnect_service.dart 方向相反——那条打 '
+          'localhost 必须直连，这条打公网必须能走代理。',
   'packages/fushi_dictionary/lib/src/formats/dictionary_downloader.dart':
       '词典链路的包内工厂钩子（BUG-1493）：createDictionaryDio 里 `?? Dio()` 的未接线回退',
 };
@@ -109,7 +114,7 @@ const Map<String, String> kBareOutboundRegistry = <String, String>{
 
 /// 登记在案的文件总数（装配点 + 豁免）。**这是自校验用的哨兵**：改清单必须同步改这个数，
 /// 光靠「新增未登记即红」挡不住「悄悄多登记一条」。
-const int kRegisteredOutboundFileCount = 19;
+const int kRegisteredOutboundFileCount = 20;
 
 /// 裸出站构造的判据。
 ///

--- a/packages/fushi_anki/CLAUDE.md
+++ b/packages/fushi_anki/CLAUDE.md
@@ -17,6 +17,7 @@ Anki 集成模块：定义 Anki 服务抽象接口，提供 AnkiDroid（Android 
 - `AnkiService` -- 抽象接口：`isAvailable()` / `getDeckNames()` / `getModelNames()` / `getModelFields()` / `addNote()` / `isDuplicate()`。
 - `AnkiRepository` (`ankidroid/`) -- AnkiDroid Content Provider 实现（Android 专用）。
 - `AnkiConnectRepository` + `AnkiConnectService` (`ankiconnect/`) -- AnkiConnect HTTP 实现（桌面/远程）。
+- `AnkiConnectInstaller` (`ankiconnect/ankiconnect_installer.dart`) -- 代装 AnkiConnect 插件（仅 Windows）：从 AnkiWeb 下裸包、**补上包内没有的 `manifest.json`** 后重新打包，再把 `.ankiaddon` 交给正在运行的 `anki.exe`，由 Anki 自己弹确认框并完成安装。下载出站走包内工厂钩子 `ankiAddonDownloadHttpClientFactory`（app 侧接线，经应用代理）——与打 localhost 必须直连的 `AnkiConnectService` 方向相反。
 - `BaseAnkiRepository` -- 共享基类。
 - `AnkiModels` -- Anki 数据模型。
 - `LapisPreset` -- 预设卡片模板。

--- a/packages/fushi_anki/lib/fushi_anki.dart
+++ b/packages/fushi_anki/lib/fushi_anki.dart
@@ -14,5 +14,6 @@ export 'src/lapis_style_preview.dart';
 export 'src/lapis_styling.dart';
 export 'src/ankidroid/anki_repository.dart';
 export 'src/ankiconnect/anki_desktop_foreground.dart';
+export 'src/ankiconnect/ankiconnect_installer.dart';
 export 'src/ankiconnect/ankiconnect_repository.dart';
 export 'src/ankiconnect/ankiconnect_service.dart';

--- a/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
@@ -49,6 +49,27 @@ abstract final class AnkiDesktopForeground {
     }
   }
 
+  /// 本机正在运行的 Anki 的可执行文件完整路径；没在运行/不适用时 null。
+  ///
+  /// 「Anki 正在运行」是它唯一的信息来源，也正因如此它比去注册表或默认安装路径
+  /// 里猜 `anki.exe` 可靠：进程自己报出来的路径不会因为绿色版、自定义安装目录或
+  /// 多版本共存而失准。代价是 Anki 没开时拿不到 —— 这是有意的取舍，见
+  /// `AnkiConnectInstaller`。
+  ///
+  /// 与 [grantForegroundToAnki] 一样全程 fail-soft：非 Windows、FFI 加载失败、
+  /// 找不到窗口都退回 null。
+  static String? findRunningAnkiExecutable() {
+    final AnkiDesktopForegroundBackend? backend = _backend;
+    if (backend == null) return null;
+    try {
+      final int? pid = backend.findAnkiProcessId();
+      if (pid == null) return null;
+      return backend.processImagePath(pid);
+    } on Object {
+      return null;
+    }
+  }
+
   /// 把前台权限让渡给本机 Anki 进程，返回它的 pid（找不到/不适用时 null）。
   ///
   /// 返回值交给 [raiseAnkiWindow]，避免在这里存跨调用的可变全局状态。
@@ -101,6 +122,9 @@ abstract interface class AnkiDesktopForegroundBackend {
 
   /// 按 Z 序取 [pid] 最顶的可见顶层窗口，必要时从最小化恢复，再置前台。
   bool raiseTopWindowOfProcess(int pid);
+
+  /// [pid] 的可执行文件完整路径；取不到返回 null。
+  String? processImagePath(int pid);
 }
 
 final class _WindowsAnkiForeground implements AnkiDesktopForegroundBackend {
@@ -234,12 +258,13 @@ final class _WindowsAnkiForeground implements AnkiDesktopForegroundBackend {
   }
 
   bool _isAnkiProcess(int pid) {
-    final String? imagePath = _processImagePath(pid);
+    final String? imagePath = processImagePath(pid);
     if (imagePath == null) return false;
     return _basenameLower(imagePath) == 'anki.exe';
   }
 
-  String? _processImagePath(int pid) {
+  @override
+  String? processImagePath(int pid) {
     final int handle = _openProcess(_processQueryLimitedInformation, 0, pid);
     if (handle == 0) return null;
     final Pointer<Utf16> path = calloc<Uint16>(_imagePathBufferLength).cast();

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_installer.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_installer.dart
@@ -1,0 +1,426 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'anki_desktop_foreground.dart';
+
+/// 下载插件包所用 [http.Client] 的进程级装配钩子（BUG-1498 同范式）。
+///
+/// 与 [AnkiConnectService] 那条**必须直连**的链路正相反：这里打的是公网
+/// `ankiweb.net`，不走应用代理的话，同一台机器上浏览器能打开的地址在 app 里可能
+/// 根本下不下来 —— Dart 的 `HttpClient` 默认连 `HTTPS_PROXY` 环境变量都不读。
+///
+/// 代理解析层住在 app 侧（要读偏好、跑 `reg query` / `scutil` / `gsettings`），本包
+/// 反向 import 不了它，所以留这个钩子由 app 在初始化时接线。未接线（null）时回退裸
+/// `http.Client()`，行为与接线前逐字等价。
+http.Client Function()? ankiAddonDownloadHttpClientFactory;
+
+/// 让 Fushi 代装 AnkiConnect —— 打通「Fushi 能连上 Anki」的第一道门槛。
+///
+/// 用户要用 Fushi 制卡就必须先有 AnkiConnect，而装它原本要手动走
+/// 工具 → 插件 → 获取插件 → 输入编号 → 重启。没装之前 Fushi 连不上 Anki，
+/// 用户正卡在设置页对着「连接失败」，这一步是纯粹的流失点。
+///
+/// ## 为什么是「交给 Anki 自己装」而不是自己铺 addons21/
+///
+/// Anki 桌面把 `.ankiaddon` 当作可打开的文件：把路径当命令行参数交给
+/// `anki.exe`，运行中的实例经单实例消息走 `onAppMsg → installAddon`，冷启动
+/// 走 `setupAddons(args) → installAddon(startup: true)`。两条路最终都进
+/// `AddonManager.install()`，于是目录写入、`user_files` 备份、旧版本删除、
+/// 冲突插件禁用、min/max 点版本兼容判定，以及那个「插件是能执行任意代码的
+/// 程序」确认框，**全部由 Anki 自己负责**。我们只负责把一个合法的包放到它
+/// 面前，不碰它的数据目录，也不维护 `meta.json` 的 schema。
+///
+/// 顺带一个反直觉的结论：**Anki 没在运行时装反而更干净**（冷启动路径在
+/// `loadAddons()` 之前就装完了，不需要重启）。但那条路要求我们自己去猜
+/// `anki.exe` 装在哪（注册表？默认路径？用户自定义？），而运行中的进程会把
+/// 完整路径**直接告诉我们**。少一个猜测来源胜过省用户一次重启，所以这里
+/// 统一要求 Anki 正在运行 —— 见 [AnkiConnectInstaller.install]。
+///
+/// ## 为什么必须自己补 manifest.json
+///
+/// AnkiWeb 的下载端点下发的是**裸包**：只有插件源码，没有 `manifest.json`
+/// （实测 AnkiConnect 包内仅 `__init__.py`/`config.json`/`config.md`/`edit.py`/
+/// `util.py`/`web.py`）。Anki 自己下载时并不依赖包内 manifest，而是把从下载
+/// URL 的 query 里刨出来的元信息**旁路**传进 `install(manifest: ...)`。
+/// 文件打开这条路（`processPackages`）没有这个旁路，`install()` 读不到包内
+/// manifest 就直接返回 `InstallError("manifest")`。
+///
+/// 所以我们必须复刻 Anki 那份旁路元信息，把它写成包内的 `manifest.json`
+/// 再交出去。字段语义与取值来源见 [AnkiWebAddonBranch]。
+abstract final class AnkiConnectInstaller {
+  /// AnkiConnect 在 AnkiWeb 上的插件编号，同时也是它的安装目录名。
+  static const String ankiConnectAddonId = '2055492159';
+
+  /// 插件在 Anki 插件列表里的显示名。
+  static const String ankiConnectAddonName = 'AnkiConnect';
+
+  /// 下载端点。`v` 是 AnkiWeb 的接口版本，与 Anki 版本无关。
+  static const String _downloadEndpoint = 'https://ankiweb.net/shared/download';
+
+  /// 请求下载时声称的 Anki「点版本」。
+  ///
+  /// 这个值**只用来让 AnkiWeb 挑分支**，不会写进 manifest（写进去的是
+  /// AnkiWeb 在重定向里回给我们的 minpt/maxpt）。我们拿不到用户 Anki 的真实
+  /// 版本 —— AnkiConnect 的 `version` 动作返回的是它自己的 API 版本 6，而这
+  /// 会儿 AnkiConnect 恰恰还没装上。所以这里声称一个「足够新」的版本，语义
+  /// 等价于「给我最新分支」。
+  ///
+  /// 这个参数**不能不传**：实测不传时 AnkiWeb 回的是 `minpt=0&maxpt=-44` 的
+  /// 老分支，而 Anki 的 manifest 约定里 `max_point_version` 为**负数**才是硬
+  /// 上限（`abs(n)` 为最高支持版本），正数只表示「在该版本上测过」并被忽略，
+  /// 于是现代 Anki 会把老分支判成不兼容并禁用。传 ≥45 的任意值都落到现代分支。
+  ///
+  /// 若用户的 Anki 老到不支持最新分支，Anki 会依据包内 manifest 的
+  /// `min_point_version` 自行判定不兼容并如实告知 —— 由 Anki 说话，好过我们
+  /// 在这里猜一个版本号。
+  static const int _requestedPointVersion = 250600;
+
+  /// 下载体积上限；AnkiConnect 实际约 25KB，这里纯粹是防御异常响应。
+  static const int _maxDownloadBytes = 32 * 1024 * 1024;
+
+  /// 单测替身：注入后取代真实的下载 + 落盘 + 启动进程。
+  @visibleForTesting
+  static AnkiConnectInstallerHost? debugHost;
+
+  static AnkiConnectInstallerHost get _host =>
+      debugHost ?? const _RealAnkiConnectInstallerHost();
+
+  /// 下载 AnkiConnect 并交给正在运行的 Anki 安装。
+  ///
+  /// 返回后**插件还没装上**：Anki 会弹自己的确认框，用户点「是」才真正安装，
+  /// 之后还要按 Anki 的提示重启。所以这里的成功只代表「已经把包交到 Anki
+  /// 手上」，绝不能对外说成「已安装」。
+  static Future<AnkiAddonInstallResult> install() async {
+    final String? ankiExecutable = _host.findRunningAnkiExecutable();
+    if (ankiExecutable == null) {
+      return const AnkiAddonInstallResult(
+        AnkiAddonInstallStatus.ankiNotRunning,
+      );
+    }
+
+    final AnkiWebAddonDownload download;
+    try {
+      download = await _host.download(
+        buildDownloadUri(
+          addonId: ankiConnectAddonId,
+          pointVersion: _requestedPointVersion,
+        ),
+        maxBytes: _maxDownloadBytes,
+      );
+    } on Object catch (error) {
+      return AnkiAddonInstallResult(
+        AnkiAddonInstallStatus.downloadFailed,
+        detail: error.toString(),
+      );
+    }
+
+    final Uint8List packaged;
+    try {
+      packaged = repackWithManifest(
+        downloadedZip: download.bytes,
+        manifest: buildManifest(
+          addonId: ankiConnectAddonId,
+          addonName: ankiConnectAddonName,
+          branch: AnkiWebAddonBranch.fromDownloadUri(download.resolvedUri),
+        ),
+      );
+    } on Object catch (error) {
+      return AnkiAddonInstallResult(
+        AnkiAddonInstallStatus.invalidPackage,
+        detail: error.toString(),
+      );
+    }
+
+    try {
+      final String path = await _host.writeTempAddon(
+        '$ankiConnectAddonName.ankiaddon',
+        packaged,
+      );
+      await _host.launch(ankiExecutable, path);
+      return const AnkiAddonInstallResult(AnkiAddonInstallStatus.handedToAnki);
+    } on Object catch (error) {
+      return AnkiAddonInstallResult(
+        AnkiAddonInstallStatus.launchFailed,
+        detail: error.toString(),
+      );
+    }
+  }
+
+  /// 拼下载 URL。抽出来是为了让「必须带 p」这条约束可被测试钉住。
+  static Uri buildDownloadUri({
+    required String addonId,
+    required int pointVersion,
+  }) {
+    return Uri.parse('$_downloadEndpoint/$addonId').replace(
+      queryParameters: <String, String>{
+        'v': '2.1',
+        'p': pointVersion.toString(),
+      },
+    );
+  }
+
+  /// 按 Anki 的 manifest schema 造一份元信息。
+  ///
+  /// schema 只强制 `package` + `name`；其余字段带 `meta: true`，会被 Anki 原样
+  /// 抄进它自己的 `meta.json`。`package` 必须是插件编号 —— 它同时是安装目录名，
+  /// 装错会导致 AnkiConnect 找不到自己的配置。
+  static Map<String, Object?> buildManifest({
+    required String addonId,
+    required String addonName,
+    required AnkiWebAddonBranch branch,
+  }) {
+    return <String, Object?>{
+      'package': addonId,
+      'name': addonName,
+      'mod': branch.modTime,
+      'min_point_version': branch.minPointVersion,
+      'max_point_version': branch.maxPointVersion,
+      'branch_index': branch.branchIndex,
+    };
+  }
+
+  /// 给 AnkiWeb 的裸包补上 `manifest.json` 后重新打包。
+  ///
+  /// 包内**已有** `manifest.json` 时原样保留：那说明上游改了下发格式，或这是
+  /// 作者自行导出的完整包，作者写的元信息永远比我们复刻的更权威。
+  static Uint8List repackWithManifest({
+    required List<int> downloadedZip,
+    required Map<String, Object?> manifest,
+  }) {
+    final Archive archive = ZipDecoder().decodeBytes(downloadedZip);
+    if (archive.files.isEmpty) {
+      throw const FormatException('AnkiWeb 返回的插件包是空的');
+    }
+    final bool hasManifest =
+        archive.files.any((ArchiveFile file) => file.name == 'manifest.json');
+    if (!hasManifest) {
+      final Uint8List encoded =
+          Uint8List.fromList(utf8.encode(jsonEncode(manifest)));
+      archive.addFile(ArchiveFile('manifest.json', encoded.length, encoded));
+    }
+    final List<int>? encoded = ZipEncoder().encode(archive);
+    if (encoded == null) {
+      throw const FormatException('重新打包插件失败');
+    }
+    return Uint8List.fromList(encoded);
+  }
+}
+
+/// [AnkiConnectInstaller] 的安装结果。
+///
+/// 注意没有「已安装」这个态：装或不装由用户在 Anki 的确认框里决定，Fushi 无从
+/// 得知。能确认插件真的到位的唯一判据是之后 AnkiConnect 能应答，那属于连接探活。
+enum AnkiAddonInstallStatus {
+  /// 包已交给 Anki；Anki 会弹确认框，用户确认后按提示重启。
+  handedToAnki,
+
+  /// 没找到正在运行的 Anki（也包含非 Windows 平台）。
+  ankiNotRunning,
+
+  /// 从 AnkiWeb 下载失败。
+  downloadFailed,
+
+  /// 下载到的内容不是一个能重新打包的插件包。
+  invalidPackage,
+
+  /// 包已备好但没能把它交给 Anki。
+  launchFailed,
+}
+
+/// 安装结果 + 失败时的原始错误描述（用于日志与错误提示，不做用户文案）。
+@immutable
+class AnkiAddonInstallResult {
+  const AnkiAddonInstallResult(this.status, {this.detail});
+
+  final AnkiAddonInstallStatus status;
+  final String? detail;
+
+  bool get isHandedToAnki => status == AnkiAddonInstallStatus.handedToAnki;
+
+  @override
+  String toString() =>
+      'AnkiAddonInstallResult($status${detail == null ? '' : ', $detail'})';
+}
+
+/// AnkiWeb 在下载重定向里回给我们的分支元信息。
+///
+/// AnkiWeb 的 `/shared/download/<id>` 会 303 到
+/// `/svc/shared/download-addon/<id>?t=…&minpt=…&maxpt=…&bidx=…`，四个 query
+/// 参数正是 Anki 自己安装时写进 `meta.json` 的那四项（见 aqt 的
+/// `extract_meta_from_download_url`）。我们必须走同一个来源，而不是硬编码 ——
+/// 上游换分支时这些值会跟着变。
+@immutable
+class AnkiWebAddonBranch {
+  const AnkiWebAddonBranch({
+    required this.modTime,
+    required this.minPointVersion,
+    required this.maxPointVersion,
+    required this.branchIndex,
+  });
+
+  /// 插件最后更新时间（unix 秒），对应 query 的 `t`。
+  final int modTime;
+
+  /// 支持的最低 Anki 点版本，对应 `minpt`。
+  final int minPointVersion;
+
+  /// 对应 `maxpt`。**负数**才表示硬上限（`abs(n)` 为最高支持版本），正数只表示
+  /// 「在该版本上测过」并被 Anki 忽略。
+  final int maxPointVersion;
+
+  /// 用户下到的是哪条分支，对应 `bidx`。
+  final int branchIndex;
+
+  /// 从下载重定向后的最终 URL 解析。缺字段或非整数一律抛 [FormatException] ——
+  /// 与其猜一个默认值写进 manifest 让 Anki 误判兼容性，不如当场失败。
+  static AnkiWebAddonBranch fromDownloadUri(Uri uri) {
+    int read(String key) {
+      final String? raw = uri.queryParameters[key];
+      if (raw == null) {
+        throw FormatException('AnkiWeb 下载地址缺少 $key 参数', uri.toString());
+      }
+      final int? value = int.tryParse(raw);
+      if (value == null) {
+        throw FormatException('AnkiWeb 下载地址的 $key 不是整数', raw);
+      }
+      return value;
+    }
+
+    return AnkiWebAddonBranch(
+      modTime: read('t'),
+      minPointVersion: read('minpt'),
+      maxPointVersion: read('maxpt'),
+      branchIndex: read('bidx'),
+    );
+  }
+}
+
+/// 一次下载的结果：包体 + **重定向后**的最终地址。
+///
+/// 最终地址不是可有可无的日志信息，分支元信息只存在于它的 query 里。
+@immutable
+class AnkiWebAddonDownload {
+  const AnkiWebAddonDownload({required this.bytes, required this.resolvedUri});
+
+  final Uint8List bytes;
+  final Uri resolvedUri;
+}
+
+/// 重定向跟随上限，防御异常的重定向环。
+const int _maxAddonDownloadRedirects = 5;
+
+/// 手动逐跳跟随重定向地下载，返回包体与**最终**地址。
+///
+/// 为什么不用 `package:http` 的自动跟随：它跟完之后**拿不到最终 URL**，而这个功能
+/// 赖以生存的分支元信息（`t`/`minpt`/`maxpt`/`bidx`）只存在于最终 URL 的 query 里。
+/// 自动跟随会把它悄悄丢掉，然后我们只能去猜兼容区间 —— 猜错的症状是「插件装上了却
+/// 被 Anki 静默禁用」。所以这一跳一跳是**必须**自己走的。
+///
+/// 独立成顶层函数而不是埋进 host 实现，是为了能用 `MockClient` 钉住它。
+@visibleForTesting
+Future<AnkiWebAddonDownload> downloadFollowingRedirects(
+  http.Client client,
+  Uri uri, {
+  required int maxBytes,
+  int maxRedirects = _maxAddonDownloadRedirects,
+}) async {
+  Uri current = uri;
+  for (int hop = 0; hop <= maxRedirects; hop++) {
+    final http.Request request = http.Request('GET', current)
+      ..followRedirects = false;
+    final http.StreamedResponse response = await client.send(request);
+    final String? location = response.headers['location'];
+    if (response.isRedirect && location != null) {
+      await response.stream.drain<void>();
+      // 相对 Location（AnkiWeb 回的正是 `/svc/shared/download-addon/...`）要按
+      // 当前地址解析成绝对地址。
+      current = current.resolve(location);
+      continue;
+    }
+    if (response.statusCode != 200) {
+      throw http.ClientException(
+        'AnkiWeb 返回 HTTP ${response.statusCode}',
+        current,
+      );
+    }
+    final Uint8List bytes = await _readCapped(response, maxBytes, current);
+    return AnkiWebAddonDownload(bytes: bytes, resolvedUri: current);
+  }
+  throw http.ClientException('AnkiWeb 重定向次数过多', uri);
+}
+
+/// 边收边判上限，不先收完再看大小。
+Future<Uint8List> _readCapped(
+  http.StreamedResponse response,
+  int maxBytes,
+  Uri uri,
+) async {
+  final BytesBuilder builder = BytesBuilder(copy: false);
+  await for (final List<int> chunk in response.stream) {
+    builder.add(chunk);
+    if (builder.length > maxBytes) {
+      throw http.ClientException('AnkiWeb 返回的内容超出上限', uri);
+    }
+  }
+  return builder.takeBytes();
+}
+
+/// 安装过程里的全部外部作用：找 Anki、下载、落盘、起进程。
+///
+/// 抽成接口是为了让编排逻辑可测 —— 真实实现只有薄薄一层。
+abstract interface class AnkiConnectInstallerHost {
+  /// 正在运行的 Anki 可执行文件完整路径；没有则 null（含非 Windows）。
+  String? findRunningAnkiExecutable();
+
+  /// 下载并跟随重定向，返回包体与最终地址。
+  Future<AnkiWebAddonDownload> download(Uri uri, {required int maxBytes});
+
+  /// 把包写进临时目录，返回完整路径。
+  Future<String> writeTempAddon(String fileName, Uint8List bytes);
+
+  /// 用 [executable] 打开 [addonPath]。
+  Future<void> launch(String executable, String addonPath);
+}
+
+class _RealAnkiConnectInstallerHost implements AnkiConnectInstallerHost {
+  const _RealAnkiConnectInstallerHost();
+
+  @override
+  String? findRunningAnkiExecutable() =>
+      AnkiDesktopForeground.findRunningAnkiExecutable();
+
+  @override
+  Future<AnkiWebAddonDownload> download(
+    Uri uri, {
+    required int maxBytes,
+  }) async {
+    final http.Client client =
+        ankiAddonDownloadHttpClientFactory?.call() ?? http.Client();
+    try {
+      return await downloadFollowingRedirects(client, uri, maxBytes: maxBytes);
+    } finally {
+      client.close();
+    }
+  }
+
+  @override
+  Future<String> writeTempAddon(String fileName, Uint8List bytes) async {
+    final Directory dir =
+        await Directory.systemTemp.createTemp('fushi_ankiaddon_');
+    final File file = File('${dir.path}${Platform.pathSeparator}$fileName');
+    await file.writeAsBytes(bytes, flush: true);
+    return file.path;
+  }
+
+  @override
+  Future<void> launch(String executable, String addonPath) async {
+    // 不等它退出：Anki 已在运行时这个进程会把参数经单实例通道转交给既有实例后
+    // 立刻退出；而我们也不该阻塞在用户面前那个确认框上。
+    await Process.start(executable, <String>[addonPath]);
+  }
+}

--- a/packages/fushi_anki/pubspec.yaml
+++ b/packages/fushi_anki/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   ffi: ^2.1.3
   shared_preferences: ^2.2.2
   http: ^1.1.0
+  # AnkiWeb 下发的插件包不带 manifest.json，必须由我们补齐后重新打包才能交给
+  # Anki 安装（见 AnkiConnectInstaller）。
+  archive: ^3.6.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/fushi_anki/test/ankiconnect_installer_test.dart
+++ b/packages/fushi_anki/test/ankiconnect_installer_test.dart
@@ -1,0 +1,412 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/src/ankiconnect/ankiconnect_installer.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// 造一个「AnkiWeb 下发的裸包」——只有源码，**没有** manifest.json。
+/// 这正是实测下来 AnkiConnect 包的形状（`__init__.py`/`config.json`/…）。
+Uint8List _bareAddonZip({Map<String, String>? extra}) {
+  final Archive archive = Archive();
+  final Map<String, String> files = <String, String>{
+    '__init__.py': 'from . import web\n',
+    'config.json': '{"webBindPort": 8765}\n',
+    ...?extra,
+  };
+  files.forEach((String name, String content) {
+    final List<int> bytes = utf8.encode(content);
+    archive.addFile(ArchiveFile(name, bytes.length, bytes));
+  });
+  final List<int>? encoded = ZipEncoder().encode(archive);
+  return Uint8List.fromList(encoded!);
+}
+
+Map<String, ArchiveFile> _entries(List<int> zip) {
+  return <String, ArchiveFile>{
+    for (final ArchiveFile file in ZipDecoder().decodeBytes(zip))
+      file.name: file,
+  };
+}
+
+const AnkiWebAddonBranch _branch = AnkiWebAddonBranch(
+  modTime: 1762717231,
+  minPointVersion: 45,
+  maxPointVersion: 45,
+  branchIndex: 1,
+);
+
+void main() {
+  group('下载地址', () {
+    // 这条不是形式主义：实测不带 p 时 AnkiWeb 回的是 minpt=0&maxpt=-44 的老分支，
+    // 而 max_point_version 为负在 Anki 里是**硬上限**，现代 Anki 会判不兼容并禁用。
+    // 少了 p 这个功能就是「装上了但被禁用」，且没有任何报错。
+    test('必须带上点版本参数，否则会拿到被现代 Anki 判为不兼容的老分支', () {
+      final Uri uri = AnkiConnectInstaller.buildDownloadUri(
+        addonId: AnkiConnectInstaller.ankiConnectAddonId,
+        pointVersion: 250600,
+      );
+      expect(uri.queryParameters['p'], '250600');
+      expect(uri.queryParameters['v'], '2.1');
+      expect(uri.path, endsWith('/2055492159'));
+      expect(uri.host, 'ankiweb.net');
+    });
+  });
+
+  group('分支元信息解析', () {
+    test('从重定向后的地址取出 t / minpt / maxpt / bidx', () {
+      final AnkiWebAddonBranch branch = AnkiWebAddonBranch.fromDownloadUri(
+        Uri.parse(
+          'https://ankiweb.net/svc/shared/download-addon/2055492159'
+          '?t=1762717231&minpt=45&maxpt=45&bidx=1',
+        ),
+      );
+      expect(branch.modTime, 1762717231);
+      expect(branch.minPointVersion, 45);
+      expect(branch.maxPointVersion, 45);
+      expect(branch.branchIndex, 1);
+    });
+
+    test('负的 maxpt 原样保留——它是硬上限，不能被归一化掉', () {
+      final AnkiWebAddonBranch branch = AnkiWebAddonBranch.fromDownloadUri(
+        Uri.parse('https://x/y?t=1&minpt=0&maxpt=-44&bidx=0'),
+      );
+      expect(branch.maxPointVersion, -44);
+    });
+
+    // 缺字段时宁可失败：猜一个默认值写进 manifest 会让 Anki 拿错误的兼容区间
+    // 去判定，症状是「装上了却被静默禁用」，比当场报错难查得多。
+    test('缺字段或非整数一律抛，不静默兜底', () {
+      expect(
+        () => AnkiWebAddonBranch.fromDownloadUri(
+          Uri.parse('https://x/y?t=1&minpt=45&bidx=1'),
+        ),
+        throwsFormatException,
+      );
+      expect(
+        () => AnkiWebAddonBranch.fromDownloadUri(
+          Uri.parse('https://x/y?t=1&minpt=45&maxpt=x&bidx=1'),
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('重新打包', () {
+    test('给裸包补上 manifest.json，且原有文件一个不少', () {
+      final Uint8List repacked = AnkiConnectInstaller.repackWithManifest(
+        downloadedZip: _bareAddonZip(),
+        manifest: AnkiConnectInstaller.buildManifest(
+          addonId: AnkiConnectInstaller.ankiConnectAddonId,
+          addonName: AnkiConnectInstaller.ankiConnectAddonName,
+          branch: _branch,
+        ),
+      );
+
+      final Map<String, ArchiveFile> entries = _entries(repacked);
+      expect(entries.keys, containsAll(<String>['__init__.py', 'config.json']));
+      expect(entries['manifest.json'], isNotNull,
+          reason: 'AnkiWeb 裸包没有 manifest，不补 Anki 会直接 InstallError("manifest")');
+
+      // 原文件内容必须原样带过去，不能被重新打包弄坏。
+      expect(
+        utf8.decode(entries['__init__.py']!.content as List<int>),
+        'from . import web\n',
+      );
+
+      final Map<String, Object?> manifest = jsonDecode(
+        utf8.decode(entries['manifest.json']!.content as List<int>),
+      ) as Map<String, Object?>;
+      // package 同时是安装目录名，错了 AnkiConnect 就找不到自己的配置。
+      expect(manifest['package'], '2055492159');
+      expect(manifest['name'], 'AnkiConnect');
+      expect(manifest['mod'], 1762717231);
+      expect(manifest['min_point_version'], 45);
+      expect(manifest['max_point_version'], 45);
+      expect(manifest['branch_index'], 1);
+    });
+
+    test('包内已有 manifest.json 时原样保留，不被我们复刻的版本覆盖', () {
+      final Uint8List repacked = AnkiConnectInstaller.repackWithManifest(
+        downloadedZip: _bareAddonZip(
+          extra: <String, String>{
+            'manifest.json': '{"package":"upstream","name":"Upstream"}',
+          },
+        ),
+        manifest: AnkiConnectInstaller.buildManifest(
+          addonId: 'ours',
+          addonName: 'Ours',
+          branch: _branch,
+        ),
+      );
+
+      final Map<String, Object?> manifest = jsonDecode(
+        utf8.decode(_entries(repacked)['manifest.json']!.content as List<int>),
+      ) as Map<String, Object?>;
+      expect(manifest['package'], 'upstream');
+      expect(manifest['name'], 'Upstream');
+    });
+
+    test('空包直接失败，不产出一个只有 manifest 的壳', () {
+      final List<int> emptyZip = ZipEncoder().encode(Archive())!;
+      expect(
+        () => AnkiConnectInstaller.repackWithManifest(
+          downloadedZip: emptyZip,
+          manifest: const <String, Object?>{'package': 'x', 'name': 'x'},
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('下载与重定向', () {
+    // 这组守的是整个功能的前提：分支元信息（t/minpt/maxpt/bidx）**只**存在于
+    // 重定向之后那个 URL 的 query 里。用 package:http 的自动跟随会把最终 URL
+    // 丢掉，于是只能去猜兼容区间——猜错的症状是「装上了却被 Anki 静默禁用」。
+    test('跟随 303，把重定向后的最终地址（带分支 query）交回来', () async {
+      final List<String> visited = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        visited.add(req.url.toString());
+        if (req.url.path.startsWith('/shared/download')) {
+          return http.Response(
+            '',
+            303,
+            headers: <String, String>{
+              'location': '/svc/shared/download-addon/2055492159'
+                  '?t=1762717231&minpt=45&maxpt=45&bidx=1',
+            },
+            isRedirect: true,
+          );
+        }
+        return http.Response.bytes(<int>[1, 2, 3], 200);
+      });
+
+      final AnkiWebAddonDownload download = await downloadFollowingRedirects(
+        client,
+        Uri.parse(
+          'https://ankiweb.net/shared/download/2055492159?v=2.1&p=250600',
+        ),
+        maxBytes: 1024,
+      );
+
+      expect(download.bytes, <int>[1, 2, 3]);
+      // 相对 Location 必须被解析成绝对地址，主机不能丢。
+      expect(download.resolvedUri.host, 'ankiweb.net');
+      expect(download.resolvedUri.queryParameters['bidx'], '1');
+      expect(download.resolvedUri.queryParameters['minpt'], '45');
+      expect(visited.length, 2);
+
+      // 解析出来的分支元信息要能直接喂给 manifest。
+      final AnkiWebAddonBranch branch =
+          AnkiWebAddonBranch.fromDownloadUri(download.resolvedUri);
+      expect(branch.modTime, 1762717231);
+      expect(branch.branchIndex, 1);
+    });
+
+    test('非 200 直接失败，不把错误页当插件包', () async {
+      final MockClient client =
+          MockClient((http.Request req) async => http.Response('nope', 404));
+
+      expect(
+        () => downloadFollowingRedirects(
+          client,
+          Uri.parse('https://ankiweb.net/shared/download/1'),
+          maxBytes: 1024,
+        ),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+
+    test('超出体积上限时中断，不把内存吃光', () async {
+      final MockClient client = MockClient(
+        (http.Request req) async =>
+            http.Response.bytes(List<int>.filled(4096, 7), 200),
+      );
+
+      expect(
+        () => downloadFollowingRedirects(
+          client,
+          Uri.parse('https://ankiweb.net/shared/download/1'),
+          maxBytes: 16,
+        ),
+        throwsA(isA<http.ClientException>()),
+      );
+    });
+
+    test('重定向成环时有上限，不无限跟下去', () async {
+      int hops = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        hops++;
+        return http.Response(
+          '',
+          303,
+          headers: <String, String>{'location': '/loop'},
+          isRedirect: true,
+        );
+      });
+
+      await expectLater(
+        downloadFollowingRedirects(
+          client,
+          Uri.parse('https://ankiweb.net/loop'),
+          maxBytes: 1024,
+          maxRedirects: 3,
+        ),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(hops, 4);
+    });
+  });
+
+  group('安装编排', () {
+    tearDown(() => AnkiConnectInstaller.debugHost = null);
+
+    test('Anki 没在运行时不下载、不落盘、不起进程', () async {
+      final _FakeHost host = _FakeHost(ankiExecutable: null);
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.ankiNotRunning);
+      expect(host.events, isEmpty);
+    });
+
+    test('成功路径：把补好 manifest 的包交给正在运行的那个 anki.exe', () async {
+      final _FakeHost host = _FakeHost(
+        ankiExecutable: r'C:\Program Files\Anki\anki.exe',
+      );
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.handedToAnki);
+      expect(result.isHandedToAnki, isTrue);
+      expect(host.events, <String>['download', 'write', 'launch']);
+      // 必须用进程自己报出来的路径，不能是别处猜的。
+      expect(host.launchedExecutable, r'C:\Program Files\Anki\anki.exe');
+      // 扩展名必须是 .ankiaddon：Anki 的 _isAddon 只认 exts[0]，用 .zip 会被
+      // 当成牌组导入走错分支。
+      expect(host.writtenFileName, endsWith('.ankiaddon'));
+      expect(host.launchedPath, endsWith('.ankiaddon'));
+
+      // 交出去的确实是补过 manifest 的包，不是原样转发。
+      expect(_entries(host.writtenBytes!)['manifest.json'], isNotNull);
+    });
+
+    test('下载失败时如实返回，不继续往下走', () async {
+      final _FakeHost host = _FakeHost(
+        ankiExecutable: r'C:\Anki\anki.exe',
+        downloadError: StateError('boom'),
+      );
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.downloadFailed);
+      expect(result.detail, contains('boom'));
+      expect(host.events, <String>['download']);
+    });
+
+    test('下载到的不是插件包时报 invalidPackage', () async {
+      final _FakeHost host = _FakeHost(
+        ankiExecutable: r'C:\Anki\anki.exe',
+        payload: Uint8List.fromList(utf8.encode('<html>404</html>')),
+      );
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.invalidPackage);
+      expect(host.events, <String>['download']);
+    });
+
+    test('重定向地址缺分支参数时也算 invalidPackage，不会交出错误 manifest', () async {
+      final _FakeHost host = _FakeHost(
+        ankiExecutable: r'C:\Anki\anki.exe',
+        resolvedUri: Uri.parse('https://ankiweb.net/no-query'),
+      );
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.invalidPackage);
+      expect(host.events, <String>['download']);
+    });
+
+    test('起进程失败时报 launchFailed', () async {
+      final _FakeHost host = _FakeHost(
+        ankiExecutable: r'C:\Anki\anki.exe',
+        launchError: ProcessException('anki.exe', <String>[], 'denied'),
+      );
+      AnkiConnectInstaller.debugHost = host;
+
+      final AnkiAddonInstallResult result =
+          await AnkiConnectInstaller.install();
+
+      expect(result.status, AnkiAddonInstallStatus.launchFailed);
+      expect(host.events, <String>['download', 'write', 'launch']);
+    });
+  });
+}
+
+class _FakeHost implements AnkiConnectInstallerHost {
+  _FakeHost({
+    required this.ankiExecutable,
+    Uint8List? payload,
+    Uri? resolvedUri,
+    this.downloadError,
+    this.launchError,
+  })  : payload = payload ?? _bareAddonZip(),
+        resolvedUri = resolvedUri ??
+            Uri.parse(
+              'https://ankiweb.net/svc/shared/download-addon/2055492159'
+              '?t=1762717231&minpt=45&maxpt=45&bidx=1',
+            );
+
+  final String? ankiExecutable;
+  final Uint8List payload;
+  final Uri resolvedUri;
+  final Object? downloadError;
+  final Object? launchError;
+
+  final List<String> events = <String>[];
+  Uint8List? writtenBytes;
+  String? writtenFileName;
+  String? launchedExecutable;
+  String? launchedPath;
+
+  @override
+  String? findRunningAnkiExecutable() => ankiExecutable;
+
+  @override
+  Future<AnkiWebAddonDownload> download(Uri uri,
+      {required int maxBytes}) async {
+    events.add('download');
+    if (downloadError != null) throw downloadError!;
+    return AnkiWebAddonDownload(bytes: payload, resolvedUri: resolvedUri);
+  }
+
+  @override
+  Future<String> writeTempAddon(String fileName, Uint8List bytes) async {
+    events.add('write');
+    writtenFileName = fileName;
+    writtenBytes = bytes;
+    return 'C:\\Temp\\$fileName';
+  }
+
+  @override
+  Future<void> launch(String executable, String addonPath) async {
+    events.add('launch');
+    launchedExecutable = executable;
+    launchedPath = addonPath;
+    if (launchError != null) throw launchError!;
+  }
+}


### PR DESCRIPTION
把「装 AnkiConnect」从手动五步（工具 → 插件 → 获取插件 → 输编号 → 重启）收成设置页里的一次点击。没有 AnkiConnect，设置页里 host/port/apiKey 填得再对也连不上 Anki，这是接入 Fushi 制卡的第一道门槛。

## 做法：交给 Anki 自己装，不自己铺 addons21/

把 `.ankiaddon` 路径当命令行参数交给正在运行的 `anki.exe`，Anki 经单实例消息走 `onAppMsg → installAddon`。于是目录写入、`user_files` 备份、旧版本删除、冲突插件禁用、点版本兼容判定，以及那个「插件是能执行任意代码的程序」确认框，**全部由 Anki 负责**。Fushi 不碰它的数据目录，也不维护 `meta.json` 的 schema。

## 两个实测出来的坑

**1. AnkiWeb 下发的是裸包，不含 `manifest.json`。** 真解包验过，AnkiConnect 包内只有 `__init__.py`/`config.json`/`config.md`/`edit.py`/`util.py`/`web.py`。Anki 自己下载时是把元信息从下载 URL 的 query **旁路**传进 `install(manifest:)` 的；文件打开这条路（`processPackages`）没有这个旁路，读不到包内 manifest 就直接 `InstallError("manifest")`。所以必须复刻那份元信息、补成包内 `manifest.json` 后重新打包。

产物已用 **Anki 自己的** jsonschema 校验过：原始裸包判空 manifest（确认会失败），重打包后通过，6 个原文件一个不少，`package_name_valid: True`。

**2. 下载 URL 的 `p`（点版本）不能省。** 实测不传时 AnkiWeb 回的是 `minpt=0&maxpt=-44` 的老分支，而 Anki 的约定里 `max_point_version` 为**负数**才是硬上限（正数只表示「测过」并被忽略），于是现代 Anki 会把它判成不兼容并**静默禁用**。传 ≥45 的任意值都落到现代分支。

## 前置条件收敛成「Anki 正在运行」

运行中的进程会把自己的完整路径直接报出来（`QueryFullProcessImageNameW`），不必去注册表或默认安装目录里猜——绿色版、自定义安装位置、多版本共存都会让猜测失准。代价是 Anki 没开时装不了；入口仍**常显**、点下去如实提示「请先启动 Anki」，藏起来用户根本发现不了这个功能。

（顺带一个反直觉结论：Anki 没在运行时装其实更干净，冷启动路径在 `loadAddons()` 之前就装完、不需要重启。但那条路要靠猜 exe 位置，少一个猜测来源比省用户一次重启更值。）

## 出站纪律

下载走包内工厂钩子 `ankiAddonDownloadHttpClientFactory` + app 侧接线（同 BUG-1498 范式）：目标是公网 `ankiweb.net`，不接应用代理的话 Dart 的 `HttpClient` 连 `HTTPS_PROXY` 环境变量都不读。**注意与同包 `ankiconnect_service.dart` 方向相反**——那条打 localhost 必须直连，已在 `outbound_http_discipline_guard` 的登记表里写明别接混（总数哨兵 19 → 20）。

## 范围（两个刻意的边界）

- **仅 Windows**：进程枚举只有 Win32 实现（`AnkiDesktopForeground`），其余平台入口隐藏、fail-soft。
- **只装 AnkiConnect 一个按钮**，不做「输入任意插件 ID」——真需求是打通第一道门槛，开放任意 ID 等于开一个装任意代码的口子。addon id 是常量，将来要扩展是加常量的事。
- AnkiDroid 没有插件系统，移动端不适用。

## 验证

- 新增 **17 个单测**：重打包 / 分支元信息解析 / 重定向跟随 / 安装编排；另给新增的 `findRunningAnkiExecutable()` 补 3 条。
- **变异实测**：对「补 manifest」与「返回重定向后的最终 URL」两处做了变异，分别红 3 条和 1 条，确认守卫真能抓；还原后 `sha256sum -c` 字节一致。
- `dart analyze` 两个包零 issue。
- 全量：`FLUTTER TEST VERDICT: PASSED - 19196 tests ran, all tests passed`（退出码 0）。

## 措辞上的一个刻意选择

结果枚举里**没有**「已安装」这个态，UI 也不说「已安装」——装不装由用户在 Anki 自己弹的确认框里决定，之后还要重启才生效，Fushi 两件事都无从得知。能证明插件真到位的只有之后 AnkiConnect 能应答，那属于连接探活。
