### PR TITLE
互联搬能力不只搬内容：追番/字幕/刮削凭据随互联 + 字幕获取统一 + 视频首页全互联 + UA 归位 fushi (BUG-1683/1684/1685/1686/1687)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,15 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1552 条。点号进各自文件。
+> 共 1557 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1687](bugs/BUG-1687-qb-category-legacy-hibiki.md) | 🚧 | 🚧 | 存量 qBittorrent 分类仍是改名前的 hibiki |
+| [BUG-1686](bugs/BUG-1686-video-home-rows-not-interconnected.md) | ✅ | ✅ | 视频首页「下一集」「最近添加」两行不含互联远端条目 |
+| [BUG-1685](bugs/BUG-1685-video-subtitle-fetch-two-implementations.md) | ✅ | ✅ | 播放页找字幕只搜 Jimaku，与下载管线的统一 registry 是两套实现 |
+| [BUG-1684](bugs/BUG-1684-outbound-user-agent-still-hibiki.md) | ✅ | ✅ | 对外 User-Agent 仍报旧名 Hibiki |
+| [BUG-1683](bugs/BUG-1683-interconnect-service-config-misses-bangumi-token.md) | ✅ | ✅ | 互联不同步 Bangumi 追番令牌与刮削/字幕/索引器凭据 |
 | [BUG-1676](bugs/BUG-1676-anki-gloss-image-overflows-card.md) | ✅ | ✅ | 制卡词典插图撑出卡片跑到屏幕右外 |
 | [BUG-1675](bugs/BUG-1675-gal-helper-stale-after-locked-update.md) | ✅ | ✅ | galgame 捕获组件 protocol_mismatch：更新时游戏开着导致 helper 被静默跳过 |
 | [BUG-1674](bugs/BUG-1674-mining-still-format.md) | ✅ | ✅ | 视频卡片图片：描述不准，且静态截图格式不可选 |

--- a/docs/bugs/BUG-1683-interconnect-service-config-misses-bangumi-token.md
+++ b/docs/bugs/BUG-1683-interconnect-service-config-misses-bangumi-token.md
@@ -1,0 +1,26 @@
+## BUG-1683 · 互联不同步 Bangumi 追番令牌与刮削/字幕/索引器凭据
+- **报告**：2026-08-16（用户：「bangumi同步等api和token应该要互联」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/sync/interconnect_service_config.dart:26`
+  —— `InterconnectServiceConfigSnapshot.sharedPreferenceKeys` 只放
+  `jimaku_api_key` / `qb_connection_config` / 漫画在线目录两项，文档注释明确写着
+  「Bangumi/Anki credentials … remain local」。于是追番令牌
+  （`media_tracking_bangumi_access_token`，见 `media_tracking_service.dart:16`）、
+  视频刮削 key、OpenSubtitles / Torznab 配置全部不出境，「互联」只搬内容不搬能力：
+  用户得在每台设备上重填同一个 token。
+  第二个缺口在消费端 —— `app_model.dart` 的 `refreshAfterSyncRun` 导入服务配置后只
+  `refreshPrefCache()`，不重建 provider runtime；而 Jimaku / OpenSubtitles / Torznab /
+  TMDB 的 client 是在 `_startVideoDownloadPipeline` 里按当时的 key 一次性建好的
+  （key 为空的 provider 干脆不进 registry），所以即使同步过来了也要等冷启动才生效。
+- **[x] ① 已修复** — `b1570a5929`。判据改成「这条配置描述的是外部服务还是本机」：
+  白名单加追番令牌 + 账号名、`video_metadata_bangumi_token`、TMDB / Fanart /
+  豆瓣授权端点与 token、OpenSubtitles 与 Torznab 配置；`yomitan_api_key`（保护本机
+  入站 API）、`media_source_secret_*`、`sync_*`、设备身份与本地路径仍绝不出境。
+  备份 zip 落第三方云盘与 Profile 分享 JSON 两条出境仍由 `PrefRedactionPolicy` 全量
+  剔除，不受本清单影响。换令牌的对账水位归零抽成共享常量
+  `kBangumiTokenScopedWatermarkPrefs`，设置页与互联导入两条写入路径共用。导入后
+  额外 `reloadVideoDownloadPipelineRuntime()` + bump 追番 `statusRevision`。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/interconnect_service_config_test.dart`
+  （host 快照含哪些键 / 不含哪些键；换令牌必须归零三个对账水位；令牌没变时不得
+  倒退水位）。
+- **备注**：本通道是已配对 + 已认证的点对点链路，对端是用户自己的设备，与备份落
+  第三方云盘、Profile 分享给别人是不同的出境等级。

--- a/docs/bugs/BUG-1684-outbound-user-agent-still-hibiki.md
+++ b/docs/bugs/BUG-1684-outbound-user-agent-still-hibiki.md
@@ -1,0 +1,22 @@
+## BUG-1684 · 对外 User-Agent 仍报旧名 Hibiki
+- **报告**：2026-08-16（用户：「api等ua没换成fushi」）
+- **真实性**：✅ 真 bug。改名批次漏了 4 处**以自己身份**对外报的 UA：
+  `fushi/lib/src/media/video/subtitle/open_subtitles_client.dart:20`（默认 `Hibiki v1`，
+  且 `fromJson` 同一字面量）、
+  `fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart:971`
+  （设置页草稿默认值）、
+  `fushi/lib/src/media/video/video_shader_downloader.dart:344,491`、
+  `fushi/lib/src/pages/implementations/custom_fonts_page.dart:916`。
+  对外部服务而言 UA 就是这个 app 的身份，两个名字同时在跑 = 同一个客户端有两个身份。
+- **[x] ① 已修复** — `b8d5a54b3c`。收敛成单一真相源
+  `fushi/lib/src/utils/net/app_user_agent.dart` 的 `fushiUserAgent(<组件名>)`。
+  OpenSubtitles 的 UA 被序列化进 `video_subtitle_opensubtitles_config` 偏好，光改构造
+  默认值改不动已落盘的那一份，故解码时把**恰好等于旧默认值**的归一到新默认值，
+  用户自填的 UA 原样保留。故意伪装成浏览器的三处（Aidoku 过 WAF、Google Lens OCR、
+  YouTube 分离流回放 UA 必须与铸造 URL 时逐字一致）是「装成别人」不是「报自己」，
+  保持原样。
+- **[x] ② 已加自动化测试** — `fushi/test/tools/outbound_user_agent_guard_test.dart`
+  （全树扫 `lib/`，带 `User-Agent`/`userAgent` 的行不得含旧名；浏览器伪装文件白名单）。
+  守卫做过变异实测：第一版正则漏了 `'User-Agent':` 的收尾引号，把 UA 改回 Hibiki
+  仍然绿，已修正后复测为红、还原后字节哈希一致。
+- **备注**：qBittorrent 分类的旧名残留另见 BUG-1687（不是 UA，且不能静默改写）。

--- a/docs/bugs/BUG-1685-video-subtitle-fetch-two-implementations.md
+++ b/docs/bugs/BUG-1685-video-subtitle-fetch-two-implementations.md
@@ -1,0 +1,23 @@
+## BUG-1685 · 播放页找字幕只搜 Jimaku，与下载管线的统一 registry 是两套实现
+- **报告**：2026-08-16（用户：「获取字幕的api应该统一（下载，视频，设置等）」）
+- **真实性**：✅ 真 bug。字幕获取有两条并行实现：
+  下载管线走 `VideoSubtitleRegistry`（`fushi/lib/src/media/video/download/video_subtitle_registry.dart`，
+  Jimaku + OpenSubtitles，含去重/优先级/失败归类），而播放页的找字幕对话框
+  `fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart:344,402`
+  自建 `JimakuClient` 直连 Jimaku。同一个动作在两个入口能力不同——播放页永远搜不到
+  OpenSubtitles，用户在设置里配了也没用；且搜索门槛硬卡 Jimaku key（同文件 `:320`），
+  只配了 OpenSubtitles 的用户连搜都搜不了。
+  配置侧同样分家：Jimaku key 在 设置 → 视频 → 字幕
+  （`fushi/lib/src/settings/settings_schema_video.dart:1138`），OpenSubtitles 只在
+  设置 → 下载 → 外部来源（`video_external_provider_settings_section.dart`）。
+- **[x] ① 已修复** — `56f073bef6`。对话框改为经 registry 搜索与下载（候选模型改成
+  provider 无关投影，语言优先取 provider 给的权威码）；搜索门槛改成「有没有可用来源」；
+  registry 延迟解析，避免绑到填 key 之前的旧实例；设置页「视频 → 字幕」内联**同一份**
+  OpenSubtitles 编辑组件（`onlySubtitleSources` 按节可裁），不复制 UI。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_subtitle_dialog_registry_test.dart`
+  （播放页列出全部已配置来源的候选；只配 OpenSubtitles 也能搜、不再报「没有 key」）。
+- **备注**：番剧下载对话框与批量匹配对话框的**手工**选字幕面板仍直连 Jimaku。它们的
+  计划持久化字段是 Jimaku 专有的（`AnimeDownloadPlan.jimakuEntryId` / `jimakuEntryName`），
+  下载完成后由 `anime_download_subtitle_resolver.dart` 按该 id 回查；改成 provider 无关
+  句柄要动已落盘的计划结构 + resolver，属独立迁移任务。下载链路的**自动**配字幕本来
+  就走 registry，不受影响。

--- a/docs/bugs/BUG-1686-video-home-rows-not-interconnected.md
+++ b/docs/bugs/BUG-1686-video-home-rows-not-interconnected.md
@@ -1,0 +1,20 @@
+## BUG-1686 · 视频首页「下一集」「最近添加」两行不含互联远端条目
+- **报告**：2026-08-16（用户：「视频首页没完全互联」）
+- **真实性**：✅ 真 bug。首页 home 分区就三条横滚行，只有「继续观看」认远端：
+  `fushi/lib/src/pages/implementations/home_video_page.dart:2425,2426` 调
+  `_buildNextEpisodeRow(filtered, …)` / `_buildRecentlyAddedRow(filtered, …)` 时只传本地行，
+  两个函数内部的成员表结构上也只装 `VideoBookRow`。后果：
+  本机看到第 1 集、第 2 集只在 host 上时「下一集」整行不出现；host 上新入库的一批在
+  子设备首页完全看不见。
+  「最近添加」还有一个数据缺口：`RemoteVideoInfo` 没有 `importedAt`，
+  `_groupVideos` 只能给远端造一个负数假 importedAt 占位排序
+  （同文件 `:4088`），窗口判定 `isVideoRecentlyAdded` 结构上永远判 false。
+- **[x] ① 已修复** — `a511a4d0ee`。三行的合集成员统一成 `_VideoSlot`（本地行 | 远端占位）：
+  取组内序 / 取观看态 / 取封面 / 点开四件事按来源分流，选集、最近添加窗口判定、排序
+  两边同一份代码。远端清单补 `importedAt`（host 下发 `VideoBooks.importedAt`，云清单
+  透传已有的 `importedAtMs`），加字段向后兼容：旧 host 不带 → null → 与改动前逐字节
+  同行为。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_home_rows_remote_test.dart`
+  （跨本地/远端合并选出「下一集」；host 带 importedAt 时远端进「最近添加」；旧 host
+  不带时不进 —— 第三条守的是向后兼容）。
+- **备注**：血缘同 BUG-995（当时只把「继续观看」与概览接上了远端）。

--- a/docs/bugs/BUG-1687-qb-category-legacy-hibiki.md
+++ b/docs/bugs/BUG-1687-qb-category-legacy-hibiki.md
@@ -1,0 +1,18 @@
+## BUG-1687 · 存量 qBittorrent 分类仍是改名前的 hibiki
+- **报告**：2026-08-16（用户：「qb分类…没换成fushi」）
+- **真实性**：✅ 真 bug，但**不能静默改写**。默认值早已是 `fushi`
+  （`fushi/lib/src/media/torrent/anime_download_config.dart:15,51`），改名批次
+  `3faab77149` 改了默认值却没有迁移已落盘的 `qb_connection_config` JSON，所以改名前
+  配置过的用户，存量值一直是 `hibiki`（新装用户不受影响）。
+- **[ ] ① 未修复（刻意不自动迁移）** — 静默改写会破坏进行中的下载：
+  * 内置引擎的分类**就是保存目录**（`embedded_torrent_backend.dart:87,103` 的
+    `_categoryPath`，`listTorrents` 按 `ownsCategoryPath` 过滤），改名后存量种子直接
+    掉出列表，要真迁移得移动几十 GB 并掐断做种；
+  * 下载任务行各自存着自己的 `category`，管线在
+    `video_download_pipeline_service.dart:1152` 用「当前配置分类 ≠ 任务分类」判任务
+    失配并抛「backend/profile/category 不再匹配」，改配置等于把存量任务全判死。
+  正确做法是把这条留给用户：分类在 设置 → 下载 里可直接改，等手头没有进行中的任务
+  时改成 `fushi` 即可（外接 qBittorrent 侧也可先在 qB 内把旧分类的种子改分类）。
+- **[ ] ② 未加自动化测试** — 无行为改动可守。
+- **备注**：与 BUG-1684（对外 UA）同一批用户反馈，但性质不同：UA 是每次请求现算的，
+  改了立刻生效且无存量数据；分类是落盘的用户配置且与磁盘布局绑定。

--- a/fushi/lib/src/media/tracking/media_tracking_service.dart
+++ b/fushi/lib/src/media/tracking/media_tracking_service.dart
@@ -38,6 +38,19 @@ const String kBookTrackingReconcileWatermarkPref =
 const String kGameTrackingReconcileWatermarkPref =
     'media_tracking_game_reconcile_watermark_v1';
 
+/// 换 Bangumi 令牌（含被清空）后必须归零的「本设备已对账水位」键。
+///
+/// 换账号 = 本地全部已完成事实都要对新账号重新对齐，继承旧账号的水位会让新账号
+/// 永远收不到迁移前看完的条目。写令牌的路径不止设置页一条：互联服务配置也会把
+/// host 的令牌落到子设备（[InterconnectServiceConfigSnapshot.applyTo]），所以这
+/// 条不变式必须是共享常量，而不是 [MediaTrackingService.setAccessToken] 里的一段
+/// 私有代码——否则两条写入路径必然漂开。
+const List<String> kBangumiTokenScopedWatermarkPrefs = <String>[
+  kVideoTrackingReconcileWatermarkPref,
+  kBookTrackingReconcileWatermarkPref,
+  kGameTrackingReconcileWatermarkPref,
+];
+
 typedef BangumiApiFactory = BangumiTrackingApi Function(String accessToken);
 
 /// 退避重试定时器工厂（BUG-1647）；生产用真 [Timer]，测试注入假实现以便
@@ -326,6 +339,11 @@ class MediaTrackingService {
 
   ValueListenable<int> get statusRevision => _statusRevision;
 
+  /// 令牌/账号名被**本服务之外**的路径改写后（互联服务配置导入、Profile 切换）
+  /// 通知状态监听者重读。服务本身不缓存令牌（[accessToken] 每次读偏好），所以
+  /// 只需要一次 revision bump，不需要重建服务。
+  void notifyStatusChanged() => _statusRevision.value++;
+
   String get accessToken =>
       (_preferences.getPref(kBangumiAccessTokenPref, defaultValue: '')
               as String)
@@ -345,9 +363,9 @@ class MediaTrackingService {
     await _preferences.setPref(kBangumiAccessTokenPref, normalized);
     if (previous != normalized) {
       // 新账号必须从全部本地已完成事实重新对齐，不能继承旧账号的校正水位。
-      await _preferences.setPref(kVideoTrackingReconcileWatermarkPref, 0);
-      await _preferences.setPref(kBookTrackingReconcileWatermarkPref, 0);
-      await _preferences.setPref(kGameTrackingReconcileWatermarkPref, 0);
+      for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+        await _preferences.setPref(key, 0);
+      }
       // 账号名属于旧令牌，换令牌后必须失效，否则 UI 会挂着上一个账号的名字。
       await _preferences.setPref(kBangumiAccountNamePref, '');
     }

--- a/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
+++ b/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
@@ -24,8 +24,7 @@ class OpenSubtitlesConfig {
     this.priority = 200,
     this.allowInsecureHttp = false,
   })  : userAgent = _resolveUserAgent(userAgent),
-        baseUrl =
-            baseUrl ?? Uri.parse('https://api.opensubtitles.com/api/v1') {
+        baseUrl = baseUrl ?? Uri.parse('https://api.opensubtitles.com/api/v1') {
     if (this.baseUrl.host.isEmpty ||
         this.baseUrl.hasQuery ||
         this.baseUrl.userInfo.isNotEmpty ||

--- a/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
+++ b/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
@@ -9,6 +9,7 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
+import 'package:fushi/src/utils/net/app_user_agent.dart';
 
 const int kMaximumSubtitleDownloadBytes = 64 * 1024 * 1024;
 
@@ -17,12 +18,14 @@ class OpenSubtitlesConfig {
     required this.apiKey,
     this.username,
     this.password,
-    this.userAgent = 'Hibiki v1',
+    String? userAgent,
     Uri? baseUrl,
     this.enabled = true,
     this.priority = 200,
     this.allowInsecureHttp = false,
-  }) : baseUrl = baseUrl ?? Uri.parse('https://api.opensubtitles.com/api/v1') {
+  })  : userAgent = _resolveUserAgent(userAgent),
+        baseUrl =
+            baseUrl ?? Uri.parse('https://api.opensubtitles.com/api/v1') {
     if (this.baseUrl.host.isEmpty ||
         this.baseUrl.hasQuery ||
         this.baseUrl.userInfo.isNotEmpty ||
@@ -40,9 +43,6 @@ class OpenSubtitlesConfig {
         'explicitly allowed or the host is loopback',
       );
     }
-    if (userAgent.trim().isEmpty) {
-      throw ArgumentError('OpenSubtitles user agent must not be empty');
-    }
   }
 
   factory OpenSubtitlesConfig.fromJson(Map<String, Object?> json) {
@@ -51,7 +51,7 @@ class OpenSubtitlesConfig {
       apiKey: json['apiKey'] as String? ?? '',
       username: json['username'] as String?,
       password: json['password'] as String?,
-      userAgent: json['userAgent'] as String? ?? 'Hibiki v1',
+      userAgent: json['userAgent'] as String?,
       baseUrl: rawBaseUrl == null || rawBaseUrl.trim().isEmpty
           ? null
           : Uri.parse(rawBaseUrl),
@@ -61,6 +61,18 @@ class OpenSubtitlesConfig {
           ? json['allowInsecureHttp']! as bool
           : false,
     );
+  }
+
+  /// 缺省 / 存量旧默认值都归一到当前 app 身份；用户自填的 UA 原样保留。
+  ///
+  /// `video_subtitle_opensubtitles_config` 是把整个配置序列化成 JSON 存的，所以
+  /// 光改构造默认值改不动已落盘的 `Hibiki v1`——那条 UA 会一直发出去。
+  static String _resolveUserAgent(String? raw) {
+    final String trimmed = raw?.trim() ?? '';
+    if (trimmed.isEmpty || trimmed == kLegacyOpenSubtitlesUserAgent) {
+      return fushiUserAgent('opensubtitles');
+    }
+    return raw!;
   }
 
   final String apiKey;

--- a/fushi/lib/src/media/video/video_shader_downloader.dart
+++ b/fushi/lib/src/media/video/video_shader_downloader.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/video/video_shader_manager.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
+import 'package:fushi/src/utils/net/app_user_agent.dart';
 
 /// Anime4K（bloc97/Anime4K）GLSL 着色器一键下载：定义官方推荐预设、生成多镜像
 /// 下载 URL、把一组 `.glsl` 拉到 [mpvShaderDirectory] 供视频页勾选启用。
@@ -340,8 +341,8 @@ Future<String?> downloadShaderFromUrl(
         followRedirects: true,
         maxRedirects: 10,
         responseType: ResponseType.bytes,
-        headers: const <String, String>{
-          'User-Agent': 'Mozilla/5.0 (Hibiki) Shader-Downloader/1.0',
+        headers: <String, String>{
+          'User-Agent': fushiUserAgent('shader-downloader'),
           'Accept': '*/*',
         },
       ));
@@ -487,8 +488,8 @@ Future<Anime4kDownloadResult> downloadAnime4kFiles(
         followRedirects: true,
         maxRedirects: 10,
         responseType: ResponseType.bytes,
-        headers: const <String, String>{
-          'User-Agent': 'Mozilla/5.0 (Hibiki) Anime4K-Downloader/1.0',
+        headers: <String, String>{
+          'User-Agent': fushiUserAgent('anime4k-downloader'),
           'Accept': '*/*',
         },
       ));

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -739,6 +739,15 @@ class AppModel with ChangeNotifier {
 
     if (report.serviceConfigsImported > 0) {
       await refreshPrefCache();
+      // 导入的服务配置不是「静态设置」，它们是 provider runtime 的构造入参：
+      // Jimaku / OpenSubtitles / Torznab / TMDB 的 client 在
+      // [_startVideoDownloadPipeline] 里按当时的 key 一次性建好，key 为空的
+      // provider 干脆不进 registry。不重建 runtime，互联搬过来的字幕/索引器
+      // 凭据要等到下次冷启动才生效（用户视角＝「同步了但还是搜不到字幕」）。
+      await reloadVideoDownloadPipelineRuntime();
+      // 追番令牌可能换人：设置页与首页的状态行监听 statusRevision，不 bump 就
+      // 一直显示导入前的账号/未连接。
+      _mediaTrackingService?.notifyStatusChanged();
     }
 
     if (report.dictionariesImported > 0) {

--- a/fushi/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/fushi/lib/src/pages/implementations/custom_fonts_page.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/reader/font_catalog.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/utils/net/app_user_agent.dart';
 import 'package:path/path.dart' as p;
 
 const _fontExtensions = {'.ttf', '.otf', '.ttc', '.woff', '.woff2'};
@@ -913,7 +914,7 @@ class _CustomFontsPageState extends BasePageState {
         followRedirects: true,
         maxRedirects: 10,
         headers: {
-          'User-Agent': 'Mozilla/5.0 (Linux; Android) Hibiki/1.0',
+          'User-Agent': fushiUserAgent('custom-fonts'),
           'Accept': '*/*',
         },
       ));

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -3044,8 +3044,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   /// 合集成员里的本地行（合集自身封面回落链只认本地文件）。
-  List<VideoBookRow> _localMembersOf(List<_VideoSlot> slots) =>
-      <VideoBookRow>[
+  List<VideoBookRow> _localMembersOf(List<_VideoSlot> slots) => <VideoBookRow>[
         for (final _VideoSlot slot in slots)
           if (slot.local != null) slot.local!,
       ];
@@ -3152,13 +3151,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           ? _primaryCollectionByEntry[
               MediaKind.video.compositeKey(local.bookUid)]
           : _remoteCollectionId(slot.remote!);
-      final bool inCollection = cid != null && _collectionsById.containsKey(cid);
+      final bool inCollection =
+          cid != null && _collectionsById.containsKey(cid);
       if (inCollection) {
-        allMembersByCollection
-            .putIfAbsent(cid, () => <_VideoSlot>[])
-            .add(slot);
+        allMembersByCollection.putIfAbsent(cid, () => <_VideoSlot>[]).add(slot);
       }
-      if (!isVideoRecentlyAdded(importedAt: _slotImportedAtMs(slot), now: now)) {
+      if (!isVideoRecentlyAdded(
+          importedAt: _slotImportedAtMs(slot), now: now)) {
         continue;
       }
       if (inCollection) {

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -2422,8 +2422,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         videoCoverHeightForPortraitWidth(cardLayout.cardWidth);
     final Widget? continueRow =
         _buildContinueRow(filtered, remoteVideos, coverHeight);
-    final Widget? nextRow = _buildNextEpisodeRow(filtered, coverHeight);
-    final Widget? recentRow = _buildRecentlyAddedRow(filtered, coverHeight);
+    final Widget? nextRow =
+        _buildNextEpisodeRow(filtered, remoteVideos, coverHeight);
+    final Widget? recentRow =
+        _buildRecentlyAddedRow(filtered, remoteVideos, coverHeight);
     if (continueRow == null && nextRow == null && recentRow == null) {
       return const SizedBox.shrink();
     }
@@ -2968,55 +2970,144 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           ),
       ];
 
+  // ── 首页横滚行的「本地 / 远端」统一槽位 ───────────────────────────────
+  //
+  // 首页三行（继续观看 / 下一集 / 最近添加）里，一个合集的成员本来就可能一半在
+  // 本机、一半只在 host 上。此前只有「继续观看」认远端，另两行的成员表结构上只
+  // 装 [VideoBookRow]，于是同一个合集在同一屏上一半互联一半不互联——用户视角就是
+  // 「视频首页没完全互联」。改成统一用 [_VideoSlot]：取组内序 / 取观看态 / 取封面 /
+  // 点开这四件事按来源分流，其余逻辑（下一集选集、最近添加窗口、排序）两边同一份。
+
+  /// 远端条目解析到的本地合集 id；host 未给归属或本地没有同名合集 → null（散卡）。
+  int? _remoteCollectionId(RemoteVideoInfo video) {
+    final RemoteCollectionMembership? membership = video.collection;
+    if (membership == null) return null;
+    return _resolveLocalCollectionId(
+      membership.collectionName,
+      membership.collectionType,
+    );
+  }
+
+  /// 组内序：本地取页级 [_memberSortIndex]，远端取 host 下发的 sortIndex。
+  int _slotSortIndex(_VideoSlot slot) {
+    final VideoBookRow? local = slot.local;
+    if (local != null) {
+      return _memberSortIndex[MediaKind.video.compositeKey(local.bookUid)] ??
+          1 << 30;
+    }
+    return slot.remote!.collection?.sortIndex ?? 1 << 30;
+  }
+
+  /// 最近观看时刻（epoch 毫秒，0 = 没看过）。远端的真相源是 host 下发的
+  /// [RemoteVideoInfo.positionUpdatedAtMs]（与「继续观看」行同一口径）。
+  int _slotWatchedAtMs(_VideoSlot slot) {
+    final VideoBookRow? local = slot.local;
+    if (local != null) {
+      return (_watchAtByUid[local.bookUid] ??
+                  _legacyWatchAtByTitle[local.title])
+              ?.millisecondsSinceEpoch ??
+          0;
+    }
+    return slot.remote!.positionUpdatedAtMs;
+  }
+
+  /// 入库时刻（epoch 毫秒）；远端 host 不带该字段（旧 host）时为 null。
+  int? _slotImportedAtMs(_VideoSlot slot) =>
+      slot.local?.importedAt ?? slot.remote?.importedAt;
+
+  List<VideoSeriesPlaybackState> _slotPlaybackStates(List<_VideoSlot> slots) =>
+      <VideoSeriesPlaybackState>[
+        for (final _VideoSlot slot in slots)
+          VideoSeriesPlaybackState(
+            lastWatchedAtMs: _slotWatchedAtMs(slot),
+            positionMs: slot.local?.lastPositionMs ?? slot.remote!.positionMs,
+            completed: slot.local != null
+                ? slot.local!.completedAt != null
+                : slot.remote!.completedAt != null,
+          ),
+      ];
+
+  ImageProvider? _slotCoverProvider(_VideoSlot slot) {
+    final VideoBookRow? local = slot.local;
+    return local != null
+        ? _localCoverProvider(local)
+        : _remoteCoverProvider(slot.remote!);
+  }
+
+  void _openSlot(_VideoSlot slot, {int? playlistCollectionId}) {
+    final VideoBookRow? local = slot.local;
+    if (local != null) {
+      unawaited(_open(local, playlistCollectionId: playlistCollectionId));
+      return;
+    }
+    unawaited(_openRemote(slot.remote!));
+  }
+
+  /// 合集成员里的本地行（合集自身封面回落链只认本地文件）。
+  List<VideoBookRow> _localMembersOf(List<_VideoSlot> slots) =>
+      <VideoBookRow>[
+        for (final _VideoSlot slot in slots)
+          if (slot.local != null) slot.local!,
+      ];
+
+  /// 「下一集」横滚行：合集成员含**本地行 + 远端占位**（同一合集两边成员合成一条
+  /// 序列后再选集）。此前只按本地成员选集：host 上有第 5 集、本机只到第 4 集时，
+  /// 这一行要么不出现、要么指向本机的旧集——用户视角就是首页没完全互联。
   Widget? _buildNextEpisodeRow(
     List<VideoBookRow> filtered,
+    List<RemoteVideoInfo> remoteVideos,
     double coverHeight,
   ) {
-    final Map<int, List<VideoBookRow>> grouped = <int, List<VideoBookRow>>{};
+    final Map<int, List<_VideoSlot>> grouped = <int, List<_VideoSlot>>{};
     for (final VideoBookRow book in filtered) {
       if (_localExtraBookUids.contains(book.bookUid)) continue;
       final int? cid =
           _primaryCollectionByEntry[MediaKind.video.compositeKey(book.bookUid)];
       if (cid != null && _collectionsById.containsKey(cid)) {
-        grouped.putIfAbsent(cid, () => <VideoBookRow>[]).add(book);
+        grouped
+            .putIfAbsent(cid, () => <_VideoSlot>[])
+            .add(_VideoSlot(local: book));
       }
     }
+    for (final RemoteVideoInfo video in remoteVideos) {
+      final int? cid = _remoteCollectionId(video);
+      if (cid == null) continue;
+      grouped
+          .putIfAbsent(cid, () => <_VideoSlot>[])
+          .add(_VideoSlot(remote: video));
+    }
     final List<_VideoRowItem> items = <_VideoRowItem>[];
-    grouped.forEach((int cid, List<VideoBookRow> members) {
-      members.sort((VideoBookRow a, VideoBookRow b) =>
-          (_memberSortIndex[MediaKind.video.compositeKey(a.bookUid)] ?? 1 << 30)
-              .compareTo(
-                  _memberSortIndex[MediaKind.video.compositeKey(b.bookUid)] ??
-                      1 << 30));
+    grouped.forEach((int cid, List<_VideoSlot> members) {
+      members.sort((_VideoSlot a, _VideoSlot b) =>
+          _slotSortIndex(a).compareTo(_slotSortIndex(b)));
       int recentMs = 0;
-      for (final VideoBookRow member in members) {
-        final DateTime? watched = _watchAtByUid[member.bookUid] ??
-            _legacyWatchAtByTitle[member.title];
-        if (watched != null) {
-          recentMs = recentMs < watched.millisecondsSinceEpoch
-              ? watched.millisecondsSinceEpoch
-              : recentMs;
-        }
+      for (final _VideoSlot member in members) {
+        final int watched = _slotWatchedAtMs(member);
+        if (watched > recentMs) recentMs = watched;
       }
       final int? targetIndex = nextEpisodeAfterLatestPlayed(
-        _seriesPlaybackStates(members),
+        _slotPlaybackStates(members),
       );
       if (targetIndex == null) return;
       final MediaCollectionRow collection = _collectionsById[cid]!;
-      final VideoBookRow target = members[targetIndex];
+      final _VideoSlot target = members[targetIndex];
       items.add(_VideoRowItem(
         recentMs: recentMs,
         build: () => _buildRowMediaCard(
           cardKey: ValueKey<String>('home_video_next_collection_$cid'),
           focusId: FushiFocusId('home-video-next-collection-$cid'),
-          cover: _localCoverProvider(target) ??
-              _collectionRowCoverProvider(collection, members),
+          cover: _slotCoverProvider(target) ??
+              _collectionRowCoverProvider(
+                collection,
+                _localMembersOf(members),
+              ),
           title: _workTitle(collection),
           coverHeight: coverHeight,
-          onTap: () => unawaited(_open(target, playlistCollectionId: cid)),
+          onTap: () => _openSlot(target, playlistCollectionId: cid),
           onLongPress: () => _showCollectionContextMenu(collection),
           episodeNumber: targetIndex + 1,
           secondaryText: t.video_home_next_episode_number(n: targetIndex + 1),
+          cloudBadge: target.local == null,
         ),
       ));
     });
@@ -3032,60 +3123,75 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// 「最近添加」横滚行：入库 [kVideoRecentlyAddedWindow]（14 天）内的本地条目
-  /// 按入库时刻倒序取前 15，「新」角标。远端占位无入库时刻，不进本行。
+  /// 「最近添加」横滚行：入库 [kVideoRecentlyAddedWindow]（14 天）内的条目按入库
+  /// 时刻倒序取前 15，「新」角标。
+  ///
+  /// 远端占位也进本行——前提是 host 下发了 [RemoteVideoInfo.importedAt]（旧 host
+  /// 不带 → 与改动前逐字节同行为，不进本行）。此前这一行结构上只装本地行，于是
+  /// 「host 上新入库了一批」在子设备首页完全看不见。
   Widget? _buildRecentlyAddedRow(
     List<VideoBookRow> filtered,
+    List<RemoteVideoInfo> remoteVideos,
     double coverHeight,
   ) {
     final DateTime now = DateTime.now();
-    final Map<int, List<VideoBookRow>> allMembersByCollection =
-        <int, List<VideoBookRow>>{};
-    final Map<int, List<VideoBookRow>> grouped = <int, List<VideoBookRow>>{};
-    final List<VideoBookRow> loose = <VideoBookRow>[];
-    for (final VideoBookRow book in filtered) {
-      if (_localExtraBookUids.contains(book.bookUid)) continue;
-      final int? allCid =
-          _primaryCollectionByEntry[MediaKind.video.compositeKey(book.bookUid)];
-      if (allCid != null && _collectionsById.containsKey(allCid)) {
+    final Map<int, List<_VideoSlot>> allMembersByCollection =
+        <int, List<_VideoSlot>>{};
+    final Map<int, List<_VideoSlot>> grouped = <int, List<_VideoSlot>>{};
+    final List<_VideoSlot> loose = <_VideoSlot>[];
+    final List<_VideoSlot> candidates = <_VideoSlot>[
+      for (final VideoBookRow book in filtered)
+        if (!_localExtraBookUids.contains(book.bookUid))
+          _VideoSlot(local: book),
+      for (final RemoteVideoInfo video in remoteVideos)
+        _VideoSlot(remote: video),
+    ];
+    for (final _VideoSlot slot in candidates) {
+      final VideoBookRow? local = slot.local;
+      final int? cid = local != null
+          ? _primaryCollectionByEntry[
+              MediaKind.video.compositeKey(local.bookUid)]
+          : _remoteCollectionId(slot.remote!);
+      final bool inCollection = cid != null && _collectionsById.containsKey(cid);
+      if (inCollection) {
         allMembersByCollection
-            .putIfAbsent(allCid, () => <VideoBookRow>[])
-            .add(book);
+            .putIfAbsent(cid, () => <_VideoSlot>[])
+            .add(slot);
       }
-      if (!isVideoRecentlyAdded(importedAt: book.importedAt, now: now)) {
+      if (!isVideoRecentlyAdded(importedAt: _slotImportedAtMs(slot), now: now)) {
         continue;
       }
-      final int? cid =
-          _primaryCollectionByEntry[MediaKind.video.compositeKey(book.bookUid)];
-      if (cid != null && _collectionsById.containsKey(cid)) {
-        grouped.putIfAbsent(cid, () => <VideoBookRow>[]).add(book);
+      if (inCollection) {
+        grouped.putIfAbsent(cid, () => <_VideoSlot>[]).add(slot);
       } else {
-        loose.add(book);
+        loose.add(slot);
       }
     }
     final List<_VideoRowItem> recent = <_VideoRowItem>[];
-    grouped.forEach((int cid, List<VideoBookRow> members) {
-      members.sort((VideoBookRow a, VideoBookRow b) =>
-          (b.importedAt ?? 0).compareTo(a.importedAt ?? 0));
+    grouped.forEach((int cid, List<_VideoSlot> members) {
+      members.sort((_VideoSlot a, _VideoSlot b) =>
+          (_slotImportedAtMs(b) ?? 0).compareTo(_slotImportedAtMs(a) ?? 0));
       final MediaCollectionRow collection = _collectionsById[cid]!;
-      final VideoBookRow latest = members.first;
-      final List<VideoBookRow> allMembers =
+      final _VideoSlot latest = members.first;
+      final List<_VideoSlot> allMembers =
           allMembersByCollection[cid] ?? members;
-      allMembers.sort((VideoBookRow a, VideoBookRow b) =>
-          (_memberSortIndex[MediaKind.video.compositeKey(a.bookUid)] ?? 1 << 30)
-              .compareTo(
-                  _memberSortIndex[MediaKind.video.compositeKey(b.bookUid)] ??
-                      1 << 30));
+      allMembers.sort((_VideoSlot a, _VideoSlot b) =>
+          _slotSortIndex(a).compareTo(_slotSortIndex(b)));
       final int latestIndex = allMembers.indexWhere(
-        (VideoBookRow value) => value.bookUid == latest.bookUid,
+        (_VideoSlot value) => identical(value, latest),
       );
       final int? episodeNumber = latestIndex < 0 ? null : latestIndex + 1;
       recent.add(_VideoRowItem(
-        recentMs: members.first.importedAt ?? 0,
+        recentMs: _slotImportedAtMs(latest) ?? 0,
         build: () => _buildRowMediaCard(
           cardKey: ValueKey<String>('home_video_recent_collection_$cid'),
           focusId: FushiFocusId('home-video-recent-collection-$cid'),
-          cover: _collectionRowCoverProvider(collection, members),
+          // 合集封面回落链只认本地文件；纯远端合集回落到最新那一集的远端封面。
+          cover: _collectionRowCoverProvider(
+                collection,
+                _localMembersOf(members),
+              ) ??
+              _slotCoverProvider(latest),
           title: _workTitle(collection),
           coverHeight: coverHeight,
           onTap: () => _openCollectionDetail(collection),
@@ -3098,10 +3204,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ),
       ));
     });
-    for (final VideoBookRow book in loose) {
+    for (final _VideoSlot slot in loose) {
+      final VideoBookRow? local = slot.local;
       recent.add(_VideoRowItem(
-        recentMs: book.importedAt ?? 0,
-        build: () => _buildRecentlyAddedCard(book, coverHeight),
+        recentMs: _slotImportedAtMs(slot) ?? 0,
+        build: () => local != null
+            ? _buildRecentlyAddedCard(local, coverHeight)
+            : _buildRecentlyAddedRemoteCard(slot.remote!, coverHeight),
       ));
     }
     recent.sort(
@@ -3427,6 +3536,30 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           ? t.video_home_recent_episode_number(n: book.currentEpisode + 1)
           : t.video_recently_added_badge,
       newBadge: true,
+    );
+  }
+
+  /// 远端占位的「最近添加」行卡：与本地同形（「新」角标 + 集数），另带云角标表明
+  /// 内容还在 host 上；短按走既有远端流播 / 下载分派。
+  Widget _buildRecentlyAddedRemoteCard(
+    RemoteVideoInfo video,
+    double coverHeight,
+  ) {
+    final String safeKey = _safeRemoteKey(video.id);
+    return _buildRowMediaCard(
+      cardKey: ValueKey<String>('home_video_recent_remote_$safeKey'),
+      focusId: FushiFocusId('home-video-recent-remote-$safeKey'),
+      cover: _remoteCoverProvider(video),
+      title: video.title,
+      coverHeight: coverHeight,
+      onTap: () => unawaited(_openRemote(video)),
+      onLongPress: () => _showRemoteVideoDialog(video),
+      episodeNumber: video.isPlaylist ? video.currentEpisode + 1 : null,
+      secondaryText: video.isPlaylist
+          ? t.video_home_recent_episode_number(n: video.currentEpisode + 1)
+          : t.video_recently_added_badge,
+      newBadge: true,
+      cloudBadge: true,
     );
   }
 
@@ -3952,7 +4085,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       items.add(CollectionOrderingItem<_VideoSlot>(
         mediaType: MediaKind.video,
         entryKey: video.id,
-        importedAt: -1 - i,
+        // host 下发了真入库戳就按它排（与本地条目同一把尺子，「最近添加」排序才
+        // 跨端一致）；旧 host 不带 → 回落到递减负值，保持既有确定性尾部序。
+        importedAt: video.importedAt ?? (-1 - i),
         payload: _VideoSlot(remote: video),
       ));
     }

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -1,32 +1,77 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/media/video/anilist_client.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
 import 'package:fushi/utils.dart';
 
-/// 一条可下载的 Jimaku 字幕候选：所属条目名 + 文件。
+/// 一条可下载的在线字幕候选：来源条目/发布名 + 文件名 + 回给来源 provider 的句柄。
+///
+/// **不再绑定 Jimaku**：本对话框此前直连 [JimakuClient]，而下载管线走的是
+/// [VideoSubtitleRegistry]（Jimaku + OpenSubtitles）——同一个「找字幕」在两个入口
+/// 能力不同，视频页永远搜不到 OpenSubtitles。现在两边共用同一套 provider，本类只是
+/// 列表渲染用的投影：语言优先取 provider 给的（OpenSubtitles 有权威 ISO 码），
+/// provider 没给才从文件名启发式识别（Jimaku 的老口径）。
 class JimakuCandidate {
-  const JimakuCandidate({required this.entryName, required this.file});
-  final String entryName;
-  final JimakuFile file;
+  const JimakuCandidate({
+    required this.entryName,
+    required this.name,
+    this.providerId = 'jimaku',
+    String? language,
+    this.source,
+  }) : _language = language;
 
-  /// 该候选文件名识别出的语言代码（`ja`/`zh`/`en`/`ko`），认不出为 `null`。
-  String? get language => detectSubtitleLanguage(file.name);
+  /// 来源条目名（Jimaku entry / OpenSubtitles release）。
+  final String entryName;
+
+  /// 字幕文件名（列表主文案、下载落盘名、语言/集号/类型的启发式来源）。
+  final String name;
+
+  /// 来源 provider id（`jimaku` / `opensubtitles`）。
+  final String providerId;
+
+  final String? _language;
+
+  /// 真实来源候选；下载时原样回给 registry。null = 测试预置的纯渲染样本。
+  final VideoSubtitleCandidate? source;
+
+  /// 语言代码（`ja`/`zh`/`en`/`ko`…）；provider 未给且文件名认不出为 `null`。
+  String? get language {
+    final String? explicit = _language?.trim();
+    if (explicit != null && explicit.isNotEmpty) return explicit;
+    return detectSubtitleLanguage(name);
+  }
 
   /// 从文件名解析出的集号（认不出为 null），用于按集升序排列。
-  int? get episode => file.episode;
+  int? get episode => source?.episode ?? parseSubtitleEpisode(name);
 
-  /// 字幕文件类型（扩展名小写不含点，如 `ass`/`srt`）。候选在入列前已过
-  /// [JimakuFile.isTextSubtitle]，故这里恒是四种可解析文本格式之一。
-  String get format => file.extension;
+  /// 字幕文件类型（扩展名小写不含点，如 `ass`/`srt`）。候选在入列前已过文本字幕
+  /// 过滤，故这里恒是四种可解析文本格式之一。
+  String get format {
+    final int dot = name.lastIndexOf('.');
+    return dot < 0 ? '' : name.substring(dot + 1).toLowerCase();
+  }
+
+  /// 由 registry 返回的 provider 候选投影成列表项。
+  factory JimakuCandidate.fromProvider(VideoSubtitleCandidate candidate) =>
+      JimakuCandidate(
+        entryName: candidate.releaseName ?? '',
+        name: candidate.fileName,
+        providerId: candidate.providerId,
+        language: candidate.language,
+        source: candidate,
+      );
 }
 
 /// Jimaku 字幕框按视口宽度自适应：手机接近满宽，中等窗口稍留边距，桌面/2K/4K
@@ -63,7 +108,7 @@ List<JimakuCandidate> sortJimakuCandidates(
     final int ea = a.episode ?? (1 << 30);
     final int eb = b.episode ?? (1 << 30);
     if (ea != eb) return ea.compareTo(eb);
-    return a.file.name.toLowerCase().compareTo(b.file.name.toLowerCase());
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
   });
   return out;
 }
@@ -141,6 +186,7 @@ class JimakuSubtitleDialog extends StatefulWidget {
     required this.initialApiKey,
     required this.onApiKeyChanged,
     required this.saveDirectory,
+    this.subtitleRegistry,
     this.initialPreferredLanguage,
     this.onPreferredLanguageChanged,
     this.httpClientFactory,
@@ -148,6 +194,13 @@ class JimakuSubtitleDialog extends StatefulWidget {
     this.debugInitialSeriesMatches,
     super.key,
   });
+
+  /// 统一字幕来源（Jimaku + OpenSubtitles）的**延迟**解析器。
+  ///
+  /// 延迟是必须的：填 key 会经 [onApiKeyChanged] 触发 provider runtime 重建，早绑
+  /// 的 registry 实例正是那个「刚填完 key 还是搜不到」的旧实例。null = 宿主没接
+  /// registry（纯渲染用的测试宿主）→ 搜索按未配置来源处理。
+  final VideoSubtitleRegistry? Function()? subtitleRegistry;
 
   /// 预填的搜索词（由视频文件名解析出的番名）。
   final String initialQuery;
@@ -261,10 +314,19 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     super.dispose();
   }
 
+  /// 当前是否有**任何**已配置的在线字幕来源（registry 里有 provider 即算）。
+  bool get _hasConfiguredSubtitleSource {
+    final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
+    return registry != null && registry.providers.isNotEmpty;
+  }
+
   Future<void> _search() async {
     final String apiKey = _apiKeyCtrl.text.trim();
     final String query = _queryCtrl.text.trim();
-    if (apiKey.isEmpty) {
+    // 门槛是「有没有可用的字幕来源」，不是「有没有 Jimaku key」：只配了
+    // OpenSubtitles 的用户照样能搜。改动前这里硬卡 Jimaku key，等于把另一路来源
+    // 挡在门外。已配来源但 key 填错/失效 → 搜索照跑，按无结果呈现（与既有一致）。
+    if (apiKey.isEmpty && !_hasConfiguredSubtitleSource) {
       _snack(t.video_jimaku_no_key);
       return;
     }
@@ -286,7 +348,10 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     // 同一条 paint-before-work 约束。
     await WidgetsBinding.instance.endOfFrame;
     if (!mounted) return;
-    await widget.onApiKeyChanged(apiKey);
+    // 只有真改过才写：每次搜索都写一遍会白白重建一次 provider runtime。
+    if (apiKey != widget.initialApiKey.trim()) {
+      await widget.onApiKeyChanged(apiKey);
+    }
 
     AniListClient? anilist;
     try {
@@ -314,7 +379,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   Future<void> _selectSeries(AniListMedia media) async {
     if (_selectedSeriesId == media.id || _searching) return;
     final String apiKey = _apiKeyCtrl.text.trim();
-    if (apiKey.isEmpty) return;
+    if (apiKey.isEmpty && !_hasConfiguredSubtitleSource) return;
     final int? episode = int.tryParse(_episodeCtrl.text.trim());
     setState(() {
       _searching = true;
@@ -333,38 +398,52 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     }
   }
 
-  /// 用给定 [anilistId]（null 时回退文本 [queryFallback]）搜 Jimaku 条目 → 列文件 →
-  /// 过滤文本字幕 → **排序**（[sortJimakuCandidates]，消除「集数乱序」）→ 落状态。
-  /// 自带 JimakuClient 生命周期（本函数创建并关闭）。
+  /// 用给定 [anilistId]（null 时回退文本 [queryFallback]）向**统一字幕来源**
+  /// （[VideoSubtitleRegistry]：Jimaku + OpenSubtitles）搜候选 → **排序**
+  /// （[sortJimakuCandidates]，消除「集数乱序」）→ 落状态。
+  ///
+  /// 此前这里自建 [JimakuClient] 直连 Jimaku，而下载管线走 registry——同一个「找
+  /// 字幕」在两个入口能力不同。现在两边同一套 provider：来源增减、失败归类、去重
+  /// 与优先级都只有一份实现。
+  ///
+  /// 分类固定按 anime 提请求：registry 对 anime 派发 Jimaku + OpenSubtitles，对非
+  /// anime 只派 OpenSubtitles。本对话框是从播放页对一个已在看的片子找字幕，缩窄
+  /// 分类只会平白丢掉 Jimaku 这一路，不会带来任何正确性。
   Future<void> _fetchCandidates({
     required int? anilistId,
     required String queryFallback,
     required int? episode,
   }) async {
-    JimakuClient? jimaku;
-    try {
-      jimaku = JimakuClient(
-        apiKey: _apiKeyCtrl.text.trim(),
-        client: await _createHttpClient(),
-      );
-      final List<JimakuEntry> entries = <JimakuEntry>[];
-      if (anilistId != null) {
-        entries.addAll(await jimaku.searchByAnilistId(anilistId));
-      }
-      if (entries.isEmpty) {
-        entries.addAll(await jimaku.searchByQuery(queryFallback));
-      }
-
-      final List<JimakuCandidate> candidates = <JimakuCandidate>[];
-      for (final JimakuEntry entry in entries) {
-        final List<JimakuFile> files =
-            await jimaku.listFiles(entry.id, episode: episode);
-        for (final JimakuFile f in files) {
-          if (f.isTextSubtitle) {
-            candidates.add(JimakuCandidate(entryName: entry.name, file: f));
-          }
-        }
-      }
+    final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
+    if (registry == null || registry.providers.isEmpty) {
+      if (!mounted) return;
+      setState(() {
+        _candidates = const <JimakuCandidate>[];
+        _searched = true;
+        _searchedWithEpisode = episode != null;
+        _selectedSeriesId = anilistId;
+      });
+      return;
+    }
+    {
+      final ProviderBatchResult<VideoSubtitleCandidate> result =
+          await registry.search(VideoSubtitleSearchRequest(
+        media: VideoMediaReference(
+          providerId: 'anilist',
+          mediaId: anilistId?.toString() ?? queryFallback,
+          mediaKind: VideoMetadataMediaKind.tv,
+          discoveryCategory: VideoDiscoveryCategory.anime,
+          title: queryFallback,
+          anilistId: anilistId,
+          episode: episode,
+        ),
+        query: queryFallback,
+        episode: episode,
+      ));
+      final List<JimakuCandidate> candidates = <JimakuCandidate>[
+        for (final VideoSubtitleCandidate candidate in result.items)
+          JimakuCandidate.fromProvider(candidate),
+      ];
       final List<JimakuCandidate> sorted = sortJimakuCandidates(
         candidates,
         preferredLanguage: _selectedLanguage,
@@ -381,8 +460,6 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         // （用户：「apikey 配完是不是可以缩小显示」）。用户仍可点「修改」展开。
         _apiKeyCollapsed = sorted.isNotEmpty;
       });
-    } finally {
-      jimaku?.close();
     }
   }
 
@@ -393,29 +470,31 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         : factory();
   }
 
+  /// 下载选中候选：交回**它自己的来源 provider**（registry 按 providerId 分派），
+  /// 落盘到 [JimakuSubtitleDialog.saveDirectory] 后 pop 回本地路径。
+  ///
+  /// 任何一路来源失败都归一成同一句「下载失败」提示——provider 的失败分类
+  /// （[ExternalProviderFailure]）是给管线重试用的，对用户只有「没下来」一种语义。
   Future<void> _download(JimakuCandidate candidate) async {
-    final String apiKey = _apiKeyCtrl.text.trim();
-    if (apiKey.isEmpty) return;
-    setState(() => _busyName = candidate.file.name);
-    JimakuClient? jimaku;
+    final VideoSubtitleCandidate? source = candidate.source;
+    final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
+    if (source == null || registry == null) return;
+    setState(() => _busyName = candidate.name);
     try {
-      jimaku = JimakuClient(
-        apiKey: apiKey,
-        client: await _createHttpClient(),
-      );
-      final Uint8List? bytes = await jimaku.downloadFile(candidate.file.url);
-      if (bytes == null) {
+      final VideoSubtitleDownload download = await registry.download(source);
+      if (download.bytes.isEmpty) {
         _snack(t.video_jimaku_download_failed);
         return;
       }
       final Directory dir = Directory(widget.saveDirectory);
       if (!dir.existsSync()) dir.createSync(recursive: true);
-      final String dest = p.join(dir.path, candidate.file.name);
-      await File(dest).writeAsBytes(bytes);
+      final String dest = p.join(dir.path, download.fileName);
+      await File(dest).writeAsBytes(download.bytes);
       if (!mounted) return;
       Navigator.pop(context, dest);
+    } on Object {
+      _snack(t.video_jimaku_download_failed);
     } finally {
-      jimaku?.close();
       if (mounted) setState(() => _busyName = null);
     }
   }
@@ -808,7 +887,7 @@ class JimakuCandidateList extends StatelessWidget {
     // G6：与库页搜索同一归一化口径（全角/片假名/标点差异不挡命中），不再是
     // 裸 toLowerCase 子串。
     final List<JimakuCandidate> shown = filterByMediaSearch(
-        candidates, filter, (JimakuCandidate c) => <String>[c.file.name]);
+        candidates, filter, (JimakuCandidate c) => <String>[c.name]);
     // 不用 shrinkWrap：外层 [ConstrainedBox] 给了有界 maxHeight，普通 ListView 会
     // 填满该高度并在内容超出时正常滚动。shrinkWrap 反而会让它贴合内容/不产生可滚
     // 余量（maxScrollExtent=0），正是「滚不动」的来源。
@@ -816,7 +895,7 @@ class JimakuCandidateList extends StatelessWidget {
       itemCount: shown.length,
       itemBuilder: (BuildContext context, int i) {
         final JimakuCandidate c = shown[i];
-        final bool busy = busyName == c.file.name;
+        final bool busy = busyName == c.name;
         // 文件名（含集数，如 第01話/E01）整段可见才能区分是第几集：换行而非单行截断
         // （TODO-673：番名都一样，区分集数的部分原本被省略号吃掉）。文件名给多行
         // 软换行，仍给一个上限避免极长名把单条撑满整个列表区，超限再 fade 兜底。
@@ -825,7 +904,7 @@ class JimakuCandidateList extends StatelessWidget {
           isThreeLine: true,
           leading: const Icon(Icons.subtitles_outlined),
           title: Text(
-            c.file.name,
+            c.name,
             maxLines: 3,
             softWrap: true,
             overflow: TextOverflow.fade,

--- a/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
@@ -149,10 +149,22 @@ class AppVideoExternalSettingsStore implements VideoExternalSettingsStore {
 /// Preferences。表单错误只显示稳定的本地化提示，不把含密钥的 URL 或异常正文写进
 /// snack、日志或诊断导出。
 class VideoExternalProviderSettingsSection extends ConsumerStatefulWidget {
-  const VideoExternalProviderSettingsSection({super.key, this.store});
+  const VideoExternalProviderSettingsSection({
+    super.key,
+    this.store,
+    this.onlySubtitleSources = false,
+  });
 
   /// 测试注入口；生产路径从 [AppModel] 构造设备本地 store。
   final VideoExternalSettingsStore? store;
+
+  /// 只渲染「在线字幕来源」那一节（OpenSubtitles）。
+  ///
+  /// 字幕来源此前分居两处：Jimaku API key 在设置 → 视频 → 字幕，OpenSubtitles 在
+  /// 设置 → 下载 → 外部来源。同一个能力两个家，用户配完一个以为配完了。这里不复制
+  /// 一份编辑 UI（那就是第二份真相源），而是让本组件按节可裁，两处渲染同一份实现、
+  /// 写同一个 `video_subtitle_opensubtitles_config`。
+  final bool onlySubtitleSources;
 
   @override
   ConsumerState<VideoExternalProviderSettingsSection> createState() =>
@@ -695,6 +707,31 @@ class _VideoExternalProviderSettingsSectionState
     }
     if (_store == null) return const SizedBox.shrink();
     final ThemeData theme = Theme.of(context);
+    if (widget.onlySubtitleSources) {
+      return Column(
+        key: const ValueKey<String>('video-external-subtitle-sources'),
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (_saveFailed)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                t.video_external_save_error,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
+          _sectionHeading(
+            theme,
+            t.video_opensubtitles_settings_title,
+            t.video_opensubtitles_settings_hint,
+            icon: Icons.subtitles_outlined,
+          ),
+          _openSubtitlesFields(),
+        ],
+      );
+    }
     return Column(
       key: const ValueKey<String>('video-external-provider-settings'),
       crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
@@ -13,6 +13,7 @@ import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/subtitle/open_subtitles_client.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/utils/net/app_user_agent.dart';
 import 'package:fushi_core/fushi_core.dart';
 
 @immutable
@@ -963,12 +964,12 @@ class _OpenSubtitlesDraft {
     required this.allowInsecureHttp,
   });
 
-  factory _OpenSubtitlesDraft.empty() => const _OpenSubtitlesDraft(
+  factory _OpenSubtitlesDraft.empty() => _OpenSubtitlesDraft(
         endpoint: 'https://api.opensubtitles.com/api/v1',
         apiKey: '',
         username: '',
         password: '',
-        userAgent: 'Hibiki v1',
+        userAgent: fushiUserAgent('opensubtitles'),
         enabled: false,
         allowInsecureHttp: false,
       );

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -717,6 +717,9 @@ extension _VideoSubtitle on _VideoFushiPageState {
         initialQuery: query,
         initialApiKey: appModel.jimakuApiKey,
         onApiKeyChanged: (String key) => appModel.setJimakuApiKey(key),
+        // 延迟解析：填 key 会重建 provider runtime，早绑的实例正是「刚填完 key
+        // 还是搜不到」的那个旧 registry。
+        subtitleRegistry: () => appModel.videoSubtitleRegistry,
         saveDirectory: saveDir,
         httpClientFactory: appModel.createDownloadHttpClient,
         initialPreferredLanguage: preferredLanguage,

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -15,6 +15,7 @@ import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/pages/implementations/video_external_provider_settings_section.dart';
 
 /// 视频设置唯一真相源（阶段 B）：每个条目声明一次，同时服务两个宿主——
 /// 全局设置页（本 destination 的 sections 直接渲染；无 host 时读写纯 pref、下次
@@ -1169,6 +1170,19 @@ SettingsDestination buildVideoDestination() {
             onChanged: (SettingsContext settingsContext, String code) async {
               await settingsContext.appModel.setJimakuDefaultLanguage(code);
             },
+          ),
+          // ── OpenSubtitles（另一路在线字幕源）─────────────────────────────
+          // 字幕来源此前分居两处：Jimaku key 在这儿，OpenSubtitles 只在
+          // 设置 → 下载 → 外部来源。同一个能力两个家，用户在这里配完 Jimaku 就以为
+          // 「字幕来源配完了」，而播放页找字幕与下载自动配字幕走的是同一套 registry
+          // （两家一起搜）。这里内联**同一份**编辑组件（不复制 UI、不第二份真相源）。
+          SettingsCustomItem(
+            id: 'video.subtitle.opensubtitles',
+            searchTitle: t.video_opensubtitles_settings_title,
+            builder: (SettingsContext settingsContext) =>
+                const VideoExternalProviderSettingsSection(
+              onlySubtitleSources: true,
+            ),
           ),
         ],
       ),

--- a/fushi/lib/src/sync/app_model_library_host_service.dart
+++ b/fushi/lib/src/sync/app_model_library_host_service.dart
@@ -1328,6 +1328,9 @@ class AppModelLibraryHostService
       tagsAddedAt: tagsAddedAt,
       tagTombstones: tagTombstones,
       collection: collection,
+      // 入库时刻下发：client 的「最近添加」行与合集组间序都按它排；不下发就只能
+      // 给远端占位造假 importedAt，远端条目结构上进不了「最近添加」。
+      importedAt: row.importedAt,
     );
   }
 

--- a/fushi/lib/src/sync/cloud_remote_video_client.dart
+++ b/fushi/lib/src/sync/cloud_remote_video_client.dart
@@ -83,6 +83,8 @@ class CloudRemoteVideoClient implements RemoteVideoSource {
       // mergeRemoteVideoTags 按名 max(add) vs max(removed) 解析（删除/改名传播）。
       tagsAddedAt: e.tagsAddedAt,
       tagTombstones: e.tagTombstones,
+      // 云清单本来就带入库戳（0 = 旧数据未知），透传给首页「最近添加」/组间序。
+      importedAt: e.importedAtMs > 0 ? e.importedAtMs : null,
     );
   }
 

--- a/fushi/lib/src/sync/cloud_remote_video_client.dart
+++ b/fushi/lib/src/sync/cloud_remote_video_client.dart
@@ -3,8 +3,7 @@ import 'dart:io';
 
 import 'package:fushi/src/sync/fushi_library_host_service.dart'
     show RemoteVideoInfo;
-import 'package:fushi/src/sync/remote_video_client.dart'
-    show RemoteVideoSource;
+import 'package:fushi/src/sync/remote_video_client.dart' show RemoteVideoSource;
 import 'package:fushi/src/sync/sync_asset_store.dart';
 import 'package:fushi/src/sync/remote_library_source.dart';
 import 'package:fushi/src/sync/sync_backend.dart'

--- a/fushi/lib/src/sync/fushi_library_host_service.dart
+++ b/fushi/lib/src/sync/fushi_library_host_service.dart
@@ -1267,6 +1267,7 @@ class RemoteVideoInfo {
     this.tagsAddedAt = const <String, int>{},
     this.tagTombstones = const <String, int>{},
     this.collection,
+    this.importedAt,
   });
 
   final String id;
@@ -1300,6 +1301,16 @@ class RemoteVideoInfo {
   /// 该视频在 host 端的主合集归属（多端库联合视图 §2.3 任务5.1；null = 散卡）。
   /// 远端占位卡据此归进对应合集行（UI 批任务 10）。
   final RemoteCollectionMembership? collection;
+
+  /// host 端 `VideoBooks.importedAt`（epoch 毫秒；null = 旧 host 不带该字段）。
+  ///
+  /// 缺了它，client 的视频首页「最近添加」行结构上就只能是本地条目——远端占位没有
+  /// 入库时刻，既排不进时间序也判不出是不是在窗口内，于是「互联」在首页只兑现了
+  /// 一半（继续观看有远端、最近添加没有）。同理 [_groupVideos] 只能给远端造一个
+  /// 负数假 importedAt 来占位排序。
+  ///
+  /// 旧 host 不带 → null → 与改动前逐字节同行为（不进「最近添加」、排序回落假值）。
+  final int? importedAt;
 
   /// 是否为多集远端播放列表（≥2 集）。client UI 据此渲染集数角标 + 切集面板。
   bool get isPlaylist => episodes.length > 1;
@@ -1396,6 +1407,7 @@ class RemoteVideoInfo {
         if (secondaryDelayUpdatedAtMs > 0)
           'secondaryDelayUpdatedAtMs': secondaryDelayUpdatedAtMs,
         if (completedAt != null) 'completedAt': completedAt,
+        if (importedAt != null) 'importedAt': importedAt,
         // 单视频（episodes <=1）向后兼容：不写 episodes/currentEpisode 键。
         if (episodes.length > 1) ...<String, Object?>{
           'episodes': <Map<String, Object?>>[
@@ -1461,6 +1473,7 @@ class RemoteVideoInfo {
         tagsAddedAt: tagsAddedAt,
         tagTombstones: tagTombstones,
         collection: collection ?? this.collection,
+        importedAt: importedAt,
       );
 
   static RemoteVideoInfo fromJson(Map<String, Object?> json) {
@@ -1495,6 +1508,7 @@ class RemoteVideoInfo {
       secondaryDelayUpdatedAtMs:
           _jsonInt(json['secondaryDelayUpdatedAtMs']) ?? 0,
       completedAt: _jsonInt(json['completedAt']),
+      importedAt: _jsonInt(json['importedAt']),
       episodes: _jsonVideoEpisodes(json['episodes']),
       currentEpisode: _jsonInt(json['currentEpisode']) ?? 0,
       tags: _jsonStringList(json['tags']),

--- a/fushi/lib/src/sync/interconnect_service_config.dart
+++ b/fushi/lib/src/sync/interconnect_service_config.dart
@@ -1,3 +1,4 @@
+import 'package:fushi/src/media/tracking/media_tracking_service.dart';
 import 'package:fushi/src/sync/fushi_library_host_service.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -14,17 +15,36 @@ class InterconnectServiceConfigSnapshot {
 
   /// Preferences that describe external services shared by the user's devices.
   ///
-  /// `yomitan_api_key` is deliberately absent: it protects this device's local
-  /// inbound API. Bangumi/Anki credentials and `media_source_secret_*` are also
-  /// device-scoped or have external write authority and remain local. Video
-  /// metadata provider keys/tokens (including the legacy TMDB override) and an
-  /// authorized Douban endpoint are likewise device-local and never enter this
-  /// payload.
+  /// 判据是**这条配置描述的是「外部服务」还是「本机」**，不是「它像不像凭据」：
+  /// 用户在一台设备上配好的第三方服务账号（Bangumi 追番、Jimaku、OpenSubtitles、
+  /// TMDB/Fanart 刮削、Torznab 索引器、qBittorrent 连接），在他自己的另一台已配对
+  /// 设备上就应该照样能用——否则「互联」只搬内容不搬能力，用户得在每台设备上重填
+  /// 一遍同一个 token。本通道是**已配对 + 已认证**的点对点链路，对端是用户自己的
+  /// 设备，与备份 zip 落第三方云盘、Profile 分享 JSON 给别人是不同的出境等级
+  /// （那两条仍由 [PrefRedactionPolicy] 全量剔除，本清单不影响它们）。
+  ///
+  /// 仍然**绝不**进这个 payload 的三类：
+  /// - `yomitan_api_key`：它保护的是**本机**入站 API，不是外部服务身份；
+  /// - `media_source_secret_*`、`sync_*`：网络来源密码/私钥与配对凭据，属设备本地；
+  /// - 设备身份与本地路径（device_id、端口、下载根、因果基线等）。
   static const Set<String> sharedPreferenceKeys = <String>{
     'jimaku_api_key',
     'qb_connection_config',
     'manga_online_catalog_base_url',
     'manga_online_catalog_enabled',
+    // Bangumi 追番同步：令牌 + 账号显示名成对同步（只搬令牌会让子设备 UI 挂着
+    // 上一个账号的名字）。令牌变更的对账水位归零见 [applyTo]。
+    kBangumiAccessTokenPref,
+    kBangumiAccountNamePref,
+    // 视频刮削 / 字幕 / 资源索引器的外部服务身份：同一套账号在哪台设备上都该
+    // 刮到同一份资料、搜到同一批字幕。
+    'video_metadata_bangumi_token',
+    'video_scraper_tmdb_api_key',
+    'video_metadata_fanart_api_key',
+    'video_metadata_douban_authorized_endpoint',
+    'video_metadata_douban_authorized_token',
+    'video_subtitle_opensubtitles_config',
+    'video_resource_torznab_config',
   };
 
   static final Map<String, String> _defaultRawValues = <String, String>{
@@ -32,6 +52,15 @@ class InterconnectServiceConfigSnapshot {
     'qb_connection_config': PrefCodec.encode(''),
     'manga_online_catalog_base_url': PrefCodec.encode('https://mokuro.moe'),
     'manga_online_catalog_enabled': PrefCodec.encode(true),
+    kBangumiAccessTokenPref: PrefCodec.encode(''),
+    kBangumiAccountNamePref: PrefCodec.encode(''),
+    'video_metadata_bangumi_token': PrefCodec.encode(''),
+    'video_scraper_tmdb_api_key': PrefCodec.encode(''),
+    'video_metadata_fanart_api_key': PrefCodec.encode(''),
+    'video_metadata_douban_authorized_endpoint': PrefCodec.encode(''),
+    'video_metadata_douban_authorized_token': PrefCodec.encode(''),
+    'video_subtitle_opensubtitles_config': PrefCodec.encode(''),
+    'video_resource_torznab_config': PrefCodec.encode(''),
   };
 
   /// Raw [PrefCodec] values, kept raw so the client does not double-encode
@@ -80,13 +109,25 @@ class InterconnectServiceConfigSnapshot {
   ///
   /// Unknown/missing fields are ignored; a real host snapshot contains every
   /// allowlisted key (including encoded defaults for cleared values).
+  ///
+  /// Bangumi 令牌换人时同时归零本设备的对账水位
+  /// （[kBangumiTokenScopedWatermarkPrefs]），与设置页写令牌那条路径共用同一条
+  /// 不变式：不归零，子设备就永远不会把「换账号之前看完的条目」推给新账号。
+  /// 水位归零本身不计入返回值——它是令牌那一行的副作用，不是导入的一条配置。
   Future<int> applyTo(FushiDatabase db) async {
     int changed = 0;
+    bool bangumiTokenChanged = false;
     for (final MapEntry<String, String> entry in preferences.entries) {
       if (!sharedPreferenceKeys.contains(entry.key)) continue;
       if (await db.getPref(entry.key) == entry.value) continue;
       await db.setPref(entry.key, entry.value);
+      if (entry.key == kBangumiAccessTokenPref) bangumiTokenChanged = true;
       changed++;
+    }
+    if (bangumiTokenChanged) {
+      for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+        await db.setPref(key, PrefCodec.encode(0));
+      }
     }
     return changed;
   }

--- a/fushi/lib/src/utils/net/app_user_agent.dart
+++ b/fushi/lib/src/utils/net/app_user_agent.dart
@@ -1,0 +1,32 @@
+/// 本 app **以自己的身份**访问第三方服务时用的 User-Agent 单一真相源。
+///
+/// 改名之后这些字面量散落在各调用方各写各的，于是有的报 `fushi`、有的还报
+/// `Hibiki`——对外部服务而言 UA 就是这个 app 的身份，两个名字同时在跑等于同一个
+/// 客户端有两个身份（限流/封禁/统计都对不上，用户也看不出哪台设备在打谁）。
+///
+/// **不适用**于故意伪装成浏览器的场景（Aidoku 源站需要浏览器 UA 才不被 WAF 拦、
+/// Google Lens OCR 要求 Chromium UA、YouTube 分离流的回放 UA 必须与铸造 URL 时
+/// 逐字一致）。那几处是「装成别人」，不是「报自己」，必须保持原样。
+library;
+
+/// 项目主页；随 UA 一起报出去，方便被访问方联系到上游。
+const String kFushiUserAgentHomepage = 'https://github.com/hajisensai/fushi';
+
+/// 组件名 [component] 的对外 UA，形如
+/// `fushi/<component> (https://github.com/hajisensai/fushi)`。
+///
+/// [component] 用小写短横线（`shader-downloader` / `custom-fonts`），描述**是哪
+/// 个子系统在发请求**——出问题时对方能直接指出是哪条链路，而不是只知道「某个
+/// fushi」。
+String fushiUserAgent(String component) {
+  final String trimmed = component.trim();
+  assert(trimmed.isNotEmpty, 'UA 组件名不能为空');
+  return 'fushi/$trimmed ($kFushiUserAgentHomepage)';
+}
+
+/// OpenSubtitles 配置里存量的旧默认 UA。
+///
+/// 这条 UA 被序列化进 `video_subtitle_opensubtitles_config` 偏好，存量用户的
+/// JSON 里躺着的就是它——只改构造默认值改不动已经落盘的那一份。解码时把**恰好
+/// 等于旧默认值**的那一份归一到新默认值（用户自己填过的自定义 UA 原样保留）。
+const String kLegacyOpenSubtitlesUserAgent = 'Hibiki v1';

--- a/fushi/test/pages/home_video_home_rows_remote_test.dart
+++ b/fushi/test/pages/home_video_home_rows_remote_test.dart
@@ -175,8 +175,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.byKey(const ValueKey<String>(
-          'home_video_recent_remote_video_remote-new')),
+      find.byKey(
+          const ValueKey<String>('home_video_recent_remote_video_remote-new')),
       findsOneWidget,
       reason: 'host 带了入库时刻 → 远端条目必须进「最近添加」',
     );
@@ -202,8 +202,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.byKey(const ValueKey<String>(
-          'home_video_recent_remote_video_remote-old')),
+      find.byKey(
+          const ValueKey<String>('home_video_recent_remote_video_remote-old')),
       findsNothing,
       reason: '没有入库时刻就判不出「最近」，不能凭空造一个',
     );

--- a/fushi/test/pages/home_video_home_rows_remote_test.dart
+++ b/fushi/test/pages/home_video_home_rows_remote_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/remote_library_source.dart';
+import 'package:fushi/src/sync/remote_video_client.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 视频首页（[VideoLibrarySection.home]）三条横滚行的互联覆盖面。
+///
+/// 「继续观看」一直认远端，「下一集」「最近添加」此前结构上只装本地行——同一个
+/// 合集在同一屏上一半互联一半不互联，host 上新入库的一批在子设备首页完全看不见。
+/// 这两条断言就是那两个缺口的行为门。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('fushi_home_rows_remote_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('fushi_home_rows_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp(RemoteVideoClient client) => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                section: VideoLibrarySection.home,
+                remoteVideoClientLoader: () async => client,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> sizeUp(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  testWidgets('「下一集」跨本地/远端合并选集：本机看到第 1 集，下一集指向 host 上的第 2 集',
+      (WidgetTester tester) async {
+    await sizeUp(tester);
+
+    final int cid =
+        await db.createMediaCollection('MyShow', collectionType: 'collection');
+    // 本地第 1 集：有播放痕迹（未看完）→ latestPlayed = 0。
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('video/local-ep1'),
+      title: Value('Local Ep1'),
+      videoPath: Value('/abs/ep1.mp4'),
+      lastPositionMs: Value(60000),
+    ));
+    await db.addToCollection(cid, MediaKind.video, 'video/local-ep1');
+
+    await tester.pumpWidget(buildApp(_ListFakeRemoteVideoClient(
+      <RemoteVideoInfo>[
+        const RemoteVideoInfo(
+          id: 'video/remote-ep2',
+          title: 'Remote Ep2',
+          collection: RemoteCollectionMembership(
+            collectionName: 'MyShow',
+            collectionType: 'collection',
+            sortIndex: 1,
+          ),
+        ),
+      ],
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(ValueKey<String>('home_video_next_collection_$cid')),
+      findsOneWidget,
+      reason: '本地只有第 1 集、第 2 集在 host 上时，「下一集」行必须出现',
+    );
+    expect(
+      find.text(t.video_home_next_episode_number(n: 2)),
+      findsOneWidget,
+      reason: '合并后的序列里下一集是第 2 集（远端那一集）',
+    );
+  });
+
+  testWidgets('「最近添加」含 host 新入库的远端条目（host 下发 importedAt）',
+      (WidgetTester tester) async {
+    await sizeUp(tester);
+
+    // 本机也有一条最近入库的散卡，确保整行本身会渲染。
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('video/local-new'),
+      title: const Value('Local New'),
+      videoPath: const Value('/abs/local-new.mp4'),
+      importedAt: Value(nowMs - 1000),
+    ));
+
+    await tester.pumpWidget(buildApp(_ListFakeRemoteVideoClient(
+      <RemoteVideoInfo>[
+        RemoteVideoInfo(
+          id: 'video/remote-new',
+          title: 'Remote New',
+          importedAt: nowMs,
+        ),
+      ],
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>(
+          'home_video_recent_remote_video_remote-new')),
+      findsOneWidget,
+      reason: 'host 带了入库时刻 → 远端条目必须进「最近添加」',
+    );
+  });
+
+  testWidgets('旧 host 不带 importedAt → 远端不进「最近添加」（与改动前同行为）',
+      (WidgetTester tester) async {
+    await sizeUp(tester);
+
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('video/local-new'),
+      title: const Value('Local New'),
+      videoPath: const Value('/abs/local-new.mp4'),
+      importedAt: Value(nowMs - 1000),
+    ));
+
+    await tester.pumpWidget(buildApp(_ListFakeRemoteVideoClient(
+      <RemoteVideoInfo>[
+        const RemoteVideoInfo(id: 'video/remote-old', title: 'Remote Old'),
+      ],
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>(
+          'home_video_recent_remote_video_remote-old')),
+      findsNothing,
+      reason: '没有入库时刻就判不出「最近」，不能凭空造一个',
+    );
+  });
+}
+
+class _ListFakeRemoteVideoClient implements RemoteVideoClient {
+  _ListFakeRemoteVideoClient(this._videos);
+  final List<RemoteVideoInfo> _videos;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async => _videos;
+
+  @override
+  Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(String id,
+          {int episodeIndex = 0}) async =>
+      const RemoteVideoStreamUrls(streamUrl: 'http://x/stream');
+
+  @override
+  Future<void> getRemoteVideoSubtitle(
+    String id,
+    File dest, {
+    int? embeddedStreamIndex,
+    void Function(double progress)? onProgress,
+    int episodeIndex = 0,
+  }) async {}
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async {}
+
+  @override
+  Future<({int positionMs, int updatedAtMs})> remoteVideoPosition(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      (positionMs: 0, updatedAtMs: 0);
+
+  @override
+  Future<void> putRemoteVideoPosition(
+    String id,
+    int positionMs,
+    int updatedAtMs, {
+    int episodeIndex = 0,
+  }) async {}
+}

--- a/fushi/test/pages/jimaku_dialog_scroll_test.dart
+++ b/fushi/test/pages/jimaku_dialog_scroll_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 import 'package:fushi/utils.dart';
 
@@ -21,7 +20,7 @@ void main() {
       n,
       (int i) => JimakuCandidate(
         entryName: 'Some Anime Series Title $i',
-        file: JimakuFile(name: 'episode.$i.WEBRip.ja.srt', url: 'https://x/$i'),
+        name: 'episode.$i.WEBRip.ja.srt',
       ),
       growable: false,
     );
@@ -196,13 +195,11 @@ void main() {
     return <JimakuCandidate>[
       JimakuCandidate(
         entryName: 'Dead Dead Demons Dededede Destruction',
-        file: JimakuFile(
-            name: '$longSeries 第01話 [WEBRip 1080p].ja.srt', url: 'https://x/1'),
+        name: '$longSeries 第01話 [WEBRip 1080p].ja.srt',
       ),
       JimakuCandidate(
         entryName: 'Dead Dead Demons Dededede Destruction',
-        file: JimakuFile(
-            name: '$longSeries 第02話 [WEBRip 1080p].ja.srt', url: 'https://x/2'),
+        name: '$longSeries 第02話 [WEBRip 1080p].ja.srt',
       ),
     ];
   }
@@ -300,18 +297,10 @@ void main() {
 
   /// 混合语言候选（ja/zh + 一个认不出语言）。
   List<JimakuCandidate> mixedLangCandidates() => <JimakuCandidate>[
-        JimakuCandidate(
-            entryName: 'S',
-            file: JimakuFile(name: 'ep01.ja.srt', url: 'https://x/1')),
-        JimakuCandidate(
-            entryName: 'S',
-            file: JimakuFile(name: 'ep02.ja.srt', url: 'https://x/2')),
-        JimakuCandidate(
-            entryName: 'S',
-            file: JimakuFile(name: 'ep01.zh.srt', url: 'https://x/3')),
-        JimakuCandidate(
-            entryName: 'S',
-            file: JimakuFile(name: 'ep01.srt', url: 'https://x/4')),
+        JimakuCandidate(entryName: 'S', name: 'ep01.ja.srt'),
+        JimakuCandidate(entryName: 'S', name: 'ep02.ja.srt'),
+        JimakuCandidate(entryName: 'S', name: 'ep01.zh.srt'),
+        JimakuCandidate(entryName: 'S', name: 'ep01.srt'),
       ];
 
   /// pump 真实对话框（混合语言候选），可注入语言记忆 + 选语言回调。

--- a/fushi/test/pages/jimaku_filter_test.dart
+++ b/fushi/test/pages/jimaku_filter_test.dart
@@ -5,7 +5,7 @@ import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 
 JimakuCandidate _cand(String fileName) => JimakuCandidate(
       entryName: 'Series',
-      file: JimakuFile(name: fileName, url: 'https://x/$fileName'),
+      name: fileName,
     );
 
 void main() {
@@ -51,7 +51,7 @@ void main() {
     test('选 ja 只留 ja 候选', () {
       final List<JimakuCandidate> out =
           filterCandidatesByLanguage(candidates, 'ja');
-      expect(out.map((JimakuCandidate c) => c.file.name),
+      expect(out.map((JimakuCandidate c) => c.name),
           <String>['ep01.ja.srt', 'ep02.ja.ass']);
     });
 
@@ -59,8 +59,7 @@ void main() {
       // 选 zh：只剩 zh。认不出语言的 ep03.srt 被排除。
       final List<JimakuCandidate> zh =
           filterCandidatesByLanguage(candidates, 'zh');
-      expect(
-          zh.map((JimakuCandidate c) => c.file.name), <String>['ep01.zh.srt']);
+      expect(zh.map((JimakuCandidate c) => c.name), <String>['ep01.zh.srt']);
       // 但「全部」永远列出全部，认不出语言的候选绝不彻底消失（保底）。
       expect(filterCandidatesByLanguage(candidates, null), hasLength(4));
     });
@@ -96,15 +95,14 @@ void main() {
     test('选 ass 只留 ass 候选（含大写扩展名）', () {
       final List<JimakuCandidate> out =
           filterCandidatesByFormat(candidates, 'ass');
-      expect(out.map((JimakuCandidate c) => c.file.name),
+      expect(out.map((JimakuCandidate c) => c.name),
           <String>['ep01.ja.ass', 'ep02.zh.ASS']);
     });
 
     test('选 srt 不会漏进 ass', () {
       final List<JimakuCandidate> out =
           filterCandidatesByFormat(candidates, 'srt');
-      expect(
-          out.map((JimakuCandidate c) => c.file.name), <String>['ep01.ja.srt']);
+      expect(out.map((JimakuCandidate c) => c.name), <String>['ep01.ja.srt']);
     });
 
     test('availableFormats 去重 + ass/srt/ssa/vtt 稳定顺序', () {
@@ -135,10 +133,10 @@ void main() {
         filterCandidatesByFormat(candidates, 'ass'),
         'ja',
       );
-      expect(langThenFormat.map((JimakuCandidate c) => c.file.name),
+      expect(langThenFormat.map((JimakuCandidate c) => c.name),
           <String>['ep01.ja.ass']);
-      expect(formatThenLang.map((JimakuCandidate c) => c.file.name),
-          langThenFormat.map((JimakuCandidate c) => c.file.name));
+      expect(formatThenLang.map((JimakuCandidate c) => c.name),
+          langThenFormat.map((JimakuCandidate c) => c.name));
     });
   });
 
@@ -152,7 +150,7 @@ void main() {
         _cand('Show - 09.ja.srt'),
       ]);
       expect(
-        sorted.map((JimakuCandidate c) => c.file.name),
+        sorted.map((JimakuCandidate c) => c.name),
         <String>[
           'Show - 02.ja.srt',
           'Show - 09.ja.srt',

--- a/fushi/test/pages/jimaku_format_filter_widget_test.dart
+++ b/fushi/test/pages/jimaku_format_filter_widget_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 import 'package:fushi/utils.dart';
 
@@ -13,7 +12,7 @@ import 'package:fushi/utils.dart';
 void main() {
   JimakuCandidate cand(String name) => JimakuCandidate(
         entryName: 'Some Anime Series',
-        file: JimakuFile(name: name, url: 'https://x/$name'),
+        name: name,
       );
 
   Future<void> pumpDialog(

--- a/fushi/test/pages/jimaku_two_pane_layout_test.dart
+++ b/fushi/test/pages/jimaku_two_pane_layout_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fushi/src/media/video/anilist_client.dart';
-import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 
 /// Jimaku 对话框两栏布局重构的回归测试。
@@ -33,7 +32,7 @@ void main() {
       n,
       (int i) => JimakuCandidate(
         entryName: 'Some Anime Series Title $i',
-        file: JimakuFile(name: 'episode.$i.WEBRip.ja.srt', url: 'https://x/$i'),
+        name: 'episode.$i.WEBRip.ja.srt',
       ),
       growable: false,
     );

--- a/fushi/test/pages/video_subtitle_dialog_registry_test.dart
+++ b/fushi/test/pages/video_subtitle_dialog_registry_test.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+
+/// 播放页「找字幕」必须与下载管线走**同一套** [VideoSubtitleRegistry]。
+///
+/// 此前对话框自建 JimakuClient 直连 Jimaku，下载管线走 registry（Jimaku +
+/// OpenSubtitles）——同一个「找字幕」在两个入口能力不同，播放页永远搜不到
+/// OpenSubtitles。这条测试就是那个能力差的行为门。
+void main() {
+  Widget host({
+    required VideoSubtitleRegistry registry,
+    required String saveDirectory,
+    String apiKey = 'jimaku-key',
+  }) =>
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: JimakuSubtitleDialog(
+              initialQuery: 'Some Anime',
+              initialApiKey: apiKey,
+              onApiKeyChanged: (String _) async {},
+              saveDirectory: saveDirectory,
+              subtitleRegistry: () => registry,
+              // AniList 恒空 → 走文本回退路径，不触网。
+              httpClientFactory: () async => http_testing.MockClient(
+                (http.Request request) async => http.Response(
+                  jsonEncode(<String, Object?>{
+                    'data': <String, Object?>{
+                      'Page': <String, Object?>{'media': <Object?>[]},
+                    },
+                  }),
+                  200,
+                  headers: <String, String>{
+                    'content-type': 'application/json; charset=utf-8',
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  testWidgets('播放页找字幕列出全部已配置来源的候选（Jimaku + OpenSubtitles）',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final VideoSubtitleRegistry registry =
+        VideoSubtitleRegistry(<VideoSubtitleProvider>[
+      _FakeSubtitleProvider(
+        id: 'jimaku',
+        priority: 100,
+        fileName: 'from.jimaku.ep01.ja.srt',
+        releaseName: 'Jimaku Entry',
+        language: 'ja',
+      ),
+      _FakeSubtitleProvider(
+        id: 'opensubtitles',
+        priority: 200,
+        fileName: 'from.opensubtitles.ep01.en.srt',
+        releaseName: 'OpenSubtitles Release',
+        language: 'en',
+      ),
+    ]);
+
+    await tester.pumpWidget(host(
+      registry: registry,
+      saveDirectory: Directory.systemTemp.createTempSync('fushi_subs').path,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    expect(find.text('from.jimaku.ep01.ja.srt'), findsOneWidget);
+    expect(
+      find.text('from.opensubtitles.ep01.en.srt'),
+      findsOneWidget,
+      reason: '播放页此前只搜 Jimaku，OpenSubtitles 的候选结构上出不来',
+    );
+  });
+
+  testWidgets('只配了 OpenSubtitles（Jimaku key 为空）也能搜，不再被 Jimaku key 卡住',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final VideoSubtitleRegistry registry =
+        VideoSubtitleRegistry(<VideoSubtitleProvider>[
+      _FakeSubtitleProvider(
+        id: 'opensubtitles',
+        priority: 200,
+        fileName: 'only.opensubtitles.ep01.en.srt',
+        releaseName: 'OpenSubtitles Release',
+        language: 'en',
+      ),
+    ]);
+
+    await tester.pumpWidget(host(
+      registry: registry,
+      saveDirectory: Directory.systemTemp.createTempSync('fushi_subs2').path,
+      apiKey: '',
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_jimaku_no_key), findsNothing,
+        reason: '门槛是「有没有可用来源」，不是「有没有 Jimaku key」');
+    expect(find.text('only.opensubtitles.ep01.en.srt'), findsOneWidget);
+  });
+}
+
+class _FakeSubtitleProvider implements VideoSubtitleProvider {
+  _FakeSubtitleProvider({
+    required this.id,
+    required this.priority,
+    required this.fileName,
+    required this.releaseName,
+    required this.language,
+  });
+
+  @override
+  final String id;
+  @override
+  final int priority;
+  final String fileName;
+  final String releaseName;
+  final String language;
+
+  @override
+  Future<ProviderBatchResult<VideoSubtitleCandidate>> search(
+    VideoSubtitleSearchRequest request,
+  ) async =>
+      ProviderBatchResult<VideoSubtitleCandidate>.success(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(
+            providerId: id,
+            remoteId: '$id:1',
+            fileName: fileName,
+            language: language,
+            providerPriority: priority,
+            releaseName: releaseName,
+          ),
+        ],
+      );
+
+  @override
+  Future<VideoSubtitleDownload> download(
+    VideoSubtitleCandidate candidate,
+  ) async =>
+      VideoSubtitleDownload(
+        bytes: Uint8List.fromList(<int>[1, 2, 3]),
+        fileName: candidate.fileName,
+        language: candidate.language,
+      );
+
+  @override
+  void close() {}
+}
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({
+    required super.providerId,
+    required super.remoteId,
+    required super.fileName,
+    required super.language,
+    required super.providerPriority,
+    super.releaseName,
+  });
+}

--- a/fushi/test/sync/interconnect_service_config_test.dart
+++ b/fushi/test/sync/interconnect_service_config_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/tracking/media_tracking_service.dart';
 import 'package:fushi/src/sync/interconnect_service_config.dart';
 import 'package:fushi/src/sync/interconnect_sync_backend.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
@@ -50,6 +51,11 @@ void main() {
       PrefCodec.encode('folder-password'),
     );
     await db.setPref('download_save_root', PrefCodec.encode(r'D:\downloads'));
+    await db.setPref(
+      kBangumiAccessTokenPref,
+      PrefCodec.encode('bangumi-tracking-token'),
+    );
+    await db.setPref(kBangumiAccountNamePref, PrefCodec.encode('nick'));
 
     final InterconnectServiceConfigSnapshot snapshot =
         InterconnectServiceConfigSnapshot.fromPreferences(
@@ -60,22 +66,33 @@ void main() {
         InterconnectServiceConfigSnapshot.sharedPreferenceKeys);
     expect(snapshot.preferences['jimaku_api_key'],
         PrefCodec.encode('jimaku-secret'));
-    expect(snapshot.preferences, isNot(contains('video_scraper_tmdb_api_key')));
+    // 外部服务身份跟着用户的设备走（同一个账号在哪台设备上都该刮到同一份资料 /
+    // 搜到同一批字幕）；本机入站 API、配对凭据、设备身份与本地路径仍然不出境。
+    expect(snapshot.preferences['video_scraper_tmdb_api_key'],
+        PrefCodec.encode('tmdb'));
     expect(
-      snapshot.preferences,
-      isNot(contains('video_metadata_fanart_api_key')),
+      snapshot.preferences['video_metadata_fanart_api_key'],
+      PrefCodec.encode('fanart-secret'),
     );
     expect(
-      snapshot.preferences,
-      isNot(contains('video_metadata_bangumi_token')),
+      snapshot.preferences['video_metadata_bangumi_token'],
+      PrefCodec.encode('bangumi-secret'),
     );
     expect(
-      snapshot.preferences,
-      isNot(contains('video_metadata_douban_authorized_endpoint')),
+      snapshot.preferences['video_metadata_douban_authorized_endpoint'],
+      PrefCodec.encode('https://private.example/douban'),
     );
     expect(
-      snapshot.preferences,
-      isNot(contains('video_metadata_douban_authorized_token')),
+      snapshot.preferences['video_metadata_douban_authorized_token'],
+      PrefCodec.encode('douban-secret'),
+    );
+    expect(
+      snapshot.preferences[kBangumiAccessTokenPref],
+      PrefCodec.encode('bangumi-tracking-token'),
+    );
+    expect(
+      snapshot.preferences[kBangumiAccountNamePref],
+      PrefCodec.encode('nick'),
     );
     expect(snapshot.preferences, isNot(contains('yomitan_api_key')));
     expect(snapshot.preferences, isNot(contains('sync_hibiki_client_token')));
@@ -131,6 +148,50 @@ void main() {
     );
     expect(await db.getPref('future_secret'), isNull);
     expect(await snapshot.applyTo(db), 0, reason: 'replay must be idempotent');
+  });
+
+  test('换 Bangumi 令牌必须归零本设备对账水位（与设置页写令牌同一条不变式）',
+      () async {
+    for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+      await db.setPref(key, PrefCodec.encode(99));
+    }
+    await db.setPref(kBangumiAccessTokenPref, PrefCodec.encode('old-token'));
+
+    final InterconnectServiceConfigSnapshot snapshot =
+        InterconnectServiceConfigSnapshot.fromJson(<String, Object?>{
+      'schemaVersion': 1,
+      'preferences': <String, Object?>{
+        kBangumiAccessTokenPref: PrefCodec.encode('new-token'),
+        kBangumiAccountNamePref: PrefCodec.encode('someone-else'),
+      },
+    });
+
+    expect(await snapshot.applyTo(db), 2,
+        reason: '水位归零是令牌那一行的副作用，不额外计数');
+    for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+      expect(await db.getPref(key), PrefCodec.encode(0), reason: key);
+    }
+  });
+
+  test('令牌没变时不碰对账水位（重放同一份 host 快照不得倒退进度）', () async {
+    await db.setPref(kBangumiAccessTokenPref, PrefCodec.encode('same-token'));
+    for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+      await db.setPref(key, PrefCodec.encode(99));
+    }
+
+    final InterconnectServiceConfigSnapshot snapshot =
+        InterconnectServiceConfigSnapshot.fromJson(<String, Object?>{
+      'schemaVersion': 1,
+      'preferences': <String, Object?>{
+        kBangumiAccessTokenPref: PrefCodec.encode('same-token'),
+        'jimaku_api_key': PrefCodec.encode('changed'),
+      },
+    });
+
+    expect(await snapshot.applyTo(db), 1);
+    for (final String key in kBangumiTokenScopedWatermarkPrefs) {
+      expect(await db.getPref(key), PrefCodec.encode(99), reason: key);
+    }
   });
 
   test('rejects unsupported schema versions', () {

--- a/fushi/test/sync/interconnect_service_config_test.dart
+++ b/fushi/test/sync/interconnect_service_config_test.dart
@@ -150,8 +150,7 @@ void main() {
     expect(await snapshot.applyTo(db), 0, reason: 'replay must be idempotent');
   });
 
-  test('换 Bangumi 令牌必须归零本设备对账水位（与设置页写令牌同一条不变式）',
-      () async {
+  test('换 Bangumi 令牌必须归零本设备对账水位（与设置页写令牌同一条不变式）', () async {
     for (final String key in kBangumiTokenScopedWatermarkPrefs) {
       await db.setPref(key, PrefCodec.encode(99));
     }
@@ -166,8 +165,7 @@ void main() {
       },
     });
 
-    expect(await snapshot.applyTo(db), 2,
-        reason: '水位归零是令牌那一行的副作用，不额外计数');
+    expect(await snapshot.applyTo(db), 2, reason: '水位归零是令牌那一行的副作用，不额外计数');
     for (final String key in kBangumiTokenScopedWatermarkPrefs) {
       expect(await db.getPref(key), PrefCodec.encode(0), reason: key);
     }

--- a/fushi/test/tools/outbound_user_agent_guard_test.dart
+++ b/fushi/test/tools/outbound_user_agent_guard_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/net/app_user_agent.dart';
+
+/// 对外 User-Agent 守卫：app **以自己的身份**发出去的 UA 不得再报旧名。
+///
+/// 改名之后 UA 字面量散落在各调用方各写各的，实测残留了 4 处 `Hibiki`
+/// （OpenSubtitles 客户端与其设置页默认值、着色器下载器 ×2、自定义字体下载）。
+/// 对外部服务来说 UA 就是这个 app 的身份，两个名字同时在跑 = 同一个客户端有两个
+/// 身份。定向测试按功能域挑文件，结构上挑不到「哪个文件里还剩一条 UA 字面量」，
+/// 所以这里按目录全树扫。
+///
+/// 白名单里的是**故意伪装成浏览器**的场景（不是「报自己」）：Aidoku 源站要浏览器
+/// UA 才不被 WAF 拦、Google Lens OCR 要求 Chromium UA、YouTube 分离流的回放 UA
+/// 必须与铸造 URL 时逐字一致。它们不受本守卫约束。
+void main() {
+  /// 允许出现浏览器伪装 UA 的文件（相对 `fushi/`）。
+  const Set<String> browserImpersonationFiles = <String>{
+    'lib/src/media/manga/aidoku/aidoku_reader_chapter.dart',
+    'lib/src/media/manga/aidoku/aidoku_source_browse_page.dart',
+    'lib/src/media/manga/ocr/google_lens_ocr_service.dart',
+    'lib/src/media/video/youtube_source_resolver.dart',
+  };
+
+  /// 旧名在**非 UA 语境**下的合法残留（迁移入口、旧包名、旧资产契约）不在扫描面
+  /// 内——本守卫只看带 `User-Agent` / `userAgent` 的那一行。
+  // 收尾引号必须吃掉：真实写法是 `'User-Agent': '...'`（map 字面量），
+  // `User-Agent` 与冒号之间隔着一个引号。漏掉它守卫就永远绿——这条正则是被
+  // 变异实测（把一条 UA 改回 Hibiki，守卫仍绿）逼出来的。
+  final RegExp userAgentLine = RegExp(
+    r'''(User-Agent|userAgent)['"]?\s*[:=]''',
+    caseSensitive: true,
+  );
+  final RegExp legacyName = RegExp('Hibiki', caseSensitive: false);
+
+  test('对外 UA 不得再报旧名 Hibiki', () {
+    final Directory lib = Directory('lib');
+    expect(lib.existsSync(), isTrue, reason: '必须在 fushi/ 下跑');
+
+    final List<String> offenders = <String>[];
+    for (final FileSystemEntity entity in lib.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final String relative = entity.path.replaceAll(r'\', '/');
+      final String key = relative.substring(relative.indexOf('lib/'));
+      if (browserImpersonationFiles.contains(key)) continue;
+      final List<String> lines = entity.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        final String line = lines[i];
+        // 注释行讲的是历史，不是发出去的字节。
+        if (line.trimLeft().startsWith('//')) continue;
+        if (!userAgentLine.hasMatch(line)) continue;
+        if (!legacyName.hasMatch(line)) continue;
+        offenders.add('$key:${i + 1}: ${line.trim()}');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: '这些行仍以旧名 Hibiki 对外报身份，改用 fushiUserAgent(<组件名>)：\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test('fushiUserAgent 形状稳定（对外身份不能随手改）', () {
+    expect(
+      fushiUserAgent('shader-downloader'),
+      'fushi/shader-downloader (https://github.com/hajisensai/fushi)',
+    );
+    expect(fushiUserAgent('  custom-fonts  '), contains('fushi/custom-fonts '));
+  });
+}

--- a/fushi/test/tools/outbound_user_agent_guard_test.dart
+++ b/fushi/test/tools/outbound_user_agent_guard_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/net/app_user_agent.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 对外 User-Agent 守卫：app **以自己的身份**发出去的 UA 不得再报旧名。
 ///
 /// 改名之后 UA 字面量散落在各调用方各写各的，实测残留了 4 处 `Hibiki`
@@ -25,9 +27,9 @@ void main() {
 
   /// 旧名在**非 UA 语境**下的合法残留（迁移入口、旧包名、旧资产契约）不在扫描面
   /// 内——本守卫只看带 `User-Agent` / `userAgent` 的那一行。
-  // 收尾引号必须吃掉：真实写法是 `'User-Agent': '...'`（map 字面量），
-  // `User-Agent` 与冒号之间隔着一个引号。漏掉它守卫就永远绿——这条正则是被
-  // 变异实测（把一条 UA 改回 Hibiki，守卫仍绿）逼出来的。
+  /// 收尾引号必须吃掉：真实写法是 `'User-Agent': '...'`（map 字面量），
+  /// `User-Agent` 与冒号之间隔着一个引号。漏掉它守卫就永远绿——这条正则是被
+  /// 变异实测（把一条 UA 改回 Hibiki，守卫仍绿）逼出来的。
   final RegExp userAgentLine = RegExp(
     r'''(User-Agent|userAgent)['"]?\s*[:=]''',
     caseSensitive: true,
@@ -44,14 +46,17 @@ void main() {
       final String relative = entity.path.replaceAll(r'\', '/');
       final String key = relative.substring(relative.indexOf('lib/'));
       if (browserImpersonationFiles.contains(key)) continue;
-      final List<String> lines = entity.readAsLinesSync();
-      for (int i = 0; i < lines.length; i++) {
-        final String line = lines[i];
-        // 注释行讲的是历史，不是发出去的字节。
-        if (line.trimLeft().startsWith('//')) continue;
+      // 注释讲的是历史，不是发出去的字节：走共享原语等长掩码（字符串字面量原样
+      // 保留，故 UA 本体不受影响；行号与原文一致，取证仍回原行切片）。手写
+      // startsWith 只跳整行注释，会放过块注释与行尾注释——source_guard_adoption
+      // 那条守卫就是为此立的。
+      final List<String> raw = entity.readAsLinesSync();
+      final List<String> masked = maskComments(raw.join('\n')).split('\n');
+      for (int i = 0; i < masked.length && i < raw.length; i++) {
+        final String line = masked[i];
         if (!userAgentLine.hasMatch(line)) continue;
         if (!legacyName.hasMatch(line)) continue;
-        offenders.add('$key:${i + 1}: ${line.trim()}');
+        offenders.add('$key:${i + 1}: ${raw[i].trim()}');
       }
     }
 


### PR DESCRIPTION
用户一次报了四条，逐条沿真实代码路径验真伪后修根因，各配自动化门。

## ① 互联不同步 Bangumi 追番令牌与外部服务凭据（BUG-1683）

`InterconnectServiceConfigSnapshot.sharedPreferenceKeys` 只放 jimaku key、qb 连接、
漫画在线目录三类，注释里明写「Bangumi 凭据留在本机」。于是「互联」只搬内容不搬能力：
用户得在每台设备上重填同一个 token。

判据改成**「这条配置描述的是外部服务还是本机」**，不是「它像不像凭据」：
追番令牌 + 账号名、`video_metadata_bangumi_token`、TMDB / Fanart / 豆瓣授权端点与
token、OpenSubtitles 与 Torznab 配置进白名单；`yomitan_api_key`（保护**本机入站** API）、
`media_source_secret_*`、`sync_*`、设备身份与本地路径仍绝不出境。

出境等级没有被放宽：这条通道的服务端 `_handleInterconnectServiceConfig` 同时要求
**TLS**（`_securityContext == null` 恒 403）**和已配对 peer token**，对端是用户自己的
设备；而备份 zip 落第三方云盘、Profile 分享 JSON 给别人这两条，仍由
`PrefRedactionPolicy` 全量剔除，本清单不影响它们。

顺带补两个真缺口：
- 换令牌必须归零对账水位，抽成共享常量 `kBangumiTokenScopedWatermarkPrefs`，设置页与
  互联导入两条写入路径共用（否则子设备拿到新账号后永远不会推送换账号之前看完的条目）；
- 导入后 `reloadVideoDownloadPipelineRuntime()` + bump 追番 `statusRevision`。Jimaku /
  OpenSubtitles / Torznab / TMDB 的 client 是按当时的 key 一次性建好的（key 为空的
  provider 干脆不进 registry），不重建就要等冷启动才生效。

## ② 对外 User-Agent 仍报旧名 Hibiki（BUG-1684）

残留 4 处**以自己身份**对外报的 UA：OpenSubtitles 客户端默认值与设置页草稿、着色器
下载器、Anime4K 下载器、自定义字体下载。收敛成单一真相源 `fushiUserAgent(<组件名>)`。

OpenSubtitles 的 UA 被序列化进 `video_subtitle_opensubtitles_config` 偏好，光改构造
默认值改不动已落盘的那一份，故解码时把**恰好等于旧默认值**的归一到新默认值，用户
自填的原样保留。故意伪装成浏览器的三处（Aidoku 过 WAF、Google Lens OCR、YouTube 分离
流回放 UA 必须与铸造 URL 时逐字一致）是「装成别人」不是「报自己」，保持原样并白名单。

新守卫做过两轮变异实测：第一版正则漏了 `'User-Agent':` 的收尾引号（改回 Hibiki 仍绿）；
第二轮改用 `helpers/source_guard.dart` 的 `maskComments` 后，行尾注释形态也能抓到。
两次还原都比对了 sha256。

## ③ 字幕获取两套实现（BUG-1685）

下载管线走 `VideoSubtitleRegistry`（Jimaku + OpenSubtitles，含去重/优先级/失败归类），
播放页「找字幕」对话框却自建 `JimakuClient` 直连 Jimaku——播放页永远搜不到
OpenSubtitles，且搜索门槛硬卡 Jimaku key，只配 OpenSubtitles 的用户连搜都搜不了。
配置侧同样分家：Jimaku key 在「视频 → 字幕」，OpenSubtitles 只在「下载 → 外部来源」。

- 对话框改为经 registry 搜索与下载，候选模型换成 provider 无关投影（语言优先取
  provider 给的权威码，没给才从文件名启发式识别 = Jimaku 老口径）；
- 门槛改成「有没有可用来源」；
- registry **延迟解析**（`() => appModel.videoSubtitleRegistry`）：填 key 会触发 runtime
  重建，早绑的实例正是那个「刚填完 key 还是搜不到」的旧 registry；
- key 只在真改过时才写回，不再每次搜索白重建一次 runtime；
- 设置「视频 → 字幕」内联**同一份** OpenSubtitles 编辑组件（`onlySubtitleSources` 按节
  可裁），不复制 UI、不产生第二份真相源。

**本轮未收编**：番剧下载对话框与批量匹配对话框的**手工**选字幕面板仍直连 Jimaku。
它们的计划持久化字段是 Jimaku 专有的（`AnimeDownloadPlan.jimakuEntryId` /
`jimakuEntryName`），下载完成后由 `anime_download_subtitle_resolver` 按该 id 回查；改成
provider 无关句柄要动已落盘的计划结构 + resolver，属独立迁移任务。下载链路的**自动**
配字幕本来就走 registry，不受影响。

## ④ 视频首页没完全互联（BUG-1686）

首页就三条横滚行，只有「继续观看」认远端；「下一集」「最近添加」的成员表结构上只装
`VideoBookRow`。后果：本机看到第 1 集、第 2 集只在 host 上时「下一集」整行不出现；
host 上新入库的一批在子设备首页完全看不见。

- 三行的合集成员统一成 `_VideoSlot`（本地行 | 远端占位），取组内序 / 取观看态 / 取封面 /
  点开四件事按来源分流，其余（选集、最近添加窗口判定、排序）两边同一份代码；
- 远端清单补 `importedAt`（host 下发 `VideoBooks.importedAt`，云清单透传已有的
  `importedAtMs`）。这是「最近添加」的必要输入——此前只能给远端造一个负数假
  importedAt 占位排序，窗口判定结构上永远 false。加字段向后兼容：旧 host 不带 → null →
  与改动前逐字节同行为，第三条测试专门守这个。

## qb 分类：刻意不自动迁移（BUG-1687，未修）

默认值早已是 `fushi`，用户看到的 `hibiki` 是改名前落盘的配置。静默改写会砸掉进行中的
下载：内置引擎的分类**就是保存目录**（`listTorrents` 按 `ownsCategoryPath` 过滤），改名后
存量种子直接掉出列表；且下载任务行各自存着自己的 category，管线用「配置分类 ≠ 任务分类」
判失配并抛错。正确做法是留给用户在没有进行中任务时到 设置 → 下载 自行改。

## 验证

- `dart analyze`（fushi，含 test）零问题；
- `dart run tool/flutter_test_failures.dart --no-pub` 全量 **19234 tests PASSED**（rebase 到
  `d124a3d915` 之后的新基底上跑的）；
- 新增测试：`test/sync/interconnect_service_config_test.dart`（白名单含/不含、换令牌归零
  水位、令牌没变不得倒退）、`test/tools/outbound_user_agent_guard_test.dart`（全树扫 + 形状
  自校验）、`test/pages/home_video_home_rows_remote_test.dart`（跨端选集、远端进最近添加、
  旧 host 兼容）、`test/pages/video_subtitle_dialog_registry_test.dart`（播放页列出全部来源、
  无 Jimaku key 也能搜）；
- 未做真机复测（本轮改动集中在数据流与列表装配，无 WebView/播放/布局渲染改动）。

https://claude.ai/code/session_01WBHGaKVLL2Gx1k7ikvkTMm
