### PR TITLE
fix(reader): 修复 iOS 上 VN 模式不可用（视口 meta + chrome inset + 页面盒，BUG-1688）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1552 条。点号进各自文件。
+> 共 1553 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1688](bugs/BUG-1688-vn-chrome-inset-viewport.md) | ✅ | ✅ | VN 模式忽略 chrome inset 与页面尺寸，正文被顶栏/底栏与刘海压住（iOS 最严重） |
 | [BUG-1676](bugs/BUG-1676-anki-gloss-image-overflows-card.md) | ✅ | ✅ | 制卡词典插图撑出卡片跑到屏幕右外 |
 | [BUG-1675](bugs/BUG-1675-gal-helper-stale-after-locked-update.md) | ✅ | ✅ | galgame 捕获组件 protocol_mismatch：更新时游戏开着导致 helper 被静默跳过 |
 | [BUG-1674](bugs/BUG-1674-mining-still-format.md) | ✅ | ✅ | 视频卡片图片：描述不准，且静态截图格式不可选 |

--- a/docs/bugs/BUG-1688-vn-chrome-inset-viewport.md
+++ b/docs/bugs/BUG-1688-vn-chrome-inset-viewport.md
@@ -1,0 +1,62 @@
+## BUG-1688 · VN 模式忽略 chrome inset 与页面尺寸，正文被顶栏/底栏与刘海压住（iOS 最严重）
+- **报告**：2026-08-16（用户：iOS 小说的 VN 模式基本处于不可用状态）
+- **真实性**：✅ 真 bug。在 macOS live `InAppWebView`（同为 WKWebView，与 iOS 同一份 VN JS、同一条自定义 scheme 交付链）上复现，读数：
+  `chromeTopInset=0 chromeBottomInset=0 pageWidth=0 pageHeight=0 innerHeight=697`，
+  `.fushi-vn-screen` 的 client rect = `top=0 bottom=697`（= 整个视口），即 VN 屏完全无视 chrome 预留带。
+  根因两处，同源：
+  - `fushi/lib/src/reader/reader_visual_novel_scripts.dart:3013`（修复前）——host-compat shim 里
+    `vn.setChromeInsets = function(topPx, bottomPx) { return null; };` 是空壳，Dart 侧
+    `fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart:1045` 每次下发的顶栏/底栏预留
+    在 VN 下全部被丢弃；且 VN 自己的 `initialize()`（同文件 911 行起）也没有像分页/连续 shell
+    （`reader_pagination_scripts.dart:2669-2687`）那样从 `C.chromeTopInset / C.chromeBottomInset /
+    C.dartPageWidth / C.dartPageHeight` 写 `--chrome-top-inset / --chrome-bottom-inset /
+    --page-width / --page-height`。于是 `reader_content_styles.dart:1000-1001` 的
+    `.fushi-vn-stage { padding-top: calc(<margin>vh + var(--chrome-top-inset, 0px)) }` 恒取 0px 兜底。
+  - `reader_visual_novel_scripts.dart:1380-1381`（修复前）——切屏量尺 `createScreenMeasurement` 用
+    `var(--page-width, 100vw) / var(--page-height, 100vh)` 撑开，VN 下这两个变量同样从没人写，
+    量尺恒等于**整个视口**，比真实 `.fushi-vn-screen` 大出整条 chrome 预留带；`updatePageSize(width,
+    height)` 又整个忽略入参，永远补不回来。结果 `fitScreensToViewport` 把每屏都切成"刚好填满整个
+    视口"，于是**每一屏**的首尾行都落进被顶栏/底栏覆盖的区域——不是偶发，是每屏必现。
+  为什么 iOS 最严重：预留带 = 顶部进度条 + 顶栏 + 底栏 + **系统安全区**，iOS 的刘海与 home
+  indicator 让这条带子最厚，被吃掉的行数最多，所以在 iOS 上直接表现为"基本不可用"。同一缺陷在
+  Android/桌面上同样存在，只是被吃掉的比例小、更容易被当成排版偏紧。
+- **[x] ① 已修复** — `fushi/lib/src/reader/reader_visual_novel_scripts.dart`：
+  1. 新增 `applyViewportVars()`，与分页 shell 用同一份 `C` 字段、同一组变量名写
+     `--chrome-top-inset / --chrome-bottom-inset / --page-width / --page-height /
+     --reader-viewport-height`，并在 `initialize()` 里排在 `ensureStage()` / `buildScreens()` **之前**
+     （晚一步就会先按错的盒切一遍屏）。
+  2. `setChromeInsets` 从空壳改为真实实现：写这两个 inset 变量后调
+     `refitScreensToCurrentViewport()` 按新可用盒重切屏（只改 padding 不重切会留下溢出的旧屏）。
+  3. `updatePageSize(width, height)` 真正消费入参，写 `--page-width / --page-height /
+     --reader-viewport-height` 后同样重切屏。
+  4. `createScreenMeasurement` 的量尺改为**真实 `.fushi-vn-screen` 的镜像**（照它的 client rect 定
+     left/top/width/height；`.fushi-vn-screen` 是 border-box，宽高原样搬过来即同一个内容盒），
+     只在首屏极早期拿不到盒时才回退旧的 `var(--page-*)` 撑开。这条是根因修复的落点：量尺与真实
+     渲染盒同源之后，chrome 预留带怎么变都不会再切出溢出屏。
+  5. `applyImageMaxVars` 的"实际 VN 视口"同步改为读 `.fushi-vn-screen` 盒（原读
+     `window.innerWidth/Height` 整视口，会把插图算到能盖住顶栏/底栏的尺寸）。
+  提交：见本分支 `worktree/ios-vn-fix-20260816`。
+- **[x] ② 已加自动化测试** —
+  - `fushi/integration_test/reader_vn_chrome_inset_dom_test.dart`（最强可落地层：真实 WebView 读 DOM
+    几何）。修复前红：`--chrome-top-inset` 实读 0.0；修复后绿：`chromeTopInset=52
+    pageWidth=1206 pageHeight=697 screenTop=52 screenHeight=645`。
+  - `fushi/test/reader/vn_viewport_geometry_bug1688_test.dart`（CI 可跑的源码守卫）：锁住四个变量确实
+    有人写、`setChromeInsets` 不再是 `return null` 空壳、`updatePageSize` 真读入参、量尺照真实屏盒量，
+    以及 `applyViewportVars` 必须排在建舞台/切屏之前。
+- **备注**：
+  - **iOS 真机门未过**：本机跑不了 iOS 构建——`fushi/ios/build_aidoku_runtime.sh:8` 硬性要求
+    `PLATFORM_NAME=iphoneos`（模拟器直接报错退出），且本机 `rustup` 只装了 `aarch64-apple-darwin`，
+    iOS/模拟器 target 都缺。验证因此落在 macOS 的 WKWebView 上（与 iOS 同内核、同 VN JS、同
+    `fushi-reader://` 自定义 scheme 交付链），iOS 安全区叠加后的实际观感仍需真机复测。
+  - 同批排查中发现、**本次未动**的相邻问题，另行记录/择期处理：
+    - `reader_engine_config.dart:13` 的注释声称引擎已改成 `<script src>` 走 fushi.local 拦截器的静态
+      资源，代码里并无 `ReaderEngineScript`，实际仍是 `onLoadStop` 后一次 `evaluateJavascript`
+      （`webview.part.dart:2649`）。陈旧注释会把 iOS 排障带偏。
+    - iOS/macOS 走 `CustomSchemeResponse`，没有 statusCode / headers 通道，`_notFound` 的 404/403 在
+      iOS 上退化成"200 空白页"，且原生 `CustomSchemeHandler` 从不 `didFailWithError` → `onReceivedError`
+      不触发，任何资源解析失误在 iOS 上没有任何错误信号。
+    - `lyrics.part.dart:195` 的 `baseUrl` 硬编码 `https://fushi.local`，无平台分支；iOS 上该文档落在
+      一个真实不存在的 https 源上，其引用的自定义字体是 `fushi-reader://` 跨源请求，而
+      `CustomSchemeResponse` 下发不了 `Access-Control-Allow-Origin`。
+    - `vn_click_advance` / `visualNovelRevealSpeed` 两个偏好当前无消费者（M0 在 `webview.part.dart:648`
+      / `:655` 强制常量），VN 的 6 个子设置至今无 UI 入口（M1 范围）。

--- a/docs/bugs/BUG-1688-vn-chrome-inset-viewport.md
+++ b/docs/bugs/BUG-1688-vn-chrome-inset-viewport.md
@@ -18,8 +18,17 @@
     height)` 又整个忽略入参，永远补不回来。结果 `fitScreensToViewport` 把每屏都切成"刚好填满整个
     视口"，于是**每一屏**的首尾行都落进被顶栏/底栏覆盖的区域——不是偶发，是每屏必现。
   为什么 iOS 最严重：预留带 = 顶部进度条 + 顶栏 + 底栏 + **系统安全区**，iOS 的刘海与 home
-  indicator 让这条带子最厚，被吃掉的行数最多，所以在 iOS 上直接表现为"基本不可用"。同一缺陷在
-  Android/桌面上同样存在，只是被吃掉的比例小、更容易被当成排版偏紧。
+  indicator 让这条带子最厚，被吃掉的行数最多。同一缺陷在 Android/桌面上同样存在，只是被吃掉的
+  比例小、更容易被当成排版偏紧。
+  - **第三处（iOS 专属，且是 iOS 上最先炸的一条，真机复现后才发现）**：VN 的 `initialize()`
+    从没跑分页/连续 shell 都跑的 `reader_pagination_scripts.dart` `_sharedInitViewport`——即重写
+    `<meta name="viewport" content="width=device-width,...">`。缺了它 WKWebView 按默认 **980 CSS px**
+    布局再整体缩放到设备宽。iPhone（iOS 26.6）真机实测：
+    `innerWidth=980 innerHeight=1743` 对 `dartPageWidth=375 dartPageHeight=667 chromeTopInset=44`，
+    两个坐标系差 ~2.6 倍——正文被缩到约四成大小，且**所有按 px 下发的量**（chrome 预留、页面盒、
+    caret inset、滑动阈值）全被按错的单位解释。Android 的 WebView 默认就是 device-width、桌面窗口
+    又普遍 ≥980（macOS 实测 `innerWidth=1206=pageWidth`，碰巧对上），所以这个缺口**只在 iOS 上显形**。
+    这才是"iOS 上 VN 模式基本不可用"的主因，前两处是叠加其上的几何错位。
 - **[x] ① 已修复** — `fushi/lib/src/reader/reader_visual_novel_scripts.dart`：
   1. 新增 `applyViewportVars()`，与分页 shell 用同一份 `C` 字段、同一组变量名写
      `--chrome-top-inset / --chrome-bottom-inset / --page-width / --page-height /
@@ -35,19 +44,37 @@
      渲染盒同源之后，chrome 预留带怎么变都不会再切出溢出屏。
   5. `applyImageMaxVars` 的"实际 VN 视口"同步改为读 `.fushi-vn-screen` 盒（原读
      `window.innerWidth/Height` 整视口，会把插图算到能盖住顶栏/底栏的尺寸）。
+  6. **新增 `applyViewportMeta()`**，内联 `ReaderPaginationScripts.sharedInitViewportJs`
+     （原 `_sharedInitViewport` 提为公开常量，三种 shell 单一真相源），并排在
+     `applyViewportVars()` **之前**——视口 meta 定义的是 CSS 像素空间本身，任何 px 量都必须在它
+     落地之后再写。这条是 iOS 上的主修复。
   提交：见本分支 `worktree/ios-vn-fix-20260816`。
 - **[x] ② 已加自动化测试** —
   - `fushi/integration_test/reader_vn_chrome_inset_dom_test.dart`（最强可落地层：真实 WebView 读 DOM
-    几何）。修复前红：`--chrome-top-inset` 实读 0.0；修复后绿：`chromeTopInset=52
-    pageWidth=1206 pageHeight=697 screenTop=52 screenHeight=645`。
+    几何）。三条不变式：① `innerWidth == --page-width`（两个坐标系重合）② `--chrome-top-inset`
+    >= 顶部进度条预留 ③ VN 屏完整落在 chrome 安全带内。
+    - macOS 修复前红（`--chrome-top-inset` 实读 0.0，`.fushi-vn-screen` = `top 0 → bottom 697` 整视口）；
+      修复后绿：`chromeTopInset=52 pageWidth=1206 pageHeight=697 screenTop=52 screenHeight=645`。
+    - **iPhone 真机（iOS 26.6）**：仅有前两处修复时 `innerWidth=980 innerHeight=1743` 对
+      `pageWidth=375 pageHeight=667`（坐标系差 2.6 倍，第三处缺口暴露）；补上视口 meta 后绿：
+      `innerWidth=375 innerHeight=667 chromeTopInset=44 screenTop=44 screenHeight=623`。
   - `fushi/test/reader/vn_viewport_geometry_bug1688_test.dart`（CI 可跑的源码守卫）：锁住四个变量确实
-    有人写、`setChromeInsets` 不再是 `return null` 空壳、`updatePageSize` 真读入参、量尺照真实屏盒量，
-    以及 `applyViewportVars` 必须排在建舞台/切屏之前。
+    有人写、`setChromeInsets` 不再是 `return null` 空壳、`updatePageSize` 真读入参、量尺照真实屏盒量、
+    `applyViewportVars` 必须排在建舞台/切屏之前，以及 VN 内联的视口 meta 与另两个 shell **字节相同**
+    且排在写几何变量之前。
 - **备注**：
-  - **iOS 真机门未过**：本机跑不了 iOS 构建——`fushi/ios/build_aidoku_runtime.sh:8` 硬性要求
-    `PLATFORM_NAME=iphoneos`（模拟器直接报错退出），且本机 `rustup` 只装了 `aarch64-apple-darwin`，
-    iOS/模拟器 target 都缺。验证因此落在 macOS 的 WKWebView 上（与 iOS 同内核、同 VN JS、同
-    `fushi-reader://` 自定义 scheme 交付链），iOS 安全区叠加后的实际观感仍需真机复测。
+  - **iOS 真机门已过**（iPhone，iOS 26.6，`00008030-000E24680CC3402E`）。本机跑通 iOS 构建需要两步
+    一次性环境准备，都不入库：
+    1. `rustup target add aarch64-apple-ios` + `rustup update stable`——`native/aidoku_runtime` 的
+       `boa_engine 0.21.1` / `icu_*` / `image 0.25.10` 等依赖要求 **rustc ≥ 1.88**，本机原为 1.87，
+       `flutter build ios` 只会吐一句被截断的 `rustc 1.87.0 is not supported by the following packages:`，
+       完整清单要到 `native/aidoku_runtime` 下直接跑 cargo 才看得到。
+    2. 真机签名：`fushi/ios/Runner.xcodeproj` 不带 `DEVELOPMENT_TEAM`，本地跑真机需临时在
+       `fushi/ios/Flutter/Debug.xcconfig` 追加 `DEVELOPMENT_TEAM=8N35BLYGL5` +
+       `CODE_SIGN_STYLE=Automatic`（本机已有 `fushi_dev_manual.mobileprovision`）。**这两行是机器特定的，
+       验证完已还原，不得提交**。
+    另：iOS **模拟器**仍然跑不了——`fushi/ios/build_aidoku_runtime.sh:8` 硬性要求
+    `PLATFORM_NAME=iphoneos`，模拟器直接报错退出。真机是当前唯一的 iOS 验证通道。
   - 同批排查中发现、**本次未动**的相邻问题，另行记录/择期处理：
     - `reader_engine_config.dart:13` 的注释声称引擎已改成 `<script src>` 走 fushi.local 拦截器的静态
       资源，代码里并无 `ReaderEngineScript`，实际仍是 `onLoadStop` 后一次 `evaluateJavascript`

--- a/fushi/integration_test/reader_vn_chrome_inset_dom_test.dart
+++ b/fushi/integration_test/reader_vn_chrome_inset_dom_test.dart
@@ -1,0 +1,298 @@
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:fushi/main.dart' as app;
+import 'package:fushi/media.dart';
+import 'package:fushi/src/epub/epub_importer.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart';
+
+import 'helpers/focus_driver.dart';
+import 'helpers/generate_test_epub.dart' show EpubGenerator;
+import 'test_helpers.dart';
+
+/// BUG-1688 回归 —— VN（视觉小说）view-mode 忽略 chrome inset / 页面尺寸（real-DOM）。
+///
+/// 根因：VN shell 是 hoshi a 移植过来的第三种 view-mode，它的 host-compat shim 把
+/// `setChromeInsets` 直接写成 `return null` 的空壳，而 VN 自己的 `initialize()` 也
+/// 从没像分页/连续 shell 那样从 `C.chromeTopInset / C.chromeBottomInset` 写
+/// `--chrome-top-inset / --chrome-bottom-inset`。于是 `_vnLayoutCss` 里
+/// `.fushi-vn-stage` 的 `padding-top: calc(...vh + var(--chrome-top-inset, 0px))`
+/// 恒取 0px 兜底值：VN 舞台按**整个视口**排版，顶部进度条/顶栏与底栏（iOS 上还要
+/// 叠刘海与 home indicator）直接压在正文上。
+///
+/// 同源第二处：`fitScreensToViewport` 的量尺 `createScreenMeasurement` 用
+/// `var(--page-width, 100vw) / var(--page-height, 100vh)` 撑开，而这两个变量只有
+/// 分页/连续 shell 的 `initialize` 会写，VN 下同样落到 100vw/100vh 兜底；且
+/// `updatePageSize(width, height)` 整个忽略入参。量尺比真实 `.fushi-vn-screen`
+/// 大出整条 chrome 预留带 → 每屏都被塞到"刚好填满整个视口"，于是**每一屏**的首尾行
+/// 都落进被 chrome 覆盖的区域。这就是"iOS 上 VN 模式基本不可用"的几何根因。
+///
+/// 本测试在 live WebView 上锁两条不变式（读 DOM 几何，不依赖截图）：
+///   1. VN 首载稳定后 `--chrome-top-inset` 必须 >= 顶部进度条预留（18px），
+///      即 inset 真的被推进了 VN 文档；
+///   2. VN 当前屏 `.fushi-vn-screen` 的可视区间必须完整落在
+///      `[chromeTopInset, innerHeight - chromeBottomInset]` 这条安全带内，
+///      即正文不被顶栏/底栏覆盖。
+///
+/// Run（macOS）：
+///   flutter test integration_test/reader_vn_chrome_inset_dom_test.dart -d macos
+void main() {
+  final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+      'BUG-1688: VN view-mode honours the reader chrome insets - the VN screen '
+      'never renders under the top/bottom chrome',
+      timeout: const Timeout(Duration(minutes: 5)),
+      (WidgetTester tester) async {
+    final List<FlutterErrorDetails> errors = [];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      errors.add(details);
+      debugPrint('[VNINSET] FlutterError: ${details.exceptionAsString()}');
+    };
+
+    try {
+      app.main();
+      expect(await waitForHome(tester), isTrue, reason: 'Home within 90s');
+      await tester.pump(const Duration(seconds: 2));
+
+      // 与 BUG-470 的顶部 inset 测试同理：挤压（非悬浮）模式才真占 18px 预留，
+      // 那正是"正文被顶栏压住"能被几何断言捕获的场景。
+      expect(ReaderFushiSource.instance.showTopProgressBar, isTrue,
+          reason: '顶部阅读进度必须默认开启（本测试的触发条件）。');
+      if (ReaderFushiSource.instance.topProgressFloating) {
+        ReaderFushiSource.instance.toggleTopProgressFloating();
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(ReaderFushiSource.instance.topProgressFloating, isFalse,
+          reason: '本测试需挤压（非悬浮）模式——挤压模式才会占预留带。');
+
+      // 开书**之前**切到 VN view-mode：view_mode 是单一 app 级偏好，per-book
+      // ReaderSettings 首载时读它来选 shell（webview.part.dart 的 s.isVnMode）。
+      await ReaderFushiSource.instance.setReaderViewMode('vn');
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(ReaderFushiSource.instance.readerViewMode, 'vn',
+          reason: 'VN view-mode 必须在开书前生效，否则装的是分页 shell。');
+
+      await enableFocusNavigation(tester);
+      final FocusDriver driver = FocusDriver(tester);
+
+      await _openBooksTab(tester, driver);
+      final String bookKey = await _seedTestBook(tester);
+      await _openBooksTab(tester, driver);
+
+      // 不断言书架卡片可见：`_activateBook` 走 `AppModel.openMedia`（与卡片 onTap
+      // 同一调用）直接把阅读器 push 上栈，书架列表的懒加载/去重命名与本测试无关。
+      await _activateBook(tester, bookKey);
+      await tester.pump(const Duration(seconds: 3));
+
+      for (int i = 0;
+          i < 40 && find.byType(ReaderFushiPage).evaluate().isEmpty;
+          i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(find.byType(ReaderFushiPage), findsOneWidget,
+          reason: 'ReaderFushiPage must mount after openMedia.');
+
+      const Key webViewKey = ValueKey<String>('fushi_webview');
+      bool webViewPresent = false;
+      for (int i = 0; i < 180; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(webViewKey).evaluate().isNotEmpty) {
+          webViewPresent = true;
+          break;
+        }
+        if (i % 20 == 0) debugPrint('[VNINSET] waiting for WebView i=$i');
+      }
+      expect(webViewPresent, isTrue, reason: 'WebView present');
+
+      const Key contentReadyKey = ValueKey<String>('fushi_content_ready');
+      bool contentReady = false;
+      for (int i = 0; i < 120; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(contentReadyKey).evaluate().isNotEmpty) {
+          contentReady = true;
+          break;
+        }
+      }
+      expect(contentReady, isTrue, reason: 'Reader content ready within 60s');
+
+      final eval = ReaderFushiPage.debugEvaluateJavascript;
+      expect(eval, isNotNull,
+          reason: 'Reader debug JS hook must be set (debug/profile build).');
+
+      Future<Map<String, dynamic>> readVnGeometry() async {
+        final Object? raw = await eval!(jsVnGeometryProbe);
+        final dynamic decoded = jsonDecode(raw.toString());
+        return decoded == null
+            ? <String, dynamic>{}
+            : (decoded as Map<String, dynamic>);
+      }
+
+      const double kExpectedReservePx = 18.0;
+      Map<String, dynamic> geo = <String, dynamic>{};
+      for (int i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+        geo = await readVnGeometry();
+        debugPrint('[VNINSET] poll#$i $geo');
+        if (geo['vnShell'] == true &&
+            geo['screenTop'] != null &&
+            ((geo['chromeTopInset'] as num?)?.toDouble() ?? 0) >=
+                kExpectedReservePx - 1.0) {
+          break;
+        }
+      }
+
+      debugPrint('[VNINSET] FINAL $geo');
+
+      expect(geo['vnShell'], isTrue,
+          reason: 'VN shell 必须真的装上了（找不到 .fushi-vn-stage 说明装的不是 '
+              'VN shell，本测试的前提不成立）。实读=$geo');
+
+      final double chromeTopInset =
+          (geo['chromeTopInset'] as num?)?.toDouble() ?? -1;
+      final double chromeBottomInset =
+          (geo['chromeBottomInset'] as num?)?.toDouble() ?? -1;
+      final double screenTop = (geo['screenTop'] as num?)?.toDouble() ?? -1;
+      final double screenBottom =
+          (geo['screenBottom'] as num?)?.toDouble() ?? -1;
+      final double innerHeight = (geo['innerHeight'] as num?)?.toDouble() ?? -1;
+
+      // 不变式 1：VN 文档必须真的收到了 chrome inset。
+      expect(chromeTopInset, greaterThanOrEqualTo(kExpectedReservePx - 1.0),
+          reason: 'BUG-1688：VN 首载稳定后 --chrome-top-inset 必须 >= 顶部进度条'
+              '预留（${kExpectedReservePx}px）。实读=$chromeTopInset。若≈0 说明 VN '
+              'shell 的 setChromeInsets 仍是空壳、initialize 也没写这两个变量。');
+
+      // 不变式 2：当前 VN 屏必须完整落在 chrome 安全带内。
+      expect(screenTop, greaterThanOrEqualTo(chromeTopInset - 1.0),
+          reason: 'BUG-1688：VN 屏顶 ($screenTop) 必须 >= --chrome-top-inset '
+              '($chromeTopInset)——否则首行被顶栏压住。');
+      expect(screenBottom,
+          lessThanOrEqualTo(innerHeight - chromeBottomInset + 1.0),
+          reason: 'BUG-1688：VN 屏底 ($screenBottom) 必须 <= 视口高 ($innerHeight) '
+              '- --chrome-bottom-inset ($chromeBottomInset)——否则末行被底栏压住。');
+
+      await takeScreenshot(binding, 'bug1688_vn_chrome_inset_verified');
+
+      final NavigatorState nav =
+          Navigator.of(tester.element(find.byType(Scaffold).first));
+      nav.pop();
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      // 还原 view-mode，别把 VN 留给后续测试 / 本机偏好。
+      await ReaderFushiSource.instance.setReaderViewMode('paginated');
+      await tester.pump(const Duration(milliseconds: 300));
+
+      assertStrictErrors(errors);
+      debugPrint('[VNINSET] === BUG-1688 VN CHROME-INSET TEST PASSED ===');
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+  });
+}
+
+/// 读 VN 舞台几何：注入的 chrome inset、当前屏 `.fushi-vn-screen` 的 client rect、
+/// 以及屏内实际渲染文本的首尾行 rect（后者用于取证，断言只用屏 rect）。
+const String jsVnGeometryProbe = r'''
+(function(){
+  function num(v){ var n = parseFloat(v); return isFinite(n) ? n : 0; }
+  var cs = getComputedStyle(document.documentElement);
+  var stage = document.querySelector('.fushi-vn-stage');
+  var screen = document.querySelector('.fushi-vn-screen');
+  var content = document.querySelector('.fushi-vn-content');
+  var out = {
+    vnShell: !!stage,
+    chromeTopInset: num(cs.getPropertyValue('--chrome-top-inset')),
+    chromeBottomInset: num(cs.getPropertyValue('--chrome-bottom-inset')),
+    pageWidth: num(cs.getPropertyValue('--page-width')),
+    pageHeight: num(cs.getPropertyValue('--page-height')),
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight
+  };
+  if (screen) {
+    var sr = screen.getBoundingClientRect();
+    out.screenTop = sr.top;
+    out.screenBottom = sr.bottom;
+    out.screenHeight = sr.height;
+  }
+  if (content) {
+    var cr = content.getBoundingClientRect();
+    out.contentTop = cr.top;
+    out.contentBottom = cr.bottom;
+    out.contentText = (content.textContent || '').trim().substr(0, 12);
+  }
+  return JSON.stringify(out);
+})()
+''';
+
+/// Books 标签置前（home 可能默认别的 tab；书架列表也会懒加载）。
+Future<void> _openBooksTab(WidgetTester tester, FocusDriver driver) async {
+  final List<Finder> navTargets = findPrimaryNavigationTargets();
+  if (navTargets.isEmpty) return;
+  final bool focused = await driver.focusWidget(navTargets.first);
+  expect(focused, isTrue, reason: 'Books tab must be reachable by focus');
+  await driver.activate();
+  await tester.pump(const Duration(milliseconds: 500));
+}
+
+/// 导入一本全新合成 EPUB（无有声书），返回其 book key。
+Future<String> _seedTestBook(WidgetTester tester) async {
+  final ProviderContainer container = ProviderScope.containerOf(
+    tester.element(find.byType(MaterialApp).first),
+  );
+  final AppModel appModel = container.read(appProvider);
+  for (int i = 0; i < 120 && !appModel.isInitialised; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  expect(appModel.isInitialised, isTrue,
+      reason: 'AppModel must be initialised before importing a book');
+
+  final Uint8List bytes = EpubGenerator().generate();
+  final String bookKey = await EpubImporter.import(
+    db: appModel.database,
+    bytes: bytes,
+    fileName: 'test_vn_chrome_inset.epub',
+  );
+  debugPrint('[VNINSET] Imported test EPUB as book key=$bookKey');
+
+  container.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+  await tester.pumpAndSettle();
+  return bookKey;
+}
+
+/// 确定性打开书架书（与 reader_top_progress_inset_dom_test 同一手法，TODO-783）。
+Future<void> _activateBook(WidgetTester tester, String bookKey) async {
+  final BuildContext appContext =
+      tester.element(find.byType(MaterialApp).first);
+  final ProviderContainer container = ProviderScope.containerOf(appContext);
+  final AppModel appModel = container.read(appProvider);
+
+  final ConsumerStatefulElement appElement = tester
+      .element(find.byType(app.FushiReaderApp)) as ConsumerStatefulElement;
+  final WidgetRef ref = appElement;
+
+  final MediaItem? item =
+      await ReaderFushiSource.instance.mediaItemForBookKey(bookKey);
+  expect(item, isNotNull,
+      reason: 'Seeded book must resolve to a MediaItem (key=$bookKey)');
+
+  unawaited(appModel.openMedia(
+    ref: ref,
+    mediaSource: ReaderFushiSource.instance,
+    item: item!,
+  ));
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+}

--- a/fushi/integration_test/reader_vn_chrome_inset_dom_test.dart
+++ b/fushi/integration_test/reader_vn_chrome_inset_dom_test.dart
@@ -35,7 +35,16 @@ import 'test_helpers.dart';
 /// 大出整条 chrome 预留带 → 每屏都被塞到"刚好填满整个视口"，于是**每一屏**的首尾行
 /// 都落进被 chrome 覆盖的区域。这就是"iOS 上 VN 模式基本不可用"的几何根因。
 ///
-/// 本测试在 live WebView 上锁两条不变式（读 DOM 几何，不依赖截图）：
+/// 第三处（**iOS 专属，且是 iOS 上最先炸的一条**）：VN 的 `initialize()` 从没跑分页/
+/// 连续 shell 都跑的 `_sharedInitViewport`——即重写 `width=device-width` 的视口 meta。
+/// 缺了它 WKWebView 按默认 **980 CSS px** 布局再整体缩放到设备宽：iPhone 真机实测
+/// `innerWidth=980 / innerHeight=1743`，而 Dart 下发的是 `dartPageWidth=375 /
+/// chromeTopInset=44`（逻辑像素），两个坐标系差 ~2.6 倍——正文被缩到约四成大小，
+/// 所有按 px 下发的量也全被按错单位解释。Android 的 WebView 默认就是 device-width、
+/// 桌面窗口又普遍 ≥980，所以这个缺口**只在 iOS 上显形**。
+///
+/// 本测试在 live WebView 上锁三条不变式（读 DOM 几何，不依赖截图）：
+///   0. `window.innerWidth` 必须等于 Dart 下发的 `--page-width`（两个坐标系重合）；
 ///   1. VN 首载稳定后 `--chrome-top-inset` 必须 >= 顶部进度条预留（18px），
 ///      即 inset 真的被推进了 VN 文档；
 ///   2. VN 当前屏 `.fushi-vn-screen` 的可视区间必须完整落在
@@ -44,6 +53,8 @@ import 'test_helpers.dart';
 ///
 /// Run（macOS）：
 ///   flutter test integration_test/reader_vn_chrome_inset_dom_test.dart -d macos
+/// Run（iOS 真机，需 DEVELOPMENT_TEAM 已配好）：
+///   flutter test integration_test/reader_vn_chrome_inset_dom_test.dart -d <udid>
 void main() {
   final IntegrationTestWidgetsFlutterBinding binding =
       IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -166,6 +177,20 @@ void main() {
       final double screenBottom =
           (geo['screenBottom'] as num?)?.toDouble() ?? -1;
       final double innerHeight = (geo['innerHeight'] as num?)?.toDouble() ?? -1;
+
+      // 不变式 0（iOS 上最先炸的那条）：WebView 的 CSS 像素空间必须与 Dart 的逻辑
+      // 像素空间重合。缺 `width=device-width` 视口 meta 时 WKWebView 按默认 980 CSS px
+      // 布局再整体缩放——iOS 真机实测 `innerWidth=980 / innerHeight=1743` 对
+      // `dartPageWidth=375 / dartPageHeight=667`，两个坐标系差 ~2.6 倍：正文缩到约四成
+      // 大小，且所有按 px 下发的量（chrome 预留、页面盒、caret inset）全被按错单位解释。
+      final double innerWidth = (geo['innerWidth'] as num?)?.toDouble() ?? -1;
+      final double pageWidth = (geo['pageWidth'] as num?)?.toDouble() ?? -1;
+      expect(pageWidth, greaterThan(0), reason: 'BUG-1688：VN 必须写 --page-width');
+      expect((innerWidth - pageWidth).abs(), lessThanOrEqualTo(1.0),
+          reason: 'BUG-1688：WebView 视口宽 ($innerWidth CSS px) 必须与 Dart 下发的 '
+              '--page-width ($pageWidth 逻辑 px) 一致。不一致 = VN 少注入了 '
+              'width=device-width 视口 meta（分页/连续 shell 的 _sharedInitViewport），'
+              'WKWebView 退回 980px 布局——iOS 上 VN 不可用的主因。');
 
       // 不变式 1：VN 文档必须真的收到了 chrome inset。
       expect(chromeTopInset, greaterThanOrEqualTo(kExpectedReservePx - 1.0),

--- a/fushi/lib/src/reader/reader_pagination_scripts.dart
+++ b/fushi/lib/src/reader/reader_pagination_scripts.dart
@@ -1705,6 +1705,16 @@ window.__fushiInstallShell = function(C) {
       window.fushiReader.applySentenceAudioCues(C.sentenceAudioCues);
     }''';
 
+  /// 三种 shell 共用的视口 meta 重写（BUG-1688 第二处：VN shell 原先没跑这段）。
+  ///
+  /// 缺了它，WKWebView 会按**默认的 980 CSS px** 布局再整体缩放到设备宽——iOS 上实测
+  /// `innerWidth=980 / innerHeight=1743`，而 Dart 侧下发的 `dartPageWidth=375`、
+  /// `chromeTopInset=44` 全是逻辑像素，两个坐标系差 ~2.6 倍：正文被缩到约四成大小，
+  /// 所有按 px 下发的量（chrome 预留、页面盒、caret inset、滑动阈值）也全被按错的
+  /// 单位解释。Android 的 WebView 默认就是 device-width、桌面窗口又普遍 ≥980，所以
+  /// 这个缺口**只在 iOS 上显形**。VN 必须与分页/连续 shell 用同一份，故此常量公开。
+  static const String sharedInitViewportJs = _sharedInitViewport;
+
   static const String _sharedInitViewport = '''
   var viewport = document.querySelector('meta[name="viewport"]');
   if (viewport) { viewport.remove(); }

--- a/fushi/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/fushi/lib/src/reader/reader_visual_novel_scripts.dart
@@ -29,6 +29,8 @@
 // ignore_for_file: lines_longer_than_80_chars
 library;
 
+import 'package:fushi/src/reader/reader_pagination_scripts.dart'
+    show ReaderPaginationScripts;
 import 'package:fushi/src/reader/reader_content_styles.dart'
     show ReaderLayoutDefaults;
 
@@ -57,6 +59,9 @@ class ReaderVisualNovelScripts {
 
   static String _shell() {
     const String initialRestoreScript = _initialRestoreJs;
+    // BUG-1688：与分页/连续 shell 同一份视口 meta 重写（单一真相源）。
+    const String sharedInitViewport =
+        ReaderPaginationScripts.sharedInitViewportJs;
     // TODO-1085 (BUG-513): single source of truth for the image viewport ratio,
     // shared with the paginated shell (ReaderLayoutDefaults.imageWidthViewportRatio),
     // consumed by applyImageMaxVars below.
@@ -916,8 +921,12 @@ window.fushiReader = {
         return this.waitForImages();
       })
       .then(() => {
-        // BUG-1688：几何变量必须在建舞台/量屏之前落地——`fitScreensToViewport`
-        // 是按当前 `.fushi-vn-screen` 盒切屏的，晚一步就会先按错的盒切一遍。
+        // BUG-1688：视口 meta 必须最先落地。缺了它 WKWebView 按 980 CSS px 布局再
+        // 缩放，文档的 CSS 像素空间与 Dart 逻辑像素空间差 ~2.6 倍（iOS 实测
+        // innerWidth=980 vs dartPageWidth=375），下面写进去的 px 全是错单位。
+        this.applyViewportMeta();
+        // 几何变量必须在建舞台/量屏之前落地——`fitScreensToViewport` 是按当前
+        // `.fushi-vn-screen` 盒切屏的，晚一步就会先按错的盒切一遍。
         this.applyViewportVars();
         this.ensureStage();
         this.applyImageMaxVars();
@@ -962,6 +971,9 @@ window.fushiReader = {
     } else {
       while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
     }
+  },
+  applyViewportMeta: function() {
+$sharedInitViewport
   },
   applyViewportVars: function() {
     // BUG-1688：VN 舞台的可用盒由 `_vnLayoutCss` 写成

--- a/fushi/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/fushi/lib/src/reader/reader_visual_novel_scripts.dart
@@ -916,6 +916,9 @@ window.fushiReader = {
         return this.waitForImages();
       })
       .then(() => {
+        // BUG-1688：几何变量必须在建舞台/量屏之前落地——`fitScreensToViewport`
+        // 是按当前 `.fushi-vn-screen` 盒切屏的，晚一步就会先按错的盒切一遍。
+        this.applyViewportVars();
         this.ensureStage();
         this.applyImageMaxVars();
         this.buildSourceIndexes();
@@ -960,6 +963,27 @@ window.fushiReader = {
       while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
     }
   },
+  applyViewportVars: function() {
+    // BUG-1688：VN 舞台的可用盒由 `_vnLayoutCss` 写成
+    // `padding-top: calc(<margin>vh + var(--chrome-top-inset, 0px))`，量尺
+    // `createScreenMeasurement` 又读 `--page-width / --page-height`。这四个变量原先
+    // **只有**分页/连续 shell 的 `initialize` 会写（reader_pagination_scripts.dart
+    // 的 `--chrome-*-inset` / `--page-*`），VN 从来不写 → 全部落到 0px / 100vw /
+    // 100vh 兜底：舞台按整个视口排版、量尺比真实屏大出整条 chrome 预留带，于是每屏
+    // 首尾行都被顶栏/底栏盖住（iOS 上还要再叠刘海与 home indicator，所以最严重）。
+    // 这里与分页 shell 用同一份 C 字段、同一组变量名对齐，VN 不再自成一套几何。
+    var root = document.documentElement;
+    if (!root || !root.style) return;
+    root.style.setProperty('--chrome-top-inset', (Number(C.chromeTopInset) || 0) + 'px');
+    root.style.setProperty('--chrome-bottom-inset', (Number(C.chromeBottomInset) || 0) + 'px');
+    var pageWidth = Number(C.dartPageWidth) || window.innerWidth || 0;
+    var pageHeight = Number(C.dartPageHeight) || window.innerHeight || 0;
+    if (pageWidth > 0) root.style.setProperty('--page-width', pageWidth + 'px');
+    if (pageHeight > 0) {
+      root.style.setProperty('--page-height', pageHeight + 'px');
+      root.style.setProperty('--reader-viewport-height', pageHeight + 'px');
+    }
+  },
   ensureStage: function() {
     if (this.stage && this.screen) return;
     this.stage = document.createElement('div');
@@ -983,8 +1007,14 @@ window.fushiReader = {
     var root = document.documentElement;
     if (!root || !root.style) return;
     var ratio = $imageWidthRatio;
-    var vw = Math.max(1, window.innerWidth || 0);
-    var vh = Math.max(1, window.innerHeight || 0);
+    // BUG-1688：「实际 VN 视口」就是 `.fushi-vn-screen` 这个盒——它已扣掉 chrome
+    // 预留带与用户边距。原来读 window.innerWidth/Height（整个视口）会把插图算到
+    // 能盖住顶栏/底栏的尺寸。取不到盒时才回退整视口（首屏极早期调用）。
+    var screenBox = this.screen && this.screen.getBoundingClientRect
+      ? this.screen.getBoundingClientRect()
+      : null;
+    var vw = Math.max(1, (screenBox && screenBox.width) || window.innerWidth || 0);
+    var vh = Math.max(1, (screenBox && screenBox.height) || window.innerHeight || 0);
     root.style.setProperty('--fushi-image-max-width', Math.max(1, Math.floor(vw * ratio)) + 'px');
     root.style.setProperty('--fushi-image-max-height', vh + 'px');
   },
@@ -1372,13 +1402,29 @@ window.fushiReader = {
     root.className = 'fushi-vn-screen';
     root.setAttribute('aria-hidden', 'true');
     root.style.position = 'fixed';
-    root.style.left = '0';
-    root.style.top = '0';
     root.style.zIndex = '-1';
     root.style.opacity = '0';
     root.style.pointerEvents = 'none';
-    root.style.width = 'var(--page-width, 100vw)';
-    root.style.height = 'var(--page-height, 100vh)';
+    // BUG-1688：量尺必须是真实 `.fushi-vn-screen` 的镜像。原来它固定在 (0,0) 并用
+    // `var(--page-width, 100vw) / var(--page-height, 100vh)` 撑开——VN 下这两个变量
+    // 从没人写（见 applyViewportVars），恒取 100vw/100vh 整视口，比真实屏盒大出整条
+    // chrome 预留带。于是 `measureScreenFits` 判「装得下」的屏，渲到真实盒里首尾行
+    // 正好落在被顶栏/底栏覆盖的区域——每一屏都如此，这就是 VN 不可用的直接成因。
+    // `.fushi-vn-screen` 是 border-box，把 rect 的宽高原样搬过来即得同一个内容盒。
+    var screenBox = this.screen && this.screen.getBoundingClientRect
+      ? this.screen.getBoundingClientRect()
+      : null;
+    if (screenBox && screenBox.width > 0 && screenBox.height > 0) {
+      root.style.left = screenBox.left + 'px';
+      root.style.top = screenBox.top + 'px';
+      root.style.width = screenBox.width + 'px';
+      root.style.height = screenBox.height + 'px';
+    } else {
+      root.style.left = '0';
+      root.style.top = '0';
+      root.style.width = 'var(--page-width, 100vw)';
+      root.style.height = 'var(--page-height, 100vh)';
+    }
     var content = document.createElement('div');
     content.className = 'fushi-vn-content';
     root.appendChild(content);
@@ -2993,15 +3039,36 @@ window.fushiReader = {
 (function() {
   var vn = window.fushiReader;
   if (!vn) return;
-  if (typeof vn.updatePageSize !== 'function') {
-    vn.updatePageSize = function(width, height) {
+  // BUG-1688：可用盒变了（视口尺寸 or chrome 预留带）就得按新盒重切屏并停在原处。
+  // updatePageSize / setChromeInsets 只在「写哪几个 CSS 变量」上不同，重切动作同一份。
+  if (typeof vn.refitScreensToCurrentViewport !== 'function') {
+    vn.refitScreensToCurrentViewport = function() {
       if (!this.screens || !this.screens.length) return;
       var progress = this.calculateProgress();
+      this.applyImageMaxVars();
       this.screens = this.fitScreensToViewport(this.baseScreens
         ? this.mergeSentenceAudioCrossScreenScreens(this.baseScreens)
         : this.screens);
       this.assignScreenProgressAnchors();
       this.renderScreen(this.screenIndexForProgress(progress), true);
+    };
+  }
+  if (typeof vn.updatePageSize !== 'function') {
+    vn.updatePageSize = function(width, height) {
+      // BUG-1688：原实现整个忽略入参，`--page-width/--page-height` 于是永远是 VN
+      // 从没写过的空值，量尺只能退回 100vw/100vh。这里与分页 shell 的 updatePageSize
+      // 写同一组变量（含 `--reader-viewport-height`），再按新盒重切屏。
+      var root = document.documentElement;
+      var w = Math.round(Number(width) || 0);
+      var h = Math.round(Number(height) || 0);
+      if (root && root.style) {
+        if (w > 0) root.style.setProperty('--page-width', w + 'px');
+        if (h > 0) {
+          root.style.setProperty('--page-height', h + 'px');
+          root.style.setProperty('--reader-viewport-height', h + 'px');
+        }
+      }
+      this.refitScreensToCurrentViewport();
     };
   }
   if (typeof vn.getFirstVisibleCharOffset !== 'function') {
@@ -3011,7 +3078,20 @@ window.fushiReader = {
     };
   }
   if (typeof vn.setChromeInsets !== 'function') {
-    vn.setChromeInsets = function(topPx, bottomPx) { return null; };
+    vn.setChromeInsets = function(topPx, bottomPx) {
+      // BUG-1688：这里原来是 `return null` 的空壳，于是 Dart 侧
+      // `_applyChromeInsets`（chrome.part.dart）每次下发的顶栏/底栏预留在 VN 下全部
+      // 丢掉，`.fushi-vn-stage` 的 `var(--chrome-*-inset, 0px)` 恒取兜底 0px。
+      // 与分页/连续 shell 的 setChromeInsets 写同一组变量，再按新的可用盒重切屏
+      // （预留带变化会改变每屏能装多少行，只改 padding 不重切会留下溢出的旧屏）。
+      var root = document.documentElement;
+      if (root && root.style) {
+        root.style.setProperty('--chrome-top-inset', (Number(topPx) || 0) + 'px');
+        root.style.setProperty('--chrome-bottom-inset', (Number(bottomPx) || 0) + 'px');
+      }
+      this.refitScreensToCurrentViewport();
+      return null;
+    };
   }
   if (typeof vn.restoreToCharOffset !== 'function') {
     vn.restoreToCharOffset = async function(charOffset) {

--- a/fushi/test/reader/vn_viewport_geometry_bug1688_test.dart
+++ b/fushi/test/reader/vn_viewport_geometry_bug1688_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_pagination_scripts.dart';
 import 'package:fushi/src/reader/reader_visual_novel_scripts.dart';
 
 /// BUG-1688 守卫 —— VN view-mode 的可用盒必须与分页/连续 shell 同源。
@@ -22,6 +23,32 @@ void main() {
   });
 
   group('BUG-1688 VN viewport geometry guard', () {
+    test('VN rewrites the viewport meta exactly like the other two shells', () {
+      // iOS 真机实测：缺这段时 WKWebView 按默认 980 CSS px 布局再整体缩放
+      // （innerWidth=980 对 dartPageWidth=375），正文缩到约四成大小、所有按 px
+      // 下发的量全被按错单位解释。Android 默认 device-width、桌面窗口普遍 ≥980，
+      // 所以这个缺口只在 iOS 上显形——即"iOS 上 VN 不可用"的主因。
+      expect(
+        shell.contains(ReaderPaginationScripts.sharedInitViewportJs),
+        isTrue,
+        reason: 'VN shell must inline the SAME viewport-meta rewrite the '
+            'paginated/continuous shells run in their initialize()',
+      );
+      expect(
+        shell.contains('applyViewportMeta: function()'),
+        isTrue,
+        reason: 'VN shell must own a viewport-meta applier',
+      );
+      // 必须排在写几何变量之前：meta 改的是 CSS 像素空间本身。
+      final int metaAt = shell.indexOf('this.applyViewportMeta();');
+      final int varsAt = shell.indexOf('this.applyViewportVars();');
+      expect(metaAt, greaterThan(-1),
+          reason: 'initialize must call applyViewportMeta');
+      expect(metaAt, lessThan(varsAt),
+          reason: 'the viewport meta defines the CSS pixel space, so it must '
+              'land before any px-valued geometry var is written');
+    });
+
     test('VN initialize applies the chrome insets + page box from the config',
         () {
       expect(

--- a/fushi/test/reader/vn_viewport_geometry_bug1688_test.dart
+++ b/fushi/test/reader/vn_viewport_geometry_bug1688_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_visual_novel_scripts.dart';
+
+/// BUG-1688 守卫 —— VN view-mode 的可用盒必须与分页/连续 shell 同源。
+///
+/// 回归形态（已在 macOS live WebView 上复现，见
+/// `integration_test/reader_vn_chrome_inset_dom_test.dart`）：VN shell 从不写
+/// `--chrome-top-inset / --chrome-bottom-inset / --page-width / --page-height`，
+/// `setChromeInsets` 还是个 `return null` 的空壳、`updatePageSize` 整个忽略入参。
+/// 于是 `.fushi-vn-stage` 的 `padding: calc(...vh + var(--chrome-*-inset, 0px))`
+/// 恒取 0px、量尺 `createScreenMeasurement` 恒退回 `100vw/100vh`，每屏都被切成
+/// "刚好填满整个视口" → 首尾行落进顶栏/底栏覆盖区。iOS 上再叠刘海与 home
+/// indicator，预留带最厚，所以表现最严重（"VN 模式基本不可用"）。
+///
+/// headless WebView 在 CI 跑不到，几何行为由上面那条集成测试在真实 WebView 上守；
+/// 本文件只锁源码结构不回退——即"这四个变量确实有人写、量尺确实照真实屏盒量"。
+void main() {
+  late String shell;
+
+  setUpAll(() {
+    shell = ReaderVisualNovelScripts.vnShellScript();
+  });
+
+  group('BUG-1688 VN viewport geometry guard', () {
+    test('VN initialize applies the chrome insets + page box from the config',
+        () {
+      expect(
+        shell.contains('applyViewportVars: function()'),
+        isTrue,
+        reason: 'VN shell must own a viewport-var applier',
+      );
+      for (final String pair in <String>[
+        "setProperty('--chrome-top-inset', (Number(C.chromeTopInset) || 0)",
+        "setProperty('--chrome-bottom-inset', (Number(C.chromeBottomInset) || 0)",
+      ]) {
+        expect(
+          shell.contains(pair),
+          isTrue,
+          reason: 'VN must push the Dart-side chrome insets into the document '
+              '($pair missing) — otherwise the stage lays out over the chrome',
+        );
+      }
+      expect(
+        shell.contains("setProperty('--page-width', pageWidth + 'px')"),
+        isTrue,
+        reason: 'VN must publish --page-width for the screen measurement',
+      );
+      expect(
+        shell.contains("setProperty('--page-height', pageHeight + 'px')"),
+        isTrue,
+        reason: 'VN must publish --page-height for the screen measurement',
+      );
+      // 必须排在建舞台/切屏之前：fitScreensToViewport 是按当前屏盒切的。
+      final int applyAt = shell.indexOf('this.applyViewportVars();');
+      final int stageAt = shell.indexOf('this.ensureStage();');
+      final int buildAt = shell.indexOf('this.buildScreens();');
+      expect(applyAt, greaterThan(-1),
+          reason: 'initialize must call applyViewportVars');
+      expect(applyAt, lessThan(stageAt),
+          reason: 'viewport vars must land before the stage is built');
+      expect(applyAt, lessThan(buildAt),
+          reason: 'viewport vars must land before screens are split');
+    });
+
+    test('setChromeInsets is a real implementation, not the old no-op stub',
+        () {
+      expect(
+        shell.contains(
+          'vn.setChromeInsets = function(topPx, bottomPx) { return null; };',
+        ),
+        isFalse,
+        reason: 'the no-op setChromeInsets stub dropped every inset update '
+            'Dart pushed (chrome.part.dart _applyChromeInsets) — VN then laid '
+            'out under the top/bottom chrome',
+      );
+      expect(
+        shell
+            .contains("setProperty('--chrome-top-inset', (Number(topPx) || 0)"),
+        isTrue,
+        reason: 'setChromeInsets must write the top inset variable',
+      );
+      expect(
+        shell.contains(
+          "setProperty('--chrome-bottom-inset', (Number(bottomPx) || 0)",
+        ),
+        isTrue,
+        reason: 'setChromeInsets must write the bottom inset variable',
+      );
+      expect(
+        shell.contains('this.refitScreensToCurrentViewport();'),
+        isTrue,
+        reason: 'an inset change resizes the usable box, so the screens must '
+            'be re-split — padding alone leaves the old overflowing screen',
+      );
+    });
+
+    test('updatePageSize consumes its arguments', () {
+      expect(
+        shell.contains('vn.updatePageSize = function(width, height)'),
+        isTrue,
+        reason: 'VN must keep the host-compat updatePageSize shim',
+      );
+      expect(
+        shell.contains('var w = Math.round(Number(width) || 0);'),
+        isTrue,
+        reason: 'updatePageSize must read its width argument (it used to '
+            'ignore both, leaving --page-width unset forever)',
+      );
+      expect(
+        shell.contains('var h = Math.round(Number(height) || 0);'),
+        isTrue,
+        reason: 'updatePageSize must read its height argument',
+      );
+    });
+
+    test('the screen measurement mirrors the real .fushi-vn-screen box', () {
+      expect(
+        shell.contains("root.style.width = screenBox.width + 'px';"),
+        isTrue,
+        reason: 'the measurement probe must be sized from the live screen rect',
+      );
+      expect(
+        shell.contains("root.style.height = screenBox.height + 'px';"),
+        isTrue,
+        reason: 'the measurement probe must be sized from the live screen rect',
+      );
+      // 兜底分支保留（首屏极早期还没有屏盒），但不能是唯一路径。
+      expect(
+        shell.contains("root.style.width = 'var(--page-width, 100vw)';"),
+        isTrue,
+        reason: 'the pre-layout fallback sizing must stay as a fallback',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 问题

用户报告：iOS 上小说的 VN（视觉小说）模式基本处于不可用状态。

## 根因（三处，已在 macOS 与 **iPhone 真机** 上分别复现）

VN 是从 hoshi a 移植来的第三种 view-mode，几何链路没接上宿主：

### ① iOS 主因：VN 从不重写视口 meta

分页/连续 shell 的 `initialize()` 都跑 `_sharedInitViewport`（重写
`<meta name="viewport" content="width=device-width,...">`），**VN 的 `initialize()` 没有**。
缺了它 WKWebView 按默认 **980 CSS px** 布局再整体缩放到设备宽。iPhone（iOS 26.6）真机实测：

```
innerWidth=980  innerHeight=1743      ← WebView 的 CSS 像素空间
pageWidth=375   pageHeight=667        ← Dart 下发的逻辑像素
chromeTopInset=44
```

两个坐标系差 ~2.6 倍：正文被缩到约四成大小，且**所有按 px 下发的量**（chrome 预留、页面盒、
caret inset、滑动阈值）全被按错的单位解释。Android 的 WebView 默认就是 device-width、桌面窗口
又普遍 ≥980（macOS 实测 `innerWidth=1206=pageWidth`，碰巧对上），所以这个缺口**只在 iOS 上显形**。

### ② `setChromeInsets` 是空壳，几何变量从没人写

host-compat shim 里 `vn.setChromeInsets = function(topPx, bottomPx) { return null; };`——Dart 侧
`chrome.part.dart:1045` 每次下发的顶栏/底栏预留全部被丢弃；VN 的 `initialize()` 也没像分页/连续
shell（`reader_pagination_scripts.dart:2669-2687`）那样写 `--chrome-*-inset` / `--page-*`。
于是 `.fushi-vn-stage` 的 `padding-top: calc(<margin>vh + var(--chrome-top-inset, 0px))` 恒取 0px。

### ③ 切屏量尺量的是整个视口，不是真实屏盒

`createScreenMeasurement` 用 `var(--page-width, 100vw) / var(--page-height, 100vh)` 撑开（VN 下必然
落兜底），`updatePageSize(width, height)` 又整个忽略入参。量尺比真实 `.fushi-vn-screen` 大出整条
chrome 预留带 → `fitScreensToViewport` 把每屏都切成"刚好填满整个视口"，**每一屏**的首尾行都落进被
顶栏/底栏覆盖的区域。macOS 修复前实测：`chromeTopInset=0 pageWidth=0 pageHeight=0`，
`.fushi-vn-screen` = `top 0 → bottom 697`（整视口）。

## 改动

`fushi/lib/src/reader/reader_visual_novel_scripts.dart`（+ `reader_pagination_scripts.dart` 提常量）

- **`applyViewportMeta()`**：内联 `ReaderPaginationScripts.sharedInitViewportJs`（原 `_sharedInitViewport`
  提为公开常量，三种 shell 单一真相源），排在所有 px 量之前——meta 定义的是 CSS 像素空间本身。
- **`applyViewportVars()`**：与分页 shell 用同一份 `C` 字段写 `--chrome-top-inset /
  --chrome-bottom-inset / --page-width / --page-height / --reader-viewport-height`，排在
  `ensureStage()` / `buildScreens()` 之前（晚一步就会先按错的盒切一遍屏）。
- `setChromeInsets` 改为真实实现，写完 inset 后按新可用盒重切屏（只改 padding 不重切会留下溢出的旧屏）。
- `updatePageSize(width, height)` 真正消费入参。
- **根因落点**：`createScreenMeasurement` 的量尺改为真实 `.fushi-vn-screen` 的镜像（照它的 client rect
  定 left/top/width/height），只在首屏极早期拿不到盒时才回退。量尺与真实渲染盒同源之后，chrome
  预留带怎么变都不会再切出溢出屏。
- `applyImageMaxVars` 的"实际 VN 视口"同步改读屏盒。

## 测试

`fushi/integration_test/reader_vn_chrome_inset_dom_test.dart`（真实 WebView 读 DOM 几何），三条不变式：
① `innerWidth == --page-width` ② `--chrome-top-inset >= 顶部进度条预留` ③ VN 屏完整落在 chrome 安全带内。

| 平台 | 修复前 | 修复后 |
|---|---|---|
| macOS | `chromeTopInset=0 pageWidth=0 pageHeight=0`，屏 `top 0 → 697`（整视口） | `chromeTopInset=52 pageWidth=1206 pageHeight=697 screenTop=52 screenHeight=645` |
| **iPhone / iOS 26.6** | `innerWidth=980 innerHeight=1743` 对 `pageWidth=375 pageHeight=667`（坐标系差 2.6 倍） | `innerWidth=375 innerHeight=667 chromeTopInset=44 screenTop=44 screenHeight=623` |

`fushi/test/reader/vn_viewport_geometry_bug1688_test.dart`（CI 可跑的源码守卫）：锁四个变量确实有人写、
`setChromeInsets` 不再是空壳、`updatePageSize` 真读入参、量尺照真实屏盒量、VN 内联的 meta 与另两个
shell **字节相同**且排在写几何变量之前。

`flutter analyze` 零问题；`flutter test test/reader/` 1360 passed。

## 本机跑 iOS 真机需要的一次性环境准备（不入库）

1. `rustup update stable` + `rustup target add aarch64-apple-ios`——`native/aidoku_runtime` 的
   `boa_engine 0.21.1` / `icu_*` / `image 0.25.10` 要求 **rustc ≥ 1.88**。`flutter build ios` 只吐一句被
   截断的 `rustc 1.87.0 is not supported by the following packages:`，完整清单要到
   `native/aidoku_runtime` 下直接跑 cargo 才看得到。
2. `fushi/ios/Flutter/Debug.xcconfig` 临时追加 `DEVELOPMENT_TEAM=8N35BLYGL5` + `CODE_SIGN_STYLE=Automatic`
   （项目本身不带 team）。**机器特定，验证完已还原，未提交。**

iOS **模拟器**仍跑不了：`fushi/ios/build_aidoku_runtime.sh:8` 硬性要求 `PLATFORM_NAME=iphoneos`。真机是
当前唯一的 iOS 验证通道。

## 同批发现、本次未动

详见 `docs/bugs/BUG-1688-vn-chrome-inset-viewport.md` 备注：`reader_engine_config.dart:13` 的陈旧注释、
iOS `CustomSchemeResponse` 无 statusCode 通道导致 404 退化成"200 空白页"且无错误信号、
`lyrics.part.dart:195` 的 `baseUrl` 硬编码 https 无平台分支、`vn_click_advance` 等 M0 常量强制项无消费者。
