### PR TITLE
漫画: Google Lens OCR 识别语言 + Cloudflare 解挑战 + Mihon 加载错误可诊断

### DIFF
--- a/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonExtensionLoader.kt
+++ b/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonExtensionLoader.kt
@@ -146,9 +146,15 @@ internal class MihonExtensionLoader(private val context: Context) {
                     .getDeclaredConstructor()
                     .newInstance()
             } catch (error: Throwable) {
+                // 把不透明的实例化失败变成可诊断的错误：附上链式根因（通常是
+                // NoClassDefFoundError / ClassNotFoundException，指明扩展需要而
+                // host 未提供的类），否则用户只看到「无法安装」而无从判断原因。
+                // reflective 调用会把真异常包在 InvocationTargetException 里，故
+                // 走到最深一层 cause。
                 throw MihonHostException(
                     "LOAD_FAILED",
-                    "Unable to instantiate extension source $className",
+                    "Unable to instantiate extension source $className: " +
+                        describeCauseChain(error),
                     error,
                 )
             }
@@ -165,6 +171,25 @@ internal class MihonExtensionLoader(private val context: Context) {
             throw MihonHostException("NO_SOURCES", "Extension did not expose any sources")
         }
         return LoadedMihonExtension(inspection, sources, classLoader)
+    }
+
+    /**
+     * Walks the whole cause chain and renders it as
+     * `Outer: msg ← Cause: msg ← Root: msg`, capped so a runaway chain can't
+     * bloat the surfaced message. The deepest link is usually the actionable
+     * one (which class/method the extension needs but the host lacks).
+     */
+    private fun describeCauseChain(error: Throwable): String {
+        val parts = mutableListOf<String>()
+        var current: Throwable? = error
+        val seen = HashSet<Throwable>()
+        while (current != null && seen.add(current) && parts.size < 6) {
+            val label = current.javaClass.simpleName.ifBlank { current.javaClass.name }
+            val message = current.message?.trim().orEmpty()
+            parts += if (message.isEmpty()) label else "$label: $message"
+            current = current.cause
+        }
+        return parts.joinToString(" ← ")
     }
 
     @Suppress("DEPRECATION")

--- a/fushi/android/app/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/fushi/android/app/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.network
 
 import android.content.Context
+import android.webkit.WebSettings
 import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor
@@ -21,7 +22,7 @@ class NetworkHelper(context: Context) {
             .cookieJar(cookieJar)
             .addInterceptor(UncaughtExceptionInterceptor())
             .addInterceptor(UserAgentInterceptor(::defaultUserAgentProvider))
-            .addInterceptor(CloudflareInterceptor())
+            .addInterceptor(CloudflareInterceptor(context, ::defaultUserAgentProvider))
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(45, TimeUnit.SECONDS)
             .callTimeout(2, TimeUnit.MINUTES)
@@ -33,8 +34,16 @@ class NetworkHelper(context: Context) {
     val cloudflareClient: OkHttpClient
         get() = client
 
-    private var userAgent: String =
-        System.getProperty("http.agent").orEmpty().ifBlank { "Hibiki Mihon Extension Host" }
+    // Cloudflare binds cf_clearance to the solving User-Agent, and the WebView
+    // that solves the challenge reports the platform's browser UA. Seeding the
+    // OkHttp UA from the same WebView default keeps the two in lockstep and
+    // makes ordinary requests look like a browser (falling back to a generic
+    // string only if WebView is somehow unavailable).
+    private var userAgent: String = runCatching { WebSettings.getDefaultUserAgent(context) }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+        ?: System.getProperty("http.agent").orEmpty()
+            .ifBlank { "Hibiki Mihon Extension Host" }
 
     fun setUA(value: String) {
         userAgent = value

--- a/fushi/android/app/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/fushi/android/app/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -1,17 +1,152 @@
 package eu.kanade.tachiyomi.network.interceptor
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
- * Host compatibility boundary for extension-core.
+ * Solves Cloudflare's "Just a moment…" interstitial the only way a headless
+ * HTTP client can: by loading the challenged URL in a real [WebView] with the
+ * **same** User-Agent the OkHttp client uses, letting Cloudflare's JavaScript
+ * run, and waiting for the `cf_clearance` cookie to appear.
  *
- * WebView-based Cloudflare challenge solving is outside the V1 native host;
- * ordinary requests pass through and challenge-dependent sources are reported
- * as incompatible instead of affecting other installed sources.
+ * The cookie lands in Android's shared [CookieManager], which is exactly what
+ * [eu.kanade.tachiyomi.network.AndroidCookieJar] reads, so the retried OkHttp
+ * request carries the clearance automatically — no cookie copying, and nothing
+ * leaves Android's private WebView store.
+ *
+ * UA parity is essential: Cloudflare binds `cf_clearance` to the User-Agent
+ * that solved the challenge. The host sets both the OkHttp UA and the WebView
+ * UA from the same provider, so a solved clearance keeps validating.
  */
-class CloudflareInterceptor : Interceptor {
-    @Synchronized
-    override fun intercept(chain: Interceptor.Chain): Response =
-        chain.proceed(chain.request())
+class CloudflareInterceptor(
+    private val context: Context,
+    private val userAgentProvider: () -> String,
+) : Interceptor {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // Serializes only the WebView solve, never ordinary requests: concurrent
+    // non-challenged calls must not queue behind each other.
+    private val solveLock = Any()
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+        if (!response.isCloudflareChallenge()) {
+            return response
+        }
+        // Drain the challenge body before opening the WebView so the socket is
+        // released; we only need the retried response.
+        response.close()
+
+        try {
+            // One WebView solve at a time; a second challenged request waits for
+            // the first to seed cf_clearance, then its own retry likely passes.
+            synchronized(solveLock) {
+                if (!hasClearance(CookieManager.getInstance(), "${request.url.scheme}://${request.url.host}")) {
+                    resolveWithWebView(request.url)
+                }
+            }
+        } catch (error: CloudflareBypassException) {
+            throw IOException(
+                "Cloudflare challenge could not be solved for ${request.url.host}",
+                error,
+            )
+        }
+
+        // Cookies (cf_clearance) now live in the shared CookieManager; retry.
+        return chain.proceed(request)
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun resolveWithWebView(url: HttpUrl) {
+        val latch = CountDownLatch(1)
+        val target = url.toString()
+        val origin = "${url.scheme}://${url.host}"
+        var webView: WebView? = null
+        var solved = false
+
+        val cookieManager = CookieManager.getInstance()
+
+        mainHandler.post {
+            val view = WebView(context)
+            webView = view
+            cookieManager.setAcceptThirdPartyCookies(view, true)
+            view.settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                databaseEnabled = true
+                userAgentString = userAgentProvider()
+                // Mirror a real browser closely enough for the challenge to run.
+                loadsImagesAutomatically = false
+                blockNetworkImage = true
+            }
+            view.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, finishedUrl: String) {
+                    // Challenge is cleared once cf_clearance exists for the host.
+                    if (hasClearance(cookieManager, origin)) {
+                        solved = true
+                        latch.countDown()
+                    }
+                }
+            }
+            view.loadUrl(target)
+        }
+
+        val completed = latch.await(CHALLENGE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        mainHandler.post {
+            webView?.stopLoading()
+            webView?.destroy()
+            webView = null
+        }
+        cookieManager.flush()
+
+        if (!completed || !solved) {
+            throw CloudflareBypassException()
+        }
+    }
+
+    private fun hasClearance(cookieManager: CookieManager, origin: String): Boolean {
+        val cookies = cookieManager.getCookie(origin).orEmpty()
+        return cookies.contains("cf_clearance=")
+    }
+
+    companion object {
+        private const val CHALLENGE_TIMEOUT_SECONDS = 30L
+    }
 }
+
+/**
+ * A Cloudflare interstitial is detected only when Cloudflare explicitly tags
+ * the response with `cf-mitigated: challenge` (the header modern challenges
+ * always send), on a challenge status code, from a Cloudflare-served response.
+ *
+ * The header is required on purpose: a bare `Server: cloudflare` 403/503 is
+ * ambiguous — many sources sit behind Cloudflare's CDN and legitimately return
+ * 403 (hotlink protection) or 503 (origin down). Triggering a 30s WebView solve
+ * on those would add latency and break otherwise-working sources, so the
+ * conservative `cf-mitigated` signal is the trigger rather than the status
+ * alone.
+ */
+private fun Response.isCloudflareChallenge(): Boolean {
+    if (code !in CLOUDFLARE_CHALLENGE_CODES) return false
+    val servedByCloudflare = header("Server")
+        ?.startsWith("cloudflare", ignoreCase = true) == true
+    if (!servedByCloudflare) return false
+    return header("cf-mitigated")?.equals("challenge", ignoreCase = true) == true
+}
+
+private val CLOUDFLARE_CHALLENGE_CODES = setOf(403, 429, 503)
+
+private class CloudflareBypassException : Exception()

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1770,6 +1770,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String manga_ocr_external_detected({required Object version}) =>
       'Detected: ${version}';
   String get manga_ocr_external_not_found => 'mokuro not found';
+  String get manga_ocr_lens_language_label => 'Recognition language';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   String get manga_ocr_model_status_missing => 'OCR models not downloaded';
@@ -7501,6 +7502,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'لغة التعرّف';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -15483,6 +15485,7 @@ class _StringsDe extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Erkennungssprache';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -23506,6 +23509,7 @@ class _StringsEs extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Idioma de reconocimiento';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -31551,6 +31555,7 @@ class _StringsFr extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Langue de reconnaissance';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -39564,6 +39569,7 @@ class _StringsId extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Bahasa pengenalan';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -47563,6 +47569,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Lingua di riconoscimento';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -55517,6 +55524,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => '認識する言語';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -63356,6 +63364,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => '인식 언어';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -71258,6 +71267,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Herkenningstaal';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -79271,6 +79281,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Idioma de reconhecimento';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -87278,6 +87289,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Язык распознавания';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -95254,6 +95266,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'ภาษาที่ใช้จดจำ';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -103221,6 +103234,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Tanıma dili';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -111195,6 +111209,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => 'Ngôn ngữ nhận dạng';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -118962,6 +118977,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => '未找到 mokuro';
   @override
+  String get manga_ocr_lens_language_label => '识别语言';
   String get manga_ocr_mobile_note => '移动端下载的模型用于漫画阅读页的框选识别。';
   @override
   String get manga_ocr_model_status_missing => 'OCR 模型未下载';
@@ -126465,6 +126481,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_ocr_external_not_found => 'mokuro not found';
   @override
+  String get manga_ocr_lens_language_label => '識別語言';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
   @override
@@ -133980,6 +133997,8 @@ extension on _StringsEn {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Recognition language';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -141052,6 +141071,8 @@ extension on _StringsAr {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'لغة التعرّف';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -148130,6 +148151,8 @@ extension on _StringsDe {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Erkennungssprache';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -155222,6 +155245,8 @@ extension on _StringsEs {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Idioma de reconocimiento';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -162317,6 +162342,8 @@ extension on _StringsFr {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Langue de reconnaissance';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -169407,6 +169434,8 @@ extension on _StringsId {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Bahasa pengenalan';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -176488,6 +176517,8 @@ extension on _StringsIt {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Lingua di riconoscimento';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -183566,6 +183597,8 @@ extension on _StringsJa {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return '認識する言語';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -190623,6 +190656,8 @@ extension on _StringsKo {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return '인식 언어';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -197695,6 +197730,8 @@ extension on _StringsNl {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Herkenningstaal';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -204781,6 +204818,8 @@ extension on _StringsPtBr {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Idioma de reconhecimento';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -211868,6 +211907,8 @@ extension on _StringsRu {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Язык распознавания';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -218947,6 +218988,8 @@ extension on _StringsTh {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'ภาษาที่ใช้จดจำ';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -226024,6 +226067,8 @@ extension on _StringsTr {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Tanıma dili';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -233103,6 +233148,8 @@ extension on _StringsVi {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return 'Ngôn ngữ nhận dạng';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':
@@ -240158,6 +240205,8 @@ extension on _StringsZhCn {
         return ({required Object version}) => '已检测到：${version}';
       case 'manga_ocr_external_not_found':
         return '未找到 mokuro';
+      case 'manga_ocr_lens_language_label':
+        return '识别语言';
       case 'manga_ocr_mobile_note':
         return '移动端下载的模型用于漫画阅读页的框选识别。';
       case 'manga_ocr_model_status_missing':
@@ -247188,6 +247237,8 @@ extension on _StringsZhHk {
         return ({required Object version}) => 'Detected: ${version}';
       case 'manga_ocr_external_not_found':
         return 'mokuro not found';
+      case 'manga_ocr_lens_language_label':
+        return '識別語言';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
       case 'manga_ocr_model_status_missing':

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Recognition language"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "لغة التعرّف"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Erkennungssprache"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Idioma de reconocimiento"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Langue de reconnaissance"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Bahasa pengenalan"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Lingua di riconoscimento"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "認識する言語"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "인식 언어"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Herkenningstaal"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Idioma de reconhecimento"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Язык распознавания"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Tanıma dili"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "搜索全部来源",
   "manga_global_search_hint": "搜索所有已启用来源",
   "manga_global_search_prompt": "输入书名，一次搜索所有已启用的漫画来源。",
-  "manga_global_search_no_sources": "没有已启用的漫画来源，请先安装并启用扩展。"
+  "manga_global_search_no_sources": "没有已启用的漫画来源，请先安装并启用扩展。",
+  "manga_ocr_lens_language_label": "识别语言"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3440,5 +3440,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first."
+  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
+  "manga_ocr_lens_language_label": "識別語言"
 }

--- a/fushi/lib/src/media/manga/aidoku/aidoku_reader_chapter.dart
+++ b/fushi/lib/src/media/manga/aidoku/aidoku_reader_chapter.dart
@@ -152,6 +152,12 @@ class AidokuReaderChapter extends OnlineMangaReaderChapter {
   String get title => manga['title']?.toString() ?? package.name;
 
   @override
+  String? get sourceLanguage {
+    // Aidoku manifest 是语言列表；只有单语言源能给出确定答案。
+    return package.languages.length == 1 ? package.languages.single : null;
+  }
+
+  @override
   String? get author {
     final List<Object?> authors =
         manga['authors'] as List<Object?>? ?? const <Object?>[];

--- a/fushi/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/src/media/manga/external_mokuro_runner.dart';
+import 'package:fushi/src/media/manga/ocr/google_lens_protocol.dart';
 import 'package:fushi/src/media/manga/ocr/manga_ocr_engine.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/ocr/manga_ocr_service.dart';
@@ -28,6 +29,8 @@ class MangaOcrSettingsSection extends ConsumerStatefulWidget {
     this.mokuroPathSetter,
     this.enginePreferenceGetter,
     this.enginePreferenceSetter,
+    this.lensLanguageGetter,
+    this.lensLanguageSetter,
     super.key,
   });
 
@@ -48,6 +51,10 @@ class MangaOcrSettingsSection extends ConsumerStatefulWidget {
   final String Function()? enginePreferenceGetter;
   final Future<void> Function(String value)? enginePreferenceSetter;
 
+  /// Google Lens 识别语言偏好读写（可选：省略时下拉不出现）。
+  final String Function()? lensLanguageGetter;
+  final Future<void> Function(String value)? lensLanguageSetter;
+
   @override
   ConsumerState<MangaOcrSettingsSection> createState() =>
       _MangaOcrSettingsSectionState();
@@ -57,6 +64,7 @@ class _MangaOcrSettingsSectionState
     extends ConsumerState<MangaOcrSettingsSection> {
   late final TextEditingController _pathCtrl;
   late MangaOcrEnginePreference _enginePreference;
+  late String _lensLanguage;
 
   MangaOcrModelStatus? _status;
   bool _loadingStatus = true;
@@ -80,6 +88,7 @@ class _MangaOcrSettingsSectionState
     _enginePreference = MangaOcrEnginePreferenceKey.fromKey(
       _readEnginePreference(),
     );
+    _lensLanguage = normalizeLensLanguage(widget.lensLanguageGetter?.call());
     if (widget.service.isSupportedPlatform) {
       unawaited(_loadStatus());
     } else {
@@ -122,6 +131,10 @@ class _MangaOcrSettingsSectionState
     if (setter != null) {
       await setter(preference.key);
     }
+  }
+
+  Future<void> _writeLensLanguage(String language) async {
+    await widget.lensLanguageSetter?.call(language);
   }
 
   Future<void> _loadStatus() async {
@@ -285,6 +298,10 @@ class _MangaOcrSettingsSectionState
         // 桌面里等于让移动端用户无法持久地退回离线引擎。外部 mokuro 是桌面工具，
         // 由下拉项自身 disable，不再靠整块 gating。
         _inset(_buildEnginePreference(theme)),
+        if (widget.lensLanguageGetter != null) ...<Widget>[
+          const SizedBox(height: 12),
+          _inset(_buildLensLanguage(theme)),
+        ],
         const SizedBox(height: 12),
         if (widget.service.isSupportedPlatform)
           _buildModelBlock(theme)
@@ -350,6 +367,36 @@ class _MangaOcrSettingsSectionState
         if (value == null) return;
         setState(() => _enginePreference = value);
         unawaited(_writeEnginePreference(value));
+      },
+    );
+  }
+
+  /// Google Lens 识别语言（默认/本地书兜底）。在线阅读优先用源声明的语言，
+  /// 只有源语言未知时才回退到这里；本地漫画整卷 OCR 直接用此值。
+  Widget _buildLensLanguage(ThemeData theme) {
+    final List<DropdownMenuItem<String>> items = <DropdownMenuItem<String>>[
+      for (final (String tag, String label) in kGoogleLensLanguageOptions)
+        DropdownMenuItem<String>(value: tag, child: Text(label)),
+      if (!kGoogleLensLanguageOptions
+          .any(((String, String) option) => option.$1 == _lensLanguage))
+        DropdownMenuItem<String>(
+          value: _lensLanguage,
+          child: Text(_lensLanguage),
+        ),
+    ];
+    return DropdownButtonFormField<String>(
+      key: const ValueKey<String>('manga_ocr_lens_language'),
+      initialValue: _lensLanguage,
+      decoration: InputDecoration(
+        labelText: t.manga_ocr_lens_language_label,
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
+      items: items,
+      onChanged: (String? value) {
+        if (value == null) return;
+        setState(() => _lensLanguage = value);
+        unawaited(_writeLensLanguage(value));
       },
     );
   }

--- a/fushi/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -98,6 +98,10 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   final TextEditingController _titleCtrl = TextEditingController();
 
   _WizardStage _stage = _WizardStage.pick;
+
+  /// Lens 识别语言（主子标签）。初值来自偏好；仅 Lens 引擎显示选择器。
+  late String _lensLanguage =
+      normalizeLensLanguage(widget.engines.initialLensLanguage);
   String? _imageDir;
   MangaOcrFolderStatus? _folderStatus;
 
@@ -387,7 +391,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
         dir,
         kMangaOcrOutDirName,
         kMangaOcrPagesCacheDirName,
-        kGoogleLensEngineSignature,
+        googleLensEngineSignature(_lensLanguage),
       )),
     );
     final List<MokuroImage> cachedPages = <MokuroImage>[];
@@ -402,9 +406,9 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     if (cachedPages.length == pages.length && pages.isNotEmpty) {
       final MokuroPayload payload = MokuroPayload(
         images: cachedPages,
-        ocr: const MangaOcrMetadata(
+        ocr: MangaOcrMetadata(
           engine: 'google_lens',
-          engineSignature: kGoogleLensEngineSignature,
+          engineSignature: googleLensEngineSignature(_lensLanguage),
           schemaVersion: 1,
         ),
       );
@@ -431,6 +435,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       volumeTitle: _title,
       startPage: widget.startPage,
       onlyMissing: widget.onlyMissing,
+      language: _lensLanguage,
     )) {
       if (event.finished) {
         yield MangaOcrBackgroundEvent.finished(
@@ -645,6 +650,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       volumeTitle: _title,
       startPage: widget.startPage,
       onlyMissing: widget.onlyMissing,
+      language: _lensLanguage,
     )
         .listen(
       (MangaOcrVolumeEvent event) {
@@ -911,6 +917,11 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
             if (_folderStatus == MangaOcrFolderStatus.valid) ...<Widget>[
               const SizedBox(height: 12),
               _engineSelector(busy),
+              if (_engine == MangaOcrEngineId.googleLens &&
+                  _lensAvailable) ...<Widget>[
+                const SizedBox(height: 12),
+                _lensLanguageSelector(busy),
+              ],
               const SizedBox(height: 12),
               TextField(
                 controller: _titleCtrl,
@@ -1033,6 +1044,37 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[selector, remoteReason],
+    );
+  }
+
+  /// Lens 识别语言下拉。选项存主子标签，显示语言自称名（无需翻译）。
+  Widget _lensLanguageSelector(bool busy) {
+    final List<DropdownMenuItem<String>> items = <DropdownMenuItem<String>>[
+      for (final (String tag, String label) in kGoogleLensLanguageOptions)
+        DropdownMenuItem<String>(value: tag, child: Text(label)),
+      // 偏好里存了列表外的语言（未来扩充/手改）时保留原值，避免选中项失效。
+      if (!kGoogleLensLanguageOptions
+          .any(((String, String) option) => option.$1 == _lensLanguage))
+        DropdownMenuItem<String>(
+          value: _lensLanguage,
+          child: Text(_lensLanguage),
+        ),
+    ];
+    return DropdownButtonFormField<String>(
+      initialValue: _lensLanguage,
+      items: items,
+      onChanged: busy
+          ? null
+          : (String? value) {
+              if (value == null) return;
+              setState(() => _lensLanguage = value);
+              widget.engines.lensLanguageSetter?.call(value);
+            },
+      decoration: InputDecoration(
+        labelText: t.manga_ocr_lens_language_label,
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
     );
   }
 

--- a/fushi/lib/src/media/manga/manga_ocr_wizard_engines.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_wizard_engines.dart
@@ -32,6 +32,8 @@ class MangaOcrWizardEngines {
     this.remoteRunner,
     this.lensRunner,
     this.initialEnginePreference,
+    this.initialLensLanguage,
+    this.lensLanguageSetter,
   });
 
   /// 生产依赖集的**唯一**装配点。所有入口都必须经此，不得再手抄参数表。
@@ -60,6 +62,8 @@ class MangaOcrWizardEngines {
           InterconnectMangaOcrClient(repo: SyncRepository(db)),
       lensRunner: GoogleLensMangaOcrService(),
       initialEnginePreference: appModel.mangaOcrEnginePreference,
+      initialLensLanguage: appModel.mangaOcrLensLanguage,
+      lensLanguageSetter: appModel.setMangaOcrLensLanguage,
     );
   }
 
@@ -78,4 +82,10 @@ class MangaOcrWizardEngines {
 
   /// 默认引擎偏好键；null 时向导按 `auto` 解析。
   final String? initialEnginePreference;
+
+  /// Lens 识别语言初值（偏好）；null = `ja`。
+  final String? initialLensLanguage;
+
+  /// 用户在向导里改语言时回写偏好；null（测试）= 不持久化。
+  final void Function(String value)? lensLanguageSetter;
 }

--- a/fushi/lib/src/media/manga/mihon/mihon_online_ocr.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_online_ocr.dart
@@ -25,6 +25,7 @@ class MihonOnlineMangaOcr {
     required this.managedDirectory,
     required this.initialPayload,
     required this.startPage,
+    required this.language,
     GoogleLensMangaOcrService? lens,
   }) : _lens = lens ?? GoogleLensMangaOcrService();
 
@@ -32,6 +33,9 @@ class MihonOnlineMangaOcr {
   final Directory managedDirectory;
   final MokuroPayload initialPayload;
   final int startPage;
+
+  /// Lens LocaleContext 语言（在线源的元数据语言，见 `sourceLanguage`）。
+  final String language;
   final GoogleLensMangaOcrService _lens;
   static final _MihonOnlineOcrMemoryCache _memoryCache =
       _MihonOnlineOcrMemoryCache(kMihonOnlineOcrMemoryPages);
@@ -98,7 +102,7 @@ class MihonOnlineMangaOcr {
           imagesDirectory.path,
           kMangaOcrOutDirName,
           kMangaOcrPagesCacheDirName,
-          kGoogleLensEngineSignature,
+          googleLensEngineSignature(language),
         ),
       ),
     );
@@ -124,6 +128,9 @@ class MihonOnlineMangaOcr {
         );
         final String memoryKey = <String>[
           p.canonicalize(managedDirectory.path),
+          // Language joins the key: switching language must not reuse the
+          // previous language's in-memory page result.
+          googleLensEngineSignature(language),
           session.cacheIdentity(pageIndex),
         ].join('\u001f');
         final MokuroImage? memoryCached = _memoryCache.get(memoryKey);
@@ -133,6 +140,7 @@ class MihonOnlineMangaOcr {
             await _lens.recognizePageBytes(
               await file.readAsBytes(),
               relativeUrl: relativeUrl,
+              language: language,
             );
         results[pageIndex] = recognized;
         if (cached == null) {
@@ -159,9 +167,9 @@ class MihonOnlineMangaOcr {
 
     final MokuroPayload payload = MokuroPayload(
       images: results,
-      ocr: const MangaOcrMetadata(
+      ocr: MangaOcrMetadata(
         engine: 'google_lens',
-        engineSignature: kGoogleLensEngineSignature,
+        engineSignature: googleLensEngineSignature(language),
         schemaVersion: 1,
       ),
     );

--- a/fushi/lib/src/media/manga/mihon/mihon_reader_chapter.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_reader_chapter.dart
@@ -15,6 +15,10 @@ abstract class OnlineMangaReaderChapter {
   int? get initialPage;
   String get title;
   String? get author;
+
+  /// 源声明的内容语言（Mihon `source.lang` / Aidoku 单语言 manifest）；
+  /// 未知或多语言源返回 null，由消费方决定回退（Lens OCR 回退用户偏好）。
+  String? get sourceLanguage;
   int get pageCount;
   List<String> get pageIdentities;
   String get identityFileName;
@@ -51,6 +55,12 @@ class MihonReaderChapter extends OnlineMangaReaderChapter {
 
   @override
   String? get author => manga.author ?? manga.artist;
+
+  @override
+  String? get sourceLanguage {
+    final String language = sourceContext.source.language.trim();
+    return language.isEmpty ? null : language;
+  }
 
   @override
   int get pageCount => pages.length;

--- a/fushi/lib/src/media/manga/ocr/google_lens_ocr_service.dart
+++ b/fushi/lib/src/media/manga/ocr/google_lens_ocr_service.dart
@@ -110,6 +110,7 @@ abstract interface class GoogleLensMangaOcrRunner {
     String? volumeTitle,
     int startPage,
     bool onlyMissing,
+    required String language,
   });
 
   Future<void> clearCache(String imageDirPath);
@@ -127,6 +128,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
     String? volumeTitle,
     int startPage = 0,
     bool onlyMissing = true,
+    required String language,
   }) {
     late final StreamController<MangaOcrVolumeEvent> controller;
     final OcrCancelToken cancelToken = OcrCancelToken();
@@ -138,6 +140,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
               imageDirPath: imageDirPath,
               startPage: startPage,
               onlyMissing: onlyMissing,
+              language: language,
               cancelToken: cancelToken,
               onProgress: (int done, int total) {
                 if (!controller.isClosed) {
@@ -180,6 +183,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
     required String imageDirPath,
     required int startPage,
     required bool onlyMissing,
+    required String language,
     required OcrCancelToken cancelToken,
     required void Function(int done, int total) onProgress,
   }) async {
@@ -194,7 +198,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
       p.join(
         outputDirectory.path,
         kMangaOcrPagesCacheDirName,
-        kGoogleLensEngineSignature,
+        googleLensEngineSignature(language),
       ),
     );
     final GoogleLensPageCache cache = GoogleLensPageCache(cacheDirectory);
@@ -221,7 +225,8 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
         results[pageIndex] = existingPage;
       } else {
         final MokuroImage? cached = await cache.read(pageIndex, page);
-        results[pageIndex] = cached ?? await _recognizePage(page);
+        results[pageIndex] =
+            cached ?? await _recognizePage(page, language: language);
         if (cached == null) {
           await cache.write(pageIndex, page, results[pageIndex]!);
         }
@@ -232,9 +237,9 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
     cancelToken.throwIfCancelled();
     final MokuroPayload payload = MokuroPayload(
       images: results.cast<MokuroImage>(),
-      ocr: const MangaOcrMetadata(
+      ocr: MangaOcrMetadata(
         engine: 'google_lens',
-        engineSignature: kGoogleLensEngineSignature,
+        engineSignature: googleLensEngineSignature(language),
         schemaVersion: 1,
       ),
     );
@@ -243,11 +248,15 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
     return output.path;
   }
 
-  Future<MokuroImage> _recognizePage(MangaOcrPageFile page) async {
+  Future<MokuroImage> _recognizePage(
+    MangaOcrPageFile page, {
+    required String language,
+  }) async {
     final Uint8List source = await page.file.readAsBytes();
     return recognizePageBytes(
       source,
       relativeUrl: page.relativeUrl,
+      language: language,
     );
   }
 
@@ -260,6 +269,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
   Future<MokuroImage> recognizePageBytes(
     Uint8List source, {
     required String relativeUrl,
+    required String language,
   }) async {
     final GoogleLensPreparedImage prepared =
         await Isolate.run<GoogleLensPreparedImage>(
@@ -269,6 +279,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
       imageData: prepared.data,
       width: prepared.width,
       height: prepared.height,
+      language: language,
     );
     final Uint8List response = await _transport.post(request);
     final List<GoogleLensParagraph> paragraphs;
@@ -276,6 +287,7 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
       // 归一化坐标与 rotation 都是相对**送检图**的，宽高比必须取 prepared 尺寸。
       paragraphs = GoogleLensProtocol.decodeResponse(
         response,
+        language: language,
         imageWidth: prepared.width,
         imageHeight: prepared.height,
       );
@@ -321,15 +333,16 @@ class GoogleLensMangaOcrService implements GoogleLensMangaOcrRunner {
 
   @override
   Future<void> clearCache(String imageDirPath) async {
-    final String path = p.join(
-      imageDirPath,
-      kMangaOcrOutDirName,
-      kMangaOcrPagesCacheDirName,
-      kGoogleLensEngineSignature,
+    // 签名带语言后缀，同一卷可能存在多种语言的 Lens 缓存目录，全部清掉。
+    final Directory root = Directory(
+      p.join(imageDirPath, kMangaOcrOutDirName, kMangaOcrPagesCacheDirName),
     );
-    final Directory directory = Directory(path);
-    if (directory.existsSync()) {
-      await directory.delete(recursive: true);
+    if (!root.existsSync()) return;
+    await for (final FileSystemEntity entry in root.list()) {
+      if (entry is Directory &&
+          p.basename(entry.path).startsWith(kGoogleLensEngineSignaturePrefix)) {
+        await entry.delete(recursive: true);
+      }
     }
   }
 
@@ -353,7 +366,8 @@ class GoogleLensPageCache {
     await directory.create(recursive: true);
     final Map<String, Object?> manifest = <String, Object?>{
       'schema_version': 1,
-      'engine_signature': kGoogleLensEngineSignature,
+      // 缓存目录名就是完整签名（前缀 + 语言），直接取目录名保证二者恒一致。
+      'engine_signature': p.basename(directory.path),
       'pages': <Map<String, Object?>>[
         for (final MangaOcrPageFile page in pages) _fingerprint(page),
       ],

--- a/fushi/lib/src/media/manga/ocr/google_lens_protocol.dart
+++ b/fushi/lib/src/media/manga/ocr/google_lens_protocol.dart
@@ -15,7 +15,46 @@ const int kGoogleLensMaximumImageDimension = 1500;
 const int kGoogleLensMaximumResponseBytes = 12 * 1024 * 1024;
 const int kGoogleLensMaximumCachedPageBytes = 32 * 1024 * 1024;
 const int kGoogleLensMaximumRegionsPerPage = 100000;
-const String kGoogleLensEngineSignature = 'google-lens-v2-niratan-ja';
+
+/// Lens 逐页缓存/产物签名的公共前缀；完整签名 = 前缀 + 识别语言
+/// （[googleLensEngineSignature]）。语言进签名是缓存正确性的一部分：同一页
+/// 用 `ja` 和 `en` 识别的结果（normalize 规则、Lens 返回文本）都不同，混在
+/// 一个目录里会拿旧语言的缓存冒充新识别。`ja` 的完整签名与历史常量
+/// `google-lens-v2-niratan-ja` 逐字节相同，旧缓存无需迁移。
+const String kGoogleLensEngineSignaturePrefix = 'google-lens-v2-niratan-';
+
+String googleLensEngineSignature(String language) =>
+    '$kGoogleLensEngineSignaturePrefix$language';
+
+/// Google Lens 识别语言的可选项：`(主子标签, 语言自称名)`。自称名不进 i18n
+/// （各语言都用本族名显示，与浏览器语言选择器同惯例）。向导与设置页共用此表，
+/// 避免两处漂移。
+const List<(String, String)> kGoogleLensLanguageOptions = <(String, String)>[
+  ('ja', '日本語'),
+  ('en', 'English'),
+  ('zh', '中文'),
+  ('ko', '한국어'),
+  ('es', 'Español'),
+  ('fr', 'Français'),
+  ('de', 'Deutsch'),
+  ('it', 'Italiano'),
+  ('pt', 'Português'),
+  ('ru', 'Русский'),
+  ('id', 'Bahasa Indonesia'),
+  ('ar', 'العربية'),
+];
+
+/// 把外部语言标签（Mihon `en`/`pt-BR`、Aidoku `zh-hans`、BCP-47 等）压成
+/// Lens LocaleContext 用的主子标签；空/`multi` 等非语言值回退 [fallback]。
+String normalizeLensLanguage(String? raw, {String fallback = 'ja'}) {
+  final String trimmed = raw?.trim().toLowerCase() ?? '';
+  if (trimmed.isEmpty) return fallback;
+  final String primary = trimmed.split(RegExp(r'[-_]')).first;
+  final bool looksLikeLanguage = RegExp(r'^[a-z]{2,3}$').hasMatch(primary) &&
+      primary != 'all' &&
+      primary != 'mul';
+  return looksLikeLanguage ? primary : fallback;
+}
 
 /// Chromium Lens overlay protobuf 的字段号真值表（BUG-1163 配套）。
 ///
@@ -226,7 +265,7 @@ class GoogleLensProtocol {
     required Uint8List imageData,
     required int width,
     required int height,
-    String language = 'ja',
+    required String language,
     int? requestId,
   }) {
     final int resolvedRequestId = requestId ?? _randomRequestId();
@@ -279,7 +318,7 @@ class GoogleLensProtocol {
   /// 正方形页上成立。漫画页恒是竖长图，必须带着宽高比还原（BUG-1172）。
   static List<GoogleLensParagraph> decodeResponse(
     Uint8List data, {
-    String language = 'ja',
+    required String language,
     required int imageWidth,
     required int imageHeight,
   }) {

--- a/fushi/lib/src/media/manga/ocr/manga_ocr_cache_recovery.dart
+++ b/fushi/lib/src/media/manga/ocr/manga_ocr_cache_recovery.dart
@@ -52,8 +52,17 @@ Future<MangaOcrCacheRecovery> recoverCachedMangaOcr({
       await resolveInstalledLocalMangaOcrEngineSignature();
   final Directory localDirectory =
       Directory(p.join(cacheRoot.path, localSignature));
-  final Directory lensDirectory =
-      Directory(p.join(cacheRoot.path, kGoogleLensEngineSignature));
+  // Lens 签名带语言后缀（`google-lens-v2-niratan-<lang>`），同一卷可能有多个
+  // 语言的缓存目录并存；全部纳入候选，逐页按文件时间取最新。
+  final List<Directory> lensDirectories = cacheRoot.existsSync()
+      ? cacheRoot
+          .listSync()
+          .whereType<Directory>()
+          .where((Directory directory) => p
+              .basename(directory.path)
+              .startsWith(kGoogleLensEngineSignaturePrefix))
+          .toList(growable: false)
+      : const <Directory>[];
   final MangaOcrFilePageCache localCache = MangaOcrFilePageCache(
     cacheDir: localDirectory,
     pageNames: <String>[
@@ -63,7 +72,10 @@ Future<MangaOcrCacheRecovery> recoverCachedMangaOcr({
       for (final MangaOcrPageFile page in pages) page.file,
     ],
   );
-  final GoogleLensPageCache lensCache = GoogleLensPageCache(lensDirectory);
+  final List<GoogleLensPageCache> lensCaches = <GoogleLensPageCache>[
+    for (final Directory directory in lensDirectories)
+      GoogleLensPageCache(directory),
+  ];
 
   final List<MokuroImage> images = List<MokuroImage>.of(basePayload.images);
   final Map<String, int> payloadIndexByUrl = <String, int>{
@@ -80,33 +92,39 @@ Future<MangaOcrCacheRecovery> recoverCachedMangaOcr({
     }
 
     final OcrPageResult? local = await localCache.read('manga_ocr', pageIndex);
-    final MokuroImage? lens = await lensCache.read(pageIndex, pages[pageIndex]);
-    if (local == null && lens == null) {
-      continue;
-    }
-
-    MokuroImage selected;
-    if (local != null && lens != null) {
+    // 候选统一成 (mtime, page) 再取最新，本地/各语言 Lens 缓存无特殊分支。
+    final List<(DateTime, MokuroImage)> candidates =
+        <(DateTime, MokuroImage)>[];
+    if (local != null) {
       final File localFile = File(p.join(
         localDirectory.path,
         ocrPageCacheFileName(pages[pageIndex].relativeUrl),
       ));
+      candidates.add((
+        (await localFile.stat()).modified,
+        _localPage(pages[pageIndex], local),
+      ));
+    }
+    for (final GoogleLensPageCache lensCache in lensCaches) {
+      final MokuroImage? lens =
+          await lensCache.read(pageIndex, pages[pageIndex]);
+      if (lens == null) continue;
       final File lensFile = File(p.join(
-        lensDirectory.path,
+        lensCache.directory.path,
         '${pageIndex.toString().padLeft(6, '0')}.json',
       ));
-      final DateTime localModified = (await localFile.stat()).modified;
-      final DateTime lensModified = (await lensFile.stat()).modified;
-      selected = !localModified.isBefore(lensModified)
-          ? _localPage(pages[pageIndex], local)
-          : lens;
-    } else if (local != null) {
-      selected = _localPage(pages[pageIndex], local);
-    } else {
-      selected = lens!;
+      candidates.add(((await lensFile.stat()).modified, lens));
+    }
+    if (candidates.isEmpty) {
+      continue;
+    }
+    // 严格更新才换人：mtime 打平时保留先入队者（本地缓存在前，维持旧行为）。
+    (DateTime, MokuroImage) newest = candidates.first;
+    for (final (DateTime, MokuroImage) candidate in candidates.skip(1)) {
+      if (candidate.$1.isAfter(newest.$1)) newest = candidate;
     }
 
-    images[payloadIndex] = selected;
+    images[payloadIndex] = newest.$2;
     recovered.add(payloadIndex);
   }
 

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -37,6 +37,7 @@ import 'package:fushi/src/media/manga/mihon/mihon_online_ocr.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_reader_chapter.dart';
 import 'package:fushi/src/media/manga/mokuro_payload.dart';
 import 'package:fushi/src/media/manga/ocr/google_lens_disclosure.dart';
+import 'package:fushi/src/media/manga/ocr/google_lens_protocol.dart';
 import 'package:fushi/src/media/manga/ocr/manga_box_rescan.dart';
 import 'package:fushi/src/media/manga/ocr/manga_ocr_engine.dart';
 import 'package:fushi/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
@@ -2205,6 +2206,12 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
             managedDirectory: online.managedDirectory,
             initialPayload: payload,
             startPage: _currentPage,
+            // 在线源自带内容语言（Mihon lang / Aidoku 单语言 manifest）；多语言
+            // 或未声明时回退用户的 Lens 语言偏好。
+            language: normalizeLensLanguage(
+              online.sourceLanguage,
+              fallback: appModel.mangaOcrLensLanguage,
+            ),
           ).run(),
         );
       } else {

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6432,6 +6432,10 @@ class AppModel with ChangeNotifier {
   Future<void> setMangaOcrEnginePreference(String value) =>
       prefsRepo.setMangaOcrEnginePreference(value);
 
+  String get mangaOcrLensLanguage => prefsRepo.mangaOcrLensLanguage;
+  Future<void> setMangaOcrLensLanguage(String value) =>
+      prefsRepo.setMangaOcrLensLanguage(value);
+
   String get mangaSpreadPreference => prefsRepo.mangaSpreadPreference;
   Future<void> setMangaSpreadPreference(String value) =>
       prefsRepo.setMangaSpreadPreference(value);

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -2025,6 +2025,17 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Google Lens 整卷 OCR 的识别语言（本地书/无源语言时的兜底）。在线阅读的
+  /// Lens OCR 优先用源自身声明的语言，本偏好只在源语言未知时回退。存主子标签
+  /// （`ja`/`en`/`zh`…），进请求前统一过 normalizeLensLanguage。
+  String get mangaOcrLensLanguage =>
+      getPref('manga_ocr_lens_language', defaultValue: 'ja') as String;
+
+  Future<void> setMangaOcrLensLanguage(String value) async {
+    await setPref('manga_ocr_lens_language', value);
+    notifyListeners();
+  }
+
   String get mangaSpreadPreference =>
       getPref('manga_spread_preference', defaultValue: 'auto') as String;
 

--- a/fushi/lib/src/settings/settings_schema_manga_ocr.dart
+++ b/fushi/lib/src/settings/settings_schema_manga_ocr.dart
@@ -27,6 +27,8 @@ SettingsSection buildMangaOcrSection() {
           service: c.ref.read(mangaOcrServiceProvider),
           enginePreferenceGetter: () => c.appModel.mangaOcrEnginePreference,
           enginePreferenceSetter: c.appModel.setMangaOcrEnginePreference,
+          lensLanguageGetter: () => c.appModel.mangaOcrLensLanguage,
+          lensLanguageSetter: c.appModel.setMangaOcrLensLanguage,
         ),
       ),
       // 漫画「在线目录」站点根 URL（O1 mokuro.moe 目录源）。空串/尾斜杠由

--- a/fushi/test/media/manga/aidoku_reader_chapter_test.dart
+++ b/fushi/test/media/manga/aidoku_reader_chapter_test.dart
@@ -126,5 +126,31 @@ void main() {
     expect(chapter.author, 'Author');
     expect(chapter.pageCount, 1);
     expect(chapter.pageIdentities.single, hasLength(64));
+    // Single-language manifest exposes its language for Lens OCR.
+    expect(chapter.sourceLanguage, 'ja');
+  });
+
+  test('Aidoku multi-language manifest reports null source language', () {
+    final AidokuReaderChapter chapter = AidokuReaderChapter(
+      package: AidokuInstalledPackage(
+        id: 'multi.fixture',
+        name: 'Fixture',
+        version: 1,
+        languages: const <String>['en', 'ja'],
+        requiresWebView: false,
+        packagePath: '/tmp/fixture.aix',
+        installedAt: DateTime.utc(2026),
+      ),
+      manga: const <String, Object?>{'key': '/manga/', 'title': 'Fixture'},
+      chapter: const <String, Object?>{'key': '/chapter/1/'},
+      pages: <AidokuImagePage>[
+        AidokuImagePage.fromJson(const <String, Object?>{
+          'content': <String, Object?>{
+            'Url': <Object?>['https://cdn.example/page.jpg', null],
+          },
+        }),
+      ],
+    );
+    expect(chapter.sourceLanguage, isNull);
   });
 }

--- a/fushi/test/media/manga/manga_ocr_cache_recovery_test.dart
+++ b/fushi/test/media/manga/manga_ocr_cache_recovery_test.dart
@@ -117,6 +117,28 @@ void main() {
     expect(sameModel.recoveredPageIndices, <int>[0]);
     expect(sameModel.payload.images[0].blocks.single.lines, <String>['旧模型']);
   });
+
+  test('recovers pages cached by a non-Japanese Lens run', () async {
+    final GoogleLensPageCache lens = _lensCache(temporary, language: 'en');
+    await lens.write(0, pages[0], _page(pages[0].relativeUrl, 'Hello world'));
+
+    final MokuroPayload formal = MokuroPayload(images: <MokuroImage>[
+      _page(pages[0].relativeUrl, ''),
+      _page(pages[1].relativeUrl, ''),
+      _page(pages[2].relativeUrl, '正式'),
+    ]);
+    final MangaOcrCacheRecovery recovery = await recoverCachedMangaOcr(
+      managedDirectory: temporary.path,
+      basePayload: formal,
+      localEngineSignature: kLocalMangaOcrEngineSignature,
+    );
+
+    expect(recovery.recoveredPageIndices, <int>[0]);
+    expect(
+      recovery.payload.images.first.blocks.single.lines.single,
+      'Hello world',
+    );
+  });
 }
 
 MangaOcrFilePageCache _localCache(
@@ -135,12 +157,13 @@ MangaOcrFilePageCache _localCache(
       pageFiles: <File>[for (final page in pages) page.file],
     );
 
-GoogleLensPageCache _lensCache(Directory root) => GoogleLensPageCache(
+GoogleLensPageCache _lensCache(Directory root, {String language = 'ja'}) =>
+    GoogleLensPageCache(
       Directory(p.join(
         root.path,
         kMangaOcrOutDirName,
         kMangaOcrPagesCacheDirName,
-        kGoogleLensEngineSignature,
+        googleLensEngineSignature(language),
       )),
     );
 

--- a/fushi/test/media/manga/manga_ocr_settings_section_ui_test.dart
+++ b/fushi/test/media/manga/manga_ocr_settings_section_ui_test.dart
@@ -80,6 +80,42 @@ void main() {
         findsOneWidget);
   });
 
+  testWidgets('lens language dropdown persists the chosen language',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(ready: true);
+    String stored = 'ja';
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+      lensLanguageGetter: () => stored,
+      lensLanguageSetter: (String value) async => stored = value,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_ocr_lens_language_label), findsOneWidget);
+    await tester
+        .tap(find.byKey(const ValueKey<String>('manga_ocr_lens_language')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('English').last);
+    await tester.pumpAndSettle();
+    expect(stored, 'en');
+  });
+
+  testWidgets('lens language dropdown is absent without a language setter',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(ready: true);
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+    )));
+    await tester.pumpAndSettle();
+    expect(find.text(t.manga_ocr_lens_language_label), findsNothing);
+  });
+
   testWidgets('detect external shows probed version',
       (WidgetTester tester) async {
     final _FakeOcrService service = _FakeOcrService(ready: true);

--- a/fushi/test/media/manga/manga_ocr_wizard_lens_test.dart
+++ b/fushi/test/media/manga/manga_ocr_wizard_lens_test.dart
@@ -41,6 +41,7 @@ class _UnavailableLocalService implements MangaOcrService {
 
 class _FakeLensRunner implements GoogleLensMangaOcrRunner {
   int requests = 0;
+  String? lastLanguage;
 
   @override
   Future<void> clearCache(String imageDirPath) async {}
@@ -51,8 +52,10 @@ class _FakeLensRunner implements GoogleLensMangaOcrRunner {
     String? volumeTitle,
     int startPage = 0,
     bool onlyMissing = true,
+    String language = 'ja',
   }) {
     requests += 1;
+    lastLanguage = language;
     return const Stream<MangaOcrVolumeEvent>.empty();
   }
 }

--- a/fushi/test/media/manga/manga_ocr_wizard_remote_test.dart
+++ b/fushi/test/media/manga/manga_ocr_wizard_remote_test.dart
@@ -89,6 +89,7 @@ class _NoopLensRunner implements GoogleLensMangaOcrRunner {
     String? volumeTitle,
     int startPage = 0,
     bool onlyMissing = false,
+    String language = 'ja',
   }) =>
       const Stream<MangaOcrVolumeEvent>.empty();
 

--- a/fushi/test/media/manga/mihon_online_ocr_test.dart
+++ b/fushi/test/media/manga/mihon_online_ocr_test.dart
@@ -61,6 +61,7 @@ void main() {
       managedDirectory: managed,
       initialPayload: initial,
       startPage: 1,
+      language: 'ja',
       lens: GoogleLensMangaOcrService(transport: transport),
     ).run().toList();
 
@@ -84,6 +85,7 @@ void main() {
       managedDirectory: managed,
       initialPayload: initial,
       startPage: 2,
+      language: 'ja',
       lens: GoogleLensMangaOcrService(transport: transport),
     ).run().toList();
 

--- a/fushi/test/media/manga/ocr/google_lens_ocr_service_test.dart
+++ b/fushi/test/media/manga/ocr/google_lens_ocr_service_test.dart
@@ -49,7 +49,7 @@ void main() {
     final GoogleLensMangaOcrService service =
         GoogleLensMangaOcrService(transport: transport);
     final List<MangaOcrVolumeEvent> events = await service
-        .ocrFolder(imageDirPath: root.path, onlyMissing: false)
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
         .toList();
 
     expect(transport.requests, 2);
@@ -57,7 +57,7 @@ void main() {
     final MokuroPayload payload =
         parseMangaJson(File(events.last.mangaJsonPath!).readAsStringSync());
     expect(payload.ocr?.engine, 'google_lens');
-    expect(payload.ocr?.engineSignature, kGoogleLensEngineSignature);
+    expect(payload.ocr?.engineSignature, googleLensEngineSignature('ja'));
     expect(payload.images, hasLength(2));
     expect(payload.images.first.blocks.single.lines.single, '日本');
     expect(payload.images.first.blocks.single.regions, hasLength(2));
@@ -66,13 +66,13 @@ void main() {
   test('page cache resumes without another network request', () async {
     final _FakeTransport first = _FakeTransport(makeGoogleLensFixture());
     await GoogleLensMangaOcrService(transport: first)
-        .ocrFolder(imageDirPath: root.path, onlyMissing: false)
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
         .drain<void>();
     expect(first.requests, 2);
 
     final _FakeTransport second = _FakeTransport(makeGoogleLensFixture());
     await GoogleLensMangaOcrService(transport: second)
-        .ocrFolder(imageDirPath: root.path, onlyMissing: false)
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
         .drain<void>();
     expect(second.requests, 0);
   });
@@ -84,7 +84,7 @@ void main() {
       root.path,
       kMangaOcrOutDirName,
       kMangaOcrPagesCacheDirName,
-      kGoogleLensEngineSignature,
+      googleLensEngineSignature('ja'),
     ));
     final GoogleLensPageCache writer = GoogleLensPageCache(directory);
     await writer.write(
@@ -135,7 +135,9 @@ void main() {
   test('source change invalidates only that Lens page', () async {
     await GoogleLensMangaOcrService(
       transport: _FakeTransport(makeGoogleLensFixture()),
-    ).ocrFolder(imageDirPath: root.path, onlyMissing: false).drain<void>();
+    )
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
+        .drain<void>();
     await Future<void>.delayed(const Duration(milliseconds: 2));
     File(p.join(root.path, 'p2.png')).writeAsBytesSync(
       img.encodePng(img.Image(width: 222, height: 200)),
@@ -144,7 +146,7 @@ void main() {
 
     final _FakeTransport transport = _FakeTransport(makeGoogleLensFixture());
     await GoogleLensMangaOcrService(transport: transport)
-        .ocrFolder(imageDirPath: root.path, onlyMissing: false)
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
         .drain<void>();
     expect(transport.requests, 1);
   });
@@ -159,6 +161,7 @@ void main() {
           imageDirPath: root.path,
           startPage: 1,
           onlyMissing: false,
+          language: 'ja',
         )
         .toList();
     progress.addAll(
@@ -167,5 +170,59 @@ void main() {
           ),
     );
     expect(progress, <int>[1, 2]);
+  });
+
+  test('per-language cache dirs are independent and clearCache removes all',
+      () async {
+    final _FakeTransport ja = _FakeTransport(makeGoogleLensFixture());
+    final GoogleLensMangaOcrService service =
+        GoogleLensMangaOcrService(transport: ja);
+    await service
+        .ocrFolder(imageDirPath: root.path, onlyMissing: false, language: 'ja')
+        .drain<void>();
+    expect(ja.requests, 2);
+
+    // Same volume in another language must not reuse the ja page cache.
+    final _FakeTransport en = _FakeTransport(makeGoogleLensFixture());
+    final List<MangaOcrVolumeEvent> events =
+        await GoogleLensMangaOcrService(transport: en)
+            .ocrFolder(
+              imageDirPath: root.path,
+              onlyMissing: false,
+              language: 'en',
+            )
+            .toList();
+    expect(en.requests, 2);
+    final MokuroPayload payload =
+        parseMangaJson(File(events.last.mangaJsonPath!).readAsStringSync());
+    expect(payload.ocr?.engineSignature, googleLensEngineSignature('en'));
+
+    final Directory cacheRoot = Directory(p.join(
+      root.path,
+      kMangaOcrOutDirName,
+      kMangaOcrPagesCacheDirName,
+    ));
+    expect(
+      Directory(p.join(cacheRoot.path, googleLensEngineSignature('ja')))
+          .existsSync(),
+      isTrue,
+    );
+    expect(
+      Directory(p.join(cacheRoot.path, googleLensEngineSignature('en')))
+          .existsSync(),
+      isTrue,
+    );
+
+    await service.clearCache(root.path);
+    expect(
+      Directory(p.join(cacheRoot.path, googleLensEngineSignature('ja')))
+          .existsSync(),
+      isFalse,
+    );
+    expect(
+      Directory(p.join(cacheRoot.path, googleLensEngineSignature('en')))
+          .existsSync(),
+      isFalse,
+    );
   });
 }

--- a/fushi/test/media/manga/ocr/google_lens_protocol_test.dart
+++ b/fushi/test/media/manga/ocr/google_lens_protocol_test.dart
@@ -26,6 +26,7 @@ void main() {
       imageData: Uint8List.fromList(<int>[9, 8, 7, 6]),
       width: 320,
       height: 240,
+      language: 'ja',
       requestId: 42,
     );
     expect(_containsBytes(request, <int>[9, 8, 7, 6]), isTrue);
@@ -35,6 +36,7 @@ void main() {
   test('decodes line text, removes CJK spaces and records UTF-16 regions', () {
     final List<GoogleLensParagraph> result = GoogleLensProtocol.decodeResponse(
       makeGoogleLensFixture(),
+      language: 'ja',
       imageWidth: 1000,
       imageHeight: 1000,
     );
@@ -59,6 +61,7 @@ void main() {
         height: 0.4,
         rotation: 1.57079632679,
       ),
+      language: 'ja',
       imageWidth: 1000,
       imageHeight: 1000,
     );
@@ -83,6 +86,7 @@ void main() {
         secondLineText: '下',
         secondLineCenterY: 0.7,
       ),
+      language: 'ja',
       imageWidth: 1000,
       imageHeight: 1000,
     );
@@ -97,6 +101,7 @@ void main() {
     expect(
       () => GoogleLensProtocol.decodeResponse(
         Uint8List.fromList(<int>[0x12, 0xff, 0xff]),
+        language: 'ja',
         imageWidth: 1000,
         imageHeight: 1000,
       ),
@@ -121,6 +126,7 @@ void main() {
         height: lineHeight,
         rotation: rotation,
       ),
+      language: 'ja',
       imageWidth: pageWidth,
       imageHeight: pageHeight,
     );
@@ -157,6 +163,7 @@ void main() {
         height: 0.08,
         rotation: -math.pi / 2,
       ),
+      language: 'ja',
       imageWidth: 1200,
       imageHeight: 1700,
     );
@@ -180,6 +187,7 @@ void main() {
         height: lineHeight,
         rotation: math.pi / 2,
       ),
+      language: 'ja',
       imageWidth: pageWidth,
       imageHeight: pageHeight,
     );
@@ -188,6 +196,50 @@ void main() {
     expect(bounds.width * pageWidth, closeTo(lineHeight * pageHeight, 0.5));
     // 行的像素高 = 未旋转时的像素宽（lineWidth * 页宽）。
     expect(bounds.height * pageHeight, closeTo(lineWidth * pageWidth, 0.5));
+  });
+
+  test('English decode keeps word spaces instead of CJK stripping', () {
+    final List<GoogleLensParagraph> result = GoogleLensProtocol.decodeResponse(
+      makeGoogleLensFixture(firstWord: 'Hello ', secondWord: 'world'),
+      language: 'en',
+      imageWidth: 1000,
+      imageHeight: 1000,
+    );
+    expect(result.single.sentence, 'Hello world');
+  });
+
+  test('request carries the requested locale language on the wire', () {
+    final Uint8List request = GoogleLensProtocol.makeRequest(
+      imageData: Uint8List.fromList(<int>[9, 8, 7, 6]),
+      width: 320,
+      height: 240,
+      language: 'en',
+      requestId: 42,
+    );
+    expect(_containsBytes(request, <int>[0x65, 0x6e]), isTrue);
+  });
+
+  test('engine signature appends the language to the shared prefix', () {
+    expect(googleLensEngineSignature('ja'), 'google-lens-v2-niratan-ja');
+    expect(googleLensEngineSignature('en'), 'google-lens-v2-niratan-en');
+    expect(
+      googleLensEngineSignature('ja'),
+      startsWith(kGoogleLensEngineSignaturePrefix),
+    );
+  });
+
+  test('normalizeLensLanguage keeps primary subtags and falls back otherwise',
+      () {
+    expect(normalizeLensLanguage('en'), 'en');
+    expect(normalizeLensLanguage('pt-BR'), 'pt');
+    expect(normalizeLensLanguage('zh_Hans'), 'zh');
+    expect(normalizeLensLanguage('EN'), 'en');
+    expect(normalizeLensLanguage(''), 'ja');
+    expect(normalizeLensLanguage(null), 'ja');
+    expect(normalizeLensLanguage('all'), 'ja');
+    expect(normalizeLensLanguage('multi'), 'ja');
+    expect(normalizeLensLanguage('42'), 'ja');
+    expect(normalizeLensLanguage(null, fallback: 'en'), 'en');
   });
 }
 

--- a/fushi/test/media/manga/ocr/google_lens_wire_contract_test.dart
+++ b/fushi/test/media/manga/ocr/google_lens_wire_contract_test.dart
@@ -157,6 +157,7 @@ void main() {
         imageData: Uint8List.fromList(<int>[1, 2, 3, 4]),
         width: 640,
         height: 480,
+        language: 'ja',
         requestId: 7,
       );
 


### PR DESCRIPTION
三个独立的漫画修复（用户报告 + 两张截图纠正了方向：漫画走 Android/Mihon）。

## 1. Google Lens OCR 识别语言（修硬编码日语）
`e9a1ac9d2` — 谷歌 OCR 之前把识别语言硬编码为 `ja`，英语等漫画识别全是乱码。
- 语言全链路贯穿为**必传** `language`（漏传编译不过，无静默日语后门）
- 缓存/产物签名带语言后缀（`google-lens-v2-niratan-<lang>`）防跨语言串味；`ja` 签名与旧常量逐字节一致，旧缓存无需迁移
- 在线源自动用声明语言（Mihon `source.lang` / 单语言 Aidoku manifest），未知/多语言回退新偏好 `mangaOcrLensLanguage`
- 识别语言下拉加到**向导 + 设置页**
- i18n `manga_ocr_lens_language_label`（17 语言）；测试覆盖：语言上线、per-language 缓存隔离 + clearCache、多语言缓存恢复、源语言映射、设置下拉持久化

## 2. Cloudflare 解挑战（MangaFire 等）
`03c98a082` — `CloudflareInterceptor` 原是空操作直通，CF 保护源永远过不了。现在用**离屏 WebView 同 UA 解挑战**，等 `cf_clearance` 落入共享 CookieManager 后重试；NetworkHelper 改用 WebView 默认 UA 保证 UA 一致。检测**必须带 `cf-mitigated: challenge` 头**，正常源的合法 403/503 不会误触发（零回归）。

## 3. Mihon 加载错误可诊断
`03c98a082` — 扩展实例化失败原来只报不透明的「无法安装」，根因被丢弃。LOAD_FAILED 现在附完整链式根因（如 `NoClassDefFoundError: <class>`），用户在自己设备上就能看到缺哪个类。

## 验证
- `flutter analyze` 全量零问题；OCR 定向测试 56 项全过
- `flutter build apk --debug` 两次编译通过（含收紧后的 CF 检测）
- **验证缺口**：CF 对 MangaFire 的端到端、LOAD_FAILED 真实根因捕获需真机——本机模拟器 NAT 无法走宿主 fake-ip 代理访问 GitHub/MangaFire，且共享模拟器 app 启动 flaky。LOAD_FAILED 改动本身即为让用户设备报出真实缺失类。

https://claude.ai/code/session_011TgJ9neZTkzTWvR6RxkyHu