### PR TITLE
feat(dictionary): 用户词典可视化编辑器

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58701 (3453 per locale)
+/// Strings: 58871 (3463 per locale)
 ///
-/// Built on 2026-08-16 at 12:44 UTC
+/// Built on 2026-08-16 at 16:17 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4680,6 +4680,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_content_language_description =>
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   String get manga_ocr_lens_language_label => 'Recognition language';
+  String get dict_user_title => 'User dictionary';
+  String get dict_user_entry_add => 'Add entry';
+  String get dict_user_entry_edit => 'Edit entry';
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  String get dict_user_field_expression => 'Headword';
+  String get dict_user_field_reading => 'Reading';
+  String get dict_user_field_meaning => 'Definition';
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -12663,6 +12675,28 @@ class _StringsAr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'لغة التعرّف';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -20713,6 +20747,28 @@ class _StringsDe extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Erkennungssprache';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -28779,6 +28835,28 @@ class _StringsEs extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconocimiento';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -36857,6 +36935,28 @@ class _StringsFr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Langue de reconnaissance';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -44863,6 +44963,28 @@ class _StringsId extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Bahasa pengenalan';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -52915,6 +53037,28 @@ class _StringsIt extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Lingua di riconoscimento';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -60781,6 +60925,28 @@ class _StringsJa extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '認識する言語';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -68654,6 +68820,28 @@ class _StringsKo extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '인식 언어';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -76686,6 +76874,28 @@ class _StringsNl extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Herkenningstaal';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -84730,6 +84940,28 @@ class _StringsPtBr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconhecimento';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -92760,6 +92992,28 @@ class _StringsRu extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Язык распознавания';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -100738,6 +100992,28 @@ class _StringsTh extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'ภาษาที่ใช้จดจำ';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -108747,6 +109023,28 @@ class _StringsTr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Tanıma dili';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -116741,6 +117039,28 @@ class _StringsVi extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Ngôn ngữ nhận dạng';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 // Path: <root>
@@ -124155,6 +124475,26 @@ class _StringsZhCn extends _StringsEn {
       '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
   @override
   String get manga_ocr_lens_language_label => '识别语言';
+  @override
+  String get dict_user_title => '用户词典';
+  @override
+  String get dict_user_entry_add => '添加词条';
+  @override
+  String get dict_user_entry_edit => '编辑词条';
+  @override
+  String get dict_user_entry_delete_confirm => '删除这条词条？';
+  @override
+  String get dict_user_field_expression => '词头';
+  @override
+  String get dict_user_field_reading => '读音';
+  @override
+  String get dict_user_field_meaning => '释义';
+  @override
+  String get dict_user_empty => '还没有词条，添加一条开始建立自己的词典。';
+  @override
+  String get dict_user_expression_required => '词头不能为空';
+  @override
+  String get dict_user_rebuild_failed => '用户词典重建失败';
 }
 
 // Path: <root>
@@ -131944,6 +132284,28 @@ class _StringsZhHk extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '識別語言';
+  @override
+  String get dict_user_title => 'User dictionary';
+  @override
+  String get dict_user_entry_add => 'Add entry';
+  @override
+  String get dict_user_entry_edit => 'Edit entry';
+  @override
+  String get dict_user_entry_delete_confirm => 'Delete this entry?';
+  @override
+  String get dict_user_field_expression => 'Headword';
+  @override
+  String get dict_user_field_reading => 'Reading';
+  @override
+  String get dict_user_field_meaning => 'Definition';
+  @override
+  String get dict_user_empty =>
+      'No entries yet. Add one to build your own dictionary.';
+  @override
+  String get dict_user_expression_required => 'Headword cannot be empty';
+  @override
+  String get dict_user_rebuild_failed =>
+      'Failed to rebuild the user dictionary';
 }
 
 /// Flat map(s) containing all translations.
@@ -139040,6 +139402,26 @@ extension on _StringsEn {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Recognition language';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -146134,6 +146516,26 @@ extension on _StringsAr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'لغة التعرّف';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -153250,6 +153652,26 @@ extension on _StringsDe {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Erkennungssprache';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -160365,6 +160787,26 @@ extension on _StringsEs {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconocimiento';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -167486,6 +167928,26 @@ extension on _StringsFr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Langue de reconnaissance';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -174589,6 +175051,26 @@ extension on _StringsId {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Bahasa pengenalan';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -181706,6 +182188,26 @@ extension on _StringsIt {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Lingua di riconoscimento';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -188785,6 +189287,26 @@ extension on _StringsJa {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '認識する言語';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -195868,6 +196390,26 @@ extension on _StringsKo {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '인식 언어';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -202979,6 +203521,26 @@ extension on _StringsNl {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Herkenningstaal';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -210087,6 +210649,26 @@ extension on _StringsPtBr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconhecimento';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -217200,6 +217782,26 @@ extension on _StringsRu {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Язык распознавания';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -224296,6 +224898,26 @@ extension on _StringsTh {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'ภาษาที่ใช้จดจำ';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -231401,6 +232023,26 @@ extension on _StringsTr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Tanıma dili';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -238502,6 +239144,26 @@ extension on _StringsVi {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Ngôn ngữ nhận dạng';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }
@@ -245544,6 +246206,26 @@ extension on _StringsZhCn {
         return '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
       case 'manga_ocr_lens_language_label':
         return '识别语言';
+      case 'dict_user_title':
+        return '用户词典';
+      case 'dict_user_entry_add':
+        return '添加词条';
+      case 'dict_user_entry_edit':
+        return '编辑词条';
+      case 'dict_user_entry_delete_confirm':
+        return '删除这条词条？';
+      case 'dict_user_field_expression':
+        return '词头';
+      case 'dict_user_field_reading':
+        return '读音';
+      case 'dict_user_field_meaning':
+        return '释义';
+      case 'dict_user_empty':
+        return '还没有词条，添加一条开始建立自己的词典。';
+      case 'dict_user_expression_required':
+        return '词头不能为空';
+      case 'dict_user_rebuild_failed':
+        return '用户词典重建失败';
       default:
         return null;
     }
@@ -252618,6 +253300,26 @@ extension on _StringsZhHk {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '識別語言';
+      case 'dict_user_title':
+        return 'User dictionary';
+      case 'dict_user_entry_add':
+        return 'Add entry';
+      case 'dict_user_entry_edit':
+        return 'Edit entry';
+      case 'dict_user_entry_delete_confirm':
+        return 'Delete this entry?';
+      case 'dict_user_field_expression':
+        return 'Headword';
+      case 'dict_user_field_reading':
+        return 'Reading';
+      case 'dict_user_field_meaning':
+        return 'Definition';
+      case 'dict_user_empty':
+        return 'No entries yet. Add one to build your own dictionary.';
+      case 'dict_user_expression_required':
+        return 'Headword cannot be empty';
+      case 'dict_user_rebuild_failed':
+        return 'Failed to rebuild the user dictionary';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Recognition language"
+  "manga_ocr_lens_language_label": "Recognition language",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "لغة التعرّف"
+  "manga_ocr_lens_language_label": "لغة التعرّف",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Erkennungssprache"
+  "manga_ocr_lens_language_label": "Erkennungssprache",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconocimiento"
+  "manga_ocr_lens_language_label": "Idioma de reconocimiento",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Langue de reconnaissance"
+  "manga_ocr_lens_language_label": "Langue de reconnaissance",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Bahasa pengenalan"
+  "manga_ocr_lens_language_label": "Bahasa pengenalan",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Lingua di riconoscimento"
+  "manga_ocr_lens_language_label": "Lingua di riconoscimento",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "認識する言語"
+  "manga_ocr_lens_language_label": "認識する言語",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "인식 언어"
+  "manga_ocr_lens_language_label": "인식 언어",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Herkenningstaal"
+  "manga_ocr_lens_language_label": "Herkenningstaal",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconhecimento"
+  "manga_ocr_lens_language_label": "Idioma de reconhecimento",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Язык распознавания"
+  "manga_ocr_lens_language_label": "Язык распознавания",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ"
+  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Tanıma dili"
+  "manga_ocr_lens_language_label": "Tanıma dili",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng"
+  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "默认内容语言",
   "settings_content_language_unset": "未设置",
   "settings_content_language_description": "内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。",
-  "manga_ocr_lens_language_label": "识别语言"
+  "manga_ocr_lens_language_label": "识别语言",
+  "dict_user_title": "用户词典",
+  "dict_user_entry_add": "添加词条",
+  "dict_user_entry_edit": "编辑词条",
+  "dict_user_entry_delete_confirm": "删除这条词条？",
+  "dict_user_field_expression": "词头",
+  "dict_user_field_reading": "读音",
+  "dict_user_field_meaning": "释义",
+  "dict_user_empty": "还没有词条，添加一条开始建立自己的词典。",
+  "dict_user_expression_required": "词头不能为空",
+  "dict_user_rebuild_failed": "用户词典重建失败"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3451,5 +3451,15 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "識別語言"
+  "manga_ocr_lens_language_label": "識別語言",
+  "dict_user_title": "User dictionary",
+  "dict_user_entry_add": "Add entry",
+  "dict_user_entry_edit": "Edit entry",
+  "dict_user_entry_delete_confirm": "Delete this entry?",
+  "dict_user_field_expression": "Headword",
+  "dict_user_field_reading": "Reading",
+  "dict_user_field_meaning": "Definition",
+  "dict_user_empty": "No entries yet. Add one to build your own dictionary.",
+  "dict_user_expression_required": "Headword cannot be empty",
+  "dict_user_rebuild_failed": "Failed to rebuild the user dictionary"
 }

--- a/fushi/lib/pages.dart
+++ b/fushi/lib/pages.dart
@@ -18,6 +18,7 @@ export 'src/pages/implementations/downloads_page.dart';
 export 'src/pages/implementations/browser_extension_page.dart';
 export 'src/pages/implementations/home_page.dart';
 export 'src/pages/implementations/text_segmentation_dialog_page.dart';
+export 'src/pages/implementations/user_dictionary_editor_page.dart';
 export 'src/pages/implementations/reader_fushi_page.dart';
 export 'src/pages/implementations/reader_fushi_history_page.dart';
 export 'src/pages/implementations/reader_pdf_page.dart';

--- a/fushi/lib/src/dictionary/user_dictionary_store.dart
+++ b/fushi/lib/src/dictionary/user_dictionary_store.dart
@@ -1,0 +1,134 @@
+/// 用户词典（可视化编辑）的领域逻辑。
+///
+/// 数据结构决定一切：已导入词典是只读二进制（blobs.bin + 定容哈希表，mmap
+/// 只读），不存在「就地改一条」的写路径。所以用户词典的真相源是偏好里的一份
+/// 词条列表（[userDictionaryEntriesPrefKey]，JSON），可视化编辑器改的是这份
+/// 列表；每次保存后把整份列表编译成标准 Yomitan zip，走**现有导入链**
+/// （`AppModel.importDictionary` + `forceReplaceExisting`）整部重建并重挂。
+/// 词典目录只是编译产物——编辑、备份、同步都只面对词条列表，二进制格式的
+/// 特殊情况在这一层整个消失。
+///
+/// 词条 `rules` 恒为空串：用户手写的词头不参与去屈折规则匹配（`*` 会让
+/// BUG-729 的活用误命中形状重现），查得到的就是用户写下的原形。
+library;
+
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+
+/// 用户词典在引擎/词典列表里的固定标题（同时是磁盘目录名与 Drift 元数据主
+/// 键）。身份必须跨语言稳定，故为常量而非 i18n 文案；编辑器页标题才走 i18n。
+const String userDictionaryTitle = 'User Dictionary';
+
+/// 偏好键：用户词典词条列表（JSON 数组）。
+const String userDictionaryEntriesPrefKey = 'user_dictionary_entries';
+
+/// 一条用户词典词条。不可变；编辑 = 整条替换（列表按下标寻址，无独立 id——
+/// 词条没有跨会话身份诉求，下标就够，引入 id 只会造出同步/去重特殊情况）。
+class UserDictionaryEntry {
+  const UserDictionaryEntry({
+    required this.expression,
+    this.reading = '',
+    this.meaning = '',
+  });
+
+  factory UserDictionaryEntry.fromJson(Map<String, dynamic> json) {
+    return UserDictionaryEntry(
+      expression: (json['expression'] ?? '').toString(),
+      reading: (json['reading'] ?? '').toString(),
+      meaning: (json['meaning'] ?? '').toString(),
+    );
+  }
+
+  /// 词头。
+  final String expression;
+
+  /// 读音（可空；空串在 Yomitan 语义下等同「与词头一致/无读音」）。
+  final String reading;
+
+  /// 释义。多行文本；编译时按行拆成 glossary 列表逐行渲染。
+  final String meaning;
+
+  Map<String, String> toJson() => <String, String>{
+        'expression': expression,
+        'reading': reading,
+        'meaning': meaning,
+      };
+}
+
+/// 从偏好原始串解码词条列表。空串/坏 JSON/形状不对一律回空列表（与
+/// `customDictCSS` 同款容错——坏数据不该把编辑器炸掉，用户重新保存即自愈）。
+List<UserDictionaryEntry> decodeUserDictionaryEntries(String raw) {
+  if (raw.isEmpty) return <UserDictionaryEntry>[];
+  try {
+    final Object? decoded = jsonDecode(raw);
+    if (decoded is! List) return <UserDictionaryEntry>[];
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(UserDictionaryEntry.fromJson)
+        .where((UserDictionaryEntry e) => e.expression.isNotEmpty)
+        .toList();
+  } on FormatException {
+    return <UserDictionaryEntry>[];
+  }
+}
+
+/// 编码词条列表为偏好原始串。空列表编码为空串（保持「从未用过」与「清空了」
+/// 在偏好层同形，不留空数组残骸）。
+String encodeUserDictionaryEntries(List<UserDictionaryEntry> entries) {
+  if (entries.isEmpty) return '';
+  return jsonEncode(
+    entries.map((UserDictionaryEntry e) => e.toJson()).toList(),
+  );
+}
+
+/// 释义多行文本 → Yomitan glossary 行列表。空白行剔除；全空时回退整段原文，
+/// 保证词条只要存在就至少有一条 glossary（native 导入器对空 glossary 词条的
+/// 行为不属于我们该依赖的契约）。
+List<String> userDictionaryGlossaryLines(String meaning) {
+  final List<String> lines = meaning
+      .split('\n')
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty)
+      .toList();
+  if (lines.isEmpty) return <String>[meaning];
+  return lines;
+}
+
+/// 把整份词条列表编译成标准 Yomitan 词典 zip（index.json + term_bank_1.json）。
+///
+/// 输出喂给现有导入链（与文件导入按钮完全同源），native 侧格式探测、标题清洗、
+/// 路径校验、发布、元数据持久化全部复用，不新增任何 native 写路径。
+List<int> buildUserDictionaryZipBytes({
+  required List<UserDictionaryEntry> entries,
+  required String revision,
+}) {
+  final Map<String, Object> index = <String, Object>{
+    'title': userDictionaryTitle,
+    'format': 3,
+    'revision': revision,
+    'sequenced': false,
+  };
+  final List<List<Object>> terms = <List<Object>>[
+    for (int i = 0; i < entries.length; i++)
+      <Object>[
+        entries[i].expression,
+        entries[i].reading,
+        '', // definitionTags
+        '', // rules：空 = 不参与去屈折（见库注释）
+        0, // score
+        userDictionaryGlossaryLines(entries[i].meaning),
+        i, // sequence
+        '', // termTags
+      ],
+  ];
+  final Archive archive = Archive()
+    ..addFile(_jsonArchiveFile('index.json', index))
+    ..addFile(_jsonArchiveFile('term_bank_1.json', terms));
+  return ZipEncoder().encode(archive)!;
+}
+
+ArchiveFile _jsonArchiveFile(String name, Object json) {
+  final List<int> bytes = utf8.encode(jsonEncode(json));
+  return ArchiveFile(name, bytes.length, bytes);
+}

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -40,6 +40,7 @@ import 'package:fushi/src/media/floating_dict_channel.dart';
 import 'package:fushi/src/models/app_font_loader.dart';
 import 'package:fushi/src/models/app_ui_font_chain.dart';
 import 'package:fushi/src/models/builtin_tags.dart';
+import 'package:fushi/src/dictionary/user_dictionary_store.dart';
 import 'package:fushi/src/epub/book_title_conflict.dart';
 import 'package:fushi/src/epub/epub_importer.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
@@ -4200,6 +4201,65 @@ class AppModel with ChangeNotifier {
       // 与 delete / reorder 路径对称（BUG-355）。放 finally：覆盖导入失败时旧词典可能
       // 已被删掉，那种半状态同样必须让 UI 重查，不能停在更旧的结果上。
       dictionarySearchAgainNotifier.notifyListeners();
+    }
+  }
+
+  // ── user dictionary (visual editor) ─────────────────────────────────
+
+  /// 用户词典词条列表（真相源：偏好 [userDictionaryEntriesPrefKey]）。
+  List<UserDictionaryEntry> get userDictionaryEntries =>
+      decodeUserDictionaryEntries(
+        prefsRepo.getPref(userDictionaryEntriesPrefKey, defaultValue: '')
+            as String,
+      );
+
+  /// 保存用户词条列表并重建挂载「User Dictionary」。
+  ///
+  /// 先落偏好（真相源永远先写，重建失败也不丢数据），再把整份列表编译成
+  /// Yomitan zip 走现有导入链整部重建（`forceReplaceExisting` = 同名替换并
+  /// 保留 order/hidden/collapsed）。清空到零条 = 删除该词典（走既有删除路径，
+  /// 引擎重载/缓存失效/同步删除传播全复用）。
+  Future<void> saveUserDictionaryEntries(
+    List<UserDictionaryEntry> entries,
+  ) async {
+    await prefsRepo.setPref(
+      userDictionaryEntriesPrefKey,
+      encodeUserDictionaryEntries(entries),
+    );
+
+    final List<Dictionary> existing = dictionaries
+        .where((Dictionary d) => d.name == userDictionaryTitle)
+        .toList();
+    if (entries.isEmpty) {
+      if (existing.isNotEmpty) {
+        await deleteDictionary(existing.first);
+      }
+      return;
+    }
+
+    // 与下载/自动更新共用 `<资源目录>/import_temp`（BUG-1500 的并发形状）。
+    // 忙时不硬闯：抛给编辑器提示稍后重存——偏好已落盘，下次保存自愈。
+    if (dictionaryDownloadController.isBusy) {
+      throw StateError('dictionary download in progress');
+    }
+
+    final List<int> zipBytes = buildUserDictionaryZipBytes(
+      entries: entries,
+      revision: 'user-${DateTime.now().millisecondsSinceEpoch}',
+    );
+    final File tempZip = File(
+      path.join(dictionaryResourceDirectory.path, 'user_dict_rebuild.zip'),
+    );
+    await tempZip.writeAsBytes(zipBytes, flush: true);
+    try {
+      await importDictionary(
+        file: tempZip,
+        progressNotifier: ValueNotifier<String>(''),
+        onImportSuccess: () {},
+        forceReplaceExisting: true,
+      );
+    } finally {
+      if (tempZip.existsSync()) tempZip.deleteSync();
     }
   }
 

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -268,6 +268,12 @@ class _DictionaryDialogPageState extends BasePageState {
             onTap: _importDictionaryFiles,
           ),
           _buildActionButton(
+            focusPrefix: 'dict-action-user-dict',
+            icon: Icons.edit_note_outlined,
+            label: t.dict_user_title,
+            onTap: _openUserDictionaryEditor,
+          ),
+          _buildActionButton(
             focusPrefix: 'dict-action-clear',
             icon: Icons.delete_sweep_outlined,
             label: t.dialog_clear_all_dictionaries,
@@ -329,6 +335,11 @@ class _DictionaryDialogPageState extends BasePageState {
         onTap: _importDictionaryFiles,
       ),
       FushiIconButton(
+        tooltip: t.dict_user_title,
+        icon: Icons.edit_note_outlined,
+        onTap: _openUserDictionaryEditor,
+      ),
+      FushiIconButton(
         tooltip: t.dialog_clear_all_dictionaries,
         icon: Icons.delete_sweep_outlined,
         enabledColor: theme.colorScheme.error,
@@ -359,6 +370,11 @@ class _DictionaryDialogPageState extends BasePageState {
             label: t.dialog_import_dictionary,
             icon: Icons.upload_file_outlined,
             action: _importDictionaryFiles,
+          ),
+          buildPopupItem(
+            label: t.dict_user_title,
+            icon: Icons.edit_note_outlined,
+            action: _openUserDictionaryEditor,
           ),
           buildPopupItem(
             label: t.dialog_clear_all_dictionaries,
@@ -460,6 +476,19 @@ class _DictionaryDialogPageState extends BasePageState {
       context: context,
       builder: (context) => dialog,
     );
+  }
+
+  /// 打开用户词典可视化编辑器；返回后刷新列表（编辑器保存会新增/重建/删除
+  /// 「User Dictionary」这本词典，本页列表必须跟上）。
+  Future<void> _openUserDictionaryEditor() async {
+    await Navigator.push(
+      context,
+      adaptivePageRoute(
+        context: context,
+        builder: (_) => const UserDictionaryEditorPage(),
+      ),
+    );
+    if (mounted) setState(() {});
   }
 
   Future<void> _importDictionaryFiles() async {

--- a/fushi/lib/src/pages/implementations/user_dictionary_editor_page.dart
+++ b/fushi/lib/src/pages/implementations/user_dictionary_editor_page.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/pages.dart';
+import 'package:fushi/src/dictionary/user_dictionary_store.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/media/media_search_text.dart';
+import 'package:fushi/utils.dart';
+
+/// 用户词典可视化编辑页。
+///
+/// 编辑的是偏好里的词条列表（真相源），每次保存后由
+/// [AppModel.saveUserDictionaryEntries] 把整份列表编译成 Yomitan zip 走现有
+/// 导入链整部重建「User Dictionary」——词条落进真实查词路径，与手动导入的
+/// 词典完全同待遇（排序/隐藏/折叠/CSS 都可用既有词典管理能力）。
+class UserDictionaryEditorPage extends BasePage {
+  const UserDictionaryEditorPage({super.key});
+
+  @override
+  BasePageState createState() => _UserDictionaryEditorPageState();
+}
+
+class _UserDictionaryEditorPageState extends BasePageState {
+  /// 首次 build 时从 AppModel 惰性加载（appModel 走 ref.watch，initState 里
+  /// 拿不到）；之后本页内存副本就是编辑现场，保存时整份交回 AppModel。
+  List<UserDictionaryEntry>? _entriesOrNull;
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  String _searchQuery = '';
+  bool _isRebuilding = false;
+
+  List<UserDictionaryEntry> get _entries =>
+      _entriesOrNull ??= appModel.userDictionaryEntries;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  /// 当前搜索词下可见的词条下标（对全量列表的下标——编辑/删除必须按全量下标
+  /// 寻址，过滤视图只是投影）。
+  List<int> get _visibleIndices => <int>[
+        for (int i = 0; i < _entries.length; i++)
+          if (matchesMediaSearch(
+            query: _searchQuery,
+            titles: <String>[
+              _entries[i].expression,
+              _entries[i].reading,
+              _entries[i].meaning,
+            ],
+          ))
+            i,
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final bool cupertino = isCupertinoPlatform(context);
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final List<int> visible = _visibleIndices;
+
+    return AdaptiveSettingsScaffold(
+      title: Text(t.dict_user_title),
+      actions: cupertino
+          ? <Widget>[
+              FushiIconButton(
+                tooltip: t.dict_user_entry_add,
+                icon: Icons.add,
+                onTap: _isRebuilding ? null : _addEntry,
+              ),
+            ]
+          : const <Widget>[],
+      children: <Widget>[
+        if (!cupertino)
+          Padding(
+            padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+            child: Wrap(
+              spacing: tokens.spacing.gap,
+              runSpacing: tokens.spacing.gap,
+              children: <Widget>[
+                _buildActionButton(
+                  focusPrefix: 'user-dict-action-add',
+                  icon: Icons.add,
+                  label: t.dict_user_entry_add,
+                  onTap: _isRebuilding ? null : _addEntry,
+                ),
+              ],
+            ),
+          ),
+        if (_isRebuilding)
+          Padding(
+            padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+            child: const LinearProgressIndicator(),
+          ),
+        if (_entries.isNotEmpty) ...<Widget>[
+          FushiSearchField(
+            controller: _searchController,
+            focusNode: _searchFocusNode,
+            hintText: t.search_ellipsis,
+            onChanged: (String value) => setState(() => _searchQuery = value),
+            onSubmitted: (_) {},
+            onClear: () {
+              _searchController.clear();
+              setState(() => _searchQuery = '');
+            },
+          ),
+          SizedBox(height: tokens.spacing.gap),
+        ],
+        if (_entries.isEmpty)
+          FushiPlaceholderMessage(
+            icon: Icons.edit_note_outlined,
+            message: t.dict_user_empty,
+          )
+        else
+          for (final int index in visible) _buildEntryRow(index),
+      ],
+    );
+  }
+
+  Widget _buildEntryRow(int index) {
+    final UserDictionaryEntry entry = _entries[index];
+    final String title = entry.reading.isEmpty
+        ? entry.expression
+        : '${entry.expression}【${entry.reading}】';
+    final String subtitle = userDictionaryGlossaryLines(entry.meaning).first;
+    return FushiListItem(
+      focusId: FushiFocusId('user-dict-entry-$index'),
+      title: Text(title),
+      subtitle: subtitle.isEmpty ? null : Text(subtitle),
+      trailing: FushiIconButton(
+        tooltip: t.dialog_delete,
+        icon: Icons.delete_outline,
+        onTap: _isRebuilding ? null : () => _deleteEntry(index),
+      ),
+      onTap: _isRebuilding ? null : () => _editEntry(index),
+    );
+  }
+
+  /// 与词典管理页动作栏同一 idiom：普通按钮 + 焦点根下的手柄/键盘焦点站。
+  Widget _buildActionButton({
+    required String focusPrefix,
+    required IconData icon,
+    required String label,
+    required VoidCallback? onTap,
+  }) {
+    final Widget button = FilledButton.tonalIcon(
+      onPressed: onTap,
+      icon: Icon(icon, size: 18),
+      label: Text(label),
+    );
+    if (onTap == null || FushiFocusRoot.maybeControllerOf(context) == null) {
+      return button;
+    }
+    return FushiActivatableFocusTarget(
+      focusIdPrefix: focusPrefix,
+      onTap: onTap,
+      child: ExcludeFocus(child: button),
+    );
+  }
+
+  Future<void> _addEntry() async {
+    final UserDictionaryEntry? entry = await showAppDialog<UserDictionaryEntry>(
+      context: context,
+      builder: (_) => const UserDictionaryEntryDialog(),
+    );
+    if (entry == null) return;
+    await _saveEntries(<UserDictionaryEntry>[..._entries, entry]);
+  }
+
+  Future<void> _editEntry(int index) async {
+    final UserDictionaryEntry? entry = await showAppDialog<UserDictionaryEntry>(
+      context: context,
+      builder: (_) => UserDictionaryEntryDialog(initialEntry: _entries[index]),
+    );
+    if (entry == null) return;
+    final List<UserDictionaryEntry> next = <UserDictionaryEntry>[..._entries];
+    next[index] = entry;
+    await _saveEntries(next);
+  }
+
+  Future<void> _deleteEntry(int index) async {
+    final UserDictionaryEntry entry = _entries[index];
+    final FushiDestructiveConfirmResult? result =
+        await showAppDialog<FushiDestructiveConfirmResult>(
+      context: context,
+      builder: (_) => FushiDestructiveConfirmDialog(
+        title: t.dict_user_entry_delete_confirm,
+        message: entry.reading.isEmpty
+            ? entry.expression
+            : '${entry.expression}【${entry.reading}】',
+      ),
+    );
+    if (result == null) return;
+    final List<UserDictionaryEntry> next = <UserDictionaryEntry>[..._entries]
+      ..removeAt(index);
+    await _saveEntries(next);
+  }
+
+  /// 落偏好 + 重建词典。重建失败只提示不回滚——偏好是真相源且已写成功，
+  /// 下次保存自愈（AppModel 注释里的忙时冲突同走此路径）。
+  Future<void> _saveEntries(List<UserDictionaryEntry> next) async {
+    setState(() {
+      _entriesOrNull = next;
+      _isRebuilding = true;
+    });
+    try {
+      await appModel.saveUserDictionaryEntries(next);
+    } catch (e, stack) {
+      ErrorLogService.instance.log('UserDictionaryEditor.rebuild', e, stack);
+      FushiToast.show(
+        msg: t.dict_user_rebuild_failed,
+        severity: ToastSeverity.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isRebuilding = false);
+      }
+    }
+  }
+}
+
+/// 单条词条的表单对话框。pop [UserDictionaryEntry] = 保存；pop null = 取消。
+///
+/// 纯表单，不碰持久化——保存动作归页面（一处 `_saveEntries` 收口偏好写入与
+/// 词典重建，向导航栈里塞副作用只会造出重复重建的特殊情况）。
+class UserDictionaryEntryDialog extends StatefulWidget {
+  const UserDictionaryEntryDialog({super.key, this.initialEntry});
+
+  /// 非 null = 编辑既有词条（表单预填）；null = 新增。
+  final UserDictionaryEntry? initialEntry;
+
+  @override
+  State<UserDictionaryEntryDialog> createState() =>
+      _UserDictionaryEntryDialogState();
+}
+
+class _UserDictionaryEntryDialogState extends State<UserDictionaryEntryDialog> {
+  late final TextEditingController _expressionController =
+      TextEditingController(text: widget.initialEntry?.expression ?? '');
+  late final TextEditingController _readingController =
+      TextEditingController(text: widget.initialEntry?.reading ?? '');
+  late final TextEditingController _meaningController =
+      TextEditingController(text: widget.initialEntry?.meaning ?? '');
+
+  @override
+  void dispose() {
+    _expressionController.dispose();
+    _readingController.dispose();
+    _meaningController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String expression = _expressionController.text.trim();
+    if (expression.isEmpty) {
+      FushiToast.show(
+        msg: t.dict_user_expression_required,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    Navigator.pop(
+      context,
+      UserDictionaryEntry(
+        expression: expression,
+        reading: _readingController.text.trim(),
+        meaning: _meaningController.text.trim(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return FushiDialogFrame(
+      maxWidth: 480,
+      maxHeightFactor: 0.88,
+      child: FushiModalSheetFrame(
+        title: widget.initialEntry == null
+            ? t.dict_user_entry_add
+            : t.dict_user_entry_edit,
+        leadingIcon: Icons.edit_note_outlined,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            FushiTextField(
+              controller: _expressionController,
+              labelText: t.dict_user_field_expression,
+              autofocus: true,
+              textInputAction: TextInputAction.next,
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            FushiTextField(
+              controller: _readingController,
+              labelText: t.dict_user_field_reading,
+              textInputAction: TextInputAction.next,
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            FushiTextField(
+              controller: _meaningController,
+              labelText: t.dict_user_field_meaning,
+              keyboardType: TextInputType.multiline,
+              minLines: 3,
+              maxLines: 8,
+            ),
+          ],
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.pop(context),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: _submit,
+              child: Text(t.dialog_save),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -155,6 +155,20 @@ SettingsDestination buildLookupDestination() {
               );
             },
           ),
+          // 用户词典可视化编辑器：词条真相源在偏好，保存后经现有导入链整部
+          // 重建挂载（详见 user_dictionary_store.dart 库注释）。
+          SettingsNavigationItem(
+            id: 'lookup.user_dictionary',
+            title: t.dict_user_title,
+            icon: Icons.edit_note_outlined,
+            onTap: (SettingsContext settingsContext) async {
+              await pushSettingsPage(
+                settingsContext,
+                (_) => const UserDictionaryEditorPage(),
+              );
+              settingsContext.refresh();
+            },
+          ),
           // 「管理音频来源」抽成共享 builder：查词分类与 Hibiki 互联分类都引用同一份
           // 定义（互联音频源 fushiRemote 就在该对话框里管，故互联分类也提供入口）。
           buildManageAudioSourcesItem(),

--- a/fushi/test/dictionary/user_dictionary_store_test.dart
+++ b/fushi/test/dictionary/user_dictionary_store_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/dictionary/user_dictionary_store.dart';
+
+void main() {
+  group('decodeUserDictionaryEntries', () {
+    test('空串与坏 JSON 回空列表（容错，不抛）', () {
+      expect(decodeUserDictionaryEntries(''), isEmpty);
+      expect(decodeUserDictionaryEntries('not json {'), isEmpty);
+      expect(decodeUserDictionaryEntries('{"a":1}'), isEmpty);
+    });
+
+    test('缺字段与空词头条目被剔除', () {
+      final String raw = jsonEncode(<Object>[
+        <String, String>{'expression': '空穂', 'reading': 'うつぼ'},
+        <String, String>{'reading': '孤儿读音'},
+        <String, String>{'expression': ''},
+      ]);
+      final List<UserDictionaryEntry> entries =
+          decodeUserDictionaryEntries(raw);
+      expect(entries, hasLength(1));
+      expect(entries.first.expression, '空穂');
+      expect(entries.first.reading, 'うつぼ');
+      expect(entries.first.meaning, '');
+    });
+  });
+
+  group('encodeUserDictionaryEntries', () {
+    test('空列表编码为空串（与「从未用过」同形）', () {
+      expect(encodeUserDictionaryEntries(<UserDictionaryEntry>[]), '');
+    });
+
+    test('编码/解码往返无损', () {
+      final List<UserDictionaryEntry> entries = <UserDictionaryEntry>[
+        const UserDictionaryEntry(
+          expression: '手向け',
+          reading: 'たむけ',
+          meaning: '饯别；供奉\n第二行释义',
+        ),
+        const UserDictionaryEntry(expression: 'のみ'),
+      ];
+      final List<UserDictionaryEntry> decoded =
+          decodeUserDictionaryEntries(encodeUserDictionaryEntries(entries));
+      expect(decoded, hasLength(2));
+      expect(decoded[0].expression, '手向け');
+      expect(decoded[0].reading, 'たむけ');
+      expect(decoded[0].meaning, '饯别；供奉\n第二行释义');
+      expect(decoded[1].expression, 'のみ');
+      expect(decoded[1].reading, '');
+      expect(decoded[1].meaning, '');
+    });
+  });
+
+  group('userDictionaryGlossaryLines', () {
+    test('按行拆分并剔除空白行', () {
+      expect(
+        userDictionaryGlossaryLines('一行\n\n  二行  \n'),
+        <String>['一行', '二行'],
+      );
+    });
+
+    test('全空回退整段原文（词条至少一条 glossary）', () {
+      expect(userDictionaryGlossaryLines(''), <String>['']);
+    });
+  });
+
+  group('buildUserDictionaryZipBytes', () {
+    test('产出标准 Yomitan 包：index.json + term_bank_1.json 逐字段对齐', () {
+      final List<int> bytes = buildUserDictionaryZipBytes(
+        entries: <UserDictionaryEntry>[
+          const UserDictionaryEntry(
+            expression: '手向け',
+            reading: 'たむけ',
+            meaning: '饯别\n供奉',
+          ),
+          const UserDictionaryEntry(expression: 'テスト', meaning: '测试'),
+        ],
+        revision: 'user-123',
+      );
+
+      final Archive archive = ZipDecoder().decodeBytes(bytes);
+      final Map<String, ArchiveFile> files = <String, ArchiveFile>{
+        for (final ArchiveFile f in archive.files) f.name: f,
+      };
+      expect(
+          files.keys, containsAll(<String>['index.json', 'term_bank_1.json']));
+
+      final Map<String, dynamic> index = jsonDecode(
+        utf8.decode(files['index.json']!.content as List<int>),
+      ) as Map<String, dynamic>;
+      expect(index['title'], userDictionaryTitle);
+      expect(index['format'], 3);
+      expect(index['revision'], 'user-123');
+      expect(index['sequenced'], false);
+
+      final List<dynamic> terms = jsonDecode(
+        utf8.decode(files['term_bank_1.json']!.content as List<int>),
+      ) as List<dynamic>;
+      expect(terms, hasLength(2));
+      final List<dynamic> first = terms[0] as List<dynamic>;
+      expect(first[0], '手向け');
+      expect(first[1], 'たむけ');
+      // rules 必须为空串：用户词条不参与去屈折（BUG-729 的活用误命中形状）。
+      expect(first[3], '');
+      expect(first[5], <String>['饯别', '供奉']);
+      expect(first[6], 0);
+      final List<dynamic> second = terms[1] as List<dynamic>;
+      expect(second[0], 'テスト');
+      expect(second[1], '');
+      expect(second[5], <String>['测试']);
+      expect(second[6], 1);
+    });
+  });
+}

--- a/fushi/test/pages/user_dictionary_editor_page_test.dart
+++ b/fushi/test/pages/user_dictionary_editor_page_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/pages.dart';
+import 'package:fushi/src/dictionary/user_dictionary_store.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/utils.dart';
+
+import '../helpers/test_platform_services.dart';
+
+class _FakeUserDictAppModel extends AppModel {
+  _FakeUserDictAppModel(this._entries) : super(testPlatformServices());
+
+  List<UserDictionaryEntry> _entries;
+
+  /// 每次保存收到的完整列表（页面契约：整份列表交给 AppModel，一处收口）。
+  final List<List<UserDictionaryEntry>> savedCalls =
+      <List<UserDictionaryEntry>>[];
+
+  @override
+  List<UserDictionaryEntry> get userDictionaryEntries => _entries;
+
+  @override
+  Future<void> saveUserDictionaryEntries(
+    List<UserDictionaryEntry> entries,
+  ) async {
+    savedCalls.add(entries);
+    _entries = entries;
+  }
+}
+
+Widget _buildApp(AppModel appModel) {
+  return ProviderScope(
+    overrides: [
+      appProvider.overrideWith((ref) => appModel),
+      platformServicesProvider.overrideWithValue(testPlatformServices()),
+    ],
+    child: TranslationProvider(
+      child: MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: const Color(0xFF386A58),
+          ),
+        ),
+        home: const UserDictionaryEditorPage(),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('空态渲染占位文案；添加词条走完整表单流程', (WidgetTester tester) async {
+    final _FakeUserDictAppModel appModel =
+        _FakeUserDictAppModel(<UserDictionaryEntry>[]);
+    await tester.pumpWidget(_buildApp(appModel));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.dict_user_empty), findsOneWidget);
+
+    await tester.tap(find.text(t.dict_user_entry_add));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextFormField).at(0), '手向け');
+    await tester.enterText(find.byType(TextFormField).at(1), 'たむけ');
+    await tester.enterText(find.byType(TextFormField).at(2), '饯别；供奉');
+    await tester.tap(find.text(t.dialog_save));
+    await tester.pumpAndSettle();
+
+    expect(appModel.savedCalls, hasLength(1));
+    final UserDictionaryEntry saved = appModel.savedCalls.single.single;
+    expect(saved.expression, '手向け');
+    expect(saved.reading, 'たむけ');
+    expect(saved.meaning, '饯别；供奉');
+    expect(find.text('手向け【たむけ】'), findsOneWidget);
+    expect(find.text(t.dict_user_empty), findsNothing);
+  });
+
+  testWidgets('词头为空不允许保存（对话框保持打开、零保存调用）', (WidgetTester tester) async {
+    final _FakeUserDictAppModel appModel =
+        _FakeUserDictAppModel(<UserDictionaryEntry>[]);
+    await tester.pumpWidget(_buildApp(appModel));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(t.dict_user_entry_add));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.dialog_save));
+    await tester.pumpAndSettle();
+
+    // 对话框未关闭（字段标签仍在），也没有触发任何保存。
+    expect(find.text(t.dict_user_field_expression), findsOneWidget);
+    expect(appModel.savedCalls, isEmpty);
+  });
+
+  testWidgets('点行进入编辑，保存后整条替换', (WidgetTester tester) async {
+    final _FakeUserDictAppModel appModel =
+        _FakeUserDictAppModel(<UserDictionaryEntry>[
+      const UserDictionaryEntry(
+        expression: '手向け',
+        reading: 'たむけ',
+        meaning: '饯别',
+      ),
+    ]);
+    await tester.pumpWidget(_buildApp(appModel));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('手向け【たむけ】'));
+    await tester.pumpAndSettle();
+    expect(find.text(t.dict_user_entry_edit), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField).at(2), '改后的释义');
+    await tester.tap(find.text(t.dialog_save));
+    await tester.pumpAndSettle();
+
+    expect(appModel.savedCalls, hasLength(1));
+    final UserDictionaryEntry saved = appModel.savedCalls.single.single;
+    expect(saved.expression, '手向け');
+    expect(saved.meaning, '改后的释义');
+    expect(find.text('改后的释义'), findsOneWidget);
+  });
+
+  testWidgets('删除需确认；确认后列表清空回到空态', (WidgetTester tester) async {
+    final _FakeUserDictAppModel appModel =
+        _FakeUserDictAppModel(<UserDictionaryEntry>[
+      const UserDictionaryEntry(expression: 'のみ', meaning: '仅仅'),
+    ]);
+    await tester.pumpWidget(_buildApp(appModel));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+    expect(find.text(t.dict_user_entry_delete_confirm), findsOneWidget);
+
+    await tester.tap(find.text(t.dialog_delete));
+    await tester.pumpAndSettle();
+
+    expect(appModel.savedCalls, hasLength(1));
+    expect(appModel.savedCalls.single, isEmpty);
+    expect(find.text(t.dict_user_empty), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 需求

支持可视化编辑词典。

## 方案（零 native 改动）

已导入词典是只读二进制（blobs.bin + 定容哈希表，mmap 只读），不存在就地编辑的写路径。因此不去改二进制，而是新增一部**用户词典**：

- **真相源**：偏好 `user_dictionary_entries`（JSON 词条列表：词头/读音/释义），可视化编辑器只做列表 CRUD。
- **编译挂载**：每次保存把整份列表编译成标准 Yomitan zip（`buildUserDictionaryZipBytes`），走**现有导入链** `importDictionary(forceReplaceExisting: true)` 整部重建「User Dictionary」——引擎重载、缓存失效、排序/隐藏/折叠保留、查词页重查全部复用既有路径。清空到零条走既有 `deleteDictionary`。
- **rules 恒空串**：用户词条不参与去屈折（避免 BUG-729 的活用误命中形状）。
- 与下载/自动更新抢 `import_temp` 时（BUG-1500 并发形状）不硬闯：忙则报错提示，偏好已落盘，下次保存自愈。

## 入口

- 设置 → 查词 → 用户词典（与自定义 CSS 并列）
- 词典管理页三处动作面：Material 动作栏 / Cupertino 桌面图标 / 移动溢出菜单

## i18n

10 个 `dict_user_*` key × 17 语言，经 `i18n_sync --add` + `dart run slang`。

## 验证

- `flutter analyze` 全量零问题
- 新测试：存储层 6 例（编解码/glossary 拆行/zip 逐字段）+ 编辑器 widget 4 例（增/改/删/空词头拒存），全绿
- 36 条目录枚举型守卫整批：`FLUTTER TEST VERDICT: PASSED - 250 tests ran`（与基线一致）
- 相邻定向（词典管理页布局/导入 force-replace/发布/仓库层/设置 schema）：`PASSED - 121 tests ran`

https://claude.ai/code/session_011AyWZxYwzmeqkYLPMznNq1