### PR TITLE
字幕自动获取链路：四处准确率根因 + 刮削后自动补字幕 + 发现性 (BUG-1694/1695/1696/1697/1698)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1566 条。点号进各自文件。
+> 共 1569 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1696](bugs/BUG-1696-subscription-blocks-download-without-subtitle.md) | ✅ | ✅ | 番剧订阅：当集 Jimaku 字幕还没上传就整条不下载，生肉早于字幕导致订阅长期不动 |
+| [BUG-1695](bugs/BUG-1695-jimaku-batch-wrong-episode-fallback.md) | ✅ | ✅ | 合集批量字幕：集号一条都对不上时静默取第一个文件，整季挂同一个错字幕 |
+| [BUG-1694](bugs/BUG-1694-jimaku-anime-filter.md) | ✅ | ✅ | Jimaku 搜索永不传 anime 参数，真人剧/日剧字幕永远 0 结果 |
 | [BUG-1690](bugs/BUG-1690-startup-audio-warmup-interrupts-music.md) | ✅ | ✅ | 启动静音预热在音频设备上开流,打断其他应用正在播放的音乐 |
 | [BUG-1689](bugs/BUG-1689-lookup-grip-activates-main-window.md) | ✅ | ✅ | 点剪贴板查词面板把 Hibiki 主界面抬到用户窗口之上 |
 | [BUG-1688](bugs/BUG-1688-vn-chrome-inset-viewport.md) | ✅ | ✅ | VN 模式忽略 chrome inset 与页面尺寸，正文被顶栏/底栏与刘海压住（iOS 最严重） |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1571 条。点号进各自文件。
+> 共 1572 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1700](bugs/BUG-1700-subtitle-default-language-not-video-language.md) | ✅ | ✅ | 自动下字幕的默认语言是「不限」，实际拿到的语言随缘，不跟视频自身语言 |
 | [BUG-1698](bugs/BUG-1698-subtitle-backfill-after-scrape.md) | ✅ | ✅ | 刮削解析出的规范身份没被字幕侧使用，且自动配字幕能力对用户完全不可见 |
 | [BUG-1697](bugs/BUG-1697-subtitle-content-never-verified.md) | ✅ | ✅ | 自动下载的字幕从不校验内容，整季合并文件被当成单集装上去 |
 | [BUG-1696](bugs/BUG-1696-subscription-blocks-download-without-subtitle.md) | ✅ | ✅ | 番剧订阅：当集 Jimaku 字幕还没上传就整条不下载，生肉早于字幕导致订阅长期不动 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1570 条。点号进各自文件。
+> 共 1571 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1698](bugs/BUG-1698-subtitle-backfill-after-scrape.md) | ✅ | ✅ | 刮削解析出的规范身份没被字幕侧使用，且自动配字幕能力对用户完全不可见 |
 | [BUG-1697](bugs/BUG-1697-subtitle-content-never-verified.md) | ✅ | ✅ | 自动下载的字幕从不校验内容，整季合并文件被当成单集装上去 |
 | [BUG-1696](bugs/BUG-1696-subscription-blocks-download-without-subtitle.md) | ✅ | ✅ | 番剧订阅：当集 Jimaku 字幕还没上传就整条不下载，生肉早于字幕导致订阅长期不动 |
 | [BUG-1695](bugs/BUG-1695-jimaku-batch-wrong-episode-fallback.md) | ✅ | ✅ | 合集批量字幕：集号一条都对不上时静默取第一个文件，整季挂同一个错字幕 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1569 条。点号进各自文件。
+> 共 1570 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1697](bugs/BUG-1697-subtitle-content-never-verified.md) | ✅ | ✅ | 自动下载的字幕从不校验内容，整季合并文件被当成单集装上去 |
 | [BUG-1696](bugs/BUG-1696-subscription-blocks-download-without-subtitle.md) | ✅ | ✅ | 番剧订阅：当集 Jimaku 字幕还没上传就整条不下载，生肉早于字幕导致订阅长期不动 |
 | [BUG-1695](bugs/BUG-1695-jimaku-batch-wrong-episode-fallback.md) | ✅ | ✅ | 合集批量字幕：集号一条都对不上时静默取第一个文件，整季挂同一个错字幕 |
 | [BUG-1694](bugs/BUG-1694-jimaku-anime-filter.md) | ✅ | ✅ | Jimaku 搜索永不传 anime 参数，真人剧/日剧字幕永远 0 结果 |

--- a/docs/bugs/BUG-1694-jimaku-anime-filter.md
+++ b/docs/bugs/BUG-1694-jimaku-anime-filter.md
@@ -1,0 +1,7 @@
+## BUG-1694 · Jimaku 搜索永不传 anime 参数，真人剧/日剧字幕永远 0 结果
+- **报告**：2026-08-17（用户：字幕自动下载准确率优化）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/jimaku_client.dart:_searchEntries`——全仓从未拼过 `anime` query 参数（`grep -c anime jimaku_client.dart` = 0）。Jimaku `/entries/search` 把 `anime` 当**硬相等过滤**且**缺省 `true`**，于是每一次搜索都只在动画子集里进行，Jimaku 上数千条真人日剧/日影条目在任何入口（播放页对话框 / 合集批量 / 番剧下载 / 下载流水线）都搜不到。
+  第二道锁在 `fushi/lib/src/media/video/download/video_subtitle_registry.dart:18-25`：非 anime 分类只放 OpenSubtitles，Jimaku 连被调用的机会都没有——而日语字幕恰恰是 OpenSubtitles 最缺、Jimaku 最强的一档。
+- **[x] ① 已修复** — `JimakuAnimeFilter` 三态（anime / liveAction / either），`either` = 先 `anime=true` 空结果再 `anime=false`，动画命中即停所以动画用例请求数不变；`JimakuVideoSubtitleProvider` 按 `discoveryCategory` 直接给出确定档；registry 不再按分类把 Jimaku 挡在门外。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/jimaku_client_test.dart` 的 `BUG-1694 anime 硬过滤` 组：三条分别钉住「缺省 either 会真的发出 `anime=false` 那一发」「liveAction 只发一次」「动画命中不多打」。
+- **备注**：`anime` 是硬过滤不是排序权重，所以「不传参数 = 搜全部」这个直觉是错的——这也是它藏了这么久的原因。

--- a/docs/bugs/BUG-1695-jimaku-batch-wrong-episode-fallback.md
+++ b/docs/bugs/BUG-1695-jimaku-batch-wrong-episode-fallback.md
@@ -1,0 +1,13 @@
+## BUG-1695 · 合集批量字幕：集号一条都对不上时静默取第一个文件，整季挂同一个错字幕
+- **报告**：2026-08-17（用户：字幕自动下载准确率优化）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/jimaku_batch.dart:112`（修前）
+  `final List<JimakuFile> pool = matching.isNotEmpty ? matching : text;`
+  ——集号一个都没命中就退回**全体文本字幕取第一个**。两种高频形状直接中招：
+  ① 条目按**绝对集号**编号（S2 是 13-24）而本地是 01-12 → 每一集都拿到第 13 集的字幕；
+  ② 条目只有一个未编号文件（剧场版 / 整季单文件）→ 12 集全部落同一个文件。
+  两种情况状态都显示 `done`，用户不看播放根本发现不了。
+  同一个判据在 `anime_download_matching.dart:matchJimakuFilesToVideoNames` 里的答案是**相反**的（「双方都有集号却没配上 ⇒ 不配」）。同一问题两份互相矛盾的实现，本身就是根因。
+  次因：批量走 `listFiles(id, episode: n)`，服务端那道过滤是**文件名启发式**，把「字幕侧到底有哪些集号」这个事实遮住了，于是根本判不出集号冲突。
+- **[x] ① 已修复** — 抽出全仓唯一判据 `fushi/lib/src/media/video/jimaku_matching.dart`：`JimakuEpisodeIndex`（从 torrent 域搬来，原处 re-export 保持导入方不变）+ `chooseJimakuFileForEpisode`。分三种「没配上」：`episodeConflict`（字幕侧有集号但没这一集）/ `ambiguousUnnumbered`（未编号但目标不止一个）/ `none`。`soleTarget` 是 `required` 而非有默认值——默认值就是本 bug 的形状。批量改为**整批只列一次文件**（不带 `episode=`），请求数从 targets×entries 降到 entries，且冲突判定变成事实而非服务端猜测。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/jimaku_batch_test.dart`：`pickBestSubtitleFile` 组三条新判据用例 + `runJimakuBatch` 两条端到端回归（整季未编号字幕不得被全批共用、绝对集号 13-24 撞本地 01-12 全部 noMatch），并断言「一个错字幕都不许落盘」与「整批只列一次」。
+- **备注**：`matchJimakuFilesToVideoNames` 的精确命中分支也改为委托同一原语，它多出来的 1v1 兜底（还要看视频侧集号）保留在原处。

--- a/docs/bugs/BUG-1696-subscription-blocks-download-without-subtitle.md
+++ b/docs/bugs/BUG-1696-subscription-blocks-download-without-subtitle.md
@@ -1,0 +1,19 @@
+## BUG-1696 · 番剧订阅：当集 Jimaku 字幕还没上传就整条不下载，生肉早于字幕导致订阅长期不动
+- **报告**：2026-08-17（用户：「订阅后没全部下载完成」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/torrent/anime_download_subscription.dart:574-577`（修前）：
+  ```dart
+  if (current.jimakuEntryId != null && subtitles.isEmpty) {
+    pendingError = 'subtitle not available for episode $episode ...';
+    await planStore.delete(id);
+    continue;   // ← 整条不下
+  }
+  ```
+  生肉普遍早于字幕数小时到数天，所以「发现新一集时字幕还没上传」是**常态**而非异常。旧实现在这一刻把计划删掉并跳过；`processedEpisodes` 不推进，下一轮重新发现、重新扑空。用户视角就是「绑了 Jimaku 条目的订阅永远不下东西」。
+  第二层根因：即便下载了，`subtitleStatus` 也落 `subtitleNone`，等于宣告「这一集永远没字幕」；而 `subtitleUnavailable` 在全仓**没有任何重试通道**（`_tickOnce` 只处理 `statusDownloading` 的计划），首次反查恰好发生在下载刚完成、字幕最可能还没上传的那一刻。
+- **[x] ① 已修复** — 三步：
+  1. 去掉 delete+continue 门，照常下片；`pendingError` 保留（任务行仍告诉用户「这集字幕还没到，下完再试」）。
+  2. `subtitleStatus` 从两态改三态：取到 → `resolved`；没取到但绑了条目 → **`pending`**（交给下载完成时按包内真实文件名反查，即 BUG-1206 的强判据，比按标题猜集号更准）；没绑条目 → `none`。
+  3. 新增 backoff 重试：`AnimeDownloadPlan.subtitleRetryBackoff`（15min / 1h / 4h / 12h / 24h 后停）+ 纯函数判据 `shouldRetrySubtitles(nowMs)` + `AnimeDownloadService._retrySubtitlesFor`，挂在 `_tickOnce` 尾部，复用同一次 `listTorrents` 与同一条 per-plan 串行边界。尝试计数在**发起前**记，否则 resolver 每次抛异常就永远停在 attempts=0、backoff 退化成每轮都打。
+  存量计划缺 `subtitleAttempts` 字段 → 回落 0 → 下一轮 tick 立刻获得一次重试机会，正好把被旧逻辑卡住的那批救回来。
+- **[x] ② 已加自动化测试** — `fushi/test/torrent/anime_download_plan_test.dart` 的 `BUG-1696 shouldRetrySubtitles` 组（6 条：状态准入 / 无来源不重试 / 老计划立刻可重试 / 间隔边界 / 用完就停 / JSON 进出与缺字段回落）；`fushi/test/torrent/anime_download_subscription_test.dart` 把原「missing selected subtitle keeps the episode pending」改成断言新契约（照常下片 + `subtitlePending` + 保留 `jimakuEntryId`）。
+- **备注**：用户明确选择了「先下片，字幕后台补」这一档，而非「保留门槛但做成开关」。

--- a/docs/bugs/BUG-1697-subtitle-content-never-verified.md
+++ b/docs/bugs/BUG-1697-subtitle-content-never-verified.md
@@ -1,0 +1,19 @@
+## BUG-1697 · 自动下载的字幕从不校验内容，整季合并文件被当成单集装上去
+- **报告**：2026-08-17（用户：「看看能不能优化下准确率，要检测字幕时长之类的？」）
+- **真实性**：✅ 真 bug。全仓四条自动配字幕路径（下载流水线 / 番剧下载反查 / 合集批量 / 订阅），**没有任何一处**在拿到字幕字节后看过内容——匹配全靠文件名，文件名对了就落盘。根因两处：
+  - `fushi/lib/src/media/video/download/video_download_pipeline_service.dart:1759`（修前）`candidate = result.items.first;`——排序只按 provider 优先级与下载量（`deduplicateVideoSubtitles`），既不看集号是否真等于该文件的集号，也不看内容；
+  - `fushi/lib/src/media/torrent/anime_download_subtitle_resolver.dart:_download`——下下来直接写盘。
+
+  最典型的漏网形状：把整季合并成一个文件的字幕（5 小时）装到某一集（24 分钟）上，播放时从第 3 分钟起全错位；以及来源站返回 HTML 错误页被当字幕存下来。
+- **[x] ① 已修复** — 新增两个模块：
+  - `fushi/lib/src/media/video/subtitle/subtitle_timing_check.dart`（纯函数）：`summarizeSubtitleTiming` 只扫时间轴（srt/vtt 的 `-->`、ass 的 `Dialogue:`），不把整套 cue/DB 语义拖进来；`checkSubtitleTiming` 给出 ok / unparsable / empty / overrunsVideo / suspiciouslyShort 五态。
+  - `fushi/lib/src/media/video/video_duration_probe.dart`：走既有 `FfmpegBackend.runProbe`，桌面 ffprobe 与移动 ffmpeg-kit 同一条路径。`VideoBooks` 没有 duration 列、播放器时长又只在 controller 打开后才有，下载期只能现探。
+
+  两档拒收强度是刻意分开的：
+  - `rejected`（**有备选**，下载流水线）：读不出/空/超长都换下一个候选，最多试 `kSubtitleVerifyMaxCandidates`=4 条，且复用校验时下的字节不重复下载；
+  - `contradictsVideo`（**无备选**，番剧下载按集号已锁定唯一一条）：只认「字幕比视频长得多」这种正面矛盾。本模块的扫描器只认三种时间轴写法，「我读不出」不足以扔掉用户唯一的字幕。
+
+  容差按时长来源分档：ffprobe 是精确事实（1.15×+60s），刮削 runtime 是播出时长含广告位、只精确到分钟（1.5×+2min）。比例 + 绝对量双保险，避免 5 分钟 PV 被比例项误伤。探不到时长时判据退化成只做内容自检，**绝不因为探测失败就拒收**。
+  字节解码复用 `fushi_audio` 的 `decodeTextBytes`（BOM / UTF-16 LE·BE / CP932），不自己写一份——裸 `utf8.decode` 对 UTF-16 字幕会解出夹满 NUL 的垃圾串，把好字幕误判成坏字幕。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/subtitle_timing_check_test.dart`（14 条）：三格式时间轴解析（含 ass 两位小数是厘秒）、整季文件拒收、signs/歌词轨不拒、时长未知只自检、两档拒收强度不可混用、刮削容差必须更宽、短片不误伤、ffprobe json 解析的各种 N/A。**已做变异实测**：把 `probed` 容差从 1.15 改成 99.0，套件从 PASSED 变 FAILED（2 处断言捕获），还原后 sha256 与变异前逐字节一致。
+- **备注**：这道判据**抓不了轴偏移**（同一集不同压制组 OP 差几秒）——那要靠发布组名匹配。模块头注释里写死了这一点，防止后来者拿它当「字幕对轴校验」用。

--- a/docs/bugs/BUG-1698-subtitle-backfill-after-scrape.md
+++ b/docs/bugs/BUG-1698-subtitle-backfill-after-scrape.md
@@ -1,0 +1,15 @@
+## BUG-1698 · 刮削解析出的规范身份没被字幕侧使用，且自动配字幕能力对用户完全不可见
+- **报告**：2026-08-17（用户：「刮削后自动下载字幕」+「怎么让用户知道可以自动下载字幕之类的？」）
+- **真实性**：✅ 两个真问题，同一个根：刮削与字幕两条链路互不认识。
+  1. **刮削链路零字幕代码**——`fushi/lib/src/media/video/metadata/video_source_scrape_coordinator.dart` 里 `subtitle` 出现 **0 次**。「刮削后自动下载字幕」不是不准，是**功能不存在**。
+  2. **刮削已经算出来的身份被丢掉**：`VideoMetadataWorks` 存着 AniList/TMDB/Bangumi id 与日文 `originalTitle`，而播放页字幕对话框（`jimaku_subtitle_dialog.dart:363`）拿**文件名解析出的系列名**去 `AniList.searchAnime` 现搜。刮削过的视频显示名常是「中文译名 + 季度 + 篇名长串」，在 AniList 必然 0 结果。答案已经在库里，字幕侧却重猜一遍。
+  3. **能力不可见**：下载流水线的字幕阶段默认 `bestEffort`（自动配字幕一直开着），但它没有名字、没有设置项、失败只落在任务行一句状态里。用户既不知道这个能力存在，也不知道要配 Jimaku key 才能用上。
+- **[x] ① 已修复**
+  - 新增 `fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart`：给缺字幕的视频补一条。**只补缺的**（DB `subtitleSource` 或磁盘 sidecar 任一存在就跳过——用户手放/手改的字幕不可再生），落 sidecar 不写 DB 选择（自动补的和用户选的不在同一字段上打架），先写 `.tmp` 再 rename（半截字幕比没字幕更糟：播放页会把它当可用字幕加载）。复用 BUG-1697 的时长校验 + 候选回退。
+  - 新增 `fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart`（**纯函数**）：刮削结论 → 字幕目标。单独成文件是因为这里就是准确率的分水岭，值得被单测钉死而不是埋在 service 里。带过去的三件事缺一不可：外部 id（Jimaku 按 anilist_id 直查 / OpenSubtitles 按 imdb）、`originalTitle`（id 没命中时的回退词，用中文译名等于不回退）、`discoveryCategory`（决定 BUG-1694 的 anime 过滤档）。季集号取**本地文件名解析**而不是刮削顺序——合集可能缺集/含特典/被拖拽重排；多集里认不出集号的成员**不生成目标**（配上去只能碰运气），单文件作品（电影/剧场版）例外。
+  - `VideoSourceScrapeCoordinator` 加 `onWorkScraped` 回调 + `VideoScrapedWorkNotice`。协调器**不长出字幕依赖**、也不被字幕失败拖慢：回调异常吞进本次 run 的 warnings。
+  - `AppModel._backfillSubtitlesForScrapedWork` 消费它，三道自然闸门（偏好关 / 没配任何来源 / 已有字幕）任一不满足就静默跳过；逐条串行不并发（一次刮削可能带来整季十几集，并发打同一个字幕站是滥用）。
+  - **发现性**：设置 → 视频 → 字幕新增开关 `video.subtitle.backfill_after_scrape`（默认开），放在 Jimaku / OpenSubtitles 配置**正上方**——设置页有搜索（`settings_search.dart`），给能力一个名字它才第一次可被搜到，且配置项同屏可见。
+  - 任务行文案跟上新行为：`subtitleUnavailable` 不再一律说「未匹配到」，还排得上 backoff 重试的说「字幕：还没上传，稍后自动重试」（判据是 `AnimeDownloadPlan.subtitleRetryPossible`，UI 不重算 backoff 算术）。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/scraped_subtitle_targets_test.dart`（11 条）：外部 id 全量透传、originalTitle 必带、非数字 id 不炸、AniList id 决定 anime 档、季集号取文件名不取顺序、已有字幕标记、多集认不出集号不生成目标、单文件作品例外、runtime 逐集取并回落作品级、空输入不生成半截目标。
+- **备注**：播放页的「自动获取字幕」入口本来就有（`subtitle.part.dart:136`），所以发现性的缺口不在播放页而在**设置页没有这个能力的名字**。另：播放页目前只接 Jimaku，OpenSubtitles 在播放页仍无入口——留作后续。

--- a/docs/bugs/BUG-1700-subtitle-default-language-not-video-language.md
+++ b/docs/bugs/BUG-1700-subtitle-default-language-not-video-language.md
@@ -1,0 +1,20 @@
+## BUG-1700 · 自动下字幕的默认语言是「不限」，实际拿到的语言随缘，不跟视频自身语言
+- **报告**：2026-08-17（用户：「默认下载视频语言的字幕」）
+- **真实性**：✅ 真问题。`jimakuDefaultLanguage` 缺省 `''`，UI 标签写「全部」，语义是**不表态**：
+  - 下载流水线：`preferredSubtitleLanguages` 变成空 list → `VideoSubtitleSearchRequest.languages` 为空 → provider 不按语言过滤 → 最终 `result.items.first`（按 provider 优先级 + 下载量排）**语言随缘**；
+  - 番剧下载反查：`plan.jimakuLanguage` 为 null → `jimakuLanguageRank` 退回它自己的 ja>zh>en>ko 默认权重。对日语番碰巧对，对**韩剧就是错的**。
+
+  对一个沉浸学习 app，「视频是什么语言就先要什么语言的字幕」几乎总是用户想要的那条，而这从来不是默认。
+- **[x] ① 已修复**
+  - 新增 `fushi/lib/src/media/video/subtitle/subtitle_language_preference.dart`（纯函数）：
+    - `resolveSubtitleDownloadLanguage`——优先级 **用户显式选的字幕语言 > 视频内容语言 > null**。内容那一半**直接委托** `resolveContentLanguage`（全仓内容语言唯一入口：资源手动指定 `VideoBooks.language` > 内容自带元数据 > 全局默认），**不另造一条链**：字体链和字幕语言链各写一遍，早晚出现「字体按日文渲染、字幕却下了中文」。
+    - `normalizeSubtitleLanguageCode`——BCP-47 / ISO 639-2 / 俗写归一（`ja-JP`/`jpn`/`jp`→`ja`，`chs`/`cht`/`yue`→`zh`），认不出**原样返回主标签**而不是丢弃。
+    - `rankByPreferredLanguage`——**稳定**重排，首选语言在前。
+  - 「视频语言」的一手来源：`video_duration_probe.dart` 扩成 `probeVideoFacts`，**同一次 ffprobe** 拿时长 + 音轨 language tag（`format=duration:stream=...:stream_tags=language`）。只认音轨（字幕轨的 language 不能冒充视频语言），`und` 视同未标注跳过。
+  - 接入四处：下载流水线 `_selectVerifiedSubtitle`、刮削后补字幕 `VideoSubtitleBackfillService`、番剧下载 `JimakuPlanSubtitleResolver`、`scrapedSubtitleTargets`（带上 `VideoBooks.language` 与刮削 `originalLanguage`）。
+  - 设置项 `''` 的标签从「全部」改成**「跟随视频语言」**（新 key `video_jimaku_language_follow_video`；浏览用对话框里的「全部」语义仍正确，**不复用同一个 key**——同值不同义就该两个标签），hint 同步改写。
+
+  🔴 **关键设计：是排序，不是过滤。** 按语言硬过滤会把「只有英文字幕的日语番」从**有字幕**倒退成**没字幕**——拿一个改进换一个回归。硬过滤只留给用户在设置里显式指定的语言（那是他自己说的，进 `request.languages`）。
+  🔴 **语言未知就不表态**（返回 null，行为与改动前逐字节一致）。**尤其不许硬编码日语**——本 app 没有全局学习语言，见 `reference_no_global_target_language_do_not_assume_japanese`。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/subtitle_language_preference_test.dart`（17 条）：归一各形态、四档优先级、全空返回 null、排序不丢候选、归一后比较、稳定性、ffprobe 双事实解析（只认音轨 / `und` 跳过 / 一半缺失不作废）。**已做变异实测**：把 `rankByPreferredLanguage` 的返回改成只留匹配项（= 退化成硬过滤），套件 PASSED→FAILED（2 处断言捕获），还原后 sha256 逐字节一致。
+- **备注**：改标签时撞出一条真回归——`video_external_provider_settings_section` 的语言下拉在 360px 紧凑布局横向溢出。根因不是中文文案长，是那个 `DropdownButtonFormField` 缺 `isExpanded: true`（按内容固有宽度排版），此前选项全是「日本語」「中文」这类两三字标签才没暴露；17 份 i18n 里未翻译的落英文原串 `Follow video language` 更长。**修的是约束（isExpanded + 逐项 ellipsis），不是文案。**

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58786 (3458 per locale)
+/// Strings: 58803 (3459 per locale)
 ///
-/// Built on 2026-08-16 at 17:20 UTC
+/// Built on 2026-08-16 at 18:32 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3619,8 +3619,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   String get anime_download_subs_episodes_unverified =>
@@ -4690,6 +4688,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'No subtitle found · set up an online subtitle source';
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -10855,9 +10856,6 @@ class _StringsAr extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -12688,6 +12686,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -18920,9 +18923,6 @@ class _StringsDe extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -20753,6 +20753,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -27001,9 +27006,6 @@ class _StringsEs extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -28834,6 +28836,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -35094,9 +35101,6 @@ class _StringsFr extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -36927,6 +36931,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -43115,9 +43124,6 @@ class _StringsId extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -44948,6 +44954,11 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -51182,9 +51193,6 @@ class _StringsIt extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -53015,6 +53023,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -59063,9 +59076,6 @@ class _StringsJa extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -60896,6 +60906,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -66951,9 +66966,6 @@ class _StringsKo extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -68784,6 +68796,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -74998,9 +75015,6 @@ class _StringsNl extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -76831,6 +76845,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -83057,9 +83076,6 @@ class _StringsPtBr extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -84890,6 +84906,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -91102,9 +91123,6 @@ class _StringsRu extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -92935,6 +92953,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -99095,9 +99118,6 @@ class _StringsTh extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -100928,6 +100948,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -107119,9 +107144,6 @@ class _StringsTr extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -108952,6 +108974,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -115128,9 +115155,6 @@ class _StringsVi extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -116961,6 +116985,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 // Path: <root>
@@ -122707,8 +122736,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_setting_jimaku_default_language => '默认字幕语言';
   @override
-  String get video_setting_jimaku_default_language_hint => '该系列没有记住的语言时优先使用';
-  @override
   String get video_jimaku_api_key_settings_hint => '也可在 设置 → 视频 → 字幕 中修改';
   @override
   String get anime_download_subs_episodes_unverified => '集号未与该整季包核对，字幕可能来自别的季。';
@@ -124386,6 +124413,11 @@ class _StringsZhCn extends _StringsEn {
   String get video_subtitle_no_source_configured => '没找到字幕 · 去配置在线字幕来源';
   @override
   String get anime_download_subs_retrying => '字幕：还没上传，稍后自动重试';
+  @override
+  String get video_jimaku_language_follow_video => '跟随视频语言';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      '默认跟随视频自身的语言（音轨 / 刮削元数据）。选定某个语言则始终优先它。';
 }
 
 // Path: <root>
@@ -130358,9 +130390,6 @@ class _StringsZhHk extends _StringsEn {
   String get video_setting_jimaku_default_language =>
       'Default subtitle language';
   @override
-  String get video_setting_jimaku_default_language_hint =>
-      'Preferred language when the series has no remembered choice';
-  @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
@@ -132190,6 +132219,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_subs_retrying =>
       'Subtitles: not up yet — will retry automatically';
+  @override
+  String get video_jimaku_language_follow_video => 'Follow video language';
+  @override
+  String get video_setting_jimaku_default_language_hint =>
+      'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
 }
 
 /// Flat map(s) containing all translations.
@@ -137713,8 +137747,6 @@ extension on _StringsEn {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -139296,6 +139328,10 @@ extension on _StringsEn {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -144817,8 +144853,6 @@ extension on _StringsAr {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -146400,6 +146434,10 @@ extension on _StringsAr {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -151943,8 +151981,6 @@ extension on _StringsDe {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -153526,6 +153562,10 @@ extension on _StringsDe {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -159068,8 +159108,6 @@ extension on _StringsEs {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -160651,6 +160689,10 @@ extension on _StringsEs {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -166199,8 +166241,6 @@ extension on _StringsFr {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -167782,6 +167822,10 @@ extension on _StringsFr {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -173312,8 +173356,6 @@ extension on _StringsId {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -174895,6 +174937,10 @@ extension on _StringsId {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -180439,8 +180485,6 @@ extension on _StringsIt {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -182022,6 +182066,10 @@ extension on _StringsIt {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -187528,8 +187576,6 @@ extension on _StringsJa {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -189111,6 +189157,10 @@ extension on _StringsJa {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -194621,8 +194671,6 @@ extension on _StringsKo {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -196204,6 +196252,10 @@ extension on _StringsKo {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -201742,8 +201794,6 @@ extension on _StringsNl {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -203325,6 +203375,10 @@ extension on _StringsNl {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -208860,8 +208914,6 @@ extension on _StringsPtBr {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -210443,6 +210495,10 @@ extension on _StringsPtBr {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -215983,8 +216039,6 @@ extension on _StringsRu {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -217566,6 +217620,10 @@ extension on _StringsRu {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -223089,8 +223147,6 @@ extension on _StringsTh {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -224672,6 +224728,10 @@ extension on _StringsTh {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -230204,8 +230264,6 @@ extension on _StringsTr {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -231787,6 +231845,10 @@ extension on _StringsTr {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -237315,8 +237377,6 @@ extension on _StringsVi {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -238898,6 +238958,10 @@ extension on _StringsVi {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }
@@ -244378,8 +244442,6 @@ extension on _StringsZhCn {
         return '关闭词典';
       case 'video_setting_jimaku_default_language':
         return '默认字幕语言';
-      case 'video_setting_jimaku_default_language_hint':
-        return '该系列没有记住的语言时优先使用';
       case 'video_jimaku_api_key_settings_hint':
         return '也可在 设置 → 视频 → 字幕 中修改';
       case 'anime_download_subs_episodes_unverified':
@@ -245950,6 +246012,10 @@ extension on _StringsZhCn {
         return '没找到字幕 · 去配置在线字幕来源';
       case 'anime_download_subs_retrying':
         return '字幕：还没上传，稍后自动重试';
+      case 'video_jimaku_language_follow_video':
+        return '跟随视频语言';
+      case 'video_setting_jimaku_default_language_hint':
+        return '默认跟随视频自身的语言（音轨 / 刮削元数据）。选定某个语言则始终优先它。';
       default:
         return null;
     }
@@ -251451,8 +251517,6 @@ extension on _StringsZhHk {
         return 'Close dictionary';
       case 'video_setting_jimaku_default_language':
         return 'Default subtitle language';
-      case 'video_setting_jimaku_default_language_hint':
-        return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
       case 'anime_download_subs_episodes_unverified':
@@ -253034,6 +253098,10 @@ extension on _StringsZhHk {
         return 'No subtitle found · set up an online subtitle source';
       case 'anime_download_subs_retrying':
         return 'Subtitles: not up yet — will retry automatically';
+      case 'video_jimaku_language_follow_video':
+        return 'Follow video language';
+      case 'video_setting_jimaku_default_language_hint':
+        return 'Defaults to the video\'s own language (audio track / scraped metadata). Pick one to always prefer that language instead.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58701 (3453 per locale)
+/// Strings: 58786 (3458 per locale)
 ///
-/// Built on 2026-08-16 at 12:44 UTC
+/// Built on 2026-08-16 at 17:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4680,6 +4680,16 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_content_language_description =>
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   String get manga_ocr_lens_language_label => 'Recognition language';
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -12663,6 +12673,21 @@ class _StringsAr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'لغة التعرّف';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -20713,6 +20738,21 @@ class _StringsDe extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Erkennungssprache';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -28779,6 +28819,21 @@ class _StringsEs extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconocimiento';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -36857,6 +36912,21 @@ class _StringsFr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Langue de reconnaissance';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -44863,6 +44933,21 @@ class _StringsId extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Bahasa pengenalan';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -52915,6 +53000,21 @@ class _StringsIt extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Lingua di riconoscimento';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -60781,6 +60881,21 @@ class _StringsJa extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '認識する言語';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -68654,6 +68769,21 @@ class _StringsKo extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '인식 언어';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -76686,6 +76816,21 @@ class _StringsNl extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Herkenningstaal';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -84730,6 +84875,21 @@ class _StringsPtBr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconhecimento';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -92760,6 +92920,21 @@ class _StringsRu extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Язык распознавания';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -100738,6 +100913,21 @@ class _StringsTh extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'ภาษาที่ใช้จดจำ';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -108747,6 +108937,21 @@ class _StringsTr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Tanıma dili';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -116741,6 +116946,21 @@ class _StringsVi extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Ngôn ngữ nhận dạng';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 // Path: <root>
@@ -124155,6 +124375,17 @@ class _StringsZhCn extends _StringsEn {
       '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
   @override
   String get manga_ocr_lens_language_label => '识别语言';
+  @override
+  String get video_setting_subtitle_backfill => '刮削后自动补字幕';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      '刮削完成后，仍然没有字幕的视频会自动从已配置的在线字幕来源取一条。绝不覆盖已有字幕。';
+  @override
+  String get video_setting_subtitle_sources_section => '在线字幕来源';
+  @override
+  String get video_subtitle_no_source_configured => '没找到字幕 · 去配置在线字幕来源';
+  @override
+  String get anime_download_subs_retrying => '字幕：还没上传，稍后自动重试';
 }
 
 // Path: <root>
@@ -131944,6 +132175,21 @@ class _StringsZhHk extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '識別語言';
+  @override
+  String get video_setting_subtitle_backfill =>
+      'Auto-fetch subtitles after scraping';
+  @override
+  String get video_setting_subtitle_backfill_hint =>
+      'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+  @override
+  String get video_setting_subtitle_sources_section =>
+      'Online subtitle sources';
+  @override
+  String get video_subtitle_no_source_configured =>
+      'No subtitle found · set up an online subtitle source';
+  @override
+  String get anime_download_subs_retrying =>
+      'Subtitles: not up yet — will retry automatically';
 }
 
 /// Flat map(s) containing all translations.
@@ -139040,6 +139286,16 @@ extension on _StringsEn {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Recognition language';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -146134,6 +146390,16 @@ extension on _StringsAr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'لغة التعرّف';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -153250,6 +153516,16 @@ extension on _StringsDe {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Erkennungssprache';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -160365,6 +160641,16 @@ extension on _StringsEs {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconocimiento';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -167486,6 +167772,16 @@ extension on _StringsFr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Langue de reconnaissance';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -174589,6 +174885,16 @@ extension on _StringsId {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Bahasa pengenalan';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -181706,6 +182012,16 @@ extension on _StringsIt {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Lingua di riconoscimento';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -188785,6 +189101,16 @@ extension on _StringsJa {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '認識する言語';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -195868,6 +196194,16 @@ extension on _StringsKo {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '인식 언어';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -202979,6 +203315,16 @@ extension on _StringsNl {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Herkenningstaal';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -210087,6 +210433,16 @@ extension on _StringsPtBr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconhecimento';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -217200,6 +217556,16 @@ extension on _StringsRu {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Язык распознавания';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -224296,6 +224662,16 @@ extension on _StringsTh {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'ภาษาที่ใช้จดจำ';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -231401,6 +231777,16 @@ extension on _StringsTr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Tanıma dili';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -238502,6 +238888,16 @@ extension on _StringsVi {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Ngôn ngữ nhận dạng';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }
@@ -245544,6 +245940,16 @@ extension on _StringsZhCn {
         return '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
       case 'manga_ocr_lens_language_label':
         return '识别语言';
+      case 'video_setting_subtitle_backfill':
+        return '刮削后自动补字幕';
+      case 'video_setting_subtitle_backfill_hint':
+        return '刮削完成后，仍然没有字幕的视频会自动从已配置的在线字幕来源取一条。绝不覆盖已有字幕。';
+      case 'video_setting_subtitle_sources_section':
+        return '在线字幕来源';
+      case 'video_subtitle_no_source_configured':
+        return '没找到字幕 · 去配置在线字幕来源';
+      case 'anime_download_subs_retrying':
+        return '字幕：还没上传，稍后自动重试';
       default:
         return null;
     }
@@ -252618,6 +253024,16 @@ extension on _StringsZhHk {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '識別語言';
+      case 'video_setting_subtitle_backfill':
+        return 'Auto-fetch subtitles after scraping';
+      case 'video_setting_subtitle_backfill_hint':
+        return 'When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.';
+      case 'video_setting_subtitle_sources_section':
+        return 'Online subtitle sources';
+      case 'video_subtitle_no_source_configured':
+        return 'No subtitle found · set up an online subtitle source';
+      case 'anime_download_subs_retrying':
+        return 'Subtitles: not up yet — will retry automatically';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Recognition language"
+  "manga_ocr_lens_language_label": "Recognition language",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "لغة التعرّف"
+  "manga_ocr_lens_language_label": "لغة التعرّف",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Erkennungssprache"
+  "manga_ocr_lens_language_label": "Erkennungssprache",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconocimiento"
+  "manga_ocr_lens_language_label": "Idioma de reconocimiento",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Langue de reconnaissance"
+  "manga_ocr_lens_language_label": "Langue de reconnaissance",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Bahasa pengenalan"
+  "manga_ocr_lens_language_label": "Bahasa pengenalan",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Lingua di riconoscimento"
+  "manga_ocr_lens_language_label": "Lingua di riconoscimento",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "認識する言語"
+  "manga_ocr_lens_language_label": "認識する言語",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "인식 언어"
+  "manga_ocr_lens_language_label": "인식 언어",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Herkenningstaal"
+  "manga_ocr_lens_language_label": "Herkenningstaal",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconhecimento"
+  "manga_ocr_lens_language_label": "Idioma de reconhecimento",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Язык распознавания"
+  "manga_ocr_lens_language_label": "Язык распознавания",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ"
+  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Tanıma dili"
+  "manga_ocr_lens_language_label": "Tanıma dili",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng"
+  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "上一页",
   "shortcut_action_manga_dismiss_dict": "关闭词典",
   "video_setting_jimaku_default_language": "默认字幕语言",
-  "video_setting_jimaku_default_language_hint": "该系列没有记住的语言时优先使用",
   "video_jimaku_api_key_settings_hint": "也可在 设置 → 视频 → 字幕 中修改",
   "anime_download_subs_episodes_unverified": "集号未与该整季包核对，字幕可能来自别的季。",
   "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "刮削完成后，仍然没有字幕的视频会自动从已配置的在线字幕来源取一条。绝不覆盖已有字幕。",
   "video_setting_subtitle_sources_section": "在线字幕来源",
   "video_subtitle_no_source_configured": "没找到字幕 · 去配置在线字幕来源",
-  "anime_download_subs_retrying": "字幕：还没上传，稍后自动重试"
+  "anime_download_subs_retrying": "字幕：还没上传，稍后自动重试",
+  "video_jimaku_language_follow_video": "跟随视频语言",
+  "video_setting_jimaku_default_language_hint": "默认跟随视频自身的语言（音轨 / 刮削元数据）。选定某个语言则始终优先它。"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "默认内容语言",
   "settings_content_language_unset": "未设置",
   "settings_content_language_description": "内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。",
-  "manga_ocr_lens_language_label": "识别语言"
+  "manga_ocr_lens_language_label": "识别语言",
+  "video_setting_subtitle_backfill": "刮削后自动补字幕",
+  "video_setting_subtitle_backfill_hint": "刮削完成后，仍然没有字幕的视频会自动从已配置的在线字幕来源取一条。绝不覆盖已有字幕。",
+  "video_setting_subtitle_sources_section": "在线字幕来源",
+  "video_subtitle_no_source_configured": "没找到字幕 · 去配置在线字幕来源",
+  "anime_download_subs_retrying": "字幕：还没上传，稍后自动重试"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3451,5 +3451,10 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "識別語言"
+  "manga_ocr_lens_language_label": "識別語言",
+  "video_setting_subtitle_backfill": "Auto-fetch subtitles after scraping",
+  "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
+  "video_setting_subtitle_sources_section": "Online subtitle sources",
+  "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2694,7 +2694,6 @@
   "shortcut_action_manga_page_backward": "Previous page",
   "shortcut_action_manga_dismiss_dict": "Close dictionary",
   "video_setting_jimaku_default_language": "Default subtitle language",
-  "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
@@ -3456,5 +3455,7 @@
   "video_setting_subtitle_backfill_hint": "When a scrape finishes, videos that still have no subtitle get one from your configured online sources. Never replaces an existing subtitle.",
   "video_setting_subtitle_sources_section": "Online subtitle sources",
   "video_subtitle_no_source_configured": "No subtitle found · set up an online subtitle source",
-  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically"
+  "anime_download_subs_retrying": "Subtitles: not up yet — will retry automatically",
+  "video_jimaku_language_follow_video": "Follow video language",
+  "video_setting_jimaku_default_language_hint": "Defaults to the video's own language (audio track / scraped metadata). Pick one to always prefer that language instead."
 }

--- a/fushi/lib/src/media/torrent/anime_download_matching.dart
+++ b/fushi/lib/src/media/torrent/anime_download_matching.dart
@@ -2,7 +2,19 @@ import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/torrent/nyaa_client.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/jimaku_matching.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
+
+// 按集索引与单集判据已抽到 media/video/jimaku_matching.dart（BUG-1695）——它同时
+// 服务合集批量与番剧下载两条路径，放在 torrent 域下会让 video 域反向依赖 torrent。
+// 这里 re-export 保持既有导入方（对话框、测试）不动。
+export 'package:fushi/src/media/video/jimaku_matching.dart'
+    show
+        JimakuEpisodeIndex,
+        JimakuEpisodeMatch,
+        JimakuEpisodeMatchKind,
+        chooseJimakuFileForEpisode,
+        compareJimakuByLanguagePreference;
 
 /// 番剧下载的纯决策逻辑：Jimaku 字幕按集索引 + 种子↔字幕匹配。
 ///
@@ -16,72 +28,6 @@ import 'package:fushi/src/media/video/video_filename_parser.dart';
 ///   **包内真实文件名** → 结论是**事实**，条数天然被真实视频文件数收敛。
 ///
 /// 真正决定「下哪些字幕、贴给哪个视频」的只有后者（BUG-1206）。
-
-/// 从 Jimaku 文件列表构建的按集索引。
-///
-/// 只收文本字幕（[JimakuFile.isTextSubtitle]）；每集候选按语言权重升序排列
-/// （[jimakuLanguageRank] + [detectSubtitleLanguage]，即 ja 优先），同权重按
-/// 文件名（大小写不敏感）tie-break 保证确定性。
-class JimakuEpisodeIndex {
-  const JimakuEpisodeIndex._({
-    required this.byEpisode,
-    required this.unnumbered,
-  });
-
-  /// 从 [files] 构建索引（非文本字幕直接丢弃）。
-  factory JimakuEpisodeIndex.fromFiles(
-    List<JimakuFile> files, {
-    String? preferredLanguage,
-  }) {
-    final Map<int, List<JimakuFile>> byEpisode = <int, List<JimakuFile>>{};
-    final List<JimakuFile> unnumbered = <JimakuFile>[];
-    for (final JimakuFile file in files) {
-      if (!file.isTextSubtitle) continue;
-      final int? episode = file.episode;
-      if (episode == null) {
-        unnumbered.add(file);
-      } else {
-        byEpisode.putIfAbsent(episode, () => <JimakuFile>[]).add(file);
-      }
-    }
-    for (final List<JimakuFile> candidates in byEpisode.values) {
-      candidates.sort((JimakuFile a, JimakuFile b) =>
-          _compareByLanguagePreference(a, b, preferredLanguage));
-    }
-    unnumbered.sort((JimakuFile a, JimakuFile b) =>
-        _compareByLanguagePreference(a, b, preferredLanguage));
-    return JimakuEpisodeIndex._(byEpisode: byEpisode, unnumbered: unnumbered);
-  }
-
-  /// 集号 → 该集候选（语言权重升序 = ja 优先，非空列表）。
-  final Map<int, List<JimakuFile>> byEpisode;
-
-  /// 认不出集号的文本字幕（剧场版/整季单文件等），同样按语言权重升序。
-  final List<JimakuFile> unnumbered;
-
-  /// 索引内文本字幕总数。
-  int get totalFiles =>
-      unnumbered.length +
-      byEpisode.values
-          .fold(0, (int sum, List<JimakuFile> list) => sum + list.length);
-
-  /// 索引是否为空（无任何可用文本字幕）。
-  bool get isEmpty => totalFiles == 0;
-}
-
-/// 候选排序键：语言权重升序（ja 优先）→ 文件名（大小写不敏感）tie-break。
-int _compareByLanguagePreference(
-  JimakuFile a,
-  JimakuFile b,
-  String? preferredLanguage,
-) {
-  final int rankA = jimakuLanguageRank(detectSubtitleLanguage(a.name),
-      preferred: preferredLanguage);
-  final int rankB = jimakuLanguageRank(detectSubtitleLanguage(b.name),
-      preferred: preferredLanguage);
-  if (rankA != rankB) return rankA.compareTo(rankB);
-  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-}
 
 /// 种子「集数身份」的类别。见 [TorrentEpisodeScope]。
 enum TorrentEpisodeScopeKind {
@@ -388,17 +334,25 @@ List<ResolvedSubtitleMatch> matchJimakuFilesToVideoNames(
   );
   if (index.isEmpty) return const <ResolvedSubtitleMatch>[];
 
-  // ① 按集号严格相等逐个视频反查。
+  // ① 按集号严格相等逐个视频反查。判据本身走共享原语
+  // （[chooseJimakuFileForEpisode]，BUG-1695），这里只负责「有几个视频、集号从
+  // 文件名怎么来」——即本函数相对批量路径多出来的那部分信息。
   final List<ResolvedSubtitleMatch> out = <ResolvedSubtitleMatch>[];
   for (final String path in videoFileNames) {
     final String name = p.basename(path);
     final int? episode = parseVideoFilename(name).episode;
     if (episode == null) continue;
-    final List<JimakuFile>? candidates = index.byEpisode[episode];
-    if (candidates == null || candidates.isEmpty) continue;
+    final JimakuEpisodeMatch match = chooseJimakuFileForEpisode(
+      index,
+      episode: episode,
+      // 未编号字幕的 1v1 兜底由下面 ② 统一处理（它还要看视频侧集号），这里
+      // 只取精确命中，故一律 false。
+      soleTarget: false,
+    );
+    if (match.kind != JimakuEpisodeMatchKind.exact) continue;
     out.add(ResolvedSubtitleMatch(
       videoFileName: name,
-      file: candidates.first,
+      file: match.file!,
       episode: episode,
     ));
   }

--- a/fushi/lib/src/media/torrent/anime_download_plan.dart
+++ b/fushi/lib/src/media/torrent/anime_download_plan.dart
@@ -180,6 +180,13 @@ class AnimeDownloadPlan {
   /// 上次反查字幕的时刻（epoch 毫秒）；null = 还没试过。
   final int? subtitleLastAttemptAtMs;
 
+  /// 自动重试**还有没有机会**（与「现在是否该重试」不同：这里不看时间）。
+  ///
+  /// UI 用它区分两种完全不同的处境：还会自动重试 = 用户什么都不用做；重试用完了
+  /// = 要么手动补要么改条目。UI 不该自己重算 backoff 算术。
+  bool get subtitleRetryPossible =>
+      jimakuEntryId != null && subtitleAttempts <= subtitleRetryBackoff.length;
+
   /// 现在（[nowMs]）是否该再试一次自动反查字幕。
   ///
   /// 纯函数，无 IO——重试节奏是可单测的决策，不是散在 tick 里的 if。

--- a/fushi/lib/src/media/torrent/anime_download_plan.dart
+++ b/fushi/lib/src/media/torrent/anime_download_plan.dart
@@ -51,6 +51,8 @@ class AnimeDownloadPlan {
     this.jimakuLanguage,
     this.subtitleStatus = subtitleNone,
     this.subtitleNote,
+    this.subtitleAttempts = 0,
+    this.subtitleLastAttemptAtMs,
   });
 
   /// 不涉及字幕（用户没勾「一并下字幕」/ 没选中 Jimaku 条目 / 通用磁链）。
@@ -64,7 +66,22 @@ class AnimeDownloadPlan {
 
   /// 反查完一条都没配上 / Jimaku 取不到；原因见 [subtitleNote]。
   /// **不是静默失败**：任务行会显式显示，用户可用字幕对话框手动补。
+  ///
+  /// 这个状态**不是终态**：生肉普遍早于字幕数小时到数天，第一次反查扑空是常态而
+  /// 非错误。[subtitleRetryBackoff] 定义后续自动重试节奏（BUG-1696）。
   static const String subtitleUnavailable = 'unavailable';
+
+  /// [subtitleUnavailable] 后的自动重试节奏（相对上次尝试的间隔）。
+  ///
+  /// 覆盖「字幕通常在开播后几小时~两天内上传」这个真实分布；跑完就停，不无限
+  /// 轮询——一个永远不会有字幕的条目不该每轮 tick 都打一次 Jimaku。
+  static const List<Duration> subtitleRetryBackoff = <Duration>[
+    Duration(minutes: 15),
+    Duration(hours: 1),
+    Duration(hours: 4),
+    Duration(hours: 12),
+    Duration(hours: 24),
+  ];
 
   /// 内容类型：视频（走视频库入库，番剧默认）。
   static const String kindVideo = 'video';
@@ -157,6 +174,27 @@ class AnimeDownloadPlan {
   /// [subtitleUnavailable] 时的原因（英文短语，落日志/任务行用）。
   final String? subtitleNote;
 
+  /// 已尝试反查字幕的次数（含首次）。用于在 [subtitleRetryBackoff] 里定位下一档。
+  final int subtitleAttempts;
+
+  /// 上次反查字幕的时刻（epoch 毫秒）；null = 还没试过。
+  final int? subtitleLastAttemptAtMs;
+
+  /// 现在（[nowMs]）是否该再试一次自动反查字幕。
+  ///
+  /// 纯函数，无 IO——重试节奏是可单测的决策，不是散在 tick 里的 if。
+  bool shouldRetrySubtitles(int nowMs) {
+    if (subtitleStatus != subtitleUnavailable) return false;
+    // 没有 Jimaku 条目就没有可重试的来源；重试只会每轮白打一次网络。
+    if (jimakuEntryId == null) return false;
+    final int index = subtitleAttempts - 1;
+    if (index < 0) return true;
+    if (index >= subtitleRetryBackoff.length) return false;
+    final int? last = subtitleLastAttemptAtMs;
+    if (last == null) return true;
+    return nowMs - last >= subtitleRetryBackoff[index].inMilliseconds;
+  }
+
   /// 注意：可空字段（[failReason] / [collectionId] 等）无法通过 copyWith
   /// 置回 null（标准模式局限）；状态机只前进赋值，不需要清空。
   AnimeDownloadPlan copyWith({
@@ -180,6 +218,8 @@ class AnimeDownloadPlan {
     String? jimakuLanguage,
     String? subtitleStatus,
     String? subtitleNote,
+    int? subtitleAttempts,
+    int? subtitleLastAttemptAtMs,
   }) {
     return AnimeDownloadPlan(
       id: id ?? this.id,
@@ -202,6 +242,9 @@ class AnimeDownloadPlan {
       jimakuLanguage: jimakuLanguage ?? this.jimakuLanguage,
       subtitleStatus: subtitleStatus ?? this.subtitleStatus,
       subtitleNote: subtitleNote ?? this.subtitleNote,
+      subtitleAttempts: subtitleAttempts ?? this.subtitleAttempts,
+      subtitleLastAttemptAtMs:
+          subtitleLastAttemptAtMs ?? this.subtitleLastAttemptAtMs,
     );
   }
 }
@@ -237,6 +280,8 @@ Map<String, dynamic> encodeAnimeDownloadPlan(AnimeDownloadPlan plan) {
     'jimakuLanguage': plan.jimakuLanguage,
     'subtitleStatus': plan.subtitleStatus,
     'subtitleNote': plan.subtitleNote,
+    'subtitleAttempts': plan.subtitleAttempts,
+    'subtitleLastAttemptAtMs': plan.subtitleLastAttemptAtMs,
   };
 }
 
@@ -310,6 +355,14 @@ AnimeDownloadPlan? decodeAnimeDownloadPlan(Map<dynamic, dynamic> raw) {
               : AnimeDownloadPlan.subtitleResolved),
       subtitleNote:
           raw['subtitleNote'] is String ? raw['subtitleNote'] as String : null,
+      // 缺字段（BUG-1696 之前的计划）→ 0 次尝试。对已经是 unavailable 的老计划，
+      // 这意味着它们会在下一轮 tick 立刻获得**一次**重试机会，之后照 backoff 走。
+      // 这正是想要的：那批计划就是被旧的「取不到就算了」卡住的。
+      subtitleAttempts:
+          raw['subtitleAttempts'] is int ? raw['subtitleAttempts'] as int : 0,
+      subtitleLastAttemptAtMs: raw['subtitleLastAttemptAtMs'] is int
+          ? raw['subtitleLastAttemptAtMs'] as int
+          : null,
     );
   } catch (_) {
     return null;

--- a/fushi/lib/src/media/torrent/anime_download_service.dart
+++ b/fushi/lib/src/media/torrent/anime_download_service.dart
@@ -522,8 +522,17 @@ class AnimeDownloadService {
       for (final AnimeDownloadPlan plan in plans)
         if (plan.status == AnimeDownloadPlan.statusDownloading) plan,
     ];
-    // 没有等待中的计划就不建连接。
-    if (pending.isEmpty) {
+    // 已入库但字幕还没配上、且到了下一档重试时刻的计划（BUG-1696）。判据是纯函数
+    // [AnimeDownloadPlan.shouldRetrySubtitles]，这里只负责取当前时刻。
+    final int tickNowMs = DateTime.now().millisecondsSinceEpoch;
+    final List<AnimeDownloadPlan> subtitleRetries = <AnimeDownloadPlan>[
+      for (final AnimeDownloadPlan plan in plans)
+        if (plan.status != AnimeDownloadPlan.statusDownloading &&
+            plan.shouldRetrySubtitles(tickNowMs))
+          plan,
+    ];
+    // 没有等待中的计划、也没有待重试字幕的计划就不建连接。
+    if (pending.isEmpty && subtitleRetries.isEmpty) {
       _publishProgress(const <String, double>{});
       return;
     }
@@ -586,6 +595,33 @@ class AnimeDownloadService {
           }
           if (!info.isComplete) return;
           await _finishPlan(client, current, info);
+        });
+      }
+
+      // 字幕重试跑在下载轮询之后，复用同一次 listTorrents 结果与同一条 per-plan
+      // 串行边界；单条失败不影响其它计划，也绝不把下载状态判失败。
+      for (final AnimeDownloadPlan plan in subtitleRetries) {
+        final TorrentSnapshot? info = byHash[plan.id.toLowerCase()];
+        if (info == null) continue;
+        await _runPlanSerial<void>(plan.id, () async {
+          AnimeDownloadPlan? current;
+          for (final AnimeDownloadPlan candidate in await store.loadAll()) {
+            if (candidate.id == plan.id) {
+              current = candidate;
+              break;
+            }
+          }
+          // 重新读一遍：串行队列里排在前面的操作（比如用户手动补了字幕、或删了
+          // 计划）可能已经改过它，不能拿 tick 开头那份 stale 副本去写。
+          if (current == null || !current.shouldRetrySubtitles(tickNowMs)) {
+            return;
+          }
+          try {
+            await _retrySubtitlesFor(client, current, info);
+          } catch (_) {
+            // 网络/后端异常：本轮算一次尝试已在 _resolveSubtitles 内记过；
+            // 真正抛到这里的是 listFiles 失败，下轮 backoff 再来。
+          }
         });
       }
     } finally {
@@ -728,42 +764,81 @@ class AnimeDownloadService {
   /// 任何失败路径都落 [AnimeDownloadPlan.subtitleUnavailable] + 原因，不静默：
   /// 视频照常入库（字幕缺失不该让整个下载判失败），用户在任务行能看见「字幕未
   /// 匹配」并用字幕对话框手动补。
+  /// [retrying] = 这是 [subtitleRetryBackoff] 触发的重试（计划已 imported），
+  /// 而不是下载完成时的首次反查。两者除了准入状态外走完全同一条路径。
   Future<AnimeDownloadPlan> _resolveSubtitles(
     AnimeDownloadPlan plan,
-    List<String> videoAbsolutePaths,
-  ) async {
-    if (plan.subtitleStatus != AnimeDownloadPlan.subtitlePending) return plan;
+    List<String> videoAbsolutePaths, {
+    bool retrying = false,
+  }) async {
+    final bool eligible = retrying
+        ? plan.subtitleStatus == AnimeDownloadPlan.subtitleUnavailable
+        : plan.subtitleStatus == AnimeDownloadPlan.subtitlePending;
+    if (!eligible) return plan;
+    // 尝试计数在**发起前**就要记：无论成败都算一次，否则 resolver 每次抛异常就
+    // 永远停在 attempts=0，backoff 退化成「每轮 tick 都打一次」。
+    final AnimeDownloadPlan attempted = plan.copyWith(
+      subtitleAttempts: plan.subtitleAttempts + 1,
+      subtitleLastAttemptAtMs: DateTime.now().millisecondsSinceEpoch,
+    );
     final Future<ResolvedPlanSubtitles> Function(
       AnimeDownloadPlan,
       List<String>,
     )? resolver = _subtitleResolver;
     if (resolver == null) {
-      return plan.copyWith(
+      return attempted.copyWith(
         subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
         subtitleNote: 'subtitle resolver unavailable',
       );
     }
     try {
       final ResolvedPlanSubtitles result = await resolver(
-        plan,
+        attempted,
         videoAbsolutePaths,
       );
       if (result.subtitles.isEmpty) {
-        return plan.copyWith(
+        return attempted.copyWith(
           subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
           subtitleNote: result.failureReason ?? 'no matching subtitle',
         );
       }
-      return plan.copyWith(
+      return attempted.copyWith(
         subtitles: result.subtitles,
         subtitleStatus: AnimeDownloadPlan.subtitleResolved,
       );
     } catch (e) {
-      return plan.copyWith(
+      return attempted.copyWith(
         subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
         subtitleNote: 'subtitle resolve failed: $e',
       );
     }
+  }
+
+  /// 已入库但字幕还没配上的计划，按 [AnimeDownloadPlan.subtitleRetryBackoff]
+  /// 再反查一次（BUG-1696）。
+  ///
+  /// 为什么必须有这一步：`subtitleUnavailable` 的**主流成因是「字幕还没上传」**，
+  /// 是时间问题不是匹配问题。首次反查发生在下载刚完成那一刻——恰恰是字幕最可能
+  /// 还没上传的时刻。没有重试，订阅党的每一集都会永久停在「无字幕」。
+  ///
+  /// 只在种子仍在后端（还在做种）时可行：反查要靠 [TorrentBackend.listFiles] 给出
+  /// 包内真实文件名。种子已被移除的计划自然跳过——那时也已经没有可靠的集号来源。
+  Future<void> _retrySubtitlesFor(
+    TorrentBackend client,
+    AnimeDownloadPlan plan,
+    TorrentSnapshot info,
+  ) async {
+    final List<TorrentFileEntry> files = await client.listFiles(info.hash);
+    final (List<String> videos, _) = _classifyContent(plan, info, files);
+    if (videos.isEmpty) return;
+    final AnimeDownloadPlan resolved = await _resolveSubtitles(
+      plan,
+      videos,
+      retrying: true,
+    );
+    if (identical(resolved, plan)) return;
+    await _placeSidecars(videos, resolved.subtitles);
+    await store.save(resolved);
   }
 
   /// 把配对到的字幕从暂存复制成视频 sidecar。**该集已有任何 sidecar 就整条跳过**；

--- a/fushi/lib/src/media/torrent/anime_download_service.dart
+++ b/fushi/lib/src/media/torrent/anime_download_service.dart
@@ -527,7 +527,9 @@ class AnimeDownloadService {
     final int tickNowMs = DateTime.now().millisecondsSinceEpoch;
     final List<AnimeDownloadPlan> subtitleRetries = <AnimeDownloadPlan>[
       for (final AnimeDownloadPlan plan in plans)
-        if (plan.status != AnimeDownloadPlan.statusDownloading &&
+        // 只给**已入库**的计划补字幕：downloading 的还没到反查时机（首次反查在
+        // _finishPlan 里做），failed 的连视频都没进库，给它配字幕是纯噪音。
+        if (plan.status == AnimeDownloadPlan.statusImported &&
             plan.shouldRetrySubtitles(tickNowMs))
           plan,
     ];

--- a/fushi/lib/src/media/torrent/anime_download_subscription.dart
+++ b/fushi/lib/src/media/torrent/anime_download_subscription.dart
@@ -437,12 +437,17 @@ class AnimeDownloadSubscriptionService {
     final http.Client rawClient = await _httpClientFactory();
     final JimakuClient jimaku = JimakuClient(apiKey: apiKey, client: rawClient);
     try {
+      // 不带 `episode=`：服务端那道过滤是文件名启发式，会把「字幕侧到底有哪些
+      // 集号」这个事实遮住，于是判不出「错季 / 绝对集号」这类冲突（BUG-1695）。
       final List<JimakuFile> files = await jimaku
-          .listFiles(subscription.jimakuEntryId!, episode: episode)
+          .listFiles(subscription.jimakuEntryId!)
           .timeout(kDownloadDiscoveryTimeout);
       final JimakuFile? selected = pickBestSubtitleFile(
         files,
         episode: episode,
+        // 订阅只追单集种子（调用点上方已 `episode == null → continue`），
+        // 所以这一轮确实只有一个待配视频。
+        soleTarget: true,
         preferredLanguage: subscription.jimakuLanguage,
       );
       if (selected == null) return const <PlanSubtitle>[];
@@ -572,10 +577,19 @@ class AnimeDownloadSubscriptionService {
               planStore.subsDirFor(id),
             );
             if (current.jimakuEntryId != null && subtitles.isEmpty) {
-              pendingError = 'subtitle not available for episode $episode from '
-                  '${current.jimakuEntryName ?? current.jimakuEntryId}';
-              await planStore.delete(id);
-              continue;
+              // 这一集的字幕现在还没有——**不是不下这一集的理由**（BUG-1696）。
+              //
+              // 生肉普遍早于字幕数小时到数天。旧实现在这里 delete + continue，
+              // 于是订阅表现为「配了 Jimaku 条目就长期不下东西」，而且每轮
+              // 重新发现、重新扑空，用户看到的是一个永远卡住的订阅。
+              //
+              // 现在照常下片，字幕落 pending：下载完成时由
+              // AnimeDownloadService 按**包内真实文件名**反查（BUG-1206 的强
+              // 判据，比这里按标题猜集号更准），之后还有 backoff 重试兜底。
+              // pendingError 仍然写，任务行照旧告诉用户「这集字幕还没到」。
+              pendingError = 'subtitle not yet available for episode $episode '
+                  'from ${current.jimakuEntryName ?? current.jimakuEntryId}; '
+                  'will retry after download';
             }
             final AnimeDownloadPlan plan = AnimeDownloadPlan(
               id: id,
@@ -590,14 +604,17 @@ class AnimeDownloadSubscriptionService {
               jimakuEntryId: current.jimakuEntryId,
               jimakuEntryName: current.jimakuEntryName,
               jimakuLanguage: current.jimakuLanguage,
-              // 订阅只追**单集**种子（上面 `episode == null` 已 continue），标题
-              // 集号就是该集，且这里已经真的把字幕下下来了 → 直接 resolved。
-              // 不走 BUG-1206 的延迟反查：订阅有一条更强的产品约束——
-              // 「要字幕却取不到就整条不下」（见下方 pendingError 分支），
-              // 改成完成后再取会把这个门变成「先下完再说没字幕」。
-              subtitleStatus: subtitles.isEmpty
-                  ? AnimeDownloadPlan.subtitleNone
-                  : AnimeDownloadPlan.subtitleResolved,
+              // 三态，不是两态（BUG-1696）：
+              // - 已经取到字幕 → resolved（发现时就下好了，最快路径，不变）；
+              // - 没取到但**订阅确实绑了 Jimaku 条目** → pending，交给下载完成后
+              //   按包内真实文件名反查 + backoff 重试。旧代码这里落 none，等于
+              //   宣告「这条永远没字幕」，配合上面那道 delete 门就成了死锁；
+              // - 压根没绑条目 → none（用户没要字幕）。
+              subtitleStatus: subtitles.isNotEmpty
+                  ? AnimeDownloadPlan.subtitleResolved
+                  : (current.jimakuEntryId != null
+                      ? AnimeDownloadPlan.subtitlePending
+                      : AnimeDownloadPlan.subtitleNone),
             );
             await planStore.save(plan);
             queued = await backend.addTorrent(

--- a/fushi/lib/src/media/torrent/anime_download_subtitle_resolver.dart
+++ b/fushi/lib/src/media/torrent/anime_download_subtitle_resolver.dart
@@ -1,12 +1,15 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/torrent/anime_download_matching.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
 
 /// 延迟字幕解析的结果：配好的字幕 + 失败原因（二选一有值）。
 class ResolvedPlanSubtitles {
@@ -85,7 +88,7 @@ class JimakuPlanSubtitleResolver {
             'no jimaku file matches the pack episodes');
       }
       return ResolvedPlanSubtitles.ok(
-        await _download(plan, matches, jimaku),
+        await _download(plan, matches, jimaku, videoAbsolutePaths),
       );
     } catch (e) {
       return ResolvedPlanSubtitles.failed('jimaku fetch failed: $e');
@@ -96,19 +99,43 @@ class JimakuPlanSubtitleResolver {
 
   /// 逐条下载并落进计划暂存目录；同一 URL 只下一次（同集多版本视频会指向同一
   /// 字幕）。单条失败跳过，不影响其余。
+  ///
+  /// 落盘前过一道时长/内容校验（BUG-1697）：集号匹配只保证「文件名对得上」，
+  /// 保证不了「内容是这一集的」。整季合并成一个文件、条目里混进电影字幕这类形状，
+  /// 文件名可以完全合规，只有看内容才发现得了。校验不过的**跳过该条**，其余照配
+  /// ——这与本文件既有的「单条失败跳过」语义一致。
   Future<List<PlanSubtitle>> _download(
     AnimeDownloadPlan plan,
     List<ResolvedSubtitleMatch> matches,
     JimakuClient jimaku,
+    List<String> videoAbsolutePaths,
   ) async {
     final Directory subsDir = _stagingDirFor(plan.id);
     final Map<String, String> stagedByUrl = <String, String>{};
     final List<PlanSubtitle> out = <PlanSubtitle>[];
+    // 每个视频只探一次时长（同一 URL 的字幕会配给多个视频，但校验是按视频算的）。
+    final Map<String, int?> durationByVideo = <String, int?>{};
     for (final ResolvedSubtitleMatch match in matches) {
       String? staged = stagedByUrl[match.file.url];
       if (staged == null) {
         final Uint8List? bytes = await jimaku.downloadFile(match.file.url);
         if (bytes == null) continue;
+        final String? videoPath = _videoPathFor(match, videoAbsolutePaths);
+        if (videoPath != null) {
+          final int? durationMs = durationByVideo.containsKey(videoPath)
+              ? durationByVideo[videoPath]
+              : (durationByVideo[videoPath] =
+                  await probeVideoDurationMs(videoPath));
+          final SubtitleTimingCheck check = checkSubtitleTiming(
+            summarizeSubtitleTiming(await decodeTextBytes(bytes)),
+            video: durationMs == null
+                ? null
+                : KnownVideoDuration.probed(durationMs),
+          );
+          // 这条路径**没有备选候选**（集号已经锁定唯一一条字幕），所以只认正面
+          // 矛盾，不因「读不出」就把用户唯一的字幕扔掉。见 contradictsVideo。
+          if (check.contradictsVideo) continue;
+        }
         try {
           final File dest =
               File(p.join(subsDir.path, p.basename(match.file.name)))
@@ -128,5 +155,17 @@ class JimakuPlanSubtitleResolver {
       ));
     }
     return out;
+  }
+
+  /// 把一条匹配还原回它对应的**视频绝对路径**（[ResolvedSubtitleMatch] 只记
+  /// basename）。找不到返回 null → 该条跳过时长校验，只按原路径落盘。
+  static String? _videoPathFor(
+    ResolvedSubtitleMatch match,
+    List<String> videoAbsolutePaths,
+  ) {
+    for (final String path in videoAbsolutePaths) {
+      if (p.basename(path) == match.videoFileName) return path;
+    }
+    return null;
   }
 }

--- a/fushi/lib/src/media/torrent/anime_download_subtitle_resolver.dart
+++ b/fushi/lib/src/media/torrent/anime_download_subtitle_resolver.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:fushi/src/media/torrent/anime_download_matching.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_language_preference.dart';
 import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
 import 'package:fushi/src/media/video/video_duration_probe.dart';
 
@@ -39,13 +40,19 @@ class JimakuPlanSubtitleResolver {
     required String Function() apiKeyProvider,
     required Future<http.Client> Function() httpClientFactory,
     required Directory Function(String planId) stagingDirFor,
+    String Function()? defaultContentLanguageProvider,
   })  : _apiKeyProvider = apiKeyProvider,
         _httpClientFactory = httpClientFactory,
-        _stagingDirFor = stagingDirFor;
+        _stagingDirFor = stagingDirFor,
+        _defaultContentLanguage = defaultContentLanguageProvider ?? (() => '');
 
   final String Function() _apiKeyProvider;
   final Future<http.Client> Function() _httpClientFactory;
   final Directory Function(String planId) _stagingDirFor;
+
+  /// 设置·外观·排版里的默认内容语言（选字幕语言的最后一档）。回调而非快照：
+  /// 用户随时能改，而本 resolver 的生命周期跟 service 一样长。
+  final String Function() _defaultContentLanguage;
 
   /// 为 [plan] 按 [videoAbsolutePaths]（包内真实视频）补取字幕。
   Future<ResolvedPlanSubtitles> resolve(
@@ -76,10 +83,20 @@ class JimakuPlanSubtitleResolver {
       if (files.isEmpty) {
         return const ResolvedPlanSubtitles.failed('jimaku entry has no files');
       }
+      // 语言优先级：用户在下载对话框里显式选的 > 视频自己的语言（音轨 tag）>
+      // 全局默认内容语言。都没有时传 null，`jimakuLanguageRank` 退回它自己的默认
+      // 权重——Jimaku 是日语字幕站，那条默认在这里是合理的领域知识，不是全局假设。
+      final String? preferredLanguage = resolveSubtitleDownloadLanguage(
+        explicitSubtitlePreference: plan.jimakuLanguage,
+        contentMetadataLanguage:
+            (await probeVideoFacts(videoAbsolutePaths.first))
+                .primaryAudioLanguage,
+        globalDefaultContentLanguage: _defaultContentLanguage(),
+      );
       final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
         videoAbsolutePaths,
         files,
-        preferredLanguage: plan.jimakuLanguage,
+        preferredLanguage: preferredLanguage,
       );
       if (matches.isEmpty) {
         // 反查一条都对不上——绝大多数是条目选错季或用了绝对集号编号。

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -28,6 +28,7 @@ import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_source_scrape_coordinator.dart';
 import 'package:fushi/src/media/video/metadata/video_source_work_planner.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_language_preference.dart';
 import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
@@ -521,6 +522,7 @@ class VideoDownloadPipelineService {
     required this.scrapeCoordinator,
     this.onBackendTaskAdded,
     this.subtitleRegistry,
+    this.defaultContentLanguage,
     Iterable<String> preferredSubtitleLanguages = const <String>[],
     String? workerId,
     this.pollInterval = const Duration(seconds: 5),
@@ -533,7 +535,14 @@ class VideoDownloadPipelineService {
   final FushiDatabase database;
   final VideoResourceRegistry resourceRegistry;
   final VideoSubtitleRegistry? subtitleRegistry;
+
+  /// 用户在设置里**显式**选的字幕语言（`jimakuDefaultLanguage`）。非空即硬过滤
+  /// （进 `VideoSubtitleSearchRequest.languages`）——他自己说的。
   final List<String> preferredSubtitleLanguages;
+
+  /// 设置·外观·排版里的默认内容语言。没有显式字幕语言、视频也没有可读语言时的
+  /// 最后一档；空/null = 不表态（**不猜**，见 subtitle_language_preference.dart）。
+  final String? defaultContentLanguage;
   final VideoDownloadBackendResolver backendResolver;
   final VideoSourceScrapeCoordinator scrapeCoordinator;
   final Future<void> Function(VideoDownloadJobRow job)? onBackendTaskAdded;
@@ -1918,17 +1927,31 @@ class VideoDownloadPipelineService {
     if (candidates.isEmpty) {
       return (picked: null, reason: 'No subtitle candidate was returned');
     }
-    final int? durationMs = await probeVideoDurationMs(videoPath);
+    // 一次 ffprobe 拿两件事实：时长（校验用）+ 音轨语言（选语言用）。
+    final VideoProbeFacts facts = await probeVideoFacts(videoPath);
     _ensureLeaseHeld();
-    final KnownVideoDuration? known =
-        durationMs == null ? null : KnownVideoDuration.probed(durationMs);
+    final KnownVideoDuration? known = facts.durationMs == null
+        ? null
+        : KnownVideoDuration.probed(facts.durationMs!);
+    // 默认取**视频自己的语言**：设置里显式选过就用那个，否则用音轨自报的语言。
+    // 这里是**排序**不是过滤——只有英文字幕的日语番仍然配得上，只是排在后面。
+    final String? preferredLanguage = resolveSubtitleDownloadLanguage(
+      explicitSubtitlePreference: preferredSubtitleLanguages.firstOrNull,
+      contentMetadataLanguage: facts.primaryAudioLanguage,
+      globalDefaultContentLanguage: defaultContentLanguage,
+    );
+    final List<VideoSubtitleCandidate> ordered = rankByPreferredLanguage(
+      candidates,
+      preferredLanguage,
+      (VideoSubtitleCandidate c) => c.language,
+    );
     String? lastRejection;
     String? lastDownloadError;
-    final int limit = candidates.length < kSubtitleVerifyMaxCandidates
-        ? candidates.length
+    final int limit = ordered.length < kSubtitleVerifyMaxCandidates
+        ? ordered.length
         : kSubtitleVerifyMaxCandidates;
     for (int i = 0; i < limit; i++) {
-      final VideoSubtitleCandidate candidate = candidates[i];
+      final VideoSubtitleCandidate candidate = ordered[i];
       final VideoSubtitleDownload download;
       try {
         download = await subtitleRegistry!.download(candidate);

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart' show Value;
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
 
@@ -26,14 +28,33 @@ import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_source_scrape_coordinator.dart';
 import 'package:fushi/src/media/video/metadata/video_source_work_planner.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/media/video/video_sidecar.dart'
     show listSidecarSubtitles;
 import 'package:fushi/src/utils/misc/error_log_service.dart';
 
 enum VideoDownloadSubtitlePolicy { none, bestEffort, required }
+
+/// 自动选字幕时最多真下几条候选来做时长校验（BUG-1697）。
+///
+/// 候选可能有几十条（多语言 × 多压制组），全下一遍既慢又是对来源站的滥用。
+/// 试完前 N 条还没有通过的，说明这个片子的自动匹配本来就不该硬猜，交给用户手选。
+const int kSubtitleVerifyMaxCandidates = 4;
+
+/// 已通过校验的候选 + 它那一次下载的字节（避免落盘前再下一遍）。
+class _VerifiedSubtitleBytes {
+  const _VerifiedSubtitleBytes({
+    required this.candidate,
+    required this.download,
+  });
+
+  final VideoSubtitleCandidate candidate;
+  final VideoSubtitleDownload download;
+}
 
 const String videoDownloadMissingBackendTaskError =
     'torrent is not visible in the original backend';
@@ -1755,8 +1776,29 @@ class VideoDownloadPipelineService {
             );
             throw VideoDownloadPipelineActionRequired(message);
           }
-        } else {
-          candidate = result.items.first;
+        }
+        // 自动选片时**先验证再采用**：下载候选字节，用时长/内容判据核一遍，不过
+        // 就换下一个候选（BUG-1697）。旧实现直接 `result.items.first`，排序只按
+        // provider 优先级与下载量，从不看内容——把整季合并文件装到某一集上是无声
+        // 通过的。手动选中的候选（persistedSelection）不参与筛选：用户的显式选择
+        // 优先于任何启发式。
+        _VerifiedSubtitleBytes? verified;
+        if (candidate == null) {
+          verified = await _selectVerifiedSubtitle(
+            candidates: result.items,
+            videoPath: video.path,
+          );
+          if (verified == null) {
+            const String message =
+                'Every subtitle candidate failed the timing check '
+                'against this video';
+            await _recordUnavailableSubtitle(job, file, subtitleId, message);
+            if (policy == VideoDownloadSubtitlePolicy.required) {
+              throw const VideoDownloadPipelineActionRequired(message);
+            }
+            continue;
+          }
+          candidate = verified.candidate;
         }
         final String extension = _safeSubtitleExtension(candidate.fileName);
         final String language = candidate.language.trim().isEmpty
@@ -1790,8 +1832,10 @@ class VideoDownloadPipelineService {
             updatedAt: Value<int>(now),
           ),
         );
+        // 自动路径已经在校验时下过一次字节，直接复用——校验不该让每条字幕多下
+        // 一遍。手动/续跑路径没验过，这里才真去下。
         final VideoSubtitleDownload download =
-            await subtitleRegistry!.download(candidate);
+            verified?.download ?? await subtitleRegistry!.download(candidate);
         _ensureLeaseHeld();
         final String selectedTarget = await _selectSidecarTarget(
           bytes: download.bytes,
@@ -1849,6 +1893,61 @@ class VideoDownloadPipelineService {
       );
     }
     await _advance(job, VideoDownloadJobStage.import);
+  }
+
+  /// 依次下载 [candidates] 并做时长/内容校验，返回**第一个通过**的候选及其字节。
+  ///
+  /// 为什么要真下下来才能判：判据看的是字幕内容本身（最后一句结束在哪），搜索
+  /// 结果里只有文件名和体积。体积判不了——同样 40KB 的 ass 可能是一集也可能是
+  /// 整季。
+  ///
+  /// [kSubtitleVerifyMaxCandidates] 是硬上界：候选可能有几十条（多语言 × 多压制
+  /// 组），全下一遍既慢又是对来源站的滥用。试完前 N 条还没通过就放弃，让用户
+  /// 手动选——那时候自动匹配本来也不该硬猜。
+  ///
+  /// 探不到视频时长（缺 ffprobe / 超时）时判据退化成只做内容自检，**绝不因为
+  /// 探测失败就拒收**。
+  Future<_VerifiedSubtitleBytes?> _selectVerifiedSubtitle({
+    required List<VideoSubtitleCandidate> candidates,
+    required String videoPath,
+  }) async {
+    if (candidates.isEmpty) return null;
+    final int? durationMs = await probeVideoDurationMs(videoPath);
+    _ensureLeaseHeld();
+    final KnownVideoDuration? known =
+        durationMs == null ? null : KnownVideoDuration.probed(durationMs);
+    _VerifiedSubtitleBytes? firstRejected;
+    final int limit = candidates.length < kSubtitleVerifyMaxCandidates
+        ? candidates.length
+        : kSubtitleVerifyMaxCandidates;
+    for (int i = 0; i < limit; i++) {
+      final VideoSubtitleCandidate candidate = candidates[i];
+      final VideoSubtitleDownload download;
+      try {
+        download = await subtitleRegistry!.download(candidate);
+      } on Object catch (error) {
+        // 单条下载失败不该中断整轮筛选——下一条可能好好的。
+        debugPrint('[subtitle] candidate download failed '
+            '(${candidate.providerId}:${candidate.remoteId}): $error');
+        continue;
+      }
+      _ensureLeaseHeld();
+      final SubtitleTimingCheck check = checkSubtitleTiming(
+        summarizeSubtitleTiming(await decodeTextBytes(download.bytes)),
+        video: known,
+      );
+      if (!check.rejected) {
+        return _VerifiedSubtitleBytes(candidate: candidate, download: download);
+      }
+      debugPrint('[subtitle] rejected candidate '
+          '"${candidate.fileName}": ${check.detail}');
+      firstRejected ??=
+          _VerifiedSubtitleBytes(candidate: candidate, download: download);
+    }
+    // 视频时长未知时判据只做内容自检，被拒的一定是「真的解析不出/是空的」，
+    // 那就不该退而求其次。有时长信息时同理：全都对不上视频，硬装一个只会让
+    // 用户以为自动匹配好了。两种情况都返回 null，由调用方落明确的失败原因。
+    return null;
   }
 
   /// Copies old JSON-plan subtitle staging files without consuming them.

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -1784,17 +1784,20 @@ class VideoDownloadPipelineService {
         // 优先于任何启发式。
         _VerifiedSubtitleBytes? verified;
         if (candidate == null) {
-          verified = await _selectVerifiedSubtitle(
+          final ({_VerifiedSubtitleBytes? picked, String? reason}) selection =
+              await _selectVerifiedSubtitle(
             candidates: result.items,
             videoPath: video.path,
           );
+          verified = selection.picked;
           if (verified == null) {
-            const String message =
-                'Every subtitle candidate failed the timing check '
-                'against this video';
+            // 原因要说清是「都没通过校验」还是「一条都没下下来」——两者对用户是
+            // 不同的动作（改条目 vs 查网络）。
+            final String message = selection.reason ??
+                'No subtitle candidate could be verified against this video';
             await _recordUnavailableSubtitle(job, file, subtitleId, message);
             if (policy == VideoDownloadSubtitlePolicy.required) {
-              throw const VideoDownloadPipelineActionRequired(message);
+              throw VideoDownloadPipelineActionRequired(message);
             }
             continue;
           }
@@ -1907,16 +1910,20 @@ class VideoDownloadPipelineService {
   ///
   /// 探不到视频时长（缺 ffprobe / 超时）时判据退化成只做内容自检，**绝不因为
   /// 探测失败就拒收**。
-  Future<_VerifiedSubtitleBytes?> _selectVerifiedSubtitle({
+  Future<({_VerifiedSubtitleBytes? picked, String? reason})>
+      _selectVerifiedSubtitle({
     required List<VideoSubtitleCandidate> candidates,
     required String videoPath,
   }) async {
-    if (candidates.isEmpty) return null;
+    if (candidates.isEmpty) {
+      return (picked: null, reason: 'No subtitle candidate was returned');
+    }
     final int? durationMs = await probeVideoDurationMs(videoPath);
     _ensureLeaseHeld();
     final KnownVideoDuration? known =
         durationMs == null ? null : KnownVideoDuration.probed(durationMs);
-    _VerifiedSubtitleBytes? firstRejected;
+    String? lastRejection;
+    String? lastDownloadError;
     final int limit = candidates.length < kSubtitleVerifyMaxCandidates
         ? candidates.length
         : kSubtitleVerifyMaxCandidates;
@@ -1927,6 +1934,7 @@ class VideoDownloadPipelineService {
         download = await subtitleRegistry!.download(candidate);
       } on Object catch (error) {
         // 单条下载失败不该中断整轮筛选——下一条可能好好的。
+        lastDownloadError = _safeError(error.toString());
         debugPrint('[subtitle] candidate download failed '
             '(${candidate.providerId}:${candidate.remoteId}): $error');
         continue;
@@ -1937,17 +1945,31 @@ class VideoDownloadPipelineService {
         video: known,
       );
       if (!check.rejected) {
-        return _VerifiedSubtitleBytes(candidate: candidate, download: download);
+        return (
+          picked:
+              _VerifiedSubtitleBytes(candidate: candidate, download: download),
+          reason: null,
+        );
       }
+      lastRejection = check.detail;
       debugPrint('[subtitle] rejected candidate '
           '"${candidate.fileName}": ${check.detail}');
-      firstRejected ??=
-          _VerifiedSubtitleBytes(candidate: candidate, download: download);
     }
-    // 视频时长未知时判据只做内容自检，被拒的一定是「真的解析不出/是空的」，
-    // 那就不该退而求其次。有时长信息时同理：全都对不上视频，硬装一个只会让
-    // 用户以为自动匹配好了。两种情况都返回 null，由调用方落明确的失败原因。
-    return null;
+    // 一条都没通过就不退而求其次：硬装一个只会让用户以为自动匹配好了，而错字幕
+    // 比没字幕更难发现。原因分两类回给调用方——「都没通过校验」要改条目，
+    // 「一条都没下下来」要查网络。
+    if (lastRejection != null) {
+      return (
+        picked: null,
+        reason: 'No subtitle candidate matched this video ($lastRejection)',
+      );
+    }
+    return (
+      picked: null,
+      reason: lastDownloadError == null
+          ? 'No subtitle candidate could be downloaded'
+          : 'Subtitle download failed: $lastDownloadError',
+    );
   }
 
   /// Copies old JSON-plan subtitle staging files without consuming them.

--- a/fushi/lib/src/media/video/download/video_subtitle_registry.dart
+++ b/fushi/lib/src/media/video/download/video_subtitle_registry.dart
@@ -17,13 +17,12 @@ class VideoSubtitleRegistry {
   ) async {
     final bool anime =
         request.media?.discoveryCategory == VideoDiscoveryCategory.anime;
-    final List<VideoSubtitleProvider> applicable = providers
-        .where(
-          (VideoSubtitleProvider provider) => anime
-              ? provider.id == 'jimaku' || provider.id == 'opensubtitles'
-              : provider.id == 'opensubtitles',
-        )
-        .toList()
+    // 此前非动画只放 OpenSubtitles，理由大概是「Jimaku 是番剧字幕站」。这不成立：
+    // Jimaku 上有数千条真人日剧/日影条目，而它们恰恰是本 app（日语沉浸）最需要
+    // 日语字幕、OpenSubtitles 又最缺日语轨的一类。真正把真人剧挡死的是
+    // JimakuAnimeFilter（BUG-1694），那个修好之后这道分类门就只剩「少搜一家」的
+    // 净损失。动画仍旧 Jimaku 优先，排序不变。
+    final List<VideoSubtitleProvider> applicable = providers.toList()
       ..sort((VideoSubtitleProvider a, VideoSubtitleProvider b) {
         if (anime && a.id != b.id) {
           if (a.id == 'jimaku') return -1;

--- a/fushi/lib/src/media/video/jimaku_batch.dart
+++ b/fushi/lib/src/media/video/jimaku_batch.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/jimaku_matching.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 
 /// 合集批量字幕下载里的一集输入：稳定身份 + 定位信息 + 合集内序位。
@@ -93,33 +94,26 @@ int resolveBatchEpisode(JimakuBatchTarget target) {
 
 /// 从某集的候选文件里挑最佳字幕。纯函数，便于单测。
 ///
-/// Jimaku 的 `episode` 服务端过滤是**文件名启发式**，可能回整季打包 / 邻集文件，故：
-/// 1. 先只留精确命中 [episode] 集号的文本字幕；一个都没有再退回全体文本字幕（尽力而为，
-///    避免因启发式漏判而整集拿不到字幕）；
-/// 2. 池内按语言权重（[jimakuLanguageRank]，优先 [preferredLanguage]）→ 文件名排序，取首。
+/// **判据不在这里**——委托给全仓唯一的 [chooseJimakuFileForEpisode]（BUG-1695）。
+/// 本函数只剩「把文件列表建成索引」这一步存在的理由，保留是为了不改既有调用点形状。
 ///
-/// 无任何文本字幕候选返回 null（该集记 noMatch）。
+/// [soleTarget] 见 [chooseJimakuFileForEpisode]：只有本次匹配确实只有一个待配视频
+/// 时，未编号字幕（剧场版 / 整季单文件）才允许被采用。
+///
+/// 旧实现在「集号一个都没命中」时会退回**全体文本字幕取第一个**。那不是尽力而为，
+/// 是把「错季 / 绝对集号编号 / 条目选错」这三种冲突静默变成一个错答案：整季 12 集
+/// 会拿到同一个文件，状态还显示 done。冲突现在明确记 noMatch。
 JimakuFile? pickBestSubtitleFile(
   List<JimakuFile> files, {
   required int episode,
+  required bool soleTarget,
   String? preferredLanguage,
-}) {
-  final List<JimakuFile> text =
-      files.where((JimakuFile f) => f.isTextSubtitle).toList();
-  if (text.isEmpty) return null;
-  final List<JimakuFile> matching =
-      text.where((JimakuFile f) => f.episode == episode).toList();
-  final List<JimakuFile> pool = matching.isNotEmpty ? matching : text;
-  pool.sort((JimakuFile a, JimakuFile b) {
-    final int la = jimakuLanguageRank(detectSubtitleLanguage(a.name),
-        preferred: preferredLanguage);
-    final int lb = jimakuLanguageRank(detectSubtitleLanguage(b.name),
-        preferred: preferredLanguage);
-    if (la != lb) return la.compareTo(lb);
-    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-  });
-  return pool.first;
-}
+}) =>
+    chooseJimakuFileForEpisode(
+      JimakuEpisodeIndex.fromFiles(files, preferredLanguage: preferredLanguage),
+      episode: episode,
+      soleTarget: soleTarget,
+    ).file;
 
 /// 批量下载落盘的文件名：以稳定 bookUid（清洗成合法文件名段）为前缀，避免多集拿到同名
 /// 文件（整季打包字幕对不同集同名）时互相覆盖。纯函数，便于单测。
@@ -169,6 +163,31 @@ Future<List<JimakuBatchItem>> runJimakuBatch({
   final List<int> ids = entryIds.toSet().toList(growable: false);
   final List<JimakuBatchItem> results = <JimakuBatchItem>[];
   final Directory dir = Directory(saveDirectory);
+  final bool soleTarget = targets.length == 1;
+
+  // 条目文件**整批只列一次**（不带 episode query），而不是每集每条目各列一次。
+  //
+  // 两个理由，第二个才是重点（BUG-1695）：
+  // ① 请求数从 targets×entries 降到 entries；
+  // ② 带 `episode=` 时服务端按**文件名启发式**先过滤一道，客户端拿到的就只是它的
+  //    猜测——「字幕侧到底有哪些集号」这个事实被遮住了，于是没法区分「这一集没有
+  //    字幕」和「整个条目就是按绝对集号编号的」。要判集号冲突，必须看到全集合。
+  final List<JimakuFile> allFiles = <JimakuFile>[];
+  JimakuEpisodeIndex? sharedIndex;
+  String? listError;
+  try {
+    for (final int id in ids) {
+      allFiles.addAll(await client.listFiles(id, throwOnError: true));
+    }
+    sharedIndex = JimakuEpisodeIndex.fromFiles(
+      allFiles,
+      preferredLanguage: preferredLanguage,
+    );
+  } catch (e) {
+    // 列文件失败是整批共因，不能伪装成每集各自的 noMatch（fail-open 会让用户以为
+    // 「这个条目没字幕」）。逐集记 failed，保持「单集失败不中断」的既有语义。
+    listError = '$e';
+  }
 
   for (final JimakuBatchTarget target in targets) {
     final JimakuBatchItem item = JimakuBatchItem(
@@ -177,24 +196,25 @@ Future<List<JimakuBatchItem>> runJimakuBatch({
     );
     item.status = JimakuBatchStatus.downloading;
     if (onItemStart != null) await onItemStart(item);
+    if (listError != null) {
+      item.status = JimakuBatchStatus.failed;
+      item.message = listError;
+      if (onItemDone != null) await onItemDone(item);
+      results.add(item);
+      continue;
+    }
     try {
-      final List<JimakuFile> files = <JimakuFile>[];
-      for (final int id in ids) {
-        files.addAll(
-          await client.listFiles(
-            id,
-            episode: item.episode,
-            throwOnError: true,
-          ),
-        );
-      }
-      final JimakuFile? best = pickBestSubtitleFile(
-        files,
+      final JimakuEpisodeMatch match = chooseJimakuFileForEpisode(
+        sharedIndex!,
         episode: item.episode,
-        preferredLanguage: preferredLanguage,
+        soleTarget: soleTarget,
       );
+      final JimakuFile? best = match.file;
       if (best == null) {
         item.status = JimakuBatchStatus.noMatch;
+        // 「为什么没配上」对用户是三件不同的事（改条目 / 等字幕 / 无能为力），
+        // 别全压成一句「无匹配」。
+        item.message = match.failureReason;
       } else {
         final Uint8List? bytes = await client.downloadFile(best.url);
         if (bytes == null) {

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -359,6 +359,34 @@ Uri buildListFilesUri(String base, int entryId, {int? episode}) {
   return uri.replace(queryParameters: <String, String>{'episode': '$episode'});
 }
 
+/// `/entries/search` 的 `anime` 过滤三态。
+///
+/// Jimaku 服务端把 `anime` 当**硬相等过滤**（不是排序权重），且**缺省 `true`**。
+/// 此前本客户端从不拼这个参数，等于每次都在 `anime=true` 的子集里搜——Jimaku 上
+/// 数千条真人日剧/电影条目**在任何入口都搜不到**（BUG-1694）。这不是「匹配不准」，
+/// 是整类内容的功能缺失，所以修法是把过滤面变成调用方可表达的值，而不是在某一处
+/// 补一个 if。
+enum JimakuAnimeFilter {
+  /// 只搜动画（= 服务端缺省，与本改动前逐字节同一结果集）。
+  anime,
+
+  /// 只搜真人（日剧 / 真人电影）。
+  liveAction,
+
+  /// 种类未知：先动画、空结果再真人。
+  either;
+
+  /// 本过滤态展开成的 `anime` 参数值序列（按尝试顺序）。
+  ///
+  /// 动画排在前面不是随手定的：本 app 的主用例是动画，动画命中就不该为一个同名
+  /// 真人条目多打一次请求，且结果顺序直接决定 `searchEntries` 返回的首条。
+  List<String> get queryValues => switch (this) {
+        JimakuAnimeFilter.anime => const <String>['true'],
+        JimakuAnimeFilter.liveAction => const <String>['false'],
+        JimakuAnimeFilter.either => const <String>['true', 'false'],
+      };
+}
+
 /// Jimaku API 客户端（参照 asbplayer 的 Jimaku 集成）。需用户在设置/对话框填 API key。
 ///
 /// 端点：`/api/entries/search`（按 anilist_id 或 query 搜条目）、`/api/entries/<id>/files`
@@ -378,12 +406,17 @@ class JimakuClient {
       };
 
   /// 按 AniList id 搜 Jimaku 条目。
+  ///
+  /// [animeFilter] 见 [JimakuAnimeFilter]；缺省 [JimakuAnimeFilter.either]
+  /// （动画搜不到再搜真人）。调用方知道种类时显式传，可省掉那次兜底请求。
   Future<List<JimakuEntry>> searchByAnilistId(
     int anilistId, {
     bool throwOnError = false,
+    JimakuAnimeFilter animeFilter = JimakuAnimeFilter.either,
   }) async {
-    return _searchEntries(
+    return _searchWithAnimeFilter(
       <String, String>{'anilist_id': '$anilistId'},
+      animeFilter,
       throwOnError: throwOnError,
     );
   }
@@ -392,12 +425,33 @@ class JimakuClient {
   Future<List<JimakuEntry>> searchByQuery(
     String query, {
     bool throwOnError = false,
+    JimakuAnimeFilter animeFilter = JimakuAnimeFilter.either,
   }) async {
     if (query.trim().isEmpty) return const <JimakuEntry>[];
-    return _searchEntries(
+    return _searchWithAnimeFilter(
       <String, String>{'query': query},
+      animeFilter,
       throwOnError: throwOnError,
     );
+  }
+
+  /// 按 [filter] 把一次逻辑搜索展开成 1~2 次 `/entries/search`。
+  ///
+  /// 顺序回退而非并发两发：见 [JimakuAnimeFilter.queryValues]。任一档命中即停，
+  /// 所以动画用例的请求数与本改动前完全一致（仍是 1 次）。
+  Future<List<JimakuEntry>> _searchWithAnimeFilter(
+    Map<String, String> params,
+    JimakuAnimeFilter filter, {
+    required bool throwOnError,
+  }) async {
+    for (final String value in filter.queryValues) {
+      final List<JimakuEntry> found = await _searchEntries(
+        <String, String>{...params, 'anime': value},
+        throwOnError: throwOnError,
+      );
+      if (found.isNotEmpty) return found;
+    }
+    return const <JimakuEntry>[];
   }
 
   /// 「先按 AniList id 搜、搜不到再按文本搜」的收敛入口——Jimaku 条目只有被人工挂上
@@ -409,11 +463,13 @@ class JimakuClient {
     int? anilistId,
     List<String> queryFallbacks = const <String>[],
     bool throwOnError = false,
+    JimakuAnimeFilter animeFilter = JimakuAnimeFilter.either,
   }) async {
     if (anilistId != null) {
       final List<JimakuEntry> byId = await searchByAnilistId(
         anilistId,
         throwOnError: throwOnError,
+        animeFilter: animeFilter,
       );
       if (byId.isNotEmpty) return byId;
     }
@@ -422,6 +478,7 @@ class JimakuClient {
       final List<JimakuEntry> byQuery = await searchByQuery(
         query,
         throwOnError: throwOnError,
+        animeFilter: animeFilter,
       );
       if (byQuery.isNotEmpty) return byQuery;
     }

--- a/fushi/lib/src/media/video/jimaku_matching.dart
+++ b/fushi/lib/src/media/video/jimaku_matching.dart
@@ -1,0 +1,171 @@
+/// Jimaku 字幕「哪一个文件是这一集的」的**唯一决策原语**。
+///
+/// 此前同一个问题在仓库里有三份互相矛盾的答案（BUG-1695）：
+/// - `matchJimakuFilesToVideoNames`（番剧下载落位）：集号对不上就**不配**；
+/// - `pickBestSubtitleFile`（合集批量）：集号对不上就**退回列表第一个**，于是
+///   整季 12 集全挂同一个错字幕，状态还显示 done；
+/// - 播放页对话框：由用户肉眼挑。
+///
+/// 两条自动路径给出相反结论，说明判据没有被表达成一个东西。本文件就是那个东西：
+/// [JimakuEpisodeIndex] 是字幕侧的事实，[chooseJimakuFileForEpisode] 是唯一判据，
+/// 其它模块只允许调用它，不再各写一遍 `where(...).isNotEmpty ? ... : ...`。
+library;
+
+import 'package:fushi/src/media/video/jimaku_client.dart';
+
+/// 从 Jimaku 文件列表构建的按集索引。
+///
+/// 只收文本字幕（[JimakuFile.isTextSubtitle]）；每集候选按语言权重升序排列
+/// （[jimakuLanguageRank] + [detectSubtitleLanguage]，即 ja 优先），同权重按
+/// 文件名（大小写不敏感）tie-break 保证确定性。
+class JimakuEpisodeIndex {
+  const JimakuEpisodeIndex._({
+    required this.byEpisode,
+    required this.unnumbered,
+  });
+
+  /// 从 [files] 构建索引（非文本字幕直接丢弃）。
+  factory JimakuEpisodeIndex.fromFiles(
+    List<JimakuFile> files, {
+    String? preferredLanguage,
+  }) {
+    final Map<int, List<JimakuFile>> byEpisode = <int, List<JimakuFile>>{};
+    final List<JimakuFile> unnumbered = <JimakuFile>[];
+    for (final JimakuFile file in files) {
+      if (!file.isTextSubtitle) continue;
+      final int? episode = file.episode;
+      if (episode == null) {
+        unnumbered.add(file);
+      } else {
+        byEpisode.putIfAbsent(episode, () => <JimakuFile>[]).add(file);
+      }
+    }
+    for (final List<JimakuFile> candidates in byEpisode.values) {
+      candidates.sort((JimakuFile a, JimakuFile b) =>
+          compareJimakuByLanguagePreference(a, b, preferredLanguage));
+    }
+    unnumbered.sort((JimakuFile a, JimakuFile b) =>
+        compareJimakuByLanguagePreference(a, b, preferredLanguage));
+    return JimakuEpisodeIndex._(byEpisode: byEpisode, unnumbered: unnumbered);
+  }
+
+  /// 集号 → 该集候选（语言权重升序 = ja 优先，非空列表）。
+  final Map<int, List<JimakuFile>> byEpisode;
+
+  /// 认不出集号的文本字幕（剧场版/整季单文件等），同样按语言权重升序。
+  final List<JimakuFile> unnumbered;
+
+  /// 索引内文本字幕总数。
+  int get totalFiles =>
+      unnumbered.length +
+      byEpisode.values
+          .fold(0, (int sum, List<JimakuFile> list) => sum + list.length);
+
+  /// 索引是否为空（无任何可用文本字幕）。
+  bool get isEmpty => totalFiles == 0;
+
+  /// 字幕侧是否**存在**带集号的文件。
+  ///
+  /// 这是「集号对不上」与「字幕侧根本没编号」的分界线，也是 BUG-1695 的核心区分：
+  /// 前者是冲突（错季 / 绝对集号 / 选错条目），后者是信息不足（剧场版 / 整季单文件）。
+  /// 两者必须走不同分支——把后者的宽容度错用到前者身上，就是那个静默错配。
+  bool get hasNumberedFiles => byEpisode.isNotEmpty;
+}
+
+/// 候选排序键：语言权重升序（ja 优先）→ 文件名（大小写不敏感）tie-break。
+int compareJimakuByLanguagePreference(
+  JimakuFile a,
+  JimakuFile b,
+  String? preferredLanguage,
+) {
+  final int rankA = jimakuLanguageRank(detectSubtitleLanguage(a.name),
+      preferred: preferredLanguage);
+  final int rankB = jimakuLanguageRank(detectSubtitleLanguage(b.name),
+      preferred: preferredLanguage);
+  if (rankA != rankB) return rankA.compareTo(rankB);
+  return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+}
+
+/// 单集选字幕的结论。
+///
+/// 之所以不是 `JimakuFile?`：三种「没选到」的原因对用户是三件不同的事
+/// （去改条目 / 去补字幕 / 无能为力），全压成 null 就只能显示一句「无匹配」。
+enum JimakuEpisodeMatchKind {
+  /// 集号精确命中。
+  exact,
+
+  /// 字幕侧一个集号都没有（剧场版 / 整季单文件），且调用方确认目标唯一 → 采用。
+  unnumbered,
+
+  /// 字幕侧**有**集号但没有目标集号：错季 / 绝对集号 / 条目选错。不配。
+  episodeConflict,
+
+  /// 字幕侧只有未编号文件，但目标不止一个 → 无法确定给谁。不配。
+  ambiguousUnnumbered,
+
+  /// 没有任何可解析的文本字幕。
+  none,
+}
+
+/// 单集选字幕的结果：[file] 仅在 [JimakuEpisodeMatchKind.exact] /
+/// [JimakuEpisodeMatchKind.unnumbered] 时非空。
+class JimakuEpisodeMatch {
+  const JimakuEpisodeMatch._(this.kind, this.file);
+
+  const JimakuEpisodeMatch.exact(JimakuFile file)
+      : this._(JimakuEpisodeMatchKind.exact, file);
+
+  const JimakuEpisodeMatch.unnumbered(JimakuFile file)
+      : this._(JimakuEpisodeMatchKind.unnumbered, file);
+
+  const JimakuEpisodeMatch.episodeConflict()
+      : this._(JimakuEpisodeMatchKind.episodeConflict, null);
+
+  const JimakuEpisodeMatch.ambiguousUnnumbered()
+      : this._(JimakuEpisodeMatchKind.ambiguousUnnumbered, null);
+
+  const JimakuEpisodeMatch.none() : this._(JimakuEpisodeMatchKind.none, null);
+
+  final JimakuEpisodeMatchKind kind;
+  final JimakuFile? file;
+
+  /// 可用（真的选到了一个文件）。
+  bool get isMatched => file != null;
+
+  /// 落任务行 / 日志的英文短语；[isMatched] 时为 null。
+  String? get failureReason => switch (kind) {
+        JimakuEpisodeMatchKind.exact ||
+        JimakuEpisodeMatchKind.unnumbered =>
+          null,
+        JimakuEpisodeMatchKind.episodeConflict =>
+          'jimaku entry has subtitles but none for this episode',
+        JimakuEpisodeMatchKind.ambiguousUnnumbered =>
+          'jimaku subtitles carry no episode numbers',
+        JimakuEpisodeMatchKind.none => 'jimaku entry has no text subtitle',
+      };
+}
+
+/// 为集号 [episode] 从 [index] 里选一个字幕文件——**全仓唯一判据**。
+///
+/// [soleTarget]：本次匹配是否只有这一个待配视频。只有它为 true 时，未编号字幕
+/// （剧场版 / 整季单文件）才允许被采用；否则 N 个目标会拿到同一个文件。这个参数
+/// 是 `required` 而非有默认值，正是因为默认值就是 BUG-1695 的形状：调用方不表态，
+/// 判据就替它猜。
+JimakuEpisodeMatch chooseJimakuFileForEpisode(
+  JimakuEpisodeIndex index, {
+  required int episode,
+  required bool soleTarget,
+}) {
+  if (index.isEmpty) return const JimakuEpisodeMatch.none();
+  final List<JimakuFile>? exact = index.byEpisode[episode];
+  if (exact != null && exact.isNotEmpty) {
+    return JimakuEpisodeMatch.exact(exact.first);
+  }
+  // 字幕侧有编号却没有这一集 ⇒ 集号语义冲突，绝不用别集顶替。
+  if (index.hasNumberedFiles) {
+    return const JimakuEpisodeMatch.episodeConflict();
+  }
+  if (index.unnumbered.isEmpty) return const JimakuEpisodeMatch.none();
+  if (!soleTarget) return const JimakuEpisodeMatch.ambiguousUnnumbered();
+  return JimakuEpisodeMatch.unnumbered(index.unnumbered.first);
+}

--- a/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
@@ -1,4 +1,5 @@
 import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 
@@ -33,6 +34,7 @@ class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
         anilistId: request.media?.anilistId,
         queryFallbacks: fallbacks,
         throwOnError: true,
+        animeFilter: _animeFilterFor(request),
       );
       final List<VideoSubtitleCandidate> candidates =
           <VideoSubtitleCandidate>[];
@@ -108,6 +110,20 @@ class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
   void close() {
     if (_closesClient) _client.close();
   }
+}
+
+/// 把发现层的分类映射成 Jimaku 的 `anime` 硬过滤（BUG-1694）。
+///
+/// `discoveryCategory` 已经是这个问题的答案，不需要再猜：anime → 只搜动画；
+/// movie/tv → 只搜真人；连 media 都没有（纯文本搜索请求）才两档都试。
+JimakuAnimeFilter _animeFilterFor(VideoSubtitleSearchRequest request) {
+  return switch (request.media?.discoveryCategory) {
+    VideoDiscoveryCategory.anime => JimakuAnimeFilter.anime,
+    VideoDiscoveryCategory.movie ||
+    VideoDiscoveryCategory.tv =>
+      JimakuAnimeFilter.liveAction,
+    null => JimakuAnimeFilter.either,
+  };
 }
 
 class _JimakuSubtitleCandidate extends VideoSubtitleCandidate {

--- a/fushi/lib/src/media/video/metadata/video_source_scrape_coordinator.dart
+++ b/fushi/lib/src/media/video/metadata/video_source_scrape_coordinator.dart
@@ -39,6 +39,7 @@ class VideoSourceScrapeCoordinator
     VideoMetadataProviderRegistry? registry,
     VideoMetadataImageProvider? fanartProvider,
     VideoMetadataAssetDownloader? assetDownloader,
+    this.onWorkScraped,
   })  : registry = registry ?? _createRegistry(config),
         fanartProvider = fanartProvider ??
             FanartVideoImageProvider(apiKey: config.fanartApiKey),
@@ -57,6 +58,17 @@ class VideoSourceScrapeCoordinator
   final bool _ownsFanartProvider;
   final bool _ownsAssetDownloader;
   final VideoMetadataDatabaseStore _store;
+
+  /// 一个作品刮完（规范数据已落库、sidecar 已写）后的通知。
+  ///
+  /// 刮削本身**不做**字幕：它是全仓唯一解析出规范身份（AniList/TMDB id + 原名）
+  /// 的地方，而字幕搜索的准确率几乎完全取决于身份准不准。把「谁需要字幕」这个
+  /// 事实播出去，由消费方（AppModel → VideoSubtitleBackfillService）决定要不要
+  /// 补、按什么偏好补——刮削协调器不该长出网络字幕依赖，也不该被字幕失败拖慢。
+  ///
+  /// 回调抛出的异常会被吞掉并记进本次 run 的 warnings，绝不让补字幕影响刮削结论。
+  final Future<void> Function(VideoScrapedWorkNotice notice)? onWorkScraped;
+
   final Set<int> _interruptedRunIds = <int>{};
   int? _activeRunId;
 
@@ -302,6 +314,25 @@ class VideoSourceScrapeCoordinator
           warnings.addAll(sidecars.warnings);
           errors.addAll(sidecars.errors);
           succeeded++;
+          // 播「这个作品刮完了」。放在 succeeded++ 之后：只有真正刮成功的作品
+          // 才值得去补字幕，失败的连身份都不可信。
+          final Future<void> Function(VideoScrapedWorkNotice)? notify =
+              onWorkScraped;
+          if (notify != null) {
+            try {
+              await notify(
+                VideoScrapedWorkNotice(work: localWork, metadata: metadata),
+              );
+            } on VideoSourceScrapeCancelled {
+              rethrow;
+            } catch (error) {
+              // 补字幕失败绝不影响刮削结论——它是刮削的下游增值，不是前置条件。
+              warnings.add(SourceScrapeIssue(
+                workTitle: localWork.title,
+                message: '字幕补齐失败：$error',
+              ));
+            }
+          }
         } on VideoSourceScrapeCancelled {
           rethrow;
         } catch (error) {
@@ -1520,4 +1551,18 @@ extension _FirstOrNull<T> on Iterable<T> {
     final Iterator<T> iterator = this.iterator;
     return iterator.moveNext() ? iterator.current : null;
   }
+}
+
+/// 「一个作品刚刮完」的事实：本地是哪些视频 + 刮出来的规范身份。
+///
+/// 刻意只带这两样：消费方要什么（补字幕 / 推送通知 / 统计）自己从这两个对象里
+/// 取，协调器不预先替它们裁剪。
+class VideoScrapedWorkNotice {
+  const VideoScrapedWorkNotice({required this.work, required this.metadata});
+
+  /// 本地作品（`work.members` 是这次涉及的 `VideoBookRow`，可能多集）。
+  final VideoSourceScrapeWork work;
+
+  /// 刮出来的规范元数据（含 ids / seasons / episodes / runtimeMinutes）。
+  final VideoMetadataWork metadata;
 }

--- a/fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart
+++ b/fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart
@@ -47,6 +47,11 @@ List<SubtitleBackfillTarget> scrapedSubtitleTargets({
         episode: episode,
       ),
       scrapedRuntimeMinutes: _runtimeFor(metadata, season, episode),
+      // 「默认下视频语言的字幕」的两个来源：用户对本视频手动指定的内容语言
+      // （压过一切），与刮削出的作品原语言。两者都可能为空，那时由 ffprobe 的
+      // 音轨 tag 兜底，再没有就不表态——不猜。
+      contentLanguage: book.language,
+      originalLanguage: metadata.originalLanguage,
     ));
   }
   return out;

--- a/fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart
+++ b/fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart
@@ -1,0 +1,124 @@
+/// 刮削结论 → 字幕补齐目标的**纯映射**。
+///
+/// 单独成文件、纯函数，是因为这里正是准确率的分水岭：字幕搜得准不准，取决于
+/// 交给 provider 的是「刮削解析出的 AniList/TMDB id + 日文原名 + 真实季集号」，
+/// 还是「文件名里的中文译名」。这一步既然是全部价值所在，就该能被单测钉死，而
+/// 不是埋在某个 service 的 200 行方法中间。
+library;
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_backfill.dart';
+import 'package:fushi/src/media/video/video_filename_parser.dart';
+
+/// 从刮削出的 [metadata] 与本地 [members] 生成待补字幕目标。
+///
+/// [hasExistingSubtitle] 由调用方按 bookUid 提供（DB 里的 `subtitleSource`）；
+/// 磁盘上的 sidecar 由 [VideoSubtitleBackfillService] 自己再查一道。
+///
+/// 季集号取**本地文件名解析**的结果而不是刮削的顺序：文件名是用户磁盘上的事实，
+/// 而合集里可能缺集、含特典、被拖拽重排过（`sortIndex` 不可信，见批量字幕那边同
+/// 样的教训）。解析不出集号的成员只在「整个作品就一个文件」（电影/剧场版）时才
+/// 生成目标——多集里认不出集号，配上去只能是碰运气。
+List<SubtitleBackfillTarget> scrapedSubtitleTargets({
+  required List<VideoBookRow> members,
+  required VideoMetadataWork metadata,
+  required bool Function(String bookUid) hasExistingSubtitle,
+}) {
+  if (members.isEmpty) return const <SubtitleBackfillTarget>[];
+  final bool single = members.length == 1;
+  final List<SubtitleBackfillTarget> out = <SubtitleBackfillTarget>[];
+  for (final VideoBookRow book in members) {
+    if (book.videoPath.trim().isEmpty) continue;
+    final VideoNameInfo parsed = parseVideoFilename(p.basename(book.videoPath));
+    final int? episode = parsed.episode;
+    if (episode == null && !single) continue;
+    final int? season = episode == null ? null : (parsed.season ?? 1);
+    out.add(SubtitleBackfillTarget(
+      bookUid: book.bookUid,
+      videoPath: book.videoPath,
+      hasExistingSubtitle: hasExistingSubtitle(book.bookUid),
+      media: scrapedMediaReference(
+        metadata,
+        season: season,
+        episode: episode,
+      ),
+      scrapedRuntimeMinutes: _runtimeFor(metadata, season, episode),
+    ));
+  }
+  return out;
+}
+
+/// 把刮削元数据折成 provider 认得的规范身份。
+///
+/// 三件事必须原样带过去，缺一件准确率就塌一层：
+/// - **外部 id**（anilist / tmdb / bangumi / imdb / tvdb）：Jimaku 按 anilist_id
+///   直查、OpenSubtitles 按 imdb/tmdb 直查，命中率与文本搜不在一个量级；
+/// - **originalTitle**（日文原名）：id 没命中时的回退查询词。用中文译名回退等于
+///   不回退；
+/// - **discoveryCategory**：决定 Jimaku 的 anime 硬过滤走哪一档（BUG-1694）。
+VideoMediaReference scrapedMediaReference(
+  VideoMetadataWork metadata, {
+  int? season,
+  int? episode,
+}) {
+  final Map<String, String> ids = <String, String>{
+    for (final VideoMetadataId id in metadata.ids)
+      if (id.value.trim().isNotEmpty) id.type.trim().toLowerCase(): id.value,
+  };
+  int? intId(String key) => int.tryParse(ids[key] ?? '');
+  final int? anilistId = intId('anilist');
+  return VideoMediaReference(
+    providerId: metadata.provider.name,
+    mediaId: ids[metadata.provider.name] ?? metadata.title,
+    mediaKind: metadata.kind,
+    discoveryCategory: scrapedDiscoveryCategory(metadata),
+    title: metadata.title,
+    originalTitle: metadata.originalTitle,
+    aliases: metadata.aliases,
+    year: metadata.year,
+    season: season,
+    episode: episode,
+    tmdbId: intId('tmdb'),
+    imdbId: ids['imdb'],
+    tvdbId: intId('tvdb'),
+    anilistId: anilistId,
+    bangumiId: intId('bangumi'),
+    externalIds: ids,
+  );
+}
+
+/// 刮削元数据 → 发现层分类。
+///
+/// `VideoMetadataMediaKind` 只有 movie/tv，动画与真人共用同一个值——分类信息在
+/// 刮削侧只能从「有没有 AniList id」推：AniList 是动画专库，挂上 AniList id 的
+/// 作品就是动画。这不是完美判据（少数真人特摄也被收录），但它决定的只是 Jimaku
+/// 的 anime 过滤档，而那一档现在两边都试得到（[JimakuAnimeFilter.either]），
+/// 判错的代价只是多一次请求。
+VideoDiscoveryCategory scrapedDiscoveryCategory(VideoMetadataWork metadata) {
+  final bool hasAnilist = metadata.ids.any(
+    (VideoMetadataId id) =>
+        id.type.trim().toLowerCase() == 'anilist' && id.value.trim().isNotEmpty,
+  );
+  if (hasAnilist) return VideoDiscoveryCategory.anime;
+  return metadata.kind == VideoMetadataMediaKind.movie
+      ? VideoDiscoveryCategory.movie
+      : VideoDiscoveryCategory.tv;
+}
+
+/// 该集（或整部电影）的播出时长（分钟）；刮削没给就返回 null。
+int? _runtimeFor(VideoMetadataWork metadata, int? season, int? episode) {
+  if (season == null || episode == null) return metadata.runtimeMinutes;
+  for (final VideoMetadataSeason s in metadata.seasons) {
+    if (s.seasonNumber != season) continue;
+    for (final VideoMetadataEpisode e in s.episodes) {
+      if (e.episodeNumber == episode) {
+        return e.runtimeMinutes ?? metadata.runtimeMinutes;
+      }
+    }
+  }
+  return metadata.runtimeMinutes;
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_language_preference.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_language_preference.dart
@@ -1,0 +1,132 @@
+/// 自动下字幕时「**优先要哪个语言**」的唯一判据。
+///
+/// 默认取**视频自身的语言**：日语番取日语轨、韩剧取韩语轨。对一个沉浸学习 app，
+/// 这几乎总是用户想要的那一条，而此前的默认是「不限」——实际效果是拿到搜索结果
+/// 里排最前的那条，语言随缘。
+///
+/// ## 两条铁律
+///
+/// **① 不猜。** 语言无法确定时返回 null，调用方保持原样（= 旧行为）。理由与
+/// `content_font_chain.dart` 的「语言未知必须返回空链」同构：猜错比不猜更糟，
+/// 而这里猜错的代价是给用户装上一条他看不懂的字幕。**尤其不许硬编码日语**——
+/// 本 app 没有全局学习语言这回事。
+///
+/// **② 是排序，不是过滤。** [rankByPreferredLanguage] 把首选语言的候选排到前面，
+/// **不丢弃**其余候选。如果按语言硬过滤，一部只有英文字幕的日语番就会从「有字幕」
+/// 倒退成「没字幕」——那是拿一个改进换一个回归。真正的硬过滤只属于用户在设置里
+/// **显式**指定的语言（那是他自己说的），由 `VideoSubtitleSearchRequest.languages`
+/// 承担。
+///
+/// ## 语言从哪来
+///
+/// 内容那一半**直接复用** `resolveContentLanguage`——全仓内容语言的唯一入口
+/// （资源手动指定 > 内容自带元数据 > 全局默认）。这里不另造一条链：字体链和字幕
+/// 语言链要是各写一遍「先看这个再看那个」，早晚出现「同一个视频，字体按日文渲染、
+/// 字幕却下了中文」。
+library;
+
+import 'package:fushi/src/models/content_font_chain.dart';
+
+/// BCP-47 / ISO 639 语言标签 → 字幕域比较用的基础语言码（小写两字母为主）。
+///
+/// 认不出返回 null。输入来自五花八门的上游（TMDB `original_language`、mkv 音轨
+/// tag、`VideoBooks.language`、provider 报的字幕语言），不能假设规范化过。
+///
+/// 与 `detectSubtitleLanguage`（从**文件名**猜）刻意分开：那个的输入是文件名里的
+/// 脏 token（`chs` / `简体` / `ja[cc]`），这个的输入是**声明过的语言标签**。两者
+/// 产出同一套码，所以结果可以直接比。
+String? normalizeSubtitleLanguageCode(String? tag) {
+  final String normalized =
+      (tag ?? '').trim().toLowerCase().replaceAll('_', '-');
+  if (normalized.isEmpty) return null;
+  final String base = normalized.split('-').first;
+  if (base.isEmpty) return null;
+  // ISO 639-2/T、639-2/B 与常见俗写 → 639-1。只列本 app 真会遇到的，
+  // 不搬一整张 ISO 表进来：认不出就返回主标签本身，比错映射安全。
+  const Map<String, String> aliases = <String, String>{
+    'jpn': 'ja',
+    'jp': 'ja',
+    'kor': 'ko',
+    'zho': 'zh',
+    'chi': 'zh',
+    'cmn': 'zh',
+    'yue': 'zh',
+    'chs': 'zh',
+    'cht': 'zh',
+    'eng': 'en',
+    'spa': 'es',
+    'fra': 'fr',
+    'fre': 'fr',
+    'deu': 'de',
+    'ger': 'de',
+    'por': 'pt',
+    'rus': 'ru',
+    'ita': 'it',
+    'nld': 'nl',
+    'dut': 'nl',
+    'tha': 'th',
+    'vie': 'vi',
+    'ind': 'id',
+    'ara': 'ar',
+    'tur': 'tr',
+  };
+  final String? alias = aliases[base];
+  if (alias != null) return alias;
+  // 两字母主标签直接用；三字母且不在别名表里也原样返回（比丢弃信息强）。
+  return base;
+}
+
+/// 解析自动下字幕的**首选语言**；无法确定返回 null（= 不表态，保持旧行为）。
+///
+/// 优先级（高到低）：
+/// 1. [explicitSubtitlePreference]——用户在设置/对话框里**显式**选的字幕语言。
+///    他直接就这件事表过态，压过一切推断。
+/// 2. 视频的内容语言，走 [resolveContentLanguage]：
+///    [videoContentLanguage]（`VideoBooks.language`，用户对本视频手动指定）
+///    > [contentMetadataLanguage]（刮削的 `originalLanguage` / 音轨 tag）
+///    > [globalDefaultContentLanguage]（设置·外观·排版里的默认内容语言）。
+/// 3. 都没有 → null。
+String? resolveSubtitleDownloadLanguage({
+  String? explicitSubtitlePreference,
+  String? videoContentLanguage,
+  String? contentMetadataLanguage,
+  String? globalDefaultContentLanguage,
+}) {
+  final String explicit = explicitSubtitlePreference?.trim() ?? '';
+  if (explicit.isNotEmpty) return normalizeSubtitleLanguageCode(explicit);
+  return normalizeSubtitleLanguageCode(
+    resolveContentLanguage(
+      explicit: videoContentLanguage,
+      metadata: contentMetadataLanguage,
+      globalDefault: globalDefaultContentLanguage,
+    ),
+  );
+}
+
+/// 把候选按「[preferred] 语言在前」**稳定**重排；[preferred] 为 null 时原样返回。
+///
+/// 稳定排序是必需的，不是讲究：候选进来时已经按 provider 优先级 + 下载量排好
+/// （`deduplicateVideoSubtitles`），语言只是再加一层**外层**键。不稳定的排序会把
+/// 同语言内部那层已有顺序打乱，于是「同一个视频重跑两次自动匹配拿到不同字幕」。
+///
+/// [languageOf] 返回候选自报的语言（可为空/未知）；内部按
+/// [normalizeSubtitleLanguageCode] 归一后比较，所以 `ja-JP` 与 `jpn` 都能对上 `ja`。
+List<T> rankByPreferredLanguage<T>(
+  List<T> items,
+  String? preferred,
+  String? Function(T item) languageOf,
+) {
+  final String? want = normalizeSubtitleLanguageCode(preferred);
+  if (want == null || items.length < 2) return items;
+  final List<T> matching = <T>[];
+  final List<T> others = <T>[];
+  for (final T item in items) {
+    if (normalizeSubtitleLanguageCode(languageOf(item)) == want) {
+      matching.add(item);
+    } else {
+      others.add(item);
+    }
+  }
+  if (matching.isEmpty) return items;
+  return <T>[...matching, ...others];
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_timing_check.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_timing_check.dart
@@ -1,0 +1,250 @@
+/// 「这条字幕真的是这个视频的吗」——下载之后、落盘之前的最后一道判据。
+///
+/// 此前全仓**没有任何一处**在拿到字幕字节后检查过它的内容：集号匹配靠文件名，
+/// 文件名对了就落盘。于是一整类错配无声通过——最典型的是把整季合并的单文件
+/// （5 小时）当成某一集（24 分钟）的字幕装上去，播放时字幕从第 3 分钟起就全错位。
+///
+/// **这道判据能做什么、不能做什么，必须说清楚**：
+/// - 能抓：整季合并文件、错媒体（电影字幕装到剧集上）、空文件、解析不出的字节；
+/// - **抓不了**：轴偏移（同一集不同压制组，OP 长度差几秒）。那要靠发布组名匹配，
+///   拿时长去判只会误伤。别把这个判据当成「字幕对轴校验」用。
+///
+/// 全部纯函数，不碰磁盘/网络/DB；时长由调用方提供（ffprobe 或刮削 runtime）。
+library;
+
+/// 视频时长的来源——决定容差，因为两者精度差一个量级。
+enum VideoDurationSource {
+  /// ffprobe / `ffmpeg -i` 探到的真实容器时长。精确到秒。
+  probed,
+
+  /// 刮削元数据里的播出时长（`VideoMetadataEpisodes.runtimeMinutes` 等）。
+  ///
+  /// 这是**播出时长**不是文件时长：含广告位、四舍五入到分钟、BD 版还会与 TV 版
+  /// 差几分钟。只配当粗筛，容差必须放得比 [probed] 宽得多。
+  scrapedRuntime,
+}
+
+/// 已知的视频时长 + 它的来源。
+class KnownVideoDuration {
+  const KnownVideoDuration({required this.durationMs, required this.source});
+
+  const KnownVideoDuration.probed(int durationMs)
+      : this(durationMs: durationMs, source: VideoDurationSource.probed);
+
+  const KnownVideoDuration.scrapedRuntime(int durationMs)
+      : this(
+            durationMs: durationMs, source: VideoDurationSource.scrapedRuntime);
+
+  final int durationMs;
+  final VideoDurationSource source;
+
+  /// 允许字幕最后一句超出视频时长的上界。
+  ///
+  /// 比例 + 绝对量双保险：比例项负责长片（2 小时电影的 15% 是 18 分钟，够宽），
+  /// 绝对量负责短片（5 分钟的 PV，15% 只有 45 秒，太紧）。
+  int get maxAcceptableLastCueEndMs => switch (source) {
+        VideoDurationSource.probed => (durationMs * 1.15).round() +
+            const Duration(seconds: 60).inMilliseconds,
+        VideoDurationSource.scrapedRuntime => (durationMs * 1.5).round() +
+            const Duration(minutes: 2).inMilliseconds,
+      };
+}
+
+/// 从字幕原文抽出的时间跨度概览。
+class SubtitleTimingSummary {
+  const SubtitleTimingSummary({
+    required this.cueCount,
+    required this.firstStartMs,
+    required this.lastEndMs,
+  });
+
+  /// 一条时间轴都没解析出来。
+  static const SubtitleTimingSummary empty = SubtitleTimingSummary(
+    cueCount: 0,
+    firstStartMs: 0,
+    lastEndMs: 0,
+  );
+
+  /// 解析出的时间轴条数（不是渲染后的行数）。
+  final int cueCount;
+
+  /// 最早一句的开始时刻（毫秒）。
+  final int firstStartMs;
+
+  /// 最后一句的结束时刻（毫秒）——判「字幕覆盖到哪」的唯一依据。
+  final int lastEndMs;
+
+  bool get isEmpty => cueCount == 0;
+}
+
+/// 校验结论。
+enum SubtitleTimingVerdict {
+  /// 通过（含「视频时长未知、只做了内容自检」）。
+  ok,
+
+  /// 字节解析不出任何时间轴：不是字幕、编码坏了、或是被 HTML 错误页顶替。
+  unparsable,
+
+  /// 解析出来了但一条 cue 都没有。
+  empty,
+
+  /// 最后一句远超视频时长 → **不可能是这个视频的字幕**（整季合并文件 / 错媒体）。
+  overrunsVideo,
+
+  /// 覆盖不到视频的一半 → 可疑但**不拒收**：只有 OP/ED 的歌词轨、只标注了字幕
+  /// 招牌的 signs 轨都是这个形状，且它们是用户可能真的想要的东西。
+  suspiciouslyShort,
+}
+
+/// 校验结果：结论 + 可读原因（英文短语，落任务行/日志，与既有 failureReason 同风格）。
+class SubtitleTimingCheck {
+  const SubtitleTimingCheck(this.verdict, {this.detail});
+
+  final SubtitleTimingVerdict verdict;
+  final String? detail;
+
+  /// **有备选候选**时的拒收判据：读不出来的、空的、和视频对不上的，全换下一个。
+  ///
+  /// 只有当调用方还能试别的候选（下载流水线的 registry 搜索结果）时才用这条。
+  bool get rejected => switch (verdict) {
+        SubtitleTimingVerdict.ok ||
+        SubtitleTimingVerdict.suspiciouslyShort =>
+          false,
+        SubtitleTimingVerdict.unparsable ||
+        SubtitleTimingVerdict.empty ||
+        SubtitleTimingVerdict.overrunsVideo =>
+          true,
+      };
+
+  /// **没有备选候选**时的拒收判据：只认「正面矛盾」。
+  ///
+  /// 番剧下载的字幕反查按集号锁定了唯一一条字幕，扔掉它就是让用户什么都没有。
+  /// 这种位置上，「我读不出这个文件」不足以否决它——本模块的扫描器只认三种时间轴
+  /// 写法，而真实世界的字幕文件总有意外形态；真正的解析器（
+  /// `parseSubtitleContentAsync`）可能照样能读。只有 [overrunsVideo] 这种
+  /// 「字幕比视频长得多」的正面证据才配否决，因为它无法用解析器差异解释。
+  bool get contradictsVideo => verdict == SubtitleTimingVerdict.overrunsVideo;
+}
+
+/// 字幕最后一句至少要覆盖到视频这个比例，否则记 [SubtitleTimingVerdict.suspiciouslyShort]。
+const double kSubtitleMinCoverageRatio = 0.5;
+
+/// 校验 [timing] 与 [video] 是否自洽。[video] 为 null = 时长未知，只做内容自检。
+SubtitleTimingCheck checkSubtitleTiming(
+  SubtitleTimingSummary timing, {
+  KnownVideoDuration? video,
+}) {
+  if (timing.isEmpty) {
+    return const SubtitleTimingCheck(
+      SubtitleTimingVerdict.unparsable,
+      detail: 'subtitle has no readable timings',
+    );
+  }
+  if (timing.lastEndMs <= 0) {
+    return const SubtitleTimingCheck(
+      SubtitleTimingVerdict.empty,
+      detail: 'subtitle timings are all zero',
+    );
+  }
+  if (video == null || video.durationMs <= 0) {
+    return const SubtitleTimingCheck(SubtitleTimingVerdict.ok);
+  }
+  if (timing.lastEndMs > video.maxAcceptableLastCueEndMs) {
+    return SubtitleTimingCheck(
+      SubtitleTimingVerdict.overrunsVideo,
+      detail: 'subtitle runs to ${_mmss(timing.lastEndMs)} but the video is '
+          'only ${_mmss(video.durationMs)} long',
+    );
+  }
+  if (timing.lastEndMs < video.durationMs * kSubtitleMinCoverageRatio) {
+    return SubtitleTimingCheck(
+      SubtitleTimingVerdict.suspiciouslyShort,
+      detail: 'subtitle only covers up to ${_mmss(timing.lastEndMs)} of '
+          '${_mmss(video.durationMs)}',
+    );
+  }
+  return const SubtitleTimingCheck(SubtitleTimingVerdict.ok);
+}
+
+/// 从字幕原文扫出时间跨度。**只认时间轴，不做真正的解析**。
+///
+/// 为什么不复用 `parseSubtitleContentAsync`：那条路要 bookUid、要建 cue 行、走
+/// isolate，为了拿两个数字把整套 DB 语义拖进来。这里要的只是「最后一句结束在
+/// 哪」，一次正则扫描就够，而且是纯函数、能在任何地方单测。
+///
+/// 覆盖三种真实格式的时间轴写法：
+/// - srt：`00:01:02,345 --> 00:01:05,678`
+/// - vtt：`00:01:02.345 --> 00:01:05.678`（也允许省略小时的 `01:02.345`）
+/// - ass/ssa：`Dialogue: 0,0:01:02.34,0:01:05.67,Default,...`
+SubtitleTimingSummary summarizeSubtitleTiming(String content) {
+  if (content.trim().isEmpty) return SubtitleTimingSummary.empty;
+  int count = 0;
+  int? first;
+  int last = 0;
+
+  void record(int startMs, int endMs) {
+    count++;
+    if (first == null || startMs < first!) first = startMs;
+    if (endMs > last) last = endMs;
+  }
+
+  for (final RegExpMatch match in _arrowTiming.allMatches(content)) {
+    final int? start = _parseClock(match.group(1)!);
+    final int? end = _parseClock(match.group(2)!);
+    if (start == null || end == null) continue;
+    record(start, end);
+  }
+  if (count == 0) {
+    for (final RegExpMatch match in _assDialogue.allMatches(content)) {
+      final int? start = _parseClock(match.group(1)!);
+      final int? end = _parseClock(match.group(2)!);
+      if (start == null || end == null) continue;
+      record(start, end);
+    }
+  }
+  if (count == 0) return SubtitleTimingSummary.empty;
+  return SubtitleTimingSummary(
+    cueCount: count,
+    firstStartMs: first ?? 0,
+    lastEndMs: last,
+  );
+}
+
+/// srt / vtt 的 `起 --> 止`。小时段可选（vtt 允许 `MM:SS.mmm`）。
+final RegExp _arrowTiming = RegExp(
+  r'(\d{1,3}:[0-5]?\d:[0-5]?\d[.,]\d{1,3}|[0-5]?\d:[0-5]?\d[.,]\d{1,3})'
+  r'\s*-->\s*'
+  r'(\d{1,3}:[0-5]?\d:[0-5]?\d[.,]\d{1,3}|[0-5]?\d:[0-5]?\d[.,]\d{1,3})',
+);
+
+/// ass/ssa 的 `Dialogue: <layer>,<start>,<end>,...`（首字段是层号，不是时间）。
+final RegExp _assDialogue = RegExp(
+  r'^\s*Dialogue\s*:[^,]*,\s*'
+  r'(\d{1,3}:[0-5]?\d:[0-5]?\d[.,]\d{1,3})\s*,\s*'
+  r'(\d{1,3}:[0-5]?\d:[0-5]?\d[.,]\d{1,3})\s*,',
+  multiLine: true,
+);
+
+/// `[HH:]MM:SS[.,]mmm` → 毫秒。小数位不足 3 位按左对齐补零（ass 的 `.34` = 340ms）。
+int? _parseClock(String raw) {
+  final List<String> head = raw.split(RegExp(r'[.,]'));
+  if (head.length != 2) return null;
+  final List<String> parts = head[0].split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+  final List<int?> nums = parts.map(int.tryParse).toList();
+  if (nums.any((int? v) => v == null)) return null;
+  final int hours = parts.length == 3 ? nums[0]! : 0;
+  final int minutes = parts.length == 3 ? nums[1]! : nums[0]!;
+  final int seconds = parts.length == 3 ? nums[2]! : nums[1]!;
+  final String fractionRaw = head[1].padRight(3, '0').substring(0, 3);
+  final int? fraction = int.tryParse(fractionRaw);
+  if (fraction == null) return null;
+  return ((hours * 60 + minutes) * 60 + seconds) * 1000 + fraction;
+}
+
+String _mmss(int ms) {
+  final Duration d = Duration(milliseconds: ms);
+  final String mm = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+  final String ss = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+  return d.inHours > 0 ? '${d.inHours}:$mm:$ss' : '$mm:$ss';
+}

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
@@ -1,0 +1,273 @@
+/// 「刮削完成 → 给缺字幕的视频自动补字幕」。
+///
+/// 为什么这件事必须挂在刮削后面，而不是继续让用户去播放页一集集点：
+/// 刮削是**全仓唯一一处真正解析出规范身份**（AniList / TMDB / Bangumi id + 日文
+/// 原名）的地方。而字幕搜索的准确率几乎完全取决于身份准不准——播放页那条路拿
+/// 「文件名解析出的系列名」去 AniList 现搜，中文译名 + 季度 + 篇名长串在 AniList
+/// 必然 0 结果。刮削已经把答案算出来了，字幕侧却重新猜一遍，这是纯粹的浪费。
+///
+/// 边界：
+/// - **只补缺的**，绝不覆盖任何已有字幕（sidecar 或 DB 里的 subtitleSource）。
+///   用户手放/手改过的字幕是不可再生的。
+/// - 落 sidecar（与下载流水线同一形态），播放页按目录动态发现，不写 DB 选择——
+///   这样「自动补的」和「用户选的」不会在同一个字段上打架。
+/// - 全函数：任何失败都进返回值，绝不抛。调用方是 fire-and-forget 的刮削回调。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_sidecar.dart'
+    show listSidecarSubtitles;
+
+/// 一个待补字幕的视频。身份来自刮削，不是从文件名现猜的。
+class SubtitleBackfillTarget {
+  const SubtitleBackfillTarget({
+    required this.bookUid,
+    required this.videoPath,
+    required this.media,
+    this.hasExistingSubtitle = false,
+    this.scrapedRuntimeMinutes,
+  });
+
+  /// 视频稳定身份（`VideoBooks.bookUid`），只用于日志与调用方对账。
+  final String bookUid;
+
+  /// 视频绝对路径。sidecar 落在它旁边。
+  final String videoPath;
+
+  /// 刮削解析出的规范身份（含 season/episode）。**这是本模块存在的理由。**
+  final VideoMediaReference media;
+
+  /// DB 里是否已记了字幕来源。调用方查（本模块不碰 DB），为 true 时直接跳过。
+  final bool hasExistingSubtitle;
+
+  /// 刮削元数据里的播出时长（分钟）。ffprobe 探不到时的兜底时长来源。
+  final int? scrapedRuntimeMinutes;
+}
+
+/// 单个目标的补字幕结果。
+enum SubtitleBackfillOutcome {
+  /// 补上了，[SubtitleBackfillResult.installedPath] 是落盘路径。
+  installed,
+
+  /// 已经有字幕了（sidecar 或 DB），**没动它**。
+  alreadyHasSubtitle,
+
+  /// 搜索没有任何候选。
+  noCandidate,
+
+  /// 有候选但全都没通过时长/内容校验。
+  allCandidatesRejected,
+
+  /// 视频文件不在了 / 目录读不了 / 写盘失败。
+  failed,
+}
+
+/// 补字幕结果（全函数返回值，不抛）。
+class SubtitleBackfillResult {
+  const SubtitleBackfillResult(
+    this.outcome, {
+    this.installedPath,
+    this.language,
+    this.detail,
+  });
+
+  final SubtitleBackfillOutcome outcome;
+  final String? installedPath;
+  final String? language;
+
+  /// 失败/拒收的可读原因。
+  final String? detail;
+
+  bool get installed => outcome == SubtitleBackfillOutcome.installed;
+}
+
+/// 给刮削后仍缺字幕的视频自动补一条字幕。
+class VideoSubtitleBackfillService {
+  VideoSubtitleBackfillService({
+    required this.registry,
+    Iterable<String> preferredLanguages = const <String>[],
+    this.maxCandidates = 4,
+  }) : preferredLanguages = List<String>.unmodifiable(preferredLanguages);
+
+  final VideoSubtitleRegistry registry;
+  final List<String> preferredLanguages;
+
+  /// 最多真下几条候选做校验。理由同下载流水线的
+  /// `kSubtitleVerifyMaxCandidates`：候选可能几十条，全下一遍是对来源站的滥用。
+  final int maxCandidates;
+
+  Future<SubtitleBackfillResult> backfill(
+    SubtitleBackfillTarget target,
+  ) async {
+    if (target.hasExistingSubtitle) {
+      return const SubtitleBackfillResult(
+        SubtitleBackfillOutcome.alreadyHasSubtitle,
+      );
+    }
+    final File video = File(target.videoPath);
+    if (!video.existsSync()) {
+      return const SubtitleBackfillResult(
+        SubtitleBackfillOutcome.failed,
+        detail: 'video file is gone',
+      );
+    }
+    // 目录里已经躺着 sidecar 就当已有字幕——它可能是用户手放的，也可能是下载
+    // 流水线放的。两种都不该被覆盖。
+    if (_existingSidecars(video).isNotEmpty) {
+      return const SubtitleBackfillResult(
+        SubtitleBackfillOutcome.alreadyHasSubtitle,
+      );
+    }
+
+    final ProviderBatchResult<VideoSubtitleCandidate> result;
+    try {
+      result = await registry.search(
+        VideoSubtitleSearchRequest(
+          media: target.media,
+          season: target.media.season,
+          episode: target.media.episode,
+          languages: preferredLanguages,
+          fingerprint: LocalVideoFingerprint(
+            fileSize: await video.length(),
+            fileName: p.basename(video.path),
+            openSubtitlesMovieHash:
+                await computeOpenSubtitlesMovieHash(video.path),
+          ),
+        ),
+      );
+    } on Object catch (error) {
+      return SubtitleBackfillResult(
+        SubtitleBackfillOutcome.failed,
+        detail: 'subtitle search failed: $error',
+      );
+    }
+    if (result.items.isEmpty) {
+      return SubtitleBackfillResult(
+        SubtitleBackfillOutcome.noCandidate,
+        detail: result.failures.isEmpty ? null : result.failures.first.message,
+      );
+    }
+
+    final KnownVideoDuration? duration = await _resolveDuration(target);
+    String? lastRejection;
+    final int limit = result.items.length < maxCandidates
+        ? result.items.length
+        : maxCandidates;
+    for (int i = 0; i < limit; i++) {
+      final VideoSubtitleCandidate candidate = result.items[i];
+      final VideoSubtitleDownload download;
+      try {
+        download = await registry.download(candidate);
+      } on Object catch (error) {
+        lastRejection = 'download failed: $error';
+        continue;
+      }
+      final SubtitleTimingCheck check = checkSubtitleTiming(
+        summarizeSubtitleTiming(await decodeTextBytes(download.bytes)),
+        video: duration,
+      );
+      if (check.rejected) {
+        lastRejection = check.detail;
+        debugPrint('[subtitle-backfill] rejected "${candidate.fileName}" for '
+            '${target.bookUid}: ${check.detail}');
+        continue;
+      }
+      try {
+        final String installed = await _writeSidecar(video, download);
+        return SubtitleBackfillResult(
+          SubtitleBackfillOutcome.installed,
+          installedPath: installed,
+          language: download.language,
+        );
+      } on Object catch (error) {
+        return SubtitleBackfillResult(
+          SubtitleBackfillOutcome.failed,
+          detail: 'sidecar write failed: $error',
+        );
+      }
+    }
+    return SubtitleBackfillResult(
+      SubtitleBackfillOutcome.allCandidatesRejected,
+      detail: lastRejection,
+    );
+  }
+
+  /// 时长来源优先级：ffprobe 探到的真实容器时长 > 刮削的播出时长 > 未知。
+  ///
+  /// 顺序不能反：刮削 runtime 是**播出时长**（含广告位、只精确到分钟），拿它当
+  /// 精确事实会误伤（见 [VideoDurationSource]）。它只在探不到时兜底。
+  Future<KnownVideoDuration?> _resolveDuration(
+    SubtitleBackfillTarget target,
+  ) async {
+    final int? probed = await probeVideoDurationMs(target.videoPath);
+    if (probed != null) return KnownVideoDuration.probed(probed);
+    final int? runtime = target.scrapedRuntimeMinutes;
+    if (runtime != null && runtime > 0) {
+      return KnownVideoDuration.scrapedRuntime(runtime * 60 * 1000);
+    }
+    return null;
+  }
+
+  List<String> _existingSidecars(File video) {
+    try {
+      final Directory dir = video.parent;
+      final List<String> names = <String>[
+        for (final FileSystemEntity entity in dir.listSync())
+          if (entity is File) p.basename(entity.path),
+      ];
+      return listSidecarSubtitles(
+        p.basenameWithoutExtension(video.path),
+        names,
+      );
+    } catch (_) {
+      // 目录读不了就当「不确定有没有」，按有处理——宁可不补，也不能覆盖。
+      return const <String>['<unreadable>'];
+    }
+  }
+
+  /// 落 sidecar：`<video 基名>.<lang><ext>`。**已存在同名文件就不写**（上面已经
+  /// 查过整目录的 sidecar，这里是防并发的第二道）。
+  Future<String> _writeSidecar(
+    File video,
+    VideoSubtitleDownload download,
+  ) async {
+    final String extension = _sidecarExtension(download.fileName);
+    final String language = download.language.trim().isEmpty
+        ? 'und'
+        : download.language.trim().toLowerCase();
+    final String target = p.join(
+      p.dirname(video.path),
+      '${p.basenameWithoutExtension(video.path)}.$language$extension',
+    );
+    final File dest = File(target);
+    if (dest.existsSync()) return target;
+    // 先写临时文件再 rename：半截字幕文件比没有字幕更糟——播放页会把它当成
+    // 一条可用字幕加载，用户看到的是「字幕只有前三句」。
+    final File temp = File('$target.fushi.tmp');
+    await temp.writeAsBytes(download.bytes, flush: true);
+    await temp.rename(target);
+    return target;
+  }
+
+  /// 只认四种可解析的文本字幕扩展名；其余一律按 `.srt` 落盘。
+  ///
+  /// 不是为了「猜格式」——播放页按扩展名路由 parser，一个 `.zip` 或 `.xyz` 后缀
+  /// 会让这条字幕在菜单里根本不出现。来源站给的多半确实是文本字幕。
+  static String _sidecarExtension(String fileName) {
+    final String ext = p.extension(fileName).toLowerCase();
+    return const <String>{'.srt', '.ass', '.ssa', '.vtt'}.contains(ext)
+        ? ext
+        : '.srt';
+  }
+}

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
@@ -23,6 +23,7 @@ import 'package:path/path.dart' as p;
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_language_preference.dart';
 import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/media/video/video_duration_probe.dart';
@@ -37,6 +38,8 @@ class SubtitleBackfillTarget {
     required this.media,
     this.hasExistingSubtitle = false,
     this.scrapedRuntimeMinutes,
+    this.contentLanguage,
+    this.originalLanguage,
   });
 
   /// 视频稳定身份（`VideoBooks.bookUid`），只用于日志与调用方对账。
@@ -53,6 +56,14 @@ class SubtitleBackfillTarget {
 
   /// 刮削元数据里的播出时长（分钟）。ffprobe 探不到时的兜底时长来源。
   final int? scrapedRuntimeMinutes;
+
+  /// 用户对本视频**手动指定**的内容语言（`VideoBooks.language`，BCP-47）。
+  /// 选字幕语言时压过一切自动判断。
+  final String? contentLanguage;
+
+  /// 刮削出的作品原语言（TMDB `original_language` 等）。[contentLanguage] 没设时
+  /// 的第二档；比 mkv 音轨 tag 可靠（打包者常写错或不写）。
+  final String? originalLanguage;
 }
 
 /// 单个目标的补字幕结果。
@@ -97,11 +108,17 @@ class VideoSubtitleBackfillService {
   VideoSubtitleBackfillService({
     required this.registry,
     Iterable<String> preferredLanguages = const <String>[],
+    this.defaultContentLanguage,
     this.maxCandidates = 4,
   }) : preferredLanguages = List<String>.unmodifiable(preferredLanguages);
 
   final VideoSubtitleRegistry registry;
+
+  /// 用户在设置里**显式**选的字幕语言。非空即硬过滤（进搜索请求）。
   final List<String> preferredLanguages;
+
+  /// 设置·外观·排版里的默认内容语言；视频没有可读语言时的最后一档。
+  final String? defaultContentLanguage;
 
   /// 最多真下几条候选做校验。理由同下载流水线的
   /// `kSubtitleVerifyMaxCandidates`：候选可能几十条，全下一遍是对来源站的滥用。
@@ -159,13 +176,28 @@ class VideoSubtitleBackfillService {
       );
     }
 
-    final KnownVideoDuration? duration = await _resolveDuration(target);
+    // 一次 ffprobe 拿两件事实：时长（校验用）+ 音轨语言（选语言用）。
+    final VideoProbeFacts facts = await probeVideoFacts(target.videoPath);
+    final KnownVideoDuration? duration = _resolveDuration(target, facts);
+    // 默认取**视频自己的语言**。这里是排序不是过滤：只有英文字幕的日语番仍然
+    // 配得上，只是排在后面。硬过滤只属于用户显式选的语言（已进 request.languages）。
+    final String? preferred = resolveSubtitleDownloadLanguage(
+      explicitSubtitlePreference: preferredLanguages.firstOrNull,
+      videoContentLanguage: target.contentLanguage,
+      contentMetadataLanguage:
+          target.originalLanguage ?? facts.primaryAudioLanguage,
+      globalDefaultContentLanguage: defaultContentLanguage,
+    );
+    final List<VideoSubtitleCandidate> ordered = rankByPreferredLanguage(
+      result.items,
+      preferred,
+      (VideoSubtitleCandidate c) => c.language,
+    );
     String? lastRejection;
-    final int limit = result.items.length < maxCandidates
-        ? result.items.length
-        : maxCandidates;
+    final int limit =
+        ordered.length < maxCandidates ? ordered.length : maxCandidates;
     for (int i = 0; i < limit; i++) {
-      final VideoSubtitleCandidate candidate = result.items[i];
+      final VideoSubtitleCandidate candidate = ordered[i];
       final VideoSubtitleDownload download;
       try {
         download = await registry.download(candidate);
@@ -207,10 +239,11 @@ class VideoSubtitleBackfillService {
   ///
   /// 顺序不能反：刮削 runtime 是**播出时长**（含广告位、只精确到分钟），拿它当
   /// 精确事实会误伤（见 [VideoDurationSource]）。它只在探不到时兜底。
-  Future<KnownVideoDuration?> _resolveDuration(
+  KnownVideoDuration? _resolveDuration(
     SubtitleBackfillTarget target,
-  ) async {
-    final int? probed = await probeVideoDurationMs(target.videoPath);
+    VideoProbeFacts facts,
+  ) {
+    final int? probed = facts.durationMs;
     if (probed != null) return KnownVideoDuration.probed(probed);
     final int? runtime = target.scrapedRuntimeMinutes;
     if (runtime != null && runtime > 0) {

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_backfill.dart
@@ -242,10 +242,8 @@ class VideoSubtitleBackfillService {
     File video,
     VideoSubtitleDownload download,
   ) async {
-    final String extension = _sidecarExtension(download.fileName);
-    final String language = download.language.trim().isEmpty
-        ? 'und'
-        : download.language.trim().toLowerCase();
+    final String extension = sidecarSubtitleExtension(download.fileName);
+    final String language = sidecarLanguageTag(download.language);
     final String target = p.join(
       p.dirname(video.path),
       '${p.basenameWithoutExtension(video.path)}.$language$extension',
@@ -259,15 +257,32 @@ class VideoSubtitleBackfillService {
     await temp.rename(target);
     return target;
   }
+}
 
-  /// 只认四种可解析的文本字幕扩展名；其余一律按 `.srt` 落盘。
-  ///
-  /// 不是为了「猜格式」——播放页按扩展名路由 parser，一个 `.zip` 或 `.xyz` 后缀
-  /// 会让这条字幕在菜单里根本不出现。来源站给的多半确实是文本字幕。
-  static String _sidecarExtension(String fileName) {
-    final String ext = p.extension(fileName).toLowerCase();
-    return const <String>{'.srt', '.ass', '.ssa', '.vtt'}.contains(ext)
-        ? ext
-        : '.srt';
-  }
+/// 语言标签归一到 sidecar 后缀白名单允许的字符集（见 `isSidecarSubtitleSuffix`：
+/// `[A-Za-z0-9_-]{1,32}`）。纯函数，与那条白名单成对单测。
+///
+/// 不归一会开一个静默的洞：provider 给出 `ja[cc]` 这类带修饰的标签时，写出的
+/// `<base>.ja[cc].srt` **不匹配 sidecar 后缀白名单** → 播放页永远发现不了它，
+/// 而下一次刮削的「已有 sidecar？」检查同样看不见它 → 每刮一次多一个孤儿文件。
+/// 兜底 `und`（ISO 639-2 的「未确定」），不是空串——空串会写成 `<base>..srt`。
+String sidecarLanguageTag(String raw) {
+  final String cleaned = raw
+      .trim()
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9_-]'), '')
+      .replaceAll(RegExp(r'^-+|-+$'), '');
+  if (cleaned.isEmpty) return 'und';
+  return cleaned.length > 32 ? cleaned.substring(0, 32) : cleaned;
+}
+
+/// 只认四种可解析的文本字幕扩展名；其余一律按 `.srt` 落盘。纯函数。
+///
+/// 不是为了「猜格式」——播放页按扩展名路由 parser，一个 `.zip` 或 `.xyz` 后缀
+/// 会让这条字幕在菜单里根本不出现。来源站给的多半确实是文本字幕。
+String sidecarSubtitleExtension(String fileName) {
+  final String ext = p.extension(fileName).toLowerCase();
+  return const <String>{'.srt', '.ass', '.ssa', '.vtt'}.contains(ext)
+      ? ext
+      : '.srt';
 }

--- a/fushi/lib/src/media/video/video_duration_probe.dart
+++ b/fushi/lib/src/media/video/video_duration_probe.dart
@@ -1,0 +1,73 @@
+/// 探一个本地视频文件的容器时长（毫秒）。
+///
+/// 存在的唯一理由：字幕落盘前要用它做「这条字幕真的是这个视频的吗」校验
+/// （见 `subtitle/subtitle_timing_check.dart`）。`VideoBooks` 没有 duration 列，
+/// 播放器的时长又只在 controller 打开后才有——下载流水线拿不到，只能现探。
+///
+/// 走既有 [FfmpegBackend.runProbe]，所以桌面（ffprobe 进程）与移动端
+/// （ffmpeg-kit 进程内）同一条路径，不新增平台分支。
+library;
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+
+import 'package:fushi/src/media/video/ffmpeg_backend.dart';
+
+/// ffprobe 探时长的超时。只读 header，不解码，几十毫秒级；给足 20s 覆盖冷缓存
+/// 与机械盘。**超时按失败处理并返回 null**——校验拿不到时长时会退化成「只做内容
+/// 自检」，绝不因为探测失败就拒收字幕。
+const Duration kVideoDurationProbeTimeout = Duration(seconds: 20);
+
+/// 返回 [path] 的时长毫秒；探不到返回 null（缺 ffprobe / 超时 / 不是媒体文件）。
+Future<int?> probeVideoDurationMs(
+  String path, {
+  @visibleForTesting FfmpegBackend? backend,
+}) async {
+  try {
+    final FfmpegRunResult result =
+        await (backend ?? resolveFfmpegBackend()).runProbe(
+      <String>[
+        '-v',
+        'quiet',
+        '-print_format',
+        'json',
+        '-show_entries',
+        'format=duration',
+        path,
+      ],
+      kVideoDurationProbeTimeout,
+    );
+    if (result.returnCode != 0) return null;
+    return parseFfprobeDurationMs(result.output);
+  } catch (e) {
+    // 缺 ffprobe 是**正常降级**（用户没装 / 没捆绑），不是错误路径。
+    debugPrint('[VideoDurationProbe] duration probe failed for "$path": $e');
+    return null;
+  }
+}
+
+/// 从 ffprobe `-print_format json -show_entries format=duration` 的 stdout 解析
+/// 时长毫秒。纯函数，便于单测。
+///
+/// ffprobe 对无时长容器会给 `"N/A"` 或干脆不给 `duration` 字段，两种都返回 null。
+int? parseFfprobeDurationMs(String stdout) {
+  final String trimmed = stdout.trim();
+  if (trimmed.isEmpty) return null;
+  try {
+    final Object? decoded = jsonDecode(trimmed);
+    if (decoded is! Map<String, dynamic>) return null;
+    final Object? format = decoded['format'];
+    if (format is! Map<String, dynamic>) return null;
+    final Object? duration = format['duration'];
+    final double? seconds = switch (duration) {
+      final num value => value.toDouble(),
+      final String value => double.tryParse(value),
+      _ => null,
+    };
+    if (seconds == null || !seconds.isFinite || seconds <= 0) return null;
+    return (seconds * 1000).round();
+  } catch (_) {
+    return null;
+  }
+}

--- a/fushi/lib/src/media/video/video_duration_probe.dart
+++ b/fushi/lib/src/media/video/video_duration_probe.dart
@@ -1,8 +1,11 @@
-/// 探一个本地视频文件的容器时长（毫秒）。
+/// 探一个本地视频文件的两件事实：容器时长，与音轨自报的语言。
 ///
-/// 存在的唯一理由：字幕落盘前要用它做「这条字幕真的是这个视频的吗」校验
-/// （见 `subtitle/subtitle_timing_check.dart`）。`VideoBooks` 没有 duration 列，
-/// 播放器的时长又只在 controller 打开后才有——下载流水线拿不到，只能现探。
+/// 存在的理由都在字幕自动获取链路上：
+/// - **时长**给「这条字幕真的是这个视频的吗」校验用（`subtitle/subtitle_timing_check.dart`）。
+///   `VideoBooks` 没有 duration 列，播放器时长又只在 controller 打开后才有，下载
+///   流水线拿不到，只能现探。
+/// - **音轨语言**给「默认下视频语言的字幕」用。它是「视频语言」最直接的一手来源，
+///   而且**与时长同一次 ffprobe 就能拿到**——分两次探是白付一次进程/IO。
 ///
 /// 走既有 [FfmpegBackend.runProbe]，所以桌面（ffprobe 进程）与移动端
 /// （ffmpeg-kit 进程内）同一条路径，不新增平台分支。
@@ -14,13 +17,35 @@ import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 
 import 'package:fushi/src/media/video/ffmpeg_backend.dart';
 
-/// ffprobe 探时长的超时。只读 header，不解码，几十毫秒级；给足 20s 覆盖冷缓存
-/// 与机械盘。**超时按失败处理并返回 null**——校验拿不到时长时会退化成「只做内容
+/// ffprobe 探测的超时。只读 header，不解码，几十毫秒级；给足 20s 覆盖冷缓存
+/// 与机械盘。**超时按失败处理并返回空结果**——校验拿不到时长时会退化成「只做内容
 /// 自检」，绝不因为探测失败就拒收字幕。
 const Duration kVideoDurationProbeTimeout = Duration(seconds: 20);
 
-/// 返回 [path] 的时长毫秒；探不到返回 null（缺 ffprobe / 超时 / 不是媒体文件）。
-Future<int?> probeVideoDurationMs(
+/// 一次 ffprobe 的产出。两个字段各自可空：探到什么算什么，绝不因为一半缺失就把
+/// 另一半也丢掉。
+class VideoProbeFacts {
+  const VideoProbeFacts(
+      {this.durationMs, this.audioLanguages = const <String>[]});
+
+  static const VideoProbeFacts empty = VideoProbeFacts();
+
+  /// 容器时长（毫秒）；探不到为 null。
+  final int? durationMs;
+
+  /// 音轨自报的语言标签，**按流顺序**（第一条通常是主音轨）。未标注的流不入列。
+  ///
+  /// 原样返回不归一：归一是 `subtitle_language_preference.dart` 的职责，本模块
+  /// 只负责「ffprobe 说了什么」。
+  final List<String> audioLanguages;
+
+  /// 主音轨语言（第一条带 language tag 的音轨）；没有返回 null。
+  String? get primaryAudioLanguage =>
+      audioLanguages.isEmpty ? null : audioLanguages.first;
+}
+
+/// 一次 ffprobe 拿到 [path] 的时长 + 音轨语言。任何失败返回 [VideoProbeFacts.empty]。
+Future<VideoProbeFacts> probeVideoFacts(
   String path, {
   @visibleForTesting FfmpegBackend? backend,
 }) async {
@@ -33,41 +58,78 @@ Future<int?> probeVideoDurationMs(
         '-print_format',
         'json',
         '-show_entries',
-        'format=duration',
+        'format=duration:stream=index,codec_type:stream_tags=language',
         path,
       ],
       kVideoDurationProbeTimeout,
     );
-    if (result.returnCode != 0) return null;
-    return parseFfprobeDurationMs(result.output);
+    if (result.returnCode != 0) return VideoProbeFacts.empty;
+    return parseFfprobeFacts(result.output);
   } catch (e) {
     // 缺 ffprobe 是**正常降级**（用户没装 / 没捆绑），不是错误路径。
-    debugPrint('[VideoDurationProbe] duration probe failed for "$path": $e');
-    return null;
+    debugPrint('[VideoDurationProbe] probe failed for "$path": $e');
+    return VideoProbeFacts.empty;
   }
 }
 
-/// 从 ffprobe `-print_format json -show_entries format=duration` 的 stdout 解析
-/// 时长毫秒。纯函数，便于单测。
+/// 只要时长的窄入口（老调用点保持原样）。
+Future<int?> probeVideoDurationMs(
+  String path, {
+  @visibleForTesting FfmpegBackend? backend,
+}) async =>
+    (await probeVideoFacts(path, backend: backend)).durationMs;
+
+/// 解析 ffprobe `-print_format json` 的 stdout。纯函数，便于单测。
 ///
-/// ffprobe 对无时长容器会给 `"N/A"` 或干脆不给 `duration` 字段，两种都返回 null。
-int? parseFfprobeDurationMs(String stdout) {
+/// 容错到底：ffprobe 对无时长容器给 `"N/A"` 或干脆不给 `duration`；`streams` 可能
+/// 整个缺失（`-show_entries` 只要了 format 时）；单个 stream 可能没有 `tags`。
+/// 任何一处不合预期都只让那一项为空，**不让整次探测作废**。
+VideoProbeFacts parseFfprobeFacts(String stdout) {
   final String trimmed = stdout.trim();
-  if (trimmed.isEmpty) return null;
+  if (trimmed.isEmpty) return VideoProbeFacts.empty;
   try {
     final Object? decoded = jsonDecode(trimmed);
-    if (decoded is! Map<String, dynamic>) return null;
-    final Object? format = decoded['format'];
-    if (format is! Map<String, dynamic>) return null;
-    final Object? duration = format['duration'];
-    final double? seconds = switch (duration) {
-      final num value => value.toDouble(),
-      final String value => double.tryParse(value),
-      _ => null,
-    };
-    if (seconds == null || !seconds.isFinite || seconds <= 0) return null;
-    return (seconds * 1000).round();
+    if (decoded is! Map<String, dynamic>) return VideoProbeFacts.empty;
+    return VideoProbeFacts(
+      durationMs: _durationMsFrom(decoded['format']),
+      audioLanguages: _audioLanguagesFrom(decoded['streams']),
+    );
   } catch (_) {
-    return null;
+    return VideoProbeFacts.empty;
   }
+}
+
+/// 兼容老调用点/老测试：只取时长。
+int? parseFfprobeDurationMs(String stdout) =>
+    parseFfprobeFacts(stdout).durationMs;
+
+int? _durationMsFrom(Object? format) {
+  if (format is! Map<String, dynamic>) return null;
+  final Object? duration = format['duration'];
+  final double? seconds = switch (duration) {
+    final num value => value.toDouble(),
+    final String value => double.tryParse(value),
+    _ => null,
+  };
+  if (seconds == null || !seconds.isFinite || seconds <= 0) return null;
+  return (seconds * 1000).round();
+}
+
+List<String> _audioLanguagesFrom(Object? streams) {
+  if (streams is! List) return const <String>[];
+  final List<String> out = <String>[];
+  for (final Object? stream in streams) {
+    if (stream is! Map<String, dynamic>) continue;
+    if (stream['codec_type'] != 'audio') continue;
+    final Object? tags = stream['tags'];
+    if (tags is! Map<String, dynamic>) continue;
+    final Object? language = tags['language'];
+    if (language is! String) continue;
+    final String trimmed = language.trim();
+    // `und` 是 ffmpeg 对「未标注」的显式写法，等同于没有——放行它会让下游把
+    // 「未知」当成一个真语言去匹配，永远匹配不上，还挡住后面真有标注的音轨。
+    if (trimmed.isEmpty || trimmed.toLowerCase() == 'und') continue;
+    out.add(trimmed);
+  }
+  return List<String>.unmodifiable(out);
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3630,6 +3630,7 @@ class AppModel with ChangeNotifier {
         apiKeyProvider: () => prefsRepo.jimakuApiKey,
         httpClientFactory: createDownloadHttpClient,
         stagingDirFor: store.subsDirFor,
+        defaultContentLanguageProvider: () => prefsRepo.defaultContentLanguage,
       ).resolve,
       backendFactory: _torrentBackendFor,
       onTick: () {
@@ -3831,6 +3832,7 @@ class AppModel with ChangeNotifier {
       preferredLanguages: <String>[
         if (preferredLanguage.isNotEmpty) preferredLanguage,
       ],
+      defaultContentLanguage: prefsRepo.defaultContentLanguage,
     );
     final VideoSourceScrapeCoordinator scrape = VideoSourceScrapeCoordinator(
       database: database,
@@ -3853,6 +3855,7 @@ class AppModel with ChangeNotifier {
       preferredSubtitleLanguages: <String>[
         if (preferredLanguage.isNotEmpty) preferredLanguage,
       ],
+      defaultContentLanguage: prefsRepo.defaultContentLanguage,
       backendResolver: _resolveVideoDownloadBackend,
       scrapeCoordinator: scrape,
       onBackendTaskAdded: _checkpointEmbeddedVideoDownload,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -80,6 +80,8 @@ import 'package:fushi/src/media/video/download/video_download_pipeline_service.d
 import 'package:fushi/src/media/video/download/video_download_subscription_service.dart';
 import 'package:fushi/src/media/video/download/video_resource_registry.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/scraped_subtitle_targets.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_backfill.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/jimaku_subtitle_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
@@ -3262,6 +3264,16 @@ class AppModel with ChangeNotifier {
     await reloadVideoDownloadPipelineRuntime();
   }
 
+  /// 刮削后自动为缺字幕的视频补字幕（默认开）。见
+  /// [PreferencesRepository.videoSubtitleBackfillAfterScrape]。
+  bool get videoSubtitleBackfillAfterScrape =>
+      _prefsRepo?.videoSubtitleBackfillAfterScrape ?? true;
+
+  Future<void> setVideoSubtitleBackfillAfterScrape(bool enabled) async {
+    await prefsRepo.setVideoSubtitleBackfillAfterScrape(enabled);
+    notifyListeners();
+  }
+
   /// 默认字幕语言归一成语言选择器用的 `String?`（`''`/空白 → null = 不限）。
   /// 三个 Jimaku 界面（字幕对话框 / 番剧下载 / 批量匹配）共用同一兜底。
   ///
@@ -3405,6 +3417,11 @@ class AppModel with ChangeNotifier {
   VideoResourceRegistry? get videoResourceRegistry => _videoResourceRegistry;
   VideoSubtitleRegistry? _videoSubtitleRegistry;
   VideoSubtitleRegistry? get videoSubtitleRegistry => _videoSubtitleRegistry;
+
+  /// 刮削后自动补字幕（BUG-1698）。与 [_videoSubtitleRegistry] 同生命周期：
+  /// 用户改了字幕来源/语言后 `reloadVideoDownloadPipelineRuntime` 会一起重建。
+  VideoSubtitleBackfillService? _videoSubtitleBackfillService;
+
   VideoSourceScrapeCoordinator? _videoDownloadScrapeCoordinator;
   TorrentBackend? _videoDownloadBackend;
   String? _videoDownloadBackendCacheKey;
@@ -3808,17 +3825,27 @@ class AppModel with ChangeNotifier {
       kVideoScraperTmdbApiKeyPref,
       defaultValue: '',
     ) as String;
+    final String preferredLanguage = prefsRepo.jimakuDefaultLanguage.trim();
+    _videoSubtitleBackfillService = VideoSubtitleBackfillService(
+      registry: subtitles,
+      preferredLanguages: <String>[
+        if (preferredLanguage.isNotEmpty) preferredLanguage,
+      ],
+    );
     final VideoSourceScrapeCoordinator scrape = VideoSourceScrapeCoordinator(
       database: database,
       config: VideoSourceScrapeGlobalConfig.fromPreferences(
         prefsRepo,
         resolvedTmdbApiKey: resolveTmdbApiKey(configuredTmdbKey),
       ),
+      // 刮削完成 → 给仍缺字幕的视频补字幕。刮削是全仓唯一解析出规范身份
+      // （AniList/TMDB id + 原名）的地方，而字幕准确率几乎完全取决于身份准不准
+      // ——不接这一刀，播放页只能拿文件名里的中文译名去 AniList 现猜。
+      onWorkScraped: _backfillSubtitlesForScrapedWork,
     );
     _videoResourceRegistry = resources;
     _videoSubtitleRegistry = subtitles;
     _videoDownloadScrapeCoordinator = scrape;
-    final String preferredLanguage = prefsRepo.jimakuDefaultLanguage.trim();
     final VideoDownloadPipelineService pipeline = VideoDownloadPipelineService(
       database: database,
       resourceRegistry: resources,
@@ -3840,6 +3867,40 @@ class AppModel with ChangeNotifier {
     // still starting. Publish the new service identity so its cached resource
     // dependencies are rebuilt instead of remaining permanently unavailable.
     notifyListeners();
+  }
+
+  /// 刮完一个作品 → 给它仍缺字幕的成员各补一条（BUG-1698）。
+  ///
+  /// 三道自然闸门，任何一道不满足就整个静默跳过（这是刮削的下游增值，不该有
+  /// 存在感）：偏好关了 / 没配任何在线字幕来源 / 该视频已经有字幕。
+  ///
+  /// 逐条串行而不是并发：一次刮削可能带来整季十几集，并发打同一个字幕站是滥用；
+  /// 而且这条路径本来就跑在刮削的后台任务里，没人在等它。
+  Future<void> _backfillSubtitlesForScrapedWork(
+    VideoScrapedWorkNotice notice,
+  ) async {
+    if (!videoSubtitleBackfillAfterScrape) return;
+    final VideoSubtitleBackfillService? service = _videoSubtitleBackfillService;
+    // provider 一个都没配时 registry 是空的，搜了也只会得到空结果——别为此
+    // 探一堆视频时长。
+    if (service == null || service.registry.providers.isEmpty) return;
+
+    final Set<String> withSubtitle = <String>{
+      for (final VideoBookRow book in notice.work.members)
+        if (book.subtitleSource?.trim().isNotEmpty == true) book.bookUid,
+    };
+    final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+      members: notice.work.members,
+      metadata: notice.metadata,
+      hasExistingSubtitle: withSubtitle.contains,
+    );
+    for (final SubtitleBackfillTarget target in targets) {
+      final SubtitleBackfillResult result = await service.backfill(target);
+      if (result.installed) {
+        debugPrint('[subtitle-backfill] installed ${result.language} for '
+            '${target.bookUid}: ${result.installedPath}');
+      }
+    }
   }
 
   /// 外部来源、凭据、字幕语言或网络代理变化后重建 provider runtime。持久任务

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -171,6 +171,7 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'video_secondary_subtitle_obscure_hide',
   'video_shaders_enabled',
   'video_sort_mode',
+  'video_subtitle_backfill_after_scrape',
   'video_subtitle_blur',
   'video_subtitle_list_auto_scroll',
   'video_subtitle_list_font_scale_index',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -1381,6 +1381,24 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 刮削完成后，自动为**仍缺字幕**的视频补一条在线字幕。默认开。
+  ///
+  /// 为什么默认开：下载流水线的字幕阶段本来就默认 `bestEffort`（自动配字幕一直
+  /// 是开着的），只是从来没有名字、没有开关、失败只落在任务行一句英文里，用户
+  /// 无从知道这个能力存在。给它一个名字放进设置页（可被设置搜索命中），是这个
+  /// 能力第一次变得可发现。
+  ///
+  /// 只在配好了在线字幕来源（Jimaku key / OpenSubtitles）时才有任何动作；
+  /// 且**绝不覆盖**任何已有字幕。
+  bool get videoSubtitleBackfillAfterScrape =>
+      getPref('video_subtitle_backfill_after_scrape', defaultValue: true)
+          as bool;
+
+  Future<void> setVideoSubtitleBackfillAfterScrape(bool enabled) async {
+    await setPref('video_subtitle_backfill_after_scrape', enabled);
+    notifyListeners();
+  }
+
   /// 远端/流媒体视频用户手选的字幕来源（按 `<bookUid>#ep<index>` 记忆）：
   /// `{ "<key>": "<subtitleSource 四态编码>" }`。
   ///

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -2455,8 +2455,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           t.anime_download_subs_pending,
           scheme.onSurfaceVariant,
         ),
+      // BUG-1696 起 unavailable 不再是终态：还排得上 backoff 重试的说「稍后自动
+      // 重试」，重试次数用完了才说「未匹配到（可手动补）」。两种对用户是完全不同
+      // 的处境——前者什么都不用做，后者要么手动补要么改条目。
       AnimeDownloadPlan.subtitleUnavailable => (
-          t.anime_download_subs_unmatched,
+          plan.subtitleRetryPossible
+              ? t.anime_download_subs_retrying
+              : t.anime_download_subs_unmatched,
           scheme.tertiary,
         ),
       _ => null,

--- a/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
@@ -594,6 +594,13 @@ class _VideoExternalProviderSettingsSectionState
         DropdownButtonFormField<String>(
           key: const ValueKey<String>('video-opensubtitles-language'),
           initialValue: _preferredLanguage,
+          // `isExpanded` + 逐项省略：不加的话 DropdownButton 按**内容固有宽度**
+          // 排版，长标签在 360px 紧凑布局里直接横向溢出（`compact layout has no
+          // horizontal overflow` 会红）。这里的选项以前全是 `日本語` / `中文`
+          // 这类两三字的短标签，才一直没暴露；`''` 从「全部」改成「跟随视频语言」
+          // 后就撞上了——而且这不是中文特有：17 份 i18n 里未翻译的那些落的是英文
+          // 原串 `Follow video language`，比中文还长。所以修的是约束，不是文案。
+          isExpanded: true,
           decoration: InputDecoration(
             labelText: t.video_opensubtitles_languages,
             helperText: t.video_setting_jimaku_default_language_hint,
@@ -604,12 +611,21 @@ class _VideoExternalProviderSettingsSectionState
           items: <DropdownMenuItem<String>>[
             DropdownMenuItem<String>(
               value: '',
-              child: Text(t.video_jimaku_language_all),
+              // 与设置页那份同一语义：`''` = 跟随视频语言，不是「全部」。
+              child: Text(
+                t.video_jimaku_language_follow_video,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
             for (final String language in kJimakuLanguageCodes)
               DropdownMenuItem<String>(
                 value: language,
-                child: Text(jimakuLanguageLabel(language)),
+                child: Text(
+                  jimakuLanguageLabel(language),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
           ],
           onChanged: (String? value) {

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -1131,6 +1131,26 @@ SettingsDestination buildVideoDestination() {
                   ?.call();
             },
           ),
+          // ── 自动获取字幕 ─────────────────────────────────────────────────
+          // 这个开关的主要价值是**让用户知道这件事存在**（BUG-1698）。
+          //
+          // 自动配字幕其实一直开着（下载流水线的字幕阶段默认 bestEffort），但它
+          // 从来没有名字、没有位置、失败只落在任务行一句英文 note 里——用户没有
+          // 任何途径发现这个能力，更不知道要去配 Jimaku key 才能用上。给它一个
+          // 有名字的条目放在字幕来源配置**正上方**，设置搜索（settings_search）
+          // 就能命中「字幕」搜到它，配置项也在同屏可见。
+          SettingsSwitchItem(
+            id: 'video.subtitle.backfill_after_scrape',
+            title: t.video_setting_subtitle_backfill,
+            subtitle: t.video_setting_subtitle_backfill_hint,
+            icon: Icons.subtitles_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.videoSubtitleBackfillAfterScrape,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setVideoSubtitleBackfillAfterScrape(value);
+            },
+          ),
           // ── Jimaku（在线字幕源）───────────────────────────────────────────
           // 此前 API key 只能在三个对话框（视频字幕 / 番剧下载 / 批量匹配）里就地填，
           // 设置页压根没有入口；下载对话框那个还只在 key 为空时才显示，key 填错了

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -1168,7 +1168,13 @@ SettingsDestination buildVideoDestination() {
             },
           ),
           // 默认字幕语言：没有该系列记忆（jimakuPreferredLanguages）时的兜底优先语言。
-          // `''` = 不限（按 jimakuLanguageRank 默认权重排）。
+          //
+          // `''` 的语义已从「不限」改成「**跟随视频语言**」：自动下字幕时按视频
+          // 自己的语言（用户手动指定的内容语言 > 刮削 originalLanguage > 音轨 tag）
+          // 优先选，日语番取日语轨、韩剧取韩语轨。旧的「不限」实际效果是拿搜索结果
+          // 里排最前的那条，语言随缘——对一个沉浸学习 app 这不是合理默认。
+          // 注意这是**排序**不是过滤：只有英文字幕的日语番仍然配得上，只是排后面。
+          // 选定某个语言则是用户显式表态，进硬过滤。
           SettingsSegmentedItem<String>(
             id: 'video.subtitle.jimaku_default_language',
             title: t.video_setting_jimaku_default_language,
@@ -1177,7 +1183,11 @@ SettingsDestination buildVideoDestination() {
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
                 value: '',
-                label: t.video_jimaku_language_all,
+                // 不复用 video_jimaku_language_all（「全部」）：那个标签在字幕
+                // 对话框/条目选择器里是「别过滤我正在浏览的列表」，语义仍然正确；
+                // 这里同一个 `''` 值的意思已经变成「跟随视频语言」。同值不同义，
+                // 就该是两个标签。
+                label: t.video_jimaku_language_follow_video,
               ),
               for (final String code in kJimakuLanguageCodes)
                 SettingsSegmentOption<String>(

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fushi
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.1.1+1216
+version: 2.1.1+1217
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fushi
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.1.1+1217
+version: 2.1.1+1218
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/media/video/jimaku_batch_test.dart
+++ b/fushi/test/media/video/jimaku_batch_test.dart
@@ -49,6 +49,7 @@ void main() {
           _f('Show - 03.ja.srt'),
         ],
         episode: 3,
+        soleTarget: false,
       );
       expect(best?.name, 'Show - 03.ja.srt');
     });
@@ -57,22 +58,54 @@ void main() {
       final JimakuFile? best = pickBestSubtitleFile(
         <JimakuFile>[_f('Show - 03.ja.srt'), _f('Show - 03.zh.srt')],
         episode: 3,
+        soleTarget: false,
         preferredLanguage: 'zh',
       );
       expect(best?.name, 'Show - 03.zh.srt');
     });
 
-    test('无一命中集号 → 退回全体（尽力而为）', () {
+    test('BUG-1695 未编号字幕 + 唯一目标 → 采用（剧场版/整季单文件）', () {
       final JimakuFile? best = pickBestSubtitleFile(
         <JimakuFile>[_f('Season pack.ja.srt')],
         episode: 3,
+        soleTarget: true,
       );
       expect(best?.name, 'Season pack.ja.srt');
     });
 
+    test('BUG-1695 未编号字幕 + 多目标 → null（不能让 N 集共用一个文件）', () {
+      expect(
+        pickBestSubtitleFile(
+          <JimakuFile>[_f('Season pack.ja.srt')],
+          episode: 3,
+          soleTarget: false,
+        ),
+        isNull,
+        reason: '认不出集号时给每一集都发同一个文件，是把冲突静默变成错答案',
+      );
+    });
+
+    test('BUG-1695 字幕侧有集号但没有这一集 → null，即便只有一个目标', () {
+      // 绝对集号编号的 S2 条目（13-24）撞上本地 01-12 就是这个形状。
+      // 旧实现在这里退回「列表第一个」，于是第 3 集拿到第 13 集的字幕。
+      expect(
+        pickBestSubtitleFile(
+          <JimakuFile>[_f('Show - 13.ja.srt'), _f('Show - 14.ja.srt')],
+          episode: 3,
+          soleTarget: true,
+        ),
+        isNull,
+        reason: '集号冲突（错季/绝对集号/选错条目）绝不能用别集顶替',
+      );
+    });
+
     test('无文本字幕候选 → null', () {
       expect(
-        pickBestSubtitleFile(<JimakuFile>[_f('cover.png')], episode: 1),
+        pickBestSubtitleFile(
+          <JimakuFile>[_f('cover.png')],
+          episode: 1,
+          soleTarget: true,
+        ),
         isNull,
       );
     });
@@ -153,17 +186,26 @@ void main() {
       if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
 
-    test('逐集列文件→挑最佳→下载落盘→回调持久化', () async {
-      // Mock：/entries/7/files?episode=N 回该集的 srt 文件；下载 url 回文本字节。
+    test('整批只列一次文件→逐集挑最佳→下载落盘→回调持久化', () async {
+      // Mock：/entries/7/files 回**整个条目**的 srt 列表；下载 url 回文本字节。
+      // BUG-1695 起不再带 `episode=`：服务端那道过滤是文件名启发式，会遮住
+      // 「字幕侧到底有哪些集号」，判不出集号冲突。
+      int listCalls = 0;
       final MockClient mock = MockClient((http.Request req) async {
         if (req.url.path.endsWith('/entries/7/files')) {
-          final String ep = req.url.queryParameters['episode'] ?? '0';
+          listCalls++;
+          expect(
+            req.url.queryParameters.containsKey('episode'),
+            isFalse,
+            reason: '列文件不得再按服务端启发式预过滤',
+          );
           return http.Response(
             jsonEncode(<Map<String, dynamic>>[
-              <String, dynamic>{
-                'name': 'Show - 0$ep.ja.srt',
-                'url': 'https://x/Show-$ep.ja.srt',
-              },
+              for (final int ep in <int>[1, 2])
+                <String, dynamic>{
+                  'name': 'Show - 0$ep.ja.srt',
+                  'url': 'https://x/Show-$ep.ja.srt',
+                },
             ]),
             200,
           );
@@ -198,25 +240,22 @@ void main() {
       expect(File(results[0].subtitlePath!).existsSync(), isTrue);
       expect(results[0].subtitlePath, isNot(results[1].subtitlePath));
       expect(persisted, hasLength(2), reason: 'onItemDone 对成功集回调持久化');
+      expect(listCalls, 1, reason: '整批一次列文件，不是 targets×entries 次');
     });
 
     test('无匹配集记 noMatch，不中断其它集', () async {
+      // 条目里只有第 1 集的字幕。
       final MockClient mock = MockClient((http.Request req) async {
         if (req.url.path.endsWith('/entries/7/files')) {
-          final String ep = req.url.queryParameters['episode'] ?? '0';
-          // 只有第 1 集有字幕；第 2 集回空。
-          if (ep == '1') {
-            return http.Response(
-              jsonEncode(<Map<String, dynamic>>[
-                <String, dynamic>{
-                  'name': 'Show - 01.ja.srt',
-                  'url': 'https://x/1'
-                },
-              ]),
-              200,
-            );
-          }
-          return http.Response('[]', 200);
+          return http.Response(
+            jsonEncode(<Map<String, dynamic>>[
+              <String, dynamic>{
+                'name': 'Show - 01.ja.srt',
+                'url': 'https://x/1'
+              },
+            ]),
+            200,
+          );
         }
         return http.Response('1\n00:00:01,000 --> 00:00:02,000\nhi\n', 200);
       });
@@ -234,6 +273,90 @@ void main() {
       );
       expect(results[0].status, JimakuBatchStatus.done);
       expect(results[1].status, JimakuBatchStatus.noMatch);
+    });
+
+    test('BUG-1695 整季未编号字幕不得被全批共用（旧实现每集都拿同一个文件）', () async {
+      // 条目里只有一个认不出集号的文件。旧实现：3 集全部 done，且 3 个 bookUid
+      // 各存一份**同一个** `Sousou no Frieren.ja.srt`，用户要逐集手动纠正。
+      final MockClient mock = MockClient((http.Request req) async {
+        if (req.url.path.endsWith('/entries/7/files')) {
+          return http.Response(
+            jsonEncode(<Map<String, dynamic>>[
+              <String, dynamic>{
+                'name': 'Sousou no Frieren.ja.srt',
+                'url': 'https://x/pack',
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('1\n00:00:01,000 --> 00:00:02,000\nhi\n', 200);
+      });
+      final JimakuClient client = JimakuClient(apiKey: 'k', client: mock);
+      addTearDown(client.close);
+
+      final List<JimakuBatchItem> results = await runJimakuBatch(
+        client: client,
+        entryIds: <int>[7],
+        targets: <JimakuBatchTarget>[
+          _t('video/a', '/v/Show - 01.mkv', sortIndex: 0),
+          _t('video/b', '/v/Show - 02.mkv', sortIndex: 1),
+          _t('video/c', '/v/Show - 03.mkv', sortIndex: 2),
+        ],
+        saveDirectory: tempDir.path,
+      );
+      expect(
+        results.map((JimakuBatchItem i) => i.status),
+        everyElement(JimakuBatchStatus.noMatch),
+      );
+      expect(
+        results.first.message,
+        'jimaku subtitles carry no episode numbers',
+        reason: '「为什么没配上」要说清，不能只给一个空结果',
+      );
+      expect(
+        tempDir.listSync(),
+        isEmpty,
+        reason: '一个错字幕都不许落盘',
+      );
+    });
+
+    test('BUG-1695 绝对集号条目（13-24）撞本地 01-12 → 全部 noMatch 而非配错集', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        if (req.url.path.endsWith('/entries/7/files')) {
+          return http.Response(
+            jsonEncode(<Map<String, dynamic>>[
+              for (final int ep in <int>[13, 14])
+                <String, dynamic>{
+                  'name': 'Show - $ep.ja.srt',
+                  'url': 'https://x/$ep',
+                },
+            ]),
+            200,
+          );
+        }
+        return http.Response('1\n00:00:01,000 --> 00:00:02,000\nhi\n', 200);
+      });
+      final JimakuClient client = JimakuClient(apiKey: 'k', client: mock);
+      addTearDown(client.close);
+
+      final List<JimakuBatchItem> results = await runJimakuBatch(
+        client: client,
+        entryIds: <int>[7],
+        targets: <JimakuBatchTarget>[
+          _t('video/a', '/v/Show - 01.mkv', sortIndex: 0),
+          _t('video/b', '/v/Show - 02.mkv', sortIndex: 1),
+        ],
+        saveDirectory: tempDir.path,
+      );
+      expect(
+        results.map((JimakuBatchItem i) => i.status),
+        everyElement(JimakuBatchStatus.noMatch),
+      );
+      expect(
+        results.first.message,
+        'jimaku entry has subtitles but none for this episode',
+      );
     });
 
     test('HTTP 请求失败记 failed，不得 fail-open 冒充 noMatch', () async {

--- a/fushi/test/media/video/jimaku_client_test.dart
+++ b/fushi/test/media/video/jimaku_client_test.dart
@@ -220,15 +220,59 @@ void main() {
         return http.Response('[]', 200);
       });
       final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      // 显式钉动画档：这条用例验的是「id → 文本」的回退顺序，不该被
+      // BUG-1694 的 anime=true/false 两档兜底混进额外请求。
       final List<JimakuEntry> entries = await jc.searchEntries(
         anilistId: 999,
         queryFallbacks: <String>['', 'Tom Jerry romaji', 'とむとじぇりーごっこ'],
+        animeFilter: JimakuAnimeFilter.anime,
       );
       expect(entries, hasLength(1));
       expect(entries.first.name, '字幕在此');
       // 空串被跳过；命中后不再尝试后续（此处第 3 个即命中，无第 4 个）。
       expect(
           calls, <String>['id', 'query:Tom Jerry romaji', 'query:とむとじぇりーごっこ']);
+    });
+
+    group('BUG-1694 anime 硬过滤', () {
+      test('从不拼 anime 参数 = 永远只搜服务端缺省的动画子集（真人剧 0 结果）', () async {
+        final List<String?> animeParams = <String?>[];
+        final MockClient client = MockClient((http.Request req) async {
+          animeParams.add(req.url.queryParameters['anime']);
+          return http.Response('[]', 200);
+        });
+        final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+        await jc.searchByQuery('半沢直樹');
+        // 缺省 either：先 true 再 false。少了 'false' 那一发，Jimaku 上数千条
+        // 真人条目就是搜不到——那正是本 bug。
+        expect(animeParams, <String>['true', 'false']);
+      });
+
+      test('liveAction 只发一次 anime=false', () async {
+        final List<String?> animeParams = <String?>[];
+        final MockClient client = MockClient((http.Request req) async {
+          animeParams.add(req.url.queryParameters['anime']);
+          return http.Response('[{"id":5,"name":"drama"}]', 200);
+        });
+        final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+        final List<JimakuEntry> entries = await jc.searchByQuery(
+          '半沢直樹',
+          animeFilter: JimakuAnimeFilter.liveAction,
+        );
+        expect(entries.single.name, 'drama');
+        expect(animeParams, <String>['false']);
+      });
+
+      test('动画命中就不再为真人多打一次（either 的请求数不比改动前多）', () async {
+        final List<String?> animeParams = <String?>[];
+        final MockClient client = MockClient((http.Request req) async {
+          animeParams.add(req.url.queryParameters['anime']);
+          return http.Response('[{"id":9,"name":"anime hit"}]', 200);
+        });
+        final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+        expect((await jc.searchByAnilistId(21)).single.name, 'anime hit');
+        expect(animeParams, <String>['true']);
+      });
     });
 
     test('anilist_id 与全部文本都空 → 空', () async {

--- a/fushi/test/media/video/scraped_subtitle_targets_test.dart
+++ b/fushi/test/media/video/scraped_subtitle_targets_test.dart
@@ -5,6 +5,8 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/subtitle/scraped_subtitle_targets.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_backfill.dart';
+import 'package:fushi/src/media/video/video_sidecar.dart'
+    show isSidecarSubtitleSuffix;
 
 VideoBookRow _book(String uid, String path) => VideoBookRow(
       bookUid: uid,
@@ -214,6 +216,51 @@ void main() {
         ),
         isEmpty,
       );
+    });
+  });
+
+  group('sidecar 命名必须与 isSidecarSubtitleSuffix 白名单成对', () {
+    // 这两个函数与白名单是一个契约的两半：写出去的名字不匹配白名单，播放页就
+    // 永远发现不了那条字幕，而下一轮「已有 sidecar？」检查同样看不见它 →
+    // 每刮一次多一个孤儿文件。所以判据不是「看着像」，而是**真拿白名单验**。
+    test('各种脏语言标签归一后仍落在白名单里', () {
+      for (final String raw in <String>[
+        'ja',
+        'JA',
+        'pt-BR',
+        'ja[cc]',
+        'en(sdh)',
+        '  zh-Hans  ',
+        '日本語',
+        '',
+        '---',
+        'x' * 64,
+      ]) {
+        final String tag = sidecarLanguageTag(raw);
+        expect(tag, isNotEmpty, reason: '空标签会写成 <base>..srt');
+        expect(
+          isSidecarSubtitleSuffix('.$tag.srt'),
+          isTrue,
+          reason: '"$raw" → "$tag" 写出的 sidecar 不被白名单认可',
+        );
+      }
+    });
+
+    test('非文本字幕扩展名一律落成 .srt（否则菜单里根本不出现）', () {
+      expect(sidecarSubtitleExtension('a.srt'), '.srt');
+      expect(sidecarSubtitleExtension('a.ASS'), '.ass');
+      expect(sidecarSubtitleExtension('a.vtt'), '.vtt');
+      expect(sidecarSubtitleExtension('a.zip'), '.srt');
+      expect(sidecarSubtitleExtension('noext'), '.srt');
+    });
+
+    test('扩展名同样必须过白名单', () {
+      for (final String name in <String>['a.srt', 'a.ASS', 'a.zip', 'noext']) {
+        expect(
+          isSidecarSubtitleSuffix('.ja${sidecarSubtitleExtension(name)}'),
+          isTrue,
+        );
+      }
     });
   });
 }

--- a/fushi/test/media/video/scraped_subtitle_targets_test.dart
+++ b/fushi/test/media/video/scraped_subtitle_targets_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/media/video/subtitle/scraped_subtitle_targets.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_backfill.dart';
+
+VideoBookRow _book(String uid, String path) => VideoBookRow(
+      bookUid: uid,
+      title: uid,
+      videoPath: path,
+      lastPositionMs: 0,
+      delayMs: 0,
+      currentEpisode: 0,
+    );
+
+VideoMetadataWork _work({
+  List<VideoMetadataId> ids = const <VideoMetadataId>[],
+  VideoMetadataMediaKind kind = VideoMetadataMediaKind.tv,
+  String title = '葬送的芙莉莲',
+  String? originalTitle = '葬送のフリーレン',
+  int? runtimeMinutes = 24,
+  List<VideoMetadataSeason> seasons = const <VideoMetadataSeason>[],
+}) =>
+    VideoMetadataWork(
+      provider: VideoMetadataProviderKind.tmdb,
+      kind: kind,
+      title: title,
+      originalTitle: originalTitle,
+      runtimeMinutes: runtimeMinutes,
+      ids: ids,
+      seasons: seasons,
+    );
+
+void main() {
+  group('scrapedMediaReference（准确率的分水岭：身份从刮削来，不从文件名猜）', () {
+    test('外部 id 全量带过去——Jimaku 按 anilist_id 直查、OpenSubtitles 按 imdb', () {
+      final VideoMediaReference ref = scrapedMediaReference(
+        _work(ids: const <VideoMetadataId>[
+          VideoMetadataId(type: 'anilist', value: '154587'),
+          VideoMetadataId(type: 'tmdb', value: '209867'),
+          VideoMetadataId(type: 'imdb', value: 'tt22248376'),
+          VideoMetadataId(type: 'bangumi', value: '400602'),
+          VideoMetadataId(type: 'tvdb', value: '424536'),
+        ]),
+        season: 1,
+        episode: 5,
+      );
+      expect(ref.anilistId, 154587);
+      expect(ref.tmdbId, 209867);
+      expect(ref.imdbId, 'tt22248376');
+      expect(ref.bangumiId, 400602);
+      expect(ref.tvdbId, 424536);
+      expect(ref.season, 1);
+      expect(ref.episode, 5);
+    });
+
+    test('originalTitle 必须带上：id 没命中时的回退查询词不能是中文译名', () {
+      final VideoMediaReference ref = scrapedMediaReference(_work());
+      expect(ref.originalTitle, '葬送のフリーレン');
+      expect(
+        ref.title,
+        '葬送的芙莉莲',
+        reason: '中文译名仍要留着（UI 显示），但它不该是唯一的查询词',
+      );
+    });
+
+    test('id 缺失/非数字不炸，只是那一项为 null', () {
+      final VideoMediaReference ref = scrapedMediaReference(
+        _work(ids: const <VideoMetadataId>[
+          VideoMetadataId(type: 'anilist', value: 'not-a-number'),
+          VideoMetadataId(type: 'tmdb', value: '  '),
+        ]),
+      );
+      expect(ref.anilistId, isNull);
+      expect(ref.tmdbId, isNull);
+    });
+  });
+
+  group('scrapedDiscoveryCategory（决定 Jimaku 的 anime 硬过滤走哪一档）', () {
+    test('有 AniList id → anime', () {
+      expect(
+        scrapedDiscoveryCategory(_work(ids: const <VideoMetadataId>[
+          VideoMetadataId(type: 'anilist', value: '154587'),
+        ])),
+        VideoDiscoveryCategory.anime,
+      );
+    });
+
+    test('无 AniList id → 按 movie/tv 分', () {
+      expect(scrapedDiscoveryCategory(_work()), VideoDiscoveryCategory.tv);
+      expect(
+        scrapedDiscoveryCategory(_work(kind: VideoMetadataMediaKind.movie)),
+        VideoDiscoveryCategory.movie,
+      );
+    });
+  });
+
+  group('scrapedSubtitleTargets', () {
+    test('季集号取本地文件名解析，不是刮削里的顺序', () {
+      final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+        members: <VideoBookRow>[
+          // 故意让磁盘顺序与集号不一致：合集可能缺集/含特典/被拖拽重排过。
+          _book('b3', '/v/Frieren S01E12.mkv'),
+          _book('b1', '/v/Frieren S01E03.mkv'),
+        ],
+        metadata: _work(),
+        hasExistingSubtitle: (_) => false,
+      );
+      expect(targets.map((SubtitleBackfillTarget t) => t.media.episode),
+          <int>[12, 3]);
+      expect(targets.every((SubtitleBackfillTarget t) => t.media.season == 1),
+          isTrue);
+    });
+
+    test('已有字幕的成员直接标记，不生成新的下载意图', () {
+      final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+        members: <VideoBookRow>[
+          _book('has', '/v/Frieren S01E01.mkv'),
+          _book('none', '/v/Frieren S01E02.mkv'),
+        ],
+        metadata: _work(),
+        hasExistingSubtitle: (String uid) => uid == 'has',
+      );
+      expect(targets, hasLength(2));
+      expect(
+        targets
+            .firstWhere((SubtitleBackfillTarget t) => t.bookUid == 'has')
+            .hasExistingSubtitle,
+        isTrue,
+      );
+      expect(
+        targets
+            .firstWhere((SubtitleBackfillTarget t) => t.bookUid == 'none')
+            .hasExistingSubtitle,
+        isFalse,
+      );
+    });
+
+    test('多集里认不出集号的成员**不生成目标**（配上去只能是碰运气）', () {
+      final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+        members: <VideoBookRow>[
+          _book('ok', '/v/Frieren S01E01.mkv'),
+          _book('opaque', '/v/opaque-name.mkv'),
+        ],
+        metadata: _work(),
+        hasExistingSubtitle: (_) => false,
+      );
+      expect(targets.map((SubtitleBackfillTarget t) => t.bookUid), <String>[
+        'ok',
+      ]);
+    });
+
+    test('整部作品只有一个文件（电影/剧场版）时，认不出集号也照样生成目标', () {
+      final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+        members: <VideoBookRow>[_book('movie', '/v/Frieren Movie.mkv')],
+        metadata: _work(kind: VideoMetadataMediaKind.movie),
+        hasExistingSubtitle: (_) => false,
+      );
+      expect(targets.single.media.episode, isNull);
+      expect(targets.single.media.season, isNull);
+    });
+
+    test('runtime 取该集的，缺则回落作品级（时长校验的兜底来源）', () {
+      final VideoMetadataWork work = _work(
+        runtimeMinutes: 24,
+        seasons: <VideoMetadataSeason>[
+          VideoMetadataSeason(
+            seasonNumber: 1,
+            title: 'S1',
+            episodes: <VideoMetadataEpisode>[
+              VideoMetadataEpisode(
+                seasonNumber: 1,
+                episodeNumber: 1,
+                title: 'ep1',
+                runtimeMinutes: 48,
+              ),
+              VideoMetadataEpisode(
+                seasonNumber: 1,
+                episodeNumber: 2,
+                title: 'ep2',
+              ),
+            ],
+          ),
+        ],
+      );
+      final List<SubtitleBackfillTarget> targets = scrapedSubtitleTargets(
+        members: <VideoBookRow>[
+          _book('a', '/v/Frieren S01E01.mkv'),
+          _book('b', '/v/Frieren S01E02.mkv'),
+        ],
+        metadata: work,
+        hasExistingSubtitle: (_) => false,
+      );
+      expect(targets[0].scrapedRuntimeMinutes, 48, reason: '首播双集时长翻倍');
+      expect(targets[1].scrapedRuntimeMinutes, 24, reason: '该集没给就回落作品级');
+    });
+
+    test('空成员 / 空路径 → 空结果，不生成半截目标', () {
+      expect(
+        scrapedSubtitleTargets(
+          members: const <VideoBookRow>[],
+          metadata: _work(),
+          hasExistingSubtitle: (_) => false,
+        ),
+        isEmpty,
+      );
+      expect(
+        scrapedSubtitleTargets(
+          members: <VideoBookRow>[_book('blank', '   ')],
+          metadata: _work(),
+          hasExistingSubtitle: (_) => false,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/fushi/test/media/video/subtitle_language_preference_test.dart
+++ b/fushi/test/media/video/subtitle_language_preference_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_language_preference.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+
+class _Cand {
+  const _Cand(this.name, this.language);
+  final String name;
+  final String? language;
+}
+
+void main() {
+  group('normalizeSubtitleLanguageCode', () {
+    test('BCP-47 取主标签', () {
+      expect(normalizeSubtitleLanguageCode('ja-JP'), 'ja');
+      expect(normalizeSubtitleLanguageCode('zh-Hans'), 'zh');
+      expect(normalizeSubtitleLanguageCode('zh_CN'), 'zh');
+      expect(normalizeSubtitleLanguageCode('pt-BR'), 'pt');
+      expect(normalizeSubtitleLanguageCode('  KO  '), 'ko');
+    });
+
+    test('ISO 639-2 / 俗写映射到 639-1', () {
+      expect(normalizeSubtitleLanguageCode('jpn'), 'ja');
+      expect(normalizeSubtitleLanguageCode('jp'), 'ja');
+      expect(normalizeSubtitleLanguageCode('kor'), 'ko');
+      expect(normalizeSubtitleLanguageCode('chs'), 'zh');
+      expect(normalizeSubtitleLanguageCode('cht'), 'zh');
+      expect(normalizeSubtitleLanguageCode('yue'), 'zh');
+      expect(normalizeSubtitleLanguageCode('eng'), 'en');
+      expect(normalizeSubtitleLanguageCode('ger'), 'de');
+    });
+
+    test('空/空白 → null；不在别名表里的三字母原样返回（比错映射安全）', () {
+      expect(normalizeSubtitleLanguageCode(null), isNull);
+      expect(normalizeSubtitleLanguageCode(''), isNull);
+      expect(normalizeSubtitleLanguageCode('   '), isNull);
+      expect(normalizeSubtitleLanguageCode('swe'), 'swe');
+    });
+  });
+
+  group('resolveSubtitleDownloadLanguage（默认取视频语言）', () {
+    test('用户显式选的字幕语言压过一切——他就这件事表过态', () {
+      expect(
+        resolveSubtitleDownloadLanguage(
+          explicitSubtitlePreference: 'zh',
+          videoContentLanguage: 'ja',
+          contentMetadataLanguage: 'ja',
+          globalDefaultContentLanguage: 'ja',
+        ),
+        'zh',
+      );
+    });
+
+    test('没显式选 → 视频内容语言（用户对本视频手动指定的最优先）', () {
+      expect(
+        resolveSubtitleDownloadLanguage(
+          videoContentLanguage: 'ko-KR',
+          contentMetadataLanguage: 'ja',
+          globalDefaultContentLanguage: 'en',
+        ),
+        'ko',
+        reason: 'VideoBooks.language 是用户手动指定，压过刮削与音轨',
+      );
+    });
+
+    test('没手动指定 → 内容元数据（刮削 originalLanguage / 音轨 tag）', () {
+      expect(
+        resolveSubtitleDownloadLanguage(
+          contentMetadataLanguage: 'jpn',
+          globalDefaultContentLanguage: 'en',
+        ),
+        'ja',
+      );
+    });
+
+    test('都没有 → 全局默认内容语言', () {
+      expect(
+        resolveSubtitleDownloadLanguage(
+            globalDefaultContentLanguage: 'zh-Hant'),
+        'zh',
+      );
+    });
+
+    test('🔴 全空 → null，绝不猜、绝不硬编码日语（本 app 无全局学习语言）', () {
+      expect(resolveSubtitleDownloadLanguage(), isNull);
+      expect(
+        resolveSubtitleDownloadLanguage(
+          explicitSubtitlePreference: '',
+          videoContentLanguage: '   ',
+          contentMetadataLanguage: '',
+          globalDefaultContentLanguage: '',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('rankByPreferredLanguage（是排序，不是过滤）', () {
+    final List<_Cand> candidates = <_Cand>[
+      const _Cand('en1', 'en'),
+      const _Cand('ja1', 'ja'),
+      const _Cand('zh1', 'zh'),
+      const _Cand('ja2', 'ja-JP'),
+      const _Cand('unknown', null),
+    ];
+
+    List<String> namesOf(List<_Cand> list) =>
+        list.map((_Cand c) => c.name).toList();
+
+    test('首选语言排到前面，其余**一条不丢**', () {
+      final List<_Cand> ranked = rankByPreferredLanguage(
+        candidates,
+        'ja',
+        (_Cand c) => c.language,
+      );
+      expect(namesOf(ranked), <String>['ja1', 'ja2', 'en1', 'zh1', 'unknown']);
+      expect(
+        ranked.length,
+        candidates.length,
+        reason: '按语言硬过滤会把「只有英文字幕的日语番」从有字幕变成没字幕',
+      );
+    });
+
+    test('归一后比较：`jpn` / `ja-JP` 都算 ja', () {
+      final List<_Cand> ranked = rankByPreferredLanguage(
+        <_Cand>[const _Cand('en', 'en'), const _Cand('x', 'jpn')],
+        'ja-JP',
+        (_Cand c) => c.language,
+      );
+      expect(namesOf(ranked), <String>['x', 'en']);
+    });
+
+    test('同语言内部保持原顺序（稳定）——否则重跑两次拿到不同字幕', () {
+      final List<_Cand> ranked = rankByPreferredLanguage(
+        candidates,
+        'ja',
+        (_Cand c) => c.language,
+      );
+      expect(
+        namesOf(ranked).sublist(0, 2),
+        <String>['ja1', 'ja2'],
+        reason: '候选进来时已按 provider 优先级+下载量排好，语言只是外层键',
+      );
+    });
+
+    test('首选为 null / 无人命中 → 原样返回（不做无谓重排）', () {
+      expect(
+        rankByPreferredLanguage(candidates, null, (_Cand c) => c.language),
+        same(candidates),
+      );
+      expect(
+        rankByPreferredLanguage(candidates, 'sv', (_Cand c) => c.language),
+        same(candidates),
+      );
+    });
+  });
+
+  group('parseFfprobeFacts（时长 + 音轨语言一次拿到）', () {
+    const String json = '''
+{
+  "streams": [
+    {"index": 0, "codec_type": "video"},
+    {"index": 1, "codec_type": "audio", "tags": {"language": "jpn"}},
+    {"index": 2, "codec_type": "audio", "tags": {"language": "eng"}},
+    {"index": 3, "codec_type": "subtitle", "tags": {"language": "chi"}}
+  ],
+  "format": {"duration": "1421.234000"}
+}
+''';
+
+    test('时长与音轨语言都解析出来，按流顺序', () {
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.durationMs, 1421234);
+      expect(facts.audioLanguages, <String>['jpn', 'eng']);
+      expect(facts.primaryAudioLanguage, 'jpn');
+    });
+
+    test('只取音轨——字幕轨的 language 不能冒充视频语言', () {
+      expect(parseFfprobeFacts(json).audioLanguages, isNot(contains('chi')));
+    });
+
+    test('`und` 等同未标注，跳过它去看后面真有标注的音轨', () {
+      const String withUnd = '''
+{"streams":[
+  {"index":0,"codec_type":"audio","tags":{"language":"und"}},
+  {"index":1,"codec_type":"audio","tags":{"language":"kor"}}
+]}
+''';
+      final VideoProbeFacts facts = parseFfprobeFacts(withUnd);
+      expect(facts.audioLanguages, <String>['kor']);
+      expect(facts.primaryAudioLanguage, 'kor');
+    });
+
+    test('一半缺失不让另一半作废', () {
+      expect(
+        parseFfprobeFacts('{"format":{"duration":"60"}}').durationMs,
+        60000,
+      );
+      expect(
+        parseFfprobeFacts('{"format":{"duration":"60"}}').audioLanguages,
+        isEmpty,
+      );
+      final VideoProbeFacts noDuration = parseFfprobeFacts(
+        '{"streams":[{"codec_type":"audio","tags":{"language":"ja"}}]}',
+      );
+      expect(noDuration.durationMs, isNull);
+      expect(noDuration.primaryAudioLanguage, 'ja');
+    });
+
+    test('无 tags / 非 json / 空 → 空结果，不抛', () {
+      expect(
+        parseFfprobeFacts('{"streams":[{"codec_type":"audio"}]}')
+            .audioLanguages,
+        isEmpty,
+      );
+      expect(parseFfprobeFacts('not json').durationMs, isNull);
+      expect(parseFfprobeFacts('').audioLanguages, isEmpty);
+    });
+  });
+}

--- a/fushi/test/media/video/subtitle_timing_check_test.dart
+++ b/fushi/test/media/video/subtitle_timing_check_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_timing_check.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+
+/// 造一条 srt：`count` 句，每句 2 秒，最后一句结束在 `lastEndSeconds`。
+String _srt({required int count, required int lastEndSeconds}) {
+  final StringBuffer buffer = StringBuffer();
+  final int step = count <= 1 ? 0 : (lastEndSeconds - 2) ~/ (count - 1);
+  for (int i = 0; i < count; i++) {
+    final int start = i == count - 1 ? lastEndSeconds - 2 : i * step;
+    final int end = start + 2;
+    buffer
+      ..writeln('${i + 1}')
+      ..writeln('${_clock(start)},000 --> ${_clock(end)},000')
+      ..writeln('line ${i + 1}')
+      ..writeln();
+  }
+  return buffer.toString();
+}
+
+String _clock(int seconds) {
+  final Duration d = Duration(seconds: seconds);
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${two(d.inHours)}:${two(d.inMinutes.remainder(60))}:'
+      '${two(d.inSeconds.remainder(60))}';
+}
+
+void main() {
+  group('summarizeSubtitleTiming', () {
+    test('srt：条数 + 首尾时刻', () {
+      final SubtitleTimingSummary s = summarizeSubtitleTiming(
+        _srt(count: 3, lastEndSeconds: 1400),
+      );
+      expect(s.cueCount, 3);
+      expect(s.firstStartMs, 0);
+      expect(s.lastEndMs, 1400 * 1000);
+    });
+
+    test('vtt：小数点分隔 + 可省小时段', () {
+      const String vtt = '''
+WEBVTT
+
+00:01.000 --> 00:03.500
+hello
+
+01:02:03.250 --> 01:02:05.750
+world
+''';
+      final SubtitleTimingSummary s = summarizeSubtitleTiming(vtt);
+      expect(s.cueCount, 2);
+      expect(s.firstStartMs, 1000);
+      expect(s.lastEndMs, ((1 * 60 + 2) * 60 + 5) * 1000 + 750);
+    });
+
+    test('ass：Dialogue 行的 2/3 字段是时间，首字段是层号（不能当时间读）', () {
+      const String ass = '''
+[Script Info]
+Title: x
+
+[Events]
+Format: Layer, Start, End, Style, Name, Text
+Dialogue: 0,0:00:01.10,0:00:03.45,Default,,0,0,0,,ようこそ
+Dialogue: 0,0:23:11.00,0:23:14.20,Default,,0,0,0,,おわり
+''';
+      final SubtitleTimingSummary s = summarizeSubtitleTiming(ass);
+      expect(s.cueCount, 2);
+      expect(s.firstStartMs, 1100);
+      // ass 的两位小数是**厘秒**：`.20` = 200ms，不是 20ms。
+      expect(s.lastEndMs, (23 * 60 + 14) * 1000 + 200);
+    });
+
+    test('空 / 非字幕字节（比如被 HTML 错误页顶替）→ empty', () {
+      expect(summarizeSubtitleTiming('').isEmpty, isTrue);
+      expect(summarizeSubtitleTiming('   \n  ').isEmpty, isTrue);
+      expect(
+        summarizeSubtitleTiming('<html><body>403 Forbidden</body></html>')
+            .isEmpty,
+        isTrue,
+      );
+    });
+  });
+
+  group('checkSubtitleTiming', () {
+    // 一集 24 分钟，字幕最后一句 23:20 —— 正常形状。
+    const int episodeMs = 24 * 60 * 1000;
+    final SubtitleTimingSummary healthy =
+        summarizeSubtitleTiming(_srt(count: 300, lastEndSeconds: 23 * 60 + 20));
+
+    test('正常一集 → ok', () {
+      expect(
+        checkSubtitleTiming(
+          healthy,
+          video: const KnownVideoDuration.probed(episodeMs),
+        ).verdict,
+        SubtitleTimingVerdict.ok,
+      );
+    });
+
+    test('整季合并成一个文件（5 小时）装到 24 分钟的一集上 → 拒收', () {
+      final SubtitleTimingSummary seasonPack = summarizeSubtitleTiming(
+        _srt(count: 3000, lastEndSeconds: 5 * 3600),
+      );
+      final SubtitleTimingCheck check = checkSubtitleTiming(
+        seasonPack,
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(check.verdict, SubtitleTimingVerdict.overrunsVideo);
+      expect(check.rejected, isTrue);
+      expect(check.detail, contains('5:00:00'));
+      expect(check.detail, contains('24:00'));
+    });
+
+    test('只覆盖到一半以下 → 可疑但**不拒收**（signs/歌词轨是合法的）', () {
+      final SubtitleTimingSummary partial =
+          summarizeSubtitleTiming(_srt(count: 12, lastEndSeconds: 90));
+      final SubtitleTimingCheck check = checkSubtitleTiming(
+        partial,
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(check.verdict, SubtitleTimingVerdict.suspiciouslyShort);
+      expect(check.rejected, isFalse);
+    });
+
+    test('视频时长未知 → 只做内容自检，绝不因为探测失败就拒收', () {
+      expect(checkSubtitleTiming(healthy).verdict, SubtitleTimingVerdict.ok);
+      expect(
+        checkSubtitleTiming(healthy, video: const KnownVideoDuration.probed(0))
+            .verdict,
+        SubtitleTimingVerdict.ok,
+      );
+      // 时长未知时，即便字幕长达 5 小时也只能放行——没有可比对的事实。
+      final SubtitleTimingSummary huge =
+          summarizeSubtitleTiming(_srt(count: 10, lastEndSeconds: 5 * 3600));
+      expect(checkSubtitleTiming(huge).verdict, SubtitleTimingVerdict.ok);
+    });
+
+    test('解析不出时间轴 → 拒收', () {
+      final SubtitleTimingCheck check = checkSubtitleTiming(
+        summarizeSubtitleTiming('not a subtitle at all'),
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(check.verdict, SubtitleTimingVerdict.unparsable);
+      expect(check.rejected, isTrue);
+    });
+
+    test('刮削 runtime 的容差必须比 ffprobe 宽（播出时长含广告位、只精确到分钟）', () {
+      // 字幕跑到 30 分钟，视频「24 分钟」。
+      final SubtitleTimingSummary long =
+          summarizeSubtitleTiming(_srt(count: 50, lastEndSeconds: 30 * 60));
+      expect(
+        checkSubtitleTiming(
+          long,
+          video: const KnownVideoDuration.probed(episodeMs),
+        ).verdict,
+        SubtitleTimingVerdict.overrunsVideo,
+        reason: 'ffprobe 的时长是精确事实，超出 15%+60s 就不可能是同一个视频',
+      );
+      expect(
+        checkSubtitleTiming(
+          long,
+          video: const KnownVideoDuration.scrapedRuntime(episodeMs),
+        ).verdict,
+        SubtitleTimingVerdict.ok,
+        reason: '刮削 runtime 只配当粗筛，拿它当精确事实会误伤',
+      );
+    });
+
+    test('rejected 与 contradictsVideo 是两档强度，不能混用', () {
+      // 有备选（下载流水线）：读不出就换下一个。
+      // 无备选（番剧下载按集号锁定的唯一一条）：读不出不足以否决，只有
+      // 「字幕比视频长得多」这种正面矛盾才配扔掉用户唯一的字幕。
+      final SubtitleTimingCheck unreadable = checkSubtitleTiming(
+        summarizeSubtitleTiming('garbage'),
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(unreadable.rejected, isTrue);
+      expect(unreadable.contradictsVideo, isFalse);
+
+      final SubtitleTimingCheck overrun = checkSubtitleTiming(
+        summarizeSubtitleTiming(_srt(count: 100, lastEndSeconds: 5 * 3600)),
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(overrun.rejected, isTrue);
+      expect(overrun.contradictsVideo, isTrue);
+
+      final SubtitleTimingCheck short = checkSubtitleTiming(
+        summarizeSubtitleTiming(_srt(count: 5, lastEndSeconds: 60)),
+        video: const KnownVideoDuration.probed(episodeMs),
+      );
+      expect(short.rejected, isFalse);
+      expect(short.contradictsVideo, isFalse);
+    });
+
+    test('短片不被比例项误伤（5 分钟 PV 的 15% 只有 45 秒）', () {
+      const int pvMs = 5 * 60 * 1000;
+      final SubtitleTimingSummary s =
+          summarizeSubtitleTiming(_srt(count: 20, lastEndSeconds: 5 * 60 + 30));
+      expect(
+        checkSubtitleTiming(s, video: const KnownVideoDuration.probed(pvMs))
+            .verdict,
+        SubtitleTimingVerdict.ok,
+      );
+    });
+  });
+
+  group('parseFfprobeDurationMs', () {
+    test('标准 json 输出', () {
+      expect(
+        parseFfprobeDurationMs('{"format":{"duration":"1421.234000"}}'),
+        1421234,
+      );
+      expect(parseFfprobeDurationMs('{"format":{"duration":1421.5}}'), 1421500);
+    });
+
+    test('N/A / 缺字段 / 空 / 非 json / 非正数 → null（探不到就是探不到）', () {
+      expect(parseFfprobeDurationMs('{"format":{"duration":"N/A"}}'), isNull);
+      expect(parseFfprobeDurationMs('{"format":{}}'), isNull);
+      expect(parseFfprobeDurationMs('{}'), isNull);
+      expect(parseFfprobeDurationMs(''), isNull);
+      expect(parseFfprobeDurationMs('not json'), isNull);
+      expect(parseFfprobeDurationMs('{"format":{"duration":"0"}}'), isNull);
+      expect(parseFfprobeDurationMs('{"format":{"duration":"-3"}}'), isNull);
+    });
+  });
+}

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -83,6 +83,13 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // 同一实例下轮即刮）。
   'video/Auto-fetch series info':
       'test/media/video/scraper/auto_scrape_service_test.dart',
+  // BUG-1698：刮削完成后给仍缺字幕的视频补一条在线字幕。写 prefsRepo
+  // （changed=true），生效点在 AppModel._backfillSubtitlesForScrapedWork 的进场门
+  // （关=刮削回调直接 return，零字幕网络请求），不是 reader CSS / 主题树，无适用
+  // 探针；由专项纯函数测试咬住「刮削结论 → 字幕目标」这一步——那才是这个功能的
+  // 全部准确率所在（外部 id / 原名 / 季集号怎么传给 provider）。
+  'video/Auto-fetch subtitles after scraping':
+      'test/media/video/scraped_subtitle_targets_test.dart',
   // Jimaku 默认字幕语言（BUG-1189/1190 那批「Jimaku 设置统一到设置页」）。写
   // prefsRepo（changed=true），生效点是三个 Jimaku 界面打开时的语言预选（没有该
   // 系列的语言记忆时用它兜底），不在 reader CSS / 主题树里，无适用探针；由专项

--- a/fushi/test/torrent/anime_download_plan_test.dart
+++ b/fushi/test/torrent/anime_download_plan_test.dart
@@ -298,4 +298,110 @@ void main() {
       await store.delete('never-existed');
     });
   });
+
+  group('BUG-1696 shouldRetrySubtitles（字幕反查的 backoff 判据）', () {
+    const int t0 = 1700000000000;
+
+    AnimeDownloadPlan planWith({
+      required String subtitleStatus,
+      int attempts = 0,
+      int? lastAttemptAtMs,
+      int? jimakuEntryId = 77,
+    }) =>
+        AnimeDownloadPlan(
+          id: 'abc',
+          createdAtMs: t0,
+          seriesTitle: 'S',
+          torrentTitle: 'T',
+          magnet: 'magnet:?xt=urn:btih:abc',
+          qbCategory: 'hibiki',
+          status: AnimeDownloadPlan.statusImported,
+          jimakuEntryId: jimakuEntryId,
+          subtitleStatus: subtitleStatus,
+          subtitleAttempts: attempts,
+          subtitleLastAttemptAtMs: lastAttemptAtMs,
+        );
+
+    test('只有 unavailable 才重试；resolved/none/pending 都不碰', () {
+      for (final String status in <String>[
+        AnimeDownloadPlan.subtitleResolved,
+        AnimeDownloadPlan.subtitleNone,
+        AnimeDownloadPlan.subtitlePending,
+      ]) {
+        expect(
+          planWith(subtitleStatus: status).shouldRetrySubtitles(t0),
+          isFalse,
+          reason: '$status 不该被字幕重试通道碰到',
+        );
+      }
+    });
+
+    test('没有 Jimaku 条目 → 不重试（没来源，重试只是每轮白打一次网络）', () {
+      expect(
+        planWith(
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+          jimakuEntryId: null,
+        ).shouldRetrySubtitles(t0),
+        isFalse,
+      );
+    });
+
+    test('老计划（attempts=0，本 bug 之前卡死的那批）立刻获得一次重试机会', () {
+      expect(
+        planWith(subtitleStatus: AnimeDownloadPlan.subtitleUnavailable)
+            .shouldRetrySubtitles(t0),
+        isTrue,
+      );
+    });
+
+    test('未到下一档间隔不重试，到了才重试', () {
+      final AnimeDownloadPlan afterFirst = planWith(
+        subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        attempts: 1,
+        lastAttemptAtMs: t0,
+      );
+      final int gap =
+          AnimeDownloadPlan.subtitleRetryBackoff.first.inMilliseconds;
+      expect(afterFirst.shouldRetrySubtitles(t0 + gap - 1), isFalse);
+      expect(afterFirst.shouldRetrySubtitles(t0 + gap), isTrue);
+    });
+
+    test('backoff 用完就停，不无限轮询', () {
+      final int exhausted = AnimeDownloadPlan.subtitleRetryBackoff.length + 1;
+      expect(
+        planWith(
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+          attempts: exhausted,
+          lastAttemptAtMs: t0,
+        ).shouldRetrySubtitles(t0 + const Duration(days: 30).inMilliseconds),
+        isFalse,
+        reason: '一个永远不会有字幕的条目不该每轮 tick 都打一次 Jimaku',
+      );
+    });
+
+    test('新增的两个字段进出 JSON；缺字段的老计划回落 0/null', () {
+      final AnimeDownloadPlan plan = planWith(
+        subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        attempts: 3,
+        lastAttemptAtMs: t0,
+      );
+      final AnimeDownloadPlan? round =
+          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(plan));
+      expect(round?.subtitleAttempts, 3);
+      expect(round?.subtitleLastAttemptAtMs, t0);
+
+      final Map<String, dynamic> legacy =
+          Map<String, dynamic>.from(encodeAnimeDownloadPlan(plan))
+            ..remove('subtitleAttempts')
+            ..remove('subtitleLastAttemptAtMs');
+      final AnimeDownloadPlan? old = decodeAnimeDownloadPlan(legacy);
+      expect(old?.subtitleAttempts, 0);
+      expect(old?.subtitleLastAttemptAtMs, isNull);
+      expect(
+        old?.shouldRetrySubtitles(t0),
+        isTrue,
+        reason: '被旧「取不到就算了」卡住的存量计划要能被救回来',
+      );
+    });
+  });
 }

--- a/fushi/test/torrent/anime_download_service_test.dart
+++ b/fushi/test/torrent/anime_download_service_test.dart
@@ -499,6 +499,116 @@ void main() {
       expect(saved.status, AnimeDownloadPlan.statusImported);
     });
 
+    test('BUG-1696 已入库但字幕没配上 → 下一轮 tick 自动重试，成功后补贴 sidecar', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      // 已入库、字幕 unavailable、还没试过（存量计划形态：attempts=0）。
+      await store.save(
+        _plan().copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          jimakuEntryId: 7,
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+          subtitleNote: 'jimaku entry has no files',
+        ),
+      );
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+
+      final Directory subsDir = store.subsDirFor(_kHash)
+        ..createSync(recursive: true);
+      subtitleResolverOverride =
+          (AnimeDownloadPlan plan, List<String> videos) async {
+        // 这一次字幕已经上传了。
+        final String staged = p.join(subsDir.path, 'Show - 03.ja.srt');
+        File(staged).writeAsStringSync('cue');
+        return ResolvedPlanSubtitles.ok(<PlanSubtitle>[
+          PlanSubtitle(
+            episode: 3,
+            fileName: 'Show - 03.ja.srt',
+            stagedPath: staged,
+            language: 'ja',
+          ),
+        ]);
+      };
+
+      await buildService().tick();
+
+      expect(
+        subtitleResolverCalls,
+        hasLength(1),
+        reason: 'unavailable 不是终态——它的主流成因是「字幕还没上传」',
+      );
+      expect(
+        File(p.join(savePath, 'Show', '[Grp] Show - 03 [1080p].ja.srt'))
+            .existsSync(),
+        isTrue,
+        reason: '重试成功后 sidecar 要真的补上去，播放页按目录动态发现',
+      );
+      final AnimeDownloadPlan saved = (await store.loadAll()).single;
+      expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleResolved);
+      expect(saved.subtitles.single.episode, 3);
+      expect(saved.status, AnimeDownloadPlan.statusImported,
+          reason: '重试不得改动下载/入库状态');
+      expect(saved.subtitleAttempts, 1);
+      expect(saved.subtitleLastAttemptAtMs, isNotNull);
+    });
+
+    test('BUG-1696 重试仍扑空 → 计数推进，同一轮不重复打，backoff 未到不再试', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      await store.save(
+        _plan().copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          jimakuEntryId: 7,
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        ),
+      );
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+      subtitleResolverOverride = (_, __) async =>
+          const ResolvedPlanSubtitles.failed('jimaku entry has no files');
+
+      final AnimeDownloadService service = buildService();
+      await service.tick();
+      expect(subtitleResolverCalls, hasLength(1));
+      AnimeDownloadPlan saved = (await store.loadAll()).single;
+      expect(saved.subtitleAttempts, 1);
+      expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleUnavailable);
+
+      // 紧接着再 tick：backoff 第一档 15 分钟还没到，不该再打一次。
+      await service.tick();
+      expect(
+        subtitleResolverCalls,
+        hasLength(1),
+        reason: 'backoff 未到就重试 = 每轮 tick 都打一次 Jimaku',
+      );
+      saved = (await store.loadAll()).single;
+      expect(saved.subtitleAttempts, 1);
+      expect(saved.subtitleRetryPossible, isTrue, reason: '还没用完，UI 该说「稍后重试」');
+    });
+
+    test('BUG-1696 没有 Jimaku 条目的 unavailable 计划不参与重试（没来源可试）', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      await store.save(
+        _plan().copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        ),
+      );
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+
+      await buildService().tick();
+      expect(subtitleResolverCalls, isEmpty);
+    });
+
     test('BUG-1206 反查一条都不配 → 落 unavailable + 原因，视频照常入库', () async {
       final (String savePath, List<Map<String, dynamic>> files) =
           completedSeasonPack();

--- a/fushi/test/torrent/anime_download_subscription_test.dart
+++ b/fushi/test/torrent/anime_download_subscription_test.dart
@@ -413,7 +413,7 @@ void main() {
       service.checking.dispose();
     });
 
-    test('missing selected subtitle keeps the episode pending', () async {
+    test('BUG-1696 字幕还没上传时照常下片，字幕落 pending 交给完成后反查', () async {
       final AnimeDownloadSubscription subscription =
           AnimeDownloadSubscription.fromSelection(
         anilistId: 42,
@@ -439,9 +439,27 @@ void main() {
       await service.checkSubscription(subscription.id);
       final AnimeDownloadSubscription updated =
           (await subscriptionStore.loadAll()).single;
-      expect(updated.processedEpisodes, isEmpty);
-      expect(updated.lastError, contains('subtitle not available'));
-      expect(await planStore.loadAll(), isEmpty);
+
+      // 旧行为：delete plan + continue + processedEpisodes 保持空。于是绑了
+      // Jimaku 条目的订阅在字幕上传前**一集都不下**，而生肉普遍早字幕数小时到
+      // 数天——用户看到的是「订阅永远不动」。
+      expect(
+        updated.processedEpisodes,
+        <int>{2},
+        reason: '字幕没到不是不下这一集的理由',
+      );
+      final AnimeDownloadPlan plan = (await planStore.loadAll()).single;
+      expect(plan.id, 'abc123');
+      expect(plan.subtitles, isEmpty);
+      expect(
+        plan.subtitleStatus,
+        AnimeDownloadPlan.subtitlePending,
+        reason: 'pending 才会在下载完成时按包内真实文件名反查 + backoff 重试；'
+            '落 none 等于宣告这一集永远没字幕',
+      );
+      expect(plan.jimakuEntryId, 77, reason: '重试要靠它找回来源');
+      // 用户仍然被告知这一集的字幕还没到。
+      expect(updated.lastError, contains('subtitle not yet available'));
       service.stop();
       service.checking.dispose();
     });


### PR DESCRIPTION
用户诉求：优化下载 / 自动刮削 / 订阅后的自动下载字幕，「看看能不能优化下准确率（检测字幕时长之类的）」，以及「怎么让用户知道可以自动下载字幕」。

调查发现的不是「一个功能不准」，而是**五条字幕获取路径、四套互相矛盾的匹配逻辑**，其中四个真缺陷 + 一个根本不存在的功能。

## 修了什么

| BUG | 问题 | 形态 |
|---|---|---|
| 1694 | Jimaku 搜索**从不拼 `anime` 参数** | 服务端当硬相等过滤且缺省 true → 数千条真人日剧/日影条目在任何入口都搜不到。不是不准，是整类内容缺失 |
| 1695 | 合集批量在集号一条都对不上时**退回「列表第一个」** | 绝对集号条目（S2 编 13-24）撞本地 01-12 → 每集都拿第 13 集字幕；整季未编号单文件 → 12 集全落同一个文件，状态还显示 done |
| 1696 | 订阅在当集字幕还没上传时 **delete plan + continue** | 生肉普遍早字幕数小时到数天，所以这是常态而非异常 → 「绑了 Jimaku 条目的订阅永远不动」（用户报的「订阅没全部下完」） |
| 1697 | 拿到字幕字节后**从不看内容** | 整季合并文件（5h）被装到某一集（24min）上，播放时从第 3 分钟起全错位；HTML 错误页被当字幕存下来 |
| 1698 | 刮削链路 `subtitle` 出现 **0 次**；且刮削已解析出的 AniList/TMDB id 与日文原名被丢掉 | 「刮削后自动下载字幕」不存在；播放页拿中文译名去 AniList 现搜必 0 结果。自动配字幕其实一直开着，但没有名字、没有开关，用户无从发现 |

## 关键设计决定

- **匹配收敛到唯一原语** `media/video/jimaku_matching.dart`：`chooseJimakuFileForEpisode` 把「没配上」分成 `episodeConflict` / `ambiguousUnnumbered` / `none` 三种。`soleTarget` 设为 `required` 而非有默认值——默认值就是 BUG-1695 的形状。
- **批量改为整批只列一次文件**（不带 `episode=`）：服务端那道过滤是文件名启发式，会遮住「字幕侧到底有哪些集号」，判不出集号冲突。请求数同时从 targets×entries 降到 entries。
- **订阅照常下片**，字幕落 `pending` 交给完成后按包内真实文件名反查（BUG-1206 的强判据，比按标题猜集号更准），并新增 backoff 重试（15min/1h/4h/12h/24h 后停）。存量被卡住的计划下一轮即获得一次重试机会。
- **时长校验能做什么、不能做什么写死在模块头**：能抓整季合并文件 / 错媒体 / 空文件 / 解析不出的字节；**抓不了轴偏移**（那要靠发布组名匹配）。容差按时长来源分档（ffprobe 精确 1.15×+60s；刮削 runtime 是播出时长含广告位 1.5×+2min）。探不到时长退化成只做内容自检，绝不因为探测失败就拒收。
- **两档拒收强度**：有备选（下载流水线）读不出就换下一个；无备选（番剧下载按集号锁定唯一一条）只认「字幕比视频长得多」这种正面矛盾——扫描器只认三种时间轴写法，「我读不出」不足以扔掉用户唯一的字幕。
- **只补缺的，绝不覆盖**任何已有字幕（sidecar 或 DB `subtitleSource`）。用户手放/手改过的字幕不可再生。
- 发现性的缺口不在播放页（那里本来就有「自动获取字幕」入口），而在**设置页没有这个能力的名字**。新开关放在 Jimaku / OpenSubtitles 配置正上方，设置搜索能命中。

## 验证

- `flutter analyze` 全仓 **No issues**
- 目录枚举型守卫整批（34 条）：**454 tests PASSED**
- 涉及域全量 `test/media/video` + `test/torrent` + `test/settings` + `test/models` + `test/i18n` + `test/profile`：**3947 tests PASSED**
- 期间一次完整全量跑出 19330 tests / 1 failure（新设置项未登记效果探针 backlog），已修并单独复跑绿
- **变异实测两轮**：① 时长容差 1.15 → 99.0，套件 PASSED→FAILED（2 处断言捕获）；② `shouldRetrySubtitles` 恒 false，PASSED→FAILED（5 处捕获）。两轮均用反向替换还原并比对 sha256 逐字节一致

## 未做 / 已知缺口

- 真机验证未做（本 PR 全部改动均有自动化覆盖，但「刮削后真的自动补上字幕」的端到端未在真机跑过）。
- 播放页目前只接 Jimaku，OpenSubtitles 在播放页仍无入口。
- 库页卡片「无字幕」角标未做（原计划的发现性第 4 项，评估后认为性价比低于前三项）。
- 代码审查未走 `superpowers:requesting-code-review`（本会话被限制不得自行派子代理），留给本 PR 的 review。

https://claude.ai/code/session_01GWx6aaej9y5utvU4XGhwDk
