### PR TITLE
feat(fushidicts): hoshidicts 上游批4同步 + 磁盘格式 v2（zstd 训练字典 / kanji stats / term score / pitch 完整规格 / lookup 排序选项）

### DIFF
--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -1044,12 +1044,16 @@ function constructPitchPositionHtml(pitches) {
         pitchGroup.pitchPositions.forEach(pos => {
             items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
         });
+        // 79c55c2 二期：pattern 式 accent 同样进 {pitch-accent-positions} 字段。
+        (pitchGroup.patterns || []).forEach(pattern => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(pattern)}</span><span>]</span></span></li>`;
+        });
         (pitchGroup.transcriptions || []).forEach(ipa => {
             items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    // No positions AND no transcriptions: return '' instead of an empty <ol>
-    // shell, so the field is treated as empty and skipped.
+    // No positions AND no patterns AND no transcriptions: return '' instead of
+    // an empty <ol> shell, so the field is treated as empty and skipped.
     return items ? `<ol>${items}</ol>` : '';
 }
 
@@ -2190,6 +2194,13 @@ function createPitchGroup(pitchData, reading) {
         li.appendChild(document.createTextNode(` [${pitch}]`));
         list.appendChild(li);
     });
+    // 79c55c2 二期：pattern 式 accent（"heiban" 等字符串位）以文本形式渲染，
+    // 无法画数字位式的高低标记。
+    (pitchData.patterns || []).forEach((pattern) => {
+        const li = el('li');
+        li.appendChild(document.createTextNode(`[${pattern}]`));
+        list.appendChild(li);
+    });
     container.appendChild(list);
 
     const transcriptions = createTranscriptionsHtml(pitchData.transcriptions);
@@ -2261,11 +2272,13 @@ function createPitchSection(pitches, reading) {
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
+            // Pattern-style accents (79c55c2) likewise keep the group alive.
             const hasTranscriptions = pitch.transcriptions?.length;
-            if (unique.length > 0 || hasTranscriptions) {
+            const hasPatterns = pitch.patterns?.length;
+            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
                 pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, transcriptions: pitch.transcriptions },
+                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
                     reading));
             }
         });

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -3679,6 +3679,18 @@ function createKanjiCard(kanji) {
         card.appendChild(kunyomiRow);
     }
 
+    // v2 词典的完整 stats 键值对（JLPT/grade 等，FushiKanjiResult.stats 直通）。
+    // v1 存量词典 stats 为空对象，零渲染开销；复用 kanji-card-row 现有样式。
+    if (kanji.stats && typeof kanji.stats === 'object') {
+        for (const [statKey, statValue] of Object.entries(kanji.stats)) {
+            if (typeof statValue !== 'string' || statValue.length === 0) continue;
+            const statRow = createKanjiReadingRow(statKey, statValue);
+            if (statRow) {
+                card.appendChild(statRow);
+            }
+        }
+    }
+
     const meanings = Array.isArray(kanji.meanings)
         ? kanji.meanings.filter((m) => typeof m === 'string' && m.length > 0)
         : [];

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -1044,12 +1044,16 @@ function constructPitchPositionHtml(pitches) {
         pitchGroup.pitchPositions.forEach(pos => {
             items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
         });
+        // 79c55c2 二期：pattern 式 accent 同样进 {pitch-accent-positions} 字段。
+        (pitchGroup.patterns || []).forEach(pattern => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(pattern)}</span><span>]</span></span></li>`;
+        });
         (pitchGroup.transcriptions || []).forEach(ipa => {
             items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    // No positions AND no transcriptions: return '' instead of an empty <ol>
-    // shell, so the field is treated as empty and skipped.
+    // No positions AND no patterns AND no transcriptions: return '' instead of
+    // an empty <ol> shell, so the field is treated as empty and skipped.
     return items ? `<ol>${items}</ol>` : '';
 }
 
@@ -2190,6 +2194,13 @@ function createPitchGroup(pitchData, reading) {
         li.appendChild(document.createTextNode(` [${pitch}]`));
         list.appendChild(li);
     });
+    // 79c55c2 二期：pattern 式 accent（"heiban" 等字符串位）以文本形式渲染，
+    // 无法画数字位式的高低标记。
+    (pitchData.patterns || []).forEach((pattern) => {
+        const li = el('li');
+        li.appendChild(document.createTextNode(`[${pattern}]`));
+        list.appendChild(li);
+    });
     container.appendChild(list);
 
     const transcriptions = createTranscriptionsHtml(pitchData.transcriptions);
@@ -2261,11 +2272,13 @@ function createPitchSection(pitches, reading) {
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
+            // Pattern-style accents (79c55c2) likewise keep the group alive.
             const hasTranscriptions = pitch.transcriptions?.length;
-            if (unique.length > 0 || hasTranscriptions) {
+            const hasPatterns = pitch.patterns?.length;
+            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
                 pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, transcriptions: pitch.transcriptions },
+                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
                     reading));
             }
         });

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -3679,6 +3679,18 @@ function createKanjiCard(kanji) {
         card.appendChild(kunyomiRow);
     }
 
+    // v2 词典的完整 stats 键值对（JLPT/grade 等，FushiKanjiResult.stats 直通）。
+    // v1 存量词典 stats 为空对象，零渲染开销；复用 kanji-card-row 现有样式。
+    if (kanji.stats && typeof kanji.stats === 'object') {
+        for (const [statKey, statValue] of Object.entries(kanji.stats)) {
+            if (typeof statValue !== 'string' || statValue.length === 0) continue;
+            const statRow = createKanjiReadingRow(statKey, statValue);
+            if (statRow) {
+                card.appendChild(statRow);
+            }
+        }
+    }
+
     const meanings = Array.isArray(kanji.meanings)
         ? kanji.meanings.filter((m) => typeof m === 'string' && m.length > 0)
         : [];

--- a/fushi/lib/src/creator/fields/pitch_accent_field.dart
+++ b/fushi/lib/src/creator/fields/pitch_accent_field.dart
@@ -44,12 +44,14 @@ class PitchAccentField extends Field {
   }) {
     final reading = entry.reading.isNotEmpty ? entry.reading : entry.word;
     final positions = _readPitchPositions(entry);
+    final patterns = _readPitchPatterns(entry);
     return {
       pitchPositionsExtraKey: getAllHtmlPitch(
         reading: reading,
         positions: positions,
       ),
-      pitchCategoriesExtraKey: _getAllCategories(reading, positions),
+      pitchCategoriesExtraKey:
+          _getAllCategories(reading, positions, patterns: patterns),
     };
   }
 
@@ -70,8 +72,9 @@ class PitchAccentField extends Field {
     return buffer.toString();
   }
 
-  static String _getAllCategories(String reading, List<int> positions) {
-    if (positions.isEmpty) return '';
+  static String _getAllCategories(String reading, List<int> positions,
+      {List<String> patterns = const []}) {
+    if (positions.isEmpty && patterns.isEmpty) return '';
     final moraCount = PitchSvg.hiraToMora(reading).length;
     final categories = <String>[];
     final seen = <int>{};
@@ -80,6 +83,13 @@ class PitchAccentField extends Field {
       final cat = _pitchCategory(pos, moraCount);
       if (cat.isNotEmpty && !categories.contains(cat)) {
         categories.add(cat);
+      }
+    }
+    // Pattern 式 accent（79c55c2）：pattern 名（"heiban" 等）在 Yomitan 用法里
+    // 本身就是类别名，直接并入类别字段（SVG 画不了 pattern，仅数字位出图）。
+    for (final pattern in patterns) {
+      if (pattern.isNotEmpty && !categories.contains(pattern)) {
+        categories.add(pattern);
       }
     }
     return categories.join(',');
@@ -131,6 +141,41 @@ class PitchAccentField extends Field {
       }
     }
     return positions;
+  }
+
+  static List<String> _readPitchPatterns(DictionaryEntry entry) {
+    if (entry.extra.isEmpty) {
+      return [];
+    }
+    Object? decoded;
+    try {
+      decoded = jsonDecode(entry.extra);
+    } catch (_) {
+      return [];
+    }
+    if (decoded is! Map) {
+      return [];
+    }
+    final rawGroups = decoded['pitches'];
+    if (rawGroups is! List) {
+      return [];
+    }
+    final patterns = <String>[];
+    for (final rawGroup in rawGroups) {
+      if (rawGroup is! Map) {
+        continue;
+      }
+      final rawPatterns = rawGroup['patterns'];
+      if (rawPatterns is! List) {
+        continue;
+      }
+      for (final rawPattern in rawPatterns) {
+        if (rawPattern is String && rawPattern.isNotEmpty) {
+          patterns.add(rawPattern);
+        }
+      }
+    }
+    return patterns;
   }
 }
 

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -16,8 +16,7 @@ import 'package:fushi/src/pages/implementations/popup_settings_injection.dart';
 import 'package:fushi/src/platform/selection_external_actions.dart';
 import 'package:fushi/src/reader/popup_swipe_close_script.dart';
 import 'package:fushi/src/reader/reader_caret_scripts.dart';
-import 'package:fushi/src/shortcuts/input_binding.dart'
-    show activeModifierKeys;
+import 'package:fushi/src/shortcuts/input_binding.dart' show activeModifierKeys;
 import 'package:fushi/src/shortcuts/reader_space_override.dart'
     show readerShouldHandleDesktopCopy;
 import 'package:fushi/src/utils/misc/lookup_audio_playback.dart';
@@ -2471,6 +2470,7 @@ JSON.stringify((function(){
       return {
         'dictionary': p['dictName'] ?? '',
         'pitchPositions': p['positions'] ?? [],
+        'patterns': p['patterns'] ?? [],
         'transcriptions': p['transcriptions'] ?? [],
       };
     }).toList();

--- a/fushi/test/dictionary/kanji_search_result_contract_test.dart
+++ b/fushi/test/dictionary/kanji_search_result_contract_test.dart
@@ -30,6 +30,7 @@ void main() {
         radical: '日',
         strokes: 4,
         meanings: <String>['day', 'sun', 'Japan'],
+        stats: <String, String>{'jlpt': '4', 'grade': '8'},
         dictName: 'KANJIDIC',
       );
       final FushiKanjiResult restored =
@@ -40,6 +41,7 @@ void main() {
       expect(restored.radical, original.radical);
       expect(restored.strokes, original.strokes);
       expect(restored.meanings, original.meanings);
+      expect(restored.stats, original.stats);
       expect(restored.dictName, original.dictName);
     });
 
@@ -52,6 +54,7 @@ void main() {
       expect(r.radical, '');
       expect(r.strokes, 0);
       expect(r.meanings, isEmpty);
+      expect(r.stats, isEmpty);
       expect(r.dictName, '');
     });
   });

--- a/fushi/test/pages/dictionary_popup_webview_test.dart
+++ b/fushi/test/pages/dictionary_popup_webview_test.dart
@@ -297,6 +297,8 @@ void main() {
         {
           'dictionary': 'NHK',
           'pitchPositions': [2],
+          // 79c55c2 二期：pattern 式 accent 平行数组（数字位词典恒空）。
+          'patterns': <String>[],
           // TODO-687 block3: pitch entries now always carry a transcriptions
           // list (empty for plain pitch-accent dicts, populated for IPA dicts).
           'transcriptions': <String>[],
@@ -395,7 +397,8 @@ void main() {
               ),
             ],
             pitches: [
-              FushiPitchEntry(dictName: 'NHK', pitchPositions: [2]),
+              FushiPitchEntry(
+                  dictName: 'NHK', pitchPositions: [2], patterns: ['heiban']),
               // IPA transcription dict: no pitch positions, only transcriptions.
               // Exercises the TODO-687 block3 passthrough end to end.
               FushiPitchEntry(
@@ -432,7 +435,8 @@ void main() {
               ),
             ],
             pitches: [
-              FushiPitchEntry(dictName: 'NHK', pitchPositions: [2]),
+              FushiPitchEntry(
+                  dictName: 'NHK', pitchPositions: [2], patterns: ['heiban']),
               FushiPitchEntry(
                 dictName: 'IPA',
                 pitchPositions: [],
@@ -497,6 +501,8 @@ void main() {
         for (var j = 0; j < nPitches.length; j++) {
           expect(nPitches[j]['dictionary'], oPitches[j]['dictionary']);
           expect(nPitches[j]['pitchPositions'], oPitches[j]['pitchPositions']);
+          // 79c55c2 二期：pattern 式 accent 两条路径逐字段一致。
+          expect(nPitches[j]['patterns'], oPitches[j]['patterns']);
           // TODO-687 block3: transcriptions must survive both paths identically
           // (parity is field-level — adding a field never auto-fails, so this
           // assertion is hand-added together with the IPA fixture data above).

--- a/fushi/test/tools/dict_legacy_marker_guard_test.dart
+++ b/fushi/test/tools/dict_legacy_marker_guard_test.dart
@@ -13,22 +13,27 @@ import 'package:flutter_test/flutter_test.dart';
 /// 这条守卫钉死「读侧兼容旧名」。写侧不需要兼容（新导入统一用新名），也**不得**
 /// 去重命名用户磁盘上的存量文件：那不可逆，且会让回退到旧版的用户反过来坏掉。
 void main() {
-  test('query.cpp 的完成标记判定同时接受新旧两个名字', () {
+  test('query.cpp 的完成标记/版本判定同时接受新旧全部名字', () {
     final File f = File('../native/fushidicts/fushidicts_src/query.cpp');
     expect(f.existsSync(), isTrue,
         reason: '找不到 ${f.path}——native 目录挪了就更新这条守卫，别删');
     final String src = f.readAsStringSync();
 
-    // 候选名必须落在**数组定义**里，而不是只在注释里提一句。
-    final int arrStart = src.indexOf('kDictCompleteMarkers[]');
-    expect(arrStart, greaterThan(-1),
-        reason: '标记候选名必须集中成单一真相源 kDictCompleteMarkers');
-    final int arrEnd = src.indexOf('};', arrStart);
-    expect(arrEnd, greaterThan(arrStart));
-    final String arr = src.substring(arrStart, arrEnd);
+    // 上游同步批4起，标记文件名同时承担格式版本语义；单一真相源从
+    // kDictCompleteMarkers 数组升级为 dict_format_version 函数。候选名必须落在
+    // **函数体**里，而不是只在注释里提一句。
+    final int fnStart = src.indexOf('int dict_format_version(');
+    expect(fnStart, greaterThan(-1),
+        reason: '标记候选名必须集中成单一真相源 dict_format_version');
+    final int fnEnd = src.indexOf('\n}', fnStart);
+    expect(fnEnd, greaterThan(fnStart));
+    final String body = src.substring(fnStart, fnEnd);
 
-    expect(arr, contains('.fushidicts_1'), reason: '当前写入端产出的名字必须在候选里');
-    expect(arr, contains('.hoshidicts_1'),
+    expect(body, contains('.fushidicts_2'),
+        reason: '当前写入端（import_yomitan）产出的 v2 名字必须在候选里');
+    expect(body, contains('.fushidicts_1'),
+        reason: 'write_simple_dict 仍产出 v1 名字，删掉它＝MDX/StarDict 词典全失效');
+    expect(body, contains('.hoshidicts_1'),
         reason: '删掉它＝所有从旧版升级上来的用户词典全部失效（查词零结果）');
 
     // 且 add_dict 必须真的走这个判定，而不是自己再判一次单一名字。
@@ -36,7 +41,7 @@ void main() {
     expect(addIdx, greaterThan(-1));
     final String addBody =
         src.substring(addIdx, (addIdx + 400).clamp(0, src.length));
-    expect(addBody, contains('has_dict_complete_marker'),
+    expect(addBody, contains('dict_format_version'),
         reason: 'add_dict 必须用共享判定，否则兼容改了也够不着');
     expect(addBody.contains('".fushidicts_1"'), isFalse,
         reason: 'add_dict 里不得再硬编码单一标记名——那正是本次事故的形态');

--- a/native/fushidicts/UPSTREAM.md
+++ b/native/fushidicts/UPSTREAM.md
@@ -112,7 +112,7 @@
 
 ## 验证
 
-- 本机无 C++ 编译器（MSVC/NDK），native 改动由 **CI Linux ctest**（TODO-578 接入）+ **5 平台 build** 验。
+- 本机 **MSVC 2022 可用**（批4 实证：`tests/run_all.bat` 走 vcvars64 + Ninja + ctest，全套 21 用例 ~6 秒）；「本机无 C++ 编译器」是过时说法。native 改动本地 ctest 先行，再由 **CI Linux ctest** + **5 平台 build** 兜异构。
 - ctest 守卫：`tests/freq_pitch_import_query_test.cpp`（freq/pitch import→query e2e）+ `text_processor` / `kanji` 现有用例不回退。
 
 ## 2026-08 Hibiki→Fushi 改名映射（P6-2）

--- a/native/fushidicts/UPSTREAM.md
+++ b/native/fushidicts/UPSTREAM.md
@@ -14,8 +14,8 @@
 
 ## 同步基线
 
-- **上游 `origin/main` 当前 tip**（本轮同步参照）：`3448d6d`（"Accept numeric Yomitan term scores (#14)"，2026-06-17）。
-- **Hibiki 本轮同步后所含的上游主线 commit**（直抄，见下表）：截至 `3448d6d`，但**跳过**了主线上的若干提交（见「未同步/待评估」）。
+- **上游 `origin/main` 当前 tip**（批4 同步参照，2026-08-16）：`8993838`（"train zstd dict on import"）。
+- **Hibiki 批4 同步后所含的上游主线 commit**：截至 `8993838`，但**跳过**了主线上的若干提交（见「批4 明确跳过/暂缓」）。
 - Hibiki 是 hoshidicts 的**深度 fork**：在上游主线 `2dd5199`（"count freq and pitch entries"，2026-05-16）一带分叉后，
   额外吸收了 sibling commit `feb48f5`（"add detected_type to ImportResult"，非 origin/main 主线，分叉自 `2dd5199`），
   并自研了大量上游没有的功能（见「Hibiki 本地改动清单」）。因此上游与 Hibiki **不是线性 pull 关系，是双向 merge / cherry-pick**。
@@ -30,13 +30,56 @@
 
 > 上述三处 apply 前已逐字节确认 Hibiki 仍是上游旧版（OLD），diff 与上游对应 commit 一致（除 Hibiki 本地上下文如 `fushi::fs_path`）。
 
-## 未同步 / 待评估（follow-up，按 TODO-621 计划 a9ae4ae38e9351fb4）
+## 历史遗留记账修正（批4 复核）
 
-| 上游 commit | 标题 | 为什么不在批1 | 后续条件 |
+批1 时列为「未同步/待评估」的两条，实际**早已在 Hibiki 落地**（当时忘了回写本文件）：
+
+| 上游 commit | 标题 | Hibiki 实际状态 |
+|---|---|---|
+| `2d4f2a2` | add normalization processors（NFKC） | ✅ 已落地：utf8proc v2.11.3 vendored 进 `fushidicts_external/utf8proc/`，NFKC 处理器在 `text_processor.cpp` 日语链 |
+| `e7dfdea` | add kanji standardization（异体字标准化） | ✅ 已落地（非直抄）：绕开 C++23 `#embed`，用离线预生成表 `kanji_standardization_data.{h,cpp}`（`tool/native_gen/gen_kanji_standardization.py`，kanji-processor pin 452cc2db，2122 条）。上游后来的 `4ffbffb`（replace #embed，提交生成的 C 数组源文件）自行收敛到与 Hibiki 等价的方案——数据集逐条同源，无需再动 |
+| `1198201` | fix swift build | 仅 SwiftPM，跳过（不变） |
+
+## 批4（2026-08-17）同步：`3448d6d`..`8993838`
+
+**已移植（直抄或适配，见各文件内注释）：**
+
+| 上游 commit | 标题 | 落到 Hibiki | 方式 |
 |---|---|---|---|
-| `2d4f2a2` | add normalization processors（NFKC 全角归一化） | 需 vendor `utf8proc` 进 `fushidicts_external/` + 改 `CMakeLists.txt` + 把处理器追加到 Hibiki 自研处理链链尾（与 P1/P2/P3 共存，非替换） | 批2 |
-| `e7dfdea` | add kanji standardization（异体字标准化） | **不能照搬**：上游用 C++23 `#embed` 嵌入数据表，Windows MSVC / Apple Clang 不支持，需改 CMake 生成 C 数组头。逻辑本身无害、与 Hibiki 自研 kanji 导入（`importer.cpp`）零冲突（落在 `text_processor.cpp`，非 importer/S0 二进制 contract） | 批3（慎，需 CMake 改写） |
-| `1198201` | fix swift build | 仅 SwiftPM，Hibiki 不用 SwiftPM 构建 | skip |
+| `9dc93b6` | expand iteration marks（々/ゝ/ゞ 展开） | `text_processor.cpp` | 适配（standardize_kanji 上下文已本地化） |
+| `ee0384b` | fullwidth numbers → kanji（２→二） | `text_processor.cpp` | 直抄 |
+| `aaf75c9` | collapseEmphaticSequences（っっ/ーー 折叠） | `text_processor.cpp`（插在假名转换后，对齐上游链序） | 直抄 |
+| `1cb9b4b` | normalize kana width before script conversion | `text_processor.cpp`（NFKC 提到日语链首；半角片假名 ﾒｶﾞﾈ 修复） | 直抄 |
+| `909c854`（仅 revert 部分） | revert `4975788` freq 向量比较 | `lookup.cpp`（回到单一最小值比较；score 排序+格式 bump 部分**未采纳**，见下） | 直抄 |
+| `d4183d4` | bloom/hash size 校验 + flush before unmap + 删 bloom migration | `bloom.{hpp,cpp}`（size 校验，置空降级不拒载）、`memory.cpp`（flush）、`query.cpp`（删 migration，消掉穿 FFI 的 throw；hash 侧保留 fork 自研 BUG-1303 clamp，不用上游拒载版） | 适配 |
+| `01630e8` | freq 嵌套 object 解析收紧 | `yomitan_parser.cpp`（optional display_value + error_on_missing_keys，对齐 flat 路径既有风格） | 直抄 |
+| `79c55c2`（parser 先行部分） | pitch accent spec：position 收 `variant<int,string>` | `yomitan_parser.cpp`（pattern 字符串位不再让整条 meta 记录解析失败；nasal/devoice/pattern 的结构化输出 + FFI/UI 二期另议） | 部分适配 |
+| `8993838` | train zstd dict on import | `importer.cpp`（train_zstd_dict + CDict 压缩 term glossary + 落盘 `dict.zstd`）、`query.cpp`（DDict + thread_local DCtx 解压）——引入 **v2 格式阶梯**（见下） | 适配 |
+| `c5d8c6d`（仅 1 行） | `<climits>` include 修复 | `lookup.cpp`（fork 同样裸用 INT_MAX） | 直抄 |
+| `64afa2f`（仅借鉴 stats 能力） | 上游 kanji dicts | kanji 记录 v2 追加 stats 段（见下）；上游 kanji 实现本体**跳过**（与 fork 自研 kanji 同 type byte 两套布局，互不兼容，fork 版能力更强） | 借鉴 |
+
+**磁盘格式 v2（`.fushidicts_2`，fork 首个版本阶梯）：**
+- `import_yomitan` 产出 `.fushidicts_2`；`write_simple_dict`（MDX/StarDict/DSL）仍产 `.fushidicts_1`。
+- 读侧 `dict_format_version()`（query.cpp）：`.fushidicts_2`→2，`.fushidicts_1`/`.hoshidicts_1`（改名前存量，冻结只读）→1，无 marker→不加载。
+- v2 增量：① kanji 记录尾部追加 stats 段 `[u8 count]([u8 klen][k][u16 vlen][v])*`（radical/strokes 之外全保留，JLPT/grade 等；S0 契约注释在 importer.cpp）；② term glossary 可能用训练字典压缩，`dict.zstd` 存在才挂 DDict（训练样本不足时不写，退普通压缩）。
+- 兼容矩阵：新引擎读 v1 老盘**完全不变**；旧引擎读 v2 盘＝整目录不加载（降级后新导入词典不可见，不毁数据，重导可救）。kanji meanings / meta 记录恒普通 zstd 帧，不吃训练字典。
+- FFI：`FfiKanjiResult` 追加 `stat_keys/stat_values/stat_count`（native+Dart 同 commit 镜像，照 918744d transcriptions 先例双层 malloc/free）；其余 ABI 零变化。
+- 守卫：`tests/format_v2_upstream_sync_test.cpp`（v2 marker/stats 读回/marker 拒载/bloom 截断降级/zstd 往返/pitch pattern 容忍）+ `tests/text_processor_test.cpp` 新增 processor 用例。
+
+**批4 明确跳过 / 暂缓（重估条件）：**
+
+| 上游 commit | 标题 | 处置 | 理由/重估条件 |
+|---|---|---|---|
+| `909c854`（score 排序部分） | term score 落盘 + 排序 | 暂缓，需决策 | 需 term 记录格式再升版（score 字段）；收益真实（Yomitan score 是排序信号），可与下次格式变更捆绑 |
+| `702dcc5` | build summary on import | 跳过 | 改写 index.json/删 styles.css，冲突 fork 读侧契约（弹窗样式丢失）+ 破坏 FfiImportResult；如需导入元数据留档，fork 自己加 sidecar |
+| `64afa2f` | kanji dicts（实现本体） | 跳过 | 与 fork 自研 kanji 同 type byte 两套布局，换=毁存量；stats 能力已借鉴进 v2 |
+| `bc62d2b` / `86c6e2f` | lookup 排序选项 / primary_reading 优先 | 暂缓 | 默认行为零变化；等排序 UI / 弹窗内链需求出现时三层贯通（注意：移植时 Auto 分支保 fork 现状） |
+| `88b073d` | c bindings 合入主线 | 跳过（政策不变） | fork 自研 FFI 桥等效且 errors 向量信息更全；原「忽略 c-bindings 分支」政策改述为「已合主线，仍跳过」 |
+| `79c55c2`（结构化部分） | Pitch{pattern,nasal,devoice} 出 FFI/UI | 暂缓，需决策 | FFI ABI 扩展 + popup_json pkey 折 key（IPA 同型坑）+ UI 渲染，等产品要 nasal/devoice 展示 |
+| `c5d8c6d`（submodule bump 部分） | 7 个依赖 pin 升级 | 暂缓 | fork 是 vendored 实拷贝，整体刷新是独立决策（当前 zstd 1.6.0 / utf8proc v2.11.3 均不落后关键功能） |
+| `f9aa482` / `7bfdc8c` / `32b8ce5` / `e1a8c1c` / `6240e06` / `f151dbb` | submodule URL / cli+benchmark 开关 / swift cli / benchmark 修复×2 / readme | 跳过 | fork 无 submodule / 无 cli/benchmark target / 不用 SwiftPM |
+| `d6c9ea2` | use native filesystem paths | 跳过 | 已被 fork 自研 `fushi::fs_path`/`to_wide`（`util/fs_utf8.hpp` + `memory.cpp` W 系 API + `win_utf8_import_test`）等价覆盖 |
+| `e88430d` | MSVC /utf-8 | 跳过 | fork `CMakeLists.txt` 已有全局 `/utf-8 /Zc:__cplusplus /permissive-`，覆盖面更大 |
 
 ## TODO-687 批3 移植的上游 commit（IPA 音标支持）
 

--- a/native/fushidicts/UPSTREAM.md
+++ b/native/fushidicts/UPSTREAM.md
@@ -57,29 +57,32 @@
 | `8993838` | train zstd dict on import | `importer.cpp`（train_zstd_dict + CDict 压缩 term glossary + 落盘 `dict.zstd`）、`query.cpp`（DDict + thread_local DCtx 解压）——引入 **v2 格式阶梯**（见下） | 适配 |
 | `c5d8c6d`（仅 1 行） | `<climits>` include 修复 | `lookup.cpp`（fork 同样裸用 INT_MAX） | 直抄 |
 | `64afa2f`（仅借鉴 stats 能力） | 上游 kanji dicts | kanji 记录 v2 追加 stats 段（见下）；上游 kanji 实现本体**跳过**（与 fork 自研 kanji 同 type byte 两套布局，互不兼容，fork 版能力更强） | 借鉴 |
+| `909c854`（score 部分，批4 二轮补齐） | term score 落盘 + 排序 | v2 term 记录在 term_tags 后追加 i32 score（v2 未发布窗口内折入，免再升 v3）；`query.cpp` 版本门控读取 + 合并取 max；`lookup.cpp` 比较器 freq 档后 score 降序。score 不出 FFI（纯 native 排序信号） | 适配 |
+| `79c55c2`（结构化部分，批4 二轮补齐） | Pitch{position,pattern,nasal,devoice} 完整规格 | `ParsedAccent`/`Pitch` 结构贯通 parser→query；pattern 出 FFI（`FfiPitch.patterns` 平行数组）→Dart（`FushiPitchEntry.patterns`）→popup JSON（`"patterns"`）→JS 渲染 `[pattern]` 文本项 + 制卡类别字段并入 pattern 名；popup_json/Dart 镜像 pkey 折 pattern（IPA 折 key 同型坑）。nasal/devoice 收在 native `Pitch` 数据模型，文本形态 UI 无渲染语义、暂不出 FFI | 适配 |
+| `bc62d2b`（批4 二轮补齐） | lookup 排序选项 | `LookupOptions{frequency_dictionary, frequency_order}` + `Lookup::lookup` 第 4 参（默认 Auto 零行为变化，排序在截断前）；新 FFI 导出 `fushidicts_lookup_with_options`（老导出原样保留）+ Dart `lookup()` 可选参数。设置 UI 是产品决策，管道先行 | 适配 |
+| `86c6e2f`（批4 二轮补齐） | primary_reading 优先 | `LookupOptions.primary_reading`，比较器最前档；同上管道贯通 | 直抄（叠在 options 上） |
 
 **磁盘格式 v2（`.fushidicts_2`，fork 首个版本阶梯）：**
 - `import_yomitan` 产出 `.fushidicts_2`；`write_simple_dict`（MDX/StarDict/DSL）仍产 `.fushidicts_1`。
 - 读侧 `dict_format_version()`（query.cpp）：`.fushidicts_2`→2，`.fushidicts_1`/`.hoshidicts_1`（改名前存量，冻结只读）→1，无 marker→不加载。
-- v2 增量：① kanji 记录尾部追加 stats 段 `[u8 count]([u8 klen][k][u16 vlen][v])*`（radical/strokes 之外全保留，JLPT/grade 等；S0 契约注释在 importer.cpp）；② term glossary 可能用训练字典压缩，`dict.zstd` 存在才挂 DDict（训练样本不足时不写，退普通压缩）。
+- v2 增量：① kanji 记录尾部追加 stats 段 `[u8 count]([u8 klen][k][u16 vlen][v])*`（radical/strokes 之外全保留，JLPT/grade 等；S0 契约注释在 importer.cpp）；② term 记录尾部追加 `[i32 score]`（Yomitan 排序信号，多记录合并取 max）；③ term glossary 可能用训练字典压缩，`dict.zstd` 存在才挂 DDict（训练样本不足时不写，退普通压缩）。
 - 兼容矩阵：新引擎读 v1 老盘**完全不变**；旧引擎读 v2 盘＝整目录不加载（降级后新导入词典不可见，不毁数据，重导可救）。kanji meanings / meta 记录恒普通 zstd 帧，不吃训练字典。
 - FFI：`FfiKanjiResult` 追加 `stat_keys/stat_values/stat_count`（native+Dart 同 commit 镜像，照 918744d transcriptions 先例双层 malloc/free）；其余 ABI 零变化。
 - 守卫：`tests/format_v2_upstream_sync_test.cpp`（v2 marker/stats 读回/marker 拒载/bloom 截断降级/zstd 往返/pitch pattern 容忍）+ `tests/text_processor_test.cpp` 新增 processor 用例。
 
-**批4 明确跳过 / 暂缓（重估条件）：**
+**批4 明确跳过 / 剩余项（批4 二轮已把「没坏处」的暂缓项全部补齐；下表为终态）：**
 
 | 上游 commit | 标题 | 处置 | 理由/重估条件 |
 |---|---|---|---|
-| `909c854`（score 排序部分） | term score 落盘 + 排序 | 暂缓，需决策 | 需 term 记录格式再升版（score 字段）；收益真实（Yomitan score 是排序信号），可与下次格式变更捆绑 |
 | `702dcc5` | build summary on import | 跳过 | 改写 index.json/删 styles.css，冲突 fork 读侧契约（弹窗样式丢失）+ 破坏 FfiImportResult；如需导入元数据留档，fork 自己加 sidecar |
 | `64afa2f` | kanji dicts（实现本体） | 跳过 | 与 fork 自研 kanji 同 type byte 两套布局，换=毁存量；stats 能力已借鉴进 v2 |
-| `bc62d2b` / `86c6e2f` | lookup 排序选项 / primary_reading 优先 | 暂缓 | 默认行为零变化；等排序 UI / 弹窗内链需求出现时三层贯通（注意：移植时 Auto 分支保 fork 现状） |
 | `88b073d` | c bindings 合入主线 | 跳过（政策不变） | fork 自研 FFI 桥等效且 errors 向量信息更全；原「忽略 c-bindings 分支」政策改述为「已合主线，仍跳过」 |
-| `79c55c2`（结构化部分） | Pitch{pattern,nasal,devoice} 出 FFI/UI | 暂缓，需决策 | FFI ABI 扩展 + popup_json pkey 折 key（IPA 同型坑）+ UI 渲染，等产品要 nasal/devoice 展示 |
-| `c5d8c6d`（submodule bump 部分） | 7 个依赖 pin 升级 | 暂缓 | fork 是 vendored 实拷贝，整体刷新是独立决策（当前 zstd 1.6.0 / utf8proc v2.11.3 均不落后关键功能） |
+| `c5d8c6d`（submodule bump 部分） | 7 个依赖 pin 升级 | 不做（有真实坏处） | fork 是 vendored 实拷贝，7 库齐升有隐性构建/行为回归风险、收益近零（zstd 1.6.0 / utf8proc v2.11.3 均不落后关键功能）；单库确有需要时按需单独 vendor |
 | `f9aa482` / `7bfdc8c` / `32b8ce5` / `e1a8c1c` / `6240e06` / `f151dbb` | submodule URL / cli+benchmark 开关 / swift cli / benchmark 修复×2 / readme | 跳过 | fork 无 submodule / 无 cli/benchmark target / 不用 SwiftPM |
 | `d6c9ea2` | use native filesystem paths | 跳过 | 已被 fork 自研 `fushi::fs_path`/`to_wide`（`util/fs_utf8.hpp` + `memory.cpp` W 系 API + `win_utf8_import_test`）等价覆盖 |
 | `e88430d` | MSVC /utf-8 | 跳过 | fork `CMakeLists.txt` 已有全局 `/utf-8 /Zc:__cplusplus /permissive-`，覆盖面更大 |
+
+真正的后续（非上游同步，产品决策）：排序选项/primary_reading 的设置 UI 与弹窗内链消费方；pitch nasal/devoice 的图形化渲染（数据模型已收全）。
 
 ## TODO-687 批3 移植的上游 commit（IPA 音标支持）
 

--- a/native/fushidicts/fushidicts_ffi.cpp
+++ b/native/fushidicts/fushidicts_ffi.cpp
@@ -39,6 +39,10 @@ struct FfiPitch {
   int32_t count;
   char** transcriptions;
   int32_t transcription_count;
+  // 79c55c2 二期：pattern 式 accent（"heiban" 等字符串位）单独成数组，positions
+  // 仍只含数字位（既有消费方字节兼容）。Dart 绑定同 commit 镜像。
+  char** patterns;
+  int32_t pattern_count;
 };
 
 struct FfiTermResult {
@@ -156,10 +160,26 @@ static FfiTermResult convert_term(const TermResult& t) {
   r.pitches = static_cast<FfiPitch*>(malloc(sizeof(FfiPitch) * r.pitch_count));
   for (int i = 0; i < r.pitch_count; i++) {
     r.pitches[i].dict_name = dup(t.pitches[i].dict_name);
-    r.pitches[i].count = static_cast<int32_t>(t.pitches[i].pitch_positions.size());
+    // 数字位与 pattern 位分流：positions 只装数字 accent（既有语义不变），
+    // pattern accent 进 patterns（79c55c2 二期）。
+    std::vector<int32_t> numeric;
+    std::vector<const std::string*> pattern_refs;
+    for (const auto& accent : t.pitches[i].pitches) {
+      if (accent.pattern.empty()) {
+        numeric.push_back(accent.position);
+      } else {
+        pattern_refs.push_back(&accent.pattern);
+      }
+    }
+    r.pitches[i].count = static_cast<int32_t>(numeric.size());
     r.pitches[i].positions = static_cast<int32_t*>(malloc(sizeof(int32_t) * r.pitches[i].count));
     for (int j = 0; j < r.pitches[i].count; j++) {
-      r.pitches[i].positions[j] = t.pitches[i].pitch_positions[j];
+      r.pitches[i].positions[j] = numeric[j];
+    }
+    r.pitches[i].pattern_count = static_cast<int32_t>(pattern_refs.size());
+    r.pitches[i].patterns = static_cast<char**>(malloc(sizeof(char*) * r.pitches[i].pattern_count));
+    for (int j = 0; j < r.pitches[i].pattern_count; j++) {
+      r.pitches[i].patterns[j] = dup(*pattern_refs[j]);
     }
     // transcriptions: char** array of IPA strings, mirroring frequency
     // display_values (malloc the pointer array, then dup each element).
@@ -202,6 +222,10 @@ static void free_term(FfiTermResult& r) {
       free(r.pitches[i].transcriptions[j]);
     }
     free(r.pitches[i].transcriptions);
+    for (int j = 0; j < r.pitches[i].pattern_count; j++) {
+      free(r.pitches[i].patterns[j]);
+    }
+    free(r.pitches[i].patterns);
   }
   free(r.pitches);
 }
@@ -414,12 +438,8 @@ void fushidicts_free_kanji_results(FfiKanjiResults* r) {
 
 // ── lookup ──────────────────────────────────────────────────────────
 
-FUSHI_EXPORT
-FfiLookupResults fushidicts_lookup(void* handle, const char* text, int32_t max_results, int32_t scan_length) {
+static FfiLookupResults marshal_lookup_results(std::vector<LookupResult>& results) {
   FfiLookupResults r{};
-  auto* h = static_cast<FushidictsHandle*>(handle);
-  Lookup lookup(h->query, h->deinflector);
-  auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length));
   r.count = static_cast<int32_t>(results.size());
   r.results = static_cast<FfiLookupResult*>(malloc(sizeof(FfiLookupResult) * r.count));
   for (int i = 0; i < r.count; i++) {
@@ -437,6 +457,41 @@ FfiLookupResults fushidicts_lookup(void* handle, const char* text, int32_t max_r
     dst.term = convert_term(src.term);
   }
   return r;
+}
+
+FUSHI_EXPORT
+FfiLookupResults fushidicts_lookup(void* handle, const char* text, int32_t max_results, int32_t scan_length) {
+  auto* h = static_cast<FushidictsHandle*>(handle);
+  Lookup lookup(h->query, h->deinflector);
+  auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length));
+  return marshal_lookup_results(results);
+}
+
+// 上游 bc62d2b/86c6e2f：带排序选项的 lookup。freq_order：0=Auto 1=Ascending
+// 2=Descending 3=Disabled；freq_dict / primary_reading 传 NULL 或空串 = 未设置。
+// 老导出 fushidicts_lookup 原样保留（Never break ABI），返回结构同一套，
+// 释放同走 fushidicts_free_lookup_results。
+FUSHI_EXPORT
+FfiLookupResults fushidicts_lookup_with_options(void* handle, const char* text, int32_t max_results,
+                                                int32_t scan_length, const char* freq_dict, int32_t freq_order,
+                                                const char* primary_reading) {
+  auto* h = static_cast<FushidictsHandle*>(handle);
+  Lookup lookup(h->query, h->deinflector);
+  LookupOptions options;
+  if (freq_dict && freq_dict[0] != '\0') {
+    options.frequency_dictionary = std::string(freq_dict);
+  }
+  switch (freq_order) {
+    case 1: options.frequency_order = LookupFrequencyOrder::Ascending; break;
+    case 2: options.frequency_order = LookupFrequencyOrder::Descending; break;
+    case 3: options.frequency_order = LookupFrequencyOrder::Disabled; break;
+    default: options.frequency_order = LookupFrequencyOrder::Auto; break;
+  }
+  if (primary_reading && primary_reading[0] != '\0') {
+    options.primary_reading = std::string(primary_reading);
+  }
+  auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length), options);
+  return marshal_lookup_results(results);
 }
 
 FUSHI_EXPORT

--- a/native/fushidicts/fushidicts_ffi.cpp
+++ b/native/fushidicts/fushidicts_ffi.cpp
@@ -108,6 +108,11 @@ struct FfiKanjiResult {
   int32_t strokes;
   char** meanings;
   int32_t meaning_count;
+  // v2 词典的完整 stats 键值对（JLPT/grade 等；v1 记录恒为 0 条）。
+  // keys/values 平行数组，长度均为 stat_count；Dart 绑定同 commit 镜像。
+  char** stat_keys;
+  char** stat_values;
+  int32_t stat_count;
   char* dict_name;
 };
 
@@ -372,6 +377,13 @@ FfiKanjiResults fushidicts_query_kanji(void* handle, const char* character) {
     for (int j = 0; j < dst.meaning_count; j++) {
       dst.meanings[j] = dup(k.meanings[j]);
     }
+    dst.stat_count = static_cast<int32_t>(k.stats.size());
+    dst.stat_keys = static_cast<char**>(malloc(sizeof(char*) * dst.stat_count));
+    dst.stat_values = static_cast<char**>(malloc(sizeof(char*) * dst.stat_count));
+    for (int j = 0; j < dst.stat_count; j++) {
+      dst.stat_keys[j] = dup(k.stats[j].first);
+      dst.stat_values[j] = dup(k.stats[j].second);
+    }
   }
   return r;
 }
@@ -390,6 +402,12 @@ void fushidicts_free_kanji_results(FfiKanjiResults* r) {
       free(k.meanings[j]);
     }
     free(k.meanings);
+    for (int j = 0; j < k.stat_count; j++) {
+      free(k.stat_keys[j]);
+      free(k.stat_values[j]);
+    }
+    free(k.stat_keys);
+    free(k.stat_values);
   }
   free(r->results);
 }

--- a/native/fushidicts/fushidicts_include/fushidicts/lookup.hpp
+++ b/native/fushidicts/fushidicts_include/fushidicts/lookup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,11 +15,24 @@ struct LookupResult {
   int preprocessor_steps;
 };
 
+// 上游 bc62d2b/86c6e2f：调用方可控的排序选项。默认 Auto 逐字节复刻既有比较器
+//（零行为变化）；显式指定 frequency_dictionary + Ascending/Descending 时按该词典
+// 排序，且发生在 max_results 截断**之前**（前端截断后自己重排是排不回被丢掉的
+// 条目的——这是该选项存在的意义）。primary_reading：reading 精确匹配者排最前
+//（Yomitan `?query=食べる&primary_reading=たべる` 内链语义）。
+enum class LookupFrequencyOrder { Auto, Ascending, Descending, Disabled };
+
+struct LookupOptions {
+  std::optional<std::string> frequency_dictionary;
+  LookupFrequencyOrder frequency_order = LookupFrequencyOrder::Auto;
+  std::optional<std::string> primary_reading;
+};
+
 class Lookup {
  public:
   Lookup(DictionaryQuery& query, Deinflector& deinflector) : query_(query), deinflector_(deinflector) {};
-  std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results = 16,
-                                   size_t scan_length = 16) const;
+  std::vector<LookupResult> lookup(const std::string& lookup_string, int max_results = 16, size_t scan_length = 16,
+                                   const LookupOptions& options = {}) const;
 
  private:
   void filter_by_pos(std::vector<TermResult>& terms, const DeinflectionResult& d) const;

--- a/native/fushidicts/fushidicts_include/fushidicts/query.hpp
+++ b/native/fushidicts/fushidicts_include/fushidicts/query.hpp
@@ -45,9 +45,19 @@ struct FrequencyEntry {
   std::vector<Frequency> frequencies;
 };
 
+// 上游 79c55c2：完整 pitch accent 规格。数字位 pattern 为空；pattern 位（"heiban"
+// 等）position 保持 0。nasal/devoice 是鼻浊音/清化 mora 下标——数据模型收全，
+// 当前文本形态 UI 只渲染 position/pattern（图形渲染是未来工作）。
+struct Pitch {
+  int position = 0;
+  std::string pattern;
+  std::vector<int> nasal;
+  std::vector<int> devoice;
+};
+
 struct PitchEntry {
   std::string dict_name;
-  std::vector<int> pitch_positions;
+  std::vector<Pitch> pitches;
   std::vector<std::string> transcriptions;
 };
 
@@ -55,6 +65,9 @@ struct TermResult {
   std::string expression;
   std::string reading;
   std::string rules;
+  // 上游 909c854：Yomitan term score（v2 词典落盘，v1 恒 0）。仅参与 native 排序，
+  // 不出 FFI 面。多词典同 (expr,reading) 合并时取 max。
+  int score = 0;
   std::vector<GlossaryEntry> glossaries;
   std::vector<FrequencyEntry> frequencies;
   std::vector<PitchEntry> pitches;

--- a/native/fushidicts/fushidicts_include/fushidicts/query.hpp
+++ b/native/fushidicts/fushidicts_include/fushidicts/query.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if defined(__clang__) && defined(__APPLE__)
@@ -25,6 +26,8 @@ struct MediaFileView {
   size_t size;
 };
 
+struct ZSTD_DDict_s;
+
 struct GlossaryEntry {
   std::string dict_name;
   std::string glossary;
@@ -32,6 +35,9 @@ struct GlossaryEntry {
   std::string term_tags;
   const uint8_t* compressed_data = nullptr;
   uint32_t compressed_size = 0;
+  // v2 词典的 term glossary 用训练字典压缩（上游 8993838）；v1 恒为 nullptr，
+  // usingDDict(nullptr) 等价普通解压。
+  const ZSTD_DDict_s* zstd_dict = nullptr;
 };
 
 struct FrequencyEntry {
@@ -61,6 +67,9 @@ struct KanjiResult {
   std::string radical;
   int strokes = 0;
   std::vector<std::string> meanings;
+  // v2 词典的完整 stats 键值对（JLPT/grade/freq 等，bank 原始顺序，radical/strokes
+  // 以外的条目；借鉴上游 64afa2f 的 stats 保留能力）。v1 存量记录恒为空。
+  std::vector<std::pair<std::string, std::string>> stats;
   std::string dict_name;
 };
 
@@ -142,7 +151,7 @@ class DictionaryQuery {
 
   void add_dict(const std::string& path, DictionaryType);
 
-  static std::string decompress_glossary(const void* data, size_t size);
+  static std::string decompress_glossary(const void* data, size_t size, const ZSTD_DDict_s* dict);
   std::vector<Dictionary> term_dicts_;
   std::vector<Dictionary> freq_dicts_;
   std::vector<Dictionary> pitch_dicts_;

--- a/native/fushidicts/fushidicts_jni.cpp
+++ b/native/fushidicts/fushidicts_jni.cpp
@@ -65,7 +65,14 @@ std::string build_kanji_json(const std::vector<KanjiResult>& kanji) {
       if (j) out.push_back(',');
       append_json_escaped(out, k.meanings[j]);
     }
-    out += "],\"dictName\":";
+    out += "],\"stats\":{";
+    for (size_t j = 0; j < k.stats.size(); j++) {
+      if (j) out.push_back(',');
+      append_json_escaped(out, k.stats[j].first);
+      out.push_back(':');
+      append_json_escaped(out, k.stats[j].second);
+    }
+    out += "},\"dictName\":";
     append_json_escaped(out, k.dict_name);
     out.push_back('}');
   }

--- a/native/fushidicts/fushidicts_src/hash/bloom.cpp
+++ b/native/fushidicts/fushidicts_src/hash/bloom.cpp
@@ -13,16 +13,24 @@ namespace {
 constexpr uint64_t num_hashes = 7;
 }
 
-void bloom::load(const uint8_t* ptr) {
+void bloom::load(const uint8_t* ptr, size_t size) {
+  num_hashes_ = 0;
+  mask_ = 0;
+  bits_ = nullptr;
+
+  if (!ptr || size < 2 * sizeof(uint64_t)) {
+    return;
+  }
   uint64_t num_bits;
   std::memcpy(&num_bits, ptr, sizeof(uint64_t));
   uint64_t num_hashes;
   std::memcpy(&num_hashes, ptr + sizeof(uint64_t), sizeof(uint64_t));
 
-  if (num_bits == 0 || (num_bits & (num_bits - 1)) != 0) {
-    num_hashes_ = 0;
-    mask_ = 0;
-    bits_ = nullptr;
+  // 头部合法性（非零、2 的幂）之外，还按文件实际大小校验位数组是否完整
+  // （上游 d4183d4）：被截断的 bloom.filter 若头部碰巧合法，bits_ 会读出映射尾。
+  // 校验不过走 fork 一贯的置空降级（contains 恒真穿透，查询仍可用），不拒载词典。
+  if (num_bits == 0 || (num_bits & (num_bits - 1)) != 0 ||
+      size != 2 * sizeof(uint64_t) + num_bits / 8) {
     return;
   }
   num_hashes_ = num_hashes;

--- a/native/fushidicts/fushidicts_src/hash/bloom.hpp
+++ b/native/fushidicts/fushidicts_src/hash/bloom.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -7,7 +8,7 @@ namespace hash {
 class bloom {
  public:
   static void build_to_file(const std::vector<uint64_t>& hashes, const std::string& path);
-  void load(const uint8_t* ptr);
+  void load(const uint8_t* ptr, size_t size);
 
   bool contains(uint64_t h) const {
     if (!bits_ || num_hashes_ == 0) return true;  // pass-through if bloom invalid

--- a/native/fushidicts/fushidicts_src/hash/hash.cpp
+++ b/native/fushidicts/fushidicts_src/hash/hash.cpp
@@ -69,20 +69,6 @@ void linear::build_to_file(const std::vector<std::pair<uint64_t, uint64_t>>& has
   ptr_->capacity = 0;
 }
 
-std::vector<uint64_t> linear::populated() const {
-  std::vector<uint64_t> result;
-  if (!ptr_->table) {
-    return result;
-  }
-  result.reserve(static_cast<size_t>(ptr_->capacity) * 7 / 10);
-  for (uint32_t i = 0; i < ptr_->capacity; i++) {
-    if (ptr_->table[i].hash != 0) {
-      result.push_back(ptr_->table[i].hash);
-    }
-  }
-  return result;
-}
-
 void linear::load(uint8_t* ptr, size_t size) {
   // BUG-1303: the capacity is a bare uint32 read straight out of the mapped
   // file. Trusting it unconditionally means a truncated / partially written /

--- a/native/fushidicts/fushidicts_src/hash/hash.hpp
+++ b/native/fushidicts/fushidicts_src/hash/hash.hpp
@@ -23,7 +23,6 @@ class linear {
   // (the one that runs on every lookup) do it too.
   void load(uint8_t* ptr, size_t size);
   void set_bloom(const bloom* b) { bloom_ = b; }
-  std::vector<uint64_t> populated() const;
 
  private:
   struct slot {

--- a/native/fushidicts/fushidicts_src/importer.cpp
+++ b/native/fushidicts/fushidicts_src/importer.cpp
@@ -360,6 +360,9 @@ ProcessedFile process_term_bank(const std::string& content, const ZSTD_CDict* cd
     write_str(processed.data, term.rules);
     write_val<uint8_t>(processed.data, static_cast<uint8_t>(term.term_tags.size()));
     write_str(processed.data, term.term_tags);
+    // v2 term 记录追加段（上游 909c854）：Yomitan score，排序信号（JMdict 系词典
+    // 用它区分常用/罕用词形）。v1 读侧到 term_tags 结束，v2 读侧版本门控读取。
+    write_val<int32_t>(processed.data, static_cast<int32_t>(term.score));
 
     processed.offsets.emplace_back(XXH3_64bits(expr.data(), expr.size()), offset);
     if (reading != expr) {

--- a/native/fushidicts/fushidicts_src/importer.cpp
+++ b/native/fushidicts/fushidicts_src/importer.cpp
@@ -3,6 +3,8 @@
 
 #include <ankerl/unordered_dense.h>
 #include <xxh3.h>
+#define ZDICT_STATIC_LINKING_ONLY
+#include <zdict.h>
 #include <zstd.h>
 
 #include <algorithm>
@@ -15,6 +17,7 @@
 #include <fstream>
 #include <future>
 #include <limits>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -220,7 +223,57 @@ void radix_sort(std::vector<std::pair<uint64_t, uint64_t>>& offsets) {
   }
 }
 
-ProcessedFile process_term_bank(const std::string& content) {
+// 上游 8993838：导入时从第一个 term bank 采样（≤2MB、<8 样本放弃）、
+// ZDICT_optimizeTrainFromBuffer_fastCover 训练 ≤110KB 的 zstd dictionary。
+// 短 glossary 的压缩率显著受益（跨条目共享统计模型）。只训 term bank——
+// meta/kanji 记录数少、收益低，且上游注明可能反噬查询性能。
+std::vector<char> train_zstd_dict(const Zip& zip, const Files& files, bool low_ram) {
+  if (files.term_banks.empty()) {
+    return {};
+  }
+
+  const std::string content = zip.read(files.term_banks[0]);
+  std::vector<Term> terms;
+  if (!yomitan_parser::parse_term_bank(content, terms)) {
+    return {};
+  }
+
+  size_t bank_bytes = 0;
+  for (const auto& term : terms) {
+    bank_bytes += term.glossary.str.size();
+  }
+
+  std::vector<char> samples;
+  std::vector<size_t> sizes;
+  constexpr size_t max_sample_bytes = 2L * 1024 * 1024;
+  const size_t step = std::max<size_t>(1, bank_bytes / max_sample_bytes);
+  for (size_t i = 0; i < terms.size() && samples.size() < max_sample_bytes; i += step) {
+    write_str(samples, terms[i].glossary.str);
+    sizes.push_back(terms[i].glossary.str.size());
+  }
+
+  if (sizes.size() < 8) {
+    return {};
+  }
+
+  ZDICT_fastCover_params_t params = {};
+  params.d = 8;
+  params.steps = 4;
+  params.splitPoint = 1.0;
+  params.nbThreads = low_ram ? 1 : std::max<unsigned int>(1, std::thread::hardware_concurrency());
+
+  std::vector<char> dict(static_cast<size_t>(110 * 1024));
+  const size_t dict_size = ZDICT_optimizeTrainFromBuffer_fastCover(
+      dict.data(), dict.size(), samples.data(), sizes.data(), static_cast<unsigned>(sizes.size()), &params);
+  if (ZDICT_isError(dict_size)) {
+    return {};
+  }
+
+  dict.resize(dict_size);
+  return dict;
+}
+
+ProcessedFile process_term_bank(const std::string& content, const ZSTD_CDict* cdict) {
   ProcessedFile processed;
   if (content.empty()) {
     return processed;
@@ -236,6 +289,8 @@ ProcessedFile process_term_bank(const std::string& content) {
   if (!cctx) {
     return processed;
   }
+  // cdict 为空时 refCDict(nullptr) 即清除引用，退回普通压缩。
+  ZSTD_CCtx_refCDict(cctx, cdict);
 
   for (auto& term : out) {
     if (processed.data.size() > kMaxDataBufferBytes) {
@@ -258,8 +313,7 @@ ProcessedFile process_term_bank(const std::string& content) {
     if (it == processed.glossaries.end()) {
       const size_t bound = ZSTD_compressBound(glossary.size());
       compressed.resize(bound);
-      const size_t compressed_size =
-          ZSTD_compressCCtx(cctx, compressed.data(), bound, glossary.data(), glossary.size(), 0);
+      const size_t compressed_size = ZSTD_compress2(cctx, compressed.data(), bound, glossary.data(), glossary.size());
       if (ZSTD_isError(compressed_size)) {
         ZSTD_freeCCtx(cctx);
         throw std::runtime_error("failed to compress glossary");
@@ -383,6 +437,14 @@ ProcessedFile process_meta_bank(const std::string& content) {
 //                                   meanings joined by newline, ZSTD-compressed,
 //                                   pooled in the shared glossary blob region
 //                                   (identical mechanism as term glossaries).
+//   -- v2 only (marker .fushidicts_2), appended after the meanings pair --
+//   [u8 stat_count] then per stat:  [u8 key_len][key][u16 val_len][val]
+//                                   full stats key/value pairs (JLPT, grade,
+//                                   freq, ...) minus the radical/strokes keys
+//                                   already extracted above (借鉴上游 64afa2f 的
+//                                   stats 保留能力). v1 readers never touch this
+//                                   region; v2 readers gate on the dict-level
+//                                   format version, so v1 records stay readable.
 //
 // meanings are joined with newline because Yomitan kanji meanings are
 // single-line phrases; the reader splits them back on newline.
@@ -450,6 +512,46 @@ void extract_kanji_stats(std::string_view stats_json, std::string_view& radical_
     }
     strokes_out = static_cast<uint16_t>(parsed);
   }
+}
+
+// 收集 stats 里 radical/strokes 之外的全部键值对（值归一成字符串：带引号的经
+// glaze 反转义，数字/布尔保留原 token）。std::map 使键有序稳定；展示排序本就由
+// UI/tag 元数据决定，不依赖 bank 原始顺序。
+std::vector<std::pair<std::string, std::string>> collect_kanji_stats(std::string_view stats_json) {
+  std::vector<std::pair<std::string, std::string>> out;
+  if (stats_json.empty()) {
+    return out;
+  }
+  std::map<std::string, glz::raw_json_view> raw;
+  auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(raw, stats_json);
+  if (error) {
+    return out;
+  }
+  for (auto& [key, val] : raw) {
+    if (key == "radical" || key == "rad" || key == "kangxi_radical" || key == "strokes" || key == "stroke count") {
+      continue;  // 已提取进专用字段，避免重复
+    }
+    if (key.empty() || key.size() > std::numeric_limits<uint8_t>::max()) {
+      continue;
+    }
+    std::string value;
+    std::string_view token = val.str;
+    if (!token.empty() && token.front() == 0x22) {
+      if (glz::read_json(value, token)) {
+        continue;
+      }
+    } else {
+      value.assign(token);
+    }
+    if (value.size() > std::numeric_limits<uint16_t>::max()) {
+      continue;
+    }
+    out.emplace_back(key, std::move(value));
+    if (out.size() >= std::numeric_limits<uint8_t>::max()) {
+      break;
+    }
+  }
+  return out;
 }
 
 ProcessedFile process_kanji_bank(const std::string& content) {
@@ -546,6 +648,16 @@ ProcessedFile process_kanji_bank(const std::string& content) {
     write_val<uint32_t>(processed.data, blob_size);
     processed.glossary_offsets.emplace_back(meanings_hash, meanings_offset_pos);
 
+    // v2 stats 追加段（见上方 S0 契约注释）。
+    const auto stats_kv = collect_kanji_stats(kanji.stats.str);
+    write_val<uint8_t>(processed.data, static_cast<uint8_t>(stats_kv.size()));
+    for (const auto& [stat_key, stat_value] : stats_kv) {
+      write_val<uint8_t>(processed.data, static_cast<uint8_t>(stat_key.size()));
+      write_str(processed.data, stat_key);
+      write_val<uint16_t>(processed.data, static_cast<uint16_t>(stat_value.size()));
+      write_str(processed.data, stat_value);
+    }
+
     processed.offsets.emplace_back(XXH3_64bits(character.data(), character.size()), offset);
     processed.count++;
   }
@@ -629,7 +741,7 @@ void write_kanji(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>
 
 void write_terms(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>& offsets, const Zip& zip,
                  const std::vector<int>& files, uint64_t& write_offset, ImportResult& result, bool low_ram,
-                 const std::string& breadcrumb_dir) {
+                 const std::string& breadcrumb_dir, const ZSTD_CDict* cdict) {
   if (files.empty()) {
     return;
   }
@@ -682,8 +794,8 @@ void write_terms(std::ofstream& file, std::vector<std::pair<uint64_t, uint64_t>>
     fushi::import_breadcrumb::set(breadcrumb_dir,
                                   "yomitan: term_bank #" + std::to_string(bank_seq++) + " / " +
                                       zip.entries[file_index].name);
-    threads.push_back(
-        std::async(std::launch::async, [&zip, file_index]() { return process_term_bank(zip.read(file_index)); }));
+    threads.push_back(std::async(
+        std::launch::async, [&zip, file_index, cdict]() { return process_term_bank(zip.read(file_index), cdict); }));
 
     if (threads.size() == max_threads) {
       write_processed(threads.front().get());
@@ -1386,11 +1498,25 @@ ImportResult import_yomitan(Zip& zip, const std::string& output_dir, bool low_ra
           return write_media(path, zip, files.media_files, breadcrumb_dir);
         });
 
+    // 上游 8993838：训练 zstd dictionary（可选，失败/样本不足即空）。训练成功则
+    // 落盘 dict.zstd，term glossary 用 CDict 压缩；读侧凭 dict.zstd 是否存在决定
+    // 是否挂 DDict（v2 marker 门控整个词典目录）。
+    fushi::import_breadcrumb::set(breadcrumb_dir, "yomitan: training zstd dictionary");
+    const std::vector<char> zstd_dict = train_zstd_dict(zip, files, low_ram);
+    std::unique_ptr<ZSTD_CDict, decltype(&ZSTD_freeCDict)> cdict(nullptr, ZSTD_freeCDict);
+    if (!zstd_dict.empty()) {
+      cdict.reset(ZSTD_createCDict(zstd_dict.data(), zstd_dict.size(), 0));
+
+      std::ofstream dict_file(fushi::fs_path(path + "/dict.zstd"), std::ios::binary);
+      setup_stream_exceptions(dict_file);
+      dict_file.write(zstd_dict.data(), static_cast<std::streamsize>(zstd_dict.size()));
+    }
+
     std::ofstream blobs(fushi::fs_path(path + "/blobs.bin"), std::ios::binary);
     setup_stream_exceptions(blobs);
     std::vector<std::pair<uint64_t, uint64_t>> offsets;
     uint64_t write_offset = 0;
-    write_terms(blobs, offsets, zip, files.term_banks, write_offset, result, low_ram, breadcrumb_dir);
+    write_terms(blobs, offsets, zip, files.term_banks, write_offset, result, low_ram, breadcrumb_dir, cdict.get());
     write_meta(blobs, offsets, zip, files.meta_banks, write_offset, result, low_ram, breadcrumb_dir);
     ankerl::unordered_dense::map<uint64_t, uint64_t> kanji_glossaries;
     write_kanji(blobs, offsets, zip, files.kanji_banks, write_offset, result, low_ram, kanji_glossaries, breadcrumb_dir);
@@ -1417,7 +1543,10 @@ ImportResult import_yomitan(Zip& zip, const std::string& output_dir, bool low_ra
 
     result.media_count = media_thread.get();
 
-    std::ofstream sui(fushi::fs_path(path + "/.fushidicts_1"), std::ios::binary);
+    // v2 = 本批引入的格式阶梯（fork 首个版本升级）：kanji 记录带 stats 追加段 +
+    // term glossary 可能使用 dict.zstd 训练字典。旧引擎认不出 v2 marker 会整目录
+    // 不加载（降级后新导入词典不可见，不毁数据、重导可救）；v1 存量照读不变。
+    std::ofstream sui(fushi::fs_path(path + "/.fushidicts_2"), std::ios::binary);
     result.success = true;
   } catch (const std::exception& e) {
     result.success = false;

--- a/native/fushidicts/fushidicts_src/json/yomitan_parser.cpp
+++ b/native/fushidicts/fushidicts_src/json/yomitan_parser.cpp
@@ -58,12 +58,13 @@ struct RawFrequency {
   std::variant<int, FrequencyValue> frequency;
 };
 
-// 上游 79c55c2（parser 先行部分）：position 可以是数字或 pattern 字符串
-//（"heiban" 等）。此前 int 独取会让含 pattern 条目的整条 meta 记录解析失败、
-// 数字条目一起陪葬。nasal/devoice 键靠 error_on_unknown_keys=false 天然容忍；
-// 结构化收集（连同 pattern 出 FFI/UI）留待二期。
+// 上游 79c55c2：position 可以是数字或 pattern 字符串（"heiban" 等）——此前 int
+// 独取会让含 pattern 条目的整条 meta 记录解析失败、数字条目一起陪葬；nasal/
+// devoice 按规格是数字或数组，归一成数组。
 struct PitchesArray {
   std::variant<int, std::string> position;
+  std::optional<std::variant<int, std::vector<int>>> nasal;
+  std::optional<std::variant<int, std::vector<int>>> devoice;
 };
 
 struct RawPitch {
@@ -102,7 +103,7 @@ struct glz::meta<internal::RawFrequency> {
 template <>
 struct glz::meta<internal::PitchesArray> {
   using T = internal::PitchesArray;
-  static constexpr auto value = object("position", &T::position);
+  static constexpr auto value = object("position", &T::position, "nasal", &T::nasal, "devoice", &T::devoice);
 };
 
 template <>
@@ -197,12 +198,25 @@ bool yomitan_parser::parse_pitch(std::string_view content, ParsedPitch& out) {
     return false;
   }
 
-  out.reading = parsed.reading;
-  for (const auto& pitch : parsed.pitches) {
-    if (std::holds_alternative<int>(pitch.position)) {
-      out.pitches.push_back(std::get<int>(pitch.position));
+  auto to_number_array = [](const std::optional<std::variant<int, std::vector<int>>>& value) -> std::vector<int> {
+    if (!value) {
+      return {};
     }
-    // pattern 字符串位暂无消费方，跳过该条而非整条拒绝（二期扩 ABI 时再结构化）。
+    if (std::holds_alternative<int>(*value)) {
+      return {std::get<int>(*value)};
+    }
+    return std::get<std::vector<int>>(*value);
+  };
+
+  out.reading = parsed.reading;
+  for (auto& pitch : parsed.pitches) {
+    ParsedAccent accent{.nasal = to_number_array(pitch.nasal), .devoice = to_number_array(pitch.devoice)};
+    if (std::holds_alternative<int>(pitch.position)) {
+      accent.position = std::get<int>(pitch.position);
+    } else {
+      accent.pattern = std::move(std::get<std::string>(pitch.position));
+    }
+    out.pitches.emplace_back(std::move(accent));
   }
   return true;
 }

--- a/native/fushidicts/fushidicts_src/json/yomitan_parser.cpp
+++ b/native/fushidicts/fushidicts_src/json/yomitan_parser.cpp
@@ -44,7 +44,7 @@ struct glz::meta<Tag> {
 namespace internal {
 struct FrequencyValue {
   int value;
-  std::string display_value;
+  std::optional<std::string> display_value;
 };
 
 struct RawFrequencyFlat {
@@ -58,8 +58,12 @@ struct RawFrequency {
   std::variant<int, FrequencyValue> frequency;
 };
 
+// 上游 79c55c2（parser 先行部分）：position 可以是数字或 pattern 字符串
+//（"heiban" 等）。此前 int 独取会让含 pattern 条目的整条 meta 记录解析失败、
+// 数字条目一起陪葬。nasal/devoice 键靠 error_on_unknown_keys=false 天然容忍；
+// 结构化收集（连同 pattern 出 FFI/UI）留待二期。
 struct PitchesArray {
-  int position = 0;
+  std::variant<int, std::string> position;
 };
 
 struct RawPitch {
@@ -166,7 +170,9 @@ bool yomitan_parser::parse_frequency(std::string_view content, ParsedFrequency& 
   }
 
   internal::RawFrequency parsed;
-  error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(parsed, content);
+  // 上游 01630e8：嵌套 object 变体与 flat 路径同样收紧——缺 frequency 键的畸形
+  // 条目从「静默解析成 0」变为拒绝；displayValue 显式空串也如实保留。
+  error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed, content);
   if (error) {
     return false;
   }
@@ -179,21 +185,25 @@ bool yomitan_parser::parse_frequency(std::string_view content, ParsedFrequency& 
   } else {
     auto& freq = std::get<internal::FrequencyValue>(parsed.frequency);
     out.value = freq.value;
-    out.display_value = freq.display_value.empty() ? std::to_string(freq.value) : freq.display_value;
+    out.display_value = freq.display_value.value_or(std::to_string(freq.value));
   }
   return true;
 }
 
 bool yomitan_parser::parse_pitch(std::string_view content, ParsedPitch& out) {
   internal::RawPitch parsed;
-  auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(parsed, content);
+  auto error = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(parsed, content);
   if (error) {
     return false;
   }
 
   out.reading = parsed.reading;
-  out.pitches =
-      parsed.pitches | std::views::transform(&internal::PitchesArray::position) | std::ranges::to<std::vector>();
+  for (const auto& pitch : parsed.pitches) {
+    if (std::holds_alternative<int>(pitch.position)) {
+      out.pitches.push_back(std::get<int>(pitch.position));
+    }
+    // pattern 字符串位暂无消费方，跳过该条而非整条拒绝（二期扩 ABI 时再结构化）。
+  }
   return true;
 }
 

--- a/native/fushidicts/fushidicts_src/json/yomitan_parser.hpp
+++ b/native/fushidicts/fushidicts_src/json/yomitan_parser.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <glaze/glaze.hpp>
-#include <cstdint>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -63,9 +63,19 @@ struct ParsedFrequency {
   std::string display_value;
 };
 
+// 上游 79c55c2：pitch accent 完整规格。position 为数字时 pattern 为空；为字符串
+// pattern（"heiban" 等）时 position 无意义（保持 0）。nasal/devoice 是鼻浊音/清化
+// 的 mora 下标（Yomitan 规格里数字或数组，归一成数组）。
+struct ParsedAccent {
+  int position = 0;
+  std::string pattern;
+  std::vector<int> nasal;
+  std::vector<int> devoice;
+};
+
 struct ParsedPitch {
   std::string_view reading;
-  std::vector<int> pitches;
+  std::vector<ParsedAccent> pitches;
   std::vector<std::string_view> transcriptions;
 };
 

--- a/native/fushidicts/fushidicts_src/lookup.cpp
+++ b/native/fushidicts/fushidicts_src/lookup.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <climits>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <sstream>
 
@@ -23,27 +24,35 @@ std::vector<std::string> split_whitespace(const std::string& str) {
 }
 
 // 上游 909c854 revert 了 4975788 的向量比较（作者自己否掉的实验：每次比较
-// 分配+排序一个 vector，partial_sort 下纯浪费）；回到单一最小值比较。
-int get_freq_value_for_dict(const TermResult& term, const std::string& dict_name) {
+// 分配+排序一个 vector，partial_sort 下纯浪费）；后随 bc62d2b 演化为 optional +
+// 方向感知（Descending 时取该词典内最大值而非最小值）。
+std::optional<int> get_freq_value_for_dict(const TermResult& term, std::string_view dictionary_name, bool descending) {
+  std::optional<int> frequency;
   for (const auto& frequency_entry : term.frequencies) {
-    if (frequency_entry.dict_name != dict_name) {
+    if (frequency_entry.dict_name != dictionary_name || frequency_entry.frequencies.empty()) {
       continue;
     }
 
-    int min_frequency = INT_MAX;
-    for (const auto& frequency : frequency_entry.frequencies) {
-      if (frequency.value >= 0) {
-        min_frequency = std::min(min_frequency, frequency.value);
+    for (const auto& candidate : frequency_entry.frequencies) {
+      if (candidate.value < 0) {
+        continue;
       }
+      frequency = frequency.has_value() ? std::optional<int>(descending ? std::max(*frequency, candidate.value)
+                                                                        : std::min(*frequency, candidate.value))
+                                        : std::optional<int>(candidate.value);
     }
-    return min_frequency;
   }
 
-  return INT_MAX;
+  return frequency;
+}
+
+bool matches_primary_reading(const TermResult& term, std::string_view primary_reading) {
+  return term.reading == primary_reading;
 }
 }
 
-std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length) const {
+std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int max_results, size_t scan_length,
+                                         const LookupOptions& options) const {
   std::map<std::pair<std::string, std::string>, LookupResult> result_map;
 
   // 候选前缀由词边界感知的扫描器生成（对齐 Yomitan searchResolution）：
@@ -133,45 +142,101 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
     query_.enrich_freq(r.term);
   }
 
-  const auto freq_dict_order = query_.get_freq_dict_order();
-  auto middle_iter = std::ranges::next(results.begin(), max_results, results.end());
-  std::ranges::partial_sort(results, middle_iter, [&freq_dict_order](const auto& a, const auto& b) {
-    auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
-    auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
-    if (len_a != len_b) {
-      return len_a > len_b;
-    }
-
-    auto steps_a = a.preprocessor_steps;
-    auto steps_b = b.preprocessor_steps;
-    if (steps_a != steps_b) {
-      return steps_a < steps_b;
-    }
-
-    auto trace_len_a = a.trace.size();
-    auto trace_len_b = b.trace.size();
-    if (trace_len_a != trace_len_b) {
-      return trace_len_a < trace_len_b;
-    }
-
-    auto match_a = a.term.expression == a.deinflected;
-    auto match_b = b.term.expression == b.deinflected;
-    if (match_a != match_b) {
-      return match_a > match_b;
-    }
-
-    for (const auto& dict_name : freq_dict_order) {
-      const int freq_a = get_freq_value_for_dict(a.term, dict_name);
-      const int freq_b = get_freq_value_for_dict(b.term, dict_name);
-      if (freq_a != freq_b) {
-        return freq_a < freq_b;
+  // 上游 bc62d2b：排序选项解析。Auto = 既有比较器（按注册顺序遍历全部 freq 词典，
+  // 零行为变化）；显式指定词典 + 升/降序时只按该词典排（找不到词典名则静默退回，
+  // 不排序也不报错——与上游一致）。
+  std::vector<std::string> auto_frequency_dictionaries;
+  std::optional<std::string_view> frequency_dictionary;
+  bool frequency_descending = false;
+  switch (options.frequency_order) {
+    case LookupFrequencyOrder::Auto:
+      auto_frequency_dictionaries = query_.get_freq_dict_order();
+      break;
+    case LookupFrequencyOrder::Ascending:
+    case LookupFrequencyOrder::Descending:
+      if (options.frequency_dictionary.has_value()) {
+        const auto selected =
+            std::ranges::find(query_.freq_dicts_, *options.frequency_dictionary, &DictionaryQuery::Dictionary::name);
+        if (selected != query_.freq_dicts_.end()) {
+          frequency_dictionary = selected->name;
+          frequency_descending = options.frequency_order == LookupFrequencyOrder::Descending;
+        }
       }
-    }
+      break;
+    case LookupFrequencyOrder::Disabled:
+      break;
+  }
+  std::string_view primary_reading;
+  if (options.primary_reading.has_value()) {
+    primary_reading = *options.primary_reading;
+  }
 
-    auto a_reading_expr_match = a.term.expression == a.term.reading;
-    auto b_reading_expr_match = b.term.expression == b.term.reading;
-    return a_reading_expr_match > b_reading_expr_match;
-  });
+  auto middle_iter = std::ranges::next(results.begin(), max_results, results.end());
+  std::ranges::partial_sort(
+      results, middle_iter,
+      [&auto_frequency_dictionaries, frequency_dictionary, frequency_descending, primary_reading](const auto& a,
+                                                                                                  const auto& b) {
+        // 上游 86c6e2f：primary_reading 精确匹配者排最前（截断前生效）。
+        if (!primary_reading.empty()) {
+          const bool primary_a = matches_primary_reading(a.term, primary_reading);
+          const bool primary_b = matches_primary_reading(b.term, primary_reading);
+          if (primary_a != primary_b) {
+            return primary_a;
+          }
+        }
+
+        auto len_a = utf8::distance(a.matched.begin(), a.matched.end());
+        auto len_b = utf8::distance(b.matched.begin(), b.matched.end());
+        if (len_a != len_b) {
+          return len_a > len_b;
+        }
+
+        auto steps_a = a.preprocessor_steps;
+        auto steps_b = b.preprocessor_steps;
+        if (steps_a != steps_b) {
+          return steps_a < steps_b;
+        }
+
+        auto trace_len_a = a.trace.size();
+        auto trace_len_b = b.trace.size();
+        if (trace_len_a != trace_len_b) {
+          return trace_len_a < trace_len_b;
+        }
+
+        auto match_a = a.term.expression == a.deinflected;
+        auto match_b = b.term.expression == b.deinflected;
+        if (match_a != match_b) {
+          return match_a > match_b;
+        }
+
+        for (const auto& dictionary_name : auto_frequency_dictionaries) {
+          const int freq_a = get_freq_value_for_dict(a.term, dictionary_name, false).value_or(INT_MAX);
+          const int freq_b = get_freq_value_for_dict(b.term, dictionary_name, false).value_or(INT_MAX);
+          if (freq_a != freq_b) {
+            return freq_a < freq_b;
+          }
+        }
+
+        if (frequency_dictionary.has_value()) {
+          const auto freq_a = get_freq_value_for_dict(a.term, *frequency_dictionary, frequency_descending);
+          const auto freq_b = get_freq_value_for_dict(b.term, *frequency_dictionary, frequency_descending);
+          if (freq_a.has_value() != freq_b.has_value()) {
+            return freq_a.has_value();
+          }
+          if (freq_a.has_value() && *freq_a != *freq_b) {
+            return frequency_descending ? *freq_a > *freq_b : *freq_a < *freq_b;
+          }
+        }
+
+        // 上游 909c854：Yomitan score 降序（v2 词典落盘；v1 恒 0 = 此档恒平）。
+        if (a.term.score != b.term.score) {
+          return a.term.score > b.term.score;
+        }
+
+        auto a_reading_expr_match = a.term.expression == a.term.reading;
+        auto b_reading_expr_match = b.term.expression == b.term.reading;
+        return a_reading_expr_match > b_reading_expr_match;
+      });
 
   if (results.size() > static_cast<size_t>(max_results)) {
     results.resize(max_results);

--- a/native/fushidicts/fushidicts_src/lookup.cpp
+++ b/native/fushidicts/fushidicts_src/lookup.cpp
@@ -3,6 +3,7 @@
 #include <utf8.h>
 
 #include <algorithm>
+#include <climits>
 #include <map>
 #include <ranges>
 #include <sstream>
@@ -21,23 +22,24 @@ std::vector<std::string> split_whitespace(const std::string& str) {
   return result;
 }
 
-std::vector<int> get_freq_values_for_dict(const TermResult& term, const std::string& dict_name) {
+// 上游 909c854 revert 了 4975788 的向量比较（作者自己否掉的实验：每次比较
+// 分配+排序一个 vector，partial_sort 下纯浪费）；回到单一最小值比较。
+int get_freq_value_for_dict(const TermResult& term, const std::string& dict_name) {
   for (const auto& frequency_entry : term.frequencies) {
     if (frequency_entry.dict_name != dict_name) {
       continue;
     }
 
-    std::vector<int> values;
+    int min_frequency = INT_MAX;
     for (const auto& frequency : frequency_entry.frequencies) {
       if (frequency.value >= 0) {
-        values.push_back(frequency.value);
+        min_frequency = std::min(min_frequency, frequency.value);
       }
     }
-    std::ranges::sort(values);
-    return values;
+    return min_frequency;
   }
 
-  return {INT_MAX};
+  return INT_MAX;
 }
 }
 
@@ -159,8 +161,8 @@ std::vector<LookupResult> Lookup::lookup(const std::string& lookup_string, int m
     }
 
     for (const auto& dict_name : freq_dict_order) {
-      const auto freq_a = get_freq_values_for_dict(a.term, dict_name);
-      const auto freq_b = get_freq_values_for_dict(b.term, dict_name);
+      const int freq_a = get_freq_value_for_dict(a.term, dict_name);
+      const int freq_b = get_freq_value_for_dict(b.term, dict_name);
       if (freq_a != freq_b) {
         return freq_a < freq_b;
       }

--- a/native/fushidicts/fushidicts_src/memory/memory.cpp
+++ b/native/fushidicts/fushidicts_src/memory/memory.cpp
@@ -137,8 +137,12 @@ void unmap(mapped_file mapping) {
   }
 
 #ifdef _WIN32
+  // 上游 d4183d4：unmap 前显式刷脏页——导入刚完成即崩溃时文件可能没落盘
+  //（只读映射无脏页，调用无害）。
+  FlushViewOfFile(mapping.data, 0);
   UnmapViewOfFile(mapping.data);
 #else
+  msync(mapping.data, mapping.size, MS_SYNC);
   munmap(mapping.data, mapping.size);
 #endif
 }

--- a/native/fushidicts/fushidicts_src/popup_json.cpp
+++ b/native/fushidicts/fushidicts_src/popup_json.cpp
@@ -91,15 +91,31 @@ std::string build_popup_json(const std::vector<LookupResult>& results,
       }
 
       for (const auto& p : r.term.pitches) {
+        // key 形状 = "dict:数字位段,pattern段|transcriptions段"，与 Dart 镜像
+        // buildPopupJsonFromLookup 的 pKey 逐字符同构（FFI 面就是数字/pattern 两个
+        // 平行数组，key 也按此分段，避免两侧 dedup 分歧）。pattern 位若只按
+        // position 建 key 会与 position 0 撞车被吞；IPA 记录无 accent，只按 accent
+        // 建 key 会把同 dict 多 IPA 折叠成 "dict:" 被吞（TODO-687 block3 同型坑）。
         std::string pkey = p.dict_name + ":";
-        for (size_t i = 0; i < p.pitch_positions.size(); i++) {
-          if (i > 0) pkey += ",";
-          pkey += std::to_string(p.pitch_positions[i]);
+        {
+          bool first = true;
+          for (const auto& accent : p.pitches) {
+            if (!accent.pattern.empty()) continue;
+            if (!first) pkey += ",";
+            first = false;
+            pkey += std::to_string(accent.position);
+          }
         }
-        // IPA entries carry no pitch positions, so a dedup key built only from
-        // positions collapses every IPA record of one dict to "dict:" and the
-        // set drops all but the first. Fold the transcriptions into the key so
-        // distinct IPA strings survive (TODO-687 block3).
+        pkey += ",";
+        {
+          bool first = true;
+          for (const auto& accent : p.pitches) {
+            if (accent.pattern.empty()) continue;
+            if (!first) pkey += ",";
+            first = false;
+            pkey += accent.pattern;
+          }
+        }
         pkey += "|";
         for (size_t i = 0; i < p.transcriptions.size(); i++) {
           if (i > 0) pkey += ",";
@@ -184,10 +200,27 @@ done:
       if (pi > 0) os << ',';
       os << R"({"dictionary":)";
       json_escape(os, gd.pitches[pi].dict_name);
+      // pitchPositions 只含数字位（与历史输出字节兼容）；pattern 位单独成
+      // "patterns" 数组（79c55c2 二期，JS 渲染为 [pattern] 文本项）。
       os << R"(,"pitchPositions":[)";
-      for (size_t k = 0; k < gd.pitches[pi].pitch_positions.size(); k++) {
-        if (k > 0) os << ',';
-        os << gd.pitches[pi].pitch_positions[k];
+      {
+        bool first = true;
+        for (const auto& accent : gd.pitches[pi].pitches) {
+          if (!accent.pattern.empty()) continue;
+          if (!first) os << ',';
+          first = false;
+          os << accent.position;
+        }
+      }
+      os << R"(],"patterns":[)";
+      {
+        bool first = true;
+        for (const auto& accent : gd.pitches[pi].pitches) {
+          if (accent.pattern.empty()) continue;
+          if (!first) os << ',';
+          first = false;
+          json_escape(os, accent.pattern);
+        }
       }
       os << R"(],"transcriptions":[)";
       for (size_t k = 0; k < gd.pitches[pi].transcriptions.size(); k++) {

--- a/native/fushidicts/fushidicts_src/query.cpp
+++ b/native/fushidicts/fushidicts_src/query.cpp
@@ -56,6 +56,13 @@ struct BlobReader {
   [[nodiscard]] bool has(size_t n) const { return ptr + n <= end; }
 };
 
+// 上游 8993838：thread_local 复用 DCtx——旧路径 ZSTD_decompress 每次内部新建
+// 上下文，materialize 一次弹窗要解压几十条 glossary，复用是纯赚的速度优化。
+ZSTD_DCtx* thread_dctx() {
+  static thread_local std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx(ZSTD_createDCtx(), ZSTD_freeDCtx);
+  return ctx.get();
+}
+
 }
 
 struct DictionaryQuery::DictionaryData {
@@ -66,6 +73,8 @@ struct DictionaryQuery::DictionaryData {
   memory::mapped_file bloom_filter;
   memory::mapped_file media;
   memory::mapped_file media_index;
+  int version = 1;                   // 磁盘格式版本（marker 文件名解析，见 dict_format_version）
+  ZSTD_DDict* zstd_dict = nullptr;   // v2 + dict.zstd 存在时非空
 
   ~DictionaryData() {
     memory::unmap(blobs);
@@ -73,6 +82,7 @@ struct DictionaryQuery::DictionaryData {
     memory::unmap(bloom_filter);
     memory::unmap(media);
     memory::unmap(media_index);
+    ZSTD_freeDDict(zstd_dict);
   }
 };
 
@@ -99,24 +109,28 @@ namespace {
 //
 // 故读侧同时接受两个名字（新名优先）。这是「读旧数据的迁移代码」，不追改用户
 // 磁盘上的存量文件——重命名用户数据既不可逆，也会让回退到旧版的用户反过来坏掉。
-constexpr const char* kDictCompleteMarkers[] = {
-    "/.fushidicts_1",   // 当前写入端产出
-    "/.hoshidicts_1",   // 改名前的存量（冻结，只读不写）
-};
-
-bool has_dict_complete_marker(const std::string& path) {
-  for (const char* marker : kDictCompleteMarkers) {
-    if (std::filesystem::is_regular_file(fushi::fs_path(path + marker))) {
-      return true;
-    }
+// marker 同时承担「导入已完成」与「格式版本」两个语义（对齐上游的版本阶梯）：
+//   v2: .fushidicts_2 —— kanji 记录带 stats 追加段 + term glossary 可能使用
+//       dict.zstd 训练字典（本批引入，fork 首个版本升级）。
+//   v1: .fushidicts_1（当前 v1 写入端 write_simple_dict 仍产出）/
+//       .hoshidicts_1（改名前的存量，冻结，只读不写）。
+// 返回 0 = 无 marker（导入未完成/损坏），词典不加载。
+int dict_format_version(const std::string& path) {
+  if (std::filesystem::is_regular_file(fushi::fs_path(path + "/.fushidicts_2"))) {
+    return 2;
   }
-  return false;
+  if (std::filesystem::is_regular_file(fushi::fs_path(path + "/.fushidicts_1")) ||
+      std::filesystem::is_regular_file(fushi::fs_path(path + "/.hoshidicts_1"))) {
+    return 1;
+  }
+  return 0;
 }
 
 }  // namespace
 
 void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
-  if (!has_dict_complete_marker(path)) {
+  const int version = dict_format_version(path);
+  if (version == 0) {
     return;
   }
 
@@ -148,6 +162,7 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   }
 
   dict.data = std::make_unique<DictionaryData>();
+  dict.data->version = version;
 
   dict.data->hash_table = memory::map_rd(path + "/hash.table");
   if (!dict.data->hash_table) {
@@ -155,12 +170,14 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   }
   dict.data->table.load(dict.data->hash_table.data, dict.data->hash_table.size);
 
+  // 上游 d4183d4 删掉了「bloom.filter 缺失时现场重建」的 migration：fork importer
+  // 从第一天就写 bloom.filter，migration 是死代码，且 build_to_file 失败会 throw
+  // 并穿过无 try/catch 的 FFI 入口（上游 TestFlight 崩溃同款路径）。缺失/损坏时
+  // bloom 保持置空（contains 恒真穿透），词典照常可查，只失去 bloom 加速。
   dict.data->bloom_filter = memory::map_rd(path + "/bloom.filter");
-  if (!dict.data->bloom_filter) {
-    hash::bloom::build_to_file(dict.data->table.populated(), path + "/bloom.filter");
-    dict.data->bloom_filter = memory::map_rd(path + "/bloom.filter");
+  if (dict.data->bloom_filter) {
+    dict.data->bloom.load(dict.data->bloom_filter.data, dict.data->bloom_filter.size);
   }
-  dict.data->bloom.load(dict.data->bloom_filter.data);
   dict.data->table.set_bloom(&dict.data->bloom);
 
   dict.data->blobs = memory::map_rd(path + "/blobs.bin");
@@ -171,6 +188,18 @@ void DictionaryQuery::add_dict(const std::string& path, DictionaryType type) {
   dict.data->media = memory::map_rd(path + "/media.bin");
   if (dict.data->media) {
     dict.data->media_index = memory::map_rd(path + "/media.idx");
+  }
+
+  // dict.zstd 是可选产物（训练样本不足时导入端不写），存在才挂 DDict；
+  // 缺失/空文件 → DDict 保持 null → usingDDict(nullptr) 普通解压。
+  if (version >= 2) {
+    std::ifstream f(fushi::fs_path(path + "/dict.zstd"), std::ios::binary);
+    if (f) {
+      const std::string blob((std::istreambuf_iterator<char>(f)), {});
+      if (!blob.empty()) {
+        dict.data->zstd_dict = ZSTD_createDDict(blob.data(), blob.size());
+      }
+    }
   }
 
   switch (type) {
@@ -269,6 +298,7 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
       entry.term_tags = term_tags;
       entry.compressed_data = data->blobs.data + glossary_offset;
       entry.compressed_size = glossary_size;
+      entry.zstd_dict = data->zstd_dict;
 
       auto [it, inserted] = term_map.try_emplace({expr, reading});
       if (inserted) {
@@ -350,8 +380,27 @@ std::vector<KanjiResult> DictionaryQuery::query_kanji(const std::string& charact
       result.strokes = static_cast<int>(strokes);
       result.dict_name = name;
 
+      // v2 stats 追加段（版本门控：v1 记录到 meanings 对就结束，不读此段）。
+      if (data->version >= 2) {
+        auto stat_count = blob.read<uint8_t>();
+        for (uint8_t s = 0; s < stat_count; s++) {
+          if (!blob.has(sizeof(uint8_t))) {
+            break;
+          }
+          auto key_len = blob.read<uint8_t>();
+          std::string_view stat_key = blob.read_str(key_len);
+          auto val_len = blob.read<uint16_t>();
+          std::string_view stat_value = blob.read_str(val_len);
+          if (stat_key.empty()) {
+            break;  // 越界被 BlobReader 钉空 → 停止而不是灌入空对
+          }
+          result.stats.emplace_back(std::string(stat_key), std::string(stat_value));
+        }
+      }
+
       if (meanings_size > 0 && meanings_offset < data->blobs.size) {
-        std::string joined = decompress_glossary(data->blobs.data + meanings_offset, meanings_size);
+        // kanji meanings 恒为普通 zstd 帧（训练字典只用于 term glossary）。
+        std::string joined = decompress_glossary(data->blobs.data + meanings_offset, meanings_size, nullptr);
         size_t start = 0;
         while (start <= joined.size()) {
           size_t nl = joined.find('\n', start);
@@ -518,7 +567,7 @@ void DictionaryQuery::enrich_pitch(TermResult& term) const {
   }
 }
 
-std::string DictionaryQuery::decompress_glossary(const void* data, size_t size) {
+std::string DictionaryQuery::decompress_glossary(const void* data, size_t size, const ZSTD_DDict_s* dict) {
   if (!data || size == 0) {
     return "";
   }
@@ -538,7 +587,7 @@ std::string DictionaryQuery::decompress_glossary(const void* data, size_t size) 
   std::string result;
   result.resize(decompressed_size);
 
-  size_t actual_size = ZSTD_decompress(result.data(), result.size(), data, size);
+  size_t actual_size = ZSTD_decompress_usingDDict(thread_dctx(), result.data(), result.size(), data, size, dict);
   if (ZSTD_isError(actual_size)) {
     return "";
   }
@@ -549,7 +598,7 @@ std::string DictionaryQuery::decompress_glossary(const void* data, size_t size) 
 
 void DictionaryQuery::materialize(TermResult& term) const {
   for (auto& g : term.glossaries) {
-    g.glossary = decompress_glossary(g.compressed_data, g.compressed_size);
+    g.glossary = decompress_glossary(g.compressed_data, g.compressed_size, g.zstd_dict);
   }
 }
 

--- a/native/fushidicts/fushidicts_src/query.cpp
+++ b/native/fushidicts/fushidicts_src/query.cpp
@@ -292,6 +292,13 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
       auto term_tag_size = blob.read<uint8_t>();
       std::string_view term_tags = blob.read_str(term_tag_size);
 
+      // v2 term 记录在 term_tags 之后追加 i32 score（上游 909c854）；v1 记录到
+      // term_tags 就结束，版本门控不读。
+      int score = 0;
+      if (data->version >= 2) {
+        score = static_cast<int>(blob.read<int32_t>());
+      }
+
       GlossaryEntry entry;
       entry.dict_name = name;
       entry.definition_tags = definition_tags;
@@ -305,6 +312,7 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
         it->second = {.expression = std::string(expr),
                       .reading = std::string(reading),
                       .rules = std::string(rules),
+                      .score = score,
                       .glossaries = {},
                       .frequencies = {}};
       } else {
@@ -314,6 +322,8 @@ std::vector<TermResult> DictionaryQuery::query_raw(const std::string& expression
           }
           it->second.rules += rules;
         }
+        // 多词典/多记录合并：score 取 max（上游 909c854）。
+        it->second.score = std::max(it->second.score, score);
       }
       it->second.glossaries.push_back(std::move(entry));
     }
@@ -503,7 +513,7 @@ void DictionaryQuery::enrich_pitch(TermResult& term) const {
     BlobReader idx(data->blobs.data + offset_addr, data->blobs.size - offset_addr);
     auto count = idx.read<uint32_t>();
 
-    std::vector<int> pitch_positions;
+    std::vector<Pitch> pitches;
     std::vector<std::string> transcriptions;
     for (uint32_t i = 0; i < count; i++) {
       if (!idx.has(sizeof(uint64_t))) {
@@ -542,7 +552,12 @@ void DictionaryQuery::enrich_pitch(TermResult& term) const {
           if (!parsed.reading.empty() && parsed.reading != term.reading) {
             continue;
           }
-          pitch_positions.insert(pitch_positions.end(), parsed.pitches.begin(), parsed.pitches.end());
+          for (auto& accent : parsed.pitches) {
+            pitches.push_back(Pitch{.position = accent.position,
+                                    .pattern = std::move(accent.pattern),
+                                    .nasal = std::move(accent.nasal),
+                                    .devoice = std::move(accent.devoice)});
+          }
         }
       } else if (mode == "ipa") {
         auto transcriptions_data_size = blob.read<uint32_t>();
@@ -557,10 +572,10 @@ void DictionaryQuery::enrich_pitch(TermResult& term) const {
         }
       }
     }
-    if (!pitch_positions.empty() || !transcriptions.empty()) {
+    if (!pitches.empty() || !transcriptions.empty()) {
       term.pitches.emplace_back(PitchEntry{
           .dict_name = name,
-          .pitch_positions = std::move(pitch_positions),
+          .pitches = std::move(pitches),
           .transcriptions = std::move(transcriptions),
       });
     }

--- a/native/fushidicts/fushidicts_src/text_processor/text_processor.cpp
+++ b/native/fushidicts/fushidicts_src/text_processor/text_processor.cpp
@@ -3,11 +3,13 @@
 #include <utf8.h>
 #include <utf8proc.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -23,12 +25,22 @@ struct TextProcessor {
 constexpr uint32_t KATAKANA_SMALL_KA = 0x30f5;
 constexpr uint32_t KATAKANA_SMALL_KE = 0x30f6;
 constexpr uint32_t KANA_PROLONGED_SOUND_MARK = 0x30fc;
+constexpr uint32_t HIRAGANA_SMALL_TSU = 0x3063;
+constexpr uint32_t KATAKANA_SMALL_TSU = 0x30c3;
 
 constexpr uint32_t HIRAGANA_CONVERSION_RANGE_START = 0x3041;
 constexpr uint32_t HIRAGANA_CONVERSION_RANGE_END = 0x3096;
 
 constexpr uint32_t KATAKANA_CONVERSION_RANGE_START = 0x30a1;
 constexpr uint32_t KATAKANA_CONVERSION_RANGE_END = 0x30f6;
+
+// 上游 9dc93b6：迭代符展开
+constexpr char32_t KANJI_ITERATION_MARK = 0x3005;
+constexpr char32_t HIRAGANA_ITERATION_MARK = 0x309d;
+constexpr char32_t HIRAGANA_VOICED_ITERATION_MARK = 0x309e;
+constexpr char32_t KATAKANA_ITERATION_MARK = 0x30fd;
+constexpr char32_t KATAKANA_VOICED_ITERATION_MARK = 0x30fe;
+constexpr char32_t DAKUTEN = 0x3099;
 
 // https://github.com/yomidevs/yomitan/blob/81d17d877fb18c62ba826210bf6db2b7f4d4deed/ext/js/language/ja/japanese.js#L121
 const std::unordered_map<char32_t, std::u32string> VOWEL_TO_KANA{
@@ -117,6 +129,49 @@ std::u32string katakana_to_hiragana(const std::u32string& text) {
     result += c;
   }
   return result;
+}
+
+bool is_emphatic(char32_t c) {
+  return c == HIRAGANA_SMALL_TSU || c == KATAKANA_SMALL_TSU || c == KANA_PROLONGED_SOUND_MARK;
+}
+
+// 上游 aaf75c9：折叠连续强调符（っっ/ーー），full_collapse 时全删。首尾强调符保留。
+// https://github.com/yomidevs/yomitan/blob/81d17d877fb18c62ba826210bf6db2b7f4d4deed/ext/js/language/ja/japanese.js#L776
+std::u32string collapse_emphatic_sequences(const std::u32string& text, bool full_collapse) {
+  ptrdiff_t left = 0;
+  while (left < static_cast<ptrdiff_t>(text.size()) && is_emphatic(text[left])) {
+    ++left;
+  }
+  ptrdiff_t right = static_cast<ptrdiff_t>(text.size()) - 1;
+  while (right >= 0 && is_emphatic(text[right])) {
+    --right;
+  }
+  if (left > right) {
+    return text;
+  }
+
+  std::u32string leading_emphatics = text.substr(0, left);
+  std::u32string trailing_emphatics = text.substr(right + 1);
+  std::u32string middle;
+  auto current_collapsed_code_point = static_cast<char32_t>(-1);
+
+  for (ptrdiff_t i = left; i <= right; ++i) {
+    char32_t c = text[i];
+    if (is_emphatic(c)) {
+      if (current_collapsed_code_point != c) {
+        current_collapsed_code_point = c;
+        if (!full_collapse) {
+          middle += c;
+          continue;
+        }
+      }
+    } else {
+      current_collapsed_code_point = static_cast<char32_t>(-1);
+      middle += c;
+    }
+  }
+
+  return leading_emphatics + middle + trailing_emphatics;
 }
 
 // Unicode 范围小写（码点驱动，无语言门控）。覆盖 18 张 Yomitan 变换表里高频、
@@ -280,9 +335,72 @@ std::u32string standardize_kanji(const std::u32string& text) {
   return result;
 }
 
+// 上游 9dc93b6：浊音迭代符（ゞ/ヾ）把前一假名 + 结合浊点经 NFC 合成浊音假名（こゞ→こご）。
+char32_t add_dakuten(char32_t kana) {
+  std::u32string pair = {kana, DAKUTEN};
+  std::string utf8 = utf8::utf32to8(pair);
+  utf8proc_uint8_t* out = utf8proc_NFC(reinterpret_cast<const utf8proc_uint8_t*>(utf8.c_str()));
+  if (!out) {
+    return kana;
+  }
+  std::u32string composed = utf8::utf8to32(std::string(reinterpret_cast<char*>(out)));
+  utf8proc_free(out);
+  return composed.size() == 1 ? composed.front() : kana;
+}
+
+char32_t expand_mark(char32_t prev, char32_t mark) {
+  switch (mark) {
+    case KANJI_ITERATION_MARK:
+    case HIRAGANA_ITERATION_MARK:
+    case KATAKANA_ITERATION_MARK:
+      return prev;
+    case HIRAGANA_VOICED_ITERATION_MARK:
+    case KATAKANA_VOICED_ITERATION_MARK:
+      return add_dakuten(prev);
+    default:
+      return 0;
+  }
+}
+
+// 上游 9dc93b6：迭代符展开（佐々木→佐佐木、こゝ→ここ）。
+std::u32string expand_iteration_marks(const std::u32string& text) {
+  std::u32string result;
+  for (size_t i = 0; i < text.size(); ++i) {
+    result += text[i];
+    if (i + 1 < text.size()) {
+      char32_t expanded = expand_mark(text[i], text[i + 1]);
+      if (expanded != 0) {
+        result += expanded;
+        ++i;
+      }
+    }
+  }
+  return result;
+}
+
+// 上游 ee0384b：全角数字 → 汉字数字（２→二）。ASCII 数字靠链中更早的
+// alphanumeric_to_fullwidth 先转全角，变体扇出组合后同样命中（2月→２月→二月）。
+constexpr std::u32string_view KANJI_NUMBERS = U"〇一二三四五六七八九";
+std::u32string numbers_to_kanji(const std::u32string& text) {
+  std::u32string result;
+  for (char32_t c : text) {
+    if (is_in_range(c, 0xff10, 0xff19)) {
+      result += KANJI_NUMBERS[c - 0xff10];
+    } else {
+      result += c;
+    }
+  }
+  return result;
+}
+
 // TODO: implement rest of preprocessors
 std::vector<TextProcessor> get_japanese_processors() {
   return {
+      // 上游 1cb9b4b：NFKC 提到链首——半角片假名（ﾒｶﾞﾈ）须先归一成全宽才能被
+      // 假名转换识别。仍满足「NFKC 在 english 的 to_lowercase 之前」（japanese 链先于
+      // english 链）：全角 Ａ 先折成半角 A，再被 to_lowercase 小写成 a。
+      {.options = {0, 1},
+       .process = [](const std::u32string& text, int opt) -> std::u32string { return opt == 1 ? nfkc(text) : text; }},
       // https://github.com/yomidevs/yomitan/blob/81d17d877fb18c62ba826210bf6db2b7f4d4deed/ext/js/language/ja/japanese-text-preprocessors.js#L66
       {.options = {0, 1, 2},
        .process =
@@ -296,18 +414,38 @@ std::vector<TextProcessor> get_japanese_processors() {
                  return text;
              }
            }},
-      // NFKC 在 english 的 to_lowercase 之前跑（japanese 链先于 english 链）：
-      // 全角 Ａ 先经 NFKC 折成半角 A，再被 to_lowercase 小写成 a。顺序关键。
-      {.options = {0, 1},
-       .process = [](const std::u32string& text, int opt) -> std::u32string { return opt == 1 ? nfkc(text) : text; }},
+      // 上游 aaf75c9：强调折叠在假名转换后、宽度处理前（对齐上游链序）。
+      {.options = {0, 1, 2},
+       .process =
+           [](const std::u32string& text, int opt) -> std::u32string {
+             switch (opt) {
+               case 1:
+                 return collapse_emphatic_sequences(text, false);
+               case 2:
+                 return collapse_emphatic_sequences(text, true);
+               default:
+                 return text;
+             }
+           }},
       {.options = {0, 1},
        .process =
            [](const std::u32string& text, int opt) -> std::u32string {
          return opt == 1 ? alphanumeric_to_fullwidth(text) : text;
        }},
-      // 上游 e7dfdea：异体字标准化处理器，追加到链尾（独立于 NFKC，顺序无关）。
-      {.options = {0, 1}, .process = [](const std::u32string& text, int opt) -> std::u32string {
+      // 上游 e7dfdea：异体字标准化处理器（独立于 NFKC，顺序无关）。
+      {.options = {0, 1},
+       .process =
+           [](const std::u32string& text, int opt) -> std::u32string {
          return opt == 1 ? standardize_kanji(text) : text;
+       }},
+      // 上游 9dc93b6 / ee0384b：迭代符展开与全角数字转汉字，按上游链序收尾。
+      {.options = {0, 1},
+       .process =
+           [](const std::u32string& text, int opt) -> std::u32string {
+         return opt == 1 ? expand_iteration_marks(text) : text;
+       }},
+      {.options = {0, 1}, .process = [](const std::u32string& text, int opt) -> std::u32string {
+         return opt == 1 ? numbers_to_kanji(text) : text;
        }}};
 }
 }

--- a/native/fushidicts/tests/CMakeLists.txt
+++ b/native/fushidicts/tests/CMakeLists.txt
@@ -77,6 +77,9 @@ add_fushi_test(lookup_freq_pitch_enrichment_test lookup_freq_pitch_enrichment_te
 add_fushi_test(hash_truncated_table_guard_test hash_truncated_table_guard_test.cpp)
 set_tests_properties(hash_truncated_table_guard_test PROPERTIES TIMEOUT 60)
 add_fushi_test(ipa_import_query_test ipa_import_query_test.cpp)
+# 上游同步批4：v2 格式阶梯（.fushidicts_2）——kanji stats 追加段读回、marker
+# 拒载语义、bloom 截断置空降级（d4183d4 size 校验）、zstd 训练字典往返。
+add_fushi_test(format_v2_upstream_sync_test format_v2_upstream_sync_test.cpp)
 # Simple dicts (MDX/StarDict/DSL) store rules="*" so filter_by_pos keeps them
 # for inflected-form lookups; pins pos_to_conditions("*")==~0 + the stored rule.
 add_fushi_test(simple_dict_deinflection_test simple_dict_deinflection_test.cpp)

--- a/native/fushidicts/tests/format_v2_upstream_sync_test.cpp
+++ b/native/fushidicts/tests/format_v2_upstream_sync_test.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "fushidicts/importer.hpp"
+#include "fushidicts/lookup.hpp"
 #include "fushidicts/query.hpp"
 
 namespace {
@@ -324,9 +325,130 @@ int main() {
         fail("E: pattern position killed the whole pitch record");
       } else {
         const PitchEntry& pe = terms.front().pitches.front();
-        expect_true("E.numeric position survives", pe.pitch_positions.size() == 1 &&
-                                                       pe.pitch_positions.front() == 2);
+        // 完整结构化（79c55c2 二期）：数字位与 pattern 位都要收下。
+        expect_true("E.accent count == 2", pe.pitches.size() == 2);
+        bool has_numeric = false, has_pattern = false;
+        for (const auto& accent : pe.pitches) {
+          if (accent.pattern.empty() && accent.position == 2) has_numeric = true;
+          if (accent.pattern == "heiban") has_pattern = true;
+        }
+        expect_true("E.numeric position survives", has_numeric);
+        expect_true("E.pattern accent survives", has_pattern);
       }
+    }
+  }
+
+  // ----- F: v2 term score 落盘 + 比较器降序（上游 909c854 后半） -----
+  {
+    const std::string kNeko = "\xE7\x8C\xAB";                     // 猫
+    const std::string kNekoReading = "\xE3\x81\xAD\xE3\x81\x93";  // ねこ
+    const std::string kNekoKata = "\xE3\x83\x8D\xE3\x82\xB3";     // ネコ
+    // 同一表记两个读音：ねこ 条目 score 1 且 reading==expression 之外的终极
+    // tiebreak 本会输给它（reading≠expr）；ネコ 条目 score 10。score 档在终极
+    // tiebreak 之前，必须让 score 高者（ネコ）排前——这正是「score 真的落盘
+    // 且真的参与排序」的判据（v1 时代两者 score 恒 0，ねこ 会赢）。
+    std::string term_bank = "[[\"" + kNeko + "\",\"" + kNekoReading + "\",\"\",\"\",1,[\"cat-hira\"],0,\"\"],"
+                            "[\"" + kNeko + "\",\"" + kNekoKata + "\",\"\",\"\",10,[\"cat-kata\"],0,\"\"]]";
+    std::vector<ZipFile> files = {
+        {"index.json", index_json("V2Score")},
+        {"term_bank_1.json", term_bank},
+    };
+    std::string zip_path = write_zip("score", files);
+    ImportResult r = dictionary_importer::import(zip_path, out_dir);
+    if (!r.success) {
+      fail("F: import failed");
+    } else {
+      DictionaryQuery q;
+      q.add_term_dict(out_dir + "/" + r.title);
+      Deinflector d;
+      Lookup lk(q, d);
+      auto results = lk.lookup(kNeko, 16, 16);
+      if (results.size() < 2) {
+        fail("F: lookup returned fewer than 2 results");
+      } else {
+        expect_eq_str("F.score-desc first", results[0].term.reading, kNekoKata);
+        expect_eq_str("F.score-desc second", results[1].term.reading, kNekoReading);
+      }
+
+      // 附带：primary_reading 覆盖一切（86c6e2f）——显式指定 ねこ 时它必须
+      // 反超 score 高的 ネコ。
+      LookupOptions primary;
+      primary.primary_reading = kNekoReading;
+      auto primary_results = lk.lookup(kNeko, 16, 16, primary);
+      if (primary_results.size() < 2) {
+        fail("F: primary_reading lookup returned fewer than 2 results");
+      } else {
+        expect_eq_str("F.primary_reading first", primary_results[0].term.reading, kNekoReading);
+      }
+    }
+  }
+
+  // ----- G: LookupOptions 显式 freq 词典升/降序（bc62d2b），截断前生效 -----
+  {
+    const std::string kNeko = "\xE7\x8C\xAB";                     // 猫
+    const std::string kNekoReading = "\xE3\x81\xAD\xE3\x81\x93";  // ねこ
+    const std::string kNekoKata = "\xE3\x83\x8D\xE3\x82\xB3";     // ネコ
+    const char* kTitle = "V2FreqOrder";
+    // 同一表记两个读音，freq 记录带 reading 定向：ねこ=100、ネコ=9000。查 猫
+    // 两个结果前置档全平（matched/steps/trace/expr==deinflected/score 均同），
+    // 序完全由 freq 档决定：Auto（升序）→ ねこ 前；显式 Descending → ネコ 前；
+    // Disabled → freq 档整个跳过（不崩溃、结果齐全即可）。
+    std::string term_bank = "[[\"" + kNeko + "\",\"" + kNekoReading + "\",\"\",\"\",0,[\"g-hira\"],0,\"\"],"
+                            "[\"" + kNeko + "\",\"" + kNekoKata + "\",\"\",\"\",0,[\"g-kata\"],0,\"\"]]";
+    std::string meta_bank = "[[\"" + kNeko + "\",\"freq\",{\"reading\":\"" + kNekoReading + "\",\"value\":100}],"
+                            "[\"" + kNeko + "\",\"freq\",{\"reading\":\"" + kNekoKata + "\",\"value\":9000}]]";
+    std::vector<ZipFile> files = {
+        {"index.json", index_json(kTitle)},
+        {"term_bank_1.json", term_bank},
+        {"term_meta_bank_1.json", meta_bank},
+    };
+    std::string zip_path = write_zip("freqorder", files);
+    ImportResult r = dictionary_importer::import(zip_path, out_dir);
+    if (!r.success) {
+      fail("G: import failed");
+    } else {
+      const std::string dict_path = out_dir + "/" + r.title;
+      DictionaryQuery q;
+      q.add_term_dict(dict_path);
+      q.add_freq_dict(dict_path);
+      Deinflector d;
+      Lookup lk(q, d);
+
+      auto auto_results = lk.lookup(kNeko, 16, 16);
+      if (auto_results.size() < 2) {
+        fail("G: auto lookup returned fewer than 2 results");
+      } else {
+        expect_eq_str("G.auto ascending first", auto_results[0].term.reading, kNekoReading);
+      }
+
+      LookupOptions desc;
+      desc.frequency_dictionary = r.title;
+      desc.frequency_order = LookupFrequencyOrder::Descending;
+      auto desc_results = lk.lookup(kNeko, 16, 16, desc);
+      if (desc_results.size() < 2) {
+        fail("G: descending lookup returned fewer than 2 results");
+      } else {
+        expect_eq_str("G.explicit descending first", desc_results[0].term.reading, kNekoKata);
+      }
+
+      LookupOptions asc;
+      asc.frequency_dictionary = r.title;
+      asc.frequency_order = LookupFrequencyOrder::Ascending;
+      auto asc_results = lk.lookup(kNeko, 16, 16, asc);
+      if (asc_results.size() < 2) {
+        fail("G: ascending lookup returned fewer than 2 results");
+      } else {
+        expect_eq_str("G.explicit ascending first", asc_results[0].term.reading, kNekoReading);
+      }
+
+      // 不存在的词典名：静默退回（有结果、不崩溃）；Disabled：跳过 freq 档。
+      LookupOptions unknown;
+      unknown.frequency_dictionary = "NoSuchDict";
+      unknown.frequency_order = LookupFrequencyOrder::Descending;
+      expect_true("G.unknown freq dict falls back silently", lk.lookup(kNeko, 16, 16, unknown).size() == 2);
+      LookupOptions disabled;
+      disabled.frequency_order = LookupFrequencyOrder::Disabled;
+      expect_true("G.disabled order still returns results", lk.lookup(kNeko, 16, 16, disabled).size() == 2);
     }
   }
 

--- a/native/fushidicts/tests/format_v2_upstream_sync_test.cpp
+++ b/native/fushidicts/tests/format_v2_upstream_sync_test.cpp
@@ -1,0 +1,339 @@
+// 上游同步批4 v2 格式守卫（.fushidicts_2 版本阶梯首次引入）：
+//   A) 新导入落 v2 marker（且不再写 v1 marker）；kanji 记录带 stats 追加段，
+//      query_kanji 读回 radical/strokes 之外的完整 stats（JLPT/grade/freq），
+//      且已提取进专用字段的 radical/strokes 键不重复出现在 stats 里。
+//   B) marker 缺失 -> 词典不加载（版本 0 拒载，导入未完成语义不变）。
+//   C) bloom.filter 截断 -> 置空降级（contains 恒真穿透），词典仍可查
+//      （上游 d4183d4 的 size 校验 + fork 的不拒载哲学）。
+//   D) term glossary 经 zstd（可能带训练字典 dict.zstd，样本不足时退普通压缩）
+//      往返一致；重开 DictionaryQuery 再验一遍（DDict 加载路径）。
+//
+// Usage: format_v2_upstream_sync_test   (no args) -> exit 0 PASS, non-zero FAIL.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "fushidicts/importer.hpp"
+#include "fushidicts/query.hpp"
+
+namespace {
+
+int g_fail = 0;
+
+void put16(std::vector<uint8_t>& b, uint16_t v) {
+  b.push_back(static_cast<uint8_t>(v & 0xff));
+  b.push_back(static_cast<uint8_t>((v >> 8) & 0xff));
+}
+void put32(std::vector<uint8_t>& b, uint32_t v) {
+  for (int i = 0; i < 4; i++) b.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xff));
+}
+
+struct ZipFile {
+  std::string name;
+  std::string data;
+};
+
+// Minimal multi-entry STORED zip (method 0, no compression, no zip64) — same
+// hand-rolled builder as kanji_import_query_test.cpp.
+std::vector<uint8_t> build_zip(const std::vector<ZipFile>& files) {
+  std::vector<uint8_t> z;
+  std::vector<uint32_t> lfh_offsets;
+
+  for (const auto& f : files) {
+    lfh_offsets.push_back(static_cast<uint32_t>(z.size()));
+    put32(z, 0x04034b50);
+    put16(z, 20);
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put32(z, 0);
+    put32(z, static_cast<uint32_t>(f.data.size()));
+    put32(z, static_cast<uint32_t>(f.data.size()));
+    put16(z, static_cast<uint16_t>(f.name.size()));
+    put16(z, 0);
+    for (char c : f.name) z.push_back(static_cast<uint8_t>(c));
+    for (char c : f.data) z.push_back(static_cast<uint8_t>(c));
+  }
+
+  const size_t cd_off = z.size();
+  for (size_t i = 0; i < files.size(); i++) {
+    const auto& f = files[i];
+    put32(z, 0x02014b50);
+    put16(z, 20);
+    put16(z, 20);
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put32(z, 0);
+    put32(z, static_cast<uint32_t>(f.data.size()));
+    put32(z, static_cast<uint32_t>(f.data.size()));
+    put16(z, static_cast<uint16_t>(f.name.size()));
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put16(z, 0);
+    put32(z, 0);
+    put32(z, lfh_offsets[i]);
+    for (char c : f.name) z.push_back(static_cast<uint8_t>(c));
+  }
+  const size_t cd_size = z.size() - cd_off;
+
+  put32(z, 0x06054b50);
+  put16(z, 0);
+  put16(z, 0);
+  put16(z, static_cast<uint16_t>(files.size()));
+  put16(z, static_cast<uint16_t>(files.size()));
+  put32(z, static_cast<uint32_t>(cd_size));
+  put32(z, static_cast<uint32_t>(cd_off));
+  put16(z, 0);
+  return z;
+}
+
+std::string tmp_dir() {
+  const char* tmp = std::getenv("TEMP");
+  if (!tmp) tmp = std::getenv("TMPDIR");
+  return std::string(tmp ? tmp : ".");
+}
+
+std::string write_zip(const char* label, const std::vector<ZipFile>& files) {
+  std::string path = tmp_dir() + "/fushi_v2fmt_" + label + ".zip";
+  std::vector<uint8_t> bytes = build_zip(files);
+  FILE* fp = std::fopen(path.c_str(), "wb");
+  if (!fp) return {};
+  std::fwrite(bytes.data(), 1, bytes.size(), fp);
+  std::fclose(fp);
+  return path;
+}
+
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_fail;
+}
+
+void expect_eq_str(const char* what, const std::string& got, const std::string& want) {
+  if (got != want) {
+    std::fprintf(stderr, "FAIL %s: got '%s' want '%s'\n", what, got.c_str(), want.c_str());
+    ++g_fail;
+  }
+}
+
+void expect_true(const char* what, bool cond) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL %s\n", what);
+    ++g_fail;
+  }
+}
+
+const std::string kHi = "\xE6\x97\xA5";  // 日
+
+std::string index_json(const char* title) {
+  return std::string("{\"title\":\"") + title + "\",\"format\":3,\"revision\":\"test\"}";
+}
+
+// stats 混合字符串/数字值：radical+strokes 走专用字段，其余进 stats 追加段。
+std::string kanji_bank_stats() {
+  return "[[\"\xE6\x97\xA5\",\"nichi jitsu\",\"hi\",\"jouyou\","
+         "[\"day\",\"sun\"],"
+         "{\"radical\":\"\xE6\x97\xA5\",\"strokes\":\"4\",\"jlpt\":\"4\",\"grade\":8,\"freq\":\"1\"}]]";
+}
+
+// D 用：足量条目 + 共享短语，给 ZDICT 采样一个现实的训练面（训练是否成功
+// 不作硬断言——样本不足退普通压缩同样是合法路径，往返一致才是契约）。
+std::string big_term_bank(int n) {
+  std::string bank = "[";
+  for (int i = 0; i < n; i++) {
+    if (i) bank.push_back(',');
+    std::string word = "word" + std::to_string(i);
+    bank += "[\"" + word + "\",\"" + word + "\",\"\",\"\",0,[\"the shared common phrase describing entry number " +
+            std::to_string(i) + " with plenty of overlapping vocabulary for dictionary training\"],0,\"\"]";
+  }
+  bank.push_back(']');
+  return bank;
+}
+
+std::string lookup_glossary(const DictionaryQuery& q, const std::string& word) {
+  std::vector<TermResult> terms = q.query(word);
+  if (terms.empty() || terms.front().glossaries.empty()) {
+    return {};
+  }
+  return terms.front().glossaries.front().glossary;
+}
+
+}  // namespace
+
+int main() {
+  namespace fs = std::filesystem;
+  const std::string out_dir = tmp_dir() + "/fushi_v2fmt_out";
+  std::error_code ec;
+  fs::remove_all(out_dir, ec);
+
+  // ----- A: v2 marker + kanji stats 追加段 -----
+  std::string kanji_dict_path;
+  {
+    std::vector<ZipFile> files = {
+        {"index.json", index_json("V2KanjiStats")},
+        {"kanji_bank_1.json", kanji_bank_stats()},
+    };
+    std::string zip_path = write_zip("kanji", files);
+    ImportResult r = dictionary_importer::import(zip_path, out_dir);
+    if (!r.success) {
+      std::fprintf(stderr, "FAIL A: import failed: %s\n",
+                   r.errors.empty() ? "(no error)" : r.errors.front().c_str());
+      ++g_fail;
+    } else {
+      kanji_dict_path = out_dir + "/" + r.title;
+      expect_true("A.marker v2 exists", fs::is_regular_file(kanji_dict_path + "/.fushidicts_2"));
+      expect_true("A.marker v1 absent", !fs::exists(kanji_dict_path + "/.fushidicts_1"));
+
+      DictionaryQuery q;
+      q.add_kanji_dict(kanji_dict_path);
+      std::vector<KanjiResult> res = q.query_kanji(kHi);
+      if (res.empty()) {
+        fail("A: query_kanji(日) returned nothing");
+      } else {
+        const KanjiResult& k = res.front();
+        expect_eq_str("A.radical", k.radical, kHi);
+        expect_true("A.strokes", k.strokes == 4);
+        // stats：radical/strokes 之外全保留（std::map 键序：freq, grade, jlpt）。
+        expect_true("A.stats count == 3", k.stats.size() == 3);
+        bool has_jlpt = false, has_grade = false, has_freq = false, leaked = false;
+        for (const auto& [key, value] : k.stats) {
+          if (key == "jlpt") has_jlpt = (value == "4");
+          if (key == "grade") has_grade = (value == "8");  // 数字 token 原样保留
+          if (key == "freq") has_freq = (value == "1");
+          if (key == "radical" || key == "strokes") leaked = true;
+        }
+        expect_true("A.stats jlpt=4", has_jlpt);
+        expect_true("A.stats grade=8", has_grade);
+        expect_true("A.stats freq=1", has_freq);
+        expect_true("A.stats no radical/strokes leak", !leaked);
+      }
+    }
+  }
+
+  // ----- B: marker 缺失 -> 拒载 -----
+  if (!kanji_dict_path.empty()) {
+    const std::string marker = kanji_dict_path + "/.fushidicts_2";
+    const std::string hidden = kanji_dict_path + "/.fushidicts_2.bak";
+    fs::rename(marker, hidden, ec);
+    if (ec) {
+      fail("B: could not rename marker");
+    } else {
+      DictionaryQuery q;
+      q.add_kanji_dict(kanji_dict_path);
+      expect_true("B.no marker -> not loaded", q.query_kanji(kHi).empty());
+      fs::rename(hidden, marker, ec);
+    }
+  }
+
+  // ----- C: bloom.filter 截断 -> 置空降级仍可查 -----
+  if (!kanji_dict_path.empty()) {
+    const std::string bloom_path = kanji_dict_path + "/bloom.filter";
+    std::vector<char> original;
+    {
+      std::ifstream in(bloom_path, std::ios::binary);
+      original.assign(std::istreambuf_iterator<char>(in), {});
+    }
+    if (original.size() < 24) {
+      fail("C: bloom.filter unexpectedly small");
+    } else {
+      {
+        // 保留头部（num_bits 仍是合法 pow2）但砍掉一半位数组——旧校验放行、
+        // 读位图越界；新 size 校验必须置空降级。
+        std::ofstream out(bloom_path, std::ios::binary | std::ios::trunc);
+        out.write(original.data(), static_cast<std::streamsize>(original.size() / 2));
+      }
+      DictionaryQuery q;
+      q.add_kanji_dict(kanji_dict_path);
+      expect_true("C.truncated bloom -> query still works", !q.query_kanji(kHi).empty());
+      {
+        std::ofstream out(bloom_path, std::ios::binary | std::ios::trunc);
+        out.write(original.data(), static_cast<std::streamsize>(original.size()));
+      }
+    }
+  }
+
+  // ----- D: term glossary（可能训练 dict.zstd）往返一致 -----
+  {
+    std::vector<ZipFile> files = {
+        {"index.json", index_json("V2ZstdTerms")},
+        {"term_bank_1.json", big_term_bank(64)},
+    };
+    std::string zip_path = write_zip("terms", files);
+    ImportResult r = dictionary_importer::import(zip_path, out_dir);
+    if (!r.success) {
+      std::fprintf(stderr, "FAIL D: import failed: %s\n",
+                   r.errors.empty() ? "(no error)" : r.errors.front().c_str());
+      ++g_fail;
+    } else {
+      const std::string dict_path = out_dir + "/" + r.title;
+      expect_true("D.marker v2 exists", fs::is_regular_file(dict_path + "/.fushidicts_2"));
+      const bool trained = fs::is_regular_file(dict_path + "/dict.zstd");
+      std::fprintf(stderr, "INFO D: dict.zstd %s\n", trained ? "trained" : "not trained (fallback)");
+
+      const std::string want0 =
+          "[\"the shared common phrase describing entry number 0 with plenty of overlapping vocabulary for "
+          "dictionary training\"]";
+      {
+        DictionaryQuery q;
+        q.add_term_dict(dict_path);
+        expect_eq_str("D.glossary word0", lookup_glossary(q, "word0"), want0);
+        expect_true("D.glossary word63 non-empty", !lookup_glossary(q, "word63").empty());
+      }
+      // 重开一遍：DDict 从 dict.zstd 冷加载的路径（训练成功时）与普通路径等价。
+      {
+        DictionaryQuery q;
+        q.add_term_dict(dict_path);
+        expect_eq_str("D.reopen glossary word0", lookup_glossary(q, "word0"), want0);
+      }
+    }
+  }
+
+  // ----- E: pitch parser 先行（上游 79c55c2 部分）——pattern 字符串位不再让
+  // 整条 meta 记录解析失败，同记录里的数字位照常读出 -----
+  {
+    const std::string kNeko = "\xE7\x8C\xAB";              // 猫
+    const std::string kNekoReading = "\xE3\x81\xAD\xE3\x81\x93";  // ねこ
+    std::string meta_bank = "[[\"" + kNeko + "\",\"pitch\",{\"reading\":\"" + kNekoReading +
+                            "\",\"pitches\":[{\"position\":\"heiban\"},{\"position\":2}]}]]";
+    // pitch enrich 要求 reading 匹配，term bank 必须带 ねこ 这个 reading。
+    std::string term_bank =
+        "[[\"" + kNeko + "\",\"" + kNekoReading + "\",\"\",\"\",0,[\"cat\"],0,\"\"]]";
+    std::vector<ZipFile> files = {
+        {"index.json", index_json("V2PitchPattern")},
+        {"term_bank_1.json", term_bank},
+        {"term_meta_bank_1.json", meta_bank},
+    };
+    std::string zip_path = write_zip("pitch", files);
+    ImportResult r = dictionary_importer::import(zip_path, out_dir);
+    if (!r.success) {
+      fail("E: import failed");
+    } else {
+      const std::string dict_path = out_dir + "/" + r.title;
+      DictionaryQuery q;
+      q.add_term_dict(dict_path);
+      q.add_pitch_dict(dict_path);
+      std::vector<TermResult> terms = q.query(kNeko);
+      if (terms.empty() || terms.front().pitches.empty()) {
+        fail("E: pattern position killed the whole pitch record");
+      } else {
+        const PitchEntry& pe = terms.front().pitches.front();
+        expect_true("E.numeric position survives", pe.pitch_positions.size() == 1 &&
+                                                       pe.pitch_positions.front() == 2);
+      }
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "%d FAIL\n", g_fail);
+    return 1;
+  }
+  std::printf("PASS\n");
+  return 0;
+}

--- a/native/fushidicts/tests/freq_pitch_import_query_test.cpp
+++ b/native/fushidicts/tests/freq_pitch_import_query_test.cpp
@@ -133,13 +133,13 @@ int main() {
                          pe.dict_name.c_str(), kTitle);
             ++g_fail;
           }
-          if (pe.pitch_positions.size() != 2) {
+          if (pe.pitches.size() != 2) {
             std::fprintf(stderr, "FAIL pitch positions count: got %zu want 2\n",
-                         pe.pitch_positions.size());
+                         pe.pitches.size());
             ++g_fail;
           } else {
-            expect_eq_int("pitch.pos0", pe.pitch_positions[0], 0);
-            expect_eq_int("pitch.pos1", pe.pitch_positions[1], 2);
+            expect_eq_int("pitch.pos0", pe.pitches[0].position, 0);
+            expect_eq_int("pitch.pos1", pe.pitches[1].position, 2);
           }
         }
       }

--- a/native/fushidicts/tests/freq_pitch_merge_query_test.cpp
+++ b/native/fushidicts/tests/freq_pitch_merge_query_test.cpp
@@ -7,7 +7,7 @@
 //
 //   1. Same dict, same expression, MULTIPLE freq records collapse into ONE
 //      FrequencyEntry holding ALL values (append, never overwrite). Same for
-//      multiple pitch records flattening into one PitchEntry.pitch_positions.
+//      multiple pitch records flattening into one PitchEntry.pitches.
 //   2. Two SEPARATE freq dicts (and two separate pitch dicts) that both carry
 //      the same expression surface as TWO entries on the TermResult, each
 //      carrying its own dict_name, values never crossing dictionaries. This is
@@ -87,8 +87,9 @@ bool contains_int(const std::vector<Frequency>& freqs, int want) {
                      [want](const Frequency& f) { return f.value == want; });
 }
 
-bool contains_pos(const std::vector<int>& positions, int want) {
-  return std::find(positions.begin(), positions.end(), want) != positions.end();
+bool contains_pos(const std::vector<Pitch>& pitches, int want) {
+  return std::any_of(pitches.begin(), pitches.end(),
+                     [want](const Pitch& p) { return p.pattern.empty() && p.position == want; });
 }
 
 // Import one fixture dir; returns its on-disk dict dir (out_root/<title>) or "".
@@ -114,7 +115,7 @@ std::string import_dict(const std::string& out_root, const char* title,
 // Case 1: same dict, same expression, multiple freq + multiple pitch records.
 //   freq:  5000 and 8000 -> one FrequencyEntry, two Frequency values.
 //   pitch: two separate pitch records (positions 0 and 2) -> one PitchEntry,
-//          flattened pitch_positions [0, 2].
+//          flattened pitch accents [0, 2].
 // ---------------------------------------------------------------------------
 void case_multi_records_same_dict() {
   const std::string out_dir =
@@ -173,10 +174,10 @@ void case_multi_records_same_dict() {
     const PitchEntry& pe = t.pitches.front();
     expect_eq_str("case1 pitch dict_name", pe.dict_name, kTitle);
     expect_eq_int("case1 pitch position count",
-                  static_cast<int>(pe.pitch_positions.size()), 2);
-    if (!contains_pos(pe.pitch_positions, 0))
+                  static_cast<int>(pe.pitches.size()), 2);
+    if (!contains_pos(pe.pitches, 0))
       fail("case1 pitch missing position 0");
-    if (!contains_pos(pe.pitch_positions, 2))
+    if (!contains_pos(pe.pitches, 2))
       fail("case1 pitch missing position 2");
   }
 }
@@ -262,15 +263,15 @@ void case_merge_across_dicts() {
   for (const PitchEntry& pe : t.pitches) {
     if (pe.dict_name == kTitleA) {
       sawA_pitch = true;
-      if (!contains_pos(pe.pitch_positions, 1))
+      if (!contains_pos(pe.pitches, 1))
         fail("case2 FreqPitchA pitch position not 1");
-      if (contains_pos(pe.pitch_positions, 3))
+      if (contains_pos(pe.pitches, 3))
         fail("case2 FreqPitchA leaked B's pitch position 3");
     } else if (pe.dict_name == kTitleB) {
       sawB_pitch = true;
-      if (!contains_pos(pe.pitch_positions, 3))
+      if (!contains_pos(pe.pitches, 3))
         fail("case2 FreqPitchB pitch position not 3");
-      if (contains_pos(pe.pitch_positions, 1))
+      if (contains_pos(pe.pitches, 1))
         fail("case2 FreqPitchB leaked A's pitch position 1");
     }
   }
@@ -355,9 +356,9 @@ void case_path_isolation_and_reading_filter() {
         fail("case3b no pitches though pitch dict registered");
       } else {
         const PitchEntry& pe = t.pitches.front();
-        if (!contains_pos(pe.pitch_positions, 0))
+        if (!contains_pos(pe.pitches, 0))
           fail("case3b kept pitch position 0 missing");
-        if (contains_pos(pe.pitch_positions, 5))
+        if (contains_pos(pe.pitches, 5))
           fail("case3b mismatched-reading pitch position 5 not dropped");
       }
     }

--- a/native/fushidicts/tests/ipa_import_query_test.cpp
+++ b/native/fushidicts/tests/ipa_import_query_test.cpp
@@ -8,7 +8,7 @@
 // storage layout (type byte 1, mode "ipa"), but the data JSON is shaped
 // differently ({"reading":...,"transcriptions":[{"ipa":...}]}). query_pitch
 // must branch on mode and route ipa data through parse_ipa, accumulating into
-// PitchEntry.transcriptions instead of pitch_positions. Nothing exercised this
+// PitchEntry.transcriptions instead of pitch accents. Nothing exercised this
 // import->query IPA path end to end before; the Dart-side tests are source
 // scans / parity checks that never link the native engine.
 //
@@ -131,11 +131,11 @@ int main() {
                          pe.dict_name.c_str(), kTitle);
             ++g_fail;
           }
-          if (!pe.pitch_positions.empty()) {
+          if (!pe.pitches.empty()) {
             std::fprintf(stderr,
-                         "FAIL ipa pitch_positions: got %zu want 0 (ipa carries "
-                         "no positions)\n",
-                         pe.pitch_positions.size());
+                         "FAIL ipa pitches: got %zu want 0 (ipa carries "
+                         "no pitch accents)\n",
+                         pe.pitches.size());
             ++g_fail;
           }
           if (pe.transcriptions.size() != 2) {

--- a/native/fushidicts/tests/lookup_freq_pitch_enrichment_test.cpp
+++ b/native/fushidicts/tests/lookup_freq_pitch_enrichment_test.cpp
@@ -93,8 +93,8 @@ std::string term_meta_bank_neko() {
 // UTF-8 byte order of the reading: ね(E3 81 AD) < び(E3 81 B3) < み(E3 81 BF),
 // i.e. ねこ, びょう, みょう. The correct frequency ranking is the opposite-ish
 // permutation びょう(100), みょう(5000), ねこ(90000). If enrichment ever moves
-// after the sort, every term's frequency list is empty, get_freq_values_for_dict
-// returns {INT_MAX} for all of them, the comparator ties on everything, and the
+// after the sort, every term's frequency list is empty, get_freq_value_for_dict
+// returns INT_MAX for all of them, the comparator ties on everything, and the
 // unsorted map order survives — which these assertions reject.
 const std::string kByouReading = "\xE3\x81\xB3\xE3\x82\x87\xE3\x81\x86";  // びょう
 const std::string kMyouReading = "\xE3\x81\xBF\xE3\x82\x87\xE3\x81\x86";  // みょう

--- a/native/fushidicts/tests/lookup_freq_pitch_enrichment_test.cpp
+++ b/native/fushidicts/tests/lookup_freq_pitch_enrichment_test.cpp
@@ -159,13 +159,13 @@ void expect_freq_value(const char* what, const LookupResult& r, int want) {
 }
 
 void expect_pitch_position(const char* what, const LookupResult& r, int want) {
-  if (r.term.pitches.empty() || r.term.pitches.front().pitch_positions.empty()) {
+  if (r.term.pitches.empty() || r.term.pitches.front().pitches.empty()) {
     std::fprintf(stderr, "FAIL %s: term %s/%s has no pitch\n", what, r.term.expression.c_str(),
                  r.term.reading.c_str());
     ++g_fail;
     return;
   }
-  expect_eq_int(what, r.term.pitches.front().pitch_positions.front(), want);
+  expect_eq_int(what, r.term.pitches.front().pitches.front().position, want);
 }
 
 // Frequency must be enriched BEFORE the partial_sort, otherwise the comparator
@@ -265,12 +265,12 @@ void check_enriched(const char* label, const LookupResult* r) {
     ++g_fail;
   } else {
     const PitchEntry& pe = r->term.pitches.front();
-    if (pe.pitch_positions.size() != 2) {
-      std::fprintf(stderr, "FAIL %s pitch count: got %zu want 2\n", label, pe.pitch_positions.size());
+    if (pe.pitches.size() != 2) {
+      std::fprintf(stderr, "FAIL %s pitch count: got %zu want 2\n", label, pe.pitches.size());
       ++g_fail;
     } else {
-      expect_eq_int(label, pe.pitch_positions[0], 0);
-      expect_eq_int(label, pe.pitch_positions[1], 2);
+      expect_eq_int(label, pe.pitches[0].position, 0);
+      expect_eq_int(label, pe.pitches[1].position, 2);
     }
   }
 

--- a/native/fushidicts/tests/text_processor_test.cpp
+++ b/native/fushidicts/tests/text_processor_test.cpp
@@ -67,6 +67,32 @@ int main() {
   // 體(U+9AD4 itaiji) -> 体(U+4F53 oyaji)。
   expect("kanji-tai-itaiji", "\xE9\xAB\x94", "\xE4\xBD\x93");
 
+  // 上游 9dc93b6 迭代符展开：佐々木 -> 佐佐木（々 U+3005 复读前一码点）。
+  expect("iter-kanji", "\xE4\xBD\x90\xE3\x80\x85\xE6\x9C\xA8", "\xE4\xBD\x90\xE4\xBD\x90\xE6\x9C\xA8");
+  // こゝ(U+309D) -> ここ；こゞ(U+309E 浊音版) -> こご（NFC 合成浊点）。
+  expect("iter-hira", "\xE3\x81\x93\xE3\x82\x9D", "\xE3\x81\x93\xE3\x81\x93");
+  expect("iter-hira-dakuten", "\xE3\x81\x93\xE3\x82\x9E", "\xE3\x81\x93\xE3\x81\x94");
+
+  // 上游 ee0384b 全角数字 -> 汉字：２(U+FF12) -> 二。
+  expect("num-fullwidth", "\xEF\xBC\x92", "\xE4\xBA\x8C");
+  // 链组合：ASCII 2 先经 alphanumeric_to_fullwidth 变 ２ 再变 二（2月 -> 二月）。
+  expect("num-ascii-chain", "2\xE6\x9C\x88", "\xE4\xBA\x8C\xE6\x9C\x88");
+
+  // 上游 aaf75c9 强调折叠：すっっごい -> すっごい(opt1 折单) / すごい(opt2 全删)。
+  expect("emphatic-collapse-1", "\xE3\x81\x99\xE3\x81\xA3\xE3\x81\xA3\xE3\x81\x94\xE3\x81\x84",
+         "\xE3\x81\x99\xE3\x81\xA3\xE3\x81\x94\xE3\x81\x84");
+  expect("emphatic-collapse-2", "\xE3\x81\x99\xE3\x81\xA3\xE3\x81\xA3\xE3\x81\x94\xE3\x81\x84",
+         "\xE3\x81\x99\xE3\x81\x94\xE3\x81\x84");
+  // 长音符同理：ラーーメン -> ラーメン。
+  expect("emphatic-prolonged", "\xE3\x83\xA9\xE3\x83\xBC\xE3\x83\xBC\xE3\x83\xA1\xE3\x83\xB3",
+         "\xE3\x83\xA9\xE3\x83\xBC\xE3\x83\xA1\xE3\x83\xB3");
+
+  // 上游 1cb9b4b 链序修复：NFKC 必须在假名转换之前——半角片假名 ﾒｶﾞﾈ 先归一成
+  // メガネ 才能被 katakana_to_hiragana 转成 めがね。旧链序（NFKC 在假名转换后）
+  // 永远产不出这个变体。
+  expect("halfwidth-kana-chain", "\xEF\xBE\x92\xEF\xBD\xB6\xEF\xBE\x9E\xEF\xBE\x88",
+         "\xE3\x82\x81\xE3\x81\x8C\xE3\x81\xAD");
+
   if (g_fail) {
     std::fprintf(stderr, "%d FAIL\n", g_fail);
     return 1;

--- a/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
+++ b/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
@@ -40,16 +40,25 @@ class FushiPitchEntry {
   const FushiPitchEntry({
     required this.dictName,
     required this.pitchPositions,
+    this.patterns = const <String>[],
     this.transcriptions = const <String>[],
   });
   final String dictName;
   final List<int> pitchPositions;
+
+  /// Pattern-style accents（Yomitan pitch 规格里 position 为字符串，如
+  /// "heiban"）。数字位仍走 [pitchPositions]，两者分流（79c55c2 二期）。
+  final List<String> patterns;
 
   /// IPA transcriptions for this dict's entry (Yomitan `ipa` meta mode). Empty
   /// for plain pitch-accent dicts. Carried alongside pitchPositions because both
   /// share the native PITCH bucket / query path (TODO-687 block3).
   final List<String> transcriptions;
 }
+
+/// lookup 排序模式（上游 bc62d2b）。enum index 即 FFI 的 freq_order 编码：
+/// auto=0（既有比较器，零行为变化）/ ascending=1 / descending=2 / disabled=3。
+enum FushiLookupFrequencyOrder { auto, ascending, descending, disabled }
 
 class FushiTermResult {
   const FushiTermResult({
@@ -246,9 +255,16 @@ FushiTermResult _convertTerm(FfiTermResult ffi) {
           transcriptions.add(_utf8OrEmpty(p.transcriptions[j]));
         }
       }
+      final patterns = <String>[];
+      if (p.patternCount > 0 && p.patterns != nullptr) {
+        for (int j = 0; j < p.patternCount; j++) {
+          patterns.add(_utf8OrEmpty(p.patterns[j]));
+        }
+      }
       pitches.add(FushiPitchEntry(
         dictName: _utf8OrEmpty(p.dictName),
         pitchPositions: positions,
+        patterns: patterns,
         transcriptions: transcriptions,
       ));
     }
@@ -572,14 +588,30 @@ class FushiDicts {
   static const int defaultScanLength = 16;
 
   // ── lookup (with deinflection) ──────────────────────────────────
+  //
+  // 排序选项（上游 bc62d2b/86c6e2f）：默认参数下走老导出、行为零变化。
+  // [frequencyDictionary]+[frequencyOrder] 指定按某 freq 词典升/降序（在
+  // max_results 截断之前生效）；[primaryReading] 让 reading 精确匹配者排最前
+  //（Yomitan 内链语义）。当前无设置 UI 消费方，管道先行。
   List<FushiLookupResult> lookup(
     String text, {
     int maxResults = defaultMaxResults,
     int scanLength = defaultScanLength,
+    String? frequencyDictionary,
+    FushiLookupFrequencyOrder frequencyOrder = FushiLookupFrequencyOrder.auto,
+    String? primaryReading,
   }) {
+    final bool useOptions = frequencyDictionary != null ||
+        frequencyOrder != FushiLookupFrequencyOrder.auto ||
+        primaryReading != null;
     final tp = text.toNativeUtf8(allocator: calloc);
+    final fd = (frequencyDictionary ?? '').toNativeUtf8(allocator: calloc);
+    final pr = (primaryReading ?? '').toNativeUtf8(allocator: calloc);
     try {
-      final r = _bindings!.lookup(_handle!, tp, maxResults, scanLength);
+      final r = useOptions
+          ? _bindings!.lookupWithOptions(_handle!, tp, maxResults, scanLength,
+              fd, frequencyOrder.index, pr)
+          : _bindings!.lookup(_handle!, tp, maxResults, scanLength);
 
       final rPtr = calloc<FfiLookupResults>();
       rPtr.ref = r;
@@ -609,6 +641,8 @@ class FushiDicts {
       }
     } finally {
       calloc.free(tp);
+      calloc.free(fd);
+      calloc.free(pr);
     }
   }
 

--- a/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
+++ b/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
@@ -128,6 +128,7 @@ class FushiKanjiResult {
     required this.radical,
     required this.strokes,
     required this.meanings,
+    this.stats = const <String, String>{},
     required this.dictName,
   });
 
@@ -143,6 +144,11 @@ class FushiKanjiResult {
       radical: map['radical'] as String? ?? '',
       strokes: (map['strokes'] as num?)?.toInt() ?? 0,
       meanings: List<String>.from(map['meanings'] as List? ?? const <String>[]),
+      stats: (map['stats'] as Map?)?.map(
+            (Object? k, Object? v) =>
+                MapEntry(k.toString(), v?.toString() ?? ''),
+          ) ??
+          const <String, String>{},
       dictName: map['dictName'] as String? ?? '',
     );
   }
@@ -153,6 +159,10 @@ class FushiKanjiResult {
   final String radical;
   final int strokes;
   final List<String> meanings;
+
+  /// v2 词典的完整 stats 键值对（JLPT/grade 等，radical/strokes 之外）；
+  /// v1 存量词典恒为空 map。
+  final Map<String, String> stats;
   final String dictName;
 
   Map<String, dynamic> toMap() => <String, dynamic>{
@@ -162,6 +172,7 @@ class FushiKanjiResult {
         'radical': radical,
         'strokes': strokes,
         'meanings': meanings,
+        'stats': stats,
         'dictName': dictName,
       };
 }
@@ -260,6 +271,16 @@ FushiKanjiResult _convertKanji(FfiKanjiResult ffi) {
       meanings.add(_utf8OrEmpty(ffi.meanings[i]));
     }
   }
+  final stats = <String, String>{};
+  if (ffi.statCount > 0 &&
+      ffi.statKeys != nullptr &&
+      ffi.statValues != nullptr) {
+    for (int i = 0; i < ffi.statCount; i++) {
+      final String key = _utf8OrEmpty(ffi.statKeys[i]);
+      if (key.isEmpty) continue;
+      stats[key] = _utf8OrEmpty(ffi.statValues[i]);
+    }
+  }
   return FushiKanjiResult(
     character: _utf8OrEmpty(ffi.character),
     onyomi: _utf8OrEmpty(ffi.onyomi),
@@ -267,6 +288,7 @@ FushiKanjiResult _convertKanji(FfiKanjiResult ffi) {
     radical: _utf8OrEmpty(ffi.radical),
     strokes: ffi.strokes,
     meanings: meanings,
+    stats: stats,
     dictName: _utf8OrEmpty(ffi.dictName),
   );
 }

--- a/packages/fushi_dictionary/lib/src/ffi/fushidicts_ffi_bindings.dart
+++ b/packages/fushi_dictionary/lib/src/ffi/fushidicts_ffi_bindings.dart
@@ -38,6 +38,11 @@ final class FfiPitch extends Struct {
   external Pointer<Pointer<Utf8>> transcriptions;
   @Int32()
   external int transcriptionCount;
+  // 79c55c2 二期：pattern 式 accent（"heiban" 等字符串位）；与 native FfiPitch
+  // 字段顺序严格镜像。
+  external Pointer<Pointer<Utf8>> patterns;
+  @Int32()
+  external int patternCount;
 }
 
 final class FfiTermResult extends Struct {
@@ -174,6 +179,15 @@ typedef _FreeQueryResultDart = void Function(Pointer<FfiQueryResult> r);
 typedef _LookupDart = FfiLookupResults Function(
     Pointer<Void> handle, Pointer<Utf8> text, int maxResults, int scanLength);
 
+typedef _LookupWithOptionsDart = FfiLookupResults Function(
+    Pointer<Void> handle,
+    Pointer<Utf8> text,
+    int maxResults,
+    int scanLength,
+    Pointer<Utf8> freqDict,
+    int freqOrder,
+    Pointer<Utf8> primaryReading);
+
 typedef _FreeLookupResultsDart = void Function(Pointer<FfiLookupResults> r);
 
 typedef _GetStylesDart = FfiDictStyles Function(Pointer<Void> handle);
@@ -234,6 +248,10 @@ class FushidictsFfiBindings {
     lookup = _lib.lookupFunction<
         FfiLookupResults Function(Pointer<Void>, Pointer<Utf8>, Int32, Int32),
         _LookupDart>('fushidicts_lookup');
+    lookupWithOptions = _lib.lookupFunction<
+        FfiLookupResults Function(Pointer<Void>, Pointer<Utf8>, Int32, Int32,
+            Pointer<Utf8>, Int32, Pointer<Utf8>),
+        _LookupWithOptionsDart>('fushidicts_lookup_with_options');
     freeLookupResults = _lib.lookupFunction<
         Void Function(Pointer<FfiLookupResults>),
         _FreeLookupResultsDart>('fushidicts_free_lookup_results');
@@ -275,6 +293,7 @@ class FushidictsFfiBindings {
   late final _QueryDart query;
   late final _FreeQueryResultDart freeQueryResult;
   late final _LookupDart lookup;
+  late final _LookupWithOptionsDart lookupWithOptions;
   late final _FreeLookupResultsDart freeLookupResults;
   late final _GetStylesDart getStyles;
   late final _FreeStylesDart freeStyles;

--- a/packages/fushi_dictionary/lib/src/ffi/fushidicts_ffi_bindings.dart
+++ b/packages/fushi_dictionary/lib/src/ffi/fushidicts_ffi_bindings.dart
@@ -130,6 +130,12 @@ final class FfiKanjiResult extends Struct {
   external Pointer<Pointer<Utf8>> meanings;
   @Int32()
   external int meaningCount;
+  // v2 词典的完整 stats 键值对（JLPT/grade 等）；与 native FfiKanjiResult 字段
+  // 顺序严格镜像（stat_keys/stat_values 平行数组，长度 statCount）。
+  external Pointer<Pointer<Utf8>> statKeys;
+  external Pointer<Pointer<Utf8>> statValues;
+  @Int32()
+  external int statCount;
   external Pointer<Utf8> dictName;
 }
 

--- a/packages/fushi_dictionary/lib/src/language/language.dart
+++ b/packages/fushi_dictionary/lib/src/language/language.dart
@@ -430,6 +430,7 @@ String buildLookupEntryExtra(FushiLookupResult r, FushiGlossaryEntry g) {
         .map((p) => {
               'dictName': p.dictName,
               'positions': p.pitchPositions,
+              'patterns': p.patterns,
               'transcriptions': p.transcriptions,
             })
         .toList(),
@@ -554,10 +555,12 @@ String buildPopupJsonFromLookup({
         }
       }
       for (final p in r.term.pitches) {
-        // Fold transcriptions into the dedup key (mirrors native popup_json):
-        // IPA entries have no pitch positions, so positions-only keys would
-        // collapse distinct IPA records of one dict and drop all but the first.
-        final pKey = '${p.dictName}:${p.pitchPositions.join(',')}'
+        // Fold patterns + transcriptions into the dedup key (mirrors native
+        // popup_json): IPA entries have no pitch accents, and pattern-only
+        // accents have no numeric positions, so a positions-only key would
+        // collapse distinct records of one dict and drop all but the first.
+        final pKey =
+            '${p.dictName}:${p.pitchPositions.join(',')},${p.patterns.join(',')}'
             '|${p.transcriptions.join(',')}';
         if (seenPitches[key]!.add(pKey)) {
           groupPitches[key]!.add(p);
@@ -636,6 +639,8 @@ String buildPopupJsonFromLookup({
       sb.write(jsonEncode(pitches[pi].dictName));
       sb.write(',"pitchPositions":');
       sb.write(jsonEncode(pitches[pi].pitchPositions));
+      sb.write(',"patterns":');
+      sb.write(jsonEncode(pitches[pi].patterns));
       sb.write(',"transcriptions":');
       sb.write(jsonEncode(pitches[pi].transcriptions));
       sb.write('}');

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -1044,12 +1044,16 @@ function constructPitchPositionHtml(pitches) {
         pitchGroup.pitchPositions.forEach(pos => {
             items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
         });
+        // 79c55c2 二期：pattern 式 accent 同样进 {pitch-accent-positions} 字段。
+        (pitchGroup.patterns || []).forEach(pattern => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(pattern)}</span><span>]</span></span></li>`;
+        });
         (pitchGroup.transcriptions || []).forEach(ipa => {
             items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    // No positions AND no transcriptions: return '' instead of an empty <ol>
-    // shell, so the field is treated as empty and skipped.
+    // No positions AND no patterns AND no transcriptions: return '' instead of
+    // an empty <ol> shell, so the field is treated as empty and skipped.
     return items ? `<ol>${items}</ol>` : '';
 }
 
@@ -2190,6 +2194,13 @@ function createPitchGroup(pitchData, reading) {
         li.appendChild(document.createTextNode(` [${pitch}]`));
         list.appendChild(li);
     });
+    // 79c55c2 二期：pattern 式 accent（"heiban" 等字符串位）以文本形式渲染，
+    // 无法画数字位式的高低标记。
+    (pitchData.patterns || []).forEach((pattern) => {
+        const li = el('li');
+        li.appendChild(document.createTextNode(`[${pattern}]`));
+        list.appendChild(li);
+    });
     container.appendChild(list);
 
     const transcriptions = createTranscriptionsHtml(pitchData.transcriptions);
@@ -2261,11 +2272,13 @@ function createPitchSection(pitches, reading) {
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
+            // Pattern-style accents (79c55c2) likewise keep the group alive.
             const hasTranscriptions = pitch.transcriptions?.length;
-            if (unique.length > 0 || hasTranscriptions) {
+            const hasPatterns = pitch.patterns?.length;
+            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
                 pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, transcriptions: pitch.transcriptions },
+                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
                     reading));
             }
         });

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3679,6 +3679,18 @@ function createKanjiCard(kanji) {
         card.appendChild(kunyomiRow);
     }
 
+    // v2 词典的完整 stats 键值对（JLPT/grade 等，FushiKanjiResult.stats 直通）。
+    // v1 存量词典 stats 为空对象，零渲染开销；复用 kanji-card-row 现有样式。
+    if (kanji.stats && typeof kanji.stats === 'object') {
+        for (const [statKey, statValue] of Object.entries(kanji.stats)) {
+            if (typeof statValue !== 'string' || statValue.length === 0) continue;
+            const statRow = createKanjiReadingRow(statKey, statValue);
+            if (statRow) {
+                card.appendChild(statRow);
+            }
+        }
+    }
+
     const meanings = Array.isArray(kanji.meanings)
         ? kanji.meanings.filter((m) => typeof m === 'string' && m.length > 0)
         : [];


### PR DESCRIPTION
## 概要

同步上游 Manhhao/hoshidicts `3448d6d..8993838`（25 commit 全评估），并引入 fork 首个磁盘格式版本阶梯 `.fushidicts_2`。明细与终态处置表见 `native/fushidicts/UPSTREAM.md` 批4节。

## 磁盘格式 v2（Never break userspace）
- v1 存量词典**照读完全不变**；`write_simple_dict`（MDX/StarDict/DSL）仍产 v1。
- v2 增量：kanji stats 追加段（JLPT/grade 等全链到弹窗卡片）+ term 记录 i32 score + 可选 `dict.zstd` 训练字典压缩。
- 唯一代价：升级后新导入的词典在降级旧版后不可见（不毁数据，重导可救）。

## 已移植（两轮）
文本处理器×3（迭代符/全角数字/强调折叠）、NFKC 链序修复（半角片假名）、revert 4975788、bloom size 校验+flush+删 migration（消穿 FFI throw）、freq 嵌套解析收紧、pitch 完整规格（pattern 渲染全链、nasal/devoice 收数据模型）、score 排序、LookupOptions+primary_reading 管道（默认零行为变化）、zstd 训练字典 + thread_local DCtx 解压提速。

## 明确不做
上游 kanji 实现本体（与 fork 自研同 type byte 两套布局，换=毁存量）、702dcc5 summary（冲突读侧契约）、c bindings（政策不变）、vendored 依赖 7 库齐升（有真实回归风险）。

## 验证
- 本机 MSVC ctest **21/21**（含新 `format_v2_upstream_sync_test`：v2 marker/stats 读回/marker 拒载/bloom 截断降级/zstd 训练实测成功+冷重开一致/pitch pattern 容忍/score 降序/primary_reading/显式升降序端到端）
- `flutter analyze`（fushi + fushi_dictionary）双绿；定向 `flutter test` 341 绿（popup 三镜像 parity 含 patterns 断言）
- `dict_legacy_marker_guard` 变异实测（删 `.hoshidicts_1` → 红 → 还原 sha256 一致）

https://claude.ai/code/session_01DoPeKrZV8andnHE9umEgFx