### PR TITLE
feat(video): YouTube 观看体验——书架进度写穿 + 画质目标偏好

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 58701 (3453 per locale)
+/// Strings: 58735 (3455 per locale)
 ///
-/// Built on 2026-08-16 at 12:44 UTC
+/// Built on 2026-08-17 at 05:42 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4680,6 +4680,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_content_language_description =>
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   String get manga_ocr_lens_language_label => 'Recognition language';
+  String get video_setting_youtube_quality => 'YouTube quality';
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -12663,6 +12666,11 @@ class _StringsAr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'لغة التعرّف';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -20713,6 +20721,11 @@ class _StringsDe extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Erkennungssprache';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -28779,6 +28792,11 @@ class _StringsEs extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconocimiento';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -36857,6 +36875,11 @@ class _StringsFr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Langue de reconnaissance';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -44863,6 +44886,11 @@ class _StringsId extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Bahasa pengenalan';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -52915,6 +52943,11 @@ class _StringsIt extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Lingua di riconoscimento';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -60781,6 +60814,11 @@ class _StringsJa extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '認識する言語';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -68654,6 +68692,11 @@ class _StringsKo extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '인식 언어';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -76686,6 +76729,11 @@ class _StringsNl extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Herkenningstaal';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -84730,6 +84778,11 @@ class _StringsPtBr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Idioma de reconhecimento';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -92760,6 +92813,11 @@ class _StringsRu extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Язык распознавания';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -100738,6 +100796,11 @@ class _StringsTh extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'ภาษาที่ใช้จดจำ';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -108747,6 +108810,11 @@ class _StringsTr extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Tanıma dili';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -116741,6 +116809,11 @@ class _StringsVi extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => 'Ngôn ngữ nhận dạng';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 // Path: <root>
@@ -124155,6 +124228,11 @@ class _StringsZhCn extends _StringsEn {
       '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
   @override
   String get manga_ocr_lens_language_label => '识别语言';
+  @override
+  String get video_setting_youtube_quality => 'YouTube 画质';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      '起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）';
 }
 
 // Path: <root>
@@ -131944,6 +132022,11 @@ class _StringsZhHk extends _StringsEn {
       'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
   @override
   String get manga_ocr_lens_language_label => '識別語言';
+  @override
+  String get video_setting_youtube_quality => 'YouTube quality';
+  @override
+  String get video_setting_youtube_quality_hint =>
+      'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
 }
 
 /// Flat map(s) containing all translations.
@@ -139040,6 +139123,10 @@ extension on _StringsEn {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Recognition language';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -146134,6 +146221,10 @@ extension on _StringsAr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'لغة التعرّف';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -153250,6 +153341,10 @@ extension on _StringsDe {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Erkennungssprache';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -160365,6 +160460,10 @@ extension on _StringsEs {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconocimiento';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -167486,6 +167585,10 @@ extension on _StringsFr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Langue de reconnaissance';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -174589,6 +174692,10 @@ extension on _StringsId {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Bahasa pengenalan';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -181706,6 +181813,10 @@ extension on _StringsIt {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Lingua di riconoscimento';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -188785,6 +188896,10 @@ extension on _StringsJa {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '認識する言語';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -195868,6 +195983,10 @@ extension on _StringsKo {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '인식 언어';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -202979,6 +203098,10 @@ extension on _StringsNl {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Herkenningstaal';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -210087,6 +210210,10 @@ extension on _StringsPtBr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Idioma de reconhecimento';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -217200,6 +217327,10 @@ extension on _StringsRu {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Язык распознавания';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -224296,6 +224427,10 @@ extension on _StringsTh {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'ภาษาที่ใช้จดจำ';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -231401,6 +231536,10 @@ extension on _StringsTr {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Tanıma dili';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -238502,6 +238641,10 @@ extension on _StringsVi {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return 'Ngôn ngữ nhận dạng';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }
@@ -245544,6 +245687,10 @@ extension on _StringsZhCn {
         return '内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。';
       case 'manga_ocr_lens_language_label':
         return '识别语言';
+      case 'video_setting_youtube_quality':
+        return 'YouTube 画质';
+      case 'video_setting_youtube_quality_hint':
+        return '起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）';
       default:
         return null;
     }
@@ -252618,6 +252765,10 @@ extension on _StringsZhHk {
         return 'Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.';
       case 'manga_ocr_lens_language_label':
         return '識別語言';
+      case 'video_setting_youtube_quality':
+        return 'YouTube quality';
+      case 'video_setting_youtube_quality_hint':
+        return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Recognition language"
+  "manga_ocr_lens_language_label": "Recognition language",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "لغة التعرّف"
+  "manga_ocr_lens_language_label": "لغة التعرّف",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Erkennungssprache"
+  "manga_ocr_lens_language_label": "Erkennungssprache",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconocimiento"
+  "manga_ocr_lens_language_label": "Idioma de reconocimiento",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Langue de reconnaissance"
+  "manga_ocr_lens_language_label": "Langue de reconnaissance",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Bahasa pengenalan"
+  "manga_ocr_lens_language_label": "Bahasa pengenalan",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Lingua di riconoscimento"
+  "manga_ocr_lens_language_label": "Lingua di riconoscimento",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "認識する言語"
+  "manga_ocr_lens_language_label": "認識する言語",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "인식 언어"
+  "manga_ocr_lens_language_label": "인식 언어",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Herkenningstaal"
+  "manga_ocr_lens_language_label": "Herkenningstaal",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Idioma de reconhecimento"
+  "manga_ocr_lens_language_label": "Idioma de reconhecimento",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Язык распознавания"
+  "manga_ocr_lens_language_label": "Язык распознавания",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ"
+  "manga_ocr_lens_language_label": "ภาษาที่ใช้จดจำ",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Tanıma dili"
+  "manga_ocr_lens_language_label": "Tanıma dili",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng"
+  "manga_ocr_lens_language_label": "Ngôn ngữ nhận dạng",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "默认内容语言",
   "settings_content_language_unset": "未设置",
   "settings_content_language_description": "内容没有声明语言时用的默认值。书/视频/游戏/词典各自的设置会覆盖它。",
-  "manga_ocr_lens_language_label": "识别语言"
+  "manga_ocr_lens_language_label": "识别语言",
+  "video_setting_youtube_quality": "YouTube 画质",
+  "video_setting_youtube_quality_hint": "起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3451,5 +3451,7 @@
   "settings_content_language_title": "Default content language",
   "settings_content_language_unset": "Not set",
   "settings_content_language_description": "Fallback language for content that does not declare one. Per-book, per-video, per-game and per-dictionary settings override this.",
-  "manga_ocr_lens_language_label": "識別語言"
+  "manga_ocr_lens_language_label": "識別語言",
+  "video_setting_youtube_quality": "YouTube quality",
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
 }

--- a/fushi/lib/src/media/video/stream_video_launch.dart
+++ b/fushi/lib/src/media/video/stream_video_launch.dart
@@ -68,6 +68,9 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
   Future<YoutubeResolvedSource> Function(String url)? youtubeResolver,
   StreamLivenessCheck? livenessCheck,
   DateTime Function()? now,
+  // 用户显式 YouTube 画质目标（设置「YouTube 画质」；null=自动=默认策略）。透传给
+  // 默认解析器，并作为缓存条目匹配键——改设置后旧档位缓存视为 miss 重解析。
+  int? youtubeTargetHeight,
 }) async {
   final String url = book.videoPath;
   final StreamVideoSpec spec =
@@ -82,7 +85,9 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
         streamCache ?? await YoutubeStreamCache.instance();
     final Future<YoutubeResolvedSource> Function(String) resolve =
         youtubeResolver ??
-            ((String u) => resolveYoutubeSource(u, withCaptions: false));
+            ((String u) => resolveYoutubeSource(u,
+                withCaptions: false,
+                playbackTargetHeight: youtubeTargetHeight));
     final StreamLivenessCheck liveness =
         livenessCheck ?? _defaultStreamLiveness;
     final DateTime Function() clock = now ?? DateTime.now;
@@ -98,7 +103,9 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
     if (videoId != null) {
       final YoutubeStreamCacheEntry? cached = await cache.get(videoId);
       if (cached != null) {
-        if (await liveness(cached.streamUrl, cached.httpHeaders)) {
+        if (cached.targetHeight != youtubeTargetHeight) {
+          // 画质目标变了：缓存的 streamUrl 是旧档位，按 miss 重解析（新结果 put 时覆盖）。
+        } else if (await liveness(cached.streamUrl, cached.httpHeaders)) {
           hit = cached;
         } else {
           // 缓存 URL 已失效（IP 锁不匹配 / 提前吊销）：剔除，落到重解析（别喂脏 URL 致黑屏）。
@@ -141,6 +148,7 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
               miningVideoHasAudio: resolved.miningVideoHasAudio,
               httpHeaders: resolved.httpHeaders,
               expiresAtMs: expiresAtMs,
+              targetHeight: youtubeTargetHeight,
             ),
           );
         }
@@ -183,11 +191,12 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
   required String id,
   required String title,
   required String url,
+  int? youtubeTargetHeight,
 }) async {
   final UrlStreamVideoClient client;
   if (isYoutubeUrl(url)) {
-    final YoutubeResolvedSource resolved =
-        await resolveYoutubeSource(url, withCaptions: false);
+    final YoutubeResolvedSource resolved = await resolveYoutubeSource(url,
+        withCaptions: false, playbackTargetHeight: youtubeTargetHeight);
     client = UrlStreamVideoClient(
       streamUrl: resolved.streamUrl,
       audioStreamUrl: resolved.audioStreamUrl,

--- a/fushi/lib/src/media/video/youtube_source_resolver.dart
+++ b/fushi/lib/src/media/video/youtube_source_resolver.dart
@@ -475,6 +475,9 @@ Future<YoutubeResolvedSource> resolveYoutubeSource(
   bool withCaptions = true,
   // A1 多 client 兜底顺序（默认 [kYoutubeManifestClientFallback]=androidVr→ios→tv）。
   List<yt.YoutubeApiClient>? ytClients,
+  // 用户显式画质目标（设置「YouTube 画质」；null=自动=默认策略 [pickPlaybackVideoStream]，
+  // 非 null 走 [pickVideoStreamForTargetHeight]，可越过默认 1080p 上限到 1440p/4K）。
+  int? playbackTargetHeight,
 }) async {
   final yt.YoutubeExplode client =
       yt.YoutubeExplode(_createYoutubeHttpClient());
@@ -488,6 +491,7 @@ Future<YoutubeResolvedSource> resolveYoutubeSource(
       preferSubtitleLang,
       withCaptions,
       ytClients ?? kYoutubeManifestClientFallback,
+      playbackTargetHeight,
     ).timeout(timeout);
   } finally {
     client.close();
@@ -500,6 +504,7 @@ Future<YoutubeResolvedSource> _resolveYoutubeSourceInner(
   String preferSubtitleLang,
   bool withCaptions,
   List<yt.YoutubeApiClient> ytClients,
+  int? playbackTargetHeight,
 ) async {
   // 制卡路径（withCaptions=false）直接从 URL 取 VideoId，**跳过 videos.get**（慢网下这一步就
   // ~9s）——制卡不需要标题/元数据，只要 getManifest 的流 URL。播放器路径仍取完整 Video（要标题）。
@@ -521,7 +526,7 @@ Future<YoutubeResolvedSource> _resolveYoutubeSourceInner(
   String streamUrl;
   String? audioStreamUrl;
   if (manifest.videoOnly.isNotEmpty && manifest.audioOnly.isNotEmpty) {
-    streamUrl = _pickPlaybackVideoUrl(manifest);
+    streamUrl = _pickPlaybackVideoUrl(manifest, playbackTargetHeight);
     audioStreamUrl = manifest.audioOnly.withHighestBitrate().url.toString();
   } else {
     streamUrl = manifest.muxed.withHighestBitrate().url.toString();
@@ -608,16 +613,13 @@ T pickPlaybackVideoStream<T>(
   return capped.first;
 }
 
-/// 选播放用 video-only 流：编码优先（avc1>vp9>av01）→ ≤1080p 最高清 → 非 throttled
-/// （[pickPlaybackVideoStream]）。命中 throttled（异常，ANDROID_VR 正常不 throttled）时告警。
-String _pickPlaybackVideoUrl(yt.StreamManifest manifest) {
+/// 选播放用 video-only 流。[targetHeight] null（自动）= 默认策略：编码优先（avc1>vp9>
+/// av01）→ ≤1080p 最高清 → 非 throttled（[pickPlaybackVideoStream]）；非 null = 用户显式
+/// 画质目标（[pickVideoStreamForTargetHeight]，画质菜单同语义、可达 1440p/4K）。命中
+/// throttled（异常，ANDROID_VR 正常不 throttled）时告警。
+String _pickPlaybackVideoUrl(yt.StreamManifest manifest, int? targetHeight) {
   final yt.VideoOnlyStreamInfo chosen =
-      pickPlaybackVideoStream<yt.VideoOnlyStreamInfo>(
-    manifest.videoOnly.toList(),
-    heightOf: (yt.VideoOnlyStreamInfo s) => s.videoResolution.height,
-    codecOf: (yt.VideoOnlyStreamInfo s) => s.videoCodec,
-    throttledOf: (yt.VideoOnlyStreamInfo s) => s.isThrottled,
-  );
+      _pickPlaybackVideoStreamInfo(manifest, targetHeight);
   if (chosen.isThrottled) {
     debugPrint(
       '[hibiki][youtube] 选中的播放流 isThrottled=true（异常，缓冲可能慢）：'
@@ -625,6 +627,58 @@ String _pickPlaybackVideoUrl(yt.StreamManifest manifest) {
     );
   }
   return chosen.url.toString();
+}
+
+/// 播放选流真身：[targetHeight] null=默认策略 / 非 null=显式画质目标（两纯函数二选一）。
+yt.VideoOnlyStreamInfo _pickPlaybackVideoStreamInfo(
+  yt.StreamManifest manifest,
+  int? targetHeight,
+) {
+  final List<yt.VideoOnlyStreamInfo> candidates = manifest.videoOnly.toList();
+  return targetHeight == null
+      ? pickPlaybackVideoStream<yt.VideoOnlyStreamInfo>(
+          candidates,
+          heightOf: (yt.VideoOnlyStreamInfo s) => s.videoResolution.height,
+          codecOf: (yt.VideoOnlyStreamInfo s) => s.videoCodec,
+          throttledOf: (yt.VideoOnlyStreamInfo s) => s.isThrottled,
+        )
+      : pickVideoStreamForTargetHeight<yt.VideoOnlyStreamInfo>(
+          candidates,
+          heightOf: (yt.VideoOnlyStreamInfo s) => s.videoResolution.height,
+          codecOf: (yt.VideoOnlyStreamInfo s) => s.videoCodec,
+          throttledOf: (yt.VideoOnlyStreamInfo s) => s.isThrottled,
+          targetHeight: targetHeight,
+        );
+}
+
+/// 纯函数：按用户显式**画质目标**选流 = 画质菜单语义（[dedupeVideoStreamsByHeight] 的
+/// 档位阶梯里取 ≤[targetHeight] 的最高档；全部高于目标时退最低档，宁流畅勿卡死）。
+///
+/// 与 [pickPlaybackVideoStream]（默认策略：编码优先高于分辨率，避软解抖）语义**刻意不同**：
+/// 用户在设置里显式选了目标画质（如 1440p/4K —— YouTube 高于 1080p 只有 vp9/av01），意图
+/// 是「要这个分辨率」，编码优先若仍压在分辨率之上，这个设置就永远到不了 1440p+，成谎言型
+/// 设置。编码偏好在**同一高度内**仍生效（dedupe 每档取 avc1>vp9>av01、非 throttled 优先），
+/// 行为与用户手动在画质菜单点 ≤目标 的最高档完全一致。
+T pickVideoStreamForTargetHeight<T>(
+  List<T> streams, {
+  required int Function(T stream) heightOf,
+  required String Function(T stream) codecOf,
+  required bool Function(T stream) throttledOf,
+  required int targetHeight,
+}) {
+  final List<T> deduped = dedupeVideoStreamsByHeight<T>(
+    streams,
+    heightOf: heightOf,
+    codecOf: codecOf,
+    throttledOf: throttledOf,
+  );
+  if (deduped.isEmpty) {
+    throw StateError('pickVideoStreamForTargetHeight: empty stream list');
+  }
+  for (final T s in deduped) {
+    if (heightOf(s) <= targetHeight) return s; // 降序阶梯首个 ≤ 目标。
+  }
+  return deduped.last; // 全部高于目标：退最低档。
 }
 
 /// 纯函数（泛型，可单测）：把 video-only 候选**去重成每个高度一条**（编码最优：avc1>vp9>
@@ -668,6 +722,9 @@ Future<YoutubeVariantSet> resolveYoutubeVideoVariants(
   String url, {
   Duration timeout = const Duration(seconds: 20),
   List<yt.YoutubeApiClient>? ytClients,
+  // 用户显式画质目标（与 [resolveYoutubeSource] 同义）：非 null 时「自动」档下标
+  // 对齐 ≤目标 的最高档，与初始播放选择一致。
+  int? playbackTargetHeight,
 }) async {
   final yt.YoutubeExplode client =
       yt.YoutubeExplode(_createYoutubeHttpClient());
@@ -676,6 +733,7 @@ Future<YoutubeVariantSet> resolveYoutubeVideoVariants(
       client,
       url,
       ytClients ?? kYoutubeManifestClientFallback,
+      playbackTargetHeight,
     ).timeout(timeout);
   } finally {
     client.close();
@@ -686,6 +744,7 @@ Future<YoutubeVariantSet> _resolveYoutubeVideoVariantsInner(
   yt.YoutubeExplode client,
   String url,
   List<yt.YoutubeApiClient> ytClients,
+  int? playbackTargetHeight,
 ) async {
   final yt.VideoId videoId = yt.VideoId(url);
   final yt.StreamManifest manifest =
@@ -714,15 +773,11 @@ Future<YoutubeVariantSet> _resolveYoutubeVideoVariantsInner(
         codec: s.videoCodec,
       ),
   ];
-  // 「自动」档 = 初始播放选择（[pickPlaybackVideoStream]：avc1 优先、≤1080p 最高清），
-  // 按高度回找它在去重表里的下标，供画质菜单「自动」项与初始高亮对齐。
+  // 「自动」档 = 初始播放选择（默认策略 [pickPlaybackVideoStream]：avc1 优先、≤1080p
+  // 最高清；有显式画质目标时 [pickVideoStreamForTargetHeight]：≤目标 的最高档），按高度
+  // 回找它在去重表里的下标，供画质菜单「自动」项与初始高亮对齐。
   final yt.VideoOnlyStreamInfo chosen =
-      pickPlaybackVideoStream<yt.VideoOnlyStreamInfo>(
-    manifest.videoOnly.toList(),
-    heightOf: (yt.VideoOnlyStreamInfo s) => s.videoResolution.height,
-    codecOf: (yt.VideoOnlyStreamInfo s) => s.videoCodec,
-    throttledOf: (yt.VideoOnlyStreamInfo s) => s.isThrottled,
-  );
+      _pickPlaybackVideoStreamInfo(manifest, playbackTargetHeight);
   int defaultIndex = variants.indexWhere(
       (YoutubeVideoVariant v) => v.height == chosen.videoResolution.height);
   if (defaultIndex < 0) defaultIndex = 0;

--- a/fushi/lib/src/media/video/youtube_stream_cache.dart
+++ b/fushi/lib/src/media/video/youtube_stream_cache.dart
@@ -28,6 +28,7 @@ class YoutubeStreamCacheEntry {
     required this.miningVideoHasAudio,
     required this.httpHeaders,
     required this.expiresAtMs,
+    this.targetHeight,
   });
 
   final String streamUrl;
@@ -35,6 +36,11 @@ class YoutubeStreamCacheEntry {
   final String? miningVideoUrl;
   final bool miningVideoHasAudio;
   final Map<String, String> httpHeaders;
+
+  /// 解析这条缓存时的用户显式画质目标（null=自动/默认策略）。用户改设置后旧缓存的
+  /// streamUrl 还是旧档位，[buildStreamVideoLaunch] 据此判缓存是否可用（不匹配=miss）。
+  /// 旧缓存 JSON 无此字段 → null（当年只有默认策略，语义正确）。
+  final int? targetHeight;
 
   /// 过期时间（unix 毫秒）= min(各流 expire) - 安全余量；此刻 >= 它即过期。
   final int expiresAtMs;
@@ -48,6 +54,7 @@ class YoutubeStreamCacheEntry {
         'miningVideoHasAudio': miningVideoHasAudio,
         'httpHeaders': httpHeaders,
         'expiresAtMs': expiresAtMs,
+        if (targetHeight != null) 'targetHeight': targetHeight,
       };
 
   /// 缺 streamUrl / expiresAtMs 抛（调用方按条目跳过脏数据）。
@@ -71,6 +78,8 @@ class YoutubeStreamCacheEntry {
       miningVideoHasAudio: json['miningVideoHasAudio'] == true,
       httpHeaders: httpHeaders,
       expiresAtMs: expiresAtMs,
+      targetHeight:
+          json['targetHeight'] is int ? json['targetHeight'] as int : null,
     );
   }
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3202,6 +3202,18 @@ class AppModel with ChangeNotifier {
   Future<void> setVideoLockWindowAspectRatio(bool value) =>
       prefsRepo.setVideoLockWindowAspectRatio(value);
 
+  /// YouTube 显式画质目标高度（0=自动；非 0 起播即选 ≤目标 的最高档，可达 1440p/4K）。
+  int get youtubeQualityTargetHeight => prefsRepo.youtubeQualityTargetHeight;
+
+  Future<void> setYoutubeQualityTargetHeight(int height) =>
+      prefsRepo.setYoutubeQualityTargetHeight(height);
+
+  /// [youtubeQualityTargetHeight] 的解析器形参形态（0 → null=默认策略）。
+  int? get youtubeQualityTargetHeightOrNull {
+    final int h = youtubeQualityTargetHeight;
+    return h > 0 ? h : null;
+  }
+
   /// 视频画面缩放/比例模式（窗口+全屏 Video fit；默认 cover=保持比例占满无黑边）。
   VideoFitMode get videoFitMode => prefsRepo.videoFitMode;
 

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -178,6 +178,7 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'video_subtitle_obscure_hide',
   'video_subtitle_opensubtitles_config',
   'video_subtitle_style',
+  'video_youtube_quality_height',
   'yomitan_api_key',
   'yomitan_api_port',
   'yomitan_api_server_enabled',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -1247,6 +1247,16 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// YouTube 显式画质目标高度（如 720/1080/2160）；0 = 自动（默认策略：编码优先、
+  /// ≤1080p，见 pickPlaybackVideoStream）。消费方把 0 换算成 null 传解析器。
+  int get youtubeQualityTargetHeight =>
+      getPref('video_youtube_quality_height', defaultValue: 0) as int;
+
+  Future<void> setYoutubeQualityTargetHeight(int height) async {
+    await setPref('video_youtube_quality_height', height < 0 ? 0 : height);
+    notifyListeners();
+  }
+
   /// 视频画面缩放/比例模式（窗口模式 + 全屏的 [Video] fit；默认 [VideoFitMode.contain]
   /// = 保持比例完整适应媒体框；已有 cover/fill 持久化值仍按原值恢复）。
   VideoFitMode get videoFitMode => VideoFitMode.fromStorage(

--- a/fushi/lib/src/pages/implementations/video_fushi/quality.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/quality.part.dart
@@ -129,7 +129,8 @@ extension _VideoQuality on _VideoFushiPageState {
     final int seq = _episodeLoadSeq;
     _rebuild(() => _youtubeVariantsLoading = true);
     try {
-      final YoutubeVariantSet set = await resolveYoutubeVideoVariants(watch);
+      final YoutubeVariantSet set = await resolveYoutubeVideoVariants(watch,
+          playbackTargetHeight: appModel.youtubeQualityTargetHeightOrNull);
       // 换集：丢弃迟到结果（新集已复位状态、bump seq），绝不覆盖新集画质态。
       if (!mounted || seq != _episodeLoadSeq) return;
       _rebuild(() {

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -2042,7 +2042,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _setLoadingPhase(_VideoLoadPhase.connecting);
       try {
         final ({UrlStreamVideoClient client, RemoteVideoInfo info}) launch =
-            await buildStreamVideoLaunch(row);
+            await buildStreamVideoLaunch(row,
+                youtubeTargetHeight: appModel.youtubeQualityTargetHeightOrNull);
         if (!mounted) return;
         _resolvedStreamInfo = launch.info;
         _resolvedStreamClient = launch.client;
@@ -2680,6 +2681,14 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         videoRemotePositionEpisodePrefKey(keyUid, episodeIndex), clamped);
     await appModel.prefsRepo.setPref(
         videoRemotePositionEpisodeAtPrefKey(keyUid, episodeIndex), nowMs);
+    // 书架流媒体书（YouTube/直链，TODO-1157）**有** VideoBooks 行（[_bookRow] 非空），
+    // 只写 prefs 会让书架的「继续观看 / 在看筛选 / 合集续播选集」对它全部失明——那些
+    // 读的是 `lastPositionMs` / `lastPlayedAt`。与本地 [_persistPosition] 对齐补写 DB 行
+    // （resume 仍走上面的 prefs LWW，两者读写路径互不干扰）。互联远端无行，保持原样。
+    if (_bookRow != null) {
+      await widget.repo
+          .updatePosition(widget.bookUid, clamped, playedAt: nowMs);
+    }
     final RemoteVideoClient? client = _effectiveRemoteClient;
     if (client == null) return;
     try {
@@ -3228,7 +3237,10 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _prewarmNextEpisodeSubtitleCache();
 
     // 首次 load 建观看统计采集器；换片复用同一 controller 实例，已 attach 不重建。
-    if (!_isRemote && _watchTracker == null) {
+    // 判据 [_bookRow] 非空 = 书架书（本地视频 + TODO-1157 流媒体书都有 VideoBooks 行）：
+    // 流媒体书（YouTube 等）在本机播放同样计观看时长/字幕字数/看完标记（用户在 app 内
+    // 看油管也是沉浸时间）。互联远端（无行，媒体归 host）保持不采集。
+    if (_bookRow != null && _watchTracker == null) {
       final FushiDatabase db = appModel.database;
       _watchTracker = VideoWatchTracker(
         title: title,

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -118,6 +118,34 @@ SettingsDestination buildVideoDestination() {
               await setVideoFitModeDual(settingsContext, mode);
             },
           ),
+          // YouTube 显式画质目标（0=自动=默认策略：编码优先、≤1080p）。非 0 起播即选
+          // ≤目标 的最高档（画质菜单同语义），4K 档在 YouTube 侧只有 vp9/av01——无硬解
+          // 设备可能软解掉帧，故默认仍是「自动」。长标签多档 → dropdown 渲染。
+          SettingsSegmentedItem<int>(
+            id: 'video.playback.youtube_quality',
+            title: t.video_setting_youtube_quality,
+            subtitle: t.video_setting_youtube_quality_hint,
+            icon: Icons.high_quality_outlined,
+            dropdown: true,
+            video: VideoPlacement(group: VideoGroup.playback, order: 15),
+            options: <SettingsSegmentOption<int>>[
+              SettingsSegmentOption<int>(
+                value: 0,
+                label: t.video_quality_auto,
+              ),
+              for (final int height in <int>[480, 720, 1080, 1440, 2160])
+                SettingsSegmentOption<int>(
+                  value: height,
+                  label: '${height}p',
+                ),
+            ],
+            selected: (SettingsContext settingsContext) =>
+                settingsContext.appModel.youtubeQualityTargetHeight,
+            onChanged: (SettingsContext settingsContext, int height) async {
+              await settingsContext.appModel
+                  .setYoutubeQualityTargetHeight(height);
+            },
+          ),
           SettingsSegmentedItem<int>(
             id: 'video.playback.double_tap',
             title: t.video_setting_double_tap,

--- a/fushi/test/media/video/stream_video_launch_test.dart
+++ b/fushi/test/media/video/stream_video_launch_test.dart
@@ -183,6 +183,39 @@ void main() {
       launch2.client.close();
     });
 
+    test('画质目标变更 -> 旧缓存视为 miss 重解析；同目标再开命中', () async {
+      int resolveCalls = 0;
+      final YoutubeStreamCache cache =
+          YoutubeStreamCache(file: File('${tmp.path}/c.json'), now: () => now);
+      Future<void> open(int? targetHeight) async {
+        final launch = await buildStreamVideoLaunch(
+          ytRow(),
+          streamCache: cache,
+          youtubeResolver: (String url) async {
+            resolveCalls++;
+            return fakeResolved('r$resolveCalls');
+          },
+          livenessCheck: (String u, Map<String, String> h) async => true,
+          now: () => now,
+          youtubeTargetHeight: targetHeight,
+        );
+        launch.client.close();
+      }
+
+      // 自动（null）解析并缓存。
+      await open(null);
+      expect(resolveCalls, 1);
+      // 用户把画质目标改成 1440：缓存的 URL 是旧档位 → miss 重解析。
+      await open(1440);
+      expect(resolveCalls, 2);
+      // 同目标再开：命中新缓存，不再解析。
+      await open(1440);
+      expect(resolveCalls, 2);
+      // 改回自动：又是一次 miss（缓存条目记的是 1440）。
+      await open(null);
+      expect(resolveCalls, 3);
+    });
+
     test('no parseable expire -> not cached (each open re-resolves)', () async {
       int resolveCalls = 0;
       final YoutubeStreamCache cache =

--- a/fushi/test/media/video/youtube_fast_load_guard_test.dart
+++ b/fushi/test/media/video/youtube_fast_load_guard_test.dart
@@ -28,7 +28,11 @@ void main() {
       () {
     expect(
       // TODO-1314：快解析 gate 现经可注入的默认 resolver 闭包（参数名 u）保留，行为不变。
-      launchSrc.contains('resolveYoutubeSource(u, withCaptions: false)'),
+      // 画质目标（playbackTargetHeight）加参后调用折行，折叠空白后断言完整参数形态。
+      launchSrc
+          .replaceAll(RegExp(r'\s+'), ' ')
+          .contains('resolveYoutubeSource(u, withCaptions: false, '
+              'playbackTargetHeight: youtubeTargetHeight)'),
       isTrue,
       reason: 'YouTube 分支必须走快解析 gate（withCaptions:false），不前置阻塞字幕/title',
     );
@@ -121,7 +125,8 @@ void main() {
 
   test('④ 阶段反馈提前：connecting 在 buildStreamVideoLaunch 调用之前', () {
     final int iConnect = pageSrc.indexOf('// TODO-1307：把「正在连接视频流…」阶段反馈提前');
-    final int iBuild = pageSrc.indexOf('await buildStreamVideoLaunch(row)');
+    // 画质目标加参后调用折行：锚到 `(row` 前缀（不含收尾括号）。
+    final int iBuild = pageSrc.indexOf('await buildStreamVideoLaunch(row');
     expect(iConnect, greaterThan(0),
         reason: 'stream book 分支必须提前置 connecting 阶段反馈');
     expect(iBuild, greaterThan(0));

--- a/fushi/test/media/video/youtube_playback_stream_pick_test.dart
+++ b/fushi/test/media/video/youtube_playback_stream_pick_test.dart
@@ -126,6 +126,69 @@ void main() {
     });
   });
 
+  group('pickVideoStreamForTargetHeight (显式画质目标 = 画质菜单语义)', () {
+    _FakeStream pickTarget(List<_FakeStream> streams, int target) {
+      return pickVideoStreamForTargetHeight<_FakeStream>(
+        streams,
+        heightOf: (_FakeStream s) => s.height,
+        codecOf: (_FakeStream s) => s.codec,
+        throttledOf: (_FakeStream s) => s.throttled,
+        targetHeight: target,
+      );
+    }
+
+    test('目标 2160：分辨率优先越过编码（vp9@2160 胜 avc1@1080）', () {
+      final List<_FakeStream> streams = <_FakeStream>[
+        const _FakeStream(1080, 'avc1.640028'),
+        const _FakeStream(2160, 'vp9'),
+        const _FakeStream(1440, 'vp9'),
+      ];
+      final _FakeStream chosen = pickTarget(streams, 2160);
+      expect(chosen.height, 2160);
+      expect(chosen.codec, 'vp9');
+    });
+
+    test('同一目标高度内编码偏好仍生效（avc1 胜 vp9）', () {
+      final List<_FakeStream> streams = <_FakeStream>[
+        const _FakeStream(1080, 'vp9'),
+        const _FakeStream(1080, 'avc1.640028'),
+        const _FakeStream(720, 'avc1.640028'),
+      ];
+      final _FakeStream chosen = pickTarget(streams, 1080);
+      expect(chosen.height, 1080);
+      expect(chosen.codec, 'avc1.640028');
+    });
+
+    test('无恰好目标档：取 ≤目标 的最高档（目标 1440，只有 1080/720 → 1080）', () {
+      final List<_FakeStream> streams = <_FakeStream>[
+        const _FakeStream(1080, 'vp9'),
+        const _FakeStream(720, 'avc1.640028'),
+      ];
+      expect(pickTarget(streams, 1440).height, 1080);
+    });
+
+    test('目标 480 降档省流：不选更高档', () {
+      final List<_FakeStream> streams = <_FakeStream>[
+        const _FakeStream(1080, 'avc1.640028'),
+        const _FakeStream(480, 'avc1.640028'),
+        const _FakeStream(360, 'avc1.640028'),
+      ];
+      expect(pickTarget(streams, 480).height, 480);
+    });
+
+    test('全部高于目标 → 退最低档（宁流畅勿卡死）', () {
+      final List<_FakeStream> streams = <_FakeStream>[
+        const _FakeStream(2160, 'vp9'),
+        const _FakeStream(1440, 'vp9'),
+      ];
+      expect(pickTarget(streams, 480).height, 1440);
+    });
+
+    test('空列表抛 StateError', () {
+      expect(() => pickTarget(<_FakeStream>[], 1080), throwsStateError);
+    });
+  });
+
   group('dedupeVideoStreamsByHeight (YouTube 画质档去重)', () {
     test('每个高度只留一条，按高度降序', () {
       final List<_FakeStream> streams = <_FakeStream>[

--- a/fushi/test/media/video/youtube_shelf_progress_guard_test.dart
+++ b/fushi/test/media/video/youtube_shelf_progress_guard_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 书架流媒体书（YouTube/直链，TODO-1157）进度写穿源码守卫。
+///
+/// 根因背景：流媒体书**有** VideoBooks 行却走互联远端（无行）的持久化路径，位置只写
+/// prefs 不写 `lastPositionMs`/`lastPlayedAt`，观看统计采集器也被 `!_isRemote` 一刀切
+/// 关掉——书架「继续观看 / 在看筛选 / 看完角标 / 合集续播选集」与观看统计对在 app 内
+/// 看 YouTube 全部失明。修复统一判据 `_bookRow != null`（= 书架书）：
+/// ① [_persistRemotePosition] 对书架流媒体书补写 DB 行（updatePosition）；
+/// ② 观看统计采集器按 `_bookRow != null` 建（互联远端仍不采集）。
+///
+/// 页面依赖 media_kit 原生播放器，widget 层不可离线测试 → 落最强可落地层：源码切片守卫
+/// （删掉任一步即红），与 TODO-1307 守卫同构。
+void main() {
+  final String pageSrc =
+      File('lib/src/pages/implementations/video_fushi_page.dart')
+          .readAsStringSync()
+          .replaceAll(String.fromCharCode(13), '');
+
+  // [_persistRemotePosition] 函数体切片（到下一个方法 doc 注释为止的窄窗口，避免同形
+  // token 在别处抢匹配）。
+  String persistRemoteSlice() {
+    final int start =
+        pageSrc.indexOf('Future<void> _persistRemotePosition(String uid');
+    expect(start, greaterThan(0), reason: '_persistRemotePosition 必须存在');
+    final int end = pageSrc.indexOf('Future<void> _loadSingle', start);
+    expect(end, greaterThan(start));
+    return pageSrc.substring(start, end);
+  }
+
+  test('① 书架流媒体书位置写穿 DB：_persistRemotePosition 含 _bookRow 门 + updatePosition',
+      () {
+    final String slice = persistRemoteSlice();
+    expect(
+      slice.contains('if (_bookRow != null)'),
+      isTrue,
+      reason: '书架书判据必须是 _bookRow != null（本地/流媒体书有行，互联远端无行）',
+    );
+    expect(
+      // dart format 会按行宽折行，去掉全部空白后断言完整调用形态。
+      slice.replaceAll(RegExp(r'\s+'), '').contains(
+          'widget.repo.updatePosition(widget.bookUid,clamped,playedAt:nowMs)'),
+      isTrue,
+      reason: '书架流媒体书必须把断点写穿 VideoBooks（lastPositionMs/lastPlayedAt），'
+          '否则书架「继续观看/在看筛选/合集续播」对流媒体书失明',
+    );
+    // DB 写必须在「真观看」阈值之后（BUG-996 同款考虑：近起点假进度不落 DB）。
+    final int iThreshold = slice.indexOf('kMeaningfulRemoteWatchMs');
+    // 折行安全锚：方法名带左括号（widget.repo 与 .updatePosition 可能被 format 拆行）。
+    final int iDbWrite = slice.indexOf('.updatePosition(');
+    expect(iThreshold, greaterThan(0));
+    expect(iDbWrite, greaterThan(iThreshold),
+        reason: 'DB 写穿必须在 5s 真观看阈值之后（避免慢流 resume 未落地时的 ~0 假进度）');
+  });
+
+  test('② 观看统计采集器按书架书（_bookRow）建，而非按 !_isRemote 一刀切', () {
+    expect(
+      pageSrc.contains('if (_bookRow != null && _watchTracker == null)'),
+      isTrue,
+      reason: '流媒体书（YouTube 等）在本机播放必须计观看时长/字幕字数/看完标记',
+    );
+    expect(
+      pageSrc.contains('if (!_isRemote && _watchTracker == null)'),
+      isFalse,
+      reason: '不得再用 !_isRemote 门控统计采集器（会把书架流媒体书一并关掉）',
+    );
+  });
+}

--- a/fushi/test/media/video/youtube_stream_cache_test.dart
+++ b/fushi/test/media/video/youtube_stream_cache_test.dart
@@ -145,6 +145,35 @@ void main() {
       expect(back.miningVideoHasAudio, e.miningVideoHasAudio);
       expect(back.expiresAtMs, e.expiresAtMs);
       expect(back.httpHeaders, e.httpHeaders);
+      // 无显式画质目标（自动）时不写字段、读回 null。
+      expect(e.toJson().containsKey('targetHeight'), isFalse);
+      expect(back.targetHeight, isNull);
+    });
+
+    test('entry json round-trips targetHeight（显式画质目标）', () {
+      const YoutubeStreamCacheEntry e = YoutubeStreamCacheEntry(
+        streamUrl: 'https://g/v?itag=308',
+        audioStreamUrl: 'https://g/a?itag=251',
+        miningVideoUrl: null,
+        miningVideoHasAudio: false,
+        httpHeaders: <String, String>{},
+        expiresAtMs: 123456,
+        targetHeight: 1440,
+      );
+      final YoutubeStreamCacheEntry back =
+          YoutubeStreamCacheEntry.fromJson(e.toJson());
+      expect(back.targetHeight, 1440);
+    });
+
+    test('旧缓存 JSON 无 targetHeight 字段 → 读回 null（自动语义，向后兼容）', () {
+      final YoutubeStreamCacheEntry back =
+          YoutubeStreamCacheEntry.fromJson(<String, dynamic>{
+        'streamUrl': 'https://g/v?itag=137',
+        'miningVideoHasAudio': true,
+        'httpHeaders': <String, dynamic>{},
+        'expiresAtMs': 99,
+      });
+      expect(back.targetHeight, isNull);
     });
   });
 }


### PR DESCRIPTION
## 背景

用户诉求：优化 app 内看油管的体验。调查发现播放内核已较完善（分离流/字幕多轨/制卡），真正每次观看都命中的两个缺口：

1. **书架进度断链**：流媒体书（YouTube/直链）**有** VideoBooks 行，却被一刀切进互联远端（无行）的持久化路径——位置只写 prefs 不写 lastPositionMs/lastPlayedAt，观看统计采集器也被 !_isRemote 关掉。结果：首页「继续观看/在看筛选/看完角标/合集续播选集」与沉浸统计对 app 内看 YouTube 全部失明。
2. **画质无偏好**：默认硬编码 ≤1080p（编码优先），没有任何画质持久化——想省流量或想看 1440p/4K 的用户每个视频都要手动点画质菜单。

## 修复

### ① 书架进度写穿（根因修复）
统一判据 `_bookRow != null`（= 书架书；本地与流媒体书有行、互联远端无行）：
- `_persistRemotePosition` 在 5s 真观看阈值后补写 `updatePosition`（DB 行），resume 仍走 prefs LWW，两条读写路径互不干扰（video_fushi_page.dart:2688）；
- `VideoWatchTracker` 按书架书建：观看时长/字幕字数/看完标记（completedAt）对 YouTube 生效；互联远端行为不变。

### ② YouTube 画质目标偏好
- 新偏好 `video_youtube_quality_height`（0=自动=原默认策略，**零行为变化**）；设置·视频·播放新增「YouTube 画质」下拉（自动/480p/720p/1080p/1440p/2160p）。
- 显式目标走新纯函数 `pickVideoStreamForTargetHeight`：≤目标的最高档、档内编码优先（与画质菜单手动选档同语义）。默认策略「编码优先高于分辨率」（TODO-1159 防软解抖）保持不动——两语义刻意分开，否则 4K 档在 avc1 封顶 1080 时永远到不了，是谎言型设置。
- 穿参 `resolveYoutubeSource` / `resolveYoutubeVideoVariants`（画质菜单「自动」档对齐）/ `buildStreamVideoLaunch`；流缓存条目记 `targetHeight`，改设置后旧档位缓存视为 miss（旧 JSON 无字段读回 null，向后兼容）。

## 验证
- `flutter analyze` 零问题（含 test）。
- `test/media/video` 全目录 + `test/settings` + `test/i18n` + `preference_keys` 守卫全绿（2613+458 个）。
- 新增：pick 纯函数 6 例、缓存 roundtrip/兼容、launch 缓存目标匹配、进度写穿源码守卫（两处变异实测均红、还原 sha256 比对一致）。
- i18n 经 i18n_sync 加 2 key（17 语言）+ slang 重生成。

## 未做（方向性，待拍板）
YouTube 搜索/播放列表导入/频道浏览、登录（受限视频）、PiP/后台播放——均为功能空白非缺陷，见会话报告。

https://claude.ai/code/session_01C9YZvi9fUGBZDNSu8zqNLV