### PR TITLE
feat(manga): 漫画库「发现」视图（抄 AnymeX）——AniList 横滑行 + 详情页自动来源匹配

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60231 (3543 per locale)
+/// Strings: 60248 (3544 per locale)
 ///
-/// Built on 2026-08-17 at 08:34 UTC
+/// Built on 2026-08-17 at 09:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4805,6 +4805,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_discovery_status_hiatus => 'On hiatus';
   String get manga_discovery_status_cancelled => 'Cancelled';
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -13003,6 +13005,9 @@ class _StringsAr extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -21268,6 +21273,9 @@ class _StringsDe extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -29549,6 +29557,9 @@ class _StringsEs extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -37842,6 +37853,9 @@ class _StringsFr extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -46063,6 +46077,9 @@ class _StringsId extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -54330,6 +54347,9 @@ class _StringsIt extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -62411,6 +62431,9 @@ class _StringsJa extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -70499,6 +70522,9 @@ class _StringsKo extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -78746,6 +78772,9 @@ class _StringsNl extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -87005,6 +87034,9 @@ class _StringsPtBr extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -95250,6 +95282,9 @@ class _StringsRu extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -103443,6 +103478,9 @@ class _StringsTh extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -111667,6 +111705,9 @@ class _StringsTr extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -119876,6 +119917,9 @@ class _StringsVi extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 // Path: <root>
@@ -127481,6 +127525,9 @@ class _StringsZhCn extends _StringsEn {
   String get manga_discovery_status_cancelled => '已腰斩';
   @override
   String get manga_discovery_status_not_yet_released => '未发售';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      '${source} · 热门';
 }
 
 // Path: <root>
@@ -135485,6 +135532,9 @@ class _StringsZhHk extends _StringsEn {
   String get manga_discovery_status_cancelled => 'Cancelled';
   @override
   String get manga_discovery_status_not_yet_released => 'Not yet released';
+  @override
+  String manga_discovery_source_popular({required Object source}) =>
+      'Popular on ${source}';
 }
 
 /// Flat map(s) containing all translations.
@@ -142761,6 +142811,8 @@ extension on _StringsEn {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -150035,6 +150087,8 @@ extension on _StringsAr {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -157331,6 +157385,8 @@ extension on _StringsDe {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -164626,6 +164682,8 @@ extension on _StringsEs {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -171927,6 +171985,8 @@ extension on _StringsFr {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -179210,6 +179270,8 @@ extension on _StringsId {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -186507,6 +186569,8 @@ extension on _StringsIt {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -193766,6 +193830,8 @@ extension on _StringsJa {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -201029,6 +201095,8 @@ extension on _StringsKo {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -208320,6 +208388,8 @@ extension on _StringsNl {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -215608,6 +215678,8 @@ extension on _StringsPtBr {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -222901,6 +222973,8 @@ extension on _StringsRu {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -230177,6 +230251,8 @@ extension on _StringsTh {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -237462,6 +237538,8 @@ extension on _StringsTr {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -244743,6 +244821,8 @@ extension on _StringsVi {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }
@@ -251965,6 +252045,8 @@ extension on _StringsZhCn {
         return '已腰斩';
       case 'manga_discovery_status_not_yet_released':
         return '未发售';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => '${source} · 热门';
       default:
         return null;
     }
@@ -259219,6 +259301,8 @@ extension on _StringsZhHk {
         return 'Cancelled';
       case 'manga_discovery_status_not_yet_released':
         return 'Not yet released';
+      case 'manga_discovery_source_popular':
+        return ({required Object source}) => 'Popular on ${source}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 59993 (3529 per locale)
+/// Strings: 60231 (3543 per locale)
 ///
-/// Built on 2026-08-17 at 06:13 UTC
+/// Built on 2026-08-17 at 08:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4790,6 +4790,21 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_setting_youtube_quality => 'YouTube quality';
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  String get library_view_discover => 'Discover';
+  String get manga_discovery_section_trending => 'Trending';
+  String get manga_discovery_section_popular => 'Popular';
+  String get manga_discovery_section_top_rated => 'Top rated';
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  String get manga_discovery_match_section => 'Read from a source';
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  String get manga_discovery_status_releasing => 'Ongoing';
+  String get manga_discovery_status_finished => 'Completed';
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -12959,6 +12974,35 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -21195,6 +21239,35 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -29447,6 +29520,35 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -37711,6 +37813,35 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -45903,6 +46034,35 @@ class _StringsId extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -54141,6 +54301,35 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -62193,6 +62382,35 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -70252,6 +70470,35 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -78470,6 +78717,35 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -86700,6 +86976,35 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -94916,6 +95221,35 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -103080,6 +103414,35 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -111275,6 +111638,35 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -119455,6 +119847,35 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 // Path: <root>
@@ -127032,6 +127453,34 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       '起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）';
+  @override
+  String get library_view_discover => '发现';
+  @override
+  String get manga_discovery_section_trending => '趋势';
+  @override
+  String get manga_discovery_section_popular => '热门';
+  @override
+  String get manga_discovery_section_top_rated => '高分';
+  @override
+  String get manga_discovery_section_latest_finished => '最新完结';
+  @override
+  String get manga_discovery_load_failed => '发现内容加载失败。';
+  @override
+  String get manga_discovery_match_section => '来源匹配';
+  @override
+  String get manga_discovery_match_running => '正在已启用来源中匹配…';
+  @override
+  String get manga_discovery_match_none => '已启用来源中未找到匹配。';
+  @override
+  String get manga_discovery_status_releasing => '连载中';
+  @override
+  String get manga_discovery_status_finished => '已完结';
+  @override
+  String get manga_discovery_status_hiatus => '休刊中';
+  @override
+  String get manga_discovery_status_cancelled => '已腰斩';
+  @override
+  String get manga_discovery_status_not_yet_released => '未发售';
 }
 
 // Path: <root>
@@ -135007,6 +135456,35 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_setting_youtube_quality_hint =>
       'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+  @override
+  String get library_view_discover => 'Discover';
+  @override
+  String get manga_discovery_section_trending => 'Trending';
+  @override
+  String get manga_discovery_section_popular => 'Popular';
+  @override
+  String get manga_discovery_section_top_rated => 'Top rated';
+  @override
+  String get manga_discovery_section_latest_finished => 'Recently completed';
+  @override
+  String get manga_discovery_load_failed => 'Couldn\'t load the discover feed.';
+  @override
+  String get manga_discovery_match_section => 'Read from a source';
+  @override
+  String get manga_discovery_match_running =>
+      'Matching in your enabled sources...';
+  @override
+  String get manga_discovery_match_none => 'No match found in enabled sources.';
+  @override
+  String get manga_discovery_status_releasing => 'Ongoing';
+  @override
+  String get manga_discovery_status_finished => 'Completed';
+  @override
+  String get manga_discovery_status_hiatus => 'On hiatus';
+  @override
+  String get manga_discovery_status_cancelled => 'Cancelled';
+  @override
+  String get manga_discovery_status_not_yet_released => 'Not yet released';
 }
 
 /// Flat map(s) containing all translations.
@@ -142255,6 +142733,34 @@ extension on _StringsEn {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -149501,6 +150007,34 @@ extension on _StringsAr {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -156769,6 +157303,34 @@ extension on _StringsDe {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -164036,6 +164598,34 @@ extension on _StringsEs {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -171309,6 +171899,34 @@ extension on _StringsFr {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -178564,6 +179182,34 @@ extension on _StringsId {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -185833,6 +186479,34 @@ extension on _StringsIt {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -193064,6 +193738,34 @@ extension on _StringsJa {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -200299,6 +201001,34 @@ extension on _StringsKo {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -207562,6 +208292,34 @@ extension on _StringsNl {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -214822,6 +215580,34 @@ extension on _StringsPtBr {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -222087,6 +222873,34 @@ extension on _StringsRu {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -229335,6 +230149,34 @@ extension on _StringsTh {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -236592,6 +237434,34 @@ extension on _StringsTr {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -243845,6 +244715,34 @@ extension on _StringsVi {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }
@@ -251039,6 +251937,34 @@ extension on _StringsZhCn {
         return 'YouTube 画质';
       case 'video_setting_youtube_quality_hint':
         return '起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）';
+      case 'library_view_discover':
+        return '发现';
+      case 'manga_discovery_section_trending':
+        return '趋势';
+      case 'manga_discovery_section_popular':
+        return '热门';
+      case 'manga_discovery_section_top_rated':
+        return '高分';
+      case 'manga_discovery_section_latest_finished':
+        return '最新完结';
+      case 'manga_discovery_load_failed':
+        return '发现内容加载失败。';
+      case 'manga_discovery_match_section':
+        return '来源匹配';
+      case 'manga_discovery_match_running':
+        return '正在已启用来源中匹配…';
+      case 'manga_discovery_match_none':
+        return '已启用来源中未找到匹配。';
+      case 'manga_discovery_status_releasing':
+        return '连载中';
+      case 'manga_discovery_status_finished':
+        return '已完结';
+      case 'manga_discovery_status_hiatus':
+        return '休刊中';
+      case 'manga_discovery_status_cancelled':
+        return '已腰斩';
+      case 'manga_discovery_status_not_yet_released':
+        return '未发售';
       default:
         return null;
     }
@@ -258265,6 +259191,34 @@ extension on _StringsZhHk {
         return 'YouTube quality';
       case 'video_setting_youtube_quality_hint':
         return 'Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)';
+      case 'library_view_discover':
+        return 'Discover';
+      case 'manga_discovery_section_trending':
+        return 'Trending';
+      case 'manga_discovery_section_popular':
+        return 'Popular';
+      case 'manga_discovery_section_top_rated':
+        return 'Top rated';
+      case 'manga_discovery_section_latest_finished':
+        return 'Recently completed';
+      case 'manga_discovery_load_failed':
+        return 'Couldn\'t load the discover feed.';
+      case 'manga_discovery_match_section':
+        return 'Read from a source';
+      case 'manga_discovery_match_running':
+        return 'Matching in your enabled sources...';
+      case 'manga_discovery_match_none':
+        return 'No match found in enabled sources.';
+      case 'manga_discovery_status_releasing':
+        return 'Ongoing';
+      case 'manga_discovery_status_finished':
+        return 'Completed';
+      case 'manga_discovery_status_hiatus':
+        return 'On hiatus';
+      case 'manga_discovery_status_cancelled':
+        return 'Cancelled';
+      case 'manga_discovery_status_not_yet_released':
+        return 'Not yet released';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "在底栏/侧栏显示该库页；关闭即隐藏",
   "video_setting_youtube_quality": "YouTube 画质",
-  "video_setting_youtube_quality_hint": "起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）"
+  "video_setting_youtube_quality_hint": "起播自动选不超过目标的最高档；「自动」优先流畅（硬解友好编码，最高 1080p）",
+  "library_view_discover": "发现",
+  "manga_discovery_section_trending": "趋势",
+  "manga_discovery_section_popular": "热门",
+  "manga_discovery_section_top_rated": "高分",
+  "manga_discovery_section_latest_finished": "最新完结",
+  "manga_discovery_load_failed": "发现内容加载失败。",
+  "manga_discovery_match_section": "来源匹配",
+  "manga_discovery_match_running": "正在已启用来源中匹配…",
+  "manga_discovery_match_none": "已启用来源中未找到匹配。",
+  "manga_discovery_status_releasing": "连载中",
+  "manga_discovery_status_finished": "已完结",
+  "manga_discovery_status_hiatus": "休刊中",
+  "manga_discovery_status_cancelled": "已腰斩",
+  "manga_discovery_status_not_yet_released": "未发售"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "已完结",
   "manga_discovery_status_hiatus": "休刊中",
   "manga_discovery_status_cancelled": "已腰斩",
-  "manga_discovery_status_not_yet_released": "未发售"
+  "manga_discovery_status_not_yet_released": "未发售",
+  "manga_discovery_source_popular": "${source} · 热门"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3527,5 +3527,19 @@
   "module_games_label": "Galgame",
   "module_toggle_hint": "Show this library tab in the navigation bar; turn off to hide it",
   "video_setting_youtube_quality": "YouTube quality",
-  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)"
+  "video_setting_youtube_quality_hint": "Start streams at the highest tier up to this target; Auto prefers smooth playback (hardware-friendly codec, up to 1080p)",
+  "library_view_discover": "Discover",
+  "manga_discovery_section_trending": "Trending",
+  "manga_discovery_section_popular": "Popular",
+  "manga_discovery_section_top_rated": "Top rated",
+  "manga_discovery_section_latest_finished": "Recently completed",
+  "manga_discovery_load_failed": "Couldn't load the discover feed.",
+  "manga_discovery_match_section": "Read from a source",
+  "manga_discovery_match_running": "Matching in your enabled sources...",
+  "manga_discovery_match_none": "No match found in enabled sources.",
+  "manga_discovery_status_releasing": "Ongoing",
+  "manga_discovery_status_finished": "Completed",
+  "manga_discovery_status_hiatus": "On hiatus",
+  "manga_discovery_status_cancelled": "Cancelled",
+  "manga_discovery_status_not_yet_released": "Not yet released"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3541,5 +3541,6 @@
   "manga_discovery_status_finished": "Completed",
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
-  "manga_discovery_status_not_yet_released": "Not yet released"
+  "manga_discovery_status_not_yet_released": "Not yet released",
+  "manga_discovery_source_popular": "Popular on ${source}"
 }

--- a/fushi/lib/src/media/manga/discovery/anilist_manga_discovery_provider.dart
+++ b/fushi/lib/src/media/manga/discovery/anilist_manga_discovery_provider.dart
@@ -1,0 +1,154 @@
+/// AniList 漫画发现数据源：一次匿名 GraphQL combined query 拿全部四条 feed。
+///
+/// 传输层复用视频元数据域的 [VideoMetadataHttpClient]——它是通用的只读 HTTP
+/// 客户端（超时/退避/429/内存缓存），没有任何视频专属逻辑；为一个域再抄一份
+/// 才是错的。查询无需登录，与视频域的 AniList provider 同一公开端点。
+library;
+
+import 'package:http/http.dart' as http;
+
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_json.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_transport.dart';
+
+class AniListMangaDiscoveryProvider implements MangaDiscoveryProvider {
+  AniListMangaDiscoveryProvider({
+    http.Client? client,
+    VideoMetadataHttpClient? transport,
+    this.endpoint = 'https://graphql.anilist.co',
+  })  : assert(client == null || transport == null),
+        _transport = transport ?? VideoMetadataHttpClient(client: client),
+        _ownsTransport = transport == null;
+
+  final VideoMetadataHttpClient _transport;
+  final bool _ownsTransport;
+  final String endpoint;
+
+  /// 四条 feed 一条请求打包（对齐 AnymeX 的 combined query 做法）：发现页打开
+  /// 只产生一次网络往返，条目字段用 fragment 收敛成一份。
+  ///
+  /// - `topRated` / `latestFinished` 带人气/评分下限：裸 `SCORE_DESC` 前排全是
+  ///   几十人打分的冷门条目，对「发现」毫无价值。
+  /// - 全部 `isAdult: false`。
+  static const String _combinedQuery = r'''
+query ($perPage: Int!) {
+  trending: Page(page: 1, perPage: $perPage) {
+    media(sort: TRENDING_DESC, type: MANGA, isAdult: false) { ...entry }
+  }
+  popular: Page(page: 1, perPage: $perPage) {
+    media(sort: POPULARITY_DESC, type: MANGA, isAdult: false) { ...entry }
+  }
+  topRated: Page(page: 1, perPage: $perPage) {
+    media(sort: SCORE_DESC, popularity_greater: 10000, type: MANGA,
+          isAdult: false) { ...entry }
+  }
+  latestFinished: Page(page: 1, perPage: $perPage) {
+    media(status: FINISHED, sort: [END_DATE_DESC, SCORE_DESC, POPULARITY_DESC],
+          averageScore_greater: 70, popularity_greater: 10000, type: MANGA,
+          isAdult: false) { ...entry }
+  }
+}
+
+fragment entry on Media {
+  id
+  title { native romaji english }
+  synonyms
+  coverImage { extraLarge large }
+  averageScore
+  description(asHtml: false)
+  genres
+  status
+  chapters
+  countryOfOrigin
+}
+''';
+
+  static const Map<MangaDiscoveryFeed, String> _feedAliases =
+      <MangaDiscoveryFeed, String>{
+    MangaDiscoveryFeed.trending: 'trending',
+    MangaDiscoveryFeed.popular: 'popular',
+    MangaDiscoveryFeed.topRated: 'topRated',
+    MangaDiscoveryFeed.latestFinished: 'latestFinished',
+  };
+
+  @override
+  Future<MangaDiscoverySnapshot> fetchSnapshot({int perPage = 20}) async {
+    final VideoMetadataHttpResponse response = await _transport.postJson(
+      Uri.parse(endpoint),
+      headers: const <String, String>{'Accept': 'application/json'},
+      body: <String, Object?>{
+        'query': _combinedQuery,
+        'variables': <String, Object?>{'perPage': perPage.clamp(1, 50)},
+      },
+      operation: 'AniList manga discovery',
+      cacheKey: 'anilist:manga-discovery:$perPage',
+    );
+    final Map<String, Object?> payload =
+        response.decodeJsonObject(operation: 'AniList manga discovery');
+    final List<Object?> errors = metadataList(payload['errors']);
+    if (errors.isNotEmpty) {
+      final String message =
+          metadataString(metadataObject(errors.first)?['message']) ??
+              '${errors.first}';
+      throw VideoMetadataNetworkException(
+        'AniList manga discovery GraphQL error: $message',
+      );
+    }
+    final Map<String, Object?> data =
+        metadataObject(payload['data']) ?? const <String, Object?>{};
+    final Map<MangaDiscoveryFeed, List<MangaDiscoveryEntry>> feeds =
+        <MangaDiscoveryFeed, List<MangaDiscoveryEntry>>{};
+    final Set<int> seenPerFeed = <int>{};
+    for (final MapEntry<MangaDiscoveryFeed, String> alias
+        in _feedAliases.entries) {
+      seenPerFeed.clear();
+      final List<MangaDiscoveryEntry> entries = <MangaDiscoveryEntry>[];
+      final Map<String, Object?>? page = metadataObject(data[alias.value]);
+      for (final Object? node in metadataList(page?['media'])) {
+        final MangaDiscoveryEntry? entry = _mapEntry(metadataObject(node));
+        if (entry != null && seenPerFeed.add(entry.anilistId)) {
+          entries.add(entry);
+        }
+      }
+      feeds[alias.key] = entries;
+    }
+    return MangaDiscoverySnapshot(feeds: feeds);
+  }
+
+  MangaDiscoveryEntry? _mapEntry(Map<String, Object?>? item) {
+    if (item == null) return null;
+    final int? id = metadataInt(item['id']);
+    if (id == null) return null;
+    final Map<String, Object?> titles =
+        metadataObject(item['title']) ?? const <String, Object?>{};
+    final Map<String, Object?> cover =
+        metadataObject(item['coverImage']) ?? const <String, Object?>{};
+    final int? rawScore = metadataInt(item['averageScore']);
+    return MangaDiscoveryEntry(
+      anilistId: id,
+      titleNative: metadataString(titles['native']),
+      titleRomaji: metadataString(titles['romaji']),
+      titleEnglish: metadataString(titles['english']),
+      synonyms: <String>[
+        for (final Object? synonym in metadataList(item['synonyms']))
+          if (metadataString(synonym) != null) metadataString(synonym)!,
+      ],
+      coverUrl:
+          metadataString(cover['extraLarge']) ?? metadataString(cover['large']),
+      averageScore: rawScore == null ? null : rawScore / 10,
+      description: metadataStripHtml(metadataString(item['description'])),
+      genres: <String>[
+        for (final Object? genre in metadataList(item['genres']))
+          if (metadataString(genre) != null) metadataString(genre)!,
+      ],
+      status: metadataString(item['status']),
+      chapters: metadataInt(item['chapters']),
+      countryOfOrigin: metadataString(item['countryOfOrigin']),
+    );
+  }
+
+  @override
+  void close() {
+    if (_ownsTransport) _transport.close();
+  }
+}

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
 import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
 import 'package:fushi/src/media/manga/discovery/manga_source_matcher.dart';
 import 'package:fushi/src/media/manga/manga_global_search_page.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_enabled_sources.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
@@ -111,16 +112,7 @@ class _MangaDiscoveryDetailPageState
     if (MihonRuntimeFactory.isSupported) {
       final MihonManager manager = ref.read(appProvider).mihonManager;
       _mihonManager = manager;
-      final Set<String> enabledExtensions = manager.installed
-          .where((MangaExtensionRow row) => row.enabled)
-          .map((MangaExtensionRow row) => row.packageName)
-          .toSet();
-      _mihonSources = manager.sources
-          .where(
-            (MangaOnlineSourceRow row) =>
-                row.enabled && enabledExtensions.contains(row.extensionPackage),
-          )
-          .toList(growable: false);
+      _mihonSources = enabledMangaOnlineSources(manager);
       for (final MangaOnlineSourceRow row in _mihonSources) {
         sources.add(
           MangaMatchSource(

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
@@ -1,0 +1,435 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
+import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
+import 'package:fushi/src/media/manga/aidoku/aidoku_source_browse_page.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
+import 'package:fushi/src/media/manga/discovery/manga_source_matcher.dart';
+import 'package:fushi/src/media/manga/manga_global_search_page.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/utils.dart';
+
+/// 发现条目详情页：AniList 元数据 + **全自动来源匹配**（用户决策 B）。
+///
+/// 打开即在全部已启用来源（Mihon 在线源 + Aidoku 包）里按标题模糊匹配，命中
+/// 列表按分数排序展示；点一条直接进对应来源的漫画详情页（章节可读）。没有任何
+/// 命中时给「搜索全部来源」兜底入口（预填首选标题的全局搜索页）。
+///
+/// 平台差异只体现在有哪些来源上：无扩展宿主的平台匹配区自然是空表 + 兜底入口。
+class MangaDiscoveryDetailPage extends ConsumerStatefulWidget {
+  const MangaDiscoveryDetailPage({
+    required this.entry,
+    super.key,
+    this.matchSourcesOverride,
+  });
+
+  final MangaDiscoveryEntry entry;
+
+  /// 测试注入：给定时跳过平台来源发现，直接用这些来源做匹配。
+  final List<MangaMatchSource>? matchSourcesOverride;
+
+  @override
+  ConsumerState<MangaDiscoveryDetailPage> createState() =>
+      _MangaDiscoveryDetailPageState();
+}
+
+/// Mihon 命中的回带载荷：打开详情页所需的最小上下文。
+class _MihonMatchPayload {
+  const _MihonMatchPayload(this.sourceContext, this.manga);
+
+  final MihonSourceContext sourceContext;
+  final MihonManga manga;
+}
+
+/// Aidoku 命中的回带载荷。
+class _AidokuMatchPayload {
+  const _AidokuMatchPayload(this.package, this.manga);
+
+  final AidokuInstalledPackage package;
+  final Map<String, Object?> manga;
+}
+
+class _MangaDiscoveryDetailPageState
+    extends ConsumerState<MangaDiscoveryDetailPage> {
+  List<MangaSourceMatch>? _matches;
+  bool _matching = false;
+  bool _started = false;
+
+  MihonManager? _mihonManager;
+  List<MangaOnlineSourceRow> _mihonSources = const <MangaOnlineSourceRow>[];
+  List<AidokuInstalledPackage> _aidokuPackages =
+      const <AidokuInstalledPackage>[];
+  AidokuRuntime? _aidokuRuntime;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_started) return;
+    _started = true;
+    unawaited(_startMatching());
+  }
+
+  /// 收集当前平台上「已启用」的两类来源，与 `MangaBrowsePage` 同一口径：
+  /// Mihon 要求扩展与在线源都启用；Aidoku 要求包启用。
+  Future<List<MangaMatchSource>> _collectSources() async {
+    final List<MangaMatchSource>? override = widget.matchSourcesOverride;
+    if (override != null) return override;
+    final List<MangaMatchSource> sources = <MangaMatchSource>[];
+    if (AidokuRuntimeFactory.isSupported) {
+      try {
+        final List<AidokuInstalledPackage> packages =
+            await (await AidokuPackageStore.open()).listInstalled();
+        _aidokuPackages = packages
+            .where((AidokuInstalledPackage package) => package.enabled)
+            .toList(growable: false);
+        final AidokuRuntime runtime =
+            _aidokuRuntime ??= AidokuRuntimeFactory.create();
+        for (final AidokuInstalledPackage package in _aidokuPackages) {
+          sources.add(
+            MangaMatchSource(
+              id: 'aidoku:${package.id}',
+              name: package.name,
+              language:
+                  package.languages.isEmpty ? '' : package.languages.first,
+              search: (String query) => _searchAidoku(runtime, package, query),
+            ),
+          );
+        }
+      } on Object {
+        // Aidoku 存储打不开只影响 Aidoku 侧来源，不拦 Mihon 匹配。
+      }
+    }
+    if (MihonRuntimeFactory.isSupported) {
+      final MihonManager manager = ref.read(appProvider).mihonManager;
+      _mihonManager = manager;
+      final Set<String> enabledExtensions = manager.installed
+          .where((MangaExtensionRow row) => row.enabled)
+          .map((MangaExtensionRow row) => row.packageName)
+          .toSet();
+      _mihonSources = manager.sources
+          .where(
+            (MangaOnlineSourceRow row) =>
+                row.enabled && enabledExtensions.contains(row.extensionPackage),
+          )
+          .toList(growable: false);
+      for (final MangaOnlineSourceRow row in _mihonSources) {
+        sources.add(
+          MangaMatchSource(
+            id: 'mihon:${row.extensionPackage}:${row.sourceId}',
+            name: row.name,
+            language: row.language,
+            search: (String query) => _searchMihon(manager, row, query),
+          ),
+        );
+      }
+    }
+    return sources;
+  }
+
+  Future<List<MangaMatchHit>> _searchMihon(
+    MihonManager manager,
+    MangaOnlineSourceRow row,
+    String query,
+  ) async {
+    final MihonSourceContext sourceContext =
+        await manager.contextForSource(row);
+    final MihonMangaPage page = await manager.runtime.search(
+      sourceContext.extension,
+      sourceContext.source,
+      page: 1,
+      query: query,
+      preferences: sourceContext.preferences,
+    );
+    return <MangaMatchHit>[
+      for (final MihonManga manga in page.items)
+        MangaMatchHit(
+          title: manga.title,
+          payload: _MihonMatchPayload(sourceContext, manga),
+        ),
+    ];
+  }
+
+  Future<List<MangaMatchHit>> _searchAidoku(
+    AidokuRuntime runtime,
+    AidokuInstalledPackage package,
+    String query,
+  ) async {
+    final Map<String, Object?> result = await runtime.search(
+      package.packagePath,
+      query: query,
+      page: 1,
+    );
+    final List<MangaMatchHit> hits = <MangaMatchHit>[];
+    for (final Object? node
+        in result['entries'] as List<Object?>? ?? const <Object?>[]) {
+      if (node is! Map<Object?, Object?>) continue;
+      final Map<String, Object?> manga = node.cast<String, Object?>();
+      if (manga['key']?.toString().isEmpty ?? true) continue;
+      hits.add(
+        MangaMatchHit(
+          title: manga['title']?.toString() ?? manga['key'].toString(),
+          payload: _AidokuMatchPayload(package, manga),
+        ),
+      );
+    }
+    return hits;
+  }
+
+  Future<void> _startMatching() async {
+    setState(() {
+      _matching = true;
+      _matches = null;
+    });
+    final List<MangaSourceMatch> matches = await matchMangaAcrossSources(
+      entry: widget.entry,
+      sources: await _collectSources(),
+    );
+    if (!mounted) return;
+    setState(() {
+      _matches = matches;
+      _matching = false;
+    });
+  }
+
+  void _openMatch(MangaSourceMatch match) {
+    switch (match.hit.payload) {
+      case final _MihonMatchPayload payload:
+        final MihonManager? manager = _mihonManager;
+        if (manager == null) return;
+        Navigator.of(context).push(
+          adaptivePageRoute<void>(
+            context: context,
+            builder: (BuildContext context) => MihonMangaDetailPage(
+              manager: manager,
+              sourceContext: payload.sourceContext,
+              manga: payload.manga,
+            ),
+          ),
+        );
+      case final _AidokuMatchPayload payload:
+        final AidokuRuntime? runtime = _aidokuRuntime;
+        if (runtime == null) return;
+        Navigator.of(context).push(
+          adaptivePageRoute<void>(
+            context: context,
+            builder: (BuildContext context) => AidokuMangaDetailPage(
+              package: payload.package,
+              runtime: runtime,
+              manga: payload.manga,
+              sourceBaseUrl: null,
+            ),
+          ),
+        );
+    }
+  }
+
+  void _openGlobalSearch() {
+    Navigator.of(context).push(
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (BuildContext context) => MangaGlobalSearchPage(
+          mihonManager: _mihonManager,
+          mihonSources: _mihonSources,
+          aidokuPackages: _aidokuPackages,
+          initialQuery: widget.entry.preferredTitle,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MangaDiscoveryEntry entry = widget.entry;
+    return FushiPageScaffold(
+      title: entry.preferredTitle,
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: <Widget>[
+          _buildHero(entry),
+          const SizedBox(height: 16),
+          _buildMatchesSection(),
+          if (entry.description?.isNotEmpty ?? false) ...<Widget>[
+            const SizedBox(height: 16),
+            Text(
+              entry.description!,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHero(MangaDiscoveryEntry entry) {
+    final ThemeData theme = Theme.of(context);
+    final List<String> subtitles = <String>[
+      for (final String? title in <String?>[
+        entry.titleRomaji,
+        entry.titleEnglish,
+      ])
+        if (title != null && title.isNotEmpty && title != entry.preferredTitle)
+          title,
+    ];
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: 130,
+          height: 185,
+          child: ClipRRect(
+            borderRadius: FushiDesignTokens.of(context).radii.cardRadius,
+            child: MangaDiscoveryCover(url: entry.coverUrl),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(entry.preferredTitle, style: theme.textTheme.titleLarge),
+              for (final String subtitle in subtitles)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  if (entry.averageScore != null)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Icon(
+                          Icons.star_rate_rounded,
+                          size: 16,
+                          color: theme.colorScheme.primary,
+                        ),
+                        Text(
+                          entry.averageScore!.toStringAsFixed(1),
+                          style: theme.textTheme.labelMedium,
+                        ),
+                      ],
+                    ),
+                  if (_statusLabel(entry.status) != null)
+                    Text(
+                      _statusLabel(entry.status)!,
+                      style: theme.textTheme.labelMedium,
+                    ),
+                ],
+              ),
+              if (entry.genres.isNotEmpty) ...<Widget>[
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: <Widget>[
+                    for (final String genre in entry.genres)
+                      FushiTagChip(label: genre),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String? _statusLabel(String? status) => switch (status) {
+        'RELEASING' => t.manga_discovery_status_releasing,
+        'FINISHED' => t.manga_discovery_status_finished,
+        'HIATUS' => t.manga_discovery_status_hiatus,
+        'CANCELLED' => t.manga_discovery_status_cancelled,
+        'NOT_YET_RELEASED' => t.manga_discovery_status_not_yet_released,
+        _ => null,
+      };
+
+  Widget _buildMatchesSection() {
+    final ThemeData theme = Theme.of(context);
+    final List<MangaSourceMatch>? matches = _matches;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                t.manga_discovery_match_section,
+                style: theme.textTheme.titleMedium,
+              ),
+            ),
+            TextButton.icon(
+              key: const ValueKey<String>('manga_discovery_global_search'),
+              onPressed: _matching ? null : _openGlobalSearch,
+              icon: const Icon(Icons.travel_explore, size: 18),
+              label: Text(t.manga_global_search_title),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        if (_matching)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Row(
+              children: <Widget>[
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 12),
+                Text(t.manga_discovery_match_running),
+              ],
+            ),
+          )
+        else if (matches == null || matches.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Text(
+              t.manga_discovery_match_none,
+              style: TextStyle(color: theme.colorScheme.outline),
+            ),
+          )
+        else
+          for (final MangaSourceMatch match in matches)
+            FushiCard(
+              padding: EdgeInsets.zero,
+              child: FushiListItem(
+                leading: CircleAvatar(
+                  child: Text(
+                    match.source.language.isEmpty
+                        ? '?'
+                        : match.source.language.toUpperCase(),
+                    style: theme.textTheme.labelSmall,
+                  ),
+                ),
+                title: Text(match.hit.title),
+                subtitle: Text(
+                  '${match.source.name} · '
+                  '${(match.score * 100).round()}%',
+                ),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _openMatch(match),
+              ),
+            ),
+      ],
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_models.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_models.dart
@@ -1,0 +1,109 @@
+/// 漫画发现页的数据模型：AniList 元数据条目 + 按 feed 分组的快照。
+///
+/// 发现页条目是**元数据**（AniList），不是任何在线来源的条目——「能读」要经
+/// `manga_source_matcher.dart` 在已启用来源里按标题匹配后才成立。这一层不持有
+/// 任何来源引用，保持纯数据。
+library;
+
+/// 发现页的四条内容行。顺序即页面展示顺序。
+enum MangaDiscoveryFeed {
+  /// 趋势（TRENDING_DESC）。
+  trending,
+
+  /// 热门（POPULARITY_DESC）。
+  popular,
+
+  /// 高分（SCORE_DESC，带人气下限过滤冷门条目）。
+  topRated,
+
+  /// 最新完结（FINISHED + END_DATE_DESC，带评分/人气下限）。
+  latestFinished,
+}
+
+/// 一条 AniList 漫画条目。字段与发现页/详情页展示需要一一对应，不多带。
+class MangaDiscoveryEntry {
+  const MangaDiscoveryEntry({
+    required this.anilistId,
+    this.titleNative,
+    this.titleRomaji,
+    this.titleEnglish,
+    this.synonyms = const <String>[],
+    this.coverUrl,
+    this.averageScore,
+    this.description,
+    this.genres = const <String>[],
+    this.status,
+    this.chapters,
+    this.countryOfOrigin,
+  });
+
+  final int anilistId;
+  final String? titleNative;
+  final String? titleRomaji;
+  final String? titleEnglish;
+  final List<String> synonyms;
+  final String? coverUrl;
+
+  /// 0–10 分（AniList 原始是 0–100，provider 已除以 10）。
+  final double? averageScore;
+  final String? description;
+  final List<String> genres;
+
+  /// AniList 原始状态串（`RELEASING` / `FINISHED` / …），展示层自行映射文案。
+  final String? status;
+  final int? chapters;
+  final String? countryOfOrigin;
+
+  /// 展示用首选标题：原文优先（本应用面向原文阅读者），罗马字、英文兜底。
+  String get preferredTitle =>
+      _firstNonEmpty(<String?>[titleNative, titleRomaji, titleEnglish]) ??
+      '#$anilistId';
+
+  /// 参与来源匹配的全部标题（去重、去空）。
+  List<String> get allTitles {
+    final List<String> titles = <String>[];
+    for (final String? title in <String?>[
+      titleNative,
+      titleRomaji,
+      titleEnglish,
+      ...synonyms,
+    ]) {
+      final String? value = _normalizeOrNull(title);
+      if (value != null && !titles.contains(value)) titles.add(value);
+    }
+    return titles;
+  }
+
+  static String? _firstNonEmpty(List<String?> values) {
+    for (final String? value in values) {
+      final String? result = _normalizeOrNull(value);
+      if (result != null) return result;
+    }
+    return null;
+  }
+
+  static String? _normalizeOrNull(String? value) {
+    final String trimmed = value?.trim() ?? '';
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+/// 发现数据源接口：页面依赖它而不是具体实现，测试注入假快照。
+abstract interface class MangaDiscoveryProvider {
+  Future<MangaDiscoverySnapshot> fetchSnapshot({int perPage});
+
+  void close();
+}
+
+/// 一次发现页抓取的完整结果：四条 feed 各自的条目列表。
+class MangaDiscoverySnapshot {
+  const MangaDiscoverySnapshot({required this.feeds});
+
+  final Map<MangaDiscoveryFeed, List<MangaDiscoveryEntry>> feeds;
+
+  List<MangaDiscoveryEntry> operator [](MangaDiscoveryFeed feed) =>
+      feeds[feed] ?? const <MangaDiscoveryEntry>[];
+
+  bool get isEmpty =>
+      feeds.values.every((List<MangaDiscoveryEntry> list) => list.isEmpty);
+}

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/src/media/manga/discovery/anilist_manga_discovery_provider.dart';
 import 'package:fushi/src/media/manga/discovery/manga_discovery_detail_page.dart';
 import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_source_feeds.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
+import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/utils.dart';
 
 /// 漫画库「发现」视图：AniList 元数据的趋势 / 热门 / 高分 / 最新完结四条横滑行。
@@ -18,11 +24,12 @@ import 'package:fushi/utils.dart';
 ///
 /// 首次切到本视图才发请求（库页壳惰性构建），结果保活在 State 里（壳 Offstage
 /// 保活），切走切回不重抓；显式刷新走页头按钮。
-class MangaDiscoveryPage extends StatefulWidget {
+class MangaDiscoveryPage extends ConsumerStatefulWidget {
   const MangaDiscoveryPage({
     super.key,
     this.navigation,
     this.provider,
+    this.sourceFeedsOverride,
   });
 
   /// 库页视图导航条（由 `MediaLibraryShell` 传入，作为页头主内容）。
@@ -31,15 +38,22 @@ class MangaDiscoveryPage extends StatefulWidget {
   /// 数据源。为空时创建 AniList provider；测试注入假实现。
   final MangaDiscoveryProvider? provider;
 
+  /// 测试注入：给定时跳过平台来源发现，直接渲染这些来源热门行。
+  final List<MangaDiscoverySourceFeed>? sourceFeedsOverride;
+
   @override
-  State<MangaDiscoveryPage> createState() => _MangaDiscoveryPageState();
+  ConsumerState<MangaDiscoveryPage> createState() => _MangaDiscoveryPageState();
 }
 
-class _MangaDiscoveryPageState extends State<MangaDiscoveryPage> {
+class _MangaDiscoveryPageState extends ConsumerState<MangaDiscoveryPage> {
   AniListMangaDiscoveryProvider? _ownedProvider;
   MangaDiscoverySnapshot? _snapshot;
   Object? _error;
   bool _loading = false;
+
+  MihonManager? _mihonManager;
+  final MihonSourceImageLoadQueue _imageQueue =
+      MihonSourceImageLoadQueue(maxConcurrent: 4);
 
   MangaDiscoveryProvider get _provider =>
       widget.provider ?? (_ownedProvider ??= AniListMangaDiscoveryProvider());
@@ -51,7 +65,33 @@ class _MangaDiscoveryPageState extends State<MangaDiscoveryPage> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 与 MangaBrowsePage 同一范式：监听 manager，来源装载/启停后行列表跟着变。
+    if (widget.sourceFeedsOverride != null) return;
+    if (!MihonRuntimeFactory.isSupported) return;
+    final MihonManager manager = ref.read(appProvider).mihonManager;
+    if (identical(manager, _mihonManager)) return;
+    _mihonManager?.removeListener(_managerChanged);
+    _mihonManager = manager..addListener(_managerChanged);
+  }
+
+  void _managerChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// 来源热门行清单：测试注入优先，否则按平台从 Mihon 宿主取。
+  List<MangaDiscoverySourceFeed> _sourceFeeds() {
+    final List<MangaDiscoverySourceFeed>? override = widget.sourceFeedsOverride;
+    if (override != null) return override;
+    final MihonManager? manager = _mihonManager;
+    if (manager == null) return const <MangaDiscoverySourceFeed>[];
+    return mihonDiscoverySourceFeeds(manager: manager, imageQueue: _imageQueue);
+  }
+
+  @override
   void dispose() {
+    _mihonManager?.removeListener(_managerChanged);
     _ownedProvider?.close();
     super.dispose();
   }
@@ -147,6 +187,13 @@ class _MangaDiscoveryPageState extends State<MangaDiscoveryPage> {
           title: t.manga_discovery_section_latest_finished,
           entries: snapshot[MangaDiscoveryFeed.latestFinished],
         ),
+        // P2：AniList 行之后接「来源热门」行——条目直接来自已启用来源，点开即
+        // 可读，不经过标题匹配。空/失败的行整行隐藏（补充内容，不立错误牌坊）。
+        for (final MangaDiscoverySourceFeed feed in _sourceFeeds())
+          MangaDiscoverySourceRow(
+            key: ValueKey<String>('manga_discovery_source_${feed.id}'),
+            feed: feed,
+          ),
       ],
     );
   }
@@ -266,6 +313,111 @@ class _MangaDiscoveryPageState extends State<MangaDiscoveryPage> {
                       ),
                     ],
                   ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 一条「来源热门」横滑行：首次挂载才加载（发现视图本身已惰性构建，行不会
+/// 因页面存在就打请求风暴）；加载中显示细进度条，空/失败整行收起。
+class MangaDiscoverySourceRow extends StatefulWidget {
+  const MangaDiscoverySourceRow({required this.feed, super.key});
+
+  final MangaDiscoverySourceFeed feed;
+
+  @override
+  State<MangaDiscoverySourceRow> createState() =>
+      _MangaDiscoverySourceRowState();
+}
+
+class _MangaDiscoverySourceRowState extends State<MangaDiscoverySourceRow> {
+  List<MangaDiscoverySourceItem>? _items;
+  bool _failed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final List<MangaDiscoverySourceItem> items =
+          await widget.feed.loadPopular();
+      if (!mounted) return;
+      setState(() => _items = items);
+    } on Object {
+      // 来源热门是补充内容：单源失败静默收起，不立错误牌坊（与匹配编排同纪律）。
+      if (!mounted) return;
+      setState(() => _failed = true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failed) return const SizedBox.shrink();
+    final List<MangaDiscoverySourceItem>? items = _items;
+    if (items == null) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: LinearProgressIndicator(minHeight: 2),
+      );
+    }
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              t.manga_discovery_source_popular(source: widget.feed.name),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 214,
+            child: HorizontalDragScrollable(
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: items.length,
+                itemBuilder: (BuildContext context, int index) =>
+                    _buildCard(items[index]),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard(MangaDiscoverySourceItem item) {
+    return SizedBox(
+      width: 130,
+      child: Padding(
+        padding: const EdgeInsets.only(right: 12),
+        child: FushiCard(
+          padding: EdgeInsets.zero,
+          onTap: () => item.open(context),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(child: item.buildCover(context)),
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(
+                  item.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
             ],

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
@@ -1,0 +1,303 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/manga/discovery/anilist_manga_discovery_provider.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_detail_page.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/utils.dart';
+
+/// 漫画库「发现」视图：AniList 元数据的趋势 / 热门 / 高分 / 最新完结四条横滑行。
+///
+/// 结构对齐 hayase 化后的视频首页决策（用户拍板）：**不做自动播轮播**，趋势行
+/// 用更大的卡片充当页首视觉锚点，其余行标准卡片，全部是可拖动的横滑行。
+///
+/// 条目是元数据不是来源条目；点开进 [MangaDiscoveryDetailPage]，由它在已启用
+/// 来源里自动匹配可读条目。本页因此在**五个平台都可用**（AniList 公开查询与
+/// 扩展宿主无关），与库页「视图列表无条件常量」的纪律一致。
+///
+/// 首次切到本视图才发请求（库页壳惰性构建），结果保活在 State 里（壳 Offstage
+/// 保活），切走切回不重抓；显式刷新走页头按钮。
+class MangaDiscoveryPage extends StatefulWidget {
+  const MangaDiscoveryPage({
+    super.key,
+    this.navigation,
+    this.provider,
+  });
+
+  /// 库页视图导航条（由 `MediaLibraryShell` 传入，作为页头主内容）。
+  final Widget? navigation;
+
+  /// 数据源。为空时创建 AniList provider；测试注入假实现。
+  final MangaDiscoveryProvider? provider;
+
+  @override
+  State<MangaDiscoveryPage> createState() => _MangaDiscoveryPageState();
+}
+
+class _MangaDiscoveryPageState extends State<MangaDiscoveryPage> {
+  AniListMangaDiscoveryProvider? _ownedProvider;
+  MangaDiscoverySnapshot? _snapshot;
+  Object? _error;
+  bool _loading = false;
+
+  MangaDiscoveryProvider get _provider =>
+      widget.provider ?? (_ownedProvider ??= AniListMangaDiscoveryProvider());
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  @override
+  void dispose() {
+    _ownedProvider?.close();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    if (_loading) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final MangaDiscoverySnapshot snapshot = await _provider.fetchSnapshot();
+      if (!mounted) return;
+      setState(() {
+        _snapshot = snapshot;
+        _loading = false;
+      });
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  void _openEntry(MangaDiscoveryEntry entry) {
+    Navigator.of(context).push(
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (BuildContext context) =>
+            MangaDiscoveryDetailPage(entry: entry),
+      ),
+    );
+  }
+
+  /// 页头。与 `MangaBrowsePage` 同一范式：导航条存在时即页头主位。
+  Widget _buildHeader() {
+    final List<Widget> actions = <Widget>[
+      IconButton(
+        key: const ValueKey<String>('manga_discovery_refresh'),
+        tooltip: t.retry,
+        onPressed: _loading ? null : () => unawaited(_load()),
+        icon: const Icon(Icons.refresh),
+      ),
+    ];
+    final Widget? navigation = widget.navigation;
+    if (navigation != null) {
+      return FushiPageHeader.customTitle(title: navigation, actions: actions);
+    }
+    return FushiPageHeader(title: t.library_view_discover, actions: actions);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DesktopContentLayout(
+      kind: DesktopContentKind.readerShelf,
+      child: Column(
+        children: <Widget>[
+          if (!isCupertinoPlatform(context)) _buildHeader(),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    final MangaDiscoverySnapshot? snapshot = _snapshot;
+    if (snapshot == null) {
+      if (_loading) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      return _buildError();
+    }
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: <Widget>[
+        _buildSection(
+          title: t.manga_discovery_section_trending,
+          entries: snapshot[MangaDiscoveryFeed.trending],
+          cardWidth: 165,
+          stripHeight: 265,
+        ),
+        _buildSection(
+          title: t.manga_discovery_section_popular,
+          entries: snapshot[MangaDiscoveryFeed.popular],
+        ),
+        _buildSection(
+          title: t.manga_discovery_section_top_rated,
+          entries: snapshot[MangaDiscoveryFeed.topRated],
+        ),
+        _buildSection(
+          title: t.manga_discovery_section_latest_finished,
+          entries: snapshot[MangaDiscoveryFeed.latestFinished],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildError() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              t.manga_discovery_load_failed,
+              textAlign: TextAlign.center,
+            ),
+            if (_error != null) ...<Widget>[
+              const SizedBox(height: 8),
+              Text(
+                '$_error',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            FilledButton.tonal(
+              key: const ValueKey<String>('manga_discovery_retry'),
+              onPressed: () => unawaited(_load()),
+              child: Text(t.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required List<MangaDiscoveryEntry> entries,
+    double cardWidth = 130,
+    double stripHeight = 214,
+  }) {
+    if (entries.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          const SizedBox(height: 8),
+          // 桌面端默认 dragDevices 不含 mouse，横滑行必须包
+          // HorizontalDragScrollable（横向滚动守卫，与全局搜索页同一处理）。
+          SizedBox(
+            height: stripHeight,
+            child: HorizontalDragScrollable(
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: entries.length,
+                itemBuilder: (BuildContext context, int index) =>
+                    _buildCard(entries[index], width: cardWidth),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard(MangaDiscoveryEntry entry, {required double width}) {
+    final double? score = entry.averageScore;
+    return SizedBox(
+      width: width,
+      child: Padding(
+        padding: const EdgeInsets.only(right: 12),
+        child: FushiCard(
+          padding: EdgeInsets.zero,
+          onTap: () => _openEntry(entry),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(child: MangaDiscoveryCover(url: entry.coverUrl)),
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      entry.preferredTitle,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    if (score != null) ...<Widget>[
+                      const SizedBox(height: 2),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Icon(
+                            Icons.star_rate_rounded,
+                            size: 14,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 2),
+                          Text(
+                            score.toStringAsFixed(1),
+                            style: Theme.of(context).textTheme.labelSmall,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// AniList 封面（公开 CDN，普通 `Image.network` 即可）；空/失败给占位图标。
+class MangaDiscoveryCover extends StatelessWidget {
+  const MangaDiscoveryCover({required this.url, super.key});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    final String value = url?.trim() ?? '';
+    if (value.isEmpty) {
+      return const ColoredBox(
+        color: Color(0x11000000),
+        child: Center(child: Icon(Icons.image_not_supported_outlined)),
+      );
+    }
+    return Image.network(
+      value,
+      fit: BoxFit.cover,
+      errorBuilder: (_, __, ___) => const ColoredBox(
+        color: Color(0x11000000),
+        child: Center(child: Icon(Icons.broken_image_outlined)),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_source_feeds.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_source_feeds.dart
@@ -1,0 +1,100 @@
+/// 发现页「来源热门行」的数据口 + Mihon 适配（P2，用户决策混合 C 的下半部）。
+///
+/// 与 `manga_source_matcher.dart` 同一纪律：页面只认「名字 + 一个加载函数 +
+/// 一组可渲染条目」，Mihon 的 context/封面/详情页跳转全部收在适配函数里——
+/// 页面因此可以用假 feed 做 widget 测试，不用架起真实扩展宿主。
+library;
+
+import 'package:flutter/widgets.dart';
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_enabled_sources.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
+import 'package:fushi/utils.dart';
+
+/// 一条可渲染的来源条目：标题 + 封面构建器 + 打开动作。
+class MangaDiscoverySourceItem {
+  const MangaDiscoverySourceItem({
+    required this.title,
+    required this.buildCover,
+    required this.open,
+  });
+
+  final String title;
+  final Widget Function(BuildContext context) buildCover;
+  final void Function(BuildContext context) open;
+}
+
+/// 一条来源热门行：加载失败/为空由页面决定整行隐藏。
+class MangaDiscoverySourceFeed {
+  const MangaDiscoverySourceFeed({
+    required this.id,
+    required this.name,
+    required this.language,
+    required this.loadPopular,
+  });
+
+  final String id;
+  final String name;
+  final String language;
+  final Future<List<MangaDiscoverySourceItem>> Function() loadPopular;
+}
+
+/// 把全部已启用 Mihon 在线来源适配成热门行。每行首次可见才真正 getPopular
+/// 第 1 页；封面走 [MihonSourceImage]（带扩展拦截器/cookie），共享 [imageQueue]
+/// 限并发。
+List<MangaDiscoverySourceFeed> mihonDiscoverySourceFeeds({
+  required MihonManager manager,
+  required MihonSourceImageLoadQueue imageQueue,
+}) {
+  return <MangaDiscoverySourceFeed>[
+    for (final MangaOnlineSourceRow row in enabledMangaOnlineSources(manager))
+      MangaDiscoverySourceFeed(
+        id: 'mihon:${row.extensionPackage}:${row.sourceId}',
+        name: row.name,
+        language: row.language,
+        loadPopular: () => _loadMihonPopular(manager, row, imageQueue),
+      ),
+  ];
+}
+
+Future<List<MangaDiscoverySourceItem>> _loadMihonPopular(
+  MihonManager manager,
+  MangaOnlineSourceRow row,
+  MihonSourceImageLoadQueue imageQueue,
+) async {
+  final MihonSourceContext sourceContext = await manager.contextForSource(row);
+  final MihonMangaPage page = await manager.runtime.getPopular(
+    sourceContext.extension,
+    sourceContext.source,
+    page: 1,
+    preferences: sourceContext.preferences,
+  );
+  return <MangaDiscoverySourceItem>[
+    for (final MihonManga manga in page.items)
+      MangaDiscoverySourceItem(
+        title: manga.title,
+        buildCover: (BuildContext context) => MihonSourceImage(
+          runtime: manager.runtime,
+          cache: manager.coverCache,
+          context: sourceContext,
+          url: manga.coverUrl,
+          loadQueue: imageQueue,
+        ),
+        open: (BuildContext context) {
+          Navigator.of(context).push(
+            adaptivePageRoute<void>(
+              context: context,
+              builder: (BuildContext context) => MihonMangaDetailPage(
+                manager: manager,
+                sourceContext: sourceContext,
+                manga: manga,
+              ),
+            ),
+          );
+        },
+      ),
+  ];
+}

--- a/fushi/lib/src/media/manga/discovery/manga_source_matcher.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_source_matcher.dart
@@ -1,0 +1,148 @@
+/// 跨来源自动匹配：给一条 AniList 发现条目，在全部已启用来源里找出最像的
+/// 可读条目（用户决策：全自动，不要手动搜索兜底当主路径）。
+///
+/// 本文件只做**纯编排**：来源被抽象成「名字 + 语言 + 一个搜索函数」，Mihon /
+/// Aidoku 的真实调用由页面适配后注入——编排逻辑因此可以用假来源做单元测试，
+/// 与 `MangaGlobalSearchPage` 的每源独立、限并发扇出同一套纪律。
+library;
+
+import 'dart:collection';
+
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_title_matcher.dart';
+
+/// 匹配分低于此值的结果直接丢弃：三指标加权下 0.55 以下基本是同题材蹭词。
+const double kMangaSourceMatchMinScore = 0.55;
+
+/// 一个可参与匹配的来源：页面把 Mihon 在线源 / Aidoku 包适配成这个形状。
+class MangaMatchSource {
+  const MangaMatchSource({
+    required this.id,
+    required this.name,
+    required this.language,
+    required this.search,
+  });
+
+  final String id;
+  final String name;
+
+  /// 来源语言码（决定先用哪个标题去搜：日文源先原文，其余先英文/罗马字）。
+  final String language;
+
+  /// 按关键词搜索本来源，返回候选命中。抛错由编排层兜住，只影响本来源。
+  final Future<List<MangaMatchHit>> Function(String query) search;
+}
+
+/// 来源搜索出的一条候选：标题参与打分，[payload] 原样带回给页面打开详情。
+class MangaMatchHit {
+  const MangaMatchHit({required this.title, required this.payload});
+
+  final String title;
+  final Object payload;
+}
+
+/// 一条匹配结果：某来源里分数最高的候选。
+class MangaSourceMatch {
+  const MangaSourceMatch({
+    required this.source,
+    required this.hit,
+    required this.score,
+  });
+
+  final MangaMatchSource source;
+  final MangaMatchHit hit;
+  final double score;
+}
+
+/// 对 [entry] 在 [sources] 里做全自动匹配。
+///
+/// 每个来源：按语言挑标题顺序逐个查询，第一个有结果的查询即定（不叠加多查询
+/// 的结果——同源多查询近乎重复，徒增请求）；候选按 [mangaTitleMatchScore] 对
+/// 全部标题打分，留下该来源最高分且 ≥ [minScore] 的一条。来源间限并发扇出，
+/// 单源失败静默跳过（发现页匹配是尽力而为，不是必达）。
+Future<List<MangaSourceMatch>> matchMangaAcrossSources({
+  required MangaDiscoveryEntry entry,
+  required List<MangaMatchSource> sources,
+  int maxConcurrent = 4,
+  double minScore = kMangaSourceMatchMinScore,
+}) async {
+  final List<String> targets = entry.allTitles;
+  if (targets.isEmpty || sources.isEmpty) return const <MangaSourceMatch>[];
+  final List<MangaSourceMatch?> results =
+      List<MangaSourceMatch?>.filled(sources.length, null);
+  final Queue<int> pending =
+      Queue<int>.of(List<int>.generate(sources.length, (int i) => i));
+  Future<void> worker() async {
+    while (pending.isNotEmpty) {
+      final int index = pending.removeFirst();
+      results[index] = await _matchOne(
+        entry,
+        sources[index],
+        targets,
+        minScore,
+      );
+    }
+  }
+
+  final int workers =
+      maxConcurrent < sources.length ? maxConcurrent : sources.length;
+  await Future.wait<void>(
+    <Future<void>>[for (int i = 0; i < workers; i++) worker()],
+  );
+  final List<MangaSourceMatch> matches = results
+      .whereType<MangaSourceMatch>()
+      .toList()
+    ..sort(
+      (MangaSourceMatch a, MangaSourceMatch b) => b.score.compareTo(a.score),
+    );
+  return matches;
+}
+
+Future<MangaSourceMatch?> _matchOne(
+  MangaDiscoveryEntry entry,
+  MangaMatchSource source,
+  List<String> targets,
+  double minScore,
+) async {
+  for (final String query in mangaMatchQueriesFor(entry, source.language)) {
+    final List<MangaMatchHit> hits;
+    try {
+      hits = await source.search(query);
+    } on Object {
+      // 单源失败（Cloudflare、超时、扩展崩溃）不拖累其余来源。
+      return null;
+    }
+    if (hits.isEmpty) continue;
+    MangaMatchHit? best;
+    double bestScore = 0;
+    for (final MangaMatchHit hit in hits) {
+      final double score = mangaTitleMatchScore(hit.title, targets);
+      if (score > bestScore) {
+        bestScore = score;
+        best = hit;
+      }
+    }
+    if (best != null && bestScore >= minScore) {
+      return MangaSourceMatch(source: source, hit: best, score: bestScore);
+    }
+    // 本查询有结果但都不像：换下一个标题继续，来源可能只认另一种写法。
+  }
+  return null;
+}
+
+/// 按来源语言排出的查询词序列（去重、去空）：日/中/韩来源先原文标题，
+/// 其余来源先英文、再罗马字、最后原文。
+List<String> mangaMatchQueriesFor(MangaDiscoveryEntry entry, String language) {
+  final String lang = language.toLowerCase();
+  final bool cjkFirst =
+      lang.startsWith('ja') || lang.startsWith('zh') || lang.startsWith('ko');
+  final List<String?> ordered = cjkFirst
+      ? <String?>[entry.titleNative, entry.titleRomaji, entry.titleEnglish]
+      : <String?>[entry.titleEnglish, entry.titleRomaji, entry.titleNative];
+  final List<String> queries = <String>[];
+  for (final String? title in ordered) {
+    final String value = title?.trim() ?? '';
+    if (value.isNotEmpty && !queries.contains(value)) queries.add(value);
+  }
+  return queries;
+}

--- a/fushi/lib/src/media/manga/discovery/manga_title_matcher.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_title_matcher.dart
@@ -1,0 +1,135 @@
+/// 标题模糊匹配打分：把「AniList 元数据条目」对上「在线来源搜索结果」。
+///
+/// 打分模型对齐 AnymeX 的 SourceMapper：token-set 0.4 + partial 0.3 + 全串
+/// ratio 0.3 加权（漫画没有 season，去掉季号加成项）。两处为 CJK 做的适配：
+/// - token 化按空白切；CJK 标题没有空白，token-set 退化为整串比较——此时
+///   partial ratio（短串在长串里找最佳窗口）承担「包含即高分」的职责，覆盖
+///   来源把副标题/卷号拼进标题的常见情况。
+/// - 归一化只删标点/符号并折叠空白，**不做任何转写**：假名/汉字/罗马字之间
+///   不互转，跨文字系统的命中交给多标题轮询（native/romaji/english 各查一轮）。
+library;
+
+import 'dart:math' as math;
+
+/// [candidate]（来源搜索结果标题）对 [targets]（AniList 各语言标题+别名）的
+/// 匹配分，取所有 target 中的最高分。返回 0.0–1.0。
+double mangaTitleMatchScore(String candidate, List<String> targets) {
+  final String source = normalizeMangaTitle(candidate);
+  if (source.isEmpty) return 0;
+  double best = 0;
+  for (final String target in targets) {
+    final String normalized = normalizeMangaTitle(target);
+    if (normalized.isEmpty) continue;
+    final double score = _pairScore(source, normalized);
+    if (score > best) best = score;
+    if (best >= 1) break;
+  }
+  return best;
+}
+
+double _pairScore(String a, String b) {
+  final double tokenSet = _tokenSetRatio(a, b);
+  final double partial = _partialRatio(a, b);
+  final double whole = _ratio(a, b);
+  final double score = tokenSet * 0.4 + partial * 0.3 + whole * 0.3;
+  return score.clamp(0.0, 1.0);
+}
+
+/// 归一化：小写、去标点/符号（保留字母数字与 CJK）、折叠空白。
+String normalizeMangaTitle(String value) {
+  final StringBuffer buffer = StringBuffer();
+  bool pendingSpace = false;
+  for (final int rune in value.toLowerCase().runes) {
+    if (_isTitleRune(rune)) {
+      if (pendingSpace && buffer.isNotEmpty) buffer.writeCharCode(0x20);
+      pendingSpace = false;
+      buffer.writeCharCode(rune);
+    } else {
+      // 标点、符号、空白统一视作分隔，折叠为单个空格。
+      pendingSpace = true;
+    }
+  }
+  return buffer.toString();
+}
+
+bool _isTitleRune(int rune) {
+  if (rune >= 0x30 && rune <= 0x39) return true; // 0-9
+  if (rune >= 0x61 && rune <= 0x7A) return true; // a-z
+  if (rune >= 0x3040 && rune <= 0x30FF) return true; // 假名
+  if (rune >= 0x3400 && rune <= 0x9FFF) return true; // CJK 扩展 A + 基本区
+  if (rune >= 0xF900 && rune <= 0xFAFF) return true; // CJK 兼容
+  if (rune >= 0xAC00 && rune <= 0xD7AF) return true; // 谚文
+  if (rune >= 0xFF10 && rune <= 0xFF19) return true; // 全角数字
+  if (rune >= 0xFF41 && rune <= 0xFF5A) return true; // 全角小写字母
+  if (rune >= 0x31F0 && rune <= 0x31FF) return true; // 片假名音标扩展
+  return false;
+}
+
+/// 全串相似度：1 - 编辑距离/较长串长度。
+double _ratio(String a, String b) {
+  if (a == b) return 1;
+  final int maxLen = math.max(a.length, b.length);
+  if (maxLen == 0) return 1;
+  return 1 - _levenshtein(a, b) / maxLen;
+}
+
+/// 短串对长串所有等长窗口的最佳 [_ratio]。窗口按短串长度滑动，步长 1。
+double _partialRatio(String a, String b) {
+  final String shorter = a.length <= b.length ? a : b;
+  final String longer = a.length <= b.length ? b : a;
+  if (shorter.isEmpty) return 0;
+  if (longer.contains(shorter)) return 1;
+  double best = 0;
+  for (int start = 0; start + shorter.length <= longer.length; start++) {
+    final double score =
+        _ratio(shorter, longer.substring(start, start + shorter.length));
+    if (score > best) best = score;
+    if (best >= 1) break;
+  }
+  return best;
+}
+
+/// 词集合相似度（fuzzywuzzy 的 token_set_ratio 简化版）：交集串与两个「交集+
+/// 差集」串两两比较取最高。CJK 无空白时退化为整串比较（词表只有一个元素）。
+double _tokenSetRatio(String a, String b) {
+  final Set<String> tokensA =
+      a.split(' ').where((String t) => t.isNotEmpty).toSet();
+  final Set<String> tokensB =
+      b.split(' ').where((String t) => t.isNotEmpty).toSet();
+  if (tokensA.isEmpty || tokensB.isEmpty) return 0;
+  final List<String> intersection = (tokensA.intersection(tokensB)).toList()
+    ..sort();
+  final List<String> onlyA = tokensA.difference(tokensB).toList()..sort();
+  final List<String> onlyB = tokensB.difference(tokensA).toList()..sort();
+  final String base = intersection.join(' ');
+  final String combinedA = <String>[...intersection, ...onlyA].join(' ').trim();
+  final String combinedB = <String>[...intersection, ...onlyB].join(' ').trim();
+  double best = _ratio(combinedA, combinedB);
+  if (base.isNotEmpty) {
+    best = math.max(best, _ratio(base, combinedA));
+    best = math.max(best, _ratio(base, combinedB));
+  }
+  return best;
+}
+
+int _levenshtein(String a, String b) {
+  if (a.isEmpty) return b.length;
+  if (b.isEmpty) return a.length;
+  List<int> previous =
+      List<int>.generate(b.length + 1, (int index) => index, growable: false);
+  List<int> current = List<int>.filled(b.length + 1, 0, growable: false);
+  for (int i = 0; i < a.length; i++) {
+    current[0] = i + 1;
+    for (int j = 0; j < b.length; j++) {
+      final int cost = a.codeUnitAt(i) == b.codeUnitAt(j) ? 0 : 1;
+      current[j + 1] = math.min(
+        math.min(current[j] + 1, previous[j + 1] + 1),
+        previous[j] + cost,
+      );
+    }
+    final List<int> swap = previous;
+    previous = current;
+    current = swap;
+  }
+  return previous[b.length];
+}

--- a/fushi/lib/src/media/manga/manga_browse_page.dart
+++ b/fushi/lib/src/media/manga/manga_browse_page.dart
@@ -8,6 +8,7 @@ import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_source_browse_page.dart';
 import 'package:fushi/src/media/manga/manga_global_search_page.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_enabled_sources.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
@@ -158,16 +159,7 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
   List<MangaOnlineSourceRow> _enabledSources() {
     final MihonManager? manager = _manager;
     if (manager == null) return const <MangaOnlineSourceRow>[];
-    final Set<String> enabledExtensions = manager.installed
-        .where((MangaExtensionRow row) => row.enabled)
-        .map((MangaExtensionRow row) => row.packageName)
-        .toSet();
-    return manager.sources
-        .where(
-          (MangaOnlineSourceRow row) =>
-              row.enabled && enabledExtensions.contains(row.extensionPackage),
-        )
-        .toList(growable: false);
+    return enabledMangaOnlineSources(manager);
   }
 
   /// 页头。与 `MediaSourcesPage` / `MangaSourcesPage` 同一范式：库页视图导航条

--- a/fushi/lib/src/media/manga/manga_library_page.dart
+++ b/fushi/lib/src/media/manga/manga_library_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
 import 'package:fushi/src/media/manga/manga_browse_page.dart';
 import 'package:fushi/src/media/manga/manga_sources_page.dart';
 import 'package:fushi/src/pages/implementations/media_library_shell.dart';
@@ -8,10 +9,12 @@ import 'package:fushi/src/pages/implementations/reader_fushi_history_page.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/utils.dart';
 
-/// 顶层漫画库页：**恒为三视图**，五个平台完全同构。
+/// 顶层漫画库页：**恒为四视图**（外加设置），五个平台完全同构。
 ///
 /// - **书架**：数据、卡片、搜索、排序、合集、进度和删除全部复用小说书架；唯一差异
 ///   是只展示 `EpubBooks.format == 'manga'` 的条目。普通书架由同一页面反向排除漫画。
+/// - **发现**：AniList 元数据的趋势/热门/高分/最新完结横滑行；条目点开后在已启用
+///   来源里自动匹配可读条目（`discovery/`）。
 /// - **浏览**：可浏览内容的在线来源清单——内置 mokuro.moe 目录 + 已启用的 Mihon
 ///   在线来源，两者并列。
 /// - **来源**：本地漫画扫描根 + 漫画扩展（仓库/安装/启停）+ 扩展提供的在线来源
@@ -41,6 +44,12 @@ class MangaLibraryPage extends StatelessWidget {
           label: t.library_view_shelf,
           builder: (BuildContext context, Widget navigation) =>
               ReaderFushiHistoryPage(mangaOnly: true, navigation: navigation),
+        ),
+        MediaLibraryViewSpec(
+          kind: MediaLibraryViewKind.discover,
+          label: t.library_view_discover,
+          builder: (BuildContext context, Widget navigation) =>
+              MangaDiscoveryPage(navigation: navigation),
         ),
         MediaLibraryViewSpec(
           kind: MediaLibraryViewKind.browse,

--- a/fushi/lib/src/media/manga/mihon/mihon_enabled_sources.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_enabled_sources.dart
@@ -1,0 +1,31 @@
+/// 「已启用在线来源」的唯一口径：来源自身启用，**且**提供它的扩展也启用。
+///
+/// 浏览页、发现详情页、发现源热门行三处消费同一份判据；口径不一致会出现
+/// 「来源页关了、别处还在发请求」这类用户没法解释的行为（与 BUG-1431 同因）。
+library;
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
+
+/// 纯过滤：从扩展表 + 来源表算出已启用来源（保持 [sources] 原有顺序）。
+List<MangaOnlineSourceRow> filterEnabledMangaOnlineSources({
+  required List<MangaExtensionRow> installed,
+  required List<MangaOnlineSourceRow> sources,
+}) {
+  final Set<String> enabledExtensions = installed
+      .where((MangaExtensionRow row) => row.enabled)
+      .map((MangaExtensionRow row) => row.packageName)
+      .toSet();
+  return sources
+      .where(
+        (MangaOnlineSourceRow row) =>
+            row.enabled && enabledExtensions.contains(row.extensionPackage),
+      )
+      .toList(growable: false);
+}
+
+List<MangaOnlineSourceRow> enabledMangaOnlineSources(MihonManager manager) =>
+    filterEnabledMangaOnlineSources(
+      installed: manager.installed,
+      sources: manager.sources,
+    );

--- a/fushi/lib/src/pages/implementations/media_library_shell.dart
+++ b/fushi/lib/src/pages/implementations/media_library_shell.dart
@@ -11,6 +11,9 @@ enum MediaLibraryViewKind {
   /// 已入库条目（书架 / 媒体库）。
   library,
 
+  /// 内容发现（漫画的 AniList 趋势/热门横滑行；条目是元数据，点开再匹配来源）。
+  discover,
+
   /// 在线源浏览（漫画的 mokuro.moe 目录；将来小说源同位）。
   browse,
 

--- a/fushi/test/media/manga/discovery/anilist_manga_discovery_provider_test.dart
+++ b/fushi/test/media/manga/discovery/anilist_manga_discovery_provider_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:fushi/src/media/manga/discovery/anilist_manga_discovery_provider.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_transport.dart';
+
+/// AniList 漫画发现 provider：combined query 一次请求解析出四条 feed，
+/// 字段映射（评分 /10、HTML 剥离、多标题）与 GraphQL 错误转异常都要真解析。
+void main() {
+  Map<String, Object?> media({
+    required int id,
+    String? native,
+    String? romaji,
+    String? english,
+    int? score,
+    String? description,
+  }) =>
+      <String, Object?>{
+        'id': id,
+        'title': <String, Object?>{
+          'native': native,
+          'romaji': romaji,
+          'english': english,
+        },
+        'synonyms': <Object?>['别名A', null],
+        'coverImage': <String, Object?>{
+          'extraLarge': 'https://img.example/$id-xl.jpg',
+          'large': 'https://img.example/$id.jpg',
+        },
+        'averageScore': score,
+        'description': description,
+        'genres': <Object?>['Fantasy', 'Adventure'],
+        'status': 'RELEASING',
+        'chapters': null,
+        'countryOfOrigin': 'JP',
+      };
+
+  AniListMangaDiscoveryProvider providerWith(
+    Future<http.Response> Function(http.Request request) handler,
+  ) =>
+      AniListMangaDiscoveryProvider(client: MockClient(handler));
+
+  test('combined query 解析四条 feed，评分除以 10，HTML 剥离', () async {
+    late Map<String, Object?> sentBody;
+    final AniListMangaDiscoveryProvider provider =
+        providerWith((http.Request request) async {
+      sentBody = jsonDecode(request.body) as Map<String, Object?>;
+      return http.Response(
+        jsonEncode(<String, Object?>{
+          'data': <String, Object?>{
+            'trending': <String, Object?>{
+              'media': <Object?>[
+                media(
+                  id: 10,
+                  native: '葬送のフリーレン',
+                  romaji: 'Sousou no Frieren',
+                  score: 89,
+                  description: '<i>魔王</i>を倒した後の物語。<br>勇者一行。',
+                ),
+                media(id: 10, native: '重复条目同 id 去重'),
+              ],
+            },
+            'popular': <String, Object?>{
+              'media': <Object?>[media(id: 20, english: 'One Piece')],
+            },
+            'topRated': <String, Object?>{'media': <Object?>[]},
+            'latestFinished': <String, Object?>{
+              'media': <Object?>[media(id: 30, romaji: 'Owari')],
+            },
+          },
+        }),
+        200,
+        headers: <String, String>{'content-type': 'application/json'},
+      );
+    });
+
+    final MangaDiscoverySnapshot snapshot = await provider.fetchSnapshot();
+    provider.close();
+
+    expect((sentBody['query']! as String), contains('type: MANGA'));
+    expect(
+      (sentBody['variables']! as Map<String, Object?>)['perPage'],
+      20,
+    );
+
+    final List<MangaDiscoveryEntry> trending =
+        snapshot[MangaDiscoveryFeed.trending];
+    expect(trending, hasLength(1), reason: '同 id 条目 feed 内去重');
+    final MangaDiscoveryEntry entry = trending.single;
+    expect(entry.anilistId, 10);
+    expect(entry.preferredTitle, '葬送のフリーレン');
+    expect(entry.averageScore, closeTo(8.9, 0.001));
+    expect(entry.description, isNot(contains('<')));
+    expect(entry.coverUrl, 'https://img.example/10-xl.jpg');
+    expect(entry.allTitles, contains('别名A'));
+    expect(entry.status, 'RELEASING');
+
+    expect(snapshot[MangaDiscoveryFeed.popular].single.preferredTitle,
+        'One Piece');
+    expect(snapshot[MangaDiscoveryFeed.topRated], isEmpty);
+    expect(snapshot[MangaDiscoveryFeed.latestFinished].single.anilistId, 30);
+    expect(snapshot.isEmpty, isFalse);
+  });
+
+  test('GraphQL errors 转成网络异常', () async {
+    final AniListMangaDiscoveryProvider provider =
+        providerWith((http.Request request) async {
+      return http.Response(
+        jsonEncode(<String, Object?>{
+          'errors': <Object?>[
+            <String, Object?>{'message': 'rate limited'},
+          ],
+        }),
+        200,
+        headers: <String, String>{'content-type': 'application/json'},
+      );
+    });
+    await expectLater(
+      provider.fetchSnapshot(),
+      throwsA(
+        isA<VideoMetadataNetworkException>().having(
+          (VideoMetadataNetworkException e) => e.message,
+          'message',
+          contains('rate limited'),
+        ),
+      ),
+    );
+    provider.close();
+  });
+}

--- a/fushi/test/media/manga/discovery/manga_discovery_detail_page_test.dart
+++ b/fushi/test/media/manga/discovery/manga_discovery_detail_page_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_detail_page.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_source_matcher.dart';
+
+/// 发现条目详情页（注入假来源，绕开平台扩展宿主）：
+///  - 打开即自动匹配，命中按来源展示（含分数）；
+///  - 无命中给「未找到匹配」文案；
+///  - 元数据（标题/评分/状态/题材/简介）照实渲染。
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  const MangaDiscoveryEntry entry = MangaDiscoveryEntry(
+    anilistId: 1,
+    titleNative: '葬送のフリーレン',
+    titleRomaji: 'Sousou no Frieren',
+    averageScore: 8.9,
+    status: 'RELEASING',
+    genres: <String>['Fantasy'],
+    description: '魔王を倒した後の物語。',
+  );
+
+  Widget wrap(Widget child) => ProviderScope(
+        child: TranslationProvider(
+          child: MaterialApp(home: child),
+        ),
+      );
+
+  testWidgets('打开即自动匹配，命中带来源名与分数展示', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MangaDiscoveryDetailPage(
+          entry: entry,
+          matchSourcesOverride: <MangaMatchSource>[
+            MangaMatchSource(
+              id: 'fake',
+              name: '假来源',
+              language: 'ja',
+              search: (String query) async => <MangaMatchHit>[
+                const MangaMatchHit(title: '葬送のフリーレン', payload: 'p'),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('葬送のフリーレン'), findsWidgets);
+    expect(find.text('8.9'), findsOneWidget);
+    expect(find.text(t.manga_discovery_status_releasing), findsOneWidget);
+    expect(find.text('Fantasy'), findsOneWidget);
+    expect(find.text('魔王を倒した後の物語。'), findsOneWidget);
+    expect(find.textContaining('假来源'), findsOneWidget);
+    expect(find.textContaining('100%'), findsOneWidget, reason: '匹配分随命中展示');
+  });
+
+  testWidgets('无命中：给「未找到匹配」+ 全局搜索兜底入口', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MangaDiscoveryDetailPage(
+          entry: entry,
+          matchSourcesOverride: const <MangaMatchSource>[],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_discovery_match_none), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('manga_discovery_global_search')),
+      findsOneWidget,
+    );
+  });
+}

--- a/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
+++ b/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
 import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_source_feeds.dart';
 
 /// 发现页视图：注入假 provider，验证四条横滑行渲染、空 feed 整段不出现、
 /// 失败态给重试按钮且重试真的重新拉取。
@@ -35,8 +37,10 @@ MangaDiscoveryEntry _entry(int id, String title, {double? score}) =>
 void main() {
   setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
 
-  Widget wrap(Widget child) => TranslationProvider(
-        child: MaterialApp(home: Scaffold(body: child)),
+  Widget wrap(Widget child) => ProviderScope(
+        child: TranslationProvider(
+          child: MaterialApp(home: Scaffold(body: child)),
+        ),
       );
 
   testWidgets('四条 feed 渲染成横滑行；空 feed 整段不出现', (WidgetTester tester) async {
@@ -54,7 +58,10 @@ void main() {
         },
       ),
     ]);
-    await tester.pumpWidget(wrap(MangaDiscoveryPage(provider: provider)));
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(
+      provider: provider,
+      sourceFeedsOverride: const <MangaDiscoverySourceFeed>[],
+    )));
     await tester.pumpAndSettle();
 
     expect(find.text(t.manga_discovery_section_trending), findsOneWidget);
@@ -80,7 +87,10 @@ void main() {
         },
       ),
     ]);
-    await tester.pumpWidget(wrap(MangaDiscoveryPage(provider: provider)));
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(
+      provider: provider,
+      sourceFeedsOverride: const <MangaDiscoverySourceFeed>[],
+    )));
     await tester.pumpAndSettle();
 
     expect(find.text(t.manga_discovery_load_failed), findsOneWidget);
@@ -89,5 +99,55 @@ void main() {
     await tester.pumpAndSettle();
     expect(provider.calls, 2);
     expect(find.text('重试后出现'), findsOneWidget);
+  });
+
+  testWidgets('P2 来源热门行：有货的行渲染、可点开，失败的行整行收起', (WidgetTester tester) async {
+    int opened = 0;
+    // AniList 快照给空：源热门行顶到视口最上方，tap 不受上方行高影响。
+    final _FakeProvider provider = _FakeProvider(<Object>[
+      const MangaDiscoverySnapshot(
+        feeds: <MangaDiscoveryFeed, List<MangaDiscoveryEntry>>{},
+      ),
+    ]);
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(
+      provider: provider,
+      sourceFeedsOverride: <MangaDiscoverySourceFeed>[
+        MangaDiscoverySourceFeed(
+          id: 'ok',
+          name: '好源',
+          language: 'ja',
+          loadPopular: () async => <MangaDiscoverySourceItem>[
+            MangaDiscoverySourceItem(
+              title: '源里的热门作品',
+              buildCover: (BuildContext context) =>
+                  const ColoredBox(color: Color(0xFF808080)),
+              open: (BuildContext context) => opened++,
+            ),
+          ],
+        ),
+        MangaDiscoverySourceFeed(
+          id: 'broken',
+          name: '坏源',
+          language: 'ja',
+          loadPopular: () async => throw StateError('Cloudflare'),
+        ),
+      ],
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(t.manga_discovery_source_popular(source: '好源')),
+      findsOneWidget,
+    );
+    expect(find.text('源里的热门作品'), findsOneWidget);
+    expect(
+      find.text(t.manga_discovery_source_popular(source: '坏源')),
+      findsNothing,
+      reason: '失败的来源行整行收起，不立错误牌坊',
+    );
+
+    await tester.tap(find.text('源里的热门作品'));
+    await tester.pump();
+    expect(opened, 1, reason: '点卡片走 feed 的 open 动作（生产适配为直进源详情页）');
   });
 }

--- a/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
+++ b/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
+
+/// 发现页视图：注入假 provider，验证四条横滑行渲染、空 feed 整段不出现、
+/// 失败态给重试按钮且重试真的重新拉取。
+class _FakeProvider implements MangaDiscoveryProvider {
+  _FakeProvider(this._results);
+
+  final List<Object> _results;
+  int calls = 0;
+
+  @override
+  Future<MangaDiscoverySnapshot> fetchSnapshot({int perPage = 20}) async {
+    final Object result =
+        _results[calls < _results.length ? calls : _results.length - 1];
+    calls++;
+    if (result is MangaDiscoverySnapshot) return result;
+    throw result as Exception;
+  }
+
+  @override
+  void close() {}
+}
+
+MangaDiscoveryEntry _entry(int id, String title, {double? score}) =>
+    MangaDiscoveryEntry(
+      anilistId: id,
+      titleNative: title,
+      averageScore: score,
+    );
+
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  Widget wrap(Widget child) => TranslationProvider(
+        child: MaterialApp(home: Scaffold(body: child)),
+      );
+
+  testWidgets('四条 feed 渲染成横滑行；空 feed 整段不出现', (WidgetTester tester) async {
+    final _FakeProvider provider = _FakeProvider(<Object>[
+      MangaDiscoverySnapshot(
+        feeds: <MangaDiscoveryFeed, List<MangaDiscoveryEntry>>{
+          MangaDiscoveryFeed.trending: <MangaDiscoveryEntry>[
+            _entry(1, '趋势作品', score: 8.9),
+          ],
+          MangaDiscoveryFeed.popular: <MangaDiscoveryEntry>[
+            _entry(2, '热门作品'),
+          ],
+          MangaDiscoveryFeed.topRated: const <MangaDiscoveryEntry>[],
+          MangaDiscoveryFeed.latestFinished: const <MangaDiscoveryEntry>[],
+        },
+      ),
+    ]);
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(provider: provider)));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_discovery_section_trending), findsOneWidget);
+    expect(find.text(t.manga_discovery_section_popular), findsOneWidget);
+    expect(find.text('趋势作品'), findsOneWidget);
+    expect(find.text('热门作品'), findsOneWidget);
+    expect(find.text('8.9'), findsOneWidget, reason: '评分随卡片展示');
+    expect(
+      find.text(t.manga_discovery_section_top_rated),
+      findsNothing,
+      reason: '空 feed 不渲染段标题（没有空壳段）',
+    );
+  });
+
+  testWidgets('加载失败给重试按钮，重试真的重新拉取', (WidgetTester tester) async {
+    final _FakeProvider provider = _FakeProvider(<Object>[
+      Exception('network down'),
+      MangaDiscoverySnapshot(
+        feeds: <MangaDiscoveryFeed, List<MangaDiscoveryEntry>>{
+          MangaDiscoveryFeed.trending: <MangaDiscoveryEntry>[
+            _entry(1, '重试后出现'),
+          ],
+        },
+      ),
+    ]);
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(provider: provider)));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_discovery_load_failed), findsOneWidget);
+    await tester
+        .tap(find.byKey(const ValueKey<String>('manga_discovery_retry')));
+    await tester.pumpAndSettle();
+    expect(provider.calls, 2);
+    expect(find.text('重试后出现'), findsOneWidget);
+  });
+}

--- a/fushi/test/media/manga/discovery/manga_source_matcher_test.dart
+++ b/fushi/test/media/manga/discovery/manga_source_matcher_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/discovery/manga_discovery_models.dart';
+import 'package:fushi/src/media/manga/discovery/manga_source_matcher.dart';
+
+/// 跨来源自动匹配编排：每源取最佳、低分丢弃、单源失败不拖累、按分排序、
+/// 查询词按来源语言排序（日文源先原文）。
+void main() {
+  const MangaDiscoveryEntry entry = MangaDiscoveryEntry(
+    anilistId: 1,
+    titleNative: '葬送のフリーレン',
+    titleRomaji: 'Sousou no Frieren',
+    titleEnglish: "Frieren: Beyond Journey's End",
+  );
+
+  MangaMatchSource source(
+    String id,
+    String language,
+    Future<List<MangaMatchHit>> Function(String query) search,
+  ) =>
+      MangaMatchSource(id: id, name: id, language: language, search: search);
+
+  test('mangaMatchQueriesFor：日文源先原文，英文源先英文', () {
+    expect(
+      mangaMatchQueriesFor(entry, 'ja'),
+      <String>[
+        '葬送のフリーレン',
+        'Sousou no Frieren',
+        "Frieren: Beyond Journey's End",
+      ],
+    );
+    expect(mangaMatchQueriesFor(entry, 'en').first,
+        "Frieren: Beyond Journey's End");
+  });
+
+  test('每源留最佳命中，低于阈值的来源被整个丢弃，结果按分降序', () async {
+    final List<MangaSourceMatch> matches = await matchMangaAcrossSources(
+      entry: entry,
+      sources: <MangaMatchSource>[
+        source(
+            'close',
+            'ja',
+            (String query) async => <MangaMatchHit>[
+                  const MangaMatchHit(title: '葬送のフリーレン 第1巻', payload: 'a'),
+                  const MangaMatchHit(title: 'ワンピース', payload: 'noise'),
+                ]),
+        source(
+            'exact',
+            'ja',
+            (String query) async => <MangaMatchHit>[
+                  const MangaMatchHit(title: '葬送のフリーレン', payload: 'b'),
+                ]),
+        source(
+            'unrelated',
+            'ja',
+            (String query) async => <MangaMatchHit>[
+                  const MangaMatchHit(title: 'ベルセルク', payload: 'c'),
+                ]),
+      ],
+    );
+    expect(matches, hasLength(2));
+    expect(matches.first.source.id, 'exact');
+    expect(matches.first.score, 1.0);
+    expect(matches.last.source.id, 'close');
+    expect(matches.last.hit.payload, 'a');
+  });
+
+  test('单源抛错静默跳过，不拖累其余来源', () async {
+    final List<MangaSourceMatch> matches = await matchMangaAcrossSources(
+      entry: entry,
+      sources: <MangaMatchSource>[
+        source('broken', 'ja', (String query) async {
+          throw StateError('Cloudflare');
+        }),
+        source(
+            'ok',
+            'ja',
+            (String query) async => <MangaMatchHit>[
+                  const MangaMatchHit(title: '葬送のフリーレン', payload: 'x'),
+                ]),
+      ],
+    );
+    expect(matches, hasLength(1));
+    expect(matches.single.source.id, 'ok');
+  });
+
+  test('首个查询空结果时换下一个标题重试，有结果但不像则不再叠加查询', () async {
+    final List<String> queries = <String>[];
+    final List<MangaSourceMatch> matches = await matchMangaAcrossSources(
+      entry: entry,
+      sources: <MangaMatchSource>[
+        source('en-only', 'en', (String query) async {
+          queries.add(query);
+          if (query == "Frieren: Beyond Journey's End") {
+            return const <MangaMatchHit>[];
+          }
+          return const <MangaMatchHit>[
+            MangaMatchHit(title: 'Sousou no Frieren', payload: 'hit'),
+          ];
+        }),
+      ],
+    );
+    expect(queries.first, "Frieren: Beyond Journey's End");
+    expect(matches.single.hit.payload, 'hit');
+  });
+
+  test('无标题或无来源返回空表', () async {
+    expect(
+      await matchMangaAcrossSources(
+        entry: const MangaDiscoveryEntry(anilistId: 2),
+        sources: <MangaMatchSource>[
+          source('any', 'ja', (String query) async {
+            fail('无标题不应发起搜索');
+          }),
+        ],
+      ),
+      isEmpty,
+    );
+    expect(
+      await matchMangaAcrossSources(
+        entry: entry,
+        sources: const <MangaMatchSource>[],
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/fushi/test/media/manga/discovery/manga_title_matcher_test.dart
+++ b/fushi/test/media/manga/discovery/manga_title_matcher_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/discovery/manga_title_matcher.dart';
+
+/// 标题模糊匹配打分器：CJK 与拉丁两条路径都要能把「同作品不同写法」判高分、
+/// 「不同作品」判低分——阈值 0.55（`kMangaSourceMatchMinScore`）两侧都得有余量。
+void main() {
+  group('normalizeMangaTitle', () {
+    test('小写化并剥离标点/符号', () {
+      expect(
+        normalizeMangaTitle("Frieren: Beyond Journey's End"),
+        'frieren beyond journey s end',
+      );
+    });
+
+    test('CJK 保留，中点/括号视作分隔', () {
+      expect(normalizeMangaTitle('葬送のフリーレン（1）'), '葬送のフリーレン 1');
+    });
+
+    test('空白折叠', () {
+      expect(normalizeMangaTitle('  a   b  '), 'a b');
+    });
+  });
+
+  group('mangaTitleMatchScore', () {
+    test('完全一致 = 1.0', () {
+      expect(mangaTitleMatchScore('葬送のフリーレン', <String>['葬送のフリーレン']), 1.0);
+    });
+
+    test('仅标点/大小写差异视同一致', () {
+      expect(
+        mangaTitleMatchScore(
+          'Frieren - Beyond Journeys End',
+          <String>["Frieren: Beyond Journey's End"],
+        ),
+        greaterThan(0.9),
+      );
+    });
+
+    test('来源标题拼了卷号仍高于阈值（partial 承担包含语义）', () {
+      expect(
+        mangaTitleMatchScore('葬送のフリーレン 第1巻', <String>['葬送のフリーレン']),
+        greaterThan(0.75),
+      );
+    });
+
+    test('取多标题中的最高分：native 不像但 english 像', () {
+      final double score = mangaTitleMatchScore(
+        'Attack on Titan',
+        <String>['進撃の巨人', 'Attack on Titan'],
+      );
+      expect(score, 1.0);
+    });
+
+    test('不同作品低于阈值', () {
+      expect(
+        mangaTitleMatchScore('ワンピース', <String>['葬送のフリーレン']),
+        lessThan(0.4),
+      );
+      expect(
+        mangaTitleMatchScore(
+            'Berserk', <String>["Frieren: Beyond Journey's End"]),
+        lessThan(0.4),
+      );
+    });
+
+    test('空输入 = 0', () {
+      expect(mangaTitleMatchScore('', <String>['x']), 0);
+      expect(mangaTitleMatchScore('！？', <String>['x']), 0);
+      expect(mangaTitleMatchScore('x', <String>[]), 0);
+    });
+  });
+}

--- a/fushi/test/media/manga/discovery/mihon_enabled_sources_test.dart
+++ b/fushi/test/media/manga/discovery/mihon_enabled_sources_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_enabled_sources.dart';
+
+/// 「已启用在线来源」唯一口径（浏览页/发现详情页/发现源热门行三处共用）：
+/// 来源启用 且 扩展启用 才算；任一侧被关都要被滤掉；顺序保持来源表原序。
+void main() {
+  MangaExtensionRow extension(String packageName, {required bool enabled}) =>
+      MangaExtensionRow(
+        packageName: packageName,
+        storeUrl: null,
+        name: packageName,
+        versionCode: 1,
+        versionName: '1.0',
+        libVersion: '1.5',
+        language: 'ja',
+        contentWarning: 0,
+        apkPath: '$packageName.apk',
+        apkSha256: 'x',
+        signerSha256: 'y',
+        enabled: enabled,
+        installedAt: 0,
+      );
+
+  MangaOnlineSourceRow source(
+    String sourceId,
+    String extensionPackage, {
+    required bool enabled,
+  }) =>
+      MangaOnlineSourceRow(
+        extensionPackage: extensionPackage,
+        sourceId: sourceId,
+        name: sourceId,
+        language: 'ja',
+        baseUrl: '',
+        enabled: enabled,
+        pinned: false,
+        sortOrder: 0,
+      );
+
+  test('来源启用且扩展启用才算；任一侧关掉都滤掉；保持原序', () {
+    final List<MangaOnlineSourceRow> result = filterEnabledMangaOnlineSources(
+      installed: <MangaExtensionRow>[
+        extension('ext.on', enabled: true),
+        extension('ext.off', enabled: false),
+      ],
+      sources: <MangaOnlineSourceRow>[
+        source('s1', 'ext.on', enabled: true),
+        source('s2', 'ext.on', enabled: false),
+        source('s3', 'ext.off', enabled: true),
+        source('s4', 'ext.on', enabled: true),
+        source('s5', 'ext.gone', enabled: true),
+      ],
+    );
+    expect(
+      result.map((MangaOnlineSourceRow row) => row.sourceId).toList(),
+      <String>['s1', 's4'],
+    );
+  });
+
+  test('空输入恒为空表', () {
+    expect(
+      filterEnabledMangaOnlineSources(
+        installed: const <MangaExtensionRow>[],
+        sources: const <MangaOnlineSourceRow>[],
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/fushi/test/pages/manga_library_page_split_test.dart
+++ b/fushi/test/pages/manga_library_page_split_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/manga/discovery/manga_discovery_page.dart';
 import 'package:fushi/src/media/manga/manga_browse_page.dart';
 import 'package:fushi/src/media/manga/manga_library_page.dart';
 import 'package:fushi/src/media/manga/manga_sources_page.dart';
@@ -24,7 +25,8 @@ import '../helpers/source_guard.dart';
 /// 1. 分流谓词本身（互补、无遗漏、无重复）；
 /// 2. 漫画库页确实带 `mangaOnly: true` 接进同一个书架实现，没有接反。
 ///
-/// PR#594 落地后追加第 3 件：顶层视图列表恒为三视图，不随平台分叉。
+/// PR#594 落地后追加第 3 件：顶层视图列表是无条件常量，不随平台分叉
+/// （发现页落地后恒为四视图 + 设置）。
 
 MediaItem _item(String identifier, String sourceKey) => MediaItem(
       mediaIdentifier: identifier,
@@ -82,8 +84,8 @@ void main() {
     testWidgets('漫画库页的书架视图接的是 mangaOnly: true 的书架实现（没接反）',
         (WidgetTester tester) async {
       // 只取 build 的产物，不真正挂载子树：整页依赖 DB / WebView / 一堆 provider，
-      // 挂起来就成了「测环境」而不是测这条接线。漫画库页现在是三视图壳
-      // （书架 / 浏览 / 来源），书架仍是其中一个视图——穿过壳取该视图的产物。
+      // 挂起来就成了「测环境」而不是测这条接线。漫画库页现在是四视图壳
+      // （书架 / 发现 / 浏览 / 来源），书架仍是其中一个视图——穿过壳取该视图的产物。
       Widget? built;
       await tester.pumpWidget(
         Builder(builder: (BuildContext context) {
@@ -93,12 +95,14 @@ void main() {
       );
       expect(built, isA<MediaLibraryShell>());
       final MediaLibraryShell shell = built! as MediaLibraryShell;
-      // 恒为三视图，**不随平台变**。Mihon 扩展是「来源」的一部分，不占 tab；
-      // 这条断言就是 PR#594 那版四视图 / 按平台分叉形态的反向锚。
+      // 恒为四视图（外加设置），**不随平台变**。Mihon 扩展是「来源」的一部分，
+      // 不占 tab；「发现」是 AniList 元数据页，五平台同构（与扩展宿主无关）。
+      // 这条断言就是 PR#594 那版按平台分叉形态的反向锚。
       expect(
         shell.views.map((MediaLibraryViewSpec v) => v.kind).toList(),
         <MediaLibraryViewKind>[
           MediaLibraryViewKind.library,
+          MediaLibraryViewKind.discover,
           MediaLibraryViewKind.browse,
           MediaLibraryViewKind.sources,
           MediaLibraryViewKind.settings,
@@ -108,15 +112,21 @@ void main() {
           tester.element(find.byType(SizedBox)), const SizedBox.shrink());
       expect(shelf, isA<ReaderFushiHistoryPage>());
       expect((shelf as ReaderFushiHistoryPage).mangaOnly, isTrue);
-      // 「浏览」是在线来源清单（mokuro.moe 与已启用 Mihon 源并列），不是别的域的页。
+      // 「发现」是 AniList 元数据发现页（趋势/热门横滑行）。
       expect(
         shell.views[1].builder(
+            tester.element(find.byType(SizedBox)), const SizedBox.shrink()),
+        isA<MangaDiscoveryPage>(),
+      );
+      // 「浏览」是在线来源清单（mokuro.moe 与已启用 Mihon 源并列），不是别的域的页。
+      expect(
+        shell.views[2].builder(
             tester.element(find.byType(SizedBox)), const SizedBox.shrink()),
         isA<MangaBrowsePage>(),
       );
       // 「来源」视图必须是漫画来源页——本地扫描根 + 扩展 + 在线来源都收在这里。
       expect(
-        shell.views[2].builder(
+        shell.views[3].builder(
             tester.element(find.byType(SizedBox)), const SizedBox.shrink()),
         isA<MangaSourcesPage>(),
       );


### PR DESCRIPTION
## 背景

用户拍板抄 AnymeX 漫画发现页，三项决策：① 数据源走混合 C 分两期（本 PR 为 P1 AniList 骨架）；② AniList 条目→可读源走全自动匹配 B；③ 不做自动播轮播（对齐视频首页 TODO-2486 的去轮播决策，趋势行用大卡横滑行代替）。

## 改动

- `fushi/lib/src/media/manga/discovery/`（新子目录）
  - `anilist_manga_discovery_provider.dart`：匿名 AniList combined GraphQL 一次拿四条 feed（趋势/热门/高分/最新完结，isAdult:false，高分/最新完结带人气与评分下限防冷门刷屏）；传输复用 `VideoMetadataHttpClient`（通用只读 HTTP 层，超时/退避/内存缓存）
  - `manga_title_matcher.dart`：纯 Dart 标题模糊打分（token-set 0.4 + partial 0.3 + ratio 0.3，对齐 AnymeX SourceMapper；CJK 无空白时由 partial ratio 承担包含语义，不做任何文字系统转写）
  - `manga_source_matcher.dart`：跨源限并发匹配编排（来源抽象成名字+语言+搜索函数，可注入假来源测试；日/中/韩源先查原文标题，其余先英文；单源失败静默跳过）
  - `manga_discovery_page.dart`：「发现」视图，四条 `HorizontalDragScrollable` 横滑行（趋势行大卡带评分角标），失败态可重试，首次切入才发请求（壳惰性构建）、结果保活
  - `manga_discovery_detail_page.dart`：元数据展示（封面/多标题/评分/连载状态/题材/简介）+ 打开即在已启用 Mihon 在线源与 Aidoku 包里全自动匹配，命中按分排序、点击直进对应源详情页（章节可读）；零命中兜底「搜索全部来源」预填首选标题
- `media_library_shell.dart`：`MediaLibraryViewKind` 加 `discover`
- `manga_library_page.dart`：视图列表插入「发现」（书架之后），恒为四视图+设置，五平台同构（AniList 与扩展宿主无关）
- i18n：`i18n_sync` 新增 14 key（17 语言）+ `dart run slang` 重生成

## 验证

- `flutter analyze` 全量：No issues found
- `flutter test test/media/manga/discovery`：20/20 绿（打分器/编排器/provider 解析/两页 widget）
- 相邻守卫：`manga_library_page_split_test`（锚点已按四视图更新）+ `media_library_shell_test` + `module_top_settings_tabs_guard` + `test/i18n` 全绿
- `md3_design_system_static_test` 全绿（首轮抓到我一处裸 fontSize，已改走 textTheme）
- 未真机验证 AniList 实网请求与真实源匹配效果（P1 骨架，实网路径与视频域 AniList provider 同端点同传输层）

## 后续（P2，另开 PR）

- 「来自源 X 的热门/最新」行（Mihon getPopular/getLatest 扇出）
- 匹配阈值/权重按真实源反馈调参

https://claude.ai/code/session_01VhaxzSbjZVfWWiVF6FrKzQ