### PR TITLE
fix(manga): R8 保住宿主 Kotlin 运行时，修所有 Mihon 扩展 LOAD_FAILED (BUG-1702/1703)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1574 条。点号进各自文件。
+> 共 1576 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1703](bugs/BUG-1703-manga-extension-error-truncated-toast.md) | ✅ | ✅ | 扩展安装/加载失败的根因被 Android 原生 toast 截成 2 行，用户永远看不到 |
+| [BUG-1702](bugs/BUG-1702-mihon-r8-kotlin-keep.md) | ✅ | ✅ | release APK 的 R8 混淆掉宿主 Kotlin 运行时，所有 Mihon 漫画扩展 LOAD_FAILED |
 | [BUG-1700](bugs/BUG-1700-subtitle-default-language-not-video-language.md) | ✅ | ✅ | 自动下字幕的默认语言是「不限」，实际拿到的语言随缘，不跟视频自身语言 |
 | [BUG-1699](bugs/BUG-1699-interconnect-collections-not-grouping.md) | ✅ | ✅ | 互联对端合集在客户端库页不成组显示 |
 | [BUG-1698](bugs/BUG-1698-subtitle-backfill-after-scrape.md) | ✅ | ✅ | 刮削解析出的规范身份没被字幕侧使用，且自动配字幕能力对用户完全不可见 |

--- a/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
+++ b/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
@@ -1,0 +1,20 @@
+## BUG-1702 · release APK 的 R8 混淆掉宿主 Kotlin 运行时，所有 Mihon 漫画扩展 LOAD_FAILED
+- **报告**：2026-08-17（用户：手机上装 Keiyoushi 漫画扩展报 `MihonRuntimeException (LOAD_FAILED): Unabl…`，截图里 toast 被截断）
+- **真实性**：✅ 真 bug。根因 `fushi/android/app/proguard-rules.pro`（缺 `kotlin.**` / `eu.kanade.tachiyomi.util.**` 的 keep）→ 表现在 `fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonExtensionLoader.kt:144`（`Class.forName(...).newInstance()` 抛异常被包成 `LOAD_FAILED`）。
+
+  实证（拆用户实际运行的 release 包 `fushi-2.1.1-arm64-v8a.apk` 与真实扩展 APK 对拆 dex）：
+  - Mihon 扩展 APK 是**独立编译**的第三方 dex，把 Kotlin 运行时当 compileOnly（由宿主提供），字节码里写死**未混淆的原名**。`tachiyomi-all.ahottie-v1.6.4.apk` 引用 22 个 `kotlin.*` 类（`kotlin.Lazy` / `kotlin.LazyKt` / `kotlin.jvm.internal.Intrinsics` / `kotlin.jvm.functions.Function0` …）。
+  - 宿主 release APK 里 `kotlin.*` 只剩 34 个类，全是被 R8 改名成单字母的 `kotlin.jvm.internal.A/B/C…` 加一个 `kotlin.Metadata`。扩展需要的那 22 个里，除 `kotlin.Metadata` 外**一个都不存在**。
+  - 佐证同一处混淆：宿主 `HttpSource` 的字段签名已变成 `headers$delegate : LW4/f;` —— `kotlin.Lazy` 被改名为 `W4.f`（字段名本身靠 `-keep class eu.kanade.tachiyomi.source.** { *; }` 保住了，类型没保住）。
+  - 扩展的 source 类构造函数第一条就是 `invoke-static kotlin.LazyKt.lazy(...)`（`ExtensionGenerated` → 父类 `n.<init>`），于是 `newInstance()` 必抛 `NoClassDefFoundError` → `LOAD_FAILED`。
+
+  影响面：**所有 Kotlin 编写的 Mihon 扩展 100% 装不上**（等于全部），与 lib 1.4 / 1.6 无关。**debug 构建不 minify，类名全在，所以本地永远复现不了**，只有 release APK 必现 —— 这正是过去被误判成「个别扩展缺类」的原因。
+
+  同批发现的第二个缺口（同一根因、同一修复）：`eu.kanade.tachiyomi.util.**` 从未被 keep，而宿主自身一次都不调用它，R8 把整个包删掉了；扩展解析 HTML 必用的 `JsoupExtensionsKt.asJsoup()` 因此在 release 上也不存在。
+
+- **[x] ① 已修复** — `fushi/android/app/proguard-rules.pro` 新增「Mihon 扩展宿主 ABI」区块，按上游 Mihon `app/proguard-rules.pro` 的 "Keep common dependencies used in extensions" 区块逐条对齐：补 `kotlin.**` / `kotlin.time.**` / `eu.kanade.tachiyomi.util.**` / `com.squareup.zstd.**` / `app.cash.quickjs.**`。（Mihon 自己走 `-dontobfuscate` 全保，Fushi 有混淆，只能逐包 keep。）提交见本条目末尾。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart`：以两个真实 Keiyoushi 扩展 dex 解析出的「引用但未定义」类清单为基准，断言 proguard-rules.pro 里每个类都被至少一条**不带 `allowobfuscation`** 的 keep 覆盖。变异实测两轮均由绿转红：① 删掉 `kotlin.**` keep → 精确报出 16 个 `kotlin.*` 缺口；② 把该 keep 改成 `-keep,allowobfuscation` → 同样报红（验证「允许改名等于没保」这条语义生效）；两轮还原后 proguard-rules.pro 的 sha256 与变异前逐字节一致。
+- **备注**：
+  - 未纳入本次修复的相邻事实，另见 BUG-1703：错误消息投递通道在 Android 上是 `Fluttertoast`（系统原生 Toast，硬上限 2 行、不可复制），所以 `MihonExtensionLoader` 在 develop 上已经带的链式根因（`03c98a0828`）**依然送不到用户眼前**，截图里就断在 `Unabl…`。用户报的 v2.1.1 更早于该提交，消息里连根因都还没有。
+  - 已知但**未**处理：宿主的 QuickJS 来自 `com.github.zhanghai.quickjs-java`，类名落在 `app.cash.quickjs.*`（与扩展预期一致），本次已补 keep；但成员级兼容未验证，用 QuickJs 的扩展仍可能 `NoSuchMethodError`，需真机复验后另开条目。
+  - 验证限制：本机模拟器 NAT 走不通宿主 fake-ip 代理，装源 E2E 只能真机验；本条的根因与修复均由 dex 级静态实证确立，尚未在真机 release 包上跑过「装扩展 → 成功」的端到端。

--- a/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
+++ b/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
@@ -14,6 +14,11 @@
 
 - **[x] ① 已修复** — `fushi/android/app/proguard-rules.pro` 新增「Mihon 扩展宿主 ABI」区块，按上游 Mihon `app/proguard-rules.pro` 的 "Keep common dependencies used in extensions" 区块逐条对齐：补 `kotlin.**` / `kotlin.time.**` / `eu.kanade.tachiyomi.util.**` / `com.squareup.zstd.**` / `app.cash.quickjs.**`。（Mihon 自己走 `-dontobfuscate` 全保，Fushi 有混淆，只能逐包 keep。）提交 `edfed870ca`。
 - **[x] ② 已加自动化测试** — `fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart`：以两个真实 Keiyoushi 扩展 dex 解析出的「引用但未定义」类清单为基准，断言 proguard-rules.pro 里每个类都被至少一条**不带 `allowobfuscation`** 的 keep 覆盖。变异实测两轮均由绿转红：① 删掉 `kotlin.**` keep → 精确报出 16 个 `kotlin.*` 缺口；② 把该 keep 改成 `-keep,allowobfuscation` → 同样报红（验证「允许改名等于没保」这条语义生效）；两轮还原后 proguard-rules.pro 的 sha256 与变异前逐字节一致。
+- **真实 release 构建复验（不是只看规则文本）**：本机造临时自签名 keystore 跑 `flutter build apk --release --target-platform android-arm64`，拆产物 dex 前后对拆：
+  - 扩展需要的 63 个宿主类，**修复前缺 22 个**（`kotlin.Lazy` / `kotlin.LazyKt` / `kotlin.jvm.internal.Intrinsics` / `kotlin.coroutines.*` / `kotlin.time.*` / `JsoupExtensionsKt`），**修复后缺 0 个**。
+  - 宿主 `kotlin.*` 类数 34 → 994；`HttpSource.headers$delegate` 的字段类型从 `LW4/f` 变回 `Lkotlin/Lazy`——扩展构造函数里那句 `getDeclaredField("headers$delegate")` + `Field.set` 的类型这才对得上。
+  - 体积代价（同配置前后各构建一次）：dex 9.73 MB → 11.53 MB（+1.79 MB / +18.4%），**APK 238.8 MB → 239.3 MB（+0.50 MB / +0.21%）**——dex 在 APK 里是压缩存的，实际增量可忽略。
+  - 顺带踩到的环境问题：本机 Android release AOT 挂 `gen_snapshot` 栈溢出（`-1073741571`），得给 `android-arm64-release/windows-x64/gen_snapshot.exe` 单独打 `editbin /STACK:128M`（此前只给 windows-x64-release 那份打过，两者是不同文件）。与本 bug 无关，但不打就构建不出来。
 - **备注**：
   - 未纳入本次修复的相邻事实，另见 BUG-1703：错误消息投递通道在 Android 上是 `Fluttertoast`（系统原生 Toast，硬上限 2 行、不可复制），所以 `MihonExtensionLoader` 在 develop 上已经带的链式根因（`03c98a0828`）**依然送不到用户眼前**，截图里就断在 `Unabl…`。用户报的 v2.1.1 更早于该提交，消息里连根因都还没有。
   - 已知但**未**处理：宿主的 QuickJS 来自 `com.github.zhanghai.quickjs-java`，类名落在 `app.cash.quickjs.*`（与扩展预期一致），本次已补 keep；但成员级兼容未验证，用 QuickJs 的扩展仍可能 `NoSuchMethodError`，需真机复验后另开条目。

--- a/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
+++ b/docs/bugs/BUG-1702-mihon-r8-kotlin-keep.md
@@ -12,7 +12,7 @@
 
   同批发现的第二个缺口（同一根因、同一修复）：`eu.kanade.tachiyomi.util.**` 从未被 keep，而宿主自身一次都不调用它，R8 把整个包删掉了；扩展解析 HTML 必用的 `JsoupExtensionsKt.asJsoup()` 因此在 release 上也不存在。
 
-- **[x] ① 已修复** — `fushi/android/app/proguard-rules.pro` 新增「Mihon 扩展宿主 ABI」区块，按上游 Mihon `app/proguard-rules.pro` 的 "Keep common dependencies used in extensions" 区块逐条对齐：补 `kotlin.**` / `kotlin.time.**` / `eu.kanade.tachiyomi.util.**` / `com.squareup.zstd.**` / `app.cash.quickjs.**`。（Mihon 自己走 `-dontobfuscate` 全保，Fushi 有混淆，只能逐包 keep。）提交见本条目末尾。
+- **[x] ① 已修复** — `fushi/android/app/proguard-rules.pro` 新增「Mihon 扩展宿主 ABI」区块，按上游 Mihon `app/proguard-rules.pro` 的 "Keep common dependencies used in extensions" 区块逐条对齐：补 `kotlin.**` / `kotlin.time.**` / `eu.kanade.tachiyomi.util.**` / `com.squareup.zstd.**` / `app.cash.quickjs.**`。（Mihon 自己走 `-dontobfuscate` 全保，Fushi 有混淆，只能逐包 keep。）提交 `edfed870ca`。
 - **[x] ② 已加自动化测试** — `fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart`：以两个真实 Keiyoushi 扩展 dex 解析出的「引用但未定义」类清单为基准，断言 proguard-rules.pro 里每个类都被至少一条**不带 `allowobfuscation`** 的 keep 覆盖。变异实测两轮均由绿转红：① 删掉 `kotlin.**` keep → 精确报出 16 个 `kotlin.*` 缺口；② 把该 keep 改成 `-keep,allowobfuscation` → 同样报红（验证「允许改名等于没保」这条语义生效）；两轮还原后 proguard-rules.pro 的 sha256 与变异前逐字节一致。
 - **备注**：
   - 未纳入本次修复的相邻事实，另见 BUG-1703：错误消息投递通道在 Android 上是 `Fluttertoast`（系统原生 Toast，硬上限 2 行、不可复制），所以 `MihonExtensionLoader` 在 develop 上已经带的链式根因（`03c98a0828`）**依然送不到用户眼前**，截图里就断在 `Unabl…`。用户报的 v2.1.1 更早于该提交，消息里连根因都还没有。

--- a/docs/bugs/BUG-1703-manga-extension-error-truncated-toast.md
+++ b/docs/bugs/BUG-1703-manga-extension-error-truncated-toast.md
@@ -4,7 +4,7 @@
 
   为什么这不是「显示得难看一点」而是功能缺陷：扩展加载失败的可操作信息，全在链式根因的**最深一层**（宿主缺哪个类），也就是消息尾部——恰好是被截掉的那一半。develop 上 `03c98a0828` 已经把完整链式 cause 拼进了异常消息，但**投递通道装不下**，所以修了等于没修；用户既看不到，也无法转述或截图给开发者，只能报「装不上」。BUG-1702 的根因因此只能靠拆 release APK 的 dex 反推，而不是读一行错误。
 
-- **[x] ① 已修复** — 新增 `fushi/lib/src/utils/misc/error_details_dialog.dart` 的 `showErrorDetails()`：全文可滚动 + `SelectableText` 可选中 + 一键复制到剪贴板。把「短状态提示」和「诊断错误」拆成两条通道——前者继续走 toast，后者走对话框。`mihon_extensions_page.dart` 5 处失败路径（加仓库 / 本地安装 / 商店安装 / 预览 / `commitInstall`，其中 `commitInstall` 正是 LOAD_FAILED 的落点）全部改走新通道，该文件已无 `FushiToast` 引用。新增 i18n key `mihon_extension_error`（走 `tool/i18n_sync.dart --add`，17 份齐全后 `dart run slang` 重生成）。
+- **[x] ① 已修复** — 新增 `fushi/lib/src/utils/misc/error_details_dialog.dart` 的 `showErrorDetails()`：全文可滚动 + `SelectableText` 可选中 + 一键复制到剪贴板。把「短状态提示」和「诊断错误」拆成两条通道——前者继续走 toast，后者走对话框。`mihon_extensions_page.dart` 5 处失败路径（加仓库 / 本地安装 / 商店安装 / 预览 / `commitInstall`，其中 `commitInstall` 正是 LOAD_FAILED 的落点）全部改走新通道，该文件已无 `FushiToast` 引用。提交 `edfed870ca`。新增 i18n key `mihon_extension_error`（走 `tool/i18n_sync.dart --add`，17 份齐全后 `dart run slang` 重生成）。
 - **[x] ② 已加自动化测试** — `fushi/test/utils/misc/error_details_dialog_test.dart`（widget 行为层）：① 断言呈现的是完整错误原文且 `maxLines` 为空（不设行数上限）；② 断言点「复制」后写进剪贴板的是**完整**错误。变异实测：给 `SelectableText` 加回 `maxLines: 2`（复刻原生 toast 的截断）→ 测试立刻由绿转红（`Expected: null / Actual: <2>`）；还原后源文件 sha256 与变异前逐字节一致。
 - **备注**：
   - 本次只改了 Mihon 扩展页这一处调用点。其余仍把长诊断错误塞进 toast 的路径（Aidoku 扩展页、桌面 Mihon runtime 等）**未**一并迁移，避免把范围扩到未复现的界面；后续按同样形状替换即可，`showErrorDetails` 已是共享入口。

--- a/docs/bugs/BUG-1703-manga-extension-error-truncated-toast.md
+++ b/docs/bugs/BUG-1703-manga-extension-error-truncated-toast.md
@@ -1,0 +1,11 @@
+## BUG-1703 · 扩展安装/加载失败的根因被 Android 原生 toast 截成 2 行，用户永远看不到
+- **报告**：2026-08-17（随 [BUG-1702](BUG-1702-mihon-r8-kotlin-keep.md) 的用户截图暴露：整条错误只显示到 `MihonRuntimeException (LOAD_FAILED): Unabl…`）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/misc/fushi_toast.dart:39`——`FushiToast.show()` 在 `Platform.isAndroid || Platform.isIOS` 时走 `Fluttertoast.showToast`，即**系统原生 Toast**：Android 12+ 强制「app 图标 + 最多 2 行 + 省略号截断」，且不可复制、不可延长、不可交互。调用点 `fushi/lib/src/media/manga/mihon/mihon_extensions_page.dart` 的 5 处 `catch` 全部把原始异常整个塞进这个通道。
+
+  为什么这不是「显示得难看一点」而是功能缺陷：扩展加载失败的可操作信息，全在链式根因的**最深一层**（宿主缺哪个类），也就是消息尾部——恰好是被截掉的那一半。develop 上 `03c98a0828` 已经把完整链式 cause 拼进了异常消息，但**投递通道装不下**，所以修了等于没修；用户既看不到，也无法转述或截图给开发者，只能报「装不上」。BUG-1702 的根因因此只能靠拆 release APK 的 dex 反推，而不是读一行错误。
+
+- **[x] ① 已修复** — 新增 `fushi/lib/src/utils/misc/error_details_dialog.dart` 的 `showErrorDetails()`：全文可滚动 + `SelectableText` 可选中 + 一键复制到剪贴板。把「短状态提示」和「诊断错误」拆成两条通道——前者继续走 toast，后者走对话框。`mihon_extensions_page.dart` 5 处失败路径（加仓库 / 本地安装 / 商店安装 / 预览 / `commitInstall`，其中 `commitInstall` 正是 LOAD_FAILED 的落点）全部改走新通道，该文件已无 `FushiToast` 引用。新增 i18n key `mihon_extension_error`（走 `tool/i18n_sync.dart --add`，17 份齐全后 `dart run slang` 重生成）。
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/error_details_dialog_test.dart`（widget 行为层）：① 断言呈现的是完整错误原文且 `maxLines` 为空（不设行数上限）；② 断言点「复制」后写进剪贴板的是**完整**错误。变异实测：给 `SelectableText` 加回 `maxLines: 2`（复刻原生 toast 的截断）→ 测试立刻由绿转红（`Expected: null / Actual: <2>`）；还原后源文件 sha256 与变异前逐字节一致。
+- **备注**：
+  - 本次只改了 Mihon 扩展页这一处调用点。其余仍把长诊断错误塞进 toast 的路径（Aidoku 扩展页、桌面 Mihon runtime 等）**未**一并迁移，避免把范围扩到未复现的界面；后续按同样形状替换即可，`showErrorDetails` 已是共享入口。
+  - 未做：把「诊断错误不得走 toast」升级成全仓源码守卫。判据不好界定（同一个 `FushiToast.show` 既服务短提示也服务错误），过早收紧会误伤大量合法调用点。

--- a/fushi/android/app/proguard-rules.pro
+++ b/fushi/android/app/proguard-rules.pro
@@ -38,19 +38,43 @@
 -dontwarn com.google.android.play.core.splitcompat.**
 -dontwarn com.google.android.play.core.splitinstall.**
 -dontwarn com.google.android.play.core.tasks.**
+# ---------------------------------------------------------------------------
+# Mihon 扩展宿主 ABI（BUG-1702）
+#
+# Mihon 扩展 APK 是**独立编译**的第三方 dex：它把宿主提供的一切（Kotlin 运行时、
+# okhttp、jsoup、rx、injekt、source-api……）都当 compileOnly，字节码里写死的是
+# **未混淆的原名**。所以凡是扩展可能引用的包，宿主 APK 里必须以原名原样存在——
+# R8 一旦重命名或删除，扩展加载即 NoClassDefFoundError。
+#
+# 这份清单漏一个包就是一整类扩展装不上，且 debug 构建（不 minify）永远复现不了，
+# 只在 release 上必现。加依赖时必须同步这里，守卫见
+# fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart。
+# 对照上游 Mihon app/proguard-rules.pro 的 "Keep common dependencies used in
+# extensions" 区块——Mihon 自己走 -dontobfuscate 全保，Fushi 有混淆，只能逐包 keep。
+# ---------------------------------------------------------------------------
 -keep class eu.kanade.tachiyomi.source.** { *; }
 -keep class eu.kanade.tachiyomi.network.** { *; }
+# asJsoup()/awaitSingle() 等扩展解析必用的顶层函数（JsoupExtensionsKt / RxExtension）。
+# 宿主自身一次都不调，漏 keep 时 R8 会把整个包删掉。
+-keep class eu.kanade.tachiyomi.util.** { *; }
 -keep class tachiyomi.core.common.util.lang.** { *; }
 -keep class mihon.core.common.extensions.** { *; }
 -keep class uy.kohesive.injekt.** { *; }
 # Third-party extension bytecode calls these host libraries dynamically, so
 # R8 cannot infer the reachable API surface from Fushi itself.
+# kotlin.** 是其中最致命的一条：扩展 dex 不打包 Kotlin 运行时，构造函数里第一条
+# 指令往往就是 invoke-static kotlin.LazyKt.lazy / kotlin.jvm.internal.Intrinsics，
+# 宿主把 kotlin.Lazy 改名成 W4.f 后，**所有** Kotlin 扩展 100% LOAD_FAILED。
+-keep class kotlin.** { public protected *; }
+-keep class kotlin.time.** { public protected *; }
 -keep class okhttp3.** { *; }
 -keep class okio.** { *; }
+-keep class com.squareup.zstd.** { public protected *; }
 -keep class org.jsoup.** { *; }
 -keep class rx.** { *; }
 -keep class kotlinx.coroutines.** { *; }
 -keep class kotlinx.serialization.** { *; }
+-keep class app.cash.quickjs.** { public protected *; }
 -keep class androidx.preference.** { *; }
 -keep class androidx.compose.runtime.** { *; }
 -keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60248 (3544 per locale)
+/// Strings: 60265 (3545 per locale)
 ///
-/// Built on 2026-08-17 at 09:58 UTC
+/// Built on 2026-08-17 at 12:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4807,6 +4807,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_discovery_status_not_yet_released => 'Not yet released';
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -13008,6 +13009,8 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -21276,6 +21279,8 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -29560,6 +29565,8 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -37856,6 +37863,8 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -46080,6 +46089,8 @@ class _StringsId extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -54350,6 +54361,8 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -62434,6 +62447,8 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -70525,6 +70540,8 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -78775,6 +78792,8 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -87037,6 +87056,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -95285,6 +95306,8 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -103481,6 +103504,8 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -111708,6 +111733,8 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -119920,6 +119947,8 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 // Path: <root>
@@ -127528,6 +127557,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       '${source} · 热门';
+  @override
+  String get mihon_extension_error => '扩展错误';
 }
 
 // Path: <root>
@@ -135535,6 +135566,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get mihon_extension_error => 'Extension error';
 }
 
 /// Flat map(s) containing all translations.
@@ -142813,6 +142846,8 @@ extension on _StringsEn {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -150089,6 +150124,8 @@ extension on _StringsAr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -157387,6 +157424,8 @@ extension on _StringsDe {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -164684,6 +164723,8 @@ extension on _StringsEs {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -171987,6 +172028,8 @@ extension on _StringsFr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -179272,6 +179315,8 @@ extension on _StringsId {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -186571,6 +186616,8 @@ extension on _StringsIt {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -193832,6 +193879,8 @@ extension on _StringsJa {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -201097,6 +201146,8 @@ extension on _StringsKo {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -208390,6 +208441,8 @@ extension on _StringsNl {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -215680,6 +215733,8 @@ extension on _StringsPtBr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -222975,6 +223030,8 @@ extension on _StringsRu {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -230253,6 +230310,8 @@ extension on _StringsTh {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -237540,6 +237599,8 @@ extension on _StringsTr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -244823,6 +244884,8 @@ extension on _StringsVi {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }
@@ -252047,6 +252110,8 @@ extension on _StringsZhCn {
         return '未发售';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => '${source} · 热门';
+      case 'mihon_extension_error':
+        return '扩展错误';
       default:
         return null;
     }
@@ -259303,6 +259368,8 @@ extension on _StringsZhHk {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'mihon_extension_error':
+        return 'Extension error';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "休刊中",
   "manga_discovery_status_cancelled": "已腰斩",
   "manga_discovery_status_not_yet_released": "未发售",
-  "manga_discovery_source_popular": "${source} · 热门"
+  "manga_discovery_source_popular": "${source} · 热门",
+  "mihon_extension_error": "扩展错误"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3542,5 +3542,6 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "mihon_extension_error": "Extension error"
 }

--- a/fushi/lib/src/media/manga/mihon/mihon_extensions_page.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_extensions_page.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
 import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/utils/misc/error_details_dialog.dart';
 import 'package:fushi/utils.dart';
 
 /// Mihon 扩展仓库与安装管理。
@@ -116,7 +117,11 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       await _manager!.addStore(url, allowInsecure: allowInsecure);
     } catch (error) {
       if (mounted) {
-        FushiToast.show(msg: '$error', severity: ToastSeverity.error);
+        unawaited(showErrorDetails(
+          context,
+          title: t.mihon_extension_error,
+          error: error,
+        ));
       }
     }
   }
@@ -159,7 +164,11 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       await _confirmAndInstall(proposal);
     } catch (error) {
       if (mounted) {
-        FushiToast.show(msg: '$error', severity: ToastSeverity.error);
+        unawaited(showErrorDetails(
+          context,
+          title: t.mihon_extension_error,
+          error: error,
+        ));
       }
     }
   }
@@ -171,7 +180,11 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       await _confirmAndInstall(proposal);
     } catch (error) {
       if (mounted) {
-        FushiToast.show(msg: '$error', severity: ToastSeverity.error);
+        unawaited(showErrorDetails(
+          context,
+          title: t.mihon_extension_error,
+          error: error,
+        ));
       }
     }
   }
@@ -232,7 +245,13 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
           // 同上：保留原始预览错误；残留 staging 会在下次启动清理。
         }
       }
-      if (mounted) FushiToast.show(msg: '$error');
+      if (mounted) {
+        unawaited(showErrorDetails(
+          context,
+          title: t.mihon_extension_error,
+          error: error,
+        ));
+      }
     }
   }
 
@@ -345,7 +364,11 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       return true;
     } catch (error) {
       if (mounted) {
-        FushiToast.show(msg: '$error', severity: ToastSeverity.error);
+        unawaited(showErrorDetails(
+          context,
+          title: t.mihon_extension_error,
+          error: error,
+        ));
       }
       return false;
     }

--- a/fushi/lib/src/utils/misc/error_details_dialog.dart
+++ b/fushi/lib/src/utils/misc/error_details_dialog.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/misc/fushi_toast.dart';
+
+/// 诊断类错误的呈现通道（BUG-1703）。
+///
+/// 为什么不能沿用 [FushiToast]：移动端它走的是系统原生 Toast，Android 12+ 强制
+/// 「app 图标 + 最多 2 行 + 省略号截断」，既不可复制也不可延长。而扩展加载失败这类
+/// 错误里唯一可操作的信息（缺哪个类、哪一层 cause）全在消息尾部，恰好是被截掉的
+/// 那一半——用户看到的只有 `Unable to instantiate extension source …`，连转述都做不到。
+///
+/// 所以短状态提示继续走 toast，**诊断错误走这里**：全文可滚动、可选中、一键复制。
+Future<void> showErrorDetails(
+  BuildContext context, {
+  required String title,
+  required Object error,
+}) {
+  final String details = error.toString();
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      final ThemeData theme = Theme.of(dialogContext);
+      return AlertDialog(
+        title: Text(title),
+        content: SizedBox(
+          width: 420,
+          child: SingleChildScrollView(
+            child: SelectableText(
+              details,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontFamily: 'monospace',
+                fontFamilyFallback: const <String>['Courier New', 'monospace'],
+              ),
+            ),
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () async {
+              await Clipboard.setData(ClipboardData(text: details));
+              if (!dialogContext.mounted) return;
+              Navigator.of(dialogContext).pop();
+              FushiToast.show(msg: t.copied_to_clipboard);
+            },
+            child: Text(t.copy),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(t.dialog_close),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart
+++ b/fushi/test/media/manga/mihon_host_abi_keep_guard_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1702 守卫：Android release 的 R8 规则必须完整保住「宿主提供给 Mihon 扩展的
+/// ABI 面」。
+///
+/// 为什么需要这条守卫：Mihon 扩展 APK 是独立编译的第三方 dex，把宿主提供的一切
+/// （Kotlin 运行时、okhttp、jsoup、rx、injekt、source-api……）都当 compileOnly，
+/// 字节码里写死的是**未混淆的原名**。宿主 APK 里少一个包、或某个包被 R8 改了名，
+/// 扩展加载就 NoClassDefFoundError → `MihonHostException(LOAD_FAILED)`。
+///
+/// 这类回归**在 debug 构建上永远复现不了**（debug 不 minify，类名全在），只在
+/// release APK 上必现，所以没有静态守卫就只能等用户报障。实测过的真实事故：
+/// `kotlin.**` 从未被 keep，R8 把宿主的 `kotlin.Lazy` 改名成 `W4.f`，于是**每一个**
+/// Kotlin 扩展在构造函数第一条 `invoke-static kotlin.LazyKt.lazy` 上就炸。
+///
+/// 基准清单不是拍脑袋列的，是从两个真实 Keiyoushi 扩展的 dex 里解析出的
+/// 「引用了但自己没定义」的类（即必须由宿主提供的），来源见 [_hostAbiReferences]。
+void main() {
+  group('Mihon 扩展宿主 ABI 的 R8 keep 覆盖', () {
+    late final File rules = File('android/app/proguard-rules.pro');
+
+    test('proguard-rules.pro 存在（路径变了要同步改本守卫）', () {
+      expect(
+        rules.existsSync(),
+        isTrue,
+        reason: '找不到 ${rules.path}；R8 规则文件挪位置了就必须同步更新这条守卫。',
+      );
+    });
+
+    test('每个扩展会引用的宿主类都被一条不可改名的 keep 覆盖', () {
+      final List<_KeepRule> keeps = _parseKeepRules(rules.readAsStringSync());
+      expect(keeps, isNotEmpty,
+          reason: 'proguard-rules.pro 里一条 -keep class 都没解析出来');
+
+      final List<String> uncovered = <String>[
+        for (final String type in _hostAbiReferences)
+          if (!keeps.any((_KeepRule rule) => rule.covers(type))) type,
+      ];
+
+      expect(
+        uncovered,
+        isEmpty,
+        reason: '这些类扩展要用、宿主却没有以原名保住，release APK 上会让扩展加载失败：\n'
+            '${uncovered.join('\n')}\n'
+            '修法：在 android/app/proguard-rules.pro 的「Mihon 扩展宿主 ABI」区块补 keep。',
+      );
+    });
+  });
+}
+
+/// 宿主必须以原名提供的类。
+///
+/// 提取方式：解出扩展 APK 的 classes.dex，取 `type_ids` 减去 `class_defs`
+/// （= 引用了但本 dex 没定义的类），再去掉由 Android 系统 classloader 提供的
+/// `android.` / `java.` / `javax.` / `dalvik.` 与纯注解包。
+///
+/// 样本（Keiyoushi 官方仓库，两个 extensions-lib 大版本各一）：
+/// - `tachiyomi-all.ahottie-v1.6.4.apk`（lib 1.6）
+/// - `tachiyomi-all.akuma-v1.4.10.apk`（lib 1.4）
+///
+/// 这是**下限**不是全集：换更多扩展只会让清单变长，所以补充样本时只该往里加。
+const List<String> _hostAbiReferences = <String>[
+  // extensions-lib / source-api（宿主按固定 Mihon commit 编入）
+  'eu.kanade.tachiyomi.network.NetworkHelper',
+  'eu.kanade.tachiyomi.network.OkHttpExtensionsKt',
+  'eu.kanade.tachiyomi.network.RequestsKt',
+  'eu.kanade.tachiyomi.source.ConfigurableSource',
+  'eu.kanade.tachiyomi.source.SourceFactory',
+  'eu.kanade.tachiyomi.source.model.Filter',
+  'eu.kanade.tachiyomi.source.model.FilterList',
+  'eu.kanade.tachiyomi.source.model.MangasPage',
+  'eu.kanade.tachiyomi.source.model.Page',
+  'eu.kanade.tachiyomi.source.model.SChapter',
+  'eu.kanade.tachiyomi.source.model.SManga',
+  'eu.kanade.tachiyomi.source.model.SMangaUpdate',
+  'eu.kanade.tachiyomi.source.model.UpdateStrategy',
+  'eu.kanade.tachiyomi.source.online.HttpSource',
+  // 宿主自己一次都不调，最容易被 R8 整包删掉
+  'eu.kanade.tachiyomi.util.JsoupExtensionsKt',
+  // Kotlin 运行时：扩展 dex 不打包，构造函数里就会用
+  'kotlin.Lazy',
+  'kotlin.LazyKt',
+  'kotlin.Metadata',
+  'kotlin.Result',
+  'kotlin.ResultKt',
+  'kotlin.collections.CollectionsKt',
+  'kotlin.coroutines.Continuation',
+  'kotlin.coroutines.intrinsics.IntrinsicsKt',
+  'kotlin.coroutines.jvm.internal.Boxing',
+  'kotlin.coroutines.jvm.internal.ContinuationImpl',
+  'kotlin.coroutines.jvm.internal.SpillingKt',
+  'kotlin.io.FilesKt',
+  'kotlin.jvm.functions.Function0',
+  'kotlin.jvm.functions.Function1',
+  'kotlin.jvm.internal.DefaultConstructorMarker',
+  'kotlin.jvm.internal.Intrinsics',
+  'kotlin.text.StringsKt',
+  'kotlin.time.Duration',
+  'kotlin.time.DurationKt',
+  'kotlin.time.DurationUnit',
+  // 网络栈
+  'okhttp3.CacheControl',
+  'okhttp3.Call',
+  'okhttp3.CompressionInterceptor',
+  'okhttp3.Gzip',
+  'okhttp3.Headers',
+  'okhttp3.HttpUrl',
+  'okhttp3.Interceptor',
+  'okhttp3.OkHttpClient',
+  'okhttp3.Request',
+  'okhttp3.RequestBody',
+  'okhttp3.Response',
+  'okhttp3.ResponseBody',
+  'okhttp3.brotli.BrotliInterceptor',
+  'okhttp3.zstd.Zstd',
+  // 解析 / 响应式 / 注入
+  'org.jsoup.nodes.Document',
+  'org.jsoup.nodes.Element',
+  'org.jsoup.select.Elements',
+  'rx.Observable',
+  'rx.functions.Func1',
+  'uy.kohesive.injekt.InjektKt',
+  'uy.kohesive.injekt.api.FullTypeReference',
+  'uy.kohesive.injekt.api.InjektFactory',
+  'uy.kohesive.injekt.api.InjektScope',
+];
+
+/// 一条**不允许改名**的 `-keep[,option…] class <pattern>` 规则。
+///
+/// 带 `allowobfuscation` 的规则在 [_parseKeepRules] 里就被丢掉了：R8 多条 keep 取
+/// 并集，只有存在至少一条不可改名的规则，类名才真的保得住。
+class _KeepRule {
+  const _KeepRule({required this.pattern});
+
+  final String pattern;
+
+  /// ProGuard 通配语义：`**` 跨包匹配（含 `.`），`*` 只在单段内匹配。
+  bool covers(String type) => _patternToRegExp(pattern).hasMatch(type);
+}
+
+final RegExp _keepLine = RegExp(r'^-keep([^\s]*)\s+class\s+([^\s{]+)');
+
+List<_KeepRule> _parseKeepRules(String source) {
+  final List<_KeepRule> rules = <_KeepRule>[];
+  for (final String raw in source.split('\n')) {
+    final String line = raw.trim();
+    if (line.startsWith('#')) continue;
+    final RegExpMatch? match = _keepLine.firstMatch(line);
+    if (match == null) continue;
+    if ((match.group(1) ?? '').contains('allowobfuscation')) continue;
+    rules.add(_KeepRule(pattern: match.group(2)!));
+  }
+  return rules;
+}
+
+RegExp _patternToRegExp(String pattern) {
+  final StringBuffer out = StringBuffer('^');
+  for (int i = 0; i < pattern.length; i++) {
+    final String char = pattern[i];
+    if (char == '*') {
+      final bool isDoubleStar = i + 1 < pattern.length && pattern[i + 1] == '*';
+      if (isDoubleStar) {
+        out.write('.*');
+        i++;
+      } else {
+        out.write('[^.]*');
+      }
+    } else if (char == '?') {
+      out.write('[^.]');
+    } else {
+      out.write(RegExp.escape(char));
+    }
+  }
+  out.write(r'$');
+  return RegExp(out.toString());
+}

--- a/fushi/test/utils/misc/error_details_dialog_test.dart
+++ b/fushi/test/utils/misc/error_details_dialog_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/error_details_dialog.dart';
+
+/// BUG-1703 守卫：扩展加载失败这类诊断错误必须**全文**可见并且能复制走。
+///
+/// 事故形态：错误消息里唯一可操作的信息（链式根因的最深一层，指明宿主缺哪个类）
+/// 在消息尾部，而移动端的 toast 是系统原生 Toast，硬上限 2 行 + 省略号截断，用户
+/// 看到的只有开头的 `Unable to instantiate extension source …`。诊断信息送不出去，
+/// 用户报不了障，也就没人能修。
+void main() {
+  /// 真实形状：长到原生 toast 一定会截断，且可操作信息全在尾部。
+  const String longError =
+      'MihonRuntimeException(LOAD_FAILED): Unable to instantiate extension '
+      'source eu.kanade.tachiyomi.extension.all.ahottie.ExtensionGenerated: '
+      'InvocationTargetException ← ExceptionInInitializerError ← '
+      'NoClassDefFoundError: Failed resolution of: Lkotlin/LazyKt;';
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) => Scaffold(
+          body: TextButton(
+            onPressed: () => showErrorDetails(
+              context,
+              title: '扩展错误',
+              error: longError,
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('错误全文原样呈现，不截断', (WidgetTester tester) async {
+    await openDialog(tester);
+
+    final SelectableText body = tester.widget<SelectableText>(
+      find.byType(SelectableText),
+    );
+    expect(body.data, longError,
+        reason: '呈现的必须是完整错误，任何截断都会把可操作的根因切掉');
+    // maxLines 为空 = 不设行数上限；这正是原生 toast 做不到的那一点。
+    expect(body.maxLines, isNull);
+  });
+
+  testWidgets('复制按钮把完整错误写进剪贴板', (WidgetTester tester) async {
+    String? copied;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map<Object?, Object?>)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await openDialog(tester);
+    await tester.tap(find.text('Copy'));
+    await tester.pumpAndSettle();
+
+    expect(copied, longError,
+        reason: '用户要能把根因整段贴给开发者，少一个字符都可能是缺失的那个类名');
+  });
+}


### PR DESCRIPTION
## 用户报告

手机上装 Keiyoushi 漫画扩展报 `MihonRuntimeException (LOAD_FAILED): Unabl…`（toast 截断，看不到根因）。

## 根因（dex 级实证，不是推测）

**不是「某个扩展不兼容」，是 release 包里所有 Kotlin 扩展 100% 装不上。**

Mihon 扩展 APK 是独立编译的第三方 dex，把宿主提供的一切（Kotlin 运行时、okhttp、jsoup…）当 compileOnly，字节码里写死**未混淆的原名**。`proguard-rules.pro` 从未 keep 过 `kotlin.**`，R8 于是把宿主的 `kotlin.Lazy` 改名成 `W4.f`、其余 `kotlin.*` 删光。扩展 source 类构造函数第一条指令就是 `invoke-static kotlin.LazyKt.lazy`，直接 `NoClassDefFoundError` → 被包成 `LOAD_FAILED`。

拆用户实际运行的 `fushi-2.1.1-arm64-v8a.apk` 与 `tachiyomi-all.ahottie-v1.6.4.apk` 对比：扩展引用的 22 个 `kotlin.*` 类，宿主里除 `kotlin.Metadata` 外**一个都不存在**；宿主 `HttpSource` 的字段签名已是 `headers$delegate : LW4/f`。

**debug 构建不 minify，类名全在，所以本地永远复现不了** —— 这正是过去被误判成「个别扩展缺类」的原因。

同批发现第二个缺口：`eu.kanade.tachiyomi.util.**`（扩展解析必用的 `asJsoup`）宿主自己一次都不调，被 R8 整包删除。

## 改动

- `proguard-rules.pro` 按上游 Mihon 的 "Keep common dependencies used in extensions" 区块逐条对齐，补 `kotlin.**` / `kotlin.time.**` / `eu.kanade.tachiyomi.util.**` / `com.squareup.zstd.**` / `app.cash.quickjs.**`（Mihon 自己走 `-dontobfuscate` 全保，本仓有混淆只能逐包 keep）
- 新增守卫 `mihon_host_abi_keep_guard_test.dart`：以真实扩展 dex 解析出的引用清单为基准，断言每个类都被至少一条**不带 `allowobfuscation`** 的 keep 覆盖
- BUG-1703：诊断错误改走可复制的 `showErrorDetails` 对话框。移动端 `FushiToast` 是系统原生 Toast，硬上限 2 行且不可复制，链式根因恰好被截在尾部 —— 消息修对了但投递通道装不下，等于没修

## 验证

- **真实 release 构建前后对拆 dex**：扩展需要的 63 个宿主类，修复前缺 22 个，**修复后缺 0 个**；`kotlin.*` 类数 34 → 994；`headers$delegate` 类型从 `LW4/f` 变回 `Lkotlin/Lazy`
- **体积代价**：APK 238.8 MB → 239.3 MB（+0.50 MB / +0.21%），dex +1.79 MB
- `flutter analyze` 全量 No issues；定向 441 tests + 全目录枚举型守卫 224 tests + 新增 2 tests 全绿
- 两条新守卫均做变异实测：删 `kotlin.**` keep / 改成 `allowobfuscation` / 给对话框加回 `maxLines: 2`，三次都由绿转红，还原后源文件 sha256 逐字节一致

## 未做

- 真机 E2E（装扩展 → 成功浏览）未跑：本机模拟器 NAT 走不通宿主代理，装源只能真机验
- 其余把长诊断错误塞进 toast 的路径（Aidoku 扩展页、桌面 runtime）未一并迁移，避免扩大到未复现的界面

https://claude.ai/code/session_01EEc44BNqAPsBMapRtHK6X8