### PR TITLE
feat(discovery): 统一发现页——小说/有声书/gal 多源发现+下载自动导入+漫画聚合迁移

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -22,6 +22,7 @@ on:
       - 'ci/**'
       - 'third_party/**'
       - 'tools/build_magpie_slim.ps1'
+      - 'tools/bundle_7za.ps1'
       - '.github/workflows/build-multiplatform.yml'
       - 'pubspec.yaml'
       - 'pubspec.lock'
@@ -641,5 +642,14 @@ jobs:
             }
             Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $file) -Force
           }
+      - name: Bundle standalone 7za for discovery auto-extract
+        shell: pwsh
+        run: |
+          # 发现页下载的 7z/rar 游戏/小说压缩包离线自动解压依赖随包 7za.exe
+          # （LGPL，官方 GitHub 镜像 + SHA-256 钉死，fail-closed）。
+          pwsh -NoProfile -ExecutionPolicy Bypass -File tools/bundle_7za.ps1 `
+            -BundleDirectory "$PWD\fushi\build\windows\x64\runner\Debug" `
+            -DownloadCache "$env:RUNNER_TEMP\hibiki-7za-cache"
+          if ($LASTEXITCODE -ne 0) { throw "bundle_7za.ps1 failed ($LASTEXITCODE)" }
       - name: Run Windows comprehensive automation contract
         run: .\ci\comprehensive-test.ps1 -Platform windows -Only appSmoke

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -427,6 +427,15 @@ jobs:
             }
             Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $file) -Force
           }
+      - name: Bundle standalone 7za for discovery auto-extract
+        shell: pwsh
+        run: |
+          # 发现页下载的 7z/rar 游戏/小说压缩包离线自动解压依赖随包 7za.exe
+          # （LGPL，官方 GitHub 镜像 + SHA-256 钉死，fail-closed）。
+          pwsh -NoProfile -ExecutionPolicy Bypass -File tools/bundle_7za.ps1 `
+            -BundleDirectory "$PWD\fushi\build\windows\x64\runner\Release" `
+            -DownloadCache "$env:RUNNER_TEMP\hibiki-7za-cache"
+          if ($LASTEXITCODE -ne 0) { throw "bundle_7za.ps1 failed ($LASTEXITCODE)" }
       # ffmpeg.exe and its MinGW runtime DLLs are vendored at
       # third_party/ffmpeg-min/windows/
       # (TODO-416). It used to be fetched from another workflow's build artifact,

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60452 (3556 per locale)
+/// Strings: 60418 (3554 per locale)
 ///
-/// Built on 2026-08-17 at 12:56 UTC
+/// Built on 2026-08-17 at 14:21 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3663,7 +3663,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.';
   String media_source_count_manga({required Object n}) => '${n} volumes';
   String get library_view_shelf => 'Shelf';
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   String get library_view_media => 'Library';
   String get scrape_failure_detail_show => 'Show details';
   String get scrape_failure_detail_hide => 'Hide details';
@@ -4382,7 +4382,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Fushi video scrape diagnostics';
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-  String get video_discovery_tab => 'Discover';
   String get video_discovery_search_hint => 'Search movies, series, anime';
   String get video_discovery_hot => 'Popular now';
   String get video_discovery_seasonal_anime => 'Seasonal anime';
@@ -4818,7 +4817,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get discovery_torrent_failed => 'Failed to add torrent task';
   String get discovery_kind_novel => 'Novels';
   String get discovery_kind_audiobook => 'Audiobooks';
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -11057,7 +11055,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -12291,8 +12289,6 @@ class _StringsAr extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -13042,8 +13038,6 @@ class _StringsAr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -19349,7 +19343,7 @@ class _StringsDe extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -20583,8 +20577,6 @@ class _StringsDe extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -21334,8 +21326,6 @@ class _StringsDe extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -27657,7 +27647,7 @@ class _StringsEs extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -28891,8 +28881,6 @@ class _StringsEs extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -29642,8 +29630,6 @@ class _StringsEs extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -35977,7 +35963,7 @@ class _StringsFr extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -37211,8 +37197,6 @@ class _StringsFr extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -37962,8 +37946,6 @@ class _StringsFr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -44225,7 +44207,7 @@ class _StringsId extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -45459,8 +45441,6 @@ class _StringsId extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -46210,8 +46190,6 @@ class _StringsId extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -52519,7 +52497,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -53753,8 +53731,6 @@ class _StringsIt extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -54504,8 +54480,6 @@ class _StringsIt extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -60627,7 +60601,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -61861,8 +61835,6 @@ class _StringsJa extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -62612,8 +62584,6 @@ class _StringsJa extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -68742,7 +68712,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -69976,8 +69946,6 @@ class _StringsKo extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -70727,8 +70695,6 @@ class _StringsKo extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -77016,7 +76982,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -78250,8 +78216,6 @@ class _StringsNl extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -79001,8 +78965,6 @@ class _StringsNl extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -85302,7 +85264,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -86536,8 +86498,6 @@ class _StringsPtBr extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -87287,8 +87247,6 @@ class _StringsPtBr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -93574,7 +93532,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -94808,8 +94766,6 @@ class _StringsRu extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -95559,8 +95515,6 @@ class _StringsRu extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -101794,7 +101748,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -103028,8 +102982,6 @@ class _StringsTh extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -103779,8 +103731,6 @@ class _StringsTh extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -110045,7 +109995,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -111279,8 +111229,6 @@ class _StringsTr extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -112030,8 +111978,6 @@ class _StringsTr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -118281,7 +118227,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -119515,8 +119461,6 @@ class _StringsVi extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -120266,8 +120210,6 @@ class _StringsVi extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -126078,7 +126020,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get library_view_shelf => '书架';
   @override
-  String get library_view_browse => '浏览';
+  String get library_view_browse => '发现';
   @override
   String get library_view_media => '媒体库';
   @override
@@ -127223,8 +127165,6 @@ class _StringsZhCn extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       '诊断包包含相对文件/目录名、刮削摘要和原始 NFO 内容；不会加入视频、字幕、图片、绝对路径、应用配置或应用凭据。原始 NFO 会原样保留，仍可能含有个人信息或密钥，请在公开分享前检查。';
   @override
-  String get video_discovery_tab => '发现';
-  @override
   String get video_discovery_search_hint => '搜索电影、剧集、动漫';
   @override
   String get video_discovery_hot => '热门推荐';
@@ -127898,8 +127838,6 @@ class _StringsZhCn extends _StringsEn {
   String get discovery_kind_novel => '小说';
   @override
   String get discovery_kind_audiobook => '有声书';
-  @override
-  String get game_section_discover => '发现';
 }
 
 // Path: <root>
@@ -133945,7 +133883,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get library_view_shelf => 'Shelf';
   @override
-  String get library_view_browse => 'Browse';
+  String get library_view_browse => 'Discover';
   @override
   String get library_view_media => 'Library';
   @override
@@ -135178,8 +135116,6 @@ class _StringsZhHk extends _StringsEn {
   String get video_scrape_diagnostic_confirm_body =>
       'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
   @override
-  String get video_discovery_tab => 'Discover';
-  @override
   String get video_discovery_search_hint => 'Search movies, series, anime';
   @override
   String get video_discovery_hot => 'Popular now';
@@ -135929,8 +135865,6 @@ class _StringsZhHk extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
-  @override
-  String get game_section_discover => 'Discover';
 }
 
 /// Flat map(s) containing all translations.
@@ -141514,7 +141448,7 @@ extension on _StringsEn {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -142592,8 +142526,6 @@ extension on _StringsEn {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -143231,8 +143163,6 @@ extension on _StringsEn {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -148814,7 +148744,7 @@ extension on _StringsAr {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -149890,8 +149820,6 @@ extension on _StringsAr {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -150531,8 +150459,6 @@ extension on _StringsAr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -156136,7 +156062,7 @@ extension on _StringsDe {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -157212,8 +157138,6 @@ extension on _StringsDe {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -157853,8 +157777,6 @@ extension on _StringsDe {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -163457,7 +163379,7 @@ extension on _StringsEs {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -164533,8 +164455,6 @@ extension on _StringsEs {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -165174,8 +165094,6 @@ extension on _StringsEs {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -170784,7 +170702,7 @@ extension on _StringsFr {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -171860,8 +171778,6 @@ extension on _StringsFr {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -172501,8 +172417,6 @@ extension on _StringsFr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -178093,7 +178007,7 @@ extension on _StringsId {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -179169,8 +179083,6 @@ extension on _StringsId {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -179810,8 +179722,6 @@ extension on _StringsId {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -185416,7 +185326,7 @@ extension on _StringsIt {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -186492,8 +186402,6 @@ extension on _StringsIt {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -187133,8 +187041,6 @@ extension on _StringsIt {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -192701,7 +192607,7 @@ extension on _StringsJa {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -193777,8 +193683,6 @@ extension on _StringsJa {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -194418,8 +194322,6 @@ extension on _StringsJa {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -199990,7 +199892,7 @@ extension on _StringsKo {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -201066,8 +200968,6 @@ extension on _StringsKo {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -201707,8 +201607,6 @@ extension on _StringsKo {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -207307,7 +207205,7 @@ extension on _StringsNl {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -208383,8 +208281,6 @@ extension on _StringsNl {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -209024,8 +208920,6 @@ extension on _StringsNl {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -214621,7 +214515,7 @@ extension on _StringsPtBr {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -215697,8 +215591,6 @@ extension on _StringsPtBr {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -216338,8 +216230,6 @@ extension on _StringsPtBr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -221940,7 +221830,7 @@ extension on _StringsRu {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -223016,8 +222906,6 @@ extension on _StringsRu {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -223657,8 +223545,6 @@ extension on _StringsRu {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -229242,7 +229128,7 @@ extension on _StringsTh {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -230318,8 +230204,6 @@ extension on _StringsTh {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -230959,8 +230843,6 @@ extension on _StringsTh {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -236553,7 +236435,7 @@ extension on _StringsTr {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -237629,8 +237511,6 @@ extension on _StringsTr {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -238270,8 +238150,6 @@ extension on _StringsTr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -243860,7 +243738,7 @@ extension on _StringsVi {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -244936,8 +244814,6 @@ extension on _StringsVi {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -245577,8 +245453,6 @@ extension on _StringsVi {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }
@@ -251119,7 +250993,7 @@ extension on _StringsZhCn {
       case 'library_view_shelf':
         return '书架';
       case 'library_view_browse':
-        return '浏览';
+        return '发现';
       case 'library_view_media':
         return '媒体库';
       case 'scrape_failure_detail_show':
@@ -252188,8 +252062,6 @@ extension on _StringsZhCn {
         return 'Fushi 视频刮削诊断';
       case 'video_scrape_diagnostic_confirm_body':
         return '诊断包包含相对文件/目录名、刮削摘要和原始 NFO 内容；不会加入视频、字幕、图片、绝对路径、应用配置或应用凭据。原始 NFO 会原样保留，仍可能含有个人信息或密钥，请在公开分享前检查。';
-      case 'video_discovery_tab':
-        return '发现';
       case 'video_discovery_search_hint':
         return '搜索电影、剧集、动漫';
       case 'video_discovery_hot':
@@ -252825,8 +252697,6 @@ extension on _StringsZhCn {
         return '小说';
       case 'discovery_kind_audiobook':
         return '有声书';
-      case 'game_section_discover':
-        return '发现';
       default:
         return null;
     }
@@ -258388,7 +258258,7 @@ extension on _StringsZhHk {
       case 'library_view_shelf':
         return 'Shelf';
       case 'library_view_browse':
-        return 'Browse';
+        return 'Discover';
       case 'library_view_media':
         return 'Library';
       case 'scrape_failure_detail_show':
@@ -259464,8 +259334,6 @@ extension on _StringsZhHk {
         return 'Fushi video scrape diagnostics';
       case 'video_scrape_diagnostic_confirm_body':
         return 'The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.';
-      case 'video_discovery_tab':
-        return 'Discover';
       case 'video_discovery_search_hint':
         return 'Search movies, series, anime';
       case 'video_discovery_hot':
@@ -260105,8 +259973,6 @@ extension on _StringsZhHk {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
-      case 'game_section_discover':
-        return 'Discover';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60248 (3544 per locale)
+/// Strings: 60452 (3556 per locale)
 ///
-/// Built on 2026-08-17 at 09:58 UTC
+/// Built on 2026-08-17 at 12:56 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4807,6 +4807,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_discovery_status_not_yet_released => 'Not yet released';
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  String get discovery_all_sources => 'All sources';
+  String get discovery_search_hint => 'Search online resources';
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  String get discovery_empty => 'No results';
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  String get discovery_load_more => 'Load more';
+  String get discovery_download_queued => 'Added to downloads';
+  String get discovery_torrent_pushed => 'Torrent task added';
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  String get discovery_kind_novel => 'Novels';
+  String get discovery_kind_audiobook => 'Audiobooks';
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -13008,6 +13020,30 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -21276,6 +21312,30 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -29560,6 +29620,30 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -37856,6 +37940,30 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -46080,6 +46188,30 @@ class _StringsId extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -54350,6 +54482,30 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -62434,6 +62590,30 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -70525,6 +70705,30 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -78775,6 +78979,30 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -87037,6 +87265,30 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -95285,6 +95537,30 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -103481,6 +103757,30 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -111708,6 +112008,30 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -119920,6 +120244,30 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 // Path: <root>
@@ -127528,6 +127876,30 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       '${source} · 热门';
+  @override
+  String get discovery_all_sources => '全部源';
+  @override
+  String get discovery_search_hint => '搜索在线资源';
+  @override
+  String get discovery_enter_query_hint => '输入关键词搜索';
+  @override
+  String get discovery_empty => '无结果';
+  @override
+  String get discovery_partial_failure => '部分源不可用';
+  @override
+  String get discovery_load_more => '加载更多';
+  @override
+  String get discovery_download_queued => '已加入下载';
+  @override
+  String get discovery_torrent_pushed => '种子任务已添加';
+  @override
+  String get discovery_torrent_failed => '种子任务添加失败';
+  @override
+  String get discovery_kind_novel => '小说';
+  @override
+  String get discovery_kind_audiobook => '有声书';
+  @override
+  String get game_section_discover => '发现';
 }
 
 // Path: <root>
@@ -135535,6 +135907,30 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_discovery_source_popular({required Object source}) =>
       'Popular on ${source}';
+  @override
+  String get discovery_all_sources => 'All sources';
+  @override
+  String get discovery_search_hint => 'Search online resources';
+  @override
+  String get discovery_enter_query_hint => 'Enter a keyword to search';
+  @override
+  String get discovery_empty => 'No results';
+  @override
+  String get discovery_partial_failure => 'Some sources are unavailable';
+  @override
+  String get discovery_load_more => 'Load more';
+  @override
+  String get discovery_download_queued => 'Added to downloads';
+  @override
+  String get discovery_torrent_pushed => 'Torrent task added';
+  @override
+  String get discovery_torrent_failed => 'Failed to add torrent task';
+  @override
+  String get discovery_kind_novel => 'Novels';
+  @override
+  String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get game_section_discover => 'Discover';
 }
 
 /// Flat map(s) containing all translations.
@@ -142813,6 +143209,30 @@ extension on _StringsEn {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -150089,6 +150509,30 @@ extension on _StringsAr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -157387,6 +157831,30 @@ extension on _StringsDe {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -164684,6 +165152,30 @@ extension on _StringsEs {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -171987,6 +172479,30 @@ extension on _StringsFr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -179272,6 +179788,30 @@ extension on _StringsId {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -186571,6 +187111,30 @@ extension on _StringsIt {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -193832,6 +194396,30 @@ extension on _StringsJa {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -201097,6 +201685,30 @@ extension on _StringsKo {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -208390,6 +209002,30 @@ extension on _StringsNl {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -215680,6 +216316,30 @@ extension on _StringsPtBr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -222975,6 +223635,30 @@ extension on _StringsRu {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -230253,6 +230937,30 @@ extension on _StringsTh {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -237540,6 +238248,30 @@ extension on _StringsTr {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -244823,6 +245555,30 @@ extension on _StringsVi {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }
@@ -252047,6 +252803,30 @@ extension on _StringsZhCn {
         return '未发售';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => '${source} · 热门';
+      case 'discovery_all_sources':
+        return '全部源';
+      case 'discovery_search_hint':
+        return '搜索在线资源';
+      case 'discovery_enter_query_hint':
+        return '输入关键词搜索';
+      case 'discovery_empty':
+        return '无结果';
+      case 'discovery_partial_failure':
+        return '部分源不可用';
+      case 'discovery_load_more':
+        return '加载更多';
+      case 'discovery_download_queued':
+        return '已加入下载';
+      case 'discovery_torrent_pushed':
+        return '种子任务已添加';
+      case 'discovery_torrent_failed':
+        return '种子任务添加失败';
+      case 'discovery_kind_novel':
+        return '小说';
+      case 'discovery_kind_audiobook':
+        return '有声书';
+      case 'game_section_discover':
+        return '发现';
       default:
         return null;
     }
@@ -259303,6 +260083,30 @@ extension on _StringsZhHk {
         return 'Not yet released';
       case 'manga_discovery_source_popular':
         return ({required Object source}) => 'Popular on ${source}';
+      case 'discovery_all_sources':
+        return 'All sources';
+      case 'discovery_search_hint':
+        return 'Search online resources';
+      case 'discovery_enter_query_hint':
+        return 'Enter a keyword to search';
+      case 'discovery_empty':
+        return 'No results';
+      case 'discovery_partial_failure':
+        return 'Some sources are unavailable';
+      case 'discovery_load_more':
+        return 'Load more';
+      case 'discovery_download_queued':
+        return 'Added to downloads';
+      case 'discovery_torrent_pushed':
+        return 'Torrent task added';
+      case 'discovery_torrent_failed':
+        return 'Failed to add torrent task';
+      case 'discovery_kind_novel':
+        return 'Novels';
+      case 'discovery_kind_audiobook':
+        return 'Audiobooks';
+      case 'game_section_discover':
+        return 'Discover';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3241,7 +3241,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie 尚未就绪。将该游戏的「窗口超分」设为「自动」即可使用随包的内置版本；仍无法启动时请更新或重装 Fushi。",
   "media_source_count_manga": "$n 卷",
   "library_view_shelf": "书架",
-  "library_view_browse": "浏览",
+  "library_view_browse": "发现",
   "library_view_media": "媒体库",
   "scrape_failure_detail_show": "显示详情",
   "scrape_failure_detail_hide": "隐藏详情",
@@ -3241,7 +3241,6 @@
   "video_scrape_diagnostic_failed": "无法导出诊断包：$reason",
   "video_scrape_diagnostic_share_subject": "Fushi 视频刮削诊断",
   "video_scrape_diagnostic_confirm_body": "诊断包包含相对文件/目录名、刮削摘要和原始 NFO 内容；不会加入视频、字幕、图片、绝对路径、应用配置或应用凭据。原始 NFO 会原样保留，仍可能含有个人信息或密钥，请在公开分享前检查。",
-  "video_discovery_tab": "发现",
   "video_discovery_search_hint": "搜索电影、剧集、动漫",
   "video_discovery_hot": "热门推荐",
   "video_discovery_seasonal_anime": "本季动漫",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "种子任务已添加",
   "discovery_torrent_failed": "种子任务添加失败",
   "discovery_kind_novel": "小说",
-  "discovery_kind_audiobook": "有声书",
-  "game_section_discover": "发现"
+  "discovery_kind_audiobook": "有声书"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "休刊中",
   "manga_discovery_status_cancelled": "已腰斩",
   "manga_discovery_status_not_yet_released": "未发售",
-  "manga_discovery_source_popular": "${source} · 热门"
+  "manga_discovery_source_popular": "${source} · 热门",
+  "discovery_all_sources": "全部源",
+  "discovery_search_hint": "搜索在线资源",
+  "discovery_enter_query_hint": "输入关键词搜索",
+  "discovery_empty": "无结果",
+  "discovery_partial_failure": "部分源不可用",
+  "discovery_load_more": "加载更多",
+  "discovery_download_queued": "已加入下载",
+  "discovery_torrent_pushed": "种子任务已添加",
+  "discovery_torrent_failed": "种子任务添加失败",
+  "discovery_kind_novel": "小说",
+  "discovery_kind_audiobook": "有声书",
+  "game_section_discover": "发现"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2723,7 +2723,7 @@
   "game_upscaling_hint_not_installed": "Magpie is not ready. Set window upscaling to Auto to use the copy bundled with Fushi; if it still does not start, update or reinstall Fushi.",
   "media_source_count_manga": "$n volumes",
   "library_view_shelf": "Shelf",
-  "library_view_browse": "Browse",
+  "library_view_browse": "Discover",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
   "scrape_failure_detail_hide": "Hide details",
@@ -3240,7 +3240,6 @@
   "video_scrape_diagnostic_failed": "Could not export diagnostic package: $reason",
   "video_scrape_diagnostic_share_subject": "Fushi video scrape diagnostics",
   "video_scrape_diagnostic_confirm_body": "The package includes relative file and folder names, scrape summaries, and original NFO contents. It does not add videos, subtitles, images, absolute paths, app configuration, or app credentials. Original NFO files are preserved unchanged and may contain personal information or secrets; review the package before sharing publicly.",
-  "video_discovery_tab": "Discover",
   "video_discovery_search_hint": "Search movies, series, anime",
   "video_discovery_hot": "Popular now",
   "video_discovery_seasonal_anime": "Seasonal anime",
@@ -3553,6 +3552,5 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks",
-  "game_section_discover": "Discover"
+  "discovery_kind_audiobook": "Audiobooks"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3542,5 +3542,17 @@
   "manga_discovery_status_hiatus": "On hiatus",
   "manga_discovery_status_cancelled": "Cancelled",
   "manga_discovery_status_not_yet_released": "Not yet released",
-  "manga_discovery_source_popular": "Popular on ${source}"
+  "manga_discovery_source_popular": "Popular on ${source}",
+  "discovery_all_sources": "All sources",
+  "discovery_search_hint": "Search online resources",
+  "discovery_enter_query_hint": "Enter a keyword to search",
+  "discovery_empty": "No results",
+  "discovery_partial_failure": "Some sources are unavailable",
+  "discovery_load_more": "Load more",
+  "discovery_download_queued": "Added to downloads",
+  "discovery_torrent_pushed": "Torrent task added",
+  "discovery_torrent_failed": "Failed to add torrent task",
+  "discovery_kind_novel": "Novels",
+  "discovery_kind_audiobook": "Audiobooks",
+  "game_section_discover": "Discover"
 }

--- a/fushi/lib/src/media/discovery/discovery_download_queue.dart
+++ b/fushi/lib/src/media/discovery/discovery_download_queue.dart
@@ -1,0 +1,505 @@
+/// 发现页 HTTP 直链下载队列：app 生命周期常驻（组装点懒建），发现页负责
+/// enqueue，关闭页面**不**中断下载（统一下载中心语义，与 torrent 任务同级）。
+///
+/// 执行模型与重试语义照搬 `MokuroMoeDownloadQueue`（顺序一次一个任务；单任务
+/// 失败/取消只标记该任务、继续下一个；自动重试**就地复活**同一任务对象、退避
+/// 期间不占执行位；手动重试清零自动重试预算）。字节层复用 `ResumableDownloader`
+/// （`.part` 续传 + Range + 原子 promote），失败/取消保留 `.part`，重试即续传。
+///
+/// torrent payload **不进本队列**：UI 拿到 `DiscoveryPayloadKind.torrent` 的条目
+/// 直接分流给 torrent 后端（`pushGenericMagnet` 链路）。这里若 resolve 出
+/// torrent（源实现 bug）按不可重试失败处理。
+///
+/// 下载完成后经注入的 [DiscoveryDownloadImporter] 自动入库；导入失败不自动
+/// 重试（同一份坏数据重跑不会变好），落 failed 等用户手动重试（重试会因目标
+/// 文件已存在而跳过下载、直接重导）。
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+import 'package:fushi/src/utils/net/app_http.dart';
+
+/// 自动重试退避梯度；长度即最大自动重试次数（语义同 `kMokuroMoeRetryBackoff`）。
+const List<Duration> kDiscoveryDownloadRetryBackoff = <Duration>[
+  Duration(seconds: 2),
+  Duration(seconds: 8),
+  Duration(seconds: 20),
+];
+
+/// 把条目物化成可执行 payload（生产接 `MediaDiscoverySource.resolvePayload`；
+/// 注入函数而非源对象，队列不依赖源注册表）。
+typedef DiscoveryPayloadResolver = Future<DiscoveryPayload> Function(
+  DiscoveryResourceItem item,
+);
+
+/// 下载完成后的自动入库回调（按 [DiscoveryResourceItem.kind] 分派到各域导入器；
+/// 生产分派表在组装点注入，本队列不 import 任何域代码）。
+typedef DiscoveryDownloadImporter = Future<DiscoveryImportOutcome> Function(
+  DiscoveryDownloadTask task,
+  File file,
+);
+
+/// 测试注入口：替换真实网络（绕 HttpClient）。
+typedef DiscoveryDownloadOpen = Future<ResumableDownloadResponse> Function(
+  Uri uri,
+  Map<String, String> headers,
+);
+
+/// 一次自动入库的结果。
+class DiscoveryImportOutcome {
+  const DiscoveryImportOutcome({this.importedCount = 0, this.summary});
+
+  /// 实际新建的库条目数（0 = 已在库被跳过等）。
+  final int importedCount;
+
+  /// 给任务行展示的一句话结果（入库标题等）。
+  final String? summary;
+}
+
+/// 任务生命周期状态。[waitingRetry] 不是终态也不占执行位（语义同 mokuro 队列）。
+enum DiscoveryDownloadStatus {
+  queued,
+  running,
+  waitingRetry,
+  done,
+  failed,
+  cancelled,
+}
+
+/// 队列中的一个下载任务（可变快照；变更经队列 notifyListeners 广播）。
+class DiscoveryDownloadTask {
+  DiscoveryDownloadTask._({required this.item, required this.destinationDir});
+
+  final DiscoveryResourceItem item;
+
+  /// 落盘目录（按媒体域由组装点决定）。
+  final String destinationDir;
+
+  DiscoveryDownloadStatus status = DiscoveryDownloadStatus.queued;
+
+  int receivedBytes = 0;
+  int? totalBytes;
+
+  /// 失败原因（status == failed / waitingRetry 时非空）。
+  String? error;
+
+  /// 已消耗的自动重试次数；手动 retry 归零。
+  int autoRetries = 0;
+
+  /// 下载完成后的落盘路径（done 时非空）。
+  String? filePath;
+
+  /// 自动入库结果（done 且导入过时非空）。
+  DiscoveryImportOutcome? importOutcome;
+
+  /// 目标文件已存在、跳过了下载（重试重导场景仍会走导入）。
+  bool skippedDownload = false;
+
+  /// 取消请求标记：running 中被 cancel 时置位，收尾按 cancelled 归类。
+  bool _cancelRequested = false;
+
+  /// 当前任务持有的网络连接（cancel 时强关以掐断响应流）。
+  HttpClient? _client;
+
+  bool get isFinished =>
+      status == DiscoveryDownloadStatus.done ||
+      status == DiscoveryDownloadStatus.failed ||
+      status == DiscoveryDownloadStatus.cancelled;
+}
+
+/// 内部哨兵：把「用户取消」与真实错误在收尾处分开。
+class _DiscoveryDownloadCancelled implements Exception {
+  const _DiscoveryDownloadCancelled();
+}
+
+/// 顺序执行的发现页直链下载队列。
+class DiscoveryDownloadQueue extends ChangeNotifier {
+  DiscoveryDownloadQueue({
+    required DiscoveryPayloadResolver resolvePayload,
+    required DiscoveryDownloadImporter importer,
+    @visibleForTesting DiscoveryDownloadOpen? openOverride,
+    @visibleForTesting List<Duration>? retryBackoffOverride,
+  })  : _resolvePayload = resolvePayload,
+        _importer = importer,
+        _openOverride = openOverride,
+        _retryBackoff = retryBackoffOverride ?? kDiscoveryDownloadRetryBackoff;
+
+  final DiscoveryPayloadResolver _resolvePayload;
+  final DiscoveryDownloadImporter _importer;
+  final DiscoveryDownloadOpen? _openOverride;
+  final List<Duration> _retryBackoff;
+
+  final List<DiscoveryDownloadTask> _tasks = <DiscoveryDownloadTask>[];
+
+  /// 退避中的重试定时器（可并存多个：A 退避时队列继续跑 B）。
+  final Map<DiscoveryDownloadTask, Timer> _retryTimers =
+      <DiscoveryDownloadTask, Timer>{};
+
+  DiscoveryDownloadTask? _running;
+  bool _disposed = false;
+
+  /// UI 进度节流：字节回调每 chunk 触发，逐次 notify 会刷爆监听方。
+  static const Duration _progressNotifyInterval = Duration(milliseconds: 250);
+  DateTime _lastProgressNotify = DateTime.fromMillisecondsSinceEpoch(0);
+
+  int get maxAutoRetries => _retryBackoff.length;
+
+  /// 累计成功新建库条目数（库页刷新信号：监听方比对增量后失效对应 provider）。
+  int _importedCount = 0;
+  int get importedCount => _importedCount;
+
+  List<DiscoveryDownloadTask> get tasks =>
+      List<DiscoveryDownloadTask>.unmodifiable(_tasks);
+
+  DiscoveryDownloadTask? get runningTask => _running;
+
+  bool get hasUnfinished =>
+      _tasks.any((DiscoveryDownloadTask t) => !t.isFinished);
+
+  int get finishedCount =>
+      _tasks.where((DiscoveryDownloadTask t) => t.isFinished).length;
+
+  int get totalCount => _tasks.length;
+
+  /// 该条目是否已排队/执行中（发现页据此禁用下载按钮，防重复入队）。
+  bool isPending(DiscoveryResourceItem item) => pendingTask(item) != null;
+
+  DiscoveryDownloadTask? pendingTask(DiscoveryResourceItem item) {
+    for (final DiscoveryDownloadTask t in _tasks) {
+      if (!t.isFinished &&
+          t.item.sourceId == item.sourceId &&
+          t.item.id == item.id) {
+        return t;
+      }
+    }
+    return null;
+  }
+
+  /// 入队一个条目；同源同 id 的未完成任务去重。返回是否真的新增。
+  bool enqueue(DiscoveryResourceItem item, {required String destinationDir}) {
+    assert(
+      item.payloadKind == DiscoveryPayloadKind.httpFile,
+      'torrent 条目走 torrent 后端，不进 HTTP 队列',
+    );
+    if (isPending(item)) return false;
+    _tasks.add(
+      DiscoveryDownloadTask._(item: item, destinationDir: destinationDir),
+    );
+    notifyListeners();
+    _pump();
+    return true;
+  }
+
+  /// 取消任务：排队/退避中→直接移除；执行中→强关连接中止（`.part` 保留，
+  /// 下次同条目续传）。已结束 no-op。
+  void cancel(DiscoveryDownloadTask task) {
+    if (task.isFinished) return;
+    _retryTimers.remove(task)?.cancel();
+    if (identical(task, _running)) {
+      task._cancelRequested = true;
+      // 强关底层连接让响应流立刻报错；没有活动连接（还在 resolve 阶段）时
+      // 由 _run 收尾处的 _cancelRequested 检查兜住。
+      task._client?.close(force: true);
+      return;
+    }
+    _tasks.remove(task);
+    notifyListeners();
+  }
+
+  /// 手动重试失败/已取消任务：**就地**复活（不新建行），自动重试预算清零。
+  void retry(DiscoveryDownloadTask task) {
+    if (task.status != DiscoveryDownloadStatus.failed &&
+        task.status != DiscoveryDownloadStatus.cancelled) {
+      return;
+    }
+    _resetForRetry(task);
+    notifyListeners();
+    _pump();
+  }
+
+  /// 批量复活一切失败/取消任务。返回真正复活的任务数。
+  int retryAllFailed() {
+    int revived = 0;
+    for (final DiscoveryDownloadTask task in _tasks) {
+      if (task.status != DiscoveryDownloadStatus.failed &&
+          task.status != DiscoveryDownloadStatus.cancelled) {
+        continue;
+      }
+      _resetForRetry(task);
+      revived++;
+    }
+    if (revived > 0) {
+      notifyListeners();
+      _pump();
+    }
+    return revived;
+  }
+
+  void _resetForRetry(DiscoveryDownloadTask task) {
+    task.status = DiscoveryDownloadStatus.queued;
+    task.autoRetries = 0;
+    task.error = null;
+    task.receivedBytes = 0;
+    task.totalBytes = null;
+    task.importOutcome = null;
+    task.skippedDownload = false;
+    task._cancelRequested = false;
+  }
+
+  /// 清掉所有已结束任务（下载页「清除已完成」）。
+  void clearFinished() {
+    final int before = _tasks.length;
+    _tasks.removeWhere((DiscoveryDownloadTask t) => t.isFinished);
+    if (_tasks.length != before) notifyListeners();
+  }
+
+  void _pump() {
+    if (_disposed || _running != null) return;
+    DiscoveryDownloadTask? next;
+    for (final DiscoveryDownloadTask t in _tasks) {
+      if (t.status == DiscoveryDownloadStatus.queued) {
+        next = t;
+        break;
+      }
+    }
+    if (next == null) return;
+    final DiscoveryDownloadTask task = next;
+    task.status = DiscoveryDownloadStatus.running;
+    _running = task;
+    notifyListeners();
+    unawaited(_run(task));
+  }
+
+  Future<void> _run(DiscoveryDownloadTask task) async {
+    Object? failure;
+    bool failureRetryable = true;
+    try {
+      final DiscoveryPayload payload = await _resolvePayload(task.item);
+      final DiscoveryHttpPayload http = switch (payload) {
+        DiscoveryHttpPayload() => payload,
+        DiscoveryTorrentPayload() => throw StateError(
+            'source resolved a torrent payload for an httpFile item',
+          ),
+      };
+      if (task._cancelRequested) throw const _DiscoveryDownloadCancelled();
+
+      final File destination = File(
+        '${task.destinationDir}${Platform.pathSeparator}'
+        '${_resolveFileName(task.item, http)}',
+      );
+      File file;
+      if (await destination.exists()) {
+        // 上一轮已下完但导入失败的重试路径：不重下，直接重导。
+        task.skippedDownload = true;
+        task.receivedBytes = await destination.length();
+        task.totalBytes = task.receivedBytes;
+        file = destination;
+      } else {
+        await Directory(task.destinationDir).create(recursive: true);
+        file = await _download(task, http, destination);
+      }
+      task.filePath = file.path;
+      if (task._cancelRequested) throw const _DiscoveryDownloadCancelled();
+
+      try {
+        final DiscoveryImportOutcome outcome = await _importer(task, file);
+        task.importOutcome = outcome;
+        _importedCount += outcome.importedCount;
+      } catch (e) {
+        // 导入失败不自动重试：同一份坏数据重跑不会变好。
+        failureRetryable = false;
+        rethrow;
+      }
+    } catch (e) {
+      failure = e;
+    }
+    _finish(task, error: failure, retryable: failureRetryable);
+  }
+
+  Future<File> _download(
+    DiscoveryDownloadTask task,
+    DiscoveryHttpPayload payload,
+    File destination,
+  ) async {
+    final DiscoveryDownloadOpen open;
+    HttpClient? client;
+    if (_openOverride != null) {
+      open = _openOverride;
+    } else {
+      client = createAppHttpClient();
+      task._client = client;
+      open = (Uri uri, Map<String, String> headers) =>
+          _openViaHttpClient(client!, payload.headers, uri, headers);
+    }
+    try {
+      final ResumableDownloader downloader = ResumableDownloader(
+        url: payload.url,
+        destination: destination,
+        partFile: File('${destination.path}.part'),
+        open: open,
+        expectedSize: payload.sizeBytes,
+        onProgress: (int received, int? total) {
+          task.receivedBytes = received;
+          task.totalBytes = total;
+          _notifyProgress();
+        },
+      );
+      return await downloader.download();
+    } finally {
+      task._client = null;
+      client?.close(force: true);
+    }
+  }
+
+  static Future<ResumableDownloadResponse> _openViaHttpClient(
+    HttpClient client,
+    Map<String, String> payloadHeaders,
+    Uri uri,
+    Map<String, String> headers,
+  ) async {
+    final HttpClientRequest request = await client.getUrl(uri);
+    request.followRedirects = true;
+    request.maxRedirects = 8;
+    payloadHeaders.forEach(request.headers.set);
+    headers.forEach(request.headers.set);
+    final HttpClientResponse response = await request.close();
+    final Map<String, String> responseHeaders = <String, String>{};
+    response.headers.forEach(
+      (String name, List<String> values) =>
+          responseHeaders[name] = values.join(', '),
+    );
+    return ResumableDownloadResponse(
+      statusCode: response.statusCode,
+      headers: responseHeaders,
+      stream: response,
+    );
+  }
+
+  /// 从 payload / URL / 条目标题推导落盘文件名（按此优先级取第一个可用者）。
+  static String _resolveFileName(
+    DiscoveryResourceItem item,
+    DiscoveryHttpPayload payload,
+  ) {
+    String? candidate = payload.fileName;
+    if (candidate == null || candidate.trim().isEmpty) {
+      final Uri? uri = Uri.tryParse(payload.url);
+      if (uri != null) {
+        for (final String segment in uri.pathSegments.reversed) {
+          if (segment.trim().isNotEmpty) {
+            candidate = Uri.decodeComponent(segment);
+            break;
+          }
+        }
+      }
+    }
+    if (candidate == null || candidate.trim().isEmpty) candidate = item.title;
+    return sanitizeDiscoveryFileName(candidate);
+  }
+
+  void _notifyProgress() {
+    if (_disposed) return;
+    final DateTime now = DateTime.now();
+    if (now.difference(_lastProgressNotify) < _progressNotifyInterval) return;
+    _lastProgressNotify = now;
+    notifyListeners();
+  }
+
+  /// 任务收尾（以 `_running` 身份判重，只收一次）。
+  void _finish(
+    DiscoveryDownloadTask task, {
+    Object? error,
+    bool retryable = true,
+  }) {
+    if (!identical(task, _running)) return;
+    _running = null;
+    if (task._cancelRequested || error is _DiscoveryDownloadCancelled) {
+      // 强关连接会让错误以各种网络异常形态上浮；只要用户请求过取消，一律
+      // 归类为 cancelled（`.part` 已保留，重试即续传）。
+      task.status = DiscoveryDownloadStatus.cancelled;
+    } else if (error != null) {
+      task.error = '$error';
+      task.status = retryable && _scheduleAutoRetry(task, error)
+          ? DiscoveryDownloadStatus.waitingRetry
+          : DiscoveryDownloadStatus.failed;
+    } else {
+      task.status = DiscoveryDownloadStatus.done;
+    }
+    if (_disposed) return;
+    notifyListeners();
+    _pump();
+  }
+
+  /// 安排一次自动重试；false = 这个错误/这个任务不该再自动重试。
+  bool _scheduleAutoRetry(DiscoveryDownloadTask task, Object error) {
+    if (_disposed) return false;
+    if (task.autoRetries >= _retryBackoff.length) return false;
+    if (!_isTransientError(error)) return false;
+
+    final Duration delay = _retryBackoff[task.autoRetries];
+    task.autoRetries++;
+    // 进度归零：重跑从 `.part` 续传点重新报字节。
+    task.receivedBytes = 0;
+    task.totalBytes = null;
+    _retryTimers[task] = Timer(delay, () {
+      _retryTimers.remove(task);
+      if (_disposed || task.status != DiscoveryDownloadStatus.waitingRetry) {
+        return;
+      }
+      task.status = DiscoveryDownloadStatus.queued;
+      notifyListeners();
+      _pump();
+    });
+    return true;
+  }
+
+  /// 值得自动重试的错误 = 瞬时网络/传输故障。HTTP 状态码只认 5xx/408/429
+  /// （从 `ResumableDownloader` 的 HttpException 文案里提取）；404/403 这类
+  /// 稳定结论、以及体积/哈希校验失败（数据错误）重试纯属白等。
+  static bool _isTransientError(Object error) {
+    if (error is ResumableDownloadIntegrityException) return false;
+    if (error is HttpException) {
+      final RegExpMatch? match =
+          RegExp(r'download failed \((\d{3})\)').firstMatch(error.message);
+      if (match != null) {
+        final int code = int.parse(match.group(1)!);
+        return code >= 500 || code == 408 || code == 429;
+      }
+      return true;
+    }
+    return error is SocketException ||
+        error is TimeoutException ||
+        error is TlsException;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    for (final Timer timer in _retryTimers.values) {
+      timer.cancel();
+    }
+    _retryTimers.clear();
+    final DiscoveryDownloadTask? running = _running;
+    if (running != null) {
+      running._cancelRequested = true;
+      running._client?.close(force: true);
+    }
+    super.dispose();
+  }
+}
+
+/// 净化落盘文件名：去路径分隔与 Windows 非法字符、控制字符，压缩空白；
+/// 空结果回退 'download'。顶层函数以便导入分派侧复用同一净化规则。
+String sanitizeDiscoveryFileName(String name) {
+  final String cleaned = name
+      .replaceAll(RegExp(r'[<>:"/\\|?*\x00-\x1f]'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim()
+      // Windows 文件名不能以点/空格结尾；顺带把 '.'/'..' 这类纯点名归零。
+      .replaceAll(RegExp(r'[. ]+$'), '');
+  return cleaned.isEmpty ? 'download' : cleaned;
+}

--- a/fushi/lib/src/media/discovery/discovery_download_queue.dart
+++ b/fushi/lib/src/media/discovery/discovery_download_queue.dart
@@ -22,6 +22,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+import 'package:fushi/src/utils/misc/safe_file_name.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 
 /// 自动重试退避梯度；长度即最大自动重试次数（语义同 `kMokuroMoeRetryBackoff`）。
@@ -496,7 +497,8 @@ class DiscoveryDownloadQueue extends ChangeNotifier {
 /// 空结果回退 'download'。顶层函数以便导入分派侧复用同一净化规则。
 String sanitizeDiscoveryFileName(String name) {
   final String cleaned = name
-      .replaceAll(RegExp(r'[<>:"/\\|?*\x00-\x1f]'), ' ')
+      // 黑名单字符集用全仓唯一真相源（BUG-1125：禁止复制字符集）。
+      .replaceAll(windowsUnsafeFileNameChars, ' ')
       .replaceAll(RegExp(r'\s+'), ' ')
       .trim()
       // Windows 文件名不能以点/空格结尾；顺带把 '.'/'..' 这类纯点名归零。

--- a/fushi/lib/src/media/discovery/discovery_models.dart
+++ b/fushi/lib/src/media/discovery/discovery_models.dart
@@ -1,0 +1,171 @@
+/// 统一发现页的领域模型：跨媒体域（小说/有声书/游戏/漫画）的在线**资源**发现契约。
+///
+/// 与视频域的元数据发现（`video_discovery_provider.dart`，TMDB/AniList 作品条目 +
+/// 跨源身份合并）不同，这里发现的是**可下载资源**（种子/HTTP 直链）：资源天然按源
+/// 展示、不做跨源去重合并；聚合只做扇出与部分成功语义（`media_discovery_service.dart`）。
+///
+/// 条目分两形：目录（[DiscoveryFolder]，仅目录型源产生，点进去继续 browse）与
+/// 资源（[DiscoveryResourceItem]，可下载）。用 sealed 层级而不是 `isDirectory` 布尔位，
+/// 让「目录没有 payload/体积/做种数」在类型上成立，而不是一堆可空字段的运行时约定。
+library;
+
+/// 发现页覆盖的媒体域。各域独立枚举（见根 CLAUDE.md 术语表），与持久化的
+/// `MediaKind` 等值域互不混用；本枚举只活在发现/下载编排层，不落库。
+enum DiscoveryMediaKind { novel, audiobook, game, manga }
+
+/// 条目将来会产出的 payload 形态。源在**列表阶段**就已知自己产什么
+/// （nyaa 恒 torrent、AList/shinnku 恒 http），UI 拿到条目即可分流下载动作：
+/// torrent 走既有 torrent 后端（`pushGenericMagnet` 链路），http 走
+/// `DiscoveryDownloadQueue`——不需要先 resolve 再分流。
+enum DiscoveryPayloadKind { torrent, httpFile }
+
+/// 可执行的下载 payload。列表阶段能给就随条目带上（[DiscoveryResourceItem.payload]）；
+/// 直链带临期签名的源（AList `/api/fs/get`）列表阶段给 null，下载时经
+/// `MediaDiscoverySource.resolvePayload` 延迟物化。
+sealed class DiscoveryPayload {
+  const DiscoveryPayload();
+}
+
+/// 磁链/种子：交给 torrent 后端。
+final class DiscoveryTorrentPayload extends DiscoveryPayload {
+  const DiscoveryTorrentPayload({required this.magnetUri});
+
+  final String magnetUri;
+}
+
+/// HTTP 直链：交给 HTTP 下载队列。
+final class DiscoveryHttpPayload extends DiscoveryPayload {
+  const DiscoveryHttpPayload({
+    required this.url,
+    this.headers = const <String, String>{},
+    this.fileName,
+    this.sizeBytes,
+  });
+
+  final String url;
+
+  /// 该直链要求的额外请求头（Referer/UA 防盗链等）。
+  final Map<String, String> headers;
+
+  /// 服务端真实文件名（可与展示标题不同）；null 时由下载侧从 URL 推导。
+  final String? fileName;
+
+  final int? sizeBytes;
+}
+
+/// 发现结果里的一个条目：目录或资源。
+sealed class DiscoveryEntry {
+  const DiscoveryEntry({required this.sourceId, required this.title});
+
+  /// 产生本条目的源 id（聚合列表里渲染源徽标用）。
+  final String sourceId;
+
+  final String title;
+}
+
+/// 目录：点击后以 [DiscoveryRequest.path] = [path] 对同源继续 browse。
+final class DiscoveryFolder extends DiscoveryEntry {
+  const DiscoveryFolder({
+    required super.sourceId,
+    required super.title,
+    required this.path,
+  });
+
+  /// 源内路径（源自定义语义，聚合层只透传）。
+  final String path;
+}
+
+/// 可下载资源。
+final class DiscoveryResourceItem extends DiscoveryEntry {
+  const DiscoveryResourceItem({
+    required super.sourceId,
+    required super.title,
+    required this.id,
+    required this.kind,
+    required this.payloadKind,
+    this.payload,
+    this.sizeBytes,
+    this.dateText,
+    this.seeders,
+    this.leechers,
+    this.coverUrl,
+    this.detailUrl,
+  });
+
+  /// 源内稳定 id（去重/防重复入队的身份键；语义源自定义：文件路径、种子页 URL 等）。
+  final String id;
+
+  final DiscoveryMediaKind kind;
+
+  final DiscoveryPayloadKind payloadKind;
+
+  /// 列表阶段已物化的 payload；null 表示需要下载时向源 resolve。
+  final DiscoveryPayload? payload;
+
+  final int? sizeBytes;
+
+  /// 展示用的发布时间原文（不解析成 DateTime——各源格式/时区五花八门，
+  /// 排序仍按源返回顺序，解析只会制造错序假象）。
+  final String? dateText;
+
+  /// 种子健康度（仅 torrent 源）。
+  final int? seeders;
+  final int? leechers;
+
+  final String? coverUrl;
+
+  /// 外部详情页（nyaa view 页、shinnku 条目页）；「在浏览器打开」动作用。
+  final String? detailUrl;
+}
+
+/// 一次发现请求。[query] 非空白即搜索，否则是目录浏览（[path] null = 源根）。
+class DiscoveryRequest {
+  const DiscoveryRequest({
+    required this.kind,
+    this.query,
+    this.path,
+    this.page = 1,
+    this.pageSize = 50,
+  })  : assert(page > 0),
+        assert(pageSize > 0);
+
+  final DiscoveryMediaKind kind;
+  final String? query;
+
+  /// browse 位置（源内路径）。深层路径只对单一源有意义：聚合（全部源）模式
+  /// 只允许 search 或根浏览，见 `MediaDiscoveryService.load` 的入参约束。
+  final String? path;
+
+  final int page;
+  final int pageSize;
+
+  bool get isSearch => query?.trim().isNotEmpty == true;
+}
+
+/// 单源单页结果。
+class DiscoveryResultPage {
+  DiscoveryResultPage({
+    required Iterable<DiscoveryEntry> entries,
+    required this.page,
+    required this.hasMore,
+  }) : entries = List<DiscoveryEntry>.unmodifiable(entries);
+
+  final List<DiscoveryEntry> entries;
+  final int page;
+  final bool hasMore;
+}
+
+/// 源能力声明：聚合层据此决定一次请求扇出到哪些源，而不是调了再看报错。
+class DiscoveryCapabilities {
+  DiscoveryCapabilities({
+    required Iterable<DiscoveryMediaKind> kinds,
+    this.supportsSearch = true,
+    this.supportsBrowse = false,
+    this.supportsPaging = false,
+  }) : kinds = Set<DiscoveryMediaKind>.unmodifiable(kinds);
+
+  final Set<DiscoveryMediaKind> kinds;
+  final bool supportsSearch;
+  final bool supportsBrowse;
+  final bool supportsPaging;
+}

--- a/fushi/lib/src/media/discovery/discovery_models.dart
+++ b/fushi/lib/src/media/discovery/discovery_models.dart
@@ -90,6 +90,7 @@ final class DiscoveryResourceItem extends DiscoveryEntry {
     this.leechers,
     this.coverUrl,
     this.detailUrl,
+    this.note,
   });
 
   /// 源内稳定 id（去重/防重复入队的身份键；语义源自定义：文件路径、种子页 URL 等）。
@@ -116,6 +117,10 @@ final class DiscoveryResourceItem extends DiscoveryEntry {
 
   /// 外部详情页（nyaa view 页、shinnku 条目页）；「在浏览器打开」动作用。
   final String? detailUrl;
+
+  /// 源特定的一句话标注（shinnku 的「熟肉/生肉/手机」、平台标签等），
+  /// 原样展示，不参与任何逻辑。
+  final String? note;
 }
 
 /// 一次发现请求。[query] 非空白即搜索，否则是目录浏览（[path] null = 源根）。

--- a/fushi/lib/src/media/discovery/import/discovery_archive_extractor.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_archive_extractor.dart
@@ -1,0 +1,163 @@
+/// 发现页下载物的解压原语。
+///
+/// 优先用 7-Zip 命令行（zip/7z/rar 全吃、正确处理 cp932 文件名；Windows 随包
+/// 分发 `7za.exe`，定位顺序见 [findSevenZip]）；找不到 7-Zip 时 zip 退回
+/// `package:archive` 内置解码，7z/rar 无替代 → [DiscoveryImportBlocker.archiveToolMissing]。
+///
+/// zip 内置解码带 zip-slip 防护：条目路径出现 `..`/绝对路径一律拒绝——下载物
+/// 来自外部站点，属不可信输入。
+library;
+
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart';
+
+/// 测试注入口：替换真实子进程执行。
+typedef DiscoveryProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments,
+);
+
+class DiscoveryArchiveExtractor {
+  DiscoveryArchiveExtractor({
+    DiscoveryProcessRunner? runProcess,
+    String? sevenZipOverride,
+  })  : _runProcess = runProcess ?? Process.run,
+        _sevenZipOverride = sevenZipOverride;
+
+  final DiscoveryProcessRunner _runProcess;
+  final String? _sevenZipOverride;
+
+  /// 已定位的 7-Zip 可执行路径缓存（空串 = 已找过且没有）。
+  String? _sevenZipCache;
+
+  /// 定位 7-Zip 命令行：构造注入 > `FUSHI_7ZA` 环境变量 > 主程序旁
+  /// `7za/7za.exe`（构建期随包，仿 voice_hook 落位）> PATH 上的 `7za`/`7z`。
+  Future<String?> findSevenZip() async {
+    final String? override = _sevenZipOverride;
+    if (override != null) return override.isEmpty ? null : override;
+    final String? cached = _sevenZipCache;
+    if (cached != null) return cached.isEmpty ? null : cached;
+
+    Future<String?> probe() async {
+      final String? env = Platform.environment['FUSHI_7ZA'];
+      if (env != null && env.isNotEmpty && File(env).existsSync()) return env;
+      final String exeDir = File(Platform.resolvedExecutable).parent.path;
+      for (final String candidate in <String>[
+        '$exeDir${Platform.pathSeparator}7za${Platform.pathSeparator}7za.exe',
+        '$exeDir${Platform.pathSeparator}7za.exe',
+      ]) {
+        if (File(candidate).existsSync()) return candidate;
+      }
+      for (final String name in <String>['7za', '7z']) {
+        try {
+          final ProcessResult result = await _runProcess(
+            Platform.isWindows ? 'where' : 'which',
+            <String>[name],
+          );
+          if (result.exitCode == 0) {
+            final String path =
+                (result.stdout as String).trim().split('\n').first.trim();
+            if (path.isNotEmpty) return path;
+          }
+        } catch (_) {
+          // where/which 本身不存在：继续下一个候选。
+        }
+      }
+      return null;
+    }
+
+    final String? found = await probe();
+    _sevenZipCache = found ?? '';
+    return found;
+  }
+
+  /// 解压 [archivePath] 到 [intoDir]（不存在会创建）。成功返回解出的目录。
+  Future<Directory> extract(String archivePath,
+      {required String intoDir}) async {
+    final Directory target = Directory(intoDir);
+    await target.create(recursive: true);
+
+    final String? sevenZip = await findSevenZip();
+    if (sevenZip != null) {
+      final ProcessResult result = await _runProcess(
+        sevenZip,
+        // -aoa 覆盖旧文件（重试重解场景）；-p- 空密码占位防交互挂起。
+        <String>['x', '-y', '-aoa', '-p-', '-o$intoDir', archivePath],
+      );
+      if (result.exitCode != 0) {
+        throw DiscoveryImportBlockedException(
+          DiscoveryImportBlocker.archiveExtractionFailed,
+          '7z exit ${result.exitCode}',
+        );
+      }
+      return target;
+    }
+
+    final String ext = archivePath.toLowerCase();
+    if (!ext.endsWith('.zip')) {
+      throw const DiscoveryImportBlockedException(
+        DiscoveryImportBlocker.archiveToolMissing,
+      );
+    }
+    await _extractZipBuiltin(archivePath, target);
+    return target;
+  }
+
+  Future<void> _extractZipBuiltin(String archivePath, Directory target) async {
+    final InputFileStream input = InputFileStream(archivePath);
+    try {
+      final Archive archive = ZipDecoder().decodeBuffer(input);
+      for (final ArchiveFile entry in archive) {
+        final String? safe = sanitizeArchiveEntryPath(entry.name);
+        if (safe == null) {
+          throw DiscoveryImportBlockedException(
+            DiscoveryImportBlocker.archiveExtractionFailed,
+            'unsafe entry path',
+          );
+        }
+        final String outPath = '${target.path}${Platform.pathSeparator}$safe';
+        if (entry.isFile) {
+          final File outFile = File(outPath);
+          await outFile.parent.create(recursive: true);
+          final OutputFileStream output = OutputFileStream(outPath);
+          try {
+            entry.writeContent(output);
+          } finally {
+            await output.close();
+          }
+        } else {
+          await Directory(outPath).create(recursive: true);
+        }
+      }
+    } on DiscoveryImportBlockedException {
+      rethrow;
+    } catch (e) {
+      throw DiscoveryImportBlockedException(
+        DiscoveryImportBlocker.archiveExtractionFailed,
+        '$e',
+      );
+    } finally {
+      await input.close();
+    }
+  }
+}
+
+/// zip-slip 防护：归一分隔符、拒绝绝对路径与 `..` 段；空/纯目录名返回原样。
+/// 不安全返回 null。
+String? sanitizeArchiveEntryPath(String entryName) {
+  final String normalized = entryName.replaceAll('\\', '/');
+  if (normalized.startsWith('/') ||
+      RegExp(r'^[A-Za-z]:').hasMatch(normalized)) {
+    return null;
+  }
+  final List<String> segments = normalized.split('/');
+  for (final String segment in segments) {
+    if (segment == '..') return null;
+  }
+  return segments
+      .where((String s) => s.isNotEmpty && s != '.')
+      .join(Platform.pathSeparator);
+}

--- a/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
@@ -1,0 +1,130 @@
+/// 发现页导入计划的执行层：把 [DiscoveryImportPlan] 落到各域导入器。
+///
+/// 域导入器以函数端口（[DiscoveryDomainImporters]）注入——执行层不 import
+/// 任何域代码，测试用假导入器即可覆盖全部编排；生产装配见
+/// `discovery_import_production.dart`。
+library;
+
+import 'dart:io';
+
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/import/discovery_archive_extractor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart';
+
+/// 各域导入器端口。返回值约定：入库成功返回身份键（bookKey/exe 路径），
+/// 因重复被跳过返回 null；失败抛异常。
+class DiscoveryDomainImporters {
+  const DiscoveryDomainImporters({
+    required this.importEpub,
+    required this.importText,
+    required this.importPdf,
+    required this.importAudiobook,
+    required this.registerGameExes,
+  });
+
+  final Future<String?> Function(String filePath) importEpub;
+  final Future<String?> Function(String filePath) importText;
+  final Future<String?> Function(String filePath) importPdf;
+  final Future<String?> Function(AlignAudiobookPlan plan) importAudiobook;
+
+  /// 返回真正新登记的条目数（查重后可能为 0）。
+  final Future<int> Function(List<String> exePaths) registerGameExes;
+}
+
+/// 计划执行器：分类 → （需要时）解压 → 重分类 → 调域导入器。
+class DiscoveryImportExecutor {
+  DiscoveryImportExecutor({
+    required DiscoveryDomainImporters importers,
+    DiscoveryArchiveExtractor? extractor,
+  })  : _importers = importers,
+        _extractor = extractor ?? DiscoveryArchiveExtractor();
+
+  final DiscoveryDomainImporters _importers;
+  final DiscoveryArchiveExtractor _extractor;
+
+  /// [DiscoveryDownloadQueue] 的 importer 端口（`DiscoveryDownloadImporter`）。
+  Future<DiscoveryImportOutcome> importDownload(
+    DiscoveryDownloadTask task,
+    File file,
+  ) =>
+      importFile(task.item.kind, file);
+
+  Future<DiscoveryImportOutcome> importFile(
+    DiscoveryMediaKind kind,
+    File file,
+  ) async {
+    DiscoveryImportPlan plan = classifyDiscoveryFile(kind, file.path);
+    if (plan is ExtractArchivePlan) {
+      final String stem = _stemOf(file.path);
+      final Directory extracted = await _extractor.extract(
+        plan.archivePath,
+        intoDir: '${file.parent.path}${Platform.pathSeparator}$stem',
+      );
+      final List<String> paths = <String>[];
+      final Map<String, int> sizes = <String, int>{};
+      for (final FileSystemEntity entity
+          in extracted.listSync(recursive: true, followLinks: false)) {
+        if (entity is File) {
+          paths.add(entity.path);
+          sizes[entity.path] = entity.lengthSync();
+        }
+      }
+      plan = classifyDiscoveryDirectory(kind, paths, fileSizes: sizes);
+    }
+    return _execute(plan);
+  }
+
+  Future<DiscoveryImportOutcome> _execute(DiscoveryImportPlan plan) async {
+    switch (plan) {
+      case ImportEpubPlan():
+        return _single(await _importers.importEpub(plan.filePath));
+      case ConvertTextPlan():
+        return _single(await _importers.importText(plan.filePath));
+      case ImportPdfPlan():
+        return _single(await _importers.importPdf(plan.filePath));
+      case AlignAudiobookPlan():
+        return _single(await _importers.importAudiobook(plan));
+      case RegisterGameExesPlan():
+        final int registered = await _importers.registerGameExes(plan.exePaths);
+        return DiscoveryImportOutcome(
+          importedCount: registered,
+          summary: registered > 0 ? _fileName(plan.exePaths.first) : null,
+        );
+      case MultiPlan():
+        int imported = 0;
+        final List<String> keys = <String>[];
+        for (final DiscoveryImportPlan child in plan.children) {
+          final DiscoveryImportOutcome outcome = await _execute(child);
+          imported += outcome.importedCount;
+          final String? summary = outcome.summary;
+          if (summary != null) keys.add(summary);
+        }
+        return DiscoveryImportOutcome(
+          importedCount: imported,
+          summary: keys.isEmpty ? null : keys.join(' / '),
+        );
+      case UnsupportedPlan():
+        throw DiscoveryImportBlockedException(plan.blocker);
+      case ExtractArchivePlan():
+        // 分类目录树不会再产出压缩包计划（嵌套压缩包 v1 不递归解）。
+        throw StateError('nested archive plans are not executable');
+    }
+  }
+
+  static DiscoveryImportOutcome _single(String? key) => DiscoveryImportOutcome(
+        importedCount: key == null ? 0 : 1,
+        summary: key,
+      );
+
+  static String _stemOf(String path) {
+    final String base = _fileName(path);
+    final int dot = base.lastIndexOf('.');
+    return dot <= 0 ? base : base.substring(0, dot);
+  }
+
+  static String _fileName(String path) {
+    final String normalized = path.replaceAll('\\', '/');
+    return normalized.substring(normalized.lastIndexOf('/') + 1);
+  }
+}

--- a/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
@@ -50,6 +50,52 @@ class DiscoveryImportExecutor {
   ) =>
       importFile(task.item.kind, file);
 
+  /// torrent 整包入口：对一组已就位的绝对路径分类入库（torrent 下载完成后
+  /// `AnimeDownloadService` 调这里）。
+  ///
+  /// 目录树直接分类不出、但包里有压缩包时（gal 种子常见形态：文件夹里一个
+  /// rar），取最大的压缩包解开并把解出的文件并入清单重新分类。
+  Future<DiscoveryImportOutcome> importPaths(
+    DiscoveryMediaKind kind,
+    List<String> filePaths,
+  ) async {
+    if (filePaths.length == 1) {
+      return importFile(kind, File(filePaths.single));
+    }
+    final Map<String, int> sizes = <String, int>{
+      for (final String path in filePaths)
+        if (File(path).existsSync()) path: File(path).lengthSync(),
+    };
+    DiscoveryImportPlan plan =
+        classifyDiscoveryDirectory(kind, filePaths, fileSizes: sizes);
+    if (plan is UnsupportedPlan) {
+      final List<String> archives = <String>[
+        for (final String path in filePaths)
+          if (isDiscoveryArchivePath(path)) path,
+      ]..sort(
+          (String a, String b) => (sizes[b] ?? 0).compareTo(sizes[a] ?? 0),
+        );
+      if (archives.isNotEmpty) {
+        final File archive = File(archives.first);
+        final Directory extracted = await _extractor.extract(
+          archive.path,
+          intoDir:
+              '${archive.parent.path}${Platform.pathSeparator}${_stemOf(archive.path)}',
+        );
+        final List<String> merged = List<String>.of(filePaths);
+        for (final FileSystemEntity entity
+            in extracted.listSync(recursive: true, followLinks: false)) {
+          if (entity is File) {
+            merged.add(entity.path);
+            sizes[entity.path] = entity.lengthSync();
+          }
+        }
+        plan = classifyDiscoveryDirectory(kind, merged, fileSizes: sizes);
+      }
+    }
+    return _execute(plan);
+  }
+
   Future<DiscoveryImportOutcome> importFile(
     DiscoveryMediaKind kind,
     File file,

--- a/fushi/lib/src/media/discovery/import/discovery_import_plan.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_plan.dart
@@ -1,0 +1,300 @@
+/// 发现页下载物 → 导入计划的**纯分类**层：不碰 IO，输入是路径/文件清单，
+/// 输出 sealed [DiscoveryImportPlan]。执行（真正调用各域导入器）在
+/// `discovery_import_executor.dart`；分类规则全部可单测。
+///
+/// 扩展名集合一律引用各域已有的单一真相（`AudiobookStorage.audioExtensions` /
+/// `TextToEpub.supportedExtensions`），不自造副本。
+library;
+
+import 'package:fushi_audio/fushi_audio.dart';
+
+import 'package:fushi/src/media/audiobook/text_to_epub.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+
+/// 字幕扩展名（`book_import_dialog.dart` 的选择器同集合；有声书对齐的输入）。
+const Set<String> kDiscoverySubtitleExtensions = <String>{
+  '.srt',
+  '.lrc',
+  '.vtt',
+  '.ass',
+  '.ssa',
+};
+
+/// 需要先解压的压缩包扩展名。zip 走内置解码，7z/rar 依赖 7-Zip 命令行。
+const Set<String> kDiscoveryArchiveExtensions = <String>{
+  '.zip',
+  '.7z',
+  '.rar',
+};
+
+/// 自动导入走不下去的稳定原因（UI 层负责翻译成用户文案）。
+enum DiscoveryImportBlocker {
+  /// 该媒体域认不出这个文件类型。
+  unknownFileType,
+
+  /// 有声书包里没有 EPUB/文本正文。
+  audiobookMissingText,
+
+  /// 有声书包里没有字幕（对齐的必要输入——本仓有声书模型是字幕对齐驱动）。
+  audiobookMissingSubtitle,
+
+  /// 有声书包里没有音频。
+  audiobookMissingAudio,
+
+  /// 游戏包里找不到可执行文件。
+  gameNoExecutable,
+
+  /// 7z/rar 需要 7-Zip 命令行而本机没有。
+  archiveToolMissing,
+
+  /// 解压失败（损坏/带密码等）。
+  archiveExtractionFailed,
+}
+
+/// 自动导入被挡下（分类不出/解压工具缺失/解压失败）。队列把它落成任务
+/// failed；[blocker] 是稳定原因码，UI 层翻译。
+class DiscoveryImportBlockedException implements Exception {
+  const DiscoveryImportBlockedException(this.blocker, [this.detail]);
+
+  final DiscoveryImportBlocker blocker;
+  final String? detail;
+
+  @override
+  String toString() => 'DiscoveryImportBlockedException(${blocker.name}'
+      '${detail == null ? '' : ': $detail'})';
+}
+
+sealed class DiscoveryImportPlan {
+  const DiscoveryImportPlan();
+}
+
+/// 直接导入一个 EPUB。
+final class ImportEpubPlan extends DiscoveryImportPlan {
+  const ImportEpubPlan(this.filePath);
+  final String filePath;
+}
+
+/// 文本先转 EPUB 再导入。
+final class ConvertTextPlan extends DiscoveryImportPlan {
+  const ConvertTextPlan(this.filePath);
+  final String filePath;
+}
+
+/// PDF 走独立 PdfImporter。
+final class ImportPdfPlan extends DiscoveryImportPlan {
+  const ImportPdfPlan(this.filePath);
+  final String filePath;
+}
+
+/// 压缩包：先解压，再对解出的文件树按同域重新分类。
+final class ExtractArchivePlan extends DiscoveryImportPlan {
+  const ExtractArchivePlan(this.archivePath);
+  final String archivePath;
+}
+
+/// 有声书对齐导入：正文（EPUB 或可转文本）+ 字幕 + 音频。
+final class AlignAudiobookPlan extends DiscoveryImportPlan {
+  const AlignAudiobookPlan({
+    required this.contentPath,
+    required this.subtitlePath,
+    required this.audioPaths,
+  });
+
+  final String contentPath;
+  final String subtitlePath;
+  final List<String> audioPaths;
+}
+
+/// 登记游戏 exe 进库。
+final class RegisterGameExesPlan extends DiscoveryImportPlan {
+  const RegisterGameExesPlan(this.exePaths);
+  final List<String> exePaths;
+}
+
+/// 多个子计划（小说包里若干本书）。
+final class MultiPlan extends DiscoveryImportPlan {
+  const MultiPlan(this.children);
+  final List<DiscoveryImportPlan> children;
+}
+
+/// 自动导入走不下去。
+final class UnsupportedPlan extends DiscoveryImportPlan {
+  const UnsupportedPlan(this.blocker);
+  final DiscoveryImportBlocker blocker;
+}
+
+String _ext(String path) {
+  final int dot = path.lastIndexOf('.');
+  if (dot < 0 || dot < path.lastIndexOf('/') || dot < path.lastIndexOf('\\')) {
+    return '';
+  }
+  return path.substring(dot).toLowerCase();
+}
+
+bool _isText(String path) {
+  final String ext = _ext(path);
+  return ext.isNotEmpty &&
+      TextToEpub.supportedExtensions.contains(ext.substring(1));
+}
+
+bool _isAudio(String path) =>
+    AudiobookStorage.audioExtensions.contains(_ext(path));
+
+bool _isSubtitle(String path) =>
+    kDiscoverySubtitleExtensions.contains(_ext(path));
+
+/// 是否需要先解压。
+bool isDiscoveryArchivePath(String path) =>
+    kDiscoveryArchiveExtensions.contains(_ext(path));
+
+/// 单个下载文件的分类入口。
+DiscoveryImportPlan classifyDiscoveryFile(
+  DiscoveryMediaKind kind,
+  String filePath,
+) {
+  if (isDiscoveryArchivePath(filePath)) return ExtractArchivePlan(filePath);
+  switch (kind) {
+    case DiscoveryMediaKind.novel:
+      final String ext = _ext(filePath);
+      if (ext == '.epub') return ImportEpubPlan(filePath);
+      if (ext == '.pdf') return ImportPdfPlan(filePath);
+      if (_isText(filePath)) return ConvertTextPlan(filePath);
+      return const UnsupportedPlan(DiscoveryImportBlocker.unknownFileType);
+    case DiscoveryMediaKind.audiobook:
+      // 单文件永远凑不齐「正文 + 字幕 + 音频」。
+      return const UnsupportedPlan(
+          DiscoveryImportBlocker.audiobookMissingAudio);
+    case DiscoveryMediaKind.game:
+      if (_ext(filePath) == '.exe') {
+        return RegisterGameExesPlan(<String>[filePath]);
+      }
+      return const UnsupportedPlan(DiscoveryImportBlocker.unknownFileType);
+    case DiscoveryMediaKind.manga:
+      // 漫画的在线导入走既有 Mihon/mokuro 链路，不经发现页下载队列。
+      return const UnsupportedPlan(DiscoveryImportBlocker.unknownFileType);
+  }
+}
+
+/// 解压后的文件树分类（[filePaths] 为递归文件清单，绝对路径）。
+///
+/// [fileSizes] 供游戏 exe 启发式挑主程序（字节数，缺省时全按 0）。
+DiscoveryImportPlan classifyDiscoveryDirectory(
+  DiscoveryMediaKind kind,
+  List<String> filePaths, {
+  Map<String, int> fileSizes = const <String, int>{},
+}) {
+  switch (kind) {
+    case DiscoveryMediaKind.novel:
+      final List<DiscoveryImportPlan> children = <DiscoveryImportPlan>[
+        for (final String path in filePaths)
+          if (_ext(path) == '.epub')
+            ImportEpubPlan(path)
+          else if (_ext(path) == '.pdf')
+            ImportPdfPlan(path)
+          else if (_isText(path))
+            ConvertTextPlan(path),
+      ];
+      if (children.isEmpty) {
+        return const UnsupportedPlan(DiscoveryImportBlocker.unknownFileType);
+      }
+      if (children.length == 1) return children.single;
+      return MultiPlan(children);
+    case DiscoveryMediaKind.audiobook:
+      String? content;
+      String? subtitle;
+      final List<String> audio = <String>[];
+      for (final String path in filePaths) {
+        if (content == null && _ext(path) == '.epub') {
+          content = path;
+        } else if (_isSubtitle(path)) {
+          subtitle ??= path;
+        } else if (_isAudio(path)) {
+          audio.add(path);
+        }
+      }
+      // EPUB 优先当正文；没有 EPUB 再退纯文本。
+      if (content == null) {
+        for (final String path in filePaths) {
+          if (_isText(path)) {
+            content = path;
+            break;
+          }
+        }
+      }
+      if (audio.isEmpty) {
+        return const UnsupportedPlan(
+          DiscoveryImportBlocker.audiobookMissingAudio,
+        );
+      }
+      if (subtitle == null) {
+        return const UnsupportedPlan(
+          DiscoveryImportBlocker.audiobookMissingSubtitle,
+        );
+      }
+      if (content == null) {
+        return const UnsupportedPlan(
+          DiscoveryImportBlocker.audiobookMissingText,
+        );
+      }
+      audio.sort();
+      return AlignAudiobookPlan(
+        contentPath: content,
+        subtitlePath: subtitle,
+        audioPaths: audio,
+      );
+    case DiscoveryMediaKind.game:
+      final String? exe = pickGalgameMainExe(filePaths, fileSizes: fileSizes);
+      if (exe == null) {
+        return const UnsupportedPlan(DiscoveryImportBlocker.gameNoExecutable);
+      }
+      return RegisterGameExesPlan(<String>[exe]);
+    case DiscoveryMediaKind.manga:
+      return const UnsupportedPlan(DiscoveryImportBlocker.unknownFileType);
+  }
+}
+
+/// 安装器/运行库一眼假的 exe 名（含即排除）。
+final RegExp _kAuxExePattern = RegExp(
+  r'(unins|setup|install|update|patch|vcredist|dxsetup|directx|dotnet|redist|'
+  r'crashreport|unitycrash|config$|settings$)',
+  caseSensitive: false,
+);
+
+/// 从解压树里挑游戏主程序：剔除辅助 exe → 目录层级浅者优先 → 同层取最大。
+/// 全被剔除时退回全量再按同规则挑（配置器命名的游戏本体不至于漏掉）。
+String? pickGalgameMainExe(
+  List<String> filePaths, {
+  Map<String, int> fileSizes = const <String, int>{},
+}) {
+  final List<String> exes = <String>[
+    for (final String path in filePaths)
+      if (_ext(path) == '.exe') path,
+  ];
+  if (exes.isEmpty) return null;
+
+  List<String> candidates = <String>[
+    for (final String path in exes)
+      if (!_kAuxExePattern.hasMatch(_baseNameNoExt(path))) path,
+  ];
+  if (candidates.isEmpty) candidates = exes;
+
+  int depthOf(String path) => '/'.allMatches(path.replaceAll('\\', '/')).length;
+  final int minDepth = candidates.map(depthOf).reduce(
+        (int a, int b) => a < b ? a : b,
+      );
+  candidates = <String>[
+    for (final String path in candidates)
+      if (depthOf(path) == minDepth) path,
+  ];
+  candidates.sort(
+    (String a, String b) => (fileSizes[b] ?? 0).compareTo(fileSizes[a] ?? 0),
+  );
+  return candidates.first;
+}
+
+String _baseNameNoExt(String path) {
+  final String normalized = path.replaceAll('\\', '/');
+  final String base = normalized.substring(normalized.lastIndexOf('/') + 1);
+  final int dot = base.lastIndexOf('.');
+  return dot < 0 ? base : base.substring(0, dot);
+}

--- a/fushi/lib/src/media/discovery/import/discovery_import_production.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_production.dart
@@ -1,0 +1,131 @@
+/// [DiscoveryDomainImporters] 的生产装配：把各域**已有**导入原语接到发现页
+/// 下载队列的自动入库端口上。零新导入逻辑——EPUB/文本/PDF/有声书对齐/游戏
+/// 登记全部复用既有单一真相：
+///
+/// - EPUB：`EpubImporter.importFromPath`（`DuplicatePolicy.skip()`，同名已在库
+///   → 跳过不重复入库，任务显示 0 新增）
+/// - 文本：`TextToEpub.convert` → `EpubImporter.import`（与书导入对话框同路）
+/// - PDF：`PdfImporter.importFromPath`
+/// - 有声书：EPUB/文本先入库拿 bookKey，再 `alignAndPersistAudiobook`
+///   （与对话框 `_importEpubWithAlignment` 同路，进度/文案省略）
+/// - 游戏：`filterOutDuplicateGameExes` 查重 → `newGalgameEntryFromExe` →
+///   `GalgameRepository.addAll`（批内 id 微秒错开，同拖拽入库）
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/epub/book_title_conflict.dart';
+import 'package:fushi/src/epub/epub_importer.dart';
+import 'package:fushi/src/media/audiobook/audiobook_alignment_service.dart';
+import 'package:fushi/src/media/audiobook/text_to_epub.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_executor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart';
+import 'package:fushi/src/mining/galgame_library.dart';
+import 'package:fushi/src/mining/galgame_repository.dart';
+import 'package:fushi/src/pdf/pdf_importer.dart';
+
+DiscoveryDomainImporters buildProductionDiscoveryImporters({
+  required FushiDatabase db,
+  required SrtBookRepository srtBookRepo,
+  required AudiobookRepository audiobookRepo,
+  required GalgameRepository galgameRepo,
+}) {
+  Future<String?> importEpub(String filePath) async {
+    try {
+      return await EpubImporter.importFromPath(
+        db: db,
+        filePath: filePath,
+        fileName: _fileName(filePath),
+        policy: const DuplicatePolicy.skip(),
+      );
+    } on DuplicateImportCancelledException {
+      return null;
+    }
+  }
+
+  Future<String?> importText(String filePath) async {
+    final String title = _stem(filePath);
+    final Uint8List bytes =
+        await TextToEpub.convert(file: File(filePath), title: title);
+    try {
+      return await EpubImporter.import(
+        db: db,
+        bytes: bytes,
+        fileName: '$title.epub',
+        policy: const DuplicatePolicy.skip(),
+      );
+    } on DuplicateImportCancelledException {
+      return null;
+    }
+  }
+
+  return DiscoveryDomainImporters(
+    importEpub: importEpub,
+    importText: importText,
+    importPdf: (String filePath) async {
+      try {
+        return await PdfImporter.importFromPath(
+          db: db,
+          filePath: filePath,
+          fileName: _fileName(filePath),
+          title: _stem(filePath),
+          policy: const DuplicatePolicy.skip(),
+        );
+      } on DuplicateImportCancelledException {
+        return null;
+      }
+    },
+    importAudiobook: (AlignAudiobookPlan plan) async {
+      final String? bookKey = plan.contentPath.toLowerCase().endsWith('.epub')
+          ? await importEpub(plan.contentPath)
+          : await importText(plan.contentPath);
+      if (bookKey == null) {
+        // 同名书已在库：v1 不做「附着到既有书」的自动决策（换音频/换字幕是
+        // 有损操作，交互入口是 AudiobookImportDialog），按跳过处理。
+        return null;
+      }
+      await alignAndPersistAudiobook(
+        db: db,
+        repo: srtBookRepo,
+        audiobookRepo: audiobookRepo,
+        bookKey: bookKey,
+        title: _stem(plan.contentPath),
+        subtitlePath: plan.subtitlePath,
+        audioPaths: plan.audioPaths,
+      );
+      return bookKey;
+    },
+    registerGameExes: (List<String> exePaths) async {
+      final List<String> fresh =
+          filterOutDuplicateGameExes(galgameRepo.games, exePaths);
+      if (fresh.isEmpty) return 0;
+      final DateTime base = DateTime.now();
+      // 批内 id 用微秒错开，防同微秒撞 id（同 games_library_page 拖拽入库）。
+      final List<GalgameEntry> entries = <GalgameEntry>[
+        for (int i = 0; i < fresh.length; i++)
+          newGalgameEntryFromExe(
+            fresh[i],
+            now: base.add(Duration(microseconds: i)),
+          ),
+      ];
+      await galgameRepo.addAll(entries);
+      return entries.length;
+    },
+  );
+}
+
+String _fileName(String path) {
+  final String normalized = path.replaceAll('\\', '/');
+  return normalized.substring(normalized.lastIndexOf('/') + 1);
+}
+
+String _stem(String path) {
+  final String base = _fileName(path);
+  final int dot = base.lastIndexOf('.');
+  return dot <= 0 ? base : base.substring(0, dot);
+}

--- a/fushi/lib/src/media/discovery/media_discovery_service.dart
+++ b/fushi/lib/src/media/discovery/media_discovery_service.dart
@@ -84,9 +84,13 @@ class MediaDiscoveryService {
   /// [sourceId] null = 「全部源」：扇出到所有支持该域、且具备本次请求所需
   /// 能力（搜索/浏览）的源。深层目录浏览（`request.path != null`）的路径是
   /// 源内语义，聚合无意义，必须指定 [sourceId]，否则 [ArgumentError]。
+  ///
+  /// [disabledSourceIds] 只作用于聚合扇出（默认聚合排除的源，如 18+ 源）；
+  /// 显式指定 [sourceId] 时不受它限制——用户点名即同意。
   Future<DiscoveryAggregateResult> load(
     DiscoveryRequest request, {
     String? sourceId,
+    Set<String> disabledSourceIds = const <String>{},
   }) async {
     if (request.path != null && sourceId == null) {
       throw ArgumentError(
@@ -104,9 +108,11 @@ class MediaDiscoveryService {
     } else {
       candidates = sourcesFor(request.kind)
           .where(
-            (MediaDiscoverySource s) => request.isSearch
-                ? s.capabilities.supportsSearch
-                : s.capabilities.supportsBrowse,
+            (MediaDiscoverySource s) =>
+                !disabledSourceIds.contains(s.id) &&
+                (request.isSearch
+                    ? s.capabilities.supportsSearch
+                    : s.capabilities.supportsBrowse),
           )
           .toList();
     }

--- a/fushi/lib/src/media/discovery/media_discovery_service.dart
+++ b/fushi/lib/src/media/discovery/media_discovery_service.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/discovery/media_discovery_source.dart';
 import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/utils/misc/bounded_concurrency.dart';
 
 /// 一个源贡献的结果分片。
 class DiscoverySourceSlice {
@@ -87,10 +88,17 @@ class MediaDiscoveryService {
   ///
   /// [disabledSourceIds] 只作用于聚合扇出（默认聚合排除的源，如 18+ 源）；
   /// 显式指定 [sourceId] 时不受它限制——用户点名即同意。
+  ///
+  /// [onUpdate]：**渐进交付**（模式取自漫画全源搜索）——每有一个源完成就用
+  /// 当前累积结果回调一次，快源不等慢源；分片顺序始终按 priority，不随完成
+  /// 顺序跳动。最终完整结果仍由返回值给出。[maxConcurrent] 限流只为不让
+  /// 几十个源同时打出去。
   Future<DiscoveryAggregateResult> load(
     DiscoveryRequest request, {
     String? sourceId,
     Set<String> disabledSourceIds = const <String>{},
+    void Function(DiscoveryAggregateResult partial)? onUpdate,
+    int maxConcurrent = 6,
   }) async {
     if (request.path != null && sourceId == null) {
       throw ArgumentError(
@@ -118,18 +126,33 @@ class MediaDiscoveryService {
     }
     if (candidates.isEmpty) return DiscoveryAggregateResult();
 
-    final List<ProviderBatchResult<DiscoveryResultPage>> results =
-        await Future.wait(
-      candidates.map(
-        (MediaDiscoverySource source) => _invoke(source, request),
-      ),
+    final List<ProviderBatchResult<DiscoveryResultPage>?> results =
+        List<ProviderBatchResult<DiscoveryResultPage>?>.filled(
+      candidates.length,
+      null,
     );
+    await runBoundedTasks(
+      List<int>.generate(candidates.length, (int i) => i),
+      maxConcurrent: maxConcurrent,
+      task: (int i) async {
+        results[i] = await _invoke(candidates[i], request);
+        onUpdate?.call(_assemble(candidates, results));
+      },
+    );
+    return _assemble(candidates, results);
+  }
 
+  /// 把（可能尚未全部完成的）逐源结果拼成聚合快照；未完成的源直接跳过。
+  static DiscoveryAggregateResult _assemble(
+    List<MediaDiscoverySource> candidates,
+    List<ProviderBatchResult<DiscoveryResultPage>?> results,
+  ) {
     final List<DiscoverySourceSlice> slices = <DiscoverySourceSlice>[];
     final List<ExternalProviderFailure> failures = <ExternalProviderFailure>[];
     int successfulSourceCount = 0;
     for (int i = 0; i < candidates.length; i++) {
-      final ProviderBatchResult<DiscoveryResultPage> result = results[i];
+      final ProviderBatchResult<DiscoveryResultPage>? result = results[i];
+      if (result == null) continue;
       for (final DiscoveryResultPage page in result.items) {
         slices.add(
           DiscoverySourceSlice(sourceId: candidates[i].id, page: page),

--- a/fushi/lib/src/media/discovery/media_discovery_service.dart
+++ b/fushi/lib/src/media/discovery/media_discovery_service.dart
@@ -1,0 +1,168 @@
+/// 发现源聚合：把一次请求扇出到（按能力筛过的）多个源，保留部分成功。
+///
+/// 刻意**不做**跨源去重合并——资源发现（种子/直链）不同于视频元数据发现：
+/// 同名资源在不同源就是不同的下载物（版本/压制/打包都不同），合并只会
+/// 抹掉用户要做的选择。结果按源分片（[DiscoverySourceSlice]）返回，
+/// UI 想平铺就用 [DiscoveryAggregateResult.entries]，想分组就用 slices。
+library;
+
+import 'dart:async';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+
+/// 一个源贡献的结果分片。
+class DiscoverySourceSlice {
+  const DiscoverySourceSlice({required this.sourceId, required this.page});
+
+  final String sourceId;
+  final DiscoveryResultPage page;
+}
+
+/// 聚合结果：分片按源 priority 顺序排列；失败与成功并存（部分成功语义
+/// 与 `ProviderBatchResult` 一致：单源挂了亮徽标，不拖垮整页）。
+class DiscoveryAggregateResult {
+  DiscoveryAggregateResult({
+    Iterable<DiscoverySourceSlice> slices = const <DiscoverySourceSlice>[],
+    Iterable<ExternalProviderFailure> failures =
+        const <ExternalProviderFailure>[],
+    this.successfulSourceCount = 0,
+  })  : slices = List<DiscoverySourceSlice>.unmodifiable(slices),
+        failures = List<ExternalProviderFailure>.unmodifiable(failures);
+
+  final List<DiscoverySourceSlice> slices;
+  final List<ExternalProviderFailure> failures;
+  final int successfulSourceCount;
+
+  /// 平铺视图（保持源 priority 顺序）。
+  List<DiscoveryEntry> get entries => <DiscoveryEntry>[
+        for (final DiscoverySourceSlice slice in slices) ...slice.page.entries,
+      ];
+
+  bool get hasMore =>
+      slices.any((DiscoverySourceSlice slice) => slice.page.hasMore);
+
+  bool get hasFailures => failures.isNotEmpty;
+
+  /// 空结果 + 一个源宕机 ≠ 全绿的空结果——语义对齐 `ProviderBatchResult.isPartial`。
+  bool get isPartial => successfulSourceCount > 0 && hasFailures;
+  bool get isTotalFailure => successfulSourceCount == 0 && hasFailures;
+}
+
+/// 发现源注册表 + 请求扇出。无状态（源开关/默认源等用户偏好由组装点筛好
+/// 再构造，或经 [sourceById] 单源直查），生命周期由持有者管理。
+class MediaDiscoveryService {
+  MediaDiscoveryService({required Iterable<MediaDiscoverySource> sources})
+      : _sources = List<MediaDiscoverySource>.of(sources)
+          ..sort(
+            (MediaDiscoverySource a, MediaDiscoverySource b) =>
+                a.priority.compareTo(b.priority),
+          );
+
+  final List<MediaDiscoverySource> _sources;
+
+  List<MediaDiscoverySource> get sources =>
+      List<MediaDiscoverySource>.unmodifiable(_sources);
+
+  MediaDiscoverySource? sourceById(String id) {
+    for (final MediaDiscoverySource source in _sources) {
+      if (source.id == id) return source;
+    }
+    return null;
+  }
+
+  /// 支持 [kind] 的源，按 priority 排序（源切换下拉的选项列表）。
+  List<MediaDiscoverySource> sourcesFor(DiscoveryMediaKind kind) => _sources
+      .where(
+        (MediaDiscoverySource s) => s.capabilities.kinds.contains(kind),
+      )
+      .toList();
+
+  /// 执行一次发现请求。
+  ///
+  /// [sourceId] null = 「全部源」：扇出到所有支持该域、且具备本次请求所需
+  /// 能力（搜索/浏览）的源。深层目录浏览（`request.path != null`）的路径是
+  /// 源内语义，聚合无意义，必须指定 [sourceId]，否则 [ArgumentError]。
+  Future<DiscoveryAggregateResult> load(
+    DiscoveryRequest request, {
+    String? sourceId,
+  }) async {
+    if (request.path != null && sourceId == null) {
+      throw ArgumentError(
+        'deep browse paths are source-local; pass sourceId',
+      );
+    }
+
+    final List<MediaDiscoverySource> candidates;
+    if (sourceId != null) {
+      final MediaDiscoverySource? source = sourceById(sourceId);
+      if (source == null) {
+        throw ArgumentError.value(sourceId, 'sourceId', 'unknown source');
+      }
+      candidates = <MediaDiscoverySource>[source];
+    } else {
+      candidates = sourcesFor(request.kind)
+          .where(
+            (MediaDiscoverySource s) => request.isSearch
+                ? s.capabilities.supportsSearch
+                : s.capabilities.supportsBrowse,
+          )
+          .toList();
+    }
+    if (candidates.isEmpty) return DiscoveryAggregateResult();
+
+    final List<ProviderBatchResult<DiscoveryResultPage>> results =
+        await Future.wait(
+      candidates.map(
+        (MediaDiscoverySource source) => _invoke(source, request),
+      ),
+    );
+
+    final List<DiscoverySourceSlice> slices = <DiscoverySourceSlice>[];
+    final List<ExternalProviderFailure> failures = <ExternalProviderFailure>[];
+    int successfulSourceCount = 0;
+    for (int i = 0; i < candidates.length; i++) {
+      final ProviderBatchResult<DiscoveryResultPage> result = results[i];
+      for (final DiscoveryResultPage page in result.items) {
+        slices.add(
+          DiscoverySourceSlice(sourceId: candidates[i].id, page: page),
+        );
+      }
+      failures.addAll(result.failures);
+      if (result.successfulProviderCount > 0) successfulSourceCount++;
+    }
+    return DiscoveryAggregateResult(
+      slices: slices,
+      failures: failures,
+      successfulSourceCount: successfulSourceCount,
+    );
+  }
+
+  /// 单源调用：源实现抛出的任何东西都收敛成脱敏失败，绝不让一个源的异常
+  /// 炸掉整次扇出。
+  Future<ProviderBatchResult<DiscoveryResultPage>> _invoke(
+    MediaDiscoverySource source,
+    DiscoveryRequest request,
+  ) async {
+    try {
+      return request.isSearch
+          ? await source.search(request)
+          : await source.browse(request);
+    } catch (e) {
+      return ProviderBatchResult<DiscoveryResultPage>.failure(
+        ExternalProviderFailure.fromException(
+          providerId: source.id,
+          operation: request.isSearch ? 'search' : 'browse',
+          error: e,
+        ),
+      );
+    }
+  }
+
+  void close() {
+    for (final MediaDiscoverySource source in _sources) {
+      source.close();
+    }
+  }
+}

--- a/fushi/lib/src/media/discovery/media_discovery_source.dart
+++ b/fushi/lib/src/media/discovery/media_discovery_source.dart
@@ -1,0 +1,65 @@
+/// 发现源契约：一个源 = 一个本类实现（nyaa / AList 站 / shinnku / Mihon 适配…）。
+///
+/// 加源零框架改动：实现本类 + 在组装点注册进 `MediaDiscoveryService` 即可。
+/// 失败语义沿用全仓统一的 `ProviderBatchResult` / `ExternalProviderFailure`
+/// （脱敏、部分成功），与视频发现/资源 provider 同一套，不再发明新错误形状。
+library;
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/external_provider.dart';
+
+abstract class MediaDiscoverySource {
+  const MediaDiscoverySource();
+
+  /// 稳定 id（持久化「默认源选择」「源开关」偏好用；改名即断档，别改）。
+  String get id;
+
+  /// UI 展示名（源站名，不走 i18n——站名没有译名）。
+  String get displayName;
+
+  /// 聚合展示顺序：小者靠前。
+  int get priority;
+
+  DiscoveryCapabilities get capabilities;
+
+  /// 关键词搜索。[DiscoveryCapabilities.supportsSearch] 为 false 的源不会被调到。
+  Future<ProviderBatchResult<DiscoveryResultPage>> search(
+    DiscoveryRequest request,
+  );
+
+  /// 目录浏览（[DiscoveryRequest.path] null = 根）。默认不支持；目录型源
+  /// （AList）覆写。声明了 [DiscoveryCapabilities.supportsBrowse] 却不覆写
+  /// 本方法属于实现 bug，返回的 unsupported 失败会直接亮在源徽标上。
+  Future<ProviderBatchResult<DiscoveryResultPage>> browse(
+    DiscoveryRequest request,
+  ) async {
+    return ProviderBatchResult<DiscoveryResultPage>.failure(
+      ExternalProviderFailure(
+        providerId: id,
+        operation: 'browse',
+        kind: ExternalProviderFailureKind.unsupported,
+        message: 'source does not support directory browse',
+      ),
+    );
+  }
+
+  /// 下载前把条目物化成可执行 payload。默认直接返回列表阶段随条目带的
+  /// payload；直链带临期签名、列表阶段给不出 URL 的源（AList `/api/fs/get`）
+  /// 覆写本方法在**下载时**取直链——晚 resolve 是刻意的：早取的签名等到
+  /// 用户点下载时可能已过期。
+  Future<DiscoveryPayload> resolvePayload(DiscoveryResourceItem item) async {
+    final DiscoveryPayload? payload = item.payload;
+    if (payload == null) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: 'resolvePayload',
+        kind: ExternalProviderFailureKind.unsupported,
+        message: 'item carries no payload and source does not resolve lazily',
+      );
+    }
+    return payload;
+  }
+
+  /// 释放源持有的连接资源。幂等；服务关闭时统一调。
+  void close() {}
+}

--- a/fushi/lib/src/media/discovery/sources/alist_discovery_source.dart
+++ b/fushi/lib/src/media/discovery/sources/alist_discovery_source.dart
@@ -1,0 +1,255 @@
+/// AList v3 站点的发现源 adapter：标准 `/api/fs/list`（目录浏览）、
+/// `/api/fs/search`（关键词搜索，站点开了索引才可用）、`/api/fs/get`
+/// （下载时延迟取 `raw_url` 直链——签名临期，列表阶段取了也会过期）。
+///
+/// 一个实例 = 一个 AList 站；内置 alist.erogame.space，用户加任意站 = 再
+/// 注册一个实例。匿名访问；站点要求登录时可给 [username]/[password]，
+/// 首次请求前换 token（`/api/auth/login`），token 失效重登一次。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/utils/net/app_http.dart';
+
+class AListDiscoverySource extends MediaDiscoverySource {
+  AListDiscoverySource({
+    required this.id,
+    required this.displayName,
+    required String baseUrl,
+    required Iterable<DiscoveryMediaKind> kinds,
+    this.priority = 20,
+    this.username,
+    this.password,
+    http.Client? client,
+  })  : _baseUrl = baseUrl.endsWith('/')
+            ? baseUrl.substring(0, baseUrl.length - 1)
+            : baseUrl,
+        _kinds = Set<DiscoveryMediaKind>.unmodifiable(kinds),
+        _client = client ?? createAppHttpIoClient();
+
+  @override
+  final String id;
+
+  @override
+  final String displayName;
+
+  @override
+  final int priority;
+
+  final String? username;
+  final String? password;
+
+  final String _baseUrl;
+  final Set<DiscoveryMediaKind> _kinds;
+  final http.Client _client;
+
+  /// 已换取的登录 token（匿名站恒 null）。
+  String? _token;
+
+  @override
+  DiscoveryCapabilities get capabilities => DiscoveryCapabilities(
+        kinds: _kinds,
+        supportsBrowse: true,
+        supportsPaging: true,
+      );
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> browse(
+    DiscoveryRequest request,
+  ) async {
+    final String path = request.path ?? '/';
+    final Map<String, dynamic> data =
+        await _post('/api/fs/list', <String, dynamic>{
+      'path': path,
+      'password': '',
+      'page': request.page,
+      'per_page': request.pageSize,
+      'refresh': false,
+    });
+    final List<dynamic> content =
+        (data['content'] as List<dynamic>?) ?? <dynamic>[];
+    final int total = (data['total'] as num?)?.toInt() ?? content.length;
+    return ProviderBatchResult<DiscoveryResultPage>.success(
+      <DiscoveryResultPage>[
+        DiscoveryResultPage(
+          entries: <DiscoveryEntry>[
+            for (final Map<String, dynamic> raw
+                in content.cast<Map<String, dynamic>>())
+              _entryFrom(raw, parent: path, kind: request.kind),
+          ],
+          page: request.page,
+          hasMore: request.page * request.pageSize < total,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> search(
+    DiscoveryRequest request,
+  ) async {
+    final Map<String, dynamic> data =
+        await _post('/api/fs/search', <String, dynamic>{
+      'parent': '/',
+      'keywords': request.query!.trim(),
+      'scope': 0,
+      'page': request.page,
+      'per_page': request.pageSize,
+      'password': '',
+    });
+    final List<dynamic> content =
+        (data['content'] as List<dynamic>?) ?? <dynamic>[];
+    final int total = (data['total'] as num?)?.toInt() ?? content.length;
+    return ProviderBatchResult<DiscoveryResultPage>.success(
+      <DiscoveryResultPage>[
+        DiscoveryResultPage(
+          entries: <DiscoveryEntry>[
+            for (final Map<String, dynamic> raw
+                in content.cast<Map<String, dynamic>>())
+              _entryFrom(
+                raw,
+                parent: raw['parent'] as String? ?? '/',
+                kind: request.kind,
+              ),
+          ],
+          page: request.page,
+          hasMore: request.page * request.pageSize < total,
+        ),
+      ],
+    );
+  }
+
+  /// 下载时经 `/api/fs/get` 取带签名的 `raw_url`。
+  @override
+  Future<DiscoveryPayload> resolvePayload(DiscoveryResourceItem item) async {
+    final Map<String, dynamic> data =
+        await _post('/api/fs/get', <String, dynamic>{
+      'path': item.id,
+      'password': '',
+    });
+    final String? rawUrl = data['raw_url'] as String?;
+    if (rawUrl == null || rawUrl.trim().isEmpty) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: 'resolvePayload',
+        kind: ExternalProviderFailureKind.invalidResponse,
+        message: 'fs/get returned no raw_url',
+      );
+    }
+    return DiscoveryHttpPayload(
+      url: rawUrl,
+      fileName: data['name'] as String?,
+      sizeBytes: (data['size'] as num?)?.toInt(),
+    );
+  }
+
+  DiscoveryEntry _entryFrom(
+    Map<String, dynamic> raw, {
+    required String parent,
+    required DiscoveryMediaKind kind,
+  }) {
+    final String name = raw['name'] as String? ?? '';
+    final bool isDir = raw['is_dir'] == true;
+    final String fullPath = parent == '/' ? '/$name' : '$parent/$name';
+    if (isDir) {
+      return DiscoveryFolder(sourceId: id, title: name, path: fullPath);
+    }
+    final String? modified = raw['modified'] as String?;
+    return DiscoveryResourceItem(
+      sourceId: id,
+      id: fullPath,
+      title: name,
+      kind: kind,
+      payloadKind: DiscoveryPayloadKind.httpFile,
+      // payload 留空 → 下载时 resolvePayload 取临期直链。
+      sizeBytes: (raw['size'] as num?)?.toInt(),
+      dateText: modified != null && modified.length >= 10
+          ? modified.substring(0, 10)
+          : modified,
+    );
+  }
+
+  /// POST JSON → 校验 AList 信封（`code`/`message`/`data`）→ 返回 data。
+  ///
+  /// `code` 401 时若配了账号自动重登一次再试；其余非 200 code 一律按
+  /// invalidResponse 失败上浮（信封 message 是站点自述文案，脱敏保留）。
+  Future<Map<String, dynamic>> _post(
+    String apiPath,
+    Map<String, dynamic> body, {
+    bool retriedAuth = false,
+  }) async {
+    await _ensureToken();
+    final http.Response response = await _client.post(
+      Uri.parse('$_baseUrl$apiPath'),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        if (_token != null) 'Authorization': _token!,
+      },
+      body: jsonEncode(body),
+    );
+    if (response.statusCode != 200) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: apiPath,
+        kind: ExternalProviderFailureKind.unavailable,
+        message: 'http status ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    final Map<String, dynamic> envelope =
+        jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    final int code = (envelope['code'] as num?)?.toInt() ?? -1;
+    if (code == 401 && !retriedAuth && username != null) {
+      _token = null;
+      return _post(apiPath, body, retriedAuth: true);
+    }
+    if (code != 200) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: apiPath,
+        kind: code == 401 || code == 403
+            ? ExternalProviderFailureKind.unauthorized
+            : ExternalProviderFailureKind.invalidResponse,
+        message: 'alist code $code: ${envelope['message'] ?? ''}',
+        statusCode: code,
+      );
+    }
+    return (envelope['data'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+  }
+
+  Future<void> _ensureToken() async {
+    final String? user = username;
+    if (user == null || _token != null) return;
+    final http.Response response = await _client.post(
+      Uri.parse('$_baseUrl/api/auth/login'),
+      headers: <String, String>{'Content-Type': 'application/json'},
+      body: jsonEncode(<String, String>{
+        'username': user,
+        'password': password ?? '',
+      }),
+    );
+    final Map<String, dynamic> envelope =
+        jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    final String? token =
+        (envelope['data'] as Map<String, dynamic>?)?['token'] as String?;
+    if (response.statusCode != 200 || token == null || token.isEmpty) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: '/api/auth/login',
+        kind: ExternalProviderFailureKind.unauthorized,
+        message: 'alist login failed',
+        statusCode: response.statusCode,
+      );
+    }
+    _token = token;
+  }
+
+  @override
+  void close() => _client.close();
+}

--- a/fushi/lib/src/media/discovery/sources/nyaa_discovery_source.dart
+++ b/fushi/lib/src/media/discovery/sources/nyaa_discovery_source.dart
@@ -1,0 +1,102 @@
+/// nyaa 系站点的发现源 adapter：复用 `NyaaClient`（RSS 首屏 + HTML 翻页），
+/// 一个实例 = 一个站点（nyaa.si / sukebei.nyaa.si），媒体域 → 站点分类 id 的
+/// 映射由组装点给定：
+///
+/// - nyaa.si：小说 `3_0`（Literature）、有声书 `2_0`（Audio）、动画 `1_0`
+/// - sukebei.nyaa.si：galgame `1_3`（Art - Games）
+///
+/// 产出 torrent payload：UI 分流给 torrent 后端，不进 HTTP 下载队列。
+library;
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/nyaa_client.dart';
+
+class NyaaDiscoverySource extends MediaDiscoverySource {
+  NyaaDiscoverySource({
+    required this.id,
+    required this.displayName,
+    required Map<DiscoveryMediaKind, String> categoryByKind,
+    required NyaaClient client,
+    this.priority = 10,
+    this.trustedOnly = false,
+  })  : _categoryByKind =
+            Map<DiscoveryMediaKind, String>.unmodifiable(categoryByKind),
+        _client = client;
+
+  @override
+  final String id;
+
+  @override
+  final String displayName;
+
+  @override
+  final int priority;
+
+  /// 只收 trusted 发布（nyaa `f=2`）。
+  final bool trustedOnly;
+
+  final Map<DiscoveryMediaKind, String> _categoryByKind;
+  final NyaaClient _client;
+
+  @override
+  DiscoveryCapabilities get capabilities => DiscoveryCapabilities(
+        kinds: _categoryByKind.keys,
+        supportsPaging: true,
+      );
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> search(
+    DiscoveryRequest request,
+  ) async {
+    final String? category = _categoryByKind[request.kind];
+    if (category == null) {
+      return ProviderBatchResult<DiscoveryResultPage>.failure(
+        ExternalProviderFailure(
+          providerId: id,
+          operation: 'search',
+          kind: ExternalProviderFailureKind.unsupported,
+          message: 'media kind not mapped to a nyaa category',
+        ),
+      );
+    }
+    final List<NyaaTorrent> torrents = await _client.search(
+      request.query!.trim(),
+      category: category,
+      filter: trustedOnly ? '2' : '0',
+      page: request.page,
+    );
+    return ProviderBatchResult<DiscoveryResultPage>.success(
+      <DiscoveryResultPage>[
+        DiscoveryResultPage(
+          entries: <DiscoveryEntry>[
+            for (final NyaaTorrent torrent in torrents)
+              DiscoveryResourceItem(
+                sourceId: id,
+                // 详情页 URL 含站内种子 id，是最稳的源内身份。
+                id: torrent.pageUrl,
+                title: torrent.title,
+                kind: request.kind,
+                payloadKind: DiscoveryPayloadKind.torrent,
+                payload: DiscoveryTorrentPayload(magnetUri: torrent.magnet),
+                sizeBytes: torrent.sizeBytes,
+                dateText:
+                    torrent.pubDate?.toLocal().toString().split('.').first,
+                seeders: torrent.seeders,
+                leechers: torrent.leechers,
+                detailUrl: torrent.pageUrl,
+                note: torrent.trusted ? 'trusted' : null,
+              ),
+          ],
+          page: request.page,
+          // 过了末页 nyaa 返回空列表（client 把 404 归一成空）；空页即到底。
+          hasMore: torrents.isNotEmpty,
+        ),
+      ],
+    );
+  }
+
+  @override
+  void close() => _client.close();
+}

--- a/fushi/lib/src/media/discovery/sources/shinnku_discovery_source.dart
+++ b/fushi/lib/src/media/discovery/sources/shinnku_discovery_source.dart
@@ -1,0 +1,213 @@
+/// shinnku.com（真红小站）的发现源 adapter。
+///
+/// 该站没有公开 JSON API：搜索走 Next.js `/search?q=` 页面的 RSC 载荷
+/// （`RSC: 1` 请求头），从流里按括号配平抽出 `"answer":[...]` 数组——站点
+/// 前后端开源（shinnku-nikaidou/shinnku-com），条目结构
+/// `{id, info:{file_path, upload_timestamp, file_size}}` 与下载直链推导规则
+/// 均以其 `frontend/lib/url.ts` 为准：
+///
+/// - `合集系列/...` → `https://galgamedownload.date/`（B2 桶，首段带反引号前缀）
+/// - 其余 → `https://zd.shinnku.top/file/shinnku/<路径>`
+///
+/// RSC 解析天生脆弱（站点改版即断）：解析不出按 invalidResponse 失败亮在
+/// 源徽标上，不影响其它源。直链列表阶段即可推导 → payload 随条目带，
+/// 不需要 resolvePayload。
+library;
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/utils/net/app_http.dart';
+
+class ShinnkuDiscoverySource extends MediaDiscoverySource {
+  ShinnkuDiscoverySource({
+    this.id = 'shinnku',
+    this.displayName = '真红小站',
+    this.priority = 30,
+    String baseUrl = 'https://www.shinnku.com',
+    http.Client? client,
+  })  : _baseUrl = baseUrl.endsWith('/')
+            ? baseUrl.substring(0, baseUrl.length - 1)
+            : baseUrl,
+        _client = client ?? createAppHttpIoClient();
+
+  @override
+  final String id;
+
+  @override
+  final String displayName;
+
+  @override
+  final int priority;
+
+  final String _baseUrl;
+  final http.Client _client;
+
+  @override
+  DiscoveryCapabilities get capabilities => DiscoveryCapabilities(
+        kinds: const <DiscoveryMediaKind>{DiscoveryMediaKind.game},
+      );
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> search(
+    DiscoveryRequest request,
+  ) async {
+    // 站点搜索无翻页（后端 n 上限一次给齐）；第 2 页起直接空页收尾。
+    if (request.page > 1) {
+      return ProviderBatchResult<DiscoveryResultPage>.success(
+        <DiscoveryResultPage>[
+          DiscoveryResultPage(
+            entries: const <DiscoveryEntry>[],
+            page: request.page,
+            hasMore: false,
+          ),
+        ],
+      );
+    }
+    final Uri uri = Uri.parse('$_baseUrl/search').replace(
+      queryParameters: <String, String>{'q': request.query!.trim()},
+    );
+    final http.Response response = await _client.get(
+      uri,
+      headers: const <String, String>{'RSC': '1'},
+    );
+    if (response.statusCode != 200) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: 'search',
+        kind: ExternalProviderFailureKind.unavailable,
+        message: 'http status ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    final String body = utf8.decode(response.bodyBytes, allowMalformed: true);
+    final List<dynamic>? answer = extractShinnkuAnswer(body);
+    if (answer == null) {
+      throw ExternalProviderFailure(
+        providerId: id,
+        operation: 'search',
+        kind: ExternalProviderFailureKind.invalidResponse,
+        message: 'RSC payload has no parsable answer array (site changed?)',
+      );
+    }
+    final List<DiscoveryEntry> entries = <DiscoveryEntry>[];
+    for (final dynamic raw in answer) {
+      if (raw is! Map<String, dynamic>) continue;
+      final Map<String, dynamic>? info = (raw['info'] as Map<String, dynamic>?);
+      final String? filePath =
+          info?['file_path'] as String? ?? raw['id'] as String?;
+      if (filePath == null || filePath.trim().isEmpty) continue;
+      final List<String> segments = filePath.split('/');
+      final int? timestamp = (info?['upload_timestamp'] as num?)?.toInt();
+      entries.add(
+        DiscoveryResourceItem(
+          sourceId: id,
+          id: filePath,
+          title: segments.last,
+          kind: DiscoveryMediaKind.game,
+          payloadKind: DiscoveryPayloadKind.httpFile,
+          payload: DiscoveryHttpPayload(
+            url: shinnkuDownloadUrl(filePath),
+            fileName: segments.last,
+            sizeBytes: (info?['file_size'] as num?)?.toInt(),
+          ),
+          sizeBytes: (info?['file_size'] as num?)?.toInt(),
+          dateText: timestamp == null
+              ? null
+              : DateTime.fromMillisecondsSinceEpoch(timestamp)
+                  .toLocal()
+                  .toString()
+                  .split(' ')
+                  .first,
+          detailUrl:
+              '$_baseUrl/files/${segments.map(Uri.encodeComponent).join('/')}',
+          note: shinnkuGameTypeNote(filePath),
+        ),
+      );
+    }
+    return ProviderBatchResult<DiscoveryResultPage>.success(
+      <DiscoveryResultPage>[
+        DiscoveryResultPage(entries: entries, page: 1, hasMore: false),
+      ],
+    );
+  }
+
+  @override
+  void close() => _client.close();
+}
+
+/// 从 RSC 流里抽出第一个能解析的 `"answer":[...]` JSON 数组；抽不出返回 null。
+///
+/// RSC 载荷是多行 `序号:JSON` 流，答案数组内嵌其中。字符串内的 `[`/`]` 与
+/// 转义符按 JSON 词法跳过，括号配平截取后交给 jsonDecode 复核。
+List<dynamic>? extractShinnkuAnswer(String body) {
+  const String marker = '"answer":';
+  int searchFrom = 0;
+  while (true) {
+    final int markerIndex = body.indexOf(marker, searchFrom);
+    if (markerIndex < 0) return null;
+    searchFrom = markerIndex + marker.length;
+    final int start = body.indexOf('[', markerIndex + marker.length);
+    if (start < 0) return null;
+    // marker 与 '[' 之间只允许空白，否则这不是数组值。
+    if (body.substring(markerIndex + marker.length, start).trim().isNotEmpty) {
+      continue;
+    }
+    int depth = 0;
+    bool inString = false;
+    bool escaped = false;
+    for (int i = start; i < body.length; i++) {
+      final String ch = body[i];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch == r'\') {
+          escaped = true;
+        } else if (ch == '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch == '"') {
+        inString = true;
+      } else if (ch == '[') {
+        depth++;
+      } else if (ch == ']') {
+        depth--;
+        if (depth == 0) {
+          try {
+            final dynamic decoded = jsonDecode(body.substring(start, i + 1));
+            if (decoded is List<dynamic>) return decoded;
+          } on FormatException {
+            // 配平截取的片段不是合法 JSON：继续找下一个 marker。
+          }
+          break;
+        }
+      }
+    }
+  }
+}
+
+/// 按上游 `frontend/lib/url.ts` 的规则推导下载直链。
+String shinnkuDownloadUrl(String filePath) {
+  final List<String> segments = filePath.split('/');
+  if (segments.first == '合集系列') {
+    // 上游 B2 桶路径首段字面量就带反引号前缀（照抄，别「修正」它）。
+    final List<String> b2Path = <String>['`【合集系列】', ...segments.skip(1)];
+    return 'https://galgamedownload.date/'
+        '${b2Path.map(Uri.encodeComponent).join('/')}';
+  }
+  return 'https://zd.shinnku.top/file/shinnku/'
+      '${segments.map(Uri.encodeComponent).join('/')}';
+}
+
+/// 按上游 `get_game_type` 的路径前缀规则给类型标注。
+String shinnkuGameTypeNote(String filePath) {
+  if (filePath.startsWith('合集系列')) return '生肉';
+  if (filePath.startsWith('zd') || filePath.startsWith('0/win')) return '熟肉';
+  return '手机';
+}

--- a/fushi/lib/src/media/manga/manga_global_search_page.dart
+++ b/fushi/lib/src/media/manga/manga_global_search_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:flutter/material.dart';
 
@@ -8,6 +7,7 @@ import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_reader_chapter.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_source_browse_page.dart';
+import 'package:fushi/src/media/manga/manga_global_search_runner.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_source_browse_page.dart';
@@ -50,67 +50,12 @@ class MangaGlobalSearchPage extends StatefulWidget {
   State<MangaGlobalSearchPage> createState() => _MangaGlobalSearchPageState();
 }
 
-/// 单个来源的搜索进度。
-enum _RunStatus { loading, done, empty, cloudflare, error }
-
-/// 一个来源在本次搜索里的运行态。Mihon / Aidoku 字段互斥，由 [source] 类型决定。
-class _SourceRun {
-  _SourceRun(this.source);
-
-  final _GlobalSource source;
-  _RunStatus status = _RunStatus.loading;
-  Object? error;
-
-  // Mihon
-  MihonSourceContext? mihonContext;
-  List<MihonManga> mihonItems = const <MihonManga>[];
-
-  // Aidoku
-  List<Map<String, Object?>> aidokuItems = const <Map<String, Object?>>[];
-}
-
-/// 归一化的来源描述，抹平 Mihon / Aidoku 两套模型。
-sealed class _GlobalSource {
-  const _GlobalSource();
-
-  String get id;
-  String get name;
-  String get language;
-}
-
-class _MihonGlobalSource extends _GlobalSource {
-  const _MihonGlobalSource(this.row);
-
-  final MangaOnlineSourceRow row;
-
-  @override
-  String get id => 'mihon:${row.extensionPackage}:${row.sourceId}';
-  @override
-  String get name => row.name;
-  @override
-  String get language => row.language;
-}
-
-class _AidokuGlobalSource extends _GlobalSource {
-  const _AidokuGlobalSource(this.package);
-
-  final AidokuInstalledPackage package;
-
-  @override
-  String get id => 'aidoku:${package.id}';
-  @override
-  String get name => package.name;
-  @override
-  String get language =>
-      package.languages.isEmpty ? '' : package.languages.first;
-}
-
 class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
   final TextEditingController _searchController = TextEditingController();
   final MihonSourceImageLoadQueue _imageQueue =
       MihonSourceImageLoadQueue(maxConcurrent: 4);
 
-  List<_SourceRun> _runs = const <_SourceRun>[];
+  List<MangaSourceSearchRun> _runs = const <MangaSourceSearchRun>[];
   int _generation = 0;
   bool _searched = false;
   AidokuRuntime? _aidokuRuntime;
@@ -131,11 +76,11 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     super.dispose();
   }
 
-  List<_GlobalSource> _sources() => <_GlobalSource>[
+  List<MangaGlobalSource> _sources() => <MangaGlobalSource>[
         for (final AidokuInstalledPackage package in widget.aidokuPackages)
-          _AidokuGlobalSource(package),
+          AidokuGlobalSource(package),
         for (final MangaOnlineSourceRow row in widget.mihonSources)
-          _MihonGlobalSource(row),
+          MihonGlobalSource(row),
       ];
 
   /// 懒创建 Aidoku 运行时：无 Aidoku 源、或平台不支持时永不创建。
@@ -150,81 +95,27 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     final String query = _searchController.text.trim();
     if (query.isEmpty) return;
     final int generation = ++_generation;
-    final List<_SourceRun> runs =
-        _sources().map(_SourceRun.new).toList(growable: false);
+    final List<MangaSourceSearchRun> runs =
+        _sources().map(MangaSourceSearchRun.new).toList(growable: false);
     setState(() {
       _searched = true;
       _runs = runs;
     });
-    // 每个来源一个不同站点，跨站并发是安全的；限流只为不让几十个源同时打出去。
-    await _runBounded(
-      runs,
-      maxConcurrent: 6,
-      task: (_SourceRun run) => _runOne(run, query, generation),
+    // 逐源扇出/限流/CF 分型在 runner（与统一发现框架共用有界并发原语）。
+    await MangaGlobalSearchRunner(
+      mihonManager: widget.mihonManager,
+      resolveAidokuRuntime: _resolveAidokuRuntime,
+    ).search(
+      runs: runs,
+      query: query,
+      isCancelled: () => !mounted || generation != _generation,
+      onRunUpdated: () {
+        if (mounted && generation == _generation) setState(() {});
+      },
     );
   }
 
-  Future<void> _runOne(_SourceRun run, String query, int generation) async {
-    try {
-      switch (run.source) {
-        case _MihonGlobalSource(:final MangaOnlineSourceRow row):
-          final MihonManager manager = widget.mihonManager!;
-          final MihonSourceContext context =
-              await manager.contextForSource(row);
-          final MihonMangaPage page = await manager.runtime.search(
-            context.extension,
-            context.source,
-            page: 1,
-            query: query,
-            preferences: context.preferences,
-          );
-          if (!mounted || generation != _generation) return;
-          run.mihonContext = context;
-          run.mihonItems = page.items;
-          run.status = page.items.isEmpty ? _RunStatus.empty : _RunStatus.done;
-        case _AidokuGlobalSource(:final AidokuInstalledPackage package):
-          final AidokuRuntime? runtime = _resolveAidokuRuntime();
-          if (runtime == null) {
-            throw const AidokuRuntimeException(
-              'RUNTIME_UNAVAILABLE',
-              'The Aidoku runtime is unavailable on this platform',
-            );
-          }
-          final Map<String, Object?> result = await runtime.search(
-            package.packagePath,
-            query: query,
-            page: 1,
-          );
-          final List<Map<String, Object?>> entries =
-              (result['entries'] as List<Object?>? ?? const <Object?>[])
-                  .whereType<Map<Object?, Object?>>()
-                  .map((Map<Object?, Object?> value) =>
-                      value.cast<String, Object?>())
-                  .where((Map<String, Object?> value) =>
-                      value['key']?.toString().isNotEmpty ?? false)
-                  .toList(growable: false);
-          if (!mounted || generation != _generation) return;
-          run.aidokuItems = entries;
-          run.status = entries.isEmpty ? _RunStatus.empty : _RunStatus.done;
-      }
-    } on Object catch (error) {
-      if (!mounted || generation != _generation) return;
-      run.error = error;
-      run.status =
-          _isCloudflare(error) ? _RunStatus.cloudflare : _RunStatus.error;
-    }
-    if (mounted && generation == _generation) setState(() {});
-  }
-
-  static bool _isCloudflare(Object error) {
-    if (error is AidokuRuntimeException) {
-      return error.code == 'CLOUDFLARE_CHALLENGE';
-    }
-    final String text = '$error';
-    return text.contains('Cloudflare') || text.contains('CF challenge');
-  }
-
-  void _openMihon(_SourceRun run, MihonManga manga) {
+  void _openMihon(MangaSourceSearchRun run, MihonManga manga) {
     final MihonSourceContext? sourceContext = run.mihonContext;
     final MihonManager? manager = widget.mihonManager;
     if (sourceContext == null || manager == null) return;
@@ -311,7 +202,7 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     );
   }
 
-  Widget _buildSection(_SourceRun run) {
+  Widget _buildSection(MangaSourceSearchRun run) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Column(
@@ -344,8 +235,8 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     );
   }
 
-  Widget _statusTrailing(_SourceRun run) => switch (run.status) {
-        _RunStatus.loading => const SizedBox(
+  Widget _statusTrailing(MangaSourceSearchRun run) => switch (run.status) {
+        MangaSearchRunStatus.loading => const SizedBox(
             width: 16,
             height: 16,
             child: CircularProgressIndicator(strokeWidth: 2),
@@ -353,25 +244,25 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
         _ => const SizedBox.shrink(),
       };
 
-  Widget _buildSectionBody(_SourceRun run) {
+  Widget _buildSectionBody(MangaSourceSearchRun run) {
     switch (run.status) {
-      case _RunStatus.loading:
+      case MangaSearchRunStatus.loading:
         return const SizedBox(height: 200);
-      case _RunStatus.cloudflare:
+      case MangaSearchRunStatus.cloudflare:
         return _SectionMessage(t.manga_source_cloudflare_blocked);
-      case _RunStatus.error:
+      case MangaSearchRunStatus.error:
         return _SectionMessage('${run.error}');
-      case _RunStatus.empty:
+      case MangaSearchRunStatus.empty:
         return _SectionMessage(t.mihon_source_no_results);
-      case _RunStatus.done:
+      case MangaSearchRunStatus.done:
         return _buildResultsStrip(run);
     }
   }
 
-  Widget _buildResultsStrip(_SourceRun run) {
+  Widget _buildResultsStrip(MangaSourceSearchRun run) {
     final int count = switch (run.source) {
-      _MihonGlobalSource() => run.mihonItems.length,
-      _AidokuGlobalSource() => run.aidokuItems.length,
+      MihonGlobalSource() => run.mihonItems.length,
+      AidokuGlobalSource() => run.aidokuItems.length,
     };
     // 桌面端默认 dragDevices 不含 mouse，横向滚动区必须包 HorizontalDragScrollable
     // 才能用鼠标左键拖动平移（横向滚动守卫）。
@@ -389,12 +280,12 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     );
   }
 
-  Widget _buildHit(_SourceRun run, int index) {
+  Widget _buildHit(MangaSourceSearchRun run, int index) {
     final Widget cover;
     final String title;
     final VoidCallback onTap;
     switch (run.source) {
-      case _MihonGlobalSource():
+      case MihonGlobalSource():
         final MihonManga manga = run.mihonItems[index];
         title = manga.title;
         cover = MihonSourceImage(
@@ -405,7 +296,7 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
           loadQueue: _imageQueue,
         );
         onTap = () => _openMihon(run, manga);
-      case _AidokuGlobalSource(:final AidokuInstalledPackage package):
+      case AidokuGlobalSource(:final AidokuInstalledPackage package):
         final Map<String, Object?> manga = run.aidokuItems[index];
         title = manga['title']?.toString() ?? manga['key'].toString();
         cover = _AidokuStripCover(url: manga['cover']?.toString());
@@ -435,27 +326,6 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
           ),
         ),
       ),
-    );
-  }
-
-  /// 有上限并发地跑 [items]，每项调 [task]。一项抛错不影响其余（[task] 内部已兜住）。
-  static Future<void> _runBounded<T>(
-    List<T> items, {
-    required int maxConcurrent,
-    required Future<void> Function(T item) task,
-  }) async {
-    final Queue<T> pending = Queue<T>.of(items);
-    Future<void> worker() async {
-      while (pending.isNotEmpty) {
-        await task(pending.removeFirst());
-      }
-    }
-
-    final int workers = maxConcurrent < items.length
-        ? maxConcurrent
-        : (items.isEmpty ? 0 : items.length);
-    await Future.wait<void>(
-      <Future<void>>[for (int i = 0; i < workers; i++) worker()],
     );
   }
 }

--- a/fushi/lib/src/media/manga/manga_global_search_runner.dart
+++ b/fushi/lib/src/media/manga/manga_global_search_runner.dart
@@ -1,0 +1,177 @@
+/// 漫画全源搜索的**聚合执行层**：源归一化描述 + 逐源运行态 + 有界并发扇出 +
+/// Cloudflare 分型。原是 `manga_global_search_page.dart` 的 private sealed
+/// class（不可复用、不可单测），抽出为公开 API；页面只留 UI 与导航。
+///
+/// **为什么不并进 `MediaDiscoverySource`**：漫画源产的是「可打开的作品条目」
+/// （点开进详情页/加书架，需要 MihonSourceContext 等强类型上下文），发现源产
+/// 的是「可下载的资源」（magnet/直链 payload）——payload、动作、去重语义都
+/// 不同，硬塞同一模型只会造出一堆可空字段和特例分支。两者统一的是**聚合语义**
+/// （有界并发 `runBoundedTasks` + 渐进逐源交付 + 单源失败不拖垮整页），不是
+/// 数据模型。
+library;
+
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
+import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+import 'package:fushi/src/utils/misc/bounded_concurrency.dart';
+
+/// 单个来源的搜索进度。
+enum MangaSearchRunStatus { loading, done, empty, cloudflare, error }
+
+/// 归一化的来源描述，抹平 Mihon / Aidoku 两套模型。
+sealed class MangaGlobalSource {
+  const MangaGlobalSource();
+
+  String get id;
+  String get name;
+  String get language;
+}
+
+final class MihonGlobalSource extends MangaGlobalSource {
+  const MihonGlobalSource(this.row);
+
+  final MangaOnlineSourceRow row;
+
+  @override
+  String get id => 'mihon:${row.extensionPackage}:${row.sourceId}';
+  @override
+  String get name => row.name;
+  @override
+  String get language => row.language;
+}
+
+final class AidokuGlobalSource extends MangaGlobalSource {
+  const AidokuGlobalSource(this.package);
+
+  final AidokuInstalledPackage package;
+
+  @override
+  String get id => 'aidoku:${package.id}';
+  @override
+  String get name => package.name;
+  @override
+  String get language =>
+      package.languages.isEmpty ? '' : package.languages.first;
+}
+
+/// 一个来源在本次搜索里的运行态。Mihon / Aidoku 字段互斥，由 [source] 类型决定。
+class MangaSourceSearchRun {
+  MangaSourceSearchRun(this.source);
+
+  final MangaGlobalSource source;
+  MangaSearchRunStatus status = MangaSearchRunStatus.loading;
+  Object? error;
+
+  // Mihon
+  MihonSourceContext? mihonContext;
+  List<MihonManga> mihonItems = const <MihonManga>[];
+
+  // Aidoku
+  List<Map<String, Object?>> aidokuItems = const <Map<String, Object?>>[];
+}
+
+/// 逐源扇出执行器（无 UI 依赖，宿主/运行时注入，可纯 fake 测试）。
+class MangaGlobalSearchRunner {
+  MangaGlobalSearchRunner({
+    required MihonManager? mihonManager,
+    required AidokuRuntime? Function() resolveAidokuRuntime,
+  })  : _mihonManager = mihonManager,
+        _resolveAidokuRuntime = resolveAidokuRuntime;
+
+  final MihonManager? _mihonManager;
+  final AidokuRuntime? Function() _resolveAidokuRuntime;
+
+  /// 并发跑一轮搜索：每个来源独立更新 [runs] 里自己那行并回调 [onRunUpdated]；
+  /// 一个源慢或失败不拖累其余。[isCancelled] 为真后不再改写任何运行态
+  /// （调用方用 generation/mounted 实现，同原页面语义）。
+  /// 每个来源一个不同站点，跨站并发安全；[maxConcurrent] 限流只为不让
+  /// 几十个源同时打出去。
+  Future<void> search({
+    required List<MangaSourceSearchRun> runs,
+    required String query,
+    required bool Function() isCancelled,
+    required void Function() onRunUpdated,
+    int maxConcurrent = 6,
+  }) {
+    return runBoundedTasks(
+      runs,
+      maxConcurrent: maxConcurrent,
+      task: (MangaSourceSearchRun run) =>
+          _runOne(run, query, isCancelled, onRunUpdated),
+    );
+  }
+
+  Future<void> _runOne(
+    MangaSourceSearchRun run,
+    String query,
+    bool Function() isCancelled,
+    void Function() onRunUpdated,
+  ) async {
+    try {
+      switch (run.source) {
+        case MihonGlobalSource(:final MangaOnlineSourceRow row):
+          final MihonManager manager = _mihonManager!;
+          final MihonSourceContext context =
+              await manager.contextForSource(row);
+          final MihonMangaPage page = await manager.runtime.search(
+            context.extension,
+            context.source,
+            page: 1,
+            query: query,
+            preferences: context.preferences,
+          );
+          if (isCancelled()) return;
+          run.mihonContext = context;
+          run.mihonItems = page.items;
+          run.status = page.items.isEmpty
+              ? MangaSearchRunStatus.empty
+              : MangaSearchRunStatus.done;
+        case AidokuGlobalSource(:final AidokuInstalledPackage package):
+          final AidokuRuntime? runtime = _resolveAidokuRuntime();
+          if (runtime == null) {
+            throw const AidokuRuntimeException(
+              'RUNTIME_UNAVAILABLE',
+              'The Aidoku runtime is unavailable on this platform',
+            );
+          }
+          final Map<String, Object?> result = await runtime.search(
+            package.packagePath,
+            query: query,
+            page: 1,
+          );
+          final List<Map<String, Object?>> entries =
+              (result['entries'] as List<Object?>? ?? const <Object?>[])
+                  .whereType<Map<Object?, Object?>>()
+                  .map((Map<Object?, Object?> value) =>
+                      value.cast<String, Object?>())
+                  .where((Map<String, Object?> value) =>
+                      value['key']?.toString().isNotEmpty ?? false)
+                  .toList(growable: false);
+          if (isCancelled()) return;
+          run.aidokuItems = entries;
+          run.status = entries.isEmpty
+              ? MangaSearchRunStatus.empty
+              : MangaSearchRunStatus.done;
+      }
+    } on Object catch (error) {
+      if (isCancelled()) return;
+      run.error = error;
+      run.status = isCloudflareError(error)
+          ? MangaSearchRunStatus.cloudflare
+          : MangaSearchRunStatus.error;
+    }
+    if (!isCancelled()) onRunUpdated();
+  }
+
+  /// Cloudflare 保护判型（Aidoku 结构化错误码 + 文案兜底）。
+  static bool isCloudflareError(Object error) {
+    if (error is AidokuRuntimeException) {
+      return error.code == 'CLOUDFLARE_CHALLENGE';
+    }
+    final String text = '$error';
+    return text.contains('Cloudflare') || text.contains('CF challenge');
+  }
+}

--- a/fushi/lib/src/media/torrent/anime_download_plan.dart
+++ b/fushi/lib/src/media/torrent/anime_download_plan.dart
@@ -92,6 +92,13 @@ class AnimeDownloadPlan {
   /// 内容类型：自动（按文件扩展名分流：视频→视频库、epub→阅读库）。
   static const String kindAuto = 'auto';
 
+  /// 内容类型：有声书（发现页种子；完成后走发现导入执行器：正文+字幕+音频
+  /// 齐则对齐入库）。
+  static const String kindAudiobook = 'audiobook';
+
+  /// 内容类型：游戏（发现页种子；完成后走发现导入执行器：解压/挑主 exe 登记）。
+  static const String kindGame = 'game';
+
   /// 下载中（qBittorrent 未完成，等下轮 tick）。
   static const String statusDownloading = 'downloading';
 

--- a/fushi/lib/src/media/torrent/anime_download_service.dart
+++ b/fushi/lib/src/media/torrent/anime_download_service.dart
@@ -120,6 +120,23 @@ List<String> resolveVideoAbsolutePaths(
   return out;
 }
 
+/// 把种子文件列表解析为**全部**文件的绝对路径（不按扩展名过滤）。纯函数，
+/// 与 [resolveVideoAbsolutePaths] 同姿态（files 为空退化用 contentPath 单文件）。
+/// 发现页内容类型（有声书/游戏）用：分类交给发现导入执行器做。
+List<String> resolveAllAbsolutePaths(
+  TorrentSnapshot info,
+  List<TorrentFileEntry> files,
+) {
+  if (files.isEmpty) {
+    return info.contentPath.isEmpty
+        ? const <String>[]
+        : <String>[info.contentPath];
+  }
+  return <String>[
+    for (final TorrentFileEntry f in files) p.join(info.savePath, f.name),
+  ];
+}
+
 /// 阅读库支持的书籍扩展名（当前只有 EPUB —— reader_fushi 走 EPUB）。
 const Set<String> kBookExtensions = <String>{'.epub'};
 
@@ -218,12 +235,17 @@ class AnimeDownloadService {
       AnimeDownloadPlan plan,
       List<String> videoAbsolutePaths,
     )? subtitleResolver,
+    Future<int?> Function(
+      AnimeDownloadPlan plan,
+      List<String> absolutePaths,
+    )? discoveryImporter,
     void Function()? onTick,
     this.interval = const Duration(seconds: 20),
   })  : _configProvider = configProvider,
         _importer = importer,
         _bookImporter = bookImporter,
         _subtitleResolver = subtitleResolver,
+        _discoveryImporter = discoveryImporter,
         _backendFactory = backendFactory ?? _defaultBackendFactory,
         _onTick = onTick;
 
@@ -255,6 +277,15 @@ class AnimeDownloadService {
     AnimeDownloadPlan plan,
     List<String> bookAbsolutePaths,
   )? _bookImporter;
+
+  /// 发现页新内容类型（[AnimeDownloadPlan.kindAudiobook] /
+  /// [AnimeDownloadPlan.kindGame]）的入库回调（AppModel 接线
+  /// `DiscoveryImportExecutor.importPaths`；null = 不支持，按失败处理）。
+  /// 返回成功入库的条目数（0/null = 无/失败）。
+  final Future<int?> Function(
+    AnimeDownloadPlan plan,
+    List<String> absolutePaths,
+  )? _discoveryImporter;
 
   /// 延迟字幕解析回调（[AnimeDownloadPlan.subtitlePending] 的计划完成时调用，
   /// 用包内真实视频文件名反查 Jimaku，见 [JimakuPlanSubtitleResolver]）。
@@ -676,6 +707,17 @@ class AnimeDownloadService {
     bool importBooks = true,
   }) async {
     final List<TorrentFileEntry> files = await client.listFiles(info.hash);
+
+    // 发现页新内容类型：整包直通发现导入执行器（解压/分类/入库），不沾视频的
+    // 字幕/sidecar/边下边播机制。keepDownloading（边下边播）只对视频有意义，
+    // 这里直接等真实完成。
+    if (plan.contentKind == AnimeDownloadPlan.kindAudiobook ||
+        plan.contentKind == AnimeDownloadPlan.kindGame) {
+      if (keepDownloading) return;
+      await _finishDiscoveryPlan(plan, info, files);
+      return;
+    }
+
     final (List<String> videos, List<String> books) = _classifyContent(
       plan,
       info,
@@ -749,6 +791,45 @@ class AnimeDownloadService {
     } else {
       await store.save(
         resolved.copyWith(
+          status: AnimeDownloadPlan.statusFailed,
+          failReason: importError ?? 'import failed',
+          importInProgress: false,
+        ),
+      );
+    }
+  }
+
+  /// 发现页内容类型（有声书/游戏）的收尾：整包文件路径交给注入的
+  /// [_discoveryImporter]，按入库条目数落 imported / failed。
+  Future<void> _finishDiscoveryPlan(
+    AnimeDownloadPlan plan,
+    TorrentSnapshot info,
+    List<TorrentFileEntry> files,
+  ) async {
+    int imported = 0;
+    String? importError;
+    final Future<int?> Function(AnimeDownloadPlan, List<String>)? importer =
+        _discoveryImporter;
+    if (importer == null) {
+      importError = 'content kind ${plan.contentKind} unsupported';
+    } else {
+      try {
+        imported =
+            await importer(plan, resolveAllAbsolutePaths(info, files)) ?? 0;
+      } catch (e) {
+        importError = 'discovery import failed: $e';
+      }
+    }
+    if (imported > 0) {
+      await store.save(
+        plan.copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          importInProgress: false,
+        ),
+      );
+    } else {
+      await store.save(
+        plan.copyWith(
           status: AnimeDownloadPlan.statusFailed,
           failReason: importError ?? 'import failed',
           importInProgress: false,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -4120,12 +4120,14 @@ class AppModel with ChangeNotifier {
       );
   DiscoveryDownloadQueue? _discoveryDownloadQueue;
 
-  /// 发现页下载的落盘目录（与 torrent 同根：用户配置的下载根 → 默认
-  /// `<baseDir>/content`，再按媒体域分子目录）。
+  /// 发现页下载的落盘目录（与 torrent 同根：用户配置的下载根 → 默认根
+  /// [downloadDefaultSaveRoot]，再按媒体域分子目录）。
+  ///
+  /// 不再自造 documents 派生点：默认根由 [startAnimeDownloadService] 在
+  /// initialise 期唯一计算（UI 可达发现页时必已就绪），这里只消费。
   String discoveryDownloadDirFor(DiscoveryMediaKind kind) {
     String root = prefsRepo.downloadSaveRoot.trim();
     if (root.isEmpty) root = downloadDefaultSaveRoot;
-    if (root.isEmpty) root = path.join(appDirectory.path, 'content');
     return path.join(root, 'discovery', kind.name);
   }
 

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -69,6 +69,12 @@ import 'package:fushi/src/media/torrent/torznab_client.dart';
 import 'package:fushi/src/media/torrent/video_download_legacy_importer.dart';
 import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/torrent/anime_download_importer.dart';
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart'
+    show DiscoveryImportOutcome;
+import 'package:fushi/src/media/discovery/discovery_models.dart'
+    show DiscoveryMediaKind;
+import 'package:fushi/src/media/discovery/import/discovery_import_executor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_production.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/torrent/anime_download_service.dart';
 import 'package:fushi/src/media/torrent/anime_download_subtitle_resolver.dart';
@@ -3638,6 +3644,8 @@ class AppModel with ChangeNotifier {
           effectiveTorrentConfig(prefsRepo.qbConnectionConfig),
       importer: buildAnimeDownloadImporter(database),
       bookImporter: _importDownloadedBooks,
+      // 发现页新内容类型（有声书/游戏）：整包直通发现导入执行器。
+      discoveryImporter: _importDiscoveryDownload,
       // BUG-1206：字幕在下载完成时按包内真实文件名反查补取，不在选种时预下。
       subtitleResolver: JimakuPlanSubtitleResolver(
         apiKeyProvider: () => prefsRepo.jimakuApiKey,
@@ -4015,6 +4023,37 @@ class AppModel with ChangeNotifier {
     _animeDownloadPlanIds = ids;
     return ids;
   }
+
+  /// 发现页新内容类型（有声书/游戏）种子完成后的入库回调：整包路径交给
+  /// [DiscoveryImportExecutor]（分类 → 解压 → 复用各域既有导入原语）。
+  /// 返回入库条目数；分类不出/解压失败抛 [DiscoveryImportBlockedException]，
+  /// service 侧收进 failReason 展示。
+  Future<int?> _importDiscoveryDownload(
+    AnimeDownloadPlan plan,
+    List<String> absolutePaths,
+  ) async {
+    final DiscoveryMediaKind? kind = switch (plan.contentKind) {
+      AnimeDownloadPlan.kindAudiobook => DiscoveryMediaKind.audiobook,
+      AnimeDownloadPlan.kindGame => DiscoveryMediaKind.game,
+      _ => null,
+    };
+    if (kind == null) return null;
+    final DiscoveryImportOutcome outcome =
+        await discoveryImportExecutor.importPaths(kind, absolutePaths);
+    return outcome.importedCount;
+  }
+
+  /// 发现页自动导入执行器（懒建；域导入器全接生产原语）。
+  DiscoveryImportExecutor get discoveryImportExecutor =>
+      _discoveryImportExecutor ??= DiscoveryImportExecutor(
+        importers: buildProductionDiscoveryImporters(
+          db: database,
+          srtBookRepo: SrtBookRepository(database),
+          audiobookRepo: AudiobookRepository(database),
+          galgameRepo: galgameRepo,
+        ),
+      );
+  DiscoveryImportExecutor? _discoveryImportExecutor;
 
   /// The pipeline persists `stage=download` only after this checkpoint. This
   /// closes the one-minute periodic-save gap where an unclean app exit could

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -69,12 +69,15 @@ import 'package:fushi/src/media/torrent/torznab_client.dart';
 import 'package:fushi/src/media/torrent/video_download_legacy_importer.dart';
 import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/torrent/anime_download_importer.dart';
-import 'package:fushi/src/media/discovery/discovery_download_queue.dart'
-    show DiscoveryImportOutcome;
-import 'package:fushi/src/media/discovery/discovery_models.dart'
-    show DiscoveryMediaKind;
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/discovery/import/discovery_import_executor.dart';
 import 'package:fushi/src/media/discovery/import/discovery_import_production.dart';
+import 'package:fushi/src/media/discovery/media_discovery_service.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/discovery/sources/alist_discovery_source.dart';
+import 'package:fushi/src/media/discovery/sources/nyaa_discovery_source.dart';
+import 'package:fushi/src/media/discovery/sources/shinnku_discovery_source.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/torrent/anime_download_service.dart';
 import 'package:fushi/src/media/torrent/anime_download_subtitle_resolver.dart';
@@ -4054,6 +4057,77 @@ class AppModel with ChangeNotifier {
         ),
       );
   DiscoveryImportExecutor? _discoveryImportExecutor;
+
+  /// 发现页源注册表（懒建，app 生命周期常驻）。内置源在此登记；加源 = 加一个
+  /// adapter 实例。Sukebei（18+）默认不进「全部源」聚合，见
+  /// [discoveryDisabledSourceIds]。
+  MediaDiscoveryService get mediaDiscoveryService =>
+      _mediaDiscoveryService ??= MediaDiscoveryService(
+        sources: <MediaDiscoverySource>[
+          NyaaDiscoverySource(
+            id: 'nyaa',
+            displayName: 'Nyaa',
+            priority: 10,
+            categoryByKind: const <DiscoveryMediaKind, String>{
+              // nyaa.si 分类：Literature=3_0 / Audio=2_0。
+              DiscoveryMediaKind.novel: '3_0',
+              DiscoveryMediaKind.audiobook: '2_0',
+            },
+            client: NyaaClient(),
+          ),
+          NyaaDiscoverySource(
+            id: 'sukebei',
+            displayName: 'Sukebei',
+            priority: 15,
+            categoryByKind: const <DiscoveryMediaKind, String>{
+              // sukebei 分类：Art - Games=1_3（galgame 种子主阵地）。
+              DiscoveryMediaKind.game: '1_3',
+            },
+            client: NyaaClient(baseUrl: 'https://sukebei.nyaa.si'),
+          ),
+          AListDiscoverySource(
+            id: 'alist-erogame',
+            displayName: 'erogame.space',
+            priority: 20,
+            baseUrl: 'https://alist.erogame.space',
+            kinds: const <DiscoveryMediaKind>{DiscoveryMediaKind.game},
+          ),
+          ShinnkuDiscoverySource(),
+        ],
+      );
+  MediaDiscoveryService? _mediaDiscoveryService;
+
+  /// 「全部源」聚合排除的源 id（用户显式单选某源时不受限）。
+  Set<String> get discoveryDisabledSourceIds => <String>{
+        for (final String id in prefsRepo.discoveryDisabledSources.split(','))
+          if (id.trim().isNotEmpty) id.trim(),
+      };
+
+  /// 发现页直链下载队列（懒建，app 生命周期常驻——关闭发现页不中断下载，
+  /// 语义同 [mokuroMoeDownloadQueue]）。
+  DiscoveryDownloadQueue get discoveryDownloadQueue =>
+      _discoveryDownloadQueue ??= DiscoveryDownloadQueue(
+        resolvePayload: (DiscoveryResourceItem item) {
+          final MediaDiscoverySource? source =
+              mediaDiscoveryService.sourceById(item.sourceId);
+          if (source == null) {
+            throw StateError('unknown discovery source: ${item.sourceId}');
+          }
+          return source.resolvePayload(item);
+        },
+        importer: (DiscoveryDownloadTask task, File file) =>
+            discoveryImportExecutor.importDownload(task, file),
+      );
+  DiscoveryDownloadQueue? _discoveryDownloadQueue;
+
+  /// 发现页下载的落盘目录（与 torrent 同根：用户配置的下载根 → 默认
+  /// `<baseDir>/content`，再按媒体域分子目录）。
+  String discoveryDownloadDirFor(DiscoveryMediaKind kind) {
+    String root = prefsRepo.downloadSaveRoot.trim();
+    if (root.isEmpty) root = downloadDefaultSaveRoot;
+    if (root.isEmpty) root = path.join(appDirectory.path, 'content');
+    return path.join(root, 'discovery', kind.name);
+  }
 
   /// The pipeline persists `stage=download` only after this checkpoint. This
   /// closes the one-minute periodic-save gap where an unclean app exit could

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -52,6 +52,9 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'desktop_clipboard_window_mode',
   'dictionary_entry_font_size',
   'dictionary_update_interval',
+  // 发现页「全部源」聚合默认排除的源 id（逗号分隔；默认 sukebei——18+ 源
+  // 只在用户显式单选时使用）。String，读写见 PreferencesRepository。
+  'discovery_disabled_sources',
   'download_custom_proxy',
   'download_network_proxy_mode',
   'download_save_root',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -2250,6 +2250,16 @@ class PreferencesRepository extends ChangeNotifier {
   /// TODO-1961：内置下载引擎的下载根（新任务落点）。空串 = 未设置 → 用默认根
   /// `<documents>/anime_downloads/content`（与本 key 出现之前逐字节一致）。
   /// 设备本地路径，不进 Profile 快照（见 `ProfileKeys._excludedPrefKeys`）。
+  /// 发现页「全部源」聚合默认排除的源 id（逗号分隔）。默认排除 sukebei
+  /// （18+ 源只在用户于源下拉里**显式单选**时使用，不进默认聚合）。
+  String get discoveryDisabledSources =>
+      getPref('discovery_disabled_sources', defaultValue: 'sukebei') as String;
+
+  Future<void> setDiscoveryDisabledSources(String value) async {
+    await setPref('discovery_disabled_sources', value);
+    notifyListeners();
+  }
+
   String get downloadSaveRoot =>
       getPref('download_save_root', defaultValue: '') as String;
 

--- a/fushi/lib/src/pages/implementations/game_shared.dart
+++ b/fushi/lib/src/pages/implementations/game_shared.dart
@@ -20,7 +20,9 @@ enum GameSection {
   monitor,
   diagnostics,
   settings,
-  importGames
+  importGames,
+  // 发现（在线源浏览/下载）。后补，只能追加在尾部（IndexedStack 索引即枚举序）。
+  discover,
 }
 
 /// App 级游戏页子区导航。默认停在游戏首页（[GameSection.dashboard]）；原生 Hook
@@ -163,6 +165,7 @@ class GameSectionTabs extends StatelessWidget {
     const List<GameSection> values = <GameSection>[
       GameSection.dashboard,
       GameSection.library,
+      GameSection.discover,
       GameSection.monitor,
       GameSection.importGames,
       GameSection.settings,
@@ -175,6 +178,9 @@ class GameSectionTabs extends StatelessWidget {
           return;
         case GameSection.library:
           onSelectLibrary();
+          return;
+        case GameSection.discover:
+          gameSectionNotifier.value = GameSection.discover;
           return;
         case GameSection.importGames:
           gameSectionNotifier.value = GameSection.importGames;
@@ -207,6 +213,10 @@ class GameSectionTabs extends StatelessWidget {
           ButtonSegment<GameSection>(
             value: GameSection.library,
             label: Text(t.game_library),
+          ),
+          ButtonSegment<GameSection>(
+            value: GameSection.discover,
+            label: Text(t.game_section_discover),
           ),
           ButtonSegment<GameSection>(
             value: GameSection.monitor,

--- a/fushi/lib/src/pages/implementations/game_shared.dart
+++ b/fushi/lib/src/pages/implementations/game_shared.dart
@@ -214,9 +214,10 @@ class GameSectionTabs extends StatelessWidget {
             value: GameSection.library,
             label: Text(t.game_library),
           ),
+          // 「发现」与书 / 漫画 / 视频库页的发现视图同名同 key（同概念一词）。
           ButtonSegment<GameSection>(
             value: GameSection.discover,
-            label: Text(t.game_section_discover),
+            label: Text(t.library_view_browse),
           ),
           ButtonSegment<GameSection>(
             value: GameSection.monitor,

--- a/fushi/lib/src/pages/implementations/home_game_page.dart
+++ b/fushi/lib/src/pages/implementations/home_game_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi/models.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/import/quick_import_section.dart';
 import 'package:fushi/src/mining/gal_hook_session_controller.dart';
 import 'package:fushi/src/mining/galgame_add_flow.dart';
@@ -10,6 +11,7 @@ import 'package:fushi/src/pages/implementations/game_diagnostics_page.dart';
 import 'package:fushi/src/pages/implementations/game_shared.dart';
 import 'package:fushi/src/pages/implementations/game_statistics_page.dart';
 import 'package:fushi/src/pages/implementations/games_library_page.dart';
+import 'package:fushi/src/pages/implementations/media_discovery_page.dart';
 import 'package:fushi/src/pages/implementations/module_settings_view.dart';
 import 'package:fushi/src/pages/implementations/texthooker_page.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
@@ -68,6 +70,7 @@ class HomeGamePage extends StatefulWidget {
   static const Key diagnosticsKey = ValueKey<String>('game-diagnostics');
   static const Key settingsKey = ValueKey<String>('game-settings');
   static const Key importKey = ValueKey<String>('game-import');
+  static const Key discoverKey = ValueKey<String>('game-discover');
 
   /// 库页顶部会话状态带（原两张总览大卡的收敛替身），整条可点进入捕获工作台。
   static const Key captureStatusKey = ValueKey<String>('game-capture-status');
@@ -189,7 +192,27 @@ class _HomeGamePageState extends State<HomeGamePage> {
             key: HomeGamePage.importKey,
             child: _buildImport(context),
           ),
+          KeyedSubtree(
+            key: HomeGamePage.discoverKey,
+            child: _buildDiscover(context),
+          ),
         ],
+      ),
+    );
+  }
+
+  /// 游戏「发现」视图：统一发现页（shinnku / AList / sukebei 等在线源，
+  /// 下载完自动解压、登记进游戏库）。
+  Widget _buildDiscover(BuildContext context) {
+    return MediaDiscoveryPage(
+      kinds: const <DiscoveryMediaKind>[DiscoveryMediaKind.game],
+      navigation: GameSectionTabs(
+        selected: GameSection.discover,
+        focusIdPrefix: 'game-discover-tab',
+        onSelectDashboard: _showDashboard,
+        onSelectLibrary: _showLibrary,
+        onSelectMonitor: _showMonitor,
+        onSelectSettings: _showSettings,
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/home_reader_page.dart
+++ b/fushi/lib/src/pages/implementations/home_reader_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/widgets.dart';
 
 import 'package:fushi/media.dart';
 import 'package:fushi/pages.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/pages/implementations/media_discovery_page.dart';
 import 'package:fushi/src/pages/implementations/media_library_shell.dart';
 import 'package:fushi/src/pages/implementations/media_sources_page.dart';
 import 'package:fushi/src/pages/implementations/module_settings_view.dart';
@@ -21,13 +23,12 @@ class _HomeReaderPageState extends BaseTabPageState<HomeReaderPage> {
   @override
   MediaType get mediaType => ReaderMediaType.instance;
 
-  /// 书 tab 是「书架 + 来源」两视图（与漫画 / 视频同一套导航结构）。
+  /// 书 tab 是「书架 + 浏览 + 来源」三视图（与漫画 / 视频同一套导航结构）。
   ///
   /// 书架视图仍走 `mediaSource.buildHistoryPage()`——书 tab 支持切换来源
   /// （EPUB / PDF / 通用），页面类型由当前来源决定，壳不得硬编某一个实现。
-  /// 「浏览」视图暂缺：小说在线源（Kakuyomu / なろう 等）尚未落地，此处不放空壳
-  /// tab——[MediaLibraryShell] 在只有一个视图时连导航条都不显示，等在线源到位
-  /// 只需在这里多声明一条。
+  /// 「浏览」= 统一发现页（小说 + 有声书在线源：nyaa 等，源可切换、默认全部源
+  /// 聚合，下载完自动入库）。
   @override
   Widget build(BuildContext context) {
     return MediaLibraryShell(
@@ -38,6 +39,18 @@ class _HomeReaderPageState extends BaseTabPageState<HomeReaderPage> {
           label: t.library_view_shelf,
           builder: (BuildContext context, Widget navigation) =>
               mediaSource.buildHistoryPage(navigation: navigation),
+        ),
+        MediaLibraryViewSpec(
+          kind: MediaLibraryViewKind.browse,
+          label: t.library_view_browse,
+          builder: (BuildContext context, Widget navigation) =>
+              MediaDiscoveryPage(
+            kinds: const <DiscoveryMediaKind>[
+              DiscoveryMediaKind.novel,
+              DiscoveryMediaKind.audiobook,
+            ],
+            navigation: navigation,
+          ),
         ),
         MediaLibraryViewSpec(
           kind: MediaLibraryViewKind.sources,

--- a/fushi/lib/src/pages/implementations/media_discovery_page.dart
+++ b/fushi/lib/src/pages/implementations/media_discovery_page.dart
@@ -1,0 +1,459 @@
+import 'dart:async' show unawaited;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_service.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/anime_download_plan.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/download_actions.dart';
+import 'package:fushi/utils.dart';
+
+/// 统一发现页：书（小说/有声书）与 galgame 共用的多源在线资源发现视图。
+///
+/// 结构：媒体域筛选（多域时）+ 源下拉（默认「全部源」聚合）+ 搜索框 +
+/// 结果列表（目录可下钻、资源可下载）。下载分流按条目 payloadKind：
+/// torrent → `pushGenericMagnet`（既有 torrent 后端 + 自动入库），
+/// http 直链 → `AppModel.discoveryDownloadQueue`（下载完自动入库）。
+/// 单源失败亮徽标不拖垮整页（`DiscoveryAggregateResult` 部分成功语义）。
+///
+/// **构建期零 provider 依赖**：游戏页 IndexedStack 急切构建全部子区，本页
+/// 在无 ProviderScope 的 widget 测试里也会被 build——容器只在首帧后加载与
+/// 交互时解析（同 `_buildImport` 的 QuickImportSection 约定）。
+class MediaDiscoveryPage extends StatefulWidget {
+  const MediaDiscoveryPage({
+    required this.kinds,
+    this.navigation,
+    super.key,
+  });
+
+  /// 本页覆盖的媒体域（书域传 [novel, audiobook]，游戏域传 [game]）。
+  final List<DiscoveryMediaKind> kinds;
+
+  /// 库页壳注入的分段导航（嵌在头部；游戏域自带段条时传 null 由外层包）。
+  final Widget? navigation;
+
+  @override
+  State<MediaDiscoveryPage> createState() => _MediaDiscoveryPageState();
+}
+
+/// 源下拉「全部源」哨兵（DropdownMenu 泛型不便用 null）。
+const String _kAllSources = '';
+
+class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
+  late DiscoveryMediaKind _kind = widget.kinds.first;
+  String _sourceId = _kAllSources;
+  final TextEditingController _queryCtrl = TextEditingController();
+
+  /// 首帧后解析到的全局模型；无 ProviderScope（纯布局测试）时保持 null，
+  /// 页面停留在提示态。
+  AppModel? _appModel;
+
+  AppModel? _resolveAppModel() {
+    if (_appModel != null) return _appModel;
+    try {
+      _appModel =
+          ProviderScope.containerOf(context, listen: false).read(appProvider);
+    } on StateError {
+      return null;
+    }
+    return _appModel;
+  }
+
+  /// 目录下钻栈（(源内路径, 显示名)）；只在单源模式下非空。
+  final List<(String, String)> _pathStack = <(String, String)>[];
+
+  final List<DiscoveryEntry> _entries = <DiscoveryEntry>[];
+  DiscoveryAggregateResult? _result;
+  bool _loading = false;
+  Object? _error;
+  int _page = 1;
+
+  /// 竞态哨兵：晚到的旧请求结果不覆盖新状态。
+  int _loadSeq = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(_load());
+    });
+  }
+
+  @override
+  void dispose() {
+    _queryCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load({bool append = false}) async {
+    final AppModel? appModel = _resolveAppModel();
+    if (appModel == null) return;
+    final String query = _queryCtrl.text.trim();
+    final bool browsing = query.isEmpty;
+    final int seq = ++_loadSeq;
+    setState(() {
+      _loading = true;
+      _error = null;
+      if (!append) {
+        _page = 1;
+        _entries.clear();
+        _result = null;
+      }
+    });
+    try {
+      final DiscoveryRequest request = DiscoveryRequest(
+        kind: _kind,
+        query: browsing ? null : query,
+        path: browsing && _pathStack.isNotEmpty ? _pathStack.last.$1 : null,
+        page: _page,
+      );
+      final DiscoveryAggregateResult result =
+          await appModel.mediaDiscoveryService.load(
+        request,
+        sourceId: _sourceId == _kAllSources ? null : _sourceId,
+        disabledSourceIds: _sourceId == _kAllSources
+            ? appModel.discoveryDisabledSourceIds
+            : const <String>{},
+      );
+      if (!mounted || seq != _loadSeq) return;
+      setState(() {
+        _result = result;
+        _entries.addAll(result.entries);
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted || seq != _loadSeq) return;
+      setState(() {
+        _loading = false;
+        _error = e;
+      });
+    }
+  }
+
+  void _selectKind(DiscoveryMediaKind kind) {
+    if (kind == _kind) return;
+    setState(() {
+      _kind = kind;
+      _sourceId = _kAllSources;
+      _pathStack.clear();
+    });
+    unawaited(_load());
+  }
+
+  void _selectSource(String sourceId) {
+    if (sourceId == _sourceId) return;
+    setState(() {
+      _sourceId = sourceId;
+      _pathStack.clear();
+    });
+    unawaited(_load());
+  }
+
+  void _openFolder(DiscoveryFolder folder) {
+    setState(() {
+      // 聚合模式下点进某源的目录 = 隐式切到该源（深层路径是源内语义）。
+      _sourceId = folder.sourceId;
+      _pathStack.add((folder.path, folder.title));
+    });
+    unawaited(_load());
+  }
+
+  void _popFolder() {
+    if (_pathStack.isEmpty) return;
+    setState(() => _pathStack.removeLast());
+    unawaited(_load());
+  }
+
+  Future<void> _download(DiscoveryResourceItem item) async {
+    final AppModel? appModel = _resolveAppModel();
+    if (appModel == null) return;
+    switch (item.payloadKind) {
+      case DiscoveryPayloadKind.torrent:
+        final DiscoveryPayload? payload = item.payload;
+        if (payload is! DiscoveryTorrentPayload) return;
+        final GenericPushOutcome outcome = await pushGenericMagnet(
+          context: context,
+          appModel: appModel,
+          magnet: payload.magnetUri,
+          contentKind: switch (item.kind) {
+            DiscoveryMediaKind.novel => AnimeDownloadPlan.kindBook,
+            DiscoveryMediaKind.audiobook => AnimeDownloadPlan.kindAudiobook,
+            DiscoveryMediaKind.game => AnimeDownloadPlan.kindGame,
+            DiscoveryMediaKind.manga => AnimeDownloadPlan.kindAuto,
+          },
+        );
+        FushiToast.show(
+          msg: genericPushMessage(outcome),
+          severity: outcome == GenericPushOutcome.ok
+              ? ToastSeverity.success
+              : ToastSeverity.error,
+        );
+      case DiscoveryPayloadKind.httpFile:
+        final bool added = appModel.discoveryDownloadQueue.enqueue(
+          item,
+          destinationDir: appModel.discoveryDownloadDirFor(item.kind),
+        );
+        if (added) {
+          FushiToast.show(
+            msg: t.discovery_download_queued,
+            severity: ToastSeverity.success,
+          );
+        }
+    }
+  }
+
+  String _kindLabel(DiscoveryMediaKind kind) => switch (kind) {
+        DiscoveryMediaKind.novel => t.discovery_kind_novel,
+        DiscoveryMediaKind.audiobook => t.discovery_kind_audiobook,
+        DiscoveryMediaKind.game => t.game_library,
+        DiscoveryMediaKind.manga => t.library_view_browse,
+      };
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    const List<String> units = <String>['KiB', 'MiB', 'GiB', 'TiB'];
+    double value = bytes / 1024;
+    int unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024;
+      unit++;
+    }
+    return '${value.toStringAsFixed(value >= 100 ? 0 : 1)} ${units[unit]}';
+  }
+
+  String _subtitleFor(
+    DiscoveryResourceItem item,
+    MediaDiscoveryService service,
+  ) {
+    final List<String> parts = <String>[
+      service.sourceById(item.sourceId)?.displayName ?? item.sourceId,
+      if (item.sizeBytes != null) _formatBytes(item.sizeBytes!),
+      if (item.dateText != null) item.dateText!,
+      if (item.seeders != null) '↑${item.seeders}',
+      if (item.note != null) item.note!,
+    ];
+    return parts.join(' · ');
+  }
+
+  Widget _buildControls(BuildContext context) {
+    final List<MediaDiscoverySource> sources =
+        _appModel?.mediaDiscoveryService.sourcesFor(_kind) ??
+            const <MediaDiscoverySource>[];
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (widget.kinds.length > 1)
+            Padding(
+              padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+              child: SegmentedButton<DiscoveryMediaKind>(
+                segments: <ButtonSegment<DiscoveryMediaKind>>[
+                  for (final DiscoveryMediaKind kind in widget.kinds)
+                    ButtonSegment<DiscoveryMediaKind>(
+                      value: kind,
+                      label: Text(_kindLabel(kind)),
+                    ),
+                ],
+                selected: <DiscoveryMediaKind>{_kind},
+                onSelectionChanged: (Set<DiscoveryMediaKind> selection) =>
+                    _selectKind(selection.first),
+              ),
+            ),
+          Row(
+            children: <Widget>[
+              DropdownMenu<String>(
+                key: const ValueKey<String>('discovery_source_menu'),
+                initialSelection: _sourceId,
+                requestFocusOnTap: false,
+                onSelected: (String? value) =>
+                    _selectSource(value ?? _kAllSources),
+                dropdownMenuEntries: <DropdownMenuEntry<String>>[
+                  DropdownMenuEntry<String>(
+                    value: _kAllSources,
+                    label: t.discovery_all_sources,
+                  ),
+                  for (final MediaDiscoverySource source in sources)
+                    DropdownMenuEntry<String>(
+                      value: source.id,
+                      label: source.displayName,
+                    ),
+                ],
+              ),
+              SizedBox(width: tokens.spacing.gap),
+              Expanded(
+                child: TextField(
+                  key: const ValueKey<String>('discovery_search_field'),
+                  controller: _queryCtrl,
+                  decoration: InputDecoration(
+                    hintText: t.discovery_search_hint,
+                    prefixIcon: const Icon(Icons.search),
+                    isDense: true,
+                  ),
+                  textInputAction: TextInputAction.search,
+                  onSubmitted: (String _) {
+                    _pathStack.clear();
+                    unawaited(_load());
+                  },
+                ),
+              ),
+            ],
+          ),
+          if (_pathStack.isNotEmpty)
+            Padding(
+              padding: EdgeInsets.only(top: tokens.spacing.gap),
+              child: Row(
+                children: <Widget>[
+                  FushiIconButton(
+                    icon: Icons.arrow_upward,
+                    tooltip: t.back,
+                    label: t.back,
+                    onTap: _popFolder,
+                  ),
+                  SizedBox(width: tokens.spacing.gap),
+                  Expanded(
+                    child: Text(
+                      _pathStack.map(((String, String) e) => e.$2).join(' / '),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final AppModel? appModel = _appModel;
+    final ThemeData theme = Theme.of(context);
+    if (appModel == null) {
+      return Center(
+        child: Text(
+          t.discovery_enter_query_hint,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+      );
+    }
+    final MediaDiscoveryService service = appModel.mediaDiscoveryService;
+    final DiscoveryDownloadQueue queue = appModel.discoveryDownloadQueue;
+
+    if (_error != null) {
+      return Center(
+        child: Text(
+          t.discovery_partial_failure,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.error),
+        ),
+      );
+    }
+    if (_loading && _entries.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_entries.isEmpty) {
+      final bool idle = _queryCtrl.text.trim().isEmpty && _result == null;
+      return Center(
+        child: Text(
+          idle ? t.discovery_enter_query_hint : t.discovery_empty,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+      );
+    }
+
+    final DiscoveryAggregateResult? result = _result;
+    return AnimatedBuilder(
+      animation: queue,
+      builder: (BuildContext context, Widget? _) => ListView(
+        padding: const EdgeInsets.all(16),
+        children: <Widget>[
+          if (result != null && result.hasFailures)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Text(
+                '${t.discovery_partial_failure} '
+                '(${result.failures.map((ExternalProviderFailure f) => f.providerId).toSet().join(', ')})',
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.error),
+              ),
+            ),
+          for (final DiscoveryEntry entry in _entries)
+            switch (entry) {
+              DiscoveryFolder() => FushiListItem(
+                  leading: const Icon(Icons.folder_outlined),
+                  title: Text(entry.title),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _openFolder(entry),
+                ),
+              DiscoveryResourceItem() => FushiListItem(
+                  leading: Icon(
+                    entry.payloadKind == DiscoveryPayloadKind.torrent
+                        ? Icons.link
+                        : Icons.insert_drive_file_outlined,
+                  ),
+                  title: Text(entry.title),
+                  titleMaxLines: 2,
+                  subtitle: Text(_subtitleFor(entry, service)),
+                  trailing: queue.isPending(entry)
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : FushiIconButton(
+                          icon: Icons.download_outlined,
+                          tooltip: t.anime_download_generic_download,
+                          label: t.anime_download_generic_download,
+                          onTap: () => unawaited(_download(entry)),
+                        ),
+                  onTap: () => unawaited(_download(entry)),
+                ),
+            },
+          if (result != null && result.hasMore)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Center(
+                child: _loading
+                    ? const CircularProgressIndicator()
+                    : TextButton(
+                        onPressed: () {
+                          _page++;
+                          unawaited(_load(append: true));
+                        },
+                        child: Text(t.discovery_load_more),
+                      ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget? navigation = widget.navigation;
+    return DesktopContentLayout(
+      kind: DesktopContentKind.readerShelf,
+      child: Column(
+        children: <Widget>[
+          if (navigation != null)
+            FushiPageHeader.customTitle(
+              title: navigation,
+              actions: const <Widget>[],
+            ),
+          _buildControls(context),
+          Expanded(child: _buildBody(context)),
+        ],
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/media_discovery_page.dart
+++ b/fushi/lib/src/pages/implementations/media_discovery_page.dart
@@ -112,6 +112,9 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
         path: browsing && _pathStack.isNotEmpty ? _pathStack.last.$1 : null,
         page: _page,
       );
+      // 追加页（加载更多）不做渐进：旧条目要保序，等整页齐了再接尾。
+      final List<DiscoveryEntry> base =
+          append ? List<DiscoveryEntry>.of(_entries) : const <DiscoveryEntry>[];
       final DiscoveryAggregateResult result =
           await appModel.mediaDiscoveryService.load(
         request,
@@ -119,11 +122,26 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
         disabledSourceIds: _sourceId == _kAllSources
             ? appModel.discoveryDisabledSourceIds
             : const <String>{},
+        // 渐进交付：快源先上屏，不等慢源（模式与漫画全源搜索一致）。
+        onUpdate: append
+            ? null
+            : (DiscoveryAggregateResult partial) {
+                if (!mounted || seq != _loadSeq) return;
+                setState(() {
+                  _result = partial;
+                  _entries
+                    ..clear()
+                    ..addAll(partial.entries);
+                });
+              },
       );
       if (!mounted || seq != _loadSeq) return;
       setState(() {
         _result = result;
-        _entries.addAll(result.entries);
+        _entries
+          ..clear()
+          ..addAll(base)
+          ..addAll(result.entries);
         _loading = false;
       });
     } catch (e) {

--- a/fushi/lib/src/pages/implementations/video_library_shell.dart
+++ b/fushi/lib/src/pages/implementations/video_library_shell.dart
@@ -121,7 +121,8 @@ class _VideoLibraryShellState extends State<VideoLibraryShell> {
           ),
           ButtonSegment<VideoLibrarySection>(
             value: VideoLibrarySection.discover,
-            label: Text(t.video_discovery_tab),
+            // 与书 / 漫画 / 游戏的发现视图同 key（同概念一词,原 video_discovery_tab 已删）。
+            label: Text(t.library_view_browse),
           ),
           ButtonSegment<VideoLibrarySection>(
             value: VideoLibrarySection.series,

--- a/fushi/lib/src/utils/misc/bounded_concurrency.dart
+++ b/fushi/lib/src/utils/misc/bounded_concurrency.dart
@@ -1,0 +1,27 @@
+/// 有界并发原语：跨源扇出（发现聚合 / 漫画全源搜索）的共用实现。
+/// 此前漫画页私有一份、发现服务再抄一份——两份同形代码就该收一处。
+library;
+
+import 'dart:collection';
+
+/// 有上限并发地跑 [items]，每项调 [task]；一项抛错会中断所在 worker，
+/// 调用方应在 [task] 内部兜住异常（两处调用点均如此）。
+Future<void> runBoundedTasks<T>(
+  List<T> items, {
+  required int maxConcurrent,
+  required Future<void> Function(T item) task,
+}) async {
+  final Queue<T> pending = Queue<T>.of(items);
+  Future<void> worker() async {
+    while (pending.isNotEmpty) {
+      await task(pending.removeFirst());
+    }
+  }
+
+  final int workers = maxConcurrent < items.length
+      ? maxConcurrent
+      : (items.isEmpty ? 0 : items.length);
+  await Future.wait<void>(
+    <Future<void>>[for (int i = 0; i < workers; i++) worker()],
+  );
+}

--- a/fushi/test/media/discovery/discovery_download_queue_test.dart
+++ b/fushi/test/media/discovery/discovery_download_queue_test.dart
@@ -1,0 +1,325 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+
+DiscoveryResourceItem _item(
+  String id, {
+  String url = 'https://example.com/files/book.epub',
+  String? fileName,
+}) {
+  return DiscoveryResourceItem(
+    sourceId: 'src',
+    title: 'title-$id',
+    id: id,
+    kind: DiscoveryMediaKind.novel,
+    payloadKind: DiscoveryPayloadKind.httpFile,
+    payload: DiscoveryHttpPayload(url: url, fileName: fileName),
+  );
+}
+
+Future<DiscoveryPayload> _defaultResolver(DiscoveryResourceItem item) async =>
+    item.payload!;
+
+Future<void> _waitFor(bool Function() condition) async {
+  for (int i = 0; i < 500 && !condition(); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  expect(condition(), isTrue);
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('discovery_queue_test');
+  });
+
+  tearDown(() async {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {
+      // Windows 上偶发句柄未释放，不让清理失败弄红测试。
+    }
+  });
+
+  ResumableDownloadResponse okBytes(List<int> body) =>
+      ResumableDownloadResponse.bytes(
+        statusCode: 200,
+        body: body,
+        headers: <String, String>{'content-length': '${body.length}'},
+      );
+
+  test('成功路径：下载落盘 → 自动导入 → done，importedCount 累计', () async {
+    final List<int> body = utf8.encode('epub-bytes');
+    final List<String> importedFiles = <String>[];
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask task, File file) async {
+        importedFiles.add(file.path);
+        return const DiscoveryImportOutcome(importedCount: 1, summary: 'ok');
+      },
+      openOverride: (Uri uri, Map<String, String> headers) async =>
+          okBytes(body),
+    );
+    addTearDown(queue.dispose);
+
+    expect(
+      queue.enqueue(_item('1'), destinationDir: tempDir.path),
+      isTrue,
+    );
+    await _waitFor(() => queue.tasks.single.isFinished);
+
+    final DiscoveryDownloadTask task = queue.tasks.single;
+    expect(task.status, DiscoveryDownloadStatus.done);
+    expect(task.filePath, endsWith('book.epub'));
+    expect(await File(task.filePath!).readAsBytes(), body);
+    expect(importedFiles.single, task.filePath);
+    expect(task.importOutcome?.summary, 'ok');
+    expect(queue.importedCount, 1);
+  });
+
+  test('同源同 id 未完成任务去重；顺序一次一个', () async {
+    final Completer<void> gate = Completer<void>();
+    final List<String> started = <String>[];
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        started.add(uri.toString());
+        await gate.future;
+        return okBytes(utf8.encode('x'));
+      },
+    );
+    addTearDown(queue.dispose);
+
+    expect(
+      queue.enqueue(_item('1'), destinationDir: tempDir.path),
+      isTrue,
+    );
+    expect(
+      queue.enqueue(_item('1'), destinationDir: tempDir.path),
+      isFalse,
+      reason: '同条目未完成时重复入队应被拒',
+    );
+    expect(
+      queue.enqueue(
+        _item('2', url: 'https://example.com/files/two.epub'),
+        destinationDir: tempDir.path,
+      ),
+      isTrue,
+    );
+    expect(queue.totalCount, 2);
+
+    await _waitFor(() => started.length == 1);
+    expect(
+      queue.tasks[1].status,
+      DiscoveryDownloadStatus.queued,
+      reason: '单飞：第一个没完，第二个不该开跑',
+    );
+
+    gate.complete();
+    await _waitFor(
+        () => queue.tasks.every((DiscoveryDownloadTask t) => t.isFinished));
+    expect(started.length, 2);
+  });
+
+  test('瞬时网络错误自动退避重试后成功', () async {
+    int calls = 0;
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(importedCount: 1),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        calls++;
+        if (calls == 1) throw const SocketException('flaky');
+        return okBytes(utf8.encode('x'));
+      },
+      retryBackoffOverride: const <Duration>[Duration(milliseconds: 20)],
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(
+      () => queue.tasks.single.status == DiscoveryDownloadStatus.done,
+    );
+    expect(calls, 2);
+    expect(queue.tasks.single.autoRetries, 1);
+  });
+
+  test('HTTP 404 是稳定结论：直接 failed，不自动重试', () async {
+    int calls = 0;
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        calls++;
+        return ResumableDownloadResponse.bytes(statusCode: 404, body: <int>[]);
+      },
+      retryBackoffOverride: const <Duration>[Duration(milliseconds: 20)],
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(() => queue.tasks.single.isFinished);
+    expect(queue.tasks.single.status, DiscoveryDownloadStatus.failed);
+    expect(calls, 1);
+    expect(queue.tasks.single.autoRetries, 0);
+  });
+
+  test('HTTP 503 属瞬时：进入退避重试', () async {
+    int calls = 0;
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        calls++;
+        if (calls == 1) {
+          return ResumableDownloadResponse.bytes(
+            statusCode: 503,
+            body: <int>[],
+          );
+        }
+        return okBytes(utf8.encode('x'));
+      },
+      retryBackoffOverride: const <Duration>[Duration(milliseconds: 20)],
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(
+      () => queue.tasks.single.status == DiscoveryDownloadStatus.done,
+    );
+    expect(calls, 2);
+  });
+
+  test('导入失败不自动重试；手动重试跳过下载直接重导', () async {
+    int opens = 0;
+    int imports = 0;
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async {
+        imports++;
+        if (imports == 1) throw const SocketException('db down');
+        return const DiscoveryImportOutcome(importedCount: 1);
+      },
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        opens++;
+        return okBytes(utf8.encode('x'));
+      },
+      retryBackoffOverride: const <Duration>[Duration(milliseconds: 20)],
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(() => queue.tasks.single.isFinished);
+    expect(
+      queue.tasks.single.status,
+      DiscoveryDownloadStatus.failed,
+      reason: '导入失败即使是网络型异常也不该吃下载重试预算',
+    );
+    expect(opens, 1);
+
+    queue.retry(queue.tasks.single);
+    await _waitFor(
+      () => queue.tasks.single.status == DiscoveryDownloadStatus.done,
+    );
+    expect(opens, 1, reason: '目标文件已在，重试不重下');
+    expect(queue.tasks.single.skippedDownload, isTrue);
+    expect(imports, 2);
+    expect(queue.importedCount, 1);
+  });
+
+  test('源 resolve 出 torrent payload 属实现 bug：failed 不重试', () async {
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: (DiscoveryResourceItem _) async =>
+          const DiscoveryTorrentPayload(magnetUri: 'magnet:?xt=x'),
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async =>
+          okBytes(<int>[]),
+      retryBackoffOverride: const <Duration>[Duration(milliseconds: 20)],
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(() => queue.tasks.single.isFinished);
+    expect(queue.tasks.single.status, DiscoveryDownloadStatus.failed);
+    expect(queue.tasks.single.autoRetries, 0);
+  });
+
+  test('取消排队中的任务直接移除；取消执行中的任务归 cancelled', () async {
+    final Completer<void> gate = Completer<void>();
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        await gate.future;
+        return okBytes(utf8.encode('x'));
+      },
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    queue.enqueue(
+      _item('2', url: 'https://example.com/files/two.epub'),
+      destinationDir: tempDir.path,
+    );
+    await _waitFor(
+      () => queue.tasks.first.status == DiscoveryDownloadStatus.running,
+    );
+
+    // 排队中的：直接移除。
+    queue.cancel(queue.tasks[1]);
+    expect(queue.totalCount, 1);
+
+    // 执行中的：置取消标记，流收尾后归 cancelled。
+    queue.cancel(queue.tasks.single);
+    gate.complete();
+    await _waitFor(() => queue.tasks.single.isFinished);
+    expect(queue.tasks.single.status, DiscoveryDownloadStatus.cancelled);
+  });
+
+  test('clearFinished 只清终态任务', () async {
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async =>
+          okBytes(utf8.encode('x')),
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(() => queue.tasks.single.isFinished);
+    queue.clearFinished();
+    expect(queue.totalCount, 0);
+  });
+
+  group('sanitizeDiscoveryFileName', () {
+    test('剥路径分隔与 Windows 非法字符', () {
+      expect(
+        sanitizeDiscoveryFileName(r'a/b\c:d*e?"f"<g>|h.epub'),
+        'a b c d e f g h.epub',
+      );
+    });
+
+    test('压缩空白并去尾点/空格', () {
+      expect(sanitizeDiscoveryFileName('  a   b.txt.  '), 'a b.txt');
+    });
+
+    test('空/纯点回退 download', () {
+      expect(sanitizeDiscoveryFileName('   '), 'download');
+      expect(sanitizeDiscoveryFileName('..'), 'download');
+    });
+  });
+}

--- a/fushi/test/media/discovery/import/discovery_import_executor_test.dart
+++ b/fushi/test/media/discovery/import/discovery_import_executor_test.dart
@@ -209,6 +209,40 @@ void main() {
     );
   });
 
+  test('importPaths:目录直接分类出 exe 则不解压', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final DiscoveryImportOutcome outcome = await executor.importPaths(
+      DiscoveryMediaKind.game,
+      <String>['/dl/Pack/game.exe', '/dl/Pack/data.xp3'],
+    );
+    expect(outcome.importedCount, 1);
+    expect(log.single, contains('game.exe'));
+  });
+
+  test('importPaths:目录分类不出但含压缩包 → 解开最大包并入清单重分类', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File zip = await _writeZip(tempDir, 'inner.zip', <String, String>{
+      'game/atri.exe': 'gamegame',
+    });
+    final File readme = File('${tempDir.path}${Platform.pathSeparator}re.txt');
+    await readme.writeAsString('readme');
+
+    final DiscoveryImportOutcome outcome = await executor.importPaths(
+      DiscoveryMediaKind.game,
+      <String>[readme.path, zip.path],
+    );
+    expect(outcome.importedCount, 1);
+    expect(log.single, contains('atri.exe'));
+  });
+
   test('域认不出的下载物按 unknownFileType 挡下', () async {
     final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
       importers: _recordingImporters(<String>[]),

--- a/fushi/test/media/discovery/import/discovery_import_executor_test.dart
+++ b/fushi/test/media/discovery/import/discovery_import_executor_test.dart
@@ -1,0 +1,230 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/import/discovery_archive_extractor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_executor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart';
+
+DiscoveryDomainImporters _recordingImporters(List<String> log) {
+  return DiscoveryDomainImporters(
+    importEpub: (String path) async {
+      log.add('epub:$path');
+      return 'key-epub';
+    },
+    importText: (String path) async {
+      log.add('text:$path');
+      return 'key-text';
+    },
+    importPdf: (String path) async {
+      log.add('pdf:$path');
+      return 'key-pdf';
+    },
+    importAudiobook: (AlignAudiobookPlan plan) async {
+      log.add('audiobook:${plan.contentPath}+${plan.subtitlePath}'
+          '+${plan.audioPaths.length}');
+      return 'key-audiobook';
+    },
+    registerGameExes: (List<String> exePaths) async {
+      log.add('game:${exePaths.join(',')}');
+      return exePaths.length;
+    },
+  );
+}
+
+Future<File> _writeZip(
+  Directory dir,
+  String name,
+  Map<String, String> entries,
+) async {
+  final Archive archive = Archive();
+  entries.forEach((String path, String content) {
+    final List<int> bytes = utf8.encode(content);
+    archive.addFile(ArchiveFile(path, bytes.length, bytes));
+  });
+  final File out = File('${dir.path}${Platform.pathSeparator}$name');
+  await out.writeAsBytes(ZipEncoder().encode(archive)!);
+  return out;
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('discovery_import_test');
+  });
+
+  tearDown(() async {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {}
+  });
+
+  test('单文件 epub 直接走 epub 导入', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+    );
+    final File epub = File('${tempDir.path}${Platform.pathSeparator}a.epub');
+    await epub.writeAsString('x');
+
+    final DiscoveryImportOutcome outcome =
+        await executor.importFile(DiscoveryMediaKind.novel, epub);
+    expect(outcome.importedCount, 1);
+    expect(outcome.summary, 'key-epub');
+    expect(log.single, 'epub:${epub.path}');
+  });
+
+  test('zip 小说包:内置解码解压(带目录)后逐本导入', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+      // 强制走内置 zip 解码路径(不依赖本机 7-Zip)。
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File zip = await _writeZip(tempDir, 'books.zip', <String, String>{
+      'vol1/a.epub': 'a',
+      'vol1/b.txt': 'b',
+      'cover.jpg': 'ignored',
+    });
+
+    final DiscoveryImportOutcome outcome =
+        await executor.importFile(DiscoveryMediaKind.novel, zip);
+    expect(outcome.importedCount, 2);
+    expect(log, hasLength(2));
+    expect(log[0], startsWith('epub:'));
+    expect(log[1], startsWith('text:'));
+    // 解出的文件真实落盘在压缩包旁的同名目录。
+    expect(
+      File('${tempDir.path}${Platform.pathSeparator}books'
+              '${Platform.pathSeparator}vol1${Platform.pathSeparator}a.epub')
+          .existsSync(),
+      isTrue,
+    );
+  });
+
+  test('zip 有声书包:齐料 → 对齐导入', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File zip = await _writeZip(tempDir, 'ab.zip', <String, String>{
+      'book.epub': 'e',
+      'book.srt': 's',
+      '01.mp3': 'm',
+      '02.mp3': 'm',
+    });
+
+    final DiscoveryImportOutcome outcome =
+        await executor.importFile(DiscoveryMediaKind.audiobook, zip);
+    expect(outcome.importedCount, 1);
+    expect(log.single, contains('audiobook:'));
+    expect(log.single, contains('+2'));
+  });
+
+  test('zip 游戏包:挑主 exe 登记', () async {
+    final List<String> log = <String>[];
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(log),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File zip = await _writeZip(tempDir, 'game.zip', <String, String>{
+      'game/atri.exe': 'gamegamegame',
+      'game/unins000.exe': 'u',
+      'game/data.xp3': 'd',
+    });
+
+    final DiscoveryImportOutcome outcome =
+        await executor.importFile(DiscoveryMediaKind.game, zip);
+    expect(outcome.importedCount, 1);
+    expect(log.single, startsWith('game:'));
+    expect(log.single, contains('atri.exe'));
+    expect(log.single, isNot(contains('unins')));
+  });
+
+  test('缺 7-Zip 时 7z 包给稳定原因码', () async {
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(<String>[]),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File archive = File('${tempDir.path}${Platform.pathSeparator}x.7z');
+    await archive.writeAsBytes(<int>[0x37, 0x7a]);
+
+    expect(
+      () => executor.importFile(DiscoveryMediaKind.game, archive),
+      throwsA(
+        isA<DiscoveryImportBlockedException>().having(
+          (DiscoveryImportBlockedException e) => e.blocker,
+          'blocker',
+          DiscoveryImportBlocker.archiveToolMissing,
+        ),
+      ),
+    );
+  });
+
+  test('注入 7za runner:命令形状正确,非零退出按解压失败', () async {
+    final List<List<String>> calls = <List<String>>[];
+    final DiscoveryArchiveExtractor extractor = DiscoveryArchiveExtractor(
+      sevenZipOverride: '/fake/7za',
+      runProcess: (String exe, List<String> args) async {
+        calls.add(<String>[exe, ...args]);
+        return ProcessResult(0, 2, '', 'wrong password');
+      },
+    );
+    final File archive = File('${tempDir.path}${Platform.pathSeparator}p.rar');
+    await archive.writeAsBytes(<int>[0x52, 0x61, 0x72]);
+
+    await expectLater(
+      extractor.extract(archive.path, intoDir: '${tempDir.path}/out'),
+      throwsA(
+        isA<DiscoveryImportBlockedException>().having(
+          (DiscoveryImportBlockedException e) => e.blocker,
+          'blocker',
+          DiscoveryImportBlocker.archiveExtractionFailed,
+        ),
+      ),
+    );
+    expect(calls.single.first, '/fake/7za');
+    expect(calls.single, contains('x'));
+    expect(calls.single, contains(archive.path));
+  });
+
+  test('恶意 zip(条目带 ..)被拒', () async {
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(<String>[]),
+      extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+    );
+    final File zip = await _writeZip(tempDir, 'evil.zip', <String, String>{
+      '../evil.txt': 'x',
+    });
+
+    expect(
+      () => executor.importFile(DiscoveryMediaKind.novel, zip),
+      throwsA(isA<DiscoveryImportBlockedException>()),
+    );
+  });
+
+  test('域认不出的下载物按 unknownFileType 挡下', () async {
+    final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+      importers: _recordingImporters(<String>[]),
+    );
+    final File file = File('${tempDir.path}${Platform.pathSeparator}x.bin');
+    await file.writeAsString('x');
+
+    expect(
+      () => executor.importFile(DiscoveryMediaKind.novel, file),
+      throwsA(
+        isA<DiscoveryImportBlockedException>().having(
+          (DiscoveryImportBlockedException e) => e.blocker,
+          'blocker',
+          DiscoveryImportBlocker.unknownFileType,
+        ),
+      ),
+    );
+  });
+}

--- a/fushi/test/media/discovery/import/discovery_import_plan_test.dart
+++ b/fushi/test/media/discovery/import/discovery_import_plan_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/import/discovery_archive_extractor.dart';
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart';
+
+void main() {
+  group('classifyDiscoveryFile', () {
+    test('压缩包一律先解压', () {
+      for (final String path in <String>['a.zip', 'b.7z', 'c.RAR']) {
+        expect(
+          classifyDiscoveryFile(DiscoveryMediaKind.novel, path),
+          isA<ExtractArchivePlan>(),
+          reason: path,
+        );
+      }
+    });
+
+    test('小说:epub/pdf/文本各走各的导入', () {
+      expect(
+        classifyDiscoveryFile(DiscoveryMediaKind.novel, 'x.epub'),
+        isA<ImportEpubPlan>(),
+      );
+      expect(
+        classifyDiscoveryFile(DiscoveryMediaKind.novel, 'x.pdf'),
+        isA<ImportPdfPlan>(),
+      );
+      expect(
+        classifyDiscoveryFile(DiscoveryMediaKind.novel, 'x.txt'),
+        isA<ConvertTextPlan>(),
+      );
+      expect(
+        (classifyDiscoveryFile(DiscoveryMediaKind.novel, 'x.mp3')
+                as UnsupportedPlan)
+            .blocker,
+        DiscoveryImportBlocker.unknownFileType,
+      );
+    });
+
+    test('游戏:裸 exe 直接登记', () {
+      final RegisterGameExesPlan plan = classifyDiscoveryFile(
+        DiscoveryMediaKind.game,
+        r'D:\games\atri.exe',
+      ) as RegisterGameExesPlan;
+      expect(plan.exePaths, <String>[r'D:\games\atri.exe']);
+    });
+
+    test('有声书:单文件永远不够料', () {
+      expect(
+        classifyDiscoveryFile(DiscoveryMediaKind.audiobook, 'x.mp3'),
+        isA<UnsupportedPlan>(),
+      );
+    });
+  });
+
+  group('classifyDiscoveryDirectory', () {
+    test('小说目录:全部书文件收成 MultiPlan', () {
+      final MultiPlan plan = classifyDiscoveryDirectory(
+        DiscoveryMediaKind.novel,
+        <String>['/d/a.epub', '/d/b.txt', '/d/cover.jpg', '/d/c.pdf'],
+      ) as MultiPlan;
+      expect(plan.children, hasLength(3));
+    });
+
+    test('小说目录只有一本时不套 MultiPlan', () {
+      expect(
+        classifyDiscoveryDirectory(
+          DiscoveryMediaKind.novel,
+          <String>['/d/a.epub', '/d/cover.jpg'],
+        ),
+        isA<ImportEpubPlan>(),
+      );
+    });
+
+    test('有声书:EPUB+字幕+音频齐 → 对齐计划;音频排序稳定', () {
+      final AlignAudiobookPlan plan = classifyDiscoveryDirectory(
+        DiscoveryMediaKind.audiobook,
+        <String>['/d/02.mp3', '/d/book.epub', '/d/book.srt', '/d/01.mp3'],
+      ) as AlignAudiobookPlan;
+      expect(plan.contentPath, '/d/book.epub');
+      expect(plan.subtitlePath, '/d/book.srt');
+      expect(plan.audioPaths, <String>['/d/01.mp3', '/d/02.mp3']);
+    });
+
+    test('有声书:无 EPUB 退纯文本当正文', () {
+      final AlignAudiobookPlan plan = classifyDiscoveryDirectory(
+        DiscoveryMediaKind.audiobook,
+        <String>['/d/a.mp3', '/d/book.txt', '/d/book.lrc'],
+      ) as AlignAudiobookPlan;
+      expect(plan.contentPath, '/d/book.txt');
+    });
+
+    test('有声书三缺一时给出稳定原因码', () {
+      expect(
+        (classifyDiscoveryDirectory(
+          DiscoveryMediaKind.audiobook,
+          <String>['/d/book.epub', '/d/book.srt'],
+        ) as UnsupportedPlan)
+            .blocker,
+        DiscoveryImportBlocker.audiobookMissingAudio,
+      );
+      expect(
+        (classifyDiscoveryDirectory(
+          DiscoveryMediaKind.audiobook,
+          <String>['/d/book.epub', '/d/a.mp3'],
+        ) as UnsupportedPlan)
+            .blocker,
+        DiscoveryImportBlocker.audiobookMissingSubtitle,
+      );
+      expect(
+        (classifyDiscoveryDirectory(
+          DiscoveryMediaKind.audiobook,
+          <String>['/d/book.srt', '/d/a.mp3'],
+        ) as UnsupportedPlan)
+            .blocker,
+        DiscoveryImportBlocker.audiobookMissingText,
+      );
+    });
+
+    test('游戏:无 exe → gameNoExecutable', () {
+      expect(
+        (classifyDiscoveryDirectory(
+          DiscoveryMediaKind.game,
+          <String>['/d/readme.txt'],
+        ) as UnsupportedPlan)
+            .blocker,
+        DiscoveryImportBlocker.gameNoExecutable,
+      );
+    });
+  });
+
+  group('pickGalgameMainExe', () {
+    test('剔除安装器/运行库,层级浅者优先,同层取最大', () {
+      final String? picked = pickGalgameMainExe(
+        <String>[
+          '/g/unins000.exe',
+          '/g/tools/config.exe',
+          '/g/game.exe',
+          '/g/launcher.exe',
+          '/g/sub/deep.exe',
+        ],
+        fileSizes: <String, int>{
+          '/g/game.exe': 100,
+          '/g/launcher.exe': 5000,
+        },
+      );
+      expect(picked, '/g/launcher.exe', reason: '同层按体积;deep.exe 层级更深被排除');
+    });
+
+    test('全是辅助名时退回全量再挑(配置器命名的本体不漏)', () {
+      expect(
+        pickGalgameMainExe(<String>['/g/setup.exe']),
+        '/g/setup.exe',
+      );
+    });
+
+    test('无 exe 返回 null', () {
+      expect(pickGalgameMainExe(<String>['/g/a.txt']), isNull);
+    });
+  });
+
+  group('sanitizeArchiveEntryPath', () {
+    test('拒绝 zip-slip 与绝对路径', () {
+      expect(sanitizeArchiveEntryPath('../evil.txt'), isNull);
+      expect(sanitizeArchiveEntryPath('a/../../evil.txt'), isNull);
+      expect(sanitizeArchiveEntryPath('/abs/path.txt'), isNull);
+      expect(sanitizeArchiveEntryPath(r'C:\abs\path.txt'), isNull);
+    });
+
+    test('正常条目归一分隔符', () {
+      expect(
+        sanitizeArchiveEntryPath('a/b/c.txt'),
+        'a${_sep}b${_sep}c.txt',
+      );
+      expect(sanitizeArchiveEntryPath(r'a\b.txt'), 'a${_sep}b.txt');
+      expect(sanitizeArchiveEntryPath('./a/./b.txt'), 'a${_sep}b.txt');
+    });
+  });
+}
+
+final String _sep = Platform.pathSeparator;

--- a/fushi/test/media/discovery/media_discovery_service_test.dart
+++ b/fushi/test/media/discovery/media_discovery_service_test.dart
@@ -1,0 +1,327 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/media_discovery_service.dart';
+import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+
+typedef _Loader = Future<ProviderBatchResult<DiscoveryResultPage>> Function(
+  DiscoveryRequest request,
+);
+
+class _FakeSource extends MediaDiscoverySource {
+  _FakeSource({
+    required this.id,
+    required this.priority,
+    required DiscoveryCapabilities capabilities,
+    _Loader? onSearch,
+    _Loader? onBrowse,
+  })  : _capabilities = capabilities,
+        _onSearch = onSearch,
+        _onBrowse = onBrowse;
+
+  @override
+  final String id;
+
+  @override
+  String get displayName => id;
+
+  @override
+  final int priority;
+
+  final DiscoveryCapabilities _capabilities;
+  final _Loader? _onSearch;
+  final _Loader? _onBrowse;
+
+  int searchCalls = 0;
+  int browseCalls = 0;
+  bool closed = false;
+
+  @override
+  DiscoveryCapabilities get capabilities => _capabilities;
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> search(
+    DiscoveryRequest request,
+  ) {
+    searchCalls++;
+    return _onSearch!(request);
+  }
+
+  @override
+  Future<ProviderBatchResult<DiscoveryResultPage>> browse(
+    DiscoveryRequest request,
+  ) {
+    browseCalls++;
+    final _Loader? onBrowse = _onBrowse;
+    if (onBrowse == null) return super.browse(request);
+    return onBrowse(request);
+  }
+
+  @override
+  void close() => closed = true;
+}
+
+ProviderBatchResult<DiscoveryResultPage> _pageOf(
+  String sourceId,
+  List<String> titles, {
+  bool hasMore = false,
+}) {
+  return ProviderBatchResult<DiscoveryResultPage>.success(
+    <DiscoveryResultPage>[
+      DiscoveryResultPage(
+        entries: <DiscoveryEntry>[
+          for (final String title in titles)
+            DiscoveryResourceItem(
+              sourceId: sourceId,
+              title: title,
+              id: title,
+              kind: DiscoveryMediaKind.novel,
+              payloadKind: DiscoveryPayloadKind.httpFile,
+            ),
+        ],
+        page: 1,
+        hasMore: hasMore,
+      ),
+    ],
+  );
+}
+
+void main() {
+  final DiscoveryCapabilities novelSearch = DiscoveryCapabilities(
+    kinds: <DiscoveryMediaKind>{DiscoveryMediaKind.novel},
+  );
+
+  test('sourcesFor 按媒体域过滤并按 priority 排序', () {
+    final _FakeSource a = _FakeSource(
+      id: 'a',
+      priority: 20,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('a', <String>[]),
+    );
+    final _FakeSource b = _FakeSource(
+      id: 'b',
+      priority: 10,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('b', <String>[]),
+    );
+    final _FakeSource g = _FakeSource(
+      id: 'g',
+      priority: 1,
+      capabilities: DiscoveryCapabilities(
+        kinds: <DiscoveryMediaKind>{DiscoveryMediaKind.game},
+      ),
+      onSearch: (DiscoveryRequest _) async => _pageOf('g', <String>[]),
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[a, b, g],
+    );
+
+    expect(
+      service
+          .sourcesFor(DiscoveryMediaKind.novel)
+          .map((MediaDiscoverySource s) => s.id),
+      <String>['b', 'a'],
+    );
+    expect(
+      service
+          .sourcesFor(DiscoveryMediaKind.game)
+          .map((MediaDiscoverySource s) => s.id),
+      <String>['g'],
+    );
+  });
+
+  test('聚合搜索只扇出到支持该域且支持搜索的源，分片按 priority 顺序', () async {
+    final _FakeSource a = _FakeSource(
+      id: 'a',
+      priority: 2,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('a', <String>['a1']),
+    );
+    final _FakeSource b = _FakeSource(
+      id: 'b',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('b', <String>['b1']),
+    );
+    final _FakeSource noSearch = _FakeSource(
+      id: 'browse-only',
+      priority: 0,
+      capabilities: DiscoveryCapabilities(
+        kinds: <DiscoveryMediaKind>{DiscoveryMediaKind.novel},
+        supportsSearch: false,
+        supportsBrowse: true,
+      ),
+      onSearch: (DiscoveryRequest _) async => _pageOf('x', <String>[]),
+    );
+    final _FakeSource game = _FakeSource(
+      id: 'game',
+      priority: 0,
+      capabilities: DiscoveryCapabilities(
+        kinds: <DiscoveryMediaKind>{DiscoveryMediaKind.game},
+      ),
+      onSearch: (DiscoveryRequest _) async => _pageOf('game', <String>[]),
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[a, b, noSearch, game],
+    );
+
+    final DiscoveryAggregateResult result = await service.load(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'q'),
+    );
+
+    expect(
+      result.slices.map((DiscoverySourceSlice s) => s.sourceId),
+      <String>['b', 'a'],
+    );
+    expect(
+      result.entries.map((DiscoveryEntry e) => e.title),
+      <String>['b1', 'a1'],
+    );
+    expect(result.successfulSourceCount, 2);
+    expect(result.hasFailures, isFalse);
+    expect(noSearch.searchCalls, 0);
+    expect(game.searchCalls, 0);
+  });
+
+  test('单源抛异常收敛为脱敏失败，不拖垮整页（部分成功）', () async {
+    final _FakeSource ok = _FakeSource(
+      id: 'ok',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('ok', <String>['x']),
+    );
+    final _FakeSource broken = _FakeSource(
+      id: 'broken',
+      priority: 2,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async =>
+          throw const SocketException('boom'),
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[ok, broken],
+    );
+
+    final DiscoveryAggregateResult result = await service.load(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'q'),
+    );
+
+    expect(result.isPartial, isTrue);
+    expect(result.isTotalFailure, isFalse);
+    expect(result.failures.single.providerId, 'broken');
+    expect(result.slices.single.sourceId, 'ok');
+  });
+
+  test('指定 sourceId 只调该源；未知 sourceId 抛 ArgumentError', () async {
+    final _FakeSource a = _FakeSource(
+      id: 'a',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('a', <String>['a1']),
+    );
+    final _FakeSource b = _FakeSource(
+      id: 'b',
+      priority: 2,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('b', <String>['b1']),
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[a, b],
+    );
+
+    final DiscoveryAggregateResult result = await service.load(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'q'),
+      sourceId: 'b',
+    );
+    expect(result.slices.single.sourceId, 'b');
+    expect(a.searchCalls, 0);
+
+    expect(
+      () => service.load(
+        const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'q'),
+        sourceId: 'nope',
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('深层目录浏览必须指定 sourceId', () async {
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[],
+    );
+    expect(
+      () => service.load(
+        const DiscoveryRequest(kind: DiscoveryMediaKind.game, path: '/sub'),
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('browse 默认实现返回 unsupported 失败', () async {
+    final _FakeSource searchOnly = _FakeSource(
+      id: 'search-only',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('s', <String>[]),
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[searchOnly],
+    );
+
+    final DiscoveryAggregateResult result = await service.load(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel),
+      sourceId: 'search-only',
+    );
+
+    expect(result.isTotalFailure, isTrue);
+    expect(
+      result.failures.single.kind,
+      ExternalProviderFailureKind.unsupported,
+    );
+  });
+
+  test('resolvePayload 默认返回条目自带 payload；无 payload 抛脱敏失败', () async {
+    final _FakeSource source = _FakeSource(
+      id: 's',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('s', <String>[]),
+    );
+    const DiscoveryHttpPayload payload =
+        DiscoveryHttpPayload(url: 'https://example.com/f.epub');
+    const DiscoveryResourceItem withPayload = DiscoveryResourceItem(
+      sourceId: 's',
+      title: 't',
+      id: '1',
+      kind: DiscoveryMediaKind.novel,
+      payloadKind: DiscoveryPayloadKind.httpFile,
+      payload: payload,
+    );
+    const DiscoveryResourceItem withoutPayload = DiscoveryResourceItem(
+      sourceId: 's',
+      title: 't',
+      id: '2',
+      kind: DiscoveryMediaKind.novel,
+      payloadKind: DiscoveryPayloadKind.httpFile,
+    );
+
+    expect(await source.resolvePayload(withPayload), same(payload));
+    expect(
+      () => source.resolvePayload(withoutPayload),
+      throwsA(isA<ExternalProviderFailure>()),
+    );
+  });
+
+  test('close 逐源下发', () {
+    final _FakeSource a = _FakeSource(
+      id: 'a',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('a', <String>[]),
+    );
+    MediaDiscoveryService(sources: <MediaDiscoverySource>[a]).close();
+    expect(a.closed, isTrue);
+  });
+}

--- a/fushi/test/media/discovery/media_discovery_service_test.dart
+++ b/fushi/test/media/discovery/media_discovery_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -311,6 +312,49 @@ void main() {
     expect(
       () => source.resolvePayload(withoutPayload),
       throwsA(isA<ExternalProviderFailure>()),
+    );
+  });
+
+  test('渐进交付：快源先上屏不等慢源，分片顺序恒按 priority', () async {
+    final Completer<void> slowGate = Completer<void>();
+    final _FakeSource fast = _FakeSource(
+      id: 'fast',
+      priority: 2,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async => _pageOf('fast', <String>['f1']),
+    );
+    final _FakeSource slow = _FakeSource(
+      id: 'slow',
+      priority: 1,
+      capabilities: novelSearch,
+      onSearch: (DiscoveryRequest _) async {
+        await slowGate.future;
+        return _pageOf('slow', <String>['s1']);
+      },
+    );
+    final MediaDiscoveryService service = MediaDiscoveryService(
+      sources: <MediaDiscoverySource>[fast, slow],
+    );
+
+    final List<List<String>> snapshots = <List<String>>[];
+    final Future<DiscoveryAggregateResult> pending = service.load(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'q'),
+      onUpdate: (DiscoveryAggregateResult partial) => snapshots.add(
+        partial.slices.map((DiscoverySourceSlice s) => s.sourceId).toList(),
+      ),
+    );
+    // 快源完成后就该有一次只含 fast 的快照——不等慢源。
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.first, <String>['fast']);
+
+    slowGate.complete();
+    final DiscoveryAggregateResult result = await pending;
+    // 最终快照与返回值都按 priority 序（slow priority 1 在前），
+    // 与完成顺序无关。
+    expect(snapshots.last, <String>['slow', 'fast']);
+    expect(
+      result.slices.map((DiscoverySourceSlice s) => s.sourceId),
+      <String>['slow', 'fast'],
     );
   });
 

--- a/fushi/test/media/discovery/sources/alist_discovery_source_test.dart
+++ b/fushi/test/media/discovery/sources/alist_discovery_source_test.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/sources/alist_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+
+http.Response _json(Map<String, dynamic> envelope) => http.Response.bytes(
+      utf8.encode(jsonEncode(envelope)),
+      200,
+      headers: <String, String>{'content-type': 'application/json'},
+    );
+
+AListDiscoverySource _source(MockClient client) => AListDiscoverySource(
+      id: 'alist-test',
+      displayName: 'Test AList',
+      baseUrl: 'https://alist.example.com/',
+      kinds: const <DiscoveryMediaKind>[DiscoveryMediaKind.game],
+      client: client,
+    );
+
+void main() {
+  test('browse:目录/文件分形,分页由 total 决定,文件 payload 留待 resolve', () async {
+    Map<String, dynamic>? capturedBody;
+    final AListDiscoverySource source = _source(
+      MockClient((http.Request request) async {
+        expect(request.url.path, '/api/fs/list');
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return _json(<String, dynamic>{
+          'code': 200,
+          'message': 'success',
+          'data': <String, dynamic>{
+            'content': <Map<String, dynamic>>[
+              <String, dynamic>{'name': '年份合集', 'is_dir': true, 'size': 0},
+              <String, dynamic>{
+                'name': 'game.rar',
+                'is_dir': false,
+                'size': 12345,
+                'modified': '2025-11-19T06:23:16.457Z',
+              },
+            ],
+            'total': 5,
+            'provider': 'Alias',
+          },
+        });
+      }),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.browse(
+      const DiscoveryRequest(
+        kind: DiscoveryMediaKind.game,
+        path: '/其他',
+        pageSize: 2,
+      ),
+    );
+
+    expect(capturedBody!['path'], '/其他');
+    expect(capturedBody!['per_page'], 2);
+
+    final DiscoveryResultPage page = result.items.single;
+    expect(page.hasMore, isTrue, reason: 'total 5 > page1*2');
+    final DiscoveryFolder folder = page.entries[0] as DiscoveryFolder;
+    expect(folder.path, '/其他/年份合集');
+    final DiscoveryResourceItem file = page.entries[1] as DiscoveryResourceItem;
+    expect(file.id, '/其他/game.rar');
+    expect(file.payload, isNull, reason: '直链临期,下载时才 resolve');
+    expect(file.payloadKind, DiscoveryPayloadKind.httpFile);
+    expect(file.sizeBytes, 12345);
+    expect(file.dateText, '2025-11-19');
+  });
+
+  test('search:条目路径来自 parent+name', () async {
+    final AListDiscoverySource source = _source(
+      MockClient((http.Request request) async {
+        expect(request.url.path, '/api/fs/search');
+        return _json(<String, dynamic>{
+          'code': 200,
+          'message': 'success',
+          'data': <String, dynamic>{
+            'content': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'parent': '/guest/其他',
+                'name': 'ATRI.rar',
+                'is_dir': false,
+                'size': 1,
+              },
+            ],
+            'total': 1,
+          },
+        });
+      }),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.game, query: 'ATRI'),
+    );
+    final DiscoveryResourceItem item =
+        result.items.single.entries.single as DiscoveryResourceItem;
+    expect(item.id, '/guest/其他/ATRI.rar');
+    expect(result.items.single.hasMore, isFalse);
+  });
+
+  test('resolvePayload 走 fs/get 取 raw_url', () async {
+    final AListDiscoverySource source = _source(
+      MockClient((http.Request request) async {
+        expect(request.url.path, '/api/fs/get');
+        expect(
+          (jsonDecode(request.body) as Map<String, dynamic>)['path'],
+          '/其他/game.rar',
+        );
+        return _json(<String, dynamic>{
+          'code': 200,
+          'message': 'success',
+          'data': <String, dynamic>{
+            'name': 'game.rar',
+            'size': 999,
+            'raw_url': 'https://cdn.example.com/game.rar?sign=abc',
+          },
+        });
+      }),
+    );
+
+    final DiscoveryPayload payload = await source.resolvePayload(
+      const DiscoveryResourceItem(
+        sourceId: 'alist-test',
+        title: 'game.rar',
+        id: '/其他/game.rar',
+        kind: DiscoveryMediaKind.game,
+        payloadKind: DiscoveryPayloadKind.httpFile,
+      ),
+    );
+    final DiscoveryHttpPayload http0 = payload as DiscoveryHttpPayload;
+    expect(http0.url, 'https://cdn.example.com/game.rar?sign=abc');
+    expect(http0.fileName, 'game.rar');
+    expect(http0.sizeBytes, 999);
+  });
+
+  test('信封 code 非 200 抛脱敏失败', () async {
+    final AListDiscoverySource source = _source(
+      MockClient(
+        (http.Request request) async => _json(<String, dynamic>{
+          'code': 500,
+          'message': 'failed to get obj: object not found',
+          'data': null,
+        }),
+      ),
+    );
+
+    expect(
+      () => source.browse(
+        const DiscoveryRequest(kind: DiscoveryMediaKind.game, path: '/x'),
+      ),
+      throwsA(
+        isA<ExternalProviderFailure>().having(
+          (ExternalProviderFailure f) => f.kind,
+          'kind',
+          ExternalProviderFailureKind.invalidResponse,
+        ),
+      ),
+    );
+  });
+}

--- a/fushi/test/media/discovery/sources/nyaa_discovery_source_test.dart
+++ b/fushi/test/media/discovery/sources/nyaa_discovery_source_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/sources/nyaa_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/nyaa_client.dart';
+
+const String _rss = '''
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
+  <channel>
+    <title>Nyaa - "q" - Torrent File RSS</title>
+    <description>RSS Feed</description>
+    <link>https://nyaa.si/</link>
+    <item>
+      <title>Some Light Novel Vol.1-3 EPUB</title>
+      <link>https://nyaa.si/download/42.torrent</link>
+      <guid isPermaLink="true">https://nyaa.si/view/42</guid>
+      <pubDate>Fri, 03 Nov 2023 12:30:00 -0000</pubDate>
+      <nyaa:seeders>7</nyaa:seeders>
+      <nyaa:leechers>1</nyaa:leechers>
+      <nyaa:downloads>99</nyaa:downloads>
+      <nyaa:infoHash>0123456789abcdef0123456789abcdef01234567</nyaa:infoHash>
+      <nyaa:categoryId>3_1</nyaa:categoryId>
+      <nyaa:size>12.0 MiB</nyaa:size>
+      <nyaa:trusted>Yes</nyaa:trusted>
+      <nyaa:remake>No</nyaa:remake>
+    </item>
+  </channel>
+</rss>
+''';
+
+void main() {
+  test('搜索映射:分类按媒体域取,条目产 torrent payload', () async {
+    Uri? captured;
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+        DiscoveryMediaKind.audiobook: '2_0',
+      },
+      client: NyaaClient(
+        client: MockClient((http.Request request) async {
+          captured = request.url;
+          return http.Response.bytes(
+            utf8.encode(_rss),
+            200,
+            headers: <String, String>{
+              'content-type': 'application/rss+xml; charset=utf-8',
+            },
+          );
+        }),
+      ),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'novel'),
+    );
+
+    expect(captured!.queryParameters['c'], '3_0');
+    expect(captured!.queryParameters['q'], 'novel');
+    expect(captured!.queryParameters['page'], 'rss');
+
+    final DiscoveryResultPage page = result.items.single;
+    expect(page.hasMore, isTrue, reason: '非空页允许翻页');
+    final DiscoveryResourceItem item =
+        page.entries.single as DiscoveryResourceItem;
+    expect(item.sourceId, 'nyaa');
+    expect(item.id, 'https://nyaa.si/view/42');
+    expect(item.detailUrl, 'https://nyaa.si/view/42');
+    expect(item.payloadKind, DiscoveryPayloadKind.torrent);
+    final DiscoveryTorrentPayload payload =
+        item.payload! as DiscoveryTorrentPayload;
+    expect(
+      payload.magnetUri,
+      contains('xt=urn:btih:0123456789abcdef0123456789abcdef01234567'),
+    );
+    expect(item.seeders, 7);
+    expect(item.leechers, 1);
+    expect(item.sizeBytes, 12 * 1024 * 1024);
+    expect(item.note, 'trusted');
+  });
+
+  test('capabilities 只声明映射过的媒体域;未映射域搜索返回 unsupported', () async {
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+      },
+      client: NyaaClient(
+        client: MockClient(
+          (http.Request request) async => http.Response('', 500),
+        ),
+      ),
+    );
+
+    expect(
+      source.capabilities.kinds,
+      const <DiscoveryMediaKind>{DiscoveryMediaKind.novel},
+    );
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.game, query: 'x'),
+    );
+    expect(result.isTotalFailure, isTrue);
+    expect(
+      result.failures.single.kind,
+      ExternalProviderFailureKind.unsupported,
+    );
+  });
+
+  test('trustedOnly 透传 f=2', () async {
+    Uri? captured;
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      trustedOnly: true,
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+      },
+      client: NyaaClient(
+        client: MockClient((http.Request request) async {
+          captured = request.url;
+          return http.Response.bytes(utf8.encode(_rss), 200);
+        }),
+      ),
+    );
+    await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'x'),
+    );
+    expect(captured!.queryParameters['f'], '2');
+  });
+}

--- a/fushi/test/media/discovery/sources/shinnku_discovery_source_test.dart
+++ b/fushi/test/media/discovery/sources/shinnku_discovery_source_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/sources/shinnku_discovery_source.dart';
+import 'package:fushi/src/media/external_provider.dart';
+
+/// 仿真 RSC 流片段（行前有序号,answer 数组内嵌其中）。
+const String _rscBody = '''
+1:"\$Sreact.fragment"
+2:I[28237,["/_next/static/chunks/x.js"],""]
+7:{"initialSearchTerm":"ATRI"}
+a:{"answer":[{"id":"0/win/ATRI -My Dear Moments- v1.3.7z","info":{"file_path":"0/win/ATRI -My Dear Moments- v1.3.7z","upload_timestamp":1714176370808,"file_size":3781414904}},{"id":"合集id","info":{"file_path":"合集系列/浮士德galgame游戏合集/5/2020年6月/[200619] ATRI steam edition (files).rar","upload_timestamp":1714207573092,"file_size":945105047}},{"id":"0/apk/ATRI[han].apk","info":{"file_path":"0/apk/ATRI[han].apk","upload_timestamp":1714207573092,"file_size":1000}}]}
+b:{"other":true}
+''';
+
+void main() {
+  test('RSC 载荷解析 + 直链推导 + 类型标注', () async {
+    Uri? captured;
+    Map<String, String>? capturedHeaders;
+    final ShinnkuDiscoverySource source = ShinnkuDiscoverySource(
+      client: MockClient((http.Request request) async {
+        captured = request.url;
+        capturedHeaders = request.headers;
+        return http.Response.bytes(utf8.encode(_rscBody), 200);
+      }),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.game, query: 'ATRI'),
+    );
+
+    expect(captured!.path, '/search');
+    expect(captured!.queryParameters['q'], 'ATRI');
+    expect(capturedHeaders!['RSC'], '1');
+
+    final List<DiscoveryEntry> entries = result.items.single.entries;
+    expect(entries, hasLength(3));
+
+    final DiscoveryResourceItem win = entries[0] as DiscoveryResourceItem;
+    expect(win.title, 'ATRI -My Dear Moments- v1.3.7z');
+    expect(win.note, '熟肉');
+    expect(win.sizeBytes, 3781414904);
+    final DiscoveryHttpPayload winPayload =
+        win.payload! as DiscoveryHttpPayload;
+    expect(
+      winPayload.url,
+      'https://zd.shinnku.top/file/shinnku/0/'
+      'win/ATRI%20-My%20Dear%20Moments-%20v1.3.7z',
+    );
+
+    final DiscoveryResourceItem collection =
+        entries[1] as DiscoveryResourceItem;
+    expect(collection.note, '生肉');
+    final DiscoveryHttpPayload collectionPayload =
+        collection.payload! as DiscoveryHttpPayload;
+    expect(
+      collectionPayload.url,
+      startsWith('https://galgamedownload.date/%60%E3%80%90'),
+      reason: '合集走 B2 桶且首段带反引号前缀(%60)',
+    );
+    expect(collectionPayload.url, isNot(contains('合集系列')));
+
+    final DiscoveryResourceItem apk = entries[2] as DiscoveryResourceItem;
+    expect(apk.note, '手机');
+    expect(apk.detailUrl, contains('/files/0/apk/'));
+  });
+
+  test('第 2 页起空页收尾,不打网络', () async {
+    int calls = 0;
+    final ShinnkuDiscoverySource source = ShinnkuDiscoverySource(
+      client: MockClient((http.Request request) async {
+        calls++;
+        return http.Response('', 500);
+      }),
+    );
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(
+        kind: DiscoveryMediaKind.game,
+        query: 'x',
+        page: 2,
+      ),
+    );
+    expect(calls, 0);
+    expect(result.items.single.entries, isEmpty);
+    expect(result.items.single.hasMore, isFalse);
+  });
+
+  test('载荷里没有 answer 数组按 invalidResponse 失败(站点改版探测器)', () async {
+    final ShinnkuDiscoverySource source = ShinnkuDiscoverySource(
+      client: MockClient(
+        (http.Request request) async =>
+            http.Response.bytes(utf8.encode('1:"nothing here"'), 200),
+      ),
+    );
+    expect(
+      () => source.search(
+        const DiscoveryRequest(kind: DiscoveryMediaKind.game, query: 'x'),
+      ),
+      throwsA(
+        isA<ExternalProviderFailure>().having(
+          (ExternalProviderFailure f) => f.kind,
+          'kind',
+          ExternalProviderFailureKind.invalidResponse,
+        ),
+      ),
+    );
+  });
+
+  group('extractShinnkuAnswer', () {
+    test('字符串内的括号与转义不破坏配平', () {
+      const String body =
+          r'x:{"answer":[{"id":"a[1]\"b","info":{"file_path":"p/[x] y.7z"}}]}';
+      final List<dynamic>? answer = extractShinnkuAnswer(body);
+      expect(answer, hasLength(1));
+      expect(
+        ((answer![0] as Map<String, dynamic>)['info']
+            as Map<String, dynamic>)['file_path'],
+        'p/[x] y.7z',
+      );
+    });
+
+    test('第一个 marker 是坏 JSON 时继续找下一个', () {
+      const String body =
+          '{"answer": "not-array"} {"answer":[{"id":"ok","info":{"file_path":"a/b"}}]}';
+      final List<dynamic>? answer = extractShinnkuAnswer(body);
+      expect(answer, hasLength(1));
+    });
+
+    test('无 marker 返回 null', () {
+      expect(extractShinnkuAnswer('nothing'), isNull);
+    });
+  });
+
+  group('shinnkuDownloadUrl / shinnkuGameTypeNote', () {
+    test('zd 前缀熟肉走 zd.shinnku.top', () {
+      expect(
+        shinnkuDownloadUrl('zd/1501-2000/x.rar'),
+        'https://zd.shinnku.top/file/shinnku/zd/1501-2000/x.rar',
+      );
+      expect(shinnkuGameTypeNote('zd/1501-2000/x.rar'), '熟肉');
+    });
+
+    test('合集系列剥首段换 B2 桶前缀', () {
+      final String url = shinnkuDownloadUrl('合集系列/子目录/y.rar');
+      expect(url, startsWith('https://galgamedownload.date/'));
+      expect(url, contains('%60')); // 反引号前缀
+      expect(url, contains(Uri.encodeComponent('子目录')));
+      expect(shinnkuGameTypeNote('合集系列/子目录/y.rar'), '生肉');
+    });
+
+    test('其余按手机标注', () {
+      expect(shinnkuGameTypeNote('0/krkr/z.7z'), '手机');
+    });
+  });
+}

--- a/fushi/test/media/manga/manga_global_search_runner_test.dart
+++ b/fushi/test/media/manga/manga_global_search_runner_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
+import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
+import 'package:fushi/src/media/manga/manga_global_search_runner.dart';
+
+AidokuInstalledPackage _package(String id, String name) =>
+    AidokuInstalledPackage(
+      id: id,
+      name: name,
+      version: 1,
+      languages: const <String>['en'],
+      requiresWebView: false,
+      packagePath: '/$id.aix',
+      installedAt: DateTime.utc(2026),
+    );
+
+class _FakeRuntime extends Fake implements AidokuRuntime {
+  final List<String> searchQueries = <String>[];
+
+  @override
+  Future<Map<String, Object?>> search(
+    String packagePath, {
+    String? query,
+    int page = 1,
+  }) async {
+    searchQueries.add(query ?? '');
+    if (packagePath.contains('blocked')) {
+      throw const AidokuRuntimeException(
+        'CLOUDFLARE_CHALLENGE',
+        'Cloudflare challenge blocked this source',
+      );
+    }
+    if (packagePath.contains('empty')) {
+      return <String, Object?>{'entries': <Object?>[]};
+    }
+    return <String, Object?>{
+      'entries': <Object?>[
+        <String, Object?>{'key': '/one-piece/', 'title': 'One Piece'},
+      ],
+    };
+  }
+}
+
+void main() {
+  test('逐源扇出：成功/空/CF 各落各的状态，每源完成回调一次', () async {
+    final _FakeRuntime runtime = _FakeRuntime();
+    final List<MangaSourceSearchRun> runs = <MangaSourceSearchRun>[
+      MangaSourceSearchRun(AidokuGlobalSource(_package('en.good', 'Good'))),
+      MangaSourceSearchRun(AidokuGlobalSource(_package('en.empty', 'Empty'))),
+      MangaSourceSearchRun(
+        AidokuGlobalSource(_package('en.blocked', 'Blocked')),
+      ),
+    ];
+    int updates = 0;
+    await MangaGlobalSearchRunner(
+      mihonManager: null,
+      resolveAidokuRuntime: () => runtime,
+    ).search(
+      runs: runs,
+      query: 'one piece',
+      isCancelled: () => false,
+      onRunUpdated: () => updates++,
+    );
+
+    expect(runs[0].status, MangaSearchRunStatus.done);
+    expect(runs[0].aidokuItems.single['title'], 'One Piece');
+    expect(runs[1].status, MangaSearchRunStatus.empty);
+    expect(runs[2].status, MangaSearchRunStatus.cloudflare);
+    expect(updates, 3);
+    expect(runtime.searchQueries, hasLength(3));
+  });
+
+  test('取消后不再改写运行态也不再回调', () async {
+    final _FakeRuntime runtime = _FakeRuntime();
+    final List<MangaSourceSearchRun> runs = <MangaSourceSearchRun>[
+      MangaSourceSearchRun(AidokuGlobalSource(_package('en.good', 'Good'))),
+    ];
+    int updates = 0;
+    await MangaGlobalSearchRunner(
+      mihonManager: null,
+      resolveAidokuRuntime: () => runtime,
+    ).search(
+      runs: runs,
+      query: 'q',
+      isCancelled: () => true,
+      onRunUpdated: () => updates++,
+    );
+
+    expect(runs.single.status, MangaSearchRunStatus.loading);
+    expect(updates, 0);
+  });
+
+  test('Aidoku 运行时不可用按普通错误落 error（不是 CF）', () async {
+    final List<MangaSourceSearchRun> runs = <MangaSourceSearchRun>[
+      MangaSourceSearchRun(AidokuGlobalSource(_package('en.good', 'Good'))),
+    ];
+    await MangaGlobalSearchRunner(
+      mihonManager: null,
+      resolveAidokuRuntime: () => null,
+    ).search(
+      runs: runs,
+      query: 'q',
+      isCancelled: () => false,
+      onRunUpdated: () {},
+    );
+    expect(runs.single.status, MangaSearchRunStatus.error);
+  });
+
+  test('isCloudflareError：结构化错误码与文案兜底', () {
+    expect(
+      MangaGlobalSearchRunner.isCloudflareError(
+        const AidokuRuntimeException('CLOUDFLARE_CHALLENGE', 'x'),
+      ),
+      isTrue,
+    );
+    expect(
+      MangaGlobalSearchRunner.isCloudflareError(
+        Exception('blocked by Cloudflare'),
+      ),
+      isTrue,
+    );
+    expect(
+      MangaGlobalSearchRunner.isCloudflareError(Exception('timeout')),
+      isFalse,
+    );
+  });
+}

--- a/fushi/test/pages/home_game_page_test.dart
+++ b/fushi/test/pages/home_game_page_test.dart
@@ -163,6 +163,17 @@ void main() {
     );
 
     final FocusDriver driver = FocusDriver(tester);
+    // 库后一位是「发现」（与书/漫画库页「浏览紧跟书架」同构）。
+    await driver.adjust(steps: 1);
+    expect(find.byKey(HomeGamePage.discoverKey), findsOneWidget);
+    expect(
+      controller.requestById(
+        const FushiFocusId('game-discover-tab-sections'),
+      ),
+      isTrue,
+      reason: '切到发现页后，新的稳定分段 ID 必须可聚焦',
+    );
+    await tester.pump();
     await driver.adjust(steps: 1);
     expect(find.byKey(HomeGamePage.monitorKey), findsOneWidget);
 
@@ -225,6 +236,17 @@ void main() {
     expect(
       controller.requestById(
         const FushiFocusId('game-library-tab-sections'),
+      ),
+      isTrue,
+    );
+    await tester.pump();
+    // 库 → 发现 → 捕获（「发现」插在库后，见 GameSectionTabs 的顺序注释）。
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(find.byKey(HomeGamePage.discoverKey), findsOneWidget);
+    expect(
+      controller.requestById(
+        const FushiFocusId('game-discover-tab-sections'),
       ),
       isTrue,
     );

--- a/fushi/test/torrent/anime_download_service_discovery_kind_test.dart
+++ b/fushi/test/torrent/anime_download_service_discovery_kind_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/torrent/anime_download_config.dart';
+import 'package:fushi/src/media/torrent/anime_download_plan.dart';
+import 'package:fushi/src/media/torrent/anime_download_service.dart';
+import 'package:fushi/src/media/torrent/qb_torrent_backend.dart';
+import 'package:fushi/src/media/torrent/qbittorrent_client.dart';
+import 'package:fushi/src/media/torrent/torrent_backend.dart';
+
+const String _kHash = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const QbConnectionConfig _kConfig = QbConnectionConfig(
+  baseUrl: 'http://127.0.0.1:8080',
+  username: 'admin',
+  password: 'secret',
+);
+
+/// 最小 qb 假后端（形状同 anime_download_service_test.dart 的 _FakeQb）。
+class _FakeQb {
+  List<Map<String, dynamic>> torrents = <Map<String, dynamic>>[];
+  List<Map<String, dynamic>> files = <Map<String, dynamic>>[];
+
+  late final MockClient mock = MockClient((http.Request request) async {
+    final String path = request.url.path;
+    if (path == '/api/v2/auth/login') {
+      return http.Response(
+        'Ok.',
+        200,
+        headers: <String, String>{'set-cookie': 'SID=fake123; path=/'},
+      );
+    }
+    if (path == '/api/v2/torrents/info') {
+      return http.Response(jsonEncode(torrents), 200);
+    }
+    if (path == '/api/v2/torrents/files') {
+      return http.Response(jsonEncode(files), 200);
+    }
+    return http.Response('not found', 404);
+  });
+
+  TorrentBackend newBackend(QbConnectionConfig config) {
+    return QbTorrentBackend(
+      QBittorrentClient(
+        baseUrl: config.baseUrl,
+        username: config.username,
+        password: config.password,
+        client: mock,
+      ),
+    );
+  }
+}
+
+AnimeDownloadPlan _plan(String contentKind) {
+  return AnimeDownloadPlan(
+    id: _kHash,
+    createdAtMs: DateTime.now().millisecondsSinceEpoch,
+    seriesTitle: 'Pack',
+    torrentTitle: 'Pack Torrent',
+    magnet: 'magnet:?xt=urn:btih:$_kHash',
+    qbCategory: 'hibiki',
+    contentKind: contentKind,
+  );
+}
+
+Map<String, dynamic> _completedTorrent() => <String, dynamic>{
+      'hash': _kHash,
+      'name': 'torrent',
+      'progress': 1.0,
+      'state': 'stalledUP',
+      'save_path': '/dl',
+      'content_path': '/dl/Pack',
+      'amount_left': 0,
+    };
+
+void main() {
+  group('resolveAllAbsolutePaths', () {
+    test('全文件 join savePath，不按扩展名过滤', () {
+      const TorrentSnapshot info = TorrentSnapshot(
+        hash: _kHash,
+        name: 'torrent',
+        progress: 1,
+        state: 'stalledUP',
+        savePath: '/dl',
+        contentPath: '/dl/Pack',
+        amountLeft: 0,
+      );
+      final List<String> all =
+          resolveAllAbsolutePaths(info, const <TorrentFileEntry>[
+        TorrentFileEntry(name: 'Pack/game.exe', size: 1, progress: 1, index: 0),
+        TorrentFileEntry(name: 'Pack/data.xp3', size: 1, progress: 1, index: 1),
+      ]);
+      expect(all, <String>[
+        p.join('/dl', 'Pack/game.exe'),
+        p.join('/dl', 'Pack/data.xp3'),
+      ]);
+    });
+
+    test('files 为空退化用 contentPath', () {
+      const TorrentSnapshot info = TorrentSnapshot(
+        hash: _kHash,
+        name: 'torrent',
+        progress: 1,
+        state: 'stalledUP',
+        savePath: '/dl',
+        contentPath: '/dl/single.rar',
+        amountLeft: 0,
+      );
+      expect(
+        resolveAllAbsolutePaths(info, const <TorrentFileEntry>[]),
+        <String>['/dl/single.rar'],
+      );
+    });
+  });
+
+  group('发现页内容类型（audiobook/game）的收尾', () {
+    late Directory tempDir;
+    late AnimeDownloadPlanStore store;
+    late _FakeQb qb;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('anime_dl_discovery_test');
+      store = AnimeDownloadPlanStore(
+        baseDir: Directory(p.join(tempDir.path, 'anime_downloads')),
+      );
+      qb = _FakeQb();
+    });
+
+    tearDown(() {
+      try {
+        tempDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    AnimeDownloadService buildService({
+      Future<int?> Function(AnimeDownloadPlan, List<String>)? discoveryImporter,
+    }) {
+      return AnimeDownloadService(
+        store: store,
+        configProvider: () => _kConfig,
+        importer: (AnimeDownloadPlan plan, List<String> videos) async {
+          fail('video importer must not run for discovery kinds');
+        },
+        bookImporter: (AnimeDownloadPlan plan, List<String> books) async {
+          fail('book importer must not run for discovery kinds');
+        },
+        discoveryImporter: discoveryImporter,
+        backendFactory: qb.newBackend,
+      );
+    }
+
+    Future<AnimeDownloadPlan> singlePlan() async =>
+        (await store.loadAll()).single;
+
+    test('kindGame 完成 → 整包路径交给 discoveryImporter → imported', () async {
+      await store.save(_plan(AnimeDownloadPlan.kindGame));
+      qb.torrents = <Map<String, dynamic>>[_completedTorrent()];
+      qb.files = <Map<String, dynamic>>[
+        <String, dynamic>{'name': 'Pack/game.exe', 'size': 10, 'progress': 1.0},
+        <String, dynamic>{'name': 'Pack/data.xp3', 'size': 99, 'progress': 1.0},
+      ];
+      final List<(String, List<String>)> calls = <(String, List<String>)>[];
+      await buildService(
+        discoveryImporter: (AnimeDownloadPlan plan, List<String> paths) async {
+          calls.add((plan.contentKind, paths));
+          return 1;
+        },
+      ).tick();
+
+      expect(calls.single.$1, AnimeDownloadPlan.kindGame);
+      expect(calls.single.$2, hasLength(2));
+      expect(
+        (await singlePlan()).status,
+        AnimeDownloadPlan.statusImported,
+      );
+    });
+
+    test('kindAudiobook 导入 0 条 → failed 带原因', () async {
+      await store.save(_plan(AnimeDownloadPlan.kindAudiobook));
+      qb.torrents = <Map<String, dynamic>>[_completedTorrent()];
+      await buildService(
+        discoveryImporter: (AnimeDownloadPlan plan, List<String> paths) async =>
+            0,
+      ).tick();
+
+      final AnimeDownloadPlan plan = await singlePlan();
+      expect(plan.status, AnimeDownloadPlan.statusFailed);
+      expect(plan.failReason, isNotNull);
+    });
+
+    test('discoveryImporter 抛异常 → failed 收进 failReason', () async {
+      await store.save(_plan(AnimeDownloadPlan.kindGame));
+      qb.torrents = <Map<String, dynamic>>[_completedTorrent()];
+      await buildService(
+        discoveryImporter: (AnimeDownloadPlan plan, List<String> paths) async =>
+            throw StateError('boom'),
+      ).tick();
+
+      final AnimeDownloadPlan plan = await singlePlan();
+      expect(plan.status, AnimeDownloadPlan.statusFailed);
+      expect(plan.failReason, contains('boom'));
+    });
+
+    test('未注入 discoveryImporter → failed unsupported', () async {
+      await store.save(_plan(AnimeDownloadPlan.kindGame));
+      qb.torrents = <Map<String, dynamic>>[_completedTorrent()];
+      await buildService().tick();
+
+      final AnimeDownloadPlan plan = await singlePlan();
+      expect(plan.status, AnimeDownloadPlan.statusFailed);
+      expect(plan.failReason, contains('unsupported'));
+    });
+  });
+}

--- a/tools/bundle_7za.ps1
+++ b/tools/bundle_7za.ps1
@@ -1,0 +1,82 @@
+# Bundle the standalone 7-Zip console (7za.exe, LGPL) into the Windows release
+# so the discovery page can auto-extract downloaded 7z/rar game/novel archives
+# offline (DiscoveryArchiveExtractor probes <exe dir>\7za\7za.exe first).
+#
+# Source: the official 7-Zip GitHub mirror (ip7z/7zip) "extra" package, pinned
+# by SHA-256. Verify-before-use: a swapped upstream archive must fail the build,
+# not ship. Extraction uses the runner's preinstalled full 7-Zip.
+#
+# Usage:
+#   pwsh -File tools/bundle_7za.ps1 -BundleDirectory <app Release dir> [-DownloadCache <dir>]
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$BundleDirectory,
+  [string]$DownloadCache = "$env:TEMP\hibiki-7za-cache"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Version = '24.09'
+$ArchiveName = '7z2409-extra.7z'
+$Url = "https://github.com/ip7z/7zip/releases/download/$Version/$ArchiveName"
+$ExpectedSha256 = '43AE97658D0FC5B4EEC4D409D85F7BED74A80945FD5704333A3599E0BD79B5FC'
+
+if (-not (Test-Path -LiteralPath $BundleDirectory -PathType Container)) {
+  throw "BundleDirectory not found: $BundleDirectory"
+}
+
+New-Item -ItemType Directory -Force -Path $DownloadCache | Out-Null
+$archivePath = Join-Path $DownloadCache $ArchiveName
+
+function Test-ArchiveHash {
+  param([string]$Path)
+  return (Test-Path -LiteralPath $Path -PathType Leaf) -and
+    ((Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash -eq $ExpectedSha256)
+}
+
+if (-not (Test-ArchiveHash $archivePath)) {
+  Write-Host "Downloading $Url"
+  Invoke-WebRequest -Uri $Url -OutFile $archivePath -UseBasicParsing
+  if (-not (Test-ArchiveHash $archivePath)) {
+    $actual = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash
+    throw "SHA-256 mismatch for ${ArchiveName}: expected $ExpectedSha256, got $actual"
+  }
+}
+
+# Locate a system 7-Zip to unpack the .7z (preinstalled on GitHub runners).
+$sevenZip = $null
+foreach ($candidate in @(
+  (Get-Command 7z -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source),
+  'C:\Program Files\7-Zip\7z.exe',
+  'C:\Program Files (x86)\7-Zip\7z.exe'
+)) {
+  if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+    $sevenZip = $candidate
+    break
+  }
+}
+if (-not $sevenZip) { throw 'No system 7-Zip found to unpack the extra package' }
+
+$extractDir = Join-Path $DownloadCache 'extracted'
+if (Test-Path -LiteralPath $extractDir) {
+  Remove-Item -LiteralPath $extractDir -Recurse -Force
+}
+& $sevenZip x '-y' "-o$extractDir" $archivePath | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "7z extraction failed ($LASTEXITCODE)" }
+
+# The extra package ships x86 7za.exe at the root and the x64 build under x64\.
+$sourceExe = Join-Path $extractDir 'x64\7za.exe'
+$licenseFile = Join-Path $extractDir 'License.txt'
+if (-not (Test-Path -LiteralPath $sourceExe -PathType Leaf)) {
+  throw "x64\7za.exe missing from $ArchiveName (upstream layout changed?)"
+}
+if (-not (Test-Path -LiteralPath $licenseFile -PathType Leaf)) {
+  throw "License.txt missing from $ArchiveName"
+}
+
+$targetDir = Join-Path $BundleDirectory '7za'
+New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+Copy-Item -LiteralPath $sourceExe -Destination (Join-Path $targetDir '7za.exe') -Force
+Copy-Item -LiteralPath $licenseFile -Destination (Join-Path $targetDir 'License.txt') -Force
+Write-Host "Bundled 7za.exe $Version into $targetDir"


### PR DESCRIPTION
## 概要

给书域(小说+有声书)和 gal 域加「发现页」:统一多源资源发现框架,源可切换、默认「全部源」聚合;条目可选源下载(torrent 走既有后端,直链走新 HTTP 队列),下载完成自动导入对应库。顺带把漫画全源搜索的聚合层迁到共享抽象。

## 7 个 commit(可按序单看)

1. `15cf2ff0b9` 框架:MediaDiscoverySource 契约 / 聚合服务(部分成功) / DiscoveryDownloadQueue(语义照搬 MokuroMoeDownloadQueue,字节层复用 ResumableDownloader)
2. `91bb4c5f14` 三源 adapter:nyaa(复用 NyaaClient,分类按域映射) / AList v3(list/search/get 延迟直链) / shinnku(RSC 载荷解析+直链规则照上游开源仓)——三源均对线上实测验证
3. `b83146b6a1` 自动导入分派:纯分类层(sealed 计划)+ 7-Zip/zip 解压(zip-slip 防护)+ 执行器 + 生产装配(全复用 EpubImporter/TextToEpub/PdfImporter/alignAndPersistAudiobook/galgame 登记)
4. `5b16977f2b` torrent 链路:AnimeDownloadPlan 加 kindAudiobook/kindGame,完成收尾直通发现导入执行器;既有 video/book/auto 行为零改动
5. `410802f25a` UI:共享 MediaDiscoveryPage + 书页「浏览」视图(预留位)+ 游戏页「发现」段 + AppModel 组装 + i18n 12 key(17 语言)
6. `5a077144c3` Windows 随包 7za.exe(SHA-256 钉死 fail-closed;本机实测脚本全程跑通)
7. `0f24b00cb2` 漫画全源搜索抽公开 runner(行为不变,widget 测试原样绿)+ 发现聚合反向吸收漫画渐进交付模式 + 有界并发原语收敛单一真相

## 设计要点

- **不做跨源去重合并**:资源发现(种子/直链)不同于视频元数据发现,同名资源在不同源是不同下载物
- **漫画为何不并入同一数据模型**:作品条目(点开详情)vs 可下载资源(payload),统一的是聚合语义不是模型,见 manga_global_search_runner.dart 文件头
- Sukebei(18+)默认不进「全部源」聚合,显式单选可用(discovery_disabled_sources 偏好)
- 有声书自动导入=「正文+字幕+音频」齐才全自动(用户拍板);纯音频包不在本轮范围
- shinnku 无正式 API,RSC 解析随站点改版失效时按 invalidResponse 亮源徽标,不拖垮聚合

## 验证

- 新增单测 ~60 条(框架/三源 fixture/导入分类/解压/执行器/torrent 新 kind/渐进聚合/漫画 runner)全绿
- 全量 flutter analyze 零问题;MD3 守卫/偏好键守卫/i18n 完整性/游戏页焦点链测试全绿
- 全量测试门(flutter_test_failures.dart)结果稍后追评

https://claude.ai/code/session_01PDp4vbyagc4FrX2vHZPH2F