### PR TITLE
fix(collection): 详情页承认跨端成员，互联客户端不再显示「合集为空」(BUG-1704)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1577 条。点号进各自文件。
+> 共 1578 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1704](bugs/BUG-1704-interconnect-collection-detail-remote-members.md) | ✅ | ✅ | 互联客户端打开合集详情显示「合集为空」：详情页只认本地视频行，丢弃 host 侧成员 |
 | [BUG-1703](bugs/BUG-1703-manga-extension-error-truncated-toast.md) | ✅ | ✅ | 扩展安装/加载失败的根因被 Android 原生 toast 截成 2 行，用户永远看不到 |
 | [BUG-1702](bugs/BUG-1702-mihon-r8-kotlin-keep.md) | ✅ | ✅ | release APK 的 R8 混淆掉宿主 Kotlin 运行时，所有 Mihon 漫画扩展 LOAD_FAILED |
 | [BUG-1701](bugs/BUG-1701-manga-webtoon-pinch-vs-scroll.md) | ✅ | ✅ | 手机端漫画条漫模式捏合缩放与上下滚动互相干扰 |

--- a/docs/bugs/BUG-1704-interconnect-collection-detail-remote-members.md
+++ b/docs/bugs/BUG-1704-interconnect-collection-detail-remote-members.md
@@ -1,0 +1,23 @@
+## BUG-1704 · 互联客户端打开合集详情显示「合集为空」：详情页只认本地视频行，丢弃 host 侧成员
+- **报告**：2026-08-18（用户：fushi 互联客户端「作品资料」页显示「合集为空」，没办法正常显示合集；同屏 toast「同步完成 · 无新增」）
+- **真实性**：✅ 真 bug。根因是**合集成员的数据结构在详情页被窄化**，不是同步链断了：
+  - 合集清单是**跨端 union**：`fushi/lib/src/sync/collection_sync_engine.dart:679`（`applyCollectionLocalChanges` → `upsertCollectionItemAt`）无条件把对端成员写进本地 `media_collection_items`，`entryKey` 是 **host 侧的 bookUid**，本机可以根本没有对应 `video_books` 行（互联通道见 `sync_orchestrator.dart:641` `_syncCollectionsLive`）。所以客户端本地必然存在「合集行有 N 个成员、本地视频行 0 个」的合集。
+  - 而详情页的成员解析把成员窄化成 `VideoBookRow`，解析不到就**直接丢弃**：`fushi/lib/src/pages/implementations/video_work_detail_page.dart:82-92`（旧 `loadMembers`，`if (row != null) result.add(row)`）、`airing_calendar_page.dart:222-231`、`media_collection_detail_page.dart:825` 三处同款重复代码。
+  - 于是 `media_collection_detail_page.dart:2447` 的 `_members.isEmpty` 命中 → 整页只渲染 `t.collection_empty` 占位（hero / 资料 / 集列表全部不渲染）。
+  - 库页看起来正常是因为它**早就**支持跨端混排（`home_video_page.dart` 的 `_VideoSlot` = 本地行 ∪ 远端占位，BUG-1699 修好了合集折叠映射）——所以用户在库页看得见合集卡，点进去却是空页。这是 BUG-1699 的**下游**一环。
+  - toast「同步完成 · 无新增」不是 bug：`summarizeSyncReport`（`manual_sync_ui.dart:20`）只统计书/词典/音频的进出，合集同步本就不计入该摘要。
+- **[x] ① 已修复** —
+  - 新数据结构 `CollectionEpisodeSlot`（`fushi/lib/src/media/collections/collection_episode_slot.dart`）：合集成员 = 本地行 **或** 只在对端的 `RemoteVideoInfo` 占位，恰一非空；与库页 `_VideoSlot` 同构。同文件的 `loadCollectionEpisodeSlots` 收口了原先散在三处的成员解析：按 `media_collection_items` 落盘序解析，本地查不到的 `entryKey` 去远端清单里补，**补不上才丢弃**（无远端上下文 / 拉取失败 → 与改动前逐字节同行为）。
+  - `MediaCollectionDetailPage` 的成员真相源从 `List<VideoBookRow> _members` 换成 `List<CollectionEpisodeSlot> _slots`，`_members` 降级为派生 getter（本地子集）。判空、分季分组、续播下标、看完计数、集列表、排序落盘、拖拽重排、按季拆分、补缺集集号全部改按 slots 算；**写本地库的管理动作**（批量字幕 / 按刮削改集名 / 删视频本体 / 单集重刮）仍只作用于 `_members` 本地子集——与库页「远端占位只支持流播 + 下载」的能力边界一致。
+  - 顺带修正的两处口径：① `_persistOrder` 现在把远端成员一并写进落盘序（它们在本地 items 表里本来就有行，漏写会让本地全序与显示序错开，并经合集同步把错序传回对端）；② 「补齐缺集」的已有集号取全部成员——此前「第 5 集在 host」会被报成缺口、去重复下载一份。
+  - 远端能力经单个可空注入 `CollectionRemoteContext`（列清单 / 流播 / 带鉴权取封面三件事同生共死）传入；`home_video_page._collectionRemoteContext()` 用**共享的** `RemoteLibraryCache`（TTL 内不打网络）+ 既有 `_openRemote`（带全部远端成员 + 起播下标 → 播放器跨成员连播）+ `remoteCoverFetcherFor` 填充。日历页不注入 = 纯本地视图。
+  - 远端集卡带云角标（`CoverBadge(Icons.cloud_outlined)`，与库页同一枚）；本机没有条目行可刮，故其右键菜单不出「条目信息」。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/collection_detail_remote_members_test.dart`（5 条）：
+  - `loadCollectionEpisodeSlots` 不丢弃只在对端的成员且保落盘序（本地只有 e2，e1/e3 在 host → 顺序 e1,e2,e3，isRemote = true,false,true）；
+  - 无远端上下文 / 远端清单拉取抛异常 → 退化成纯本地视图，不抛（旧行为守卫）；
+  - 全员只在对端时详情页**不显示** `collection_empty`、两张集卡都在；
+  - 点远端集卡 → 走远端流播入口，回调收到全部远端成员 + 正确起播下标。
+  - 变异实测：把 `loadCollectionEpisodeSlots` 的远端分支短路掉 → 3 条断言变红（含「合集为空」那条），还原后源文件 sha256 与变异前逐字节一致。
+- **备注**：
+  - 书 / 漫画 / 游戏侧的 `MediaCollectionGridDetailPage` 是同一形状的隐患（同样只认本地行），但用户报的是视频「作品资料」页，且书侧远端占位的数据链（`RemoteBookInfo.collection`）与视频侧不同源，未在本次改动范围内——留作后续单独任务。
+  - 真机复测（互联客户端打开一个全员在 host 的合集）未做，本轮证据是 widget 层。

--- a/fushi/lib/src/media/collections/collection_episode_slot.dart
+++ b/fushi/lib/src/media/collections/collection_episode_slot.dart
@@ -1,0 +1,138 @@
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart'
+    show RemoteVideoInfo;
+import 'package:fushi/src/sync/remote_cover_fetcher.dart';
+import 'package:fushi_core/fushi_core.dart'
+    show MediaCollectionItemRow, MediaKind, VideoBookRow;
+
+/// 合集的一个**成员槽**：本地视频行 [local] 或「只在对端、本机没有」的远端占位
+/// [remote]，二者恰一非空。
+///
+/// 为什么合集成员不能只是 [VideoBookRow]：合集清单是**跨端 union**
+/// （`CollectionSyncEngine` / `applyCollectionLocalChanges`），互联客户端本地的
+/// `media_collection_items` 里必然存在「entryKey 是 host 侧 bookUid、本机没有对应
+/// 视频行」的成员行。把成员窄化成本地行，等于在客户端把整个合集判空
+/// （BUG-1704：详情页显示「合集为空」）。库页早就用同构的 `_VideoSlot` 混排本地卡与
+/// 远端占位卡，详情页沿用同一模型。
+///
+/// 能力边界与库页一致：远端槽只支持**流播 / 下载**，不参与任何写本地库的管理动作
+/// （改集名、批量字幕、补缺集、删除本体）——那些动作的调用方取 [local] 子集。
+class CollectionEpisodeSlot {
+  const CollectionEpisodeSlot.local(VideoBookRow this.local) : remote = null;
+  const CollectionEpisodeSlot.remote(RemoteVideoInfo this.remote)
+      : local = null;
+
+  /// 本机视频行；null = 该集只在对端。
+  final VideoBookRow? local;
+
+  /// 对端下发的远端条目；null = 该集在本机。
+  final RemoteVideoInfo? remote;
+
+  /// 该集只在对端（渲染云角标、禁用本地管理动作的唯一判据）。
+  bool get isRemote => local == null;
+
+  /// 成员键：本地是 `VideoBooks.bookUid`，远端是 host 侧的 video id——二者同域
+  /// （host 下发的 id 就是它自己的 bookUid），故也正是本地 `media_collection_items`
+  /// 里那一行的 `entryKey`。
+  String get entryKey => local?.bookUid ?? remote!.id;
+
+  String get title => local?.title ?? remote!.title;
+
+  /// 集号 / 分季解析的输入：本地用真实文件路径，远端只有 host 给的标题
+  /// （host 端标题默认就是文件名，解析不出时各调用方自有回落）。
+  String get filename => local?.videoPath ?? remote!.title;
+
+  int get positionMs => local?.lastPositionMs ?? remote!.positionMs;
+
+  bool get completed =>
+      local != null ? local!.completedAt != null : remote!.completedAt != null;
+
+  /// 最近播放时刻（epoch 毫秒）；远端的真相源是 host 下发的进度更新戳，与首页
+  /// 「继续观看」行同一口径。
+  int? get lastPlayedAtMs =>
+      local != null ? local!.lastPlayedAt : remote!.positionUpdatedAtMs;
+
+  int? get importedAt => local?.importedAt ?? remote?.importedAt;
+
+  /// 封面本地路径（远端槽恒 null，封面走 [remoteCoverUrl]）。
+  String? get coverPath => local?.coverPath;
+
+  String? get remoteCoverUrl => remote?.coverUrl;
+}
+
+/// 解析一个合集的**有序**视频成员槽（本地行 + 只在对端的远端占位）。
+///
+/// 顺序即 `media_collection_items` 的落盘序（跨端 LWW 同步的合集序），远端成员天然
+/// 落在它在 host 上的位置——「第 5 集只在 host、1~4 在本机」显示成连续的 1..5，而不是
+/// 把远端集堆到末尾。
+///
+/// [loadRemoteVideos] = null（日历页一类没有远端上下文的调用方）或对端不可达时，
+/// 解析不到本地行的成员**照旧丢弃**，与远端支持引入前逐字节同行为。
+Future<List<CollectionEpisodeSlot>> loadCollectionEpisodeSlots({
+  required VideoBookRepository repository,
+  required int collectionId,
+  Future<List<RemoteVideoInfo>> Function()? loadRemoteVideos,
+}) async {
+  final List<MediaCollectionItemRow> items =
+      await repository.getCollectionItems(collectionId);
+  final List<String> videoKeys = <String>[
+    for (final MediaCollectionItemRow item in items)
+      if (item.mediaType == MediaKind.video.dbValue) item.entryKey,
+  ];
+  final Map<String, VideoBookRow> localByUid = <String, VideoBookRow>{};
+  for (final String key in videoKeys) {
+    final VideoBookRow? row = await repository.getByBookUid(key);
+    if (row != null) localByUid[key] = row;
+  }
+  final bool anyMissing =
+      videoKeys.any((String key) => !localByUid.containsKey(key));
+  Map<String, RemoteVideoInfo> remoteById = const <String, RemoteVideoInfo>{};
+  // 全员本地时一次远端清单都不问：详情页是高频入口，没有缺口就没有理由付网络/缓存
+  // 代价（有缓存也仍是一次 provider 往返）。
+  if (anyMissing && loadRemoteVideos != null) {
+    try {
+      final List<RemoteVideoInfo> remote = await loadRemoteVideos();
+      remoteById = <String, RemoteVideoInfo>{
+        for (final RemoteVideoInfo info in remote) info.id: info,
+      };
+    } catch (_) {
+      // 离线 / 未配对 / 拉取失败：退化成「只有本地成员」，与库页远端占位卡的离线
+      // 语义一致（不显示占位，绝不因为对端不可达就让页面报错）。
+      remoteById = const <String, RemoteVideoInfo>{};
+    }
+  }
+  return <CollectionEpisodeSlot>[
+    for (final String key in videoKeys)
+      if (localByUid[key] case final VideoBookRow local)
+        CollectionEpisodeSlot.local(local)
+      else if (remoteById[key] case final RemoteVideoInfo info)
+        CollectionEpisodeSlot.remote(info),
+  ];
+}
+
+/// 合集视图的**远端上下文**：让「只在对端」的成员能列出、能播、能取封面。
+///
+/// 三件事必然同生共死——有互联 client 才拿得到远端清单、才有带鉴权的封面链、才有
+/// 流播入口，所以合成一个可空注入而不是三个各自为政的回调。null = 调用方没有远端
+/// 上下文（如日历页），合集视图退化成纯本地，与远端支持引入前逐字节相同。
+class CollectionRemoteContext {
+  const CollectionRemoteContext({
+    required this.loadRemoteVideos,
+    required this.openEpisode,
+    this.coverFetcher,
+  });
+
+  /// 拉对端视频清单（调用方走共享的 [RemoteLibraryCache]，TTL 内不打网络）。
+  final Future<List<RemoteVideoInfo>> Function() loadRemoteVideos;
+
+  /// 打开一个远端成员：收到本合集**全部**远端成员与起播下标，播放器据此建剧集
+  /// 列表并跨成员连播（与库页远端占位卡同一入口）。
+  final void Function(
+    RemoteVideoInfo episode,
+    List<RemoteVideoInfo> members,
+    int index,
+  ) openEpisode;
+
+  /// 远端封面取数器（钉扎 HTTP 客户端）；null = 远端集只画占位图标。
+  final RemoteCoverFetcher? coverFetcher;
+}

--- a/fushi/lib/src/pages/implementations/airing_calendar_page.dart
+++ b/fushi/lib/src/pages/implementations/airing_calendar_page.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/media/torrent/anime_download_subscription.dart';
 import 'package:fushi/src/media/torrent/download_network_proxy.dart';
 import 'package:fushi/src/media/video/airing_calendar_cache.dart';
@@ -219,17 +220,12 @@ class _AiringCalendarPageState extends ConsumerState<AiringCalendarPage> {
         builder: (_) => MediaCollectionDetailPage(
           database: db,
           collection: collection,
-          loadMembers: () async {
-            final List<MediaCollectionItemRow> members =
-                await db.getCollectionItems(collection.id);
-            final List<VideoBookRow> rows = <VideoBookRow>[];
-            for (final MediaCollectionItemRow m in members) {
-              if (m.mediaType != MediaKind.video.dbValue) continue;
-              final VideoBookRow? row = await repo.getByBookUid(m.entryKey);
-              if (row != null) rows.add(row);
-            }
-            return rows;
-          },
+          // 日历页没有互联 client（无远端上下文）：只在对端的成员照旧不列出，
+          // 与远端支持引入前逐字节相同。
+          loadEpisodes: () => loadCollectionEpisodeSlots(
+            repository: repo,
+            collectionId: collection.id,
+          ),
           onOpenEpisode: (VideoBookRow episode) {
             Navigator.push<void>(
               context,

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -55,6 +55,7 @@ import 'package:fushi/src/media/collections/batch_combine.dart';
 import 'package:fushi/src/media/collections/collection_context_dialog.dart';
 import 'package:fushi/src/media/collections/collection_continue.dart';
 import 'package:fushi/src/media/collections/collection_grouping.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/media/collections/collection_one_key_sort.dart'
     show sortNewCollectionMembersNaturally;
 import 'package:fushi/src/media/collections/shelf_sort.dart';
@@ -5370,11 +5371,41 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
+  /// 详情页的远端上下文（BUG-1704）：合集清单是跨端 union，客户端本地的成员行里必然
+  /// 有「只在 host 上」的集。库页早就把它们混排成远端占位卡了，详情页拿同一份清单
+  /// （共享 [RemoteLibraryCache]，TTL 内不打网络）、同一条鉴权封面链、同一个流播入口
+  /// ——否则用户在库页看得见合集、点进去却是「合集为空」。
+  ///
+  /// 没有远端源（未启用互联 / 未配对 / 关掉「显示远端条目」）→ null = 纯本地视图。
+  CollectionRemoteContext? _collectionRemoteContext() {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    if (source == null || !_shouldLoadRemoteVideos) return null;
+    return CollectionRemoteContext(
+      loadRemoteVideos: () => _remoteCache.read(
+        sourceId: source.remoteLibrarySourceId,
+        key: RemoteLibraryCacheKeys.videos,
+        fetch: source.listRemoteVideos,
+      ),
+      openEpisode: (
+        RemoteVideoInfo episode,
+        List<RemoteVideoInfo> members,
+        int index,
+      ) =>
+          unawaited(_openRemote(
+        episode,
+        collectionMembers: members,
+        startIndex: index,
+      )),
+      coverFetcher: remoteCoverFetcherFor(_remoteVideoClient),
+    );
+  }
+
   /// 打开合集详情页（Jellyfin 式）。有序成员从 [FushiDatabase.getCollectionItems] 解析，
   /// 点某集经 playlistCollectionId 进播放器带剧集面板/上下集/连播；写库后重载库页。
   void _openCollectionDetail(MediaCollectionRow collection) {
     final VideoBookRepository repo = widget.repo;
     final FushiDatabase db = ref.read(appProvider).database;
+    final CollectionRemoteContext? remote = _collectionRemoteContext();
     Navigator.push<void>(
       context,
       adaptivePageRoute<void>(
@@ -5384,6 +5415,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           repository: repo,
           workRef: VideoWorkRef.collection(collection.id),
           onChanged: _refresh,
+          remote: remote,
           // 详情页管理菜单「刮削资料与封面」+ 集卡「条目信息」（BUG-1662）：注入
           // 库页同一套刮削入口，合集语境下的重刮不再是断头路。
           onScrapeCollection: _openCollectionCoverMatch,

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/media/collections/collection_asset_reclaim.dart';
 import 'package:fushi/src/media/collections/collection_continue.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
 import 'package:fushi/src/media/collections/collection_season_groups.dart';
@@ -40,6 +41,9 @@ import 'package:fushi/src/pages/implementations/collection_relations_section.dar
 import 'package:fushi/src/pages/implementations/collection_split_dialog.dart';
 import 'package:fushi/src/pages/implementations/jimaku_batch_dialog.dart';
 import 'package:fushi/src/pages/implementations/video_fushi_page.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart'
+    show RemoteVideoInfo;
+import 'package:fushi/src/sync/remote_cover_image.dart';
 import 'package:fushi/src/utils/components/fushi_reorderable_grid.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -53,8 +57,9 @@ class MediaCollectionDetailPage extends StatefulWidget {
   const MediaCollectionDetailPage({
     required this.database,
     required this.collection,
-    required this.loadMembers,
+    required this.loadEpisodes,
     required this.onOpenEpisode,
+    this.remote,
     required this.onChanged,
     this.onScrape,
     this.onEpisodeScrapeInfo,
@@ -65,11 +70,19 @@ class MediaCollectionDetailPage extends StatefulWidget {
   final FushiDatabase database;
   final MediaCollectionRow collection;
 
-  /// 解析本合集**有序**成员的 VideoBooks 行（调用方持 repo + collectionId）。
-  final Future<List<VideoBookRow>> Function() loadMembers;
+  /// 解析本合集**有序**成员槽（调用方持 repo + collectionId；见
+  /// [loadCollectionEpisodeSlots]）。
+  ///
+  /// 返回的是 [CollectionEpisodeSlot] 而不是 `VideoBookRow`：合集清单是跨端 union，
+  /// 互联客户端本地的成员行里必然有「只在 host 上」的集。把它窄化成本地行会让客户端
+  /// 把整个合集判空（BUG-1704）。
+  final Future<List<CollectionEpisodeSlot>> Function() loadEpisodes;
 
   /// 打开某集（调用方用 playlistCollectionId 进播放器带面板）。
   final void Function(VideoBookRow episode) onOpenEpisode;
+
+  /// 远端上下文（列远端成员 / 流播 / 取封面）；null = 纯本地视图。
+  final CollectionRemoteContext? remote;
 
   /// 改名 / 删除后刷新库页。
   final VoidCallback onChanged;
@@ -104,18 +117,33 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   static const double _kEpisodeTwoColumnMinWidth = 900;
 
   late String _name;
-  List<VideoBookRow> _members = const <VideoBookRow>[];
+
+  /// 本合集**有序**成员槽（本地行 + 只在对端的远端占位）——本页唯一的成员真相源。
+  List<CollectionEpisodeSlot> _slots = const <CollectionEpisodeSlot>[];
   bool _loading = true;
 
-  /// 分季：video 成员 bookUid → 分组键，**由 videoPath 文件名现场派生**（不落库，
-  /// 数据模型见 collection_season_groups.dart）。路径不随重排变化，故只在
-  /// [_reload] 重算。
-  Map<String, String> _groupKeyByUid = const <String, String>{};
+  /// 成员里的**本地行**子集，保持落盘序。写本地库的管理动作（批量字幕 / 改集名 /
+  /// 补缺集 / 删本体 / 拆分标题）一律取它——远端槽在本机没有可写的行。
+  List<VideoBookRow> get _members => <VideoBookRow>[
+        for (final CollectionEpisodeSlot slot in _slots)
+          if (slot.local case final VideoBookRow row) row,
+      ];
 
-  /// 由 [_members] + [_groupKeyByUid] 派生的分节（季号升序、PV/特典殿后）。
+  /// 成员里只在对端的那些（按序），供远端连播列表与起播下标换算。
+  List<RemoteVideoInfo> get _remoteMembers => <RemoteVideoInfo>[
+        for (final CollectionEpisodeSlot slot in _slots)
+          if (slot.remote case final RemoteVideoInfo info) info,
+      ];
+
+  /// 分季：成员 [CollectionEpisodeSlot.entryKey] → 分组键，**由文件名现场派生**
+  /// （不落库，数据模型见 collection_season_groups.dart）。远端槽没有本地路径，用
+  /// host 下发的标题（host 端标题默认即文件名）。键不随重排变化，故只在 [_reload] 重算。
+  Map<String, String> _groupKeyByEntry = const <String, String>{};
+
+  /// 由 [_slots] + [_groupKeyByEntry] 派生的分节（季号升序、PV/特典殿后）。
   /// ≥2 节 → 顶部出季 tab；否则整页与单季合集完全一致（不平白加一层 UI）。
-  List<CollectionSeasonSection<VideoBookRow>> _sections =
-      const <CollectionSeasonSection<VideoBookRow>>[];
+  List<CollectionSeasonSection<CollectionEpisodeSlot>> _sections =
+      const <CollectionSeasonSection<CollectionEpisodeSlot>>[];
 
   /// 季 tab 控制器：只在 ≥2 节时存在，节数变化（移出成员导致某季清空）时重建。
   TabController? _seasonTabs;
@@ -190,7 +218,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   }
 
   Future<void> _reload() async {
-    final List<VideoBookRow> members = await widget.loadMembers();
+    final List<CollectionEpisodeSlot> slots = await widget.loadEpisodes();
+    // 下面这一整段刮削 / 元数据解析全是**本地库**的事（sourceId 索引、集级刮削行、
+    // 附加图），远端槽在本机没有行可查，故按本地子集跑，与远端支持引入前逐字节相同。
+    final List<VideoBookRow> members = <VideoBookRow>[
+      for (final CollectionEpisodeSlot slot in slots)
+        if (slot.local case final VideoBookRow row) row,
+    ];
     // 刮削资料与合集行一起重取：刮削**经用户确认后可能回写合集名**
     //（`applyCollectionScrape` 的 confirmedTitle），而 widget.collection 是进页时的
     // 快照，只认它会让详情页标题停在旧文件夹名。
@@ -248,9 +282,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       for (final VideoMetadataExtraRow extra in workExtras)
         if (extra.bookUid != null) extra.bookUid!,
     };
-    final List<VideoBookRow> episodeMembers = members
-        .where(
-            (VideoBookRow member) => !localExtraUids.contains(member.bookUid))
+    // 花絮/特典（canonical extras）不进集列表——它们在 [_buildExtrasSection] 单列。
+    final List<CollectionEpisodeSlot> episodeSlots = slots
+        .where((CollectionEpisodeSlot slot) =>
+            !localExtraUids.contains(slot.entryKey))
         .toList(growable: false);
     // 集级刮削资料（一集一行、episodeNumber 非空才算集级；见 [_episodeMetaByUid]）。
     final Map<String, VideoScrapeMetaRow> episodeMeta =
@@ -266,10 +301,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         await widget.database.getMediaCollectionById(widget.collection.id);
     if (!mounted) return;
     setState(() {
-      _members = episodeMembers;
-      _groupKeyByUid = <String, String>{
-        for (final VideoBookRow r in episodeMembers)
-          r.bookUid: collectionGroupKeyForFilename(r.videoPath),
+      _slots = episodeSlots;
+      _groupKeyByEntry = <String, String>{
+        for (final CollectionEpisodeSlot slot in episodeSlots)
+          slot.entryKey: collectionGroupKeyForFilename(slot.filename),
       };
       _rebuildSections();
       _episodeMetaByUid = episodeMeta;
@@ -353,10 +388,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 重建分节并让季 tab 控制器跟上节数。**必须在 setState 内调用**（会改
   /// [_sections] / [_seasonTabs] / [_selectedSeason]）。
   void _rebuildSections() {
-    _sections = sortCollectionSeasonSections<VideoBookRow>(
-      buildCollectionSeasonSections<VideoBookRow>(
-        members: _members,
-        keyOf: (VideoBookRow r) => _groupKeyByUid[r.bookUid],
+    _sections = sortCollectionSeasonSections<CollectionEpisodeSlot>(
+      buildCollectionSeasonSections<CollectionEpisodeSlot>(
+        members: _slots,
+        keyOf: (CollectionEpisodeSlot slot) => _groupKeyByEntry[slot.entryKey],
       ),
     );
     final int count = _sections.length;
@@ -372,11 +407,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     // 1 季，看第二季的用户一进来就是「大图第二季 / 列表第一季」两套内容。
     if (!_seasonSelectionInitialized) {
       _seasonSelectionInitialized = true;
-      final String? uid = _continueUid;
-      final int index = uid == null
+      final String? key = _continueKey;
+      final int index = key == null
           ? -1
-          : _sections.indexWhere((CollectionSeasonSection<VideoBookRow> s) =>
-              s.items.any((VideoBookRow r) => r.bookUid == uid));
+          : _sections.indexWhere(
+              (CollectionSeasonSection<CollectionEpisodeSlot> s) => s.items
+                  .any((CollectionEpisodeSlot slot) => slot.entryKey == key));
       if (index >= 0) _selectedSeason = index;
     }
     _selectedSeason = _selectedSeason.clamp(0, count - 1);
@@ -407,26 +443,30 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   bool get _hasSeasonTabs => _sections.length >= 2;
 
   /// 当前选中的季（无 tab 时为 null）。
-  CollectionSeasonSection<VideoBookRow>? get _selectedSection => _hasSeasonTabs
-      ? _sections[_selectedSeason.clamp(0, _sections.length - 1)]
-      : null;
+  CollectionSeasonSection<CollectionEpisodeSlot>? get _selectedSection =>
+      _hasSeasonTabs
+          ? _sections[_selectedSeason.clamp(0, _sections.length - 1)]
+          : null;
 
   /// 当前 tab 下应展示的剧集（无 tab 时就是全表）。
-  List<VideoBookRow> get _visibleMembers => _selectedSection?.items ?? _members;
+  List<CollectionEpisodeSlot> get _visibleSlots =>
+      _selectedSection?.items ?? _slots;
 
+  /// 续播下标按**全部**成员算：互联客户端上「本机看到第 3 集、第 4 集还在 host」时
+  /// 续播就该指向那一集——远端进度的真相源是 host 下发的断点，与首页「继续观看」同口径。
   int get _continueIndex => continueMemberIndex(<CollectionMemberProgress>[
-        for (final VideoBookRow r in _members)
+        for (final CollectionEpisodeSlot slot in _slots)
           CollectionMemberProgress(
-            positionMs: r.lastPositionMs,
-            completed: r.completedAt != null,
-            lastPlayedAt: r.lastPlayedAt,
+            positionMs: slot.positionMs,
+            completed: slot.completed,
+            lastPlayedAt: slot.lastPlayedAtMs,
           ),
       ]);
 
-  /// 续播成员的 uid：分季视图里行下标是**节内**下标，与全局 [_continueIndex]
-  /// 对不上，高亮统一按 uid 判定（平铺视图两者等价）。
-  String? get _continueUid =>
-      _members.isEmpty ? null : _members[_continueIndex].bookUid;
+  /// 续播成员的键：分季视图里行下标是**节内**下标，与全局 [_continueIndex]
+  /// 对不上，高亮统一按成员键判定（平铺视图两者等价）。
+  String? get _continueKey =>
+      _slots.isEmpty ? null : _slots[_continueIndex].entryKey;
 
   /// 分组键 → tab / 分节标题（`s<N>` → 「第 N 季」；其余 → PV·特典）。
   String _groupLabel(String groupKey) {
@@ -437,16 +477,16 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   }
 
   int get _watchedCount =>
-      _members.where((VideoBookRow row) => row.completedAt != null).length;
+      _slots.where((CollectionEpisodeSlot slot) => slot.completed).length;
 
   /// 展示用集名（TODO-2491）：集级刮削行的 title。集名缺失时集级刮削会把**作品名**
   /// 回填进 title（那不是集名，与 episode_rename.dart 同判据），此时不当集名用。
   /// 无集级资料 → null，调用方回落 [VideoBookRow.title]（文件名现状，零变化）。
-  String? _scrapedEpisodeTitle(VideoBookRow row) {
+  String? _scrapedEpisodeTitle(CollectionEpisodeSlot slot) {
     final String? canonical =
-        _canonicalEpisodeByUid[row.bookUid]?.title?.trim();
+        _canonicalEpisodeByUid[slot.entryKey]?.title?.trim();
     if (canonical != null && canonical.isNotEmpty) return canonical;
-    final VideoScrapeMetaRow? meta = _episodeMetaByUid[row.bookUid];
+    final VideoScrapeMetaRow? meta = _episodeMetaByUid[slot.entryKey];
     if (meta == null) return null;
     final String title = meta.title.trim();
     if (title.isEmpty) return null;
@@ -454,20 +494,21 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     return title;
   }
 
-  /// 集卡展示名：优先集级刮削集名，回落条目标题（文件名）。
-  String _episodeDisplayTitle(VideoBookRow row) =>
-      _scrapedEpisodeTitle(row) ?? row.title;
+  /// 集卡展示名：优先集级刮削集名，回落条目标题（文件名）。远端集本机没有刮削行，
+  /// 恒走 host 下发的标题。
+  String _episodeDisplayTitle(CollectionEpisodeSlot slot) =>
+      _scrapedEpisodeTitle(slot) ?? slot.title;
 
   /// 集卡**序号**：文件名解析出的真实集号优先，解析不出才回落列表顺位号
   /// （BUG-1544）。缺集 / 只导入了一部分时顺位号必然与真实集号错位——用户看到
   /// 「03」点开却是 E05。集号是文件名里写着的事实，不是列表下标的函数。
-  int _episodeDisplayNumber(VideoBookRow row, int index) =>
-      parsedEpisodeNumberOf(row.videoPath) ?? index + 1;
+  int _episodeDisplayNumber(CollectionEpisodeSlot slot, int index) =>
+      parsedEpisodeNumberOf(slot.filename) ?? index + 1;
 
   /// 集简介（集级刮削 summary；无 → null 不占位）。
-  String? _episodeSummary(VideoBookRow row) {
-    final String? summary = (_canonicalEpisodeByUid[row.bookUid]?.overview ??
-            _episodeMetaByUid[row.bookUid]?.summary)
+  String? _episodeSummary(CollectionEpisodeSlot slot) {
+    final String? summary = (_canonicalEpisodeByUid[slot.entryKey]?.overview ??
+            _episodeMetaByUid[slot.entryKey]?.summary)
         ?.trim();
     return (summary == null || summary.isEmpty) ? null : summary;
   }
@@ -557,7 +598,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     );
   }
 
-  /// 把当前 [_members] 顺序一次落盘（sortIndex 全表回写）。库页合集行与播放器
+  /// 把当前 [_slots] 顺序一次落盘（sortIndex 全表回写）。库页合集行与播放器
   /// 换集读同一 `getCollectionItems`，落盘即三处同序（层次 C 单一真相源）。
   ///
   /// 本页只渲染 video 成员（调用方 `loadMembers` 按 mediaType 过滤），而一个合集**可以**
@@ -568,8 +609,11 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     await widget.database.reorderCollectionItems(
       widget.collection.id,
       <CollectionMemberKey>[
-        for (final VideoBookRow r in _members)
-          (mediaType: MediaKind.video.dbValue, entryKey: r.bookUid),
+        // 远端槽同样进落盘序：它们在本地 `media_collection_items` 里**本来就有行**
+        // （合集清单是跨端 union），漏掉它们等于让本地全序与显示序错开，且下一轮合集
+        // 同步会把这个错序传回对端。
+        for (final CollectionEpisodeSlot slot in _slots)
+          (mediaType: MediaKind.video.dbValue, entryKey: slot.entryKey),
       ],
     );
     widget.onChanged();
@@ -579,31 +623,33 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// ReorderableListView 的「移除前下标」修正）→ 内存 move → 落盘。
   ///
   /// 分季 tab 下拖的是**本季**列表：下标是节内的，先在节内 move，再把各节按
-  /// **落盘序**（[_members] 里各组首次出现的顺序，不是 tab 的展示序）拼回全序，
+  /// **落盘序**（[_slots] 里各组首次出现的顺序，不是 tab 的展示序）拼回全序，
   /// 避免拖一集顺带把整表按 tab 序重写。
   Future<void> _onReorder(int oldIndex, int newIndex) async {
     if (oldIndex == newIndex) return;
-    final List<VideoBookRow> section = List<VideoBookRow>.of(_visibleMembers);
-    final VideoBookRow moved = section.removeAt(oldIndex);
+    final List<CollectionEpisodeSlot> section =
+        List<CollectionEpisodeSlot>.of(_visibleSlots);
+    final CollectionEpisodeSlot moved = section.removeAt(oldIndex);
     section.insert(newIndex, moved);
     if (!_hasSeasonTabs) {
       setState(() {
-        _members = section;
+        _slots = section;
         _rebuildSections();
       });
       await _persistOrder();
       return;
     }
     final String movedKey =
-        _groupKeyByUid[moved.bookUid] ?? kCollectionExtrasGroupKey;
-    final List<CollectionSeasonSection<VideoBookRow>> persisted =
-        buildCollectionSeasonSections<VideoBookRow>(
-      members: _members,
-      keyOf: (VideoBookRow r) => _groupKeyByUid[r.bookUid],
+        _groupKeyByEntry[moved.entryKey] ?? kCollectionExtrasGroupKey;
+    final List<CollectionSeasonSection<CollectionEpisodeSlot>> persisted =
+        buildCollectionSeasonSections<CollectionEpisodeSlot>(
+      members: _slots,
+      keyOf: (CollectionEpisodeSlot slot) => _groupKeyByEntry[slot.entryKey],
     );
     setState(() {
-      _members = <VideoBookRow>[
-        for (final CollectionSeasonSection<VideoBookRow> s in persisted)
+      _slots = <CollectionEpisodeSlot>[
+        for (final CollectionSeasonSection<CollectionEpisodeSlot> s
+            in persisted)
           ...(s.groupKey == movedKey ? section : s.items),
       ];
       _rebuildSections();
@@ -614,12 +660,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 一键整理（覆盖 95% 场景）：按 [compare] 重排全表并落盘。乱序的手攒播放列表
   /// 一键回名称序 / 加入时序。
   Future<void> _applyOneKeySort(
-    int Function(VideoBookRow a, VideoBookRow b) compare,
+    int Function(CollectionEpisodeSlot a, CollectionEpisodeSlot b) compare,
   ) async {
-    final List<VideoBookRow> next = List<VideoBookRow>.of(_members)
-      ..sort(compare);
+    final List<CollectionEpisodeSlot> next =
+        List<CollectionEpisodeSlot>.of(_slots)..sort(compare);
     setState(() {
-      _members = next;
+      _slots = next;
       _rebuildSections();
     });
     await _persistOrder();
@@ -629,15 +675,15 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// **展示**本身是派生的、进页面即生效，本动作只负责把落盘全序也整理成分季连续
   /// （单季合集执行后无可见变化，幂等）。
   Future<void> _sortBySeason() async {
-    if (_members.isEmpty) return;
-    final CollectionSeasonRegroup<VideoBookRow> regroup =
-        regroupMembersBySeason<VideoBookRow>(
-      members: _members,
-      filenameOf: (VideoBookRow r) => r.videoPath,
-      titleOf: (VideoBookRow r) => r.title,
+    if (_slots.isEmpty) return;
+    final CollectionSeasonRegroup<CollectionEpisodeSlot> regroup =
+        regroupMembersBySeason<CollectionEpisodeSlot>(
+      members: _slots,
+      filenameOf: (CollectionEpisodeSlot slot) => slot.filename,
+      titleOf: (CollectionEpisodeSlot slot) => slot.title,
     );
     setState(() {
-      _members = regroup.ordered;
+      _slots = regroup.ordered;
       _rebuildSections();
     });
     await _persistOrder();
@@ -654,18 +700,18 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 条目（同一集的两个来源 / 都还没刮到标题）此前每次整理都可能换个顺序，而顺序
   /// 是要落盘的，看起来就像列表自己在动。
   Widget _buildSortMenu() {
-    CollectionSortMeta metaOf(VideoBookRow r) => (
-          title: r.title,
-          importedAt: r.importedAt ?? 0,
-          key: r.bookUid,
+    CollectionSortMeta metaOf(CollectionEpisodeSlot slot) => (
+          title: slot.title,
+          importedAt: slot.importedAt ?? 0,
+          key: slot.entryKey,
         );
     return buildDetailSortMenu(
       onSortByTitle: () => _applyOneKeySort(
-        (VideoBookRow a, VideoBookRow b) =>
+        (CollectionEpisodeSlot a, CollectionEpisodeSlot b) =>
             compareCollectionMembers(metaOf(a), metaOf(b), byTitle: true),
       ),
       onSortByImported: () => _applyOneKeySort(
-        (VideoBookRow a, VideoBookRow b) =>
+        (CollectionEpisodeSlot a, CollectionEpisodeSlot b) =>
             compareCollectionMembers(metaOf(a), metaOf(b), byTitle: false),
       ),
     );
@@ -766,17 +812,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         builder: (_) => MediaCollectionDetailPage(
           database: widget.database,
           collection: target,
-          loadMembers: () async {
-            final List<MediaCollectionItemRow> items =
-                await widget.database.getCollectionItems(target.id);
-            final List<VideoBookRow> rows = <VideoBookRow>[];
-            for (final MediaCollectionItemRow item in items) {
-              if (item.mediaType != MediaKind.video.dbValue) continue;
-              final VideoBookRow? row = await repo.getByBookUid(item.entryKey);
-              if (row != null) rows.add(row);
-            }
-            return rows;
-          },
+          loadEpisodes: () => loadCollectionEpisodeSlots(
+            repository: repo,
+            collectionId: target.id,
+            loadRemoteVideos: widget.remote?.loadRemoteVideos,
+          ),
+          // 远端上下文原样传下去：相关作品也可能是「只在对端」的那一部。
+          remote: widget.remote,
           onOpenEpisode: (VideoBookRow episode) {
             Navigator.push<void>(
               context,
@@ -808,9 +850,9 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   }
 
   /// 文件名解出的集号；解不出回落集级刮削行的 episodeNumber（两者都无 → null）。
-  int? _episodeNumberOf(VideoBookRow episode) =>
-      parseVideoFilename(p.basename(episode.videoPath)).episode ??
-      _episodeMetaByUid[episode.bookUid]?.episodeNumber;
+  int? _episodeNumberOf(CollectionEpisodeSlot slot) =>
+      parseVideoFilename(p.basename(slot.filename)).episode ??
+      _episodeMetaByUid[slot.entryKey]?.episodeNumber;
 
   /// 打开下载对话框（TODO-2485）：合集绑了 anilistId → 本地合成 [AniListMedia]
   /// （id + 合集名，零网络）直达选种段并预填集号；未绑定 → 回落预填合集名的
@@ -839,10 +881,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// next.bgm.tv p1 API），不自建社区功能——降级为外链：经公开无鉴权的
   /// `/v0/episodes` 把集号解析成章节 id，浏览器打开 `bgm.tv/ep/<id>`；解析不到
   /// （集号缺失/源无该集）明示提示并退到条目页；网络失败明示错误、同样退条目页。
-  Future<void> _openEpisodeOnBangumi(VideoBookRow episode) async {
+  Future<void> _openEpisodeOnBangumi(CollectionEpisodeSlot slot) async {
     final ScrapeMetadata? meta = _scrapeMeta;
     if (meta == null) return;
-    final int? episodeNumber = _episodeNumberOf(episode);
+    final int? episodeNumber = _episodeNumberOf(slot);
     final BangumiClient bangumi = BangumiClient();
     int? episodeId;
     try {
@@ -885,9 +927,11 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 「补齐缺集」：按文件名集号找 1..max 的第一个缺口；无内部缺口但刮削话数
   /// 大于 max → 下一集（max+1）。真没有缺集（或一集集号都解不出）→ 提示。
   void _fillMissingEpisodes() {
+    // 集号取全部成员（含只在 host 上的集）：客户端上「第 5 集在对端」不是缺集，
+    // 只按本地行算会把已经有的集报成缺口、去下载一份重复的。
     final Set<int> present = <int>{
-      for (final VideoBookRow member in _members)
-        if (parseVideoFilename(p.basename(member.videoPath)).episode
+      for (final CollectionEpisodeSlot slot in _slots)
+        if (parseVideoFilename(p.basename(slot.filename)).episode
             case final int episode)
           episode,
     };
@@ -918,11 +962,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 逐集「移出合集」（整理排序页删除后本页是视频侧唯一移出入口）：确认 →
   /// [FushiDatabase.removeFromCollection]（空合集自动删）→ 重载；合集被清空则
   /// 退回上层。条目本身绝不删除。
-  Future<void> _removeEpisode(VideoBookRow ep) async {
+  Future<void> _removeEpisode(CollectionEpisodeSlot slot) async {
     if (!await confirmDetailRemoveMember()) return;
     if (!mounted) return;
+    // 成员键即 `media_collection_items.entry_key`——远端集在本地同样有成员行，移出
+    // 它是合法且会经合集同步传播到对端的操作（与库页移出语义一致）。
     await widget.database.removeFromCollection(
-        widget.collection.id, MediaKind.video, ep.bookUid);
+        widget.collection.id, MediaKind.video, slot.entryKey);
     if (!mounted) return;
     widget.onChanged();
     FushiToast.show(
@@ -953,18 +999,22 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 「删除合集」菜单一致：只解链 + 回收合集自有封面，绝不删条目）。
   Future<void> _splitBySeason() async {
     if (!_hasSeasonTabs) return;
-    final List<CollectionSeasonSection<VideoBookRow>> sections = _sections;
+    final List<CollectionSeasonSection<CollectionEpisodeSlot>> sections =
+        _sections;
     final CollectionSplitChoice? choice = await showCollectionSplitDialog(
       context: context,
       sections: <CollectionSplitPlanSection>[
-        for (final CollectionSeasonSection<VideoBookRow> section in sections)
+        for (final CollectionSeasonSection<CollectionEpisodeSlot> section
+            in sections)
           CollectionSplitPlanSection(
             defaultName: '$_name ${_groupLabel(section.groupKey)}',
             members: <CollectionSplitMember>[
-              for (final VideoBookRow row in section.items)
+              // 远端槽照样进拆分：新合集的成员键就是它在 items 表里的 entryKey，
+              // 漏掉它们等于拆分时把对端那几集的归属丢了。
+              for (final CollectionEpisodeSlot slot in section.items)
                 CollectionSplitMember(
-                  id: row.bookUid,
-                  title: _episodeDisplayTitle(row),
+                  id: slot.entryKey,
+                  title: _episodeDisplayTitle(slot),
                 ),
             ],
             isSeason: seasonNumberOfGroupKey(section.groupKey) != null,
@@ -1087,15 +1137,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// BUG-1299：走 [PortraitCoverImage] 的横槽自适应（横版截帧铺满、竖版海报
   /// 模糊垫底 + contain），不再 `BoxFit.cover` 把海报裁成中间一条。
   Widget _episodeThumb(
-    VideoBookRow ep,
+    CollectionEpisodeSlot slot,
     ColorScheme cs, {
     double w = 96,
     double h = 54,
   }) {
-    final ImageProvider? cover = resolveMediaCoverImage(
-      kind: MediaKind.video,
-      localPath: ep.coverPath,
-    );
+    final ImageProvider? cover = _episodeCover(slot);
     if (cover != null) {
       return ClipRRect(
         borderRadius: FushiBorderRadius.card,
@@ -1112,6 +1159,46 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       );
     }
     return _thumbPlaceholder(w, h, cs);
+  }
+
+  /// 集缩略图 provider：本地行走既有封面链；远端集先认 host 已同步下来的本地封面
+  /// 文件，再回落带鉴权的远端 URL（与库页远端占位卡同一条链），都没有 → null。
+  ImageProvider? _episodeCover(CollectionEpisodeSlot slot) {
+    final String? localPath = slot.coverPath;
+    if (localPath != null && localPath.isNotEmpty) {
+      return resolveMediaCoverImage(
+        kind: MediaKind.video,
+        localPath: localPath,
+      );
+    }
+    final RemoteVideoInfo? remote = slot.remote;
+    if (remote == null) return null;
+    final String? cachedPath = remote.coverPath;
+    if (cachedPath != null && File(cachedPath).existsSync()) {
+      return FileImage(File(cachedPath));
+    }
+    final String? url = remote.coverUrl;
+    final RemoteCoverFetcher? fetcher = widget.remote?.coverFetcher;
+    if (url != null && url.isNotEmpty && fetcher != null) {
+      return RemoteCoverImage(url, fetcher, cacheKey: remote.id);
+    }
+    return null;
+  }
+
+  /// 打开一个成员槽：本地行走 [MediaCollectionDetailPage.onOpenEpisode]；只在对端的
+  /// 走 [MediaCollectionDetailPage.onOpenRemoteEpisode]，并带上本合集**全部**远端成员
+  /// 与起播下标，播放器据此建剧集列表 + 跨成员连播。没注入远端回调则不动作。
+  void _openSlot(CollectionEpisodeSlot slot) {
+    final VideoBookRow? local = slot.local;
+    if (local != null) {
+      widget.onOpenEpisode(local);
+      return;
+    }
+    final RemoteVideoInfo? remote = slot.remote;
+    final CollectionRemoteContext? context = widget.remote;
+    if (remote == null || context == null) return;
+    final List<RemoteVideoInfo> members = _remoteMembers;
+    context.openEpisode(remote, members, members.indexOf(remote));
   }
 
   Widget _thumbPlaceholder(double w, double h, ColorScheme cs) => Container(
@@ -1132,7 +1219,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     final Size screen = MediaQuery.sizeOf(context);
     final double height = (screen.height * 0.60).clamp(460.0, 680.0);
     final ImageProvider? cover = _heroCover;
-    final VideoBookRow episode = _members[_continueIndex];
+    final CollectionEpisodeSlot episode = _slots[_continueIndex];
     final bool rtl = Directionality.of(context) == TextDirection.rtl;
     // 可读性渐变：压在封面之上、竖版海报前景之下（层序由 [LandscapeCoverImage]
     // 保证，见该组件文档）。无封面时直接铺在底色上，与引入组件前一致。
@@ -1289,7 +1376,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   Widget _buildHeroInfo(
     BuildContext context,
     FushiDesignTokens tokens,
-    VideoBookRow episode,
+    CollectionEpisodeSlot episode,
   ) {
     final TextTheme text = Theme.of(context).textTheme;
     final ScrapeMetadata? meta = _scrapeMeta;
@@ -1391,7 +1478,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         SizedBox(height: tokens.spacing.card),
         Text(
           '${t.collection_continue_progress(n: _continueIndex + 1)}  ·  '
-          '${episode.title}',
+          '${_episodeDisplayTitle(episode)}',
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: text.labelLarge?.copyWith(
@@ -1403,7 +1490,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         FilledButton.icon(
           icon: const Icon(Icons.play_arrow_rounded),
           label: Text(t.collection_play),
-          onPressed: () => widget.onOpenEpisode(episode),
+          onPressed: () => _openSlot(episode),
         ),
       ],
     );
@@ -1434,7 +1521,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     if (year != null) parts.add('$year');
     final String? status = _canonicalWork?.status;
     if (status != null && status.trim().isNotEmpty) parts.add(status);
-    final int episodeCount = meta?.episodeCount ?? _members.length;
+    final int episodeCount = meta?.episodeCount ?? _slots.length;
     if (episodeCount > 0) {
       parts.add(t.collection_hero_total_episodes(count: episodeCount));
     }
@@ -1451,7 +1538,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     parts.add(
       t.collection_watched_progress(
         done: _watchedCount,
-        total: _members.length,
+        total: _slots.length,
       ),
     );
     return parts;
@@ -2034,7 +2121,8 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         indicatorColor: cs.primary,
         dividerColor: Colors.transparent,
         tabs: <Widget>[
-          for (final CollectionSeasonSection<VideoBookRow> section in _sections)
+          for (final CollectionSeasonSection<CollectionEpisodeSlot> section
+              in _sections)
             Tab(
               key:
                   ValueKey<String>('collection-season-tab-${section.groupKey}'),
@@ -2051,7 +2139,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 分季时只列本季（[_visibleMembers]），拖拽是节内重排，由 [_onReorder] 拼回
   /// 全序落盘。
   Widget _buildEpisodeGrid(ColorScheme cs, FushiDesignTokens tokens) {
-    final List<VideoBookRow> visible = _visibleMembers;
+    final List<CollectionEpisodeSlot> visible = _visibleSlots;
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         const double spacing = 12;
@@ -2067,9 +2155,9 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           mainAxisSpacing: spacing,
           feedbackBorderRadius: FushiBorderRadius.card,
           keyForIndex: (int i) =>
-              ValueKey<String>('collection-episode-row-${visible[i].bookUid}'),
+              ValueKey<String>('collection-episode-row-${visible[i].entryKey}'),
           onReorder: _onReorder,
-          onActivateItem: (int i) => widget.onOpenEpisode(visible[i]),
+          onActivateItem: (int i) => _openSlot(visible[i]),
           onContextMenu: (int i, Offset globalPosition) =>
               _showEpisodeMenu(visible[i], globalPosition),
           itemBuilder: (BuildContext context, int i) =>
@@ -2089,14 +2177,14 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 焦点不走指针，[FushiFocusTarget] 照常可聚焦、Enter 开播。
   Widget _buildEpisodeCard(
     BuildContext context,
-    VideoBookRow episode,
+    CollectionEpisodeSlot episode,
     int index,
     ColorScheme cs,
     FushiDesignTokens tokens,
   ) {
-    final bool completed = episode.completedAt != null;
-    final bool started = episode.lastPositionMs > 0 && !completed;
-    final bool isContinue = episode.bookUid == _continueUid;
+    final bool completed = episode.completed;
+    final bool started = episode.positionMs > 0 && !completed;
+    final bool isContinue = episode.entryKey == _continueKey;
     final String? summary = _episodeSummary(episode);
     const double pad = 10;
     const double thumbHeight = _kEpisodeCardHeight - pad * 2;
@@ -2115,7 +2203,18 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  _episodeThumb(episode, cs, w: thumbWidth, h: thumbHeight),
+                  Stack(
+                    children: <Widget>[
+                      _episodeThumb(episode, cs, w: thumbWidth, h: thumbHeight),
+                      // 云角标 = 这一集只在对端（与库页远端占位卡同一枚角标）。
+                      if (episode.isRemote)
+                        const Positioned(
+                          right: 4,
+                          bottom: 4,
+                          child: CoverBadge(icon: Icons.cloud_outlined),
+                        ),
+                    ],
+                  ),
                   SizedBox(width: tokens.spacing.rowVertical),
                   Expanded(
                     child: Column(
@@ -2167,7 +2266,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                               Text(
                                 t.collection_episode_watched_at(
                                   position: formatVideoPosition(
-                                    episode.lastPositionMs,
+                                    episode.positionMs,
                                   ),
                                 ),
                                 style: TextStyle(
@@ -2205,13 +2304,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       actions: <Type, Action<Intent>>{
         ActivateIntent: CallbackAction<ActivateIntent>(
           onInvoke: (_) {
-            widget.onOpenEpisode(episode);
+            _openSlot(episode);
             return null;
           },
         ),
       },
       child: FushiFocusTarget(
-        id: FushiFocusId('collection-episode-${episode.bookUid}'),
+        id: FushiFocusId('collection-episode-${episode.entryKey}'),
         child: card,
       ),
     );
@@ -2221,7 +2320,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 消掉 FushiAppUiScale 缩放（BUG-781 同族纪律）。管理能力从旧管理列表的行内
   /// 按钮收进本菜单（拖拽排序仍是直接拖卡）。
   Future<void> _showEpisodeMenu(
-    VideoBookRow episode,
+    CollectionEpisodeSlot episode,
     Offset globalPosition,
   ) async {
     final RenderObject? overlay =
@@ -2259,7 +2358,8 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           ),
         // 单集条目信息（含「重新刮削」，BUG-1662）：某一集刮错了，此前在合集
         // 语境下没有任何 UI 路径可以重刮——库页墙上只有合集卡，摸不到成员。
-        if (widget.onEpisodeScrapeInfo != null)
+        // 远端集在本机没有条目行可刮 —— 不出这一项（点了只会打开一个空壳）。
+        if (widget.onEpisodeScrapeInfo != null && episode.local != null)
           PopupMenuItem<_EpisodeMenuAction>(
             value: _EpisodeMenuAction.scrapeInfo,
             child: Row(
@@ -2289,7 +2389,9 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       case _EpisodeMenuAction.openBangumi:
         await _openEpisodeOnBangumi(episode);
       case _EpisodeMenuAction.scrapeInfo:
-        await widget.onEpisodeScrapeInfo?.call(episode);
+        if (episode.local case final VideoBookRow row) {
+          await widget.onEpisodeScrapeInfo?.call(row);
+        }
         // 重刮会改写集级资料/标题，重载让新集名立即上卡。
         if (mounted) await _reload();
       case _EpisodeMenuAction.removeFromCollection:
@@ -2382,7 +2484,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               _CollectionManageAction.sortBySeason,
               Icons.segment,
               t.collection_sort_by_season,
-              enabled: _members.isNotEmpty,
+              enabled: _slots.isNotEmpty,
             ),
             _manageMenuItem(
               _CollectionManageAction.subtitles,
@@ -2400,7 +2502,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               _CollectionManageAction.fillMissing,
               Icons.playlist_add,
               t.collection_episode_fill_missing,
-              enabled: _members.isNotEmpty,
+              enabled: _slots.isNotEmpty,
             ),
             _manageMenuItem(
               _CollectionManageAction.splitBySeason,
@@ -2444,7 +2546,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           ? SafeArea(
               child: Center(child: adaptiveIndicator(context: context)),
             )
-          : _members.isEmpty
+          : _slots.isEmpty
               ? SafeArea(
                   child: FushiPlaceholderMessage(
                     icon: Icons.collections_bookmark_outlined,

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/media/media_cover_source.dart';
 import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
@@ -32,6 +33,7 @@ class VideoWorkDetailPage extends StatelessWidget {
     required this.repository,
     required this.workRef,
     required this.onChanged,
+    this.remote,
     this.onScrapeCollection,
     this.onEpisodeScrapeInfo,
     this.onDeleteMembersMedia,
@@ -42,6 +44,10 @@ class VideoWorkDetailPage extends StatelessWidget {
   final VideoBookRepository repository;
   final VideoWorkRef workRef;
   final VoidCallback onChanged;
+
+  /// 远端上下文：合集成员里「只在对端」的集靠它列出 / 流播 / 取封面。null = 纯本地
+  /// 视图（调用方没有互联 client），与远端支持引入前逐字节相同。
+  final CollectionRemoteContext? remote;
 
   /// 管理菜单「刮削资料与封面」（BUG-1662）。null = 调用方不提供刮削能力，菜单
   /// 不出该项（与 [onDeleteMembersMedia] 同一注入纪律）。
@@ -78,18 +84,14 @@ class VideoWorkDetailPage extends StatelessWidget {
           return MediaCollectionDetailPage(
             database: database,
             collection: collection,
-            loadMembers: () async {
-              final List<MediaCollectionItemRow> items =
-                  await repository.getCollectionItems(collection.id);
-              final List<VideoBookRow> result = <VideoBookRow>[];
-              for (final MediaCollectionItemRow item in items) {
-                if (item.mediaType != MediaKind.video.dbValue) continue;
-                final VideoBookRow? row =
-                    await repository.getByBookUid(item.entryKey);
-                if (row != null) result.add(row);
-              }
-              return result;
-            },
+            // 成员解析走共享的 [loadCollectionEpisodeSlots]：合集清单是跨端 union，
+            // 「本机没有这一行」不等于「这一集不存在」（BUG-1704）。
+            loadEpisodes: () => loadCollectionEpisodeSlots(
+              repository: repository,
+              collectionId: collection.id,
+              loadRemoteVideos: remote?.loadRemoteVideos,
+            ),
+            remote: remote,
             onOpenEpisode: (VideoBookRow episode) {
               Navigator.push<void>(
                 context,

--- a/fushi/test/pages/collection_detail_remote_members_test.dart
+++ b/fushi/test/pages/collection_detail_remote_members_test.dart
@@ -1,0 +1,213 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart'
+    show RemoteCollectionMembership, RemoteVideoInfo;
+import 'package:fushi_core/fushi_core.dart';
+
+/// BUG-1704 · 互联客户端打开合集详情显示「合集为空」。
+///
+/// 合集清单是**跨端 union**（`applyCollectionLocalChanges` 无条件把对端成员写进本地
+/// `media_collection_items`，entryKey 是 host 侧 bookUid），所以客户端本地必然存在
+/// 「合集行有成员、但一行本地视频都没有」的合集。详情页此前把成员窄化成
+/// `VideoBookRow`，解析不到的成员**直接丢弃**——整页判空。
+///
+/// 守卫三件事：
+/// ① 成员解析（[loadCollectionEpisodeSlots]）不丢弃只在对端的成员，且保落盘序；
+/// ② 全员在对端时详情页不显示「合集为空」，而是列出各集；
+/// ③ 点远端集卡走远端流播入口，并带上全部远端成员 + 起播下标（跨成员连播）。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FushiDatabase db;
+  late VideoBookRepository repo;
+  late int collectionId;
+
+  RemoteVideoInfo remoteEpisode(String id, String title, int sortIndex) =>
+      RemoteVideoInfo(
+        id: id,
+        title: title,
+        collection: RemoteCollectionMembership(
+          collectionName: 'Show',
+          collectionType: 'playlist',
+          sortIndex: sortIndex,
+        ),
+      );
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    repo = VideoBookRepository(db);
+    collectionId =
+        await db.createMediaCollection('Show', collectionType: 'playlist');
+  });
+
+  tearDown(() => db.close());
+
+  /// 集列表在 hero 之下：默认 800x600 视口里它整段落在视口外、懒加载不建卡。
+  /// 与既有详情页 widget 测试同一手法，用够高的离屏视口把整页一次渲染出来。
+  void useTallSurface(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1280, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  MediaCollectionRow collectionRow() => MediaCollectionRow(
+        id: collectionId,
+        name: 'Show',
+        collectionType: 'playlist',
+        coverSource: null,
+        sortOrder: 0,
+        createdAt: 0,
+        orderUpdatedAt: 0,
+      );
+
+  Widget detailPage({
+    required List<RemoteVideoInfo> remoteVideos,
+    void Function(RemoteVideoInfo, List<RemoteVideoInfo>, int)? onOpenRemote,
+  }) =>
+      TranslationProvider(
+        child: MaterialApp(
+          home: MediaCollectionDetailPage(
+            database: db,
+            collection: collectionRow(),
+            loadEpisodes: () => loadCollectionEpisodeSlots(
+              repository: repo,
+              collectionId: collectionId,
+              loadRemoteVideos: () async => remoteVideos,
+            ),
+            onOpenEpisode: (VideoBookRow _) {},
+            remote: CollectionRemoteContext(
+              loadRemoteVideos: () async => remoteVideos,
+              openEpisode: onOpenRemote ??
+                  (RemoteVideoInfo _, List<RemoteVideoInfo> __, int ___) {},
+            ),
+            onChanged: () {},
+          ),
+        ),
+      );
+
+  test('只在对端的成员不被丢弃，且保持落盘序', () async {
+    // 本地只有第 2 集；第 1、3 集只在 host 上（成员行照样在本地 items 表里）。
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('video/e2'),
+      title: const Value('Show 02'),
+      videoPath: const Value('/v/Show 02.mkv'),
+    ));
+    for (final String uid in <String>['video/e1', 'video/e2', 'video/e3']) {
+      await db.addToCollection(collectionId, MediaKind.video, uid);
+    }
+
+    final List<CollectionEpisodeSlot> slots = await loadCollectionEpisodeSlots(
+      repository: repo,
+      collectionId: collectionId,
+      loadRemoteVideos: () async => <RemoteVideoInfo>[
+        remoteEpisode('video/e1', 'Show 01', 0),
+        remoteEpisode('video/e3', 'Show 03', 2),
+      ],
+    );
+
+    expect(
+      slots.map((CollectionEpisodeSlot s) => s.entryKey).toList(),
+      <String>['video/e1', 'video/e2', 'video/e3'],
+    );
+    expect(
+      slots.map((CollectionEpisodeSlot s) => s.isRemote).toList(),
+      <bool>[true, false, true],
+    );
+  });
+
+  test('没有远端上下文时行为不变：解析不到本地行的成员照旧丢弃', () async {
+    await db.addToCollection(collectionId, MediaKind.video, 'video/e1');
+
+    final List<CollectionEpisodeSlot> slots = await loadCollectionEpisodeSlots(
+      repository: repo,
+      collectionId: collectionId,
+    );
+
+    expect(slots, isEmpty);
+  });
+
+  test('远端清单拉取失败时退化成纯本地视图，不抛', () async {
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('video/e2'),
+      title: const Value('Show 02'),
+      videoPath: const Value('/v/Show 02.mkv'),
+    ));
+    await db.addToCollection(collectionId, MediaKind.video, 'video/e1');
+    await db.addToCollection(collectionId, MediaKind.video, 'video/e2');
+
+    final List<CollectionEpisodeSlot> slots = await loadCollectionEpisodeSlots(
+      repository: repo,
+      collectionId: collectionId,
+      loadRemoteVideos: () async => throw Exception('offline'),
+    );
+
+    expect(slots.map((CollectionEpisodeSlot s) => s.entryKey).toList(),
+        <String>['video/e2']);
+  });
+
+  testWidgets('全员只在对端：详情页不显示「合集为空」，而是列出各集', (WidgetTester tester) async {
+    for (final String uid in <String>['video/e1', 'video/e2']) {
+      await db.addToCollection(collectionId, MediaKind.video, uid);
+    }
+
+    useTallSurface(tester);
+    await tester.pumpWidget(detailPage(remoteVideos: <RemoteVideoInfo>[
+      remoteEpisode('video/e1', 'Show 01', 0),
+      remoteEpisode('video/e2', 'Show 02', 1),
+    ]));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.collection_empty), findsNothing);
+    expect(
+        find.byKey(const ValueKey<String>('collection-episode-row-video/e1')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey<String>('collection-episode-row-video/e2')),
+        findsOneWidget);
+  });
+
+  testWidgets('点远端集卡：走远端流播入口，带全部远端成员与起播下标', (WidgetTester tester) async {
+    for (final String uid in <String>['video/e1', 'video/e2']) {
+      await db.addToCollection(collectionId, MediaKind.video, uid);
+    }
+    RemoteVideoInfo? opened;
+    List<RemoteVideoInfo>? passedMembers;
+    int? passedIndex;
+
+    useTallSurface(tester);
+    await tester.pumpWidget(detailPage(
+      remoteVideos: <RemoteVideoInfo>[
+        remoteEpisode('video/e1', 'Show 01', 0),
+        remoteEpisode('video/e2', 'Show 02', 1),
+      ],
+      onOpenRemote: (
+        RemoteVideoInfo episode,
+        List<RemoteVideoInfo> members,
+        int index,
+      ) {
+        opened = episode;
+        passedMembers = members;
+        passedIndex = index;
+      },
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('collection-episode-row-video/e2')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(opened?.id, 'video/e2');
+    expect(passedMembers?.map((RemoteVideoInfo v) => v.id).toList(),
+        <String>['video/e1', 'video/e2']);
+    expect(passedIndex, 1);
+  });
+}

--- a/fushi/test/pages/collection_detail_scrape_entry_test.dart
+++ b/fushi/test/pages/collection_detail_scrape_entry_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -71,7 +72,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
             onScrape: onScrape,

--- a/fushi/test/pages/collection_episode_cards_test.dart
+++ b/fushi/test/pages/collection_episode_cards_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi/src/utils/components/fushi_reorderable_grid.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -78,7 +79,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
           ),

--- a/fushi/test/pages/collection_episode_rename_flow_test.dart
+++ b/fushi/test/pages/collection_episode_rename_flow_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -81,7 +82,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
           ),

--- a/fushi/test/pages/collection_hero_scrape_meta_test.dart
+++ b/fushi/test/pages/collection_hero_scrape_meta_test.dart
@@ -8,6 +8,7 @@ import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/scraper/collection_scrape_apply.dart';
 import 'package:fushi/src/media/video/scraper/scraper_types.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -106,7 +107,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
           ),

--- a/fushi/test/pages/collection_hero_v77_credits_test.dart
+++ b/fushi/test/pages/collection_hero_v77_credits_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -52,7 +53,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (_) {},
             onChanged: () {},
           ),

--- a/fushi/test/pages/collection_split_by_season_test.dart
+++ b/fushi/test/pages/collection_split_by_season_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -72,7 +73,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
           ),

--- a/fushi/test/pages/media_collection_detail_escape_test.dart
+++ b/fushi/test/pages/media_collection_detail_escape_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi/src/shortcuts/global_navigation.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
@@ -74,7 +75,10 @@ void main() {
           createdAt: 0,
           orderUpdatedAt: 0,
         ),
-        loadMembers: members ?? loadMembers,
+        loadEpisodes: () async => <CollectionEpisodeSlot>[
+          for (final VideoBookRow row in await (members ?? loadMembers)())
+            CollectionEpisodeSlot.local(row),
+        ],
         onOpenEpisode: (VideoBookRow _) {},
         onChanged: () {},
       );

--- a/fushi/test/pages/media_collection_detail_season_tabs_test.dart
+++ b/fushi/test/pages/media_collection_detail_season_tabs_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi/src/utils/components/fushi_reorderable_grid.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -99,7 +100,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: onChanged ?? () {},
           ),

--- a/fushi/test/pages/media_collection_detail_sort_test.dart
+++ b/fushi/test/pages/media_collection_detail_sort_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart' show kLongPressTimeout;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/collection_episode_slot.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -85,7 +86,10 @@ void main() {
               createdAt: 0,
               orderUpdatedAt: 0,
             ),
-            loadMembers: loadMembers,
+            loadEpisodes: () async => <CollectionEpisodeSlot>[
+              for (final VideoBookRow row in await (loadMembers)())
+                CollectionEpisodeSlot.local(row),
+            ],
             onOpenEpisode: onOpenEpisode ?? (VideoBookRow _) {},
             onChanged: () {},
           ),


### PR DESCRIPTION
## 症状

互联客户端（iOS）打开合集「作品资料」页 → 整页只有「合集为空」，用户报「没办法正常显示合集」。库页上这个合集卡是**看得见**的。

## 根因

合集清单是**跨端 union**——`applyCollectionLocalChanges`（`collection_sync_engine.dart:679`）无条件把对端成员写进本地 `media_collection_items`，`entryKey` 是 **host 侧的 bookUid**，本机可以根本没有对应的 `video_books` 行。

而详情页的成员解析把成员窄化成 `VideoBookRow`，解析不到就**直接丢弃**（`video_work_detail_page.dart` / `airing_calendar_page.dart` / `media_collection_detail_page.dart` 三处同款重复代码），于是 `_members.isEmpty` 命中 → 整页只渲染占位。

库页看起来正常，是因为它早就支持跨端混排（`_VideoSlot` = 本地行 ∪ 远端占位，BUG-1699）。本条是 BUG-1699 的**下游**一环。

toast「同步完成 · 无新增」不是 bug：`summarizeSyncReport` 本就不统计合集同步。

## 改动

- 新数据结构 `CollectionEpisodeSlot`（本地行 | 只在对端的 `RemoteVideoInfo` 占位，恰一非空），与库页 `_VideoSlot` 同构；`loadCollectionEpisodeSlots` 收口三处重复的成员解析：按落盘序解析，本地查不到的 `entryKey` 去远端清单补，**补不上才丢弃**（无远端上下文 / 拉取失败 → 与改动前逐字节同行为）。
- 详情页成员真相源换成 `_slots`，`_members` 降级为派生的本地子集 getter。判空 / 分季 / 续播下标 / 看完计数 / 集列表 / 排序落盘 / 拖拽重排 / 按季拆分 / 补缺集集号改按 slots 算；**写本地库的管理动作**（批量字幕 / 按刮削改集名 / 删本体 / 单集重刮）仍只作用于本地子集——与库页「远端占位只支持流播 + 下载」的能力边界一致。
- 顺带修正两处口径：落盘序含远端成员（否则本地全序与显示序错开，并经合集同步把错序传回对端）；补缺集的已有集号含远端集（否则「第 5 集在 host」被报成缺口、去重复下载）。
- 远端能力经单个可空注入 `CollectionRemoteContext`（列清单 / 流播 / 带鉴权取封面三件事同生共死）；`home_video_page` 用共享 `RemoteLibraryCache`（TTL 内不打网络）+ 既有 `_openRemote`（带全部远端成员 + 起播下标 → 跨成员连播）+ `remoteCoverFetcherFor` 填充。日历页不注入 = 纯本地视图。
- 远端集卡带云角标；本机没有条目行可刮，其右键菜单不出「条目信息」。

## 验证

- `flutter analyze` 全量 **No issues**
- 新测试 `fushi/test/pages/collection_detail_remote_members_test.dart` 5 条全绿（含两条旧行为守卫：无远端上下文 / 远端拉取失败 → 退化纯本地）
- 相邻既有详情页测试 12 个文件 **55 条**全绿（9 个文件因签名迁移同步更新）
- 目录枚举型守卫整批 **250 条**全绿（与 docs 基线一致）
- 变异实测：短路 `loadCollectionEpisodeSlots` 的远端分支 → 3 条断言变红（含「合集为空」那条），还原后源文件 sha256 与变异前逐字节一致

未做：真机复测（互联客户端打开一个全员在 host 的合集），本轮证据是 widget 层。

BUG-1704

https://claude.ai/code/session_01StSJ5saHDitVGquCyokrV7