### PR TITLE
fix(torrent+downloads): 兼容 qBittorrent 5.2 的 204 编码，下载页空态不再误导 (BUG-1705/1706)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1577 条。点号进各自文件。
+> 共 1579 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1706](bugs/BUG-1706-downloads-resource-gate-message.md) | ✅ | ✅ | 下载页资源标签把「无受管视频来源」误报成「请先配置下载后端」 |
+| [BUG-1705](bugs/BUG-1705-qb-login-204.md) | ✅ | ✅ | qBittorrent 5.2+ 登录成功返回 204 被判成登录失败 |
 | [BUG-1703](bugs/BUG-1703-manga-extension-error-truncated-toast.md) | ✅ | ✅ | 扩展安装/加载失败的根因被 Android 原生 toast 截成 2 行，用户永远看不到 |
 | [BUG-1702](bugs/BUG-1702-mihon-r8-kotlin-keep.md) | ✅ | ✅ | release APK 的 R8 混淆掉宿主 Kotlin 运行时，所有 Mihon 漫画扩展 LOAD_FAILED |
 | [BUG-1701](bugs/BUG-1701-manga-webtoon-pinch-vs-scroll.md) | ✅ | ✅ | 手机端漫画条漫模式捏合缩放与上下滚动互相干扰 |

--- a/docs/bugs/BUG-1705-qb-login-204.md
+++ b/docs/bugs/BUG-1705-qb-login-204.md
@@ -1,0 +1,22 @@
+## BUG-1705 · qBittorrent 5.2+ 登录成功返回 204 被判成登录失败
+- **报告**：2026-08-18（用户：截图 + 上游 issue pennydreadful/bookshelf#160）
+- **真实性**：✅ 真 bug，且**波及面比报告更大**（不只是登录）。根因 `fushi/lib/src/media/torrent/qbittorrent_client.dart:347`（旧行：`if (res.statusCode != 200) { … return false; }`）以及同文件另外 7 处硬判 `statusCode == 200` 的动作接口。
+
+  上游根因（对照 qbittorrent/qBittorrent `release-5.1.2` 与 `release-5.2.3` 源码逐版本核实）：
+  - `src/webui/api/apicontroller.h`：`RegularAPIResult.data` 是默认构造的 `QVariant`；`setResult(const QString &)` 直接 `m_result.data = result`。传 `QString()`（null QString）时 `QVariant::isNull()` 为真。
+  - `src/webui/webapplication.cpp:406`：`if (result.data.isNull()) response.status = {.code = 204};`。**5.1.2 全文没有 204**，这是 5.2 新增的编码。
+  - 于是所有「做完了没东西可回」的接口在 5.2 从 `200` + 空 body 变成 **204**：`auth/login`、`torrents/{delete,stop,start,setLocation,renameFile,filePrio,createCategory,recheck}`（后者在 5.2.3 里统一写作 `setResult(QString())`）。
+  - `AuthController::loginAction()` 同时把失败编码从 5.1 的 `200` + body `Fails.` 改成 `throw APIError(APIErrorType::Unauthorized)` → **401**。封禁仍是 403 + `…banned…`（移到 `WebApplication::isBanned()`），旧判据可用。
+  - `TorrentsController::addAction()` 从 `setResult("Ok.")` 改成返回统计 JSON；磁力链元数据未到手时 `setStatus(APIStatus::Async)` → **202**；一个都没加成功时 `throw APIError(Conflict)` → **409**。旧判据 `200 && body.startsWith('Ok')` 对 5.2 恒为 false。
+  - 会话过期路径两版都是 `ForbiddenHTTPError()` → 403，`_request` 的「403 重登一次」逻辑不受影响，未动。
+
+  用户现场表现：qBittorrent 5.2.3 + WebUI `http://127.0.0.1:1236` 正常返回 200，账密地址端口都对，Hibiki 仍报登录失败。
+
+- **[x] ① 已修复** — `fushi/lib/src/media/torrent/qbittorrent_client.dart` 新增三个纯函数协议层，把两代编码差异收在一处，调用点不再各自硬判状态码：
+  - `isQbActionSuccess(int)`：200（≤5.1）或 204（≥5.2）都算成功。用于 delete / createCategory / pause·stop / resume·start / renameFile / setLocation / filePrio。
+  - `classifyQbLoginFailure(int, String)`：成功返回 null；204 与 `200 Ok.` 都判成功，401 与 `200 Fails.` 都判账密错误，403+banned 单独报。
+  - `isQbAddAccepted(int, String)`：吃下 `200 Ok.`（≤5.1）、`200` 统计 JSON 与 `202` pending（≥5.2），全 0 / 409 判失败。
+  - 需要解析响应体的查询接口（`torrents/info`、`torrents/files`、`app/version`、`transfer/info`、`app/preferences`、`sync/torrentPeers`、`torrents/{trackers,pieceStates}`）**保持只认 200**——它们收到 204 就是真异常。
+- **[x] ② 已加自动化测试** — `fushi/test/torrent/qbittorrent_api_v52_test.dart`（20 条）：三个纯函数的两代编码判读逐条钉死；`MockClient` 仿真 qb 5.2.3 服务器（登录 204+SID、动作接口 204、add 回统计 JSON、旧端点 404 回退）跑端到端；另有 qb 5.1 服务器的回归护栏，确保老服务器没被改坏。
+  - 变异实测：把 `isQbActionSuccess` 退回 `statusCode == 200` → 3 条红；还原后文件 sha256 与变异前逐字节一致。
+- **备注**：同类问题上游生态已普遍打过补丁（Sonarr `ae18ad61`、Radarr#11339）。本仓只有 `qbittorrent_client.dart` 一处 qB HTTP 实现，已全量覆盖（`grep auth/login` 复核）。用户本机 1236 端口在排查时未启动，无法现场抓包，故改用上游 `release-5.2.3` / `release-5.1.2` 源码逐行比对取证。

--- a/docs/bugs/BUG-1706-downloads-resource-gate-message.md
+++ b/docs/bugs/BUG-1706-downloads-resource-gate-message.md
@@ -1,0 +1,16 @@
+## BUG-1706 · 下载页资源标签把「无受管视频来源」误报成「请先配置下载后端」
+- **报告**：2026-08-18（用户：下载页「资源」标签截图）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/downloads_page.dart:65-86`（改前）：`_loadResourceDependencies()` 在**三种截然不同**的情况下都 `return null` —— ① 资源注册表/下载流水线没就绪（后端真没配）、② `getManagedVideoDownloadSources()` 返回空（后端没问题，缺的是本地视频文件夹）、③ 后端身份解析抛异常（配了但连不上）。消费端 `_buildResourceTab` 只看得见一个 `null`，于是三种情况共用同一句 `t.download_backend_not_configured`（「请先配置下载后端。」）和同一个跳转到「下载设置」的按钮。
+
+  用户现场：qBittorrent 后端已配好（`http://127.0.0.1:1236`、账密齐、分类 `fushi`），受管视频来源 0 条，默认下载目标来源未设。页面报「请先配置下载后端」，用户照提示跳到下载设置页，看见后端配置完好无缺，无从下手——提示把他指向了一个根本没问题的地方。
+
+  注：`getManagedVideoDownloadSources()`（`app_model.dart:3734`）只收 `transport == 'local'` 且 `rootPath` 是**真实存在的绝对路径目录**的视频来源，所以「加过网络来源」或「加过但目录已删」同样会落到这一支。
+
+- **[x] ① 已修复** — 把「缺什么」从页面里抽成纯函数，三种原因分开：
+  - 新增 `fushi/lib/src/pages/implementations/downloads_resource_gap.dart`：`sealed class DownloadsResourceGap` = `DownloadsResourceNoBackend({String? detail})` | `DownloadsResourceNoManagedSource()`，加纯函数 `findDownloadsResourceGap({backendReady, managedSourceCount, identityError})`（返回 null = 前置条件齐备）。判定顺序（先后端、再来源、最后身份）也收在这里，不掺 I/O。
+  - `downloads_page.dart` 的 `_DownloadsResourceState` 改为 `_DownloadsResourceBlocked(gap)` | `_DownloadsResourceReady(...)`；空态按 gap 分流：缺来源 → 「还没有受管视频来源…」+「添加视频来源」按钮，就地开 `MediaSourcesDialog(mediaKind: 'video')`，关掉后重算前置条件；缺后端 → 原文案 +「去设置」，且后端自己报的不可用原因（`VideoDownloadBackendUnavailable.message`）优先透传，不再退化成「请先配置」。
+  - 顺带修掉一次无谓的网络往返：没来源时不再去连后端解析身份。
+  - 新增 i18n key `download_no_managed_video_source` / `download_add_video_source`（走 `tool/i18n_sync.dart --add`，17 份齐，`dart run slang` 重新生成）。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/downloads_resource_gap_test.dart`（7 条）：钉死「后端就绪 + 0 来源」必须判 `DownloadsResourceNoManagedSource` 且**不得**是 `DownloadsResourceNoBackend`（即用户现场那一支）、后端未就绪时的优先级、不可用原因透传、非预期异常不编造原因。
+  - 变异实测：把缺来源那支改回 `DownloadsResourceNoBackend()` → 红；还原后文件 sha256 与变异前逐字节一致。
+- **备注**：`home_page.dart` 的两个同形入口（`_openVideoDiscoveryResourceSearch` / `_openVideoDiscoverySubscription`）此前就已分开报 `media_source_no_sources`，不受本 bug 影响，未动。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60435 (3555 per locale)
+/// Strings: 60469 (3557 per locale)
 ///
-/// Built on 2026-08-17 at 14:43 UTC
+/// Built on 2026-08-18 at 04:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4818,6 +4818,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get discovery_torrent_failed => 'Failed to add torrent task';
   String get discovery_kind_novel => 'Novels';
   String get discovery_kind_audiobook => 'Audiobooks';
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -13041,6 +13044,11 @@ class _StringsAr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -21331,6 +21339,11 @@ class _StringsDe extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -29637,6 +29650,11 @@ class _StringsEs extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -37955,6 +37973,11 @@ class _StringsFr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -46201,6 +46224,11 @@ class _StringsId extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -54493,6 +54521,11 @@ class _StringsIt extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -62599,6 +62632,11 @@ class _StringsJa extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -70712,6 +70750,11 @@ class _StringsKo extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -78984,6 +79027,11 @@ class _StringsNl extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -87268,6 +87316,11 @@ class _StringsPtBr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -95538,6 +95591,11 @@ class _StringsRu extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -103756,6 +103814,11 @@ class _StringsTh extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -112005,6 +112068,11 @@ class _StringsTr extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -120239,6 +120307,11 @@ class _StringsVi extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 // Path: <root>
@@ -127869,6 +127942,11 @@ class _StringsZhCn extends _StringsEn {
   String get discovery_kind_novel => '小说';
   @override
   String get discovery_kind_audiobook => '有声书';
+  @override
+  String get download_no_managed_video_source =>
+      '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
+  @override
+  String get download_add_video_source => '添加视频来源';
 }
 
 // Path: <root>
@@ -135898,6 +135976,11 @@ class _StringsZhHk extends _StringsEn {
   String get discovery_kind_novel => 'Novels';
   @override
   String get discovery_kind_audiobook => 'Audiobooks';
+  @override
+  String get download_no_managed_video_source =>
+      'No managed video source yet. Downloads need a local video folder to land in.';
+  @override
+  String get download_add_video_source => 'Add video source';
 }
 
 /// Flat map(s) containing all translations.
@@ -143198,6 +143281,10 @@ extension on _StringsEn {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -150496,6 +150583,10 @@ extension on _StringsAr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -157816,6 +157907,10 @@ extension on _StringsDe {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -165135,6 +165230,10 @@ extension on _StringsEs {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -172460,6 +172559,10 @@ extension on _StringsFr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -179767,6 +179870,10 @@ extension on _StringsId {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -187088,6 +187195,10 @@ extension on _StringsIt {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -194371,6 +194482,10 @@ extension on _StringsJa {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -201658,6 +201773,10 @@ extension on _StringsKo {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -208973,6 +209092,10 @@ extension on _StringsNl {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -216285,6 +216408,10 @@ extension on _StringsPtBr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -223602,6 +223729,10 @@ extension on _StringsRu {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -230902,6 +231033,10 @@ extension on _StringsTh {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -238211,6 +238346,10 @@ extension on _StringsTr {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -245516,6 +245655,10 @@ extension on _StringsVi {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }
@@ -252762,6 +252905,10 @@ extension on _StringsZhCn {
         return '小说';
       case 'discovery_kind_audiobook':
         return '有声书';
+      case 'download_no_managed_video_source':
+        return '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
+      case 'download_add_video_source':
+        return '添加视频来源';
       default:
         return null;
     }
@@ -260040,6 +260187,10 @@ extension on _StringsZhHk {
         return 'Novels';
       case 'discovery_kind_audiobook':
         return 'Audiobooks';
+      case 'download_no_managed_video_source':
+        return 'No managed video source yet. Downloads need a local video folder to land in.';
+      case 'download_add_video_source':
+        return 'Add video source';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "种子任务已添加",
   "discovery_torrent_failed": "种子任务添加失败",
   "discovery_kind_novel": "小说",
-  "discovery_kind_audiobook": "有声书"
+  "discovery_kind_audiobook": "有声书",
+  "download_no_managed_video_source": "还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。",
+  "download_add_video_source": "添加视频来源"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3553,5 +3553,7 @@
   "discovery_torrent_pushed": "Torrent task added",
   "discovery_torrent_failed": "Failed to add torrent task",
   "discovery_kind_novel": "Novels",
-  "discovery_kind_audiobook": "Audiobooks"
+  "discovery_kind_audiobook": "Audiobooks",
+  "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
+  "download_add_video_source": "Add video source"
 }

--- a/fushi/lib/src/media/torrent/qbittorrent_client.dart
+++ b/fushi/lib/src/media/torrent/qbittorrent_client.dart
@@ -28,6 +28,77 @@ String? extractSidCookie(String? setCookieHeader) {
   return sid;
 }
 
+/// 「无返回体的动作接口成功了吗」——同时覆盖 qBittorrent 4.1~5.1 与 5.2+。
+///
+/// BUG-1705：qb 5.2 起，控制器统一以 `setResult(QString())` 表示「做完了，
+/// 没东西可回」，而 `QVariant(QString())` 是 null variant，被 WebApplication
+/// 编码成 **204 No Content**；5.1 及以前同一批接口回的是 200 + 空 body。
+/// 受影响的是 `auth/login`、`torrents/{delete,stop,start,setLocation,
+/// renameFile,filePrio,createCategory,recheck}` 一整批。只认 200 会把这些
+/// **已经生效**的调用全判成失败。
+///
+/// 反过来，回 JSON/文本的查询接口（`torrents/info`、`torrents/files`、
+/// `app/version` 等）拿到 204 就是真异常（没 body 可解析），那些调用点保持
+/// 只认 200，不要套用本判据。
+bool isQbActionSuccess(int statusCode) =>
+    statusCode == 200 || statusCode == 204;
+
+/// 判读 `POST /api/v2/auth/login` 的响应：登录成功返回 null，失败返回可读原因。
+///
+/// 两代协议的成败编码完全不同，必须都吃下（BUG-1705）：
+/// - qb ≤5.1：成功 `200` + body `Ok.`；凭据错误 `200` + body `Fails.`。
+/// - qb ≥5.2：成功 `204` 空 body；凭据错误 `401`（`APIError(Unauthorized)`）。
+/// - 两代相同：登录失败超限被封 `403` + body 含 `banned`。
+String? classifyQbLoginFailure(int statusCode, String body) {
+  final String trimmed = body.trim();
+  // 登录失败超限（默认 5 次）后 qb 返回 403 + "…banned…"，解封前填对
+  // 账密也进不去——必须单独说清，否则用户会反复重试把封禁续期。
+  if (statusCode == 403) {
+    return trimmed.toLowerCase().contains('banned')
+        ? 'IP banned by qBittorrent after too many failed logins '
+            '(unban: restart qBittorrent or wait, default 1 hour)'
+        : 'HTTP 403${trimmed.isEmpty ? '' : ': $trimmed'}';
+  }
+  if (statusCode == 401) return 'login rejected (wrong username/password)';
+  if (statusCode == 204) return null;
+  if (statusCode != 200) {
+    return 'HTTP $statusCode${trimmed.isEmpty ? '' : ': $trimmed'}';
+  }
+  if (!trimmed.startsWith('Ok')) {
+    return 'login rejected (wrong username/password)';
+  }
+  return null;
+}
+
+/// 判读 `POST /api/v2/torrents/add` 的响应：任务是否真的入列。
+///
+/// BUG-1705：qb 5.2 把这个接口的返回从纯文本 `Ok.` / `Fails.` 换成了统计
+/// JSON，并且**磁力链元数据还没到手时回 202**（`APIStatus::Async`，任务其实
+/// 已经入列），全部失败时直接抛 `Conflict` → 409。旧判据
+/// `200 && body.startsWith('Ok')` 对 5.2 恒为 false —— 种子明明加进去了，
+/// 上层却按「添加失败」处理。
+bool isQbAddAccepted(int statusCode, String body) {
+  // 202 = 已入列、元数据待拉取（磁力链的常态）。
+  if (statusCode == 202) return true;
+  if (statusCode != 200) return false;
+  final String trimmed = body.trim();
+  // qb ≤5.1：纯文本 `Ok.` / `Fails.`。
+  if (!trimmed.startsWith('{')) return trimmed.startsWith('Ok');
+  // qb ≥5.2：统计 JSON。全失败时 qb 走 409 不到这里，但可能只加进去一部分，
+  // 按「到底有没有真加进去」判，别把部分成功说成全败。
+  try {
+    final Object? decoded = jsonDecode(trimmed);
+    if (decoded is! Map<String, dynamic>) return false;
+    final Object? success = decoded['success_count'];
+    final Object? pending = decoded['pending_count'];
+    final int added = (success is num ? success.toInt() : 0) +
+        (pending is num ? pending.toInt() : 0);
+    return added > 0;
+  } on FormatException {
+    return false;
+  }
+}
+
 /// 解析 `/api/v2/torrents/info` 响应（JSON 数组）为中性 [TorrentSnapshot]。
 /// 纯函数，容错：坏 JSON / 非数组返回空列表；缺 `hash` 的条目跳过；
 /// 其余字段缺省用安全默认值（`save_path` / `content_path` / `amount_left`）。
@@ -333,23 +404,9 @@ class QBittorrentClient {
         headers: <String, String>{'Referer': baseUrl},
         body: <String, String>{'username': username, 'password': password},
       ).timeout(requestTimeout);
-      final String body = res.body.trim();
-      // 登录失败超限（默认 5 次）后 qb 返回 403 + "…banned…"，解封前填对
-      // 账密也进不去——必须单独说清，否则用户会反复重试把封禁续期。
-      if (res.statusCode == 403) {
-        _lastFailure = body.toLowerCase().contains('banned')
-            ? 'IP banned by qBittorrent after too many failed logins '
-                '(unban: restart qBittorrent or wait, default 1 hour)'
-            : 'HTTP 403: $body';
-        return false;
-      }
-      // 成功是 200 + body `Ok.`；密码错误也是 200 但 body `Fails.`。
-      if (res.statusCode != 200) {
-        _lastFailure = 'HTTP ${res.statusCode}${body.isEmpty ? '' : ': $body'}';
-        return false;
-      }
-      if (!body.startsWith('Ok')) {
-        _lastFailure = 'login rejected (wrong username/password)';
+      final String? failure = classifyQbLoginFailure(res.statusCode, res.body);
+      if (failure != null) {
+        _lastFailure = failure;
         return false;
       }
       _sid = extractSidCookie(res.headers['set-cookie']);
@@ -402,7 +459,7 @@ class QBittorrentClient {
   }
 
   /// 添加下载：[urls] 是 magnet 链接或 .torrent URL（多个换行连接）。
-  /// 200 且 body `Ok.` 视为成功。
+  /// 成败判读见 [isQbAddAccepted]（qb 5.2 换了返回编码）。
   ///
   /// [sequentialDownload] 开顺序下载、[firstLastPiecePrio] 开首尾块优先：两者
   /// 齐开时视频文件从下载初期就可顺序播放（边下边播的前置条件）。
@@ -425,9 +482,7 @@ class QBittorrentClient {
         if (firstLastPiecePrio) 'firstLastPiecePrio': 'true',
       },
     );
-    return res != null &&
-        res.statusCode == 200 &&
-        res.body.trim().startsWith('Ok');
+    return res != null && isQbAddAccepted(res.statusCode, res.body);
   }
 
   /// Uploads validated `.torrent` metainfo using qBittorrent's multipart
@@ -454,9 +509,7 @@ class QBittorrentClient {
       torrentBytes: bytes,
       torrentFileName: fileName,
     );
-    return res != null &&
-        res.statusCode == 200 &&
-        res.body.trim().startsWith('Ok');
+    return res != null && isQbAddAccepted(res.statusCode, res.body);
   }
 
   /// 确保分类存在：`POST /api/v2/torrents/createCategory`；
@@ -471,7 +524,8 @@ class QBittorrentClient {
         if (savePath != null) 'savePath': savePath,
       },
     );
-    return res != null && (res.statusCode == 200 || res.statusCode == 409);
+    return res != null &&
+        (isQbActionSuccess(res.statusCode) || res.statusCode == 409);
   }
 
   /// 列种子：`GET /api/v2/torrents/info`，[category] 非空时只列该分类。
@@ -508,7 +562,7 @@ class QBittorrentClient {
         'deleteFiles': deleteFiles ? 'true' : 'false',
       },
     );
-    return res != null && res.statusCode == 200;
+    return res != null && isQbActionSuccess(res.statusCode);
   }
 
   /// TODO-2481：暂停单个种子：`POST /api/v2/torrents/pause`（form 参数
@@ -537,14 +591,14 @@ class QBittorrentClient {
       '/api/v2/torrents/$primary',
       form: form,
     );
-    if (res != null && res.statusCode == 200) return true;
+    if (res != null && isQbActionSuccess(res.statusCode)) return true;
     if (res == null || res.statusCode != 404) return false;
     final http.Response? retry = await _request(
       'POST',
       '/api/v2/torrents/$renamed',
       form: form,
     );
-    return retry != null && retry.statusCode == 200;
+    return retry != null && isQbActionSuccess(retry.statusCode);
   }
 
   /// TODO-1961-c：改名种子内文件：`POST /api/v2/torrents/renameFile`
@@ -571,7 +625,7 @@ class QBittorrentClient {
       },
     );
     if (res == null) return (false, 'qBittorrent request failed');
-    if (res.statusCode == 200) return (true, null);
+    if (isQbActionSuccess(res.statusCode)) return (true, null);
     final String body = res.body.trim();
     return (false, body.isEmpty ? 'HTTP ${res.statusCode}' : body);
   }
@@ -595,7 +649,7 @@ class QBittorrentClient {
       form: <String, String>{'hashes': hash, 'location': location},
     );
     if (res == null) return (false, 'qBittorrent request failed');
-    if (res.statusCode == 200) return (true, null);
+    if (isQbActionSuccess(res.statusCode)) return (true, null);
     final String body = res.body.trim();
     return (false, body.isEmpty ? 'HTTP ${res.statusCode}' : body);
   }
@@ -642,7 +696,7 @@ class QBittorrentClient {
 
   /// TODO-2482：设置若干文件的下载优先级：`POST /api/v2/torrents/filePrio`
   /// （form：hash / id=`index|index|...` / priority，值域见
-  /// `_qbFilePriorityFromValue` 的注释）。200 = 成功。
+  /// `_qbFilePriorityFromValue` 的注释）。成功判据见 [isQbActionSuccess]。
   Future<bool> setFilePriority({
     required String hash,
     required List<int> fileIndexes,
@@ -658,7 +712,7 @@ class QBittorrentClient {
         'priority': '$priority',
       },
     );
-    return res != null && res.statusCode == 200;
+    return res != null && isQbActionSuccess(res.statusCode);
   }
 
   /// TODO-2482：会话级协议状态：组合 `GET /api/v2/transfer/info`（速率 +

--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -11,6 +11,8 @@ import 'package:fushi/src/media/video/download/video_resource_registry.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/airing_calendar_page.dart';
 import 'package:fushi/src/pages/implementations/anime_download_dialog.dart';
+import 'package:fushi/src/pages/implementations/downloads_resource_gap.dart';
+import 'package:fushi/src/pages/implementations/media_sources_dialog.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
 import 'package:fushi/src/pages/implementations/torrent_settings_section.dart';
 import 'package:fushi/src/pages/implementations/video_discovery_acquisition_dialogs.dart';
@@ -45,7 +47,7 @@ class DownloadsPage extends ConsumerStatefulWidget {
 }
 
 class _DownloadsPageState extends ConsumerState<DownloadsPage> {
-  late Future<_DownloadsResourceDependencies?> _resourceDependencies;
+  late Future<_DownloadsResourceState> _resourceDependencies;
   VideoDownloadPipelineService? _resourcePipelineSnapshot;
   bool _hasLegacyAnimeTasks = false;
 
@@ -62,58 +64,97 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     _resourceDependencies = _loadResourceDependencies(appModel);
   }
 
-  Future<_DownloadsResourceDependencies?> _loadResourceDependencies([
+  Future<_DownloadsResourceState> _loadResourceDependencies([
     AppModel? current,
   ]) async {
     final AppModel appModel = current ?? ref.read(appProvider);
     final VideoResourceRegistry? registry = appModel.videoResourceRegistry;
     final VideoDownloadPipelineService? pipeline =
         appModel.videoDownloadPipelineService;
-    if (registry == null || pipeline == null) return null;
-    final List<MediaSourceRow> sources =
-        await appModel.getManagedVideoDownloadSources();
-    if (sources.isEmpty) return null;
-    try {
-      return _DownloadsResourceDependencies(
+    final bool backendReady = registry != null && pipeline != null;
+    final List<MediaSourceRow> sources = backendReady
+        ? await appModel.getManagedVideoDownloadSources()
+        : const <MediaSourceRow>[];
+    VideoDownloadBackendIdentity? identity;
+    Object? identityError;
+    // 没来源就别去连后端了：身份解析要打真后端，白连一趟还会把「缺来源」
+    // 盖成一条连接错误。
+    if (backendReady && sources.isNotEmpty) {
+      try {
+        identity = await appModel.currentVideoDownloadBackendIdentity();
+      } on Object catch (error) {
+        identityError = error;
+      }
+    }
+    final DownloadsResourceGap? gap = findDownloadsResourceGap(
+      backendReady: backendReady,
+      managedSourceCount: sources.length,
+      identityError: identityError,
+    );
+    if (gap == null &&
+        registry != null &&
+        pipeline != null &&
+        identity != null) {
+      return _DownloadsResourceReady(
         registry: registry,
         pipeline: pipeline,
-        identity: await appModel.currentVideoDownloadBackendIdentity(),
+        identity: identity,
         sources: sources,
         defaultSourceId: appModel.prefsRepo.videoDownloadTargetSourceId,
       );
-    } on Object {
-      return null;
     }
+    // gap == null 时上面三个必然非空，这条只是让类型收敛。
+    return _DownloadsResourceBlocked(
+      gap ?? const DownloadsResourceNoBackend(),
+    );
+  }
+
+  /// 「缺受管视频来源」空态的动作：就地开来源管理对话框加一个本地视频文件夹，
+  /// 关掉后重算前置条件——不用把用户支去别的页面再走回来。
+  Future<void> _addVideoSource() async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext _) => const MediaSourcesDialog(mediaKind: 'video'),
+    );
+    if (!mounted) return;
+    setState(() {
+      _resourceDependencies = _loadResourceDependencies();
+    });
   }
 
   Widget _buildResourceTab(BuildContext tabContext) {
-    return FutureBuilder<_DownloadsResourceDependencies?>(
+    return FutureBuilder<_DownloadsResourceState>(
       future: _resourceDependencies,
       builder: (
         BuildContext context,
-        AsyncSnapshot<_DownloadsResourceDependencies?> snapshot,
+        AsyncSnapshot<_DownloadsResourceState> snapshot,
       ) {
         if (snapshot.connectionState != ConnectionState.done) {
           return const Center(child: CircularProgressIndicator());
         }
-        final _DownloadsResourceDependencies? dependencies = snapshot.data;
-        if (dependencies == null) {
-          return Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Text(t.download_backend_not_configured),
-                const SizedBox(height: 12),
-                FilledButton.tonalIcon(
-                  onPressed: () =>
-                      DefaultTabController.of(tabContext).animateTo(3),
-                  icon: const Icon(Icons.settings_outlined),
-                  label: Text(t.download_open_settings),
-                ),
-              ],
-            ),
-          );
+        final _DownloadsResourceState? state = snapshot.data;
+        if (state is! _DownloadsResourceReady) {
+          final DownloadsResourceGap gap = state is _DownloadsResourceBlocked
+              ? state.gap
+              : const DownloadsResourceNoBackend();
+          return switch (gap) {
+            DownloadsResourceNoManagedSource() => _buildResourceGate(
+                message: t.download_no_managed_video_source,
+                icon: Icons.create_new_folder_outlined,
+                label: t.download_add_video_source,
+                onPressed: _addVideoSource,
+              ),
+            DownloadsResourceNoBackend(detail: final String? detail) =>
+              _buildResourceGate(
+                message: detail ?? t.download_backend_not_configured,
+                icon: Icons.settings_outlined,
+                label: t.download_open_settings,
+                onPressed: () =>
+                    DefaultTabController.of(tabContext).animateTo(3),
+              ),
+          };
         }
+        final _DownloadsResourceReady dependencies = state;
         return VideoResourceSearchSurface(
           key: const ValueKey<String>('downloads-resource-search'),
           registry: dependencies.registry,
@@ -131,6 +172,32 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
           ),
         );
       },
+    );
+  }
+
+  /// 「资源」标签的空态：一句说清缺什么 + 一个直接补上它的按钮。
+  Widget _buildResourceGate({
+    required String message,
+    required IconData icon,
+    required String label,
+    required VoidCallback onPressed,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(message, textAlign: TextAlign.center),
+            const SizedBox(height: 12),
+            FilledButton.tonalIcon(
+              onPressed: onPressed,
+              icon: Icon(icon),
+              label: Text(label),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -427,8 +494,22 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
   }
 }
 
-class _DownloadsResourceDependencies {
-  const _DownloadsResourceDependencies({
+/// 「资源」标签的前置条件解析结果：要么齐备可用，要么缺了具体某一环。
+/// 缺什么由 [findDownloadsResourceGap] 判定（BUG-1706）。
+sealed class _DownloadsResourceState {
+  const _DownloadsResourceState();
+}
+
+/// 前置条件没齐；[gap] 说清缺的是后端还是受管视频来源。
+class _DownloadsResourceBlocked extends _DownloadsResourceState {
+  const _DownloadsResourceBlocked(this.gap);
+
+  final DownloadsResourceGap gap;
+}
+
+/// 前置条件齐备，可以搜资源并推送下载。
+class _DownloadsResourceReady extends _DownloadsResourceState {
+  const _DownloadsResourceReady({
     required this.registry,
     required this.pipeline,
     required this.identity,

--- a/fushi/lib/src/pages/implementations/downloads_resource_gap.dart
+++ b/fushi/lib/src/pages/implementations/downloads_resource_gap.dart
@@ -1,0 +1,52 @@
+import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
+
+/// 下载页「资源」标签的前置条件缺口：缺的到底是哪一环。
+///
+/// BUG-1706：这三种情况此前在页面里一律折叠成一个 `null`，于是「下载后端配得
+/// 好好的、只是还没有受管视频来源」也被报成「请先配置下载后端」。用户照提示跳
+/// 到下载设置页，看见 qBittorrent 地址账密俱全、连接正常，就此卡死——提示把他
+/// 指向了一个根本没问题的地方。原因分开，提示和按钮才能各自指对地方。
+///
+/// 判定顺序本身也是契约（见 [findDownloadsResourceGap]），所以整段决策收在这个
+/// 纯函数里，不掺 I/O、不依赖数据库，便于钉住。
+sealed class DownloadsResourceGap {
+  const DownloadsResourceGap();
+}
+
+/// 下载后端没配好，或配了但连不上 → 该去「下载设置」。
+class DownloadsResourceNoBackend extends DownloadsResourceGap {
+  const DownloadsResourceNoBackend({this.detail});
+
+  /// 后端自己给出的不可用原因（如内置引擎缺运行时）；null = 压根还没配置。
+  final String? detail;
+}
+
+/// 后端没问题，缺的是下载完成后落地用的受管视频来源 → 该去加一个本地视频文件夹。
+class DownloadsResourceNoManagedSource extends DownloadsResourceGap {
+  const DownloadsResourceNoManagedSource();
+}
+
+/// 判断「资源」标签缺哪一环；返回 null = 前置条件齐备，可以搜资源。
+///
+/// 顺序是有意的：先问后端在不在（不在就谈不上别的），再问有没有落地用的受管
+/// 视频来源，最后才去解析后端身份——身份解析要连真后端，没来源时白连一趟。
+///
+/// [backendReady]：资源注册表与下载流水线都已就绪。
+/// [managedSourceCount]：`getManagedVideoDownloadSources()` 过滤后的来源条数
+/// （必须是真实存在的本地绝对路径目录，网络来源不算）。
+/// [identityError]：解析后端身份时抛出的异常；null = 没抛。
+DownloadsResourceGap? findDownloadsResourceGap({
+  required bool backendReady,
+  required int managedSourceCount,
+  required Object? identityError,
+}) {
+  if (!backendReady) return const DownloadsResourceNoBackend();
+  if (managedSourceCount <= 0) return const DownloadsResourceNoManagedSource();
+  if (identityError == null) return null;
+  // 后端配了但连不上：把后端自己给出的原因透传，别退化成「请先配置」——
+  // 用户已经配过了，再叫他去配一遍只会让他反复确认同一份正确配置。
+  if (identityError is VideoDownloadBackendUnavailable) {
+    return DownloadsResourceNoBackend(detail: identityError.message);
+  }
+  return const DownloadsResourceNoBackend();
+}

--- a/fushi/test/pages/downloads_resource_gap_test.dart
+++ b/fushi/test/pages/downloads_resource_gap_test.dart
@@ -1,0 +1,102 @@
+// BUG-1706：下载页「资源」标签把三种截然不同的缺口报成同一句话。
+//
+// 用户现场：qBittorrent 后端已配好（地址 http://127.0.0.1:1236、账密齐、
+// 分类 fushi），本地受管视频来源 0 条，于是页面显示「请先配置下载后端。」+
+// 「去设置」。用户照着跳到下载设置页，看到后端配置完好无缺，无从下手——
+// 提示把他指向了一个根本没问题的地方。
+//
+// 根因是页面把「后端没就绪」「没有受管视频来源」「后端身份解析失败」三种
+// 情况一律折叠成一个 `null`，只剩一句话可说。本文件钉住三者必须分开，以及
+// 判定顺序。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
+import 'package:fushi/src/pages/implementations/downloads_resource_gap.dart';
+
+void main() {
+  group('findDownloadsResourceGap', () {
+    test('后端就绪 + 有受管来源 + 身份解析成功 → 无缺口', () {
+      expect(
+        findDownloadsResourceGap(
+          backendReady: true,
+          managedSourceCount: 2,
+          identityError: null,
+        ),
+        isNull,
+      );
+    });
+
+    test('后端已配好、只是没有受管视频来源 → 报「缺来源」，绝不能报成「缺后端」', () {
+      final DownloadsResourceGap? gap = findDownloadsResourceGap(
+        backendReady: true,
+        managedSourceCount: 0,
+        identityError: null,
+      );
+      expect(
+        gap,
+        isA<DownloadsResourceNoManagedSource>(),
+        reason: 'BUG-1706 的用户现场：后端配置完好，缺的只是本地视频文件夹。'
+            '报成「请先配置下载后端」会把用户支到一个没问题的页面。',
+      );
+      expect(gap, isNot(isA<DownloadsResourceNoBackend>()));
+    });
+
+    test('后端没就绪 → 报「缺后端」', () {
+      expect(
+        findDownloadsResourceGap(
+          backendReady: false,
+          managedSourceCount: 3,
+          identityError: null,
+        ),
+        isA<DownloadsResourceNoBackend>(),
+      );
+    });
+
+    test('后端没就绪时优先报后端：没来源也先说后端（谈别的没意义）', () {
+      expect(
+        findDownloadsResourceGap(
+          backendReady: false,
+          managedSourceCount: 0,
+          identityError: null,
+        ),
+        isA<DownloadsResourceNoBackend>(),
+      );
+    });
+
+    test('后端配了但不可用 → 透传后端自己给的原因，不退化成「请先配置」', () {
+      final DownloadsResourceGap? gap = findDownloadsResourceGap(
+        backendReady: true,
+        managedSourceCount: 1,
+        identityError: const VideoDownloadBackendUnavailable(
+          videoDownloadEmbeddedBackendUnavailableMessage,
+        ),
+      );
+      expect(gap, isA<DownloadsResourceNoBackend>());
+      expect(
+        (gap! as DownloadsResourceNoBackend).detail,
+        videoDownloadEmbeddedBackendUnavailableMessage,
+        reason: '用户已经配过后端了，只说「请先配置」等于没说；'
+            '得把后端自己报的原因端到他面前。',
+      );
+    });
+
+    test('身份解析抛的是别的异常 → 仍报缺后端，但不编造原因', () {
+      final DownloadsResourceGap? gap = findDownloadsResourceGap(
+        backendReady: true,
+        managedSourceCount: 1,
+        identityError: ArgumentError('qBittorrent address must not be empty'),
+      );
+      expect(gap, isA<DownloadsResourceNoBackend>());
+      expect((gap! as DownloadsResourceNoBackend).detail, isNull);
+    });
+
+    test('尚未配置的缺后端不带 detail（由 UI 落到通用文案）', () {
+      final DownloadsResourceGap? gap = findDownloadsResourceGap(
+        backendReady: false,
+        managedSourceCount: 0,
+        identityError: null,
+      );
+      expect((gap! as DownloadsResourceNoBackend).detail, isNull);
+    });
+  });
+}

--- a/fushi/test/torrent/qbittorrent_api_v52_test.dart
+++ b/fushi/test/torrent/qbittorrent_api_v52_test.dart
@@ -1,0 +1,274 @@
+// BUG-1705：qBittorrent 5.2 换了 WebUI API 的成败编码，客户端此前只认 200。
+//
+// 上游根因（qbittorrent/qBittorrent release-5.2.3）：
+// - `APIController::setResult(const QString &)` 把 `QString()` 存进 `QVariant`，
+//   而 null QString 让 `QVariant::isNull()` 为真；`WebApplication` 见到 null
+//   data 就回 **204 No Content**。凡是「做完了没东西可回」的接口——
+//   `auth/login`、`torrents/{delete,stop,start,setLocation,renameFile,
+//   filePrio,createCategory,recheck}`——在 5.2 全部从 200 变 204。
+// - `auth/login` 的失败编码也变了：`throw APIError(APIErrorType::Unauthorized)`
+//   → **401**，不再是 5.1 的 `200` + body `Fails.`。
+// - `torrents/add` 从纯文本 `Ok.` / `Fails.` 变成统计 JSON，且磁力链元数据
+//   未到手时走 `APIStatus::Async` → **202**，全失败时抛 Conflict → **409**。
+//
+// 本文件两头都钉死：5.2 的新编码必须判成成功，5.1 的老编码不能被判坏
+// （Never break userspace）。
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/torrent/qbittorrent_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// qBittorrent 5.2.x 行为的最小仿真：登录回 204 + SID，动作接口回 204 空体。
+///
+/// [seen] 按路径记下收到的请求，供调用方断言参数。
+MockClient _qb52Server({
+  Map<String, http.Request>? seen,
+  Set<String> absentEndpoints = const <String>{},
+}) {
+  return MockClient((http.Request request) async {
+    final String path = request.url.path;
+    seen?[path] = request;
+    if (path == '/api/v2/auth/login') {
+      // 5.2：成功 = 204 空 body，SID 仍在 Set-Cookie 里。
+      return http.Response(
+        '',
+        204,
+        headers: <String, String>{'set-cookie': 'SID=v52tok; path=/'},
+      );
+    }
+    if (absentEndpoints.contains(path)) {
+      return http.Response('Not Found', 404);
+    }
+    if (path == '/api/v2/app/version') return http.Response('v5.2.3', 200);
+    if (path == '/api/v2/torrents/add') {
+      return http.Response(
+        jsonEncode(<String, Object>{
+          'success_count': 1,
+          'failure_count': 0,
+          'pending_count': 0,
+          'added_torrent_ids': <String>['abc'],
+        }),
+        200,
+      );
+    }
+    // 其余动作接口：5.2 一律 204 空体。
+    return http.Response('', 204);
+  });
+}
+
+/// qBittorrent 5.1.x 行为的最小仿真（回归护栏：老服务器不能被改坏）。
+MockClient _qb51Server() {
+  return MockClient((http.Request request) async {
+    final String path = request.url.path;
+    if (path == '/api/v2/auth/login') {
+      return http.Response(
+        'Ok.',
+        200,
+        headers: <String, String>{'set-cookie': 'SID=v51tok; path=/'},
+      );
+    }
+    if (path == '/api/v2/app/version') return http.Response('v5.1.2', 200);
+    if (path == '/api/v2/torrents/add') return http.Response('Ok.', 200);
+    // 5.1：动作接口 200 + 空 body。
+    return http.Response('', 200);
+  });
+}
+
+QBittorrentClient _client(http.Client inner) => QBittorrentClient(
+      baseUrl: 'http://qb.local:1236',
+      username: 'admin',
+      password: 'secret',
+      client: inner,
+    );
+
+void main() {
+  group('classifyQbLoginFailure（登录成败判读，两代协议）', () {
+    test('qb ≥5.2：204 空 body = 登录成功', () {
+      expect(classifyQbLoginFailure(204, ''), isNull);
+    });
+
+    test('qb ≤5.1：200 + Ok. = 登录成功', () {
+      expect(classifyQbLoginFailure(200, 'Ok.'), isNull);
+    });
+
+    test('qb ≥5.2：401 = 账密错误，说人话不是裸 HTTP 码', () {
+      expect(
+        classifyQbLoginFailure(401, ''),
+        'login rejected (wrong username/password)',
+      );
+    });
+
+    test('qb ≤5.1：200 + Fails. = 账密错误', () {
+      expect(
+        classifyQbLoginFailure(200, 'Fails.'),
+        'login rejected (wrong username/password)',
+      );
+    });
+
+    test('两代相同：403 + banned 单独报，别让用户反复重试续期封禁', () {
+      final String? reason = classifyQbLoginFailure(
+        403,
+        'Your IP address has been banned after too many failed '
+        'authentication attempts.',
+      );
+      expect(reason, contains('IP banned by qBittorrent'));
+    });
+
+    test('403 但不是封禁：原样透出状态码与 body', () {
+      expect(classifyQbLoginFailure(403, 'nope'), 'HTTP 403: nope');
+    });
+
+    test('其它状态码：带上 body 便于自查', () {
+      expect(classifyQbLoginFailure(500, 'boom'), 'HTTP 500: boom');
+      expect(classifyQbLoginFailure(502, ''), 'HTTP 502');
+    });
+  });
+
+  group('isQbActionSuccess（无返回体的动作接口）', () {
+    test('200（≤5.1）与 204（≥5.2）都算成功', () {
+      expect(isQbActionSuccess(200), isTrue);
+      expect(isQbActionSuccess(204), isTrue);
+    });
+
+    test('404 / 403 / 409 / 500 都不算成功', () {
+      expect(isQbActionSuccess(404), isFalse);
+      expect(isQbActionSuccess(403), isFalse);
+      expect(isQbActionSuccess(409), isFalse);
+      expect(isQbActionSuccess(500), isFalse);
+    });
+  });
+
+  group('isQbAddAccepted（torrents/add 两代返回体）', () {
+    test('qb ≤5.1：200 Ok. 收下，200 Fails. 不收', () {
+      expect(isQbAddAccepted(200, 'Ok.'), isTrue);
+      expect(isQbAddAccepted(200, 'Fails.'), isFalse);
+    });
+
+    test('qb ≥5.2：200 + success_count>0 的统计 JSON 收下', () {
+      expect(
+        isQbAddAccepted(
+          200,
+          '{"success_count":2,"failure_count":0,"pending_count":0,'
+          '"added_torrent_ids":["a","b"]}',
+        ),
+        isTrue,
+      );
+    });
+
+    test('qb ≥5.2：磁力链元数据待拉取的 202 也算已入列', () {
+      expect(
+        isQbAddAccepted(
+          202,
+          '{"success_count":0,"failure_count":0,"pending_count":1,'
+          '"added_torrent_ids":[]}',
+        ),
+        isTrue,
+      );
+    });
+
+    test('一个都没加进去（全 0 / 409）不算成功', () {
+      expect(
+        isQbAddAccepted(
+          200,
+          '{"success_count":0,"failure_count":3,"pending_count":0,'
+          '"added_torrent_ids":[]}',
+        ),
+        isFalse,
+      );
+      expect(isQbAddAccepted(409, ''), isFalse);
+    });
+
+    test('坏 JSON / 非对象 JSON 不吞异常也不误判成功', () {
+      expect(isQbAddAccepted(200, '{not json'), isFalse);
+      expect(isQbAddAccepted(200, '{"success_count":"many"}'), isFalse);
+    });
+  });
+
+  group('对 qBittorrent 5.2 服务器的端到端行为', () {
+    test('204 登录被判成功：后续请求带上 SID 直接可用', () async {
+      final Map<String, http.Request> seen = <String, http.Request>{};
+      final QBittorrentClient client = _client(_qb52Server(seen: seen));
+      expect(await client.login(), isTrue);
+      expect(client.lastFailure, isNull);
+      expect(await client.fetchVersion(), 'v5.2.3');
+      expect(
+        seen['/api/v2/app/version']!
+            .headers
+            .entries
+            .firstWhere(
+                (MapEntry<String, String> e) => e.key.toLowerCase() == 'cookie')
+            .value,
+        'SID=v52tok',
+      );
+      client.close();
+    });
+
+    test('回 204 的动作接口全部判成功（此前全被判失败）', () async {
+      final QBittorrentClient client = _client(_qb52Server());
+      expect(await client.deleteTorrent('h1'), isTrue);
+      expect(await client.ensureCategory('fushi'), isTrue);
+      expect(
+        await client.setFilePriority(
+            hash: 'h1', fileIndexes: <int>[0], priority: 7),
+        isTrue,
+      );
+      expect(
+        await client.renameFile(hash: 'h1', oldPath: 'a', newPath: 'b'),
+        (true, null),
+      );
+      expect(
+        await client.setLocation(hash: 'h1', location: 'E:/Anime'),
+        (true, null),
+      );
+      client.close();
+    });
+
+    test('暂停/恢复：旧端点 404 回退新端点后仍认 204', () async {
+      final QBittorrentClient client = _client(_qb52Server(
+        absentEndpoints: <String>{
+          '/api/v2/torrents/pause',
+          '/api/v2/torrents/resume',
+        },
+      ));
+      expect(await client.pauseTorrent('h1'), isTrue);
+      expect(await client.resumeTorrent('h1'), isTrue);
+      client.close();
+    });
+
+    test('torrents/add 回统计 JSON 也算添加成功', () async {
+      final QBittorrentClient client = _client(_qb52Server());
+      expect(await client.addTorrents(<String>['magnet:?xt=x']), isTrue);
+      client.close();
+    });
+  });
+
+  group('对 qBittorrent 5.1 服务器的回归护栏（不许改坏老服务器）', () {
+    test('200 Ok. 登录、200 空体动作、200 Ok. 添加全部照旧成功', () async {
+      final QBittorrentClient client = _client(_qb51Server());
+      expect(await client.login(), isTrue);
+      expect(await client.fetchVersion(), 'v5.1.2');
+      expect(await client.deleteTorrent('h1'), isTrue);
+      expect(await client.ensureCategory('fushi'), isTrue);
+      expect(await client.pauseTorrent('h1'), isTrue);
+      expect(await client.addTorrents(<String>['magnet:?xt=x']), isTrue);
+      expect(
+        await client.setLocation(hash: 'h1', location: 'E:/Anime'),
+        (true, null),
+      );
+      client.close();
+    });
+
+    test('200 Fails. 的错误账密仍被判成登录失败', () async {
+      final QBittorrentClient client = _client(
+        MockClient(
+            (http.Request request) async => http.Response('Fails.', 200)),
+      );
+      expect(await client.login(), isFalse);
+      expect(client.lastFailure, contains('wrong username/password'));
+      client.close();
+    });
+  });
+}


### PR DESCRIPTION
用户报了两件事，一件截图 + 一件外部 issue 线索，验下来是两个独立真 bug。

## BUG-1705 · qBittorrent 5.2 登录（以及一整批动作接口）被判成失败

用户 qBittorrent 5.2.3、WebUI 正常返回 200、账密地址端口都对，Hibiki 仍报登录失败。

对照上游 `release-5.1.2` 与 `release-5.2.3` 源码逐版本核实，根因不止登录：

- `APIController::setResult(const QString&)` 把 `QString()` 存进 `QVariant`；null QString 让 `QVariant::isNull()` 为真，`webapplication.cpp:406` 据此回 **204**。**5.1.2 全文没有 204**，这是 5.2 新增编码。
- 于是 `auth/login`、`torrents/{delete,stop,start,setLocation,renameFile,filePrio,createCategory,recheck}` 在 5.2 **全部从 200 变 204**。
- `loginAction()` 的凭据错误从 `200 Fails.` 变成 `APIError(Unauthorized)` → **401**。
- `addAction()` 从 `setResult("Ok.")` 变成统计 JSON；磁力链元数据未到手时 `APIStatus::Async` → **202**；全失败 → **409**。旧判据 `200 && body.startsWith('Ok')` 对 5.2 恒 false。
- 会话过期两版都是 403，`_request` 的重登逻辑不受影响，未动。

改法：把两代差异收进三个纯函数（`isQbActionSuccess` / `classifyQbLoginFailure` / `isQbAddAccepted`），十几个调用点不再各自硬判状态码。需要解析响应体的查询接口（info/files/version/preferences/…）**保持只认 200**——它们收到 204 才是真异常。

## BUG-1706 · 下载页「资源」标签的空态指错地方

后端配好（`127.0.0.1:1236`、账密齐、分类 fushi）、受管视频来源 0 条时，页面报「请先配置下载后端。」+「去设置」。用户跳过去看见后端配置完好，无从下手。

根因是 `_loadResourceDependencies()` 对三种情况都 `return null`（后端没就绪 / 没有受管来源 / 身份解析失败），消费端只剩一句话可说。

改法：抽出纯函数 `findDownloadsResourceGap` + sealed `DownloadsResourceGap`，缺来源给「添加视频来源」按钮就地开来源对话框、关掉后重算前置条件；缺后端才去设置，且后端自己报的原因优先透传。顺带去掉一次无谓往返（没来源时不再连后端）。

## 验证

- `flutter analyze` 干净。
- 新增测试 27 条（qB 协议 20 + 空态判定 7），两条关键判据都做了**变异实测**：变异必红、还原后文件 sha256 与变异前逐字节一致。
- 定向 385 条绿（test/torrent + test/i18n + 下载页相关）。
- 目录枚举型守卫整批 250 条绿（与文档基线数一致）。
- 全量 19560 条：1 条红 `test/sync/sync_orchestrator_collections_test.dart:270`，**与本 PR 无关**——单跑绿、test/sync 整目录 2234 条绿、该测试依赖闭包不含本 PR 任何文件；症状（满负载下成员随机复活）正是该文件 `tick()` 注释里记录的既有负载敏感 flaky。

## 未做

真机复测未做（用户 1236 端口排查时未启动，无法现场抓包），故 qB 侧取证走的是上游源码逐行比对而非抓包。
