### PR TITLE
feat(video): 控制条可自定义「快捷键」按钮 + 字幕对齐到当前时间按钮

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60996 (3588 per locale)
+/// Strings: 61064 (3592 per locale)
 ///
-/// Built on 2026-08-18 at 13:05 UTC
+/// Built on 2026-08-18 at 15:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4871,6 +4871,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_no_managed_video_source =>
       'No managed video source yet. Downloads need a local video folder to land in.';
   String get download_add_video_source => 'Add video source';
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -13180,6 +13185,15 @@ class _StringsAr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -21556,6 +21570,15 @@ class _StringsDe extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -29948,6 +29971,15 @@ class _StringsEs extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -38352,6 +38384,15 @@ class _StringsFr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -46684,6 +46725,15 @@ class _StringsId extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -55062,6 +55112,15 @@ class _StringsIt extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -63254,6 +63313,15 @@ class _StringsJa extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -71453,6 +71521,15 @@ class _StringsKo extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -79811,6 +79888,15 @@ class _StringsNl extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -88181,6 +88267,15 @@ class _StringsPtBr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -96537,6 +96632,15 @@ class _StringsRu extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -104841,6 +104945,15 @@ class _StringsTh extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -113176,6 +113289,15 @@ class _StringsTr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -121496,6 +121618,15 @@ class _StringsVi extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 // Path: <root>
@@ -129197,6 +129328,14 @@ class _StringsZhCn extends _StringsEn {
       '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
   @override
   String get download_add_video_source => '添加视频来源';
+  @override
+  String get video_subtitle_prev_cue_align => '上一句对齐到当前';
+  @override
+  String get video_subtitle_next_cue_align => '下一句对齐到当前';
+  @override
+  String video_control_custom_action({required Object index}) => '快捷键 ${index}';
+  @override
+  String get video_control_custom_action_none => '不绑定';
 }
 
 // Path: <root>
@@ -137312,6 +137451,15 @@ class _StringsZhHk extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get video_subtitle_prev_cue_align => 'Align previous line to now';
+  @override
+  String get video_subtitle_next_cue_align => 'Align next line to now';
+  @override
+  String video_control_custom_action({required Object index}) =>
+      'Shortcut ${index}';
+  @override
+  String get video_control_custom_action_none => 'Not assigned';
 }
 
 /// Flat map(s) containing all translations.
@@ -144678,6 +144826,14 @@ extension on _StringsEn {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -152042,6 +152198,14 @@ extension on _StringsAr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -159428,6 +159592,14 @@ extension on _StringsDe {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -166813,6 +166985,14 @@ extension on _StringsEs {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -174204,6 +174384,14 @@ extension on _StringsFr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -181577,6 +181765,14 @@ extension on _StringsId {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -188964,6 +189160,14 @@ extension on _StringsIt {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -196313,6 +196517,14 @@ extension on _StringsJa {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -203666,6 +203878,14 @@ extension on _StringsKo {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -211047,6 +211267,14 @@ extension on _StringsNl {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -218425,6 +218653,14 @@ extension on _StringsPtBr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -225808,6 +226044,14 @@ extension on _StringsRu {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -233174,6 +233418,14 @@ extension on _StringsTh {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -240549,6 +240801,14 @@ extension on _StringsTr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -247920,6 +248180,14 @@ extension on _StringsVi {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }
@@ -255232,6 +255500,14 @@ extension on _StringsZhCn {
         return '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
       case 'download_add_video_source':
         return '添加视频来源';
+      case 'video_subtitle_prev_cue_align':
+        return '上一句对齐到当前';
+      case 'video_subtitle_next_cue_align':
+        return '下一句对齐到当前';
+      case 'video_control_custom_action':
+        return ({required Object index}) => '快捷键 ${index}';
+      case 'video_control_custom_action_none':
+        return '不绑定';
       default:
         return null;
     }
@@ -262576,6 +262852,14 @@ extension on _StringsZhHk {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'video_subtitle_prev_cue_align':
+        return 'Align previous line to now';
+      case 'video_subtitle_next_cue_align':
+        return 'Align next line to now';
+      case 'video_control_custom_action':
+        return ({required Object index}) => 'Shortcut ${index}';
+      case 'video_control_custom_action_none':
+        return 'Not assigned';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "以后自动扫描此文件夹里的新视频",
   "manga_import_folder_as_source_hint": "以后自动扫描此文件夹里的新漫画",
   "download_no_managed_video_source": "还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。",
-  "download_add_video_source": "添加视频来源"
+  "download_add_video_source": "添加视频来源",
+  "video_subtitle_prev_cue_align": "上一句对齐到当前",
+  "video_subtitle_next_cue_align": "下一句对齐到当前",
+  "video_control_custom_action": "快捷键 $index",
+  "video_control_custom_action_none": "不绑定"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3586,5 +3586,9 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "video_subtitle_prev_cue_align": "Align previous line to now",
+  "video_subtitle_next_cue_align": "Align next line to now",
+  "video_control_custom_action": "Shortcut $index",
+  "video_control_custom_action_none": "Not assigned"
 }

--- a/fushi/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/fushi/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -46,6 +46,7 @@ class SubtitleWaveformAlignPanel extends StatefulWidget {
     required this.loadWaveform,
     this.onCommitDelay,
     this.onAutoAlign,
+    this.onSnapDelayToCue,
     this.onPlayCue,
     this.isPlaying,
     this.onTogglePlayPause,
@@ -81,6 +82,12 @@ class SubtitleWaveformAlignPanel extends StatefulWidget {
   /// 时放大对轴视图显示「自动对轴」按钮，与顶部快速设置的自动对轴按钮同一逻辑、零第二套
   /// 状态。null = 不显示该按钮（无字幕 / 无视频路径）。
   final Future<int?> Function()? onAutoAlign;
+
+  /// 「上一句 / 下一句字幕对齐到当前播放时间」回调（= 页面 `_snapSubtitleDelayToCue`，
+  /// 与键盘 Ctrl+Shift+←/→ 同一执行体）。按目标 cue 求**绝对**偏移并写穿延迟，返回
+  /// 本次写穿的新延迟供放大视图同步本地预览；已是首末句 / 位置未就绪返回 null（不改值）。
+  /// 本面板只透传给 [SubtitleWaveformZoomView]。null = 不显示这两个按钮（无字幕 cue）。
+  final int? Function({required bool next})? onSnapDelayToCue;
 
   /// TODO-1244：逐句试听回调。放大对轴视图的每句字幕旁挂一个播放按钮，点击把播放器
   /// seek 到该句（叠加当前预览延迟后的）时间并播放，方便用户核对「这段波形是哪句话」。
@@ -166,6 +173,7 @@ class _SubtitleWaveformAlignPanelState
         initialDelayMs: widget.initialDelayMs,
         onCommitDelay: widget.onCommitDelay,
         onAutoAlign: widget.onAutoAlign,
+        onSnapDelayToCue: widget.onSnapDelayToCue,
         onPlayCue: widget.onPlayCue,
         isPlaying: widget.isPlaying,
         onTogglePlayPause: widget.onTogglePlayPause,
@@ -274,6 +282,7 @@ class SubtitleWaveformZoomView extends StatefulWidget {
     required this.initialDelayMs,
     this.onCommitDelay,
     this.onAutoAlign,
+    this.onSnapDelayToCue,
     this.onPlayCue,
     this.isPlaying,
     this.onTogglePlayPause,
@@ -304,6 +313,11 @@ class SubtitleWaveformZoomView extends StatefulWidget {
   /// 放大对轴视图显示「自动对轴」按钮，点击调此回调求整体平移并经 [onCommitDelay] 同步；
   /// null = 不显示按钮。
   final Future<int?> Function()? onAutoAlign;
+
+  /// 「上一句 / 下一句字幕对齐到当前播放时间」回调（同
+  /// [SubtitleWaveformAlignPanel.onSnapDelayToCue]）。传入时底部调轴控件条显示这两个
+  /// 按钮，点击后把回传的新延迟经 [_commit] 同步到本地预览 + cue 线；null = 不显示。
+  final int? Function({required bool next})? onSnapDelayToCue;
 
   /// TODO-1244：逐句试听回调。文本条每句的播放按钮点击时把播放器 seek 到该句（叠加当前
   /// 预览延迟后的）时间并播放。null = 不显示播放按钮。
@@ -681,6 +695,19 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
     } finally {
       if (mounted) setState(() => _autoAligning = false);
     }
+  }
+
+  /// 「上一句 / 下一句字幕对齐到当前播放时间」（asbplayer 式绝对偏移，与键盘
+  /// Ctrl+Shift+←/→ 同一执行体）。页面侧回调完成决策与写穿，这里只把回传的新延迟经
+  /// [_commit] 同步进本地 [_delayMs] + 输入框 + 波形 cue 线（与自动对轴同款契约）。
+  /// 返回 null（已是首末句 / 位置未就绪）时保持原值不动，也不置低置信提示——那是自动
+  /// 对轴的置信度语义，与本动作无关。
+  Future<void> _snapDelayToCue({required bool next}) async {
+    final int? Function({required bool next})? cb = widget.onSnapDelayToCue;
+    if (cb == null) return;
+    final int? newDelayMs = cb(next: next);
+    if (newDelayMs == null || !mounted) return;
+    await _commit(newDelayMs);
   }
 
   void _zoomBy(double factor) {
@@ -1347,6 +1374,22 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
           padding: EdgeInsets.all(gap / 2),
           onTap: () => _commit(_delayMs + 1000),
         ),
+        // 「上/下一句对齐到当前时间」：与快速设置面板调轴行同一对按钮、同一执行体。
+        // 在放大视图里尤其顺手——播放头就在波形上，点完立刻能看到 cue 线跳到位。
+        if (widget.onSnapDelayToCue != null) ...<Widget>[
+          FushiIconButton(
+            icon: Icons.align_horizontal_left,
+            tooltip: t.video_subtitle_prev_cue_align,
+            padding: EdgeInsets.all(gap / 2),
+            onTap: () => _snapDelayToCue(next: false),
+          ),
+          FushiIconButton(
+            icon: Icons.align_horizontal_right,
+            tooltip: t.video_subtitle_next_cue_align,
+            padding: EdgeInsets.all(gap / 2),
+            onTap: () => _snapDelayToCue(next: true),
+          ),
+        ],
       ],
     );
 

--- a/fushi/lib/src/media/video/video_control_customization.dart
+++ b/fushi/lib/src/media/video/video_control_customization.dart
@@ -168,9 +168,10 @@ enum VideoControlItem {
   // 触摸端没有键盘——近 40 个视频动作里只有 ~25 个有具名按钮，其余在手机上根本没法
   // 触发。与其为每个动作再加一个枚举项，不如给几个可绑定的通用槽位。
   //
-  // **未绑定的槽位在播放器上不渲染**（见 `_shouldRenderControlItem`），所以新增这 4
-  // 项对现有用户零影响：老配置解出来它们要么在隐藏托盘、要么在默认槽位但因未绑定而
-  // 不显示，播放器长相完全不变。
+  // **未绑定也照常渲染**（用户拍板，见 `_shouldRenderControlItem`）：空槽位点一下就
+  // 地弹动作选择器，所以它不是死按钮，而是手机上最短的配置路径——看得见、点得到、
+  // 当场配好。代价是所有用户（含老用户，见 [currentChrome] 的兜底 assignment）升级后
+  // 底栏右区会多出 4 个按钮；不想要的可以像其它按钮一样拖进隐藏托盘。
   customAction1('customAction1'),
   customAction2('customAction2'),
   customAction3('customAction3'),
@@ -514,9 +515,9 @@ class VideoControlLayout {
       VideoControlItem.settings: VideoControlSlot.bottomRight,
       VideoControlItem.favoriteSentence: VideoControlSlot.bottomRight,
       VideoControlItem.subtitleList: VideoControlSlot.screenRight,
-      // 自定义「快捷键」按钮默认落底栏右区：绑定后就出现在顺手位置，不用再拖一次。
-      // 未绑定时不渲染（见 `_shouldRenderControlItem`），所以放在这里不会让默认布局
-      // 平白多出 4 个按钮。
+      // 自定义「快捷键」按钮默认落底栏右区，未绑定也显示——空槽位点一下即弹动作
+      // 选择器，是手机上最短的配置路径。与 [currentChrome] 保持一致（那份还兼任老
+      // 布局的解码兜底）。
       VideoControlItem.customAction1: VideoControlSlot.bottomRight,
       VideoControlItem.customAction2: VideoControlSlot.bottomRight,
       VideoControlItem.customAction3: VideoControlSlot.bottomRight,
@@ -614,6 +615,13 @@ class VideoControlLayout {
       VideoControlItem.subtitleList: VideoControlSlot.screenRight,
       VideoControlItem.favoriteSentence: VideoControlSlot.screenRight,
       VideoControlItem.settings: VideoControlSlot.screenRight,
+      // -- 自定义「快捷键 1..4」按钮：默认可见（未绑定也显示，点它就地配动作）。
+      // 这条 assignment 同时是**老布局的解码兜底**：不列在这里，老用户升级后这几个
+      // 按钮会被判成「用户移除过」而落进隐藏托盘，播放器上永远不出现。
+      VideoControlItem.customAction1: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction2: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction3: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction4: VideoControlSlot.bottomRight,
     },
     explicitOrder: const <VideoControlSlot, List<VideoControlItem>>{
       VideoControlSlot.topLeft: <VideoControlItem>[
@@ -648,6 +656,16 @@ class VideoControlLayout {
         VideoControlItem.volume,
         VideoControlItem.fullscreen,
         VideoControlItem.speed,
+        // 自定义「快捷键 1..4」按钮默认落底栏右区，**未绑定也显示**（用户拍板）。
+        //
+        // 必须写在 [currentChrome] 而不只是 [defaults]：老用户的持久化布局里没有这几个
+        // 新枚举项，解码时按 `currentChrome.slotOf(item)` 兜底——不列在这里就会被判成
+        // 「用户移除过」而落进隐藏托盘，于是升级后**在播放器上永远看不到它们**，得先
+        // 翻进编辑器把它们拖出来才知道有这功能。空槽位点一下即弹动作选择器，不是死按钮。
+        VideoControlItem.customAction1,
+        VideoControlItem.customAction2,
+        VideoControlItem.customAction3,
+        VideoControlItem.customAction4,
       ],
       VideoControlSlot.screenRight: <VideoControlItem>[
         VideoControlItem.subtitleList,

--- a/fushi/lib/src/media/video/video_control_customization.dart
+++ b/fushi/lib/src/media/video/video_control_customization.dart
@@ -160,7 +160,21 @@ enum VideoControlItem {
   nextChapter('nextChapter'),
   chapterList('chapterList'),
   title('title', isSpecialRender: true),
-  positionIndicator('positionIndicator', isSpecialRender: true);
+  positionIndicator('positionIndicator', isSpecialRender: true),
+
+  // -- 自定义「快捷键」按钮（用户请求）--
+  // 4 个空槽位，各由用户绑一个视频动作（绑定表见 [VideoCustomActionBindings]，与本
+  // 布局分开持久化：这里只管「按钮放在哪」，那里只管「按钮干什么」）。存在的理由是
+  // 触摸端没有键盘——近 40 个视频动作里只有 ~25 个有具名按钮，其余在手机上根本没法
+  // 触发。与其为每个动作再加一个枚举项，不如给几个可绑定的通用槽位。
+  //
+  // **未绑定的槽位在播放器上不渲染**（见 `_shouldRenderControlItem`），所以新增这 4
+  // 项对现有用户零影响：老配置解出来它们要么在隐藏托盘、要么在默认槽位但因未绑定而
+  // 不显示，播放器长相完全不变。
+  customAction1('customAction1'),
+  customAction2('customAction2'),
+  customAction3('customAction3'),
+  customAction4('customAction4');
 
   const VideoControlItem(
     this.storageValue, {
@@ -188,6 +202,39 @@ enum VideoControlItem {
 
   /// Legacy [VideoControlButton] peer (learning keys only; transport keys null).
   final VideoControlButton? legacyButton;
+
+  /// 自定义「快捷键」按钮的槽位下标（0-based，对应
+  /// [VideoCustomActionBindings.actionAt] 的参数）；非自定义按钮返回 null。
+  ///
+  /// 单一真相源：图标 / 标签 / 是否渲染 / 点击执行四条路径都用它把枚举项换算成槽位
+  /// 号，而不是各自写一遍 `item == customAction1 ? 0 : ...` 的四分支 switch。
+  int? get customActionSlotIndex {
+    switch (this) {
+      case VideoControlItem.customAction1:
+        return 0;
+      case VideoControlItem.customAction2:
+        return 1;
+      case VideoControlItem.customAction3:
+        return 2;
+      case VideoControlItem.customAction4:
+        return 3;
+      // ignore: no_default_cases
+      default:
+        return null;
+    }
+  }
+
+  /// 是否是自定义「快捷键」按钮槽位。
+  bool get isCustomAction => customActionSlotIndex != null;
+
+  /// 全部自定义「快捷键」按钮槽位，按序号升序（= 快捷键1、2、3、4）。
+  static List<VideoControlItem> get customActionItems => <VideoControlItem>[
+        for (final VideoControlItem item in VideoControlItem.values)
+          if (item.isCustomAction) item,
+      ]..sort(
+          (VideoControlItem a, VideoControlItem b) =>
+              a.customActionSlotIndex!.compareTo(b.customActionSlotIndex!),
+        );
 
   static VideoControlItem? fromStorage(String value) {
     for (final VideoControlItem item in VideoControlItem.values) {
@@ -467,6 +514,13 @@ class VideoControlLayout {
       VideoControlItem.settings: VideoControlSlot.bottomRight,
       VideoControlItem.favoriteSentence: VideoControlSlot.bottomRight,
       VideoControlItem.subtitleList: VideoControlSlot.screenRight,
+      // 自定义「快捷键」按钮默认落底栏右区：绑定后就出现在顺手位置，不用再拖一次。
+      // 未绑定时不渲染（见 `_shouldRenderControlItem`），所以放在这里不会让默认布局
+      // 平白多出 4 个按钮。
+      VideoControlItem.customAction1: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction2: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction3: VideoControlSlot.bottomRight,
+      VideoControlItem.customAction4: VideoControlSlot.bottomRight,
     },
     explicitOrder: const <VideoControlSlot, List<VideoControlItem>>{
       VideoControlSlot.topLeft: <VideoControlItem>[

--- a/fushi/lib/src/media/video/video_control_item_presentation.dart
+++ b/fushi/lib/src/media/video/video_control_item_presentation.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_labels.dart';
 
 /// Single source of truth for the icon + label presentation of every
 /// [VideoControlItem] / [VideoControlButton].
@@ -55,7 +58,19 @@ String videoControlButtonLabel(VideoControlButton button) {
 }
 
 /// Icon for [item]. Legacy button items defer to [videoControlButtonIcon].
-IconData videoControlItemIcon(VideoControlItem item) {
+///
+/// [bindings] 只对自定义「快捷键 1..4」按钮有意义：它们没有固定图标，长相取决于用户
+/// 绑了哪个动作（用户拍板：按钮显示该动作的图标，一眼认得出，不用记住 1 是什么）。
+/// 不传 / 未绑定时退回通用的「快捷键」闪电图标——编辑器调色板里那个还没配动作的空槽位
+/// 正是这个样子。
+IconData videoControlItemIcon(
+  VideoControlItem item, {
+  VideoCustomActionBindings? bindings,
+}) {
+  final int? slotIndex = item.customActionSlotIndex;
+  if (slotIndex != null) {
+    return bindings?.actionAt(slotIndex)?.buttonIcon ?? Icons.bolt_outlined;
+  }
   final VideoControlButton? legacy = item.legacyButton;
   if (legacy != null) return videoControlButtonIcon(legacy);
   switch (item) {
@@ -109,12 +124,33 @@ IconData videoControlItemIcon(VideoControlItem item) {
     case VideoControlItem.favoriteSentence:
     case VideoControlItem.settings:
       return Icons.tune;
+    case VideoControlItem.customAction1:
+    case VideoControlItem.customAction2:
+    case VideoControlItem.customAction3:
+    case VideoControlItem.customAction4:
+      // 不可达：函数开头已按 [customActionSlotIndex] 解析并返回。保留分支只为让穷举
+      // 检查继续生效——将来新增枚举项时仍然是「漏写即编译失败」。
+      return Icons.bolt_outlined;
   }
 }
 
 /// Localised label for [item]. Legacy button items defer to
 /// [videoControlButtonLabel]; the `back` case uses [MaterialLocalizations].
-String videoControlItemLabel(VideoControlItem item, BuildContext context) {
+///
+/// [bindings] 同 [videoControlItemIcon]：自定义「快捷键 1..4」按钮显示其**绑定动作**的
+/// 名字（tooltip / 无障碍标签都读这里），未绑定时退回「快捷键 N」这个槽位名——用户在
+/// 编辑器里正是靠这个名字认出「这是第几个槽位」。
+String videoControlItemLabel(
+  VideoControlItem item,
+  BuildContext context, {
+  VideoCustomActionBindings? bindings,
+}) {
+  final int? slotIndex = item.customActionSlotIndex;
+  if (slotIndex != null) {
+    final ShortcutAction? action = bindings?.actionAt(slotIndex);
+    if (action != null) return action.label;
+    return t.video_control_custom_action(index: slotIndex + 1);
+  }
   final VideoControlButton? legacy = item.legacyButton;
   if (legacy != null) return videoControlButtonLabel(legacy);
   switch (item) {
@@ -167,6 +203,12 @@ String videoControlItemLabel(VideoControlItem item, BuildContext context) {
     case VideoControlItem.subtitleList:
     case VideoControlItem.favoriteSentence:
     case VideoControlItem.settings:
+      return item.storageValue;
+    case VideoControlItem.customAction1:
+    case VideoControlItem.customAction2:
+    case VideoControlItem.customAction3:
+    case VideoControlItem.customAction4:
+      // 不可达：函数开头已按 [customActionSlotIndex] 解析并返回（见 icon 同款注释）。
       return item.storageValue;
   }
 }

--- a/fushi/lib/src/media/video/video_control_layout_edit_overlay.dart
+++ b/fushi/lib/src/media/video/video_control_layout_edit_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
 import 'package:fushi/src/media/video/video_control_item_presentation.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/misc/platform_utils.dart';
 
@@ -14,12 +15,18 @@ class VideoControlLayoutEditOverlay extends StatefulWidget {
     required this.onLayoutChanged,
     required this.onClose,
     this.isTouchControls = false,
+    this.customActionBindings = VideoCustomActionBindings.empty,
     super.key,
   });
 
   final VideoControlLayout layout;
   final Future<void> Function(VideoControlLayout layout) onLayoutChanged;
   final VoidCallback onClose;
+
+  /// 自定义「快捷键 1..4」按钮当前绑的动作：决定本覆盖层里那几个 chip 显示成哪个动作
+  /// 的图标与名字。本覆盖层**只管摆位置、不改绑**（它已经是个拖拽密集的界面，再叠一层
+  /// tap 语义容易误触）；改绑走设置里的 [VideoControlLayoutEditor]。
+  final VideoCustomActionBindings customActionBindings;
 
   /// Touch surface (no right-click context menu fallback): forbids removing the
   /// sole in-player settings entry so the user cannot soft-lock the controls
@@ -645,14 +652,21 @@ class _VideoControlLayoutEditOverlayState
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Icon(
-              videoControlItemIcon(item),
+              videoControlItemIcon(
+                item,
+                bindings: widget.customActionBindings,
+              ),
               size: 15,
               color: cs.onSecondaryContainer,
             ),
             const SizedBox(width: 5),
             Flexible(
               child: Text(
-                videoControlItemLabel(item, context),
+                videoControlItemLabel(
+                  item,
+                  context,
+                  bindings: widget.customActionBindings,
+                ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 softWrap: false,

--- a/fushi/lib/src/media/video/video_control_layout_editor.dart
+++ b/fushi/lib/src/media/video/video_control_layout_editor.dart
@@ -5,6 +5,10 @@ import 'package:flutter/material.dart';
 
 import 'package:fushi/src/media/video/video_control_customization.dart';
 import 'package:fushi/src/media/video/video_control_item_presentation.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_labels.dart';
 import 'package:fushi/utils.dart';
 
 /// 控制条 9 槽位拖拽编辑器（TODO-274/312 phase 2）。从旧
@@ -17,6 +21,8 @@ class VideoControlLayoutEditor extends StatefulWidget {
     required this.layout,
     required this.onLayoutChanged,
     required this.isTouchControls,
+    this.customActionBindings = VideoCustomActionBindings.empty,
+    this.onCustomActionBindingsChanged,
     super.key,
   });
 
@@ -29,6 +35,14 @@ class VideoControlLayoutEditor extends StatefulWidget {
   /// 触屏控件（无右键菜单兜底）：禁止把「设置」按钮拖入 hidden 移除（TODO-554）。
   final bool isTouchControls;
 
+  /// 自定义「快捷键 1..4」按钮当前绑的动作（决定 chip 的图标与名字）。
+  final VideoCustomActionBindings customActionBindings;
+
+  /// 改绑回调：点「快捷键 N」chip 选动作后落盘 + 实时生效（调用方负责）。
+  /// null = 不提供改绑入口（chip 仍可拖动，只是点不出选择器）。
+  final Future<void> Function(VideoCustomActionBindings bindings)?
+      onCustomActionBindingsChanged;
+
   @override
   State<VideoControlLayoutEditor> createState() =>
       _VideoControlLayoutEditorState();
@@ -38,9 +52,17 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
   late VideoControlLayout _controlLayout = widget.layout;
   String? _controlMoveRejectionMessage;
 
+  /// 自定义「快捷键」按钮绑定的本地镜像：与 [_controlLayout] 同款——本地先改、UI 立刻
+  /// 反映，同时把新值交给外部落盘（外部回传经 didUpdateWidget 同步回来）。
+  late VideoCustomActionBindings _customActionBindings =
+      widget.customActionBindings;
+
   @override
   void didUpdateWidget(VideoControlLayoutEditor oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.customActionBindings != widget.customActionBindings) {
+      _customActionBindings = widget.customActionBindings;
+    }
     if (oldWidget.layout != widget.layout) {
       _controlLayout = widget.layout;
       // 外部重置/换布局后清掉上一轮的拖拽驳回提示（旧 sheet 行为）：提示描述的
@@ -492,6 +514,24 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
       dragging: false,
       highlighted: highlighted,
     );
+    // 「快捷键 N」槽位：点一下选它执行哪个动作（拖动仍然照常改位置——Draggable 用的是
+    // 即时拖拽识别器，与 onTap 在手势竞技场里按「有没有位移」自然分流，不互相吃事件）。
+    // 这是本功能唯一的配置入口：按钮就在编辑器里，点它配、拖它摆，不用去别的页面找。
+    if (item.isCustomAction && widget.onCustomActionBindingsChanged != null) {
+      return GestureDetector(
+        onTap: () => unawaited(_pickCustomAction(item)),
+        child: _wrapDraggableChip(chip, item, sourceSlot, sourceIndex),
+      );
+    }
+    return _wrapDraggableChip(chip, item, sourceSlot, sourceIndex);
+  }
+
+  Widget _wrapDraggableChip(
+    Widget chip,
+    VideoControlItem item,
+    VideoControlSlot? sourceSlot,
+    int? sourceIndex,
+  ) {
     return Draggable<VideoControlDragData>(
       data: VideoControlDragData(
         item: item,
@@ -515,6 +555,53 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
     );
   }
 
+  /// 点「快捷键 N」chip：选它执行哪个动作。
+  ///
+  /// 列表就是 [kVideoAssignableActions]（= 视频页真正接过线的动作），外加一条「不绑定」
+  /// 用来清空槽位——清空后该按钮在播放器上直接消失（见 `_shouldRenderControlItem`），
+  /// 不留一个按了没反应的空壳。选完立即落盘 + 生效，没有「保存」步骤。
+  Future<void> _pickCustomAction(VideoControlItem item) async {
+    final int? slotIndex = item.customActionSlotIndex;
+    final Future<void> Function(VideoCustomActionBindings)? onChanged =
+        widget.onCustomActionBindingsChanged;
+    if (slotIndex == null || onChanged == null) return;
+    final ShortcutAction? current = _customActionBindings.actionAt(slotIndex);
+    final _CustomActionPick? pick = await showDialog<_CustomActionPick>(
+      context: context,
+      builder: (BuildContext dialogContext) => SimpleDialog(
+        title: Text(t.video_control_custom_action(index: slotIndex + 1)),
+        children: <Widget>[
+          // 「不绑定」置顶：解绑是唯一「让按钮消失」的路径，藏在几十条动作末尾会找不到。
+          FushiListItem(
+            title: Text(t.video_control_custom_action_none),
+            leading: const Icon(Icons.block),
+            selected: current == null,
+            onTap: () => Navigator.of(dialogContext).pop(
+              const _CustomActionPick(null),
+            ),
+          ),
+          for (final ShortcutAction action in kVideoAssignableActions)
+            FushiListItem(
+              title: Text(action.label),
+              leading: Icon(action.buttonIcon ?? Icons.bolt_outlined),
+              selected: current == action,
+              onTap: () => Navigator.of(dialogContext).pop(
+                _CustomActionPick(action),
+              ),
+            ),
+        ],
+      ),
+    );
+    // null = 用户点外部 / 返回键取消（区别于显式选了「不绑定」，那是
+    // `_CustomActionPick(null)`）——取消必须保持原绑定不动。
+    if (pick == null || !mounted) return;
+    final VideoCustomActionBindings next =
+        _customActionBindings.withAction(slotIndex, pick.action);
+    if (next == _customActionBindings) return;
+    setState(() => _customActionBindings = next);
+    await onChanged(next);
+  }
+
   void _handleControlDragCanceled(VideoControlItem item) {
     final String? message = switch (item) {
       VideoControlItem.volume => t.video_control_reject_volume_bottom,
@@ -533,7 +620,11 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
   }) {
     final ColorScheme cs = Theme.of(context).colorScheme;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final String label = videoControlItemLabel(item, context);
+    final String label = videoControlItemLabel(
+      item,
+      context,
+      bindings: _customActionBindings,
+    );
     final Color background =
         highlighted ? cs.primaryContainer : cs.secondaryContainer;
     final Color foreground =
@@ -560,7 +651,11 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
                 ]
               : null,
         ),
-        child: Icon(videoControlItemIcon(item), size: 18, color: foreground),
+        child: Icon(
+          videoControlItemIcon(item, bindings: _customActionBindings),
+          size: 18,
+          color: foreground,
+        ),
       ),
     );
     return Tooltip(
@@ -681,4 +776,15 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
         return t.video_control_slot_top_center;
     }
   }
+}
+
+/// 动作选择对话框的返回值。
+///
+/// 存在的唯一理由：把「取消」和「显式选了不绑定」分开。两者的 [ShortcutAction] 都是
+/// null，直接 `pop<ShortcutAction?>(null)` 会让点外部关闭 == 清空绑定——用户只是想
+/// 关掉弹窗，按钮却没了。包一层后取消是 `null`、不绑定是 `_CustomActionPick(null)`。
+class _CustomActionPick {
+  const _CustomActionPick(this.action);
+
+  final ShortcutAction? action;
 }

--- a/fushi/lib/src/media/video/video_control_layout_editor.dart
+++ b/fushi/lib/src/media/video/video_control_layout_editor.dart
@@ -6,9 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
 import 'package:fushi/src/media/video/video_control_item_presentation.dart';
 import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
-import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+import 'package:fushi/src/media/video/video_custom_action_picker.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
-import 'package:fushi/src/shortcuts/shortcut_labels.dart';
 import 'package:fushi/utils.dart';
 
 /// 控制条 9 槽位拖拽编辑器（TODO-274/312 phase 2）。从旧
@@ -555,45 +554,23 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
     );
   }
 
-  /// 点「快捷键 N」chip：选它执行哪个动作。
+  /// 点「快捷键 N」chip：选它执行哪个动作。选完立即落盘 + 生效，没有「保存」步骤。
   ///
-  /// 列表就是 [kVideoAssignableActions]（= 视频页真正接过线的动作），外加一条「不绑定」
-  /// 用来清空槽位——清空后该按钮在播放器上直接消失（见 `_shouldRenderControlItem`），
-  /// 不留一个按了没反应的空壳。选完立即落盘 + 生效，没有「保存」步骤。
+  /// 弹窗本体走共享的 [showVideoCustomActionPicker]——播放器控制条上直接点空按钮走的
+  /// 是同一个入口，两处列表/顺序/选中态必然一致。
   Future<void> _pickCustomAction(VideoControlItem item) async {
     final int? slotIndex = item.customActionSlotIndex;
     final Future<void> Function(VideoCustomActionBindings)? onChanged =
         widget.onCustomActionBindingsChanged;
     if (slotIndex == null || onChanged == null) return;
     final ShortcutAction? current = _customActionBindings.actionAt(slotIndex);
-    final _CustomActionPick? pick = await showDialog<_CustomActionPick>(
+    final VideoCustomActionPick? pick = await showVideoCustomActionPicker(
       context: context,
-      builder: (BuildContext dialogContext) => SimpleDialog(
-        title: Text(t.video_control_custom_action(index: slotIndex + 1)),
-        children: <Widget>[
-          // 「不绑定」置顶：解绑是唯一「让按钮消失」的路径，藏在几十条动作末尾会找不到。
-          FushiListItem(
-            title: Text(t.video_control_custom_action_none),
-            leading: const Icon(Icons.block),
-            selected: current == null,
-            onTap: () => Navigator.of(dialogContext).pop(
-              const _CustomActionPick(null),
-            ),
-          ),
-          for (final ShortcutAction action in kVideoAssignableActions)
-            FushiListItem(
-              title: Text(action.label),
-              leading: Icon(action.buttonIcon ?? Icons.bolt_outlined),
-              selected: current == action,
-              onTap: () => Navigator.of(dialogContext).pop(
-                _CustomActionPick(action),
-              ),
-            ),
-        ],
-      ),
+      slotNumber: slotIndex + 1,
+      current: current,
     );
     // null = 用户点外部 / 返回键取消（区别于显式选了「不绑定」，那是
-    // `_CustomActionPick(null)`）——取消必须保持原绑定不动。
+    // `VideoCustomActionPick(null)`）——取消必须保持原绑定不动。
     if (pick == null || !mounted) return;
     final VideoCustomActionBindings next =
         _customActionBindings.withAction(slotIndex, pick.action);
@@ -776,15 +753,4 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
         return t.video_control_slot_top_center;
     }
   }
-}
-
-/// 动作选择对话框的返回值。
-///
-/// 存在的唯一理由：把「取消」和「显式选了不绑定」分开。两者的 [ShortcutAction] 都是
-/// null，直接 `pop<ShortcutAction?>(null)` 会让点外部关闭 == 清空绑定——用户只是想
-/// 关掉弹窗，按钮却没了。包一层后取消是 `null`、不绑定是 `_CustomActionPick(null)`。
-class _CustomActionPick {
-  const _CustomActionPick(this.action);
-
-  final ShortcutAction? action;
 }

--- a/fushi/lib/src/media/video/video_custom_action_bindings.dart
+++ b/fushi/lib/src/media/video/video_custom_action_bindings.dart
@@ -55,12 +55,15 @@ class VideoCustomActionBindings {
   }
 
   /// 序列化：逗号分隔的动作 key，空槽位写空串（如 `video_next_subtitle,,,`）。
+  /// 一个都没绑时返回空串，而不是 `",,,"`——让「全空」只有一种写法，与偏好的默认值
+  /// （空串）重合，解绑回初始态后存储里不留一条看着像配置过的垃圾。
   ///
   /// 用 [ShortcutAction.key] 而不是枚举下标：枚举声明序会因为设置页分组排序而变动
   /// （[ShortcutAction] 头部明确写了「声明顺序 = 展示顺序」），存下标等于把持久化
   /// 绑死在展示顺序上，重排一次所有用户的绑定就全串位。
-  String encode() =>
-      _actions.map((ShortcutAction? a) => a?.key ?? '').join(',');
+  String encode() => isEmpty
+      ? ''
+      : _actions.map((ShortcutAction? a) => a?.key ?? '').join(',');
 
   /// 反序列化。空串 / 格式不符 / 未知 key（动作被删或改名）一律降级成未绑定槽位，
   /// 绝不抛异常——这条路径在 app 启动读偏好时跑，抛了就是白屏。

--- a/fushi/lib/src/media/video/video_custom_action_bindings.dart
+++ b/fushi/lib/src/media/video/video_custom_action_bindings.dart
@@ -19,7 +19,8 @@ import 'package:fushi/src/shortcuts/shortcut_action.dart';
 class VideoCustomActionBindings {
   const VideoCustomActionBindings._(this._actions);
 
-  /// 全空绑定（默认值）：4 个槽位都未绑定，播放器上一个自定义按钮都不显示。
+  /// 全空绑定（默认值）：4 个槽位都未绑定。按钮**照常显示**在控制条上，点任意一个
+  /// 即弹动作选择器就地配置（未绑定不等于不显示，见 `_shouldRenderControlItem`）。
   static const VideoCustomActionBindings empty = VideoCustomActionBindings._(
     <ShortcutAction?>[null, null, null, null],
   );

--- a/fushi/lib/src/media/video/video_custom_action_bindings.dart
+++ b/fushi/lib/src/media/video/video_custom_action_bindings.dart
@@ -1,0 +1,105 @@
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+
+/// 视频播放器「快捷键 1..N」自定义动作按钮的绑定表。
+///
+/// 动机（用户请求）：视频页有近 40 个可执行动作，但控制条只给其中 ~25 个配了具名
+/// 按钮，其余只能靠键盘/手柄触发——**手机上没有键盘，那些动作等于不存在**。与其为
+/// 每个动作再造一个具名 [VideoControlItem]（枚举无限膨胀，且每加一个动作都要跟着加
+/// 按钮），不如给控制条几个**空槽位**，由用户各绑一个动作。
+///
+/// 数据结构就是一个定长 [slotCount] 的有序表：下标 = 槽位序号（「快捷键1」= 下标 0），
+/// 值 = 绑定的动作，`null` = 该槽位未绑定。刻意**不用** `slot1/slot2/slot3` 三个独立
+/// 字段或 Map<int, ShortcutAction>：定长列表天然表达「序号连续、可为空、数量固定」，
+/// 让越界和缺号这两类特殊情况在构造时就消失。
+///
+/// 与快捷键注册表（[FushiShortcutRegistry]）的关系：**只共用动作枚举，不共用绑定**。
+/// 注册表管的是「哪个键 / 哪个手柄按钮触发这个动作」，本表管的是「哪个屏幕按钮触发
+/// 这个动作」，两者正交——用户既可以把「下一句字幕」绑到键盘 N，也可以同时把它放进
+/// 快捷键1 按钮，互不影响、互不覆盖。
+class VideoCustomActionBindings {
+  const VideoCustomActionBindings._(this._actions);
+
+  /// 全空绑定（默认值）：4 个槽位都未绑定，播放器上一个自定义按钮都不显示。
+  static const VideoCustomActionBindings empty = VideoCustomActionBindings._(
+    <ShortcutAction?>[null, null, null, null],
+  );
+
+  /// 槽位数量。与 [VideoControlItem] 里的 `customAction1..4` 一一对应——改这个常量
+  /// 必须同步加/删对应的枚举项，守卫测试 `video_custom_action_bindings_test` 会核对
+  /// 两侧数量一致（否则会出现「有槽位没按钮」或「有按钮没槽位」的半接线）。
+  static const int slotCount = 4;
+
+  /// 定长 [slotCount] 的绑定表，下标 = 槽位序号 - 1。
+  final List<ShortcutAction?> _actions;
+
+  /// 槽位 [slotIndex]（0-based）绑定的动作；未绑定或越界返回 null。
+  ///
+  /// 越界返回 null 而不是抛异常：调用方是渲染路径，持久化里混进脏数据时应当安静地
+  /// 不显示按钮，而不是让整个播放器崩掉。
+  ShortcutAction? actionAt(int slotIndex) {
+    if (slotIndex < 0 || slotIndex >= slotCount) return null;
+    return _actions[slotIndex];
+  }
+
+  /// 是否一个槽位都没绑定（播放器据此完全跳过自定义按钮渲染）。
+  bool get isEmpty => _actions.every((ShortcutAction? a) => a == null);
+
+  /// 返回把槽位 [slotIndex] 改绑成 [action]（null = 解绑）后的新表。不可变对象，
+  /// 原表不变——与 [VideoControlLayout] 的写法一致，调用方拿到新值后自行落盘。
+  VideoCustomActionBindings withAction(int slotIndex, ShortcutAction? action) {
+    if (slotIndex < 0 || slotIndex >= slotCount) return this;
+    final List<ShortcutAction?> next = List<ShortcutAction?>.of(_actions);
+    next[slotIndex] = action;
+    return VideoCustomActionBindings._(
+        List<ShortcutAction?>.unmodifiable(next));
+  }
+
+  /// 序列化：逗号分隔的动作 key，空槽位写空串（如 `video_next_subtitle,,,`）。
+  ///
+  /// 用 [ShortcutAction.key] 而不是枚举下标：枚举声明序会因为设置页分组排序而变动
+  /// （[ShortcutAction] 头部明确写了「声明顺序 = 展示顺序」），存下标等于把持久化
+  /// 绑死在展示顺序上，重排一次所有用户的绑定就全串位。
+  String encode() =>
+      _actions.map((ShortcutAction? a) => a?.key ?? '').join(',');
+
+  /// 反序列化。空串 / 格式不符 / 未知 key（动作被删或改名）一律降级成未绑定槽位，
+  /// 绝不抛异常——这条路径在 app 启动读偏好时跑，抛了就是白屏。
+  ///
+  /// 长度不匹配时按位截断 / 补空：老配置槽位少于 [slotCount] 时后面补 null，多于时
+  /// 丢弃超出部分，保证任何历史 payload 都能解出一张合法的定长表。
+  factory VideoCustomActionBindings.decode(String raw) {
+    if (raw.isEmpty) return empty;
+    final List<String> parts = raw.split(',');
+    final List<ShortcutAction?> actions = <ShortcutAction?>[
+      for (int i = 0; i < slotCount; i++)
+        i < parts.length ? _actionFrom(parts[i]) : null,
+    ];
+    return VideoCustomActionBindings._(
+      List<ShortcutAction?>.unmodifiable(actions),
+    );
+  }
+
+  /// 单个槽位的 key → 动作。空串 = 未绑定；未知 key = 未绑定（不是错误：动作可能在
+  /// 新版里被删掉，老配置照样要能读）。
+  static ShortcutAction? _actionFrom(String key) {
+    final String trimmed = key.trim();
+    if (trimmed.isEmpty) return null;
+    return ShortcutAction.fromKey(trimmed);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! VideoCustomActionBindings) return false;
+    for (int i = 0; i < slotCount; i++) {
+      if (_actions[i] != other._actions[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(_actions);
+
+  @override
+  String toString() => 'VideoCustomActionBindings(${encode()})';
+}

--- a/fushi/lib/src/media/video/video_custom_action_picker.dart
+++ b/fushi/lib/src/media/video/video_custom_action_picker.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_labels.dart';
+import 'package:fushi/utils.dart';
+
+/// 「快捷键 N」动作选择的结果。
+///
+/// 存在的唯一理由：把**取消**和**显式选了「不绑定」**分开。两者携带的
+/// [ShortcutAction] 都是 null，若直接 `pop<ShortcutAction?>(null)`，点弹窗外部关闭就
+///会被当成「清空绑定」——用户只是想关掉弹窗，配好的按钮却没了。
+/// 包一层之后：取消 = `null`，不绑定 = `VideoCustomActionPick(null)`。
+class VideoCustomActionPick {
+  const VideoCustomActionPick(this.action);
+
+  /// 用户选中的动作；null = 显式选择「不绑定」（清空该槽位）。
+  final ShortcutAction? action;
+}
+
+/// 弹出「快捷键 [slotNumber]」的动作选择器（1-based 序号，仅用于标题文案）。
+///
+/// 两个宿主共用同一个入口，保证两处看到的列表、顺序、选中态完全一致：
+///   · 控件布局编辑器里点 chip（摆位置时顺手配）；
+///   · **播放器控制条上直接点未绑定的按钮**（手机上不用先进设置面板——这正是本功能
+///     「便于手机使用」的初衷，也是「未绑定按钮也显示」得以成立的前提：它不是死按钮，
+///     而是就地的配置入口）。
+///
+/// 列表内容是 [kVideoAssignableActions]（= 视频页真正接过线的动作），外加置顶的一条
+/// 「不绑定」。返回 null 表示用户取消。
+Future<VideoCustomActionPick?> showVideoCustomActionPicker({
+  required BuildContext context,
+  required int slotNumber,
+  required ShortcutAction? current,
+}) {
+  return showDialog<VideoCustomActionPick>(
+    context: context,
+    builder: (BuildContext dialogContext) => SimpleDialog(
+      title: Text(t.video_control_custom_action(index: slotNumber)),
+      children: <Widget>[
+        // 「不绑定」置顶：解绑是唯一「把按钮变回空槽」的路径，排在几十条动作末尾会找不到。
+        FushiListItem(
+          title: Text(t.video_control_custom_action_none),
+          leading: const Icon(Icons.block),
+          selected: current == null,
+          onTap: () => Navigator.of(dialogContext).pop(
+            const VideoCustomActionPick(null),
+          ),
+        ),
+        for (final ShortcutAction action in kVideoAssignableActions)
+          FushiListItem(
+            title: Text(action.label),
+            leading: Icon(action.buttonIcon ?? Icons.bolt_outlined),
+            selected: current == action,
+            onTap: () => Navigator.of(dialogContext).pop(
+              VideoCustomActionPick(action),
+            ),
+          ),
+      ],
+    ),
+  );
+}

--- a/fushi/lib/src/media/video/video_player_shortcuts.dart
+++ b/fushi/lib/src/media/video/video_player_shortcuts.dart
@@ -174,6 +174,68 @@ class VideoPlayerShortcutActions {
 /// single fixed wiring between the (remappable) registry actions and the
 /// concrete player operations; the keys themselves come from the registry so
 /// users can rebind them (TODO-134).
+/// 能绑到视频页**屏幕按钮**（自定义「快捷键 1..4」）上的动作全集。
+///
+/// 真相源是 [videoActionCallbacks]：只有它接过线的动作才真的能在本页执行，把别的动作
+/// 放进选择列表 = 用户配得上、按了没反应。这里之所以另写一份常量而不是直接取
+/// `videoActionCallbacks(...).keys`，是因为**设置页拿不到 live 的
+/// [VideoPlayerShortcutActions]**（那需要一个正在播放的 controller），而选择列表在没
+/// 打开视频时也要能展示。
+///
+/// ⚠️ 两份必须一致：守卫测试 `video_custom_action_bindings_test` 用一个哑实例调
+/// [videoActionCallbacks] 并与本表逐个比对，漏加 / 多加即红。顺序 = 选择列表的展示
+/// 顺序，按「播放 → 字幕 → 对轴 → 音量 → 画面 → 学习」分簇，与设置页快捷键分组同序。
+const List<ShortcutAction> kVideoAssignableActions = <ShortcutAction>[
+  // 播放控制
+  ShortcutAction.videoTogglePlayPause,
+  ShortcutAction.videoPlay,
+  ShortcutAction.videoPause,
+  ShortcutAction.videoSeekBackward,
+  ShortcutAction.videoSeekForward,
+  ShortcutAction.videoPreviousFrame,
+  ShortcutAction.videoNextFrame,
+  // 倍速
+  ShortcutAction.videoSpeedUp,
+  ShortcutAction.videoSpeedDown,
+  ShortcutAction.videoResetSpeed,
+  ShortcutAction.videoHoldSpeed,
+  // 字幕跳转 / 重播
+  ShortcutAction.videoPreviousSubtitle,
+  ShortcutAction.videoNextSubtitle,
+  ShortcutAction.videoReplayCurrentSubtitle,
+  ShortcutAction.videoReplayPreviousSubtitle,
+  // 章节
+  ShortcutAction.videoPreviousChapter,
+  ShortcutAction.videoNextChapter,
+  // 字幕显示 / 遮蔽
+  ShortcutAction.videoToggleSubtitleList,
+  ShortcutAction.videoToggleSubtitleBlur,
+  ShortcutAction.videoCycleSubtitleObscure,
+  ShortcutAction.videoToggleSubtitleHide,
+  ShortcutAction.videoCycleSecondarySubtitleObscure,
+  ShortcutAction.videoToggleSecondarySubtitleHide,
+  // 字幕对轴
+  ShortcutAction.videoOpenSubtitleAlign,
+  ShortcutAction.videoSubtitleDelayIncrease,
+  ShortcutAction.videoSubtitleDelayDecrease,
+  ShortcutAction.videoAlignSubtitleToPrev,
+  ShortcutAction.videoAlignSubtitleToNext,
+  // 音量
+  ShortcutAction.videoVolumeUp,
+  ShortcutAction.videoVolumeDown,
+  ShortcutAction.videoToggleMute,
+  // 画面 / 杂项
+  ShortcutAction.videoToggleFullscreen,
+  ShortcutAction.videoScreenshot,
+  ShortcutAction.videoToggleShaderCompare,
+  ShortcutAction.videoToggleImmersiveLock,
+  // 学习
+  ShortcutAction.videoToggleFavoriteSentence,
+  ShortcutAction.videoEnterCaret,
+  // 「返回上一级」：视频页把它解释成逐级退出阶梯（关字幕列表 → 退侧栏 → … → 退页）。
+  ShortcutAction.globalBack,
+];
+
 Map<ShortcutAction, VoidCallback> videoActionCallbacks(
   VideoPlayerShortcutActions actions,
 ) {

--- a/fushi/lib/src/media/video/video_quick_settings_host.dart
+++ b/fushi/lib/src/media/video/video_quick_settings_host.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import 'package:fushi/src/media/video/video_asbplayer_config.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
@@ -32,6 +33,7 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
     this.onSetSecondaryDelay,
     this.hasSecondarySubtitle,
     this.onAutoAlign,
+    this.onSnapDelayToCue,
     this.subtitleWaveformCues = const <AudioCue>[],
     this.videoDurationMs = 0,
     this.loadSubtitleWaveform,
@@ -62,6 +64,8 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
     required this.onImmersiveModeChanged,
     required this.controlLayout,
     this.onControlLayoutChanged,
+    this.customActionBindings,
+    this.onCustomActionBindingsChanged,
     this.qualityOptionCount = 0,
     this.qualityCurrentLabel,
     this.onOpenQuality,
@@ -103,6 +107,19 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
   final bool Function()? hasSecondarySubtitle;
 
   final Future<int?> Function()? onAutoAlign;
+
+  /// asbplayer 式「把上一句 / 下一句字幕对齐到当前播放时间」（按目标 cue 求**绝对**
+  /// 偏移，一键把整轨粗对齐到当前台词时刻）。与键盘 Ctrl+Shift+←/→ 同一执行体
+  /// （页面 `_snapSubtitleDelayToCue`），此处只是把它暴露成**可点的按钮**——触摸端
+  /// 没有键盘，此前这个动作在手机上完全无法触发。
+  ///
+  /// 返回本次写穿的新延迟（毫秒）：调轴面板据此把本地权威镜像 / 滑条 / 数值输入框 /
+  /// 波形预览同步到新值（与 [onAutoAlign] 同款契约）。已是首末句无相邻 cue、播放位置
+  /// 未就绪等不改延迟的分支返回 null，面板保持原值不动。
+  ///
+  /// null 回调 = 当前无字幕 cue（无可对齐对象），面板不显示这两个按钮。
+  final int? Function({required bool next})? onSnapDelayToCue;
+
   final List<AudioCue> subtitleWaveformCues;
   final int videoDurationMs;
   final Future<List<double>> Function()? loadSubtitleWaveform;
@@ -160,6 +177,13 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
   final VideoControlLayout Function() controlLayout;
   final Future<void> Function(VideoControlLayout layout)?
       onControlLayoutChanged;
+
+  /// 自定义「快捷键 1..4」按钮当前绑定的动作（活值 getter，与 [controlLayout] 同款）。
+  final VideoCustomActionBindings Function()? customActionBindings;
+
+  /// 改绑「快捷键 N」后落盘 + 实时生效。null = 编辑器不提供改绑入口。
+  final Future<void> Function(VideoCustomActionBindings bindings)?
+      onCustomActionBindingsChanged;
 
   // ── HLS 画质入口 / Skia 降级入口（仅特定流/机型出现）─────────────────────
   final int qualityOptionCount;

--- a/fushi/lib/src/media/video/video_settings_actions.dart
+++ b/fushi/lib/src/media/video/video_settings_actions.dart
@@ -5,6 +5,7 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 import 'package:fushi/src/media/video/video_asbplayer_config.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_control_layout_editor.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
@@ -673,5 +674,8 @@ Widget buildVideoControlLayoutEditor(SettingsContext context) {
     layout: host.controlLayout(),
     onLayoutChanged: host.onControlLayoutChanged,
     isTouchControls: host.isTouchControls,
+    customActionBindings:
+        host.customActionBindings?.call() ?? VideoCustomActionBindings.empty,
+    onCustomActionBindingsChanged: host.onCustomActionBindingsChanged,
   );
 }

--- a/fushi/lib/src/media/video/video_subtitle_sync_row.dart
+++ b/fushi/lib/src/media/video/video_subtitle_sync_row.dart
@@ -139,6 +139,22 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
     }
   }
 
+  /// 「上一句 / 下一句字幕对齐到当前播放时间」按钮（asbplayer 式绝对偏移，与键盘
+  /// Ctrl+Shift+←/→ 同一执行体）。决策与写穿都在页面侧回调里，本行只负责把回传的
+  /// 新延迟同步进本地权威镜像 / 滑条 / 数值输入框——与 [_runAutoAlign] 同款契约，
+  /// 否则点完按钮延迟已经变了、面板控件却停在旧值。
+  ///
+  /// 回调返回 null（已是首末句无相邻 cue / 播放位置未就绪）时不动当前值。不做防重入
+  /// spinner：这条路径是纯同步计算 + 一次写穿，没有 [_runAutoAlign] 的 ffmpeg 探测开销。
+  Future<void> _snapDelayToCue({required bool next}) async {
+    final int? Function({required bool next})? cb =
+        widget.host.onSnapDelayToCue;
+    if (cb == null) return;
+    final int? newDelayMs = cb(next: next);
+    if (newDelayMs == null || !mounted) return;
+    await _commitDelay(newDelayMs);
+  }
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -225,6 +241,23 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
                   padding: EdgeInsets.all(tokens.spacing.gap / 2),
                   onTap: _runAutoAlign,
                 ),
+        // 「上/下一句对齐到当前时间」：此前只有键盘 Ctrl+Shift+←/→ 能触发，触摸端
+        // 完全够不着。与自动对轴并列——都是「一键求绝对偏移」，区别是这里由用户用
+        // 播放头指定对齐目标（不依赖音频探测，无 ffmpeg 也能用）。
+        if (host.onSnapDelayToCue != null) ...<Widget>[
+          FushiIconButton(
+            icon: Icons.align_horizontal_left,
+            tooltip: t.video_subtitle_prev_cue_align,
+            padding: EdgeInsets.all(tokens.spacing.gap / 2),
+            onTap: () => _snapDelayToCue(next: false),
+          ),
+          FushiIconButton(
+            icon: Icons.align_horizontal_right,
+            tooltip: t.video_subtitle_next_cue_align,
+            padding: EdgeInsets.all(tokens.spacing.gap / 2),
+            onTap: () => _snapDelayToCue(next: true),
+          ),
+        ],
       ],
     );
 
@@ -284,6 +317,7 @@ class _VideoSubtitleSyncRowState extends State<VideoSubtitleSyncRow> {
               // TODO-1316：放大波形对轴视图内的「自动对轴」按钮复用与顶部同一 onAutoAlign
               // 逻辑，成功后经上面的 onCommitDelay 同步权威延迟。
               onAutoAlign: host.onAutoAlign,
+              onSnapDelayToCue: host.onSnapDelayToCue,
               onPlayCue: host.onPlaySubtitleCue,
               isPlaying: host.subtitleIsPlaying,
               onTogglePlayPause: host.onToggleSubtitlePlayPause,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -102,6 +102,7 @@ import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_subtitle_obscure_mode.dart';
 import 'package:fushi/src/media/tracking/media_tracking_repository.dart';
 import 'package:fushi/src/media/tracking/media_tracking_service.dart';
@@ -3283,6 +3284,15 @@ class AppModel with ChangeNotifier {
 
   Future<void> setVideoControlLayout(VideoControlLayout layout) =>
       prefsRepo.setVideoControlLayout(layout);
+
+  /// 视频「快捷键 1..4」自定义动作按钮的绑定（槽位 → 视频动作）。
+  VideoCustomActionBindings get videoCustomActionBindings =>
+      prefsRepo.videoCustomActionBindings;
+
+  Future<void> setVideoCustomActionBindings(
+    VideoCustomActionBindings bindings,
+  ) =>
+      prefsRepo.setVideoCustomActionBindings(bindings);
 
   /// 视频字幕外观（JSON；见 VideoSubtitleStyle）。
   String get videoSubtitleStyle => prefsRepo.videoSubtitleStyle;

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -9,6 +9,7 @@ import 'package:fushi/src/media/video/download/video_download_backend_identity.d
 import 'package:fushi/src/media/video/subtitle/open_subtitles_client.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
 import 'package:fushi/src/media/video/video_subtitle_obscure_mode.dart';
 import 'package:fushi/src/mining/galgame_library.dart';
@@ -1325,6 +1326,24 @@ class PreferencesRepository extends ChangeNotifier {
 
   Future<void> setVideoControlLayout(VideoControlLayout layout) async {
     await setPref('video_control_customization', layout.encode());
+    notifyListeners();
+  }
+
+  /// 视频「快捷键 1..4」自定义动作按钮的绑定（用户请求）：槽位序号 → 视频动作。
+  ///
+  /// 与 [videoControlLayout] **分开存**：布局管「按钮在哪个槽位、显不显示」，本表管
+  /// 「按钮按下去干什么」。两者正交——用户可以只改位置不改动作，反之亦然；混进同一个
+  /// JSON 只会让那个已经在扛 v1→v2→v3 迁移的 payload 再多一层版本。
+  /// 空串 = 一个都没绑（[VideoCustomActionBindings.empty]），播放器不显示任何自定义按钮。
+  VideoCustomActionBindings get videoCustomActionBindings =>
+      VideoCustomActionBindings.decode(
+        getPref('video_custom_action_bindings', defaultValue: '') as String,
+      );
+
+  Future<void> setVideoCustomActionBindings(
+    VideoCustomActionBindings bindings,
+  ) async {
+    await setPref('video_custom_action_bindings', bindings.encode());
     notifyListeners();
   }
 

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -1334,7 +1334,8 @@ class PreferencesRepository extends ChangeNotifier {
   /// 与 [videoControlLayout] **分开存**：布局管「按钮在哪个槽位、显不显示」，本表管
   /// 「按钮按下去干什么」。两者正交——用户可以只改位置不改动作，反之亦然；混进同一个
   /// JSON 只会让那个已经在扛 v1→v2→v3 迁移的 payload 再多一层版本。
-  /// 空串 = 一个都没绑（[VideoCustomActionBindings.empty]），播放器不显示任何自定义按钮。
+  /// 空串 = 一个都没绑（[VideoCustomActionBindings.empty]）。此时按钮仍显示在控制条上，
+  /// 点它就地弹动作选择器——空槽位是配置入口，不是死按钮。
   VideoCustomActionBindings get videoCustomActionBindings =>
       VideoCustomActionBindings.decode(
         getPref('video_custom_action_bindings', defaultValue: '') as String,

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -233,6 +233,10 @@ extension _VideoLayout on _VideoFushiPageState {
           _controlLayoutNotifier,
           _subtitleListVisible,
           _episodeListVisible,
+          // 自定义「快捷键」按钮绑定：改绑后按钮的图标 / tooltip / 执行体全变，且
+          // 「从未绑定变成已绑定」还决定它显不显示（见 `_shouldRenderControlItem`）。
+          // 不并进来就是「设置里改了、播放器上纹丝不动」。
+          _customActionBindingsNotifier,
         ],
       ),
       builder: (BuildContext context, _) {
@@ -471,6 +475,7 @@ extension _VideoLayout on _VideoFushiPageState {
                               onClose: _hideVideoControlEditOverlay,
                               // TODO-554：触屏保留「设置」按钮入口不可移除。
                               isTouchControls: !_isDesktopVideoControls,
+                              customActionBindings: _customActionBindings,
                             ),
                           );
                         },

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -1566,19 +1566,25 @@ extension _VideoSubtitle on _VideoFushiPageState {
   /// `_delayMs`，拿到新延迟后走既有权威写穿 [_setDelayMs]（clamp + 落盘 + OSD + 即时重算）。
   /// 无 controller / 无 cue / 位置未就绪 / 已是首末句无相邻 cue 时 no-op（不弹窗、不改延迟）。
   ///
+  /// 返回本次实际写穿的新延迟（毫秒），供**调轴面板按钮**路径把滑条 / 数值输入框 / 波形
+  /// 预览同步到新值——与 [_autoAlignSubtitle] 同款契约（TODO-1206）：面板持有自己的本地
+  /// 权威镜像 `_delayMs`，若这里只写穿页面侧而不回传，点完按钮面板控件会停在旧值。
+  /// no-op 的各分支返回 null（面板据此保持原值不动）。键盘路径忽略返回值，行为不变。
+  ///
   /// TODO-2837：本对齐（连同波形对轴 / 自动对轴）**只作用于主字幕轨**；副字幕的
   /// asbplayer 式/波形对齐是后续工作，本轮副轨只有快速设置面板的独立调轴段。
-  void _snapSubtitleDelayToCue({required bool next}) {
+  int? _snapSubtitleDelayToCue({required bool next}) {
     final VideoPlayerController? controller = _controller;
-    if (controller == null) return;
+    if (controller == null) return null;
     final int? newDelayMs = VideoPlayerController.snapSubtitleDelayMs(
       cues: controller.cues,
       positionMs: controller.positionMs,
       currentDelayMs: _delayMs,
       next: next,
     );
-    if (newDelayMs == null) return;
+    if (newDelayMs == null) return null;
     unawaited(_setDelayMs(newDelayMs));
+    return newDelayMs;
   }
 
   /// TODO-701 阶段1：一键字幕自动对轴。抽当前视频的逐帧音频能量包络（[extractAudioEnergyEnvelope]
@@ -1747,6 +1753,9 @@ extension _VideoSubtitle on _VideoFushiPageState {
           initialDelayMs: _delayMs,
           onCommitDelay: _setDelayMs,
           onAutoAlign: canAutoAlign ? _autoAlignSubtitle : null,
+          // 「上/下一句对齐到当前时间」：本弹窗必然有 cue（进入前已判空并降级），故直接
+          // 接上执行体，与快速设置面板路径同源。
+          onSnapDelayToCue: _snapSubtitleDelayToCue,
           onPlayCue: (int startMs) async {
             await controller.seekMs(startMs);
             await controller.play();

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -64,6 +64,8 @@ import 'package:fushi/src/media/video/video_asbplayer_config.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_chrome_colors.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_control_item_presentation.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_control_layout_edit_overlay.dart';
 import 'package:fushi/src/media/video/video_control_popover_placement.dart';
 import 'package:fushi/src/media/video/video_controls_focus_gate.dart';
@@ -1137,6 +1139,17 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   final ValueNotifier<VideoControlLayout> _controlLayoutNotifier =
       ValueNotifier<VideoControlLayout>(VideoControlLayout.currentChrome);
 
+  /// 自定义「快捷键 1..4」按钮的绑定（槽位 → 视频动作）。与 [_controlLayoutNotifier]
+  /// 同样走 notifier 而不是裸字段：控制层（含全屏路由那棵独立子树）只在监听到通知时
+  /// 才重建，绑定改了却不通知 = 按钮图标/行为停在旧动作上（BUG-391 那条「漏监听 =
+  /// 改了白改」的同款陷阱，见 layout.part.dart 的 merge 列表）。
+  final ValueNotifier<VideoCustomActionBindings> _customActionBindingsNotifier =
+      ValueNotifier<VideoCustomActionBindings>(VideoCustomActionBindings.empty);
+
+  /// 当前生效的自定义按钮绑定表。
+  VideoCustomActionBindings get _customActionBindings =>
+      _customActionBindingsNotifier.value;
+
   List<SubtitleSource> _subtitleMenuSources = const <SubtitleSource>[];
   bool _subtitleMenuLoading = false;
 
@@ -2062,6 +2075,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _subtitleStyle = VideoSubtitleStyle.decode(appModel.videoSubtitleStyle);
     _asbConfig = VideoAsbplayerConfig.decode(appModel.videoAsbplayerConfig);
     _controlLayoutNotifier.value = appModel.videoControlLayout;
+    _customActionBindingsNotifier.value = appModel.videoCustomActionBindings;
     _lockWindowAspectRatio = appModel.videoLockWindowAspectRatio;
     _videoFitMode = appModel.videoFitMode;
 
@@ -2156,6 +2170,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _subtitleStyle = VideoSubtitleStyle.decode(appModel.videoSubtitleStyle);
     _asbConfig = VideoAsbplayerConfig.decode(appModel.videoAsbplayerConfig);
     _controlLayoutNotifier.value = appModel.videoControlLayout;
+    _customActionBindingsNotifier.value = appModel.videoCustomActionBindings;
 
     // 客户端合集连播（Phase 3 合集 = N 个独立 VideoBooks 行）：host 不把兄弟集填进
     // RemoteVideoInfo.episodes（那是旧单行 playlistJson 模型），故由 client 用合集成员列表
@@ -3653,6 +3668,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _videoControlPopover.dispose();
     _videoControlEditMode.dispose();
     _controlLayoutNotifier.dispose();
+    _customActionBindingsNotifier.dispose();
     _immersiveLocked.dispose();
     _lockButtonHideTimer?.cancel();
     _lockButtonVisible.dispose();
@@ -5154,6 +5170,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case VideoControlItem.previousChapter:
       case VideoControlItem.nextChapter:
       case VideoControlItem.chapterList:
+      // 自定义「快捷键」按钮就是一个普通图标按钮：图标 / tooltip 由绑定动作决定
+      // （见 `_videoControlItemIcon` / `_videoControlItemTooltip`），点击走
+      // `_activateVideoControlItem` 查动作表。没有任何专属渲染需求。
+      case VideoControlItem.customAction1:
+      case VideoControlItem.customAction2:
+      case VideoControlItem.customAction3:
+      case VideoControlItem.customAction4:
         return _plainSlotButton(item, controller, desktop: desktop, slot: slot);
       case VideoControlItem.volume:
       case VideoControlItem.title:
@@ -5199,6 +5222,14 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   }
 
   bool _shouldRenderControlItem(VideoControlItem item) {
+    // 自定义「快捷键」按钮：**绑了动作才显示**。这条规则同时承担两件事——
+    //   ① 没配过的槽位不会变成播放器上按了没反应的死按钮；
+    //   ② 新增这 4 个枚举项对现有用户零影响（老布局解出来它们即便落在可见槽位，
+    //      也因为绑定为空而不渲染，控制条长相完全不变）。
+    final int? slotIndex = item.customActionSlotIndex;
+    if (slotIndex != null) {
+      return _customActionBindings.actionAt(slotIndex) != null;
+    }
     switch (item) {
       case VideoControlItem.previousEpisode:
       case VideoControlItem.nextEpisode:
@@ -5234,6 +5265,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case VideoControlItem.subtitleTrack:
       case VideoControlItem.audioTrack:
         return true;
+      case VideoControlItem.customAction1:
+      case VideoControlItem.customAction2:
+      case VideoControlItem.customAction3:
+      case VideoControlItem.customAction4:
+        // 不可达：函数开头已按绑定是否为空决定。保留分支维持穷举检查。
+        return false;
     }
   }
 
@@ -5367,6 +5404,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
 
   /// Icon for any chip-renderable [VideoControlItem] (learning + transport/nav).
   IconData _videoControlItemIcon(VideoControlItem item) {
+    // 自定义「快捷键」按钮没有固定图标：长相 = 当前绑定动作的图标（未绑定时是通用
+    // 闪电图标）。这条与编辑器 chip 共用 [videoControlItemIcon]，两处永远同款。
+    if (item.isCustomAction) {
+      return videoControlItemIcon(item, bindings: _customActionBindings);
+    }
     final VideoControlButton? legacy = item.legacyButton;
     if (legacy != null) return _videoControlButtonIcon(legacy);
     switch (item) {
@@ -5421,11 +5463,25 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case VideoControlItem.favoriteSentence:
       case VideoControlItem.settings:
         return Icons.tune;
+      case VideoControlItem.customAction1:
+      case VideoControlItem.customAction2:
+      case VideoControlItem.customAction3:
+      case VideoControlItem.customAction4:
+        // 不可达：函数开头已委托 [videoControlItemIcon] 按绑定解析。
+        return Icons.bolt_outlined;
     }
   }
 
   /// Tooltip for any chip-renderable [VideoControlItem].
   String _videoControlItemTooltip(VideoControlItem item) {
+    // 自定义「快捷键」按钮：tooltip = 绑定动作的名字（未绑定时是「快捷键 N」槽位名）。
+    if (item.isCustomAction) {
+      return videoControlItemLabel(
+        item,
+        context,
+        bindings: _customActionBindings,
+      );
+    }
     final VideoControlButton? legacy = item.legacyButton;
     if (legacy != null) return _videoControlButtonTooltip(legacy);
     switch (item) {
@@ -5479,6 +5535,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case VideoControlItem.favoriteSentence:
       case VideoControlItem.settings:
         return '';
+      case VideoControlItem.customAction1:
+      case VideoControlItem.customAction2:
+      case VideoControlItem.customAction3:
+      case VideoControlItem.customAction4:
+        // 不可达：函数开头已委托 [videoControlItemLabel] 按绑定解析。
+        return '';
     }
   }
 
@@ -5492,6 +5554,22 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     LayerLink? popoverLink,
     VideoControlSlot? sourceSlot,
   }) {
+    // 自定义「快捷键」按钮：查**键盘 / 手柄用的同一张动作表**并执行。这里刻意不写
+    // 第二套 switch——[videoActionCallbacks] 已经是「动作 → 本页具体操作」的唯一接线，
+    // 屏幕按钮再抄一份就等于承诺两份实现永远一致（沉浸门控、防重入这些都在回调里）。
+    // 未绑定 / 表里没有该动作（动作被删）时静默 no-op：按钮本就不该渲染出来。
+    final int? slotIndex = item.customActionSlotIndex;
+    if (slotIndex != null) {
+      final ShortcutAction? action = _customActionBindings.actionAt(slotIndex);
+      if (action == null) return;
+      final VoidCallback? callback =
+          videoActionCallbacks(_buildVideoShortcutActions(controller))[action];
+      if (callback == null) return;
+      // 与其它控制条按钮一致：按一下续命控制条，否则 3s 到点隐藏、手指还在按钮上。
+      _pokeControlsVisible();
+      callback();
+      return;
+    }
     final VideoControlButton? legacy = item.legacyButton;
     if (legacy != null) {
       _activateVideoControlButton(
@@ -5598,6 +5676,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case VideoControlItem.subtitleList:
       case VideoControlItem.favoriteSentence:
       case VideoControlItem.settings:
+      // 不可达：函数开头已按绑定查 [videoActionCallbacks] 执行并 return。
+      case VideoControlItem.customAction1:
+      case VideoControlItem.customAction2:
+      case VideoControlItem.customAction3:
+      case VideoControlItem.customAction4:
         break;
     }
   }
@@ -6147,6 +6230,16 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     if (mounted) setState(() {});
   }
 
+  /// 落盘 + 即时生效「快捷键 1..4」按钮的新绑定。与 [_setVideoControlLayout] 同款：
+  /// 先推 notifier（控制层与全屏子树立刻重建，图标/行为当场变），再持久化。
+  Future<void> _setVideoCustomActionBindings(
+    VideoCustomActionBindings bindings,
+  ) async {
+    _customActionBindingsNotifier.value = bindings;
+    await appModel.setVideoCustomActionBindings(bindings);
+    if (mounted) setState(() {});
+  }
+
   // 原 `_showVideoControlEditOverlay`（TODO-440 画面内拖拽编辑入口）已删：旧面板只
   // 声明了 onEditControlsOnscreen 参数从未渲染入口，方法早已不可达；schema 投影版
   // 不再保留死参数。关闭路径（_hideVideoControlEditOverlay）仍被浮层互斥逻辑使用。
@@ -6443,6 +6536,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       subtitleStyle: () => _subtitleStyle,
       danmakuStyle: () => _danmakuStyle,
       controlLayout: () => _controlLayout,
+      customActionBindings: () => _customActionBindings,
+      onCustomActionBindingsChanged: _setVideoCustomActionBindings,
       onSetDelay: _setDelayMs,
       // TODO-2837：副字幕独立调轴（null = 跟随主字幕）。行只在副字幕轨激活
       // （secondaryCues 非空）时显示——hasSecondarySubtitle 是活值 getter，
@@ -6456,6 +6551,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       onAutoAlign: (_controller?.cues.isNotEmpty ?? false) &&
               (_controller?.videoPath?.isNotEmpty ?? false)
           ? _autoAlignSubtitle
+          : null,
+      // 「上/下一句对齐到当前时间」按钮：与键盘 Ctrl+Shift+←/→ 同一执行体。只要有
+      // 字幕 cue 就能对齐（纯按 cue 时间轴求偏移，**不需要**视频本地路径 / 音频探测，
+      // 故门条件比自动对轴松一档）；无 cue 时置 null 让面板不显示按钮。
+      onSnapDelayToCue: (_controller?.cues.isNotEmpty ?? false)
+          ? _snapSubtitleDelayToCue
           : null,
       // TODO-1051 阶段B：字幕对轴波形面板输入。有 cue + 本地视频路径时给波形抽取回调
       // （否则 null，面板不显示）；面板拖动预览、松手才经 onSetDelay(_setDelayMs) 落盘。

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -66,6 +66,7 @@ import 'package:fushi/src/media/video/video_chrome_colors.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
 import 'package:fushi/src/media/video/video_control_item_presentation.dart';
 import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/media/video/video_custom_action_picker.dart';
 import 'package:fushi/src/media/video/video_control_layout_edit_overlay.dart';
 import 'package:fushi/src/media/video/video_control_popover_placement.dart';
 import 'package:fushi/src/media/video/video_controls_focus_gate.dart';
@@ -5222,14 +5223,14 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   }
 
   bool _shouldRenderControlItem(VideoControlItem item) {
-    // 自定义「快捷键」按钮：**绑了动作才显示**。这条规则同时承担两件事——
-    //   ① 没配过的槽位不会变成播放器上按了没反应的死按钮；
-    //   ② 新增这 4 个枚举项对现有用户零影响（老布局解出来它们即便落在可见槽位，
-    //      也因为绑定为空而不渲染，控制条长相完全不变）。
-    final int? slotIndex = item.customActionSlotIndex;
-    if (slotIndex != null) {
-      return _customActionBindings.actionAt(slotIndex) != null;
-    }
+    // 自定义「快捷键」按钮：**未绑定也显示**（用户拍板）。空槽位不是死按钮——点它
+    // 就地弹动作选择器（见 `_activateVideoControlItem`），这是手机上最短的配置路径：
+    // 看得见 → 点得到 → 当场配好，不用先翻进设置面板找编辑器。
+    //
+    // 想让某个槽位彻底消失，走控件编辑器把它拖进隐藏托盘（和其它按钮同一套操作），
+    // 而不是靠「没绑动作」这个隐式条件——后者会让「我明明配置过它，怎么不见了」
+    // 和「怎么才能把它调出来」同时变成谜。
+    if (item.isCustomAction) return true;
     switch (item) {
       case VideoControlItem.previousEpisode:
       case VideoControlItem.nextEpisode:
@@ -5554,19 +5555,26 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     LayerLink? popoverLink,
     VideoControlSlot? sourceSlot,
   }) {
-    // 自定义「快捷键」按钮：查**键盘 / 手柄用的同一张动作表**并执行。这里刻意不写
-    // 第二套 switch——[videoActionCallbacks] 已经是「动作 → 本页具体操作」的唯一接线，
-    // 屏幕按钮再抄一份就等于承诺两份实现永远一致（沉浸门控、防重入这些都在回调里）。
-    // 未绑定 / 表里没有该动作（动作被删）时静默 no-op：按钮本就不该渲染出来。
+    // 自定义「快捷键」按钮，两种语义按是否绑过动作分流：
+    //   · 已绑定 → 查**键盘 / 手柄用的同一张动作表**并执行。这里刻意不写第二套
+    //     switch——[videoActionCallbacks] 已是「动作 → 本页具体操作」的唯一接线，屏幕
+    //     按钮再抄一份就等于承诺两份实现永远一致（沉浸门控、防重入都在回调里）。
+    //   · 未绑定 → 就地弹动作选择器配置它。空槽位照样渲染（见
+    //     `_shouldRenderControlItem`），靠这条分流才不至于变成按了没反应的死按钮。
     final int? slotIndex = item.customActionSlotIndex;
     if (slotIndex != null) {
       final ShortcutAction? action = _customActionBindings.actionAt(slotIndex);
-      if (action == null) return;
+      // 与其它控制条按钮一致：按一下续命控制条，否则 3s 到点隐藏、手指还在按钮上。
+      // 弹选择器那条路尤其需要——弹窗期间控制条不该在背后自己消失。
+      _pokeControlsVisible();
+      if (action == null) {
+        unawaited(_pickVideoCustomAction(slotIndex));
+        return;
+      }
       final VoidCallback? callback =
           videoActionCallbacks(_buildVideoShortcutActions(controller))[action];
+      // 表里没有该动作（动作在新版被删）时静默 no-op，不崩。
       if (callback == null) return;
-      // 与其它控制条按钮一致：按一下续命控制条，否则 3s 到点隐藏、手指还在按钮上。
-      _pokeControlsVisible();
       callback();
       return;
     }
@@ -6238,6 +6246,30 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _customActionBindingsNotifier.value = bindings;
     await appModel.setVideoCustomActionBindings(bindings);
     if (mounted) setState(() {});
+  }
+
+  /// 在播放器上直接点空的「快捷键 N」按钮 → 就地选动作。手机上最短的配置路径：
+  /// 看得见、点得到、当场配好，不用先翻进设置面板找控件编辑器。选择器与编辑器共用
+  /// [showVideoCustomActionPicker]，列表与选中态两处必然一致。
+  ///
+  /// guardOverlay：弹窗走 root navigator 会夺走视频键盘焦点，任何退出路径（选完 /
+  /// Esc / 点外部 / 抛异常）都必须归还，否则关掉弹窗后空格等快捷键要等到下次点画面
+  /// 才恢复——这是本页所有覆盖层的既有范式（见 [_openSubtitleWaveformAlign]）。
+  Future<void> _pickVideoCustomAction(int slotIndex) async {
+    final ShortcutAction? current = _customActionBindings.actionAt(slotIndex);
+    final VideoCustomActionPick? pick = await _focusOwnership.guardOverlay(
+      () => showVideoCustomActionPicker(
+        context: context,
+        slotNumber: slotIndex + 1,
+        current: current,
+      ),
+    );
+    // null = 取消（点外部 / 返回键）；显式选「不绑定」是 VideoCustomActionPick(null)。
+    if (pick == null || !mounted) return;
+    final VideoCustomActionBindings next =
+        _customActionBindings.withAction(slotIndex, pick.action);
+    if (next == _customActionBindings) return;
+    await _setVideoCustomActionBindings(next);
   }
 
   // 原 `_showVideoControlEditOverlay`（TODO-440 画面内拖拽编辑入口）已删：旧面板只

--- a/fushi/lib/src/shortcuts/shortcut_labels.dart
+++ b/fushi/lib/src/shortcuts/shortcut_labels.dart
@@ -245,3 +245,119 @@ extension MouseBindingLabel on MouseBinding {
     }
   }
 }
+
+/// 动作的按钮图标（视频页「快捷键 1..4」自定义按钮用）。
+///
+/// 为什么返回可空、而不是像同文件其它 switch 那样穷举全部动作：能被绑到屏幕按钮上的
+/// 只有视频页真正能执行的那批动作（`videoActionCallbacks` 的 keys），给阅读器 / 漫画 /
+/// 首页那些永远绑不上的动作硬凑图标是纯噪声。null = 没有专属图标，由调用方兜底。
+///
+/// ⚠️ 这里有 default 分支，漏配图标**不会**编译失败，所以由守卫测试
+/// `video_custom_action_bindings_test` 反向兜住：`videoActionCallbacks` 的每一个 key
+/// 都必须在这里拿到非 null 图标，新增视频动作时忘了配图标即测试红。否则用户会看到一个
+/// 没有语义的通用按钮，而「按钮长成它绑的那个动作」正是这个功能的设计承诺。
+extension ShortcutActionIcon on ShortcutAction {
+  IconData? get buttonIcon {
+    switch (this) {
+      // 播放控制
+      case ShortcutAction.videoTogglePlayPause:
+        return Icons.play_arrow_rounded;
+      case ShortcutAction.videoPlay:
+        return Icons.play_circle_outline;
+      case ShortcutAction.videoPause:
+        return Icons.pause_circle_outline;
+      case ShortcutAction.videoSeekBackward:
+        return Icons.fast_rewind_rounded;
+      case ShortcutAction.videoSeekForward:
+        return Icons.fast_forward_rounded;
+      case ShortcutAction.videoPreviousFrame:
+        return Icons.skip_previous_outlined;
+      case ShortcutAction.videoNextFrame:
+        return Icons.skip_next_outlined;
+
+      // 倍速
+      case ShortcutAction.videoSpeedUp:
+        return Icons.speed;
+      case ShortcutAction.videoSpeedDown:
+        return Icons.slow_motion_video;
+      case ShortcutAction.videoResetSpeed:
+        return Icons.restore;
+      case ShortcutAction.videoHoldSpeed:
+        return Icons.fast_forward;
+
+      // 字幕跳转 / 重播
+      case ShortcutAction.videoPreviousSubtitle:
+        return Icons.skip_previous;
+      case ShortcutAction.videoNextSubtitle:
+        return Icons.skip_next;
+      case ShortcutAction.videoReplayCurrentSubtitle:
+        return Icons.replay;
+      case ShortcutAction.videoReplayPreviousSubtitle:
+        return Icons.replay_5;
+
+      // 章节
+      case ShortcutAction.videoPreviousChapter:
+        return Icons.first_page;
+      case ShortcutAction.videoNextChapter:
+        return Icons.last_page;
+
+      // 字幕显示 / 遮蔽
+      case ShortcutAction.videoToggleSubtitleList:
+        return Icons.format_list_bulleted;
+      case ShortcutAction.videoToggleSubtitleBlur:
+        return Icons.blur_on;
+      case ShortcutAction.videoCycleSubtitleObscure:
+        return Icons.visibility_off_outlined;
+      case ShortcutAction.videoToggleSubtitleHide:
+        return Icons.subtitles_off_outlined;
+      case ShortcutAction.videoCycleSecondarySubtitleObscure:
+        return Icons.blur_linear;
+      case ShortcutAction.videoToggleSecondarySubtitleHide:
+        return Icons.closed_caption_disabled_outlined;
+
+      // 字幕对轴
+      case ShortcutAction.videoOpenSubtitleAlign:
+        return Icons.graphic_eq;
+      case ShortcutAction.videoSubtitleDelayIncrease:
+        return Icons.more_time;
+      case ShortcutAction.videoSubtitleDelayDecrease:
+        return Icons.history_toggle_off;
+      case ShortcutAction.videoAlignSubtitleToPrev:
+        return Icons.align_horizontal_left;
+      case ShortcutAction.videoAlignSubtitleToNext:
+        return Icons.align_horizontal_right;
+
+      // 音量
+      case ShortcutAction.videoVolumeUp:
+        return Icons.volume_up;
+      case ShortcutAction.videoVolumeDown:
+        return Icons.volume_down;
+      case ShortcutAction.videoToggleMute:
+        return Icons.volume_off;
+
+      // 画面 / 杂项
+      case ShortcutAction.videoToggleFullscreen:
+        return Icons.fullscreen;
+      case ShortcutAction.videoScreenshot:
+        return Icons.photo_camera_outlined;
+      case ShortcutAction.videoToggleShaderCompare:
+        return Icons.compare;
+      case ShortcutAction.videoToggleImmersiveLock:
+        return Icons.lock_outline;
+
+      // 学习
+      case ShortcutAction.videoToggleFavoriteSentence:
+        return Icons.star_border_rounded;
+      case ShortcutAction.videoEnterCaret:
+        return Icons.text_fields;
+
+      // 全 app 共用「返回上一级」：视频页把它解释成逐级退出阶梯。
+      case ShortcutAction.globalBack:
+        return Icons.arrow_back;
+
+      // ignore: no_default_cases
+      default:
+        return null;
+    }
+  }
+}

--- a/fushi/test/media/video/video_custom_action_bindings_test.dart
+++ b/fushi/test/media/video/video_custom_action_bindings_test.dart
@@ -206,25 +206,57 @@ void main() {
   });
 
   group('默认布局向后兼容', () {
-    test('老配置解码后不会平白多出可见的自定义按钮', () {
-      // 铁律：新增 4 个枚举项对现有用户零影响。老 payload 里没有它们，解码后它们
-      // 要么进隐藏托盘、要么落默认槽位——但因为绑定为空，播放器一律不渲染
-      // （渲染门在 `_shouldRenderControlItem`，此处只核布局侧不炸）。
+    test('老配置解码后自定义按钮落底栏右区（可见），且不打乱原有布局', () {
+      // 用户拍板「未绑定也显示」后，这条的语义反过来了：老用户升级**必须**能在播放器上
+      // 看到这 4 个按钮，否则得先翻进编辑器把它们从隐藏托盘拖出来才知道有这功能。
+      // 兜底槽位由 [VideoControlLayout.currentChrome] 的 assignment 决定——它同时是老
+      // 布局解码时「这个没见过的 item 该放哪」的唯一依据，漏写就会被判成「用户移除过」。
       const String legacyV2 =
           '{"version":2,"slots":{"bottomRight":["speed","settings"],'
           '"bottomCenter":["playPause"]}}';
       final VideoControlLayout layout = VideoControlLayout.decode(legacyV2);
-      // 老 payload 能正常解出且保留原有按钮。
+      // 老 payload 原有按钮原地不动。
       expect(
         layout.itemsIn(VideoControlSlot.bottomCenter),
         contains(VideoControlItem.playPause),
       );
-      // 自定义按钮不会挤进老用户的 bottomCenter。
+      expect(
+        layout.itemsIn(VideoControlSlot.bottomRight),
+        containsAll(<VideoControlItem>[
+          VideoControlItem.speed,
+          VideoControlItem.settings,
+        ]),
+      );
       for (final VideoControlItem item in VideoControlItem.customActionItems) {
+        // 落在底栏右区且可见，不进 removed。
+        expect(
+          layout.itemsIn(VideoControlSlot.bottomRight),
+          contains(item),
+          reason: '${item.storageValue} 升级后应可见于底栏右区',
+        );
+        expect(layout.slotOf(item), VideoControlSlot.bottomRight);
+        // 不挤进老用户的底栏中区（传输键簇）。
         expect(
           layout.itemsIn(VideoControlSlot.bottomCenter).contains(item),
           isFalse,
-          reason: '${item.storageValue} 不该出现在老配置的底栏中区',
+          reason: '${item.storageValue} 不该出现在底栏中区',
+        );
+      }
+    });
+
+    test('用户把自定义按钮拖进隐藏托盘后，解码回来仍是隐藏的', () {
+      // 「未绑定也显示」是默认值，不是强制值——不想要的人拖走之后必须留得住，
+      // 否则每次启动都会自己冒回来。
+      const String v3Hidden =
+          '{"version":3,"slots":{"bottomCenter":["playPause"]},'
+          '"removed":["customAction1","customAction2",'
+          '"customAction3","customAction4"]}';
+      final VideoControlLayout layout = VideoControlLayout.decode(v3Hidden);
+      for (final VideoControlItem item in VideoControlItem.customActionItems) {
+        expect(
+          layout.slotOf(item),
+          VideoControlSlot.hidden,
+          reason: '${item.storageValue} 被移除后不该自己回到播放器上',
         );
       }
     });

--- a/fushi/test/media/video/video_custom_action_bindings_test.dart
+++ b/fushi/test/media/video/video_custom_action_bindings_test.dart
@@ -65,6 +65,19 @@ void main() {
       }
     });
 
+    test('全空表编码回空串（「全空」只有一种写法）', () {
+      // 与偏好默认值（空串）重合：解绑回初始态后存储里不该留一条 ",,," 这样
+      // 看着像配置过、实际什么都没绑的垃圾。
+      expect(VideoCustomActionBindings.empty.encode(), '');
+      final VideoCustomActionBindings roundTrip = VideoCustomActionBindings
+          .empty
+          .withAction(0, ShortcutAction.videoPlay)
+          .withAction(0, null);
+      expect(roundTrip.encode(), '');
+      expect(VideoCustomActionBindings.decode(roundTrip.encode()),
+          VideoCustomActionBindings.empty);
+    });
+
     test('round-trip 保持每个槽位的动作与位置', () {
       final VideoCustomActionBindings b = VideoCustomActionBindings.empty
           .withAction(0, ShortcutAction.videoNextSubtitle)

--- a/fushi/test/media/video/video_custom_action_bindings_test.dart
+++ b/fushi/test/media/video/video_custom_action_bindings_test.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_control_item_presentation.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_labels.dart';
+
+/// 哑动作实例：每个回调都是 no-op，只用来把 [videoActionCallbacks] 的 **keys** 取出来。
+/// 守卫比对的是「哪些动作接过线」，与回调具体做什么无关。
+VideoPlayerShortcutActions _dummyActions() {
+  void noop() {}
+  return VideoPlayerShortcutActions(
+    togglePlayPause: noop,
+    play: noop,
+    pause: noop,
+    previousSubtitle: noop,
+    nextSubtitle: noop,
+    replayCurrentSubtitle: noop,
+    replayPreviousSubtitle: noop,
+    seekBackward: noop,
+    seekForward: noop,
+    toggleShaderCompare: noop,
+    volumeUp: noop,
+    volumeDown: noop,
+    toggleMute: noop,
+    speedUp: noop,
+    speedDown: noop,
+    resetSpeed: noop,
+    toggleHoldSpeed: noop,
+    previousFrame: noop,
+    nextFrame: noop,
+    screenshot: noop,
+    toggleFullscreen: noop,
+    toggleSubtitleList: noop,
+    toggleImmersiveLock: noop,
+    toggleSubtitleBlur: noop,
+    cycleSubtitleObscure: noop,
+    toggleSubtitleHide: noop,
+    cycleSecondarySubtitleObscure: noop,
+    toggleSecondarySubtitleHide: noop,
+    toggleFavoriteSentence: noop,
+    previousChapter: noop,
+    nextChapter: noop,
+    openSubtitleAlign: noop,
+    subtitleDelayIncrease: noop,
+    subtitleDelayDecrease: noop,
+    alignSubtitleToPrev: noop,
+    alignSubtitleToNext: noop,
+    enterCaret: noop,
+    escape: noop,
+  );
+}
+
+void main() {
+  group('VideoCustomActionBindings 编解码', () {
+    test('空串解出全空表', () {
+      final VideoCustomActionBindings b = VideoCustomActionBindings.decode('');
+      expect(b, VideoCustomActionBindings.empty);
+      expect(b.isEmpty, isTrue);
+      for (int i = 0; i < VideoCustomActionBindings.slotCount; i++) {
+        expect(b.actionAt(i), isNull);
+      }
+    });
+
+    test('round-trip 保持每个槽位的动作与位置', () {
+      final VideoCustomActionBindings b = VideoCustomActionBindings.empty
+          .withAction(0, ShortcutAction.videoNextSubtitle)
+          .withAction(2, ShortcutAction.videoToggleSubtitleBlur);
+      final VideoCustomActionBindings back =
+          VideoCustomActionBindings.decode(b.encode());
+      expect(back, b);
+      expect(back.actionAt(0), ShortcutAction.videoNextSubtitle);
+      expect(back.actionAt(1), isNull);
+      expect(back.actionAt(2), ShortcutAction.videoToggleSubtitleBlur);
+      expect(back.actionAt(3), isNull);
+    });
+
+    test('未知 / 已删除的动作 key 降级成未绑定，不抛异常', () {
+      // 动作在新版里被删名后，老配置必须照样能读出一张合法的表（这条路径在启动读
+      // 偏好时跑，抛异常就是白屏）。
+      final VideoCustomActionBindings b = VideoCustomActionBindings.decode(
+        'video_next_subtitle,this_action_no_longer_exists,,',
+      );
+      expect(b.actionAt(0), ShortcutAction.videoNextSubtitle);
+      expect(b.actionAt(1), isNull);
+    });
+
+    test('长度不匹配的老 payload 按位截断 / 补空', () {
+      final VideoCustomActionBindings short =
+          VideoCustomActionBindings.decode('video_play');
+      expect(short.actionAt(0), ShortcutAction.videoPlay);
+      expect(short.actionAt(1), isNull);
+
+      final VideoCustomActionBindings long = VideoCustomActionBindings.decode(
+        'video_play,video_pause,video_play,video_pause,video_play,video_pause',
+      );
+      expect(long.actionAt(3), ShortcutAction.videoPause);
+      // 超出 slotCount 的部分被丢弃，不影响表内合法槽位。
+      expect(
+          long.encode().split(',').length, VideoCustomActionBindings.slotCount);
+    });
+
+    test('越界读写安全：不抛异常、不改表', () {
+      const VideoCustomActionBindings b = VideoCustomActionBindings.empty;
+      expect(b.actionAt(-1), isNull);
+      expect(b.actionAt(VideoCustomActionBindings.slotCount), isNull);
+      expect(b.withAction(99, ShortcutAction.videoPlay), b);
+    });
+  });
+
+  group('槽位与按钮的接线守卫', () {
+    test('槽位数与 customAction 枚举项数一一对应', () {
+      // 改 slotCount 却没加/删对应枚举项 = 「有槽位没按钮」或「有按钮没槽位」。
+      expect(
+        VideoControlItem.customActionItems.length,
+        VideoCustomActionBindings.slotCount,
+      );
+      // 槽位下标必须是 0..slotCount-1 且不重不漏。
+      expect(
+        VideoControlItem.customActionItems
+            .map((VideoControlItem i) => i.customActionSlotIndex)
+            .toList(),
+        List<int>.generate(VideoCustomActionBindings.slotCount, (int i) => i),
+      );
+    });
+
+    test('自定义按钮是 chip-renderable（否则编辑器里根本摆不上去）', () {
+      for (final VideoControlItem item in VideoControlItem.customActionItems) {
+        expect(item.isChipRenderable, isTrue, reason: item.storageValue);
+        expect(
+          VideoControlItem.customizableItems.contains(item),
+          isTrue,
+          reason: '${item.storageValue} 必须出现在编辑器调色板里',
+        );
+      }
+    });
+
+    test('非自定义按钮的 customActionSlotIndex 恒为 null', () {
+      for (final VideoControlItem item in VideoControlItem.values) {
+        if (item.isCustomAction) continue;
+        expect(item.customActionSlotIndex, isNull, reason: item.storageValue);
+      }
+    });
+  });
+
+  group('可绑动作表守卫', () {
+    test('kVideoAssignableActions 与 videoActionCallbacks 的 keys 完全一致', () {
+      // 这是本功能最关键的不变式：选择列表里出现、但页面没接线的动作 = 用户配得上、
+      // 按了没反应；反过来接了线却不在列表里 = 用户根本选不到。设置页拿不到 live
+      // controller，只能维护一份常量表，故必须在这里和真实接线逐个对齐。
+      final Set<ShortcutAction> wired =
+          videoActionCallbacks(_dummyActions()).keys.toSet();
+      final Set<ShortcutAction> assignable = kVideoAssignableActions.toSet();
+      expect(
+        assignable.difference(wired),
+        isEmpty,
+        reason: '这些动作在选择列表里但页面没接线（按了会没反应）',
+      );
+      expect(
+        wired.difference(assignable),
+        isEmpty,
+        reason: '这些动作页面接了线但用户选不到（漏加进 kVideoAssignableActions）',
+      );
+    });
+
+    test('可绑动作表无重复项', () {
+      expect(
+        kVideoAssignableActions.toSet().length,
+        kVideoAssignableActions.length,
+      );
+    });
+
+    test('每个可绑动作都有专属图标', () {
+      // 没有图标就会退化成通用闪电图标，而「按钮长成它绑的那个动作」正是这个功能的
+      // 设计承诺（用户拍板：显示动作图标而非数字 1/2/3）。
+      for (final ShortcutAction action in kVideoAssignableActions) {
+        expect(
+          action.buttonIcon,
+          isNotNull,
+          reason: '${action.key} 缺按钮图标（ShortcutActionIcon.buttonIcon）',
+        );
+      }
+    });
+
+    test('每个可绑动作都有非空本地化名字', () {
+      for (final ShortcutAction action in kVideoAssignableActions) {
+        expect(action.label, isNotEmpty, reason: action.key);
+      }
+    });
+  });
+
+  group('默认布局向后兼容', () {
+    test('老配置解码后不会平白多出可见的自定义按钮', () {
+      // 铁律：新增 4 个枚举项对现有用户零影响。老 payload 里没有它们，解码后它们
+      // 要么进隐藏托盘、要么落默认槽位——但因为绑定为空，播放器一律不渲染
+      // （渲染门在 `_shouldRenderControlItem`，此处只核布局侧不炸）。
+      const String legacyV2 =
+          '{"version":2,"slots":{"bottomRight":["speed","settings"],'
+          '"bottomCenter":["playPause"]}}';
+      final VideoControlLayout layout = VideoControlLayout.decode(legacyV2);
+      // 老 payload 能正常解出且保留原有按钮。
+      expect(
+        layout.itemsIn(VideoControlSlot.bottomCenter),
+        contains(VideoControlItem.playPause),
+      );
+      // 自定义按钮不会挤进老用户的 bottomCenter。
+      for (final VideoControlItem item in VideoControlItem.customActionItems) {
+        expect(
+          layout.itemsIn(VideoControlSlot.bottomCenter).contains(item),
+          isFalse,
+          reason: '${item.storageValue} 不该出现在老配置的底栏中区',
+        );
+      }
+    });
+
+    test('默认布局里自定义按钮可被移除（不是 pinned）', () {
+      for (final VideoControlItem item in VideoControlItem.customActionItems) {
+        expect(item.canBeRemovedFromPlayer, isTrue);
+        expect(item.pinnedRequired, isFalse);
+      }
+    });
+  });
+
+  group('presentation 按绑定解析', () {
+    testWidgets('未绑定显示槽位名 + 通用图标；绑定后显示动作名 + 动作图标', (WidgetTester tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              ctx = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      const VideoControlItem slot1 = VideoControlItem.customAction1;
+      // 未绑定：通用图标 + 「快捷键 1」这类槽位名（非空）。
+      expect(
+        videoControlItemIcon(
+          slot1,
+          bindings: VideoCustomActionBindings.empty,
+        ),
+        Icons.bolt_outlined,
+      );
+      // 完全不传 bindings 也必须退回通用图标（编辑器调色板路径）。
+      expect(videoControlItemIcon(slot1), Icons.bolt_outlined);
+      final String emptyLabel = videoControlItemLabel(
+        slot1,
+        ctx,
+        bindings: VideoCustomActionBindings.empty,
+      );
+      expect(emptyLabel, isNotEmpty);
+      expect(emptyLabel, isNot(ShortcutAction.videoNextSubtitle.label));
+
+      // 绑定后：图标与名字都跟着动作走。
+      final VideoCustomActionBindings bound = VideoCustomActionBindings.empty
+          .withAction(0, ShortcutAction.videoNextSubtitle);
+      expect(
+        videoControlItemIcon(slot1, bindings: bound),
+        ShortcutAction.videoNextSubtitle.buttonIcon,
+      );
+      expect(
+        videoControlItemLabel(slot1, ctx, bindings: bound),
+        ShortcutAction.videoNextSubtitle.label,
+      );
+      // 只绑了槽位 1，槽位 2 仍是未绑定外观（不串位）。
+      expect(
+        videoControlItemIcon(
+          VideoControlItem.customAction2,
+          bindings: bound,
+        ),
+        Icons.bolt_outlined,
+      );
+    });
+  });
+}

--- a/fushi/test/media/video/video_custom_action_editor_test.dart
+++ b/fushi/test/media/video/video_custom_action_editor_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/video/video_control_customization.dart';
+import 'package:fushi/src/media/video/video_control_layout_editor.dart';
+import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_labels.dart';
+
+/// 「快捷键 N」chip 的配置入口行为测试。
+///
+/// 守卫测试只能核对「表和表对得上」，测不出这里真正易碎的一点：chip 同时挂着
+/// [Draggable]（改位置）和 `onTap`（改绑动作），两者在手势竞技场里竞争。tap 一旦被
+/// 拖拽识别器吃掉，这个功能就**完全没有配置入口**——而静态分析、类型检查、一致性
+/// 守卫全都照样绿。所以这条链路必须用真手势跑一遍。
+/// 测试视口。默认的 800×600 装不下这个编辑器（九宫格 + 调色板 + 隐藏托盘），
+/// 溢出后 chip 会被挤出可点区域，测出来的「点不到」是测试壳的假象而不是产品问题。
+/// 用一块够大的画布，让手势测的是真实的手势竞争，不是布局裁剪。
+void _useLargeSurface(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1400, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+}
+
+Future<void> _pumpEditor(
+  WidgetTester tester, {
+  required VideoCustomActionBindings bindings,
+  required Future<void> Function(VideoCustomActionBindings) onChanged,
+  VideoControlLayout? layout,
+}) async {
+  _useLargeSurface(tester);
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Scaffold(
+        body: SizedBox.expand(
+          child: VideoControlLayoutEditor(
+            layout: layout ?? VideoControlLayout.defaults,
+            onLayoutChanged: (VideoControlLayout _) async {},
+            isTouchControls: true,
+            customActionBindings: bindings,
+            onCustomActionBindingsChanged: onChanged,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// 按拖拽载荷精确定位「快捷键 N」chip。
+///
+/// 刻意**不按 tooltip 文字找**：控制条里本来就有同名标签（`VideoControlItem.nextCue`
+/// 的标签就是「下一句字幕」，与绑了该动作的槽位 chip 一模一样），按文字找会静默命中
+/// 那个传输按钮，点下去什么都不弹——测出来的红是 finder 的错，不是产品的错。载荷里的
+/// [VideoControlItem] 才是唯一无歧义的身份。
+Finder _slotChip(VideoControlItem item) => find
+    .byWidgetPredicate(
+      (Widget w) =>
+          w is Draggable<VideoControlDragData> && w.data?.item == item,
+    )
+    .first;
+
+void main() {
+  testWidgets('点未绑定的「快捷键1」chip 能弹出动作选择器并改绑', (WidgetTester tester) async {
+    VideoCustomActionBindings? saved;
+    await _pumpEditor(
+      tester,
+      bindings: VideoCustomActionBindings.empty,
+      onChanged: (VideoCustomActionBindings b) async => saved = b,
+    );
+
+    // 未绑定的槽位在编辑器里以槽位名出现（播放器上不显示，但编辑器必须能看到，
+    // 否则用户根本没有下手的地方）。
+    final String slotLabel = t.video_control_custom_action(index: 1);
+    expect(find.byTooltip(slotLabel), findsWidgets);
+
+    // 关键：tap 必须能穿过 Draggable 打开选择器。
+    await tester.tap(_slotChip(VideoControlItem.customAction1));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(ShortcutAction.videoNextSubtitle.label),
+      findsOneWidget,
+      reason: '动作选择器没弹出来（tap 很可能被 Draggable 吃掉了）',
+    );
+
+    await tester
+        .ensureVisible(find.text(ShortcutAction.videoNextSubtitle.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(ShortcutAction.videoNextSubtitle.label));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull, reason: '选完动作没有回调落盘');
+    expect(saved!.actionAt(0), ShortcutAction.videoNextSubtitle);
+    // 只改动了被点的那个槽位，其余保持未绑定。
+    expect(saved!.actionAt(1), isNull);
+    expect(saved!.actionAt(2), isNull);
+    expect(saved!.actionAt(3), isNull);
+  });
+
+  testWidgets('已绑定的 chip 显示动作名，可改绑成「不绑定」清空槽位', (WidgetTester tester) async {
+    VideoCustomActionBindings? saved;
+    final VideoCustomActionBindings bound = VideoCustomActionBindings.empty
+        .withAction(0, ShortcutAction.videoNextSubtitle);
+    await _pumpEditor(
+      tester,
+      bindings: bound,
+      onChanged: (VideoCustomActionBindings b) async => saved = b,
+    );
+
+    // 绑定后 chip 以动作名示人（用户拍板：按钮显示动作，不用记住 1 是什么）。
+    final String actionLabel = ShortcutAction.videoNextSubtitle.label;
+    expect(find.byTooltip(actionLabel), findsWidgets);
+
+    await tester.tap(_slotChip(VideoControlItem.customAction1));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text(t.video_control_custom_action_none));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.video_control_custom_action_none));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    expect(saved!.actionAt(0), isNull, reason: '「不绑定」必须真的清空槽位');
+  });
+
+  testWidgets('取消选择器（点外部）保持原绑定不变', (WidgetTester tester) async {
+    // 这条钉的是 `_CustomActionPick` 存在的理由：取消与「显式选不绑定」都是 null
+    // 动作，若不区分，点外部关弹窗会把用户配好的按钮清掉。
+    bool called = false;
+    final VideoCustomActionBindings bound = VideoCustomActionBindings.empty
+        .withAction(0, ShortcutAction.videoNextSubtitle);
+    await _pumpEditor(
+      tester,
+      bindings: bound,
+      onChanged: (VideoCustomActionBindings _) async => called = true,
+    );
+
+    await tester.tap(_slotChip(VideoControlItem.customAction1));
+    await tester.pumpAndSettle();
+    expect(find.text(t.video_control_custom_action_none), findsOneWidget);
+
+    // 点弹窗外部（barrier）关闭。
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+
+    expect(
+      called,
+      isFalse,
+      reason: '取消不该触发改绑回调（否则点外部就把绑定清空了）',
+    );
+  });
+
+  testWidgets('选择器列出全部可绑动作，且不含未接线的动作', (WidgetTester tester) async {
+    await _pumpEditor(
+      tester,
+      bindings: VideoCustomActionBindings.empty,
+      onChanged: (VideoCustomActionBindings _) async {},
+    );
+
+    await tester.tap(_slotChip(VideoControlItem.customAction1));
+    await tester.pumpAndSettle();
+
+    // 抽查几个必须在列表里的动作（含本轮新加按钮的那对对齐动作）。
+    for (final ShortcutAction action in <ShortcutAction>[
+      ShortcutAction.videoTogglePlayPause,
+      ShortcutAction.videoNextSubtitle,
+      ShortcutAction.videoToggleSubtitleBlur,
+      ShortcutAction.videoAlignSubtitleToNext,
+    ]) {
+      expect(
+        find.text(action.label),
+        findsWidgets,
+        reason: '${action.key} 应出现在可绑动作列表里',
+      );
+    }
+
+    // 阅读器动作永远绑不到视频按钮上（视频页没有它的执行体）。
+    expect(
+      find.text(ShortcutAction.readerPageForward.label),
+      findsNothing,
+      reason: '非视频动作不该出现在列表里（选了会没反应）',
+    );
+  });
+}

--- a/fushi/test/media/video/video_custom_action_editor_test.dart
+++ b/fushi/test/media/video/video_custom_action_editor_test.dart
@@ -5,6 +5,7 @@ import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/video/video_control_customization.dart';
 import 'package:fushi/src/media/video/video_control_layout_editor.dart';
 import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
+import 'package:fushi/src/media/video/video_custom_action_picker.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_labels.dart';
 
@@ -74,8 +75,8 @@ void main() {
       onChanged: (VideoCustomActionBindings b) async => saved = b,
     );
 
-    // 未绑定的槽位在编辑器里以槽位名出现（播放器上不显示，但编辑器必须能看到，
-    // 否则用户根本没有下手的地方）。
+    // 未绑定的槽位以「快捷键 N」这个槽位名出现（播放器上同样显示，点它就地弹本
+    // 选择器；编辑器里则是摆位置顺手配）。
     final String slotLabel = t.video_control_custom_action(index: 1);
     expect(find.byTooltip(slotLabel), findsWidgets);
 
@@ -128,7 +129,7 @@ void main() {
   });
 
   testWidgets('取消选择器（点外部）保持原绑定不变', (WidgetTester tester) async {
-    // 这条钉的是 `_CustomActionPick` 存在的理由：取消与「显式选不绑定」都是 null
+    // 这条钉的是 [VideoCustomActionPick] 存在的理由：取消与「显式选不绑定」都是 null
     // 动作，若不区分，点外部关弹窗会把用户配好的按钮清掉。
     bool called = false;
     final VideoCustomActionBindings bound = VideoCustomActionBindings.empty
@@ -152,6 +153,61 @@ void main() {
       isFalse,
       reason: '取消不该触发改绑回调（否则点外部就把绑定清空了）',
     );
+  });
+
+  testWidgets('共享选择器：取消返回 null，选动作/选「不绑定」返回可区分的结果',
+      (WidgetTester tester) async {
+    // 播放器控制条点空按钮走的就是这个函数（与编辑器同一个）。它是「未绑定也显示」
+    // 得以成立的前提——空按钮不是死按钮，而是就地的配置入口，所以这里单独钉住它的
+    // 三种返回，尤其是「取消 ≠ 不绑定」（两者都不带动作，混淆就会让点外部清空绑定）。
+    VideoCustomActionPick? result;
+    bool opened = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => TextButton(
+              onPressed: () async {
+                opened = true;
+                result = await showVideoCustomActionPicker(
+                  context: context,
+                  slotNumber: 1,
+                  current: null,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // ① 取消（点外部）→ null
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(opened, isTrue);
+    expect(find.text(t.video_control_custom_action_none), findsOneWidget);
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+    expect(result, isNull, reason: '取消必须返回 null，不能被当成「不绑定」');
+
+    // ② 选一个动作 → 带动作的结果
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester
+        .ensureVisible(find.text(ShortcutAction.videoNextSubtitle.label));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(ShortcutAction.videoNextSubtitle.label));
+    await tester.pumpAndSettle();
+    expect(result?.action, ShortcutAction.videoNextSubtitle);
+
+    // ③ 选「不绑定」→ 非 null 但 action 为 null（与取消区分开）
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.video_control_custom_action_none));
+    await tester.pumpAndSettle();
+    expect(result, isNotNull, reason: '「不绑定」是一次显式选择，不是取消');
+    expect(result!.action, isNull);
   });
 
   testWidgets('选择器列出全部可绑动作，且不含未接线的动作', (WidgetTester tester) async {


### PR DESCRIPTION
## 动机

视频页有 37 个可执行动作，控制条只给其中 ~25 个配了具名按钮，其余只能靠键盘/手柄触发——**手机上没有键盘，那些动作等于不存在**。本 PR 的两条改动同源于此。

## 1. 控制条可自定义「快捷键 1~4」按钮

4 个新 `VideoControlItem`，长在**现有九槽位编辑器**里（可拖到顶/底/左右侧栏任意位置、可隐藏），没有另起一套布局系统。

- **未绑定也显示**，点空按钮**就地弹动作选择器**——手机上最短的配置路径：看得见 → 点得到 → 当场配好，不用先翻进设置面板。空按钮因此不是死按钮。
- 按钮长成**所绑动作的样子**（图标 + 名字），不用记住「1 是什么」。
- 点击执行走 `videoActionCallbacks`——**键盘和手柄用的同一张动作表**，没有第二套执行逻辑，沉浸门控 / 防重入都自动继承。
- 绑定表 `VideoCustomActionBindings` 是定长 4 的槽位→动作表，独立偏好 `video_custom_action_bindings`，与控件布局正交（一个管「按钮在哪」，一个管「按钮干什么」）。
- 可绑动作集 `kVideoAssignableActions` 由守卫测试与真实接线**逐个比对**，杜绝「设置里配得上、按下去没反应」。

### 兼容性影响（需要留意）

所有用户（**含存量**）升级后底栏右区会多出 4 个按钮。这是刻意的：`currentChrome` 同时是老布局的解码兜底，不给这几个新枚举项写 assignment 就会被判成「用户移除过」而落进隐藏托盘，存量用户在播放器上永远看不到它们，这次改动对他们完全失效。不想要的可以像其它按钮一样拖进隐藏托盘，**且拖走后留得住**（有测试钉住这两个相反方向）。

## 2. 字幕调轴「上/下一句对齐到当前时间」按钮

执行体 `_snapSubtitleDelayToCue` 早就存在（asbplayer 式绝对偏移，默认 `Ctrl+Shift+←/→`），但**只接了键盘**——`VideoQuickSettingsHost` 上根本没这个回调，触摸端够不着。

快速设置的调轴行与波形对轴放大视图各加一对按钮，回调**返回新延迟**以同步滑条 / 输入框 / 波形（照搬 `onAutoAlign` 已确立的契约，否则点完按钮数值不动）。

## 验证

- `flutter analyze` 0 issues
- 本功能新增测试 **22 例**全过（编解码 / 接线守卫 / 图标齐备 / 升级可见性双向 / 4 例真手势跑通「tap 与 Draggable 共存」的配置入口）
- 控件布局全套 **121 例**、相邻定向 **150 例**、目录枚举型守卫整批 **250 例** 全过
- 一致性守卫与图标守卫做过**变异实测**：改坏确实变红，还原后 sha256 逐字节一致
- 全量 19704 例；其中 17 条红全部落在漫画页(×2)与合集封面(×1)三个文件，切到本分支基线 `5bc4d16c14` 跑同样文件得到**完全一致的 12 error / 35 tests 与相同用例名**，属 develop 既有红，与本 PR 无关

## 缺口

- 未做真机验证。
- 播放器侧「按钮渲染 + 点击执行」这最后一公里没有 widget 测试覆盖（配置链路有 4 例真手势测试）；三条渲染路径（底栏 / 顶栏 / 侧栏）经代码走查确认都过同一个渲染门。

https://claude.ai/code/session_01JbNmcEcwgYAHvEnosvLLg7
