### PR TITLE
fix(manga): OCR 引擎写清取舍、按引擎收起模型块、占用与释放量按磁盘记账 (BUG-1732)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1598 条。点号进各自文件。
+> 共 1599 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1732](bugs/BUG-1732-manga-ocr-engine-picker-and-model-accounting.md) | ✅ | ✅ | manga-ocr-engine-picker-and-model-accounting |
 | [BUG-1723](bugs/BUG-1723-android-predictive-back-gesture-freezes-taps.md) | ✅ | ✅ | 安卓侧滑返回后全屏点击失效 |
 | [BUG-1722](bugs/BUG-1722-manga-default-store-needs-network.md) | ✅ | ✅ | 默认 keiyoushi 扩展仓库绑死在首次启动能连上 github，手机上永远看不到 |
 | [BUG-1721](bugs/BUG-1721-scrape-history-no-rescrape-entry.md) | ✅ | ✅ | 后台任务历史条目无法重新刮削或手动指定作品 |

--- a/docs/bugs/BUG-1732-manga-ocr-engine-picker-and-model-accounting.md
+++ b/docs/bugs/BUG-1732-manga-ocr-engine-picker-and-model-accounting.md
@@ -1,0 +1,32 @@
+## BUG-1732 · manga-ocr-engine-picker-and-model-accounting
+
+- **报告**：2026-08-19（用户：截图两张 + 「这里说一下每个的特点，比如谷歌需要网，但是速度快，质量较本地差」「同时应该支持删除 ocr 模型之类的」「这里显示不对，用的谷歌的怎么还能下载模型」「有这个但好像就删了 450mb 实际上应该有几个 G 好像下的时候」）
+- **真实性**：✅ 真 bug（三条症状，同一处设置区）
+
+### 症状与根因
+
+| # | 用户症状 | 根因 `file:line`（修前的 develop `788482ecce`） |
+|---|---|---|
+| 1 | 引擎下拉只有五个裸名字，挑不出该用哪个 | `fushi/lib/src/media/manga/manga_ocr_settings_section.dart:337-365` —— `items` 每项只有一个 `Text(标签)`，联网/上传/质量/下载量这些**唯一有意义的差别**一个字都没写 |
+| 2 | 选了 Google Lens，页面还在劝你下 450 MB 本地模型 | 同文件 `:306` —— 模型块的显示条件只有 `widget.service.isSupportedPlatform`，**与引擎选择完全脱钩**；一个永远用不到本地模型的用户被一直劝下载，且换引擎后那几百 MB 在 UI 上无处可删 |
+| 3 | 「删了 450 MB，可下的时候好像有几个 G」 | 两处合力：<br>① `fushi/lib/src/ocr/manga_ocr_service_impl.dart:464-487` —— `downloadedBytes` 只累加**清单里列出且已就绪**的文件，中断留下的 `.part`、上游换档后的遗留档既不显示也不计入，于是「页面上的 450 MB」和「磁盘实际少了多少」是两个数；<br>② 同文件 `:496` —— `deleteModels()` 返回 `void`，删完只弹一句「模型已删除」，**不回报释放量**，用户只能自己去看磁盘；<br>③ 设置区 `:161-192` —— 下载进度直接照搬下载器的**按文件**事件（`event.receivedBytes / event.totalBytes`），一根进度条来回跑四趟（11 MB + 343 MB + 117 MB + 30 KB），把一套 450 MB 的模型感知成「好几个 G」 |
+
+清单四个文件之和 = 11,120,765 + 343,454,249 + 117,480,262 + 30,216 = **472,085,492 B ≈ 450 MiB**，正是用户看到的那个数——所以删除并没有漏删清单内容，对不上的是**记账口径**（清单 vs 磁盘）与**进度呈现**（逐文件 vs 总体）。
+
+### 修复
+
+- **[x] ① 已修复** — commit `<填>`
+  - `manga_ocr_service.dart`：`MangaOcrModelStatus.downloadedBytes` → `diskBytes`（语义改为**模型目录真实递归占用**，含 `.part` 与遗留档）+ 新增 `hasAnyFiles`；`deleteModels()` 返回 `Future<int>`（实际释放字节）。
+  - 新增 `fushi/lib/src/utils/misc/directory_bytes.dart` 的 `measureDirectoryBytes`：占用统计的单一真相源，不跟随符号链接，单条目 stat 失败跳过。
+  - `manga_ocr_service_impl.dart`：`modelStatus()` 按目录实测；`deleteModels()` 先量后删并返回释放量；`ocrFolder` 的就绪闸门改走新的 `_manifestComplete()`（只 stat 清单文件），**不让热路径为了展示去递归扫盘**。
+  - 设置区：引擎下拉每项补一句取舍说明（`selectedItemBuilder` 保证闭合态仍是单行）；本地模型区按引擎分三态（用得到 → 完整块 / 用不到但磁盘有文件 → 「用不到 + 占用 + 删除」/ 用不到且干净 → 整块不渲染）；进度按文件名归并成**总体**进度并显示「已下 / 总量」；删除 toast 报实际释放量；模型不全但有残留时同样给删除入口。
+  - i18n 经 `fushi/tool/i18n_sync.dart --add` 加 10 个键 × 17 语言 + `dart run slang` 重生成。
+- **[x] ② 已加自动化测试** — commit `<填>`
+  - `fushi/test/media/manga/manga_ocr_settings_section_ui_test.dart`：`engine dropdown spells out each engine trade-off` / `Google Lens engine never prompts for a local model download` / `local models left on disk stay deletable under a cloud engine` / `ready row reports real disk usage, not the manifest total` / `download progress aggregates every file into one total`。
+  - `fushi/test/ocr/manga_ocr_service_impl_test.dart`：`清单外的残留档一样计入占用，并计入删除释放量` / `模型不全但残留占着磁盘：hasAnyFiles 为真，可被删除释放` / `目录不存在：删除返回 0 而不是抛错`。
+  - `fushi/test/utils/directory_bytes_test.dart`：4 条（不存在 / 空目录 / 递归 / `.part` 计入）。
+  - **变异实测**：把 `_buildLocalModelArea` 的 `if (_localModelsUsedByEngine)` 改成 `if (true)`，`Google Lens engine never prompts for a local model download` 与 `local models left on disk stay deletable under a cloud engine` 立刻转红；反向替换还原后源码 sha256 与变异前一致（`24b93f39ee3338f549406623d5d541100a19560c4328fb169a519457b4cbcb65`）。
+
+### 备注
+
+「下的时候好像有几个 G」还有一条**未被本次修复覆盖**的可能来源：下载器 `_finalizePart` 在长度校验不符时会删掉 `.part` 整文件重下（`manga_ocr_model_downloader.dart:176-183`），网络不稳时**累计流量**确实可能达到几个 G，而落盘恒为 450 MB。本次改动让「要下多少 / 已下多少 / 占了多少 / 释放了多少」四个数字都变成可见且一致的真实值，但没有改重下策略本身；若后续用户仍报「下载量远超 450 MB」，应从这条重下路径查（考虑保留部分 `.part` 或按分块校验续传）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 60996 (3588 per locale)
+/// Strings: 61166 (3598 per locale)
 ///
-/// Built on 2026-08-18 at 13:05 UTC
+/// Built on 2026-08-19 at 04:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4871,6 +4871,27 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_no_managed_video_source =>
       'No managed video source yet. Downloads need a local video folder to land in.';
   String get download_add_video_source => 'Add video source';
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -13180,6 +13201,37 @@ class _StringsAr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -21556,6 +21608,37 @@ class _StringsDe extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -29948,6 +30031,37 @@ class _StringsEs extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -38352,6 +38466,37 @@ class _StringsFr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -46684,6 +46829,37 @@ class _StringsId extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -55062,6 +55238,37 @@ class _StringsIt extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -63254,6 +63461,37 @@ class _StringsJa extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -71453,6 +71691,37 @@ class _StringsKo extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -79811,6 +80080,37 @@ class _StringsNl extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -88181,6 +88481,37 @@ class _StringsPtBr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -96537,6 +96868,37 @@ class _StringsRu extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -104841,6 +105203,37 @@ class _StringsTh extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -113176,6 +113569,37 @@ class _StringsTr extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -121496,6 +121920,37 @@ class _StringsVi extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 // Path: <root>
@@ -129197,6 +129652,30 @@ class _StringsZhCn extends _StringsEn {
       '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
   @override
   String get download_add_video_source => '添加视频来源';
+  @override
+  String get manga_ocr_engine_auto_desc => '优先用你已配好的离线引擎，不会自作主张上传到 Lens。';
+  @override
+  String get manga_ocr_engine_local_onnx_desc => '完全离线，质量最好。需要一次性下载模型，老设备上较慢。';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      '需要联网，会把页面图片上传给 Google。速度快、不用下模型，但质量不如本地模型。';
+  @override
+  String get manga_ocr_engine_external_desc => '调用你自己安装的 mokuro 命令行，仅桌面可用。';
+  @override
+  String get manga_ocr_engine_paired_host_desc => '交给局域网里已配对的设备来跑，本机不下任何模型。';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) => '已占用 ${size}';
+  @override
+  String manga_ocr_model_download_size({required Object size}) => '需下载 ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      '模型已删除，释放 ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine => '当前引擎用不到这些本地模型文件。';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} / ${total}';
 }
 
 // Path: <root>
@@ -137312,6 +137791,37 @@ class _StringsZhHk extends _StringsEn {
       'No managed video source yet. Downloads need a local video folder to land in.';
   @override
   String get download_add_video_source => 'Add video source';
+  @override
+  String get manga_ocr_engine_auto_desc =>
+      'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+  @override
+  String get manga_ocr_engine_local_onnx_desc =>
+      'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+  @override
+  String get manga_ocr_engine_google_lens_desc =>
+      'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+  @override
+  String get manga_ocr_engine_external_desc =>
+      'Calls a mokuro command line you installed yourself. Desktop only.';
+  @override
+  String get manga_ocr_engine_paired_host_desc =>
+      'Hands the work to a paired device on your network. Nothing is downloaded here.';
+  @override
+  String manga_ocr_model_disk_usage({required Object size}) =>
+      'Using ${size} on disk';
+  @override
+  String manga_ocr_model_download_size({required Object size}) =>
+      'Needs ${size}';
+  @override
+  String manga_ocr_delete_done_freed({required Object size}) =>
+      'Models deleted, freed ${size}';
+  @override
+  String get manga_ocr_model_unused_by_engine =>
+      'The current engine doesn\'t use these local model files.';
+  @override
+  String manga_ocr_download_total_progress(
+          {required Object done, required Object total}) =>
+      '${done} of ${total}';
 }
 
 /// Flat map(s) containing all translations.
@@ -144678,6 +145188,27 @@ extension on _StringsEn {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -152042,6 +152573,27 @@ extension on _StringsAr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -159428,6 +159980,27 @@ extension on _StringsDe {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -166813,6 +167386,27 @@ extension on _StringsEs {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -174204,6 +174798,27 @@ extension on _StringsFr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -181577,6 +182192,27 @@ extension on _StringsId {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -188964,6 +189600,27 @@ extension on _StringsIt {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -196313,6 +196970,27 @@ extension on _StringsJa {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -203666,6 +204344,27 @@ extension on _StringsKo {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -211047,6 +211746,27 @@ extension on _StringsNl {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -218425,6 +219145,27 @@ extension on _StringsPtBr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -225808,6 +226549,27 @@ extension on _StringsRu {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -233174,6 +233936,27 @@ extension on _StringsTh {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -240549,6 +241332,27 @@ extension on _StringsTr {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -247920,6 +248724,27 @@ extension on _StringsVi {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }
@@ -255232,6 +256057,27 @@ extension on _StringsZhCn {
         return '还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。';
       case 'download_add_video_source':
         return '添加视频来源';
+      case 'manga_ocr_engine_auto_desc':
+        return '优先用你已配好的离线引擎，不会自作主张上传到 Lens。';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return '完全离线，质量最好。需要一次性下载模型，老设备上较慢。';
+      case 'manga_ocr_engine_google_lens_desc':
+        return '需要联网，会把页面图片上传给 Google。速度快、不用下模型，但质量不如本地模型。';
+      case 'manga_ocr_engine_external_desc':
+        return '调用你自己安装的 mokuro 命令行，仅桌面可用。';
+      case 'manga_ocr_engine_paired_host_desc':
+        return '交给局域网里已配对的设备来跑，本机不下任何模型。';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => '已占用 ${size}';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => '需下载 ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => '模型已删除，释放 ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return '当前引擎用不到这些本地模型文件。';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} / ${total}';
       default:
         return null;
     }
@@ -262576,6 +263422,27 @@ extension on _StringsZhHk {
         return 'No managed video source yet. Downloads need a local video folder to land in.';
       case 'download_add_video_source':
         return 'Add video source';
+      case 'manga_ocr_engine_auto_desc':
+        return 'Prefers an offline engine you already set up; never uploads to Lens on its own.';
+      case 'manga_ocr_engine_local_onnx_desc':
+        return 'Fully offline, best quality. Needs a one-time model download and is slow on old hardware.';
+      case 'manga_ocr_engine_google_lens_desc':
+        return 'Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.';
+      case 'manga_ocr_engine_external_desc':
+        return 'Calls a mokuro command line you installed yourself. Desktop only.';
+      case 'manga_ocr_engine_paired_host_desc':
+        return 'Hands the work to a paired device on your network. Nothing is downloaded here.';
+      case 'manga_ocr_model_disk_usage':
+        return ({required Object size}) => 'Using ${size} on disk';
+      case 'manga_ocr_model_download_size':
+        return ({required Object size}) => 'Needs ${size}';
+      case 'manga_ocr_delete_done_freed':
+        return ({required Object size}) => 'Models deleted, freed ${size}';
+      case 'manga_ocr_model_unused_by_engine':
+        return 'The current engine doesn\'t use these local model files.';
+      case 'manga_ocr_download_total_progress':
+        return ({required Object done, required Object total}) =>
+            '${done} of ${total}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "以后自动扫描此文件夹里的新视频",
   "manga_import_folder_as_source_hint": "以后自动扫描此文件夹里的新漫画",
   "download_no_managed_video_source": "还没有受管视频来源。下载完成的视频需要一个本地视频文件夹才能入库。",
-  "download_add_video_source": "添加视频来源"
+  "download_add_video_source": "添加视频来源",
+  "manga_ocr_engine_auto_desc": "优先用你已配好的离线引擎，不会自作主张上传到 Lens。",
+  "manga_ocr_engine_local_onnx_desc": "完全离线，质量最好。需要一次性下载模型，老设备上较慢。",
+  "manga_ocr_engine_google_lens_desc": "需要联网，会把页面图片上传给 Google。速度快、不用下模型，但质量不如本地模型。",
+  "manga_ocr_engine_external_desc": "调用你自己安装的 mokuro 命令行，仅桌面可用。",
+  "manga_ocr_engine_paired_host_desc": "交给局域网里已配对的设备来跑，本机不下任何模型。",
+  "manga_ocr_model_disk_usage": "已占用 $size",
+  "manga_ocr_model_download_size": "需下载 $size",
+  "manga_ocr_delete_done_freed": "模型已删除，释放 $size",
+  "manga_ocr_model_unused_by_engine": "当前引擎用不到这些本地模型文件。",
+  "manga_ocr_download_total_progress": "$done / $total"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3586,5 +3586,15 @@
   "video_import_folder_as_source_hint": "Keep scanning this folder for new videos",
   "manga_import_folder_as_source_hint": "Keep scanning this folder for new manga",
   "download_no_managed_video_source": "No managed video source yet. Downloads need a local video folder to land in.",
-  "download_add_video_source": "Add video source"
+  "download_add_video_source": "Add video source",
+  "manga_ocr_engine_auto_desc": "Prefers an offline engine you already set up; never uploads to Lens on its own.",
+  "manga_ocr_engine_local_onnx_desc": "Fully offline, best quality. Needs a one-time model download and is slow on old hardware.",
+  "manga_ocr_engine_google_lens_desc": "Needs internet and uploads page images to Google. Fast with no download, but quality is below the local model.",
+  "manga_ocr_engine_external_desc": "Calls a mokuro command line you installed yourself. Desktop only.",
+  "manga_ocr_engine_paired_host_desc": "Hands the work to a paired device on your network. Nothing is downloaded here.",
+  "manga_ocr_model_disk_usage": "Using $size on disk",
+  "manga_ocr_model_download_size": "Needs $size",
+  "manga_ocr_delete_done_freed": "Models deleted, freed $size",
+  "manga_ocr_model_unused_by_engine": "The current engine doesn't use these local model files.",
+  "manga_ocr_download_total_progress": "$done of $total"
 }

--- a/fushi/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -72,7 +72,14 @@ class _MangaOcrSettingsSectionState
   // 下载态。
   bool _downloading = false;
   String? _downloadingFile;
-  double? _downloadProgress;
+
+  /// 逐文件已收字节（文件名 → 字节）。
+  ///
+  /// 下载器的事件是**按文件**报进度的（每个文件各自 0→100%），照搬到 UI 上就是
+  /// 一根进度条来回跑四趟：用户看到「下了一次又一次」，把 450 MB 的一套模型感知
+  /// 成好几个 G（BUG-1732 用户原话）。这里按文件名归并累计，进度条只走一趟，
+  /// 并显示「已下 / 总量」的绝对字节，让「到底要下多少」有个准数。
+  final Map<String, int> _receivedByFile = <String, int>{};
   StreamSubscription<MangaOcrDownloadEvent>? _downloadSub;
 
   bool _deleting = false;
@@ -152,20 +159,25 @@ class _MangaOcrSettingsSectionState
     });
   }
 
+  /// 全套模型的预期总字节数（清单常量之和）；未知时为 0。
+  int get _downloadTotalBytes => _status?.totalBytes ?? 0;
+
+  int get _downloadReceivedBytes =>
+      _receivedByFile.values.fold<int>(0, (int a, int b) => a + b);
+
   void _startDownload() {
     setState(() {
       _downloading = true;
       _downloadingFile = null;
-      _downloadProgress = null;
+      _receivedByFile.clear();
     });
     _downloadSub = widget.service.downloadModels().listen(
       (MangaOcrDownloadEvent event) {
         if (!mounted) return;
         setState(() {
           _downloadingFile = event.fileName;
-          _downloadProgress = event.totalBytes > 0
-              ? (event.receivedBytes / event.totalBytes).clamp(0.0, 1.0)
-              : null;
+          // 同名文件取最新值而不是累加：同一文件会连发多条递增进度事件。
+          _receivedByFile[event.fileName] = event.receivedBytes;
         });
       },
       onError: (Object e) {
@@ -219,14 +231,19 @@ class _MangaOcrSettingsSectionState
     );
     if (ok != true || !mounted) return;
     setState(() => _deleting = true);
+    int freed = 0;
     try {
-      await widget.service.deleteModels();
+      freed = await widget.service.deleteModels();
     } finally {
       if (mounted) setState(() => _deleting = false);
     }
     if (!mounted) return;
+    // 报实际释放量而不是干巴巴一句「已删除」：用户抱怨「只删了 450 MB」正是因为
+    // 删除完全不回报数字，只能靠自己去看磁盘（BUG-1732）。
     FushiToast.show(
-      msg: t.manga_ocr_delete_done,
+      msg: freed > 0
+          ? t.manga_ocr_delete_done_freed(size: _formatBytes(freed))
+          : t.manga_ocr_delete_done,
       severity: ToastSeverity.success,
     );
     await _loadStatus();
@@ -304,7 +321,7 @@ class _MangaOcrSettingsSectionState
         ],
         const SizedBox(height: 12),
         if (widget.service.isSupportedPlatform)
-          _buildModelBlock(theme)
+          _buildLocalModelArea(theme)
         else
           _inset(
             Padding(
@@ -325,44 +342,95 @@ class _MangaOcrSettingsSectionState
     );
   }
 
+  /// 引擎选项表：标签 + **取舍说明** + 可用性，一处定义。
+  ///
+  /// 说明不是装饰：几个引擎的差别全在「要不要联网 / 会不会上传页面图 / 质量高低 /
+  /// 要不要下几百 MB 模型」上，而下拉里只有五个裸名字时，用户没有任何依据挑
+  /// （用户原话：这里说一下每个的特点）。取舍写在选项自己身上，别指望用户去翻
+  /// 文档或试错。
+  ///
+  /// 平台不适用的项**保留在列表里**只置灰（不裁项）：裁掉会让「已存 external_mokuro
+  /// 的偏好」在移动端找不到匹配 value 而触发 Dropdown 断言。
+  List<_EngineOption> _engineOptions() {
+    return <_EngineOption>[
+      _EngineOption(
+        preference: MangaOcrEnginePreference.auto,
+        label: t.manga_ocr_engine_auto,
+        description: t.manga_ocr_engine_auto_desc,
+        enabled: true,
+      ),
+      _EngineOption(
+        preference: MangaOcrEnginePreference.localOnnx,
+        label: t.manga_ocr_engine_local_onnx,
+        description: t.manga_ocr_engine_local_onnx_desc,
+        enabled: widget.service.isSupportedPlatform,
+      ),
+      _EngineOption(
+        preference: MangaOcrEnginePreference.googleLens,
+        label: t.manga_ocr_engine_google_lens,
+        description: t.manga_ocr_engine_google_lens_desc,
+        enabled: true,
+      ),
+      _EngineOption(
+        preference: MangaOcrEnginePreference.externalMokuro,
+        label: t.manga_ocr_engine_external,
+        description: t.manga_ocr_engine_external_desc,
+        enabled: isDesktopPlatform,
+      ),
+      // 互联「配对主机代跑」：服务端/客户端链路早已完整（/api/ocr/job*），此前
+      // 只是没进偏好枚举，导致它永远只能被 auto 兜底顺序选中、无法显式指定。
+      // 移动端没有本地 ONNX 时这是唯一可用的整卷引擎。
+      _EngineOption(
+        preference: MangaOcrEnginePreference.pairedHost,
+        label: t.manga_remote_ocr_engine,
+        description: t.manga_ocr_engine_paired_host_desc,
+        enabled: true,
+      ),
+    ];
+  }
+
   Widget _buildEnginePreference(ThemeData theme) {
+    final List<_EngineOption> options = _engineOptions();
     return DropdownButtonFormField<MangaOcrEnginePreference>(
       key: const ValueKey<String>('manga_ocr_default_engine'),
       initialValue: _enginePreference,
+      isExpanded: true,
       decoration: InputDecoration(
         labelText: t.manga_ocr_default_engine,
         isDense: true,
         border: const OutlineInputBorder(),
       ),
-      items: <DropdownMenuItem<MangaOcrEnginePreference>>[
-        DropdownMenuItem<MangaOcrEnginePreference>(
-          value: MangaOcrEnginePreference.auto,
-          child: Text(t.manga_ocr_engine_auto),
-        ),
-        DropdownMenuItem<MangaOcrEnginePreference>(
-          value: MangaOcrEnginePreference.localOnnx,
-          enabled: widget.service.isSupportedPlatform,
-          child: Text(t.manga_ocr_engine_local_onnx),
-        ),
-        DropdownMenuItem<MangaOcrEnginePreference>(
-          value: MangaOcrEnginePreference.googleLens,
-          child: Text(t.manga_ocr_engine_google_lens),
-        ),
-        // 仍然出现在列表里（而不是按平台裁项）：裁项会让「已存 external_mokuro
-        // 的偏好」在移动端找不到匹配 value 而触发 Dropdown 断言。
-        DropdownMenuItem<MangaOcrEnginePreference>(
-          value: MangaOcrEnginePreference.externalMokuro,
-          enabled: isDesktopPlatform,
-          child: Text(t.manga_ocr_engine_external),
-        ),
-        // 互联「配对主机代跑」：服务端/客户端链路早已完整（/api/ocr/job*），此前
-        // 只是没进偏好枚举，导致它永远只能被 auto 兜底顺序选中、无法显式指定。
-        // 移动端没有本地 ONNX 时这是唯一可用的整卷引擎。
-        DropdownMenuItem<MangaOcrEnginePreference>(
-          value: MangaOcrEnginePreference.pairedHost,
-          child: Text(t.manga_remote_ocr_engine),
-        ),
+      // 闭合态只显示单行标签：说明是给「挑的时候」看的，收起后再占两行只会把
+      // 设置行撑高。
+      selectedItemBuilder: (BuildContext context) => <Widget>[
+        for (final _EngineOption option in options)
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(option.label, overflow: TextOverflow.ellipsis),
+          ),
       ],
+      items: <DropdownMenuItem<MangaOcrEnginePreference>>[
+        for (final _EngineOption option in options)
+          DropdownMenuItem<MangaOcrEnginePreference>(
+            value: option.preference,
+            enabled: option.enabled,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(option.label),
+                Text(
+                  option.description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+      // 两行项比默认 kMinInteractiveDimension 高，不给足高度会 overflow。
+      itemHeight: null,
       onChanged: (MangaOcrEnginePreference? value) {
         if (value == null) return;
         setState(() => _enginePreference = value);
@@ -401,7 +469,24 @@ class _MangaOcrSettingsSectionState
     );
   }
 
-  Widget _buildModelBlock(ThemeData theme) {
+  /// 当前引擎偏好是否真的会用到本地 ONNX 模型。
+  ///
+  /// `auto` 会在离线优先的兜底顺序里挑到本地模型，所以算「用得到」；显式选了
+  /// Lens / 外部 mokuro / 配对主机的，本机一个字节都不需要。
+  bool get _localModelsUsedByEngine =>
+      _enginePreference == MangaOcrEnginePreference.auto ||
+      _enginePreference == MangaOcrEnginePreference.localOnnx;
+
+  /// 本地模型区：**按当前引擎决定形态**。
+  ///
+  /// 修的是「我选的是 Google Lens，这儿怎么还让我下模型」（用户原话）——原先这块
+  /// 只受平台闸门控制，跟引擎选择完全脱钩，于是一个永远用不到本地模型的用户被
+  /// 一直劝着下 450 MB。三种形态：
+  /// - 引擎用得到（auto / 本地 ONNX）→ 完整块：状态 + 下载/删除。
+  /// - 引擎用不到但**磁盘上还留着文件** → 只给「用不到 + 占用多少 + 删除」，
+  ///   这正是「应该支持删除 ocr 模型」的落点：换了引擎之后那几百 MB 得能清掉。
+  /// - 引擎用不到且磁盘干净 → 整块不渲染，不再劝下载。
+  Widget _buildLocalModelArea(ThemeData theme) {
     if (_loadingStatus) {
       return _inset(
         const Padding(
@@ -410,12 +495,43 @@ class _MangaOcrSettingsSectionState
         ),
       );
     }
+    if (_localModelsUsedByEngine) {
+      return _buildModelBlock(theme);
+    }
+    final MangaOcrModelStatus? status = _status;
+    if (status == null || !status.hasAnyFiles) {
+      return const SizedBox.shrink();
+    }
+    return _buildOrphanModelBlock(theme, status);
+  }
+
+  /// 引擎用不到、但磁盘上还占着的本地模型：说清楚 + 给删除。
+  Widget _buildOrphanModelBlock(ThemeData theme, MangaOcrModelStatus status) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        AdaptiveSettingsRow(
+          title: t.manga_ocr_model_unused_by_engine,
+          subtitle: t.manga_ocr_model_disk_usage(
+            size: _formatBytes(status.diskBytes),
+          ),
+          icon: Icons.folder_off_outlined,
+          showIcon: true,
+        ),
+        const SizedBox(height: 8),
+        _inset(
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _deleteButton(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModelBlock(ThemeData theme) {
     final MangaOcrModelStatus? status = _status;
     final bool ready = status?.allReady ?? false;
-    final String? sizeText = status == null || status.totalBytes <= 0
-        ? null
-        : '${_formatBytes(status.downloadedBytes)} / '
-            '${_formatBytes(status.totalBytes)}';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -423,18 +539,28 @@ class _MangaOcrSettingsSectionState
           title: ready
               ? t.manga_ocr_model_status_ready
               : t.manga_ocr_model_status_missing,
-          subtitle: sizeText,
+          subtitle: _modelSizeSubtitle(status),
           icon: ready ? Icons.check_circle_outline : Icons.download_outlined,
           showIcon: true,
         ),
         if (_downloading) ...<Widget>[
           const SizedBox(height: 8),
-          _inset(LinearProgressIndicator(value: _downloadProgress)),
+          _inset(LinearProgressIndicator(value: _downloadProgressValue)),
           const SizedBox(height: 4),
           if (_downloadingFile != null)
             _inset(
               Text(
                 t.manga_ocr_downloading_file(file: _downloadingFile!),
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          if (_downloadTotalBytes > 0)
+            _inset(
+              Text(
+                t.manga_ocr_download_total_progress(
+                  done: _formatBytes(_downloadReceivedBytes),
+                  total: _formatBytes(_downloadTotalBytes),
+                ),
                 style: theme.textTheme.bodySmall,
               ),
             ),
@@ -453,17 +579,7 @@ class _MangaOcrSettingsSectionState
             Align(
               alignment: Alignment.centerLeft,
               child: ready
-                  ? OutlinedButton.icon(
-                      onPressed: _deleting ? null : _confirmDelete,
-                      icon: _deleting
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(Icons.delete_outline, size: 18),
-                      label: Text(t.manga_ocr_delete),
-                    )
+                  ? _deleteButton()
                   : FilledButton.icon(
                       onPressed: _startDownload,
                       icon: const Icon(Icons.download_outlined, size: 18),
@@ -471,8 +587,67 @@ class _MangaOcrSettingsSectionState
                     ),
             ),
           ),
+          // 模型不全但磁盘上有残留（中断的 `.part`、换档后的遗留档）时，除了
+          // 「继续下载」也得能直接清掉——否则那几百 MB 在 UI 上无处可删。
+          if (!ready && (status?.hasAnyFiles ?? false)) ...<Widget>[
+            const SizedBox(height: 4),
+            _inset(
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _deleteButton(),
+              ),
+            ),
+          ],
         ],
       ],
+    );
+  }
+
+  /// 体积副标题：已占多少 + 还需下多少，两者都按真实数字给。
+  ///
+  /// 旧实现是 `已下载 / 清单总量` 这种双数字拼接，而「已下载」只累加清单内已就绪
+  /// 文件——`.part` 残留与遗留档一律看不见，用户于是遇到「显示 450 MB、删掉后
+  /// 磁盘却少了别的数」（BUG-1732）。
+  String? _modelSizeSubtitle(MangaOcrModelStatus? status) {
+    if (status == null) {
+      return null;
+    }
+    final String? usage = status.hasAnyFiles
+        ? t.manga_ocr_model_disk_usage(size: _formatBytes(status.diskBytes))
+        : null;
+    if (status.allReady) {
+      return usage;
+    }
+    final String? needed = status.totalBytes > 0
+        ? t.manga_ocr_model_download_size(
+            size: _formatBytes(status.totalBytes),
+          )
+        : null;
+    final String joined =
+        <String?>[usage, needed].whereType<String>().join(' · ');
+    return joined.isEmpty ? null : joined;
+  }
+
+  /// 总体下载进度（0~1）；总量未知时返回 null 走不确定进度条。
+  double? get _downloadProgressValue {
+    final int total = _downloadTotalBytes;
+    if (total <= 0) {
+      return null;
+    }
+    return (_downloadReceivedBytes / total).clamp(0.0, 1.0);
+  }
+
+  Widget _deleteButton() {
+    return OutlinedButton.icon(
+      onPressed: _deleting ? null : _confirmDelete,
+      icon: _deleting
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.delete_outline, size: 18),
+      label: Text(t.manga_ocr_delete),
     );
   }
 
@@ -532,4 +707,22 @@ class _MangaOcrSettingsSectionState
   }
 
   static String _formatBytes(int bytes) => FushiByteFormat.bytes(bytes);
+}
+
+/// 引擎下拉的一项：偏好值 + 标签 + 取舍说明 + 本平台是否可用。
+class _EngineOption {
+  const _EngineOption({
+    required this.preference,
+    required this.label,
+    required this.description,
+    required this.enabled,
+  });
+
+  final MangaOcrEnginePreference preference;
+  final String label;
+
+  /// 一句话取舍：联网/上传/质量/下载量，用户据此挑引擎。
+  final String description;
+
+  final bool enabled;
 }

--- a/fushi/lib/src/ocr/manga_ocr_service.dart
+++ b/fushi/lib/src/ocr/manga_ocr_service.dart
@@ -19,8 +19,12 @@ abstract class MangaOcrService {
   /// 事件按文件粒度报告字节进度；出错以 error 事件结束流。
   Stream<MangaOcrDownloadEvent> downloadModels();
 
-  /// 删除已下载模型，释放磁盘。
-  Future<void> deleteModels();
+  /// 删除已下载模型，释放磁盘；返回**实际释放的字节数**。
+  ///
+  /// 返回值不是「清单总和」这种推算值，而是删除前模型目录的真实递归占用，
+  /// 因此把未完成的 `.part`、旧清单遗留档一并计入——用户看到的释放量与磁盘
+  /// 实际变化一致（BUG-1732）。
+  Future<int> deleteModels();
 
   /// 对一个裸图片目录跑整卷 OCR，产出内部 manga.json（不落库；落库由
   /// 导入器接手）。事件：逐页完成进度 → 最终 [MangaOcrVolumeEvent.finished]
@@ -36,20 +40,31 @@ class MangaOcrModelStatus {
   const MangaOcrModelStatus({
     required this.detectorReady,
     required this.recognizerReady,
-    required this.downloadedBytes,
+    required this.diskBytes,
     required this.totalBytes,
   });
 
   final bool detectorReady;
   final bool recognizerReady;
 
-  /// 已就绪文件的磁盘字节数。
-  final int downloadedBytes;
+  /// 模型目录的**真实递归占用**字节数。
+  ///
+  /// BUG-1732：这里以前叫 `downloadedBytes`，只累加清单里列出且已就绪的文件——
+  /// 于是「设置页显示 450 MB」与「删掉后磁盘少了多少」是两个数：中断留下的
+  /// `.part`、上游换档后遗留的旧模型档都不在清单里，用户既看不到也不知道能删。
+  /// 真相源只能是磁盘本身，故改为按目录实际大小记账。
+  final int diskBytes;
 
-  /// 全套模型的预期总字节数（用于设置页展示体积）。
+  /// 全套模型的预期总字节数（清单常量之和，用于展示「需要下多少」）。
   final int totalBytes;
 
   bool get allReady => detectorReady && recognizerReady;
+
+  /// 磁盘上是否还留着任何模型文件（含未完成的 `.part` 与遗留档）。
+  ///
+  /// 与 [allReady] 分开：非本地引擎下「模型不全但仍占着几百 MB」必须能被看见、
+  /// 能被删，否则用户永远找不到那块空间。
+  bool get hasAnyFiles => diskBytes > 0;
 }
 
 /// 模型下载进度事件。

--- a/fushi/lib/src/ocr/manga_ocr_service_impl.dart
+++ b/fushi/lib/src/ocr/manga_ocr_service_impl.dart
@@ -38,6 +38,7 @@ import 'package:fushi/src/ocr/manga_ocr_tokenizer.dart';
 import 'package:fushi/src/ocr/ocr_inference.dart';
 import 'package:fushi/src/ocr/ocr_inference_ort.dart';
 import 'package:fushi/src/ocr/text_detector.dart';
+import 'package:fushi/src/utils/misc/directory_bytes.dart';
 
 /// 纯函数：`Platform.operatingSystem` 字符串 → [OcrPlatform]。
 /// 未知平台（fuchsia 等）落 linux 档（纯 CPU），不会选到不存在的 EP。
@@ -460,19 +461,31 @@ class MangaOcrServiceImpl implements MangaOcrService {
   @override
   bool get isSupportedPlatform => _platformSupport();
 
+  /// 清单是否齐全（只 stat 清单里那几个文件，不遍历目录）。
+  ///
+  /// 与 [modelStatus] 分开：跑 OCR 的热路径只需要这个答案，而占用统计要递归遍历
+  /// 整个模型目录——把两者绑在一起等于让每次开跑都白扫一遍磁盘。
+  Future<bool> _manifestComplete() async {
+    final Directory dir = await _modelsDirProvider();
+    return _manifest.every(
+      (MangaOcrModelFile model) =>
+          isMangaOcrModelFileReady(File(p.join(dir.path, model.fileName))),
+    );
+  }
+
   @override
   Future<MangaOcrModelStatus> modelStatus() async {
     final Directory dir = await _modelsDirProvider();
     bool detectorReady = true;
     bool recognizerReady = true;
-    int downloadedBytes = 0;
     int totalBytes = 0;
     for (final MangaOcrModelFile model in _manifest) {
       totalBytes += model.expectedBytes;
       final File file = File(p.join(dir.path, model.fileName));
       if (isMangaOcrModelFileReady(file)) {
-        downloadedBytes += file.lengthSync();
-      } else if (model.role == MangaOcrModelRole.detector) {
+        continue;
+      }
+      if (model.role == MangaOcrModelRole.detector) {
         detectorReady = false;
       } else {
         recognizerReady = false;
@@ -481,7 +494,9 @@ class MangaOcrServiceImpl implements MangaOcrService {
     return MangaOcrModelStatus(
       detectorReady: detectorReady,
       recognizerReady: recognizerReady,
-      downloadedBytes: downloadedBytes,
+      // 占用按目录实际大小，不按清单累加：`.part` 残留与遗留旧档同样占磁盘，
+      // 用户看到的数字必须能被「删除」兑现（BUG-1732）。
+      diskBytes: await measureDirectoryBytes(dir),
       totalBytes: totalBytes,
     );
   }
@@ -493,11 +508,15 @@ class MangaOcrServiceImpl implements MangaOcrService {
   }
 
   @override
-  Future<void> deleteModels() async {
+  Future<int> deleteModels() async {
     final Directory dir = await _modelsDirProvider();
-    if (await dir.exists()) {
-      await dir.delete(recursive: true);
+    if (!await dir.exists()) {
+      return 0;
     }
+    // 先量后删：删完再量只会得到 0，用户就永远拿不到「到底释放了多少」。
+    final int freed = await measureDirectoryBytes(dir);
+    await dir.delete(recursive: true);
+    return freed;
   }
 
   Future<MangaOcrModelPaths> _resolveModelPaths() async {
@@ -538,8 +557,9 @@ class MangaOcrServiceImpl implements MangaOcrService {
             throw StateError(
                 'manga OCR is not supported on ${Platform.operatingSystem}');
           }
-          final MangaOcrModelStatus status = await modelStatus();
-          if (!status.allReady) {
+          // 只问「齐不齐」，不量「占多少」：占用统计要递归遍历整个模型目录，
+          // 那是设置页展示的开销，没有理由压在每次开跑 OCR 的路径上。
+          if (!await _manifestComplete()) {
             throw StateError('manga OCR models are not downloaded');
           }
           final MangaOcrModelPaths modelPaths = await _resolveModelPaths();

--- a/fushi/lib/src/utils/misc/directory_bytes.dart
+++ b/fushi/lib/src/utils/misc/directory_bytes.dart
@@ -1,0 +1,39 @@
+/// 目录真实占用测量。
+///
+/// 存在的理由（BUG-1732）：凡是「这块功能占了多少磁盘、删掉能释放多少」的
+/// 展示，只要改成按静态清单/预期值累加，就必然和用户 `du` 出来的数字对不上——
+/// 中断留下的临时档、上游换档后的遗留档、失败重试的半成品都不在任何清单里。
+/// 唯一不会骗人的真相源是目录本身，所以统一走这个函数量，别再各处手写累加。
+library;
+
+import 'dart:io';
+
+/// [dir] 的递归字节占用；目录不存在返回 0。
+///
+/// - 只统计常规文件（[File]）：符号链接不跟随（[Directory.list] 默认
+///   `followLinks: true` 会把链接目标算成本目录的占用，甚至在环形链接上打转），
+///   故显式关掉。
+/// - 单个条目 stat 失败（并发删除、权限不足）跳过而不是整体抛错：量占用是
+///   展示用途，为一个读不到的文件让整页报错不划算。
+Future<int> measureDirectoryBytes(Directory dir) async {
+  if (!await dir.exists()) {
+    return 0;
+  }
+  int total = 0;
+  try {
+    await for (final FileSystemEntity entity
+        in dir.list(recursive: true, followLinks: false)) {
+      if (entity is! File) {
+        continue;
+      }
+      try {
+        total += await entity.length();
+      } catch (_) {
+        // 条目在遍历途中消失/不可读：跳过。
+      }
+    }
+  } on FileSystemException {
+    // 目录在遍历途中被删：已累计的部分照常返回。
+  }
+  return total;
+}

--- a/fushi/test/media/manga/manga_module_ocr_entry_engines_test.dart
+++ b/fushi/test/media/manga/manga_module_ocr_entry_engines_test.dart
@@ -45,7 +45,7 @@ class _UnsupportedOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => const MangaOcrModelStatus(
         detectorReady: false,
         recognizerReady: false,
-        downloadedBytes: 0,
+        diskBytes: 0,
         totalBytes: 1,
       );
 
@@ -54,7 +54,7 @@ class _UnsupportedOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/media/manga/manga_ocr_settings_section_ui_test.dart
+++ b/fushi/test/media/manga/manga_ocr_settings_section_ui_test.dart
@@ -9,10 +9,27 @@ import 'package:fushi/utils.dart';
 
 /// Fake 服务，模型状态与下载流可编程。
 class _FakeOcrService implements MangaOcrService {
-  _FakeOcrService({this.supported = true, this.ready = false});
+  _FakeOcrService({
+    this.supported = true,
+    this.ready = false,
+    this.diskBytesOverride,
+    this.downloadEvents,
+  });
 
   final bool supported;
   bool ready;
+
+  /// 磁盘占用与「清单是否齐全」解耦：残留 `.part`/遗留档就是「不 ready 但占着
+  /// 磁盘」，这正是引擎用不到时仍须可删的那一档。
+  final int? diskBytesOverride;
+
+  /// 自定义下载事件源（不给则走默认单文件两条）。
+  ///
+  /// 用 controller 而不是事件列表：进度断言要看的是**下载进行中**的中间态，流一
+  /// 旦自然结束，UI 立刻收起进度条，那一帧就抓不到了。
+  final StreamController<MangaOcrDownloadEvent>? downloadEvents;
+
+  int deleteCalls = 0;
 
   @override
   bool get isSupportedPlatform => supported;
@@ -21,12 +38,18 @@ class _FakeOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
         detectorReady: ready,
         recognizerReady: ready,
-        downloadedBytes: ready ? 40 * 1024 * 1024 : 0,
+        diskBytes: diskBytesOverride ?? (ready ? 40 * 1024 * 1024 : 0),
         totalBytes: 40 * 1024 * 1024,
       );
 
   @override
   Stream<MangaOcrDownloadEvent> downloadModels() async* {
+    final StreamController<MangaOcrDownloadEvent>? scripted = downloadEvents;
+    if (scripted != null) {
+      yield* scripted.stream;
+      ready = true;
+      return;
+    }
     yield const MangaOcrDownloadEvent(
       fileName: 'detector.onnx',
       receivedBytes: 10,
@@ -42,8 +65,10 @@ class _FakeOcrService implements MangaOcrService {
   }
 
   @override
-  Future<void> deleteModels() async {
+  Future<int> deleteModels() async {
+    deleteCalls++;
     ready = false;
+    return 40 * 1024 * 1024;
   }
 
   @override
@@ -171,5 +196,148 @@ void main() {
         findsNothing);
     expect(find.byKey(const ValueKey<String>('manga_cloud_ocr_api_key')),
         findsNothing);
+  });
+
+  // ---- BUG-1732：引擎取舍说明 / 按引擎收起模型块 / 真实占用与释放量 ----
+
+  testWidgets('engine dropdown spells out each engine trade-off',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(ready: true);
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+      enginePreferenceGetter: () => 'auto',
+      enginePreferenceSetter: (String _) async {},
+    )));
+    await tester.pumpAndSettle();
+
+    await tester
+        .tap(find.byKey(const ValueKey<String>('manga_ocr_default_engine')));
+    await tester.pumpAndSettle();
+
+    // 谷歌要联网、快、但质量不如本地——用户挑引擎的依据必须写在选项上。
+    expect(find.text(t.manga_ocr_engine_google_lens_desc), findsWidgets);
+    expect(find.text(t.manga_ocr_engine_local_onnx_desc), findsWidgets);
+    expect(find.text(t.manga_ocr_engine_paired_host_desc), findsWidgets);
+  });
+
+  testWidgets('Google Lens engine never prompts for a local model download',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(ready: false);
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+      enginePreferenceGetter: () => 'google_lens',
+      enginePreferenceSetter: (String _) async {},
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+        find.widgetWithText(FilledButton, t.manga_ocr_download), findsNothing);
+    expect(find.text(t.manga_ocr_model_status_missing), findsNothing);
+  });
+
+  testWidgets('local models left on disk stay deletable under a cloud engine',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(
+      ready: false,
+      diskBytesOverride: 3 * 1024 * 1024 * 1024,
+    );
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+      enginePreferenceGetter: () => 'google_lens',
+      enginePreferenceSetter: (String _) async {},
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_ocr_model_unused_by_engine), findsOneWidget);
+    expect(
+      find.text(t.manga_ocr_model_disk_usage(
+        size: FushiByteFormat.bytes(3 * 1024 * 1024 * 1024),
+      )),
+      findsOneWidget,
+    );
+    expect(
+        find.widgetWithText(FilledButton, t.manga_ocr_download), findsNothing);
+
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, t.manga_ocr_delete).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, t.manga_ocr_delete));
+    await tester.pumpAndSettle();
+    expect(service.deleteCalls, 1);
+  });
+
+  testWidgets('ready row reports real disk usage, not the manifest total',
+      (WidgetTester tester) async {
+    final _FakeOcrService service = _FakeOcrService(
+      ready: true,
+      diskBytesOverride: 512 * 1024 * 1024,
+    );
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(t.manga_ocr_model_disk_usage(
+        size: FushiByteFormat.bytes(512 * 1024 * 1024),
+      )),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('download progress aggregates every file into one total',
+      (WidgetTester tester) async {
+    // 下载器按文件报进度；照搬就是进度条来回跑好几趟，用户把 450 MB 感知成
+    // 好几个 G。断言的是跨文件累计后的绝对字节数。
+    final StreamController<MangaOcrDownloadEvent> events =
+        StreamController<MangaOcrDownloadEvent>();
+    addTearDown(events.close);
+    final _FakeOcrService service =
+        _FakeOcrService(ready: false, downloadEvents: events);
+    await tester.pumpWidget(wrap(MangaOcrSettingsSection(
+      service: service,
+      mokuroPathGetter: () => '',
+      mokuroPathSetter: (String _) async {},
+      probeExternal: (String _) async => null,
+    )));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, t.manga_ocr_download));
+    await tester.pump();
+
+    // 检测器整档下完（10 MB），识别 encoder 下到 5 MB：总进度必须是 15 MB，
+    // 而不是「当前文件 5/30」这种一条条各自归零的读数。
+    events.add(const MangaOcrDownloadEvent(
+      fileName: 'detector.onnx',
+      receivedBytes: 10 * 1024 * 1024,
+      totalBytes: 10 * 1024 * 1024,
+    ));
+    events.add(const MangaOcrDownloadEvent(
+      fileName: 'encoder_model.onnx',
+      receivedBytes: 5 * 1024 * 1024,
+      totalBytes: 30 * 1024 * 1024,
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.text(t.manga_ocr_download_total_progress(
+        done: FushiByteFormat.bytes(15 * 1024 * 1024),
+        total: FushiByteFormat.bytes(40 * 1024 * 1024),
+      )),
+      findsOneWidget,
+    );
   });
 }

--- a/fushi/test/media/manga/manga_ocr_wizard_dialog_test.dart
+++ b/fushi/test/media/manga/manga_ocr_wizard_dialog_test.dart
@@ -28,7 +28,7 @@ class _FakeOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
         detectorReady: ready,
         recognizerReady: ready,
-        downloadedBytes: ready ? 50 : 0,
+        diskBytes: ready ? 50 : 0,
         totalBytes: 50,
       );
 
@@ -37,7 +37,7 @@ class _FakeOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/media/manga/manga_ocr_wizard_lens_test.dart
+++ b/fushi/test/media/manga/manga_ocr_wizard_lens_test.dart
@@ -20,7 +20,7 @@ class _UnavailableLocalService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => const MangaOcrModelStatus(
         detectorReady: false,
         recognizerReady: false,
-        downloadedBytes: 0,
+        diskBytes: 0,
         totalBytes: 1,
       );
 
@@ -29,7 +29,7 @@ class _UnavailableLocalService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/media/manga/manga_ocr_wizard_remote_test.dart
+++ b/fushi/test/media/manga/manga_ocr_wizard_remote_test.dart
@@ -34,7 +34,7 @@ class _UnsupportedOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => const MangaOcrModelStatus(
         detectorReady: false,
         recognizerReady: false,
-        downloadedBytes: 0,
+        diskBytes: 0,
         totalBytes: 1,
       );
 
@@ -43,7 +43,7 @@ class _UnsupportedOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/ocr/manga_ocr_service_impl_test.dart
+++ b/fushi/test/ocr/manga_ocr_service_impl_test.dart
@@ -116,7 +116,7 @@ void main() {
       expect(status.detectorReady, isFalse);
       expect(status.recognizerReady, isFalse);
       expect(status.allReady, isFalse);
-      expect(status.downloadedBytes, 0);
+      expect(status.diskBytes, 0);
       expect(status.totalBytes, 4 + 5 + 6 + 7);
     });
 
@@ -127,7 +127,7 @@ void main() {
           await service(_FakeRunner()).modelStatus();
       expect(status.detectorReady, isTrue);
       expect(status.recognizerReady, isFalse);
-      expect(status.downloadedBytes, 4);
+      expect(status.diskBytes, 4);
     });
 
     test('零字节文件不算就绪', () async {
@@ -142,13 +142,52 @@ void main() {
       final MangaOcrServiceImpl impl = service(_FakeRunner());
       MangaOcrModelStatus status = await impl.modelStatus();
       expect(status.allReady, isTrue);
-      expect(status.downloadedBytes, status.totalBytes);
+      expect(status.diskBytes, status.totalBytes);
 
-      await impl.deleteModels();
+      final int freed = await impl.deleteModels();
+      expect(freed, status.totalBytes);
       expect(modelsDir.existsSync(), isFalse);
       status = await impl.modelStatus();
       expect(status.allReady, isFalse);
-      expect(status.downloadedBytes, 0);
+      expect(status.diskBytes, 0);
+    });
+
+    // BUG-1732：占用与释放量的真相源是磁盘，不是清单。中断留下的 `.part`、上游
+    // 换档后的遗留档都不在清单里——按清单记账时它们既不显示也「删不掉」（用户
+    // 只看到删了清单那点体积），于是「显示 450 MB / 磁盘上却是另一个数」。
+    test('清单外的残留档一样计入占用，并计入删除释放量', () async {
+      writeAllModels();
+      File(p.join(modelsDir.path, 'encoder_model.onnx.part'))
+          .writeAsBytesSync(List<int>.filled(1000, 1));
+      File(p.join(modelsDir.path, 'legacy-detector-fp32.onnx'))
+          .writeAsBytesSync(List<int>.filled(500, 1));
+      final MangaOcrServiceImpl impl = service(_FakeRunner());
+
+      final MangaOcrModelStatus status = await impl.modelStatus();
+      expect(status.allReady, isTrue);
+      expect(status.totalBytes, 4 + 5 + 6 + 7);
+      expect(status.diskBytes, 4 + 5 + 6 + 7 + 1000 + 500);
+      expect(status.hasAnyFiles, isTrue);
+
+      expect(await impl.deleteModels(), 4 + 5 + 6 + 7 + 1000 + 500);
+      expect(modelsDir.existsSync(), isFalse);
+    });
+
+    test('模型不全但残留占着磁盘：hasAnyFiles 为真，可被删除释放', () async {
+      File(p.join(modelsDir.path, 'encoder_model.onnx.part'))
+          .writeAsBytesSync(List<int>.filled(2048, 1));
+      final MangaOcrServiceImpl impl = service(_FakeRunner());
+
+      final MangaOcrModelStatus status = await impl.modelStatus();
+      expect(status.allReady, isFalse);
+      expect(status.hasAnyFiles, isTrue);
+      expect(status.diskBytes, 2048);
+      expect(await impl.deleteModels(), 2048);
+    });
+
+    test('目录不存在：删除返回 0 而不是抛错', () async {
+      modelsDir.deleteSync(recursive: true);
+      expect(await service(_FakeRunner()).deleteModels(), 0);
     });
   });
 

--- a/fushi/test/pages/manga_fushi_page_test.dart
+++ b/fushi/test/pages/manga_fushi_page_test.dart
@@ -88,7 +88,7 @@ class _FakeMangaOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
         detectorReady: false,
         recognizerReady: ready,
-        downloadedBytes: 0,
+        diskBytes: 0,
         totalBytes: 1,
       );
 
@@ -97,7 +97,7 @@ class _FakeMangaOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/sync/fushi_sync_server_manga_ocr_test.dart
+++ b/fushi/test/sync/fushi_sync_server_manga_ocr_test.dart
@@ -45,7 +45,7 @@ class _FakeOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
         detectorReady: ready,
         recognizerReady: ready,
-        downloadedBytes: ready ? 1 : 0,
+        diskBytes: ready ? 1 : 0,
         totalBytes: 1,
       );
 
@@ -54,7 +54,7 @@ class _FakeOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/sync/interconnect_manga_ocr_client_test.dart
+++ b/fushi/test/sync/interconnect_manga_ocr_client_test.dart
@@ -41,7 +41,7 @@ class _FakeOcrService implements MangaOcrService {
   Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
         detectorReady: ready,
         recognizerReady: ready,
-        downloadedBytes: ready ? 1 : 0,
+        diskBytes: ready ? 1 : 0,
         totalBytes: 1,
       );
 
@@ -50,7 +50,7 @@ class _FakeOcrService implements MangaOcrService {
       const Stream<MangaOcrDownloadEvent>.empty();
 
   @override
-  Future<void> deleteModels() async {}
+  Future<int> deleteModels() async => 0;
 
   @override
   Stream<MangaOcrVolumeEvent> ocrFolder({

--- a/fushi/test/utils/directory_bytes_test.dart
+++ b/fushi/test/utils/directory_bytes_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/directory_bytes.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory root;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('fushi_dir_bytes_');
+  });
+
+  tearDown(() {
+    if (root.existsSync()) {
+      root.deleteSync(recursive: true);
+    }
+  });
+
+  test('目录不存在返回 0', () async {
+    final Directory missing = Directory(p.join(root.path, 'nope'));
+    expect(await measureDirectoryBytes(missing), 0);
+  });
+
+  test('空目录返回 0', () async {
+    expect(await measureDirectoryBytes(root), 0);
+  });
+
+  test('递归累加子目录里的每个文件', () async {
+    File(p.join(root.path, 'a.bin')).writeAsBytesSync(List<int>.filled(100, 1));
+    final Directory nested = Directory(p.join(root.path, 'sub', 'deep'))
+      ..createSync(recursive: true);
+    File(p.join(nested.path, 'b.bin'))
+        .writeAsBytesSync(List<int>.filled(23, 1));
+
+    expect(await measureDirectoryBytes(root), 123);
+  });
+
+  test('任何扩展名都算，包含未完成的 .part', () async {
+    File(p.join(root.path, 'encoder_model.onnx'))
+        .writeAsBytesSync(List<int>.filled(7, 1));
+    File(p.join(root.path, 'encoder_model.onnx.part'))
+        .writeAsBytesSync(List<int>.filled(11, 1));
+
+    expect(await measureDirectoryBytes(root), 18);
+  });
+}


### PR DESCRIPTION
用户三条反馈（截图两张），同一处设置区「漫画 OCR」。

## 1. 引擎下拉写清每个的特点

> 这里说一下每个的特点，比如谷歌需要网，但是速度快，质量较本地差

下拉此前只有五个裸名字。现在每项带一句取舍说明（联网 / 上传 / 质量 / 下载量），闭合态经 `selectedItemBuilder` 仍是单行，不撑高设置行。

## 2. 选了 Google Lens 不再劝你下模型

> 这里显示不对，用的谷歌的怎么还能下载模型

根因：本地模型块的显示条件只有 `service.isSupportedPlatform`，**与引擎选择完全脱钩**（`manga_ocr_settings_section.dart:306`）。

改为按引擎分三态：

| 引擎 | 显示 |
|---|---|
| auto / 本地 ONNX | 完整块（状态 + 下载/删除） |
| Lens / 外部 mokuro / 配对主机，且磁盘还留着文件 | 「当前引擎用不到这些本地模型文件」+ 占用多少 + 删除按钮 |
| Lens / 外部 mokuro / 配对主机，且磁盘干净 | 整块不渲染 |

第二态同时是「应该支持删除 ocr 模型」的落点——换引擎后那几百 MB 从此有处可删。

## 3. 「删了 450 MB，可下的时候好像有几个 G」

清单四个文件之和恰是 472,085,492 B ≈ 450 MiB，所以删除没有漏删清单内容，对不上的是**记账口径**和**进度呈现**：

- `MangaOcrModelStatus.downloadedBytes` 只累加**清单内已就绪**文件 → 改名 `diskBytes`，语义换成模型目录**真实递归占用**，中断留下的 `.part`、上游换档后的遗留旧档一并计入；新增 `hasAnyFiles`。
- `deleteModels()` 返回 `void`，删完只说一句「已删除」，不回报释放量 → 改返回 `Future<int>`（先量后删），toast 报出实际释放字节。
- 下载进度直接照搬下载器的**按文件**事件，一根进度条来回跑四趟（11 MB + 343 MB + 117 MB + 30 KB）→ 按文件名归并成**总体**进度，并显示「已下 / 总量」。
- 新增 `measureDirectoryBytes` 作为占用统计的单一真相源。
- `ocrFolder` 的就绪闸门改走只 stat 清单文件的 `_manifestComplete()`——占用统计要递归扫盘，没理由压在每次开跑 OCR 的路径上。

## 验证

- `flutter analyze`（含 test）：No issues found
- 定向 + 相邻：591 tests PASSED（`test/media/manga/`、`test/ocr/`、两条 sync OCR、manga 页）
- 目录枚举型守卫整批：250 tests PASSED（与文档基线一致）
- **变异实测**：把 `_buildLocalModelArea` 的 `if (_localModelsUsedByEngine)` 改成 `if (true)`，`Google Lens engine never prompts for a local model download` 与 `local models left on disk stay deletable under a cloud engine` 立刻转红；反向替换还原后源码 sha256 与变异前一致。

## 遗留（已记在 BUG 文件备注里）

「下的时候好像有几个 G」还有一条未被本次覆盖的可能来源：下载器 `_finalizePart` 在长度校验不符时删掉 `.part` 整文件重下，网络不稳时**累计流量**确实可能上 G，而落盘恒 450 MB。本次让四个数字（要下多少 / 已下多少 / 占了多少 / 释放了多少）都变成可见且一致的真实值，但没有改重下策略本身。
