### PR TITLE
feat(onboarding): 补落地五模块开关——小说/浏览器扩展也可隐藏（PR#880 合并后遗失的 f74e889f06）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61506 (3618 per locale)
+/// Strings: 61591 (3623 per locale)
 ///
-/// Built on 2026-08-19 at 04:25 UTC
+/// Built on 2026-08-19 at 06:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4910,6 +4910,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  String get module_books_label => 'Novels';
+  String get module_extension_label => 'Browser extension';
+  String get onboarding_feature_books => 'Novel library';
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -13290,6 +13297,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -21736,6 +21755,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -30198,6 +30229,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -38672,6 +38715,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -47075,6 +47130,18 @@ class _StringsId extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -55523,6 +55590,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -63786,6 +63865,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -72056,6 +72147,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -80484,6 +80587,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -88924,6 +89039,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -97350,6 +97477,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -105724,6 +105863,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -114130,6 +114281,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -122521,6 +122684,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 // Path: <root>
@@ -130287,6 +130462,16 @@ class _StringsZhCn extends _StringsEn {
   String get storage_bundled_hint => '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
   @override
   String get storage_dictionary_delete_incomplete => '词典删除未完成、条目仍在，详见错误日志';
+  @override
+  String get module_books_label => '小说';
+  @override
+  String get module_extension_label => '浏览器扩展';
+  @override
+  String get onboarding_feature_books => '小说库';
+  @override
+  String get onboarding_feature_books_hint => '看小说（EPUB），查词与有声书同步';
+  @override
+  String get onboarding_feature_extension_hint => '网页查词（仅桌面）';
 }
 
 // Path: <root>
@@ -138473,6 +138658,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get module_books_label => 'Novels';
+  @override
+  String get module_extension_label => 'Browser extension';
+  @override
+  String get onboarding_feature_books => 'Novel library';
+  @override
+  String get onboarding_feature_books_hint =>
+      'Read EPUB novels with dictionary lookup and audiobook sync';
+  @override
+  String get onboarding_feature_extension_hint =>
+      'Look up words on any web page (desktop only)';
 }
 
 /// Flat map(s) containing all translations.
@@ -145900,6 +146097,16 @@ extension on _StringsEn {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -153325,6 +153532,16 @@ extension on _StringsAr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -160772,6 +160989,16 @@ extension on _StringsDe {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -168218,6 +168445,16 @@ extension on _StringsEs {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -175670,6 +175907,16 @@ extension on _StringsFr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -183104,6 +183351,16 @@ extension on _StringsId {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -190552,6 +190809,16 @@ extension on _StringsIt {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -197962,6 +198229,16 @@ extension on _StringsJa {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -205376,6 +205653,16 @@ extension on _StringsKo {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -212818,6 +213105,16 @@ extension on _StringsNl {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -220257,6 +220554,16 @@ extension on _StringsPtBr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -227701,6 +228008,16 @@ extension on _StringsRu {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -235128,6 +235445,16 @@ extension on _StringsTh {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -242564,6 +242891,16 @@ extension on _StringsTr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -249996,6 +250333,16 @@ extension on _StringsVi {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }
@@ -257369,6 +257716,16 @@ extension on _StringsZhCn {
         return '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
       case 'storage_dictionary_delete_incomplete':
         return '词典删除未完成、条目仍在，详见错误日志';
+      case 'module_books_label':
+        return '小说';
+      case 'module_extension_label':
+        return '浏览器扩展';
+      case 'onboarding_feature_books':
+        return '小说库';
+      case 'onboarding_feature_books_hint':
+        return '看小说（EPUB），查词与有声书同步';
+      case 'onboarding_feature_extension_hint':
+        return '网页查词（仅桌面）';
       default:
         return null;
     }
@@ -264774,6 +265131,16 @@ extension on _StringsZhHk {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'module_books_label':
+        return 'Novels';
+      case 'module_extension_label':
+        return 'Browser extension';
+      case 'onboarding_feature_books':
+        return 'Novel library';
+      case 'onboarding_feature_books_hint':
+        return 'Read EPUB novels with dictionary lookup and audiobook sync';
+      case 'onboarding_feature_extension_hint':
+        return 'Look up words on any web page (desktop only)';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "未安装",
   "storage_bundled_section": "随包组件",
   "storage_bundled_hint": "随安装包携带，删除后下次更新会自动恢复，此处仅展示。",
-  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志"
+  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志",
+  "module_books_label": "小说",
+  "module_extension_label": "浏览器扩展",
+  "onboarding_feature_books": "小说库",
+  "onboarding_feature_books_hint": "看小说（EPUB），查词与有声书同步",
+  "onboarding_feature_extension_hint": "网页查词（仅桌面）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3616,5 +3616,10 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "module_books_label": "Novels",
+  "module_extension_label": "Browser extension",
+  "onboarding_feature_books": "Novel library",
+  "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
 }

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1711,10 +1711,12 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                                   ? null
                                   : buildFushiMacosSidebar(
                                       activeTabs: homeActiveTabs(
-                                        // 漫画/视频按「功能模块」偏好显隐（与
-                                        // HomePage._activeTabs 同一真值）。games
-                                        // （galgame 库）仅 Windows；macOS 根侧栏此处
-                                        // 恒 false（gamesEnabled 缺省），不显示。
+                                        // 小说/漫画/视频/扩展按「功能模块」偏好
+                                        // 显隐（与 HomePage._activeTabs 同一真值）。
+                                        // games（galgame 库）仅 Windows；macOS 根
+                                        // 侧栏此处恒 false（gamesEnabled 缺省）。
+                                        booksEnabled:
+                                            appModel.moduleBooksEnabled,
                                         videoEnabled:
                                             appModel.moduleVideoEnabled,
                                         mangaEnabled:
@@ -1722,7 +1724,9 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                                         // 浏览器扩展 tab「电脑才有」：此处为 macOS 根
                                         // 侧栏，macOS 即桌面 → 与底栏/rail 同一门控。
                                         browserExtensionEnabled:
-                                            DesktopLookupService.isDesktop,
+                                            DesktopLookupService.isDesktop &&
+                                                appModel
+                                                    .moduleBrowserExtensionEnabled,
                                       ),
                                     ),
                               child: child!,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -5801,6 +5801,13 @@ class AppModel with ChangeNotifier {
   Future<void> setOnboardingCompleted({required bool value}) =>
       prefsRepo.setOnboardingCompleted(value: value);
 
+  bool get moduleBooksEnabled => prefsRepo.moduleBooksEnabled;
+  Future<void> setModuleBooksEnabled(bool value) =>
+      prefsRepo.setModuleBooksEnabled(value);
+  bool get moduleBrowserExtensionEnabled =>
+      prefsRepo.moduleBrowserExtensionEnabled;
+  Future<void> setModuleBrowserExtensionEnabled(bool value) =>
+      prefsRepo.setModuleBrowserExtensionEnabled(value);
   bool get moduleMangaEnabled => prefsRepo.moduleMangaEnabled;
   Future<void> setModuleMangaEnabled(bool value) =>
       prefsRepo.setModuleMangaEnabled(value);

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -114,6 +114,8 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'mine_to_server',
   'mining_audio_quality',
   'mining_image_quality',
+  'module_books_enabled',
+  'module_browser_extension_enabled',
   'module_games_enabled',
   'module_manga_enabled',
   'module_video_enabled',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -802,9 +802,26 @@ class PreferencesRepository extends ChangeNotifier {
     await setPref('first_time_setup', false);
   }
 
-  /// 「功能模块」显隐：漫画/视频/游戏三个媒体库 tab 是否出现在底栏/侧栏。默认
-  /// 全开（与旧版行为一致）；新手引导的功能选择与 设置 → 系统 → 功能模块 写同
-  /// 一真值。games 在读取端还叠加 Windows 平台门控，这里只存用户意愿。
+  /// 「功能模块」显隐：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 是否出现在
+  /// 底栏/侧栏。默认全开（与旧版行为一致）；新手引导的功能选择与 设置 → 系统 →
+  /// 功能模块 写同一真值。games（Windows）与浏览器扩展（桌面）在读取端还叠加
+  /// 平台门控，这里只存用户意愿。首页/下载/词典/设置恒在，不提供开关。
+  bool get moduleBooksEnabled =>
+      getPref('module_books_enabled', defaultValue: true) as bool;
+
+  Future<void> setModuleBooksEnabled(bool value) async {
+    await setPref('module_books_enabled', value);
+    notifyListeners();
+  }
+
+  bool get moduleBrowserExtensionEnabled =>
+      getPref('module_browser_extension_enabled', defaultValue: true) as bool;
+
+  Future<void> setModuleBrowserExtensionEnabled(bool value) async {
+    await setPref('module_browser_extension_enabled', value);
+    notifyListeners();
+  }
+
   bool get moduleMangaEnabled =>
       getPref('module_manga_enabled', defaultValue: true) as bool;
 

--- a/fushi/lib/src/onboarding/onboarding_steps.dart
+++ b/fushi/lib/src/onboarding/onboarding_steps.dart
@@ -6,12 +6,16 @@ library;
 
 /// 功能选择步骤里可勾选的项，分两类：
 ///
-/// - **库页模块**（[isModule] == true，漫画/视频/游戏）：勾选状态在离开功能选择
+/// - **库页模块**（小说/漫画/视频/游戏/浏览器扩展）：勾选状态在离开功能选择
 ///   步骤时写进 `module_*_enabled` 偏好，未勾选的从底栏/侧栏隐藏（设置 → 系统 →
-///   功能模块 可随时改回）。模块不产生引导步骤。
+///   功能模块 可随时改回）。模块不产生引导步骤——唯一例外是浏览器扩展：它同时
+///   门控「扩展安装引导」这一步（模块都不要了自然不必引导安装）。
 /// - **配置能力**（推荐包/Anki/备份/互联）：勾选只决定向导后续走哪些配置步骤，
 ///   不写任何持久化开关。
 enum OnboardingFeature {
+  /// 小说库页（模块）。
+  books,
+
   /// 漫画库页（模块）。
   manga,
 
@@ -20,6 +24,9 @@ enum OnboardingFeature {
 
   /// galgame 游戏库页（模块，仅 Windows 提供勾选）。
   games,
+
+  /// 浏览器扩展 tab（模块，仅桌面提供勾选；同时门控扩展安装引导步骤）。
+  browserExtension,
 
   /// 官方推荐包：日语推荐词典 + 日/英发音音频库（Fushi 备份 zip，向导内直接
   /// 下载导入）。
@@ -35,11 +42,13 @@ enum OnboardingFeature {
   interconnect,
 }
 
-/// 库页模块集合（勾选写 tab 显隐偏好，不产生引导步骤）。
+/// 库页模块集合（勾选写 tab 显隐偏好；除 browserExtension 外不产生引导步骤）。
 const Set<OnboardingFeature> kOnboardingModuleFeatures = <OnboardingFeature>{
+  OnboardingFeature.books,
   OnboardingFeature.manga,
   OnboardingFeature.video,
   OnboardingFeature.games,
+  OnboardingFeature.browserExtension,
 };
 
 /// 向导步骤身份（枚举身份而非整数索引，插入/裁剪步骤不会打乱路由判断）。
@@ -69,8 +78,8 @@ enum OnboardingStepId {
 /// 恒以 [OnboardingStepId.welcome]、[OnboardingStepId.features] 开头，
 /// [OnboardingStepId.fonts]、[OnboardingStepId.finish] 结尾；中间配置步骤按固定
 /// 顺序（推荐包 → Anki → 备份 → 互联 → 扩展）出现：能力步骤只保留被勾选的，
-/// 浏览器扩展步骤由 [browserExtensionAvailable]（桌面平台）门控。库页模块勾选
-/// 不产生步骤。
+/// 浏览器扩展安装引导步骤 = [browserExtensionAvailable]（桌面平台）**且**扩展
+/// 模块被勾选。其余库页模块勾选不产生步骤。
 List<OnboardingStepId> onboardingStepSequence({
   required Set<OnboardingFeature> selected,
   required bool browserExtensionAvailable,
@@ -84,7 +93,9 @@ List<OnboardingStepId> onboardingStepSequence({
     if (selected.contains(OnboardingFeature.backup)) OnboardingStepId.backup,
     if (selected.contains(OnboardingFeature.interconnect))
       OnboardingStepId.interconnect,
-    if (browserExtensionAvailable) OnboardingStepId.browserExtension,
+    if (browserExtensionAvailable &&
+        selected.contains(OnboardingFeature.browserExtension))
+      OnboardingStepId.browserExtension,
     OnboardingStepId.fonts,
     OnboardingStepId.finish,
   ];

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -109,15 +109,17 @@ enum HomeTab {
 /// [HomePage]。底栏/侧栏的位置索引由此列表导出。
 List<HomeTab> homeActiveTabs({
   required bool videoEnabled,
+  bool booksEnabled = true,
   bool mangaEnabled = true,
   bool gamesEnabled = false,
   bool browserExtensionEnabled = false,
 }) =>
     <HomeTab>[
       HomeTab.home,
-      HomeTab.books,
-      // 漫画/视频/游戏三个媒体库 tab 可按「功能模块」偏好隐藏（新手引导的功能
-      // 选择与 设置 → 系统 → 功能模块 写同一真值）；书架/词典/设置恒在。
+      // 小说/漫画/视频/游戏/浏览器扩展五个库页 tab 可按「功能模块」偏好隐藏
+      // （新手引导的功能选择与 设置 → 系统 → 功能模块 写同一真值）；首页/下载/
+      // 词典/设置恒在，是隐藏后的安全回退面。
+      if (booksEnabled) HomeTab.books,
       if (mangaEnabled) HomeTab.manga,
       if (videoEnabled) HomeTab.video,
       if (gamesEnabled) HomeTab.games,
@@ -156,7 +158,8 @@ HomeTab homeTabForVisualIndex({
 }) {
   final int logicalIndex =
       reversed ? (tabs.length - 1 - visualIndex) : visualIndex;
-  if (logicalIndex < 0 || logicalIndex >= tabs.length) return HomeTab.books;
+  // 回退到恒在的 home（书架 tab 现可被「功能模块」偏好隐藏，不再是安全回退）。
+  if (logicalIndex < 0 || logicalIndex >= tabs.length) return HomeTab.home;
   return tabs[logicalIndex];
 }
 
@@ -753,21 +756,23 @@ class _HomePageState extends BasePageState<HomePage>
   /// games（galgame 库）额外叠加 Windows 平台门控（galgame 引擎-hook 注入本就
   /// Windows-only），紧跟视频之后。底栏/侧栏的位置索引由此列表导出。
   List<HomeTab> _activeTabs() => homeActiveTabs(
-        // 漫画/视频/游戏按「功能模块」偏好显隐（games 仍叠加 Windows 平台门控，
-        // galgame 引擎-hook 注入本就 Windows-only）；偏好默认全开，行为与旧版一致。
+        // 小说/漫画/视频/游戏/扩展按「功能模块」偏好显隐（games 仍叠加 Windows
+        // 平台门控——galgame 引擎-hook 注入本就 Windows-only；扩展仍叠加桌面
+        // 门控「电脑才有」）；偏好默认全开，行为与旧版一致。
+        booksEnabled: appModel.moduleBooksEnabled,
         videoEnabled: appModel.moduleVideoEnabled,
         mangaEnabled: appModel.moduleMangaEnabled,
         gamesEnabled: Platform.isWindows && appModel.moduleGamesEnabled,
-        // 「电脑才有」：浏览器扩展 tab 仅桌面（Windows/macOS/Linux）显示。
-        browserExtensionEnabled: DesktopLookupService.isDesktop,
+        browserExtensionEnabled: DesktopLookupService.isDesktop &&
+            appModel.moduleBrowserExtensionEnabled,
       );
 
-  /// 渲染用的当前 tab：若 `_currentTab` 已不在可见列表（例如刚关掉实验开关时仍停在
-  /// 视频 tab），回落到书架，避免渲染一个不存在的 tab。`_currentTab` 自身保持不变，
-  /// 下一次 [_selectTab] 会纠正它。
+  /// 渲染用的当前 tab：若 `_currentTab` 已不在可见列表（例如刚在「功能模块」里
+  /// 关掉当前所在库页），回落到恒在的首页，避免渲染一个不存在的 tab。
+  /// `_currentTab` 自身保持不变，下一次 [_selectTab] 会纠正它。
   HomeTab get _visibleTab {
     final List<HomeTab> tabs = _activeTabs();
-    return tabs.contains(_currentTab) ? _currentTab : HomeTab.books;
+    return tabs.contains(_currentTab) ? _currentTab : HomeTab.home;
   }
 
   /// 统一切换顶层 tab：进入「设置」前记录来源 tab，供设置全屏返回箭头切回。

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -80,6 +80,9 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
   @override
   void initState() {
     super.initState();
+    if (appModelNoUpdate.moduleBooksEnabled) {
+      _selected.add(OnboardingFeature.books);
+    }
     if (appModelNoUpdate.moduleMangaEnabled) {
       _selected.add(OnboardingFeature.manga);
     }
@@ -88,6 +91,10 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
     }
     if (Platform.isWindows && appModelNoUpdate.moduleGamesEnabled) {
       _selected.add(OnboardingFeature.games);
+    }
+    if (_browserExtensionAvailable &&
+        appModelNoUpdate.moduleBrowserExtensionEnabled) {
+      _selected.add(OnboardingFeature.browserExtension);
     }
     // 上一轮推荐包导入成功后进程已重启：把落盘的 9.5 GB zip 删掉（flag 判定，
     // 未导入过 / 半截下载不受影响）。
@@ -108,11 +115,18 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
     await Navigator.of(context).maybePop();
   }
 
-  /// 离开功能选择步骤时，把模块勾选写进 tab 显隐偏好（只写有变化的）。
+  /// 离开功能选择步骤时，把模块勾选写进 tab 显隐偏好（只写有变化的；平台上
+  /// 没提供勾选的模块不写，保留用户意愿）。
   Future<void> _applyModuleSelection() async {
+    final bool books = _selected.contains(OnboardingFeature.books);
     final bool manga = _selected.contains(OnboardingFeature.manga);
     final bool video = _selected.contains(OnboardingFeature.video);
     final bool games = _selected.contains(OnboardingFeature.games);
+    final bool extension =
+        _selected.contains(OnboardingFeature.browserExtension);
+    if (appModel.moduleBooksEnabled != books) {
+      await appModel.setModuleBooksEnabled(books);
+    }
     if (appModel.moduleMangaEnabled != manga) {
       await appModel.setModuleMangaEnabled(manga);
     }
@@ -121,6 +135,10 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
     }
     if (Platform.isWindows && appModel.moduleGamesEnabled != games) {
       await appModel.setModuleGamesEnabled(games);
+    }
+    if (_browserExtensionAvailable &&
+        appModel.moduleBrowserExtensionEnabled != extension) {
+      await appModel.setModuleBrowserExtensionEnabled(extension);
     }
   }
 
@@ -415,7 +433,9 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
         SizedBox(height: tokens.spacing.gap),
         for (final OnboardingFeature feature in OnboardingFeature.values)
           if (kOnboardingModuleFeatures.contains(feature) &&
-              (feature != OnboardingFeature.games || Platform.isWindows))
+              (feature != OnboardingFeature.games || Platform.isWindows) &&
+              (feature != OnboardingFeature.browserExtension ||
+                  _browserExtensionAvailable))
             OnboardingFeatureTile(
               icon: _featureIcon(feature),
               title: _featureTitle(feature),
@@ -545,6 +565,10 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   IconData _featureIcon(OnboardingFeature feature) {
     switch (feature) {
+      case OnboardingFeature.books:
+        return Icons.menu_book_outlined;
+      case OnboardingFeature.browserExtension:
+        return Icons.extension_outlined;
       case OnboardingFeature.manga:
         return Icons.photo_library_outlined;
       case OnboardingFeature.video:
@@ -564,6 +588,10 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   String _featureTitle(OnboardingFeature feature) {
     switch (feature) {
+      case OnboardingFeature.books:
+        return t.onboarding_feature_books;
+      case OnboardingFeature.browserExtension:
+        return t.module_extension_label;
       case OnboardingFeature.manga:
         return t.onboarding_feature_manga;
       case OnboardingFeature.video:
@@ -583,6 +611,10 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   String _featureHint(OnboardingFeature feature) {
     switch (feature) {
+      case OnboardingFeature.books:
+        return t.onboarding_feature_books_hint;
+      case OnboardingFeature.browserExtension:
+        return t.onboarding_feature_extension_hint;
       case OnboardingFeature.manga:
         return t.onboarding_feature_manga_hint;
       case OnboardingFeature.video:

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -7,6 +7,7 @@ import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/sync/sync_settings_schema.dart'
     show buildDataStorageLocationSection;
+import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/sync/sync_http.dart';
 import 'package:fushi/src/utils/misc/crash_dump_locator.dart';
 import 'package:fushi/src/utils/misc/platform_updater.dart';
@@ -145,12 +146,24 @@ SettingsDestination buildSystemDestination() {
           ),
         ],
       ),
-      // 「功能模块」：漫画/视频/游戏三个媒体库 tab 的显隐开关（与新手引导的功能
-      // 选择写同一真值）。书架/词典/设置恒在，不提供开关；games 仅 Windows 显示
-      // （读取端还叠加平台门控）。
+      // 「功能模块」：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 的显隐开关
+      // （与新手引导的功能选择写同一真值）。首页/下载/词典/设置恒在，不提供开关；
+      // games 仅 Windows、扩展仅桌面显示（读取端还叠加平台门控）。
       SettingsSection(
         title: t.settings_section_modules,
         items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'system.module_books',
+            title: t.module_books_label,
+            subtitle: t.module_toggle_hint,
+            icon: Icons.menu_book_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.moduleBooksEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setModuleBooksEnabled(value);
+              settingsContext.refresh();
+            },
+          ),
           SettingsSwitchItem(
             id: 'system.module_manga',
             title: t.module_manga_label,
@@ -185,6 +198,20 @@ SettingsDestination buildSystemDestination() {
                 settingsContext.appModel.moduleGamesEnabled,
             onChanged: (SettingsContext settingsContext, bool value) async {
               await settingsContext.appModel.setModuleGamesEnabled(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'system.module_browser_extension',
+            title: t.module_extension_label,
+            subtitle: t.module_toggle_hint,
+            icon: Icons.extension_outlined,
+            visible: (_) => DesktopLookupService.isDesktop,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.moduleBrowserExtensionEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setModuleBrowserExtensionEnabled(value);
               settingsContext.refresh();
             },
           ),

--- a/fushi/test/models/preferences_repository_test.dart
+++ b/fushi/test/models/preferences_repository_test.dart
@@ -58,15 +58,21 @@ void main() {
 
     test('module tab toggles default to true and round-trip', () async {
       // 「功能模块」显隐默认全开——升级用户底栏不变（Never break userspace）。
+      expect(repo.moduleBooksEnabled, true);
       expect(repo.moduleMangaEnabled, true);
       expect(repo.moduleVideoEnabled, true);
       expect(repo.moduleGamesEnabled, true);
+      expect(repo.moduleBrowserExtensionEnabled, true);
+      await repo.setModuleBooksEnabled(false);
       await repo.setModuleMangaEnabled(false);
       await repo.setModuleVideoEnabled(false);
       await repo.setModuleGamesEnabled(false);
+      await repo.setModuleBrowserExtensionEnabled(false);
+      expect(repo.moduleBooksEnabled, false);
       expect(repo.moduleMangaEnabled, false);
       expect(repo.moduleVideoEnabled, false);
       expect(repo.moduleGamesEnabled, false);
+      expect(repo.moduleBrowserExtensionEnabled, false);
     });
 
     test('currentHomeTabIndex defaults to 0', () {

--- a/fushi/test/onboarding/onboarding_steps_test.dart
+++ b/fushi/test/onboarding/onboarding_steps_test.dart
@@ -3,7 +3,7 @@ import 'package:fushi/src/onboarding/onboarding_steps.dart';
 
 void main() {
   group('onboardingStepSequence', () {
-    test('empty selection yields fixed skeleton (desktop)', () {
+    test('empty selection yields fixed skeleton (no capability steps)', () {
       expect(
         onboardingStepSequence(
           selected: <OnboardingFeature>{},
@@ -12,24 +12,43 @@ void main() {
         <OnboardingStepId>[
           OnboardingStepId.welcome,
           OnboardingStepId.features,
-          OnboardingStepId.browserExtension,
           OnboardingStepId.fonts,
           OnboardingStepId.finish,
         ],
       );
     });
 
-    test('mobile skeleton drops the browser-extension step', () {
+    test('extension guide step needs BOTH desktop platform and selection', () {
+      final Set<OnboardingFeature> withExtension = <OnboardingFeature>{
+        OnboardingFeature.browserExtension,
+      };
+      // 桌面 + 勾选 → 有引导步骤。
+      expect(
+        onboardingStepSequence(
+          selected: withExtension,
+          browserExtensionAvailable: true,
+        ),
+        contains(OnboardingStepId.browserExtension),
+      );
+      // 移动端即便勾选（不可能出现，但语义上）也没有该步骤。
+      expect(
+        onboardingStepSequence(
+          selected: withExtension,
+          browserExtensionAvailable: false,
+        ),
+        isNot(contains(OnboardingStepId.browserExtension)),
+      );
+      // 桌面但用户关掉了扩展模块 → 不引导安装。
       expect(
         onboardingStepSequence(
           selected: <OnboardingFeature>{},
-          browserExtensionAvailable: false,
+          browserExtensionAvailable: true,
         ),
         isNot(contains(OnboardingStepId.browserExtension)),
       );
     });
 
-    test('full capability selection yields all steps in fixed order', () {
+    test('full selection yields all steps in fixed order', () {
       expect(
         onboardingStepSequence(
           selected: OnboardingFeature.values.toSet(),
@@ -49,9 +68,15 @@ void main() {
       );
     });
 
-    test('module features (manga/video/games) never add steps', () {
+    test('tab-only module features (books/manga/video/games) never add steps',
+        () {
       final List<OnboardingStepId> withModules = onboardingStepSequence(
-        selected: kOnboardingModuleFeatures,
+        selected: <OnboardingFeature>{
+          OnboardingFeature.books,
+          OnboardingFeature.manga,
+          OnboardingFeature.video,
+          OnboardingFeature.games,
+        },
         browserExtensionAvailable: false,
       );
       final List<OnboardingStepId> without = onboardingStepSequence(

--- a/fushi/test/pages/home_page_tabs_test.dart
+++ b/fushi/test/pages/home_page_tabs_test.dart
@@ -142,21 +142,52 @@ void main() {
       expect(tabs, contains(HomeTab.settings));
     });
 
-    test('三个模块全关时书架/词典/设置/下载仍恒在', () {
+    test('booksEnabled=false 只隐藏书架 tab，首页/词典/设置不动', () {
+      final List<HomeTab> tabs =
+          homeActiveTabs(videoEnabled: true, booksEnabled: false);
+      expect(tabs, isNot(contains(HomeTab.books)));
+      expect(tabs, contains(HomeTab.home));
+      expect(tabs, contains(HomeTab.dictionaries));
+      expect(tabs, contains(HomeTab.settings));
+    });
+
+    test('browserExtensionEnabled=false 隐藏扩展 tab', () {
+      final List<HomeTab> withExt =
+          homeActiveTabs(videoEnabled: true, browserExtensionEnabled: true);
+      final List<HomeTab> withoutExt =
+          homeActiveTabs(videoEnabled: true, browserExtensionEnabled: false);
+      expect(withExt, contains(HomeTab.browserExtension));
+      expect(withoutExt, isNot(contains(HomeTab.browserExtension)));
+    });
+
+    test('五个模块全关时首页/词典/设置/下载仍恒在（安全回退面）', () {
       final List<HomeTab> tabs = homeActiveTabs(
         videoEnabled: false,
+        booksEnabled: false,
         mangaEnabled: false,
         gamesEnabled: false,
+        browserExtensionEnabled: false,
       );
       expect(
         tabs,
         <HomeTab>[
           HomeTab.home,
-          HomeTab.books,
           HomeTab.downloads,
           HomeTab.dictionaries,
           HomeTab.settings,
         ],
+      );
+    });
+
+    test('隐藏 tab 后越界视觉索引回退到恒在的 home（不再是可隐藏的书架）', () {
+      final List<HomeTab> tabs = homeActiveTabs(
+        videoEnabled: false,
+        booksEnabled: false,
+        mangaEnabled: false,
+      );
+      expect(
+        homeTabForVisualIndex(tabs: tabs, visualIndex: 99, reversed: false),
+        HomeTab.home,
       );
     });
   });

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -39,9 +39,11 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // HomePage/macOS 侧栏的可见 tab 列表——harness 里没有挂 HomePage 外壳，探不到
   // 底栏。行为由 homeActiveTabs 纯函数用例咬住：mangaEnabled/videoEnabled/
   // gamesEnabled=false 各自隐藏对应 tab、书架/词典/设置/下载恒在。
+  'system/Novels': 'test/pages/home_page_tabs_test.dart',
   'system/Manga': 'test/pages/home_page_tabs_test.dart',
   'system/Video': 'test/pages/home_page_tabs_test.dart',
   'system/Galgame': 'test/pages/home_page_tabs_test.dart',
+  'system/Browser extension': 'test/pages/home_page_tabs_test.dart',
   // 漫画观看偏好五项。写 prefsRepo（changed=true），生效点全部在**漫画阅读器的
   // WebView 文档**里——这些值被注入成 CSS 过渡声明 / JS 常量（ZOOM_SENS、
   // TAP_ZONE_PAGING、IS_RTL、PAGE_ANIM），widget harness 里没有 WebView，也就没有


### PR DESCRIPTION
## 背景

PR #880（新手引导向导）于 2026-08-17T06:46Z 合并时只包含第一条 commit `e29e400419`；当晚 21:38 追加 push 到同分支的 `f74e889f06`（功能模块开关扩为五个）从未进入 develop——PR 合并后追加的 commit 不会自动落地。用户今日反馈「新手引导里面小说和浏览器插件的底栏也能隐藏」，即此遗失改动。

## 改动（cherry-pick f74e889f06 → develop 最新基底 16e95e4c82）

- 新增偏好 `module_books_enabled` / `module_browser_extension_enabled`（默认 true，零破坏）
- `homeActiveTabs` 增加 `booksEnabled`；浏览器扩展 tab = 桌面平台门控 && 模块偏好
- 书架不再恒在：越界视觉索引/当前 tab 被隐藏时的回退点从 books 改为恒在的 home
- 设置→系统→功能模块补「小说」「浏览器扩展」两开关（扩展仅桌面显示）
- 新手引导功能选择步骤补两模块勾选行；扩展模块同时门控「扩展安装引导」步骤
- i18n：5 个新 key × 17 语言；与 develop 新增 key 的尾部冲突已按「两侧都保留 + slang 重生成」解决

## 验证

- `flutter analyze` 全绿（No issues found）
- 定向测试 127 条全过：`test/onboarding` + `home_page_tabs_test` + `preferences_repository_test` + `settings_schema_coverage_test`
- 合入前本地全量套件走 `tool/flutter_test_failures.dart`（结果在合并说明中给出）


https://claude.ai/code/session_01Cjv9FKiH3RY1TjA6LTcSiW