### PR TITLE
feat(tracking): 临时下线 Bangumi 同步（可逆总开关）

### DIFF
--- a/fushi/lib/src/media/tracking/media_tracking_service.dart
+++ b/fushi/lib/src/media/tracking/media_tracking_service.dart
@@ -13,6 +13,15 @@ import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+/// Bangumi 同步临时下线总开关（2026-08-19 用户决定：匹配/同步效果太差，先撤下、
+/// 改好后再加回）。false = 首页同步卡与设置入口不挂载、四个生产触发点（冷启动
+/// syncNow、视频看完、阅读进度落盘、游玩状态变更）不进本服务，对用户等效「功能
+/// 不存在」。服务/仓储/两张表/偏好键/i18n 全部原样保留：恢复只需把这里改回
+/// true；下线期间错过的完成事实由 `_reconcileAndSync` 的水位重扫补齐，不丢数据。
+/// 刻意不把闸门放进服务本体：`media/tracking` 三个测试文件直接驱动服务，下线期
+/// 间照常守护回归。
+const bool kMediaTrackingEnabled = false;
+
 const String kBangumiAccessTokenPref = 'media_tracking_bangumi_access_token';
 
 /// 连接成功时记下的 Bangumi 昵称/用户名。令牌本身不可读回账号，重开 app 后若不存

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2285,7 +2285,9 @@ class AppModel with ChangeNotifier {
         preferences: prefsRepo,
         userAgent: _mediaTrackingUserAgent,
       );
-      unawaited(mediaTrackingService.syncNow());
+      if (kMediaTrackingEnabled) {
+        unawaited(mediaTrackingService.syncNow());
+      }
 
       final Map<String, String> prefsSnapshot = prefsRepo.prefsSnapshot;
 
@@ -6134,6 +6136,7 @@ class AppModel with ChangeNotifier {
         // 游玩状态改动上报媒体记录（Bangumi 收藏 type）。fail-open：同步不可用时
         // 本地状态照常生效，事件留在 outbox 由后续同步重试。
         onPlayStatusChanged: (String id, GalgamePlayStatus status) {
+          if (!kMediaTrackingEnabled) return;
           unawaited(
             mediaTrackingService.recordGameStatus(
               gameId: id,

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -725,9 +725,10 @@ class _HomeDashboardPageState
     }
 
     // Bangumi 追踪状态（映射 + 待办 + 上次同步结果）。读的是本地库与偏好，不发
-    // 网络请求，可以和其它聚合一起进首屏。
-    final MediaTrackingStatus tracking =
-        await appModel.mediaTrackingService.loadStatus();
+    // 网络请求，可以和其它聚合一起进首屏。临时下线期间卡不挂载，状态也不必查。
+    final MediaTrackingStatus tracking = kMediaTrackingEnabled
+        ? await appModel.mediaTrackingService.loadStatus()
+        : MediaTrackingStatus.empty;
 
     if (!mounted) return;
     setState(() {
@@ -912,9 +913,12 @@ class _HomeDashboardPageState
         _buildActivitySection(tokens, now, appModel, booksByKey, videosByUid);
     final Widget? recentCard =
         _buildRecentlyAddedSection(tokens, appModel, books, now);
-    // Bangumi 同步卡恒显示（未连接时也要显示——「没连上」本身就是用户最需要看到的
+    // Bangumi 同步临时下线（kMediaTrackingEnabled，见 media_tracking_service.dart）。
+    // 上线状态下此卡恒显示（未连接时也要显示——「没连上」本身就是用户最需要看到的
     // 那条状态，隐藏它就回到了「看完了没反应」的黑盒）。
-    final Widget trackingCard = _buildTrackingCard(tokens, appModel, now);
+    final Widget? trackingCard = kMediaTrackingEnabled
+        ? _buildTrackingCard(tokens, appModel, now)
+        : null;
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
@@ -957,8 +961,10 @@ class _HomeDashboardPageState
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   mainAxisSize: MainAxisSize.min,
                   children: <Widget>[
-                    trackingCard,
-                    SizedBox(height: tokens.spacing.card),
+                    if (trackingCard != null) ...<Widget>[
+                      trackingCard,
+                      SizedBox(height: tokens.spacing.card),
+                    ],
                     activityCard,
                   ],
                 ),
@@ -974,8 +980,10 @@ class _HomeDashboardPageState
               SizedBox(height: tokens.spacing.card),
               continueCard,
               SizedBox(height: tokens.spacing.card),
-              trackingCard,
-              SizedBox(height: tokens.spacing.card),
+              if (trackingCard != null) ...<Widget>[
+                trackingCard,
+                SizedBox(height: tokens.spacing.card),
+              ],
               activityCard,
               if (recentCard != null) ...<Widget>[
                 SizedBox(height: tokens.spacing.card),

--- a/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
@@ -1230,6 +1230,7 @@ extension _ReaderNavigation on _ReaderFushiPageState {
       await appModel.database
           .markEpubBookCompletedIfUnset(widget.bookKey, DateTime.now());
     }
+    if (!kMediaTrackingEnabled) return;
     await appModel.mediaTrackingService.recordBookProgress(
       bookKey: widget.bookKey,
       completedChapterCount: section + (progress >= 0.999 ? 1 : 0),

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -46,6 +46,8 @@ import 'package:fushi/src/media/display_title.dart';
 import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:fushi/src/media/audiobook/reader_quick_settings_sheet.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart';
+import 'package:fushi/src/media/tracking/media_tracking_service.dart'
+    show kMediaTrackingEnabled;
 import 'package:fushi/src/mining/immersion_mining_request.dart'
     show immersionMiningAudioExtension;
 import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart'

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -25,6 +25,8 @@ import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/storage/app_paths.dart';
 import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart';
+import 'package:fushi/src/media/tracking/media_tracking_service.dart'
+    show kMediaTrackingEnabled;
 import 'package:fushi/src/pages/implementations/video_loading_overlay.dart';
 import 'package:fushi/src/utils/misc/swipe_dismiss_wrapper.dart';
 // 只取语义枚举与调色板：视频页的通知一律走左上角 _showOsd，不得用 FushiToast
@@ -3267,14 +3269,16 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         ),
         markCompleted: (String uid) =>
             db.markVideoCompleted(uid, DateTime.now()),
-        onEpisodeCompleted: () =>
-            appModel.mediaTrackingService.recordVideoCompleted(
-          bookUid: widget.bookUid,
-          collectionId: widget.playlistCollectionId,
-          episodeIndex: _currentEpisode,
-          seriesCompleted:
-              _episodes.isNotEmpty && _currentEpisode == _episodes.length - 1,
-        ),
+        onEpisodeCompleted: () async {
+          if (!kMediaTrackingEnabled) return;
+          await appModel.mediaTrackingService.recordVideoCompleted(
+            bookUid: widget.bookUid,
+            collectionId: widget.playlistCollectionId,
+            episodeIndex: _currentEpisode,
+            seriesCompleted:
+                _episodes.isNotEmpty && _currentEpisode == _episodes.length - 1,
+          );
+        },
         // v49：一次观看 session 结束落一条活动事件，喂首页 Activity 时间轴。
         recordActivity: (String t, String uid, String dateKey, int timestampMs,
                 int durationMs, int chars) =>

--- a/fushi/lib/src/settings/settings_schema.dart
+++ b/fushi/lib/src/settings/settings_schema.dart
@@ -9,6 +9,8 @@ import 'package:fushi/src/settings/settings_schema_game.dart';
 import 'package:fushi/src/settings/settings_schema_listening.dart';
 import 'package:fushi/src/settings/settings_schema_lookup.dart';
 import 'package:fushi/src/settings/settings_schema_manga.dart';
+import 'package:fushi/src/media/tracking/media_tracking_service.dart'
+    show kMediaTrackingEnabled;
 import 'package:fushi/src/settings/settings_schema_tracking.dart';
 import 'package:fushi/src/settings/settings_schema_profiles.dart';
 import 'package:fushi/src/settings/settings_schema_reading.dart';
@@ -93,7 +95,9 @@ List<SettingsDestination> _buildDestinations() {
     buildMangaDestination(),
     buildListeningDestination(),
     buildVideoDestination(),
-    buildMediaTrackingDestination(),
+    // Bangumi 同步临时下线（编译期常量开关，不破坏 schema 缓存的纯度前提；
+    // 见 media_tracking_service.dart 的 kMediaTrackingEnabled）。
+    if (kMediaTrackingEnabled) buildMediaTrackingDestination(),
     // 「下载」大类：内联既有 torrent 设置组件（详见 buildDownloadsDestination）。
     buildDownloadsDestination(),
     // 「游戏」大类：游戏库 / 捕获工作台 / 诊断的可搜导航入口（仅 Windows，详见

--- a/fushi/test/pages/home_dashboard_page_test.dart
+++ b/fushi/test/pages/home_dashboard_page_test.dart
@@ -1246,7 +1246,13 @@ void main() {
   // BUG-1220：追踪链路原本零可观测（成功即删 outbox 行、失败只进错误日志并退避、
   // 没建映射就静默返回），用户「看完了没反应」时无处可看。这张卡是唯一出口，
   // 三种断裂状态各自必须说得出话。
-  group('Bangumi 同步卡（BUG-1220）', () {
+  //
+  // 2026-08-19 Bangumi 同步临时下线（kMediaTrackingEnabled=false）：卡不再挂载，
+  // 整组随功能一起停用；恢复开关时删掉 skip 原样启用。
+  group('Bangumi 同步卡（BUG-1220）',
+      skip: kMediaTrackingEnabled
+          ? false
+          : 'Bangumi 同步临时下线（kMediaTrackingEnabled=false）', () {
     void useWideSurface(WidgetTester tester) {
       tester.view.physicalSize = const Size(1400, 1800);
       tester.view.devicePixelRatio = 1.0;


### PR DESCRIPTION
用户 2026-08-19 决定：Bangumi 同步目前效果很差，先整体撤下，改好后再加回。

## 做法（最小可逆下线，不删代码不动表）

- `media_tracking_service.dart` 新增编译期常量 `kMediaTrackingEnabled = false`（kDebugMode 同款形态；恢复功能只需改回 `true`，全部闸点 grep 这个常量即可找齐）。
- **停后台同步**：四个生产触发点落闸——冷启动 `syncNow`（app_model）、看完一集 `recordVideoCompleted`（video_fushi_page）、阅读进度 `recordBookProgress`（reader navigation.part）、游玩状态 `recordGameStatus`（galgameRepo 回调）。退避定时器只在同步轮收尾挂起，触发点全断后自然不再产生。
- **隐藏 UI**：首页 dashboard 同步卡（宽/窄两分支，空判形态与 recentCard 对齐；状态查询同步跳过）、设置页 `buildMediaTrackingDestination`（collection-if 保留零参调用文本，schema 缓存纯度守卫与顺序守卫均不受影响）。
- **保留**：服务/仓储/`media_tracking_mappings`+`media_tracking_outbox` 两表/9 个偏好键/55 个 i18n key/互联令牌搬运与脱敏名单。下线期间错过的完成事实由水位重扫（`_reconcileAndSync`）在恢复后补齐，不丢数据。
- **刻意不动**：刮削侧 Bangumi（`media/video/scraper/bangumi_client.dart`、`media/metadata/bangumi_api_client.dart`、galgame `bangumi_adapter`、`video_metadata_bangumi_token`）——用户不满的是同步，刮削照常。
- 闸门不进服务本体：`test/media/tracking/` 三个测试文件照常全绿守护回归；仅 dashboard 测试的 Bangumi 卡组随功能 skip（恢复开关时删 skip 即原样启用）。

## 验证

- `flutter analyze` 全量：No issues found（0 info）。
- 定向 `flutter test --no-pub`（dashboard / settings 三守卫 / tracking 三件套 / interconnect_service_config）：**125 passed, 7 skipped**（跳过的正是 Bangumi 卡组），退出码 0。

https://claude.ai/code/session_01GpVhe4pWafMr3sjKoHfuxi