### PR TITLE
feat(sources): 网络来源推广到视频(WebDAV原地流播)与漫画(整卷下载导入)

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61506 (3618 per locale)
+/// Strings: 61523 (3619 per locale)
 ///
-/// Built on 2026-08-19 at 04:25 UTC
+/// Built on 2026-08-19 at 06:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4910,6 +4910,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -13290,6 +13292,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -21736,6 +21741,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -30198,6 +30206,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -38672,6 +38683,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -47075,6 +47089,9 @@ class _StringsId extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -55523,6 +55540,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -63786,6 +63806,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -72056,6 +72079,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -80484,6 +80510,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -88924,6 +88953,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -97350,6 +97382,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -105724,6 +105759,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -114130,6 +114168,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -122521,6 +122562,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 // Path: <root>
@@ -130287,6 +130331,8 @@ class _StringsZhCn extends _StringsEn {
   String get storage_bundled_hint => '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
   @override
   String get storage_dictionary_delete_incomplete => '词典删除未完成、条目仍在，详见错误日志';
+  @override
+  String get media_source_network_subtitle_video => 'WebDAV 远程库（原地串流）';
 }
 
 // Path: <root>
@@ -138473,6 +138519,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get media_source_network_subtitle_video =>
+      'WebDAV remote library (streams in place)';
 }
 
 /// Flat map(s) containing all translations.
@@ -145900,6 +145949,8 @@ extension on _StringsEn {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -153325,6 +153376,8 @@ extension on _StringsAr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -160772,6 +160825,8 @@ extension on _StringsDe {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -168218,6 +168273,8 @@ extension on _StringsEs {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -175670,6 +175727,8 @@ extension on _StringsFr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -183104,6 +183163,8 @@ extension on _StringsId {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -190552,6 +190613,8 @@ extension on _StringsIt {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -197962,6 +198025,8 @@ extension on _StringsJa {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -205376,6 +205441,8 @@ extension on _StringsKo {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -212818,6 +212885,8 @@ extension on _StringsNl {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -220257,6 +220326,8 @@ extension on _StringsPtBr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -227701,6 +227772,8 @@ extension on _StringsRu {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -235128,6 +235201,8 @@ extension on _StringsTh {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -242564,6 +242639,8 @@ extension on _StringsTr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -249996,6 +250073,8 @@ extension on _StringsVi {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }
@@ -257369,6 +257448,8 @@ extension on _StringsZhCn {
         return '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
       case 'storage_dictionary_delete_incomplete':
         return '词典删除未完成、条目仍在，详见错误日志';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV 远程库（原地串流）';
       default:
         return null;
     }
@@ -264774,6 +264855,8 @@ extension on _StringsZhHk {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'media_source_network_subtitle_video':
+        return 'WebDAV remote library (streams in place)';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "未安装",
   "storage_bundled_section": "随包组件",
   "storage_bundled_hint": "随安装包携带，删除后下次更新会自动恢复，此处仅展示。",
-  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志"
+  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志",
+  "media_source_network_subtitle_video": "WebDAV 远程库（原地串流）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3616,5 +3616,6 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "media_source_network_subtitle_video": "WebDAV remote library (streams in place)"
 }

--- a/fushi/lib/src/media/manga/manga_importer.dart
+++ b/fushi/lib/src/media/manga/manga_importer.dart
@@ -228,7 +228,7 @@ class MangaImporter {
     // 标题 → 冲突解析 → bookKey（= 净化标题即主键，与 EpubImporter/PdfImporter 同口径）。
     final String proposedTitle = (title != null && title.trim().isNotEmpty)
         ? title.trim()
-        : _deriveTitle(root, mokuroPath);
+        : deriveMokuroTitle(root, mokuroPath);
 
     return _copyAndInsert(
       db: db,
@@ -400,7 +400,12 @@ class MangaImporter {
   /// 从 mokuro 顶层 `title` + `volume` 派生显示标题（进而派生 bookKey）。组合 `title volume`
   /// 让同系列不同卷得到唯一 bookKey（否则两卷 sanitize 后撞主键、被迫加 `(2)` 后缀）。缺 title
   /// 退化文件名（mokuro 惯例文件名即卷名，天然唯一）。
-  static String _deriveTitle(Map<String, Object?> root, String mokuroPath) {
+  ///
+  /// 公开是给来源库扫描的网络去重预检用（SourceLibraryScanner 先读远端 `.mokuro`
+  /// 派生标题、命中已入库即跳过整卷下载）：预检必须与导入器同一套身份派生，
+  /// 不允许出现第二套判重规则。
+  static String deriveMokuroTitle(
+      Map<String, Object?> root, String mokuroPath) {
     final String title = (root['title'] as String?)?.trim() ?? '';
     final String volume = (root['volume'] as String?)?.trim() ?? '';
     final String base = p.basenameWithoutExtension(mokuroPath);

--- a/fushi/lib/src/media/source_library/source_library_scanner.dart
+++ b/fushi/lib/src/media/source_library/source_library_scanner.dart
@@ -53,7 +53,7 @@ import 'package:fushi/src/media/source_library/source_file_system.dart';
 import 'package:fushi/src/media/source_library/source_library_credential_store.dart';
 import 'package:fushi/src/media/source_library/source_library_row.dart';
 import 'package:fushi/src/media/video/external_video.dart'
-    show normalizeVideoPath;
+    show decodedSourceBasename, normalizeVideoPath;
 import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
 import 'package:fushi/src/media/video/url_stream_video.dart'
@@ -450,22 +450,20 @@ class SourceLibraryScanner {
           // 来源扫描与旧「导入视频文件夹」共用同一套作品/季/集解析规则：散片
           // 保持独立，多集整理为 playlist 合集。先完成逐文件入库，字幕 cue / 封面
           // 的既有增强不变；再只做归组，重扫复用已有成员且不删除缺失文件。
-          // 网络（WebDAV）来源 v1 不归组：URL 路径的百分号编码会渗进合集名，且
-          // 文件名解析规则按本地命名写成——先平铺入库，归组留后续。
-          if (files.isLocal) {
-            grouping = await VideoFolderGroupCoordinator(
-              database: _db,
-              repository: _videoRepo,
-            ).groupPaths(
-              videoPaths: <String>[
-                for (final ScanVideoItem item in plan.videos)
-                  if (classifyLocalVideoExtra(item.videoPath) == null)
-                    item.videoPath,
-              ],
-              createdVideoPaths: createdVideoPaths,
-              sourceId: source.id,
-            );
-          }
+          // 网络（WebDAV）来源同样归组：文件名解析统一走解码 basename
+          // （decodedSourceBasename），URL 的百分号编码不渗进合集名。
+          grouping = await VideoFolderGroupCoordinator(
+            database: _db,
+            repository: _videoRepo,
+          ).groupPaths(
+            videoPaths: <String>[
+              for (final ScanVideoItem item in plan.videos)
+                if (classifyLocalVideoExtra(item.videoPath) == null)
+                  item.videoPath,
+            ],
+            createdVideoPaths: createdVideoPaths,
+            sourceId: source.id,
+          );
           mediaCount += await _importPlaylists(plan, source.id, files);
           await VideoSourceMetadataIndexer(_db).index(source);
         case SourceLibraryKind.manga:
@@ -658,7 +656,7 @@ class SourceLibraryScanner {
   ///
   /// 缺页 / 坏 JSON 与本地语义一致：抛 [MangaImportException] 冒泡记进
   /// lastScanError。WebDAV 的 href 分段是百分号编码的，查表键与镜像文件名统一
-  /// 用解码后的相对路径（[_decodedRemoteBasename]）。
+  /// 用解码后的相对路径（[decodedSourceBasename]）。
   Future<int> _importMangaRemote(
     ScanPlan plan,
     int sourceId,
@@ -671,7 +669,7 @@ class SourceLibraryScanner {
         .toSet();
     int count = 0;
     for (final ScanMangaItem item in plan.mangas) {
-      final String mokuroName = _decodedRemoteBasename(item.mokuroPath);
+      final String mokuroName = decodedSourceBasename(item.mokuroPath);
       final String jsonStr = await fs.readText(item.mokuroPath);
       final Object? rawRoot = jsonDecode(jsonStr);
       final Map<String, Object?> root = rawRoot is Map
@@ -762,20 +760,6 @@ class SourceLibraryScanner {
     return slash <= 0 ? '' : path.substring(0, slash);
   }
 
-  /// 远端路径的 basename；http(s)（WebDAV href）做百分号解码，其余原样。
-  static String _decodedRemoteBasename(String path) {
-    final int slash = path.lastIndexOf('/');
-    final String raw = slash < 0 ? path : path.substring(slash + 1);
-    if (path.startsWith('http://') || path.startsWith('https://')) {
-      try {
-        return Uri.decodeComponent(raw);
-      } catch (_) {
-        return raw;
-      }
-    }
-    return raw;
-  }
-
   /// Imports every video in the plan (with sidecar subtitle cues); returns the
   /// physical paths that were newly inserted in this scan.
   ///
@@ -836,7 +820,7 @@ class SourceLibraryScanner {
           streamSpecJson = StreamVideoSpec(
             subtitleUrl: subUrl,
             subtitleFileName:
-                subUrl == null ? null : _decodedRemoteBasename(subUrl),
+                subUrl == null ? null : decodedSourceBasename(subUrl),
           ).toStorageJson();
         } else if (item.subtitlePath != null) {
           final String fmt = _extOf(p.basename(item.subtitlePath!));
@@ -876,7 +860,7 @@ class SourceLibraryScanner {
         // 标题用解码后的文件名：WebDAV 条目路径是百分号编码的 href，直接取
         // basename 会把 %20 之类渗进书架标题。
         final String title = streamInPlace
-            ? p.basenameWithoutExtension(_decodedRemoteBasename(item.videoPath))
+            ? p.basenameWithoutExtension(decodedSourceBasename(item.videoPath))
             : p.basenameWithoutExtension(item.videoPath);
         await _videoRepo.saveVideoBook(
           VideoBooksCompanion(
@@ -942,13 +926,6 @@ class SourceLibraryScanner {
     SourceFileSystem fs,
   ) async {
     if (plan.playlists.isEmpty) return 0;
-    // 网络视频来源 v1 不导 m3u8 清单：条目相对路径解析（resolveM3uEntryPath）
-    // 按本地磁盘语义写成，远端 URL 基底需要独立的解析与验证。跳过不算错误。
-    if (!fs.isLocal) {
-      debugPrint('SourceLibraryScanner: skipping ${plan.playlists.length} '
-          'playlist manifest(s) on a network video source (unsupported in v1)');
-      return 0;
-    }
 
     // 统一合集：拆集后无单条 playlist 行 → 用「同名 playlist 合集是否已存在」区分
     // 首次导入 vs 重扫。合集名 = m3u8 basename（**不随 manifest 内集路径编辑而变** →
@@ -967,8 +944,9 @@ class SourceLibraryScanner {
     try {
       int count = 0;
       for (final ScanPlaylistItem item in plan.playlists) {
-        final String collectionName =
-            p.basenameWithoutExtension(item.playlistPath);
+        // 合集名走解码 basename：网络清单的 href 是百分号编码的。
+        final String collectionName = p
+            .basenameWithoutExtension(decodedSourceBasename(item.playlistPath));
 
         playlistTmp ??= Directory.systemTemp.createTempSync('m1c_scan_pls_');
         final String localM3u8 =
@@ -976,8 +954,12 @@ class SourceLibraryScanner {
         final String content = await readTextWithEncoding(File(localM3u8));
         // baseDir is the ORIGINAL m3u8 path's directory (source namespace):
         // locally the real on-disk dir, matching manual / drag-drop import when
-        // resolving relative episode paths.
-        final String baseDir = p.dirname(item.playlistPath);
+        // resolving relative episode paths; remotely the manifest's URL dir
+        // (resolveM3uEntryPath 对 URL 基底按 URL 语义 join，条目解析成可播的
+        // 远端流 URL，逐集入库后与直扫视频同一条 stream 播放链)。
+        final String baseDir = fs.isLocal
+            ? p.dirname(item.playlistPath)
+            : _remoteParentDir(item.playlistPath);
         final List<PlaylistEntry> entries =
             parseM3u8(content: content, baseDir: baseDir);
         // 空 / 不可解析清单：跳过（不当成「清单变空 → 清光成员」，避免读盘瞬时失败

--- a/fushi/lib/src/media/source_library/source_library_scanner.dart
+++ b/fushi/lib/src/media/source_library/source_library_scanner.dart
@@ -16,10 +16,19 @@
 // configJson + SourceLibraryCredentialStore), and remote EPUBs are downloaded via
 // copyToLocal before import. Routing is transport-agnostic here: any non-'local'
 // transport builds a NetworkSourceFileSystem which dispatches SFTP/FTP/WebDAV
-// internally, so [buildNetworkFileSystem] needs no per-transport branch. Network
-// VIDEO sources are rejected (a raw remote path is not playable). Existing manual
-// import paths (dialogs) are untouched; sourceId defaults to null.
+// internally, so [buildNetworkFileSystem] needs no per-transport branch.
+// Existing manual import paths (dialogs) are untouched; sourceId defaults to null.
+//
+// 网络来源三域现状：
+// - book：三 transport 全通（远端 EPUB copyToLocal 下载后导入）。
+// - manga：三 transport 全通（[_importMangaRemote]：读远端 `.mokuro` 派生标题做
+//   去重预检，未命中才整卷镜像到临时目录，交给既有 MangaImporter——落库产物与
+//   本地导入逐字节同构）。
+// - video：仅 WebDAV（条目路径即 http(s) URL，按流媒体书原地入库
+//   videoPath=URL，播放走既有 stream 通道 + 打开时按 sourceId 现解析 Basic 认证，
+//   见 source_stream_headers.dart）；SFTP/FTP 无 HTTP 直链、播放器吃不了，仍拒绝。
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
@@ -36,6 +45,10 @@ import 'package:fushi/src/media/drag_drop/drop_classification.dart'
     show kDragPlaylistExtensions;
 import 'package:fushi/src/media/import/sidecar_finder.dart';
 import 'package:fushi/src/media/manga/manga_importer.dart';
+import 'package:fushi/src/media/manga/manga_storage.dart'
+    show MangaImportException;
+import 'package:fushi/src/media/manga/mokuro_payload.dart'
+    show MokuroImage, MokuroPayload, parseMokuro;
 import 'package:fushi/src/media/source_library/source_file_system.dart';
 import 'package:fushi/src/media/source_library/source_library_credential_store.dart';
 import 'package:fushi/src/media/source_library/source_library_row.dart';
@@ -43,6 +56,8 @@ import 'package:fushi/src/media/video/external_video.dart'
     show normalizeVideoPath;
 import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
+import 'package:fushi/src/media/video/url_stream_video.dart'
+    show StreamVideoSpec;
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/media/video/video_folder_group_coordinator.dart';
@@ -372,7 +387,7 @@ class SourceLibraryScanner {
   /// - 'video': each video -> [VideoBookRepository.saveVideoBook] (with sourceId)
   ///   plus parsed cues when a same-name subtitle exists.
   /// - 'manga': each `.mokuro` -> [MangaImporter.importFromMokuroPath] (with
-  ///   sourceId)，仅 local transport（见 [_importManga] 首版边界）。
+  ///   sourceId)；网络 transport 先整卷镜像下载（见 [_importMangaRemote]）。
   ///
   /// After insert, calls [FushiDatabase.updateMediaSourceScanResult] to write the
   /// media count / timestamp; any throw records its text in lastScanError
@@ -403,16 +418,13 @@ class SourceLibraryScanner {
           'Unsupported media kind for scan (expected book | video | manga)',
         );
       }
-      // 网络视频来源不受支持：远端 SFTP/FTP 路径不可被播放器直接播放（只支持网络
-      // 「书」来源——EPUB 小体积、扫描时下载后导入）。
-      if (!files.isLocal && kind == SourceLibraryKind.video) {
-        throw StateError('Network video sources are not supported');
-      }
-      // 网络漫画来源首版不支持（按视频先例）：一卷 mokuro 漫画 = `.mokuro` +
-      // 同级整目录页图，逐页下载的体量/断点语义远超「扫描时顺手下载」，且导入器
-      // 只吃本地路径探测同级图片。首版仅 local transport。
-      if (!files.isLocal && kind == SourceLibraryKind.manga) {
-        throw StateError('Network manga sources are not supported');
+      // 网络视频来源仅支持 WebDAV：条目路径本身就是 http(s) URL，可按流媒体书
+      // 原地入库播放（[_importVideos] streamInPlace）；SFTP/FTP 远端路径无 HTTP
+      // 直链、播放器吃不了，仍拒绝（放开需要本地转流桥，留后续）。
+      if (!files.isLocal &&
+          kind == SourceLibraryKind.video &&
+          source.transport != 'webdav') {
+        throw StateError('Network video sources support WebDAV only');
       }
       final List<SourceFileEntry> entries = await files.listFiles(
         source.rootPath,
@@ -438,22 +450,26 @@ class SourceLibraryScanner {
           // 来源扫描与旧「导入视频文件夹」共用同一套作品/季/集解析规则：散片
           // 保持独立，多集整理为 playlist 合集。先完成逐文件入库，字幕 cue / 封面
           // 的既有增强不变；再只做归组，重扫复用已有成员且不删除缺失文件。
-          grouping = await VideoFolderGroupCoordinator(
-            database: _db,
-            repository: _videoRepo,
-          ).groupPaths(
-            videoPaths: <String>[
-              for (final ScanVideoItem item in plan.videos)
-                if (classifyLocalVideoExtra(item.videoPath) == null)
-                  item.videoPath,
-            ],
-            createdVideoPaths: createdVideoPaths,
-            sourceId: source.id,
-          );
+          // 网络（WebDAV）来源 v1 不归组：URL 路径的百分号编码会渗进合集名，且
+          // 文件名解析规则按本地命名写成——先平铺入库，归组留后续。
+          if (files.isLocal) {
+            grouping = await VideoFolderGroupCoordinator(
+              database: _db,
+              repository: _videoRepo,
+            ).groupPaths(
+              videoPaths: <String>[
+                for (final ScanVideoItem item in plan.videos)
+                  if (classifyLocalVideoExtra(item.videoPath) == null)
+                    item.videoPath,
+              ],
+              createdVideoPaths: createdVideoPaths,
+              sourceId: source.id,
+            );
+          }
           mediaCount += await _importPlaylists(plan, source.id, files);
           await VideoSourceMetadataIndexer(_db).index(source);
         case SourceLibraryKind.manga:
-          mediaCount = await _importManga(plan, source.id);
+          mediaCount = await _importManga(plan, source.id, files);
       }
     } catch (e, stack) {
       scanError = e.toString();
@@ -597,11 +613,18 @@ class SourceLibraryScanner {
   /// BUG-443 范式（对齐 [_importBooks] / `_importVideos`）：`skipIfExists: true`
   /// 让已导入卷（含同批同标题）抛 [DuplicateImportCancelledException]，逐卷捕获
   /// 静默跳过（不计数、不算错误）。其它导入异常（坏 JSON / 缺图）不捕获，向上
-  /// 冒泡记进 lastScanError（与 book 分支同语义）。仅 local transport——网络
-  /// manga 源已在 [scan] 入口整体拒绝，故本方法直接用磁盘路径、不接 copyToLocal。
+  /// 冒泡记进 lastScanError（与 book 分支同语义）。网络 transport 走
+  /// [_importMangaRemote]（整卷镜像下载后仍复用本导入器）。
   /// 页图不经 [planScanFromFileList] 关联：导入器自己按 mokuro 惯例在 `.mokuro`
   /// 同级探测图片来源。
-  Future<int> _importManga(ScanPlan plan, int sourceId) async {
+  Future<int> _importManga(
+    ScanPlan plan,
+    int sourceId,
+    SourceFileSystem fs,
+  ) async {
+    if (!fs.isLocal) {
+      return _importMangaRemote(plan, sourceId, fs);
+    }
     int count = 0;
     for (final ScanMangaItem item in plan.mangas) {
       try {
@@ -623,6 +646,136 @@ class SourceLibraryScanner {
     return count;
   }
 
+  /// 网络漫画来源整卷下载导入。
+  ///
+  /// 一卷 mokuro 漫画 = `.mokuro` + 同级页图，体量远超一次「顺手下载」，所以先用
+  /// 远端 `.mokuro`（小文本）派生标题做**去重预检**——重扫已入库的卷零页图流量；
+  /// 未命中才把该卷页图按 payload 相对路径镜像到本地临时目录（保留子目录布局），
+  /// 交给既有 [MangaImporter.importFromMokuroPath]：导入器只吃本地路径，落库时
+  /// 仍是恒复制进书目录，产物与本地导入逐字节同构。预检与导入器用同一套身份
+  /// （[MangaImporter.deriveMokuroTitle] + [sanitizeTtuFilename]，见
+  /// resolveDuplicateTitle），不是第二套判重规则。
+  ///
+  /// 缺页 / 坏 JSON 与本地语义一致：抛 [MangaImportException] 冒泡记进
+  /// lastScanError。WebDAV 的 href 分段是百分号编码的，查表键与镜像文件名统一
+  /// 用解码后的相对路径（[_decodedRemoteBasename]）。
+  Future<int> _importMangaRemote(
+    ScanPlan plan,
+    int sourceId,
+    SourceFileSystem fs,
+  ) async {
+    if (plan.mangas.isEmpty) return 0;
+    final List<EpubBookRow> existingBooks = await _db.getAllEpubBooks();
+    final Set<String> existingTitleKeys = existingBooks
+        .map((EpubBookRow b) => sanitizeTtuFilename(b.title))
+        .toSet();
+    int count = 0;
+    for (final ScanMangaItem item in plan.mangas) {
+      final String mokuroName = _decodedRemoteBasename(item.mokuroPath);
+      final String jsonStr = await fs.readText(item.mokuroPath);
+      final Object? rawRoot = jsonDecode(jsonStr);
+      final Map<String, Object?> root = rawRoot is Map
+          ? rawRoot.cast<String, Object?>()
+          : <String, Object?>{};
+      final String title = MangaImporter.deriveMokuroTitle(root, mokuroName);
+      if (existingTitleKeys.contains(sanitizeTtuFilename(title))) {
+        debugPrint('SourceLibraryScanner skip duplicate manga '
+            '$title (${item.mokuroPath})');
+        continue;
+      }
+      final MokuroPayload payload = parseMokuro(jsonStr);
+      if (payload.images.isEmpty) {
+        throw const MangaImportException('Mokuro file has no pages');
+      }
+
+      // 远端相对路径（解码、正斜杠）→ 远端全路径查找表，作用域 = `.mokuro` 父目录。
+      final String parentDir = _remoteParentDir(item.mokuroPath);
+      final bool isUrl =
+          parentDir.startsWith('http://') || parentDir.startsWith('https://');
+      final List<SourceFileEntry> remoteFiles =
+          await fs.listFiles(parentDir, recursive: true);
+      final String prefix = parentDir.endsWith('/') ? parentDir : '$parentDir/';
+      final Map<String, String> remoteByRel = <String, String>{};
+      for (final SourceFileEntry e in remoteFiles) {
+        if (e.isDirectory || !e.path.startsWith(prefix)) continue;
+        final List<String> segs = e.path
+            .substring(prefix.length)
+            .split('/')
+            .where((String s) => s.isNotEmpty)
+            .map((String s) => isUrl ? Uri.decodeComponent(s) : s)
+            .toList();
+        if (segs.isEmpty) continue;
+        remoteByRel[segs.join('/')] = e.path;
+      }
+
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('m1c_scan_manga_');
+      try {
+        // 逐页镜像（保留相对子目录布局——导入器按 payload.url 相对 `.mokuro`
+        // 同级解析）。`..` 段直接拒绝：临时镜像在书目录 sanitize 之前落盘，
+        // 不能靠后面那道防穿越。
+        for (final MokuroImage page in payload.images) {
+          final List<String> segs = page.url
+              .split(RegExp(r'[\\/]+'))
+              .where((String s) => s.isNotEmpty)
+              .toList();
+          if (segs.isEmpty || segs.contains('..')) {
+            throw MangaImportException('Invalid manga page path: ${page.url}');
+          }
+          final String? remotePath = remoteByRel[segs.join('/')];
+          if (remotePath == null) {
+            throw MangaImportException('Missing manga page image: ${page.url}');
+          }
+          final Directory destDir = Directory(p.joinAll(
+              <String>[tmp.path, ...segs.sublist(0, segs.length - 1)]));
+          destDir.createSync(recursive: true);
+          await fs.copyToLocal(remotePath, destDir.path);
+        }
+        final String localMokuro = p.join(tmp.path, mokuroName);
+        await File(localMokuro).writeAsString(jsonStr, flush: true);
+        try {
+          await MangaImporter.importFromMokuroPath(
+            db: _db,
+            mokuroPath: localMokuro,
+            sourceId: sourceId,
+            policy: const DuplicatePolicy.skip(),
+          );
+          count++;
+          // 同批第二卷同标题也要被预检拦住（对齐 resolveDuplicateTitle 的同批语义）。
+          existingTitleKeys.add(sanitizeTtuFilename(title));
+        } on DuplicateImportCancelledException catch (e) {
+          debugPrint('SourceLibraryScanner skip duplicate manga '
+              '${e.title} (${item.mokuroPath})');
+        }
+      } finally {
+        try {
+          tmp.deleteSync(recursive: true);
+        } catch (_) {}
+      }
+    }
+    return count;
+  }
+
+  /// 远端路径的父目录（正斜杠语义；SFTP/FTP 路径与 WebDAV href URL 通用）。
+  static String _remoteParentDir(String path) {
+    final int slash = path.lastIndexOf('/');
+    return slash <= 0 ? '' : path.substring(0, slash);
+  }
+
+  /// 远端路径的 basename；http(s)（WebDAV href）做百分号解码，其余原样。
+  static String _decodedRemoteBasename(String path) {
+    final int slash = path.lastIndexOf('/');
+    final String raw = slash < 0 ? path : path.substring(slash + 1);
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      try {
+        return Uri.decodeComponent(raw);
+      } catch (_) {
+        return raw;
+      }
+    }
+    return raw;
+  }
+
   /// Imports every video in the plan (with sidecar subtitle cues); returns the
   /// physical paths that were newly inserted in this scan.
   ///
@@ -639,6 +792,12 @@ class SourceLibraryScanner {
     SourceFileSystem fs,
   ) async {
     if (plan.videos.isEmpty) return const <String>[];
+    // 网络（仅 WebDAV 能走到这里，[scan] 入口已拒 SFTP/FTP）：条目路径就是
+    // http(s) URL，按流媒体书**原地**入库——videoPath=URL、sidecar 字幕 URL 进
+    // streamSpecJson，播放走既有 stream 通道（isStreamVideoBook 判据 =
+    // videoPath 是 http）。不下载视频、不抽封面、不解析 cue（字幕由播放页按
+    // spec.subtitleUrl 现下载，认证头打开时按 sourceId 现解析）。
+    final bool streamInPlace = !fs.isLocal;
     final List<VideoBookRow> existingRows = await _videoRepo.listAll();
     // Existing book_uid set for silent same-name dedup (matches import dialog).
     final Set<String> existingKeys =
@@ -670,8 +829,16 @@ class SourceLibraryScanner {
 
         String? subtitleSource;
         String? subtitleFormat;
+        String? streamSpecJson;
         List<AudioCue> cues = const <AudioCue>[];
-        if (item.subtitlePath != null) {
+        if (streamInPlace) {
+          final String? subUrl = item.subtitlePath;
+          streamSpecJson = StreamVideoSpec(
+            subtitleUrl: subUrl,
+            subtitleFileName:
+                subUrl == null ? null : _decodedRemoteBasename(subUrl),
+          ).toStorageJson();
+        } else if (item.subtitlePath != null) {
           final String fmt = _extOf(p.basename(item.subtitlePath!));
           subtitleTmp ??= Directory.systemTemp.createTempSync('m1c_scan_subs_');
           final String localSub =
@@ -706,14 +873,20 @@ class SourceLibraryScanner {
           }
         }
 
+        // 标题用解码后的文件名：WebDAV 条目路径是百分号编码的 href，直接取
+        // basename 会把 %20 之类渗进书架标题。
+        final String title = streamInPlace
+            ? p.basenameWithoutExtension(_decodedRemoteBasename(item.videoPath))
+            : p.basenameWithoutExtension(item.videoPath);
         await _videoRepo.saveVideoBook(
           VideoBooksCompanion(
             bookUid: Value(bookUid),
-            title: Value(p.basenameWithoutExtension(item.videoPath)),
+            title: Value(title),
             videoPath: Value(item.videoPath),
             coverPath: Value<String?>(coverPath),
             subtitleSource: Value<String?>(subtitleSource),
             subtitleFormat: Value<String?>(subtitleFormat),
+            streamSpecJson: Value<String?>(streamSpecJson),
             embeddedSubtitleTrack: subtitleSource == null
                 ? const Value<int?>(0)
                 : const Value<int?>(null),
@@ -769,6 +942,13 @@ class SourceLibraryScanner {
     SourceFileSystem fs,
   ) async {
     if (plan.playlists.isEmpty) return 0;
+    // 网络视频来源 v1 不导 m3u8 清单：条目相对路径解析（resolveM3uEntryPath）
+    // 按本地磁盘语义写成，远端 URL 基底需要独立的解析与验证。跳过不算错误。
+    if (!fs.isLocal) {
+      debugPrint('SourceLibraryScanner: skipping ${plan.playlists.length} '
+          'playlist manifest(s) on a network video source (unsupported in v1)');
+      return 0;
+    }
 
     // 统一合集：拆集后无单条 playlist 行 → 用「同名 playlist 合集是否已存在」区分
     // 首次导入 vs 重扫。合集名 = m3u8 basename（**不随 manifest 内集路径编辑而变** →

--- a/fushi/lib/src/media/source_library/source_stream_headers.dart
+++ b/fushi/lib/src/media/source_library/source_stream_headers.dart
@@ -1,0 +1,38 @@
+// 网络来源库流媒体的播放期 HTTP 头解析（v1：WebDAV Basic 认证）。
+//
+// 凭据红线：密码只活在 SourceLibraryCredentialStore（Preferences），不落
+// MediaSources.configJson，也**不复制进每行 VideoBooks.streamSpecJson**——按
+// VideoBooks.sourceId 在打开时现解析：改密码一处生效，行级零副本，删来源
+// （FK setNull）后自然退化为无认证直链。
+
+import 'dart:convert';
+
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/source_library/source_library_credential_store.dart';
+import 'package:fushi/src/media/source_library/source_library_row.dart';
+
+/// 按 [sourceId] 解析打开该来源流媒体（视频流 / spec 里的字幕 URL）所需的
+/// HTTP 头。
+///
+/// 无来源（手动导入 / 来源已删）、本地来源、或凭据为空 → 空 map（调用方展开
+/// 合并零分支）。目前只有 WebDAV 来源产出 `Authorization: Basic`：用户名来自
+/// configJson（白名单键）、密码来自凭据存储。
+Future<Map<String, String>> resolveSourceStreamHeaders({
+  required FushiDatabase db,
+  required int? sourceId,
+}) async {
+  if (sourceId == null) return const <String, String>{};
+  final SourceLibraryRow? source = await db.getMediaSourceById(sourceId);
+  if (source == null || source.transport != 'webdav') {
+    return const <String, String>{};
+  }
+  final Map<String, Object?> cfg = decodeSourceConfig(source.configJson);
+  final String username = (cfg['username'] as String?) ?? '';
+  final SourceLibrarySecret secret =
+      await SourceLibraryCredentialStore(db).readSecret(source.id);
+  final String password = secret.password ?? '';
+  if (username.isEmpty && password.isEmpty) return const <String, String>{};
+  final String token = base64Encode(utf8.encode('$username:$password'));
+  return <String, String>{'Authorization': 'Basic $token'};
+}

--- a/fushi/lib/src/media/video/external_video.dart
+++ b/fushi/lib/src/media/video/external_video.dart
@@ -27,6 +27,26 @@ bool isSupportedVideoFile(String path) {
   return _supportedVideoExtensions.contains(ext);
 }
 
+/// 纯函数：取来源命名空间路径的 basename（`/` 与 `\` 都当分隔符）；http(s)
+/// URL（WebDAV href / 直链）的段是百分号编码的，先解码再返回。
+///
+/// 文件名解析（系列归组）、标题展示、身份派生（bookUid）都吃这一个口径——
+/// 派生点唯一，编码字节才不会渗进系列名/集标题/uid（网络来源 URL 路径与
+/// 本地路径在这些消费点上是同一种正常情况，不是特例分支）。解码失败（非法
+/// 百分号序列）原样返回，不抛。
+String decodedSourceBasename(String path) {
+  final int sep = path.lastIndexOf(RegExp(r'[\\/]'));
+  final String raw = sep >= 0 ? path.substring(sep + 1) : path;
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    try {
+      return Uri.decodeComponent(raw);
+    } catch (_) {
+      return raw;
+    }
+  }
+  return raw;
+}
+
 /// 纯函数：归一化视频路径用于「同一物理文件」比对/派生唯一标识。
 ///
 /// 统一分隔符（反斜杠转 `/`）、去掉冗余 `.`、`..` 段，保证 `D:/a/b.mkv` 与

--- a/fushi/lib/src/media/video/m3u8_playlist.dart
+++ b/fushi/lib/src/media/video/m3u8_playlist.dart
@@ -3,6 +3,9 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/video/external_video.dart'
+    show decodedSourceBasename;
+
 /// **纯函数**：从 `VideoBooks.playlistJson` 解析出集数；空 / 非播放列表 / 解析失败
 /// 返回 0。供视频库卡片角标与「单视频 vs 播放列表」区分用——返回 ≥2 即播放列表。
 int playlistEpisodeCount(String? playlistJson) {
@@ -144,14 +147,48 @@ String resolveM3uEntryPath(
   final p.Context ctx = context ?? p.context;
   final String entry = entryRaw.trim();
   if (entry.isEmpty) return entry;
+  // 绝对 http(s) URL 条目（HLS/直链清单）：原样直通。此前会落进下面的
+  // 「相对」分支被 join 到 playlistDir 上，纯属误判。
+  if (_isHttpUrl(entry)) return entry;
   if (_isAbsoluteM3uEntryPath(entry)) {
     // Absolute: normalize only; never join playlistDir (would break drive/UNC).
     return ctx.normalize(entry);
+  }
+  // 网络（WebDAV）清单：基底是 URL，相对条目按 URL 语义解析——正斜杠 join、
+  // 段按需百分号编码（清单里通常写明文文件名；已编码段不二次编码）、`..`
+  // 钳制在 `scheme://host` 之下。不能走 p.Context：它会把 `https://` 的
+  // 双斜杠折叠掉。
+  if (_isHttpUrl(playlistDir)) {
+    final List<String> base = playlistDir.split('/');
+    while (base.isNotEmpty && base.last.isEmpty) {
+      base.removeLast();
+    }
+    for (final String seg in entry.replaceAll('\\', '/').split('/')) {
+      if (seg.isEmpty || seg == '.') continue;
+      if (seg == '..') {
+        // base 形如 ['https:', '', 'host', ...]：前三段是 scheme://host，不可越。
+        if (base.length > 3) base.removeLast();
+        continue;
+      }
+      base.add(_encodeUrlSegmentIfNeeded(seg));
+    }
+    return base.join('/');
   }
   // Relative: normalize both separators to `/`, resolve against the m3u8 dir.
   final String rel = entry.replaceAll('\\', '/');
   return ctx.normalize(ctx.join(playlistDir, rel));
 }
+
+/// 纯字符串判 http(s) URL（不经 Uri.parse，空串/畸形不抛）。
+bool _isHttpUrl(String s) =>
+    s.startsWith('http://') || s.startsWith('https://');
+
+final RegExp _pctEncodedSeq = RegExp(r'%[0-9A-Fa-f]{2}');
+
+/// URL 路径段按需编码：已含合法 %XX 序列的段视为「作者已编码」原样保留
+/// （二次编码会把 %20 变成 %2520）；其余按组件编码（空格/中文/括号全覆盖）。
+String _encodeUrlSegmentIfNeeded(String seg) =>
+    _pctEncodedSeq.hasMatch(seg) ? seg : Uri.encodeComponent(seg);
 
 /// Pure string test for whether m3u8 entry [entry] is an ABSOLUTE path (no IO,
 /// host-independent). True for: UNC prefix (`\`/`//`), Windows drive root
@@ -213,9 +250,10 @@ List<PlaylistEntry> parseM3u8({
 
     // 非注释非空行 = 视频相对/绝对路径。
     final String absPath = resolveM3uEntryPath(line, baseDir);
+    // 标题回退用解码 basename：URL 条目的 %20 之类不渗进集标题。
     final String title = (pendingTitle != null && pendingTitle.isNotEmpty)
         ? pendingTitle
-        : p.basename(absPath);
+        : decodedSourceBasename(absPath);
     entries.add(PlaylistEntry(title: title, path: absPath));
     pendingTitle = null;
   }

--- a/fushi/lib/src/media/video/stream_video_launch.dart
+++ b/fushi/lib/src/media/video/stream_video_launch.dart
@@ -71,6 +71,11 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
   // 用户显式 YouTube 画质目标（设置「YouTube 画质」；null=自动=默认策略）。透传给
   // 默认解析器，并作为缓存条目匹配键——改设置后旧档位缓存视为 miss 重解析。
   int? youtubeTargetHeight,
+  // 来源库网络视频（WebDAV）打开时按 sourceId 现解析的认证头（见
+  // source_stream_headers.dart 的凭据红线：不落行级 spec）。与 spec 里的防盗链
+  // header 合并后同时用于视频流与 spec.subtitleUrl 字幕下载；仅直链分支消费
+  // （YouTube 书不出自来源库）。
+  Map<String, String> sourceHttpHeaders = const <String, String>{},
 }) async {
   final String url = book.videoPath;
   final StreamVideoSpec spec =
@@ -174,7 +179,10 @@ Future<({UrlStreamVideoClient client, RemoteVideoInfo info})>
       subtitleFileName: spec.subtitleFileName,
       // 直链/HLS 是单条 muxed 流（自带音轨）→ 制卡音频从它抽，无分离 audio-only 流。
       miningVideoHasAudio: true,
-      httpHeaderFields: spec.httpHeaderFields,
+      httpHeaderFields: <String, String>{
+        ...spec.httpHeaderFields,
+        ...sourceHttpHeaders,
+      },
     );
   }
   final RemoteVideoInfo info =

--- a/fushi/lib/src/media/video/video_filename_parser.dart
+++ b/fushi/lib/src/media/video/video_filename_parser.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/media_extensions.dart';
+import 'package:fushi/src/media/video/external_video.dart'
+    show decodedSourceBasename;
 import 'package:fushi/src/media/video/scraper/filename_parser.dart';
 import 'package:fushi/src/media/video/scraper/scraper_types.dart';
 
@@ -165,12 +167,16 @@ List<VideoGroup> groupVideosIntoPlaylists(List<String> paths) {
   final Map<String, String> displaySeries = <String, String>{};
 
   for (final String path in paths) {
-    final VideoNameInfo info = parseVideoFilename(p.basename(path));
+    // 解码后的文件名参与解析/展示（decodedSourceBasename）：网络来源的
+    // http(s) URL 段是百分号编码的，不解码会把 %20 之类渗进系列名与集标题；
+    // 本地路径原样返回，行为不变。
+    final String name = decodedSourceBasename(path);
+    final VideoNameInfo info = parseVideoFilename(name);
     final String key = info.series.toLowerCase();
     displaySeries.putIfAbsent(key, () => info.series);
     byKey.putIfAbsent(key, () => <VideoEpisode>[]).add(VideoEpisode(
           path: path,
-          title: p.basenameWithoutExtension(path),
+          title: p.basenameWithoutExtension(name),
           season: info.season,
           episode: info.episode,
         ));

--- a/fushi/lib/src/media/video/video_import_dialog.dart
+++ b/fushi/lib/src/media/video/video_import_dialog.dart
@@ -12,6 +12,8 @@ import 'package:fushi/src/media/import/import_flow_mixin.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/media/import/sidecar_finder.dart';
+import 'package:fushi/src/media/video/external_video.dart'
+    show decodedSourceBasename;
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
 import 'package:fushi/src/media/video/url_stream_video.dart';
 import 'package:fushi/src/media/video/youtube_source_resolver.dart';
@@ -43,15 +45,16 @@ String playlistBookUid(String m3u8Path) {
   return 'video/playlist/${sanitizeTtuFilename(base)}';
 }
 
-/// 取路径最后一段并去扩展名，**同时把 `/` 和 `\` 都当分隔符**（与宿主平台无关）。
+/// 取路径最后一段并去扩展名，**同时把 `/` 和 `\` 都当分隔符**（与宿主平台无关），
+/// http(s) URL 段先百分号解码（[decodedSourceBasename] 单一派生点）。
 ///
 /// 纯函数。`p.basenameWithoutExtension` 只认宿主平台的分隔符——在 Linux/macOS 上
 /// 不会把 Windows 路径的 `\` 当分隔符，于是 `D:\a\x.mkv` 整串被当文件名，破坏
 /// 「同一文件名跨不同绝对路径/不同机器得相同 bookUid」的身份不变量。这里两种分隔符
-/// 都认，保证 `D:\a\E01.mkv` 与 `/home/u/E01.mkv` 在任何平台都派生出 `E01`。
+/// 都认，保证 `D:\a\E01.mkv` 与 `/home/u/E01.mkv` 在任何平台都派生出 `E01`；
+/// 网络来源的 `https://.../E01.mkv`（含 %20 编码）同理派生出解码后的 `E01`。
 String _crossPlatformBasenameWithoutExtension(String path) {
-  final int sep = path.lastIndexOf(RegExp(r'[\\/]'));
-  final String name = sep >= 0 ? path.substring(sep + 1) : path;
+  final String name = decodedSourceBasename(path);
   final int dot = name.lastIndexOf('.');
   return dot > 0 ? name.substring(0, dot) : name;
 }

--- a/fushi/lib/src/pages/implementations/media_sources_view.dart
+++ b/fushi/lib/src/pages/implementations/media_sources_view.dart
@@ -1,6 +1,6 @@
 // TODO-817 M1c / TODO-1274 来源库管理视图：列出某媒体种类（'video' | 'book' |
-// 'manga'）的来源库，支持添加本地文件夹、添加网络来源（SFTP/FTP/WebDAV，仅 'book'）、
-// 重新扫描、打开文件夹（仅 Windows 本地）、移除来源、拖拽重排。
+// 'manga'）的来源库，支持添加本地文件夹、添加网络来源、重新扫描、打开文件夹
+// （仅 Windows 本地）、移除来源、拖拽重排。
 //
 // 本文件是**内容体**，两处消费：
 // - [MediaSourcesDialog]（`media_sources_dialog.dart`）——旧的对话框入口，逐像素不变；
@@ -12,10 +12,13 @@
 // MediaSources.configJson；密码/私钥经 SourceLibraryCredentialStore 以 base64 单独落
 // Preferences（键 `media_source_secret_<id>`），绝不进入 configJson。
 //
-// 网络来源只对 'book' 开放：EPUB 小体积、扫描时下载后导入；远端 SFTP/FTP/WebDAV 视频
-// 路径不可被播放器直接播放，故 'video' 只保留本地来源。漫画同理只支持本地（卷体积大且
-// 导入要解包，远端流式扫描无意义）。WebDAV 的 rootPath 即完整集合 URL（scheme/host/
-// 端口/路径都在里面），无需单独存 host/port（见 NetworkSourceFileSystem）。
+// 网络来源三域全开放，transport 集按域收窄（[_networkTransports]）：
+// - 'book'：SFTP/FTP/WebDAV（EPUB 小体积、扫描时下载后导入）；
+// - 'manga'：SFTP/FTP/WebDAV（整卷下载后导入，重扫有标题预检不重下载）；
+// - 'video'：仅 WebDAV（条目 URL 按流媒体书原地入库播放；SFTP/FTP 无 HTTP
+//   直链、播放器吃不了，扫描器也会拒绝）。
+// WebDAV 的 rootPath 即完整集合 URL（scheme/host/端口/路径都在里面），无需单独存
+// host/port（见 NetworkSourceFileSystem）。
 
 import 'dart:async' show unawaited;
 import 'dart:io' show Directory, File, Platform, Process;
@@ -132,8 +135,11 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   /// 不再出现任何 `ref.*`，BUG-513 的不变量（ref 只在 initState）继续成立。
   late final AppModel _appModel;
 
-  /// 网络来源仅对 'book' 开放（见文件头说明）。
-  bool get _networkSupported => widget.mediaKind == 'book';
+  /// 本域可选的网络传输：书/漫画三 transport 全通（远端文件下载后导入）；
+  /// 视频仅 WebDAV（条目 URL 原地流播，SFTP/FTP 无 HTTP 直链，扫描器会拒）。
+  List<String> get _networkTransports => widget.mediaKind == 'video'
+      ? const <String>['webdav']
+      : const <String>['sftp', 'ftp', 'webdav'];
 
   /// 页面页头与所有行级 mutation 共用的忙状态。
   bool get isBusy =>
@@ -644,17 +650,11 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
             1;
   }
 
-  /// 添加来源：让用户选本地文件夹或网络来源（后者仅 'book' 开放）。
+  /// 添加来源：让用户选本地文件夹或网络来源（三域全开放；视频网络仅 WebDAV）。
   ///
   /// 公开给外层的唯一动作入口（对话框页脚 / 页面页头按钮都调它）。
   Future<void> addSource() async {
     if (isBusy) return;
-    // 视频来源只有本地文件夹这一种合法入口，直接选择并立即登记/扫描，避免再弹一层
-    // 只有一个选项的对话框。书籍仍保留本地/网络选择，漫画 UX 保持不变。
-    if (widget.mediaKind == 'video') {
-      await addLocalFolder();
-      return;
-    }
     final _AddSourceChoice? choice = await showAppDialog<_AddSourceChoice>(
       context: context,
       builder: (BuildContext ctx) => SimpleDialog(
@@ -672,30 +672,32 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
               ],
             ),
           ),
-          if (_networkSupported)
-            SimpleDialogOption(
-              onPressed: () => Navigator.pop(ctx, _AddSourceChoice.network),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  const Icon(Icons.cloud_outlined),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        Text(t.media_source_add_network),
-                        Text(
-                          t.media_source_network_subtitle,
-                          style: Theme.of(ctx).textTheme.bodySmall,
-                        ),
-                      ],
-                    ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx, _AddSourceChoice.network),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const Icon(Icons.cloud_outlined),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(t.media_source_add_network),
+                      Text(
+                        // 视频域只开 WebDAV（原地流播），副标题别承诺 SFTP/FTP。
+                        widget.mediaKind == 'video'
+                            ? t.media_source_network_subtitle_video
+                            : t.media_source_network_subtitle,
+                        style: Theme.of(ctx).textTheme.bodySmall,
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
+          ),
         ],
       ),
     );
@@ -885,12 +887,15 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     }
   }
 
-  /// 添加网络来源：弹连接表单（SFTP/FTP）→ 落库连接参数 + 单独存凭据 → 立即扫描。
+  /// 添加网络来源：弹连接表单（transport 集按域收窄，见 [_networkTransports]）
+  /// → 落库连接参数 + 单独存凭据 → 立即扫描。
   Future<void> _addNetworkSource() async {
+    final List<String> transports = _networkTransports;
     final _NetworkSourceResult? result =
         await showAppDialog<_NetworkSourceResult>(
       context: context,
-      builder: (BuildContext ctx) => const _NetworkSourceFormDialog(),
+      builder: (BuildContext ctx) =>
+          _NetworkSourceFormDialog(transports: transports),
     );
     if (!mounted || result == null) return;
 
@@ -1419,10 +1424,16 @@ class _NetworkSourceResult {
   final bool useTls;
 }
 
-/// 网络来源连接表单：SFTP/FTP 二选一，填 host/port/user/password（SFTP 可用私钥、
-/// FTP 可开 TLS）+ 远端根路径 + 可选显示名，附「测试连接」（复用 sync 后端）。
+/// 网络来源连接表单：在 [transports] 里选 transport，填 host/port/user/password
+/// （SFTP 可用私钥、FTP 可开 TLS；WebDAV 用整 URL）+ 远端根路径 + 可选显示名，
+/// 附「测试连接」（复用 sync 后端）。
 class _NetworkSourceFormDialog extends StatefulWidget {
-  const _NetworkSourceFormDialog();
+  const _NetworkSourceFormDialog({
+    this.transports = const <String>['sftp', 'ftp', 'webdav'],
+  });
+
+  /// 本域可选的传输集（视频域收窄到仅 WebDAV）。首项是初始选中。
+  final List<String> transports;
 
   @override
   State<_NetworkSourceFormDialog> createState() =>
@@ -1430,7 +1441,7 @@ class _NetworkSourceFormDialog extends StatefulWidget {
 }
 
 class _NetworkSourceFormDialogState extends State<_NetworkSourceFormDialog> {
-  String _transport = 'sftp';
+  late String _transport = widget.transports.first;
   final TextEditingController _hostController = TextEditingController();
   final TextEditingController _portController =
       TextEditingController(text: '22');
@@ -1615,10 +1626,16 @@ class _NetworkSourceFormDialogState extends State<_NetworkSourceFormDialog> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               SegmentedButton<String>(
-                segments: const <ButtonSegment<String>>[
-                  ButtonSegment<String>(value: 'sftp', label: Text('SFTP')),
-                  ButtonSegment<String>(value: 'ftp', label: Text('FTP')),
-                  ButtonSegment<String>(value: 'webdav', label: Text('WebDAV')),
+                segments: <ButtonSegment<String>>[
+                  for (final String tp in widget.transports)
+                    ButtonSegment<String>(
+                      value: tp,
+                      label: Text(switch (tp) {
+                        'sftp' => 'SFTP',
+                        'ftp' => 'FTP',
+                        _ => 'WebDAV',
+                      }),
+                    ),
                 ],
                 selected: <String>{_transport},
                 onSelectionChanged: (Set<String> s) =>

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -36,6 +36,7 @@ import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:fushi/src/media/media_cover_source.dart';
 import 'package:fushi/src/media/video/dandanplay_client.dart';
 import 'package:fushi/src/media/video/danmaku_manual_match_panel.dart';
+import 'package:fushi/src/media/source_library/source_stream_headers.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
 import 'package:fushi/src/media/video/subtitle_embedded_fonts.dart';
 import 'package:fushi/src/media/video/video_episode_start_policy.dart';
@@ -2041,9 +2042,17 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       // 解析 getManifest 有网络往返、慢网仍可数秒）之前，避免解析期页面裸转圈「点了没动静」。
       _setLoadingPhase(_VideoLoadPhase.connecting);
       try {
+        // 来源库网络视频（WebDAV）：认证头按 sourceId 现解析（凭据不落行级
+        // spec——改来源密码一处生效）；非来源书解析为空 map，零分支。
+        final Map<String, String> sourceHeaders =
+            await resolveSourceStreamHeaders(
+          db: appModel.database,
+          sourceId: row.sourceId,
+        );
         final ({UrlStreamVideoClient client, RemoteVideoInfo info}) launch =
             await buildStreamVideoLaunch(row,
-                youtubeTargetHeight: appModel.youtubeQualityTargetHeightOrNull);
+                youtubeTargetHeight: appModel.youtubeQualityTargetHeightOrNull,
+                sourceHttpHeaders: sourceHeaders);
         if (!mounted) return;
         _resolvedStreamInfo = launch.info;
         _resolvedStreamClient = launch.client;

--- a/fushi/test/media/source_library/source_library_scanner_network_test.dart
+++ b/fushi/test/media/source_library/source_library_scanner_network_test.dart
@@ -357,23 +357,27 @@ void main() {
   group('network VIDEO source over WebDAV imports stream-in-place (fake fs)',
       () {
     testWidgets(
-        'entry URL becomes a stream book: videoPath=URL, decoded title, '
-        'sidecar subtitle in streamSpecJson, no cover, no collections',
-        (WidgetTester tester) async {
+        'entry URLs become stream books with decoded titles; same-series '
+        'episodes group into a collection; m3u8 manifest imports as a '
+        'playlist of remote-URL episodes', (WidgetTester tester) async {
       final FushiDatabase db = _memDb();
       addTearDown(db.close);
 
       final Directory tmp =
           Directory.systemTemp.createTempSync('net_webdav_video_');
       addTearDown(() => tmp.deleteSync(recursive: true));
-      // 占位本地字节：流播导入不该碰它们（copyToLocal 必须为 0）。
+      // 占位本地字节：流播导入只该下载清单文本，不碰视频/字幕字节。
       final String dummy = p.join(tmp.path, 'dummy.bin');
       File(dummy).writeAsBytesSync(<int>[0]);
+      final String manifest = p.join(tmp.path, 'best.m3u8');
+      File(manifest).writeAsStringSync('#EXTM3U\nclip 1.mkv\nclip 2.mkv\n');
 
       const String root = 'https://dav.example.com/media';
       final _FakeVirtualNetworkFs fs = _FakeVirtualNetworkFs(<String, String>{
-        '$root/Show%20A/ep%201.mkv': dummy,
-        '$root/Show%20A/ep%201.srt': dummy,
+        '$root/Show%20A/Show%20A%20S01E01.mkv': dummy,
+        '$root/Show%20A/Show%20A%20S01E01.srt': dummy,
+        '$root/Show%20A/Show%20A%20S01E02.mkv': dummy,
+        '$root/Lists/Best%20Of.m3u8': manifest,
       });
 
       final int sid = await db.insertMediaSource(MediaSourcesCompanion.insert(
@@ -390,28 +394,41 @@ void main() {
       });
 
       final List<VideoBookRow> videos = await VideoBookRepository(db).listAll();
-      expect(videos, hasLength(1));
-      final VideoBookRow video = videos.single;
-      expect(video.videoPath, '$root/Show%20A/ep%201.mkv',
-          reason: 'stream-in-place keeps the remote URL as videoPath');
-      expect(video.title, 'ep 1',
+      // 2 部直扫单集 + 清单拆出的 2 集。
+      expect(videos, hasLength(4));
+      final VideoBookRow e01 = videos.singleWhere((VideoBookRow v) =>
+          v.videoPath == '$root/Show%20A/Show%20A%20S01E01.mkv');
+      expect(e01.title, 'Show A S01E01',
           reason: 'title must be percent-decoded, not the raw href basename');
-      expect(video.coverPath, isNull,
+      expect(e01.coverPath, isNull,
           reason: 'no cover extraction for remote streams');
-      expect(video.sourceId, sid);
+      expect(e01.sourceId, sid);
       final StreamVideoSpec spec =
-          StreamVideoSpec.fromStorageJson(video.streamSpecJson);
-      expect(spec.subtitleUrl, '$root/Show%20A/ep%201.srt',
+          StreamVideoSpec.fromStorageJson(e01.streamSpecJson);
+      expect(spec.subtitleUrl, '$root/Show%20A/Show%20A%20S01E01.srt',
           reason: 'sidecar subtitle rides in streamSpecJson (played via the '
               'stream channel, not local cue parsing)');
-      expect(spec.subtitleFileName, 'ep 1.srt');
-      expect(fs.copyToLocalCalls, 0,
-          reason: 'stream-in-place must not download the video or subtitle');
-      expect(await db.getAllMediaCollections(), isEmpty,
-          reason: 'v1 does not group network videos into collections');
+      expect(spec.subtitleFileName, 'Show A S01E01.srt');
+      expect(fs.copyToLocalCalls, 1,
+          reason: 'only the m3u8 manifest text is downloaded; video and '
+              'subtitle bytes stream in place');
+
+      // 清单集：相对明文条目解析成编码后的远端 URL（可直接喂播放器）。
+      final VideoBookRow clip1 = videos.singleWhere(
+          (VideoBookRow v) => v.videoPath == '$root/Lists/clip%201.mkv');
+      expect(clip1.sourceId, sid);
+
+      // 归组：同系列两集折叠成 'Show A' 合集（解码名）；清单成 'Best Of' 合集。
+      final List<MediaCollectionRow> collections =
+          await db.getAllMediaCollections();
+      expect(
+        collections.map((MediaCollectionRow c) => c.name).toSet(),
+        <String>{'Show A', 'Best Of'},
+        reason: '合集名必须是解码后的（不能带 %20）',
+      );
 
       final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
-      expect(after.mediaCount, 1);
+      expect(after.mediaCount, 3, reason: '2 部直扫视频 + 1 个清单合集');
       expect(after.lastScanError, isNull);
     });
   });

--- a/fushi/test/media/source_library/source_library_scanner_network_test.dart
+++ b/fushi/test/media/source_library/source_library_scanner_network_test.dart
@@ -1,9 +1,14 @@
-// TODO-1274 网络来源扫描测试（无需真实 SFTP/FTP 服务器）：
+// TODO-1274 网络来源扫描测试（无需真实 SFTP/FTP/WebDAV 服务器）：
 //  (1) buildNetworkFileSystem 路由：local → LocalSourceFileSystem；
 //      sftp/ftp → NetworkSourceFileSystem，连接参数/凭据注入正确。
-//  (2) 网络「视频」来源被拒：scan 记 lastScanError、不插入任何视频（远端路径不可播）。
+//  (2) 网络「视频」来源仅 WebDAV：SFTP/FTP 记 lastScanError、不插入任何视频
+//      （远端路径无 HTTP 直链不可播）；WebDAV 按流媒体书**原地**入库——
+//      videoPath=URL、sidecar 字幕 URL 进 streamSpecJson、标题百分号解码、
+//      不抽封面、不建合集。
 //  (3) 网络「书」来源：注入 fake fs，扫描时先 copyToLocal 下载远端 EPUB 再导入，
 //      epub_books.sourceId 回填、mediaCount=1、无错误。
+//  (4) 网络「漫画」来源：整卷镜像下载后经 MangaImporter 导入（sourceId 回填）；
+//      重扫命中标题预检，零页图重下载。
 
 import 'dart:convert';
 import 'dart:io';
@@ -17,6 +22,8 @@ import 'package:fushi/src/epub/epub_storage.dart';
 import 'package:fushi/src/media/source_library/source_file_system.dart';
 import 'package:fushi/src/media/source_library/source_library_row.dart';
 import 'package:fushi/src/media/source_library/source_library_scanner.dart';
+import 'package:fushi/src/media/video/url_stream_video.dart'
+    show StreamVideoSpec;
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
@@ -107,6 +114,68 @@ class _FakeNetworkBookFs implements SourceFileSystem {
   }
 }
 
+/// 虚拟网络 fs：把「远端命名空间路径」（`/remote/...` 或百分号编码的
+/// `https://...` href）映射到本地真文件。列目录 / 读文本 / 下载全部离线可测。
+class _FakeVirtualNetworkFs implements SourceFileSystem {
+  _FakeVirtualNetworkFs(this.files);
+
+  /// virtualPath → 本地真文件路径。
+  final Map<String, String> files;
+
+  int copyToLocalCalls = 0;
+
+  @override
+  bool get isLocal => false;
+
+  static String _decodedName(String vpath) {
+    final String raw = vpath.substring(vpath.lastIndexOf('/') + 1);
+    if (vpath.startsWith('http://') || vpath.startsWith('https://')) {
+      return Uri.decodeComponent(raw);
+    }
+    return raw;
+  }
+
+  @override
+  Future<List<SourceFileEntry>> listFiles(
+    String dirPath, {
+    bool recursive = false,
+  }) async {
+    final String prefix = dirPath.endsWith('/') ? dirPath : '$dirPath/';
+    final List<SourceFileEntry> out = <SourceFileEntry>[];
+    for (final String vpath in files.keys) {
+      if (!vpath.startsWith(prefix)) continue;
+      final String rest = vpath.substring(prefix.length);
+      // 递归模式只回文件（对齐真实实现）；非递归只列一层。
+      if (!recursive && rest.contains('/')) continue;
+      out.add(SourceFileEntry(
+        name: _decodedName(vpath),
+        path: vpath,
+        isDirectory: false,
+      ));
+    }
+    return out;
+  }
+
+  @override
+  Future<List<String>> listSiblingNames(String filePath) async {
+    final String dir = filePath.substring(0, filePath.lastIndexOf('/'));
+    final List<SourceFileEntry> entries = await listFiles(dir);
+    return entries.map((SourceFileEntry e) => e.name).toList();
+  }
+
+  @override
+  Future<String> readText(String filePath) async =>
+      File(files[filePath]!).readAsString();
+
+  @override
+  Future<String> copyToLocal(String filePath, String destDir) async {
+    copyToLocalCalls++;
+    final String local = p.join(destDir, _decodedName(filePath));
+    File(local).writeAsBytesSync(File(files[filePath]!).readAsBytesSync());
+    return local;
+  }
+}
+
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -188,8 +257,8 @@ void main() {
   });
 
   test(
-      'network VIDEO source is rejected: scan records error, no video inserted',
-      () async {
+      'network VIDEO source over SFTP is rejected (WebDAV only): '
+      'scan records error, no video inserted', () async {
     final FushiDatabase db = _memDb();
     addTearDown(db.close);
 
@@ -281,6 +350,169 @@ void main() {
 
       final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
       expect(after.mediaCount, 1);
+      expect(after.lastScanError, isNull);
+    });
+  });
+
+  group('network VIDEO source over WebDAV imports stream-in-place (fake fs)',
+      () {
+    testWidgets(
+        'entry URL becomes a stream book: videoPath=URL, decoded title, '
+        'sidecar subtitle in streamSpecJson, no cover, no collections',
+        (WidgetTester tester) async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('net_webdav_video_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+      // 占位本地字节：流播导入不该碰它们（copyToLocal 必须为 0）。
+      final String dummy = p.join(tmp.path, 'dummy.bin');
+      File(dummy).writeAsBytesSync(<int>[0]);
+
+      const String root = 'https://dav.example.com/media';
+      final _FakeVirtualNetworkFs fs = _FakeVirtualNetworkFs(<String, String>{
+        '$root/Show%20A/ep%201.mkv': dummy,
+        '$root/Show%20A/ep%201.srt': dummy,
+      });
+
+      final int sid = await db.insertMediaSource(MediaSourcesCompanion.insert(
+        label: 'Remote WebDAV Vids',
+        mediaKind: 'video',
+        rootPath: root,
+        transport: const Value('webdav'),
+        createdAt: 1000,
+      ));
+      final SourceLibraryRow source = (await db.getMediaSourceById(sid))!;
+
+      await tester.runAsync(() async {
+        await SourceLibraryScanner(db).scan(source, fs: fs);
+      });
+
+      final List<VideoBookRow> videos = await VideoBookRepository(db).listAll();
+      expect(videos, hasLength(1));
+      final VideoBookRow video = videos.single;
+      expect(video.videoPath, '$root/Show%20A/ep%201.mkv',
+          reason: 'stream-in-place keeps the remote URL as videoPath');
+      expect(video.title, 'ep 1',
+          reason: 'title must be percent-decoded, not the raw href basename');
+      expect(video.coverPath, isNull,
+          reason: 'no cover extraction for remote streams');
+      expect(video.sourceId, sid);
+      final StreamVideoSpec spec =
+          StreamVideoSpec.fromStorageJson(video.streamSpecJson);
+      expect(spec.subtitleUrl, '$root/Show%20A/ep%201.srt',
+          reason: 'sidecar subtitle rides in streamSpecJson (played via the '
+              'stream channel, not local cue parsing)');
+      expect(spec.subtitleFileName, 'ep 1.srt');
+      expect(fs.copyToLocalCalls, 0,
+          reason: 'stream-in-place must not download the video or subtitle');
+      expect(await db.getAllMediaCollections(), isEmpty,
+          reason: 'v1 does not group network videos into collections');
+
+      final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
+      expect(after.mediaCount, 1);
+      expect(after.lastScanError, isNull);
+    });
+  });
+
+  group('network MANGA source mirrors the volume then imports (fake fs)', () {
+    late Directory tmp;
+    late Directory pp;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('net_manga_fixture_');
+      pp = Directory.systemTemp.createTempSync('net_manga_pp_');
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (MethodCall call) async => pp.path,
+      );
+      EpubStorage.debugBaseDirectoryOverride = pp.path;
+    });
+    tearDown(() {
+      EpubStorage.debugBaseDirectoryOverride = null;
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        null,
+      );
+      for (final Directory d in <Directory>[tmp, pp]) {
+        try {
+          if (d.existsSync()) d.deleteSync(recursive: true);
+        } catch (_) {}
+      }
+    });
+
+    testWidgets(
+        'volume downloads page-by-page and imports with sourceId; '
+        're-scan hits the title pre-check with zero page downloads',
+        (WidgetTester tester) async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+
+      // 本地 fixture 站位远端卷：Vol1.mokuro + Vol1/ 两张页图。
+      final String pageA = p.join(tmp.path, 'p001.jpg');
+      final String pageB = p.join(tmp.path, 'p002.jpg');
+      File(pageA).writeAsBytesSync(<int>[1, 2, 3]);
+      File(pageB).writeAsBytesSync(<int>[4, 5, 6]);
+      final String mokuroLocal = p.join(tmp.path, 'Vol1.mokuro');
+      File(mokuroLocal).writeAsStringSync(jsonEncode(<String, Object?>{
+        'version': '0.2.0',
+        'title': 'RemoteManga',
+        'pages': <Object?>[
+          <String, Object?>{
+            'img_width': 800,
+            'img_height': 1200,
+            'img_path': 'Vol1/p001.jpg',
+            'blocks': <Object?>[],
+          },
+          <String, Object?>{
+            'img_width': 800,
+            'img_height': 1200,
+            'img_path': 'Vol1/p002.jpg',
+            'blocks': <Object?>[],
+          },
+        ],
+      }));
+
+      final _FakeVirtualNetworkFs fs = _FakeVirtualNetworkFs(<String, String>{
+        '/remote/manga/Vol1.mokuro': mokuroLocal,
+        '/remote/manga/Vol1/p001.jpg': pageA,
+        '/remote/manga/Vol1/p002.jpg': pageB,
+      });
+
+      final int sid = await db.insertMediaSource(MediaSourcesCompanion.insert(
+        label: 'Remote Manga',
+        mediaKind: 'manga',
+        rootPath: '/remote/manga',
+        transport: const Value('sftp'),
+        createdAt: 1000,
+      ));
+      final SourceLibraryRow source = (await db.getMediaSourceById(sid))!;
+
+      await tester.runAsync(() async {
+        await SourceLibraryScanner(db).scan(source, fs: fs);
+      });
+
+      final List<EpubBookRow> books = await db.getAllEpubBooks();
+      expect(books, hasLength(1));
+      expect(books.single.title, 'RemoteManga');
+      expect(books.single.format, 'manga');
+      expect(books.single.sourceId, sid);
+      expect(fs.copyToLocalCalls, 2,
+          reason: 'both pages are mirrored before import');
+
+      SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
+      expect(after.mediaCount, 1);
+      expect(after.lastScanError, isNull);
+
+      // 重扫：标题预检命中已入库卷，零页图重下载、不重复导入、不算错误。
+      await tester.runAsync(() async {
+        await SourceLibraryScanner(db).scan(after, fs: fs);
+      });
+      expect(await db.getAllEpubBooks(), hasLength(1));
+      expect(fs.copyToLocalCalls, 2,
+          reason: 're-scan must not re-download any page (title pre-check)');
+      after = (await db.getMediaSourceById(sid))!;
       expect(after.lastScanError, isNull);
     });
   });

--- a/fushi/test/media/source_library/source_library_scanner_test.dart
+++ b/fushi/test/media/source_library/source_library_scanner_test.dart
@@ -1399,7 +1399,9 @@ sub_b/ep2.mp4
       expect(after.lastScanError, isNull);
     });
 
-    test('non-local transport is rejected (first-version limit)', () async {
+    test('non-local transport with empty remote listing scans clean', () async {
+      // 网络 manga 源已放开（整卷下载导入，见 scanner_network_test 的正向用例）；
+      // 这里只钉「空远端目录 → 0 媒体、无错误」的边界。
       final FushiDatabase db = _memDb();
       addTearDown(db.close);
 
@@ -1415,8 +1417,7 @@ sub_b/ep2.mp4
 
       expect(await db.getAllEpubBooks(), isEmpty);
       final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
-      expect(after.lastScanError, contains('Network manga sources'),
-          reason: '网络 manga 源按视频先例整体拒绝并记进 lastScanError');
+      expect(after.lastScanError, isNull);
       expect(after.mediaCount, 0);
     });
   });
@@ -1481,8 +1482,7 @@ class _FakeSjisCharsetDetector extends CharsetDetectorPlatform
   }
 }
 
-/// 非 local 传输的假文件系统：只用于断言 scan 入口的 transport 门（manga 首版
-/// 拒网络源）。门在 listFiles 之前触发，故各方法不应被走到——走到即测试失败。
+/// 非 local 传输的空假文件系统：远端目录列出来是空的，读/下载不应被走到。
 class _FakeRemoteFs implements SourceFileSystem {
   @override
   bool get isLocal => false;
@@ -1491,9 +1491,8 @@ class _FakeRemoteFs implements SourceFileSystem {
   Future<List<SourceFileEntry>> listFiles(
     String dirPath, {
     bool recursive = false,
-  }) async {
-    throw StateError('transport gate must reject before listing');
-  }
+  }) async =>
+      const <SourceFileEntry>[];
 
   @override
   Future<List<String>> listSiblingNames(String filePath) async =>

--- a/fushi/test/media/source_library/source_stream_headers_test.dart
+++ b/fushi/test/media/source_library/source_stream_headers_test.dart
@@ -1,0 +1,73 @@
+// resolveSourceStreamHeaders：来源库网络视频打开时的认证头解析。
+// 凭据红线回归：Authorization 只在打开时由凭据存储现算，绝不落
+// MediaSources.configJson / VideoBooks.streamSpecJson。
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/source_library/source_library_credential_store.dart';
+import 'package:fushi/src/media/source_library/source_stream_headers.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+FushiDatabase _memDb() => FushiDatabase.forTesting(NativeDatabase.memory());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('webdav source + secret -> Basic auth header from credential store',
+      () async {
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+
+    final int sid = await db.insertMediaSource(MediaSourcesCompanion.insert(
+      label: 'Remote WebDAV Vids',
+      mediaKind: 'video',
+      rootPath: 'https://dav.example.com/media',
+      transport: const Value('webdav'),
+      configJson: Value(encodeSourceConfig(<String, Object?>{
+        'host': 'dav.example.com',
+        'port': 443,
+        'username': 'u',
+        'useTls': false,
+      })),
+      createdAt: 1000,
+    ));
+    await SourceLibraryCredentialStore(db).saveSecret(sid, password: 'pw');
+
+    final Map<String, String> headers =
+        await resolveSourceStreamHeaders(db: db, sourceId: sid);
+    expect(headers, <String, String>{
+      'Authorization': 'Basic ${base64Encode(utf8.encode('u:pw'))}',
+    });
+  });
+
+  test('null sourceId / local source / missing source -> empty headers',
+      () async {
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+
+    expect(await resolveSourceStreamHeaders(db: db, sourceId: null), isEmpty);
+
+    final int localId = await db.insertMediaSource(
+      MediaSourcesCompanion.insert(
+        label: 'Local Vids',
+        mediaKind: 'video',
+        rootPath: 'D:/videos',
+        createdAt: 1000,
+      ),
+    );
+    expect(
+      await resolveSourceStreamHeaders(db: db, sourceId: localId),
+      isEmpty,
+      reason: 'local sources need no auth headers',
+    );
+
+    expect(
+      await resolveSourceStreamHeaders(db: db, sourceId: 999999),
+      isEmpty,
+      reason: 'a deleted source (FK setNull races) degrades to no headers',
+    );
+  });
+}

--- a/fushi/test/media/video/m3u8_playlist_test.dart
+++ b/fushi/test/media/video/m3u8_playlist_test.dart
@@ -411,6 +411,50 @@ seg1.ts
       expect(resolveM3uEntryPath('   ', '/base', context: pos), '');
     });
 
+    // 网络（WebDAV）视频来源的清单：URL 基底按 URL 语义解析，不经 p.Context
+    // （它会把 https:// 的双斜杠折叠掉）。宿主平台无关——windows context 也得
+    // 给出同样的 URL。
+    group('URL 基底（网络视频来源）', () {
+      const String base = 'https://dav.example.com/media/Lists';
+
+      test('相对明文条目：正斜杠 join + 段按需百分号编码', () {
+        expect(resolveM3uEntryPath('clip 1.mkv', base, context: win),
+            'https://dav.example.com/media/Lists/clip%201.mkv');
+        expect(resolveM3uEntryPath('Show A/E01 (BD).mkv', base, context: pos),
+            'https://dav.example.com/media/Lists/Show%20A/E01%20(BD).mkv');
+      });
+
+      test('已编码段不二次编码（%20 不变 %2520）', () {
+        expect(resolveM3uEntryPath('Show%20A/ep%201.mkv', base, context: win),
+            'https://dav.example.com/media/Lists/Show%20A/ep%201.mkv');
+      });
+
+      test('`..` 上跳但钳制在 scheme://host 之下', () {
+        expect(resolveM3uEntryPath('../Show A/E01.mkv', base, context: win),
+            'https://dav.example.com/media/Show%20A/E01.mkv');
+        expect(resolveM3uEntryPath('../../../../E01.mkv', base, context: win),
+            'https://dav.example.com/E01.mkv',
+            reason: '越过 host 根的 .. 全部钳制');
+      });
+
+      test('绝对 http(s) 条目直通（不 join、不改写）——本地基底同样成立', () {
+        const String url = 'https://cdn.example.com/hls/stream.m3u8';
+        expect(resolveM3uEntryPath(url, base, context: win), url);
+        expect(resolveM3uEntryPath(url, 'D:${bs}pl', context: win), url,
+            reason: '此前 URL 条目被误判为相对路径 join 到本地目录上');
+      });
+
+      test('parseM3u8 对 URL 基底产出可播 URL + 解码标题回退', () {
+        const String manifest = '#EXTM3U\nclip 1.mkv\n';
+        final List<PlaylistEntry> entries =
+            parseM3u8(content: manifest, baseDir: base);
+        expect(entries.single.path,
+            'https://dav.example.com/media/Lists/clip%201.mkv');
+        expect(entries.single.title, 'clip 1.mkv',
+            reason: '标题回退必须是解码后的文件名，不能带 %20');
+      });
+    });
+
     test('parseM3u8 routes an absolute entry through the resolver (not joined)',
         () {
       // Forward-slash absolute entry so the manifest carries no backslash; on

--- a/fushi/test/media/video/real_path_directory_picker_test.dart
+++ b/fushi/test/media/video/real_path_directory_picker_test.dart
@@ -53,17 +53,19 @@ void main() {
       );
     });
 
-    test('video addSource directly opens local folder picker', () {
+    test('video addSource offers local/network chooser (network = WebDAV only)',
+        () {
+      // 网络来源三域开放后，视频不再短路直选文件夹：与书/漫画共用同一个
+      // 本地/网络选择对话框；本地文件夹入口仍在对话框内可达。
       final String src = File(
         'lib/src/pages/implementations/media_sources_view.dart',
       ).readAsStringSync();
       final String body = _methodBody(src, 'Future<void> addSource()');
       expect(body, isNotEmpty, reason: '来源视图必须保留公开的 addSource 入口');
-      final int direct = body.indexOf("widget.mediaKind == 'video'");
-      final int dialog = body.indexOf('showAppDialog<_AddSourceChoice>');
-      expect(direct, greaterThanOrEqualTo(0));
+      expect(body, contains('showAppDialog<_AddSourceChoice>'));
       expect(body, contains('await addLocalFolder()'));
-      expect(direct, lessThan(dialog), reason: '视频应在弹来源类型对话框之前直接进入文件夹选择');
+      expect(src, contains("const <String>['webdav']"),
+          reason: '视频网络 transport 必须收窄到仅 WebDAV');
     });
 
     test('android branch uses native SAF channel, no custom browser', () {

--- a/fushi/test/media/video/stream_video_launch_test.dart
+++ b/fushi/test/media/video/stream_video_launch_test.dart
@@ -65,6 +65,30 @@ void main() {
       expect(launch.client.httpHeaderFields, isEmpty);
       launch.client.close();
     });
+
+    // 来源库 WebDAV 视频：打开时按 sourceId 现解析的认证头与 spec 防盗链头合并
+    // 进同一个 map（同时用于视频流与字幕下载），认证头不落行级 spec（凭据红线）。
+    test('sourceHttpHeaders merge into direct-stream client headers', () async {
+      const StreamVideoSpec spec = StreamVideoSpec(
+        subtitleUrl: 'https://dav.example.com/lib/ep1.srt',
+        subtitleFileName: 'ep1.srt',
+        referer: 'https://example.com/',
+      );
+      final launch = await buildStreamVideoLaunch(
+        _row(
+          videoPath: 'https://dav.example.com/lib/ep1.mkv',
+          streamSpecJson: spec.toStorageJson(),
+        ),
+        sourceHttpHeaders: const <String, String>{
+          'Authorization': 'Basic dTpwdw==',
+        },
+      );
+      expect(launch.client.httpHeaderFields, <String, String>{
+        'Referer': 'https://example.com/',
+        'Authorization': 'Basic dTpwdw==',
+      });
+      launch.client.close();
+    });
   });
 
   group('buildStreamVideoLaunch YouTube resolve cache (TODO-1314)', () {

--- a/fushi/test/media/video/video_filename_parser_test.dart
+++ b/fushi/test/media/video/video_filename_parser_test.dart
@@ -190,6 +190,21 @@ void main() {
   });
 
   group('groupVideosIntoPlaylists', () {
+    test('URL 路径（网络来源）：解码后参与解析，编码不渗进系列名/集标题', () {
+      const String base = 'https://dav.example.com/media/Show%20A';
+      final List<VideoGroup> groups = groupVideosIntoPlaylists(<String>[
+        '$base/Show%20A%20S01E01.mkv',
+        '$base/Show%20A%20S01E02.mkv',
+      ]);
+      expect(groups, hasLength(1));
+      final VideoGroup g = groups.single;
+      expect(g.series, 'Show A', reason: '系列名必须是解码后的（不能是 Show%20A）');
+      expect(g.isPlaylist, isTrue);
+      expect(g.episodes.first.title, 'Show A S01E01', reason: '集标题同理解码');
+      expect(g.episodes.first.path, '$base/Show%20A%20S01E01.mkv',
+          reason: 'path 保持原始 URL（播放/入库身份不动）');
+    });
+
     test('整季分集标题各不相同 → 仍归一组，按集号排序（BUG-1435）', () {
       const String prefix = '/v/日々は過ぎれど飯うまし.S01E';
       const String suffix = '.WEBRip.Netflix.ja[cc].mkv';

--- a/fushi/test/pages/media_sources_dialog_test.dart
+++ b/fushi/test/pages/media_sources_dialog_test.dart
@@ -398,11 +398,14 @@ void main() {
 
     test('webdav transport wired: segment + WebDavSyncBackend test connection',
         () {
-      // TODO-1274: WebDAV 作为第三种网络传输接入——分段按钮含 webdav，测试连接复用
-      // sync 子系统的 WebDavSyncBackend（PROPFIND 探活），凭据仍走 saveSecret（上面
-      // 的红线守卫覆盖），绝不作为列写进来源行。
-      expect(src.contains("value: 'webdav'"), isTrue,
-          reason: '网络来源分段必须提供 WebDAV 选项');
+      // TODO-1274: WebDAV 作为第三种网络传输接入——transport 集含 webdav（书/漫画
+      // 三选、视频仅 WebDAV，见 _networkTransports），测试连接复用 sync 子系统的
+      // WebDavSyncBackend（PROPFIND 探活），凭据仍走 saveSecret（上面的红线守卫
+      // 覆盖），绝不作为列写进来源行。
+      expect(src.contains("const <String>['sftp', 'ftp', 'webdav']"), isTrue,
+          reason: '书/漫画的网络来源 transport 集必须提供 SFTP/FTP/WebDAV 三选');
+      expect(src.contains("const <String>['webdav']"), isTrue,
+          reason: '视频网络来源必须收窄到仅 WebDAV（SFTP/FTP 无 HTTP 直链不可播）');
       expect(src.contains('WebDavSyncBackend.instance.testConnection'), isTrue,
           reason: 'WebDAV 测试连接必须复用 sync 的 WebDavSyncBackend');
     });

--- a/fushi/test/pages/video_source_actions_wiring_guard_test.dart
+++ b/fushi/test/pages/video_source_actions_wiring_guard_test.dart
@@ -30,15 +30,19 @@ void main() {
     expect(home, isNot(contains('showVideoSourceScrapeDialog')));
   });
 
-  test('视频添加来源直选文件夹，扫描收尾通知媒体库变化', () {
+  test('视频添加来源走本地/网络选择器（网络仅 WebDAV），扫描收尾通知媒体库变化', () {
+    // 网络来源三域开放后，视频不再短路直选文件夹：与书/漫画共用同一个
+    // 本地/网络选择对话框，只是 transport 集收窄到仅 WebDAV（原地流播）。
     final String source = File(
       'lib/src/pages/implementations/media_sources_view.dart',
     ).readAsStringSync();
-    final int direct = source.indexOf("if (widget.mediaKind == 'video')");
-    final int chooser = source.indexOf('showAppDialog<_AddSourceChoice>');
-    expect(direct, greaterThanOrEqualTo(0));
-    expect(direct, lessThan(chooser));
+    expect(source, contains('showAppDialog<_AddSourceChoice>'));
     expect(source, contains('await addLocalFolder();'));
+    expect(
+        source,
+        contains(
+            "widget.mediaKind == 'video'\n      ? const <String>['webdav']"),
+        reason: '视频网络 transport 必须收窄到仅 WebDAV');
     expect(source, contains('onLibraryChanged?.call();'));
   });
 


### PR DESCRIPTION
## 概要
用户需求「所有导入支持网络文件夹」第一批：把已有的网络来源层（SFTP/FTP/WebDAV，此前仅书籍开放）推广到视频与漫画。

- **视频**：仅放行 WebDAV——条目路径本身是 http(s) URL，按流媒体书**原地**入库（videoPath=URL、sidecar 字幕 URL 进 streamSpecJson），播放复用既有 stream 通道；SFTP/FTP 无 HTTP 直链仍拒绝（后续可加本地转流桥）。v1 网络视频不归组、不导 m3u8 清单、不抽封面。
- **漫画**：三 transport 全通。先读远端 .mokuro（小文本）派生标题做去重预检（与导入器同一套身份派生，重扫零页图重下载），未命中才整卷镜像到临时目录，交给既有 MangaImporter（落库产物与本地导入逐字节同构）。
- **认证**：新 source_stream_headers.dart，打开时按 VideoBooks.sourceId 从凭据库现解析 WebDAV Basic 认证头（凭据红线：不落 configJson/行级 streamSpecJson；改密码一处生效），buildStreamVideoLaunch 合并进视频流与字幕请求头。
- **UI**：三域库页开放「网络来源」入口，transport 集按域收窄（视频仅 WebDAV）；新 i18n key media_source_network_subtitle_video（i18n_sync + slang 重生成）。

## 验证
- flutter analyze 全量绿（No issues found）。
- 定向测试全绿：test/media/source_library（82 通过，含新 WebDAV 流播导入、网络漫画镜像+重扫预检、认证头解析）、stream_video_launch_test（头合并）、media_sources_dialog_test / video_source_actions_wiring_guard_test（守卫更新到新契约）。
- 更新的源码形状守卫做过变异实测（放宽视频 transports → 两条守卫红）→ 还原 sha256 一致。

https://claude.ai/code/session_01E6x4drSY8aUDGzCqZ2UzER