### PR TITLE
feat(video): Jellyfin/Emby 媒体服务器远端视频库

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61506 (3618 per locale)
+/// Strings: 61608 (3624 per locale)
 ///
-/// Built on 2026-08-19 at 04:25 UTC
+/// Built on 2026-08-19 at 06:48 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4910,6 +4910,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  String get jellyfin_server_url => 'Server URL';
+  String get jellyfin_sign_in => 'Sign in';
+  String get jellyfin_sign_out => 'Sign out';
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -13290,6 +13297,19 @@ class _StringsAr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -21736,6 +21756,19 @@ class _StringsDe extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -30198,6 +30231,19 @@ class _StringsEs extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -38672,6 +38718,19 @@ class _StringsFr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -47075,6 +47134,19 @@ class _StringsId extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -55523,6 +55595,19 @@ class _StringsIt extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -63786,6 +63871,19 @@ class _StringsJa extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -72056,6 +72154,19 @@ class _StringsKo extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -80484,6 +80595,19 @@ class _StringsNl extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -88924,6 +89048,19 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -97350,6 +97487,19 @@ class _StringsRu extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -105724,6 +105874,19 @@ class _StringsTh extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -114130,6 +114293,19 @@ class _StringsTr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -122521,6 +122697,19 @@ class _StringsVi extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 // Path: <root>
@@ -130287,6 +130476,18 @@ class _StringsZhCn extends _StringsEn {
   String get storage_bundled_hint => '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
   @override
   String get storage_dictionary_delete_incomplete => '词典删除未完成、条目仍在，详见错误日志';
+  @override
+  String get jellyfin_settings_title => '媒体服务器（Jellyfin / Emby）';
+  @override
+  String get jellyfin_server_url => '服务器地址';
+  @override
+  String get jellyfin_sign_in => '登录';
+  @override
+  String get jellyfin_sign_out => '退出登录';
+  @override
+  String get jellyfin_sign_in_failed => '登录失败';
+  @override
+  String get jellyfin_settings_hint => '服务器上的视频会出现在媒体库中，点击直接串流播放。';
 }
 
 // Path: <root>
@@ -138473,6 +138674,19 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get jellyfin_settings_title => 'Media server (Jellyfin / Emby)';
+  @override
+  String get jellyfin_server_url => 'Server URL';
+  @override
+  String get jellyfin_sign_in => 'Sign in';
+  @override
+  String get jellyfin_sign_out => 'Sign out';
+  @override
+  String get jellyfin_sign_in_failed => 'Sign-in failed';
+  @override
+  String get jellyfin_settings_hint =>
+      'Videos on the server show up in the video library and stream directly.';
 }
 
 /// Flat map(s) containing all translations.
@@ -145900,6 +146114,18 @@ extension on _StringsEn {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -153325,6 +153551,18 @@ extension on _StringsAr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -160772,6 +161010,18 @@ extension on _StringsDe {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -168218,6 +168468,18 @@ extension on _StringsEs {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -175670,6 +175932,18 @@ extension on _StringsFr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -183104,6 +183378,18 @@ extension on _StringsId {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -190552,6 +190838,18 @@ extension on _StringsIt {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -197962,6 +198260,18 @@ extension on _StringsJa {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -205376,6 +205686,18 @@ extension on _StringsKo {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -212818,6 +213140,18 @@ extension on _StringsNl {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -220257,6 +220591,18 @@ extension on _StringsPtBr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -227701,6 +228047,18 @@ extension on _StringsRu {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -235128,6 +235486,18 @@ extension on _StringsTh {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -242564,6 +242934,18 @@ extension on _StringsTr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -249996,6 +250378,18 @@ extension on _StringsVi {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }
@@ -257369,6 +257763,18 @@ extension on _StringsZhCn {
         return '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
       case 'storage_dictionary_delete_incomplete':
         return '词典删除未完成、条目仍在，详见错误日志';
+      case 'jellyfin_settings_title':
+        return '媒体服务器（Jellyfin / Emby）';
+      case 'jellyfin_server_url':
+        return '服务器地址';
+      case 'jellyfin_sign_in':
+        return '登录';
+      case 'jellyfin_sign_out':
+        return '退出登录';
+      case 'jellyfin_sign_in_failed':
+        return '登录失败';
+      case 'jellyfin_settings_hint':
+        return '服务器上的视频会出现在媒体库中，点击直接串流播放。';
       default:
         return null;
     }
@@ -264774,6 +265180,18 @@ extension on _StringsZhHk {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'jellyfin_settings_title':
+        return 'Media server (Jellyfin / Emby)';
+      case 'jellyfin_server_url':
+        return 'Server URL';
+      case 'jellyfin_sign_in':
+        return 'Sign in';
+      case 'jellyfin_sign_out':
+        return 'Sign out';
+      case 'jellyfin_sign_in_failed':
+        return 'Sign-in failed';
+      case 'jellyfin_settings_hint':
+        return 'Videos on the server show up in the video library and stream directly.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "未安装",
   "storage_bundled_section": "随包组件",
   "storage_bundled_hint": "随安装包携带，删除后下次更新会自动恢复，此处仅展示。",
-  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志"
+  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志",
+  "jellyfin_settings_title": "媒体服务器（Jellyfin / Emby）",
+  "jellyfin_server_url": "服务器地址",
+  "jellyfin_sign_in": "登录",
+  "jellyfin_sign_out": "退出登录",
+  "jellyfin_sign_in_failed": "登录失败",
+  "jellyfin_settings_hint": "服务器上的视频会出现在媒体库中，点击直接串流播放。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "jellyfin_settings_title": "Media server (Jellyfin / Emby)",
+  "jellyfin_server_url": "Server URL",
+  "jellyfin_sign_in": "Sign in",
+  "jellyfin_sign_out": "Sign out",
+  "jellyfin_sign_in_failed": "Sign-in failed",
+  "jellyfin_settings_hint": "Videos on the server show up in the video library and stream directly."
 }

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -87,6 +87,8 @@ import 'package:fushi/src/sync/remote_library_cache.dart';
 import 'package:fushi/src/sync/remote_video_client.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_progress_banner.dart';
+import 'package:fushi/src/sync/jellyfin_video_client.dart'
+    show JellyfinServerConfig, JellyfinVideoClient;
 import 'package:fushi/src/sync/sync_repository.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/utils/components/batch_tag_dialog_frame.dart';
@@ -786,6 +788,17 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     return CloudRemoteVideoClient(backend: backend, backendType: type);
   }
 
+  /// Jellyfin/Emby 媒体服务器分支：设置里登录过服务器（配置在 SyncRepository
+  /// `sync_jellyfin_server`）即可出 client——它具备完整 [RemoteVideoClient] 能力
+  /// （直连流播/字幕/服务器端断点），与互联 live 库同级；每次取数新建实例，
+  /// 缓存身份按服务器细分（`jellyfin:<serverUrl>`，BUG-1202 口径）。
+  Future<JellyfinVideoClient?> _resolveJellyfinVideoClient() async {
+    final AppModel appModel = ref.read(appProvider);
+    final SyncRepository syncRepo = SyncRepository(appModel.database);
+    final JellyfinServerConfig? config = await syncRepo.getJellyfinServer();
+    return config?.buildClient();
+  }
+
   /// 是否应该去问远端要视频清单。
   ///
   /// BUG-1182：`showRemoteEntries` 开关此前只在渲染期的 [_visibleRemoteVideos] 生效，
@@ -817,9 +830,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       _remoteVideoSource = null;
       return null;
     }
-    // TODO-2119：互联优先、否则回退云盘；两者都是 [RemoteVideoSource]，所以下面
-    // 「列清单 → 去重 → 出占位卡」这条主干只写一遍，不再按后端类型分叉。
+    // TODO-2119：互联优先、次选 Jellyfin 媒体服务器、否则回退云盘；三者都是
+    // [RemoteVideoSource]，所以下面「列清单 → 去重 → 出占位卡」这条主干只写
+    // 一遍，不再按后端类型分叉。
     final RemoteVideoSource? source = await _resolveRemoteVideoClient() ??
+        await _resolveJellyfinVideoClient() ??
         await _resolveCloudRemoteVideoClient();
     _remoteVideoSource = source;
     if (source == null) return null;

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -13,6 +13,7 @@ import 'package:fushi/src/media/video/video_subtitle_style.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/sync/jellyfin_settings_widget.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/pages/implementations/video_external_provider_settings_section.dart';
 
@@ -1196,6 +1197,23 @@ SettingsDestination buildVideoDestination() {
                 const VideoExternalProviderSettingsSection(
               onlySubtitleSources: true,
             ),
+          ),
+        ],
+      ),
+      // ── 媒体服务器（Jellyfin / Emby）───────────────────────────────────
+      // 登录后服务器条目混排进视频库网格（home_video_page 远端源解析链），
+      // 点击直连串流播放；配置读写全在 JellyfinConfigWidget（SyncRepository
+      // `sync_jellyfin_server`，设备本地键，不随备份跨设备）。
+      SettingsSection(
+        title: t.jellyfin_settings_title,
+        collapsedByDefault: true,
+        items: <SettingsItem>[
+          SettingsCustomItem(
+            id: 'video.media_server.jellyfin',
+            // 搜索得命中品牌名（Jellyfin/Emby），t 标题只有「媒体服务器」语义。
+            searchTitle: 'Jellyfin · Emby · ${t.jellyfin_settings_title}',
+            builder: (SettingsContext settingsContext) =>
+                JellyfinConfigWidget(settingsContext: settingsContext),
           ),
         ],
       ),

--- a/fushi/lib/src/sync/jellyfin_settings_widget.dart
+++ b/fushi/lib/src/sync/jellyfin_settings_widget.dart
@@ -1,0 +1,208 @@
+// Jellyfin / Emby 媒体服务器登录设置组件（视频设置「媒体服务器」分区消费）。
+//
+// 状态两态：未登录 = 地址/用户名/密码表单 + 「登录」（AuthenticateByName 成功即
+// 落 SyncRepository `sync_jellyfin_server`）；已登录 = 服务器/账号展示 + 「退出
+// 登录」（删键）。配置生效面在视频库页的远端源解析链
+// （home_video_page `_resolveJellyfinVideoClient`），此处只管配置读写。
+
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/settings/settings_context.dart';
+import 'package:fushi/src/sync/jellyfin_video_client.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi/utils.dart';
+
+/// Jellyfin 服务器配置块。
+class JellyfinConfigWidget extends StatefulWidget {
+  const JellyfinConfigWidget({required this.settingsContext, super.key});
+
+  final SettingsContext settingsContext;
+
+  @override
+  State<JellyfinConfigWidget> createState() => _JellyfinConfigWidgetState();
+}
+
+class _JellyfinConfigWidgetState extends State<JellyfinConfigWidget> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _userController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  SyncRepository get _syncRepo =>
+      SyncRepository(widget.settingsContext.appModel.database);
+
+  /// null = 读取中；含 null 值 = 未登录。
+  Future<JellyfinServerConfig?>? _configFuture;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _configFuture = _syncRepo.getJellyfinServer();
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _userController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signIn() async {
+    final String rawUrl = _urlController.text;
+    final String username = _userController.text.trim();
+    final String password = _passwordController.text;
+    final String serverUrl = JellyfinApi.normalizeServerUrl(rawUrl);
+    if (serverUrl.isEmpty || username.isEmpty) {
+      FushiToast.show(
+        msg: t.jellyfin_sign_in_failed,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    setState(() => _busy = true);
+    final JellyfinApi api = JellyfinApi(serverUrl: serverUrl);
+    try {
+      final JellyfinAuthResult auth =
+          await api.authenticateByName(username, password);
+      if (auth.accessToken.isEmpty || auth.userId.isEmpty) {
+        throw JellyfinApiException(0, '/Users/AuthenticateByName');
+      }
+      await _syncRepo.setJellyfinServer(JellyfinServerConfig(
+        serverUrl: serverUrl,
+        username: username,
+        userId: auth.userId,
+        accessToken: auth.accessToken,
+        serverName: auth.serverName,
+      ));
+      if (!mounted) return;
+      _passwordController.clear();
+      setState(() {
+        _configFuture = _syncRepo.getJellyfinServer();
+      });
+      FushiToast.show(
+        msg: t.sync_connection_success,
+        severity: ToastSeverity.success,
+      );
+    } catch (e) {
+      if (mounted) {
+        FushiToast.show(
+          msg: '${t.jellyfin_sign_in_failed}: $e',
+          severity: ToastSeverity.error,
+        );
+      }
+    } finally {
+      api.close();
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _signOut() async {
+    setState(() => _busy = true);
+    try {
+      await _syncRepo.setJellyfinServer(null);
+      if (mounted) {
+        setState(() {
+          _configFuture = _syncRepo.getJellyfinServer();
+        });
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<JellyfinServerConfig?>(
+      future: _configFuture,
+      builder: (BuildContext context,
+          AsyncSnapshot<JellyfinServerConfig?> snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+          );
+        }
+        final JellyfinServerConfig? config = snapshot.data;
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: config == null ? _buildSignInForm() : _buildSignedIn(config),
+        );
+      },
+    );
+  }
+
+  Widget _buildSignInForm() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          t.jellyfin_settings_hint,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 12),
+        FushiTextField(
+          controller: _urlController,
+          labelText: t.jellyfin_server_url,
+          hintText: 'http://192.168.1.10:8096',
+        ),
+        const SizedBox(height: 12),
+        FushiTextField(
+          controller: _userController,
+          labelText: t.sync_username,
+        ),
+        const SizedBox(height: 12),
+        FushiTextField(
+          controller: _passwordController,
+          labelText: t.sync_password,
+          obscureText: true,
+        ),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerRight,
+          child: _busy
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : FilledButton.tonal(
+                  onPressed: _signIn,
+                  child: Text(t.jellyfin_sign_in),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSignedIn(JellyfinServerConfig config) {
+    final String serverLabel = (config.serverName?.isNotEmpty ?? false)
+        ? '${config.serverName} · ${config.serverUrl}'
+        : config.serverUrl;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        FushiListItem(
+          leading: const Icon(Icons.dns_outlined),
+          title: Text(serverLabel),
+          subtitle: Text(config.username),
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: _busy
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : TextButton(
+                  onPressed: _signOut,
+                  child: Text(t.jellyfin_sign_out),
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/fushi/lib/src/sync/jellyfin_video_client.dart
+++ b/fushi/lib/src/sync/jellyfin_video_client.dart
@@ -1,0 +1,752 @@
+// Jellyfin / Emby 媒体服务器视频客户端。
+//
+// 两层结构：
+// - [JellyfinApi]：薄 HTTP 封装（认证 / 视图 / 条目 / 进度上报 / URL 构造），
+//   JSON→DTO 解析全部是纯静态方法，测试用 MockClient 离线覆盖。
+// - [JellyfinVideoClient] `implements RemoteVideoClient`：把 Jellyfin 条目适配成
+//   互联/云端同款的远端视频契约（列清单 / 整片下载 / 流播 URL / 外挂字幕 /
+//   跨端断点），库页与播放页零新概念消费。
+//
+// 协议事实：
+// - Jellyfin 与 Emby 的这批端点同源兼容（AuthenticateByName / Views / Items /
+//   Videos/{id}/stream / Sessions/Playing/Stopped），一套实现双吃。
+// - 播放路径的 [RemoteVideoStreamUrls] 没有 HTTP 头通道，所以流/图片/字幕 URL
+//   一律用 `api_key` 查询参数自带认证（两家都支持），不依赖 header 注入。
+// - 时间单位：服务器用 tick（100ns），1ms = 10000 ticks（[kTicksPerMs]）。
+// - 断点：读走条目 UserData.PlaybackPositionTicks；写走
+//   `Sessions/Playing/Stopped`（无会话生命周期也会持久化 resume 位置，是
+//   scrobbler 类客户端的通用做法）。服务器端没有「较新时间戳者胜」合并，
+//   语义是 last-write-wins；[putRemoteVideoPosition] 的 updatedAtMs 只在本端
+//   语境有意义，不上传。
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' show sha1;
+import 'package:http/http.dart' as http;
+
+import 'package:fushi/src/sync/fushi_library_host_service.dart'
+    show
+        RemoteCollectionMembership,
+        RemoteVideoEmbeddedSubtitleTrack,
+        RemoteVideoInfo,
+        RemoteVideoStreamUrls;
+import 'package:fushi/src/sync/remote_cover_fetcher.dart';
+import 'package:fushi/src/sync/remote_video_client.dart';
+import 'package:fushi/src/utils/net/app_http.dart';
+
+/// 1 毫秒 = 10000 个 Jellyfin tick（100ns）。
+const int kTicksPerMs = 10000;
+
+/// 已登录 Jellyfin/Emby 服务器的持久化配置（落 SyncRepository 的
+/// `sync_jellyfin_server` prefs 键；presence = 已启用，登出即删键）。
+///
+/// 令牌与互联 per-peer token 同款落 Drift prefs（不是明文红线的 configJson——
+/// 该红线针对 MediaSources 行；prefs 是既有凭据落点，见 sync_repository.dart
+/// 各后端凭据键）。
+class JellyfinServerConfig {
+  const JellyfinServerConfig({
+    required this.serverUrl,
+    required this.username,
+    required this.userId,
+    required this.accessToken,
+    this.serverName,
+  });
+
+  /// 归一化后的服务器根 URL（[JellyfinApi.normalizeServerUrl] 口径）。
+  final String serverUrl;
+  final String username;
+  final String userId;
+  final String accessToken;
+  final String? serverName;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'serverUrl': serverUrl,
+        'username': username,
+        'userId': userId,
+        'accessToken': accessToken,
+        if (serverName != null) 'serverName': serverName,
+      };
+
+  static JellyfinServerConfig? fromJson(Map<String, dynamic> json) {
+    final String serverUrl = (json['serverUrl'] as String?) ?? '';
+    final String userId = (json['userId'] as String?) ?? '';
+    final String accessToken = (json['accessToken'] as String?) ?? '';
+    if (serverUrl.isEmpty || userId.isEmpty || accessToken.isEmpty) {
+      return null;
+    }
+    return JellyfinServerConfig(
+      serverUrl: serverUrl,
+      username: (json['username'] as String?) ?? '',
+      userId: userId,
+      accessToken: accessToken,
+      serverName: json['serverName'] as String?,
+    );
+  }
+
+  /// 从配置构造可用客户端（每次取数新建实例，缓存身份见
+  /// [JellyfinVideoClient.remoteLibrarySourceId]）。
+  JellyfinVideoClient buildClient({http.Client? httpClient}) =>
+      JellyfinVideoClient(
+        api: JellyfinApi(
+          serverUrl: serverUrl,
+          accessToken: accessToken,
+          client: httpClient,
+        ),
+        userId: userId,
+      );
+}
+
+/// 认证成功的结果：访问令牌 + 用户 id + 服务器显示名。
+class JellyfinAuthResult {
+  const JellyfinAuthResult({
+    required this.accessToken,
+    required this.userId,
+    this.serverName,
+  });
+
+  final String accessToken;
+  final String userId;
+  final String? serverName;
+}
+
+/// 一个媒体库视图（Jellyfin「媒体库」，如 电影 / 剧集 / 动漫）。
+class JellyfinLibraryView {
+  const JellyfinLibraryView({
+    required this.id,
+    required this.name,
+    this.collectionType,
+  });
+
+  final String id;
+  final String name;
+
+  /// 'movies' | 'tvshows' | 'music' | 'books' | ... | null（混合）。
+  final String? collectionType;
+
+  /// 是否值得出现在视频域（音乐/图书/照片库不展示）。
+  bool get isVideoish =>
+      collectionType == null ||
+      const <String>{'movies', 'tvshows', 'homevideos', 'musicvideos', 'mixed'}
+          .contains(collectionType);
+}
+
+/// 条目里的一条字幕流（外挂或内嵌）。
+class JellyfinSubtitleStream {
+  const JellyfinSubtitleStream({
+    required this.index,
+    required this.codec,
+    this.language,
+    this.title,
+    this.isExternal = false,
+    this.isTextSubtitleStream = true,
+  });
+
+  final int index;
+  final String codec;
+  final String? language;
+  final String? title;
+  final bool isExternal;
+  final bool isTextSubtitleStream;
+}
+
+/// 一个库条目（电影 / 剧 / 季 / 集 / 文件夹）。只保留视频域消费的字段。
+class JellyfinItem {
+  const JellyfinItem({
+    required this.id,
+    required this.name,
+    required this.type,
+    this.isFolder = false,
+    this.seriesName,
+    this.seasonNumber,
+    this.episodeNumber,
+    this.durationMs,
+    this.hasPrimaryImage = false,
+    this.positionMs = 0,
+    this.playedPercentage,
+    this.mediaSourceId,
+    this.subtitleStreams = const <JellyfinSubtitleStream>[],
+    this.childCount,
+    this.productionYear,
+  });
+
+  final String id;
+  final String name;
+
+  /// 'Movie' | 'Series' | 'Season' | 'Episode' | 'Folder' | 'BoxSet' | ...
+  final String type;
+  final bool isFolder;
+  final String? seriesName;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final int? durationMs;
+  final bool hasPrimaryImage;
+
+  /// 服务器端 resume 位置（UserData.PlaybackPositionTicks → ms）。
+  final int positionMs;
+  final double? playedPercentage;
+
+  /// 默认媒体源 id（字幕流 URL 需要）。
+  final String? mediaSourceId;
+  final List<JellyfinSubtitleStream> subtitleStreams;
+  final int? childCount;
+  final int? productionYear;
+
+  /// 可直接播放的叶子条目（电影/单集）。
+  bool get isPlayableVideo => type == 'Movie' || type == 'Episode';
+
+  /// 展示标题：单集拼上剧名与季集号（`剧名 S01E02 集名`），其余用条目名。
+  String get displayTitle {
+    if (type != 'Episode' || seriesName == null || seriesName!.isEmpty) {
+      return name;
+    }
+    final String code = (seasonNumber != null && episodeNumber != null)
+        ? ' S${seasonNumber.toString().padLeft(2, '0')}'
+            'E${episodeNumber.toString().padLeft(2, '0')}'
+        : '';
+    return '$seriesName$code $name';
+  }
+}
+
+/// 一页条目（`/Items` 的 TotalRecordCount 分页语义）。
+class JellyfinItemsPage {
+  const JellyfinItemsPage({required this.items, required this.totalCount});
+
+  final List<JellyfinItem> items;
+  final int totalCount;
+}
+
+/// Jellyfin HTTP 异常：状态码 + 端点，供 UI 按连接失败呈现。
+class JellyfinApiException implements Exception {
+  const JellyfinApiException(this.statusCode, this.endpoint);
+
+  final int statusCode;
+  final String endpoint;
+
+  @override
+  String toString() => 'JellyfinApiException($statusCode, $endpoint)';
+}
+
+/// 薄 HTTP 封装。所有 JSON 解析走纯静态方法（离线可测）。
+class JellyfinApi {
+  JellyfinApi({
+    required this.serverUrl,
+    this.accessToken,
+    http.Client? client,
+  }) : _client = client ?? createAppHttpIoClient();
+
+  /// 归一化后的服务器根 URL（含 scheme、无尾斜杠）。
+  final String serverUrl;
+
+  /// 访问令牌；[authenticateByName] 成功后回填。
+  String? accessToken;
+
+  final http.Client _client;
+
+  /// 归一化用户输入的服务器地址：补 scheme（缺省 http，局域网常态）、去尾斜杠。
+  static String normalizeServerUrl(String raw) {
+    String url = raw.trim();
+    if (url.isEmpty) return url;
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = 'http://$url';
+    }
+    while (url.endsWith('/')) {
+      url = url.substring(0, url.length - 1);
+    }
+    return url;
+  }
+
+  /// MediaBrowser 认证头（Jellyfin/Emby 通用；认证前无 Token 字段）。
+  Map<String, String> get _headers => <String, String>{
+        'Authorization': 'MediaBrowser Client="Hibiki", Device="Hibiki", '
+            'DeviceId="hibiki-app", Version="1.0"'
+            '${accessToken == null ? '' : ', Token="$accessToken"'}',
+        'Content-Type': 'application/json',
+      };
+
+  Uri _uri(String path, [Map<String, String>? query]) =>
+      Uri.parse('$serverUrl$path').replace(queryParameters: query);
+
+  Future<Map<String, Object?>> _getJson(
+    String path, [
+    Map<String, String>? query,
+  ]) async {
+    final http.Response res =
+        await _client.get(_uri(path, query), headers: _headers);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw JellyfinApiException(res.statusCode, path);
+    }
+    final Object? decoded = jsonDecode(utf8.decode(res.bodyBytes));
+    return decoded is Map<String, dynamic>
+        ? decoded.cast<String, Object?>()
+        : <String, Object?>{};
+  }
+
+  /// 用户名/密码认证（POST /Users/AuthenticateByName），成功回填 [accessToken]。
+  Future<JellyfinAuthResult> authenticateByName(
+    String username,
+    String password,
+  ) async {
+    final http.Response res = await _client.post(
+      _uri('/Users/AuthenticateByName'),
+      headers: _headers,
+      body: jsonEncode(<String, String>{'Username': username, 'Pw': password}),
+    );
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw JellyfinApiException(res.statusCode, '/Users/AuthenticateByName');
+    }
+    final Object? decoded = jsonDecode(utf8.decode(res.bodyBytes));
+    final JellyfinAuthResult result = parseAuthResult(
+        decoded is Map<String, dynamic>
+            ? decoded.cast<String, Object?>()
+            : <String, Object?>{});
+    accessToken = result.accessToken;
+    return result;
+  }
+
+  /// 用户可见的媒体库视图（GET /Users/{uid}/Views）。
+  Future<List<JellyfinLibraryView>> views(String userId) async {
+    final Map<String, Object?> json = await _getJson('/Users/$userId/Views');
+    return parseViews(json);
+  }
+
+  /// 列 [parentId] 的直接子级（GET /Users/{uid}/Items，非递归，浏览用）。
+  Future<JellyfinItemsPage> children({
+    required String userId,
+    String? parentId,
+    int startIndex = 0,
+    int limit = 200,
+  }) async {
+    final Map<String, Object?> json =
+        await _getJson('/Users/$userId/Items', <String, String>{
+      if (parentId != null) 'ParentId': parentId,
+      'StartIndex': '$startIndex',
+      'Limit': '$limit',
+      'Fields': 'ChildCount,ProductionYear',
+      'SortBy': 'IsFolder,SortName',
+      'SortOrder': 'Ascending',
+    });
+    return parseItemsPage(json);
+  }
+
+  /// 递归列出 [parentId]（缺省全库）下所有可播视频叶子（电影 + 单集）。
+  Future<List<JellyfinItem>> recursiveVideoItems({
+    required String userId,
+    String? parentId,
+    int limit = 2000,
+  }) async {
+    final Map<String, Object?> json =
+        await _getJson('/Users/$userId/Items', <String, String>{
+      if (parentId != null) 'ParentId': parentId,
+      'Recursive': 'true',
+      'IncludeItemTypes': 'Movie,Episode',
+      'Limit': '$limit',
+      'Fields': 'ProductionYear',
+      'SortBy': 'SortName',
+      'SortOrder': 'Ascending',
+    });
+    return parseItemsPage(json).items;
+  }
+
+  /// 单条目详情（含 MediaSources/MediaStreams，字幕流选择用）。
+  Future<JellyfinItem> itemDetail({
+    required String userId,
+    required String itemId,
+  }) async {
+    final Map<String, Object?> json =
+        await _getJson('/Users/$userId/Items/$itemId');
+    return parseItem(json);
+  }
+
+  /// 上报播放位置（POST /Sessions/Playing/Stopped——无会话生命周期也持久化
+  /// resume 位置；服务器 last-write-wins）。
+  Future<void> reportStopped({
+    required String itemId,
+    required int positionMs,
+  }) async {
+    final http.Response res = await _client.post(
+      _uri('/Sessions/Playing/Stopped'),
+      headers: _headers,
+      body: jsonEncode(<String, Object?>{
+        'ItemId': itemId,
+        'PositionTicks': positionMs * kTicksPerMs,
+      }),
+    );
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw JellyfinApiException(res.statusCode, '/Sessions/Playing/Stopped');
+    }
+  }
+
+  /// 直连播放流 URL（static=true 原文件直出，内嵌字幕/音轨全保留；`api_key`
+  /// 查询参数自带认证——[RemoteVideoStreamUrls] 没有 HTTP 头通道）。
+  String streamUrl(String itemId) =>
+      '$serverUrl/Videos/$itemId/stream?static=true&api_key=${accessToken ?? ''}';
+
+  /// 封面 URL（Primary 图；无图的条目由调用方按 hasPrimaryImage 过滤）。
+  String imageUrl(String itemId) =>
+      '$serverUrl/Items/$itemId/Images/Primary?api_key=${accessToken ?? ''}';
+
+  /// 字幕流下载 URL（外挂或可提取文本内嵌轨都走这个端点）。
+  String subtitleUrl({
+    required String itemId,
+    required String mediaSourceId,
+    required int streamIndex,
+    required String codec,
+  }) {
+    final String ext = _subtitleExt(codec);
+    return '$serverUrl/Videos/$itemId/$mediaSourceId/Subtitles/$streamIndex'
+        '/Stream.$ext?api_key=${accessToken ?? ''}';
+  }
+
+  static String _subtitleExt(String codec) {
+    switch (codec.toLowerCase()) {
+      case 'subrip':
+      case 'srt':
+        return 'srt';
+      case 'ass':
+      case 'ssa':
+        return 'ass';
+      case 'webvtt':
+      case 'vtt':
+        return 'vtt';
+      default:
+        // 图形字幕（pgs/dvdsub）无法转文本，调用方不应选到这里；兜底转 vtt。
+        return 'vtt';
+    }
+  }
+
+  /// 拉取 [url] 的全部字节（封面用）。非 2xx 抛 [JellyfinApiException]。
+  Future<Uint8List> fetchBytes(String url) async {
+    final http.Response res =
+        await _client.get(Uri.parse(url), headers: _headers);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw JellyfinApiException(res.statusCode, Uri.parse(url).path);
+    }
+    return res.bodyBytes;
+  }
+
+  /// 通用下载：GET [url] 流式写入 [dest]，按 Content-Length 汇报进度。
+  Future<void> downloadToFile(
+    String url,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async {
+    final http.Request req = http.Request('GET', Uri.parse(url));
+    req.headers.addAll(_headers);
+    final http.StreamedResponse res = await _client.send(req);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw JellyfinApiException(res.statusCode, Uri.parse(url).path);
+    }
+    final int? total = res.contentLength;
+    int received = 0;
+    final IOSink sink = dest.openWrite();
+    bool ok = false;
+    try {
+      await for (final List<int> chunk in res.stream) {
+        sink.add(chunk);
+        received += chunk.length;
+        if (total != null && total > 0) {
+          onProgress?.call(received / total);
+        }
+      }
+      ok = true;
+    } finally {
+      await sink.close();
+      if (!ok) {
+        try {
+          dest.deleteSync();
+        } catch (_) {}
+      }
+    }
+  }
+
+  void close() => _client.close();
+
+  // ── 纯 JSON 解析（离线可测） ─────────────────────────────────────────
+
+  static JellyfinAuthResult parseAuthResult(Map<String, Object?> json) {
+    final Map<String, Object?> user =
+        (json['User'] as Map?)?.cast<String, Object?>() ?? <String, Object?>{};
+    return JellyfinAuthResult(
+      accessToken: (json['AccessToken'] as String?) ?? '',
+      userId: (user['Id'] as String?) ?? '',
+      serverName: json['ServerName'] as String?,
+    );
+  }
+
+  static List<JellyfinLibraryView> parseViews(Map<String, Object?> json) {
+    final List<Object?> items = (json['Items'] as List?) ?? const <Object?>[];
+    return <JellyfinLibraryView>[
+      for (final Object? raw in items)
+        if (raw is Map)
+          JellyfinLibraryView(
+            id: (raw['Id'] as String?) ?? '',
+            name: (raw['Name'] as String?) ?? '',
+            collectionType: raw['CollectionType'] as String?,
+          ),
+    ];
+  }
+
+  static JellyfinItemsPage parseItemsPage(Map<String, Object?> json) {
+    final List<Object?> items = (json['Items'] as List?) ?? const <Object?>[];
+    return JellyfinItemsPage(
+      items: <JellyfinItem>[
+        for (final Object? raw in items)
+          if (raw is Map) parseItem(raw.cast<String, Object?>()),
+      ],
+      totalCount: (json['TotalRecordCount'] as num?)?.toInt() ?? items.length,
+    );
+  }
+
+  static JellyfinItem parseItem(Map<String, Object?> json) {
+    final Map<String, Object?> userData =
+        (json['UserData'] as Map?)?.cast<String, Object?>() ??
+            <String, Object?>{};
+    final int? runTimeTicks = (json['RunTimeTicks'] as num?)?.toInt();
+    final int positionTicks =
+        (userData['PlaybackPositionTicks'] as num?)?.toInt() ?? 0;
+
+    // 默认媒体源 + 字幕流：取 MediaSources[0]（direct play 与 stream URL 同源）。
+    String? mediaSourceId;
+    final List<JellyfinSubtitleStream> subs = <JellyfinSubtitleStream>[];
+    final List<Object?> sources =
+        (json['MediaSources'] as List?) ?? const <Object?>[];
+    if (sources.isNotEmpty && sources.first is Map) {
+      final Map<String, Object?> src =
+          (sources.first as Map).cast<String, Object?>();
+      mediaSourceId = src['Id'] as String?;
+      final List<Object?> streams =
+          (src['MediaStreams'] as List?) ?? const <Object?>[];
+      for (final Object? raw in streams) {
+        if (raw is! Map) continue;
+        final Map<String, Object?> s = raw.cast<String, Object?>();
+        if (s['Type'] != 'Subtitle') continue;
+        subs.add(JellyfinSubtitleStream(
+          index: (s['Index'] as num?)?.toInt() ?? 0,
+          codec: (s['Codec'] as String?) ?? '',
+          language: s['Language'] as String?,
+          title: s['DisplayTitle'] as String?,
+          isExternal: (s['IsExternal'] as bool?) ?? false,
+          isTextSubtitleStream: (s['IsTextSubtitleStream'] as bool?) ?? true,
+        ));
+      }
+    }
+
+    final Map<String, Object?> imageTags =
+        (json['ImageTags'] as Map?)?.cast<String, Object?>() ??
+            <String, Object?>{};
+
+    return JellyfinItem(
+      id: (json['Id'] as String?) ?? '',
+      name: (json['Name'] as String?) ?? '',
+      type: (json['Type'] as String?) ?? '',
+      isFolder: (json['IsFolder'] as bool?) ?? false,
+      seriesName: json['SeriesName'] as String?,
+      seasonNumber: (json['ParentIndexNumber'] as num?)?.toInt(),
+      episodeNumber: (json['IndexNumber'] as num?)?.toInt(),
+      durationMs: runTimeTicks == null ? null : runTimeTicks ~/ kTicksPerMs,
+      hasPrimaryImage: imageTags.containsKey('Primary'),
+      positionMs: positionTicks ~/ kTicksPerMs,
+      playedPercentage: (userData['PlayedPercentage'] as num?)?.toDouble(),
+      mediaSourceId: mediaSourceId,
+      subtitleStreams: subs,
+      childCount: (json['ChildCount'] as num?)?.toInt(),
+      productionYear: (json['ProductionYear'] as num?)?.toInt(),
+    );
+  }
+}
+
+/// Jellyfin 服务器作为远端视频源：把条目适配成互联/云端同款契约。
+///
+/// [remoteLibrarySourceId] 按服务器 URL 细分（不同服务器 = 不同清单 = 不同
+/// 缓存槽，见 remote_library_source.dart 的 BUG-1202 口径）。
+///
+/// 「显示视频库」的结构表达：单集经 [RemoteCollectionMembership] 按剧名折叠成
+/// playlist 合集卡（组内序 = 季×10000+集），复用库页既有的合集混排/上下集/
+/// 剧集面板——不另造 Jellyfin 专属浏览层。
+class JellyfinVideoClient implements RemoteVideoClient, RemoteCoverFetcher {
+  JellyfinVideoClient({required this.api, required this.userId});
+
+  final JellyfinApi api;
+  final String userId;
+
+  @override
+  String get remoteLibrarySourceId => 'jellyfin:${api.serverUrl}';
+
+  @override
+  Future<Uint8List> fetchRemoteCover(String coverUrl) =>
+      api.fetchBytes(coverUrl);
+
+  /// 磁盘封面缓存命名空间（BUG-1693 口径：配对身份级）：服务器 + 用户。
+  /// 换令牌（重新登录同账号）不变——封面没变别白白重下；换服务器/账号必变。
+  @override
+  String get coverCacheNamespace =>
+      'jellyfin-${sha1.convert(utf8.encode('${api.serverUrl}|$userId'))}';
+
+  /// 把一个条目适配成 [RemoteVideoInfo]（列表卡片消费）。
+  RemoteVideoInfo infoFromItem(JellyfinItem item) => RemoteVideoInfo(
+        id: item.id,
+        title: item.displayTitle,
+        durationMs: item.durationMs,
+        hasCover: item.hasPrimaryImage,
+        coverUrl: item.hasPrimaryImage ? api.imageUrl(item.id) : null,
+        positionMs: item.positionMs,
+        collection: _collectionOf(item),
+      );
+
+  /// 单集 → 按剧名归入 playlist 合集（库页折叠成一张剧卡）；电影独立。
+  static RemoteCollectionMembership? _collectionOf(JellyfinItem item) {
+    final String? series = item.seriesName;
+    if (item.type != 'Episode' || series == null || series.isEmpty) {
+      return null;
+    }
+    return RemoteCollectionMembership(
+      collectionName: series,
+      collectionType: 'playlist',
+      sortIndex: (item.seasonNumber ?? 0) * 10000 + (item.episodeNumber ?? 0),
+    );
+  }
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
+    final List<JellyfinItem> items =
+        await api.recursiveVideoItems(userId: userId);
+    return <RemoteVideoInfo>[
+      for (final JellyfinItem item in items)
+        if (item.isPlayableVideo) infoFromItem(item),
+    ];
+  }
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) =>
+      api.downloadToFile(api.streamUrl(id), dest, onProgress: onProgress);
+
+  @override
+  Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(
+    String id, {
+    int episodeIndex = 0,
+  }) async {
+    // Jellyfin 的每一集都是独立条目，episodeIndex 恒 0（多集语义不适用）。
+    final JellyfinItem item = await api.itemDetail(userId: userId, itemId: id);
+    final String? mediaSourceId = item.mediaSourceId;
+
+    // 外挂文本字幕优先作为默认外挂轨；其余文本轨全部报给播放页的字幕轨选择器。
+    JellyfinSubtitleStream? external;
+    final List<RemoteVideoEmbeddedSubtitleTrack> tracks =
+        <RemoteVideoEmbeddedSubtitleTrack>[];
+    for (final JellyfinSubtitleStream s in item.subtitleStreams) {
+      if (!s.isTextSubtitleStream || mediaSourceId == null) continue;
+      final String url = api.subtitleUrl(
+        itemId: id,
+        mediaSourceId: mediaSourceId,
+        streamIndex: s.index,
+        codec: s.codec,
+      );
+      external ??= s.isExternal ? s : null;
+      tracks.add(RemoteVideoEmbeddedSubtitleTrack(
+        streamIndex: s.index,
+        codec: s.codec,
+        language: s.language,
+        title: s.title,
+        url: url,
+        fileName: _subtitleFileName(item, s),
+      ));
+    }
+
+    return RemoteVideoStreamUrls(
+      streamUrl: api.streamUrl(id),
+      subtitleUrl: external == null || mediaSourceId == null
+          ? null
+          : api.subtitleUrl(
+              itemId: id,
+              mediaSourceId: mediaSourceId,
+              streamIndex: external.index,
+              codec: external.codec,
+            ),
+      subtitleFileName:
+          external == null ? null : _subtitleFileName(item, external),
+      // direct play 是单条 muxed 流（自带音轨）。
+      miningVideoHasAudio: true,
+      embeddedSubtitleTracks: tracks,
+    );
+  }
+
+  static String _subtitleFileName(JellyfinItem item, JellyfinSubtitleStream s) {
+    final String ext = JellyfinApi._subtitleExt(s.codec);
+    final String lang = (s.language ?? '').isEmpty ? '' : '.${s.language}';
+    return '${item.displayTitle}$lang.$ext';
+  }
+
+  @override
+  Future<void> getRemoteVideoSubtitle(
+    String id,
+    File dest, {
+    int? embeddedStreamIndex,
+    int episodeIndex = 0,
+    void Function(double progress)? onProgress,
+  }) async {
+    final JellyfinItem item = await api.itemDetail(userId: userId, itemId: id);
+    final String? mediaSourceId = item.mediaSourceId;
+    if (mediaSourceId == null) {
+      throw const FileSystemException('Jellyfin item has no media source');
+    }
+    JellyfinSubtitleStream? pick;
+    for (final JellyfinSubtitleStream s in item.subtitleStreams) {
+      if (!s.isTextSubtitleStream) continue;
+      if (embeddedStreamIndex != null) {
+        if (s.index == embeddedStreamIndex) {
+          pick = s;
+          break;
+        }
+      } else {
+        // 未指定轨：外挂优先，其次第一条文本轨。
+        if (s.isExternal) {
+          pick = s;
+          break;
+        }
+        pick ??= s;
+      }
+    }
+    if (pick == null) {
+      throw const FileSystemException('Jellyfin item has no text subtitle');
+    }
+    await api.downloadToFile(
+      api.subtitleUrl(
+        itemId: id,
+        mediaSourceId: mediaSourceId,
+        streamIndex: pick.index,
+        codec: pick.codec,
+      ),
+      dest,
+      onProgress: onProgress,
+    );
+  }
+
+  @override
+  Future<({int positionMs, int updatedAtMs})> remoteVideoPosition(
+    String id, {
+    int episodeIndex = 0,
+  }) async {
+    final JellyfinItem item = await api.itemDetail(userId: userId, itemId: id);
+    // 服务器不给「位置更新时刻」，报 0 让调用方按「远端无更新时间」处理
+    // （本地较新时间戳自然赢，不会被远端老位置无脑覆盖）。
+    return (positionMs: item.positionMs, updatedAtMs: 0);
+  }
+
+  @override
+  Future<void> putRemoteVideoPosition(
+    String id,
+    int positionMs,
+    int updatedAtMs, {
+    int episodeIndex = 0,
+  }) =>
+      // last-write-wins（服务器无按时间戳合并）；updatedAtMs 不上传。
+      api.reportStopped(itemId: id, positionMs: positionMs);
+
+  void close() => api.close();
+}

--- a/fushi/lib/src/sync/sync_repository.dart
+++ b/fushi/lib/src/sync/sync_repository.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart' show ValueNotifier;
 import 'package:fushi/src/sync/fushi_sync_server.dart';
+import 'package:fushi/src/sync/jellyfin_video_client.dart'
+    show JellyfinServerConfig;
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/tls/fushi_pinning_http.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -927,6 +929,29 @@ class SyncRepository {
     return id;
   }
 
+  // ── Jellyfin / Emby 媒体服务器 ───────────────────────────────────
+
+  static const _keyJellyfinServer = 'sync_jellyfin_server';
+
+  /// 已登录的 Jellyfin/Emby 服务器配置；未配置 / 已登出 / 脏 JSON → null。
+  /// v1 单服务器（与视频页单远端源架构对齐）。
+  Future<JellyfinServerConfig?> getJellyfinServer() async {
+    final String? raw = await _getStringOrNull(_keyJellyfinServer);
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return JellyfinServerConfig.fromJson(decoded);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// 保存 / 清除（null = 登出删键）Jellyfin 服务器配置。
+  Future<void> setJellyfinServer(JellyfinServerConfig? config) => config == null
+      ? _deleteKey(_keyJellyfinServer)
+      : _setString(_keyJellyfinServer, jsonEncode(config.toJson()));
+
   // ── Hibiki Client (connect to another Hibiki instance) ─────────
 
   static const _keyFushiClientUrl = 'sync_hibiki_client_url';
@@ -1184,6 +1209,8 @@ class SyncRepository {
     _keyFushiClientUrls,
     _keyFushiClientToken,
     _keyFushiClientUrl,
+    // Jellyfin 服务器绑定含访问令牌，属设备本地凭据，绝不随备份跨设备。
+    _keyJellyfinServer,
     // 「要不要接收 host 的 service-config（外部服务 API key）」是每台设备自己的
     // 信任决策，跨设备携带会把 A 机的选择强加给 B 机。
     _keyInterconnectServiceConfigSync,

--- a/fushi/test/sync/jellyfin_video_client_test.dart
+++ b/fushi/test/sync/jellyfin_video_client_test.dart
@@ -1,0 +1,352 @@
+// JellyfinApi / JellyfinVideoClient 离线单测（MockClient，无真实服务器）。
+// 覆盖：URL 归一化、认证头与令牌回填、JSON→DTO 解析（tick→ms、字幕流、
+// 单集展示标题）、RemoteVideoClient 适配（清单映射 / 流 URL 自带 api_key /
+// 外挂字幕优先 / 断点读写）。
+
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart'
+    show RemoteVideoInfo, RemoteVideoStreamUrls;
+import 'package:fushi/src/sync/jellyfin_video_client.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+Map<String, Object?> _episodeJson({
+  String id = 'ep1',
+  int? positionTicks,
+  List<Map<String, Object?>> subtitleStreams = const <Map<String, Object?>>[],
+}) =>
+    <String, Object?>{
+      'Id': id,
+      'Name': 'The Pilot',
+      'Type': 'Episode',
+      'SeriesName': 'Show A',
+      'ParentIndexNumber': 1,
+      'IndexNumber': 2,
+      'RunTimeTicks': 90 * 60 * 1000 * kTicksPerMs,
+      'ImageTags': <String, Object?>{'Primary': 'tag'},
+      'UserData': <String, Object?>{
+        'PlaybackPositionTicks': positionTicks ?? 0,
+      },
+      'MediaSources': <Object?>[
+        <String, Object?>{
+          'Id': 'src1',
+          'MediaStreams': <Object?>[
+            <String, Object?>{'Type': 'Video', 'Index': 0},
+            ...subtitleStreams,
+          ],
+        },
+      ],
+    };
+
+void main() {
+  group('JellyfinApi.normalizeServerUrl', () {
+    test('补 scheme、去尾斜杠', () {
+      expect(JellyfinApi.normalizeServerUrl('nas.local:8096/'),
+          'http://nas.local:8096');
+      expect(JellyfinApi.normalizeServerUrl('https://jf.example.com//'),
+          'https://jf.example.com');
+      expect(JellyfinApi.normalizeServerUrl('  '), '');
+    });
+  });
+
+  group('解析（纯函数）', () {
+    test('parseAuthResult 取令牌与用户 id', () {
+      final JellyfinAuthResult r =
+          JellyfinApi.parseAuthResult(<String, Object?>{
+        'AccessToken': 'tok',
+        'ServerName': 'NAS',
+        'User': <String, Object?>{'Id': 'u1'},
+      });
+      expect(r.accessToken, 'tok');
+      expect(r.userId, 'u1');
+      expect(r.serverName, 'NAS');
+    });
+
+    test('parseViews 保留 collectionType；isVideoish 滤掉音乐/图书', () {
+      final List<JellyfinLibraryView> views =
+          JellyfinApi.parseViews(<String, Object?>{
+        'Items': <Object?>[
+          <String, Object?>{
+            'Id': 'v1',
+            'Name': '电影',
+            'CollectionType': 'movies'
+          },
+          <String, Object?>{
+            'Id': 'v2',
+            'Name': '音乐',
+            'CollectionType': 'music'
+          },
+          <String, Object?>{'Id': 'v3', 'Name': '混合'},
+        ],
+      });
+      expect(views, hasLength(3));
+      expect(views[0].isVideoish, isTrue);
+      expect(views[1].isVideoish, isFalse);
+      expect(views[2].isVideoish, isTrue);
+    });
+
+    test('parseItem：tick→ms、字幕流、单集展示标题', () {
+      final JellyfinItem item = JellyfinApi.parseItem(_episodeJson(
+        positionTicks: 5000 * kTicksPerMs,
+        subtitleStreams: <Map<String, Object?>>[
+          <String, Object?>{
+            'Type': 'Subtitle',
+            'Index': 2,
+            'Codec': 'subrip',
+            'Language': 'jpn',
+            'IsExternal': true,
+            'IsTextSubtitleStream': true,
+          },
+        ],
+      ));
+      expect(item.durationMs, 90 * 60 * 1000);
+      expect(item.positionMs, 5000);
+      expect(item.hasPrimaryImage, isTrue);
+      expect(item.displayTitle, 'Show A S01E02 The Pilot');
+      expect(item.mediaSourceId, 'src1');
+      expect(item.subtitleStreams.single.index, 2);
+      expect(item.subtitleStreams.single.isExternal, isTrue);
+      expect(item.isPlayableVideo, isTrue);
+    });
+  });
+
+  group('JellyfinApi HTTP（MockClient）', () {
+    test('authenticateByName 带 MediaBrowser 头并回填令牌', () async {
+      late http.Request seen;
+      final JellyfinApi api = JellyfinApi(
+        serverUrl: 'http://nas:8096',
+        client: MockClient((http.Request req) async {
+          seen = req;
+          return http.Response(
+            jsonEncode(<String, Object?>{
+              'AccessToken': 'tok',
+              'User': <String, Object?>{'Id': 'u1'},
+            }),
+            200,
+          );
+        }),
+      );
+      final JellyfinAuthResult r = await api.authenticateByName('u', 'p');
+      expect(seen.url.path, '/Users/AuthenticateByName');
+      expect(seen.headers['Authorization'], contains('MediaBrowser'));
+      expect(
+          jsonDecode(seen.body), <String, Object?>{'Username': 'u', 'Pw': 'p'});
+      expect(r.userId, 'u1');
+      expect(api.accessToken, 'tok', reason: '认证成功必须回填令牌供后续 URL 构造');
+    });
+
+    test('认证失败抛 JellyfinApiException（状态码保留）', () async {
+      final JellyfinApi api = JellyfinApi(
+        serverUrl: 'http://nas:8096',
+        client: MockClient((_) async => http.Response('', 401)),
+      );
+      await expectLater(
+        api.authenticateByName('u', 'bad'),
+        throwsA(isA<JellyfinApiException>()
+            .having((JellyfinApiException e) => e.statusCode, 'status', 401)),
+      );
+    });
+
+    test('reportStopped 上报 ticks（ms×10000）', () async {
+      late http.Request seen;
+      final JellyfinApi api = JellyfinApi(
+        serverUrl: 'http://nas:8096',
+        accessToken: 'tok',
+        client: MockClient((http.Request req) async {
+          seen = req;
+          return http.Response('', 204);
+        }),
+      );
+      await api.reportStopped(itemId: 'ep1', positionMs: 1234);
+      expect(seen.url.path, '/Sessions/Playing/Stopped');
+      expect(jsonDecode(seen.body), <String, Object?>{
+        'ItemId': 'ep1',
+        'PositionTicks': 1234 * kTicksPerMs
+      });
+      expect(seen.headers['Authorization'], contains('Token="tok"'));
+    });
+  });
+
+  group('JellyfinVideoClient (RemoteVideoClient 适配)', () {
+    JellyfinVideoClient clientWith(MockClient mock) => JellyfinVideoClient(
+          api: JellyfinApi(
+            serverUrl: 'http://nas:8096',
+            accessToken: 'tok',
+            client: mock,
+          ),
+          userId: 'u1',
+        );
+
+    test('remoteLibrarySourceId 按服务器细分', () {
+      final JellyfinVideoClient c =
+          clientWith(MockClient((_) async => http.Response('{}', 200)));
+      expect(c.remoteLibrarySourceId, 'jellyfin:http://nas:8096');
+    });
+
+    test('coverCacheNamespace 按服务器+用户稳定细分（BUG-1693 口径）', () {
+      final JellyfinVideoClient a =
+          clientWith(MockClient((_) async => http.Response('{}', 200)));
+      final JellyfinVideoClient b = JellyfinVideoClient(
+        api: JellyfinApi(
+          serverUrl: 'http://other:8096',
+          accessToken: 'tok2',
+          client: MockClient((_) async => http.Response('{}', 200)),
+        ),
+        userId: 'u1',
+      );
+      expect(a.coverCacheNamespace, startsWith('jellyfin-'));
+      expect(a.coverCacheNamespace, isNot(b.coverCacheNamespace),
+          reason: '换服务器必须换封面缓存命名空间（防串味）');
+      final JellyfinVideoClient a2 =
+          clientWith(MockClient((_) async => http.Response('{}', 200)));
+      expect(a.coverCacheNamespace, a2.coverCacheNamespace,
+          reason: '同服务器同用户跨实例稳定（换令牌不重下封面）');
+    });
+
+    test('listRemoteVideos 映射标题/时长/封面 URL（自带 api_key）/断点', () async {
+      final JellyfinVideoClient c =
+          clientWith(MockClient((http.Request req) async {
+        expect(req.url.path, '/Users/u1/Items');
+        expect(req.url.queryParameters['Recursive'], 'true');
+        expect(req.url.queryParameters['IncludeItemTypes'], 'Movie,Episode');
+        return http.Response(
+          jsonEncode(<String, Object?>{
+            'Items': <Object?>[
+              _episodeJson(positionTicks: 60000 * kTicksPerMs)
+            ],
+            'TotalRecordCount': 1,
+          }),
+          200,
+        );
+      }));
+      final List<RemoteVideoInfo> list = await c.listRemoteVideos();
+      final RemoteVideoInfo info = list.single;
+      expect(info.id, 'ep1');
+      expect(info.title, 'Show A S01E02 The Pilot');
+      expect(info.durationMs, 90 * 60 * 1000);
+      expect(info.positionMs, 60000);
+      expect(info.hasCover, isTrue);
+      expect(info.coverUrl,
+          'http://nas:8096/Items/ep1/Images/Primary?api_key=tok');
+      // 「显示视频库」结构表达：单集按剧名折叠成 playlist 合集卡。
+      expect(info.collection?.collectionName, 'Show A');
+      expect(info.collection?.collectionType, 'playlist');
+      expect(info.collection?.sortIndex, 1 * 10000 + 2,
+          reason: '组内序 = 季×10000+集，跨季自然有序');
+    });
+
+    test('remoteVideoStreamUrls：直连流自带 api_key，外挂文本字幕优先', () async {
+      final JellyfinVideoClient c =
+          clientWith(MockClient((http.Request req) async {
+        expect(req.url.path, '/Users/u1/Items/ep1');
+        return http.Response(
+          jsonEncode(_episodeJson(
+            subtitleStreams: <Map<String, Object?>>[
+              <String, Object?>{
+                'Type': 'Subtitle',
+                'Index': 1,
+                'Codec': 'ass',
+                'IsExternal': false,
+                'IsTextSubtitleStream': true,
+              },
+              <String, Object?>{
+                'Type': 'Subtitle',
+                'Index': 3,
+                'Codec': 'subrip',
+                'Language': 'jpn',
+                'IsExternal': true,
+                'IsTextSubtitleStream': true,
+              },
+              <String, Object?>{
+                'Type': 'Subtitle',
+                'Index': 4,
+                'Codec': 'pgssub',
+                'IsExternal': false,
+                'IsTextSubtitleStream': false,
+              },
+            ],
+          )),
+          200,
+        );
+      }));
+      final RemoteVideoStreamUrls urls = await c.remoteVideoStreamUrls('ep1');
+      expect(urls.streamUrl,
+          'http://nas:8096/Videos/ep1/stream?static=true&api_key=tok');
+      expect(urls.subtitleUrl,
+          'http://nas:8096/Videos/ep1/src1/Subtitles/3/Stream.srt?api_key=tok',
+          reason: '外挂文本轨优先作为默认外挂字幕');
+      expect(urls.subtitleFileName, 'Show A S01E02 The Pilot.jpn.srt');
+      expect(urls.embeddedSubtitleTracks, hasLength(2),
+          reason: '图形字幕（pgssub）不进文本轨选择器');
+      expect(urls.miningVideoHasAudio, isTrue);
+    });
+
+    test('remoteVideoPosition 读 UserData；put 走 reportStopped', () async {
+      final List<http.Request> seen = <http.Request>[];
+      final JellyfinVideoClient c =
+          clientWith(MockClient((http.Request req) async {
+        seen.add(req);
+        if (req.method == 'POST') return http.Response('', 204);
+        return http.Response(
+            jsonEncode(_episodeJson(positionTicks: 42000 * kTicksPerMs)), 200);
+      }));
+      final ({int positionMs, int updatedAtMs}) pos =
+          await c.remoteVideoPosition('ep1');
+      expect(pos.positionMs, 42000);
+      expect(pos.updatedAtMs, 0, reason: '服务器无更新时刻——报 0 让本地较新时间戳自然赢');
+
+      await c.putRemoteVideoPosition('ep1', 90000, 1755000000000);
+      expect(seen.last.method, 'POST');
+      expect(seen.last.url.path, '/Sessions/Playing/Stopped');
+      expect(jsonDecode(seen.last.body)['PositionTicks'], 90000 * kTicksPerMs);
+    });
+  });
+
+  group('JellyfinServerConfig 持久化（SyncRepository）', () {
+    test('set → get 往返；null = 登出删键', () async {
+      final FushiDatabase db =
+          FushiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      expect(await repo.getJellyfinServer(), isNull);
+
+      const JellyfinServerConfig config = JellyfinServerConfig(
+        serverUrl: 'http://nas:8096',
+        username: 'u',
+        userId: 'u1',
+        accessToken: 'tok',
+        serverName: 'NAS',
+      );
+      await repo.setJellyfinServer(config);
+      final JellyfinServerConfig? loaded = await repo.getJellyfinServer();
+      expect(loaded, isNotNull);
+      expect(loaded!.serverUrl, 'http://nas:8096');
+      expect(loaded.userId, 'u1');
+      expect(loaded.accessToken, 'tok');
+      expect(loaded.serverName, 'NAS');
+
+      await repo.setJellyfinServer(null);
+      expect(await repo.getJellyfinServer(), isNull);
+    });
+
+    test('缺关键字段的脏 JSON → null（不崩）', () {
+      expect(
+        JellyfinServerConfig.fromJson(<String, dynamic>{
+          'serverUrl': 'http://nas:8096',
+        }),
+        isNull,
+      );
+    });
+
+    test('sync_jellyfin_server 在设备本地键目录（令牌不随备份跨设备）', () {
+      expect(
+          SyncRepository.deviceLocalPrefKeys, contains('sync_jellyfin_server'));
+    });
+  });
+}


### PR DESCRIPTION
## 概要
用户需求「支持 Jellyfin 之类的」（v1 视频域 + Emby API 同源兼容，用户已确认）。

- **客户端**：`jellyfin_video_client.dart` 两层——`JellyfinApi` 薄 HTTP 封装（AuthenticateByName / Views / Items / stream / Sessions/Playing/Stopped，JSON 解析全部纯静态离线可测）+ `JellyfinVideoClient implements RemoteVideoClient, RemoteCoverFetcher`。播放路径 `RemoteVideoStreamUrls` 没有 HTTP 头通道，故流/封面/字幕 URL 一律 `api_key` 查询参数自带认证（Jellyfin/Emby 都支持）。
- **零改动复用**：`VideoFushiPage.neutralizedRemote` 播放链、`RemoteLibraryCache`（缓存身份 `jellyfin:<serverUrl>`，BUG-1202 口径）、`RemoteCoverImage` 封面链（命名空间按服务器+用户，BUG-1693 口径）、下载/字幕/进度 UI、卡片渲染。
- **显示视频库**（用户要求）：单集经 `RemoteCollectionMembership` 按剧名折叠成 playlist 合集卡（组内序=季×10000+集），库结构直接呈现在视频库网格，点进合集有剧集面板/上下集。
- **断点双向**：读条目 UserData、写 `Sessions/Playing/Stopped`（服务器 last-write-wins，无时间戳合并——updatedAtMs 报 0 让本地较新值自然赢）。
- **接线**：视频页远端源解析链扩成 互联 ?? Jellyfin ?? 云盘；配置存 `SyncRepository` 新键 `sync_jellyfin_server`（已登记设备本地键目录，令牌不随备份跨设备）；视频设置新增「媒体服务器（Jellyfin / Emby）」分区（登录/登出，searchTitle 带品牌名可搜）。

## 验证
- flutter analyze 全量绿（No issues found）。
- 定向测试全绿：jellyfin_video_client_test（离线 MockClient 覆盖认证/解析/适配/持久化）+ sync_repository_test（41 通过）；md3 设计守卫 + 远端视频相邻 4 组（77 通过）；i18n 完整性（22 通过）。
- 未连真实 Jellyfin 服务器实测（本机无实例）——端点与参数按 Jellyfin 10.8+/Emby 公开 API 惯例实现，标注 implemented_unverified，真机验证缺口见 PR 描述。

https://claude.ai/code/session_01E6x4drSY8aUDGzCqZ2UzER