### PR TITLE
fix: repair popup sizing and Windows actions

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1531 条。点号进各自文件。
+> 共 1534 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1653](bugs/BUG-1653-popup-dictionary-itest-desktop-drift.md) | ✅ | ✅ | popup_dictionary 应用级测试在桌面端因平台与导航假设失效 |
+| [BUG-1652](bugs/BUG-1652-windows-webview-click-stale-cursor.md) | ✅ | ✅ | Windows WebView 点击使用旧光标坐标导致词条操作无响应 |
+| [BUG-1651](bugs/BUG-1651-popup-auto-fit-height.md) | ✅ | ✅ | 查词弹窗忽略内容高度导致底部大面积留白 |
 | [BUG-1649](bugs/BUG-1649-manga-folder-epub-import.md) | ✅ | ✅ | 漫画页选文件夹导入：目录内是 epub 卷时报 Manga image folder has no pages |
 | [BUG-1648](bugs/BUG-1648-embedded-torrent-idle-discovery.md) | ✅ | ✅ | 已完成任务恢复后 DHT 常驻导致网关周期性高延迟 |
 | [BUG-1647](bugs/BUG-1647-bangumi-sync-stuck-in-backoff.md) | ✅ | ✅ | Bangumi 同步失败后卡在退避窗口且无自动重试，只能手动同步 |

--- a/docs/bugs/BUG-1651-popup-auto-fit-height.md
+++ b/docs/bugs/BUG-1651-popup-auto-fit-height.md
@@ -1,0 +1,15 @@
+## BUG-1651 · 查词弹窗忽略内容高度导致底部大面积留白
+- **报告**：2026-08-14（用户：视频查词弹窗底部出现大面积空白）
+- **真实性**：✅ 真 bug。`popup.js::_reportPopupHeight` 已把 DOM 内容高度放在
+  `popupRendered` 的第一个参数上报，但 `dictionary_popup_webview.dart` 只读取 render
+  token；`dictionary_page_mixin.dart::_calcMixinPopupPosition` 因此始终使用偏好里的最大
+  高度，内容较少时外壳也不会收缩。
+- **[x] ① 已修复** — `popupRendered` 同时回传 WebView 视口高度，Dart 用
+  `当前外壳高度 + 内容高度 - 视口高度` 得出包含 Flutter 顶栏的目标总高，并在用户
+  最小/最大高度内自适应；底部固定模式和正在拖拽尺寸时保持原有固定尺寸语义。
+- **[x] ② 已加自动化测试** — `dictionary_popup_layer_test.dart` 覆盖收缩、内容增长、
+  最大高度与无效测量；`dictionary_popup_webview_test.dart` 覆盖离屏视口回退；
+  `popup_font_ready_gate_test.js` 覆盖 JS 高度/视口/token 三元上报。macOS 真 app 浮层
+  实测 DOM 内容 267、外壳从最大 360 自动收到 296。
+- **备注**：仅对用户截图所在的 video/首页/texthooker mixin 弹窗启用；reader 家族本次
+  不扩范围。

--- a/docs/bugs/BUG-1652-windows-webview-click-stale-cursor.md
+++ b/docs/bugs/BUG-1652-windows-webview-click-stale-cursor.md
@@ -1,0 +1,13 @@
+## BUG-1652 · Windows WebView 点击使用旧光标坐标导致词条操作无响应
+- **报告**：2026-08-14（用户：右上角“+”与“收藏”点击无反应）
+- **真实性**：✅ 真 bug。Windows `custom_platform_view.dart` 的 hover/move 会调用
+  `setCursorPos`，但 mouse down/up 只调用按钮状态同步；native WebView2 的
+  `setPointerButtonState` 使用缓存的 `lastCursorPos_`，弹窗出现在静止光标下或跨平台视图
+  边界时，down/up 会落到旧 DOM 坐标，按钮业务 handler 根本收不到 click。
+- **[x] ① 已修复** — 所有非触摸事件统一规划为“先同步本次 localPosition，再按位同步
+  按钮状态”，down/up/cancel/hover/move 都走同一有序路径。
+- **[x] ② 已加自动化测试** — `mouse_button_mask_diff_test.dart` 新增 down/up 命令顺序
+  回归，断言坐标命令严格排在 primary button 翻转之前；原多键与 sticky-state 用例保持
+  全绿。
+- **备注**：业务层 `mineEntry` / `favoriteEntry` 的 JS→Dart 回调原本完整，两个按钮一起
+  失效发生在它们共同的 Windows 指针输入前置链路。

--- a/docs/bugs/BUG-1653-popup-dictionary-itest-desktop-drift.md
+++ b/docs/bugs/BUG-1653-popup-dictionary-itest-desktop-drift.md
@@ -1,0 +1,14 @@
+## BUG-1653 · popup_dictionary 应用级测试在桌面端因平台与导航假设失效
+- **报告**：2026-08-14（用户：要求修复后手动测试全部功能并修复发现项）
+- **真实性**：✅ 真 bug。`integration_test/popup_dictionary_test.dart` 只按 Android 编写：
+  无条件调用 `getExternalStorageDirectory()`；复跑时同名词典已存在却只认
+  `onImportSuccess`；并假定词典永远是导航第 2 项。macOS 真 app 巡检分别在这三处失败，
+  无法抵达弹窗功能验证。
+- **[x] ① 已修复** — 桌面端每轮生成确定性词典、重复导入改验真实已安装状态；外部存储
+  只在 Android 查询；导航按 `HomeTab.dictionaries` 的生产身份定位。测试同时扩展为真
+  WebView 浮层验收：DOM 按钮存在、高度自适应、收藏/取消收藏写穿 SQLite、关闭浮层。
+- **[x] ② 已加自动化测试** — 修复即落在现有 `popup_dictionary` 应用级目标中；macOS
+  `flutter test integration_test/popup_dictionary_test.dart -d macos --no-pub` 已全绿。
+- **备注**：macOS runner 无可抓取 CGWindow，且离屏 WKWebView 的 `window.innerHeight`
+  为 0；BUG-1651 同步增加 Flutter RenderBox 高度回退，实测单词条外壳从最大 360 收到
+  296。

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -3651,7 +3651,8 @@ function _reportPopupHeight() {
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __fushiScrollHeight(),
-            window.__fushiRenderToken || 0);
+            window.__fushiRenderToken || 0,
+            window.innerHeight || document.documentElement.clientHeight || 0);
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
@@ -4340,7 +4341,8 @@ window.updatePopupIncremental = function() {
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __fushiScrollHeight(),
-        window.__fushiRenderToken || 0);
+        window.__fushiRenderToken || 0,
+        window.innerHeight || document.documentElement.clientHeight || 0);
 };
 
 

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -3651,7 +3651,8 @@ function _reportPopupHeight() {
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __fushiScrollHeight(),
-            window.__fushiRenderToken || 0);
+            window.__fushiRenderToken || 0,
+            window.innerHeight || document.documentElement.clientHeight || 0);
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
@@ -4340,7 +4341,8 @@ window.updatePopupIncremental = function() {
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __fushiScrollHeight(),
-        window.__fushiRenderToken || 0);
+        window.__fushiRenderToken || 0,
+        window.innerHeight || document.documentElement.clientHeight || 0);
 };
 
 

--- a/fushi/integration_test/popup_dictionary_test.dart
+++ b/fushi/integration_test/popup_dictionary_test.dart
@@ -9,8 +9,10 @@ import 'package:path_provider/path_provider.dart';
 
 import 'package:fushi/main.dart' as app;
 import 'package:fushi/models.dart';
+import 'package:fushi/pages.dart';
 
 import 'helpers/focus_driver.dart';
+import 'helpers/library_fixture.dart';
 import 'test_helpers.dart';
 
 /// Integration test for popup dictionary path fix verification.
@@ -61,12 +63,25 @@ void main() {
 
       final cacheDir = await getTemporaryDirectory();
       final File dictFile = File('${cacheDir.path}/test_dict.zip');
+      String primarySearchTerm = '食べる';
+      bool generatedFallback = false;
 
-      if (!dictFile.existsSync()) {
+      if (!Platform.isAndroid) {
+        // Desktop runs have no runner-provisioned external fixture and retain
+        // the cache across runs. Rewrite the deterministic fixture every time
+        // so an old `test_dict.zip` cannot make this test order-dependent.
+        await writeGeneratedDictionary(dictFile);
+        primarySearchTerm = 'testword';
+        generatedFallback = true;
+        debugPrint('[popup-test] Generated local dictionary fixture');
+      } else if (!dictFile.existsSync()) {
         // The runner pushes the fixture into the app's own external-files dir
         // (readable with no permission); /sdcard/Download is a legacy fallback
         // but is blocked for the app uid under scoped storage.
-        final Directory? extDir = await getExternalStorageDirectory();
+        // `getExternalStorageDirectory` is Android-only. Desktop app-level
+        // verification uses the generated fixture fallback below.
+        final Directory? extDir =
+            Platform.isAndroid ? await getExternalStorageDirectory() : null;
         final List<File> candidates = <File>[
           if (extDir != null) File('${extDir.path}/test_dict.zip'),
           File('/sdcard/Download/test_dict.zip'),
@@ -107,6 +122,13 @@ void main() {
         debugPrint('[popup-test] Dictionary import error: $e');
       }
 
+      // importDictionary intentionally does not call onImportSuccess when the
+      // same generated fixture is already installed. Desktop reruns are
+      // persistent, so verify the fixture instead of waiting 30 seconds.
+      if (!importSuccess && generatedFallback) {
+        importSuccess = await seedDictionary(tester);
+      }
+
       // Pump frames to let the model update listeners.
       for (int i = 0; i < 60; i++) {
         await tester.pump(const Duration(milliseconds: 500));
@@ -121,13 +143,17 @@ void main() {
 
       progressNotifier.dispose();
 
+      // Phase 4 below needs the deterministic `testword` entry even when the
+      // Android runner supplied a full Japanese dictionary fixture.
+      expect(await seedDictionary(tester), isTrue,
+          reason: 'generated popup-action fixture must be installed');
+
       // ── Phase 2: Navigate to dictionary tab ──
 
-      final List<Finder> navTargets = findPrimaryNavigationTargets();
-      expect(navTargets.length, greaterThanOrEqualTo(2),
-          reason: 'Navigation must have at least 2 targets (Books, Dicts)');
-
-      final bool focusedDict = await driver.focusWidget(navTargets[1]);
+      // Home tabs are conditional; locate the dictionary destination by its
+      // production identity instead of assuming it is always index 1.
+      final Finder dictionaryTab = findNavTargetForTab(HomeTab.dictionaries);
+      final bool focusedDict = await driver.focusWidget(dictionaryTab);
       expect(focusedDict, isTrue,
           reason: 'Dictionary tab must be reachable by focus');
       await driver.activate();
@@ -138,7 +164,11 @@ void main() {
       // ── Phase 3: Search for a word ──
 
       final Finder searchField = findSearchField();
-      await tester.enterText(searchField, '食べる');
+      await tester.enterText(searchField, primarySearchTerm);
+      final HomeDictionarySearchDebug popupDebug = tester.state(
+        find.byType(HomeDictionaryPage),
+      ) as HomeDictionarySearchDebug;
+      await popupDebug.debugSearch(primarySearchTerm, writeHistory: true);
       await tester.pump(const Duration(seconds: 5));
 
       await takeScreenshot(binding, 'popup_test_search_result');
@@ -148,7 +178,89 @@ void main() {
       debugPrint('[popup-test] Search results: $resultCount evidence widgets');
 
       expect(resultCount, greaterThan(0),
-          reason: 'Dictionary search for 食べる must return at least one result');
+          reason:
+              'Dictionary search for $primarySearchTerm must return results');
+
+      // ── Phase 4: Exercise the real in-app nested popup host ──
+
+      final bool originalBottomDocked = appModel.popupBottomDocked;
+      await appModel.setPopupBottomDocked(false);
+      addTearDown(
+        () => appModel.setPopupBottomDocked(originalBottomDocked),
+      );
+      final int popupMatches = await popupDebug.debugOpenPopup('testword');
+      expect(popupMatches, greaterThan(0));
+
+      Map<Object?, Object?>? snapshot;
+      for (int i = 0; i < 80; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        final dynamic raw = await popupDebug.debugEvaluateTopPopup(r'''
+(() => ({
+  ready: document.readyState,
+  mineButtons: document.querySelectorAll('.mine-button').length,
+  favoriteButtons: document.querySelectorAll('.favorite-button').length,
+  contentHeight: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight),
+  viewportHeight: window.innerHeight
+}))()
+''');
+        if (raw is Map && raw['favoriteButtons'] == 1) {
+          snapshot = raw.cast<Object?, Object?>();
+          break;
+        }
+      }
+
+      debugPrint('[popup-test] Nested popup snapshot: $snapshot; '
+          'autoFit=${popupDebug.debugTopPopupAutoFitHeight}');
+      expect(snapshot, isNotNull,
+          reason: 'real popup WebView must render mine/favorite controls');
+      expect(snapshot!['mineButtons'], 1);
+      expect(snapshot['favoriteButtons'], 1);
+      expect(popupDebug.debugTopPopupAutoFitHeight, isNotNull,
+          reason:
+              'popupRendered must feed DOM metrics back to the Flutter host');
+      expect(
+        popupDebug.debugTopPopupAutoFitHeight!,
+        lessThan(appModel.popupMaxHeight * appModel.appUiScale),
+        reason: 'single generated entry must shrink below the configured max '
+            'instead of leaving the reported blank lower half',
+      );
+
+      // DOM click exercises the actual JS -> native WebView -> Dart favorite bridge.
+      // Windows native pointer ordering itself is covered by the plugin event test.
+      await popupDebug.debugEvaluateTopPopup(
+        "document.querySelector('.favorite-button').click(); true",
+      );
+      bool favorited = false;
+      for (int i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        favorited = await appModel.database.isFavoriteWord(
+          expression: 'testword',
+          reading: 'testword',
+          sourceType: 'book',
+        );
+        if (favorited) break;
+      }
+      expect(favorited, isTrue,
+          reason:
+              'favorite button must cross the real JS/Dart bridge and write DB');
+
+      await popupDebug.debugEvaluateTopPopup(
+        "document.querySelector('.favorite-button').click(); true",
+      );
+      for (int i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+        favorited = await appModel.database.isFavoriteWord(
+          expression: 'testword',
+          reading: 'testword',
+          sourceType: 'book',
+        );
+        if (!favorited) break;
+      }
+      expect(favorited, isFalse,
+          reason: 'second favorite activation must remove the same DB row');
+
+      popupDebug.debugClosePopup();
+      await tester.pump(const Duration(milliseconds: 300));
 
       await takeScreenshot(binding, 'popup_test_verified');
 

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -223,19 +223,30 @@ mixin DictionaryPageMixin {
   /// 一处分流即覆盖 buildNestedPopupLayer / buildPopupLoadingPlaceholder 两个调用点，且
   /// 不触碰 video 页本体。盒子尺寸口径与原两处一致（maxWidth/Height × appUiScale，padding
   /// 与 reserve 走 calcPopupPosition 默认 6/0）。
-  Rect _calcMixinPopupPosition(Rect selectionRect, Size screen) {
+  Rect _calcMixinPopupPosition(
+    Rect selectionRect,
+    Size screen, {
+    double? autoFitHeight,
+  }) {
     // 与 base_source_page._calculatePopupPosition 共用 [resolvePopupRect]。mixin
     // 家族（video/首页/texthooker）不预留 reserve、不竖排避让（全用默认），盒子尺寸
     // 随界面大小放大（同 base 的 popupMaxWidth/Height）。Phase B 拖把手时用预览态
     // [_popupResizePreview] 临时覆盖偏好实时预览（松手落库，见 [_onMixinPopupResizeEnd]）。
+    final double preferredMaxHeight =
+        (_popupResizePreview?.height ?? mixinAppModel.popupMaxHeight) *
+            mixinAppModel.appUiScale;
+    final double effectiveMaxHeight = _popupResizePreview != null
+        ? preferredMaxHeight
+        : (autoFitHeight ?? preferredMaxHeight)
+            .clamp(0.0, preferredMaxHeight)
+            .toDouble();
     final Rect anchored = resolvePopupRect(
       selectionRect: selectionRect,
       screen: screen,
       bottomDocked: mixinAppModel.popupBottomDocked,
       maxWidth: (_popupResizePreview?.width ?? mixinAppModel.popupMaxWidth) *
           mixinAppModel.appUiScale,
-      maxHeight: (_popupResizePreview?.height ?? mixinAppModel.popupMaxHeight) *
-          mixinAppModel.appUiScale,
+      maxHeight: effectiveMaxHeight,
     );
     // Phase B 拖拽尺寸（2026-07-15）：被拖的那张卡（选区匹配）冻结左上角，从右下生长，
     // 消除「词靠右缘时贴词定位把左缘左移」的 bug（同 base_source_page）。dock 模式不冻结。
@@ -640,7 +651,11 @@ mixin DictionaryPageMixin {
     required void Function(int index) onPop,
   }) {
     final DictionaryPopupEntry entry = controller.entries[index];
-    final Rect pos = _calcMixinPopupPosition(entry.selectionRect, screen);
+    final Rect pos = _calcMixinPopupPosition(
+      entry.selectionRect,
+      screen,
+      autoFitHeight: entry.autoFitHeight,
+    );
     // Phase B 拖拽尺寸：缓存顶层卡当前 rect/选区，供 [_onMixinPopupResizeStart] 冻结左上角。
     if (index == controller.entries.length - 1) {
       _topPopupSelectionRect = entry.selectionRect;
@@ -708,6 +723,27 @@ mixin DictionaryPageMixin {
           // 把光标 transfer 进刚显示的顶层弹窗（BaseSourcePageState 家族的
           // onDictionaryPopupRendered 同语义；mixin 家族此前没有该钩子）。
           onNestedPopupRendered(index);
+        },
+        onContentMetrics: (double contentHeight, double viewportHeight) {
+          if (!mounted ||
+              !controller.entries.contains(entry) ||
+              mixinAppModel.popupBottomDocked ||
+              _popupResizePreview != null) {
+            return;
+          }
+          final double preferredMaxHeight =
+              mixinAppModel.popupMaxHeight * mixinAppModel.appUiScale;
+          final double nextHeight = resolveAutoFitPopupHeight(
+            currentPopupHeight: pos.height,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            minHeight: kLookupPopupMinHeight * mixinAppModel.appUiScale,
+            maxHeight: preferredMaxHeight,
+          );
+          if ((nextHeight - (entry.autoFitHeight ?? pos.height)).abs() < 1) {
+            return;
+          }
+          setState(() => entry.autoFitHeight = nextHeight);
         },
         // TODO-058 fail-safe：WebView 加载失败也走同一翻可见路径（不卡死）。
         onRenderError: () {

--- a/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
@@ -52,6 +52,10 @@ class DictionaryPopupEntry {
   /// 是否已无更多结果可加载（分页到底）。
   bool allLoaded;
 
+  /// BUG-1651：本层按 DOM 内容测量得到的外壳总高度（Flutter 逻辑像素）。null 表示
+  /// 尚未测量，先按用户最大高度布局；每次新顶层查词重置，增量结果则在当前高度上伸缩。
+  double? autoFitHeight;
+
   /// 仅常驻热槽为 true：其 WebView 全程挂载复用，关栈时隐藏而非销毁。
   final bool isWarmSlot;
 
@@ -193,6 +197,7 @@ class DictionaryPopupController extends ChangeNotifier {
       ..revealOnRender = false
       ..isSearching = false
       ..allLoaded = false;
+    e.autoFitHeight = null;
   }
 
   /// 顶层查词目标：能复用常驻热槽（首条且 isWarmSlot）就原地复用并丢弃子层；
@@ -218,6 +223,7 @@ class DictionaryPopupController extends ChangeNotifier {
         ..selectionRect = rect
         ..result = initialResult
         ..allLoaded = false
+        ..autoFitHeight = null
         ..isSearching = true
         ..revealOnRender = false
         ..visible = visible;

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -239,6 +239,30 @@ Rect resolvePopupRect({
   );
 }
 
+/// BUG-1651：根据 WebView 内容高度与当前视口高度的差值，求下一帧弹窗总高度。
+///
+/// `currentPopupHeight` 是包含 Flutter 顶栏/header 的外壳高度；JS 上报的两个值只属于
+/// WebView body。用差值增减当前总高，就不需要在 Dart 重复猜顶栏高度。结果受用户的
+/// 最小/最大高度约束；平台视图初始化期的 0/NaN 测量保持原高，避免闪跳。
+double resolveAutoFitPopupHeight({
+  required double currentPopupHeight,
+  required double contentHeight,
+  required double viewportHeight,
+  required double minHeight,
+  required double maxHeight,
+}) {
+  if (!currentPopupHeight.isFinite ||
+      !contentHeight.isFinite ||
+      !viewportHeight.isFinite ||
+      contentHeight < 0 ||
+      viewportHeight <= 0 ||
+      minHeight > maxHeight) {
+    return currentPopupHeight;
+  }
+  final double desired = currentPopupHeight + contentHeight - viewportHeight;
+  return desired.clamp(minHeight, maxHeight).toDouble();
+}
+
 /// Phase B 拖拽尺寸（2026-07-15）— 把贴词算出的 [anchored] rect 的**原点钉回**
 /// [topLeft]（拖拽起始时那张卡的左上角），只保留其尺寸并夹住不越出屏幕（右下不出界）。
 ///
@@ -445,6 +469,7 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.onTapOutside,
     this.onScrolledToBottom,
     this.onRendered,
+    this.onContentMetrics,
     this.onRenderError,
     this.inputSpec = const DictionaryPopupInputSpec(),
     this.onHostInputToken,
@@ -537,6 +562,10 @@ class DictionaryPopupLayer extends StatelessWidget {
   final VoidCallback? onTapOutside;
   final VoidCallback? onScrolledToBottom;
   final VoidCallback? onRendered;
+
+  /// JS 内容高度与当前 WebView 视口高度。宿主用二者差值自适应外壳总高。
+  final void Function(double contentHeight, double viewportHeight)?
+      onContentMetrics;
 
   /// TODO-058 fail-safe：弹窗 WebView 主框架加载失败时触发，宿主据此立即翻可见
   /// 挂起的冷层（加载失败也显示，不卡死）。
@@ -959,6 +988,7 @@ class DictionaryPopupLayer extends StatelessWidget {
             onSentenceContextPreview: onSentenceContextPreview,
             onScrolledToBottom: onScrolledToBottom,
             onRendered: onRendered,
+            onContentMetrics: onContentMetrics,
             onRenderError: onRenderError,
             inputSpec: inputSpec,
             onHostInputToken: onHostInputToken,

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -16,8 +16,7 @@ import 'package:fushi/src/pages/implementations/popup_settings_injection.dart';
 import 'package:fushi/src/platform/selection_external_actions.dart';
 import 'package:fushi/src/reader/popup_swipe_close_script.dart';
 import 'package:fushi/src/reader/reader_caret_scripts.dart';
-import 'package:fushi/src/shortcuts/input_binding.dart'
-    show activeModifierKeys;
+import 'package:fushi/src/shortcuts/input_binding.dart' show activeModifierKeys;
 import 'package:fushi/src/shortcuts/reader_space_override.dart'
     show readerShouldHandleDesktopCopy;
 import 'package:fushi/src/utils/misc/lookup_audio_playback.dart';
@@ -73,6 +72,24 @@ class MinePopupResult {
 /// WebView2 原生菜单）。两项：查词（平移自原 WebView2 自定义项）+ 复制（自补，BUG-402）。
 enum _PopupContextMenuAction { search, copy }
 
+/// BUG-1651：选择可信的 WebView 视口高度。
+///
+/// 正常窗口优先用 JS `window.innerHeight`；macOS 离屏 runner / 原生视图尚未挂到
+/// CGWindow 时 JS 会报 0，但 Flutter platform-view widget 已有真实布局高度，此时回退
+/// [layoutHeight]。两边都无效才返回 null，让宿主保持当前尺寸。
+double? resolvePopupViewportHeight({
+  required double? reportedHeight,
+  required double? layoutHeight,
+}) {
+  if (reportedHeight != null && reportedHeight.isFinite && reportedHeight > 0) {
+    return reportedHeight;
+  }
+  if (layoutHeight != null && layoutHeight.isFinite && layoutHeight > 0) {
+    return layoutHeight;
+  }
+  return null;
+}
+
 class DictionaryPopupWebView extends ConsumerStatefulWidget {
   const DictionaryPopupWebView({
     required this.result,
@@ -98,6 +115,7 @@ class DictionaryPopupWebView extends ConsumerStatefulWidget {
     this.onScrolledToBottom,
     this.onTopPullReleased,
     this.onRendered,
+    this.onContentMetrics,
     this.onRenderError,
     this.inputSpec = const DictionaryPopupInputSpec(),
     this.onHostInputToken,
@@ -200,6 +218,10 @@ class DictionaryPopupWebView extends ConsumerStatefulWidget {
   /// Fired after the popup content finishes rendering (the `popupRendered` JS
   /// handler). Used by the reader to hand the char-level cursor to this popup.
   final VoidCallback? onRendered;
+
+  /// `popupRendered` 同步带回的 DOM 内容高度与 WebView 当前视口高度。
+  final void Function(double contentHeight, double viewportHeight)?
+      onContentMetrics;
 
   /// TODO-058 fail-safe：主框架加载失败（`onReceivedError`）时触发。挂起到
   /// `popupRendered` 才显示的冷层若加载失败，`popupRendered` 永不会发；宿主据此
@@ -1575,6 +1597,28 @@ JSON.stringify((function(){
                     : int.tryParse(rawToken?.toString() ?? '');
                 if (token != null && token != _renderToken) {
                   return null;
+                }
+                final double? contentHeight = (args.isNotEmpty ? args[0] : null)
+                        is num
+                    ? (args[0] as num).toDouble()
+                    : double.tryParse(
+                        (args.isNotEmpty ? args[0] : null)?.toString() ?? '',
+                      );
+                final Object? rawViewport = args.length > 2 ? args[2] : null;
+                final double? reportedViewportHeight = rawViewport is num
+                    ? rawViewport.toDouble()
+                    : double.tryParse(rawViewport?.toString() ?? '');
+                final RenderObject? renderObject = context.findRenderObject();
+                final double? viewportHeight = resolvePopupViewportHeight(
+                  reportedHeight: reportedViewportHeight,
+                  layoutHeight: renderObject is RenderBox &&
+                          renderObject.attached &&
+                          renderObject.hasSize
+                      ? renderObject.size.height
+                      : null,
+                );
+                if (contentHeight != null && viewportHeight != null) {
+                  widget.onContentMetrics?.call(contentHeight, viewportHeight);
                 }
                 // 记录「当前已推结果渲染完成」，供 refreshCurrentResult 去重判定
                 // （识别渲染信号早于宿主盖板架起的竞态）。

--- a/fushi/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dictionary_page.dart
@@ -38,6 +38,18 @@ abstract class HomeDictionarySearchDebug {
   /// 以便测试 await 失败路径，避免依赖 UI 文本输入的异步链。[writeHistory] 默认
   /// false 以隔离历史写入 / autoRead 等副作用，只验证查词状态机。
   Future<void> debugSearch(String term, {bool writeHistory});
+
+  /// 直接走 HomeDictionaryPage 的生产 `_pushNestedPopup` 路径打开 app 内查词浮层。
+  Future<int> debugOpenPopup(String term);
+
+  /// 当前顶层浮层按 DOM 测量得到的自适应总高；尚未测量/无层时为 null。
+  double? get debugTopPopupAutoFitHeight;
+
+  /// 在当前顶层浮层 WebView 内执行验收脚本（测试功能按钮与 DOM 状态）。
+  Future<dynamic> debugEvaluateTopPopup(String source);
+
+  /// 关闭整条浮层栈，等价于用户从顶层关闭。
+  void debugClosePopup();
 }
 
 /// The body content for the Dictionary tab in the main menu.
@@ -784,6 +796,32 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     _lastDispatchedSearch = null;
     _search(term, writeHistory: writeHistory);
     return _lastDispatchedSearch ?? Future<void>.value();
+  }
+
+  @override
+  Future<int> debugOpenPopup(String term) => _pushNestedPopup(
+        term,
+        const Rect.fromLTWH(180, 180, 24, 24),
+        reuseWarmSlot: true,
+      );
+
+  @override
+  double? get debugTopPopupAutoFitHeight {
+    final int index = _popup.lastVisibleIndex;
+    return index < 0 ? null : _popup.entries[index].autoFitHeight;
+  }
+
+  @override
+  Future<dynamic> debugEvaluateTopPopup(String source) async {
+    final int index = _popup.lastVisibleIndex;
+    if (index < 0) return null;
+    return _popup.entries[index].webViewKey.currentState?.debugEval(source);
+  }
+
+  @override
+  void debugClosePopup() {
+    final int index = _popup.lastVisibleIndex;
+    if (index >= 0) _popNestedPopupAt(index);
   }
 
   // ── search results with nested popups ──────────────────────────────

--- a/fushi/test/pages/dictionary_popup_layer_test.dart
+++ b/fushi/test/pages/dictionary_popup_layer_test.dart
@@ -8,6 +8,47 @@ import 'package:fushi/src/utils/misc/swipe_dismiss_wrapper.dart';
 import '../widgets/widget_test_helpers.dart';
 
 void main() {
+  group('resolveAutoFitPopupHeight', () {
+    test('按内容与 WebView 视口的差值收掉底部空白', () {
+      expect(
+        resolveAutoFitPopupHeight(
+          currentPopupHeight: 360,
+          contentHeight: 210,
+          viewportHeight: 310,
+          minHeight: 200,
+          maxHeight: 600,
+        ),
+        260,
+      );
+    });
+
+    test('内容变多时重新长高，但不超过用户最大高度', () {
+      expect(
+        resolveAutoFitPopupHeight(
+          currentPopupHeight: 260,
+          contentHeight: 430,
+          viewportHeight: 210,
+          minHeight: 200,
+          maxHeight: 360,
+        ),
+        360,
+      );
+    });
+
+    test('无效测量保持当前高度，避免平台初始化期弹窗跳变', () {
+      expect(
+        resolveAutoFitPopupHeight(
+          currentPopupHeight: 360,
+          contentHeight: double.nan,
+          viewportHeight: 0,
+          minHeight: 200,
+          maxHeight: 600,
+        ),
+        360,
+      );
+    });
+  });
+
   test('calcPopupPosition stays inside a constrained popup surface', () {
     final Rect popupRect = calcPopupPosition(
       selectionRect: const Rect.fromLTWH(2, 2, 1, 1),

--- a/fushi/test/pages/dictionary_popup_webview_test.dart
+++ b/fushi/test/pages/dictionary_popup_webview_test.dart
@@ -8,6 +8,29 @@ import 'package:fushi_dictionary/fushi_dictionary.dart';
 import '../helpers/source_guard.dart';
 
 void main() {
+  group('resolvePopupViewportHeight', () {
+    test('uses the live JS viewport when it is valid', () {
+      expect(
+        resolvePopupViewportHeight(reportedHeight: 280, layoutHeight: 310),
+        280,
+      );
+    });
+
+    test('falls back to Flutter layout for an offscreen native WebView', () {
+      expect(
+        resolvePopupViewportHeight(reportedHeight: 0, layoutHeight: 310),
+        310,
+      );
+    });
+
+    test('returns null when neither side has a usable viewport', () {
+      expect(
+        resolvePopupViewportHeight(reportedHeight: 0, layoutHeight: 0),
+        isNull,
+      );
+    });
+  });
+
   group('dictionary popup asset bootstrap', () {
     test('iOS uses inline popup assets instead of a file URL main frame', () {
       final source = File(

--- a/fushi/test/pages/popup_font_ready_gate_test.js
+++ b/fushi/test/pages/popup_font_ready_gate_test.js
@@ -23,7 +23,7 @@ function deferred() {
 }
 
 function makeSandbox(fontReady, configured) {
-  const calls = { rendered: 0, relayout: 0, layoutReads: 0 };
+  const calls = { rendered: 0, relayout: 0, layoutReads: 0, renderedArgs: null };
   const body = {};
   Object.defineProperty(body, 'offsetWidth', {
     get() { calls.layoutReads += 1; return 640; },
@@ -33,11 +33,15 @@ function makeSandbox(fontReady, configured) {
     _renderInProgress: true,
     __fushiDictionaryFontsConfigured: configured,
     flutter_inappwebview: {
-      callHandler(name) {
-        if (name === 'popupRendered') calls.rendered += 1;
+      callHandler(name, ...args) {
+        if (name === 'popupRendered') {
+          calls.rendered += 1;
+          calls.renderedArgs = args;
+        }
         return Promise.resolve();
       },
     },
+    innerHeight: 280,
     fushiRelayoutDictionaries() { calls.relayout += 1; },
   };
   const sandbox = {
@@ -72,6 +76,8 @@ async function flushPromises() {
       'the host reveal signal must fire after fonts.ready');
     assert.strictEqual(calls.relayout, 1,
       'masonry layout must run after the font metrics are final');
+    assert.deepStrictEqual(calls.renderedArgs, [100, 0, 280],
+      'popupRendered must report content height, render token, and viewport height');
   }
 
   {

--- a/fushi/test/reader/webview2_mouse_button_sync_guard_test.dart
+++ b/fushi/test/reader/webview2_mouse_button_sync_guard_test.dart
@@ -41,19 +41,24 @@ void main() {
   });
 
   test('五个非触摸指针入口都全量同步 ev.buttons', () {
-    expect(src.contains('void _syncMouseButtons(int buttons)'), isTrue,
+    expect(src.contains('void _syncMouseInput(Offset position, int buttons)'),
+        isTrue,
         reason: '全量同步入口被改名/删除，守卫须同步更新');
     // hover / down / up / cancel / move 各一处：hover 的掩码恒 0，是残留位唯一可靠的
     // 自愈点；缺任何一处都会让某类漏发的 up 无法补上。
-    final int calls = '_syncMouseButtons(ev.buttons)'.allMatches(src).length;
+    final int calls =
+        '_syncMouseInput(ev.localPosition, ev.buttons)'.allMatches(src).length;
     expect(calls, greaterThanOrEqualTo(5),
         reason: 'onPointerHover / Down / Up / Cancel / Move 五个入口都必须调用，'
             '实际只有 $calls 处');
   });
 
   test('同步走纯函数差分，且差分只对变化位产出翻转', () {
-    expect(src.contains('diffMouseButtonMasks(_mouseButtons, buttons)'), isTrue,
-        reason: '_syncMouseButtons 必须复用可单测的纯函数 diffMouseButtonMasks');
+    expect(src.contains('planMouseInputDispatches('), isTrue,
+        reason: '_syncMouseInput 必须复用可单测的有序输入规划器');
+    expect(src.contains('diffMouseButtonMasks(previousButtons, nextButtons)'),
+        isTrue,
+        reason: '有序输入规划器必须继续复用 BUG-1419 的逐位差分真值');
     expect(src.contains('List<MouseButtonTransition> diffMouseButtonMasks('),
         isTrue,
         reason: 'diffMouseButtonMasks 是 BUG-1419 的真值来源，不得内联回 State');

--- a/packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
+++ b/packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
@@ -101,6 +101,33 @@ List<MouseButtonTransition> diffMouseButtonMasks(int previous, int next) {
   return transitions;
 }
 
+/// 一次非触摸鼠标事件要按顺序下发给 WebView2 的命令。
+///
+/// [position] 与 [buttonTransition] 恰有一个非空。用 record 保持这个纯规划器轻量；
+/// 真正的 MethodChannel 调用仍由 widget state 执行。
+typedef MouseInputDispatch = ({
+  Offset? position,
+  MouseButtonTransition? buttonTransition,
+});
+
+/// BUG-1652：规划一次非触摸鼠标事件的完整下发顺序。
+///
+/// WebView2 的 `setPointerButtonState` 使用 native 端缓存的 `lastCursorPos_`。因此即使
+/// Flutter 没先发 hover/move（弹窗刚出现在静止光标下、或光标跨平台视图边界），
+/// down/up 也必须先把**本次事件坐标**写进去，否则 click 会落在旧 DOM 位置。
+List<MouseInputDispatch> planMouseInputDispatches({
+  required Offset position,
+  required int previousButtons,
+  required int nextButtons,
+}) {
+  return <MouseInputDispatch>[
+    (position: position, buttonTransition: null),
+    for (final MouseButtonTransition transition
+        in diffMouseButtonMasks(previousButtons, nextButtons))
+      (position: null, buttonTransition: transition),
+  ];
+}
+
 const MethodChannel _pluginChannel = IN_APP_WEBVIEW_STATIC_CHANNEL;
 
 /// setSize 去抖判定（TODO-428/420）。
@@ -429,16 +456,24 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
     );
   }
 
-  /// 把 [buttons]（Flutter 指针事件的按钮位掩码）全量同步给 WebView2。
-  ///
-  /// 每个非触摸指针事件都调用它：`onPointerHover` 的掩码恒为 0，所以任何原因漏掉的
-  /// button-up（模态路由夺走 up、指针在 WebView 外抬起、多键并按）都会在用户下一次
-  /// 移动鼠标时自愈，不再需要重启 app。差分本身是纯函数
-  /// [diffMouseButtonMasks]（可单测）。
-  void _syncMouseButtons(int buttons) {
-    for (final MouseButtonTransition t
-        in diffMouseButtonMasks(_mouseButtons, buttons)) {
-      _controller._setPointerButtonState(t.button, t.isDown);
+  /// BUG-1652：坐标与按钮翻转作为一个有序输入批次下发。所有 mouse 事件都走这里，
+  /// 保证 down/up 不再依赖此前是否恰好收到 hover/move。
+  void _syncMouseInput(Offset position, int buttons) {
+    for (final MouseInputDispatch dispatch in planMouseInputDispatches(
+      position: position,
+      previousButtons: _mouseButtons,
+      nextButtons: buttons,
+    )) {
+      final Offset? cursorPosition = dispatch.position;
+      if (cursorPosition != null) {
+        _controller._setCursorPos(cursorPosition);
+        continue;
+      }
+      final MouseButtonTransition transition = dispatch.buttonTransition!;
+      _controller._setPointerButtonState(
+        transition.button,
+        transition.isDown,
+      );
     }
     _mouseButtons = buttons;
   }
@@ -460,10 +495,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                         // Ignoring hover events on touch for now
                         return;
                       }
-                      _controller._setCursorPos(ev.localPosition);
                       // BUG-1419：hover 的语义就是「当前没有任何键按下」，是残留
                       // MK_* 位唯一可靠的自愈点。坐标先同步，补发的 up 才落在实处。
-                      _syncMouseButtons(ev.buttons);
+                      _syncMouseInput(ev.localPosition, ev.buttons);
                     },
                     onPointerDown: (ev) {
                       _reportSurfaceSize();
@@ -488,7 +522,7 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.pressure);
                         return;
                       }
-                      _syncMouseButtons(ev.buttons);
+                      _syncMouseInput(ev.localPosition, ev.buttons);
                     },
                     onPointerUp: (ev) {
                       _pointerKind = ev.kind;
@@ -503,7 +537,7 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                       }
                       // PointerUpEvent.buttons 是**抬起之后**仍按住的键，多键并按时
                       // 只清掉真正松开的那一位。
-                      _syncMouseButtons(ev.buttons);
+                      _syncMouseInput(ev.localPosition, ev.buttons);
                     },
                     onPointerCancel: (ev) {
                       _pointerKind = ev.kind;
@@ -522,7 +556,7 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                       }
                       // 取消 = 该指针的所有键都不再按住（Flutter 的 cancel 事件
                       // buttons 已为 0，这里显式走同一条差分路径补发 up）。
-                      _syncMouseButtons(ev.buttons);
+                      _syncMouseInput(ev.localPosition, ev.buttons);
                     },
                     onPointerMove: (ev) {
                       _pointerKind = ev.kind;
@@ -534,10 +568,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.size,
                             ev.pressure);
                       } else {
-                        _controller._setCursorPos(ev.localPosition);
                         // 拖动中掩码变化（第二个键按下/松开）也必须逐位补发，
                         // 否则又会退化成旧的粘滞状态。
-                        _syncMouseButtons(ev.buttons);
+                        _syncMouseInput(ev.localPosition, ev.buttons);
                       }
                     },
                     onPointerSignal: (signal) {

--- a/packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart
+++ b/packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart
@@ -93,4 +93,34 @@ void main() {
       ]);
     });
   });
+
+  group('planMouseInputDispatches', () {
+    test('按下前先把 WebView2 虚拟光标移到本次事件坐标', () {
+      final commands = planMouseInputDispatches(
+        position: const Offset(126, 48),
+        previousButtons: 0,
+        nextButtons: kPrimaryMouseButton,
+      );
+
+      expect(commands, hasLength(2));
+      expect(commands.first.position, const Offset(126, 48));
+      expect(commands.first.buttonTransition, isNull);
+      expect(commands.last.position, isNull);
+      expect(commands.last.buttonTransition?.button, PointerButton.primary);
+      expect(commands.last.buttonTransition?.isDown, isTrue);
+    });
+
+    test('抬起同样先同步坐标，click 的 down/up 落在同一个 DOM 目标', () {
+      final commands = planMouseInputDispatches(
+        position: const Offset(126, 48),
+        previousButtons: kPrimaryMouseButton,
+        nextButtons: 0,
+      );
+
+      expect(commands, hasLength(2));
+      expect(commands.first.position, const Offset(126, 48));
+      expect(commands.last.buttonTransition?.button, PointerButton.primary);
+      expect(commands.last.buttonTransition?.isDown, isFalse);
+    });
+  });
 }

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3651,7 +3651,8 @@ function _reportPopupHeight() {
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __fushiScrollHeight(),
-            window.__fushiRenderToken || 0);
+            window.__fushiRenderToken || 0,
+            window.innerHeight || document.documentElement.clientHeight || 0);
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
@@ -4340,7 +4341,8 @@ window.updatePopupIncremental = function() {
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __fushiScrollHeight(),
-        window.__fushiRenderToken || 0);
+        window.__fushiRenderToken || 0,
+        window.innerHeight || document.documentElement.clientHeight || 0);
 };
 
 


### PR DESCRIPTION
本地 develop 上未推送的提交 \`64d6a2bdc\`，按 PR 流程补开 draft PR。

## 改动
- 弹窗自适应高度修复（BUG-1651）
- Windows WebView 点击后鼠标指针状态失效修复（BUG-1652）
- 弹窗词典集成测试桌面端漂移修复（BUG-1653）

涉及 19 个文件：popup.js（app 内 / 扩展 / vendor 三份）、dictionary_popup_* 系列、custom_platform_view.dart，以及配套 widget 测试与守卫测试。

## 状态
- 该提交此前只存在于本地，未推送、未开 PR
- **尚未在最新 develop 上验证**：分支 base 落后 origin/develop 282 个提交，未跑 rebase、未跑测试
- 合并前需要 rebase 到最新 develop 并跑测试门

🤖 Generated with [Claude Code](https://claude.com/claude-code)