### PR TITLE
fix: 修复四个用户报告问题（互联配对文案 / VN 跟随与搜索 / macOS 顶部横带 / 触摸板翻页）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,15 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1605 条。点号进各自文件。
+> 共 1610 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1745](bugs/BUG-1745-trackpad-vertical-wheel-multi-page.md) | ✅ | ✅ | 纵向触摸板惯性绕过手势闸门，一次滑动连翻多页 |
+| [BUG-1744](bugs/BUG-1744-macos-reader-fullscreen-top-band.md) | ✅ | ✅ | macOS 阅读器全屏下顶部残留 28pt 拖拽横带 |
+| [BUG-1743](bugs/BUG-1743-vn-scroll-to-search-match-missing.md) | ✅ | ✅ | VN 缺 scrollToSearchMatch 且调用点无存在性守卫 |
+| [BUG-1742](bugs/BUG-1742-vn-non-sasayaki-audiobook-follow.md) | ✅ | ✅ | VN 模式下非 sasayaki 书的有声书自动跟随失效 |
+| [BUG-1741](bugs/BUG-1741-interconnect-pair-probe-reason-lost.md) | ✅ | ✅ | 互联配对报错文案完全误导：三层静默吞异常 + TLS host 回落 v1 死路 |
 | [BUG-1731](bugs/BUG-1731-host-video-progress-reverse-sync.md) | ✅ | ✅ | 互联子端看片进度不反向推进 host 的继续观看/下一集 |
 | [BUG-1730](bugs/BUG-1730-ass-word-wrap-midword-break.md) | ✅ | ✅ | ass 字幕英文单词中间断行（Wrap 逐字符换行无词边界） |
 | [BUG-1729](bugs/BUG-1729-waveform-cue-strip-overlap.md) | ✅ | ✅ | 波形对轴弹窗字幕条带重叠cue叠画 |

--- a/docs/bugs/BUG-1741-interconnect-pair-probe-reason-lost.md
+++ b/docs/bugs/BUG-1741-interconnect-pair-probe-reason-lost.md
@@ -1,0 +1,80 @@
+## BUG-1741 · 互联配对报错文案完全误导：三层静默吞异常 + TLS host 回落 v1 死路
+- **报告**：2026-08-19（用户：）
+- **真实性**：✅ 真 bug。两条根因均沿真实代码路径证实。
+
+  **根因 A · 三层静默吞异常**（BUG-1553 只修了 v2 client 那一层，配对**前置探测**三层至今全静默）：
+  1. `fushi/lib/src/sync/tls/fushi_tofu_probe.dart:46` — `on Object { return captured; }`
+     吞掉 `HandshakeException`（对端根本不讲 TLS）/ `SocketException` / `TimeoutException`，全文件无
+     `ErrorLogService`。
+  2. `fushi/lib/src/sync/pairing/fushi_ping_client.dart:76` — `on Object { return null; }`
+     把 `TlsException`（**钉扎指纹不符，安全事件**）、`SocketException`、`TimeoutException`、
+     `FormatException` 与 `:57/:59/:62` 三个无区分早退（非 200 / 非 JSON / 非 fushi）压成同一个 `null`。
+  3. `fushi/lib/src/sync/pairing/discovered_pairing_probe.dart:71/:74/:87` — 三个 `continue`
+     再把上面压平的 `null` 压成整体 `:95 return null`，返回类型里根本没有承载 reason 的字段。
+
+  出口文案 `fushi/lib/src/sync/sync_settings_schema/interconnect.part.dart:299`：
+  `ping == null || !isFushi || !supportsPairV2` 三合一 → `t.sync_pair_not_fushi`
+  「此地址未找到 Fushi 设备」。**误导的确切形态**：host 在线、证书指纹与已钉扎的不符（真实原因是
+  可能的中间人 / host 重装证书），用户被告知「这里没有设备」——与真相完全相反，排查方向从第一步就错。
+  `_ensurePinnedFingerprintTrusted`（`:696`）本是为这个场景准备的告警闸，但流程在 `:299` 就 return 了，
+  **永远走不到**。
+
+  另：`interconnect.part.dart:213` 把 URL 解析失败（根本没发起连接）说成 `t.sync_connection_failed`
+  「连接失败」。
+
+  **根因 B · TLS host 回落 v1 死路**：
+  - 物理根据 `fushi/lib/src/sync/lan_discovery_service.dart:28` — `String get webDavUrl => 'http://$host:$port';`
+    硬编码明文 scheme。
+  - TLS host 只 `bindSecure` 一个 socket（`fushi_sync_server.dart:172`），**完全不提供明文端口**。
+  - mDNS TXT 的 `tls=1` 在部分平台会被 resolve 丢掉（`discovered_pairing_probe.dart:26-28` 自承）→
+    `tlsEnabled=false` → 候选顺序变 `[http, https]`；https 候选一旦握手不成被根因 A 第 1 层吞掉就
+    `continue`，http 候选打在 TLS-only 端口上被 reset 又被第 2 层吞掉 → 整体 `null` →
+    `interconnect.part.dart:1509` 落到 `_pairLegacyV1`。
+  - v1 必然失败：`:1533` 对 `device.webDavUrl`（必然 `http://`）发明文 POST → 抛 → `:1564`
+    `t.sync_pair_failed`「配对失败」，真实原因一个字都没体现。
+  - **附带持久化污染**：`:1527` 把错的 `http://` 地址写进候选列表，那台设备此后每次「测试连接」
+    都失败，且 UI 里看不出 scheme 错了 —— 永久性坏掉。
+
+- **[x] ① 已修复** — 提交见本分支。
+  - `fushi_ping_client.dart`：新增 `FushiPingFailure{tls,timeout,unreachable,notFushi}` +
+    `FushiPingOutcome` + `probeFushiPing()`（带分型与 `ErrorLogService` 留痕）；`fetchFushiPing`
+    降级为丢原因的薄封装保持旧调用方零改动。TLS 判定排在最前（IOClient 让 TLS 异常原样穿透）。
+  - `fushi_tofu_probe.dart`：新增 `FushiTofuFailure{notTls,unreachable,timeout}` +
+    `FushiTofuOutcome`（含 `speaksTls`）+ `probeFingerprint()`；`captureFingerprint` 同样降级为薄封装。
+  - `discovered_pairing_probe.dart`：新增 `DiscoveredPairingProbeOutcome`（`failure` +
+    **`peerSpeaksTls`**）+ `probeDiscoveredPairingEndpointDetailed()`，按严重度
+    `tls > timeout > unreachable > notFushi` 收口；`notTls` 在明文 host 上零信息量，**不参与评选**
+    （否则会盖掉 http 候选带回的 `notFushi` 这种真正有用的结论）。
+  - `interconnect.part.dart`：
+    - `_connectToDevice`：`peerSpeaksTls || device.tlsEnabled` 时**禁止回落 v1**，直接报真实原因；
+      探明 https 端点却不支持 v2 时报 `sync_pair_unavailable`；v1 改用 `probe?.baseUrl ?? device.webDavUrl`。
+    - `_pairLegacyV1` 签名加 `baseUrl`，内部三处 `device.webDavUrl` 全部改用它（消除硬编码 http 污染）。
+    - `_attemptManualPair`：TOFU 失败按 `notTls` 报「对端未启用 HTTPS，改用 http://」；明文地址
+      `unreachable` 时回头探 TOFU，若对端讲 TLS 则报「该设备只接受 HTTPS」；`!supportsPairV2` 与
+      「找不到设备」拆开；https 无指纹报 `sync_pair_tls_failed` 而非笼统的「配对失败」。
+    - URL normalize 失败改报 `sync_pair_invalid_url`。
+    - 新增 `_pingFailureMessage` / `_tofuFailureMessage` 到共享 `_PairingV2FlowMixin`。
+  - i18n 新增 3 key（`i18n_sync.dart --add` × 17 语言 + `dart run slang`）：
+    `sync_pair_invalid_url` / `sync_pair_peer_requires_https` / `sync_pair_peer_not_https`。
+    已存在的 `sync_pair_tls_failed` / `sync_pair_timeout` 此前只有 `_pairV2FailureMessage` 一个消费者，
+    现在探测阶段也能用上。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/sync/pairing/fushi_ping_client_test.dart`：新增 `probeFushiPing 失败分型` 组
+    （TlsException/HandshakeException→tls、超时→timeout、SocketException→unreachable、
+    非 Hibiki→notFushi 且与 unreachable 可分辨、非 200 保留状态码）+ `classifyFushiProbeFailure` 组。
+    此前该文件只有 4 个 happy/null case，**零异常路径断言**。
+  - `fushi/test/sync/pairing/discovered_pairing_probe_test.dart`：全部注入缝换成新契约，新增
+    「失败原因 + TLS 确证」组：钉扎失败带出 tls 且 `peerSpeaksTls=true`（禁止回落 v1）、TXT 丢标志时
+    https 握手成功也算确证、真·旧版明文 host 无 TLS 证据允许回落、多候选取最严重原因、成功时无 failure。
+  - 三条源码守卫更新为新契约并加了新不变量：
+    `interconnect_manual_pair_guard_test.dart`（必须用 `probeFushiPing`，**禁止**退回 `fetchFushiPing`）、
+    `interconnect_tls_entry_guard_test.dart`（必须消费 `peerSpeaksTls` 与 `_pingFailureMessage`，
+    v1 必须用 `probe?.baseUrl ?? device.webDavUrl`）、
+    `interconnect_client_panel_guard_test.dart`（忙态锚点跟到新 API 名）。
+  - 验证：`flutter test test/sync/ --no-pub` → 2218 passed。
+
+- **备注**：`docs/bugs/BUG-1553-interconnect-pair-failure-reason-lost.md` 的「同源但未修」段落说的
+  正是本条。本次不改 server 侧、不改 v2 client（BUG-1553 已修好那一层）。
+  探测层与 UI 层的分型词汇表刻意与 `FushiPairV2Client._classifyTransportFailure` 保持同一套，
+  避免第三套 reason 词汇。

--- a/docs/bugs/BUG-1742-vn-non-sasayaki-audiobook-follow.md
+++ b/docs/bugs/BUG-1742-vn-non-sasayaki-audiobook-follow.md
@@ -1,0 +1,57 @@
+## BUG-1742 · VN 模式下非 sasayaki 书的有声书自动跟随失效
+- **报告**：2026-08-19（用户：）
+- **真实性**：✅ 真 bug。根因是「VN 把正文搬出 document」与「跟随靠 document.querySelector」的正面冲突。
+
+  **VN 把正文移出 document**：`fushi/lib/src/reader/reader_visual_novel_scripts.dart:950-962`
+  `detachChapterSource()` 新建一个**游离**的 `<div>`（`this.sourceRoot`，从不 append 进 document），
+  把 `document.body` 的全部子节点搬进去，再 `document.body.replaceChildren()` 清空。此后 document 里
+  只有一个 stage，当前屏内容是 `renderScreen`（`:2433-2457`）**克隆**出来的。
+  即：不是 shadow DOM / iframe，而是整章正文进了游离节点，document 里任一时刻最多只有当前一屏。
+
+  **跟随路径踩空**：`fushi/lib/src/media/audiobook/audiobook_bridge.dart:206-219`
+  `window.__fushiHighlight` 的 `:212 var el = document.querySelector(selector);` +
+  `:213 if (!el) return;` —— 目标 cue 不在当前屏 → 返回 null → **静默 no-op**，永远不翻到目标屏。
+  即便恰在当前屏，`__fushiRevealTarget`（`:148-165`）依次找 `scrollToRange`/`revealElement`/
+  `scrollToTarget`，**VN 三个都没有**，落到 `scrollIntoView`，而 VN stage 是定屏无滚动 → 仍无效果。
+
+  **为什么只有非 sasayaki 书坏**：分叉在 `audiobook_bridge.dart:440-472`。
+  `SubtitleRematchCodec.tryDecode(raw)` 能解码（sasayaki）→ 走
+  `window.fushiReader.highlightSentenceAudioCue`，VN 实现了它（`:2911-2937`，按 charOffset 找屏 →
+  `renderScreen`），**完全不依赖 DOM 里有没有那个元素**，所以正常。
+  解不出（纯 SRT/VTT/LRC 合成书，`textFragmentId = '[data-cue-id="N"]'`，见
+  `packages/fushi_audio/lib/src/parsers/vtt_parser.dart:147` / `lrc_parser.dart:128` /
+  `matching/cues_to_epub.dart:150`）→ 走 `__fushiHighlight` 的 `document.querySelector` → 踩空。
+
+  Dart 侧无 VN 分支：`reader_fushi/audiobook.part.dart` 全文无 vn/VN 命中，
+  `_onCueChanged`（`:640-647`）无条件调 `AudiobookBridge.highlight`。
+
+- **[x] ① 已修复** — 提交见本分支。
+  - `reader_visual_novel_scripts.dart` 的 host-compat shim 块新增：
+    - `vn.contentRoot()` → 返回 `this.sourceRoot`（正文根的唯一正确取法；**不是** `createWalker` 的
+      默认根 `this.screen`，那只是当前屏）。
+    - `vn.screenIndexForCharOffset(charOffset)` → 从 `restoreToCharOffset` 里提出来的两段式查找
+      （先找覆盖该偏移的屏，再取第一个末尾越过它的屏），供跟随与搜索复用。
+    - `vn.highlightSelectorCue(selector, reveal)` → 选择器 → `contentRoot()` 找源节点 →
+      `contentStream.sourcePositionForNode()` 换算字符偏移 → 屏索引 → `renderScreen(idx, true)`。
+      与 sasayaki 的 `highlightSentenceAudioCue` 收敛到同一条链路。`reveal=false` 时不翻屏
+      （那是「别打断当前阅读位置」的显式请求）。渲染后在当前屏克隆上打 `.fushi-active`
+      （克隆每次渲染重建，所以只能渲染后打、也不必清旧的）。
+  - `audiobook_bridge.dart` 的非 sasayaki 分支：优先
+    `window.fushiReader.highlightSelectorCue`，无此方法（分页/连续模式）回落 `__fushiHighlight`
+    —— 那两个模式行为零变化。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/reader/vn_shell_smoke_test.dart` 新增：VN 必须实现全部宿主接口
+    （`contentRoot`/`screenIndexForCharOffset`/`highlightSelectorCue`/`scrollToSearchMatch`/
+    `clearSearchHighlight`，engine 三 shell 并存时同样带齐）；`contentRoot` 必须返回 `sourceRoot`
+    而非 document；选择器跟随必须走「`contentRoot()` → `sourcePositionForNode` →
+    `screenIndexForCharOffset` → `renderScreen`」且保留 `reveal=false` 早退。
+  - `fushi/test/reader/vn_non_sasayaki_follow_guard_test.dart`（新建）：接线守卫 —— 非 sasayaki
+    分支必须优先走 `highlightSelectorCue` 且带 `typeof` 判定；`__fushiHighlight` 回落必须在其 else 分支；
+    `cue==null` 的清除路径不受本次改动波及。
+  - 验证：`flutter test test/reader/ test/pages/ test/media/ --no-pub` → 8961 passed。
+
+- **备注**：headless 无真 InAppWebView，**逐句翻屏须真机复验**（见
+  `docs/agent/integration-testing.md`）。守卫只锁接线与源码不变量。
+  与 [[BUG-1743]] 同属「VN 缺宿主接口」这一族，同一 shim 块落地。
+  `SASAYAKI_PARITY_PLAN.md` 讲的是上游 Anki handlebar，与 VN 无关，没有 VN↔sasayaki 能力差异清单。

--- a/docs/bugs/BUG-1743-vn-scroll-to-search-match-missing.md
+++ b/docs/bugs/BUG-1743-vn-scroll-to-search-match-missing.md
@@ -1,0 +1,54 @@
+## BUG-1743 · VN 缺 scrollToSearchMatch 且调用点无存在性守卫
+- **报告**：2026-08-19（用户：）
+- **真实性**：✅ 真 bug。
+
+  **缺实现**：`scrollToSearchMatch` 只定义在分页/连续共享的 `window.fushiReader` 上
+  （`fushi/lib/src/reader/reader_pagination_scripts.dart:1599-1662`，同族 `clearSearchHighlight`
+  在 `:1663`）。`reader_visual_novel_scripts.dart` 全文**零命中**
+  `scrollToSearchMatch` / `clearSearchHighlight` / `scrollToRange` / `scrollToTarget`。
+  VN 的 host-compat shim 块（`:2990-3049`）当时只补了 4 个方法
+  （`updatePageSize` / `getFirstVisibleCharOffset` / `setChromeInsets` / `restoreToCharOffset`）。
+
+  **调用点裸调**：`reader_pagination_scripts.dart:729-730`
+  `'window.fushiReader.scrollToSearchMatch(...)'` —— 对比同族收藏路径用的是带守卫写法
+  `'window.fushiReader && window.fushiReader.restoreToCharOffset(...)'`，search 这条是裸调。
+  全部 Dart 调用点均无模式检查：
+  `reader_fushi/chrome.part.dart:1620-1623`（`onSearchJump` 构造）、`:1656`（同章直接 evaluate，
+  **无 try-catch**）、`:2227`/`:2245`（收藏跳转 by-text 回退，BUG-876）、
+  `reader_fushi/navigation.part.dart:599-612`（队列消费端，有 try/catch 但无函数存在性检查）。
+  队列在 VN 下确实会被触发：`navigation.part.dart:190-197` 的注释直接点名 VN。
+  搜索入口在 VN 下也没被禁用（`reader_quick_settings_sheet.dart:695` 只判 epubBook / onSearchJump）。
+
+  **实际后果**：JS 抛 `TypeError: ...scrollToSearchMatch is not a function`。但
+  `evaluateJavascript` 的 JS 运行时异常在移动端通道上一般**不回传成 Dart 异常**（返回 null），
+  所以队列消费端的 try/catch + ErrorLogService 抓不到，1c/2b 更是连 catch 都没有。
+  用户可见症状：VN 下**搜索结果点了没反应**（同章）/ **只跳到目标章第一屏**（跨章，章节导航本身
+  成功、只有章内定位失败）；缺 offset 的收藏跳转同理停在章首。同一次 evaluate 里 TypeError 之后的
+  语句也会被一并中断。
+
+- **[x] ① 已修复** — 提交见本分支。
+  - `reader_visual_novel_scripts.dart` shim 块新增 `vn.scrollToSearchMatch(query, hintOffset)`：
+    **不能沿用分页版**（那版 `createWalker()` 只走当前屏、且靠 VN 没有的 `scrollToRange` 滚动）。
+    VN 版在整章 `contentStream.textEntries` 上拼全文匹配，就近策略与分页版一致（取离 `hintOffset`
+    最近的一处命中），再走「字符偏移 → 屏索引 → `renderScreen`」链路，返回 `calculateProgress()`
+    与分页版契约一致（调用方靠它落库）。
+    **关键换算**：命中下标是「拼接后的原始文本」坐标，而屏索引吃的是**可匹配字符**坐标
+    （`countChars` 跳过空白/不可匹配字符）。直接拿命中下标当 charOffset 用会在任何含空白的章节上
+    系统性偏移，故必须经命中所在 entry 的前缀 `countChars(prefix)` 换算。
+  - 同时补 `vn.clearSearchHighlight()`（`CSS.highlights.delete`，带 try）。
+  - `reader_pagination_scripts.dart` 的 `scrollToSearchMatchInvocation` /
+    `clearSearchHighlightInvocation` 加**存在性守卫**（第二层防线，与 `pageInfoInvocation` 同款写法）：
+    即便某个 shell 未实现也只是 no-op，不再抛 TypeError 污染控制台 / 中断同一次 evaluate 的后续语句。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/reader/vn_shell_smoke_test.dart`：VN 宿主接口清单守卫（见 [[BUG-1742]]）+
+    「VN 搜索在整章 contentStream 上匹配并做坐标换算」——断言**不得**出现 `createWalker(`
+    （照搬分页版只会在当前屏内找，跨屏命中永远找不到）、必须有 `countChars(prefix)` 换算、
+    必须走 `screenIndexForCharOffset`、必须返回 `calculateProgress()`。
+  - `fushi/test/reader/reader_pagination_scripts_test.dart`：两条逐字符串断言改为 `contains`
+    并新增守卫断言（转义意图保留：`a"b` / CJK / 反斜杠换行三条原有覆盖不变）。
+  - 验证：`flutter test test/reader/ test/pages/ test/media/ --no-pub` → 8961 passed。
+
+- **备注**：headless 跑不到真 WebView，**VN 下的搜索跳转须真机复验**。
+  shim 块现在是「VN 必须实现的宿主接口清单」的唯一真相点，新增接口请一并更新
+  `vn_shell_smoke_test.dart` 的清单断言。与 [[BUG-1742]] 同一批落地。

--- a/docs/bugs/BUG-1744-macos-reader-fullscreen-top-band.md
+++ b/docs/bugs/BUG-1744-macos-reader-fullscreen-top-band.md
@@ -1,0 +1,65 @@
+## BUG-1744 · macOS 阅读器全屏下顶部残留 28pt 拖拽横带
+- **报告**：2026-08-19（用户报「顶部横带」）
+- **真实性**：✅ 真 bug。
+
+  `fushi/lib/src/pages/implementations/reader_fushi_page.dart:2850-2864`（修前）无条件挂了一条
+  `Positioned(top:0, height: kMacTitleBarHeight /* 28 */)` 的 `DragToMoveArea` + 不透明
+  `ColoredBox(color: bgColor)`；配套的正文让位在 `:1842-1846`：
+
+  ```dart
+  double get _macosWindowTitlebarInset => Platform.isMacOS ? kMacTitleBarHeight : 0;
+  double get _readerTopOffset => _stableTopInset + _macosWindowTitlebarInset + _topProgressReserve;
+  ```
+
+  **唯一条件是 `Platform.isMacOS`**。对 `reader_fushi_page.dart` + `reader_fushi/*.dart` 全量 grep
+  `fullscreen|isFullScreen|WindowManipulator` **零命中**，而 macOS 全屏由
+  `fushi/lib/src/shortcuts/global_navigation.dart:368-376` 的 `WindowManipulator` 驱动。
+  于是进原生全屏后：既没有标题栏也没有交通灯、窗口也拖不动，这条 28pt 不透明带和它同高的正文
+  让位仍在 —— 就是用户看到的顶部横带。
+
+  连带影响（同一真相源）：`popupTopReserve`（`:1857`）、`reader_chrome_floating.dart:111-123` 的
+  `independentDocumentInsets`（歌词 / spread 整页图被顶掉 28px，露出 Scaffold 底色，是横带**最容易
+  被肉眼看见**的场景）、顶部进度 pill（`chrome.part.dart` 的 `_stableTopInset + _macosWindowTitlebarInset`）。
+  CSS 侧 `--chrome-top-inset` 由 `_readerTopOffset` 喂入（`webview.part.dart:685` 首载、
+  `chrome.part.dart:1043-1047` 运行时 `setChromeInsets`），所以正文顶部实际留白 = 28 + 24 = 52px。
+
+  `didChangeDependencies`（`:2682-2701`）只比较 `viewPadding.top/bottom`，**不监听全屏切换**；
+  桌面进出全屏时 viewPadding 通常不变（两边都是 0），那条回喂路径永远不会触发。
+
+- **[x] ① 已修复** — 提交见本分支。
+  - 新建 `fushi/lib/src/platform/macos_fullscreen_state.dart`：macOS 原生全屏态的**唯一真相源**，
+    挂 `NSWindowDelegate` 的 `windowDidEnterFullScreen` / `windowDidExitFullScreen`，暴露
+    `ValueListenable<bool>`，并在注册后补一次 `isWindowFullscreened()` 查询作初值（系统可能恢复了
+    上次的全屏会话）。非 macOS 恒 false 且不注册。
+    **为什么不用别的信号**：`WindowManipulator.isWindowFullscreened()` 是异步查询、无变化通知，
+    只能轮询；`window_manager` 的 `WindowListener` 在 macOS 上收不到全屏通知（macos_window_utils
+    持有 NSWindow.delegate 并覆盖了它，见 `global_navigation.dart` 的 TODO-1375）；只在 app 自己的
+    F11 快捷键里记状态会漏掉**绿灯按钮和「显示」菜单**——那是用户进全屏最常用的两条路。
+    AppKit 的 delegate 回调是唯一覆盖全部入口的信号。
+    依赖走 `package:macos_ui`（它 re-export 了 `NSWindowDelegate` 与 `WindowManipulator`），
+    与 `global_navigation.dart` 同款，避免 `depend_on_referenced_packages`。
+  - `reader_fushi_page.dart`：`_macosWindowTitlebarInset` 改为
+    `Platform.isMacOS && !_macosFullscreen ? kMacTitleBarHeight : 0`（单一真相源，
+    `_readerTopOffset` / `popupTopReserve` / `independentDocumentInsets` / 顶部进度 pill 全部自动跟随）；
+    `DragToMoveArea` 那个 `Positioned` 整体门控 `if (Platform.isMacOS && !_macosFullscreen)`
+    （只归零 inset 不够，带子本身仍会盖住正文）；initState 订阅 + dispose 摘钩；
+    新增 `_onMacosFullscreenChanged()` —— **setState 之外必须调 `_applyChromeInsets()`**，
+    因为 JS 的 `--chrome-top-inset` 由它单独推送、不跟 Flutter 重建走，漏了它正文 padding-top
+    会停在旧的 28px 上（横带原样还在）。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart` 新增 BUG-1744 组：
+    inset 必须按全屏态门控、`DragToMoveArea` 的 `Positioned` 必须整体门控（取窗为 `build()`，
+    不是 `_buildBody()`）、状态必须取自 `MacosFullscreenState`、delegate 必须同时实现
+    enter/exit 两个回调（只监听进入的话退出全屏后横带不会回来）、`_onMacosFullscreenChanged`
+    必须同时 setState + `_applyChromeInsets`、dispose 必须摘监听。
+  - BUG-1343 的既有守卫（`DragToMoveArea(` / `'fushi_reader_window_drag_area'` /
+    `kMacTitleBarHeight` / `_macosWindowTitlebarInset` / `_readerTopOffset =>` /
+    `titlebarInset:` / `_stableTopInset + _macosWindowTitlebarInset`）全部锚点保留、未改动，仍绿。
+  - 验证：`flutter test test/macos/ --no-pub` → 13 passed。
+
+- **备注**：**须 Mac 真机复验**（headless 无真 NSWindow，delegate 回调跑不到）：窗口态下拖拽带
+  仍在且可拖动 → F11 / 绿灯 / 「显示」菜单三条路进全屏，横带消失且正文顶到边 → 退出全屏后
+  拖拽带回来。歌词模式 / spread 整页图两种独立文档场景一并验（它们走
+  `independentDocumentInsets`，是横带最显眼的场景）。
+  与 [[BUG-1745]] 同为本轮 macOS 阅读器体感问题，但两者根因无关、可独立回滚。

--- a/docs/bugs/BUG-1745-trackpad-vertical-wheel-multi-page.md
+++ b/docs/bugs/BUG-1745-trackpad-vertical-wheel-multi-page.md
@@ -1,0 +1,59 @@
+## BUG-1745 · 纵向触摸板惯性绕过手势闸门，一次滑动连翻多页
+- **报告**：2026-08-19（用户报「触摸板翻页」）
+- **真实性**：✅ 真 bug。是 BUG-1342 / BUG-1380 两轮修复之后**仍然存在的残余**。
+
+  **根因 A（主因）：闸门只对横向生效，纵向触摸板整段惯性漏光。**
+  JS 侧按每个 tick 的主轴分类（`reader_fushi/webview.part.dart:1377-1385`，修前）：
+  ```js
+  var horizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY);
+  ...callHandler('onWheelPaginate', direction, horizontal ? 'horizontal' : 'vertical');
+  ```
+  Dart 侧闸门（`webview.part.dart:2178-2185`，修前）条件是 `axis == 'horizontal' && ...`。
+  BUG-1342 的修复文档明写「纵向鼠标滚轮不进此 gate，保留原有固定窗口节流」——那个假设是
+  **「纵向 = 鼠标滚轮」**。但 macOS 触摸板上下双指滑同样是纵向，惯性流持续 1~1.5 秒，全部落进
+  `_paginate` 的固定 450ms 窗（`chrome.part.dart:102-109`，默认值见 `reader_settings.dart:458`）：
+  1500ms / 450ms ≈ **一次上下滑翻 3 页**。设置里的滑块下限是 150ms
+  （`settings_schema_reading.dart:629-631`），用户为了「跟手」调到下限就是**一次滑翻 10 页**。
+
+  **根因 B（叠加）：轴分类是 per-tick、闸门是 per-axis，横滑里的漂移帧会漏出闸门。**
+  同一次横向手势里个别 tick 会出现 `|deltaY| >= |deltaX|`（手指纵向漂移、惯性尾段轴向噪声），
+  判据又是严格 `>`（`|dx| == |dy|` 也归 vertical），这些 tick 被标成 `'vertical'` →
+  整条 `axis == 'horizontal' &&` 短路 → 直接进 `_paginate`，只受 450ms 窗管。于是一次横滑 =
+  闸门放行 1 页 + 若干漂移 tick 在 450ms 后再各翻 1 页。
+  弹窗滚动路径（`docs/bugs/BUG-701-touchpad-wheel-subpixel.md`）踩过同一个坑并已用
+  「严格 `>` + 抖动余量」修掉，**阅读器分页路径当时漏了**。
+
+- **[x] ① 已修复** — 提交见本分支。
+  - `reader_fushi/webview.part.dart` JS 侧：
+    - 主轴判据加抖动余量 `PAGED_WHEEL_AXIS_MARGIN = 6`：`absX > absY + MARGIN` 才算 horizontal
+      （配方与 BUG-701 一致）。
+    - 新增 `_isTrackpadWheel(e)`：`deltaMode !== 0` 排除真滚轮；分数像素增量 / 两轴同时非零 /
+      `wheelDelta` 不是 120 的整数倍 → 判触摸板。**只用单事件可得的量**——JS 侧不能存手势状态
+      （翻章会重建 document，这正是 BUG-1342 把闸门放进 Dart 的理由），时间维度的聚合仍由
+      跨 document 持久的 `ReaderWheelGestureGate` 负责。
+    - `onWheelPaginate` 增加第三个参数 `'trackpad' | 'mouse'`。
+  - Dart 侧闸门判据从 `axis == 'horizontal'` 改为 `pointerKind == 'trackpad'`：
+    真正要区分的从来不是轴，而是「离散 tick（鼠标，一格一页是正确期望）」与
+    「连续惯性流（触摸板，一次滑动一页）」。纵向触摸板从此进闸门，纵向鼠标滚轮零变化。
+    `args.length <= 2` 时按「横向即触摸板」缺省推断，与改动前行为逐字一致（向后兼容老 shell）。
+  - BUG-1380 的 `canTurnPage: !_paginationInFlight` 契约原样保留（换章加载期的 tick 只查询不认领）。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/reader/trackpad_wheel_classification_test.dart`（新建）：闸门在**纵向**输入上的
+    行为不变量 —— 1.5 秒惯性（94 拍 ×16ms）只翻 1 页（旧实现翻 3 页）；间隔调到下限 150ms 仍是
+    1 页（旧实现 10 页）；两次滑动间有完整静默则各翻 1 页；离散慢速 tick（600ms 间隔）各自成手势
+    5 次；BUG-1380 的「翻不动页的 tick 不认领手势」契约在纵向上同样成立。
+  - `fushi/test/reader/reader_mouse_paging_boundary_guard_static_test.dart`：主轴守卫更新为
+    带抖动余量的形态（`absX > absY + PAGED_WHEEL_AXIS_MARGIN`），新增「必须回传输入设备类型」
+    与「闸门判据必须是 `pointerKind == 'trackpad'`、**禁止**退回 `axis == 'horizontal' &&`」两条。
+    该文件原有的 21 条 wheel 守卫（方向归一、arm-then-fire、不读 `invertSwipeDirection`、
+    `canTurnPage` 实参等）全部保留未改。
+  - 验证：`flutter test test/reader/ --no-pub` 全绿。
+
+- **备注**：**须 Mac 真机复验**（`_isTrackpadWheel` 的启发式依赖真实 WheelEvent 的
+  `deltaMode`/`wheelDelta`，headless 造不出）：上下双指滑一次应恰好翻一页；鼠标滚轮一格仍应
+  一页；横滑不再出现「1 页 + 补翻」。
+  **本轮未动**（属于产品缺口而非本 bug 的时序根因，需单独立项）：滚轮翻页方向不读
+  `invertSwipeDirection`、也不读书写方向 rtl，与触摸滑动路径（`swipeLeftIsForward(invert:, rtl:)`）
+  方向不一致且无开关可调；BUG-1380 备注里也记过这条。
+  与 [[BUG-1744]] 同为本轮 macOS 阅读器体感问题，根因无关、可独立回滚。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61591 (3623 per locale)
+/// Strings: 61642 (3626 per locale)
 ///
-/// Built on 2026-08-19 at 06:16 UTC
+/// Built on 2026-08-19 at 14:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4917,6 +4917,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Read EPUB novels with dictionary lookup and audiobook sync';
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  String get sync_pair_invalid_url => 'Invalid address format';
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -13309,6 +13314,14 @@ class _StringsAr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -21767,6 +21780,14 @@ class _StringsDe extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -30241,6 +30262,14 @@ class _StringsEs extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -38727,6 +38756,14 @@ class _StringsFr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -47142,6 +47179,14 @@ class _StringsId extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -55602,6 +55647,14 @@ class _StringsIt extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -63877,6 +63930,14 @@ class _StringsJa extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -72159,6 +72220,14 @@ class _StringsKo extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -80599,6 +80668,14 @@ class _StringsNl extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -89051,6 +89128,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -97489,6 +97574,14 @@ class _StringsRu extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -105875,6 +105968,14 @@ class _StringsTh extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -114293,6 +114394,14 @@ class _StringsTr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -122696,6 +122805,14 @@ class _StringsVi extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 // Path: <root>
@@ -130472,6 +130589,13 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_feature_books_hint => '看小说（EPUB），查词与有声书同步';
   @override
   String get onboarding_feature_extension_hint => '网页查词（仅桌面）';
+  @override
+  String get sync_pair_invalid_url => '地址格式无效';
+  @override
+  String get sync_pair_peer_requires_https =>
+      '该设备只接受 HTTPS，请改用 https:// 开头的地址。';
+  @override
+  String get sync_pair_peer_not_https => '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
 }
 
 // Path: <root>
@@ -138670,6 +138794,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get sync_pair_invalid_url => 'Invalid address format';
+  @override
+  String get sync_pair_peer_requires_https =>
+      'This device only accepts HTTPS. Use an https:// address.';
+  @override
+  String get sync_pair_peer_not_https =>
+      'The peer isn\'t using HTTPS on this port. Use an http:// address.';
 }
 
 /// Flat map(s) containing all translations.
@@ -146107,6 +146239,12 @@ extension on _StringsEn {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -153542,6 +153680,12 @@ extension on _StringsAr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -160999,6 +161143,12 @@ extension on _StringsDe {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -168455,6 +168605,12 @@ extension on _StringsEs {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -175917,6 +176073,12 @@ extension on _StringsFr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -183361,6 +183523,12 @@ extension on _StringsId {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -190819,6 +190987,12 @@ extension on _StringsIt {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -198239,6 +198413,12 @@ extension on _StringsJa {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -205663,6 +205843,12 @@ extension on _StringsKo {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -213115,6 +213301,12 @@ extension on _StringsNl {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -220564,6 +220756,12 @@ extension on _StringsPtBr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -228018,6 +228216,12 @@ extension on _StringsRu {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -235455,6 +235659,12 @@ extension on _StringsTh {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -242901,6 +243111,12 @@ extension on _StringsTr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -250343,6 +250559,12 @@ extension on _StringsVi {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }
@@ -257726,6 +257948,12 @@ extension on _StringsZhCn {
         return '看小说（EPUB），查词与有声书同步';
       case 'onboarding_feature_extension_hint':
         return '网页查词（仅桌面）';
+      case 'sync_pair_invalid_url':
+        return '地址格式无效';
+      case 'sync_pair_peer_requires_https':
+        return '该设备只接受 HTTPS，请改用 https:// 开头的地址。';
+      case 'sync_pair_peer_not_https':
+        return '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
       default:
         return null;
     }
@@ -265141,6 +265369,12 @@ extension on _StringsZhHk {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'sync_pair_invalid_url':
+        return 'Invalid address format';
+      case 'sync_pair_peer_requires_https':
+        return 'This device only accepts HTTPS. Use an https:// address.';
+      case 'sync_pair_peer_not_https':
+        return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "浏览器扩展",
   "onboarding_feature_books": "小说库",
   "onboarding_feature_books_hint": "看小说（EPUB），查词与有声书同步",
-  "onboarding_feature_extension_hint": "网页查词（仅桌面）"
+  "onboarding_feature_extension_hint": "网页查词（仅桌面）",
+  "sync_pair_invalid_url": "地址格式无效",
+  "sync_pair_peer_requires_https": "该设备只接受 HTTPS，请改用 https:// 开头的地址。",
+  "sync_pair_peer_not_https": "对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3621,5 +3621,8 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "sync_pair_invalid_url": "Invalid address format",
+  "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
+  "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address."
 }

--- a/fushi/lib/src/media/audiobook/audiobook_bridge.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_bridge.dart
@@ -464,9 +464,18 @@ window.__fushiAnnotate = function(chapterHref) {
       );
       return;
     }
+    // BUG-1742：VN 模式把整章正文搬出了 document（只留当前一屏的克隆），
+    // __fushiHighlight 的 document.querySelector 因此几乎必然落空并静默早退——
+    // 非 sasayaki 书（SRT/VTT/LRC 合成书）的自动跟随就是这样彻底失效的。
+    // VN 实现了 highlightSelectorCue（选择器 → 字符偏移 → 翻屏），优先用它；
+    // 分页/连续模式没有这个方法，回落原路径，行为零变化。
     await controller.evaluateJavascript(
-      source: 'if(typeof __fushiHighlight!=="undefined")'
-          '__fushiHighlight(${jsonEncode(raw)}, $reveal, $pauseEnabled);',
+      source: 'if(window.fushiReader&&'
+          'typeof window.fushiReader.highlightSelectorCue==="function"){'
+          'window.fushiReader.highlightSelectorCue('
+          '${jsonEncode(raw)}, $reveal);'
+          '}else if(typeof __fushiHighlight!=="undefined"){'
+          '__fushiHighlight(${jsonEncode(raw)}, $reveal, $pauseEnabled);}',
     );
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
@@ -1374,14 +1374,44 @@ install: function(C) {
   // BUG-1342：只把每个 tick 的语义方向和主轴交给 Dart。手势 session 不能存在 JS
   // document 中，因为翻章会重建 document、在同一段惯性中重置闸门。横向主轴由跨章节
   // 持久的 ReaderWheelGestureGate 聚合；纵向鼠标滚轮维持既有固定窗口节流。
+  // BUG-1745：主轴判据要带抖动余量。一次横向触摸板滑动里总有几拍
+  // |deltaY| >= |deltaX|（手指纵向漂移 / 惯性尾段轴向噪声）；用严格 > 分类会把
+  // 这些拍标成 vertical，于是它们绕过闸门直接进 _paginate，一次横滑变成
+  // 「闸门放行 1 页 + 若干漂移拍再各翻 1 页」。弹窗滚动路径（BUG-701）已经用
+  // 同一配方修过，分页路径当时漏了。
+  var PAGED_WHEEL_AXIS_MARGIN = 6;
+  // BUG-1745：触摸板 vs 鼠标滚轮。二者对「一次输入 = 翻几页」的期望完全相反：
+  // 鼠标一格就该翻一页（离散 tick），触摸板一次滑动连同惯性会喷 1~1.5 秒的 tick
+  // 流、必须聚合成一次翻页。判据只用单事件可得的量（JS 侧不能存手势状态——翻章
+  // 会重建 document，见下方注释），时间维度的聚合交给 Dart 侧跨 document 持久的
+  // ReaderWheelGestureGate。
+  function _isTrackpadWheel(e) {
+    // line / page 模式只有真实滚轮会产生。
+    if (e.deltaMode !== 0) return false;
+    var dx = Math.abs(e.deltaX);
+    var dy = Math.abs(e.deltaY);
+    // 分数像素增量是触摸板独有的。
+    if (dx % 1 !== 0 || dy % 1 !== 0) return true;
+    // 两轴同时非零 = 二维手势，滚轮给不出。
+    if (dx > 0 && dy > 0) return true;
+    // Chromium 给鼠标滚轮的 wheelDelta 恒为 120 的整数倍；触摸板不是。
+    var wd = e.wheelDeltaY;
+    if (typeof wd === 'number' && wd !== 0 && Math.abs(wd) % 120 !== 0) return true;
+    var wdx = e.wheelDeltaX;
+    if (typeof wdx === 'number' && wdx !== 0 && Math.abs(wdx) % 120 !== 0) return true;
+    return false;
+  }
   function _handlePagedWheelTick(e) {
-    var horizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY);
+    var absX = Math.abs(e.deltaX);
+    var absY = Math.abs(e.deltaY);
+    var horizontal = absX > absY + PAGED_WHEEL_AXIS_MARGIN;
     var delta = horizontal ? e.deltaX : e.deltaY;
     if (delta === 0) return;
     e.preventDefault();
     var direction = delta > 0 ? 'forward' : 'backward';
     window.flutter_inappwebview.callHandler('onWheelPaginate', direction,
-      horizontal ? 'horizontal' : 'vertical');
+      horizontal ? 'horizontal' : 'vertical',
+      _isTrackpadWheel(e) ? 'trackpad' : 'mouse');
   }
   // END PAGED_WHEEL_GESTURE_HELPER
   // TODO-656: 横排连续模式放行原生滚动时，记上一拍 scrollTop，下一拍无变化（原生卡
@@ -2168,6 +2198,11 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
             if (args.length < 2 || _lyricsMode) return;
             final String dir = args[0] as String;
             final String axis = args[1] as String;
+            // BUG-1745：老 shell（或未来别的注入点）可能只传两个参数；缺省按
+            // 「横向即触摸板」推断，与本次改动前的行为完全一致。
+            final String pointerKind = args.length > 2
+                ? args[2] as String
+                : (axis == 'horizontal' ? 'trackpad' : 'mouse');
             final int throttleMs =
                 ReaderFushiSource.instance.wheelPageTurnInterval;
             // BUG-1380：闸门的 token 消费必须晚于「这一 tick 能不能翻页」的确认。
@@ -2175,7 +2210,15 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
             // token，整段惯性的后续 tick 全在闸门早退 → 用户这一次滑动零反馈。
             // canTurnPage=false 时闸门只查询不认领，且仍放行到 _paginate——那里的
             // in-flight 分支要靠这些 tick 续跨章冷却窗（TODO-1229 v2）。
-            if (axis == 'horizontal' &&
+            // BUG-1745：闸门的判据从「轴」改成「输入设备」。
+            //
+            // 旧判据 `axis == 'horizontal'` 隐含假设「纵向 = 鼠标滚轮」，可
+            // macOS 触摸板上下双指滑同样是纵向：一次滑动的惯性流持续 1~1.5 秒，
+            // 全部漏过闸门、只受 _paginate 的固定 450ms 窗管，于是一次上下滑
+            // 稳定翻 3 页；用户若把「滚轮翻页间隔」调到下限 150ms 就是 10 页。
+            // 真正要区分的从来不是轴，而是「离散 tick（鼠标，一格一页）」与
+            // 「连续惯性流（触摸板，一次滑动一页）」。
+            if (pointerKind == 'trackpad' &&
                 !_pagedWheelGestureGate.shouldStartNewGesture(
                   now: DateTime.now(),
                   settleInterval: Duration(milliseconds: throttleMs),

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -76,6 +76,7 @@ import 'package:fushi/src/webview/webview_death_guard.dart';
 import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/media/audiobook/floating_lyric_channel.dart';
 import 'package:fushi/src/media/audiobook/pointer_seek.dart';
+import 'package:fushi/src/platform/macos_fullscreen_state.dart';
 import 'package:fushi/src/platform/selection_external_actions.dart';
 import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
@@ -1844,8 +1845,16 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   /// BUG-1343：macOS 的 NSWindow 全局启用了透明标题栏 + full-size content，而默认 MD3 根壳
   /// 不挂 MacosWindow/ToolBar。阅读器需自行保留一条可拖拽标题栏，否则原生 WebView
   /// 吞满顶边后窗口没有稳定抓手。其它平台严格为 0。
+  ///
+  /// BUG-1744：原生全屏下这条带子必须归零。全屏时既没有标题栏也没有交通灯，窗口
+  /// 也不能被拖动——留着它就是一条纯浪费的不透明横带（用户报的「顶部横带」），
+  /// 还连带把正文整体下压 28pt。这里是单一真相源：[_readerTopOffset] /
+  /// [popupTopReserve] / `independentDocumentInsets` / 顶部进度条全部读它。
   double get _macosWindowTitlebarInset =>
-      Platform.isMacOS ? kMacTitleBarHeight : 0;
+      Platform.isMacOS && !_macosFullscreen ? kMacTitleBarHeight : 0;
+
+  /// macOS 原生全屏态。非 macOS 恒为 false。
+  bool _macosFullscreen = false;
 
   double get _readerTopOffset =>
       _stableTopInset + _macosWindowTitlebarInset + _topProgressReserve;
@@ -1882,6 +1891,13 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     WidgetsBinding.instance.addObserver(this);
     _exitFlushCallback =
         ExitFlushRegistry.instance.register(_flushAllForProcessExit);
+    // BUG-1744：macOS 全屏进出必须重算顶部让位并把新 inset 回喂给 WebView。
+    // didChangeDependencies 只比较 viewPadding，而桌面全屏切换通常不改
+    // viewPadding（两边都是 0），所以那条路径永远不会触发。
+    _macosFullscreen = MacosFullscreenState.instance.isFullscreen.value;
+    MacosFullscreenState.instance.isFullscreen
+        .addListener(_onMacosFullscreenChanged);
+    unawaited(MacosFullscreenState.instance.ensureRegistered());
     // The inset reading-content focus ring only paints in traditional
     // (keyboard/gamepad) highlight mode; rebuild it when the mode flips so it
     // appears/disappears with the input device, not only on focus changes.
@@ -2386,6 +2402,8 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     // Complete it as failed now (and clear its precise-locate request) instead
     // of leaving the callback alive until the 10-second timeout.
     _failNavigation();
+    MacosFullscreenState.instance.isFullscreen
+        .removeListener(_onMacosFullscreenChanged);
     assert(() {
       // TODO-2603：页面走了就释放钩子所有权，下一个阅读器才能装（无条件清，与旧行为
       // 逐字一致——钩子本来就是无条件清的，这里只多清一个所有者字段）。
@@ -2693,6 +2711,19 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     _armResizeRepaginateDebounce();
   }
 
+  /// BUG-1744：全屏翻转 → 重算 [_macosWindowTitlebarInset] → 回喂 WebView 几何。
+  ///
+  /// 只 setState 是不够的：JS 侧的 `--chrome-top-inset` 由 [_applyChromeInsets]
+  /// 单独推送，不跟着 Flutter 重建走。漏了它，正文 padding-top 会停在旧的 28px
+  /// 上（全屏后顶部仍留一条空白带，正是要修的症状）。
+  void _onMacosFullscreenChanged() {
+    if (!mounted) return;
+    final bool next = MacosFullscreenState.instance.isFullscreen.value;
+    if (next == _macosFullscreen) return;
+    setState(() => _macosFullscreen = next);
+    unawaited(_applyChromeInsets());
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -2861,7 +2892,9 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
                           ),
                         ),
                       ),
-                    if (Platform.isMacOS)
+                    // BUG-1744：全屏时窗口不可拖动、也没有交通灯要让位——这条
+                    // 不透明带在全屏下纯粹是一条顶部横带，必须整体不挂。
+                    if (Platform.isMacOS && !_macosFullscreen)
                       Positioned(
                         top: 0,
                         left: 0,

--- a/fushi/lib/src/platform/macos_fullscreen_state.dart
+++ b/fushi/lib/src/platform/macos_fullscreen_state.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+// macos_ui re-exports both（见 `global_navigation.dart` 同款写法）；直接依赖
+// macos_window_utils 会触发 depend_on_referenced_packages（它只是传递依赖）。
+import 'package:macos_ui/macos_ui.dart'
+    show NSWindowDelegate, WindowManipulator;
+
+/// BUG-1744：macOS 原生全屏状态的**唯一真相源**。
+///
+/// 背景：macOS 壳给 NSWindow 开了透明标题栏 + full-size content，阅读器为此在
+/// 顶部保留了一条 [kMacTitleBarHeight] 高的可拖拽带（BUG-1343），并让正文同高
+/// 让位。但那条带子的唯一条件是 `Platform.isMacOS`——进原生全屏后既没有标题栏
+/// 也没有交通灯，这条不透明带和它的正文让位却仍在，就是用户看到的「顶部横带」。
+///
+/// 为什么不复用别的信号：
+/// - `WindowManipulator.isWindowFullscreened()` 是**异步查询**，没有变化通知，
+///   拿它只能轮询。
+/// - `window_manager` 的 [WindowListener] 在 macOS 上收不到全屏通知：
+///   macos_window_utils 持有 NSWindow.delegate 并把 window_manager 的 delegate
+///   覆盖掉（见 `global_navigation.dart` 的 TODO-1375）。
+/// - 只在应用自己的 F11 快捷键里记状态会漏掉绿灯按钮和「显示」菜单——那是用户
+///   进全屏最常用的两条路。
+///
+/// 所以直接挂 [NSWindowDelegate]：`windowDidEnter/ExitFullScreen` 由 AppKit 在
+/// **所有**入口上发出，是唯一能覆盖全部路径的信号。
+///
+/// 非 macOS 平台恒为 false，且不注册任何 delegate。
+class MacosFullscreenState {
+  MacosFullscreenState._();
+
+  static final MacosFullscreenState instance = MacosFullscreenState._();
+
+  final ValueNotifier<bool> _isFullscreen = ValueNotifier<bool>(false);
+
+  bool _registered = false;
+
+  /// 当前是否处于 macOS 原生全屏。非 macOS 恒为 false。
+  ValueListenable<bool> get isFullscreen => _isFullscreen;
+
+  /// 幂等注册 NSWindow delegate。多次调用只注册一次。
+  ///
+  /// 首帧之前无从得知窗口是否已在全屏（例如系统恢复了上次的全屏会话），所以还会
+  /// 补一次异步查询作为初值。
+  Future<void> ensureRegistered() async {
+    if (!Platform.isMacOS || _registered) return;
+    _registered = true;
+    try {
+      WindowManipulator.addNSWindowDelegate(
+        _FushiFullscreenDelegate(_isFullscreen),
+      );
+    } catch (e) {
+      // 平台通道不可用（测试 / 未初始化的壳）时降级成「非全屏」，与旧行为一致。
+      debugPrint('[Fushi] macOS fullscreen delegate skipped: $e');
+      return;
+    }
+    try {
+      _isFullscreen.value = await WindowManipulator.isWindowFullscreened();
+    } catch (e) {
+      debugPrint('[Fushi] macOS fullscreen initial query skipped: $e');
+    }
+  }
+
+  /// 测试用：直接置位，不碰平台通道。
+  @visibleForTesting
+  void debugSet({required bool fullscreen}) {
+    _isFullscreen.value = fullscreen;
+  }
+}
+
+class _FushiFullscreenDelegate extends NSWindowDelegate {
+  _FushiFullscreenDelegate(this._sink);
+
+  final ValueNotifier<bool> _sink;
+
+  @override
+  void windowDidEnterFullScreen() {
+    _sink.value = true;
+    super.windowDidEnterFullScreen();
+  }
+
+  @override
+  void windowDidExitFullScreen() {
+    _sink.value = false;
+    super.windowDidExitFullScreen();
+  }
+}

--- a/fushi/lib/src/reader/reader_pagination_scripts.dart
+++ b/fushi/lib/src/reader/reader_pagination_scripts.dart
@@ -726,11 +726,20 @@ class ReaderPaginationScripts {
   static String clearSentenceAudioCueInvocation() =>
       'window.fushiReader.clearSentenceAudioCue()';
 
+  /// BUG-1743：存在性守卫是第二层防线。裸调 `window.fushiReader.scrollToSearchMatch`
+  /// 在未实现该方法的 shell 上抛 TypeError，而 evaluateJavascript 的 JS 异常在
+  /// 移动端通道上一般不回传成 Dart 异常——调用点的 try/catch 抓不到，症状只是
+  /// 「点了没反应」，且同一次 evaluate 里后续语句会被一并中断。
+  /// 同文件 [pageInfoInvocation] 与收藏跳转路径用的都是同款守卫写法。
   static String scrollToSearchMatchInvocation(String query, int hintOffset) =>
-      'window.fushiReader.scrollToSearchMatch(${_jsStringLiteral(query)}, $hintOffset)';
+      '(window.fushiReader && '
+      'typeof window.fushiReader.scrollToSearchMatch === "function") '
+      '? window.fushiReader.scrollToSearchMatch('
+      '${_jsStringLiteral(query)}, $hintOffset) : null';
 
-  static String clearSearchHighlightInvocation() =>
-      'window.fushiReader.clearSearchHighlight()';
+  static String clearSearchHighlightInvocation() => '(window.fushiReader && '
+      'typeof window.fushiReader.clearSearchHighlight === "function") '
+      '? window.fushiReader.clearSearchHighlight() : null';
 
   /// Returns the current page / total pages within the loaded chapter as a JSON
   /// string (`{"currentPage":N,"totalPages":M}`), or the literal `"null"` when

--- a/fushi/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/fushi/lib/src/reader/reader_visual_novel_scripts.dart
@@ -3105,6 +3105,144 @@ $sharedInitViewport
       return null;
     };
   }
+  // BUG-1742：VN 在 detachChapterSource 里把整章正文搬进一个**游离**的 div
+  // (this.sourceRoot)，document.body 里从此只剩当前一屏的克隆。任何靠
+  // document.querySelector 找正文元素的宿主路径在 VN 下都必然落空——这正是
+  // 「非 sasayaki 书的有声书自动跟随失效」的根。正文根必须从这里取。
+  if (typeof vn.contentRoot !== 'function') {
+    vn.contentRoot = function() {
+      return this.sourceRoot || document.body;
+    };
+  }
+  // 章内字符偏移 → 屏索引。restoreToCharOffset 里本来就有这套两段式查找
+  // （先找覆盖该偏移的屏，再取第一个末尾越过它的屏，覆盖偏移落在屏间空白/
+  // 媒体单元的情况）；提成共享 helper 供跟随与搜索复用。
+  if (typeof vn.screenIndexForCharOffset !== 'function') {
+    vn.screenIndexForCharOffset = function(charOffset) {
+      var target = Number(charOffset);
+      if (!Number.isFinite(target) || target < 0) return -1;
+      if (!this.screens || !this.screens.length) return -1;
+      for (var i = 0; i < this.screens.length; i++) {
+        if (this.screenContainsCharOffset(this.screens[i], target)) return i;
+      }
+      for (var j = 0; j < this.screens.length; j++) {
+        if (this.screenEndCharCount(this.screens[j]) >= target) return j;
+      }
+      return -1;
+    };
+  }
+  // BUG-1742：非 sasayaki 书（SRT/VTT/LRC 合成书）的 cue 是纯 CSS 选择器
+  // `[data-cue-id="N"]`，宿主原本用 __fushiHighlight → document.querySelector
+  // 找它。在 VN 下目标多半根本不在 document 里，querySelector 返回 null 后那条
+  // 路径静默早退，跟随永远不翻屏。
+  //
+  // VN 的「跟随」语义本来就不是滚动而是翻屏，所以这里与 sasayaki 的
+  // highlightSentenceAudioCue 收敛到同一条链路：选择器 → 源节点 → 字符偏移 →
+  // 屏索引 → renderScreen。
+  if (typeof vn.highlightSelectorCue !== 'function') {
+    vn.highlightSelectorCue = function(selector, reveal) {
+      if (!selector) return null;
+      var root = this.contentRoot();
+      var node = (root && root.querySelector) ? root.querySelector(selector) : null;
+      if (!node) return null;
+      var stream = this.contentStream;
+      if (!stream || typeof stream.sourcePositionForNode !== 'function') return null;
+      var position = stream.sourcePositionForNode(node);
+      var index = this.screenIndexForCharOffset(position ? position.startChar : -1);
+      if (index < 0) return null;
+      var markActive = (function() {
+        // 当前屏是克隆出来的，class 每次 renderScreen 都会重建——所以只能在
+        // 渲染之后打，且不必清理旧的（下一次渲染自然没有）。
+        try {
+          var scope = this.screen;
+          if (!scope || !scope.querySelectorAll) return;
+          Array.prototype.forEach.call(
+            scope.querySelectorAll('.fushi-active'),
+            function(el) { el.classList.remove('fushi-active'); }
+          );
+          var clone = scope.querySelector(selector);
+          if (clone && clone.classList) clone.classList.add('fushi-active');
+        } catch (_ignored) {}
+      }).bind(this);
+      if (index !== this.currentScreenIndex) {
+        // reveal=false 是「别打断用户当前阅读位置」的显式请求，不许翻屏。
+        if (!reveal) return null;
+        this.renderScreen(index, true);
+        markActive();
+        return this.calculateProgress();
+      }
+      if (reveal && !this.revealComplete) this.completeCurrentReveal();
+      markActive();
+      return null;
+    };
+  }
+  // BUG-1743：VN 此前完全没有 scrollToSearchMatch，而宿主是裸调
+  // `window.fushiReader.scrollToSearchMatch(...)`——VN 下必抛 TypeError，表现为
+  // 「搜索结果点了没反应」/「跨章只跳到目标章第一屏」。
+  //
+  // 不能沿用分页版实现：那一版用 createWalker() 只走当前屏，且靠 scrollToRange
+  // 滚动，两个前提在 VN 下都不成立。VN 版在整章的 contentStream 上匹配，再走
+  // 与 restoreToCharOffset 同款的「字符偏移 → 屏」链路翻屏。
+  if (typeof vn.scrollToSearchMatch !== 'function') {
+    vn.scrollToSearchMatch = function(query, hintOffset) {
+      if (!query) return null;
+      var stream = this.contentStream;
+      if (!stream || !stream.textEntries || !stream.textEntries.length) return null;
+      var entries = stream.textEntries;
+      var segments = [];
+      var full = '';
+      for (var i = 0; i < entries.length; i++) {
+        var text = String(entries[i].text || '');
+        segments.push({ entry: entries[i], start: full.length, text: text });
+        full += text;
+      }
+      var lowerQuery = String(query).toLowerCase();
+      var lowerFull = full.toLowerCase();
+      var matches = [];
+      var searchFrom = 0;
+      while (searchFrom <= lowerFull.length) {
+        var idx = lowerFull.indexOf(lowerQuery, searchFrom);
+        if (idx < 0) break;
+        matches.push(idx);
+        searchFrom = idx + 1;
+      }
+      if (!matches.length) return null;
+      // 就近策略与分页版一致：同章多处命中时取离 hintOffset 最近的一处。
+      var hint = Number(hintOffset);
+      if (!Number.isFinite(hint)) hint = 0;
+      var best = matches[0];
+      var bestDist = Math.abs(best - hint);
+      for (var m = 1; m < matches.length; m++) {
+        var dist = Math.abs(matches[m] - hint);
+        if (dist < bestDist) { best = matches[m]; bestDist = dist; }
+      }
+      var seg = null;
+      for (var s = 0; s < segments.length; s++) {
+        if (best < segments[s].start + segments[s].text.length) { seg = segments[s]; break; }
+      }
+      if (!seg) seg = segments[segments.length - 1];
+      // 命中下标是「拼接后的原始文本」坐标，而屏索引吃的是**可匹配字符**坐标
+      // （countChars 会跳过空白/不可匹配字符）。直接拿 best 当 charOffset 用会
+      // 在任何含空白的章节上系统性偏移，必须经命中所在 entry 的前缀换算。
+      var localRaw = Math.max(0, best - seg.start);
+      var prefix = seg.text.slice(0, localRaw);
+      var countChars = (typeof stream.countChars === 'function')
+        ? stream.countChars.bind(stream)
+        : function(t) { return String(t || '').length; };
+      var charOffset = seg.entry.startChar + countChars(prefix);
+      var index = this.screenIndexForCharOffset(charOffset);
+      if (index < 0) return null;
+      if (index !== this.currentScreenIndex) this.renderScreen(index, true);
+      return this.calculateProgress();
+    };
+  }
+  if (typeof vn.clearSearchHighlight !== 'function') {
+    vn.clearSearchHighlight = function() {
+      if (window.__fushiCssHighlightsSupported) {
+        try { CSS.highlights.delete('fushi-search'); } catch (_ignored) {}
+      }
+    };
+  }
   if (typeof vn.restoreToCharOffset !== 'function') {
     vn.restoreToCharOffset = async function(charOffset) {
       await this.ensureReady();

--- a/fushi/lib/src/sync/pairing/discovered_pairing_probe.dart
+++ b/fushi/lib/src/sync/pairing/discovered_pairing_probe.dart
@@ -36,30 +36,73 @@ List<String> discoveredPairingCandidateUrls({
   return tlsAdvertised ? <String>[https, http] : <String>[http, https];
 }
 
-/// 按候选顺序探测一台发现设备，返回第一个 ping 通的端点。
+/// BUG-1741：整段探测的收口结果——探到的端点，或**为什么没探到**。
+class DiscoveredPairingProbeOutcome {
+  const DiscoveredPairingProbeOutcome.found(
+    DiscoveredPairingProbeResult this.result, {
+    required this.peerSpeaksTls,
+  }) : failure = null;
+
+  const DiscoveredPairingProbeOutcome.failed(
+    FushiPingFailure this.failure, {
+    required this.peerSpeaksTls,
+  }) : result = null;
+
+  /// 探到的可用端点；失败时为 null。
+  final DiscoveredPairingProbeResult? result;
+
+  /// 整段探测的失败原因（按严重度取最重的一条）；成功时为 null。
+  final FushiPingFailure? failure;
+
+  /// 探测过程中**确证**对端在该端口讲 TLS（TOFU 握手拿到了证书）。
+  ///
+  /// 调用方据此禁止回落 v1 明文配对：对一个 TLS-only 端口发明文 POST 必然失败，
+  /// 回落只会把真实原因（证书 / 超时）换成一句无意义的「配对失败」。
+  final bool peerSpeaksTls;
+}
+
+/// 失败原因的严重度：越靠前越该优先展示给用户。
 ///
-/// https 候选先经 TOFU 一次性握手取指纹（取不到 → 跳过该候选，绝不裸读
-/// https），再用钉扎 ping 确认；明文 http 候选直接 ping。全部失败返回 null
-/// （调用方回落 v1 明文配对老路径，旧版 host 行为零变化）。
+/// tls 是安全事件，必须盖过后面几种；notFushi 最弱——只要有过任何一次
+/// 「连得上但对不上」以外的失败，都比「这里没有 Hibiki」更接近真相。
+const List<FushiPingFailure> _failureSeverity = <FushiPingFailure>[
+  FushiPingFailure.tls,
+  FushiPingFailure.timeout,
+  FushiPingFailure.unreachable,
+  FushiPingFailure.notFushi,
+];
+
+FushiPingFailure _worst(FushiPingFailure? a, FushiPingFailure b) {
+  if (a == null) return b;
+  return _failureSeverity.indexOf(a) <= _failureSeverity.indexOf(b) ? a : b;
+}
+
+/// 按候选顺序探测一台发现设备，返回第一个 ping 通的端点**或失败原因**。
+///
+/// https 候选先经 TOFU 一次性握手取指纹（取不到 → 记下原因并跳过该候选，绝不
+/// 裸读 https），再用钉扎 ping 确认；明文 http 候选直接 ping。
 ///
 /// [captureFingerprint] / [ping] 为测试注入缝，生产默认真实现。
-Future<DiscoveredPairingProbeResult?> probeDiscoveredPairingEndpoint({
+Future<DiscoveredPairingProbeOutcome> probeDiscoveredPairingEndpointDetailed({
   required String host,
   required int port,
   required bool tlsAdvertised,
-  Future<String?> Function(String host, int port)? captureFingerprint,
-  Future<FushiPingResult?> Function(String baseUrl,
+  Future<FushiTofuOutcome> Function(String host, int port)? captureFingerprint,
+  Future<FushiPingOutcome> Function(String baseUrl,
           {String? pinnedFingerprint})?
       ping,
 }) async {
-  final Future<String?> Function(String host, int port) capture =
+  final Future<FushiTofuOutcome> Function(String host, int port) capture =
       captureFingerprint ??
-          (String h, int p) => FushiTofuProbe.captureFingerprint(h, p);
-  final Future<FushiPingResult?> Function(String baseUrl,
+          (String h, int p) => FushiTofuProbe.probeFingerprint(h, p);
+  final Future<FushiPingOutcome> Function(String baseUrl,
           {String? pinnedFingerprint}) doPing =
       ping ??
           (String baseUrl, {String? pinnedFingerprint}) =>
-              fetchFushiPing(baseUrl, pinnedFingerprint: pinnedFingerprint);
+              probeFushiPing(baseUrl, pinnedFingerprint: pinnedFingerprint);
+
+  FushiPingFailure? worst;
+  bool peerSpeaksTls = false;
 
   for (final String baseUrl in discoveredPairingCandidateUrls(
     host: host,
@@ -67,30 +110,90 @@ Future<DiscoveredPairingProbeResult?> probeDiscoveredPairingEndpoint({
     tlsAdvertised: tlsAdvertised,
   )) {
     if (baseUrl.startsWith('https://')) {
-      final String? captured = await capture(host, port);
-      if (captured == null || captured.isEmpty) continue;
-      final FushiPingResult? result =
+      final FushiTofuOutcome tofu = await capture(host, port);
+      if (tofu.speaksTls) peerSpeaksTls = true;
+      final String? captured = tofu.fingerprint;
+      if (captured == null || captured.isEmpty) {
+        final FushiPingFailure? mapped = _tofuToPingFailure(tofu.failure);
+        if (mapped != null) worst = _worst(worst, mapped);
+        continue;
+      }
+      final FushiPingOutcome outcome =
           await doPing(baseUrl, pinnedFingerprint: captured);
-      if (result == null) continue;
+      final FushiPingResult? result = outcome.result;
+      if (result == null) {
+        worst = _worst(worst, outcome.failure ?? FushiPingFailure.unreachable);
+        continue;
+      }
       // 钉扎指纹以 ping 回传为准（与捕获一致，钉扎 client 已保证）；回传缺失时
       // 用捕获值。https 必须有指纹才可用（镜像手动配对的硬约束）。
       final String? fingerprint = (result.fingerprint?.isNotEmpty ?? false)
           ? result.fingerprint
           : captured;
-      return DiscoveredPairingProbeResult(
-        baseUrl: baseUrl,
-        fingerprint: fingerprint,
-        ping: result,
+      return DiscoveredPairingProbeOutcome.found(
+        DiscoveredPairingProbeResult(
+          baseUrl: baseUrl,
+          fingerprint: fingerprint,
+          ping: result,
+        ),
+        peerSpeaksTls: true,
       );
     } else {
-      final FushiPingResult? result = await doPing(baseUrl);
-      if (result == null) continue;
-      return DiscoveredPairingProbeResult(
-        baseUrl: baseUrl,
-        fingerprint: null,
-        ping: result,
+      final FushiPingOutcome outcome = await doPing(baseUrl);
+      final FushiPingResult? result = outcome.result;
+      if (result == null) {
+        worst = _worst(worst, outcome.failure ?? FushiPingFailure.unreachable);
+        continue;
+      }
+      return DiscoveredPairingProbeOutcome.found(
+        DiscoveredPairingProbeResult(
+          baseUrl: baseUrl,
+          fingerprint: null,
+          ping: result,
+        ),
+        peerSpeaksTls: peerSpeaksTls,
       );
     }
   }
-  return null;
+  return DiscoveredPairingProbeOutcome.failed(
+    worst ?? FushiPingFailure.unreachable,
+    peerSpeaksTls: peerSpeaksTls,
+  );
 }
+
+/// TOFU 失败原因 → ping 失败原因的归一（两套枚举面向同一个用户可见结论）。
+///
+/// 返回 null 表示**这次失败不构成证据**，不参与最终原因的评选。
+FushiPingFailure? _tofuToPingFailure(FushiTofuFailure? failure) {
+  switch (failure) {
+    case FushiTofuFailure.timeout:
+      return FushiPingFailure.timeout;
+    case FushiTofuFailure.unreachable:
+      return FushiPingFailure.unreachable;
+    case FushiTofuFailure.notTls:
+    case null:
+      // 「该端口不讲 TLS」在一台明文 host 上正是预期结果，零信息量。若拿它去
+      // 评选最终原因，会把 http 候选带回来的「连上了但不是 Hibiki」这种真正
+      // 有用的结论盖掉。
+      return null;
+  }
+}
+
+/// [probeDiscoveredPairingEndpointDetailed] 的丢原因薄封装（旧签名）。
+Future<DiscoveredPairingProbeResult?> probeDiscoveredPairingEndpoint({
+  required String host,
+  required int port,
+  required bool tlsAdvertised,
+  Future<FushiTofuOutcome> Function(String host, int port)? captureFingerprint,
+  Future<FushiPingOutcome> Function(String baseUrl,
+          {String? pinnedFingerprint})?
+      ping,
+}) async =>
+    (await probeDiscoveredPairingEndpointDetailed(
+      host: host,
+      port: port,
+      tlsAdvertised: tlsAdvertised,
+      captureFingerprint: captureFingerprint,
+      ping: ping,
+    ))
+        .result;

--- a/fushi/lib/src/sync/pairing/fushi_ping_client.dart
+++ b/fushi/lib/src/sync/pairing/fushi_ping_client.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:fushi/src/sync/tls/fushi_pinning_http.dart';
+import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:http/http.dart' as http;
 
 /// TODO-963 M2: `/api/ping` 的 client 侧响应模型。无鉴权探测，配对前用。
@@ -29,16 +32,59 @@ class FushiPingResult {
   final String? deviceName;
 }
 
-/// 向 [baseUrl] 的 `/api/ping` 发一次探测。
+/// BUG-1741：`/api/ping` 探测的失败分型（机器可读，与 [FushiPairV2Client] 的
+/// failure reason 共用同一套词汇）。
+///
+/// 分型存在的唯一理由：旧实现把「证书指纹对不上」（安全事件）、「对端超时」、
+/// 「端口没人监听」和「那台机器不是 Hibiki」**全部**压成同一个 `null`，UI 只能
+/// 挑一句最含糊的话说，用户被引向完全错误的排查方向。
+enum FushiPingFailure {
+  /// 证书类失败：钉扎指纹不符 / 握手被对端拒绝。**安全事件**，绝不可与
+  /// 「找不到设备」同呈现。
+  tls,
+
+  /// 对端在超时窗口内没有应答。
+  timeout,
+
+  /// 连不上：端口无监听、被防火墙拦、或明文请求打在 TLS-only 端口上被 reset。
+  unreachable,
+
+  /// 连上了、也应答了，但对端不是 Hibiki（非 200 / 非 JSON / `app != 'fushi'`）。
+  notFushi,
+}
+
+/// [probeFushiPing] 的结果：要么拿到可信的 [result]，要么给出 [failure] 原因。
+class FushiPingOutcome {
+  const FushiPingOutcome.ok(FushiPingResult this.result)
+      : failure = null,
+        statusCode = null;
+
+  const FushiPingOutcome.failed(FushiPingFailure this.failure,
+      {this.statusCode})
+      : result = null;
+
+  /// 探测成功时的应答（`isFushi` 恒为 true）；失败时为 null。
+  final FushiPingResult? result;
+
+  /// 探测失败原因；成功时为 null。
+  final FushiPingFailure? failure;
+
+  /// [FushiPingFailure.notFushi] 由「非 200 应答」引起时的状态码，便于日志定位。
+  final int? statusCode;
+
+  bool get isOk => result != null;
+}
+
+/// 向 [baseUrl] 的 `/api/ping` 发一次探测，**带失败原因**。
 ///
 /// - 明文 http baseUrl：用普通 client。
 /// - https baseUrl 且已知 [pinnedFingerprint]：走钉扎 client（指纹必须相等）。
 /// - https baseUrl 但 **未知** 指纹（首次 TOFU）：调用方应先用
-///   [FushiTofuProbe.captureFingerprint] 取指纹核对后再传进来；此处不接受裸 https
+///   [FushiTofuProbe.probeFingerprint] 取指纹核对后再传进来；此处不接受裸 https
 ///   无指纹探测（避免无钉扎读 https）。
 ///
-/// 失败（连不上 / 非 hibiki / 解析失败）返回 null。绝不返回部分可信结果。
-Future<FushiPingResult?> fetchFushiPing(
+/// 绝不返回部分可信结果：只要有任何一步不确定就走 [FushiPingOutcome.failed]。
+Future<FushiPingOutcome> probeFushiPing(
   String baseUrl, {
   String? pinnedFingerprint,
   http.Client? httpClient,
@@ -54,28 +100,69 @@ Future<FushiPingResult?> fetchFushiPing(
   try {
     final http.Response resp =
         await client.get(Uri.parse('$baseUrl/api/ping')).timeout(timeout);
-    if (resp.statusCode != 200) return null;
+    if (resp.statusCode != 200) {
+      return FushiPingOutcome.failed(
+        FushiPingFailure.notFushi,
+        statusCode: resp.statusCode,
+      );
+    }
     final dynamic decoded = jsonDecode(resp.body);
-    if (decoded is! Map) return null;
+    if (decoded is! Map) {
+      return const FushiPingOutcome.failed(FushiPingFailure.notFushi);
+    }
     final Map<String, dynamic> json = decoded.cast<String, dynamic>();
     final bool isFushi = json['app'] == 'fushi';
-    if (!isFushi) return null;
+    if (!isFushi) {
+      return const FushiPingOutcome.failed(FushiPingFailure.notFushi);
+    }
     final dynamic pairing = json['pairing'];
     final bool supportsPairV2 = pairing is Map && pairing['v2'] == true;
     final dynamic tls = json['tls'];
     final bool tlsEnabled = tls is Map && tls['enabled'] == true;
     final String? fingerprint =
         tls is Map ? tls['fingerprint'] as String? : null;
-    return FushiPingResult(
-      isFushi: true,
-      supportsPairV2: supportsPairV2,
-      tlsEnabled: tlsEnabled,
-      fingerprint: fingerprint,
-      deviceName: json['deviceName'] as String?,
+    return FushiPingOutcome.ok(
+      FushiPingResult(
+        isFushi: true,
+        supportsPairV2: supportsPairV2,
+        tlsEnabled: tlsEnabled,
+        fingerprint: fingerprint,
+        deviceName: json['deviceName'] as String?,
+      ),
     );
-  } on Object {
-    return null;
+  } catch (e, stack) {
+    // BUG-1741：分型 + 留痕。此前这里是裸 `on Object { return null; }`，
+    // 「钉扎指纹不符」查不到任何线索，事后连日志都没有。
+    ErrorLogService.instance.log('Ping:$baseUrl', e, stack);
+    return FushiPingOutcome.failed(classifyFushiProbeFailure(e));
   } finally {
     if (ownsClient) client.close();
   }
 }
+
+/// 把传输层异常映射成 [FushiPingFailure]。
+///
+/// [TlsException] 是 dart:io 里证书类失败的共同接口（[HandshakeException] /
+/// [CertificateException] 都 implements 它）。package:http 的 IOClient 只把
+/// `SocketException` / `HttpException` 转成 `ClientException`，TLS 异常原样穿透
+/// ——所以 TLS 判定必须放在最前面。
+FushiPingFailure classifyFushiProbeFailure(Object e) {
+  if (e is TlsException) return FushiPingFailure.tls;
+  if (e is TimeoutException) return FushiPingFailure.timeout;
+  return FushiPingFailure.unreachable;
+}
+
+/// [probeFushiPing] 的丢原因薄封装，供只关心「通没通」的旧调用方使用。
+Future<FushiPingResult?> fetchFushiPing(
+  String baseUrl, {
+  String? pinnedFingerprint,
+  http.Client? httpClient,
+  Duration timeout = const Duration(seconds: 5),
+}) async =>
+    (await probeFushiPing(
+      baseUrl,
+      pinnedFingerprint: pinnedFingerprint,
+      httpClient: httpClient,
+      timeout: timeout,
+    ))
+        .result;

--- a/fushi/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -219,8 +219,10 @@ class _FushiServerConfigWidgetState extends State<_FushiServerConfigWidget>
     try {
       normalizedResult = normalizeFushiInterconnectManualUrl(result);
     } catch (e, stack) {
+      // BUG-1741：这里根本没发起过连接——normalize 只是解析字符串。说「连接失败」
+      // 会把用户支去查网络/防火墙，而真正要改的是他刚敲错的那行地址。
       ErrorLogService.instance.log('SyncConfig.addFushiUrl', e, stack);
-      if (mounted) _showSnackBar(context, t.sync_connection_failed);
+      if (mounted) _showSnackBar(context, t.sync_pair_invalid_url);
       return;
     }
 
@@ -287,23 +289,50 @@ class _FushiServerConfigWidgetState extends State<_FushiServerConfigWidget>
     final bool isHttps = parsed.scheme.toLowerCase() == 'https';
     _setPairV2Busy(true);
     try {
+      final int port = parsed.hasPort ? parsed.port : (isHttps ? 443 : 80);
+
       // https 首连：先用一次性 TOFU 探测捕获 host 证书指纹（仅取指纹，不传数据）。
       String? capturedFingerprint;
       if (isHttps) {
-        final int port = parsed.hasPort ? parsed.port : 443;
-        capturedFingerprint =
-            await FushiTofuProbe.captureFingerprint(parsed.host, port);
+        final FushiTofuOutcome tofu =
+            await FushiTofuProbe.probeFingerprint(parsed.host, port);
         if (!mounted) return;
+        if (!tofu.speaksTls) {
+          // BUG-1741：握手都没成，后面的 ping 必然也失败。此前这里不作分辨地
+          // 一路走到「未找到 Fushi 设备」——而真相往往只是用户把 http host 写成了
+          // https。分型后直接告诉他该改哪个字。
+          _showSnackBar(context, _tofuFailureMessage(tofu.failure));
+          return;
+        }
+        capturedFingerprint = tofu.fingerprint;
       }
 
       // /api/ping 探测：确认 hibiki + 支持 v2 + 取展示名/指纹（https 用捕获指纹钉扎读）。
-      final FushiPingResult? ping = await fetchFushiPing(
+      final FushiPingOutcome outcome = await probeFushiPing(
         baseUrl,
         pinnedFingerprint: capturedFingerprint,
       );
       if (!mounted) return;
-      if (ping == null || !ping.isFushi || !ping.supportsPairV2) {
-        _showSnackBar(context, t.sync_pair_not_fushi);
+      final FushiPingResult? ping = outcome.result;
+      if (ping == null) {
+        // BUG-1741：明文地址打不通时回头确认对端是不是 TLS-only。那不是「这里没有
+        // 设备」，是「地址的 scheme 写错了」——两句话指向完全相反的排查方向，而旧
+        // 实现把它们说成同一句。
+        if (!isHttps && outcome.failure == FushiPingFailure.unreachable) {
+          final FushiTofuOutcome tofu =
+              await FushiTofuProbe.probeFingerprint(parsed.host, port);
+          if (!mounted) return;
+          if (tofu.speaksTls) {
+            _showSnackBar(context, t.sync_pair_peer_requires_https);
+            return;
+          }
+        }
+        _showSnackBar(context, _pingFailureMessage(outcome.failure));
+        return;
+      }
+      if (!ping.supportsPairV2) {
+        // 连上了、确实是 Hibiki，只是版本太旧——与「找不到设备」是两回事。
+        _showSnackBar(context, t.sync_pair_unavailable);
         return;
       }
       // https host 的钉扎指纹以 ping 回传为准（与捕获一致），明文 http 无指纹。
@@ -311,7 +340,8 @@ class _FushiServerConfigWidgetState extends State<_FushiServerConfigWidget>
           isHttps ? (ping.fingerprint ?? capturedFingerprint) : null;
       // https 必须有指纹才能继续（否则无法钉扎，拒绝裸 https）。
       if (isHttps && (fingerprint == null || fingerprint.isEmpty)) {
-        _showSnackBar(context, t.sync_pair_failed);
+        // 语义就是「拿不到可钉扎的证书」，不是笼统的「配对失败」。
+        _showSnackBar(context, t.sync_pair_tls_failed);
         return;
       }
 
@@ -835,6 +865,39 @@ mixin _PairingV2FlowMixin<T extends StatefulWidget> on State<T> {
     await _syncSettings(_pairSettingsContext).setInterconnectEnabled(true);
     _syncSettings(_pairSettingsContext).reloadClientConfig();
     return t.sync_pair_success;
+  }
+
+  /// BUG-1741：把**配对前探测**的失败分型翻成人话。
+  ///
+  /// 探测层此前把「证书对不上」「超时」「端口没人」「不是 Hibiki」全压成一个
+  /// null，UI 只能一律说「此地址未找到 Fushi 设备」——对着一台明明在线、只是证书
+  /// 换了的机器说「这里没有设备」，用户的排查方向从第一步就是错的。
+  String _pingFailureMessage(FushiPingFailure? failure) {
+    switch (failure) {
+      case FushiPingFailure.tls:
+        return t.sync_pair_tls_failed;
+      case FushiPingFailure.timeout:
+        return t.sync_pair_timeout;
+      case FushiPingFailure.unreachable:
+        return t.sync_connection_failed;
+      case FushiPingFailure.notFushi:
+      case null:
+        return t.sync_pair_not_fushi;
+    }
+  }
+
+  /// BUG-1741：TOFU 握手失败的人话。`notTls` 是最常见的一种——用户把明文 host
+  /// 写成了 https，此时该说的是「改 scheme」而不是「配对失败」。
+  String _tofuFailureMessage(FushiTofuFailure? failure) {
+    switch (failure) {
+      case FushiTofuFailure.notTls:
+        return t.sync_pair_peer_not_https;
+      case FushiTofuFailure.timeout:
+        return t.sync_pair_timeout;
+      case FushiTofuFailure.unreachable:
+      case null:
+        return t.sync_connection_failed;
+    }
   }
 
   /// BUG-1553：把 client 的机器可读 reason 翻成人话。此前只认三个 reason，
@@ -1502,13 +1565,14 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
 
     setState(() => _pairingUrl = device.webDavUrl);
     try {
-      final DiscoveredPairingProbeResult? probe =
-          await probeDiscoveredPairingEndpoint(
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
         host: device.host,
         port: device.port,
         tlsAdvertised: device.tlsEnabled,
       );
       if (!mounted) return;
+      final DiscoveredPairingProbeResult? probe = outcome.result;
       if (probe != null && probe.ping.supportsPairV2) {
         // 先记录探明 scheme 的地址（host 拒绝也保留，可回退手粘 token）；钉扎
         // 指纹在配对成功后经 _onPairSuccess 落库（TOFU 记录器）。
@@ -1524,8 +1588,33 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
         );
         return;
       }
+      // BUG-1741：对端确证讲 TLS（或 mDNS 明说 tls=1）时**禁止**回落 v1。
+      //
+      // v1 只会往 `device.webDavUrl` 发明文 POST，而那个 getter 硬编码
+      // `http://`（lan_discovery_service.dart）。TLS host 根本不 bind 明文端口，
+      // 这一发必然抛，最后换来一句「配对失败」——真实原因（证书不符 / 超时）在
+      // 三层探测里已经被吞光。更糟的是它还会把那条错的 http:// 地址写进候选列表，
+      // 从此那台设备每次「测试连接」都失败，且 UI 里看不出 scheme 错了。
+      if (probe == null && (outcome.peerSpeaksTls || device.tlsEnabled)) {
+        _showSnackBar(
+          context,
+          '${device.name}: ${_pingFailureMessage(outcome.failure)}',
+        );
+        return;
+      }
+      // 探明是 https 端点却不支持 v2：同样不能拿明文 v1 去敲，只能如实说版本过旧。
+      if (probe != null && probe.baseUrl.startsWith('https://')) {
+        _showSnackBar(context, '${device.name}: ${t.sync_pair_unavailable}');
+        return;
+      }
       // 旧版 host：无 /api/ping 或不支持 v2 → v1 明文配对老路径（行为零变化）。
-      await _pairLegacyV1(device, repo, state);
+      // 已探明端点时用探明的 baseUrl，不再盲信硬编码 http 的 webDavUrl。
+      await _pairLegacyV1(
+        probe?.baseUrl ?? device.webDavUrl,
+        device,
+        repo,
+        state,
+      );
     } finally {
       if (mounted) setState(() => _pairingUrl = null);
       // Single source of truth bumped → client-config widget reloads URL + token.
@@ -1537,13 +1626,14 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
   /// v1 明文配对（旧版 host 兼容路径，与 v2 化前的实现一致）：直接 POST
   /// /api/pair 等 host 审批发 token。仅在对端不支持 v2 时走到。
   Future<void> _pairLegacyV1(
+    String baseUrl,
     FushiDevice device,
     SyncRepository repo,
     _SyncSettingsState state,
   ) async {
     // Always record the address (deduped) so the user keeps the URL even if
     // the host declines and they fall back to pasting the token.
-    await repo.addFushiClientUrl(device.webDavUrl);
+    await repo.addFushiClientUrl(baseUrl);
     // A client connection now exists → lock this device out of server mode.
     state.setHasClientConnection(true);
 
@@ -1551,7 +1641,7 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
     try {
       final http.Response resp = await http
           .post(
-            Uri.parse('${device.webDavUrl}/api/pair'),
+            Uri.parse('$baseUrl/api/pair'),
             headers: <String, String>{'Content-Type': 'application/json'},
             body:
                 jsonEncode(<String, String>{'name': await _localDeviceName()}),
@@ -1565,7 +1655,7 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
             body is Map<String, dynamic> ? body['token'] as String? : null;
         if (token != null && token.isNotEmpty) {
           // BUG-1550：v1 老路径同样把凭据落在这条地址上（理由见 _onPairSuccess）。
-          await repo.setFushiClientTokenForUrl(device.webDavUrl, token);
+          await repo.setFushiClientTokenForUrl(baseUrl, token);
           // BUG-1693：与 v2 路径一致——拿到 token（配对成功）才落「互联已启用」。
           await state.setInterconnectEnabled(true);
           message = t.sync_pair_success;
@@ -1580,8 +1670,7 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
     } catch (e, stack) {
       // Pairing probe failed (no server/timeout/declined). Keep the URL; record
       // why instead of swallowing.
-      ErrorLogService.instance
-          .log('LanDiscovery.pair:${device.webDavUrl}', e, stack);
+      ErrorLogService.instance.log('LanDiscovery.pair:$baseUrl', e, stack);
       message = t.sync_pair_failed;
     }
     if (mounted) _showSnackBar(context, '${device.name}: $message');

--- a/fushi/lib/src/sync/tls/fushi_tofu_probe.dart
+++ b/fushi/lib/src/sync/tls/fushi_tofu_probe.dart
@@ -1,6 +1,44 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fushi/src/sync/tls/fushi_pinning_http.dart';
+import 'package:fushi/src/utils/misc/error_log_service.dart';
+
+/// BUG-1741：TOFU 握手的失败分型。
+///
+/// 「握手失败」和「连不上」是两件事：前者证明**端口上有东西，只是不讲 TLS**
+/// （多半是用户把 http host 写成了 https），后者是根本没连上。旧实现把两者都
+/// 压成 null，配对流程因此无法判断「该不该回落明文 v1」。
+enum FushiTofuFailure {
+  /// 端口可连，但不是 TLS 端点（明文服务 / 协议版本谈不拢）。
+  notTls,
+
+  /// 连不上（无监听 / 防火墙）。
+  unreachable,
+
+  /// 超时。
+  timeout,
+}
+
+/// [FushiTofuProbe.probeFingerprint] 的结果。
+class FushiTofuOutcome {
+  const FushiTofuOutcome.captured(String this.fingerprint) : failure = null;
+
+  const FushiTofuOutcome.failed(FushiTofuFailure this.failure)
+      : fingerprint = null;
+
+  /// 捕获到的 host 证书 SHA-256 指纹（`aa:bb:..`）；失败时为 null。
+  final String? fingerprint;
+
+  /// 失败原因；成功时为 null。
+  final FushiTofuFailure? failure;
+
+  /// 已确证对端在该端口讲 TLS。
+  ///
+  /// 配对流程用它做「禁止回落 v1 明文配对」的判据：明文 POST 打向一个只讲
+  /// https 的端口**必然**失败，回落过去只会换来一句无意义的「配对失败」。
+  bool get speaksTls => (fingerprint?.isNotEmpty ?? false);
+}
 
 /// TODO-963 M2: TOFU 首连「捕获 host 证书指纹」探测。
 ///
@@ -16,8 +54,8 @@ import 'package:fushi/src/sync/tls/fushi_pinning_http.dart';
 ///   这一计算结果，而非硬编码放行——捕获失败（理论上不会）即拒绝握手。
 class FushiTofuProbe {
   /// 连到 [host]:[port] 做一次 TLS 握手，返回 host 证书的 SHA-256 指纹
-  /// （aa:bb:.. 形式）。失败（连不上 / 非 TLS / 超时）返回 null。
-  static Future<String?> captureFingerprint(
+  /// （aa:bb:.. 形式）或**失败原因**。
+  static Future<FushiTofuOutcome> probeFingerprint(
     String host,
     int port, {
     Duration timeout = const Duration(seconds: 5),
@@ -42,9 +80,22 @@ class FushiTofuProbe {
         final X509Certificate? peer = socket?.peerCertificate;
         return peer == null ? null : fingerprintOfDer(peer.der);
       }();
-      return captured;
-    } on Object {
-      return captured; // 连接异常时若已捕获到指纹仍可返回（握手中途失败）。
+      final String? fingerprint = captured;
+      if (fingerprint == null || fingerprint.isEmpty) {
+        return const FushiTofuOutcome.failed(FushiTofuFailure.notTls);
+      }
+      return FushiTofuOutcome.captured(fingerprint);
+    } catch (e, stack) {
+      // 握手中途失败但已拿到证书：指纹本身仍然可信（它就是对端出示的那张），
+      // 保持旧行为返回它。
+      final String? fingerprint = captured;
+      if (fingerprint != null && fingerprint.isNotEmpty) {
+        return FushiTofuOutcome.captured(fingerprint);
+      }
+      // BUG-1741：分型 + 留痕。此前这里静默返回 null，调用方无从分辨
+      // 「对端不讲 TLS」与「对端不在」——而这两者的正确处置完全相反。
+      ErrorLogService.instance.log('TofuProbe:$host:$port', e, stack);
+      return FushiTofuOutcome.failed(_classify(e));
     } finally {
       try {
         await socket?.close();
@@ -53,4 +104,20 @@ class FushiTofuProbe {
       }
     }
   }
+
+  /// 连到明文端口时 `SecureSocket.connect` 抛的是 [HandshakeException]（实现了
+  /// [TlsException]）；连不上抛 [SocketException]；超时抛 [TimeoutException]。
+  static FushiTofuFailure _classify(Object e) {
+    if (e is TlsException) return FushiTofuFailure.notTls;
+    if (e is TimeoutException) return FushiTofuFailure.timeout;
+    return FushiTofuFailure.unreachable;
+  }
+
+  /// [probeFingerprint] 的丢原因薄封装（旧签名，保持既有调用方零改动）。
+  static Future<String?> captureFingerprint(
+    String host,
+    int port, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async =>
+      (await probeFingerprint(host, port, timeout: timeout)).fingerprint;
 }

--- a/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
+++ b/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
@@ -24,6 +24,8 @@ void main() {
   final String readerChrome = File(
     'lib/src/pages/implementations/reader_fushi/chrome.part.dart',
   ).readAsStringSync();
+  final String fullscreenState =
+      File('lib/src/platform/macos_fullscreen_state.dart').readAsStringSync();
 
   test('macOS fullscreen toggles through the single NSWindow owner', () {
     // 根因：window_manager.setFullScreen 与 macos_window_utils（NSWindow.delegate
@@ -129,6 +131,65 @@ void main() {
       readerChrome,
       contains('_stableTopInset + _macosWindowTitlebarInset'),
       reason: '顶部进度 pill 必须落在 drag strip 下方，不能盖住拖动区或交通灯',
+    );
+  });
+
+  // BUG-1744：用户报的「阅读器顶部横带」。BUG-1343 引入的 28pt 拖拽带唯一条件是
+  // Platform.isMacOS——进原生全屏后既没有标题栏也没有交通灯、窗口也拖不动，这条
+  // 不透明带和它同高的正文让位却仍在，就是那条横带。
+  test('BUG-1744 fullscreen drops the titlebar strip and its content inset',
+      () {
+    // 让位量必须由全屏态门控（单一真相源：_readerTopOffset / popupTopReserve /
+    // independentDocumentInsets / 顶部进度 pill 全部读它）。
+    expect(
+      reader,
+      contains(
+          'Platform.isMacOS && !_macosFullscreen ? kMacTitleBarHeight : 0'),
+      reason: '_macosWindowTitlebarInset 未按全屏态门控 → 全屏下正文仍被下压 28pt',
+    );
+    // 带子本身也必须整体不挂，只归零 inset 会留下一条盖住正文的不透明条。
+    // （DragToMoveArea 挂在 build() 的 Stack 里，不在 _buildBody()。）
+    final String pageBuild =
+        methodBody(reader, '  Widget build(BuildContext context)');
+    expect(
+      containsCodeLine(pageBuild, 'if (Platform.isMacOS && !_macosFullscreen)'),
+      isTrue,
+      reason: '全屏下仍挂 DragToMoveArea 的 ColoredBox = 一条纯浪费的顶部横带',
+    );
+    expect(
+      containsCodeLine(pageBuild, 'DragToMoveArea('),
+      isTrue,
+      reason: '守卫取错了窗口（DragToMoveArea 应在同一个 build 方法体内）',
+    );
+    // 状态来源必须是能覆盖**全部**入口的 NSWindowDelegate：绿灯按钮和「显示」
+    // 菜单都不经过 app 自己的 F11 快捷键，只记快捷键状态会漏掉最常用的两条路。
+    expect(
+      reader,
+      contains('MacosFullscreenState.instance'),
+      reason: '全屏态必须取自单一真相源 MacosFullscreenState',
+    );
+    expect(
+      fullscreenState,
+      contains('windowDidEnterFullScreen'),
+      reason: 'NSWindowDelegate 是唯一能覆盖绿灯/菜单/快捷键全部入口的信号',
+    );
+    expect(
+      fullscreenState,
+      contains('windowDidExitFullScreen'),
+      reason: '只监听进入不监听退出，退出全屏后横带不会回来',
+    );
+    // 光 setState 不够：JS 的 --chrome-top-inset 由 _applyChromeInsets 单独推送，
+    // 漏了它正文 padding-top 会停在旧的 28px 上（横带原样还在）。
+    final String onChange =
+        methodBody(reader, '  void _onMacosFullscreenChanged()');
+    expect(containsCodeLine(onChange, '_applyChromeInsets'), isTrue,
+        reason: '全屏翻转后必须把新 inset 回喂 WebView，否则 CSS 侧仍留 28px 空白');
+    expect(containsCodeLine(onChange, 'setState'), isTrue);
+    // 监听器必须摘掉，否则页面走了还在被全局 notifier 持有。
+    expect(
+      reader,
+      contains('removeListener(_onMacosFullscreenChanged)'),
+      reason: 'dispose 未摘监听 = 泄漏 + 已 dispose 的 State 上 setState',
     );
   });
 }

--- a/fushi/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
+++ b/fushi/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
@@ -186,9 +186,21 @@ void main() {
           isTrue,
           reason: '主轴须一并回传，Dart 侧才能只对横向触控板 burst 开跨章节手势闸门');
       // 主轴判据：按绝对值更大的轴取 delta，斜向 tick 不得被次轴符号带偏。
-      expect(containsCodeLine(tick, 'Math.abs(e.deltaX) > Math.abs(e.deltaY)'),
+      // BUG-1745：再加抖动余量——一次横滑里的纵向漂移拍若被判成 vertical，就会
+      // 绕过闸门直接翻页（弹窗滚动路径 BUG-701 已用同一配方修过）。
+      expect(
+          containsCodeLine(tick, 'var absX = Math.abs(e.deltaX)') &&
+              containsCodeLine(tick, 'var absY = Math.abs(e.deltaY)') &&
+              containsCodeLine(tick, 'absX > absY + PAGED_WHEEL_AXIS_MARGIN'),
           isTrue,
-          reason: '分页滚轮必须按绝对值更大的主轴判横/纵，不能任一轴为正就前进');
+          reason: '分页滚轮必须按绝对值更大的主轴判横/纵（且带抖动余量），'
+              '不能任一轴为正就前进');
+      // BUG-1745：设备类型必须一并回传。闸门的判据是「触摸板惯性流 vs 鼠标离散
+      // tick」，不是轴——纵向触摸板滑动此前完全没进闸门，一次滑翻 3 页。
+      expect(
+          containsCodeLine(tick, "_isTrackpadWheel(e) ? 'trackpad' : 'mouse'"),
+          isTrue,
+          reason: '未回传输入设备类型，纵向触摸板惯性会绕过手势闸门连翻多页');
       expect(
           containsCodeLine(
               tick, 'var delta = horizontal ? e.deltaX : e.deltaY'),
@@ -244,8 +256,13 @@ void main() {
           reason: '滚轮翻页经 _paginate 入口节流闸门（throttleMs: wheelPageTurnInterval）');
       expect(containsCodeLine(body, 'wheelPageTurnInterval'), isTrue,
           reason: '滚轮 throttleMs 源是 wheelPageTurnInterval');
-      expect(containsCodeLine(body, "axis == 'horizontal'"), isTrue,
-          reason: '只有横向触控板手势进入跨章节 burst 闸门');
+      // BUG-1745：闸门判据从「轴」改成「输入设备」。旧的 axis=='horizontal' 隐含
+      // 假设「纵向 = 鼠标滚轮」，可 macOS 触摸板上下双指滑同样是纵向——整段惯性
+      // 全部漏过闸门，一次滑动稳定翻 3 页（间隔调到下限则 10 页）。
+      expect(containsCodeLine(body, "pointerKind == 'trackpad'"), isTrue,
+          reason: '触控板手势（含纵向）必须进入跨章节 burst 闸门');
+      expect(containsCodeLine(body, "axis == 'horizontal' &&"), isFalse,
+          reason: '按轴开闸门会把纵向触摸板惯性放走（BUG-1745 根因）');
       expect(
           containsCodeLine(
               body, '_pagedWheelGestureGate.shouldStartNewGesture'),

--- a/fushi/test/reader/reader_pagination_scripts_test.dart
+++ b/fushi/test/reader/reader_pagination_scripts_test.dart
@@ -107,9 +107,16 @@ void main() {
     });
 
     test('clearSearchHighlightInvocation', () {
+      final String result =
+          ReaderPaginationScripts.clearSearchHighlightInvocation();
+      expect(result, contains('window.fushiReader.clearSearchHighlight()'));
+      // BUG-1743：同款存在性守卫（VN 的 clearSearchHighlight 由 shim 提供，
+      // 但任何未实现的 shell 都不该因此抛异常）。
       expect(
-        ReaderPaginationScripts.clearSearchHighlightInvocation(),
-        'window.fushiReader.clearSearchHighlight()',
+        result,
+        contains(
+          'typeof window.fushiReader.clearSearchHighlight === "function"',
+        ),
       );
     });
   });
@@ -266,8 +273,18 @@ void main() {
           ReaderPaginationScripts.scrollToSearchMatchInvocation('a"b', 7);
       // The query must be emitted as a single, properly escaped JS string
       // literal so the raw quote cannot terminate the argument early.
-      expect(result, 'window.fushiReader.scrollToSearchMatch("a\\"b", 7)');
+      expect(
+        result,
+        contains('window.fushiReader.scrollToSearchMatch("a\\"b", 7)'),
+      );
       expect(result, isNot(contains('"a"b"')));
+      // BUG-1743：调用必须带存在性守卫——VN 等 shell 未实现时裸调会抛
+      // TypeError，中断同一次 evaluate 里的后续语句且 Dart 侧抓不到。
+      expect(
+        result,
+        contains(
+            'typeof window.fushiReader.scrollToSearchMatch === "function"'),
+      );
     });
 
     test('scrollToSearchMatchInvocation escapes backslash and newline', () {
@@ -286,7 +303,10 @@ void main() {
     test('scrollToSearchMatchInvocation preserves CJK query verbatim', () {
       final String result =
           ReaderPaginationScripts.scrollToSearchMatchInvocation('猫', 100);
-      expect(result, 'window.fushiReader.scrollToSearchMatch("猫", 100)');
+      expect(
+        result,
+        contains('window.fushiReader.scrollToSearchMatch("猫", 100)'),
+      );
     });
 
     test('highlightSentenceAudioCueInvocation escapes cue id and embeds bool',

--- a/fushi/test/reader/trackpad_wheel_classification_test.dart
+++ b/fushi/test/reader/trackpad_wheel_classification_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_pagination_scripts.dart';
+
+/// BUG-1745：触摸板纵向翻页。
+///
+/// 症状：macOS 触摸板上下双指滑一次，翻 3~4 页（把「滚轮翻页间隔」调到下限
+/// 150ms 时能翻十页）。
+///
+/// 根因：`ReaderWheelGestureGate`（一次惯性流聚合成一次翻页）此前只对
+/// `axis == 'horizontal'` 生效，判据里隐含「纵向 = 鼠标滚轮」的假设。但 macOS
+/// 触摸板上下滑同样是纵向，惯性流持续 1~1.5 秒，全部漏过闸门、只受 `_paginate`
+/// 的固定 450ms 窗管 → 1500ms / 450ms ≈ 3 页。
+///
+/// 修复把闸门判据换成「输入设备」：触摸板（连续惯性流）进闸门，鼠标滚轮（离散
+/// tick，一格一页是正确期望）保留固定窗节流。
+///
+/// 本文件覆盖闸门在**纵向**输入上的行为不变量；JS 侧的设备判别与主轴抖动余量由
+/// `reader_mouse_paging_boundary_guard_static_test.dart` 的源码守卫锁定。
+void main() {
+  const Duration settle = Duration(milliseconds: 450);
+  final DateTime t0 = DateTime(2026, 8, 19, 12);
+
+  /// 模拟一段惯性流：[count] 个间隔 [stepMs] 毫秒的 tick，返回实际翻页次数。
+  int turnsFor({
+    required int count,
+    required int stepMs,
+    required ReaderWheelGestureGate gate,
+    required DateTime start,
+  }) {
+    int turns = 0;
+    for (int i = 0; i < count; i++) {
+      final DateTime now = start.add(Duration(milliseconds: i * stepMs));
+      if (gate.shouldStartNewGesture(
+        now: now,
+        settleInterval: settle,
+        canTurnPage: true,
+      )) {
+        turns++;
+      }
+    }
+    return turns;
+  }
+
+  test('一次 1.5 秒的纵向触摸板惯性只翻一页', () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    // 触摸板惯性典型形态：~16ms 一拍，持续 1.5 秒。
+    expect(
+      turnsFor(count: 94, stepMs: 16, gate: gate, start: t0),
+      1,
+      reason: '整段惯性属于同一次手势；旧实现在纵向上会翻 3 页',
+    );
+  });
+
+  test('把翻页间隔调到下限 150ms 也仍是一页（旧实现会翻十页）', () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    int turns = 0;
+    for (int i = 0; i < 94; i++) {
+      if (gate.shouldStartNewGesture(
+        now: t0.add(Duration(milliseconds: i * 16)),
+        settleInterval: const Duration(milliseconds: 150),
+        canTurnPage: true,
+      )) {
+        turns++;
+      }
+    }
+    expect(turns, 1);
+  });
+
+  test('两次滑动之间有完整静默 → 各翻一页', () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    expect(turnsFor(count: 30, stepMs: 16, gate: gate, start: t0), 1);
+    // 上一段最后一拍在 t0+464ms；再静默一个完整 settle 窗后才算新手势。
+    final DateTime second = t0.add(const Duration(milliseconds: 30 * 16 + 500));
+    expect(turnsFor(count: 30, stepMs: 16, gate: gate, start: second), 1);
+  });
+
+  test('鼠标滚轮的离散 tick 不进闸门 —— 一格一页由固定窗节流决定', () {
+    // 设备判别在 JS 侧（_isTrackpadWheel），Dart 侧只对 pointerKind=='trackpad'
+    // 开闸门。这里锁的是闸门本身对「离散慢速 tick」不会误聚合：即便鼠标输入被
+    // 误判成触摸板，间隔大于 settle 的 tick 仍各自成手势。
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    expect(turnsFor(count: 5, stepMs: 600, gate: gate, start: t0), 5);
+  });
+
+  test('翻不动页的 tick 不认领手势（BUG-1380 契约在纵向上同样成立）', () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    // 换章加载覆盖了惯性开头：这些 tick 只查询、不认领。
+    for (int i = 0; i < 20; i++) {
+      gate.shouldStartNewGesture(
+        now: t0.add(Duration(milliseconds: i * 16)),
+        settleInterval: settle,
+        canTurnPage: false,
+      );
+    }
+    // 加载落定后，紧接着的下一拍必须仍能翻一页（不是零反馈）。
+    expect(
+      gate.shouldStartNewGesture(
+        now: t0.add(const Duration(milliseconds: 20 * 16)),
+        settleInterval: settle,
+        canTurnPage: true,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/fushi/test/reader/vn_non_sasayaki_follow_guard_test.dart
+++ b/fushi/test/reader/vn_non_sasayaki_follow_guard_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1742 接线守卫：VN 模式下**非 sasayaki 书**的有声书自动跟随。
+///
+/// 分叉在 [AudiobookBridge.highlight]：cue 的 textFragmentId 能被
+/// `SubtitleRematchCodec` 解码（sasayaki）时走 `window.fushiReader` 的方法调用，
+/// VN 实现了它、一切正常；否则（纯 SRT/VTT/LRC 合成书，textFragmentId 是
+/// `[data-cue-id="N"]` 这样的裸 CSS 选择器）走 `__fushiHighlight`，而后者用
+/// `document.querySelector` 找元素。
+///
+/// VN 的 `detachChapterSource` 把整章正文搬进一个游离的 div，document 里任一时刻
+/// 只剩当前一屏的克隆——目标 cue 只要不在当前屏，querySelector 就返回 null 并
+/// **静默早退**，跟随永远不会翻到目标屏。即便恰好在当前屏，后续的
+/// `__fushiRevealTarget` 也只能落到 `scrollIntoView`，而 VN stage 是定屏无滚动。
+///
+/// 所以这条路径必须优先走 VN 的 `highlightSelectorCue`（选择器 → 字符偏移 →
+/// 翻屏），分页/连续模式没有该方法、自动回落原路径。
+///
+/// headless 无真 InAppWebView，逐句翻屏须真机复验；本守卫只锁接线不变量。
+void main() {
+  final String source =
+      File('lib/src/media/audiobook/audiobook_bridge.dart').readAsStringSync();
+
+  final int start = source.indexOf('  static Future<void> highlight(');
+  final int end =
+      source.indexOf('  static Future<void> resetImagePauseAnchor(');
+
+  test('方法边界可定位（防守卫因重命名失效）', () {
+    expect(start, greaterThanOrEqualTo(0),
+        reason: 'AudiobookBridge.highlight 丢失');
+    expect(end, greaterThan(start));
+  });
+
+  final String body = source.substring(start, end);
+
+  test('非 sasayaki 分支优先走 VN 的 highlightSelectorCue', () {
+    expect(
+      body.contains('window.fushiReader.highlightSelectorCue'),
+      isTrue,
+      reason: '非 sasayaki cue 未接 VN 原语 —— VN 下自动跟随会静默失效',
+    );
+    expect(
+      body.contains(
+          'typeof window.fushiReader.highlightSelectorCue==="function"'),
+      isTrue,
+      reason: '必须带存在性判定，否则分页/连续模式会抛 TypeError',
+    );
+  });
+
+  test('分页/连续模式仍回落 __fushiHighlight（行为零变化）', () {
+    expect(
+      body.contains('__fushiHighlight('),
+      isTrue,
+      reason: '丢了 __fushiHighlight 回落，分页/连续模式的跟随会一起坏掉',
+    );
+    final int vnCall = body.indexOf('highlightSelectorCue(');
+    final int fallback = body.indexOf('}else if(typeof __fushiHighlight');
+    expect(fallback, greaterThan(vnCall),
+        reason: 'VN 原语必须在前、__fushiHighlight 作为 else 回落');
+  });
+
+  test('清除高亮仍走原路径（VN 侧无需特例）', () {
+    expect(
+      body.contains('__fushiHighlight("")'),
+      isTrue,
+      reason: 'cue==null 的清除路径不应被本次改动波及',
+    );
+  });
+}

--- a/fushi/test/reader/vn_shell_smoke_test.dart
+++ b/fushi/test/reader/vn_shell_smoke_test.dart
@@ -356,6 +356,82 @@ void main() {
         reason:
             'engine-assembled VN shell must keep shim-before-boot ordering');
   });
+
+  // BUG-1742 / BUG-1743：shim 块是「VN 必须实现的宿主接口清单」的唯一真相点。
+  // 宿主里有一批共享路径假定 window.fushiReader 上有这些方法，VN 缺哪个就在哪个
+  // 功能上静默失效（跟随不翻屏 / 搜索点了没反应），而且 JS 的 TypeError 在
+  // evaluateJavascript 通道上抓不到，线上只表现为「没反应」。
+  test('BUG-1742/1573: VN 实现全部宿主接口（跟随 + 章内文本定位）', () {
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
+    for (final String method in <String>[
+      'contentRoot',
+      'screenIndexForCharOffset',
+      'highlightSelectorCue',
+      'scrollToSearchMatch',
+      'clearSearchHighlight',
+    ]) {
+      expect(
+        shell.contains('vn.$method = '),
+        isTrue,
+        reason: 'VN 缺宿主接口 $method —— 对应功能会在 VN 模式下静默失效',
+      );
+    }
+    // 引擎三 shell 并存时 VN 那份同样要带齐。
+    final String engine = ReaderPaginationScripts.engineShell(
+        vnMode: true, continuousMode: false);
+    expect(engine.contains('vn.highlightSelectorCue = '), isTrue);
+    expect(engine.contains('vn.scrollToSearchMatch = '), isTrue);
+  });
+
+  test('BUG-1742: VN 的正文根取 sourceRoot，绝不是 document', () {
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
+    final int start = shell.indexOf('vn.contentRoot = ');
+    expect(start, greaterThanOrEqualTo(0));
+    final String body = shell.substring(start, start + 200);
+    // detachChapterSource 把整章正文搬进游离的 sourceRoot；从 document 取根
+    // 就等于回到 BUG-1742 那条静默落空的老路。
+    expect(body.contains('this.sourceRoot'), isTrue,
+        reason: 'contentRoot 必须返回 sourceRoot（正文已被搬出 document）');
+  });
+
+  test('BUG-1742: 选择器跟随走「字符偏移 → 屏」链路，而不是滚动', () {
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
+    final int start = shell.indexOf('vn.highlightSelectorCue = ');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = shell.indexOf('vn.scrollToSearchMatch = ', start);
+    expect(end, greaterThan(start));
+    final String body = shell.substring(start, end);
+    expect(body.contains('this.contentRoot()'), isTrue,
+        reason: '必须在 contentRoot 上找元素，document 里只有当前屏的克隆');
+    expect(body.contains('sourcePositionForNode'), isTrue,
+        reason: '必须把源节点换算成字符偏移');
+    expect(body.contains('this.screenIndexForCharOffset'), isTrue);
+    expect(body.contains('this.renderScreen('), isTrue,
+        reason: 'VN 的跟随语义是翻屏；scrollIntoView 在定屏 stage 上无效果');
+    expect(body.contains('if (!reveal) return null;'), isTrue,
+        reason: 'reveal=false 是「别打断当前阅读位置」的显式请求，不许翻屏');
+  });
+
+  test('BUG-1743: VN 搜索在整章 contentStream 上匹配并做坐标换算', () {
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
+    final int start = shell.indexOf('vn.scrollToSearchMatch = ');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = shell.indexOf('vn.clearSearchHighlight = ', start);
+    expect(end, greaterThan(start));
+    final String body = shell.substring(start, end);
+    // 分页版用 createWalker()（只走当前屏）+ scrollToRange（VN 无此方法）——
+    // 照搬过来在 VN 下只会在当前屏内找，跨屏命中永远找不到。
+    expect(body.contains('createWalker('), isFalse,
+        reason: 'VN 必须在整章 contentStream 上匹配，不能只走当前屏');
+    expect(body.contains('stream.textEntries'), isTrue);
+    // 命中下标是拼接后的原始文本坐标，屏索引吃的是可匹配字符坐标。
+    expect(body.contains('countChars(prefix)'), isTrue,
+        reason: '缺少 raw→matchable 换算会在任何含空白的章节上系统性偏移');
+    expect(body.contains('seg.entry.startChar'), isTrue);
+    expect(body.contains('this.screenIndexForCharOffset'), isTrue);
+    expect(body.contains('return this.calculateProgress();'), isTrue,
+        reason: '返回契约与分页版一致（调用方靠它落库）');
+  });
 }
 
 String _extractRestoreHandlerCallback(String source) {

--- a/fushi/test/sync/interconnect_client_panel_guard_test.dart
+++ b/fushi/test/sync/interconnect_client_panel_guard_test.dart
@@ -62,8 +62,10 @@ void main() {
 
     final String masked = maskComments(attempt);
     final int busyOn = masked.indexOf('_setPairV2Busy(true)');
-    final int probe = masked.indexOf('FushiTofuProbe.captureFingerprint');
-    final int ping = masked.indexOf('fetchFushiPing(');
+    // BUG-1741：两个探测都换成了带失败原因的分型版本（probeFingerprint /
+    // probeFushiPing）；忙态必须先于它们的语义不变。
+    final int probe = masked.indexOf('FushiTofuProbe.probeFingerprint');
+    final int ping = masked.indexOf('probeFushiPing(');
     final int pair = masked.indexOf('_runPairingV2(');
     expect(busyOn, isNonNegative, reason: '手动配对必须自己置忙态，不能只靠内层');
     expect(probe, isNonNegative);

--- a/fushi/test/sync/interconnect_manual_pair_guard_test.dart
+++ b/fushi/test/sync/interconnect_manual_pair_guard_test.dart
@@ -36,17 +36,24 @@ void main() {
     );
   });
 
-  test('手动配对先跑 reachability 探测（scope ①：fetchFushiPing）', () {
+  test('手动配对先跑 reachability 探测（scope ①：probeFushiPing）', () {
     expect(
       source.contains('Future<void> _attemptManualPair(String rawUrl) async {'),
       isTrue,
       reason: '手动 IP 配对编排方法 _attemptManualPair 丢失',
     );
-    // 探测走已有的 /api/ping 客户端 fetchFushiPing——配对前先确认可达 + 是 hibiki。
+    // 探测走 /api/ping 客户端——配对前先确认可达 + 是 hibiki。BUG-1741 起必须用
+    // 带失败分型的 probeFushiPing：丢原因的 fetchFushiPing 会让 UI 只能说一句
+    // 「此地址未找到 Fushi 设备」，把证书不符/超时/端口没人全说成同一件事。
+    expect(
+      source.contains('await probeFushiPing('),
+      isTrue,
+      reason: '手动 IP 配对未先跑 reachability 探测（probeFushiPing）',
+    );
     expect(
       source.contains('await fetchFushiPing('),
-      isTrue,
-      reason: '手动 IP 配对未先跑 reachability 探测（fetchFushiPing）',
+      isFalse,
+      reason: '手动配对退回丢原因的 fetchFushiPing，报错文案会重新变得误导',
     );
     // 探测失败 / 非 hibiki 必须有 UI 反馈（向后兼容：仍保留地址供手粘 token）。
     expect(

--- a/fushi/test/sync/interconnect_tls_entry_guard_test.dart
+++ b/fushi/test/sync/interconnect_tls_entry_guard_test.dart
@@ -88,9 +88,27 @@ void main() {
     final String connect = source.substring(start, end);
     // scheme 选择 + 探测（TXT tls 标志 + /api/ping 定案）。
     expect(
-      connect.contains('await probeDiscoveredPairingEndpoint('),
+      connect.contains('await probeDiscoveredPairingEndpointDetailed('),
       isTrue,
-      reason: '发现配对未先探测 scheme（probeDiscoveredPairingEndpoint）',
+      reason: '发现配对未先探测 scheme（probeDiscoveredPairingEndpointDetailed）',
+    );
+    // BUG-1741：必须消费探测带回的失败原因与 TLS 确证，否则又会把 TLS host
+    // 推进 v1 明文死路，并把真实原因换成一句「配对失败」。
+    expect(
+      connect.contains('outcome.peerSpeaksTls'),
+      isTrue,
+      reason: '发现配对未消费 peerSpeaksTls，TLS host 会被回落进 v1 明文死路',
+    );
+    expect(
+      connect.contains('_pingFailureMessage(outcome.failure)'),
+      isTrue,
+      reason: '发现配对丢弃了探测失败原因，UI 只能给出误导文案',
+    );
+    // v1 必须用探明的 baseUrl，不能再盲信硬编码 http 的 device.webDavUrl。
+    expect(
+      connect.contains('probe?.baseUrl ?? device.webDavUrl'),
+      isTrue,
+      reason: 'v1 回落未使用探明 scheme 的 baseUrl（会把错的 http:// 永久写进列表）',
     );
     expect(
       connect.contains('tlsAdvertised: device.tlsEnabled'),

--- a/fushi/test/sync/pairing/discovered_pairing_probe_test.dart
+++ b/fushi/test/sync/pairing/discovered_pairing_probe_test.dart
@@ -1,13 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/sync/pairing/discovered_pairing_probe.dart';
 import 'package:fushi/src/sync/pairing/fushi_ping_client.dart';
+import 'package:fushi/src/sync/tls/fushi_tofu_probe.dart';
 
 /// TODO-961：发现配对的 scheme 选择 + 探测编排单测。
 ///
 /// - 候选顺序纯函数：TXT `tls=1` → https 优先；未广播 → http 优先、https 兜底
 ///   （覆盖平台 resolve 丢 TXT 属性的真实情况）。
 /// - 探测编排：https 先 TOFU 捕获指纹（取不到 → 跳过，绝不裸读 https）、钉扎
-///   ping 定案；全部失败返回 null（调用方回落 v1 明文老路径）。
+///   ping 定案。
+/// - BUG-1741：探测失败不再压平成一个裸 null——要带出**为什么**失败，以及是否
+///   确证对端讲 TLS（后者决定调用方能不能回落 v1 明文配对）。
 void main() {
   const FushiPingResult v2TlsPing = FushiPingResult(
     isFushi: true,
@@ -21,6 +24,8 @@ void main() {
     supportsPairV2: true,
     tlsEnabled: false,
   );
+  const FushiPingOutcome unreachable =
+      FushiPingOutcome.failed(FushiPingFailure.unreachable);
 
   group('discoveredPairingCandidateUrls', () {
     test('TXT 广播 tls=1 时 https 优先', () {
@@ -56,11 +61,14 @@ void main() {
         host: 'h',
         port: 38765,
         tlsAdvertised: true,
-        captureFingerprint: (String host, int port) async => 'aa:bb:cc',
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
         ping: (String baseUrl, {String? pinnedFingerprint}) async {
           pingedUrls.add(baseUrl);
           pingedPins.add(pinnedFingerprint);
-          return baseUrl.startsWith('https://') ? v2TlsPing : null;
+          return baseUrl.startsWith('https://')
+              ? const FushiPingOutcome.ok(v2TlsPing)
+              : unreachable;
         },
       );
 
@@ -81,10 +89,13 @@ void main() {
         host: 'h',
         port: 38765,
         tlsAdvertised: true,
-        captureFingerprint: (String host, int port) async => null,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.failed(FushiTofuFailure.unreachable),
         ping: (String baseUrl, {String? pinnedFingerprint}) async {
           pingedUrls.add(baseUrl);
-          return baseUrl.startsWith('http://') ? v2PlainPing : null;
+          return baseUrl.startsWith('http://')
+              ? const FushiPingOutcome.ok(v2PlainPing)
+              : unreachable;
         },
       );
 
@@ -107,7 +118,9 @@ void main() {
             fail('明文 host ping 通后不应再做 TOFU 握手'),
         ping: (String baseUrl, {String? pinnedFingerprint}) async {
           pingedUrls.add(baseUrl);
-          return baseUrl.startsWith('http://') ? v2PlainPing : null;
+          return baseUrl.startsWith('http://')
+              ? const FushiPingOutcome.ok(v2PlainPing)
+              : unreachable;
         },
       );
 
@@ -122,9 +135,12 @@ void main() {
         host: 'h',
         port: 38765,
         tlsAdvertised: false,
-        captureFingerprint: (String host, int port) async => 'aa:bb:cc',
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
         ping: (String baseUrl, {String? pinnedFingerprint}) async =>
-            baseUrl.startsWith('https://') ? v2TlsPing : null,
+            baseUrl.startsWith('https://')
+                ? const FushiPingOutcome.ok(v2TlsPing)
+                : unreachable,
       );
 
       expect(result, isNotNull);
@@ -143,26 +159,121 @@ void main() {
         host: 'h',
         port: 38765,
         tlsAdvertised: true,
-        captureFingerprint: (String host, int port) async => 'de:ad:be',
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('de:ad:be'),
         ping: (String baseUrl, {String? pinnedFingerprint}) async =>
-            baseUrl.startsWith('https://') ? noFpPing : null,
+            baseUrl.startsWith('https://')
+                ? const FushiPingOutcome.ok(noFpPing)
+                : unreachable,
       );
 
       expect(result, isNotNull);
       expect(result!.fingerprint, 'de:ad:be');
     });
 
-    test('两个 scheme 都探不通（旧 host 无 /api/ping）返回 null → 回落 v1', () async {
+    test('两个 scheme 都探不通（旧 host 无 /api/ping）返回 null', () async {
       final DiscoveredPairingProbeResult? result =
           await probeDiscoveredPairingEndpoint(
         host: 'h',
         port: 38765,
         tlsAdvertised: false,
-        captureFingerprint: (String host, int port) async => null,
-        ping: (String baseUrl, {String? pinnedFingerprint}) async => null,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.failed(FushiTofuFailure.unreachable),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            unreachable,
       );
 
       expect(result, isNull);
+    });
+  });
+
+  // BUG-1741：这一组是「配对报错文案完全误导」的根：探测层此前把所有失败压成
+  // 一个 null，调用方既不知道为什么失败，也不知道对端到底讲不讲 TLS——于是把
+  // TLS host 一律推进 v1 明文死路，最后只能说一句「配对失败」。
+  group('probeDiscoveredPairingEndpointDetailed（失败原因 + TLS 确证）', () {
+    test('钉扎失败：带出 tls 原因，且确证对端讲 TLS（禁止回落 v1）', () async {
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
+        host: 'h',
+        port: 38765,
+        tlsAdvertised: true,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            const FushiPingOutcome.failed(FushiPingFailure.tls),
+      );
+
+      expect(outcome.result, isNull);
+      expect(outcome.failure, FushiPingFailure.tls);
+      // TOFU 握手成功过 → 对端确实在讲 TLS。明文 v1 打过去必然失败。
+      expect(outcome.peerSpeaksTls, isTrue);
+    });
+
+    test('TXT 丢了 tls 标志：http 先失败，https 握手成功也算确证讲 TLS', () async {
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
+        host: 'h',
+        port: 38765,
+        tlsAdvertised: false,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            const FushiPingOutcome.failed(FushiPingFailure.timeout),
+      );
+
+      expect(outcome.result, isNull);
+      expect(outcome.peerSpeaksTls, isTrue);
+    });
+
+    test('真·旧版明文 host：没有任何 TLS 证据，允许回落 v1', () async {
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
+        host: 'h',
+        port: 38765,
+        tlsAdvertised: false,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.failed(FushiTofuFailure.notTls),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            const FushiPingOutcome.failed(FushiPingFailure.notFushi),
+      );
+
+      expect(outcome.result, isNull);
+      expect(outcome.peerSpeaksTls, isFalse);
+      expect(outcome.failure, FushiPingFailure.notFushi);
+    });
+
+    test('多候选失败时取最严重的原因：tls 盖过 unreachable', () async {
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
+        host: 'h',
+        port: 38765,
+        tlsAdvertised: true,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            baseUrl.startsWith('https://')
+                ? const FushiPingOutcome.failed(FushiPingFailure.tls)
+                : unreachable,
+      );
+
+      expect(outcome.failure, FushiPingFailure.tls);
+    });
+
+    test('探测成功时不带失败原因', () async {
+      final DiscoveredPairingProbeOutcome outcome =
+          await probeDiscoveredPairingEndpointDetailed(
+        host: 'h',
+        port: 38765,
+        tlsAdvertised: true,
+        captureFingerprint: (String host, int port) async =>
+            const FushiTofuOutcome.captured('aa:bb:cc'),
+        ping: (String baseUrl, {String? pinnedFingerprint}) async =>
+            const FushiPingOutcome.ok(v2TlsPing),
+      );
+
+      expect(outcome.failure, isNull);
+      expect(outcome.result?.baseUrl, 'https://h:38765');
+      expect(outcome.peerSpeaksTls, isTrue);
     });
   });
 }

--- a/fushi/test/sync/pairing/fushi_ping_client_test.dart
+++ b/fushi/test/sync/pairing/fushi_ping_client_test.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/sync/pairing/fushi_ping_client.dart';
@@ -64,5 +66,108 @@ void main() {
     expect(r, isNotNull);
     expect(r!.tlsEnabled, isFalse);
     expect(r.fingerprint, isNull);
+  });
+
+  // BUG-1741：探测失败必须带出原因。此前整个函数是 `on Object { return null; }`，
+  // 「证书指纹对不上」（安全事件）、「对端超时」、「端口没人」和「那不是 Hibiki」
+  // 在调用方眼里长得一模一样，UI 只能挑最含糊的一句说。
+  group('probeFushiPing 失败分型', () {
+    test('钉扎指纹不符（TlsException）→ tls，而不是裸 null', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        throw const TlsException('pinned fingerprint mismatch');
+      });
+      final FushiPingOutcome o =
+          await probeFushiPing('https://host:38765', httpClient: mock);
+      expect(o.isOk, isFalse);
+      expect(o.failure, FushiPingFailure.tls);
+    });
+
+    test('HandshakeException 也归 tls（它 implements TlsException）', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        throw const HandshakeException('handshake failed');
+      });
+      final FushiPingOutcome o =
+          await probeFushiPing('https://host:38765', httpClient: mock);
+      expect(o.failure, FushiPingFailure.tls);
+    });
+
+    test('超时 → timeout', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+        return http.Response('{}', 200);
+      });
+      final FushiPingOutcome o = await probeFushiPing(
+        'http://host:38765',
+        httpClient: mock,
+        timeout: const Duration(milliseconds: 10),
+      );
+      expect(o.failure, FushiPingFailure.timeout);
+    });
+
+    test('连不上（SocketException）→ unreachable', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        throw const SocketException('connection refused');
+      });
+      final FushiPingOutcome o =
+          await probeFushiPing('http://host:38765', httpClient: mock);
+      expect(o.failure, FushiPingFailure.unreachable);
+    });
+
+    test('连上但不是 Hibiki → notFushi（与 unreachable 必须可分辨）', () async {
+      final MockClient mock = MockClient(
+        (http.Request req) async =>
+            http.Response(jsonEncode(<String, dynamic>{'app': 'other'}), 200),
+      );
+      final FushiPingOutcome o =
+          await probeFushiPing('http://host:8080', httpClient: mock);
+      expect(o.failure, FushiPingFailure.notFushi);
+    });
+
+    test('非 200 → notFushi 并保留状态码供日志定位', () async {
+      final MockClient mock =
+          MockClient((http.Request req) async => http.Response('nope', 403));
+      final FushiPingOutcome o =
+          await probeFushiPing('http://host:8080', httpClient: mock);
+      expect(o.failure, FushiPingFailure.notFushi);
+      expect(o.statusCode, 403);
+    });
+
+    test('成功时 failure 为 null', () async {
+      final MockClient mock = MockClient(
+        (http.Request req) async => http.Response(
+          jsonEncode(<String, dynamic>{
+            'app': 'fushi',
+            'pairing': <String, dynamic>{'v2': true},
+          }),
+          200,
+        ),
+      );
+      final FushiPingOutcome o =
+          await probeFushiPing('http://host:38765', httpClient: mock);
+      expect(o.isOk, isTrue);
+      expect(o.failure, isNull);
+      expect(o.result!.supportsPairV2, isTrue);
+    });
+  });
+
+  group('classifyFushiProbeFailure', () {
+    test('TLS 判定必须排在最前（IOClient 让 TLS 异常原样穿透）', () {
+      expect(
+        classifyFushiProbeFailure(const TlsException('x')),
+        FushiPingFailure.tls,
+      );
+      expect(
+        classifyFushiProbeFailure(TimeoutException('x')),
+        FushiPingFailure.timeout,
+      );
+      expect(
+        classifyFushiProbeFailure(const SocketException('x')),
+        FushiPingFailure.unreachable,
+      );
+      expect(
+        classifyFushiProbeFailure(Exception('x')),
+        FushiPingFailure.unreachable,
+      );
+    });
   });
 }


### PR DESCRIPTION
四个用户报告问题，一问题一提交，各自可独立回滚。全部沿真实代码路径定位根因，无延迟/重试/吞异常式掩盖。

## ① 互联配对报错文案完全误导 — BUG-1741

两条根因：

**三层静默吞异常。** `fushi_tofu_probe:46` / `fushi_ping_client:76` / `discovered_pairing_probe` 的三个 `continue`，把「钉扎指纹不符」（安全事件）、超时、端口无监听、对端不是 Hibiki **全压成同一个 `null`**。UI 只能说一句「此地址未找到 Fushi 设备」—— 对着一台在线、只是证书换了的机器说「这里没有设备」，用户排查方向从第一步就是错的。三层都没有 `ErrorLogService`，事后连线索都没有。`_ensurePinnedFingerprintTrusted` 本是为这个场景准备的告警闸，但流程在报错处就 return 了，永远走不到。

**TLS host 回落 v1 死路。** `lan_discovery_service:28` 的 `webDavUrl` 硬编码 `http://`，而 TLS host 只 `bindSecure`、不提供明文端口。mDNS TXT 的 `tls=1` 在部分平台会被 resolve 丢掉，探测一失败就落 v1，明文 POST 必然抛 →「配对失败」。更糟的是它还把那条错的 `http://` 地址写进候选列表，那台设备此后每次「测试连接」都失败、UI 里还看不出 scheme 错了 —— 永久性坏掉。

修法：探测三层各自带出失败分型 + 留痕（旧签名降级为薄封装，既有调用方零改动）；探测结果携带 `peerSpeaksTls`，确证对端讲 TLS 时**禁止回落 v1**；v1 改用探明的 `baseUrl`。手动配对能分辨「对端未启用 HTTPS」与「该设备只接受 HTTPS」；URL 解析失败不再谎报「连接失败」。i18n +3 key ×17 语言。

## ② VN 下非 sasayaki 书的有声书跟随失效 — BUG-1742

VN 的 `detachChapterSource` 把整章正文搬进一个**游离的 div**，document 里任一时刻只剩当前一屏的克隆。非 sasayaki 书（SRT/VTT/LRC 合成书）的 cue 是裸 CSS 选择器，走 `__fushiHighlight` 的 `document.querySelector` → 目标不在当前屏就返回 null 并静默早退，跟随永远不翻屏。sasayaki 走 `fushiReader` 方法调用（VN 已实现，按 charOffset 找屏），所以只有非 sasayaki 书坏。

给 VN 补 `contentRoot()` / `highlightSelectorCue()`，与 sasayaki 收敛到同一条「选择器 → 字符偏移 → 翻屏」链路；分页/连续模式回落原路径，行为零变化。

## ③ VN 缺 scrollToSearchMatch 且调用点无守卫 — BUG-1743

VN 里零实现，而调用点是裸调。JS 的 TypeError 在 `evaluateJavascript` 通道上不回传成 Dart 异常，调用点的 try/catch 抓不到 —— 线上只表现为「搜索点了没反应」（同章）/「只跳到目标章第一屏」（跨章）。

补 VN 版：不能沿用分页版（那版 `createWalker` 只走当前屏、且靠 VN 没有的 `scrollToRange` 滚动），改在整章 contentStream 上匹配。**关键是坐标换算** —— 命中下标是拼接后的原始文本坐标，屏索引吃的是可匹配字符坐标，直接用会在任何含空白的章节上系统性偏移。调用点另加存在性守卫作第二层防线。

## ④ 顶部横带 + 触摸板翻页 — BUG-1744 / BUG-1745

**顶部横带**：BUG-1343 那条 28pt macOS 拖拽带唯一条件是 `Platform.isMacOS`，全屏下没标题栏没交通灯、窗口也拖不动，带子和 28pt 正文让位却仍在。`didChangeDependencies` 救不了 —— 它只比较 `viewPadding`，桌面进出全屏时 viewPadding 不变。新建 `MacosFullscreenState` 挂 `NSWindowDelegate`（唯一能覆盖绿灯 / 「显示」菜单 / F11 全部入口的信号；`isWindowFullscreened` 只能轮询，`window_manager` 的 listener 在 macOS 上收不到）。

**触摸板翻页**：手势闸门条件是 `axis == 'horizontal'`，隐含「纵向 = 鼠标滚轮」的假设。但 macOS 触摸板上下滑同样是纵向，1.5 秒惯性全漏过闸门、只受 450ms 固定窗管 → **一次滑翻 3 页**；间隔调到下限 150ms 就是 10 页。另有轴分类无抖动余量，横滑里的漂移帧会漏出闸门补翻页（BUG-701 在弹窗路径已修过同一个坑）。判据改成「触摸板 vs 鼠标」而非轴。

## 验证

- `flutter analyze` 全量：No issues found
- `dart run tool/flutter_test_failures.dart --no-pub`：**PASSED - 19804 tests ran, all tests passed**
- 分支已 rebase 到 develop（harness 默认从 origin/main 切分支）；rebase 后重新跑了上述全套

## 仍需真机复验（headless 跑不到）

- VN 下逐句翻屏跟随、VN 搜索跳转
- macOS：窗口态拖拽带仍可拖 → 三条路进全屏横带消失、正文顶到边 → 退出后恢复；歌词 / spread 整页图两种独立文档场景
- macOS 触摸板：上下滑一次恰好一页；鼠标滚轮一格仍一页；横滑不再「1 页 + 补翻」

## 本轮刻意未动

滚轮翻页方向不读 `invertSwipeDirection` / rtl，与触摸滑动方向不一致且无开关可调 —— 属产品缺口而非本次的时序根因，需单独立项（详见 BUG-1745 备注）。
