### PR TITLE
feat(video): 支持加载 mpv Lua 脚本（mpv_scripts 目录 + load-script）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61506 (3618 per locale)
+/// Strings: 61608 (3624 per locale)
 ///
-/// Built on 2026-08-19 at 04:25 UTC
+/// Built on 2026-08-19 at 06:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4910,6 +4910,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -13290,6 +13298,20 @@ class _StringsAr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -21736,6 +21758,20 @@ class _StringsDe extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -30198,6 +30234,20 @@ class _StringsEs extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -38672,6 +38722,20 @@ class _StringsFr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -47075,6 +47139,20 @@ class _StringsId extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -55523,6 +55601,20 @@ class _StringsIt extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -63786,6 +63878,20 @@ class _StringsJa extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -72056,6 +72162,20 @@ class _StringsKo extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -80484,6 +80604,20 @@ class _StringsNl extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -88924,6 +89058,20 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -97350,6 +97498,20 @@ class _StringsRu extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -105724,6 +105886,20 @@ class _StringsTh extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -114130,6 +114306,20 @@ class _StringsTr extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -122521,6 +122711,20 @@ class _StringsVi extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 // Path: <root>
@@ -130287,6 +130491,19 @@ class _StringsZhCn extends _StringsEn {
   String get storage_bundled_hint => '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
   @override
   String get storage_dictionary_delete_incomplete => '词典删除未完成、条目仍在，详见错误日志';
+  @override
+  String get video_setting_mpv_lua_scripts => '加载 Lua 脚本';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      '装载 mpv_scripts 目录里的全部 .lua 脚本。关闭在下次打开视频时生效。';
+  @override
+  String get video_setting_mpv_lua_scripts_import => '导入 Lua 脚本';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => '脚本已导入';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy => '复制脚本目录路径';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => '已复制目录路径';
 }
 
 // Path: <root>
@@ -138473,6 +138690,20 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get storage_dictionary_delete_incomplete =>
       'Dictionary still present after deletion, see error log';
+  @override
+  String get video_setting_mpv_lua_scripts => 'Load Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_hint =>
+      'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+  @override
+  String get video_setting_mpv_lua_scripts_import => 'Import Lua scripts';
+  @override
+  String get video_setting_mpv_lua_scripts_imported => 'Scripts imported';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copy =>
+      'Copy scripts folder path';
+  @override
+  String get video_setting_mpv_lua_scripts_dir_copied => 'Folder path copied';
 }
 
 /// Flat map(s) containing all translations.
@@ -145900,6 +146131,18 @@ extension on _StringsEn {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -153325,6 +153568,18 @@ extension on _StringsAr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -160772,6 +161027,18 @@ extension on _StringsDe {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -168218,6 +168485,18 @@ extension on _StringsEs {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -175670,6 +175949,18 @@ extension on _StringsFr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -183104,6 +183395,18 @@ extension on _StringsId {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -190552,6 +190855,18 @@ extension on _StringsIt {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -197962,6 +198277,18 @@ extension on _StringsJa {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -205376,6 +205703,18 @@ extension on _StringsKo {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -212818,6 +213157,18 @@ extension on _StringsNl {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -220257,6 +220608,18 @@ extension on _StringsPtBr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -227701,6 +228064,18 @@ extension on _StringsRu {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -235128,6 +235503,18 @@ extension on _StringsTh {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -242564,6 +242951,18 @@ extension on _StringsTr {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -249996,6 +250395,18 @@ extension on _StringsVi {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }
@@ -257369,6 +257780,18 @@ extension on _StringsZhCn {
         return '随安装包携带，删除后下次更新会自动恢复，此处仅展示。';
       case 'storage_dictionary_delete_incomplete':
         return '词典删除未完成、条目仍在，详见错误日志';
+      case 'video_setting_mpv_lua_scripts':
+        return '加载 Lua 脚本';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return '装载 mpv_scripts 目录里的全部 .lua 脚本。关闭在下次打开视频时生效。';
+      case 'video_setting_mpv_lua_scripts_import':
+        return '导入 Lua 脚本';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return '脚本已导入';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return '复制脚本目录路径';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return '已复制目录路径';
       default:
         return null;
     }
@@ -264774,6 +265197,18 @@ extension on _StringsZhHk {
         return 'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
       case 'storage_dictionary_delete_incomplete':
         return 'Dictionary still present after deletion, see error log';
+      case 'video_setting_mpv_lua_scripts':
+        return 'Load Lua scripts';
+      case 'video_setting_mpv_lua_scripts_hint':
+        return 'Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.';
+      case 'video_setting_mpv_lua_scripts_import':
+        return 'Import Lua scripts';
+      case 'video_setting_mpv_lua_scripts_imported':
+        return 'Scripts imported';
+      case 'video_setting_mpv_lua_scripts_dir_copy':
+        return 'Copy scripts folder path';
+      case 'video_setting_mpv_lua_scripts_dir_copied':
+        return 'Folder path copied';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "未安装",
   "storage_bundled_section": "随包组件",
   "storage_bundled_hint": "随安装包携带，删除后下次更新会自动恢复，此处仅展示。",
-  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志"
+  "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志",
+  "video_setting_mpv_lua_scripts": "加载 Lua 脚本",
+  "video_setting_mpv_lua_scripts_hint": "装载 mpv_scripts 目录里的全部 .lua 脚本。关闭在下次打开视频时生效。",
+  "video_setting_mpv_lua_scripts_import": "导入 Lua 脚本",
+  "video_setting_mpv_lua_scripts_imported": "脚本已导入",
+  "video_setting_mpv_lua_scripts_dir_copy": "复制脚本目录路径",
+  "video_setting_mpv_lua_scripts_dir_copied": "已复制目录路径"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3616,5 +3616,11 @@
   "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
-  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log"
+  "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
+  "video_setting_mpv_lua_scripts": "Load Lua scripts",
+  "video_setting_mpv_lua_scripts_hint": "Load all .lua files in the mpv_scripts folder into the player. Turning off takes effect the next time a video is opened.",
+  "video_setting_mpv_lua_scripts_import": "Import Lua scripts",
+  "video_setting_mpv_lua_scripts_imported": "Scripts imported",
+  "video_setting_mpv_lua_scripts_dir_copy": "Copy scripts folder path",
+  "video_setting_mpv_lua_scripts_dir_copied": "Folder path copied"
 }

--- a/fushi/lib/src/media/video/video_lua_script_manager.dart
+++ b/fushi/lib/src/media/video/video_lua_script_manager.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:fushi/src/storage/app_paths.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:path/path.dart' as p;
+
+/// mpv Lua 脚本管理：固定目录、列出、导入、经 `load-script` 命令装载到播放器。
+///
+/// 语义对齐 mpv 自己的 `scripts/` 目录：放进 [mpvLuaScriptDirectory] 的 `.lua`
+/// 文件在开关开启时**整目录**装载（按文件名排序），删掉/移走文件即禁用——不引入
+/// 每文件启用集这层多余状态（与着色器不同：脚本没有"档位组合"语义）。
+///
+/// 装载走 libmpv 的 `load-script` **命令**（`mpv_command`），不是 property——
+/// `scripts` 选项是 init-only，media_kit 建 handle 后经 setProperty 写它是静默
+/// no-op。与 [applyShadersToPlayer]（video_shader_manager.dart）同一条
+/// `NativePlayer.command` 边界，五平台 libmpv 后端均可达；随包 libmpv 未编 Lua
+/// 或非 libmpv 后端时单条命令失败静默吞掉（best-effort，不影响播放）。
+///
+/// **不可卸载**：mpv 没有 unload-script 命令，脚本一旦装进 Player 实例就伴随其
+/// 整个生命周期；重复 `load-script` 同一路径会实例化第二份脚本。因此装载必须
+/// **每 Player 实例幂等**（[VideoPlayerController.applyLuaScripts] 用已装载集
+/// 去重），关闭开关只对之后新建的 Player 生效（下次进入视频页）。
+///
+/// 能力边界（用户可感）：键盘/鼠标事件由 Flutter 层消费、到不了 libmpv，依赖
+/// 按键绑定或 OSC 交互的脚本无处触发；监听属性/事件、自动改属性的逻辑型脚本
+/// 正常工作，脚本 OSD 会随视频帧渲染。`script-opts` 属性运行时可设，高级用户
+/// 可经 [VideoMpvConfig.rawConf] 给脚本传参。
+
+/// Lua 脚本文件扩展名。
+const String kLuaScriptExtension = '.lua';
+
+/// Lua 脚本存放目录：`<documents>/mpv_scripts`（不存在则创建）。
+Future<Directory> mpvLuaScriptDirectory() async {
+  final Directory dir = await AppPaths.mpvLuaScriptsDirectory();
+  if (!dir.existsSync()) dir.createSync(recursive: true);
+  return dir;
+}
+
+/// 列出 [dir] 里的 Lua 脚本**绝对路径**（仅顶层、按路径排序）。纯函数（只读目录），
+/// 便于用临时目录单测。不递归——子目录留给用户放脚本自己的资源/模块，避免把
+/// `xxx/modules/*.lua` 这类依赖文件当独立脚本重复装载。
+List<String> listLuaScriptFilesIn(Directory dir) {
+  if (!dir.existsSync()) return const <String>[];
+  final List<String> out = <String>[];
+  for (final FileSystemEntity e in dir.listSync(followLinks: false)) {
+    if (e is! File) continue;
+    if (p.extension(e.path).toLowerCase() == kLuaScriptExtension) {
+      out.add(e.path);
+    }
+  }
+  out.sort();
+  return out;
+}
+
+/// 把 [sourcePath] 脚本复制进 [dir]，返回目标文件名（basename）。重名覆盖。
+/// 与 [importShaderFileTo]（video_shader_manager.dart）同范式，便于临时目录单测。
+String importLuaScriptFileTo(Directory dir, String sourcePath) {
+  if (!dir.existsSync()) dir.createSync(recursive: true);
+  final String name = p.basename(sourcePath);
+  File(sourcePath).copySync(p.join(dir.path, name));
+  return name;
+}
+
+/// 列出脚本目录里的 Lua 脚本绝对路径（异步包装 [listLuaScriptFilesIn]）。
+Future<List<String>> listLuaScriptPaths() async =>
+    listLuaScriptFilesIn(await mpvLuaScriptDirectory());
+
+/// 导入脚本到默认目录（异步包装 [importLuaScriptFileTo]）。
+Future<String> importLuaScriptFile(String sourcePath) async =>
+    importLuaScriptFileTo(await mpvLuaScriptDirectory(), sourcePath);
+
+/// 构建把 [absolutePaths] 装载进 libmpv 的 `load-script` 命令序列。纯函数，便于单测。
+/// 每个路径一条独立命令（`mpv_command` 数组形式），天然规避路径转义问题。
+List<List<String>> buildLoadScriptCommands(List<String> absolutePaths) {
+  return <List<String>>[
+    for (final String path in absolutePaths) <String>['load-script', path],
+  ];
+}
+
+/// 把 [absolutePaths] 逐条经 `load-script` 装载到 media_kit [player]。
+///
+/// best-effort 且**逐条**兜异常（与 [applyShadersToPlayer] 的整体 try 不同）：
+/// 单个脚本坏了（语法错/路径失效）不挡后面的脚本。幂等去重由调用方负责
+/// （见文件头"不可卸载"段），本函数只管下发。
+Future<void> applyLuaScriptsToPlayer(
+    Player player, List<String> absolutePaths) async {
+  final dynamic native = player.platform;
+  if (native == null) return;
+  for (final List<String> cmd in buildLoadScriptCommands(absolutePaths)) {
+    try {
+      await native.command(cmd);
+    } catch (_) {
+      // 非 libmpv 后端 / 未编 Lua / 单个脚本装载失败：跳过这条，继续下一条。
+    }
+  }
+}

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:fushi/src/media/video/video_black_flicker_detector.dart';
 import 'package:fushi/src/media/video/video_episode_start_policy.dart';
 import 'package:fushi/src/startup/media_handle_registry.dart';
+import 'package:fushi/src/media/video/video_lua_script_manager.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/media/video/video_playback_source.dart';
 import 'package:fushi/src/media/video/video_shader_manager.dart';
@@ -1063,6 +1064,26 @@ class VideoPlayerController extends ChangeNotifier
     await applyShadersToPlayer(player, _shaderPaths);
   }
 
+  /// 本 Player 实例已装载的 Lua 脚本绝对路径。mpv 无 unload-script，重复
+  /// `load-script` 会实例化第二份脚本，故装载必须每 Player 实例幂等（见
+  /// video_lua_script_manager.dart 文件头）。Player 与 controller 同生命周期
+  /// （复用不重建），无需随换集清空。
+  final Set<String> _loadedLuaScripts = <String>{};
+
+  /// 装载 mpv Lua 脚本（设置面板开启开关 / [load] 均走此入口）。幂等：已装载
+  /// 的路径跳过；未 [load]（无 player）时 no-op——脚本随下次 [load] 由页面
+  /// 重新解析传入。关闭开关无法从运行中的实例卸载，只对之后新建的 Player 生效。
+  Future<void> applyLuaScripts(List<String> absolutePaths) async {
+    final Player? player = _player;
+    if (player == null) return;
+    final List<String> fresh = <String>[
+      for (final String path in absolutePaths)
+        if (_loadedLuaScripts.add(path)) path,
+    ];
+    if (fresh.isEmpty) return;
+    await applyLuaScriptsToPlayer(player, fresh);
+  }
+
   /// 着色器「对比原画」旁路态：true 时临时清空 libmpv 着色器（看原画），但**保留**
   /// 启用集 [_shaderPaths]，恢复时一键贴回。供效果对比用（B：缺效果预览/对比）。
   bool _shadersBypassed = false;
@@ -1111,6 +1132,7 @@ class VideoPlayerController extends ChangeNotifier
     bool subtitleExplicitlyOff = false,
     int? renderGraphicStreamIndex,
     List<String> shaderPaths = const <String>[],
+    List<String> luaScriptPaths = const <String>[],
     VideoMpvConfig mpvConfig = VideoMpvConfig.defaults,
     Map<String, String> httpHeaderFields = const <String, String>{},
     bool autoPlay = false,
@@ -1333,6 +1355,11 @@ class VideoPlayerController extends ChangeNotifier
     _mpvConfig = mpvConfig;
     await applyMpvConfigToPlayer(player, _mpvConfig);
     if (!_isCurrentLoad(player, loadToken)) return; // mpv 配置下发后换片/销毁。
+
+    // 装载 mpv Lua 脚本（开关开启时页面传入目录全集）。幂等：换集复用同一
+    // Player 时已装载路径跳过，不会重复实例化脚本（见 [applyLuaScripts]）。
+    await applyLuaScripts(luaScriptPaths);
+    if (!_isCurrentLoad(player, loadToken)) return; // 脚本装载后换片/销毁。
 
     initialVolume = initialVolume.clamp(0.0, 100.0).toDouble();
     _lastVolume = initialVolume;

--- a/fushi/lib/src/media/video/video_quick_settings_host.dart
+++ b/fushi/lib/src/media/video/video_quick_settings_host.dart
@@ -56,6 +56,7 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
     this.onRespectAssStyleChanged,
     required this.onAsbConfigChanged,
     required this.onMpvConfigChanged,
+    this.onLuaScriptsEnabledChanged,
     required this.onApplyShaders,
     required this.onSelectShaderTier,
     this.onMpvShaderDirChanged,
@@ -158,6 +159,11 @@ class VideoQuickSettingsHost extends VideoSettingsHost {
 
   // ── mpv 配置（页面持久化 + applyMpvConfig 实时应用）──────────────────────
   final Future<void> Function(VideoMpvConfig config) onMpvConfigChanged;
+
+  /// mpv Lua 脚本开关（页面持久化 + 开启时把脚本目录即时装载进活播放器；关闭
+  /// 无法卸载、下次进入视频页生效——见 video_lua_script_manager.dart）。
+  /// null = 无播放器上下文，schema 行退化为直接写 pref。
+  final Future<void> Function(bool enabled)? onLuaScriptsEnabledChanged;
 
   // ── 着色器（下载/勾选/一键选档，仅播放中实时应用）────────────────────────
   final Future<void> Function(List<String> enabledNames) onApplyShaders;

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3139,6 +3139,13 @@ class AppModel with ChangeNotifier {
   Future<void> setVideoShadersEnabled(String json) =>
       prefsRepo.setVideoShadersEnabled(json);
 
+  /// mpv Lua 脚本装载开关（见 video_lua_script_manager.dart；默认关，
+  /// 关闭只对之后新建的播放器生效）。
+  bool get videoMpvLuaScriptsEnabled => prefsRepo.videoMpvLuaScriptsEnabled;
+
+  Future<void> setVideoMpvLuaScriptsEnabled(bool value) =>
+      prefsRepo.setVideoMpvLuaScriptsEnabled(value);
+
   /// 用户手动指定的本机 mpv 配置/着色器目录（空=自动）。
   String get videoMpvShaderDir => prefsRepo.videoMpvShaderDir;
 

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -175,6 +175,7 @@ const Set<String> kKnownPreferenceKeys = <String>{
   'video_mining_image_mode',
   'video_mining_still_format',
   'video_mpv_config',
+  'video_mpv_lua_scripts_enabled',
   'video_mpv_shader_dir',
   'video_remote_subtitle',
   // 用户停用的内置视频资源索引器 id（逗号分隔，默认空 = 全部启用）。

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -893,6 +893,18 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// mpv Lua 脚本装载开关（默认关）。开时视频播放器创建后把
+  /// `<documents>/mpv_scripts` 目录里的全部 `.lua` 经 `load-script` 装载
+  /// （见 video_lua_script_manager.dart）；mpv 无 unload-script，关闭只对
+  /// 之后新建的播放器生效。
+  bool get videoMpvLuaScriptsEnabled =>
+      getPref('video_mpv_lua_scripts_enabled', defaultValue: false) as bool;
+
+  Future<void> setVideoMpvLuaScriptsEnabled(bool value) async {
+    await setPref('video_mpv_lua_scripts_enabled', value);
+    notifyListeners();
+  }
+
   /// 用户手动指定的本机 mpv 配置/着色器目录（「从本机 mpv 导入」自动找不到时指定后
   /// 记住，下次优先扫它）。空串=未指定，走自动候选目录。
   String get videoMpvShaderDir =>

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -76,6 +76,7 @@ import 'package:fushi/src/media/video/video_danmaku_overlay.dart';
 import 'package:fushi/src/media/video/video_danmaku_source.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
+import 'package:fushi/src/media/video/video_lua_script_manager.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/media/video/video_player_controller.dart';
 import 'package:fushi/src/media/video/video_screenshot_filename.dart';
@@ -3083,6 +3084,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
             decodeEnabledShaders(appModel.videoShadersEnabled),
           )
         : const <String>[];
+    // 开关开启时装载 mpv_scripts 目录全部 Lua 脚本（每 Player 实例幂等，
+    // 见 video_lua_script_manager.dart）。
+    final List<String> luaScriptPaths = appModel.videoMpvLuaScriptsEnabled
+        ? await listLuaScriptPaths()
+        : const <String>[];
     controller.setOnCompleted(_handlePlaybackCompleted);
     // TODO-1119 / BUG-545：Windows 高显卡占用黑屏闪烁运行时提示。仅 Windows 挂回调
     // （其它平台 null＝控制器完全不采样，零开销）；判定持续迟帧后弹一次可关闭提示条。
@@ -3107,6 +3113,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         subtitleExplicitlyOff: SubtitleSource.isOff(externalSubtitlePath),
         renderGraphicStreamIndex: renderGraphicStreamIndex,
         shaderPaths: shaderPaths,
+        luaScriptPaths: luaScriptPaths,
         mpvConfig: mpvConfig,
         httpHeaderFields: _streamHttpHeaderFields,
         autoPlay: true,
@@ -6667,6 +6674,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
               )
             : const <String>[];
         await _controller?.applyShaders(paths);
+      },
+      // mpv Lua 脚本开关：落 pref；开启时把脚本目录即时装载进活播放器（幂等，
+      // 已装载路径跳过）。关闭不可卸载（mpv 无 unload-script），下次进入生效。
+      onLuaScriptsEnabledChanged: (bool enabled) async {
+        await appModel.setVideoMpvLuaScriptsEnabled(enabled);
+        if (!enabled) return;
+        await _controller?.applyLuaScripts(await listLuaScriptPaths());
       },
       onLockWindowAspectRatioChanged: _setLockWindowAspectRatio,
       onVideoFitModeChanged: _setVideoFitMode,

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -1,9 +1,12 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:fushi/src/media/video/dandanplay_client.dart';
 import 'package:fushi/src/media/video/video_asbplayer_config.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_horizontal_seek_gesture.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
+import 'package:fushi/src/media/video/video_lua_script_manager.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/media/video/video_settings_actions.dart';
 import 'package:fushi/src/media/video/video_subtitle_obscure_mode.dart';
@@ -1447,6 +1450,84 @@ SettingsDestination buildVideoDestination() {
             ),
             builder: buildVideoMpvRawConfField,
           ),
+          // mpv Lua 脚本：`<documents>/mpv_scripts` 整目录装载（对齐 mpv `scripts/`
+          // 目录语义，删文件即禁用）。host 在场开启即时装载（幂等）；mpv 无
+          // unload-script，关闭一律下次进入视频页生效（见 video_lua_script_manager.dart）。
+          SettingsSwitchItem(
+            id: 'video.player.mpv_lua_scripts',
+            title: t.video_setting_mpv_lua_scripts,
+            subtitle: t.video_setting_mpv_lua_scripts_hint,
+            icon: Icons.data_object_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.mpv,
+              order: 212,
+              section: t.video_setting_mpv_group_advanced,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.videoMpvLuaScriptsEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              final Future<void> Function(bool)? live =
+                  videoQuickSettingsHostOf(settingsContext)
+                      ?.onLuaScriptsEnabledChanged;
+              if (live != null) {
+                await live(value);
+              } else {
+                await settingsContext.appModel
+                    .setVideoMpvLuaScriptsEnabled(value);
+              }
+            },
+          ),
+          SettingsActionItem(
+            id: 'video.player.mpv_lua_scripts_import',
+            title: t.video_setting_mpv_lua_scripts_import,
+            icon: Icons.note_add_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.mpv,
+              order: 214,
+              section: t.video_setting_mpv_group_advanced,
+            ),
+            onTap: (SettingsContext settingsContext) async {
+              final FilePickerResult? result =
+                  await FilePicker.platform.pickFiles(
+                type: FileType.custom,
+                allowedExtensions: const <String>['lua'],
+                allowMultiple: true,
+              );
+              if (result == null) return;
+              bool imported = false;
+              for (final PlatformFile f in result.files) {
+                final String? path = f.path;
+                if (path == null) continue;
+                await importLuaScriptFile(path);
+                imported = true;
+              }
+              if (!imported) return;
+              _showVideoSettingsSnackBar(
+                settingsContext,
+                t.video_setting_mpv_lua_scripts_imported,
+              );
+            },
+          ),
+          // 复制目录路径（全平台一致，不做平台分支的文件管理器跳转）：用户拿路径
+          // 自行增删/编辑脚本文件。
+          SettingsActionItem(
+            id: 'video.player.mpv_lua_scripts_dir',
+            title: t.video_setting_mpv_lua_scripts_dir_copy,
+            icon: Icons.folder_copy_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.mpv,
+              order: 216,
+              section: t.video_setting_mpv_group_advanced,
+            ),
+            onTap: (SettingsContext settingsContext) async {
+              final String dirPath = (await mpvLuaScriptDirectory()).path;
+              await Clipboard.setData(ClipboardData(text: dirPath));
+              _showVideoSettingsSnackBar(
+                settingsContext,
+                '${t.video_setting_mpv_lua_scripts_dir_copied}\n$dirPath',
+              );
+            },
+          ),
           // 重置：全部回 mpv 默认（含清空原始 conf 框，经 pref 回填输入框）。
           SettingsActionItem(
             id: 'video.player.mpv_reset',
@@ -1565,6 +1646,14 @@ Future<void> _commitVideoDanmakuConfig(
   final DandanplayConfig current = settingsContext.appModel.videoDanmakuConfig;
   await settingsContext.appModel.setVideoDanmakuConfig(mutate(current));
   settingsContext.refresh();
+}
+
+/// 轻量提示条（与 settings_schema_lookup.dart 的 `_showSettingsSnackBar` 同款）。
+void _showVideoSettingsSnackBar(
+    SettingsContext settingsContext, String message) {
+  final BuildContext ctx = settingsContext.context;
+  if (!ctx.mounted) return;
+  ScaffoldMessenger.of(ctx).showSnackBar(SnackBar(content: Text(message)));
 }
 
 /// mpv 布尔开关的声明模板：读写同一 [AppModel.videoMpvConfig]，无 host 落 pref

--- a/fushi/lib/src/storage/app_paths.dart
+++ b/fushi/lib/src/storage/app_paths.dart
@@ -458,6 +458,7 @@ class AppPaths {
   ///  - `game_covers` —— [gameCoversDirectory]；游戏库封面（手选 + 自动获取）。
   ///  - `video_subtitles` —— [videoSubtitlesDirectory]；`VideoStorage.subtitlesDirName`。
   ///  - `mpv_shaders` —— [mpvShadersDirectory]。
+  ///  - `mpv_scripts` —— [mpvLuaScriptsDirectory]。
   ///  - `remote_videos` —— [remoteVideosDirectory]。
   ///  - `videos` —— backup restore 的视频落点（`backup.part.dart`
   ///    `join(appDirectory, 'videos')`）。
@@ -487,6 +488,7 @@ class AppPaths {
     'game_covers',
     'video_subtitles',
     'mpv_shaders',
+    'mpv_scripts',
     'remote_videos',
     'videos',
     'anime_downloads',
@@ -574,6 +576,10 @@ class AppPaths {
   /// mpv 着色器目录 `<documents>/mpv_shaders`。
   static Future<Directory> mpvShadersDirectory() =>
       documentsSubdirectory('mpv_shaders');
+
+  /// mpv Lua 脚本目录 `<documents>/mpv_scripts`。
+  static Future<Directory> mpvLuaScriptsDirectory() =>
+      documentsSubdirectory('mpv_scripts');
 
   /// 远程视频下载目录 `<documents>/remote_videos`。
   static Future<Directory> remoteVideosDirectory() =>

--- a/fushi/lib/src/storage/storage_usage_service.dart
+++ b/fushi/lib/src/storage/storage_usage_service.dart
@@ -44,7 +44,8 @@ enum StorageCategoryId {
   /// 字幕副本：`video_subtitles`。
   subtitles,
 
-  /// 视频着色器：`mpv_shaders`（Anime4K 下载与用户自导入混放）。
+  /// 视频着色器与 mpv Lua 脚本：`mpv_shaders`（Anime4K 下载与用户自导入混放）
+  /// + `mpv_scripts`（体量极小，不值得独立类目）。
   shaders,
 
   /// 自定义字体：`custom_fonts`。
@@ -169,7 +170,7 @@ const Map<StorageCategoryId, List<String>> kStorageCategoryDocumentsChildren =
     'thumbnails',
   ],
   StorageCategoryId.subtitles: <String>['video_subtitles'],
-  StorageCategoryId.shaders: <String>['mpv_shaders'],
+  StorageCategoryId.shaders: <String>['mpv_shaders', 'mpv_scripts'],
   StorageCategoryId.customFonts: <String>['custom_fonts'],
   StorageCategoryId.web: <String>['webArchive', 'browser'],
   StorageCategoryId.exports: <String>[

--- a/fushi/test/media/video/video_lua_script_manager_test.dart
+++ b/fushi/test/media/video/video_lua_script_manager_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_lua_script_manager.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('listLuaScriptFilesIn', () {
+    late Directory dir;
+
+    setUp(() {
+      dir = Directory.systemTemp.createTempSync('lua_scripts_test_');
+    });
+
+    tearDown(() {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    });
+
+    test('只收顶层 .lua（扩展名不分大小写），按路径排序', () {
+      File(p.join(dir.path, 'b_second.lua')).writeAsStringSync('-- b');
+      File(p.join(dir.path, 'a_first.LUA')).writeAsStringSync('-- a');
+      File(p.join(dir.path, 'readme.txt')).writeAsStringSync('not a script');
+      File(p.join(dir.path, 'osc.lua.bak')).writeAsStringSync('not a script');
+      // 子目录不递归：脚本自己的模块/资源不当独立脚本装载。
+      final Directory sub = Directory(p.join(dir.path, 'modules'))
+        ..createSync();
+      File(p.join(sub.path, 'dep.lua')).writeAsStringSync('-- dep');
+
+      final List<String> out = listLuaScriptFilesIn(dir);
+
+      expect(out, <String>[
+        p.join(dir.path, 'a_first.LUA'),
+        p.join(dir.path, 'b_second.lua'),
+      ]);
+    });
+
+    test('目录不存在返回空列表', () {
+      final Directory missing = Directory(p.join(dir.path, 'nope'));
+      expect(listLuaScriptFilesIn(missing), isEmpty);
+    });
+
+    test('空目录返回空列表', () {
+      expect(listLuaScriptFilesIn(dir), isEmpty);
+    });
+  });
+
+  group('buildLoadScriptCommands', () {
+    test('每个路径一条 load-script 命令，保持输入顺序', () {
+      final List<List<String>> cmds = buildLoadScriptCommands(
+        <String>[r'C:\a\x.lua', r'C:\a\y.lua'],
+      );
+      expect(cmds, <List<String>>[
+        <String>['load-script', r'C:\a\x.lua'],
+        <String>['load-script', r'C:\a\y.lua'],
+      ]);
+    });
+
+    test('空输入产生空命令序列（调用方零下发）', () {
+      expect(buildLoadScriptCommands(const <String>[]), isEmpty);
+    });
+  });
+
+  group('importLuaScriptFileTo', () {
+    late Directory src;
+    late Directory dst;
+
+    setUp(() {
+      src = Directory.systemTemp.createTempSync('lua_import_src_');
+      dst = Directory.systemTemp.createTempSync('lua_import_dst_');
+    });
+
+    tearDown(() {
+      for (final Directory d in <Directory>[src, dst]) {
+        if (d.existsSync()) d.deleteSync(recursive: true);
+      }
+    });
+
+    test('复制进目标目录并返回文件名；重名覆盖', () {
+      final File source = File(p.join(src.path, 'auto_profile.lua'))
+        ..writeAsStringSync('-- v1');
+      expect(importLuaScriptFileTo(dst, source.path), 'auto_profile.lua');
+      expect(
+        File(p.join(dst.path, 'auto_profile.lua')).readAsStringSync(),
+        '-- v1',
+      );
+
+      source.writeAsStringSync('-- v2');
+      importLuaScriptFileTo(dst, source.path);
+      expect(
+        File(p.join(dst.path, 'auto_profile.lua')).readAsStringSync(),
+        '-- v2',
+      );
+    });
+
+    test('目标目录不存在时创建', () {
+      final Directory nested = Directory(p.join(dst.path, 'nested'));
+      final File source = File(p.join(src.path, 's.lua'))
+        ..writeAsStringSync('-- s');
+      importLuaScriptFileTo(nested, source.path);
+      expect(File(p.join(nested.path, 's.lua')).existsSync(), isTrue);
+    });
+  });
+}

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -104,6 +104,12 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // 真按它预选语言 chip）。
   'video/Default subtitle language':
       'test/pages/jimaku_default_language_test.dart',
+  // mpv Lua 脚本装载开关。写 prefsRepo（changed=true），生效点在视频播放器创建后
+  // 经 libmpv `load-script` 命令装载脚本目录（widget harness 无 libmpv Player，
+  // 无可探渲染输入）；由专项测试咬住目录枚举（仅顶层 .lua、排序）、load-script
+  // 命令构建与导入落盘，装载幂等语义见 video_lua_script_manager.dart 文件头。
+  'video/Load Lua scripts':
+      'test/media/video/video_lua_script_manager_test.dart',
   // 多端库联合视图（spec 2026-07-12 §2.6）：上传视频文件开关。写 SyncRepository
   // gate（changed=true），生效点在 SyncOrchestrator 云后端上传阶段（非 reader
   // CSS / 主题树），无适用探针；由专项 orchestrator 行为测试咬住（关=零上传、


### PR DESCRIPTION
## 概要

视频播放器支持装载 mpv Lua 脚本：设置 → 视频 → mpv 高级分区新增「加载 Lua 脚本」开关（默认关）、「导入 Lua 脚本」、「复制脚本目录路径」三项。脚本目录 `<documents>/mpv_scripts`，语义对齐 mpv 自己的 `scripts/` 目录——开关开启时目录内全部顶层 `.lua` 在播放器创建后经 libmpv `load-script` 命令逐个装载，删文件即禁用。

## 实现

- 新增 `video_lua_script_manager.dart`：目录解析/枚举（仅顶层、排序）、导入落盘、`load-script` 命令构建与 best-effort 逐条下发（未编 Lua / 非 libmpv 后端静默跳过）
- `VideoPlayerController.applyLuaScripts`：每 Player 实例幂等（mpv 无 unload-script，重复装载会实例化第二份脚本）；`load()` 新增 `luaScriptPaths` 参数随片装载，换集复用 Player 不重复装载
- 播放中开启开关经 `VideoQuickSettingsHost.onLuaScriptsEnabledChanged` 即时装载；关闭下次进入视频页生效（UI 文案注明）
- 偏好键 `video_mpv_lua_scripts_enabled`；`mpv_scripts` 进 documents 白名单 + 存储用量 shaders 类目；i18n 6 键 × 17 语言（i18n_sync + slang 重生成）

## 验证

- `dart analyze` 全量绿（CI 同款 info 级也算）
- 定向测试 41 项全过：新专项测试（目录枚举/命令构建/导入）+ documents 白名单守卫 + 存储类目守卫 + 设置覆盖测试（新开关已登记 `kCoveredElsewhere`）+ i18n 完整性
- 随包 Windows libmpv 实测编入 LuaJIT（strings 探测）；真机播放路径未验证（implemented_unverified），建议首个脚本用 OSD 型（如 stats.lua）目检

https://claude.ai/code/session_017HHa3a1NVHixghseZBqgkf