### PR TITLE
feat(reader/interconnect): 插图页并入正文、优先书籍样式默认开启；互联新增共享统计/收藏夹开关

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61591 (3623 per locale)
+/// Strings: 61693 (3629 per locale)
 ///
-/// Built on 2026-08-19 at 06:16 UTC
+/// Built on 2026-08-19 at 09:03 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4917,6 +4917,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Read EPUB novels with dictionary lookup and audiobook sync';
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  String get interconnect_share_statistics => 'Share statistics';
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  String get interconnect_share_favorites => 'Share favorites';
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  String get interconnect_share_section => 'Share with paired devices';
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -13309,6 +13318,21 @@ class _StringsAr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -21767,6 +21791,21 @@ class _StringsDe extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -30241,6 +30280,21 @@ class _StringsEs extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -38727,6 +38781,21 @@ class _StringsFr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -47142,6 +47211,21 @@ class _StringsId extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -55602,6 +55686,21 @@ class _StringsIt extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -63877,6 +63976,21 @@ class _StringsJa extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -72159,6 +72273,21 @@ class _StringsKo extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -80599,6 +80728,21 @@ class _StringsNl extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -89051,6 +89195,21 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -97489,6 +97648,21 @@ class _StringsRu extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -105875,6 +106049,21 @@ class _StringsTh extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -114293,6 +114482,21 @@ class _StringsTr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -122696,6 +122900,21 @@ class _StringsVi extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 // Path: <root>
@@ -130472,6 +130691,19 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_feature_books_hint => '看小说（EPUB），查词与有声书同步';
   @override
   String get onboarding_feature_extension_hint => '网页查词（仅桌面）';
+  @override
+  String get interconnect_share_statistics => '共享统计';
+  @override
+  String get interconnect_share_statistics_hint => '阅读与观看时长、字数、查词与制卡计数';
+  @override
+  String get interconnect_share_favorites => '共享收藏夹';
+  @override
+  String get interconnect_share_favorites_hint => '收藏的词与句子，取消收藏也会同步';
+  @override
+  String get interconnect_share_section => '与已配对设备共享';
+  @override
+  String get interconnect_share_section_footer =>
+      '这些内容与已配对设备双向合并，默认开启。关掉后本设备既不再发送，也不再接收。';
 }
 
 // Path: <root>
@@ -138670,6 +138902,21 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get interconnect_share_statistics => 'Share statistics';
+  @override
+  String get interconnect_share_statistics_hint =>
+      'Reading and watching time, character counts, lookup and mining counters';
+  @override
+  String get interconnect_share_favorites => 'Share favorites';
+  @override
+  String get interconnect_share_favorites_hint =>
+      'Favorite words and sentences, including un-favoriting';
+  @override
+  String get interconnect_share_section => 'Share with paired devices';
+  @override
+  String get interconnect_share_section_footer =>
+      'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
 }
 
 /// Flat map(s) containing all translations.
@@ -146107,6 +146354,18 @@ extension on _StringsEn {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -153542,6 +153801,18 @@ extension on _StringsAr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -160999,6 +161270,18 @@ extension on _StringsDe {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -168455,6 +168738,18 @@ extension on _StringsEs {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -175917,6 +176212,18 @@ extension on _StringsFr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -183361,6 +183668,18 @@ extension on _StringsId {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -190819,6 +191138,18 @@ extension on _StringsIt {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -198239,6 +198570,18 @@ extension on _StringsJa {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -205663,6 +206006,18 @@ extension on _StringsKo {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -213115,6 +213470,18 @@ extension on _StringsNl {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -220564,6 +220931,18 @@ extension on _StringsPtBr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -228018,6 +228397,18 @@ extension on _StringsRu {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -235455,6 +235846,18 @@ extension on _StringsTh {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -242901,6 +243304,18 @@ extension on _StringsTr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -250343,6 +250758,18 @@ extension on _StringsVi {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }
@@ -257726,6 +258153,18 @@ extension on _StringsZhCn {
         return '看小说（EPUB），查词与有声书同步';
       case 'onboarding_feature_extension_hint':
         return '网页查词（仅桌面）';
+      case 'interconnect_share_statistics':
+        return '共享统计';
+      case 'interconnect_share_statistics_hint':
+        return '阅读与观看时长、字数、查词与制卡计数';
+      case 'interconnect_share_favorites':
+        return '共享收藏夹';
+      case 'interconnect_share_favorites_hint':
+        return '收藏的词与句子，取消收藏也会同步';
+      case 'interconnect_share_section':
+        return '与已配对设备共享';
+      case 'interconnect_share_section_footer':
+        return '这些内容与已配对设备双向合并，默认开启。关掉后本设备既不再发送，也不再接收。';
       default:
         return null;
     }
@@ -265141,6 +265580,18 @@ extension on _StringsZhHk {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'interconnect_share_statistics':
+        return 'Share statistics';
+      case 'interconnect_share_statistics_hint':
+        return 'Reading and watching time, character counts, lookup and mining counters';
+      case 'interconnect_share_favorites':
+        return 'Share favorites';
+      case 'interconnect_share_favorites_hint':
+        return 'Favorite words and sentences, including un-favoriting';
+      case 'interconnect_share_section':
+        return 'Share with paired devices';
+      case 'interconnect_share_section_footer':
+        return 'These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "浏览器扩展",
   "onboarding_feature_books": "小说库",
   "onboarding_feature_books_hint": "看小说（EPUB），查词与有声书同步",
-  "onboarding_feature_extension_hint": "网页查词（仅桌面）"
+  "onboarding_feature_extension_hint": "网页查词（仅桌面）",
+  "interconnect_share_statistics": "共享统计",
+  "interconnect_share_statistics_hint": "阅读与观看时长、字数、查词与制卡计数",
+  "interconnect_share_favorites": "共享收藏夹",
+  "interconnect_share_favorites_hint": "收藏的词与句子，取消收藏也会同步",
+  "interconnect_share_section": "与已配对设备共享",
+  "interconnect_share_section_footer": "这些内容与已配对设备双向合并，默认开启。关掉后本设备既不再发送，也不再接收。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "interconnect_share_statistics": "Share statistics",
+  "interconnect_share_statistics_hint": "Reading and watching time, character counts, lookup and mining counters",
+  "interconnect_share_favorites": "Share favorites",
+  "interconnect_share_favorites_hint": "Favorite words and sentences, including un-favoriting",
+  "interconnect_share_section": "Share with paired devices",
+  "interconnect_share_section_footer": "These are merged both ways with the paired device and are on by default. Turning one off stops both sending and receiving it."
 }

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -1669,7 +1669,7 @@ class ReaderFushiSource extends ReaderMediaSource {
   // would double-reload.
   bool get readerMergeImagePages =>
       readerSettings?.mergeImagePages ??
-      getPreference<bool>(key: 'merge_image_pages', defaultValue: false);
+      getPreference<bool>(key: 'merge_image_pages', defaultValue: true);
   Future<void> setReaderMergeImagePages(bool v) async {
     await (readerSettings?.setMergeImagePages(v) ??
         setPreference<bool>(key: 'merge_image_pages', value: v));
@@ -1717,7 +1717,7 @@ class ReaderFushiSource extends ReaderMediaSource {
 
   bool get readerPrioritizeReaderStyles =>
       readerSettings?.prioritizeReaderStyles ??
-      getPreference<bool>(key: 'reader_styles', defaultValue: false);
+      getPreference<bool>(key: 'reader_styles', defaultValue: true);
   Future<void> setReaderPrioritizeReaderStyles(bool v) async {
     await (readerSettings?.setPrioritizeReaderStyles(v) ??
         setPreference<bool>(key: 'reader_styles', value: v));

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -336,8 +336,12 @@ class ReaderSettings {
   /// TODO-1128: when true, the reader folds each run of trailing standalone
   /// single-image (0-char) chapters into the preceding text chapter's
   /// continuous flow instead of paging to each illustration separately.
-  /// Default false (conservative first ship); a structural layout key.
-  bool get mergeImagePages => _get<bool>('merge_image_pages', false);
+  /// A structural layout key. Now defaults to true: the conservative
+  /// first-ship default (false) made every illustration steal a page turn,
+  /// which is the wrong reading rhythm for the light novels this targets.
+  /// Users who explicitly turned it off keep their stored `false` — `_get`
+  /// never persists a default, so only an explicit `_set` wins over this.
+  bool get mergeImagePages => _get<bool>('merge_image_pages', true);
   Future<void> setMergeImagePages(bool v) => _set<bool>('merge_image_pages', v);
 
   bool get enableVerticalFontKerning => _get<bool>('vert_kerning', false);
@@ -356,7 +360,12 @@ class ReaderSettings {
   Future<void> setEnableTextJustification(bool v) =>
       _set<bool>('text_justify', v);
 
-  bool get prioritizeReaderStyles => _get<bool>('reader_styles', false);
+  /// When true the reader stops stamping `!important` on the image-sizing and
+  /// link-colour declarations it generates, so the book's own stylesheet wins.
+  /// Defaults to true: publisher CSS is authored for the illustrations it ships
+  /// with, and overriding it by default distorted spreads and full-bleed art.
+  /// Same persistence rule as [mergeImagePages] — an explicit user `false` wins.
+  bool get prioritizeReaderStyles => _get<bool>('reader_styles', true);
   Future<void> setPrioritizeReaderStyles(bool v) =>
       _set<bool>('reader_styles', v);
 

--- a/fushi/lib/src/sync/aggregate_snapshot.dart
+++ b/fushi/lib/src/sync/aggregate_snapshot.dart
@@ -157,6 +157,46 @@ class AggregateSnapshot {
     );
   }
 
+  /// 按用户的共享许可裁掉整族数据，用于互联通道的「共享统计 / 共享收藏夹」两个
+  /// 开关（云通道不调用本方法，其行为逐字节不变）。
+  ///
+  /// 快照的字段天然分成两族且不重叠：统计族（四张统计表 + 逐时桶 + 制卡计数 +
+  /// 查词/制卡计数）与收藏族（收藏词 / 收藏句 + 两类删除墓碑）。裁剪就是把不许
+  /// 共享的那一族整族置空，而不是在下游撒 if——下游的 merge / apply 面对空列表
+  /// 已经是正确的 no-op（并集折叠里空集是单位元），无需任何特例分支。
+  ///
+  /// 墓碑跟着它保护的那一族走：收藏关掉时连「取消收藏」也不该外流，否则本设备的
+  /// 删除意图仍在改写对端。
+  ///
+  /// 两个许可都为真时返回入参本身（零拷贝，`identical` 仍成立，与
+  /// [AggregateSyncService.filterTombstoned] 同纪律）。
+  AggregateSnapshot select({
+    required bool stats,
+    required bool favorites,
+  }) {
+    if (stats && favorites) return this;
+    return AggregateSnapshot(
+      readingStats: stats ? readingStats : const <ReadingStatRecord>[],
+      videoStats: stats ? videoStats : const <VideoStatRecord>[],
+      readingHourly: stats ? readingHourly : const <HourlyRecord>[],
+      readingHourlyByFormat:
+          stats ? readingHourlyByFormat : const <HourlyFormatRecord>[],
+      videoHourly: stats ? videoHourly : const <HourlyRecord>[],
+      miningStats: stats ? miningStats : const <MiningRecord>[],
+      lookupMiningCounters:
+          stats ? lookupMiningCounters : const <LookupMiningRecord>[],
+      favoriteWords: favorites ? favoriteWords : const <FavoriteWordRecord>[],
+      favoriteSentences:
+          favorites ? favoriteSentences : const <FavoriteSentence>[],
+      favoriteWordTombstones: favorites
+          ? favoriteWordTombstones
+          : const <AggregateTombstoneRecord>[],
+      favoriteSentenceTombstones: favorites
+          ? favoriteSentenceTombstones
+          : const <AggregateTombstoneRecord>[],
+    );
+  }
+
   static List<T> _decodeList<T>(
     Object? raw,
     T? Function(Map<String, Object?> row) decode,

--- a/fushi/lib/src/sync/aggregate_sync_service.dart
+++ b/fushi/lib/src/sync/aggregate_sync_service.dart
@@ -202,12 +202,24 @@ class AggregateSyncService {
   ///
   /// No schema change; the snapshot is a transient JSON payload, local state
   /// lives in the existing statistic tables + favorite_sentences pref.
+  ///
+  /// [shareStats] / [shareFavorites] 是用户在互联设置里的「共享统计 / 共享收藏夹」
+  /// 许可（两者默认 true = 既有行为）。裁剪在**本方法内**做，而不是交给调用方：
+  /// 上行有两条路径（老 host 退化推送 + 正常合并后推送）、下行有一条，任何一条漏
+  /// 裁都等于开关没关。与 [filterTombstoned] 同一条理由——让不变式在每条路径上都
+  /// 成立，而不是靠推理。下行同样裁剪：只停上传会让对端数据继续折进本地，用户看到
+  /// 的仍是「关了还在同步」。两者皆 false 时整轮 no-op（连请求都不发）。
   Future<void> syncOverClient({
     required Future<Object?> Function() fetchRemote,
     required Future<void> Function(Object json) pushMerged,
+    bool shareStats = true,
+    bool shareFavorites = true,
   }) async {
+    if (!shareStats && !shareFavorites) return;
+
     // 1) Materialise local state.
-    final AggregateSnapshot localSnapshot = await materializeLocalSnapshot();
+    final AggregateSnapshot localSnapshot = (await materializeLocalSnapshot())
+        .select(stats: shareStats, favorites: shareFavorites);
 
     // 2) Fetch the host's snapshot. null => old host without the endpoint:
     //    degrade to push-only (still share our state; skip the local fold).
@@ -225,7 +237,8 @@ class AggregateSyncService {
 
     // 3) Fold the host snapshot into the local one through the same pure merge
     //    the cloud channel uses (single source of truth; commutative/idempotent).
-    final AggregateSnapshot remote = AggregateSnapshot.fromJson(remoteJson);
+    final AggregateSnapshot remote = AggregateSnapshot.fromJson(remoteJson)
+        .select(stats: shareStats, favorites: shareFavorites);
     final AggregateSnapshot merged = mergeSnapshots(localSnapshot, remote);
 
     // 4) Apply the merged result back locally (MAX / union writes; idempotent).

--- a/fushi/lib/src/sync/sync_auto_trigger.dart
+++ b/fushi/lib/src/sync/sync_auto_trigger.dart
@@ -224,6 +224,7 @@ Future<List<SyncChannel>> enabledSyncChannelBackends(
 class ChannelSyncFlags {
   const ChannelSyncFlags({
     required this.syncStats,
+    required this.syncFavorites,
     required this.syncAudioBookPosition,
     required this.syncContent,
     required this.syncAudioBookFiles,
@@ -232,6 +233,11 @@ class ChannelSyncFlags {
     required this.syncLocalAudio,
   });
   final bool syncStats;
+
+  /// 收藏词 / 收藏句是否参与本通道的聚合同步。云通道恒等于 [syncStats]（云侧
+  /// 聚合快照里统计与收藏本来就由同一个开关代管，拆开会改变云备份的既有行为）；
+  /// 互联通道读自己的 `interconnect_sync_favorites`。
+  final bool syncFavorites;
   final bool syncAudioBookPosition;
   final bool syncContent;
   final bool syncAudioBookFiles;
@@ -243,7 +249,9 @@ class ChannelSyncFlags {
 /// 按通道解析分资产同步开关（BUG-988）。[isInterconnect]==true（互联通道）时「重内容」
 /// 四类——书籍/内容、词典、有声书文件、视频文件——读互联专属上传开关（默认 false，让
 /// 用户独立控制是否上传给互联对端，不被「启用互联连接」裹挟）；false（云备份通道）读
-/// 原共享 sync_*_enabled。位置/统计/本地音频不区分通道（轻量进度，跨设备续读是互联本意）。
+/// 原共享 sync_*_enabled。统计与收藏也已分通道（互联侧读 `interconnect_sync_stats` /
+/// `interconnect_sync_favorites`，默认 true = 拆开关前的行为）。位置/本地音频仍不区分
+/// 通道（轻量进度，跨设备续读是互联本意）。
 ///
 /// 不再 `@visibleForTesting`：`AppModel._propagateDictionaryDeleteToRemote` 是生产
 /// 消费方——「这条通道该不该同步词典」必须复用同一份分通道门控，各处重抄必漂
@@ -253,7 +261,14 @@ Future<ChannelSyncFlags> resolveChannelSyncFlags(
   required bool isInterconnect,
 }) async {
   return ChannelSyncFlags(
-    syncStats: await repo.isSyncStatsEnabled(),
+    // 统计与收藏在互联通道上各有自己的开关（默认 true = 拆开关前的既有行为）；
+    // 云通道仍由 sync_stats_enabled 一把管两族，逐字节不变。
+    syncStats: isInterconnect
+        ? await repo.isInterconnectSyncStatsEnabled()
+        : await repo.isSyncStatsEnabled(),
+    syncFavorites: isInterconnect
+        ? await repo.isInterconnectSyncFavoritesEnabled()
+        : await repo.isSyncStatsEnabled(),
     syncAudioBookPosition: await repo.isSyncAudioBookEnabled(),
     syncContent: isInterconnect
         ? await repo.isInterconnectSyncContentEnabled()
@@ -332,6 +347,7 @@ Future<SyncRunReport?> _runSyncChannelInner({
     tempDir: tempDir,
     deviceId: await repo.getOrCreateDeviceId(),
     syncStats: flags.syncStats,
+    syncFavorites: flags.syncFavorites,
     syncAudioBookPosition: flags.syncAudioBookPosition,
     syncContent: flags.syncContent,
     syncAudioBookFiles: flags.syncAudioBookFiles,
@@ -897,6 +913,7 @@ Future<void> _runCollectionsSync({required FushiDatabase db}) async {
             tempDir: Directory.systemTemp,
             deviceId: await repo.getOrCreateDeviceId(),
             syncStats: false,
+            syncFavorites: false,
             syncAudioBookPosition: false,
             syncContent: false,
             syncAudioBookFiles: false,

--- a/fushi/lib/src/sync/sync_orchestrator.dart
+++ b/fushi/lib/src/sync/sync_orchestrator.dart
@@ -397,6 +397,7 @@ class SyncOrchestrator {
     required Directory tempDir,
     this.deviceId = '',
     required this.syncStats,
+    this.syncFavorites = true,
     required this.syncAudioBookPosition,
     required this.syncContent,
     required this.syncAudioBookFiles,
@@ -435,6 +436,11 @@ class SyncOrchestrator {
   final String deviceId;
 
   final bool syncStats;
+
+  /// 收藏词 / 收藏句是否参与聚合同步。互联通道由「共享收藏夹」开关驱动，与
+  /// [syncStats] 互相独立；云通道两者同源（见 [ChannelSyncFlags.syncFavorites]）。
+  /// 默认 true：省略该参数的既有调用点行为不变。
+  final bool syncFavorites;
   final bool syncAudioBookPosition;
   final bool syncContent;
   final bool syncAudioBookFiles;
@@ -615,11 +621,12 @@ class SyncOrchestrator {
       await _syncBookProgressLive(report, b);
       await _syncVideoProgressLive(report, b);
       await _syncAudiobookProgressLive(report, b);
-      // 互联聚合（统计 + 收藏）live 双向合并（TODO-1056 phase C）。复用 syncStats
-      // 开关（聚合 = 统计 + 收藏，同属「统计同步」语义，不新增设置项 / schema）。
+      // 互联聚合（统计 + 收藏）live 双向合并（TODO-1056 phase C）。两族各自由互联
+      // 页的「共享统计 / 共享收藏夹」开关控制（默认均 true = 拆开关前的行为），裁剪
+      // 在 [AggregateSyncService.syncOverClient] 内按族做，两族都关时整轮不发请求。
       // 互联无 per-device 快照文件、不依赖 deviceId：host 单份权威快照，client GET →
       // 并集折叠 → 写回本地 → PUT 回 host（host 再 MAX/并集折叠进自己 DB）。
-      if (syncStats) await _syncAggregateLive(report, b);
+      if (syncStats || syncFavorites) await _syncAggregateLive(report, b);
     }
 
     // 云后端聚合同步（统计 + 收藏跨端共享，TODO-1056 phase B）。互联 live 端点
@@ -723,6 +730,8 @@ class SyncOrchestrator {
       await AggregateSyncService(_db, scope: _scope).syncOverClient(
         fetchRemote: backend.getRemoteAggregate,
         pushMerged: backend.putRemoteAggregate,
+        shareStats: syncStats,
+        shareFavorites: syncFavorites,
       );
     } catch (e) {
       report.noteError('aggregate live sync', e);

--- a/fushi/lib/src/sync/sync_repository.dart
+++ b/fushi/lib/src/sync/sync_repository.dart
@@ -222,6 +222,14 @@ class SyncRepository {
   static const _keyInterconnectSyncAudioBookFiles =
       'interconnect_sync_audiobook_files';
   static const _keyInterconnectSyncVideoFiles = 'interconnect_sync_video_files';
+  // 互联通道专属的「共享统计 / 共享收藏夹」开关。此前互联的聚合同步（统计 + 收藏
+  // 词句）无条件复用云备份的 sync_stats_enabled，用户在互联页既看不到这两类数据
+  // 正在跨设备流动，也没法只对互联单独关掉——与 BUG-988 拆四个上传开关时修掉的
+  // 是同一个毛病（互联通道借用云备份开关 = 用户失去分通道控制权）。
+  // 默认 true：既有行为就是「跟着 syncStats 默认 true 一起同步」，拆开关不改变
+  // 任何人当前看到的结果，只是把隐式变显式、可关。
+  static const _keyInterconnectSyncStats = 'interconnect_sync_stats';
+  static const _keyInterconnectSyncFavorites = 'interconnect_sync_favorites';
   // apikey 同步设定重设计（2026-08-17）：互联 service-config（host 的外部服务
   // API key / 服务配置，interconnect_service_config.dart 白名单）此前是**无 UI、
   // 无开关**的隐形通道——用户既看不见「配对后 host 的 Jimaku/TMDB key 会同步过来」
@@ -633,6 +641,23 @@ class SyncRepository {
       _db.getPrefTyped<bool>(_keyInterconnectSyncVideoFiles, false);
   Future<void> setInterconnectSyncVideoFilesEnabled(bool v) =>
       _db.setPrefTyped<bool>(_keyInterconnectSyncVideoFiles, v);
+
+  /// 互联通道「共享统计」：阅读/观看时长、字数、逐时桶、查词与制卡计数。默认 true
+  /// = 既有行为不变（此前由云备份的 [isSyncStatsEnabled] 一刀切代管）。关掉后本设备
+  /// 既不把统计推给对端，也不把对端统计折进本地——两个方向一起停，否则「关了还在收」
+  /// 会让本地统计继续被对端撑大，用户看到的仍是没关掉。
+  Future<bool> isInterconnectSyncStatsEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncStats, true);
+  Future<void> setInterconnectSyncStatsEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncStats, v);
+
+  /// 互联通道「共享收藏夹」：收藏词 + 收藏句（以及它们的删除墓碑，取消收藏要能
+  /// 跨端传播）。与统计同为聚合快照的一半，但语义不同——收藏是用户挑出来的内容，
+  /// 值得独立开关。默认 true = 既有行为不变；同样双向一起停。
+  Future<bool> isInterconnectSyncFavoritesEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncFavorites, true);
+  Future<void> setInterconnectSyncFavoritesEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncFavorites, v);
 
   /// 互联 service-config 同步（host 的外部服务 API key / 服务配置随互联下发）。
   /// 默认 true = 既有行为不变；关掉后本设备不再向 host 请求 service-config，

--- a/fushi/lib/src/sync/sync_settings_schema.dart
+++ b/fushi/lib/src/sync/sync_settings_schema.dart
@@ -493,6 +493,45 @@ SettingsDestination buildInterconnectDestination() {
           ),
         ],
       ),
+      // 与已配对设备共享：统计 + 收藏夹的双向合并开关。刻意**不并进上面的「上传到
+      // 互联对端」区块**——那一区是纯 OUTBOUND 的重内容文件、脚注向用户承诺「默认
+      // 全部关闭」；这两项是轻量个人数据、双向合并、且默认开启（拆开关前它们本来就
+      // 在跟着云备份的「同步统计」无条件流动，只是用户看不见也关不掉）。混在一起会
+      // 让那句脚注当场变成假话。
+      SettingsSection(
+        title: t.interconnect_share_section,
+        footer: t.interconnect_share_section_footer,
+        visible: (SettingsContext ctx) =>
+            interconnectActive(ctx) && !_isHostingInterconnect(ctx),
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'interconnect.share_statistics',
+            title: t.interconnect_share_statistics,
+            subtitle: t.interconnect_share_statistics_hint,
+            icon: Icons.bar_chart_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncStats,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncStats = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncStatsEnabled(value);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'interconnect.share_favorites',
+            title: t.interconnect_share_favorites,
+            subtitle: t.interconnect_share_favorites_hint,
+            icon: Icons.star_outline,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncFavorites,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncFavorites = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncFavoritesEnabled(value);
+            },
+          ),
+        ],
+      ),
       // 交给已配对设备：本机把某类工作整个甩给对端主机去做。两项都只有 client 角色
       // 讲得通（host 没有「对端」可交），故与上面的上传区同门控——互联启用且本机不在
       // host 模式。
@@ -667,6 +706,10 @@ class _SyncSettingsState {
   bool interconnectSyncDictionary = false;
   bool interconnectSyncAudioBookFiles = false;
   bool interconnectSyncVideoFiles = false;
+  // 互联专属的「共享统计 / 共享收藏夹」（双向合并，非上传）。默认 true = 拆开关前
+  // 由云备份 syncStats 无条件代管时的既有行为。
+  bool interconnectSyncStats = true;
+  bool interconnectSyncFavorites = true;
   // apikey 同步设定重设计（2026-08-17）：service-config（host 的外部服务 API key）
   // 接收开关。默认 true = 既有行为；此前这条通道无 UI 无开关，用户不可见也关不掉。
   bool interconnectServiceConfigSync = true;
@@ -756,6 +799,9 @@ class _SyncSettingsState {
           await _repo.isInterconnectSyncAudioBookFilesEnabled();
       interconnectSyncVideoFiles =
           await _repo.isInterconnectSyncVideoFilesEnabled();
+      interconnectSyncStats = await _repo.isInterconnectSyncStatsEnabled();
+      interconnectSyncFavorites =
+          await _repo.isInterconnectSyncFavoritesEnabled();
       interconnectServiceConfigSync =
           await _repo.isInterconnectServiceConfigSyncEnabled();
       serverEnabled = await _repo.isServerEnabled();

--- a/fushi/test/reader/reader_display_defaults_test.dart
+++ b/fushi/test/reader/reader_display_defaults_test.dart
@@ -1,0 +1,119 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/src/reader/reader_content_styles.dart';
+import 'package:fushi/src/reader/reader_settings.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 锁定两个阅读器显示项的**默认开启**，以及「显式关过的用户不被默认值覆盖」。
+///
+/// 这两个键各有两处默认字面量（[ReaderSettings] 的 `_get` 真值 + reader 未
+/// 初始化时 [ReaderFushiSource] 的 `getPreference` 兜底）。两处漂开时用户会
+/// 看到「设置页显示开着、阅读器却按关的渲染」，所以这里逐项对比两条读路径，
+/// 而不是只断言其中一条。
+FushiDatabase _testDb() {
+  return FushiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+}
+
+void main() {
+  group('reader display defaults (merge_image_pages / reader_styles)', () {
+    late FushiDatabase db;
+
+    setUp(() {
+      db = _testDb();
+      MediaSource.setDatabase(db);
+      ReaderFushiSource.readerSettings = null;
+    });
+
+    tearDown(() async {
+      ReaderFushiSource.readerSettings = null;
+      await db.close();
+    });
+
+    test('merge illustration pages into text defaults to ON', () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+
+      expect(settings.mergeImagePages, isTrue);
+      // reader 未初始化时的兜底读路径必须给出同一个答案。
+      expect(ReaderFushiSource.instance.readerMergeImagePages, isTrue);
+    });
+
+    test('prioritize book styles defaults to ON', () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+
+      expect(settings.prioritizeReaderStyles, isTrue);
+      expect(ReaderFushiSource.instance.readerPrioritizeReaderStyles, isTrue);
+    });
+
+    test('an explicit user OFF survives the new default', () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      await settings.setMergeImagePages(false);
+      await settings.setPrioritizeReaderStyles(false);
+
+      final ReaderSettings restored = ReaderSettings(db);
+      await restored.refreshFromDb();
+
+      expect(restored.mergeImagePages, isFalse);
+      expect(restored.prioritizeReaderStyles, isFalse);
+    });
+
+    test('defaults are not written to the DB (so they stay changeable)',
+        () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      // 触发读取，走 _get 的缺键分支。
+      settings.mergeImagePages;
+      settings.prioritizeReaderStyles;
+
+      final Map<String, String> prefs = await db.getAllPrefs();
+      expect(prefs.containsKey('src:reader_fushi:merge_image_pages'), isFalse);
+      expect(prefs.containsKey('src:reader_fushi:reader_styles'), isFalse);
+    });
+  });
+
+  group('prioritize book styles: CSS effect of the new default', () {
+    late FushiDatabase db;
+
+    setUp(() {
+      db = _testDb();
+      MediaSource.setDatabase(db);
+      ReaderFushiSource.readerSettings = null;
+    });
+
+    tearDown(() async {
+      ReaderFushiSource.readerSettings = null;
+      await db.close();
+    });
+
+    test('by default the reader no longer forces image sizing with !important',
+        () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      final String css = ReaderContentStyles.css(settings: settings);
+
+      // 这几条是 readerStylePriority 后缀的实际落点；默认开启 = 书自带 CSS 赢。
+      expect(css, contains('width: auto;'));
+      expect(css, isNot(contains('width: auto !important;')));
+      expect(css, contains('object-fit: contain;'));
+      expect(css, isNot(contains('object-fit: contain !important;')));
+      // 与本开关无关的强制项不受影响（同一条规则内的分栏/断页保护）。
+      expect(css, contains('break-inside: avoid !important;'));
+    });
+
+    test('turning it off restores the !important overrides', () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      await settings.setPrioritizeReaderStyles(false);
+      final String css = ReaderContentStyles.css(settings: settings);
+
+      expect(css, contains('width: auto !important;'));
+      expect(css, contains('object-fit: contain !important;'));
+    });
+  });
+}

--- a/fushi/test/sync/interconnect_share_scope_test.dart
+++ b/fushi/test/sync/interconnect_share_scope_test.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/aggregate_snapshot.dart';
+import 'package:fushi/src/sync/aggregate_sync_service.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'temp_dir_cleanup.dart';
+
+/// 互联「共享统计 / 共享收藏夹」两个开关。
+///
+/// 聚合快照的字段天然分成互不重叠的两族（统计族 / 收藏族），两个开关各管一族。
+/// 这里锁三件事：
+///   ① 纯函数 [AggregateSnapshot.select] 的裁剪是整族的、且两族互不牵连；
+///   ② 裁剪对**上下行都生效**——只裁上行的话，关掉开关后对端数据仍会折进本地，
+///      用户看到的是「关了还在同步」；
+///   ③ 两族都关时整轮 no-op，连请求都不发。
+Future<FushiDatabase> _freshDb(String prefix) async {
+  final Directory dir = await Directory.systemTemp.createTemp(prefix);
+  addTearDown(() => cleanupTempDir(dir));
+  return FushiDatabase(dir.path);
+}
+
+FavoriteSentence _sentence() => FavoriteSentence(
+      id: 'fav-peer',
+      text: '対端の文',
+      bookTitle: 'Peer Book',
+      bookKey: 'bk-peer',
+      sectionIndex: 0,
+      normCharOffset: 10,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+
+/// 一份两族齐全的对端快照。
+AggregateSnapshot _peerSnapshot() => AggregateSnapshot(
+      readingStats: const <ReadingStatRecord>[
+        ReadingStatRecord(
+          title: 'Peer Book',
+          dateKey: '2026-06-01',
+          charactersRead: 120,
+          readingTimeMs: 60000,
+          lastStatisticModified: 10,
+        ),
+      ],
+      videoStats: const <VideoStatRecord>[
+        VideoStatRecord(
+          title: 'Peer Video',
+          dateKey: '2026-06-01',
+          subtitleChars: 50,
+          watchTimeMs: 30000,
+          lastModified: 12,
+        ),
+      ],
+      lookupMiningCounters: const <LookupMiningRecord>[
+        LookupMiningRecord(
+          bookKey: 'bk-peer',
+          title: 'Peer Book',
+          sourceType: 'book',
+          dateKey: '2026-06-01',
+          lookupCount: 7,
+          mineCount: 3,
+        ),
+      ],
+      favoriteWords: const <FavoriteWordRecord>[
+        FavoriteWordRecord(
+          expression: 'peerword',
+          reading: 'r1',
+          glossary: 'g1',
+          sourceType: 'book',
+          dateKey: '2026-06-01',
+          createdAt: 100,
+        ),
+      ],
+      favoriteSentences: <FavoriteSentence>[_sentence()],
+    );
+
+void main() {
+  group('AggregateSnapshot.select 按族裁剪', () {
+    test('只共享统计：收藏族整族清空，统计族原样保留', () {
+      final AggregateSnapshot out =
+          _peerSnapshot().select(stats: true, favorites: false);
+
+      expect(out.readingStats, hasLength(1));
+      expect(out.videoStats, hasLength(1));
+      expect(out.lookupMiningCounters, hasLength(1));
+      expect(out.favoriteWords, isEmpty);
+      expect(out.favoriteSentences, isEmpty);
+    });
+
+    test('只共享收藏：统计族整族清空，收藏族原样保留', () {
+      final AggregateSnapshot out =
+          _peerSnapshot().select(stats: false, favorites: true);
+
+      expect(out.readingStats, isEmpty);
+      expect(out.videoStats, isEmpty);
+      expect(out.lookupMiningCounters, isEmpty);
+      expect(out.favoriteWords, hasLength(1));
+      expect(out.favoriteSentences, hasLength(1));
+    });
+
+    test('收藏关掉时，取消收藏的墓碑也不外流', () {
+      final AggregateSnapshot withTombstones = AggregateSnapshot(
+        favoriteWordTombstones: const <AggregateTombstoneRecord>[
+          AggregateTombstoneRecord(itemKey: 'k1', deletedAt: 5),
+        ],
+        favoriteSentenceTombstones: const <AggregateTombstoneRecord>[
+          AggregateTombstoneRecord(itemKey: 'k2', deletedAt: 6),
+        ],
+      );
+
+      final AggregateSnapshot out =
+          withTombstones.select(stats: true, favorites: false);
+      expect(out.favoriteWordTombstones, isEmpty);
+      expect(out.favoriteSentenceTombstones, isEmpty);
+    });
+
+    test('两族都许可时零拷贝返回入参本身', () {
+      final AggregateSnapshot snap = _peerSnapshot();
+      expect(
+          identical(snap.select(stats: true, favorites: true), snap), isTrue);
+    });
+
+    test('两族都不许可时是空快照', () {
+      expect(_peerSnapshot().select(stats: false, favorites: false).isEmpty,
+          isTrue);
+    });
+  });
+
+  group('syncOverClient 的许可裁剪（上下行都要生效）', () {
+    test('关掉共享收藏：上行 payload 无收藏族，且对端收藏不落本地库', () async {
+      final FushiDatabase db = await _freshDb('agg_share_fav_off_');
+      addTearDown(db.close);
+
+      Object? pushedJson;
+      await AggregateSyncService(db).syncOverClient(
+        fetchRemote: () async => _peerSnapshot().toJson(),
+        pushMerged: (Object json) async => pushedJson = json,
+        shareStats: true,
+        shareFavorites: false,
+      );
+
+      final AggregateSnapshot outgoing = AggregateSnapshot.fromJson(pushedJson);
+      expect(outgoing.readingStats.map((ReadingStatRecord r) => r.title),
+          contains('Peer Book'),
+          reason: '统计仍许可，必须照常共享');
+      expect(outgoing.favoriteWords, isEmpty);
+      expect(outgoing.favoriteSentences, isEmpty);
+
+      // 下行：对端的收藏词不得被折进本地库。
+      expect(await db.getAllFavoriteWords(), isEmpty);
+    });
+
+    test('关掉共享统计：上行 payload 无统计族，且对端统计不落本地库', () async {
+      final FushiDatabase db = await _freshDb('agg_share_stats_off_');
+      addTearDown(db.close);
+
+      Object? pushedJson;
+      await AggregateSyncService(db).syncOverClient(
+        fetchRemote: () async => _peerSnapshot().toJson(),
+        pushMerged: (Object json) async => pushedJson = json,
+        shareStats: false,
+        shareFavorites: true,
+      );
+
+      final AggregateSnapshot outgoing = AggregateSnapshot.fromJson(pushedJson);
+      expect(outgoing.readingStats, isEmpty);
+      expect(outgoing.videoStats, isEmpty);
+      expect(outgoing.lookupMiningCounters, isEmpty);
+      expect(outgoing.favoriteWords.map((FavoriteWordRecord r) => r.expression),
+          contains('peerword'),
+          reason: '收藏仍许可，必须照常共享');
+
+      // 下行：对端的阅读统计不得被折进本地库。
+      expect(await db.getAllReadingStatistics(), isEmpty);
+    });
+
+    test('两个都关：不发请求，也不推任何东西', () async {
+      final FushiDatabase db = await _freshDb('agg_share_both_off_');
+      addTearDown(db.close);
+
+      bool fetched = false;
+      bool pushed = false;
+      await AggregateSyncService(db).syncOverClient(
+        fetchRemote: () async {
+          fetched = true;
+          return _peerSnapshot().toJson();
+        },
+        pushMerged: (Object json) async => pushed = true,
+        shareStats: false,
+        shareFavorites: false,
+      );
+
+      expect(fetched, isFalse, reason: '关掉了就不该再问对端要数据');
+      expect(pushed, isFalse);
+    });
+
+    test('老 host（fetchRemote 返回 null）的退化推送同样过裁剪', () async {
+      final FushiDatabase db = await _freshDb('agg_share_oldhost_');
+      addTearDown(db.close);
+      // 本机有一条收藏词，作为唯一可推内容。
+      await db.addFavoriteWord(
+        expression: 'localword',
+        reading: 'r',
+        glossary: 'g',
+        sourceType: 'book',
+        dateKey: '2026-06-01',
+      );
+
+      Object? pushedJson;
+      await AggregateSyncService(db).syncOverClient(
+        fetchRemote: () async => null,
+        pushMerged: (Object json) async => pushedJson = json,
+        shareStats: true,
+        shareFavorites: false,
+      );
+
+      // 收藏关掉后本机没有任何可共享内容 → 退化路径也不该推空快照。
+      expect(pushedJson, isNull);
+    });
+  });
+
+  group('偏好键默认值', () {
+    test('共享统计 / 共享收藏夹默认开启，且可持久化关掉', () async {
+      final FushiDatabase db = await _freshDb('agg_share_prefs_');
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      expect(await repo.isInterconnectSyncStatsEnabled(), isTrue);
+      expect(await repo.isInterconnectSyncFavoritesEnabled(), isTrue);
+
+      await repo.setInterconnectSyncStatsEnabled(false);
+      await repo.setInterconnectSyncFavoritesEnabled(false);
+
+      expect(await repo.isInterconnectSyncStatsEnabled(), isFalse);
+      expect(await repo.isInterconnectSyncFavoritesEnabled(), isFalse);
+    });
+
+    test('两个开关互不牵连', () async {
+      final FushiDatabase db = await _freshDb('agg_share_prefs_indep_');
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setInterconnectSyncStatsEnabled(false);
+
+      expect(await repo.isInterconnectSyncFavoritesEnabled(), isTrue);
+    });
+  });
+}

--- a/fushi/test/sync/interconnect_upload_toggles_test.dart
+++ b/fushi/test/sync/interconnect_upload_toggles_test.dart
@@ -72,8 +72,7 @@ void main() {
     expect(cloud.syncDictionary, isFalse);
   });
 
-  test('位置/统计/本地音频不区分通道（轻量进度共享，跨设备续读是互联本意）', () async {
-    await repo.setSyncStatsEnabled(false);
+  test('位置/本地音频不区分通道（轻量进度共享，跨设备续读是互联本意）', () async {
     await repo.setSyncLocalAudioEnabled(true);
 
     final ChannelSyncFlags ic =
@@ -81,12 +80,40 @@ void main() {
     final ChannelSyncFlags cloud =
         await resolveChannelSyncFlags(repo, isInterconnect: false);
 
-    expect(ic.syncStats, cloud.syncStats);
-    expect(ic.syncStats, isFalse);
     expect(ic.syncLocalAudio, cloud.syncLocalAudio);
     expect(ic.syncLocalAudio, isTrue);
     // 有声书播放位置恒同步（isSyncAudioBookEnabled 恒 true）——两通道一致。
     expect(ic.syncAudioBookPosition, isTrue);
     expect(cloud.syncAudioBookPosition, isTrue);
+  });
+
+  // 统计/收藏此前跟着云备份的 sync_stats_enabled 一刀切（上面那条测试的原始形态就
+  // 断言过「统计不区分通道」）。互联页现在各有一个默认开启的开关，与四个上传开关
+  // 同一纪律：互联的事互联自己决定。
+  test('统计/收藏分通道：云关掉不牵连互联（默认开启）', () async {
+    await repo.setSyncStatsEnabled(false);
+
+    final ChannelSyncFlags ic =
+        await resolveChannelSyncFlags(repo, isInterconnect: true);
+    final ChannelSyncFlags cloud =
+        await resolveChannelSyncFlags(repo, isInterconnect: false);
+
+    expect(cloud.syncStats, isFalse);
+    expect(cloud.syncFavorites, isFalse, reason: '云侧两族仍同源，行为逐字节不变');
+    expect(ic.syncStats, isTrue, reason: '互联读自己的键，默认开启');
+    expect(ic.syncFavorites, isTrue);
+  });
+
+  test('关互联的共享统计不牵连共享收藏，也不牵连云通道', () async {
+    await repo.setInterconnectSyncStatsEnabled(false);
+
+    final ChannelSyncFlags ic =
+        await resolveChannelSyncFlags(repo, isInterconnect: true);
+    final ChannelSyncFlags cloud =
+        await resolveChannelSyncFlags(repo, isInterconnect: false);
+
+    expect(ic.syncStats, isFalse);
+    expect(ic.syncFavorites, isTrue, reason: '两个开关互相独立');
+    expect(cloud.syncStats, isTrue, reason: '云通道读 sync_stats_enabled，默认开启');
   });
 }

--- a/fushi/test/sync/sync_settings_visibility_test.dart
+++ b/fushi/test/sync/sync_settings_visibility_test.dart
@@ -301,9 +301,10 @@ void main() {
 
     test('is its own top-level destination (not inside syncBackup)', () {
       expect(dest.id, SettingsDestinationId.interconnect);
-      // 启用开关 + 连接设备 + 上传到互联对端（BUG-988）+ 交给已配对设备（制卡/备份
-      // 后端）+ 本机服务器 + 互联相关配置镜像（远端词典/音频来源/远端占位卡）。
-      expect(dest.sections, hasLength(6));
+      // 启用开关 + 连接设备 + 上传到互联对端（BUG-988）+ 与已配对设备共享（统计/
+      // 收藏夹，双向、默认开）+ 交给已配对设备（制卡/备份后端）+ 本机服务器 +
+      // 互联相关配置镜像（远端词典/音频来源/远端占位卡）。
+      expect(dest.sections, hasLength(7));
     });
 
     test('enable toggle is unconditional; config sections gated on the toggle',
@@ -339,16 +340,25 @@ void main() {
         'interconnect.upload_video_files',
       ]);
       expect(dest.sections[2].visible, isNotNull);
+      // 与已配对设备共享：统计 / 收藏夹。刻意独立成区而不并进上面的上传区——那一区
+      // 是纯 OUTBOUND 的重内容、脚注承诺「默认全部关闭」，这两项双向且默认开启。
+      expect(idsOf(dest.sections[3]), <String>[
+        'interconnect.share_statistics',
+        'interconnect.share_favorites',
+      ]);
+      expect(dest.sections[3].visible, isNotNull);
+      expect(dest.sections[3].footer, isNotNull,
+          reason: '双向 + 默认开启这件事必须在 UI 上说清楚');
       // 交给已配对设备：制卡到已配对设备（原在「制卡」分类）+ 用互联做备份后端
       // + 从 host 同步外部服务配置（BUG-1693 的 apikey 同步开关）。
-      expect(idsOf(dest.sections[3]), <String>[
+      expect(idsOf(dest.sections[4]), <String>[
         'interconnect.mine_to_server',
         'interconnect.backup_backend',
         'interconnect.service_config_sync',
       ]);
-      expect(dest.sections[3].visible, isNotNull);
-      expect(idsOf(dest.sections[4]), <String>['sync.server_mode']);
       expect(dest.sections[4].visible, isNotNull);
+      expect(idsOf(dest.sections[5]), <String>['sync.server_mode']);
+      expect(dest.sections[5].visible, isNotNull);
     });
 
     test('peer address list keeps its title and empty-state guidance', () {
@@ -392,18 +402,18 @@ void main() {
       // 作用于互联对端；在互联分类镜像同一入口（共享 builder，非复制），仅互联被选为
       // 同步方式时可见（与其它互联配置区一致）。
       expect(
-        idsOf(dest.sections[5]),
+        idsOf(dest.sections[6]),
         <String>[
           'lookup.remote_lookup',
           'lookup.audio_sources',
           'sync.show_remote_entries',
         ],
       );
-      expect(dest.sections[5].visible, isNotNull);
+      expect(dest.sections[6].visible, isNotNull);
     });
 
     test('host-server group keeps its explanatory footer', () {
-      expect(dest.sections[4].footer, isNotNull);
+      expect(dest.sections[5].footer, isNotNull);
     });
   });
 }


### PR DESCRIPTION
## 改了什么

三个默认值，外加一处「把隐式行为变成显式可控」。

### 1. 插图页并入正文 → 默认开启

`merge_image_pages` 从 false 改 true。每张插图独占一页，光是翻过去就断一次阅读节奏，而这本来就是给轻小说用的。

### 2. 优先书籍样式 → 默认开启

`reader_styles` 从 false 改 true。此前阅读器给图片尺寸和链接色盖 `!important`，把出版方针对自家插图写的样式压掉，跨页图与出血图因此变形。

两个键**各有两处默认字面量**：`ReaderSettings` 的 `_get` 真值 + reader 未初始化时 `ReaderFushiSource` 的 `getPreference` 兜底。两处都改了 —— 只改一处会出现「设置页显示开着、阅读器却按关的渲染」。

`_get` 从不把默认值落盘，所以没手动动过开关的老用户直接跟随新默认；显式关过的用户 DB 里有 `b:false`，仍然赢过默认值。

### 3. 互联新增「共享统计」「共享收藏夹」，默认开启

这一条和字面需求略有出入，说明一下：**这两类数据本来就在互联上跨设备同步**，只是搭着云备份的 `sync_stats_enabled` 走 —— 用户在互联页既看不见它们正在外发，也没法只对互联单独关掉。所以这不是新增共享能力，而是把隐式行为变成显式可控，**默认值保持现状不变**，任何人升级后的行为都不会改变。

这与 BUG-988 当初把四个上传开关从云备份开关里拆出来时修的是同一个毛病。

**裁剪落在一个纯函数上。** 聚合快照的字段天然分成互不重叠的两族（统计族 / 收藏族），`AggregateSnapshot.select({stats, favorites})` 关掉一族就整族置空 —— 下游 merge / apply 面对空列表本来就是正确的 no-op（并集折叠里空集是单位元），不需要在任何地方撒 if。取消收藏的墓碑跟着收藏族走：收藏关掉时，本设备的删除意图也不该继续改写对端。

**裁剪做在 `syncOverClient` 内部，不交给调用方。** 上行有两条路径（老 host 退化推送 + 正常合并后推送）、下行一条，任何一条漏裁就等于开关没关 —— 与既有的 `filterTombstoned` 同一条理由：让不变式在每条路径上都成立，而不是靠推理。下行同样裁剪，否则「只停上传」会让对端数据继续折进本地，用户看到的仍是「关了还在同步」。两族都关时整轮 no-op，连请求都不发。

**UI 单独成区，没并进「上传到互联对端」。** 那一区是纯 outbound 的重内容文件，脚注向用户承诺「默认全部关闭」；这两项是双向合并且默认开启，混进去会让那句脚注当场变成假话。

云通道行为逐字节不变（`syncFavorites` 在云侧恒等于 `syncStats`）。新键按既有归属规则属「行为开关」，随备份恢复，不进 `deviceLocalPrefKeys`。

## 验证

- `flutter analyze`（含 test 目录）：No issues found
- 定向测试全绿：reader 6 条 + sync 11 条 + settings / visibility / upload_toggles 390 条
- **变异实测**：把 `select()` 改成无条件 `return this`，6 条测试转红（覆盖上行、下行、老 host 退化三条路径）；还原后源码 sha256 与变异前逐字节一致
- 全量 `flutter_test_failures.dart` 完整跑通一次：**19786 个测试完成，11 个 error**。逐个查过，全部是本机环境因素 —— 9 条 `update_manifest_publish_race`（PowerShell 环境里没有 `bash` 时的稳定形态）+ 1 条 `airing_calendar_cache` suite 装载竞态 + 1 个重复事件。这两个文件补上 `bash` 串行重跑，17 个测试全绿。

说实话：我没能再拿到一份「零 error 的全量」。之后重试四次都没跑完，根因是本机 native asset hook 的缓存机制 —— sqlite3 那层用 `download-` 加对象 hashCode 当目录名，而 Dart 的 String hashCode 每个进程都重新随机化，那层缓存**永远命不中**；一改 PATH 上层 hooks_runner 缓存也失效，就必须联网重下，而本机直连 GitHub 不稳。这是环境问题，不是这个 PR 的问题。

## 被改动的既有测试

`interconnect_upload_toggles_test.dart` 里「位置/统计/本地音频不区分通道」那条断言，锁的正是本次**有意改掉**的旧事实（统计不分通道）。改成锁定新的分通道语义，并补了两条独立性断言。不是为了让测试变绿而放宽断言。

`sync_settings_visibility_test.dart` 的 section 索引因新增区块顺延，同步更新，并补了「新区块必须有 footer」的断言。

## 顺带确证的一个 bug（本 PR 未修）

排查「Mac 左右翻页怪怪的」时确证：**双页展开模式下左右键方向不翻转**。`onSpreadKey` 桥只做 `resolveSpreadKeyBridgeAction` 后直接执行注册表原义动作（`webview.part.dart:2114-2128`），完全跳过了单页路径那道 RTL 覆写（`caret.part.dart:255-262` 的 leftIsForward = rtl XOR reverse）。所以竖排日文书开双页时，左键变成「上一页」，与单页模式正好相反。跨平台，不限 macOS。

未在本 PR 修 —— 等确认要不要按 BUGS.md 流程单独立条。

https://claude.ai/code/session_015ugDcbimBGYMaoZH3hv78i
