### PR TITLE
fix: 用户报的六件事（扩展返回键/隐藏词典/订阅卡死/设置布局/拖动浮层/悬浮动效）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1607 条。点号进各自文件。
+> 共 1608 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1746](bugs/BUG-1746-subscription-never-retries-failed-episode.md) | ✅ | ✅ | 订阅只看 jobId 存在就跳过，故障集永久卡死不再下载 |
 | [BUG-1742](bugs/BUG-1742-extension-hidden-dict-still-shown.md) | ✅ | ✅ | 浏览器扩展里被关闭的词典仍然出释义 |
 | [BUG-1741](bugs/BUG-1741-browser-extension-page-no-back.md) | ✅ | ✅ | 浏览器扩展页被设置 push 进来时没有返回键 |
 | [BUG-1731](bugs/BUG-1731-host-video-progress-reverse-sync.md) | ✅ | ✅ | 互联子端看片进度不反向推进 host 的继续观看/下一集 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1605 条。点号进各自文件。
+> 共 1607 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1742](bugs/BUG-1742-extension-hidden-dict-still-shown.md) | ✅ | ✅ | 浏览器扩展里被关闭的词典仍然出释义 |
+| [BUG-1741](bugs/BUG-1741-browser-extension-page-no-back.md) | ✅ | ✅ | 浏览器扩展页被设置 push 进来时没有返回键 |
 | [BUG-1731](bugs/BUG-1731-host-video-progress-reverse-sync.md) | ✅ | ✅ | 互联子端看片进度不反向推进 host 的继续观看/下一集 |
 | [BUG-1730](bugs/BUG-1730-ass-word-wrap-midword-break.md) | ✅ | ✅ | ass 字幕英文单词中间断行（Wrap 逐字符换行无词边界） |
 | [BUG-1729](bugs/BUG-1729-waveform-cue-strip-overlap.md) | ✅ | ✅ | 波形对轴弹窗字幕条带重叠cue叠画 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,10 +33,10 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1749](bugs/BUG-1749-extension-hidden-dict-still-shown.md) | ✅ | ✅ | 浏览器扩展里被关闭的词典仍然出释义 |
+| [BUG-1748](bugs/BUG-1748-browser-extension-page-no-back.md) | ✅ | ✅ | 浏览器扩展页被设置 push 进来时没有返回键 |
 | [BUG-1747](bugs/BUG-1747-subtitle-source-settings-width-tear.md) | ✅ | ✅ | 字幕来源设置三种行各有一套左右边界 |
 | [BUG-1746](bugs/BUG-1746-subscription-never-retries-failed-episode.md) | ✅ | ✅ | 订阅只看 jobId 存在就跳过，故障集永久卡死不再下载 |
-| [BUG-1742](bugs/BUG-1742-extension-hidden-dict-still-shown.md) | ✅ | ✅ | 浏览器扩展里被关闭的词典仍然出释义 |
-| [BUG-1741](bugs/BUG-1741-browser-extension-page-no-back.md) | ✅ | ✅ | 浏览器扩展页被设置 push 进来时没有返回键 |
 | [BUG-1731](bugs/BUG-1731-host-video-progress-reverse-sync.md) | ✅ | ✅ | 互联子端看片进度不反向推进 host 的继续观看/下一集 |
 | [BUG-1730](bugs/BUG-1730-ass-word-wrap-midword-break.md) | ✅ | ✅ | ass 字幕英文单词中间断行（Wrap 逐字符换行无词边界） |
 | [BUG-1729](bugs/BUG-1729-waveform-cue-strip-overlap.md) | ✅ | ✅ | 波形对轴弹窗字幕条带重叠cue叠画 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1608 条。点号进各自文件。
+> 共 1609 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1747](bugs/BUG-1747-subtitle-source-settings-width-tear.md) | ✅ | ✅ | 字幕来源设置三种行各有一套左右边界 |
 | [BUG-1746](bugs/BUG-1746-subscription-never-retries-failed-episode.md) | ✅ | ✅ | 订阅只看 jobId 存在就跳过，故障集永久卡死不再下载 |
 | [BUG-1742](bugs/BUG-1742-extension-hidden-dict-still-shown.md) | ✅ | ✅ | 浏览器扩展里被关闭的词典仍然出释义 |
 | [BUG-1741](bugs/BUG-1741-browser-extension-page-no-back.md) | ✅ | ✅ | 浏览器扩展页被设置 push 进来时没有返回键 |

--- a/docs/bugs/BUG-1741-browser-extension-page-no-back.md
+++ b/docs/bugs/BUG-1741-browser-extension-page-no-back.md
@@ -1,0 +1,27 @@
+## BUG-1741 · 浏览器扩展页被设置 push 进来时没有返回键
+- **报告**：2026-08-19（用户：设置 → 查词 → 浏览器扩展，进去之后没有返回键）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/pages/implementations/browser_extension_page.dart:143`
+- **[x] ① 已修复** — `browser_extension_page.dart` 的 `FushiPageHeader` 按 `Navigator.canPop()` 补 `leading` 返回键
+- **[x] ② 已加自动化测试** — `fushi/test/pages/browser_extension_page_back_button_guard_test.dart`（源码扫描守卫，已变异实测：退回无 leading 的原状必红）
+- **备注**：
+
+### 根因
+
+`BrowserExtensionPage` 是**双身份页**，但只按其中一半写了页头：
+
+1. 桌面顶层导航 tab（`home_page.dart` 的 `HomeTab`）——侧栏在旁边，`canPop()` 为 false，本就不该有返回箭头。BUG-1658 把顶层各 tab 页头统一成 `FushiPageHeader` 大标题时，只考虑了这一半。
+2. 设置项 `settings_schema_lookup.dart:164` 的 `SettingsNavigationItem` 又把**同一个 widget** `pushSettingsPage` 成全屏 `MaterialPageRoute`（`settings_actions.dart:17-27`，裸 push 不套页壳）。此时它推在根 Navigator 上，**把左侧导航栏一起盖掉**，而 `FushiPageHeader(title: ...)` 没传 `leading`、`Scaffold` 也没有 `appBar` ⇒ 页面上不存在任何返回控件。
+
+对照组说明这不是页壳的锅：相邻的「词典管理」走 `AdaptiveSettingsScaffold` → `FushiToolScaffold` 拿自动 leading；「自定义 CSS」「管理音频来源」是 dialog 自带关闭。
+
+同仓 `DownloadsPage` 是**完全同构的双身份页**，它按 `canPop()` 分流（`downloads_page.dart:172-190`），注释原文写着「独立 push 进来（无 home 壳）时在 leading 位保留返回按钮——旧 AppBar 的自动返回键由这里承接」。本页漏掉了这一半。
+
+### 不是死锁，但属 UI 缺失
+
+Esc 实际可退：`ShortcutAction.globalBack` 默认绑 Esc / Alt+← / 手柄 B（`shortcut_defaults.dart:161-166`），处理体 `global_navigation.dart:222-230` 判 `_topRouteIsPopup` 为 false（这里是 `MaterialPageRoute` 不是 `PopupRoute`）⇒ 真 pop，且该页没写 `PopScope` 拦截。但没有任何视觉提示，鼠标用户唯一能做的就是关窗口。
+
+### 修复
+
+`browser_extension_page.dart:143` 照抄 `DownloadsPage` 既有范式，按 `Navigator.of(context).canPop()` 给 `leading`。作顶层 tab 时 `canPop()` 为 false，`leading` 仍是 null，**页头几何与 BUG-1658 的结论完全不变**。
+
+未选用的替代方案：改用 `AdaptiveSettingsScaffold`/`FushiToolScaffold` 拿自动 leading——那会把顶层 tab 的页头几何换成小标题工具栏，正是 BUG-1658 修掉的东西，属回归。

--- a/docs/bugs/BUG-1742-extension-hidden-dict-still-shown.md
+++ b/docs/bugs/BUG-1742-extension-hidden-dict-still-shown.md
@@ -1,0 +1,42 @@
+## BUG-1742 · 浏览器扩展里被关闭的词典仍然出释义
+- **报告**：2026-08-19（用户：浏览器的关闭了日语词典，但是还是显示日语词典）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/sync/fushi_remote_api_handlers.dart:99-109`（响应 envelope 不下发隐藏名单）+ `packages/fushi_dictionary/lib/src/language/language.dart:497`（popupJson 生成期不过滤）
+- **[x] ① 已修复** — 过滤下沉到 `buildPopupJsonFromLookup` 这个唯一数据出口，四个消费者一次性全对
+- **[x] ② 已加自动化测试** — `fushi/test/pages/popup_hidden_dictionary_filter_test.dart` 新增两条源码扫描守卫（已做三轮变异实测）
+- **备注**：同根顺带修好「扩展制卡把隐藏词典释义写进 Anki 卡片」（BUG-432 在扩展路径上的原样重现）
+
+### 根因：三镜像漏了第三面
+
+「禁用词典」不是 `enabled` 布尔列，是 `dictionary_metadata.hidden_languages_json`（`tables.dart:306-330`），判据 `Dictionary.isHidden(language)`（`dictionary.dart:82-84`）。
+
+关键结构性前提（`app_model.dart` 的 `bucketDictPaths`，注释原文）：**隐藏的 freq/pitch/kanji 不进 FFI 引擎，但 term 词典故意仍进桶**——因为 term 的隐藏「在渲染期按 hidden 过滤」。于是 term 的过滤只活在 JS 里：
+
+- 宿主注入 `window.hiddenDictionaryNames`（`popup_settings_injection.dart:739`）
+- JS 消费（`assets/popup/popup.js` 的 `createGlossarySectionWrapper` + 制卡字段组装）
+
+这条注入通道只有 `dictionary_popup_webview.dart` 走（app 内三个表面 + 全局查词窗）。**浏览器扩展是同一份 `popup.js` 的第三面镜子，宿主换成了 HTTP 响应，那一步注入从来没跟过来**：
+
+- `fushi_remote_api_handlers.dart:99-109` 的响应 envelope 只有 `theme` / `audioSources` / `extensionBuild` / `dictionaryStyles*`，**没有 `hiddenDictionaryNames`**
+- 扩展侧 `content.js` / `side-panel.js` 只 `window.audioSources = ...`，从不置位 hidden
+- ⇒ 扩展里 `window.hiddenDictionaryNames` 恒为 `undefined` → `|| []` → **一条都不滤**
+
+查询侧两边**本来就是同源的**（同一 `AppModel`、同一 FFI 引擎、同一 `buildPopupJsonFromLookup`、同一 `_popupSearchCache`），所以这**不是**引擎问题、不是缓存陈旧、不是 profile 串味：切换开关时 `app_model.dart` 已经 `FushiDicts.initializeTyped` 重建引擎并 `clearDictionaryResultsCache()` 清掉 `_popupSearchCache`，扩展下一次查词拿到的就是全新算的 popupJson——它只是从头到尾没收到过隐藏名单。
+
+守卫看不见第三面镜子：原 `popup_hidden_dictionary_filter_test.dart` 只扫 `assets/popup/popup.js` 与 `dictionary_popup_webview.dart` 的注入，扩展宿主（HTTP 响应）不在扫描面内，所以 BUG-419 / BUG-432 修完之后这条泄漏一直没人发现。
+
+### 修复：过滤下沉到唯一数据出口，而不是给第三面镜子再补一次注入
+
+未选用的方案 A（在 envelope 加 `hiddenDictionaryNames` + 扩展三处 `window.xxx = ...` 置位）：那等于承认「每新增一个宿主都要记得再注入一次」，下一个消费者照样会漏。
+
+采用的方案：`buildPopupJsonFromLookup` 加**必填** `required Set<String> hiddenDictionaries`，在 glossary 循环最前 `continue`（`language.dart`）。
+
+- 必填而非可选带默认值：可选参数等于允许调用点静默漏传，编译器不管；必填让三个生产调用点在编译期强制传。
+- `continue` 放在循环最前而不是只跳 `groupGlossaries.add`：只有隐藏词典释义的词头不该撑起一张空卡片，也不该占用 `maximumTerms` 词头预算。
+- 隐藏名单收口成 `AppModel.hiddenDictionaryNames` 单一 getter，`popup_settings_injection.dart` 改为消费它（此前那个 `where/map` 表达式只有注入侧独有一份，别的消费者拿不到）。
+
+效果：popupJson 从源头就不含隐藏词典 ⇒ **app 内弹窗 / 全局查词窗 / 浏览器扩展 / 制卡四条路径同时对齐**，JS 侧原有的 `hiddenDictionaryNames.includes` 过滤退化为冗余保险。
+
+### 已知遗留（不在本次范围）
+
+1. `window.collapsedDictionaryNames`（折叠词典）同样没下发给扩展，扩展里「折叠」仍不生效。折叠是纯展示态，不适合在数据源剔除，需要另走 envelope 补下发。
+2. 隐藏判据四处都硬编码 `JapaneseLanguage.instance`（`app_model.dart` ×3、`dictionary_dialog_page.dart:1467`）。本仓无全局学习语言，这是既有隐患；本次保持语义不变，未扩大改动面。

--- a/docs/bugs/BUG-1746-subscription-never-retries-failed-episode.md
+++ b/docs/bugs/BUG-1746-subscription-never-retries-failed-episode.md
@@ -1,0 +1,89 @@
+## BUG-1746 · 订阅只看 jobId 存在就跳过，故障集永久卡死不再下载
+- **报告**：2026-08-19（用户：我是订阅的从第三集下载开始，它只给我下载了 5、6、7 集）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/media/video/download/video_download_subscription_service.dart` 的入队去重判据（两处副本）
+- **[x] ① 已修复** — 判据收成 `videoDownloadJobLifecycleStillCounts` / `subscriptionItemStillClaimed` 单一真相源，按任务真实下场决定要不要重派
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/video_download_subscription_service_test.dart` 的 `BUG-1746 订阅重试判据` group（真行为测试，走内存 DB + 真 service，已双向变异实测）
+- **备注**：用户生产库实证见下
+
+### 用户生产库实证（2026-08-19 取，只读副本）
+
+唯一一条订阅（Re:Zero 4th Season，`start_after_episode=1`）的 13 条 `video_download_subscription_items`
+与 `video_download_jobs` 关联后：
+
+| 集 | items.status | job.lifecycle | 备注 |
+|---|---|---|---|
+| ep01–02 | queued | **needsAttention** | `The built-in download engine runtime is missing` |
+| ep03–08 | queued | **cancelled** | 08-12 23:53:58→23:54:06 连续取消 |
+| ep09–12 | queued | completed | |
+| ep13 | queued | active | 下载中 9% |
+
+**起始集数逻辑本身是对的**（13 集全部被正确识别并建了条目，集号解析没出错）。用户看到的
+「只下了中间几集」是这 8 集入队后再没被重试过。
+
+### 根因：把「派过任务」当成了「任务成功了」
+
+```dart
+// 旧判据（去重）
+if (existing != null &&
+    (existing.jobId != null || status in {queued, processed, skipped})) {
+  continue;   // ← 完全不看那个 job 现在什么状态
+}
+// 旧判据（入队，第二处副本）
+if (item.jobId != null) return true;
+```
+
+`jobId` 只说明**曾经派过任务**，不说明任务成功了。任务被取消或失败之后 jobId 依然留在订阅
+条目上，于是每轮轮询都 `continue` / `return true`，那一集再也不会被下载。
+
+这是本仓反复出现的形状：**两件事编成一个字段**（对照 `anime_download_service` 的
+`plan.importedEarly` 把「已入库」和「内容已定稿」编成一个 bool）。
+
+三处同一判据的副本让它更难发现：
+1. `_checkSubscription` 的去重 `existing.jobId != null`
+2. `_enqueueItem` 开头的 `if (item.jobId != null) return true;`
+3. `_enqueueItem` 里复用既有任务的循环——它按 fingerprint+provider+resourceId 匹配，
+   **会把一个已经 failed 的旧任务重新绑回条目**，放开前两处后这里会让该集在
+   「重派 → 立刻又撞上失败任务」之间空转。
+
+### 修复
+
+判据收成两个纯函数（`video_download_subscription_service.dart` 顶层，可直接单测）：
+
+- `videoDownloadJobLifecycleStillCounts(String? lifecycle)`
+- `subscriptionItemStillClaimed(item, lifecycleByJobId)`
+
+分界线按**是谁决定不下的**划，而不是按「成功/失败」划：
+
+| lifecycle | 还算数？ | 理由 |
+|---|---|---|
+| `active` / `completed` | ✅ | 显然有人在管 |
+| `cancelled` | ✅ | 用户明确说「不要这一集」。自动补回来的话用户永远取消不掉 |
+| `failed` / `needsAttention` | ❌ | 系统故障（实测例：内置下载引擎运行时缺失）。故障排除后本该继续 |
+| 任务记录不存在（null） | ❌ | 没有任何东西在管这一集 |
+
+`_enqueueItem` 里那份重复判据**直接删掉**（而不是也改一遍）——判据只留一处，注释写明前置
+条件由调用方保证；复用既有任务的循环补上同一判据，不再把失败任务绑回来。
+
+`_managedEpisodeKeys`（文件级「这一集是否已经在库里」）保持不动：它排除 cancelled/failed
+但保留 needsAttention 是对的，因为一个 needsAttention 的任务可能已经把文件下好了。两者
+语义不同、层级不同，顺序上先判任务级再判文件级，自洽。
+
+### 测试期间发现的假绿（记录下来防止后人重蹈）
+
+新测试第一版「不重复入队」的用例是**假绿**：`_drain()` 只认领**已到期**的订阅
+（`claimNextVideoDownloadSubscription(nowAt:)`），第一轮跑完 `nextCheckAt = 当前 + checkInterval`。
+测试里 `now` 固定，第二轮 `checkNow()` 根本认领不到订阅、整轮空转——断言「没有重复入队」
+于是恒真，测的是「压根没跑」而不是「跑了但正确地没派」。修法是让第二轮的 service 时钟
+前进到 nextCheckAt 之后（`runRound(atMs:)`）。
+
+### 变异实测
+
+- 判据退回「派过就算数」（`stillCounts` 恒 true）→ needsAttention / failed 两条用例必红 ✅
+- 判据把 cancelled 也算作可重试 → 「用户取消不会被自动补回来」用例必红 ✅
+- 两次还原后源文件 sha256 逐字节一致 ✅
+
+### 未修（另立）
+
+订阅面板不显示条目级状态，用户无从看出「这几集失败了」。`items.status` 也确实不跟随
+job lifecycle（13 条全停在 `queued`），但它没有 UI 消费者、只用于去重，本次不动它——
+真正该做的是面板上给订阅条目一个可见的失败/取消态，属功能新增而非本 bug 范围。

--- a/docs/bugs/BUG-1747-subtitle-source-settings-width-tear.md
+++ b/docs/bugs/BUG-1747-subtitle-source-settings-width-tear.md
@@ -1,0 +1,49 @@
+## BUG-1747 · 字幕来源设置三种行各有一套左右边界
+- **报告**：2026-08-19（用户：设置 → 视频 → 字幕来源「这个右边的 UI 不太对劲」）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart` 的 `_field` 局部限宽 480 与整段缺少统一宽度容器
+- **[x] ① 已修复** — 整段收进 `kTorrentSettingsContentMaxWidth`（560）左对齐容器，删掉 `_field` / `_subtitleLanguageField` 各自那份 480
+- **[x] ② 已加自动化测试** — `fushi/test/settings/video_external_provider_settings_section_test.dart` 的宽窗边界一致性用例（已变异实测）
+- **备注**：同一份 `_field` 拷贝也在 `torrent_settings_section.dart:238`，「下载 → 外部来源」那段有同样的撕裂，本次未动（见「未修」）
+
+### 现象（用户截图实测几何）
+
+右侧内容 pane 从 x≈430 一直到窗口右缘（≥1415），而：
+
+| 行 | 宽度 | 来源 |
+|---|---|---|
+| 单列输入框（API 端点 / API 密钥 / User-Agent / 默认字幕语言） | 约 573px | `_field` 自己的 `ConstrainedBox(maxWidth: 480)` × 界面缩放 1.19 |
+| Switch（已启用 / 允许不安全的 HTTP） | 占满整个 pane，拇指贴 x≈1385 | 裸 `SwitchListTile.adaptive` 吃 `CrossAxisAlignment.stretch` 的**紧约束** |
+| 用户名 / 密码 | 第三套：各占 pane 一半 | `Row` 全宽 → `Expanded` 各半 → `_field` 的 480 在半宽下不生效 |
+
+看起来就是「输入框只占左半边、开关孤零零贴在最右、中间一大片空白」，双列行还和上下的单列框右边缘对不齐。
+
+### 根因：同一个 Column 里三种孩子用三种方式消费约束
+
+不是某一行写错了，是**这一段从来没有一对共同的左右边界**。`Align + ConstrainedBox` 让输入框自己缩，`stretch` 让开关自己撑满，`Expanded` 让双列行按父宽二分——三者各自都"对"，合在一起就撕。
+
+### 这个问题修过一次，又被撤掉了
+
+- `BUG-1084`：4K 下输入框被拉到 3000px → 引入 `_field` 的 480 局部限宽。
+- `BUG-1278`（2026-07-29，**用户报的就是这次同样的现象**）→ 修法是把整组表单收进 `kTorrentSettingsContentMaxWidth = 560` 并居中。
+- `040e583eac`（2026-08-03，PR #751）加了 `constrainWidth` 开关，把设置详情 pane 的两个调用点全改成 `constrainWidth: false` 走 full-bleed 分支。**BUG-1278 的修复在真实 app 里就此失效**——而守卫 `torrent_settings_field_width_test.dart` 只测 `constrainWidth: true`，所以一直是绿的，没人发现。
+
+更关键的是：用户这次报的**字幕来源**那段走的是 `settings_schema_video.dart:1191` 的 `SettingsCustomItem`，**根本不经过 `TorrentSettingsSection`**，从来就没有任何外层宽度容器。
+
+### 修复
+
+`VideoExternalProviderSettingsSection` 内部新增 `_constrainSectionWidth`，build 的两个分支都套上：左对齐 + `maxWidth: kTorrentSettingsContentMaxWidth`。同时删掉 `_field` 与 `_subtitleLanguageField` 各自那份 480——它们的存在理由（BUG-1084）由外层容器完整承接。
+
+于是三种行的宽度都等于容器宽度：单列框填满、Switch 填满、双列行两半合计填满，左右边界完全一致。
+
+用**左对齐**而不是 BUG-1278 的居中：这一段嵌在设置详情的行流里，居中会与上下普通设置行的左基线再撕一次。
+
+### 测试
+
+宽窗（1400）harness 是必需的：560 的窄 harness 下输入框（旧上限 480）与开关只差 80px，肉眼和断言都容易放过；1400 下差距是几百像素，正是用户截图的样子。断言三者左右边缘重合，并保留「输入框宽度 ≤561」守住 BUG-1084。
+
+变异实测：把 `_field` 的局部 480 加回去 → 用例必红；还原后源文件 sha256 逐字节一致。
+
+### 未修（同源，另立）
+
+1. `torrent_settings_section.dart:238` 有同一份 `_field` 拷贝（也是 480），「设置 → 下载 → 外部来源」那段在 `constrainWidth: false` 下有一模一样的撕裂。两份 `_field` 应当合并成一个共享组件，而不是各修各的。
+2. `settings_schema_downloads.dart:58` / `downloads_page.dart:483` 的 `constrainWidth: false` 让 BUG-1278 的修复在真实 app 里失效，而守卫只测 `true` 分支。这是「修复只活在测试里」的典型，值得单独复核 PR #751 的意图。

--- a/docs/bugs/BUG-1748-browser-extension-page-no-back.md
+++ b/docs/bugs/BUG-1748-browser-extension-page-no-back.md
@@ -1,9 +1,9 @@
-## BUG-1741 · 浏览器扩展页被设置 push 进来时没有返回键
+## BUG-1748 · 浏览器扩展页被设置 push 进来时没有返回键
 - **报告**：2026-08-19（用户：设置 → 查词 → 浏览器扩展，进去之后没有返回键）
 - **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/pages/implementations/browser_extension_page.dart:143`
 - **[x] ① 已修复** — `browser_extension_page.dart` 的 `FushiPageHeader` 按 `Navigator.canPop()` 补 `leading` 返回键
 - **[x] ② 已加自动化测试** — `fushi/test/pages/browser_extension_page_back_button_guard_test.dart`（源码扫描守卫，已变异实测：退回无 leading 的原状必红）
-- **备注**：
+- **备注**：最初以 BUG-1741 提交（见 commit 信息），开 PR 前 `bug.dart check` 报与在飞分支 `worktree-fix-four-issues-20260819` 撞号，按规则 `renumber 1741 1748`。
 
 ### 根因
 

--- a/docs/bugs/BUG-1749-extension-hidden-dict-still-shown.md
+++ b/docs/bugs/BUG-1749-extension-hidden-dict-still-shown.md
@@ -1,9 +1,9 @@
-## BUG-1742 · 浏览器扩展里被关闭的词典仍然出释义
+## BUG-1749 · 浏览器扩展里被关闭的词典仍然出释义
 - **报告**：2026-08-19（用户：浏览器的关闭了日语词典，但是还是显示日语词典）
 - **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/sync/fushi_remote_api_handlers.dart:99-109`（响应 envelope 不下发隐藏名单）+ `packages/fushi_dictionary/lib/src/language/language.dart:497`（popupJson 生成期不过滤）
 - **[x] ① 已修复** — 过滤下沉到 `buildPopupJsonFromLookup` 这个唯一数据出口，四个消费者一次性全对
 - **[x] ② 已加自动化测试** — `fushi/test/pages/popup_hidden_dictionary_filter_test.dart` 新增两条源码扫描守卫（已做三轮变异实测）
-- **备注**：同根顺带修好「扩展制卡把隐藏词典释义写进 Anki 卡片」（BUG-432 在扩展路径上的原样重现）
+- **备注**：最初以 BUG-1742 提交（见 commit 信息），撞号后 `renumber 1742 1749`。同根顺带修好「扩展制卡把隐藏词典释义写进 Anki 卡片」（BUG-432 在扩展路径上的原样重现）
 
 ### 根因：三镜像漏了第三面
 

--- a/fushi/lib/src/media/collections/collection_drag.dart
+++ b/fushi/lib/src/media/collections/collection_drag.dart
@@ -15,6 +15,8 @@ library;
 import 'package:flutter/material.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+import 'package:fushi/src/focus/fushi_focus_controller.dart'
+    show FushiFocusRoot;
 import 'package:fushi/utils.dart';
 
 /// [addMediaRefToCollection] 的结果：三种结局各自对应一条不同的用户可见提示。
@@ -103,7 +105,7 @@ Future<CollectionAddOutcome> addMediaRefToCollection({
 ///
 /// [enabled] 为 false 时原样返回 [child]（不建 Draggable）——多选态下卡片点击是
 /// 切换选中，此时不应能拖走。
-class MediaCardDraggable extends StatelessWidget {
+class MediaCardDraggable extends StatefulWidget {
   const MediaCardDraggable({
     required this.mediaRef,
     required this.label,
@@ -124,34 +126,117 @@ class MediaCardDraggable extends StatelessWidget {
   final bool enabled;
 
   @override
+  State<MediaCardDraggable> createState() => _MediaCardDraggableState();
+}
+
+class _MediaCardDraggableState extends State<MediaCardDraggable> {
+  /// 挂在 [Draggable] 上，供浮层量取**原卡的真实尺寸**。
+  ///
+  /// 不能改用 `LayoutBuilder` 拿父约束：父约束常常是宽松的（卡片直接放在
+  /// `Scaffold.body` 里时是 0..屏宽 × 0..屏高），拿它当浮层尺寸会把浮层撑成
+  /// 整屏。`Draggable` 的 RenderBox 尺寸就等于卡片尺寸，且拖动期间
+  /// （child 被 `childWhenDragging` 等尺寸替换）保持不变。
+  final GlobalKey _anchorKey = GlobalKey();
+
+  @override
   Widget build(BuildContext context) {
-    if (!enabled) return child;
+    if (!widget.enabled) return widget.child;
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         // 触屏：不建拖拽源（见类 doc）。
-        return child;
+        return widget.child;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
       case TargetPlatform.macOS:
         return Draggable<MediaRef>(
-          data: mediaRef,
-          // 浮层跟指针而不是保持「按下点相对卡片的位置」：浮层是紧凑 chip、尺寸
-          // 与原卡完全不同，沿用 childDragAnchorStrategy 会让它偏到指针外面去。
-          dragAnchorStrategy: pointerDragAnchorStrategy,
-          feedback: _DragFeedback(label: label),
-          childWhenDragging: Opacity(opacity: 0.3, child: child),
-          child: child,
+          key: _anchorKey,
+          data: widget.mediaRef,
+          // 卡片形浮层与原卡同尺寸，保持「按下点相对卡片的位置」才跟手。
+          // （旧实现的浮层是紧凑 chip、尺寸与原卡完全不同，才必须改用
+          // pointerDragAnchorStrategy 把浮层钉在指针上。）
+          dragAnchorStrategy: childDragAnchorStrategy,
+          feedback: _CardDragFeedback(
+            anchorKey: _anchorKey,
+            label: widget.label,
+            child: widget.child,
+          ),
+          childWhenDragging: Opacity(opacity: 0.3, child: widget.child),
+          child: widget.child,
         );
     }
   }
 }
 
-/// 拖拽浮层：紧凑 chip（图标 + 条目名），不复用卡片本体。
+/// 拖拽浮层：把卡片本体原样再渲染一份，跟着指针走。
 ///
-/// 刻意不拿 [MediaCardDraggable.child] 当 feedback：卡片内含 `FushiFocusTarget`
-/// （焦点 id 唯一）与 `InkWell`，同一棵树里渲染第二份会造成焦点 id 撞车。
+/// 复用真卡而不是手写一份「纯视觉副本」——后者必然与真卡漂移（改了卡片样式忘了
+/// 改浮层，两处越走越远）。
+///
+/// 卡片内含 `FushiFocusTarget`，同一棵树里渲染第二份本来会撞焦点 id：焦点表按 id
+/// 唯一（`FushiFocusController.register` 是 `_entries[id] = entry` 直接覆盖），
+/// 第二份注册会顶掉真卡的 entry，浮层消失时 `unregister` 又把这条 entry 整个删
+/// 掉，真卡从此在手柄/键盘焦点表里消失。
+///
+/// 这里用 `FushiFocusRoot(enabled: false)` 把浮层子树的焦点控制器屏蔽成 null
+/// （[FushiFocusRoot.enabled] 的既有语义：结构恒定、只把 scope 暴露的 controller
+/// 置空），子树里的 `FushiFocusTarget._register` 因 `controller == null` 直接
+/// 返回——**撞车的前提不存在了**，于是不必再要求每个调用方手写副本。
+///
+/// feedback 由 Flutter 的 `_DragAvatar` 包在 `IgnorePointer` 里，卡片内的
+/// `InkWell` / 菜单按钮在浮层上不会响应，无需额外处理。
+class _CardDragFeedback extends StatelessWidget {
+  const _CardDragFeedback({
+    required this.anchorKey,
+    required this.label,
+    required this.child,
+  });
+
+  /// 原卡所在的 [Draggable]，用来量它的真实尺寸。
+  final GlobalKey anchorKey;
+
+  /// 量不到尺寸时降级用的条目名。
+  final String label;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    // build 发生在拖动开始、浮层插进 Overlay 的那一刻，此时原卡早已 layout 完，
+    // 量得到确定尺寸。量不到（理论上只会在原卡同帧被移除时发生）就降级成 chip：
+    // 无约束地渲染一张卡片可能撑爆 Overlay。
+    final RenderObject? box = anchorKey.currentContext?.findRenderObject();
+    final Size? size = box is RenderBox && box.hasSize ? box.size : null;
+    if (size == null || size.isEmpty) return _DragFeedback(label: label);
+    return FushiFocusRoot(
+      enabled: false,
+      child: Opacity(
+        opacity: 0.92,
+        child: Material(
+          color: Colors.transparent,
+          elevation: 8,
+          borderRadius: tokens.radii.cardRadius,
+          clipBehavior: Clip.antiAlias,
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 拖拽浮层（降级）：紧凑 chip（图标 + 条目名）。
+///
+/// 只在量不到原卡尺寸时使用；正常情况走 [_CardDragFeedback]。
+///
+/// （旧注释「刻意不拿 child 当 feedback，会撞焦点 id」已不再成立：
+/// [_CardDragFeedback] 用 `FushiFocusRoot(enabled: false)` 屏蔽了浮层子树的
+/// 焦点注册。这里保留 chip 只是为了拿不到卡片尺寸时有个安全降级。）
 class _DragFeedback extends StatelessWidget {
   const _DragFeedback({required this.label});
 

--- a/fushi/lib/src/media/video/download/video_download_subscription_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_subscription_service.dart
@@ -42,6 +42,49 @@ class VideoDownloadSubscriptionConfigurationError implements Exception {
 /// `video_download_subscription_items`，最后才调用持久下载流水线 enqueue。
 /// 因此搜索重试、应用重启和多 worker 都不会把同一 `movie` / `SxxExx`
 /// 重复变成下载任务。
+/// 一个下载任务的下场还算不算数——即「这一集已经有人管了，订阅不用再派」。
+///
+/// BUG-1746 的根因是把「曾经派过任务」（`jobId != null`）当成了「任务成功了」。
+/// 两者不是一回事：任务被取消或失败之后 jobId 依然留在订阅条目上，旧判据据此
+/// 每轮都 `continue`，那一集就再也不会被下载——用户看到的是「订阅只下了中间
+/// 几集」，而面板上什么异常都不显示。
+///
+/// 分界线按**是谁决定不下的**划：
+/// - `cancelled` 是用户明确说「不要这一集」，尊重它，不自动重下（否则用户取消
+///   一次、订阅补回来一次，永远取消不掉）；
+/// - `failed` / `needsAttention` 是系统故障（实测例：内置下载引擎运行时缺失、
+///   种子源暂时不可达），故障排除之后本该继续下，不能让这一集永久卡死；
+/// - `active` / `completed` 显然还算数。
+///
+/// [lifecycle] 为 null 表示任务记录已经不在了（被清理/库被换过），此时没有任何
+/// 东西在管这一集，应当允许重新派。
+bool videoDownloadJobLifecycleStillCounts(String? lifecycle) {
+  if (lifecycle == null) return false;
+  return lifecycle != VideoDownloadJobLifecycle.failed &&
+      lifecycle != VideoDownloadJobLifecycle.needsAttention;
+}
+
+/// 这一集是否已经被一个「仍然算数」的任务认领。判据的唯一真相源——
+/// 入队去重与复用既有任务都走它，别再在别处写第二份 `jobId != null`。
+bool subscriptionItemStillClaimed(
+  VideoDownloadSubscriptionItemRow item,
+  Map<String, String> lifecycleByJobId,
+) {
+  // processed / skipped 是入队之外的终态：已经落库、或被明确判定为不用下。
+  // 它们与任务无关，不看 lifecycle。
+  if (item.status == VideoDownloadSubscriptionItemStatus.processed ||
+      item.status == VideoDownloadSubscriptionItemStatus.skipped) {
+    return true;
+  }
+  final String? jobId = item.jobId;
+  if (jobId == null) {
+    // 没有 jobId 却标着 queued 只可能是历史遗留行（_markItemQueued 必定同时写
+    // 两者）。保持旧行为不重复入队，避免给存量库凭空造重复任务。
+    return item.status == VideoDownloadSubscriptionItemStatus.queued;
+  }
+  return videoDownloadJobLifecycleStillCounts(lifecycleByJobId[jobId]);
+}
+
 class VideoDownloadSubscriptionService {
   VideoDownloadSubscriptionService({
     required this.database,
@@ -246,6 +289,12 @@ class VideoDownloadSubscriptionService {
     };
     final Set<String> managedEpisodeKeys =
         await _managedEpisodeKeys(subscription);
+    // BUG-1746：判「这一集还用不用管」必须看任务的真实下场，不能只看 jobId 在不在。
+    final Map<String, String> lifecycleByJobId = <String, String>{
+      for (final VideoDownloadJobRow job
+          in await database.getVideoDownloadJobs())
+        job.jobId: job.lifecycle,
+    };
     final List<String> keys = releasesByItem.keys.toList()
       ..sort(_compareLogicalItemKeys);
     bool hasPersistentJob = false;
@@ -253,11 +302,7 @@ class VideoDownloadSubscriptionService {
     for (final String key in keys) {
       final VideoDownloadSubscriptionItemRow? existing = existingByKey[key];
       if (existing != null &&
-          (existing.jobId != null ||
-              existing.status == VideoDownloadSubscriptionItemStatus.queued ||
-              existing.status ==
-                  VideoDownloadSubscriptionItemStatus.processed ||
-              existing.status == VideoDownloadSubscriptionItemStatus.skipped)) {
+          subscriptionItemStillClaimed(existing, lifecycleByJobId)) {
         hasPersistentJob = hasPersistentJob || existing.jobId != null;
         continue;
       }
@@ -473,7 +518,9 @@ class VideoDownloadSubscriptionService {
     VideoDownloadSubscriptionItemRow item,
   ) async {
     _ensureLeaseHeld();
-    if (item.jobId != null) return true;
+    // 前置条件：调用方已用 [subscriptionItemStillClaimed] 判过这一集还用不用管。
+    // 这里**不再**重复写一遍 `item.jobId != null` —— 那份副本正是 BUG-1746 的
+    // 第二道锁：放开上面的判定后它会照旧把重试挡在门外。判据只留一处。
     final String providerId = persistedVideoResourceProviderId(candidate);
     final List<VideoDownloadJobRow> jobs =
         await database.getVideoDownloadJobs();
@@ -482,6 +529,9 @@ class VideoDownloadSubscriptionService {
       if (job.fingerprint == subscription.fingerprint &&
           job.resourceProvider == providerId &&
           job.selectedResourceId == candidate.remoteId) {
+        // 复用既有任务前同样要看它算不算数：把一个 failed / needsAttention 的
+        // 旧任务重新绑回来，这一集会在「重派 → 立刻又撞上失败任务」之间空转。
+        if (!videoDownloadJobLifecycleStillCounts(job.lifecycle)) continue;
         await _markItemQueued(item.id, job.jobId);
         return true;
       }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1402,6 +1402,16 @@ class AppModel with ChangeNotifier {
   List<Dictionary> get pitchDictionaries => dictRepo.pitchDictionaries;
   List<Dictionary> get kanjiDictionaries => dictRepo.kanjiDictionaries;
 
+  /// 被用户在词典管理里关掉的词典名集合，查词结果生成与弹窗注入共用这一个真相源。
+  ///
+  /// term 词典是故意仍进 FFI 引擎的（见 [bucketDictPaths]：隐藏不影响匹配长度），
+  /// 所以隐藏必须在查询之后生效。收口到这里是为了防漂移：之前这个表达式只在
+  /// `popup_settings_injection` 里有一份，别的消费者（浏览器扩展的 HTTP 路径）拿不到它。
+  Set<String> get hiddenDictionaryNames => dictionaries
+      .where((Dictionary d) => d.isHidden(JapaneseLanguage.instance))
+      .map((Dictionary d) => d.name)
+      .toSet();
+
   bool _dictTypesMigrated = false;
 
   void _migrateDictionaryTypes() {
@@ -4936,6 +4946,7 @@ class AppModel with ChangeNotifier {
       result.popupJson = buildPopupJsonFromLookup(
         results: ffiResults,
         maximumTerms: effectiveMaxTerms,
+        hiddenDictionaries: hiddenDictionaryNames,
       );
       result = result.withKanjiResults(kanjiResults);
     } else {
@@ -4971,6 +4982,7 @@ class AppModel with ChangeNotifier {
         result.popupJson = buildPopupJsonFromLookup(
           results: ffiResults,
           maximumTerms: effectiveMaxTerms,
+          hiddenDictionaries: hiddenDictionaryNames,
         );
         result = result.withKanjiResults(kanjiResults);
       }
@@ -7529,6 +7541,7 @@ class _AppModelRemoteLookupService
       final String popupJson = buildPopupJsonFromLookup(
         results: ffiResults,
         maximumTerms: maximumTerms,
+        hiddenDictionaries: _appModel.hiddenDictionaryNames,
       );
       if (timing != null) {
         timing.popupJsonMicros = finishPhase(popupJsonWatch);

--- a/fushi/lib/src/pages/implementations/browser_extension_page.dart
+++ b/fushi/lib/src/pages/implementations/browser_extension_page.dart
@@ -140,7 +140,19 @@ class _BrowserExtensionPageState extends ConsumerState<BrowserExtensionPage> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          FushiPageHeader(title: t.nav_browser_extension),
+          // 本页是双身份页：作顶层 tab 时侧栏在旁边、canPop 为 false，不出箭头
+          // （页头几何与 BUG-1658 结论一致）；被「设置 → 查词 → 浏览器扩展」
+          // push 成全屏路由时侧栏被盖住，这里承接返回键（同 DownloadsPage 范式）。
+          FushiPageHeader(
+            title: t.nav_browser_extension,
+            leading: Navigator.of(context).canPop()
+                ? FushiIconButton(
+                    icon: Icons.arrow_back,
+                    tooltip: t.back,
+                    onTap: () => Navigator.of(context).maybePop(),
+                  )
+                : null,
+          ),
           Expanded(child: _buildContentList(theme, appModel)),
         ],
       ),

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -5651,14 +5651,20 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ],
       ),
     );
+    // 悬停抬升：与游戏库同一个壳（含墨水屏 / 减弱动态效果两处降级）。多选态
+    // 关掉——那时卡片是勾选目标，跟着指针放大只会干扰框选。
+    final Widget liftedCard = FushiHoverLift(
+      enabled: !_selectionMode,
+      builder: (BuildContext _, bool __) => fushiCard,
+    );
     // 选择态下禁用标签拖放命中（避免选卡时误触拖标签）。
     final Widget card = _selectionMode
-        ? fushiCard
+        ? liftedCard
         : BookDragTarget(
             bookId: book.bookUid,
             onTagDropped: (BookTagRow tag) =>
                 _addTagToVideoBook(book.bookUid, tag),
-            child: fushiCard,
+            child: liftedCard,
           );
     return CardDropZone<VideoBookRow>(
       meta: book,

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -624,10 +624,9 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
       .where((d) => d.isCollapsed(JapaneseLanguage.instance))
       .map((d) => d.name)
       .toList());
-  final String hiddenNames = jsonEncode(appModel.dictionaries
-      .where((d) => d.isHidden(JapaneseLanguage.instance))
-      .map((d) => d.name)
-      .toList());
+  // 与 popupJson 生成期共用同一个真相源，别再抄第二份表达式。
+  final String hiddenNames =
+      jsonEncode(appModel.hiddenDictionaryNames.toList());
   final String globalDictCSS = appModel.globalDictCSS;
   final String customDictCSSJson = jsonEncode(appModel.customDictCSS);
 

--- a/fushi/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -288,7 +288,14 @@ extension _ReaderHistoryCardWidgets on _ReaderFushiHistoryPageState {
       onLongPress: _selectionMode ? null : onLongPress,
       child: interactiveCard,
     );
-    Widget result = card;
+    // 悬停抬升：与游戏库 / 视频库同一个壳（内含墨水屏与「减弱动态效果」两处
+    // 降级）。多选态关掉——那时卡片是勾选目标，跟指针放大只会干扰框选。
+    // AnimatedScale 只做绘制变换、不改变 layout 尺寸，
+    // `book_drag_target_layout_test.dart` 的等尺寸断言仍成立。
+    Widget result = FushiHoverLift(
+      enabled: !_selectionMode,
+      builder: (BuildContext _, bool __) => card,
+    );
     if (dragBookId != null && onTagDropped != null && !_selectionMode) {
       result = BookDragTarget(
         bookId: dragBookId,

--- a/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
@@ -14,6 +14,8 @@ import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/subtitle/open_subtitles_client.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/source_toggle_section.dart';
+import 'package:fushi/src/pages/implementations/torrent_settings_section.dart'
+    show kTorrentSettingsContentMaxWidth;
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/utils/net/app_user_agent.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -429,30 +431,31 @@ class _VideoExternalProviderSettingsSectionState
     bool secret = false,
     TextInputType? keyboardType,
   }) {
+    // 宽度由整段的外层容器（[_constrainSectionWidth]）统一承接，这里不再自己
+    // 缩到 480——那份局部限宽正是几何撕裂的来源：同一个 Column 里输入框缩到
+    // 480、Switch 吃满 stretch 紧约束占满整宽、用户名/密码 Row 又各占一半，
+    // 三种行三套左右边界。
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 480),
-          child: TextFormField(
-            key: key,
-            initialValue: initialValue,
-            obscureText: secret,
-            enableSuggestions: !secret,
-            autocorrect: !secret,
-            keyboardType: keyboardType,
-            decoration: InputDecoration(
-              labelText: label,
-              hintText: hint,
-              helperText: helper,
-              helperMaxLines: 3,
-              errorText: errorText,
-              isDense: true,
-              border: const OutlineInputBorder(),
-            ),
-            onChanged: onChanged,
+      child: SizedBox(
+        width: double.infinity,
+        child: TextFormField(
+          key: key,
+          initialValue: initialValue,
+          obscureText: secret,
+          enableSuggestions: !secret,
+          autocorrect: !secret,
+          keyboardType: keyboardType,
+          decoration: InputDecoration(
+            labelText: label,
+            hintText: hint,
+            helperText: helper,
+            helperMaxLines: 3,
+            errorText: errorText,
+            isDense: true,
+            border: const OutlineInputBorder(),
           ),
+          onChanged: onChanged,
         ),
       ),
     );
@@ -700,56 +703,53 @@ class _VideoExternalProviderSettingsSectionState
   Widget _subtitleLanguageField() {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 480),
-          child: DropdownButtonFormField<String>(
-            key: const ValueKey<String>('video-subtitle-default-language'),
-            initialValue: _preferredLanguage,
-            // `isExpanded` + 逐项省略：不加的话 DropdownButton 按**内容固有宽度**
-            // 排版，长标签在 360px 紧凑布局里直接横向溢出（`compact layout has no
-            // horizontal overflow` 会红）。这里的选项以前全是 `日本語` / `中文`
-            // 这类两三字的短标签，才一直没暴露；`''` 从「全部」改成「跟随视频语言」
-            // 后就撞上了——而且这不是中文特有：17 份 i18n 里未翻译的那些落的是英文
-            // 原串 `Follow video language`，比中文还长。所以修的是约束，不是文案。
-            isExpanded: true,
-            decoration: InputDecoration(
-              labelText: t.video_setting_jimaku_default_language,
-              helperText: t.video_setting_jimaku_default_language_hint,
-              helperMaxLines: 3,
-              isDense: true,
-              border: const OutlineInputBorder(),
+      child: SizedBox(
+        width: double.infinity,
+        child: DropdownButtonFormField<String>(
+          key: const ValueKey<String>('video-subtitle-default-language'),
+          initialValue: _preferredLanguage,
+          // `isExpanded` + 逐项省略：不加的话 DropdownButton 按**内容固有宽度**
+          // 排版，长标签在 360px 紧凑布局里直接横向溢出（`compact layout has no
+          // horizontal overflow` 会红）。这里的选项以前全是 `日本語` / `中文`
+          // 这类两三字的短标签，才一直没暴露；`''` 从「全部」改成「跟随视频语言」
+          // 后就撞上了——而且这不是中文特有：17 份 i18n 里未翻译的那些落的是英文
+          // 原串 `Follow video language`，比中文还长。所以修的是约束，不是文案。
+          isExpanded: true,
+          decoration: InputDecoration(
+            labelText: t.video_setting_jimaku_default_language,
+            helperText: t.video_setting_jimaku_default_language_hint,
+            helperMaxLines: 3,
+            isDense: true,
+            border: const OutlineInputBorder(),
+          ),
+          items: <DropdownMenuItem<String>>[
+            DropdownMenuItem<String>(
+              value: '',
+              // 与设置页那份同一语义：`''` = 跟随视频语言，不是「全部」。
+              child: Text(
+                t.video_jimaku_language_follow_video,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-            items: <DropdownMenuItem<String>>[
+            for (final String language in kJimakuLanguageCodes)
               DropdownMenuItem<String>(
-                value: '',
-                // 与设置页那份同一语义：`''` = 跟随视频语言，不是「全部」。
+                value: language,
                 child: Text(
-                  t.video_jimaku_language_follow_video,
+                  jimakuLanguageLabel(language),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              for (final String language in kJimakuLanguageCodes)
-                DropdownMenuItem<String>(
-                  value: language,
-                  child: Text(
-                    jimakuLanguageLabel(language),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-            ],
-            onChanged: (String? value) {
-              final String language = value ?? '';
-              setState(() => _preferredLanguage = language);
-              _save(
-                (VideoExternalSettingsStore store) =>
-                    store.savePreferredSubtitleLanguage(language),
-              );
-            },
-          ),
+          ],
+          onChanged: (String? value) {
+            final String language = value ?? '';
+            setState(() => _preferredLanguage = language);
+            _save(
+              (VideoExternalSettingsStore store) =>
+                  store.savePreferredSubtitleLanguage(language),
+            );
+          },
         ),
       ),
     );
@@ -891,6 +891,29 @@ class _VideoExternalProviderSettingsSectionState
     );
   }
 
+  /// 把整段收进与下载设置同一个内容宽度（[kTorrentSettingsContentMaxWidth]）并
+  /// **左对齐**。
+  ///
+  /// 这一段此前三种行各有一套左右边界：输入框自己缩到 480；`SwitchListTile`
+  /// 直接吃 `CrossAxisAlignment.stretch` 的紧约束、贴到 pane 最右；用户名/密码
+  /// 的 `Row` 又是全宽再各占一半。宽窗下看起来就是「输入框只占左半边、开关孤零
+  /// 零在最右、中间一大片空白」。
+  ///
+  /// 收进同一个容器后三者边界一致，同时保住 BUG-1084 的结论（4K 全屏下输入框
+  /// 不会被拉到三千像素）。用左对齐而不是 BUG-1278 的居中：这一段嵌在设置详情
+  /// 的行流里，居中会与上下普通设置行的左基线再撕一次。
+  Widget _constrainSectionWidth(Widget content) {
+    return Align(
+      alignment: Alignment.topLeft,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: kTorrentSettingsContentMaxWidth,
+        ),
+        child: SizedBox(width: double.infinity, child: content),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -902,7 +925,7 @@ class _VideoExternalProviderSettingsSectionState
     if (_store == null) return const SizedBox.shrink();
     final ThemeData theme = Theme.of(context);
     if (widget.onlySubtitleSources) {
-      return Column(
+      return _constrainSectionWidth(Column(
         key: const ValueKey<String>('video-external-subtitle-sources'),
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
@@ -918,9 +941,9 @@ class _VideoExternalProviderSettingsSectionState
             ),
           ..._subtitleSourceBlocks(theme),
         ],
-      );
+      ));
     }
-    return Column(
+    return _constrainSectionWidth(Column(
       key: const ValueKey<String>('video-external-provider-settings'),
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -1036,7 +1059,7 @@ class _VideoExternalProviderSettingsSectionState
           ),
         const SizedBox(height: 8),
       ],
-    );
+    ));
   }
 }
 

--- a/fushi/lib/src/utils/components/fushi_hover_lift.dart
+++ b/fushi/lib/src/utils/components/fushi_hover_lift.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
+
+/// 卡片悬浮抬升：鼠标移入时轻微放大，并把 hover 态交给 [builder]，由调用方决定
+/// 还要不要顺带加深阴影/描边。
+///
+/// 抽出来的原因：这套动效原本只长在 [GalgamePosterCard] 里（全 app 唯一一处
+/// `AnimatedScale`），书架 / 漫画 / 视频库的卡片都只有 `InkWell` 水波纹、鼠标
+/// 悬停毫无反馈。把它复制到各库页会得到 N 份互相漂移的实现，所以先收成一个壳。
+///
+/// 两处降级是 [GalgamePosterCard] 原实现缺的，推广前必须补上——否则动效铺开
+/// 之后这两类设备/偏好会明显变差：
+/// - **墨水屏**（[isEinkTheme]）：持续缩放会不断触发整屏重绘刷屏，直接关掉动效，
+///   hover 反馈交给 builder 自己（通常改成描边）。
+/// - **减弱动态效果**（`MediaQuery.disableAnimations`，系统无障碍开关）：同样
+///   关掉缩放，但 hover 状态照常传给 builder，静态反馈保留。
+///
+/// 触屏平台上 [MouseRegion] 本就不会触发，无需按平台分流。
+class FushiHoverLift extends StatefulWidget {
+  const FushiHoverLift({
+    super.key,
+    required this.builder,
+    this.enabled = true,
+    this.scale = kFushiHoverLiftScale,
+  });
+
+  /// 拿到当前 hover 态自行构建内容。hover 态在 [enabled] 为 false 时恒为 false。
+  final Widget Function(BuildContext context, bool hovering) builder;
+
+  /// false 时既不建 [MouseRegion] 也不缩放（例如多选态、或调用方不想要动效）。
+  final bool enabled;
+
+  /// 悬停时的缩放倍数。默认与游戏库既有观感一致。
+  final double scale;
+
+  @override
+  State<FushiHoverLift> createState() => _FushiHoverLiftState();
+}
+
+/// 悬停缩放倍数：与 `docs/design/galgame-library-reina-visual-parity.md` 里定的
+/// 游戏库观感一致，推广到其余库页时不另立数值。
+const double kFushiHoverLiftScale = 1.05;
+
+/// 悬停动画时长（游戏库既有实现的落地值）。
+const Duration kFushiHoverLiftDuration = Duration(milliseconds: 120);
+
+class _FushiHoverLiftState extends State<FushiHoverLift> {
+  bool _hovering = false;
+
+  void _setHover(bool value) {
+    if (_hovering == value) return;
+    setState(() => _hovering = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) {
+      // 保证 builder 拿到的 hover 态与「没有 MouseRegion」一致。
+      if (_hovering) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _setHover(false);
+        });
+      }
+      return widget.builder(context, false);
+    }
+    final bool reduceMotion =
+        MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+    final bool animate = !reduceMotion && !isEinkTheme(context);
+    final Widget content = widget.builder(context, _hovering);
+    return MouseRegion(
+      onEnter: (_) => _setHover(true),
+      onExit: (_) => _setHover(false),
+      child: animate
+          ? AnimatedScale(
+              scale: _hovering ? widget.scale : 1.0,
+              duration: kFushiHoverLiftDuration,
+              curve: Curves.easeOut,
+              child: content,
+            )
+          : content,
+    );
+  }
+}

--- a/fushi/lib/src/utils/components/galgame_poster_card.dart
+++ b/fushi/lib/src/utils/components/galgame_poster_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+import 'package:fushi/src/utils/components/fushi_hover_lift.dart';
 import 'package:fushi/src/utils/components/shelf_card_widgets.dart';
 
 /// galgame 竖版海报卡（对齐 ReinaManager 库页/首页的卡片观感，见
@@ -67,20 +68,18 @@ class GalgamePosterCard extends StatefulWidget {
 }
 
 class _GalgamePosterCardState extends State<GalgamePosterCard> {
-  bool _hovering = false;
-
-  void _setHover(bool value) {
-    if (_hovering != value) {
-      setState(() => _hovering = value);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
+    // hover 态与缩放交给共享的 [FushiHoverLift]（书架 / 漫画 / 视频库同一套），
+    // 它顺带带来本组件原先缺的两处降级：墨水屏与「减弱动态效果」。
+    return FushiHoverLift(builder: _buildForHover);
+  }
+
+  Widget _buildForHover(BuildContext context, bool hovering) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colors = theme.colorScheme;
 
-    final Widget cover = _buildCover(context, colors);
+    final Widget cover = _buildCover(context, colors, hovering);
 
     final TextStyle? titleStyle = theme.textTheme.titleSmall?.copyWith(
       fontWeight: FontWeight.w600,
@@ -115,10 +114,9 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
       ],
     );
 
-    // hover 放大 + 阴影：AnimatedScale 做缩放，AnimatedContainer 做阴影过渡。
+    // 缩放由外层 [FushiHoverLift] 负责；这里只留光标与手势。阴影仍随 hovering
+    // 在 [_buildCover] 里插值（那是卡片自己的视觉，壳不该知道）。
     final Widget interactive = MouseRegion(
-      onEnter: (_) => _setHover(true),
-      onExit: (_) => _setHover(false),
       cursor:
           widget.onTap == null ? MouseCursor.defer : SystemMouseCursors.click,
       child: GestureDetector(
@@ -126,12 +124,7 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
         onLongPress: widget.onLongPress,
         onSecondaryTap: widget.onSecondaryTap,
         behavior: HitTestBehavior.opaque,
-        child: AnimatedScale(
-          scale: _hovering ? 1.05 : 1.0,
-          duration: const Duration(milliseconds: 120),
-          curve: Curves.easeOut,
-          child: card,
-        ),
+        child: card,
       ),
     );
 
@@ -167,9 +160,9 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
   late final FushiFocusId _fallbackFocusId =
       FushiFocusId('galgame-poster-${identityHashCode(this)}');
 
-  Widget _buildCover(BuildContext context, ColorScheme colors) {
+  Widget _buildCover(BuildContext context, ColorScheme colors, bool hovering) {
     const BorderRadius radius = FushiBorderRadius.poster;
-    final bool elevated = _hovering || widget.selected;
+    final bool elevated = hovering || widget.selected;
 
     return AspectRatio(
       aspectRatio: 3 / 4,

--- a/fushi/lib/utils.dart
+++ b/fushi/lib/utils.dart
@@ -20,6 +20,7 @@ export 'src/utils/components/fushi_text_selection_controls.dart';
 export 'src/utils/components/content_language_picker.dart';
 export 'src/utils/components/fushi_list_tile.dart';
 export 'src/utils/components/fushi_focusable.dart';
+export 'src/utils/components/fushi_hover_lift.dart';
 export 'src/utils/components/fushi_focus_ring.dart';
 export 'src/utils/components/galgame_poster_card.dart';
 export 'src/utils/components/fushi_design_tokens.dart';

--- a/fushi/test/media/collection_media_drop_test.dart
+++ b/fushi/test/media/collection_media_drop_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/media/collections/collection_drag.dart';
 import 'package:fushi/src/media/collections/collection_shelf_row.dart';
 
@@ -165,6 +167,131 @@ void main() {
 
     expect(droppedTag, isNotNull, reason: '标签通道必须收到');
     expect(droppedMedia, isNull, reason: '媒体通道绝不能被标签拖放误触发');
+  });
+
+  /// 拖拽浮层从「紧凑 chip（只有条目名）」改成「卡片本体」。
+  ///
+  /// 原实现刻意不复用卡片，理由写在旧注释里：卡片内含 `FushiFocusTarget`，
+  /// 焦点表按 id 唯一（`register` 是 `_entries[id] = entry` 直接覆盖），同一棵树
+  /// 渲染第二份会让浮层顶掉真卡的 entry，浮层消失时 `unregister` 又把这条 entry
+  /// 整个删掉——**真卡从此在手柄/键盘焦点表里消失**。
+  ///
+  /// 现在浮层用 `FushiFocusRoot(enabled: false)` 把子树的控制器屏蔽成 null，
+  /// 其中的 `FushiFocusTarget` 只渲染不注册。
+  ///
+  /// ⚠️ **变异实测结论（别高估下面第二条用例）**：把屏蔽整层去掉、把
+  /// `FushiFocusController.unregister` 的 `focusNode` / `owner` 双重校验去掉、
+  /// 两者同时去掉——三种变异下这一组**都照样全绿**。原因是拖动结束时真卡的
+  /// `FushiFocusTarget` 会 `didUpdateWidget` 重新注册，最终状态在所有变异下相同，
+  /// 而 `requestById` 只看「entry 在不在且可聚焦」，浮层那份 entry 同样满足。
+  ///
+  /// 所以第二条用例守住的是「拖完之后真卡仍可被焦点导航命中」这个**最终状态**
+  /// （能挡住 unregister 误删整条 entry 那类回归），**不是**屏蔽本身。屏蔽保留的
+  /// 理由是：意图明确，且避免拖动期间焦点表里的 entry 指向浮层那一份——该性质
+  /// 目前没有可落地的断言方式（controller 不暴露 entry，而给真卡传显式 FocusNode
+  /// 会被浮层复用同一实例、直接 assert）。留在这里是为了不让后人误以为它有守卫。
+  group('拖拽浮层是卡片本体', () {
+    const FushiFocusId cardFocusId = FushiFocusId('drag-card');
+    const Key cardVisualKey = Key('card-visual');
+
+    Future<FushiFocusController> pumpFocusableCard(WidgetTester tester) async {
+      late FushiFocusController controller;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.windows),
+          // 复刻真实 app 的层级：`main.dart` 把 FushiFocusRoot 挂在
+          // `MaterialApp.builder` 里，即**在 Navigator 之上**，于是 Overlay
+          // （Draggable 浮层的宿主）落在它之下、能拿到同一个 controller。
+          // 若像最初那样把它写进 `home:`，浮层反而在焦点根之外、天然拿不到
+          // controller——撞车根本不会发生，这一组守卫就成了空转（实测：去掉
+          // 屏蔽后测试照样全绿）。
+          builder: (BuildContext context, Widget? child) =>
+              FushiFocusRoot(child: child!),
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                controller = FushiFocusRoot.controllerOf(context);
+                return Align(
+                  alignment: Alignment.topLeft,
+                  child: MediaCardDraggable(
+                    mediaRef: bookRef,
+                    label: '書名',
+                    // 必须是能命中 hitTest 的可见盒：裸 SizedBox（无 child）
+                    // 的 RenderBox 不 hitTestSelf，指针根本落不到 Draggable
+                    // 上，拖动永远起不来（这条曾让本用例空转）。
+                    child: const FushiFocusTarget(
+                      id: cardFocusId,
+                      child: ColoredBox(
+                        key: cardVisualKey,
+                        color: Color(0xFF884422),
+                        child: SizedBox(width: 60, height: 80),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return controller;
+    }
+
+    testWidgets('拖起来时浮层渲染卡片本体，且与原卡同尺寸', (WidgetTester tester) async {
+      await pumpFocusableCard(tester);
+      final Size cardSize = tester.getSize(find.byKey(cardVisualKey));
+      expect(cardSize, const Size(60, 80));
+
+      final TestGesture gesture = await tester
+          .startGesture(tester.getCenter(find.byKey(cardVisualKey)));
+      await tester.pump();
+      // 先小步过 slop 让 recognizer onStart，再移动（同 dragOntoHeader 范式）。
+      await gesture.moveBy(const Offset(0, 30));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+
+      // 卡片被渲染了两份：原位（childWhenDragging）+ 浮层。
+      expect(find.byKey(cardVisualKey), findsNWidgets(2),
+          reason: '浮层必须是卡片本体，而不是只有条目名的 chip');
+      final List<Size> sizes = find
+          .byKey(cardVisualKey)
+          .evaluate()
+          .map((Element e) => (e.renderObject! as RenderBox).size)
+          .toList();
+      expect(sizes, everyElement(const Size(60, 80)),
+          reason: '浮层尺寸必须等于原卡真实尺寸；'
+              '若改用父约束（常是宽松的 0..屏宽）会把浮层撑成整屏');
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('浮层不注册焦点：拖动前中后真卡的焦点条目始终有效', (WidgetTester tester) async {
+      final FushiFocusController controller = await pumpFocusableCard(tester);
+      expect(controller.requestById(cardFocusId), isTrue,
+          reason: '前置条件：真卡本来就注册了焦点条目');
+
+      final TestGesture gesture = await tester
+          .startGesture(tester.getCenter(find.byKey(cardVisualKey)));
+      await tester.pump();
+      // 先小步过 slop 让 recognizer onStart，再移动（同 dragOntoHeader 范式）。
+      await gesture.moveBy(const Offset(0, 30));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+
+      expect(controller.requestById(cardFocusId), isTrue,
+          reason: '浮层里的第二份 FushiFocusTarget 不得覆盖真卡的 entry');
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(controller.requestById(cardFocusId), isTrue,
+          reason: '浮层消失时不得把真卡的 entry 一起注销——'
+              '这正是原实现不敢复用卡片的那个失效模式');
+    });
   });
 
   group('MediaCardDraggable 按平台分流', () {

--- a/fushi/test/media/video/download/video_download_subscription_service_test.dart
+++ b/fushi/test/media/video/download/video_download_subscription_service_test.dart
@@ -220,6 +220,158 @@ void main() {
     expect(row.lastError, isNull);
   });
 
+  /// BUG-1746：订阅曾把「派过任务」（jobId != null）当成「这一集搞定了」。
+  /// 任务被取消或失败之后 jobId 依然挂在条目上，旧判据每轮都 continue，那一集
+  /// 就再也不会被下——用户看到的是「订阅只下了中间几集」，而面板上毫无异常。
+  /// 实测现场：某条订阅 13 集里 ep01/02 卡在「内置下载引擎运行时缺失」、
+  /// ep03-08 被取消，全部再没重试过。
+  ///
+  /// 分界线按「是谁决定不下的」划：系统故障该重试，用户取消该尊重。
+  group('BUG-1746 订阅重试判据', () {
+    /// 跑一轮订阅检查，返回本轮入队的 remoteId。
+    ///
+    /// [atMs] 必须随轮次前进：`_drain()` 只认领**已到期**的订阅
+    /// （`claimNextVideoDownloadSubscription(nowAt:)`），第一轮跑完
+    /// `nextCheckAt = 当前 + checkInterval`。若两轮用同一个时刻，第二轮根本
+    /// 认领不到订阅、整轮空转——那样「没有重复入队」的断言会变成假绿，
+    /// 测的是「压根没跑」而不是「跑了但正确地没派」。
+    Future<List<String>> runRound(
+      FushiDatabase database, {
+      required List<String> alreadyEnqueued,
+      required int atMs,
+    }) async {
+      final List<String> enqueued = <String>[];
+      final VideoDownloadSubscriptionService service = _service(
+        database: database,
+        now: () => DateTime.fromMillisecondsSinceEpoch(atMs),
+        provider: _FakeResourceProvider(
+          id: 'nyaa',
+          candidates: <VideoResourceCandidate>[
+            _candidate(remoteId: 'ep-1', episode: 1),
+          ],
+        ),
+        enqueue: (VideoDownloadEnqueueRequest request) async {
+          enqueued.add(request.resource.remoteId);
+          return _persistFakeJob(
+            database,
+            request,
+            'job-${alreadyEnqueued.length + enqueued.length}',
+          );
+        },
+      );
+      await service.checkNow();
+      return enqueued;
+    }
+
+    /// 第二轮的时刻：第一轮的 nextCheckAt 之后。
+    const int secondRoundAt = _nowAt + 3600 * 1000;
+
+    Future<FushiDatabase> seed() async {
+      final FushiDatabase database = await _openDatabase();
+      final int sourceId = await _insertVideoSource(database);
+      await _insertSubscription(
+        database,
+        id: 'anime',
+        sourceId: sourceId,
+        resourceProvider: 'nyaa',
+        mediaKind: 'tv',
+        discoveryCategory: 'anime',
+        season: 1,
+        startAfterEpisode: 1,
+        filters: <String, Object?>{
+          'strict': true,
+          'releaseGroup': 'SubsPlease',
+          'resolution': '1080p',
+          'trustedOnly': true,
+          'nyaaCategory': '1_2',
+        },
+      );
+      return database;
+    }
+
+    /// 直接改 lifecycle：生产里由流水线/用户操作写，这里只关心订阅怎么读它。
+    Future<void> setLifecycle(
+      FushiDatabase database,
+      String jobId,
+      String lifecycle,
+    ) =>
+        database.customStatement(
+          'UPDATE video_download_jobs SET lifecycle = ? WHERE job_id = ?',
+          <Object?>[lifecycle, jobId],
+        );
+
+    test('needsAttention（系统故障）的一集会在下一轮重新入队', () async {
+      final FushiDatabase database = await seed();
+      final List<String> first =
+          await runRound(database, alreadyEnqueued: <String>[], atMs: _nowAt);
+      expect(first, <String>['ep-1'], reason: '第一轮应正常入队');
+
+      await setLifecycle(
+        database,
+        'job-1',
+        VideoDownloadJobLifecycle.needsAttention,
+      );
+
+      final List<String> second =
+          await runRound(database, alreadyEnqueued: first, atMs: secondRoundAt);
+      expect(second, <String>['ep-1'],
+          reason: '内置下载引擎运行时缺失这类系统故障排除后，这一集必须能被重新派；'
+              '旧判据只看 jobId 在不在，会让它永久卡死');
+    });
+
+    test('failed 的一集同样会被重新入队', () async {
+      final FushiDatabase database = await seed();
+      final List<String> first =
+          await runRound(database, alreadyEnqueued: <String>[], atMs: _nowAt);
+      expect(first, <String>['ep-1']);
+
+      await setLifecycle(database, 'job-1', VideoDownloadJobLifecycle.failed);
+
+      expect(
+          await runRound(database, alreadyEnqueued: first, atMs: secondRoundAt),
+          <String>['ep-1'],
+          reason: 'failed 是系统侧的失败，不是用户意图');
+    });
+
+    test('用户取消（cancelled）的一集不会被订阅自动补回来', () async {
+      final FushiDatabase database = await seed();
+      final List<String> first =
+          await runRound(database, alreadyEnqueued: <String>[], atMs: _nowAt);
+      expect(first, <String>['ep-1']);
+
+      await setLifecycle(
+        database,
+        'job-1',
+        VideoDownloadJobLifecycle.cancelled,
+      );
+
+      expect(
+          await runRound(database, alreadyEnqueued: first, atMs: secondRoundAt),
+          isEmpty,
+          reason: 'cancelled 是用户明确说不要这一集；自动补回来的话用户永远取消不掉');
+    });
+
+    test('active / completed 的一集不重复入队（原行为不变）', () async {
+      for (final String lifecycle in <String>[
+        VideoDownloadJobLifecycle.active,
+        VideoDownloadJobLifecycle.completed,
+      ]) {
+        final FushiDatabase database = await seed();
+        final List<String> first =
+            await runRound(database, alreadyEnqueued: <String>[], atMs: _nowAt);
+        expect(first, <String>['ep-1']);
+
+        await setLifecycle(database, 'job-1', lifecycle);
+
+        expect(
+            await runRound(database,
+                alreadyEnqueued: first, atMs: secondRoundAt),
+            isEmpty,
+            reason: '$lifecycle 的任务仍算数，重复入队会造重复下载');
+      }
+    });
+  });
+
   test('anime roman numeral title uses the canonical third-season key',
       () async {
     final FushiDatabase database = await _openDatabase();

--- a/fushi/test/models/dict_engine_max_results_alignment_test.dart
+++ b/fushi/test/models/dict_engine_max_results_alignment_test.dart
@@ -105,8 +105,13 @@ void main() {
         final List<FushiLookupResult> full = engineResults(count: 200);
         expect(
           buildPopupJsonFromLookup(
-              results: full.take(maxTerms).toList(), maximumTerms: maxTerms),
-          buildPopupJsonFromLookup(results: full, maximumTerms: maxTerms),
+              results: full.take(maxTerms).toList(),
+              maximumTerms: maxTerms,
+              hiddenDictionaries: const <String>{}),
+          buildPopupJsonFromLookup(
+              results: full,
+              maximumTerms: maxTerms,
+              hiddenDictionaries: const <String>{}),
         );
       });
     }

--- a/fushi/test/models/lookup_term_budget_counts_headwords_test.dart
+++ b/fushi/test/models/lookup_term_budget_counts_headwords_test.dart
@@ -143,9 +143,9 @@ void main() {
       int maximumTerms,
     ) {
       final String json = buildPopupJsonFromLookup(
-        results: results,
-        maximumTerms: maximumTerms,
-      );
+          results: results,
+          maximumTerms: maximumTerms,
+          hiddenDictionaries: const <String>{});
       return (jsonDecode(json) as List).cast<Map<String, dynamic>>();
     }
 

--- a/fushi/test/pages/browser_extension_page_back_button_guard_test.dart
+++ b/fushi/test/pages/browser_extension_page_back_button_guard_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../helpers/source_guard.dart';
 
-/// BUG-1741 守卫：`BrowserExtensionPage` 是**双身份页**——既是桌面顶层导航 tab
+/// BUG-1748 守卫：`BrowserExtensionPage` 是**双身份页**——既是桌面顶层导航 tab
 /// （`HomeTab.browserExtension`，侧栏在旁边，不该出返回箭头），又被
 /// `settings_schema_lookup.dart` 的 `SettingsNavigationItem` 裸 push 成全屏
 /// `MaterialPageRoute`（此时侧栏被整个盖住）。BUG-1658 把顶层 tab 页头统一成
@@ -16,7 +16,7 @@ import '../helpers/source_guard.dart';
 /// 注释里会提到 leading、canPop、AppBar 这些词，裸 contains 会两个方向都
 /// 误判，故先经 [maskCommentsAndScriptLines] 掩掉注释与三引号语料。
 void main() {
-  test('BUG-1741：扩展页页头按 canPop 分流给返回键（顶层 tab 身份下仍不出箭头）', () {
+  test('BUG-1748：扩展页页头按 canPop 分流给返回键（顶层 tab 身份下仍不出箭头）', () {
     final File f =
         File('lib/src/pages/implementations/browser_extension_page.dart');
     expect(f.existsSync(), isTrue,

--- a/fushi/test/pages/browser_extension_page_back_button_guard_test.dart
+++ b/fushi/test/pages/browser_extension_page_back_button_guard_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1741 守卫：`BrowserExtensionPage` 是**双身份页**——既是桌面顶层导航 tab
+/// （`HomeTab.browserExtension`，侧栏在旁边，不该出返回箭头），又被
+/// `settings_schema_lookup.dart` 的 `SettingsNavigationItem` 裸 push 成全屏
+/// `MaterialPageRoute`（此时侧栏被整个盖住）。BUG-1658 把顶层 tab 页头统一成
+/// `FushiPageHeader` 大标题时只写了前一半，于是从设置进来的用户没有任何返回控件。
+///
+/// 同仓 `DownloadsPage` 是完全同构的双身份页，它按 `Navigator.canPop()` 分流。
+/// 本守卫钉死「扩展页也必须按 canPop 分流给 leading」这个不变式。
+///
+/// 注释里会提到 leading、canPop、AppBar 这些词，裸 contains 会两个方向都
+/// 误判，故先经 [maskCommentsAndScriptLines] 掩掉注释与三引号语料。
+void main() {
+  test('BUG-1741：扩展页页头按 canPop 分流给返回键（顶层 tab 身份下仍不出箭头）', () {
+    final File f =
+        File('lib/src/pages/implementations/browser_extension_page.dart');
+    expect(f.existsSync(), isTrue,
+        reason: '找不到 browser_extension_page.dart（路径变了要同步本守卫）');
+    final String code = maskCommentsAndScriptLines(f.readAsStringSync());
+
+    final int headerAt = code.indexOf('FushiPageHeader(');
+    expect(headerAt, greaterThanOrEqualTo(0),
+        reason: '页头必须仍是 FushiPageHeader（BUG-1658 的统一大标题几何）');
+
+    // 断言字面量：'leading: Navigator.of(context).canPop()'
+    // 必须是条件分流而不是无条件给 leading——作顶层 tab 时侧栏就在旁边，
+    // 无条件出箭头会让 tab 页头凭空多一个不能用的返回键。
+    final int leadingAt =
+        code.indexOf('leading: Navigator.of(context).canPop()', headerAt);
+    expect(leadingAt, greaterThan(headerAt),
+        reason: '被设置 push 成全屏路由时侧栏被盖住，页头必须承接返回键；'
+            '且必须按 canPop 分流，顶层 tab 身份下不出箭头');
+
+    // 断言字面量：'maybePop()'——真正能退出去，而不是只画一个箭头。
+    expect(code.substring(leadingAt, leadingAt + 400), contains('maybePop()'),
+        reason: '返回键必须真的 pop 路由');
+
+    // 未选用的替代方案（改用 AdaptiveSettingsScaffold/FushiToolScaffold 拿自动
+    // leading）会把顶层 tab 的页头几何换成小标题工具栏，正是 BUG-1658 修掉的
+    // 东西，属回归。这里钉死不得回退到 AppBar 门头。
+    expect(code, isNot(contains('appBar: AppBar(')),
+        reason: '不得回退到旧 AppBar 门头（BUG-1658）');
+  });
+}

--- a/fushi/test/pages/dictionary_popup_empty_reading_group_test.dart
+++ b/fushi/test/pages/dictionary_popup_empty_reading_group_test.dart
@@ -39,7 +39,10 @@ void main() {
   }
 
   List<Map<String, dynamic>> groups(List<FushiLookupResult> results) {
-    final json = buildPopupJsonFromLookup(results: results, maximumTerms: 100);
+    final json = buildPopupJsonFromLookup(
+        results: results,
+        maximumTerms: 100,
+        hiddenDictionaries: const <String>{});
     return (jsonDecode(json) as List).cast<Map<String, dynamic>>();
   }
 

--- a/fushi/test/pages/dictionary_popup_webview_test.dart
+++ b/fushi/test/pages/dictionary_popup_webview_test.dart
@@ -453,9 +453,9 @@ void main() {
       const maxTerms = 100;
 
       final newJson = buildPopupJsonFromLookup(
-        results: lookupResults,
-        maximumTerms: maxTerms,
-      );
+          results: lookupResults,
+          maximumTerms: maxTerms,
+          hiddenDictionaries: const <String>{});
       final oldResult = buildResultFromLookup(
         searchTerm: '食べた',
         results: lookupResults,
@@ -551,18 +551,18 @@ void main() {
 
       // ① 屈折命中（matched≠deinflected 且非空）→ 恰好一条痕迹。
       final withTrace = jsonDecode(buildPopupJsonFromLookup(
-        results: [make(matched: '食べた', deinflected: '食べる')],
-        maximumTerms: 100,
-      )) as List;
+          results: [make(matched: '食べた', deinflected: '食べる')],
+          maximumTerms: 100,
+          hiddenDictionaries: const <String>{})) as List;
       expect((withTrace.single as Map<String, dynamic>)['deinflectionTrace'], [
         {'name': '食べた → 食べる', 'description': ''},
       ]);
 
       // ② 原形直查（matched == deinflected）→ 空数组，不生成自指痕迹。
       final noInflection = jsonDecode(buildPopupJsonFromLookup(
-        results: [make(matched: '食べる', deinflected: '食べる')],
-        maximumTerms: 100,
-      )) as List;
+          results: [make(matched: '食べる', deinflected: '食べる')],
+          maximumTerms: 100,
+          hiddenDictionaries: const <String>{})) as List;
       expect(
         (noInflection.single as Map<String, dynamic>)['deinflectionTrace'],
         isEmpty,
@@ -570,9 +570,9 @@ void main() {
 
       // ③ 引擎未回填 deinflected（空串）→ 同样空数组，不生成「x → 」残缺痕迹。
       final emptyDeinflected = jsonDecode(buildPopupJsonFromLookup(
-        results: [make(matched: '食べた', deinflected: '')],
-        maximumTerms: 100,
-      )) as List;
+          results: [make(matched: '食べた', deinflected: '')],
+          maximumTerms: 100,
+          hiddenDictionaries: const <String>{})) as List;
       expect(
         (emptyDeinflected.single as Map<String, dynamic>)['deinflectionTrace'],
         isEmpty,
@@ -604,9 +604,9 @@ void main() {
     test('maximumTerms 约束词头卡数，不腰斩单个词头的注释', () {
       final lookupResults = makeLookupResults();
       final json = buildPopupJsonFromLookup(
-        results: lookupResults,
-        maximumTerms: 2,
-      );
+          results: lookupResults,
+          maximumTerms: 2,
+          hiddenDictionaries: const <String>{});
       final parsed = jsonDecode(json) as List;
       expect(parsed.length, 1, reason: '两条结果同属一个词头，只该出一张卡');
       final entry = parsed.single as Map<String, dynamic>;
@@ -619,37 +619,38 @@ void main() {
 
     test('maximumTerms 真的截断词头卡数', () {
       final json = buildPopupJsonFromLookup(
-        results: <FushiLookupResult>[
-          ...makeLookupResults(),
-          FushiLookupResult(
-            matched: '食べた',
-            deinflected: '食べる',
-            trace: const [],
-            preprocessorSteps: 0,
-            term: FushiTermResult(
-              expression: '喰べる',
-              reading: 'くべる',
-              rules: '',
-              glossaries: [
-                FushiGlossaryEntry(
-                  dictName: '大辞林',
-                  glossary: jsonEncode('別表記・別読み'),
-                  definitionTags: '',
-                  termTags: '',
-                ),
-              ],
-              frequencies: const [],
-              pitches: const [],
+          results: <FushiLookupResult>[
+            ...makeLookupResults(),
+            FushiLookupResult(
+              matched: '食べた',
+              deinflected: '食べる',
+              trace: const [],
+              preprocessorSteps: 0,
+              term: FushiTermResult(
+                expression: '喰べる',
+                reading: 'くべる',
+                rules: '',
+                glossaries: [
+                  FushiGlossaryEntry(
+                    dictName: '大辞林',
+                    glossary: jsonEncode('別表記・別読み'),
+                    definitionTags: '',
+                    termTags: '',
+                  ),
+                ],
+                frequencies: const [],
+                pitches: const [],
+              ),
             ),
-          ),
-        ],
-        maximumTerms: 1,
-      );
+          ],
+          maximumTerms: 1,
+          hiddenDictionaries: const <String>{});
       expect((jsonDecode(json) as List).length, 1);
     });
 
     test('returns empty array for empty results', () {
-      final json = buildPopupJsonFromLookup(results: [], maximumTerms: 100);
+      final json = buildPopupJsonFromLookup(
+          results: [], maximumTerms: 100, hiddenDictionaries: const <String>{});
       expect(json, '[]');
     });
   });

--- a/fushi/test/pages/popup_hidden_dictionary_filter_test.dart
+++ b/fushi/test/pages/popup_hidden_dictionary_filter_test.dart
@@ -99,12 +99,73 @@ void main() {
         reason: 'hiddenDictionaryNames injection must sit next to '
             'collapsedDictionaryNames');
 
+    // 注入侧消费真相源 getter，而不是自己抄一份 where/map 表达式。
+    // 断言字面量：'appModel.hiddenDictionaryNames'
     expect(
-      dart.contains('d.isHidden(JapaneseLanguage.instance)'),
+      dart.contains('appModel.hiddenDictionaryNames'),
+      isTrue,
+      reason: 'the injection host must consume AppModel.hiddenDictionaryNames '
+          'instead of re-deriving the hidden set locally',
+    );
+
+    // 真相源本身仍必须由 isHidden(targetLanguage) 推导——与管理页显示/隐藏开关
+    // 拨的是同一个判据。断言字面量：'d.isHidden(JapaneseLanguage.instance)'
+    final String appModelSrc =
+        File('lib/src/models/app_model.dart').readAsStringSync();
+    final int getterAt =
+        appModelSrc.indexOf('Set<String> get hiddenDictionaryNames');
+    expect(getterAt, greaterThanOrEqualTo(0),
+        reason: 'AppModel must expose hiddenDictionaryNames as the single '
+            'source of truth for the hidden dictionary set');
+    expect(
+      appModelSrc
+          .substring(getterAt, getterAt + 400)
+          .contains('d.isHidden(JapaneseLanguage.instance)'),
       isTrue,
       reason: 'the hidden set must be derived from isHidden(targetLanguage), '
           'the same predicate the management show/hide switch toggles',
     );
+  });
+
+  test('popupJson drops hidden dictionaries at the source (all hosts)', () {
+    // 这条守的是本次修复的核心不变式：过滤下沉到 popupJson 生成期这个唯一数据
+    // 出口。此前过滤只活在渲染期 JS 里，靠宿主注入 window.hiddenDictionaryNames
+    // 驱动——app 内 WebView 注入了，浏览器扩展走的 HTTP 路径从来不下发它，于是
+    // 被关掉的词典在扩展弹窗里照旧出释义、还一并写进 Anki 卡片。只要过滤留在
+    // 生成器里，任何新宿主（不经 JS 注入的）都自动正确。
+    final String lang = File(
+      '../packages/fushi_dictionary/lib/src/language/language.dart',
+    ).readAsStringSync();
+
+    // 断言字面量：'required Set<String> hiddenDictionaries'
+    // 必填（不是可选带默认值）——可选参数等于允许调用点漏传。
+    expect(
+      lang.contains('required Set<String> hiddenDictionaries'),
+      isTrue,
+      reason: 'buildPopupJsonFromLookup must take the hidden set as a REQUIRED '
+          'parameter so no host can silently skip the filter',
+    );
+
+    final int builderAt = lang.indexOf('String buildPopupJsonFromLookup(');
+    expect(builderAt, greaterThanOrEqualTo(0));
+    final int glossaryLoop =
+        lang.indexOf('for (final g in r.term.glossaries) {', builderAt);
+    expect(glossaryLoop, greaterThan(builderAt));
+
+    // 断言字面量：'if (hiddenDictionaries.contains(g.dictName)) continue;'
+    // 必须 continue 整个 glossary 迭代，而不是只跳 groupGlossaries.add——
+    // 只有隐藏词典释义的词头不该撑起空卡片，也不该占 maximumTerms 词头预算。
+    final int skipAt = lang.indexOf(
+        'if (hiddenDictionaries.contains(g.dictName)) continue;', glossaryLoop);
+    expect(skipAt, greaterThan(glossaryLoop),
+        reason: 'hidden dictionaries must be skipped at the top of the '
+            'glossary loop inside buildPopupJsonFromLookup');
+
+    final int groupCreate =
+        lang.indexOf('if (!groupExpression.containsKey(key)) {', glossaryLoop);
+    expect(groupCreate, greaterThan(skipAt),
+        reason: 'the skip must precede group creation, otherwise a headword '
+            'whose only glossaries are hidden still renders an empty card');
   });
 }
 

--- a/fushi/test/settings/video_external_provider_settings_section_test.dart
+++ b/fushi/test/settings/video_external_provider_settings_section_test.dart
@@ -94,6 +94,27 @@ Widget _harness(_FakeStore store, {bool onlySubtitleSources = false}) =>
       ),
     );
 
+/// 宽窗 harness：原 bug 只在 pane 明显宽于内容宽度时才看得出来——560 的窄
+/// harness 下输入框（旧上限 480）与开关（占满 560）只差 80px，肉眼和断言都容易
+/// 放过；1400 下差距是好几百像素，正是用户截图里的样子。
+Widget _wideHarness(_FakeStore store) => ProviderScope(
+      child: MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Scaffold(
+          body: SizedBox(
+            width: 1400,
+            child: SingleChildScrollView(
+              child: VideoExternalProviderSettingsSection(
+                key: const ValueKey<String>('wide'),
+                store: store,
+                onlySubtitleSources: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
 Finder _textField(Key key) => find.descendant(
       of: find.byKey(key),
       matching: find.byType(TextField),
@@ -110,6 +131,66 @@ Future<void> _settleAutosave(WidgetTester tester) async {
 }
 
 void main() {
+  /// BUG-1747：宽窗下这一段三种行各有一套左右边界——输入框自己缩到 480、
+  /// `SwitchListTile` 吃 `CrossAxisAlignment.stretch` 的紧约束占满整个 pane、
+  /// 用户名/密码 `Row` 又是全宽再各占一半。用户看到的是「输入框只占左半边、
+  /// 开关孤零零贴在最右、中间一大片空白」。
+  ///
+  /// 不变式：整段收进同一个内容宽度容器后，三者右边缘必须重合。
+  testWidgets('BUG-1747：宽窗下输入框/开关/双列行的左右边界一致', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final _FakeStore store = _FakeStore(
+      VideoExternalSettingsSnapshot(
+        openSubtitlesConfig: OpenSubtitlesConfig(
+          apiKey: 'sub-secret',
+          username: 'alice',
+          password: 'password',
+        ),
+      ),
+    );
+    await tester.pumpWidget(_wideHarness(store));
+    await tester.pumpAndSettle();
+
+    final Finder endpoint =
+        _textField(const ValueKey<String>('video-opensubtitles-endpoint'));
+    await _show(tester, endpoint);
+    final Rect endpointRect = tester.getRect(endpoint);
+
+    final Finder insecure =
+        find.byKey(const ValueKey<String>('video-opensubtitles-insecure-http'));
+    await _show(tester, insecure);
+    final Rect switchRect = tester.getRect(insecure);
+
+    expect(
+      endpointRect.left,
+      moreOrLessEquals(switchRect.left, epsilon: 1.0),
+      reason: '输入框与开关必须同一条左基线',
+    );
+    expect(
+      endpointRect.right,
+      moreOrLessEquals(switchRect.right, epsilon: 1.0),
+      reason: '输入框此前被局部限宽到 480、开关占满整个 pane，右边缘差几百像素；'
+          '收进同一个内容宽度容器后必须重合',
+    );
+
+    // 双列行（用户名/密码）是第三套宽度：Row 全宽 → Expanded 各半 → 再被局部
+    // 480 二次裁。它的整体左右边界同样要落在同一对基线上。
+    final Rect username = tester.getRect(
+        _textField(const ValueKey<String>('video-opensubtitles-username')));
+    final Rect password = tester.getRect(
+        _textField(const ValueKey<String>('video-opensubtitles-password')));
+    expect(username.left, moreOrLessEquals(endpointRect.left, epsilon: 1.0),
+        reason: '双列行左边界要与单列框一致');
+    expect(password.right, moreOrLessEquals(endpointRect.right, epsilon: 1.0),
+        reason: '双列行右边界要与单列框一致（此前密码框一路铺到 pane 最右）');
+
+    // 同时保住 BUG-1084：4K 全屏下输入框不得被拉成三千像素。
+    expect(endpointRect.width, lessThanOrEqualTo(561),
+        reason: '整段仍受内容宽度上限约束（BUG-1084）');
+  });
+
   testWidgets('secret fields are masked and unsafe remote HTTP is not saved',
       (WidgetTester tester) async {
     tester.view.physicalSize = const Size(800, 3200);

--- a/fushi/test/widgets/fushi_hover_lift_test.dart
+++ b/fushi/test/widgets/fushi_hover_lift_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
+import 'package:fushi/src/utils/components/fushi_hover_lift.dart';
+
+/// [FushiHoverLift] 是把游戏库那套「悬停放大 + 阴影加深」推广到书架 / 漫画 /
+/// 视频库时抽出来的壳。原实现（`GalgamePosterCard` 内联）**没有**墨水屏与
+/// 「减弱动态效果」两处降级——动效只在一个页面时问题不大，铺开到所有库页后
+/// 就会明显劣化，所以这两条降级和 hover 本身一样要有守卫。
+void main() {
+  const Key contentKey = Key('lift-content');
+
+  /// 记录 builder 每次拿到的 hover 态，用来分辨「没缩放」与「连 hover 都没有」。
+  late List<bool> seenHover;
+
+  Widget harness({
+    bool enabled = true,
+    bool disableAnimations = false,
+    ThemeData? theme,
+  }) {
+    seenHover = <bool>[];
+    return MaterialApp(
+      theme: theme,
+      home: MediaQuery(
+        data: MediaQueryData(disableAnimations: disableAnimations),
+        child: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: FushiHoverLift(
+              enabled: enabled,
+              builder: (BuildContext context, bool hovering) {
+                seenHover.add(hovering);
+                return const ColoredBox(
+                  key: contentKey,
+                  color: Color(0xFF335577),
+                  child: SizedBox(width: 80, height: 60),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<TestGesture> hoverOnto(WidgetTester tester) async {
+    final TestGesture mouse =
+        await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    addTearDown(mouse.removePointer);
+    await tester.pump();
+    await mouse.moveTo(tester.getCenter(find.byKey(contentKey)));
+    await tester.pumpAndSettle();
+    return mouse;
+  }
+
+  double? currentScale(WidgetTester tester) {
+    final Iterable<AnimatedScale> scales =
+        tester.widgetList<AnimatedScale>(find.byType(AnimatedScale));
+    return scales.isEmpty ? null : scales.first.scale;
+  }
+
+  testWidgets('鼠标移入放大到 kFushiHoverLiftScale，移出复位', (WidgetTester tester) async {
+    await tester.pumpWidget(harness());
+    expect(currentScale(tester), 1.0);
+
+    final TestGesture mouse = await hoverOnto(tester);
+    expect(currentScale(tester), kFushiHoverLiftScale);
+    expect(seenHover.last, isTrue, reason: 'builder 必须拿到 hover 态才能加深阴影');
+
+    await mouse.moveTo(const Offset(500, 500));
+    await tester.pumpAndSettle();
+    expect(currentScale(tester), 1.0);
+    expect(seenHover.last, isFalse);
+  });
+
+  testWidgets('减弱动态效果：不缩放，但 hover 态照常传给 builder', (WidgetTester tester) async {
+    await tester.pumpWidget(harness(disableAnimations: true));
+    await hoverOnto(tester);
+    expect(find.byType(AnimatedScale), findsNothing,
+        reason: '系统开了「减弱动态效果」就不该有缩放动画');
+    expect(seenHover.last, isTrue, reason: '静态 hover 反馈（阴影/描边）必须保留，只去掉动效');
+  });
+
+  testWidgets('墨水屏：不缩放（持续缩放会不停刷屏），hover 态仍传给 builder',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(harness(
+      theme: ThemeData(
+        extensions: const <ThemeExtension<dynamic>>[
+          FushiEinkTheme(true),
+        ],
+      ),
+    ));
+    await hoverOnto(tester);
+    expect(find.byType(AnimatedScale), findsNothing,
+        reason: '墨水屏上连续缩放会不断触发整屏重绘/残影');
+    expect(seenHover.last, isTrue, reason: 'hover 反馈本身要留着（墨水屏上通常改成描边）');
+  });
+
+  testWidgets('enabled=false 时不建 MouseRegion，builder 恒拿到 false',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(harness(enabled: false));
+    expect(find.byType(AnimatedScale), findsNothing);
+    await hoverOnto(tester);
+    expect(seenHover, everyElement(isFalse),
+        reason: '禁用时不得有任何 hover 态泄漏给 builder');
+  });
+}

--- a/packages/fushi_dictionary/lib/src/language/language.dart
+++ b/packages/fushi_dictionary/lib/src/language/language.dart
@@ -497,6 +497,7 @@ String lookupHeadwordKey(FushiLookupResult r) {
 String buildPopupJsonFromLookup({
   required List<FushiLookupResult> results,
   required int maximumTerms,
+  required Set<String> hiddenDictionaries,
 }) {
   if (results.isEmpty) return '[]';
 
@@ -527,6 +528,15 @@ String buildPopupJsonFromLookup({
       break outer;
     }
     for (final g in r.term.glossaries) {
+      // 被用户关掉的词典在源头就不进 popupJson。此前这步只存在于渲染期的 JS
+      // （靠宿主注入 window.hiddenDictionaryNames 驱动），app 内 WebView 注入了、浏览器
+      // 扩展走的 HTTP 路径从来不下发它 ⇒ 关掉的词典在扩展里照旧出释义，
+      // 连制卡也一并写进去。过滤下沉到这个唯一数据出口后，app 内弹窗 / 全局查词窗 /
+      // 浏览器扩展 / 制卡四个消费者一次性全对；JS 侧原有过滤退化为冗余保险。
+      //
+      // 放在循环最前（而不是只跳 groupGlossaries.add）：只有隐藏词典释义的词头不应
+      // 该撑起一张空卡片，也不应占用 maximumTerms 词头预算。
+      if (hiddenDictionaries.contains(g.dictName)) continue;
       if (!groupExpression.containsKey(key)) {
         groupKeys.add(key);
         groupExpression[key] = r.term.expression;


### PR DESCRIPTION
本轮处理用户在 2026-08-19 一次性报的 7 件事，6 件已落地，1 件（浏览器扩展上下句）查清待定，另有视频黑边仍在定位。

## 已修

| 问题 | 根因 | 编号 |
|---|---|---|
| 设置 → 查词 → 浏览器扩展，进去没有返回键 | `BrowserExtensionPage` 是双身份页，只按「顶层 tab」那一半写了页头。被 `SettingsNavigationItem` 裸 push 成全屏路由时侧栏被整个盖住，而 `FushiPageHeader` 没传 `leading`、`Scaffold` 也没 `appBar` | BUG-1748 |
| 浏览器扩展里关掉日语词典仍出释义 | term 词典的隐藏过滤只活在渲染期 JS 里，靠宿主注入 `window.hiddenDictionaryNames` 驱动；扩展走的 HTTP 路径从来不下发它。三镜像漏了第三面 | BUG-1749 |
| 订阅「从第 3 集开始」却只下了 5、6、7 集 | 判据只看 `existing.jobId != null`，把「派过任务」当成「任务成功了」。任务被取消/失败后 jobId 仍在，每轮轮询都 continue，那一集永久卡死 | BUG-1746 |
| 设置 → 视频 → 字幕来源右侧 UI 撕裂 | 同一个 Column 里三种孩子用三种方式消费约束：输入框自己缩到 480、Switch 吃 stretch 紧约束占满 pane、用户名/密码 Row 全宽再各占一半 | BUG-1747 |
| 拖卡片进合集时拖的是名字不是卡片 | 浮层是紧凑 chip。原注释说明刻意不复用卡片（焦点 id 撞车），但那把问题解成了「每个调用方手写视觉副本」 | — |
| 游戏库的卡片悬浮动效没有其他模块 | 这套动效只长在 `GalgamePosterCard` 里（`AnimatedScale` 全仓唯一命中） | — |

## 几个值得单独说的点

**订阅那条的根因和标题不一样。** 用户报的是「起始集数不生效」，实测查用户生产库（只读副本）后发现：那条订阅 13 集全部被正确识别并建了条目，集号解析和 `startAfterEpisode` 都是好的。真实情况是 ep01-02 卡在「内置下载引擎运行时缺失」、ep03-08 被取消，此后再没重试过。修法按「是谁决定不下的」划界：`cancelled` 是用户明确说不要，尊重；`failed`/`needsAttention` 是系统故障，排除后本该继续。

**词典那条走的是「下沉到唯一数据出口」而不是「给第三面镜子再补一次注入」。** 后者等于承认每新增一个宿主都要记得再注入一次。改为给 `buildPopupJsonFromLookup` 加**必填**参数在源头剔除，于是 app 内弹窗 / 全局查词窗 / 浏览器扩展 / 制卡四条路径一次性全对，JS 侧原有过滤退化为冗余保险。连带修好了扩展制卡把隐藏词典释义写进 Anki（BUG-432 在扩展路径上的原样重现）。

**拖动那条消除的是限制本身。** 用 `FushiFocusRoot(enabled: false)` 屏蔽浮层子树的焦点注册（该组件的既有语义），卡片就能安全地渲染第二份，四个调用点一行不用改。

**字幕来源那条挖出一个「修复只活在测试里」的历史**：BUG-1278 当年给下载设置加的 560 居中容器，已被 `040e583eac`（PR #751）的 `constrainWidth: false` 撤掉，而守卫 `torrent_settings_field_width_test.dart` 只测 `constrainWidth: true`，所以一直是绿的。

## 验证

- `flutter analyze`：主应用与 `packages/fushi_dictionary` 均 `No issues found`
- 36 条目录枚举型守卫整批：263 tests 全绿
- media / pages / widgets 三域：8500+ tests 全绿
- 每条修复都做了变异实测。**两处如实记录了「测不出来」**，没有留假绿：
  - 拖动那条的焦点断言：去掉屏蔽、去掉 `unregister` 双重校验、两者同时去掉，三种变异下都不红（因为拖动结束时真卡会重新注册，最终状态相同）。已在测试注释里写明它守的是最终状态而非屏蔽本身。
  - 订阅测试第一版是假绿：`_drain()` 只认领**已到期**的订阅，测试时钟不推进则第二轮整轮空转，「没有重复入队」的断言恒真。修法是让第二轮 service 的时钟走到 `nextCheckAt` 之后。
- BUG-1741/1742 与在飞分支 `worktree-fix-four-issues-20260819` 撞号，已按规则 `bug.dart renumber` 改为 1748/1749（四处一起改 + 自校验零残留），`check` 跨源复核通过。

## 未完成

**视频全屏上下黑边**：仍在定位。已排除的：文件内容本身无黑边（5 个时间点 cropdetect 全 `1920:1080:0:0`）；Flutter 层无写死尺寸、无错误 aspect 来源、无「拿不到宽高就退默认比例」的 fallback。用户补充「mpv 也是全屏且无黑边、app 全屏上下有黑边」后，「窗口比例 != 视频比例」这条解释也被推翻（全屏时屏幕 16:9、视频 16:9，`contain` 几何上不可能补黑）。当前最可能的方向是渲染纹理的比例不是 16:9（HEVC 1080 补齐到 1088 的 crop 未应用），正在查 `third_party/media_kit_video/windows/` 的纹理尺寸来源。**不在本 PR 范围**。

顺带记录两个本轮发现、未修的问题：
1. `anime_download_service.dart` 的边下边播会把没下完的文件当成品入库，且下载真完成后 `if (!plan.importedEarly)` 把整段视频导入跳过 —— 该条目的时长/封面/内嵌字幕枚举永远停在首次入库那一刻。`importedEarly` 把「已入库」和「内容已定稿」编成了一个 bool。
2. 浏览器扩展在**普通网页**上制卡时 Anki 的 sentence 字段本来就是空的（`popupSelectionText` 只在 `ontouchstart` 里赋值），而 `vendor/selection.js` 里完整的 DOM 切句实现零调用点。没有「当前句」就谈不上「上下句」。
