### PR TITLE
fix(manga/video/drop): 修复用户报的五个问题 (BUG-1750~1755)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,16 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1605 条。点号进各自文件。
+> 共 1611 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1755](bugs/BUG-1755-ass-wrap-width-anchored-to-window.md) | ✅ | ✅ | 字幕换行宽度锚在窗口而非视频画面，最大化后排版突变（BUG-1730 续） |
+| [BUG-1754](bugs/BUG-1754-drop-video-folder-ignored.md) | ✅ | ✅ | 视频页拖入文件夹完全静默 |
+| [BUG-1753](bugs/BUG-1753-drop-multi-video-only-first.md) | ✅ | ✅ | 拖入多个视频只导入第一个 |
+| [BUG-1752](bugs/BUG-1752-drop-fires-on-hidden-tabs.md) | ✅ | ✅ | 拖放同时命中隐藏 tab：视频页拖文件夹弹出「导入漫画」 |
+| [BUG-1751](bugs/BUG-1751-manga-wheel-zoom-step-unpredictable.md) | ✅ | ✅ | 漫画滚轮缩放步进取决于本机 deltaY，与右键菜单不同口径 |
+| [BUG-1750](bugs/BUG-1750-manga-rtl-slide-direction-inverted.md) | ✅ | ✅ | 漫画 RTL 翻页滑动动画方向与输入语义相反 |
 | [BUG-1731](bugs/BUG-1731-host-video-progress-reverse-sync.md) | ✅ | ✅ | 互联子端看片进度不反向推进 host 的继续观看/下一集 |
 | [BUG-1730](bugs/BUG-1730-ass-word-wrap-midword-break.md) | ✅ | ✅ | ass 字幕英文单词中间断行（Wrap 逐字符换行无词边界） |
 | [BUG-1729](bugs/BUG-1729-waveform-cue-strip-overlap.md) | ✅ | ✅ | 波形对轴弹窗字幕条带重叠cue叠画 |

--- a/docs/bugs/BUG-1750-manga-rtl-slide-direction-inverted.md
+++ b/docs/bugs/BUG-1750-manga-rtl-slide-direction-inverted.md
@@ -1,0 +1,14 @@
+## BUG-1750 · 漫画 RTL 翻页滑动动画方向与输入语义相反
+- **报告**：2026-08-20（用户：「The page slide animations are still inverted for Manga」）
+- **真实性**：✅ 真 bug。根因是**输入侧镜像了 RTL、视觉侧没镜像**，两者相反：
+  - 视觉：`fushi/lib/src/media/manga/manga_overlay_html.dart` 的 `__mangaApplyTranslate` 用 `-spread.offsetLeft` 定位，而 spread 按 spreadIndex 升序写进 DOM、根 strip 又写死 `#manga-root{...direction:ltr;}`，于是「下一跨页」恒在**右**边，前进恒为「画面左滑、新页从右进」——与 LTR 一致、与 RTL 相反。
+  - 输入：tap zone（`manga_overlay_html.dart` 的 `_tapZoneTurn`，`IS_RTL ? 'next' : 'prev'`）与方向键（`fushi/lib/src/shortcuts/manga_arrow_override.dart:33-43`，注释白纸黑字写「rtl：下一页在左 → 左键前进」）都已按 RTL 镜像。
+  - RTL 是**默认值**（`preferences_repository.dart` 的 `manga_reading_direction` 默认 `'rtl'`），所以默认配置下必现：按前进键，画面往后退的方向滑。
+  - **引入点** `cd4be252548`（2026-07-27，标题写的是 OCR）：原本 `direction:rtl` 加在根 strip 上（那时 RTL 滑动方向是对的），但 Chromium 把 RTL 起点偏移混进 `offsetLeft` 导致整组图片错位无法居中；那次为拿回稳定的 `offsetLeft` 把根 strip 钉死 LTR，**顺手把 RTL 的视觉翻页方向一起废掉了**，输入侧没跟着改。`040e583eac8`（PR#751）给 tap zone 加 `IS_RTL` 镜像，把矛盾坐实。
+  - swipe（`dx < 0 ? 'next' : 'prev'`）与滚轮翻页从未参与 RTL；其注释声称「由 Dart 端依据阅读方向 clamp」是**假的**——`_onMangaTurn` 只有 `next ? +1 : -1` 和边界钳位。
+- **[x] ① 已修复** — 保留 `direction:ltr`（那是 `offsetLeft` 稳定性的必要条件，不能回退），改成**按阅读方向倒序写入 DOM**：RTL 时 spread N 的 `offsetLeft` 变成 `(n-1-N)×100vw`，仍是稳定的 100vw 整数倍，但「下一跨页」落到左边，前进 = 画面右滑、新页从左进。`__mangaApplyTranslate` 用 `data-spread` 属性选择器定位，与 DOM 顺序无关，一行未改。同时把 swipe 判据改成 `(swipeRight === IS_RTL) ? 'next' : 'prev'`（RTL 下向右滑 = 下一页，与 Mihon 等 RTL 阅读器一致），并删掉那条撒谎的注释。滚轮翻页保持「下滚 = next」不镜像（方向无关的惯例）。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/manga_overlay_html_test.dart`：`spread RTL 的 strip 几何倒序：下一跨页在左，翻页动画方向才对`（三个 spread，断言 RTL 的 `data-spread` 顺序为 `[2,1,0]`、LTR 为 `[0,1,2]`，并复查两个方向都保持根 strip `direction:ltr`）+ `swipe 方向随 RTL 镜像，与 strip 几何同源`（正向断言新判据、反向断言写死的 `dx < 0 ? 'next' : 'prev'` 不再出现）。**已做变异测试**：把 `if (rtl)` 改成 `if (!rtl)` → 该用例红（`Expected: [2,1,0] Actual: [0,1,2]`），还原后文件 sha256 与变异前逐字节相同。
+- **备注**：
+  - 既有守卫 `spread RTL 只反转组内页序，根 strip 保持 LTR 稳定几何` **仍然通过**——本修复没有动 `direction:ltr`，只动了写入顺序。该守卫原先的措辞「DOM 顺序不变」只在单 spread 下成立，已改成明确指向「组内两页」。
+  - webtoon 不涉及（`rtl = !isWebtoon && ...`，纵向模式无 translateX 动画）。
+  - 未动的相邻问题：`MangaFushiPage.horizontalKeyTurn` 是死代码（全仓仅定义处一处命中，`d78d0274d3` 重构后调用方全改走 `resolveMangaArrowPageTurn`），留待清理。

--- a/docs/bugs/BUG-1751-manga-wheel-zoom-step-unpredictable.md
+++ b/docs/bugs/BUG-1751-manga-wheel-zoom-step-unpredictable.md
@@ -1,0 +1,16 @@
+## BUG-1751 · 漫画滚轮缩放步进取决于本机 deltaY，与右键菜单不同口径
+- **报告**：2026-08-20（用户：「the zoom function in the manga reader on the scroll wheel … currently zooms by like..... 112% and it would be super nice to have better granular control」，希望像右键菜单一样按 10% 步进）
+- **真实性**：✅ 真 bug（口径不一致 + 不可预期）。根因 `fushi/lib/src/media/manga/manga_overlay_html.dart` 的 Ctrl+wheel 监听：`_zoomAbout(ZOOM * Math.exp(steps * 0.2 * ZOOM_SENS), …)`，其中 `steps = clamp(-deltaY/100, -4, 4)`。
+  - 代码注释假设「一格标准滚轮 deltaY=100 ≈ +22%」，但 **WebView2 在高 DPI 上一格根本不是 100**：BUG-1065 实测同款机器（4K / 150% 缩放）app 内一格 `deltaY≈67`。用户实测约 112% 对应 `deltaY≈57`。也就是说「一格缩多少」取决于运行环境的 deltaY 绝对值，用户无法预期、文档也说不准。
+  - 另一半是**同一功能两套口径**：右键菜单（`manga_fushi_page.dart` 的 `_MangaContextAction.zoomIn/zoomOut` → `_setZoomPercent(_zoomPercent ± 10)`）和设置滑块（`settings_schema_manga.dart` 的 `manga.default_zoom`，step 10）都是 ±10 个百分点的**线性**步进，只有滚轮是乘法。
+  - 历史：最早是「deltaY 只当符号 + 恒 ±0.1 加法」，因「缩放极其不灵敏」改成乘法；这次是把线性步进要回来，但改掉当年真正的毛病（触控板碎 delta 与鼠标一格同等对待）。
+- **[x] ① 已修复** — 滚轮改为**对齐到 `ZOOM_STEP` 网格的定量步进**：`ZOOM_STEP = max(1, round(10 * ZOOM_SENS))`（默认灵敏度 → 恰好 10 个百分点），目标值 `dir>0 ? (floor(cur/STEP)+1)*STEP : (ceil(cur/STEP)-1)*STEP`，所以序列恒为 100→110→120…，捏合留下的非整倍率也会被拉回网格。三个要点：
+  1. **「一格」的判定复用本文件翻页滚轮的同一套累计口径**（阈值 40 + 反向清账）：鼠标一格无论 deltaY 是 57/67/100 都 ≥40，恒好一步；触控板碎 delta 攒够 40 才走一步。跨阈即清零、不留余数——留余数会让 deltaY=57 攒出 1,1,2,1,1,2 的非匀速台阶，正好毁掉「一格 = 10%」的承诺。
+  2. **浮点毛刺**：先 `cur = Math.round(ZOOM*1000)/10` 再取整。否则 `ZOOM=1.2` 常存成 `1.2000000000000002`，`Math.ceil(120.00000000000003/10)=13`，缩小一步算出 120 → 被 `_zoomAbout` 的 0.0005 死区吃掉 → **缩不动**。
+  3. **`ZOOM_SENS` 仍然管用**（设置项承诺它覆盖滚轮）：改为缩放**步长本身**而不是指数底数，语义仍是「越大每一步缩得越多」，注释不撒谎。
+  锚点数学、clamp、`onMangaZoomChanged` 回传全部复用原 `_zoomAbout`，一行未改（它只接收目标绝对倍率）。触屏捏合**保持连续比例**（`Math.pow(g.dist/pinch.dist, ZOOM_SENS)`）——捏合必须跟手，不能有台阶。Flutter 侧零改动（回传的整数百分比天然是步长的整数倍）。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/manga_overlay_html_test.dart` 的 `desktop zoom and right-button drag/menu contract is embedded` 改写为新契约：正向断言 `ZOOM_STEP` 定义式、网格上下取整两式、消浮点毛刺式、阈值 40 累计式、反向清账式；反向断言 `Math.exp(` 在整份文档里**不再出现**（全文件已无其它 `Math.exp` 用法，实测 grep 为空）。捏合的 `Math.pow` 断言原样保留。
+- **备注**：
+  - 该测试原本的断言 `expect(doc.contains('Math.exp(steps * 0.2 * ZOOM_SENS)'))` + reason「滚轮缩放必须是按 delta 幅值的乘法缩放，不能是定长加法」与本次需求**语义相反**，是连注释一起改写的，不是放宽。
+  - 滚轮缩放仍需按住 Ctrl/Cmd（裸滚轮在 spread 模式归翻页，两个监听器互斥，未动）。
+  - 代价：线性步进下 100%→400% 需要 30 格。灵敏度设置（25%~400%）是逃生口——设 400% 时一格 40 个百分点、8 格到顶。

--- a/docs/bugs/BUG-1752-drop-fires-on-hidden-tabs.md
+++ b/docs/bugs/BUG-1752-drop-fires-on-hidden-tabs.md
@@ -1,0 +1,15 @@
+## BUG-1752 · 拖放同时命中隐藏 tab：视频页拖文件夹弹出「导入漫画」
+- **报告**：2026-08-20（用户带截图：停在**视频页**，拖入视频文件夹 `[VCB-Studio] Yuru Yuri [Ma10p_1080p]`，结果弹出「导入漫画」对话框 + 橙色 toast「拖入的文件里没有新的游戏 .exe」，而视频页本身毫无反应。用户：「反正就没正确显示过」「这些具体地方以打开的页面为准」）
+- **真实性**：✅ 真 bug。一次拖放**同时**触发了三个页面的处理器，根因链三层：
+  1. `third_party/desktop_drop/lib/src/drop_target.dart` — `DropTarget` 把自己加进**进程级全局监听器列表**，每次 OS drop 事件所有监听者都被调用，唯一过滤是各自 `renderBox.paintBounds.contains(position)`。上游注释自陈：「把新页面推到 drop target 前面时你必须自己禁用它」。
+  2. `fushi/lib/src/pages/implementations/home_page.dart` — 书/漫画/视频/游戏四个 tab 是 `Offstage` 保活的。Flutter 的 `RenderOffstage.performLayout` 在 offstage 时**仍以完整约束给子树布局**（`Stack(fit: StackFit.expand)` 给的是全屏紧约束），只关掉 Flutter 自己的 `hitTest`。desktop_drop 不走 Flutter hitTest → **每个访问过的 tab 的 drop target 都是全屏大小、全部命中**。
+  3. `fushi/lib/src/media/drag_drop/fushi_file_drop_target.dart` — 唯一的门 `_routeVisible` 判的是 `ModalRoute.isCurrent`，而四个 tab **同在 HomePage 这一条路由上**，对它们同时为 true。业务层重复的同款检查（`home_video_page.dart` / `reader_history/books.part.dart`）同样无效。
+  实际链路：书架表面注入了 `isDirectory` 判据 → 目录归 `mangas` → `importNewManga` → 弹「导入漫画」；游戏库不分类直接 `filterOutDuplicateGameExes` → 无 exe → toast；视频页当时**没传** `isDirectory` → 目录落 `unknown` → `ignore` → 静默（后者单独立项 BUG-1754）。
+  「以前显示导入书籍、现在显示导入漫画」也解释了：`948190783a` 起目录就被判成漫画（那时仍复用 `BookImportDialog`，标题「导入书籍」），`9fd958bd0e` 漫画导入分家后落到 `MangaImportDialog`，标题才变「导入漫画」——从头到尾都是同一个错误路由。
+- **[x] ① 已修复** — 新增 `fushi/lib/src/media/drag_drop/drop_surface_scope.dart`：`DropSurfaceScope` 声明「这棵子树属于哪个可见表面」，`activeFor(context)` 用 `visitAncestorElements` 逐层 AND（嵌套可组合）。`FushiFileDropTarget` 的判定加上 `DropSurfaceScope.activeFor(context)`。作用域由 `home_page.dart` 在**构建 tab 内容的那一处**统一提供，判据与 `Offstage` 用同一个 `_visibleTab`，保证「看得见的那个」与「接拖放的那个」永远同一个。
+  刻意**不是**给 11 个注册点各加一个 `enabled` 参数：那样等于「要写守卫检查每个调用点有没有传对」，而调用点漏传就是 bug 本身。现在 11 个注册点一行未改，以后新增的入口天生带上。
+- **[x] ② 已加自动化测试** — `fushi/test/media/drag_drop/drop_surface_routing_test.dart` 的 `DropSurfaceScope 决定谁接这次拖放` 三条：无作用域时放行（对话框/播放页各自独占路由，行为不变）；`Offstage(offstage: true)` 包住的子树被判不活跃、可见子树放行（直接钉住本 bug 的形状——Offstage 挡不住 desktop_drop，只有作用域能挡）；嵌套逐层 AND。
+- **备注**：
+  - 只挡「谁接」，不改任何一个表面接到之后**做什么**——分类/决策纯函数一行未动。
+  - 未做（更彻底的架构，单独立项）：把 11 个 `DropTarget` 收敛成 app 根部**唯一**一个真 `DropTarget` + 一个 registry 裁决。当前作用域方案已让「多个表面同时响应」在结构上不可能，但每个 widget 仍各自向 desktop_drop 注册。
+  - 未做：库页**内部**子视图（视频页的 首页/发现/系列/全部视频/导入/设置）没有全局真值可读（`_VideoLibraryShellState._section` 是私有字段），所以「在发现子页拖入」仍会被本地库表面接走。`DropSurfaceScope` 的嵌套语义已经为它留好口子，补一层即可。

--- a/docs/bugs/BUG-1753-drop-multi-video-only-first.md
+++ b/docs/bugs/BUG-1753-drop-multi-video-only-first.md
@@ -1,0 +1,11 @@
+## BUG-1753 · 拖入多个视频只导入第一个
+- **报告**：2026-08-20（用户：「手动将多个影片拖拽进去的时候，只会导入第一个，而不是导入所有」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/home_video_page.dart` 的 `_handleVideoDrop`：`case DropIntent.importNewVideo:` 只消费 `files.videos.first`，其余被静默丢弃。
+  这不是一处漏改——`DropIntent` 是**标量**（一次拖放 = 一个意图），整条链路的数据模型里没有「多个」这个概念：`home_video_page.dart` / `reader_history/books.part.dart` / `media/drag_drop/import_dialog_drop.dart` / `media/manga/manga_import_dialog.dart` 共 20 余处 `.first`，而 `VideoDialogDropResult.videoPath` 本身就是 `String?` 而非 `List<String>`。唯一的批量字段是 `audioPaths`。
+- **[x] ① 已修复** — 新增 `_openVideoImportQueue(videos, subtitles)`：拖入的**每个**视频排成队列逐个预填 `VideoImportDialog`。没有硬塞一个批量模式进对话框——该对话框结构上是单条目的（每条视频各有标题/字幕/元数据要确认）。两条语义写进了实现：
+  - **字幕配对**：只有一个视频时沿用历史行为（第一条字幕给它）；多个视频时按**文件名主干**大小写不敏感配对（`EP01.mkv` ↔ `ep01.srt`），配不上就不给——多集拖入时把同一条字幕挂到每一集比不挂更糟。
+  - **取消只跳过该条，队列继续**：拖 5 个进来、其中 1 个不想要，不该连带取消另外 4 个。
+- **[x] ② 已加自动化测试** — 配对判据抽成纯函数 `subtitleForVideoByStem`（`fushi/lib/src/media/drag_drop/drop_classification.dart`，原先是页面里的私有静态方法、测不到），`fushi/test/media/drag_drop/drop_surface_routing_test.dart` 的 `多文件拖入：字幕按文件名主干配对` 两条：主干相同即配对（大小写不敏感、且不受列表顺序影响——故意把不匹配的 `EP02.srt` 排在前面）；配不上返回 null。
+- **备注**：
+  - 只修了**视频**表面（用户报的就是这条）。书架 `books.part.dart` 的 `.first` 仍在，拖多本 epub 同样只导第一本——同源不同表面，单独立项。
+  - 未做：把 `DropIntent` 从标量改成 `List<DropAction>`、`import_dialog_drop.dart` 的 `String? videoPath` 改成列表。那是根治「模型里没有『多个』」的改法，爆炸半径覆盖全部拖放落点，不在本轮。

--- a/docs/bugs/BUG-1754-drop-video-folder-ignored.md
+++ b/docs/bugs/BUG-1754-drop-video-folder-ignored.md
@@ -1,0 +1,18 @@
+## BUG-1754 · 视频页拖入文件夹完全静默
+- **报告**：2026-08-20（用户：「导入文件夹应该直接添加文件夹到来源」；截图里拖入的正是一个剧集文件夹）
+- **真实性**：✅ 真 bug。两处叠加：
+  1. `fushi/lib/src/pages/implementations/home_video_page.dart` 的 `_handleVideoDrop` 调 `classifyDroppedFiles(paths)` 时**没传** `isDirectory` 谓词。该谓词是分类器唯一的外注入判据（目录没有扩展名，纯扩展名分类分不出「目录」与「无扩展名文件」，而分类器不碰文件系统）。不传 → 目录落 `unknown` → `decideDropIntent` 走到 `files.hasAny` 之前的分支全不命中 → `DropIntent.ignore` → **什么都不做、什么都不说**。
+  2. `fushi/lib/src/media/drag_drop/drop_classification.dart` 把「这是目录」这个**事实**就地编码成「这是漫画」这个**判断**（`isDirectory(path) → mangas.add(path)`）。判断做早了，别的表面再也拿不到原始事实——即使视频页传了谓词，也只会拿到一个「漫画」。
+  「以打开的页面为准」的另一半（拖放同时命中隐藏 tab）是 BUG-1752。
+- **[x] ① 已修复** — 三步，分别对应上面的两处：
+  - 分类器新增 `DroppedFiles.directories`，**只记录事实**；目录仍同时进 `mangas`，书架/漫画库的「整目录页图导入一本漫画」逐字节不变。
+  - `decideDropIntent` 的 video 分支新增 `if (files.directories.isNotEmpty) return DropIntent.addFolderAsSource;`，**排在 videos/playlists 之前**——拖一整个剧集目录进来要的是加来源，不是导入恰好也选中的那一个 mp4。books/manga 分支不变。
+  - 视频页补上 `isDirectory: (path) => Directory(path).existsSync()`，并新增 `_addDroppedFoldersAsSources`：媒体类型取自**当前页面**（恒 `SourceLibraryKind.video`），不从目录内容猜。
+  落地走**新抽的共享函数** `fushi/lib/src/media/source_library/add_local_folder_source.dart` 的 `addLocalFolderAsSource`（归一化路径 → 同 transport+路径去重 → 插入 → 立即扫描），与来源页「添加本地文件夹」按钮产出完全相同的来源行；两条入口不会漂成两套语义。结果给 toast（新增 / 已存在两种）。
+- **[x] ② 已加自动化测试** — `fushi/test/media/drag_drop/drop_surface_routing_test.dart`：
+  - `目录是事实，不是判断`：传 `isDirectory` 时目录同时进 `directories` 与 `mangas`；不传时两者都空（历史行为逐字节不变）。
+  - `decideDropIntent：文件夹按落点表面解释`：视频页 → `addFolderAsSource`；视频页**混合**拖入（目录 + mkv）仍 → `addFolderAsSource`；books 与 manga 两个表面 → 仍是 `importNewManga`（既有能力不许被拿掉）。
+- **备注**：
+  - 用户原话是「直接添加文件夹到来源」，故实现为**直接加为常驻来源**，没有再弹「设为常驻来源 / 仅导入这一次」二选一。来源页那个二选一对话框（`media_sources_view.dart` 的 `importFolder`）仍只挂在文件选择器上。若之后希望拖放也先问一句，改 `_addDroppedFoldersAsSources` 一处即可。
+  - `addLocalFolderAsSource` 目前只有拖放路径在用；把 `MediaSourcesViewState.addLocalFolder` 也改成调它（消除那 15 行重复）留待后续，本轮不动那个 State 以控爆炸半径。
+  - 书架/漫画库拖文件夹仍是「一本漫画」。若用户之后也希望那两个表面按来源处理，改的是 `decideDropIntent` 的对应分支，事实字段已经就位。

--- a/docs/bugs/BUG-1755-ass-wrap-width-anchored-to-window.md
+++ b/docs/bugs/BUG-1755-ass-wrap-width-anchored-to-window.md
@@ -1,0 +1,14 @@
+## BUG-1755 · 字幕换行宽度锚在窗口而非视频画面，最大化后排版突变（BUG-1730 续）
+- **报告**：2026-08-20（用户：.ass 字幕在英文单词中间断行，「it mostly seems to happen when the subs are anchored to the bottom, but not the top」，且「I use a 1440p monitor and this is a 1080p video. With the window at the same size as 1080p the subtitles looked the same but when I maximised the window it scaled the text size」。附 MPC 与 Fushi 对比截图：MPC 两行均衡，Fushi 一行占满 + 第二行只剩 `oration.`）
+- **真实性**：✅ 真 bug，但**中词断行本身已由 BUG-1730 修掉**（`3aa5907ff0`，`groupSubtitleGraphemesForWrap` 把拉丁词整组包进 `Row`，已在 origin/develop）。用户截图应出自该提交之前的构建。本条记的是 BUG-1730「备注」里明确留下的**两条未修根因**，正好就是用户自己诊断出的两点：
+  1. **换行宽度基准与字号基准不同源**（对应「最大化就变」）。字号锚在 fit:contain 后的**视频内容矩形高**（`video_subtitle_overlay.dart` 的 `_assFontScale` / `fitVideoContentSize`，与 mpv/libass 同口径），换行可用宽度却锚在**容器宽**（`Positioned.fill` 的 overlay 宽减去 ASS MarginL/R 和字幕盒固定 24px 内边距）。几何推导：letterbox 档二者都 ∝ 容器宽，换行容量恒定；**pillarbox 档**（窗口比视频扁，1080p 视频 + 带标题栏的窗口正是这一档）字号 ∝ 容器高、可用宽 ∝ 容器宽，于是**换行容量 ∝ 容器宽高比**。1920×1048（比 1.832）最大化到 2560×1440（比 1.778）≈ 换行容量少 3%，一行「刚好塞满」的字幕就被推过阈值。
+  2. **顶/底不对称**（对应「底部锚定才断行、顶部不断」）。`final SubtitleMarkup? posMarkup = forcedAnchor != null ? null : ownMarkup;` —— 这是**竖直**强制锚定，却把水平排版盒一起丢了：底锚（默认，`forcedAnchor == null`）扣掉双侧 ASS MarginL/R（常见 26~80px），顶锚 `posMarkup` 为 null → `_scaledMarginX(null, null)` 恒返回 null → 一点不扣、换行宽度反而更大。
+  - 顺带核实并**排除**了一个假设：代码里没有「字号跟窗口走而不跟视频内容矩形走」的路径（ASS 字号严格 ∝ 视频显示高）。用户感知的「字号变大」更可能是「同样的字幕被换成两行、第二行只剩一个词」造成的视觉误判。
+- **[x] ① 已修复** — 两处，都在 `fushi/lib/src/media/video/video_subtitle_overlay.dart`：
+  - 新增 `_pillarboxSideInset()`（fit:contain 后单侧黑边宽，letterbox / 分辨率未知时为 0），在 `_paddingFor` 里叠进左右 padding。可用宽度自此 ∝ 视频内容宽，与字号同源，**换行位置对窗口尺寸恒定不变**。
+  - 水平边距改读 `ownMarkup` 而非 `posMarkup`（竖直的 `scaledMarginV` / `rawMarginV` **必须**继续走 `posMarkup`，否则用户选的锚定会被 ASS MarginV 顶回去）。顶/底自此同宽。`respectAssStyle == false` 时 `ownMarkup` 恒 null，纯字幕路径零变化。
+- **[x] ② 已加自动化测试** — 新增 `fushi/test/media/video/video_subtitle_wrap_viewport_test.dart`：16:9 视频 + 固定 200px 高（⇒ 视频内容矩形恒定），容器宽 500 → 760，断言**断行位置一字不变**（并先断言这句话确实会换行，避免空转）；另一条断言整行水平范围落在视频内容矩形内、不排进左右黑边。**已做变异测试**：把 `sideBar` 写死成 0 → 两条全红；还原后文件 sha256 与变异前逐字节相同。（测试宽度必须 ≤ 测试窗口宽 800——`Center` 给 loose 约束，`SizedBox(width:1000)` 会被 constrain 成 800，黑边算式就对不上。）
+- **备注**：
+  - **未修、且是与 MPC 差异的另一半**：`\q`（WrapStyle）**完全没解析**（`ass_parser.dart` 只读 PlayResX/Y，override 标签分发里没有 `'q'` 分支，`SubtitleMarkup` 无该字段）。当前恒 ≈WrapStyle 1（贪心填满，上行更宽），而 **ASS 缺省是 WrapStyle 0 = 均衡换行**（libass 会把两行断得长度接近）。这正是截图里 MPC 给出两行均衡、Fushi 给出「满行 + 一个词」的直接原因。要修需要把贪心 `Wrap` 换成先测量后择点的均衡布局，与逐字形样式（`\fscx`/描边分层/竖排旋转）的测量精度耦合，爆炸半径大，单独立项。
+  - **未修**：`\h`（不断行空格）在 `packages/fushi_audio/lib/src/parsers/subtitle_markup.dart` 被写成普通空格，于是分组函数把作者明确禁止断行的位置当成断行机会。分组函数已经把 NBSP 当词内字符（`g != ' '`），但 `plainText` 是查词/制卡/落库的同一份文本，直接写 NBSP 会改变它；正确做法是照 `\N` 的既有范式加一个 `nonBreakingGraphemes` 下标表。同处 `\n`（软换行）也被当空格。
+  - **行为变化（有意）**：黑边内缩对 srt/vtt 同样施加（字幕属于画面、不该排进黑边），pillarbox 下这不是像素级不变。居中对齐时视觉中心不动，只是换行宽度收窄到画面宽。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 61591 (3623 per locale)
+/// Strings: 61693 (3629 per locale)
 ///
-/// Built on 2026-08-19 at 06:16 UTC
+/// Built on 2026-08-20 at 03:11 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4917,6 +4917,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Read EPUB novels with dictionary lookup and audiobook sync';
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -13309,6 +13317,20 @@ class _StringsAr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -21767,6 +21789,20 @@ class _StringsDe extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -30241,6 +30277,20 @@ class _StringsEs extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -38727,6 +38777,20 @@ class _StringsFr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -47142,6 +47206,20 @@ class _StringsId extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -55602,6 +55680,20 @@ class _StringsIt extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -63877,6 +63969,20 @@ class _StringsJa extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -72159,6 +72265,20 @@ class _StringsKo extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -80599,6 +80719,20 @@ class _StringsNl extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -89051,6 +89185,20 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -97489,6 +97637,20 @@ class _StringsRu extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -105875,6 +106037,20 @@ class _StringsTh extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -114293,6 +114469,20 @@ class _StringsTr extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -122696,6 +122886,20 @@ class _StringsVi extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 // Path: <root>
@@ -130472,6 +130676,18 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_feature_books_hint => '看小说（EPUB），查词与有声书同步';
   @override
   String get onboarding_feature_extension_hint => '网页查词（仅桌面）';
+  @override
+  String get shortcut_action_manga_pan_up => '向上平移';
+  @override
+  String get shortcut_action_manga_pan_down => '向下平移';
+  @override
+  String get shortcut_action_manga_pan_left => '向左平移';
+  @override
+  String get shortcut_action_manga_pan_right => '向右平移';
+  @override
+  String get drag_drop_folder_source_added => '已把文件夹添加为来源并开始扫描';
+  @override
+  String get drag_drop_folder_source_exists => '该文件夹已经是来源了';
 }
 
 // Path: <root>
@@ -138670,6 +138886,20 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get onboarding_feature_extension_hint =>
       'Look up words on any web page (desktop only)';
+  @override
+  String get shortcut_action_manga_pan_up => 'Pan up';
+  @override
+  String get shortcut_action_manga_pan_down => 'Pan down';
+  @override
+  String get shortcut_action_manga_pan_left => 'Pan left';
+  @override
+  String get shortcut_action_manga_pan_right => 'Pan right';
+  @override
+  String get drag_drop_folder_source_added =>
+      'Folder added as a library source and scanned.';
+  @override
+  String get drag_drop_folder_source_exists =>
+      'That folder is already a library source.';
 }
 
 /// Flat map(s) containing all translations.
@@ -146107,6 +146337,18 @@ extension on _StringsEn {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -153542,6 +153784,18 @@ extension on _StringsAr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -160999,6 +161253,18 @@ extension on _StringsDe {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -168455,6 +168721,18 @@ extension on _StringsEs {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -175917,6 +176195,18 @@ extension on _StringsFr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -183361,6 +183651,18 @@ extension on _StringsId {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -190819,6 +191121,18 @@ extension on _StringsIt {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -198239,6 +198553,18 @@ extension on _StringsJa {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -205663,6 +205989,18 @@ extension on _StringsKo {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -213115,6 +213453,18 @@ extension on _StringsNl {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -220564,6 +220914,18 @@ extension on _StringsPtBr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -228018,6 +228380,18 @@ extension on _StringsRu {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -235455,6 +235829,18 @@ extension on _StringsTh {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -242901,6 +243287,18 @@ extension on _StringsTr {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -250343,6 +250741,18 @@ extension on _StringsVi {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }
@@ -257726,6 +258136,18 @@ extension on _StringsZhCn {
         return '看小说（EPUB），查词与有声书同步';
       case 'onboarding_feature_extension_hint':
         return '网页查词（仅桌面）';
+      case 'shortcut_action_manga_pan_up':
+        return '向上平移';
+      case 'shortcut_action_manga_pan_down':
+        return '向下平移';
+      case 'shortcut_action_manga_pan_left':
+        return '向左平移';
+      case 'shortcut_action_manga_pan_right':
+        return '向右平移';
+      case 'drag_drop_folder_source_added':
+        return '已把文件夹添加为来源并开始扫描';
+      case 'drag_drop_folder_source_exists':
+        return '该文件夹已经是来源了';
       default:
         return null;
     }
@@ -265141,6 +265563,18 @@ extension on _StringsZhHk {
         return 'Read EPUB novels with dictionary lookup and audiobook sync';
       case 'onboarding_feature_extension_hint':
         return 'Look up words on any web page (desktop only)';
+      case 'shortcut_action_manga_pan_up':
+        return 'Pan up';
+      case 'shortcut_action_manga_pan_down':
+        return 'Pan down';
+      case 'shortcut_action_manga_pan_left':
+        return 'Pan left';
+      case 'shortcut_action_manga_pan_right':
+        return 'Pan right';
+      case 'drag_drop_folder_source_added':
+        return 'Folder added as a library source and scanned.';
+      case 'drag_drop_folder_source_exists':
+        return 'That folder is already a library source.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "浏览器扩展",
   "onboarding_feature_books": "小说库",
   "onboarding_feature_books_hint": "看小说（EPUB），查词与有声书同步",
-  "onboarding_feature_extension_hint": "网页查词（仅桌面）"
+  "onboarding_feature_extension_hint": "网页查词（仅桌面）",
+  "shortcut_action_manga_pan_up": "向上平移",
+  "shortcut_action_manga_pan_down": "向下平移",
+  "shortcut_action_manga_pan_left": "向左平移",
+  "shortcut_action_manga_pan_right": "向右平移",
+  "drag_drop_folder_source_added": "已把文件夹添加为来源并开始扫描",
+  "drag_drop_folder_source_exists": "该文件夹已经是来源了"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3621,5 +3621,11 @@
   "module_extension_label": "Browser extension",
   "onboarding_feature_books": "Novel library",
   "onboarding_feature_books_hint": "Read EPUB novels with dictionary lookup and audiobook sync",
-  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)"
+  "onboarding_feature_extension_hint": "Look up words on any web page (desktop only)",
+  "shortcut_action_manga_pan_up": "Pan up",
+  "shortcut_action_manga_pan_down": "Pan down",
+  "shortcut_action_manga_pan_left": "Pan left",
+  "shortcut_action_manga_pan_right": "Pan right",
+  "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
+  "drag_drop_folder_source_exists": "That folder is already a library source."
 }

--- a/fushi/lib/src/media/drag_drop/drop_classification.dart
+++ b/fushi/lib/src/media/drag_drop/drop_classification.dart
@@ -140,6 +140,7 @@ class DroppedFiles {
     required this.unknown,
     this.mangas = const <String>[],
     this.unsupportedMangas = const <String>[],
+    this.directories = const <String>[],
   });
 
   final List<String> books;
@@ -157,6 +158,14 @@ class DroppedFiles {
   /// 认得出是漫画包但导入器不支持的（cbr/cb7/rar，见
   /// [kDragUnsupportedMangaExtensions]）——落点据此给明确提示而非静默。
   final List<String> unsupportedMangas;
+
+  /// 被 `isDirectory` 谓词判定为**目录**的路径，作为**事实**原样记录。
+  ///
+  /// 与 [mangas] 是交叠而非互斥的：目录同时也会进 [mangas]，保住书架/漫画库既有的
+  /// 「整目录页图导入一本漫画」。分开记的理由是——「这是个目录」是事实，「目录算漫画」
+  /// 是判断，判断必须留给知道落点表面的 [decideDropIntent] 去做。此前事实被就地
+  /// 编码成判断，于是视频页永远拿不到「用户拖进来的是个文件夹」这个信息。
+  final List<String> directories;
 
   /// 拖入的可导入网络流 URL（http(s)，非文件路径）。浏览器地址栏/链接拖进来时，
   /// 原生（Windows CFSTR_INETURLW / macOS public.url / Linux text/uri-list）把 URL
@@ -220,6 +229,7 @@ DroppedFiles classifyDroppedFiles(
   final List<String> urls = <String>[];
   final List<String> mangas = <String>[];
   final List<String> unsupportedMangas = <String>[];
+  final List<String> directories = <String>[];
   final List<String> unknown = <String>[];
 
   for (final String path in paths) {
@@ -232,6 +242,7 @@ DroppedFiles classifyDroppedFiles(
     // 目录（漫画页图文件夹）：整目录导入一本漫画。放在扩展名分类之前——目录名
     // 带点时（如 `第01巻.v2`）会被 p.extension 当成扩展名而误分类。
     if (isDirectory != null && isDirectory(path)) {
+      directories.add(path);
       mangas.add(path);
       continue;
     }
@@ -292,6 +303,7 @@ DroppedFiles classifyDroppedFiles(
     urls: urls,
     mangas: mangas,
     unsupportedMangas: unsupportedMangas,
+    directories: directories,
     unknown: unknown,
   );
 }
@@ -307,4 +319,19 @@ List<String> classifyDroppedFilesForDictionary(List<String> paths) {
       .where((String pth) => p.extension(pth).toLowerCase() == '.css')
       .toList();
   return <String>[...files.dictionaries, ...cssAttachments];
+}
+
+/// 给一个视频挑配对字幕：按**文件名主干**（不含扩展名）大小写不敏感匹配，
+/// 找不到返回 null。
+///
+/// 多个视频一起拖入时用它逐个配对——把同一条字幕挂到每一集比不挂更糟。单个视频
+/// 的历史行为（直接取第一条字幕）由调用方保留，不走这里。
+String? subtitleForVideoByStem(String videoPath, List<String> subtitles) {
+  final String stem = p.basenameWithoutExtension(videoPath).toLowerCase();
+  for (final String subtitle in subtitles) {
+    if (p.basenameWithoutExtension(subtitle).toLowerCase() == stem) {
+      return subtitle;
+    }
+  }
+  return null;
 }

--- a/fushi/lib/src/media/drag_drop/drop_decision.dart
+++ b/fushi/lib/src/media/drag_drop/drop_decision.dart
@@ -27,6 +27,14 @@ enum DropIntent {
   /// 拖入的可导入网络流 URL → 走视频「流媒体导入」（[_importStreamUrl]，入库进视频
   /// 书架）。books/video 两表面都自动切到视频导入，与拖视频文件的自动切换一致（TODO-1306）。
   importVideoUrl,
+
+  /// 拖入的是**文件夹** → 按当前页面的媒体类型登记成扫描根（source library）并扫描。
+  ///
+  /// 只有 [DropSurface.video] 产出它：书架/漫画库把目录当「一本漫画的页图文件夹」是
+  /// 既有能力（`importFromImageFolder`），不能拿掉。视频页此前对目录**完全静默**
+  /// （没传 isDirectory 谓词 → 落 unknown → ignore），用户拖一整季文件夹进去毫无反应。
+  addFolderAsSource,
+
   attachToBookCard,
   attachToVideoCard,
   needCardTarget,
@@ -96,6 +104,9 @@ DropIntent decideDropIntent({
         cardHit: cardHit,
       );
     case DropSurface.video:
+      // 文件夹优先于其中的单个文件：用户拖一整个剧集目录进来，要的是「把这个目录
+      // 加成来源」，不是「导入我恰好也选中的那一个 mp4」。
+      if (files.directories.isNotEmpty) return DropIntent.addFolderAsSource;
       if (files.urls.isNotEmpty) return DropIntent.importVideoUrl;
       if (files.playlists.isNotEmpty) return DropIntent.importNewPlaylist;
       if (files.videos.isNotEmpty) return DropIntent.importNewVideo;

--- a/fushi/lib/src/media/drag_drop/drop_surface_scope.dart
+++ b/fushi/lib/src/media/drag_drop/drop_surface_scope.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/widgets.dart';
+
+/// 声明「这棵子树属于哪个可见表面」，让 [FushiFileDropTarget] 在 drop 落地那一刻
+/// 判断自己是不是用户当前真正看着的那个页面。
+///
+/// 为什么需要它：`desktop_drop` 是**全局广播**——每个 `DropTarget` 把自己加进一个
+/// 进程级监听器列表，一次 OS drop 事件所有监听者都会被调用，唯一的过滤是各自
+/// `RenderBox.paintBounds.contains(位置)`（见 vendored `desktop_drop` 的
+/// `_onDropEvent`，其文档也明说「把新页面推到 drop target 前面时你必须自己禁用它」）。
+/// 而 home-shell 的四个库页是 `Offstage` 保活的，`RenderOffstage.performLayout` 在
+/// offstage 时仍以完整约束给子树布局（只关掉 Flutter 自己的 `hitTest`），于是**每个
+/// 访问过的 tab 的 drop target 都仍然是全屏大小、全部命中**。
+///
+/// 原有的唯一门控 `ModalRoute.isCurrent` 挡不住这个：四个 tab 同在 HomePage 这一条
+/// 路由上，`isCurrent` 对它们同时为 true。实测后果是「在视频页拖入一个视频文件夹 →
+/// 隐藏的书架页把它当漫画弹出『导入漫画』对话框，隐藏的游戏页同时弹『拖入的文件里
+/// 没有新的游戏 .exe』，而真正可见的视频页一动不动」。
+///
+/// 这里修的是**结构**而不是逐个调用点补判断：作用域由 shell 在「构建 tab 内容」的
+/// 那一处统一提供，11 个 drop 注册点一行都不用改，以后新增的入口天生带上。
+class DropSurfaceScope extends InheritedWidget {
+  const DropSurfaceScope({
+    required this.isActive,
+    required super.child,
+    super.key,
+  });
+
+  /// 在 drop 落地那一刻求值：本子树当前是否是用户看得见的表面。
+  ///
+  /// 用回调而不是 bool 字段，是因为拖放判定只发生在事件到达的瞬间，不需要让
+  /// widget 树为了「当前哪个 tab」而重建。
+  final bool Function() isActive;
+
+  /// [context] 所在子树当前是否可以接收拖放。
+  ///
+  /// **所有**祖先作用域都必须活跃（逐层 AND），所以嵌套是可组合的：外层声明
+  /// 「视频 tab 可见吗」，内层再声明「视频 tab 内部当前是不是本地库那一屏」。
+  /// 没有任何作用域时返回 true——对话框、播放页这类自己独占一条路由的表面
+  /// 不受影响，行为与改动前一致。
+  static bool activeFor(BuildContext context) {
+    bool active = true;
+    context.visitAncestorElements((Element element) {
+      final Widget widget = element.widget;
+      if (widget is DropSurfaceScope && !widget.isActive()) {
+        active = false;
+        return false;
+      }
+      return true;
+    });
+    return active;
+  }
+
+  /// 恒 false：本作用域只在事件到达时被**主动**读取（[activeFor] 不建立依赖），
+  /// 不驱动任何重建。
+  @override
+  bool updateShouldNotify(DropSurfaceScope oldWidget) => false;
+}

--- a/fushi/lib/src/media/drag_drop/fushi_file_drop_target.dart
+++ b/fushi/lib/src/media/drag_drop/fushi_file_drop_target.dart
@@ -2,9 +2,11 @@ import 'dart:async' show FutureOr;
 import 'dart:io' show Platform;
 
 import 'package:desktop_drop/desktop_drop.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show debugPrint, kIsWeb, visibleForTesting;
 import 'package:flutter/widgets.dart';
 
+import 'package:fushi/src/media/drag_drop/drop_surface_scope.dart';
 import 'package:fushi/utils.dart';
 
 /// File drop callback. [globalPosition] uses Flutter global/view coordinates,
@@ -51,13 +53,15 @@ class FushiFileDropTarget extends StatelessWidget {
       enable: enabled,
       onDragDone: (DropDoneDetails detail) {
         final bool routeVisible = _routeVisible(context);
-        final bool active = enabled && routeVisible;
+        final bool surfaceActive = DropSurfaceScope.activeFor(context);
+        final bool active = enabled && routeVisible && surfaceActive;
         final List<String> paths = detail.files
             .map((DropItem f) => f.path)
             .where((String s) => s.isNotEmpty)
             .toList();
         _log(
           'done active=$active routeVisible=$routeVisible '
+          'surface=$surfaceActive '
           'files=${paths.length} local=${detail.localPosition} '
           'global=${detail.globalPosition}',
         );
@@ -73,7 +77,8 @@ class FushiFileDropTarget extends StatelessWidget {
       },
       onDragEntered: (DropEventDetails detail) {
         final bool routeVisible = _routeVisible(context);
-        final bool active = enabled && routeVisible;
+        final bool surfaceActive = DropSurfaceScope.activeFor(context);
+        final bool active = enabled && routeVisible && surfaceActive;
         _log(
           'enter active=$active routeVisible=$routeVisible '
           'local=${detail.localPosition} global=${detail.globalPosition}',
@@ -81,7 +86,8 @@ class FushiFileDropTarget extends StatelessWidget {
       },
       onDragUpdated: (DropEventDetails detail) {
         final bool routeVisible = _routeVisible(context);
-        final bool active = enabled && routeVisible;
+        final bool surfaceActive = DropSurfaceScope.activeFor(context);
+        final bool active = enabled && routeVisible && surfaceActive;
         _log(
           'update active=$active routeVisible=$routeVisible '
           'local=${detail.localPosition} global=${detail.globalPosition}',
@@ -89,7 +95,8 @@ class FushiFileDropTarget extends StatelessWidget {
       },
       onDragExited: (DropEventDetails detail) {
         final bool routeVisible = _routeVisible(context);
-        final bool active = enabled && routeVisible;
+        final bool surfaceActive = DropSurfaceScope.activeFor(context);
+        final bool active = enabled && routeVisible && surfaceActive;
         _log(
           'exit active=$active routeVisible=$routeVisible '
           'local=${detail.localPosition} global=${detail.globalPosition}',

--- a/fushi/lib/src/media/manga/manga_overlay_html.dart
+++ b/fushi/lib/src/media/manga/manga_overlay_html.dart
@@ -622,9 +622,26 @@ String mangaWindowDocument(
     }
   }
   if (!isWebtoon) {
-    for (final MapEntry<int, StringBuffer> entry in spreadPages.entries) {
+    // strip 的**几何顺序**必须跟着阅读方向走，否则翻页动画方向是反的。
+    //
+    // 根 strip 恒 `direction:ltr`（见上方注释）：把 `direction:rtl` 放上去会让
+    // Chromium 把 RTL 起点偏移混进 offsetLeft，translate 后整组图片错位。所以
+    // RTL 不能靠 CSS 反排——改成按**倒序写入 DOM**：spread N 的 offsetLeft 变成
+    // (n-1-N)×100vw，仍是稳定的 100vw 整数倍（`__mangaApplyTranslate` 的
+    // `-offsetLeft` 口径不变），但「下一跨页」落到左边，于是前进时画面向右滑、
+    // 新页从左边进——与 tap zone（IS_RTL 镜像）和方向键（resolveMangaArrowPageTurn）
+    // 早已按 RTL 镜像过的输入语义对上。此前只镜像输入不镜像几何，RTL（默认值）下
+    // 「按前进键 → 画面往后退的方向滑」。
+    //
+    // `__mangaApplyTranslate` 用 `data-spread` 属性选择器定位目标，与 DOM 顺序
+    // 无关，故无需改动；窗口化文档只渲染连续的一段 spread，倒序后仍连续。
+    List<int> spreadOrder = spreadPages.keys.toList()..sort();
+    if (rtl) {
+      spreadOrder = spreadOrder.reversed.toList();
+    }
+    for (final int spreadIndex in spreadOrder) {
       pagesHtml.write('<div class="manga-spread" '
-          'data-spread="${entry.key}">${entry.value}</div>');
+          'data-spread="$spreadIndex">${spreadPages[spreadIndex]}</div>');
     }
   }
 
@@ -1023,6 +1040,26 @@ String _mangaGestureJs({
     if (flickRaf) { cancelAnimationFrame(flickRaf); flickRaf = null; }
     flickVy = 0;
   }
+  // PAN 的合法区间：可见内容是**一个跨页**（100vw×100vh；webtoon 横向同宽，纵向归
+  // window.scrollY）。#manga-canvas 是 transform-origin:0 0，内容被 scale 后宽
+  // vw*ZOOM，于是 PAN_X 只能落在 [vw*(1-ZOOM), 0]——上界 0 = 内容左边缘贴视口左边，
+  // 下界 = 右边缘贴视口右边。ZOOM<=1 时区间退化（内容比视口小），此时位置由
+  // _recenterPan 居中拥有，不参与钳制。
+  //
+  // 此前 PAN 完全没有边界：拖动能把页面推出视口且回不来（放大后尤其容易），方向键
+  // 平移是离散步进、按几十下必然踩到。钳制放在 _panBy 里，拖动/惯性/方向键三条
+  // 平移路径共用同一条规则。
+  function _clampPan(){
+    if (ZOOM <= 1) return;
+    var minX = window.innerWidth * (1 - ZOOM);
+    if (PAN_X < minX) PAN_X = minX;
+    if (PAN_X > 0) PAN_X = 0;
+    if (!IS_WEBTOON) {
+      var minY = window.innerHeight * (1 - ZOOM);
+      if (PAN_Y < minY) PAN_Y = minY;
+      if (PAN_Y > 0) PAN_Y = 0;
+    }
+  }
   function _panBy(dx, dy){
     var canvasMoved = false;
     if (IS_WEBTOON) {
@@ -1032,8 +1069,17 @@ String _mangaGestureJs({
       if (dx) { PAN_X += dx; canvasMoved = true; }
       if (dy) { PAN_Y += dy; canvasMoved = true; }
     }
-    if (canvasMoved) _applyCanvas();
+    if (canvasMoved) { _clampPan(); _applyCanvas(); }
   }
+  // 方向键平移（Flutter 侧 ShortcutRegistry 驱动，见 MangaReaderInputAction.pan*）。
+  // 参数是**视口比例**而不是像素：同一步长在 1080p 和 4K 上手感一致。
+  // 符号按「视野怎么动」给（与滚动条直觉一致）：fx>0 = 视野右移，fy>0 = 视野下移；
+  // _panBy 的入参是「内容怎么动」，故取负。
+  // spread 模式在 ZOOM<=1 时整页已放得下，_panBy 自然 no-op（静默无效，不回落成翻页，
+  // 免得和翻页键语义打架）；webtoon 的上下平移恒等于滚动文档，任何倍率都有效。
+  window.__mangaPanBy = function(fx, fy){
+    _panBy(-window.innerWidth * fx, -window.innerHeight * fy);
+  };
   // 惯性：每秒衰减到 0.2%，低于 40px/s 停。阈值挡掉松手时的微抖动，
   // 否则每次抬手都会看到一小段无意的漂移。
   function _startFlick(vy){
@@ -1167,10 +1213,16 @@ String _mangaGestureJs({
         ax > ay && (ax >= 72 || (ax >= 36 && vel >= 900))) {
       var b = _bridge();
       if (!b) return;
-      // RTL：向左滑（dx<0）视觉上是「下一跨页」（往故事推进，左移露出左侧后续页）；
-      // LTR：向左滑是上一跨页。dir 语义统一为「页序方向」(+1 进 / -1 退)，由 Dart 端
-      // 依据已知阅读方向 clamp。这里只报方向：左滑 -> 'next'，右滑 -> 'prev'。
-      b.callHandler('onMangaTurn', dx < 0 ? 'next' : 'prev');
+      // swipe 跟手：拖动内容向左（dx<0）露出的是 strip **右边**那一跨页。右边是哪
+      // 一页取决于几何顺序——LTR 正序时右边是 next，RTL 倒序时右边是 prev（见文档
+      // 生成处的 spreadOrder）。所以必须按 IS_RTL 镜像，RTL 下「向右滑 = 下一页」，
+      // 与 Mihon 等 RTL 阅读器一致。
+      //
+      // 旧注释声称「dir 由 Dart 端依据阅读方向 clamp」——Dart 侧（_onMangaTurn）只有
+      // `next ? +1 : -1` 和边界钳位，从来没有方向 clamp，按那句推理必然推错。
+      var swipeRight = dx > 0;
+      b.callHandler('onMangaTurn',
+          (swipeRight === IS_RTL) ? 'next' : 'prev');
     } else if (ax < 20 && ay < 20 && el < 500) {
       _onTap(x, y);
     }
@@ -1271,29 +1323,51 @@ String _mangaGestureJs({
     e.preventDefault();
   }, {passive:false});
 
-  // Ctrl/Command + wheel：以指针为锚的**比例**缩放。
+  // Ctrl/Command + wheel：以指针为锚、**按 ZOOM_STEP 网格定量**的缩放。
   //
-  // 旧实现把 e.deltaY 只当符号用（恒 ±0.1 的加法步长），于是：① 触控板的高频小
-  // delta 与鼠标的一格大 delta 被同等对待；② 加法步长在高倍率下相对变化越来越小
-  // （1.9→2.0 只有 5.3%）。两者叠加就是用户说的「缩放极其不灵敏」。
-  // 现在按 delta 幅值走乘法缩放：一格标准滚轮（deltaY=100）≈ 22%，触控板的小 delta
-  // 按比例给小步长，任何倍率下手感一致。deltaMode 归一化后再算，否则「行/页」模式
-  // 的浏览器会得到完全不同的步长。
-  function _wheelSteps(e){
+  // 历史两版都不对：最早「e.deltaY 只当符号 + 恒 ±0.1 加法」，后改成按 delta 幅值的
+  // 乘法 exp(steps*0.2*SENS)。乘法版的毛病是**每格缩多少取决于本机 deltaY 的绝对值**：
+  // 注释假设一格 = 100，但 WebView2 在高 DPI 上根本不是 100（BUG-1065 实测 150% 缩放
+  // 机器一格只有 67），于是用户实测「一格约 112%」——既不是设计值 22%，也无法预期。
+  // 而右键菜单/设置滑块用的是 ±10 个百分点，同一个功能两套口径。
+  //
+  // 现在统一到菜单口径：一格滚轮 = 恰好一个 ZOOM_STEP 网格步，且目标值**对齐到网格**，
+  // 所以序列恒为 100→110→120…，而不是 100→112→125…；捏合留下的非整值也会被拉回网格。
+  // ZOOM_SENS 仍然管用（设置项承诺它覆盖滚轮），改为缩放**步长本身**而非指数底数。
+  var ZOOM_STEP = Math.max(1, Math.round(10 * ZOOM_SENS));
+  // 「一格」的判定复用本文件翻页滚轮的同一套累计口径（阈值 40 + 反向清账，见下方
+  // BUG-051 段）：鼠标一格无论 deltaY 是 57/67/100 都 >=40，恒好一步；触控板的碎
+  // delta 攒够 40 才走一步。跨过阈值即清零、不留余数——留余数会让 deltaY=57 这类值
+  // 攒出 1,1,2,1,1,2 的非匀速台阶，正好毁掉「一格 = 10%」这个承诺。
+  var _zoomAccum = 0;
+  var _zoomDir = 0;
+  function _wheelZoomNotch(e){
     var dy = e.deltaY || 0;
     if (e.deltaMode === 1) dy *= 16;
     else if (e.deltaMode === 2) dy *= window.innerHeight;
-    // 单次事件封顶 4 格，防惯性滚动一帧糊上天。
-    return Math.max(-4, Math.min(4, -dy / 100));
+    if (dy === 0) return 0;
+    var dir = dy > 0 ? -1 : 1;
+    if (dir !== _zoomDir) { _zoomAccum = 0; _zoomDir = dir; }
+    _zoomAccum += Math.abs(dy);
+    if (_zoomAccum < 40) return 0;
+    _zoomAccum = 0;
+    return dir;
   }
   document.addEventListener('wheel', function(e){
     if (RESCAN) return;
     if (!(e.ctrlKey || e.metaKey)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
-    var steps = _wheelSteps(e);
-    if (steps === 0) return;
-    _zoomAbout(ZOOM * Math.exp(steps * 0.2 * ZOOM_SENS), e.clientX, e.clientY);
+    var dir = _wheelZoomNotch(e);
+    if (dir === 0) return;
+    // 先把 ZOOM 化成保留 1 位小数的百分比再上下取整：ZOOM 是浮点，1.2 常存成
+    // 1.2000000000000002，直接 Math.ceil(120.00000000000003 / 10) 会得 13 而不是 12，
+    // 缩小一步就变成原地不动（_zoomAbout 的 0.0005 死区把它吃掉）。
+    var cur = Math.round(ZOOM * 1000) / 10;
+    var next = dir > 0
+      ? (Math.floor(cur / ZOOM_STEP) + 1) * ZOOM_STEP
+      : (Math.ceil(cur / ZOOM_STEP) - 1) * ZOOM_STEP;
+    _zoomAbout(next / 100, e.clientX, e.clientY);
   }, {passive:false});
 
   // ── 桌面鼠标滚轮翻页（仅 spread，BUG-051）──

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -99,7 +99,20 @@ enum MangaReaderInputAction {
   /// [PopScope] 闸门照跑）。与 [dismissDictionary] 是同一个键（默认 Esc）的两级——
   /// 弹窗可见先关弹窗，没弹窗才退出，判据在 [MangaFushiPage.inputActionForShortcut]。
   backOrExit,
+
+  /// 键盘平移（默认 Ctrl+方向键）：在放大后的页面上把**视野**朝该方向挪一步。
+  ///
+  /// 与 [previous]/[next] 是不同语义——翻页换的是 spread，平移只动当前页的视野，
+  /// 所以不吃「webtoon 让位原生滚动」「弹窗可见让位」那两道翻页门控（见
+  /// [MangaFushiPage.inputActionForShortcut]）：webtoon 的上下平移本来就等于滚文档。
+  panUp,
+  panDown,
+  panLeft,
+  panRight,
 }
+
+/// 一次键盘平移移动的视口比例。按比例而非像素，1080p 与 4K 手感一致。
+const double kMangaPanStepFraction = 0.15;
 
 enum _MangaReaderInputSource { flutter, nativeWebView, volumeKey }
 
@@ -359,6 +372,17 @@ class MangaFushiPage extends BaseSourcePage {
           ? MangaReaderInputAction.dismissDictionary
           : MangaReaderInputAction.backOrExit;
     }
+    // 平移排在两道翻页门控**之前**：它动的是当前页的视野、不是 spread，所以
+    // 「webtoon 让位原生滚动」与「弹窗可见让位」都不适用——webtoon 的上下平移本身
+    // 就是滚文档，弹窗开着时也该能挪画面去看被挡住的部分。
+    final MangaReaderInputAction? pan = switch (action) {
+      ShortcutAction.mangaPanUp => MangaReaderInputAction.panUp,
+      ShortcutAction.mangaPanDown => MangaReaderInputAction.panDown,
+      ShortcutAction.mangaPanLeft => MangaReaderInputAction.panLeft,
+      ShortcutAction.mangaPanRight => MangaReaderInputAction.panRight,
+      _ => null,
+    };
+    if (pan != null) return pan;
     if (!horizontalArrow) {
       if (dictionaryShown) return null;
       if (mode == MangaReadingMode.webtoon) return null;
@@ -393,6 +417,31 @@ class MangaFushiPage extends BaseSourcePage {
     handlerName: 'onMangaNavigationKey',
     keys: const <String>['ArrowLeft', 'ArrowRight', 'Escape', 'Esc'],
     forwardRepeats: false,
+    stopPropagation: true,
+  );
+
+  /// 键盘平移专用的第二座桥。
+  ///
+  /// 单独一座而不是往 [navigationKeyBridgeScript] 的键表里加：翻页那座是
+  /// `forwardRepeats: false`（本页有意「按住方向键不堆翻页风暴」），而平移恰恰要连发
+  /// ——按住 Ctrl+↓ 应该持续挪画面。生成器按 handlerName 派生独立闭包与安装守卫，
+  /// 同一 document 里多座桥共存互不干扰（见 webViewKeyBridgeScript 文档）。
+  ///
+  /// 键表是**默认键位**的 token。回传后仍走 [_handleNativeNavigationKey] →
+  /// 注册表解析，所以改键在 Flutter 持焦路径立即生效；但 WebView2 持焦时只有列在
+  /// 这张表里的键会被截获——这是翻页桥既有的同款限制（它的表同样是硬编码的
+  /// ArrowLeft/ArrowRight），不是本次新引入的，要根治得让两座桥的 token 表都从
+  /// 注册表实时生成，单独立项。
+  @visibleForTesting
+  static final String panKeyBridgeScript = webViewKeyBridgeScript(
+    handlerName: 'onMangaPanKey',
+    keys: const <String>[
+      'Ctrl+ArrowUp',
+      'Ctrl+ArrowDown',
+      'Ctrl+ArrowLeft',
+      'Ctrl+ArrowRight',
+    ],
+    forwardRepeats: true,
     stopPropagation: true,
   );
 
@@ -1911,7 +1960,11 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
   /// - 查词弹窗显示时，左右键关闭弹窗并翻页，Escape 只关闭弹窗；避免原生词典
   ///   WebView 持焦后把翻页键吞掉或让 Escape 落到外层退书。
   KeyEventResult _handleReaderKey(FocusNode node, KeyEvent event) {
-    if (event is! KeyDownEvent) {
+    // 长按连发**只放给平移**：按住方向键持续挪画面是正常操作，而翻页恒不连发
+    // （本页既有语义，与 navigationKeyBridgeScript 的 forwardRepeats:false 同口径，
+    // 两条输入路径必须一致，否则 WebView 持焦与否手感不同）。
+    final bool repeat = event is KeyRepeatEvent;
+    if (event is! KeyDownEvent && !repeat) {
       return KeyEventResult.ignored;
     }
     final MangaReaderInputAction? action = _resolveMangaKeyAction(
@@ -1919,6 +1972,9 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
       activeModifierKeys(),
     );
     if (action == null) return KeyEventResult.ignored;
+    if (repeat && _panStepFor(action) == null) {
+      return KeyEventResult.ignored;
+    }
     _executeReaderInputAction(
       action,
       source: _MangaReaderInputSource.flutter,
@@ -1947,6 +2003,21 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     );
   }
 
+  /// 平移动作 → 传给 `window.__mangaPanBy` 的**视口比例**步长；非平移动作返回 null。
+  ///
+  /// 符号按「视野怎么动」给（与滚动条直觉一致，JS 侧再翻成内容位移）：
+  /// dx>0 视野右移，dy>0 视野下移。
+  static Offset? _panStepFor(MangaReaderInputAction action) {
+    const double s = kMangaPanStepFraction;
+    return switch (action) {
+      MangaReaderInputAction.panLeft => const Offset(-s, 0),
+      MangaReaderInputAction.panRight => const Offset(s, 0),
+      MangaReaderInputAction.panUp => const Offset(0, -s),
+      MangaReaderInputAction.panDown => const Offset(0, s),
+      _ => null,
+    };
+  }
+
   void _executeReaderInputAction(
     MangaReaderInputAction action, {
     required _MangaReaderInputSource source,
@@ -1960,6 +2031,17 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
           action == MangaReaderInputAction.backOrExit) {
         unawaited(_setRescanMode(false));
       }
+      return;
+    }
+    // 平移在这里就地返回：它不翻页、不关词典、也不该被翻页的跨源去抖吃掉（按住
+    // 方向键连续挪画面是正常操作，而翻页去抖正是为了压掉连发）。
+    final Offset? panStep = _panStepFor(action);
+    if (panStep != null) {
+      unawaited(_controller?.evaluateJavascript(
+            source: 'window.__mangaPanBy && '
+                'window.__mangaPanBy(${panStep.dx}, ${panStep.dy});',
+          ) ??
+          Future<void>.value());
       return;
     }
     final DateTime now = DateTime.now();
@@ -3483,6 +3565,15 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
             _handleNativeNavigationKey(args[0] as String);
           },
         );
+        // 平移桥（第二座，允许连发）。回调与翻页桥同一个——token 一律走
+        // InputBinding.deserialize + 注册表解析，动作由绑定决定而不是由桥决定。
+        controller.addJavaScriptHandler(
+          handlerName: 'onMangaPanKey',
+          callback: (List<dynamic> args) {
+            if (args.isEmpty || args[0] is! String) return;
+            _handleNativeNavigationKey(args[0] as String);
+          },
+        );
         controller.addJavaScriptHandler(
           handlerName: 'onMangaContextMenu',
           callback: (List<dynamic> args) {
@@ -3585,6 +3676,12 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     }
     await controller.evaluateJavascript(
       source: MangaFushiPage.navigationKeyBridgeScript,
+    );
+    if (!mounted || !_windowGate.owns(ticket)) {
+      return;
+    }
+    await controller.evaluateJavascript(
+      source: MangaFushiPage.panKeyBridgeScript,
     );
     if (!mounted || !_windowGate.owns(ticket)) {
       return;

--- a/fushi/lib/src/media/source_library/add_local_folder_source.dart
+++ b/fushi/lib/src/media/source_library/add_local_folder_source.dart
@@ -1,0 +1,76 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/source_library/source_library_row.dart';
+import 'package:fushi/src/media/source_library/source_library_scanner.dart';
+
+/// 把一个**本地文件夹**登记成常驻扫描根并立即扫一遍。
+///
+/// 抽成共享函数而不是让各调用点各写一份：来源页的「添加本地文件夹」按钮和拖放落点
+/// 必须产出**完全相同**的来源行（同样的归一化路径、同样的默认标签、同样的去重判据、
+/// 同样的插入后立即扫描），否则两条入口会漂成两套语义。
+///
+/// 返回值：
+/// - [AddLocalFolderOutcome.added]：新来源行已插入并扫描完成，[rootPath] 是归一化后
+///   的路径。
+/// - [AddLocalFolderOutcome.duplicate]：同 transport+路径的来源已存在，未做任何写入。
+///
+/// [mediaKind] 取 `SourceLibraryKind` 的字符串值（`book` / `video` / `manga`）——
+/// 由**当前打开的页面**决定，不从文件内容猜。
+Future<AddLocalFolderResult> addLocalFolderAsSource({
+  required FushiDatabase db,
+  required String mediaKind,
+  required String path,
+}) async {
+  final String norm = normalizeSourceRootPath(path, transport: 'local');
+  final List<MediaSourceRow> existing =
+      await db.getMediaSourcesByKind(mediaKind);
+  final bool duplicate = existing
+      .any((MediaSourceRow r) => r.transport == 'local' && r.rootPath == norm);
+  if (duplicate) {
+    return AddLocalFolderResult(
+        outcome: AddLocalFolderOutcome.duplicate, rootPath: norm);
+  }
+  final int sortOrder = existing.isEmpty
+      ? 0
+      : existing
+              .map((MediaSourceRow r) => r.sortOrder)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+  final int newId = await db.insertMediaSource(
+    MediaSourcesCompanion(
+      label: Value(defaultLabelFromRoot(norm, transport: 'local')),
+      mediaKind: Value(mediaKind),
+      transport: const Value('local'),
+      rootPath: Value(norm),
+      recursive: const Value(true),
+      sortOrder: Value(sortOrder),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ),
+  );
+  // 插入后立刻扫描：不扫的话来源列表里是一条 0 媒体的空行，用户以为没生效。
+  final SourceLibraryRow? fresh = await db.getMediaSourceById(newId);
+  if (fresh != null) {
+    await SourceLibraryScanner(db).scan(fresh);
+  }
+  return AddLocalFolderResult(
+      outcome: AddLocalFolderOutcome.added, rootPath: norm, sourceId: newId);
+}
+
+enum AddLocalFolderOutcome { added, duplicate }
+
+class AddLocalFolderResult {
+  const AddLocalFolderResult({
+    required this.outcome,
+    required this.rootPath,
+    this.sourceId,
+  });
+
+  final AddLocalFolderOutcome outcome;
+
+  /// 归一化后的扫描根路径（提示语要显示它，而不是用户拖进来的原始串）。
+  final String rootPath;
+
+  /// 仅 [AddLocalFolderOutcome.added] 时非空。
+  final int? sourceId;
+}

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -1462,11 +1462,19 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // MarginV 放在不同高度的同锚点 cue（标题 + 多行歌词）各就其位（TODO-1341 后续）。
     final double? scaledMarginV = forceTop ? null : _scaledMarginV(posMarkup);
     // ASS MarginL/MarginR（水平边距）缩放到显示尺寸：横移对白（说话人一侧）/ an7 左上
-    // 招牌的左缘偏移各就其位。强制置顶的纯 SRT 副字幕（posMarkup null）恒无边距。
+    // 招牌的左缘偏移各就其位。
+    //
+    // 这里读 [ownMarkup] 而**不是** [posMarkup]（BUG-1730 续）：posMarkup 在
+    // `forcedAnchor != null` 时被整个置 null，那是**竖直**强制锚定，却把水平排版盒
+    // 一起丢掉了 —— 于是底锚（默认，forcedAnchor==null）扣掉双侧 MarginL/R（常见
+    // 26~80px），顶锚反而一点不扣、换行宽度更大。用户报的「底部锚定才断行、顶部不断」
+    // 就是这条不对称。竖直方向（scaledMarginV / rawMarginV）必须继续走 posMarkup，
+    // 否则用户选的锚定会被 ASS MarginV 顶回去。
+    // respectAssStyle=false 时 ownMarkup 恒 null，纯字幕路径零行为变化。
     final double? scaledMarginL =
-        _scaledMarginX(posMarkup, posMarkup?.cueStyle?.marginL);
+        _scaledMarginX(ownMarkup, ownMarkup?.cueStyle?.marginL);
     final double? scaledMarginR =
-        _scaledMarginX(posMarkup, posMarkup?.cueStyle?.marginR);
+        _scaledMarginX(ownMarkup, ownMarkup?.cueStyle?.marginR);
     // 原始 MarginV（PlayRes 像素）：底部基线真相源 [resolveBottomBaseline] 要用它判断
     // 本组是否落在基线桶——与 [_positionKey] 的分组判据同一个量（BUG-1335）。
     final double? rawMarginV = forceTop ? null : posMarkup?.cueStyle?.marginV;
@@ -2596,6 +2604,17 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// ASS `MarginL`/`MarginR`（水平边距，PlayResX 像素）按 显示区宽 / PlayResX 缩放到显示
   /// 尺寸（与 [_scaledMarginV] 之于 PlayResY 同构）。缺 PlayResX 时回退 [_assFontScale]
   /// （等比视频两者相等）。无边距（null / <=0）返回 null。夹到 [0, 显示区宽] 防异常撑爆。
+  /// fit:contain 后视频内容矩形**单侧**黑边宽（pillarbox）。letterbox / 未知分辨率
+  /// 时为 0。字幕排版盒的水平可用区必须是视频内容矩形而不是整个容器，否则换行宽度
+  /// 会跟着窗口宽高比变（见 [_paddingFor] 的说明）。
+  double _pillarboxSideInset() {
+    final double? contentW = _lastVideoContentWidth;
+    final double? layoutW = _lastLayoutWidth;
+    if (contentW == null || layoutW == null) return 0;
+    final double bar = (layoutW - contentW) / 2;
+    return bar > 0 ? bar : 0;
+  }
+
   double? _scaledMarginX(SubtitleMarkup? markup, double? margin) {
     if (margin == null || margin <= 0) return null;
     final double? playResX = markup?.playResX;
@@ -2748,9 +2767,22 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     );
     // ASS MarginL/MarginR 水平边距：Align 内侧 padding 恰是 ASS 排版盒语义——居中对齐时
     // 盒宽 = 文本 + L + R、Align 居中该盒 → 文本中心右移 (L-R)/2；左/右对齐时文本起点 /
-    // 终点分别落在 L / 宽-R。无边距恒 0（srt/vtt 像素级不变）。
-    final double left = scaledMarginL ?? 0;
-    final double right = scaledMarginR ?? 0;
+    // 终点分别落在 L / 宽-R。无 ASS 边距时该项为 0。
+    //
+    // 再叠一层 pillarbox 侧边条（BUG-1730 续）：字号锚在**视频内容矩形高**
+    // （[_assFontScale]，与 mpv/libass 同口径），换行宽度此前却锚在**容器宽**，两者
+    // 不同源。pillarbox（窗口比视频扁，1080p 视频 + 带标题栏的窗口正是这一档）下
+    // 字号 ∝ 容器高、可用宽 ∝ 容器宽，于是换行容量 ∝ 窗口宽高比：同一句字幕在
+    // 1920×1048 窗口里放得下，最大化到 2560×1440（宽高比 1.832→1.778，容量少约 3%）
+    // 就被推过阈值多断一行——用户报的「窗口一最大化字幕排版就变」。
+    // 把黑边宽度算进左右 padding 后，可用宽 ∝ 视频内容宽，与字号同源，换行位置
+    // 对窗口尺寸恒定不变（与其它播放器一致）。letterbox 时侧边条为 0，零行为变化。
+    // 侧边条对 srt/vtt 同样施加（字幕本来就属于视频画面、不该排进黑边）：居中对齐
+    // 下视觉中心不动，只是换行宽度收窄到画面宽——pillarbox 下这是行为变化，不是
+    // 像素级不变，属于有意的口径修正。
+    final double sideBar = _pillarboxSideInset();
+    final double left = sideBar + (scaledMarginL ?? 0);
+    final double right = sideBar + (scaledMarginR ?? 0);
     return switch (v) {
       SubtitleVAlign.bottom => EdgeInsets.only(
           left: left,

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -32,6 +32,7 @@ import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_service.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
+import 'package:fushi/src/media/drag_drop/drop_surface_scope.dart';
 import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
 import 'package:fushi/src/media/video/download/video_resource_registry.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart'
@@ -2057,7 +2058,15 @@ class _HomePageState extends BasePageState<HomePage>
               offstage: visible != tab,
               child: TickerMode(
                 enabled: visible == tab,
-                child: _buildTabContent(tab),
+                child: DropSurfaceScope(
+                  // Offstage 只关 Flutter 的 hitTest，不影响 desktop_drop——它按
+                  // 全局广播 + 各自 paintBounds 判定，而隐藏的保活 tab 仍以全屏
+                  // 约束布局，于是**每个访问过的 tab 都会收到同一次拖放**。判据与
+                  // 上面 offstage 用的是同一个 `_visibleTab`，保证「看得见的那个」
+                  // 与「接拖放的那个」永远是同一个。
+                  isActive: () => _visibleTab == tab,
+                  child: _buildTabContent(tab),
+                ),
               ),
             ),
         // 非保活 tab：仅在选中时构建、切走即销毁，保留其 initState 挂载语义。

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -94,6 +94,7 @@ import 'package:fushi/src/utils/cover_image.dart';
 import 'package:fushi/src/pages/implementations/collection_name_dialog.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/utils/misc/shelf_ordering.dart';
+import 'package:fushi/src/media/source_library/add_local_folder_source.dart';
 import 'package:path/path.dart' as p;
 
 /// 顶层 helper：打开本地视频播放页的**共享路由入口**（本页 hero/卡片与首页
@@ -1140,7 +1141,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final ModalRoute<dynamic>? route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) return;
 
-    final DroppedFiles files = classifyDroppedFiles(paths);
+    // 必须注入 isDirectory 谓词：不传的话目录落进 unknown，视频页对「拖入文件夹」
+    // 完全静默（用户报的「拖文件夹没反应」）。分类只记录事实，目录算什么由
+    // decideDropIntent 按落点表面决定。
+    final DroppedFiles files = classifyDroppedFiles(
+      paths,
+      isDirectory: (String path) => Directory(path).existsSync(),
+    );
     debugPrint(
       '[fushi-drop] [home-video] classified '
       'videos=${files.videos.length} playlists=${files.playlists.length} '
@@ -1156,11 +1163,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     switch (intent) {
       case DropIntent.importNewVideo:
-        _openVideoImportPrefilled(
-          videoPath: files.videos.first,
-          subtitlePath:
-              files.subtitles.isNotEmpty ? files.subtitles.first : null,
-        );
+        // 拖入的**每个**视频都要导入。旧实现只取 `files.videos.first`，多选拖入时
+        // 其余文件被静默丢弃（用户报「手动拖多个影片进去只会导入第一个」）。
+        // VideoImportDialog 结构上是单条目的（每条视频各有标题/字幕/元数据要确认），
+        // 所以这里排成队列逐个预填，而不是硬塞一个批量模式进对话框。
+        unawaited(_openVideoImportQueue(files.videos, files.subtitles));
+      case DropIntent.addFolderAsSource:
+        unawaited(_addDroppedFoldersAsSources(files.directories));
       case DropIntent.importNewPlaylist:
         _openPlaylistImportPrefilled(playlistPath: files.playlists.first);
       case DropIntent.importVideoUrl:
@@ -1200,6 +1209,61 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 按文件名派生 bookUid，用户确认后保存，关闭后刷新列表。「把字幕挂到已有视频卡」
   /// 不走这里——它会对已存在视频重算 bookUid 触发同名去重建重复条目（TODO-079），
   /// 改走 [_attachSubtitleToVideoCard] 直接对命中卡 bookUid 落库。
+  /// 拖入文件夹 → 登记成视频扫描根并扫描（每个拖入的目录各一条）。
+  ///
+  /// 媒体类型取自**当前页面**（视频页恒 `video`），不从目录内容猜——这正是用户要的
+  /// 「以打开的页面为准」。走共享的 [addLocalFolderAsSource]，与来源页「添加本地
+  /// 文件夹」按钮产出完全相同的来源行。
+  Future<void> _addDroppedFoldersAsSources(List<String> directories) async {
+    int added = 0;
+    for (final String dir in directories) {
+      final AddLocalFolderResult result = await addLocalFolderAsSource(
+        db: appModel.database,
+        mediaKind: SourceLibraryKind.video.dbValue,
+        path: dir,
+      );
+      switch (result.outcome) {
+        case AddLocalFolderOutcome.added:
+          added++;
+        case AddLocalFolderOutcome.duplicate:
+          break;
+      }
+      if (!mounted) return;
+    }
+    if (!mounted) return;
+    if (added > 0) _refresh();
+    FushiToast.show(
+      msg: added > 0
+          ? t.drag_drop_folder_source_added
+          : t.drag_drop_folder_source_exists,
+      severity: added > 0 ? ToastSeverity.success : ToastSeverity.warning,
+    );
+  }
+
+  /// 逐个导入拖入的多个视频。
+  ///
+  /// 字幕配对：只有一个视频时沿用历史行为（把第一条字幕给它）；多个视频时按**文件
+  /// 名主干**配对（`EP01.mkv` ↔ `EP01.srt`），配不上就不给——多集拖入时把同一条字幕
+  /// 挂到每一集比不挂更糟。
+  ///
+  /// 用户在某一条上点取消只跳过该条，队列继续：拖 5 个进来、其中 1 个不想要，不应该
+  /// 连带取消另外 4 个。
+  Future<void> _openVideoImportQueue(
+    List<String> videos,
+    List<String> subtitles,
+  ) async {
+    for (final String video in videos) {
+      if (!mounted) return;
+      final String? subtitle = videos.length == 1
+          ? (subtitles.isNotEmpty ? subtitles.first : null)
+          : subtitleForVideoByStem(video, subtitles);
+      await _openVideoImportPrefilled(
+        videoPath: video,
+        subtitlePath: subtitle,
+      );
+    }
+  }
+
   Future<void> _openVideoImportPrefilled({
     required String videoPath,
     String? subtitlePath,

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -1152,6 +1152,12 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
       cardHit: hitBookKey != null,
     );
     switch (intent) {
+      // 书架/漫画库不产出这个意图：目录在这两个表面仍是「一本漫画的页图文件夹」
+      // （importNewManga），把整个目录登记成扫描根是视频页的语义。列出来只为让
+      // `decideDropIntent` 以后给 books 也加上文件夹语义时，这里编译期就红。
+      case DropIntent.addFolderAsSource:
+        debugPrint('[fushi-drop] [reader-shelf] intent=addFolderAsSource '
+            '(not produced on this surface)');
       case DropIntent.importNewBook:
         _openBookImportPrefilled(
           epubPath: files.books.first,

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -391,6 +391,13 @@ enum ShortcutAction {
   // 「关弹窗并翻页」，那条语义在 [MangaReaderInputAction] 侧，与本动作无关。
   // 退出漫画走 universal 的 [globalBack] 阶梯（弹窗可见先关弹窗，否则退出）。
   mangaDismissDict(ShortcutScope.manga, 'manga_dismiss_dict'),
+  // 放大后在页面上平移视野（默认 Ctrl+方向键）。裸方向键已被翻页占死，所以默认
+  // 走修饰键组合；用户可在快捷键设置里改成任意键。语义是「视野往哪个方向走」，
+  // 与滚动条直觉一致，不随阅读方向镜像（镜像只对**翻页**有意义）。
+  mangaPanUp(ShortcutScope.manga, 'manga_pan_up'),
+  mangaPanDown(ShortcutScope.manga, 'manga_pan_down'),
+  mangaPanLeft(ShortcutScope.manga, 'manga_pan_left'),
+  mangaPanRight(ShortcutScope.manga, 'manga_pan_right'),
 
   // Gamepad（TODO-700 T6）：dpad 四向作为可绑触发键。默认各绑对应 dpad 键，执行体
   // = 通用方向焦点移动（与摇杆同效果，但摇杆固定走 onStickMove 通道、不经注册表，

--- a/fushi/lib/src/shortcuts/shortcut_defaults.dart
+++ b/fushi/lib/src/shortcuts/shortcut_defaults.dart
@@ -354,6 +354,22 @@ class ShortcutDefaults {
     // 「只关词典、绝不退出」（漫画版）：**默认空绑定**，理由与 readerDismissDict
     // 完全相同——Esc 归 universal 的 globalBack 一键阶梯。
     ShortcutAction.mangaDismissDict: const ShortcutBindingSet(),
+    // 放大后平移视野：默认 Ctrl+方向键。裸方向键四个全被翻页占了
+    // （mangaPageForward/Backward 各绑两个），同 scope 内撞绑会被靠前声明者吃掉，
+    // 所以默认必须带修饰键。用户可在快捷键设置里改。
+    ShortcutAction.mangaPanUp: _kb([
+      _key(LogicalKeyboardKey.arrowUp, const <ModifierKey>{ModifierKey.ctrl}),
+    ]),
+    ShortcutAction.mangaPanDown: _kb([
+      _key(LogicalKeyboardKey.arrowDown, const <ModifierKey>{ModifierKey.ctrl}),
+    ]),
+    ShortcutAction.mangaPanLeft: _kb([
+      _key(LogicalKeyboardKey.arrowLeft, const <ModifierKey>{ModifierKey.ctrl}),
+    ]),
+    ShortcutAction.mangaPanRight: _kb([
+      _key(
+          LogicalKeyboardKey.arrowRight, const <ModifierKey>{ModifierKey.ctrl}),
+    ]),
     ShortcutAction.videoReplayCurrentSubtitle: _kb([
       _key(LogicalKeyboardKey.keyR),
     ], [

--- a/fushi/lib/src/shortcuts/shortcut_labels.dart
+++ b/fushi/lib/src/shortcuts/shortcut_labels.dart
@@ -23,6 +23,14 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_manga_page_backward;
       case ShortcutAction.mangaDismissDict:
         return t.shortcut_action_manga_dismiss_dict;
+      case ShortcutAction.mangaPanUp:
+        return t.shortcut_action_manga_pan_up;
+      case ShortcutAction.mangaPanDown:
+        return t.shortcut_action_manga_pan_down;
+      case ShortcutAction.mangaPanLeft:
+        return t.shortcut_action_manga_pan_left;
+      case ShortcutAction.mangaPanRight:
+        return t.shortcut_action_manga_pan_right;
       case ShortcutAction.readerPageForward:
         return t.shortcut_action_reader_page_forward;
       case ShortcutAction.readerPageBackward:

--- a/fushi/test/media/drag_drop/drop_surface_routing_test.dart
+++ b/fushi/test/media/drag_drop/drop_surface_routing_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/drag_drop/drop_classification.dart';
+import 'package:fushi/src/media/drag_drop/drop_decision.dart';
+import 'package:fushi/src/media/drag_drop/drop_surface_scope.dart';
+
+/// 拖放「落到哪个页面」与「文件夹算什么」的守卫。
+///
+/// 背景（用户实测）：停在**视频页**把一个视频文件夹拖进窗口，结果隐藏的书架页弹出
+/// 「导入漫画」对话框、隐藏的游戏页同时弹「拖入的文件里没有新的游戏 .exe」，而真正
+/// 可见的视频页一动不动。根因是 desktop_drop 全局广播 + home-shell 用 Offstage 保活
+/// （RenderOffstage 在隐藏时仍以完整约束布局，只关 Flutter 自己的 hitTest），四个 tab
+/// 的 drop target 同时命中；唯一的门 `ModalRoute.isCurrent` 对同级 tab 恒为 true。
+void main() {
+  group('DropSurfaceScope 决定谁接这次拖放', () {
+    testWidgets('没有作用域时放行（对话框 / 播放页各自独占路由，行为不变）', (WidgetTester tester) async {
+      late BuildContext captured;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(builder: (BuildContext context) {
+          captured = context;
+          return const SizedBox();
+        }),
+      ));
+      expect(DropSurfaceScope.activeFor(captured), isTrue);
+    });
+
+    testWidgets('隐藏 tab 的子树被判为不活跃，可见 tab 放行', (WidgetTester tester) async {
+      late BuildContext hidden;
+      late BuildContext visible;
+      await tester.pumpWidget(MaterialApp(
+        home: Stack(children: <Widget>[
+          // 隐藏的保活 tab：Offstage 不阻止 desktop_drop，只有作用域能挡。
+          Offstage(
+            offstage: true,
+            child: DropSurfaceScope(
+              isActive: () => false,
+              child: Builder(builder: (BuildContext context) {
+                hidden = context;
+                return const SizedBox();
+              }),
+            ),
+          ),
+          DropSurfaceScope(
+            isActive: () => true,
+            child: Builder(builder: (BuildContext context) {
+              visible = context;
+              return const SizedBox();
+            }),
+          ),
+        ]),
+      ));
+      expect(DropSurfaceScope.activeFor(hidden), isFalse,
+          reason: '隐藏 tab 绝不能接拖放——这正是「视频页拖文件夹却弹出导入漫画」的根因');
+      expect(DropSurfaceScope.activeFor(visible), isTrue);
+    });
+
+    testWidgets('嵌套作用域逐层 AND：外层不活跃则内层一律不活跃', (WidgetTester tester) async {
+      late BuildContext inner;
+      await tester.pumpWidget(MaterialApp(
+        home: DropSurfaceScope(
+          isActive: () => false,
+          child: DropSurfaceScope(
+            isActive: () => true,
+            child: Builder(builder: (BuildContext context) {
+              inner = context;
+              return const SizedBox();
+            }),
+          ),
+        ),
+      ));
+      expect(DropSurfaceScope.activeFor(inner), isFalse,
+          reason: '内层「我这一屏是当前子页」不能凌驾于外层「我这个 tab 根本没显示」');
+    });
+  });
+
+  group('目录是事实，不是判断', () {
+    test('classifyDroppedFiles 把目录同时记进 directories 与 mangas', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[r'C:\anime\[VCB-Studio] Yuru Yuri'],
+        isDirectory: (String path) => true,
+      );
+      // directories = 事实（谁都能读）；mangas = 书架/漫画库的既有解释，保留不动。
+      expect(files.directories, <String>[r'C:\anime\[VCB-Studio] Yuru Yuri']);
+      expect(files.mangas, <String>[r'C:\anime\[VCB-Studio] Yuru Yuri']);
+    });
+
+    test('不传 isDirectory 时不产生 directories（历史行为逐字节不变）', () {
+      final DroppedFiles files =
+          classifyDroppedFiles(<String>[r'C:\anime\Yuru Yuri']);
+      expect(files.directories, isEmpty);
+      expect(files.mangas, isEmpty);
+    });
+  });
+
+  group('decideDropIntent：文件夹按落点表面解释', () {
+    DroppedFiles folderDrop() => classifyDroppedFiles(
+          <String>[r'C:\anime\S01'],
+          isDirectory: (String path) => true,
+        );
+
+    test('视频页：文件夹 → 登记成扫描根（此前是完全静默）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.video,
+          files: folderDrop(),
+          cardHit: false,
+        ),
+        DropIntent.addFolderAsSource,
+      );
+    });
+
+    test('视频页：文件夹优先于同批拖入的单个视频文件', () {
+      final DroppedFiles mixed = classifyDroppedFiles(
+        <String>[r'C:\anime\S01', r'C:\anime\ep1.mkv'],
+        isDirectory: (String path) => !path.endsWith('.mkv'),
+      );
+      expect(
+        decideDropIntent(
+          surface: DropSurface.video,
+          files: mixed,
+          cardHit: false,
+        ),
+        DropIntent.addFolderAsSource,
+        reason: '拖一整个剧集目录进来要的是加来源，不是导入恰好也选中的那一个 mp4',
+      );
+    });
+
+    test('书架 / 漫画库：文件夹仍是「一本漫画的页图文件夹」，既有能力不许被拿掉', () {
+      for (final DropSurface surface in <DropSurface>[
+        DropSurface.books,
+        DropSurface.manga
+      ]) {
+        expect(
+          decideDropIntent(
+            surface: surface,
+            files: folderDrop(),
+            cardHit: false,
+          ),
+          DropIntent.importNewManga,
+          reason: '$surface 的整目录页图导入是既有功能',
+        );
+      }
+    });
+  });
+
+  group('多文件拖入：字幕按文件名主干配对', () {
+    test('主干相同即配对，大小写不敏感', () {
+      expect(
+        subtitleForVideoByStem(r'C:\a\EP01.mkv', <String>[
+          r'C:\a\EP02.srt',
+          r'C:\a\ep01.srt',
+        ]),
+        r'C:\a\ep01.srt',
+      );
+    });
+
+    test('配不上就返回 null——宁可不挂，也不要把同一条字幕挂到每一集', () {
+      expect(
+        subtitleForVideoByStem(
+            r'C:\a\EP01.mkv', <String>[r'C:\a\something else.srt']),
+        isNull,
+      );
+    });
+  });
+}

--- a/fushi/test/media/manga/manga_overlay_html_test.dart
+++ b/fushi/test/media/manga/manga_overlay_html_test.dart
@@ -678,7 +678,9 @@ void main() {
         spreadDirection: 'rtl',
         inlineSelectionJs: '',
       );
-      // DOM 顺序不变，根 strip 保持 LTR；每个 spread 内部用 RTL 翻转双页。
+      // 同一个 spread 内部的两页 DOM 顺序不变（左右由 CSS direction 翻）；根 strip
+      // 保持 LTR，让 offsetLeft 恒为 100vw 的整数倍。跨 spread 的排列顺序另见
+      // 「spread RTL 的 strip 几何倒序」。
       expect(docRtl.indexOf('a.jpg') < docRtl.indexOf('b.jpg'), isTrue);
       expect(
           docRtl.contains('#manga-root{display:flex;flex-direction:row;'
@@ -695,6 +697,96 @@ void main() {
       );
       expect(docLtr.contains('justify-content:center;direction:ltr'), isTrue);
       expect(docLtr.contains('direction:rtl'), isFalse);
+    });
+
+    test('spread RTL 的 strip 几何倒序：下一跨页在左，翻页动画方向才对', () {
+      final MokuroImage page = _pageWithTwoBlocks();
+      List<int> spreadOrderOf(String doc) {
+        // 只取 spread 容器：每页的 .manga-page 也带 data-spread，混进来会得到
+        // [2,2,1,1,0,0] 这种成对序列。
+        final RegExp re = RegExp(r'class="manga-spread" data-spread="(\d+)"');
+        return re
+            .allMatches(doc)
+            .map((RegExpMatch m) => int.parse(m.group(1)!))
+            .toList();
+      }
+
+      final String docRtl = mangaWindowDocument(
+        <MokuroImage>[page, page, page],
+        <String>['a.jpg', 'b.jpg', 'c.jpg'],
+        mode: MangaReadingMode.spread,
+        spreadDirection: 'rtl',
+        pageSpreadIndices: const <int>[0, 1, 2],
+        inlineSelectionJs: '',
+      );
+      // RTL：spread 2 排在最左（offsetLeft 最小），所以「前进」= 画面向右滑、新页
+      // 从左边进——与 tap zone / 方向键早已按 RTL 镜像的输入语义一致。
+      // 修复前这里是 [0, 1, 2]：输入镜像了、视觉没镜像，按前进键画面往后退的方向滑。
+      expect(spreadOrderOf(docRtl), <int>[2, 1, 0]);
+
+      final String docLtr = mangaWindowDocument(
+        <MokuroImage>[page, page, page],
+        <String>['a.jpg', 'b.jpg', 'c.jpg'],
+        mode: MangaReadingMode.spread,
+        spreadDirection: 'ltr',
+        pageSpreadIndices: const <int>[0, 1, 2],
+        inlineSelectionJs: '',
+      );
+      expect(spreadOrderOf(docLtr), <int>[0, 1, 2]);
+
+      // 两个方向都必须保持根 strip 的 LTR 几何：offsetLeft 得是稳定的 100vw 整数倍，
+      // 否则 __mangaApplyTranslate 的 -offsetLeft 口径失效（这正是当初钉死 LTR 的原因）。
+      for (final String doc in <String>[docRtl, docLtr]) {
+        expect(
+            doc.contains('#manga-root{display:flex;flex-direction:row;'
+                'direction:ltr;'),
+            isTrue);
+      }
+    });
+
+    test('swipe 方向随 RTL 镜像，与 strip 几何同源', () {
+      final MokuroImage page = _pageWithTwoBlocks();
+      final String doc = mangaWindowDocument(
+        <MokuroImage>[page],
+        <String>['a.jpg'],
+        mode: MangaReadingMode.spread,
+        spreadDirection: 'rtl',
+        inlineSelectionJs: '',
+      );
+      // 拖动内容向左露出的是 strip 右边那一跨页；RTL 倒序后右边是 prev，所以判据
+      // 必须含 IS_RTL。修复前是写死的 `dx < 0 ? 'next' : 'prev'`。
+      expect(doc.contains("(swipeRight === IS_RTL) ? 'next' : 'prev'"), isTrue,
+          reason: 'swipe 必须按 IS_RTL 镜像，否则与倒序后的 strip 几何相反');
+      expect(doc.contains("dx < 0 ? 'next' : 'prev'"), isFalse,
+          reason: '不许再有不看阅读方向的写死 swipe 判据');
+    });
+
+    test('键盘平移导出 __mangaPanBy，且平移被钳制在视口内', () {
+      final MokuroImage page = _pageWithTwoBlocks();
+      final String doc = mangaWindowDocument(
+        <MokuroImage>[page],
+        <String>['a.jpg'],
+        mode: MangaReadingMode.spread,
+        spreadDirection: 'rtl',
+        inlineSelectionJs: '',
+      );
+      // 视口比例入参 + 「视野怎么动」的符号（故 _panBy 取负）。
+      expect(doc.contains('window.__mangaPanBy = function(fx, fy){'), isTrue,
+          reason: '方向键平移要走导出的 JS 入口，而不是在 JS 里自己监听键盘');
+      expect(
+          doc.contains(
+              '_panBy(-window.innerWidth * fx, -window.innerHeight * fy);'),
+          isTrue);
+      // 钳制：PAN_X ∈ [vw*(1-ZOOM), 0]，spread 的 PAN_Y 同理。此前完全没有边界，
+      // 拖动/方向键能把页面推出视口且回不来。
+      expect(doc.contains('function _clampPan(){'), isTrue);
+      expect(
+          doc.contains('var minX = window.innerWidth * (1 - ZOOM);'), isTrue);
+      expect(doc.contains('if (canvasMoved) { _clampPan(); _applyCanvas(); }'),
+          isTrue,
+          reason: '拖动/惯性/方向键三条平移路径必须共用同一条钳制规则');
+      // ZOOM<=1 时位置归 _recenterPan 居中，钳制必须让路，否则缩小后页面被顶到左边。
+      expect(doc.contains('if (ZOOM <= 1) return;'), isTrue);
     });
 
     test('Lens regions render transparent character hit targets', () {
@@ -775,10 +867,34 @@ void main() {
       expect(doc.contains("callHandler('onMangaContextMenu'"), isTrue);
       expect(doc.contains("callHandler('onMangaZoomChanged'"), isTrue);
       expect(doc.contains('e.ctrlKey || e.metaKey'), isTrue);
-      // 滚轮缩放必须按 deltaY **幅值**做乘法缩放。旧实现只取符号、恒 ±0.1 加法步长
-      // （触控板与鼠标同等对待 + 高倍率下相对变化越来越小）＝「缩放极其不灵敏」。
-      expect(doc.contains('Math.exp(steps * 0.2 * ZOOM_SENS)'), isTrue,
-          reason: '滚轮缩放必须是按 delta 幅值的乘法缩放，不能是定长加法');
+      // 滚轮缩放必须是**对齐到 ZOOM_STEP 网格的定量步进**，与右键菜单的 ±10 个
+      // 百分点同口径。曾经用过按 delta 幅值的乘法 `Math.exp(steps * 0.2 * ZOOM_SENS)`，
+      // 那让「一格缩多少」取决于本机 deltaY 的绝对值（WebView2 高 DPI 上一格不是
+      // 100，BUG-1065 实测 67），用户实测一格约 112%、既非设计值也无法预期。
+      expect(
+          doc.contains(
+              'var ZOOM_STEP = Math.max(1, Math.round(10 * ZOOM_SENS));'),
+          isTrue,
+          reason: '滚轮步长必须是 10 个百分点（乘灵敏度）的定量网格，不能是乘法缩放');
+      expect(doc.contains('Math.exp('), isFalse,
+          reason: '乘法指数缩放已废弃：一格缩多少不能取决于本机 deltaY 绝对值');
+      expect(
+          doc.contains('(Math.floor(cur / ZOOM_STEP) + 1) * ZOOM_STEP'), isTrue,
+          reason: '放大必须对齐到网格，否则捏合留下的非整值会一路歪下去');
+      expect(
+          doc.contains('(Math.ceil(cur / ZOOM_STEP) - 1) * ZOOM_STEP'), isTrue,
+          reason: '缩小必须对齐到网格');
+      expect(doc.contains('var cur = Math.round(ZOOM * 1000) / 10;'), isTrue,
+          reason: '必须先消掉浮点毛刺，否则 1.2000000000000002 缩小一步会原地不动');
+      // 「一格」的判定复用翻页滚轮的累计口径（阈值 40 + 反向清账）：鼠标一格无论
+      // deltaY 是 57/67/100 都 >=40 恒好一步，触控板碎 delta 攒够才走。
+      expect(doc.contains('if (_zoomAccum < 40) return 0;'), isTrue,
+          reason: '必须按累计位移判定一格，否则触控板碎 delta 要么失灵要么暴走');
+      expect(
+          doc.contains(
+              'if (dir !== _zoomDir) { _zoomAccum = 0; _zoomDir = dir; }'),
+          isTrue,
+          reason: '反向必须立刻清账，否则来回滚会被上一方向的余量吃掉');
       expect(doc.contains('e.deltaMode === 1'), isTrue,
           reason: 'deltaMode 必须归一化，否则行/页模式步长完全不同');
     });

--- a/fushi/test/media/video/video_subtitle_wrap_viewport_test.dart
+++ b/fushi/test/media/video/video_subtitle_wrap_viewport_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_overlay.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+/// 字幕换行宽度必须锚在**视频内容矩形**，不能锚在容器。
+///
+/// 用户实测：1440p 显示器放 1080p 视频，窗口保持 1080p 大小时字幕排版正常，**一最大化
+/// 就变**（多断出一行）。根因是两个基准不同源——字号锚在 fit:contain 后的视频内容矩形高
+/// （`_assFontScale`，与 mpv/libass 同口径），换行可用宽度却锚在容器宽。pillarbox（窗口
+/// 比视频扁）下字号 ∝ 容器高、可用宽 ∝ 容器宽，于是**换行容量 ∝ 窗口宽高比**：一行「刚好
+/// 塞满」的字幕，窗口宽高比一变就被推过阈值。
+///
+/// 这里钉的不变式：**视频内容矩形不变时，容器宽怎么变，断行位置都不许变。**
+AudioCue _cue(String text) {
+  return AudioCue()
+    ..bookKey = 'b'
+    ..chapterHref = 'ch'
+    ..sentenceIndex = 0
+    ..textFragmentId = '#s1'
+    ..text = text
+    ..startMs = 0
+    ..endMs = 5000
+    ..audioFileIndex = 0;
+}
+
+/// pump 一个 16:9 视频的字幕层，容器宽由 [width] 给、高固定。
+///
+/// 高固定 + 视频比固定 ⇒ fit:contain 后的**视频内容矩形完全相同**（pillarbox 档：
+/// 内容高 = 容器高，内容宽 = 容器高 × 16/9 ≈ 355.6px），只有左右黑边宽度随容器变。
+Future<void> _pumpPillarbox(
+  WidgetTester tester,
+  String text, {
+  required double width,
+  double height = 200,
+  double fontSize = 20,
+}) async {
+  final VideoPlayerController c = VideoPlayerController()
+    ..debugVideoWidthOverride = 1920
+    ..debugVideoHeightOverride = 1080;
+  c.setCues(<AudioCue>[_cue(text)]);
+  c.debugUpdateCueForPosition(100);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: width,
+          height: height,
+          child: VideoSubtitleOverlay(controller: c, fontSize: fontSize),
+        ),
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+/// 按渲染几何重建可视行（同 video_subtitle_word_wrap_test 的做法）：收集所有单字符
+/// Text 的全局 topLeft，按 dy 分行、行内按 dx 排序拼接。
+List<String> _visualLines(WidgetTester tester) {
+  final Iterable<Element> elements = find
+      .descendant(
+          of: find.byType(VideoSubtitleOverlay), matching: find.byType(Text))
+      .evaluate();
+  final List<({double dy, double dx, String ch})> glyphs =
+      <({double dy, double dx, String ch})>[];
+  for (final Element e in elements) {
+    final Text t = e.widget as Text;
+    final String? s = t.data;
+    if (s == null || s.isEmpty) continue;
+    final RenderObject? ro = e.renderObject;
+    if (ro is! RenderBox || !ro.hasSize) continue;
+    final Offset p = ro.localToGlobal(Offset.zero);
+    glyphs.add((dy: p.dy, dx: p.dx, ch: s));
+  }
+  glyphs.sort((({double dy, double dx, String ch}) a,
+      ({double dy, double dx, String ch}) b) {
+    final int byY = a.dy.compareTo(b.dy);
+    return byY != 0 ? byY : a.dx.compareTo(b.dx);
+  });
+  final List<String> lines = <String>[];
+  double? lineY;
+  StringBuffer buf = StringBuffer();
+  for (final ({double dy, double dx, String ch}) g in glyphs) {
+    if (lineY == null || (g.dy - lineY).abs() > 1.0) {
+      if (buf.isNotEmpty) lines.add(buf.toString());
+      buf = StringBuffer();
+      lineY = g.dy;
+    }
+    buf.write(g.ch);
+  }
+  if (buf.isNotEmpty) lines.add(buf.toString());
+  return lines;
+}
+
+void main() {
+  group('换行宽度锚在视频内容矩形，不随窗口宽高比变', () {
+    // 16:9 视频 + 200px 高 ⇒ 内容宽恒 ≈355.6px，两个容器宽都远大于它（都是 pillarbox）。
+    const String text = 'aaa bbb ccc ddd eee fff ggg';
+
+    // 宽度都必须 <= 测试窗口宽（默认 800）：Center 给的是 loose 约束，
+    // SizedBox(width: 1000) 会被 constrain 成 800，算出来的黑边宽度就对不上了。
+    testWidgets('容器从 500px 拉宽到 760px，断行位置一字不变', (WidgetTester tester) async {
+      await _pumpPillarbox(tester, text, width: 500);
+      final List<String> narrow = _visualLines(tester);
+
+      await _pumpPillarbox(tester, text, width: 760);
+      final List<String> wide = _visualLines(tester);
+
+      expect(narrow.length, greaterThan(1),
+          reason: '前提：这句话在 355.6px 的视频内容宽里必须真的会换行，否则本测试空转');
+      expect(wide, narrow,
+          reason: '修复前换行宽度 = 容器宽，拉宽窗口会把断行位置整个挪走——'
+              '这正是用户报的「窗口一最大化字幕排版就变」');
+    });
+
+    testWidgets('字幕不排进左右黑边：整行水平范围落在视频内容矩形内', (WidgetTester tester) async {
+      const double width = 760;
+      await _pumpPillarbox(tester, text, width: width);
+
+      final Iterable<Element> elements = find
+          .descendant(
+              of: find.byType(VideoSubtitleOverlay),
+              matching: find.byType(Text))
+          .evaluate();
+      final RenderBox overlay =
+          tester.renderObject<RenderBox>(find.byType(VideoSubtitleOverlay));
+      final double overlayLeft = overlay.localToGlobal(Offset.zero).dx;
+      // 内容宽 = 200 × 16/9；左右黑边各 (760 - 内容宽) / 2。
+      const double contentWidth = 200 * 16 / 9;
+      const double sideBar = (width - contentWidth) / 2;
+
+      double minDx = double.infinity;
+      double maxDx = -double.infinity;
+      for (final Element e in elements) {
+        final RenderObject? ro = e.renderObject;
+        if (ro is! RenderBox || !ro.hasSize) continue;
+        final double left = ro.localToGlobal(Offset.zero).dx - overlayLeft;
+        minDx = left < minDx ? left : minDx;
+        final double right = left + ro.size.width;
+        maxDx = right > maxDx ? right : maxDx;
+      }
+      expect(minDx, greaterThanOrEqualTo(sideBar - 1),
+          reason: '字幕左缘不得越过左黑边——字幕属于画面，不属于窗口');
+      expect(maxDx, lessThanOrEqualTo(width - sideBar + 1),
+          reason: '字幕右缘不得越过右黑边');
+    });
+  });
+}


### PR DESCRIPTION
用户一次报了五个问题，逐个做了根因修复。每条都有独立 bug 文件（BUG-1750~1755）记录根因 `file:line`、修复和测试。

## 1. 漫画 RTL 翻页滑动动画方向相反 (BUG-1750)

**不是新问题，是回归。** `cd4be252548`（2026-07-27，标题写的是 OCR）为修 `offsetLeft` 错位把根 strip 钉死 `direction:ltr`，视觉运动自此恒为 LTR；而 tap zone 和方向键（`manga_arrow_override.dart` 的注释白纸黑字写着「rtl：下一页在左」）早已按 RTL 镜像。RTL 是**默认值**，所以默认配置下必现：按前进键，画面往后退的方向滑。

保留 `ltr` 几何（那是 `offsetLeft` 稳定性的必要条件，不能回退），改成**按阅读方向倒序写入 DOM**。`__mangaApplyTranslate` 用 `data-spread` 选择器定位，一行未改。swipe 判据一并按 `IS_RTL` 镜像（RTL 下向右滑 = 下一页，与 Mihon 一致），并删掉「由 Dart 端按阅读方向 clamp」这条从未成立的注释。

## 2. 漫画滚轮缩放步进 (BUG-1751)

用户实测「一格约 112%」。原因是 `exp(steps*0.2*SENS)` 让每格缩放量取决于**本机 deltaY 的绝对值**——注释假设一格 100，但 WebView2 在高 DPI 上不是（BUG-1065 实测同款机器 67）。且右键菜单/设置滑块都是 ±10 个百分点，同一功能两套口径。

改为对齐 `ZOOM_STEP` 网格的定量步进（默认 10 个百分点）。「一格」的判定**复用本文件翻页滚轮已有的累计口径**（阈值 40 + 反向清账），所以 deltaY 是 57/67/100 都恒好一步、触控板碎 delta 攒够才走。另外先消浮点毛刺——否则 `1.2000000000000002` 缩小一步会被 `_zoomAbout` 的 0.0005 死区吃掉、**缩不动**。捏合保持连续比例（必须跟手）。

## 3. 方向键平移页面（新增功能）

`ShortcutScope.manga` 新增 `mangaPan{Up,Down,Left,Right}`，默认 **Ctrl+方向键**——裸方向键四个全被翻页占死了，可在快捷键设置里改（设置页自动枚举，UI 零改动）。长按连发只放给平移，翻页保持不连发。

顺带修了一个既有缺陷：**PAN 此前完全没有边界**，拖动能把页面推出视口且回不来。钳制放在 `_panBy` 里，拖动/惯性/方向键三条路径共用同一条规则。

## 4. 拖放落到隐藏 tab (BUG-1752)

用户截图：停在**视频页**拖入视频文件夹，弹出「导入漫画」对话框 + 「拖入的文件里没有新的游戏 .exe」，视频页本身毫无反应。

三层根因：`desktop_drop` 是全局广播；home-shell 四个 tab 用 `Offstage` 保活，而 `RenderOffstage` 隐藏时**仍以完整约束布局**（只关 Flutter 自己的 hitTest），四个 drop target 全部命中；唯一的门 `ModalRoute.isCurrent` 对同级 tab 恒为 true。

新增 `DropSurfaceScope`（逐层 AND，可嵌套），由 `home_page` 在构建 tab 内容的**那一处**统一提供。刻意不是给 11 个注册点各加一个 `enabled` 参数——那样等于「要写守卫检查每个调用点有没有传对」，而漏传就是 bug 本身。现在 11 个注册点一行未改，新入口天生带上。

## 5. 拖多个视频只导第一个 / 拖文件夹静默 (BUG-1753 / BUG-1754)

- `DropIntent` 是标量、各分支只取 `.first`。视频表面改为队列逐个预填；多视频时字幕按文件名主干配对，取消只跳过该条。
- 视频页没传 `isDirectory` 谓词 → 目录落 `unknown` → 静默；且分类器把「是目录」这个**事实**就地编码成「是漫画」这个**判断**。改为记录 `directories` 事实，由 `decideDropIntent` 按落点表面解释：视频页 → 登记扫描根，书架/漫画库的整目录页图导入原样保留。落地走新抽的共享函数 `addLocalFolderAsSource`，与来源页按钮产出相同的来源行。

## 6. 字幕换行 (BUG-1755，BUG-1730 续)

中词断行本身已由 `3aa5907ff0` 修掉（已在 develop，用户截图应出自更早的构建）。本 PR 修的是 BUG-1730 备注里明确留下的两条未修根因，正好是用户自己诊断出的两点：

- **「最大化就变」**：字号锚在视频内容矩形高、换行宽度却锚在容器宽。pillarbox 下换行容量 ∝ 窗口宽高比（1920×1048 → 2560×1440 少约 3%），一行「刚好塞满」的字幕就被推过阈值。补 pillarbox 黑边内缩使两者同源。
- **「底部才断、顶部不断」**：`posMarkup = forcedAnchor != null ? null : ownMarkup` 是**竖直**强制锚定，却把水平排版盒一起丢了。水平 MarginL/R 改读 `ownMarkup`（竖直的仍走 `posMarkup`，否则用户锚定会被 ASS MarginV 顶回去）。

## 验证

- `flutter analyze` 全绿（含 test）。
- **目录枚举型守卫 36 条：250 tests PASSED**，与 `fast-workflow.md` 记录的基线 250 一致。
- manga + drag_drop + shortcuts + pages：**3980 PASSED**；video + i18n：**2723 PASSED**。全部经 `flutter_test_failures.dart` 出 verdict。
- 新守卫都做过**变异测试**（RTL 倒序改成 `!rtl` → 红；`sideBar` 写死 0 → 两条红），还原后文件 sha256 与变异前逐字节相同。

## 未做（已在各 bug 文件「备注」里记）

- **ASS `\q` (WrapStyle) 仍未解析**。缺省是 WrapStyle 0 = **均衡换行**，而当前恒贪心填满——这是与 MPC 截图差异的**另一半**（MPC 两行均衡，Fushi 满行 + 一个词）。要修需把贪心 `Wrap` 换成先测量后择点，与逐字形样式的测量精度耦合，爆炸半径大。
- `\h`（不断行空格）在 parser 里被写成普通空格，于是会在作者禁止断行处断行。正确改法是照 `\N` 的既有范式加下标表，不能直接写 NBSP（`plainText` 是查词/制卡/落库的同一份文本）。
- 书架表面的多文件 `.first`、`DropIntent` 标量模型、库页**内部**子视图的拖放作用域。

**未做真机验证**：以上都是本机测试+静态推导，阅读器/播放/拖放的真机复测未做。

https://claude.ai/code/session_018u7Mk3mxFqK2q31d8u3fHU
