### PR TITLE
feat(dict): 查词弹窗接通真实变形链与语法说明

### DIFF
--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -575,6 +575,42 @@
     color: inherit;
 }
 
+/* 「«」读作「来自」：右边那层变形接在左边这层之上，`-て « -いる « -た` 即
+   词典形先接て、再接いる、最后接た。与 Yomitan 同一种读法。分隔符走 ::before
+   而不是插 DOM 节点，选区复制时不会把它一起带走。 */
+.deinflection-tag:not(:first-child)::before {
+    content: '«';
+    margin-right: 4px;
+    margin-left: 2px;
+    opacity: 0.55;
+}
+
+/* 只有带语法说明的标签可点/可 hover（见 popup.js 的 createDeinflectionTag）。 */
+.deinflection-tag.has-description {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+/* 词形变化的语法说明浮层（桌面 hover；触屏走 .overlay）。位置由 JS 按锚点算好
+   写进 left/top，这里只管观感。 */
+.grammar-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 728;
+    max-width: 460px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-color);
+    background: var(--surface-container-high);
+    border: 1px solid var(--outline-variant);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
 .frequency-group {
     display: inline-flex;
     font-size: 11px;

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -634,6 +634,42 @@ html.global-lookup .mine-button:not(:disabled) {
     color: inherit;
 }
 
+/* 「«」读作「来自」：右边那层变形接在左边这层之上，`-て « -いる « -た` 即
+   词典形先接て、再接いる、最后接た。与 Yomitan 同一种读法。分隔符走 ::before
+   而不是插 DOM 节点，选区复制时不会把它一起带走。 */
+.deinflection-tag:not(:first-child)::before {
+    content: '«';
+    margin-right: 4px;
+    margin-left: 2px;
+    opacity: 0.55;
+}
+
+/* 只有带语法说明的标签可点/可 hover（见 popup.js 的 createDeinflectionTag）。 */
+.deinflection-tag.has-description {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+/* 词形变化的语法说明浮层（桌面 hover；触屏走 .overlay）。位置由 JS 按锚点算好
+   写进 left/top，这里只管观感。 */
+.grammar-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 728;
+    max-width: 460px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-color);
+    background: var(--surface-container-high);
+    border: 1px solid var(--outline-variant);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
 .frequency-group {
     display: inline-flex;
     font-size: 11px;

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -507,6 +507,62 @@ function closeOverlay() {
     __fushiRootNode().querySelector('.overlay').style.display = 'none';
 }
 
+/* 词形变化标签的语法说明浮层（桌面 hover）。
+   点击走 showDescription 的全屏 overlay——触屏上没有 hover，且窄屏放不下这块浮层。
+   浮层是懒创建的，挂在 __fushiOverlayParent()（shadow root 或 document.body）下，
+   这样扩展注入到宿主页面时也不会跑到词典的 Shadow DOM 外面去。 */
+function ensureGrammarTooltip() {
+    const root = __fushiRootNode();
+    let tooltip = root.querySelector('.grammar-tooltip');
+    if (!tooltip) {
+        tooltip = el('div', { className: 'grammar-tooltip' });
+        __fushiOverlayParent().appendChild(tooltip);
+    }
+    return tooltip;
+}
+
+function showGrammarTooltip(element) {
+    /* 只有能 hover 的指针设备才显示。触屏浏览器会在 tap 时补发一次 mouseenter，
+       那样浮层会一直粘在屏幕上没人收（没有后续的 mouseleave）。 */
+    try {
+        if (window.matchMedia && !window.matchMedia('(hover: hover)').matches) return;
+    } catch (_) { /* matchMedia 不可用时按可 hover 处理 */ }
+
+    const description = element.getAttribute('data-description');
+    if (!description) return;
+
+    const tooltip = ensureGrammarTooltip();
+    tooltip.textContent = description;
+    tooltip.style.display = 'block';
+    /* 先落地再量：宽度受 CSS max-width 约束，量完才知道该往哪边收。 */
+    tooltip.style.left = '0px';
+    tooltip.style.top = '0px';
+
+    const anchor = element.getBoundingClientRect();
+    const box = tooltip.getBoundingClientRect();
+    const margin = 8;
+
+    let left = anchor.left;
+    const maxLeft = window.innerWidth - box.width - margin;
+    if (left > maxLeft) left = maxLeft;
+    if (left < margin) left = margin;
+
+    let top = anchor.bottom + 6;
+    if (top + box.height > window.innerHeight - margin) {
+        const above = anchor.top - box.height - 6;
+        /* 上方也放不下就维持在下方：宁可截断底部，也不要顶出视口外够不着。 */
+        if (above >= margin) top = above;
+    }
+
+    tooltip.style.left = left + 'px';
+    tooltip.style.top = top + 'px';
+}
+
+function hideGrammarTooltip() {
+    const tooltip = __fushiRootNode().querySelector('.grammar-tooltip');
+    if (tooltip) tooltip.style.display = 'none';
+}
+
 // https://github.com/yomidevs/yomitan/blob/c24d4c9b39ceec1b5fd133df774c41972e9ebbdc/ext/js/language/ja/japanese.js#L171
 function createFuriganaSegment(text, reading) {
     return {text, reading};
@@ -2070,12 +2126,28 @@ function renderTaggedTermPairs(parent, pairs) {
 }
 
 function createDeinflectionTag(tag) {
+    // 语法说明来自 assets/transforms/<lang>.json，随 deinflectionTrace 一起送到。
+    // 文本变体归一的回落标签（colour → color）没有说明，这时不加 has-description：
+    // 不给指针手型、不挂 hover/click，免得点开一个空框。
+    const hasDescription = !!tag.description;
+    if (!hasDescription) {
+        return el('span', {
+            className: 'deinflection-tag',
+            textContent: tag.name
+        });
+    }
     return el('span', {
-        className: 'deinflection-tag',
+        className: 'deinflection-tag has-description',
         textContent: tag.name,
         'data-description': tag.description,
         onclick() {
             showDescription(this);
+        },
+        onmouseenter() {
+            showGrammarTooltip(this);
+        },
+        onmouseleave() {
+            hideGrammarTooltip();
         }
     });
 }

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -634,6 +634,42 @@ html.global-lookup .mine-button:not(:disabled) {
     color: inherit;
 }
 
+/* 「«」读作「来自」：右边那层变形接在左边这层之上，`-て « -いる « -た` 即
+   词典形先接て、再接いる、最后接た。与 Yomitan 同一种读法。分隔符走 ::before
+   而不是插 DOM 节点，选区复制时不会把它一起带走。 */
+.deinflection-tag:not(:first-child)::before {
+    content: '«';
+    margin-right: 4px;
+    margin-left: 2px;
+    opacity: 0.55;
+}
+
+/* 只有带语法说明的标签可点/可 hover（见 popup.js 的 createDeinflectionTag）。 */
+.deinflection-tag.has-description {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+/* 词形变化的语法说明浮层（桌面 hover；触屏走 .overlay）。位置由 JS 按锚点算好
+   写进 left/top，这里只管观感。 */
+.grammar-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 728;
+    max-width: 460px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-color);
+    background: var(--surface-container-high);
+    border: 1px solid var(--outline-variant);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
 .frequency-group {
     display: inline-flex;
     font-size: 11px;

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -507,6 +507,62 @@ function closeOverlay() {
     __fushiRootNode().querySelector('.overlay').style.display = 'none';
 }
 
+/* 词形变化标签的语法说明浮层（桌面 hover）。
+   点击走 showDescription 的全屏 overlay——触屏上没有 hover，且窄屏放不下这块浮层。
+   浮层是懒创建的，挂在 __fushiOverlayParent()（shadow root 或 document.body）下，
+   这样扩展注入到宿主页面时也不会跑到词典的 Shadow DOM 外面去。 */
+function ensureGrammarTooltip() {
+    const root = __fushiRootNode();
+    let tooltip = root.querySelector('.grammar-tooltip');
+    if (!tooltip) {
+        tooltip = el('div', { className: 'grammar-tooltip' });
+        __fushiOverlayParent().appendChild(tooltip);
+    }
+    return tooltip;
+}
+
+function showGrammarTooltip(element) {
+    /* 只有能 hover 的指针设备才显示。触屏浏览器会在 tap 时补发一次 mouseenter，
+       那样浮层会一直粘在屏幕上没人收（没有后续的 mouseleave）。 */
+    try {
+        if (window.matchMedia && !window.matchMedia('(hover: hover)').matches) return;
+    } catch (_) { /* matchMedia 不可用时按可 hover 处理 */ }
+
+    const description = element.getAttribute('data-description');
+    if (!description) return;
+
+    const tooltip = ensureGrammarTooltip();
+    tooltip.textContent = description;
+    tooltip.style.display = 'block';
+    /* 先落地再量：宽度受 CSS max-width 约束，量完才知道该往哪边收。 */
+    tooltip.style.left = '0px';
+    tooltip.style.top = '0px';
+
+    const anchor = element.getBoundingClientRect();
+    const box = tooltip.getBoundingClientRect();
+    const margin = 8;
+
+    let left = anchor.left;
+    const maxLeft = window.innerWidth - box.width - margin;
+    if (left > maxLeft) left = maxLeft;
+    if (left < margin) left = margin;
+
+    let top = anchor.bottom + 6;
+    if (top + box.height > window.innerHeight - margin) {
+        const above = anchor.top - box.height - 6;
+        /* 上方也放不下就维持在下方：宁可截断底部，也不要顶出视口外够不着。 */
+        if (above >= margin) top = above;
+    }
+
+    tooltip.style.left = left + 'px';
+    tooltip.style.top = top + 'px';
+}
+
+function hideGrammarTooltip() {
+    const tooltip = __fushiRootNode().querySelector('.grammar-tooltip');
+    if (tooltip) tooltip.style.display = 'none';
+}
+
 // https://github.com/yomidevs/yomitan/blob/c24d4c9b39ceec1b5fd133df774c41972e9ebbdc/ext/js/language/ja/japanese.js#L171
 function createFuriganaSegment(text, reading) {
     return {text, reading};
@@ -2070,12 +2126,28 @@ function renderTaggedTermPairs(parent, pairs) {
 }
 
 function createDeinflectionTag(tag) {
+    // 语法说明来自 assets/transforms/<lang>.json，随 deinflectionTrace 一起送到。
+    // 文本变体归一的回落标签（colour → color）没有说明，这时不加 has-description：
+    // 不给指针手型、不挂 hover/click，免得点开一个空框。
+    const hasDescription = !!tag.description;
+    if (!hasDescription) {
+        return el('span', {
+            className: 'deinflection-tag',
+            textContent: tag.name
+        });
+    }
     return el('span', {
-        className: 'deinflection-tag',
+        className: 'deinflection-tag has-description',
         textContent: tag.name,
         'data-description': tag.description,
         onclick() {
             showDescription(this);
+        },
+        onmouseenter() {
+            showGrammarTooltip(this);
+        },
+        onmouseleave() {
+            hideGrammarTooltip();
         }
     });
 }

--- a/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
@@ -16,7 +16,7 @@ class _GroupedEntry {
   final String expression;
   final String reading;
   final String matched;
-  final List<Map<String, String>> deinflectionTrace;
+  final List<DeinflectionTag> deinflectionTrace;
   final List<_GlossaryItem> glossaries;
 }
 
@@ -80,14 +80,10 @@ class _DictionaryPopupNativeState extends ConsumerState<DictionaryPopupNative> {
 
       final key = '${entry.word}\n${entry.reading}';
       if (!grouped.containsKey(key)) {
-        final trace = <Map<String, String>>[];
-        if (extraData != null && extraData.containsKey('deinflected')) {
-          final matched = extraData['matched'] as String? ?? '';
-          final deinflected = extraData['deinflected'] as String? ?? '';
-          if (matched != deinflected && deinflected.isNotEmpty) {
-            trace.add({'name': '$matched → $deinflected'});
-          }
-        }
+        // 变形标签（含语法说明）由 buildDeinflectionTags 统一生成、随 extra 送达。
+        final List<DeinflectionTag> trace = extraData == null
+            ? const <DeinflectionTag>[]
+            : deinflectionTagsFromExtra(extraData);
 
         grouped[key] = _GroupedEntry(
           expression: entry.word,
@@ -244,16 +240,72 @@ class _DictionaryPopupNativeState extends ConsumerState<DictionaryPopupNative> {
     Color tagBg,
     FushiDesignTokens tokens,
   ) {
+    final ThemeData theme = Theme.of(context);
+    final List<Widget> children = <Widget>[];
+    for (int i = 0; i < entry.deinflectionTrace.length; i++) {
+      final DeinflectionTag tag = entry.deinflectionTrace[i];
+      // 「«」读作「来自」：右边那一层变形是接在左边这一层之上的。与 Yomitan 和
+      // WebView 弹窗（popup.css 的 .deinflection-tag:not(:first-child)::before）
+      // 保持同一种读法。
+      if (i > 0) {
+        children.add(Text(
+          '«',
+          style: theme.textTheme.labelSmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ));
+      }
+      children.add(FushiTagChip(
+        label: tag.name,
+        color: tagBg,
+        // 没有语法说明的标签（文本变体归一的回落条目）不可点，免得点开一个空框。
+        onTap:
+            tag.description.isEmpty ? null : () => _showGrammarDescription(tag),
+      ));
+    }
     return Padding(
       padding: EdgeInsets.only(top: tokens.spacing.gap / 4),
       child: Wrap(
         spacing: tokens.spacing.gap / 4,
-        children: entry.deinflectionTrace.map((trace) {
-          return FushiTagChip(
-            label: trace['name'] ?? '',
-            color: tagBg,
-          );
-        }).toList(),
+        runSpacing: tokens.spacing.gap / 4,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: children,
+      ),
+    );
+  }
+
+  /// 展示某一层词形变化的语法说明（来自 `assets/transforms/<lang>.json`）。
+  Future<void> _showGrammarDescription(DeinflectionTag tag) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) => FushiDialogFrame(
+        padding: EdgeInsets.all(tokens.spacing.card),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              tag.name,
+              style: Theme.of(dialogContext).textTheme.titleMedium,
+            ),
+            Text(
+              t.dict_category_grammar,
+              style: Theme.of(dialogContext).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(dialogContext).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            SelectableText(tag.description),
+            SizedBox(height: tokens.spacing.gap),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: Text(t.dialog_close),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -2410,13 +2410,12 @@ JSON.stringify((function(){
       group['matched'] = matched;
     }
 
+    // 变形标签（含语法说明）由 buildDeinflectionTags 统一生成、随 extra 送达，
+    // 这里只解析不再自己拼——回落语义只有那一份。
     final trace = group['deinflectionTrace'] as List<Map<String, String>>;
-    if (trace.isEmpty && extraData.containsKey('deinflected')) {
-      final traceMatched = matched ?? '';
-      final deinflected = extraData['deinflected'] as String? ?? '';
-      if (traceMatched != deinflected && deinflected.isNotEmpty) {
-        trace.add({'name': '$traceMatched → $deinflected', 'description': ''});
-      }
+    if (trace.isEmpty) {
+      trace
+          .addAll(deinflectionTagsToJson(deinflectionTagsFromExtra(extraData)));
     }
 
     _appendUniqueMetadata(

--- a/fushi/test/dictionary/deinflection_grammar_tags_test.dart
+++ b/fushi/test/dictionary/deinflection_grammar_tags_test.dart
@@ -1,0 +1,309 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'package:path/path.dart' as p;
+
+import '../helpers/source_guard.dart';
+
+/// 查词弹窗的**语法说明**（词形变化链上每一层的语法解释）。
+///
+/// 数据早就全在包里：`assets/transforms/<lang>.json` 每个 transform 都带 Yomitan
+/// 的语法说明，`deinflector.cpp` 解析进 `TransformGroup{name, description}`，
+/// `lookup.cpp` 把整条 trace 挂在每个 LookupResult 上，FFI 也把 name+description
+/// 都送到了 Dart。断的是最后一米：四处拼弹窗 JSON 的代码各自把 trace 丢掉，
+/// 换成一条现编的 `matched → deinflected` 且 `description` 恒为空串。
+///
+/// 这组测试锁住修好之后的语义，外加一条源码守卫防止那四份拷贝重新长回来。
+void main() {
+  FushiTermResult term() => FushiTermResult(
+        expression: '当たる',
+        reading: 'あたる',
+        rules: '',
+        glossaries: [
+          FushiGlossaryEntry(
+            dictName: 'JMdict',
+            glossary: jsonEncode(['to hit']),
+            definitionTags: '',
+            termTags: '',
+          ),
+        ],
+        frequencies: [],
+        pitches: [],
+      );
+
+  // 引擎压栈顺序 = 剥离顺序：`当たっていた` 先剥最外层的 -た，再剥 -いる，
+  // 最后剥 -て。所以 trace 是 [-た, -いる, -て]。
+  const List<FushiTransformGroup> ateiruTrace = [
+    FushiTransformGroup(name: '-た', description: 'Indicates the past.'),
+    FushiTransformGroup(name: '-いる', description: 'Indicates continuation.'),
+    FushiTransformGroup(name: '-て', description: 'て-form.'),
+  ];
+
+  FushiLookupResult lookup({
+    required String matched,
+    required String deinflected,
+    List<FushiTransformGroup> trace = const [],
+  }) =>
+      FushiLookupResult(
+        matched: matched,
+        deinflected: deinflected,
+        trace: trace,
+        preprocessorSteps: 0,
+        term: term(),
+      );
+
+  group('buildDeinflectionTags', () {
+    test('trace 反转成接续顺序，语法说明逐条带上', () {
+      // 用户看到的是「从词典形出发依次接了哪些变形」，与 Yomitan 的
+      // `-て « -いる « -た` 同序——正是引擎压栈顺序的反转。
+      final List<DeinflectionTag> tags = buildDeinflectionTags(
+        matched: '当たっていた',
+        deinflected: '当たる',
+        trace: ateiruTrace,
+      );
+
+      expect(tags.map((t) => t.name).toList(), ['-て', '-いる', '-た']);
+      expect(tags.map((t) => t.description).toList(), [
+        'て-form.',
+        'Indicates continuation.',
+        'Indicates the past.',
+      ]);
+    });
+
+    test('trace 非空时不再生成 "matched → deinflected" 那条现编标签', () {
+      final List<DeinflectionTag> tags = buildDeinflectionTags(
+        matched: '当たっていた',
+        deinflected: '当たる',
+        trace: ateiruTrace,
+      );
+
+      expect(
+        tags.any((t) => t.name.contains('→')),
+        isFalse,
+        reason: '有真实变形链时不该再退回那条没有语法说明的合并标签',
+      );
+    });
+
+    test('trace 为空但 matched≠deinflected → 回落成单条，说明为空', () {
+      // 这是 lookup.cpp 的**文本变体归一**（colour→color 一类）：它不经过任何
+      // 变形规则，所以没有 trace 也没有语法说明。回落分支删掉的话，这类查询会
+      // 完全不提示词形变化——属于行为回退，不是简化。
+      final List<DeinflectionTag> tags = buildDeinflectionTags(
+        matched: 'colour',
+        deinflected: 'color',
+        trace: const [],
+      );
+
+      expect(tags.length, 1);
+      expect(tags.single.name, 'colour → color');
+      expect(tags.single.description, isEmpty);
+    });
+
+    test('原形直查（matched == deinflected）→ 空，不生成自指标签', () {
+      expect(
+        buildDeinflectionTags(
+          matched: '当たる',
+          deinflected: '当たる',
+          trace: const [],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('引擎未回填 deinflected（空串）→ 空，不生成「x → 」残缺标签', () {
+      expect(
+        buildDeinflectionTags(
+          matched: '当たっていた',
+          deinflected: '',
+          trace: const [],
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('extra 往返', () {
+    test('buildLookupEntryExtra 写出的标签能被 deinflectionTagsFromExtra 原样读回', () {
+      // 走 extra 的两条路径（原生弹窗、buildLookupEntriesJson）此前只能看到
+      // matched/deinflected，语法说明就是断在这里的。
+      final String extra = buildLookupEntryExtra(
+        lookup(
+          matched: '当たっていた',
+          deinflected: '当たる',
+          trace: ateiruTrace,
+        ),
+        term().glossaries.single,
+      );
+
+      final List<DeinflectionTag> tags = deinflectionTagsFromExtra(
+        jsonDecode(extra) as Map<String, dynamic>,
+      );
+
+      expect(tags.map((t) => t.name).toList(), ['-て', '-いる', '-た']);
+      expect(tags.first.description, 'て-form.');
+    });
+
+    test('老 extra（没有 deinflectionTrace 键）仍按 matched/deinflected 回落', () {
+      final List<DeinflectionTag> tags = deinflectionTagsFromExtra(
+        <String, dynamic>{'matched': 'colour', 'deinflected': 'color'},
+      );
+
+      expect(tags.single.name, 'colour → color');
+      expect(tags.single.description, isEmpty);
+    });
+
+    test('老 extra 且 matched == deinflected → 空', () {
+      expect(
+        deinflectionTagsFromExtra(
+          <String, dynamic>{'matched': '当たる', 'deinflected': '当たる'},
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('两条弹窗路径都送出真实变形链', () {
+    test('buildPopupJsonFromLookup（主路径）', () {
+      final List decoded = jsonDecode(buildPopupJsonFromLookup(
+        results: [
+          lookup(
+            matched: '当たっていた',
+            deinflected: '当たる',
+            trace: ateiruTrace,
+          )
+        ],
+        maximumTerms: 100,
+        hiddenDictionaries: const <String>{},
+      )) as List;
+
+      expect((decoded.single as Map<String, dynamic>)['deinflectionTrace'], [
+        {'name': '-て', 'description': 'て-form.'},
+        {'name': '-いる', 'description': 'Indicates continuation.'},
+        {'name': '-た', 'description': 'Indicates the past.'},
+      ]);
+    });
+
+    test('buildLookupEntriesJson（extra 路径）与主路径逐字段一致', () {
+      final List<FushiLookupResult> results = [
+        lookup(
+          matched: '当たっていた',
+          deinflected: '当たる',
+          trace: ateiruTrace,
+        )
+      ];
+
+      final List viaLookup = jsonDecode(buildPopupJsonFromLookup(
+        results: results,
+        maximumTerms: 100,
+        hiddenDictionaries: const <String>{},
+      )) as List;
+
+      final List viaExtra = jsonDecode(
+        DictionaryPopupWebViewState.buildLookupEntriesJson(
+          buildResultFromLookup(
+            searchTerm: '当たっていた',
+            results: results,
+            maximumTerms: 100,
+          ),
+        ),
+      ) as List;
+
+      expect(
+        (viaExtra.single as Map<String, dynamic>)['deinflectionTrace'],
+        (viaLookup.single as Map<String, dynamic>)['deinflectionTrace'],
+      );
+    });
+  });
+
+  group('源码守卫：变形标签只有一处生成', () {
+    final String root = _repoRoot();
+
+    test('Dart 侧：只有 buildDeinflectionTags 拼那条 "matched → deinflected"', () {
+      // 不变式：回落标签的拼接字面量（下方 needle）只允许出现在 language.dart 的
+      // buildDeinflectionTags 函数体里。消费点各自再拼一遍，正是语法说明断掉四次
+      // 的原因——它们拼出来的 description 永远是空串。
+      //
+      // 断言字面量（守卫变异测试用，勿删）：空格 + U+2192 + 空格
+      const String needle = ' → ';
+
+      final String languagePath = p.join(root, 'packages', 'fushi_dictionary',
+          'lib', 'src', 'language', 'language.dart');
+      final String languageSrc = maskCommentsAndScriptLines(
+        File(languagePath).readAsStringSync(),
+      );
+
+      final String? body =
+          topLevelFunctionBody(languageSrc, 'buildDeinflectionTags');
+      expect(body, isNotNull,
+          reason: 'buildDeinflectionTags 必须是 language.dart 的顶层函数');
+      expect(body!.contains(needle), isTrue,
+          reason: '回落分支必须留在 buildDeinflectionTags 内（不能删）');
+
+      // 整个 language.dart 里该字面量只此一处。
+      expect(
+        needle.allMatches(languageSrc).length,
+        1,
+        reason: 'language.dart 里只允许 buildDeinflectionTags 拼这条回落标签',
+      );
+
+      // 三个消费点一处都不许拼。
+      final List<String> consumers = [
+        p.join(root, 'fushi', 'lib', 'src', 'pages', 'implementations',
+            'dictionary_popup_webview.dart'),
+        p.join(root, 'fushi', 'lib', 'src', 'pages', 'implementations',
+            'dictionary_popup_native.dart'),
+      ];
+      for (final String path in consumers) {
+        final String src =
+            maskCommentsAndScriptLines(File(path).readAsStringSync());
+        expect(src.contains(needle), isFalse,
+            reason: '${p.basename(path)} 必须走 buildDeinflectionTags，'
+                '不能自己拼变形标签（自己拼出来的 description 恒为空串）');
+      }
+    });
+
+    test('C++ 侧：popup_json.cpp 只在 write_deinflection_tags 里拼', () {
+      // 断言字面量（守卫变异测试用，勿删）： \xe2\x86\x92  即 UTF-8 的「→」
+      const String arrow = r'\xe2\x86\x92';
+
+      final String path = p.join(
+          root, 'native', 'fushidicts', 'fushidicts_src', 'popup_json.cpp');
+      final String src = File(path).readAsStringSync();
+
+      expect(
+        arrow.allMatches(src).length,
+        1,
+        reason: 'popup_json.cpp 里「→」只允许出现在 write_deinflection_tags 的'
+            '回落分支——多一处就说明有人又在别处现编变形标签了',
+      );
+      expect(
+        src.contains('write_deinflection_tags(os, gd.matched, gd.deinflected'),
+        isTrue,
+        reason: 'deinflectionTrace 必须由 write_deinflection_tags 写出，'
+            '它才是与 Dart 侧 buildDeinflectionTags 对齐的那一份',
+      );
+      expect(
+        src.contains('gd.trace = r.trace') ||
+            src.contains('gd.trace') && src.contains('it->second.trace'),
+        isTrue,
+        reason: '分组时必须把真实 trace 一起带上，否则永远只剩回落分支',
+      );
+    });
+  });
+}
+
+String _repoRoot() {
+  Directory dir = Directory.current;
+  while (!File(p.join(dir.path, 'native', 'fushidicts', 'CMakeLists.txt'))
+      .existsSync()) {
+    final Directory parent = dir.parent;
+    if (parent.path == dir.path) {
+      fail('could not locate repo root from ${Directory.current.path}');
+    }
+    dir = parent;
+  }
+  return dir.path;
+}

--- a/fushi/test/pages/dictionary_popup_native_test.dart
+++ b/fushi/test/pages/dictionary_popup_native_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_native.dart';
@@ -47,5 +49,100 @@ void main() {
       'expression': '猫',
       'reading': 'ねこ',
     });
+  });
+
+  /// extra 里的 deinflectionTrace 已经是 buildDeinflectionTags 的**成品**
+  /// （顺序已反转成接续顺序），原生弹窗只负责渲染与展示说明。
+  DictionarySearchResult resultWithTrace(List<Map<String, String>> trace) =>
+      DictionarySearchResult(
+        searchTerm: '当たっていた',
+        entries: <DictionaryEntry>[
+          DictionaryEntry(
+            word: '当たる',
+            reading: 'あたる',
+            meaning: 'to hit',
+            dictionaryName: 'JMdict',
+            extra: jsonEncode(<String, dynamic>{
+              'matched': '当たっていた',
+              'deinflected': '当たる',
+              'deinflectionTrace': trace,
+            }),
+          ),
+        ],
+      );
+
+  testWidgets('变形标签按接续顺序渲染，点开能看到该层的语法说明', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      buildTestApp(
+        SizedBox(
+          width: 400,
+          height: 480,
+          child: DictionaryPopupNative(
+            result: resultWithTrace(<Map<String, String>>[
+              <String, String>{'name': '-て', 'description': 'て-form.'},
+              <String, String>{
+                'name': '-いる',
+                'description': 'Indicates continuation.',
+              },
+              <String, String>{
+                'name': '-た',
+                'description': 'Indicates the past.',
+              },
+            ]),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 三层变形都要出现，中间用「«」分隔（与 Yomitan / WebView 弹窗同一读法）。
+    expect(find.text('-て'), findsOneWidget);
+    expect(find.text('-いる'), findsOneWidget);
+    expect(find.text('-た'), findsOneWidget);
+    expect(find.text('«'), findsNWidgets(2));
+
+    // 语法说明在点开之前不该出现在弹窗里。
+    expect(find.text('て-form.'), findsNothing);
+
+    await tester.tap(find.text('-て'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('て-form.'), findsOneWidget);
+    expect(find.text('Indicates the past.'), findsNothing);
+  });
+
+  testWidgets('没有语法说明的回落标签不可点（点了也不弹空框）', (
+    WidgetTester tester,
+  ) async {
+    // 文本变体归一（colour→color）没有经过任何变形规则，因此没有语法说明。
+    await tester.pumpWidget(
+      buildTestApp(
+        SizedBox(
+          width: 400,
+          height: 480,
+          child: DictionaryPopupNative(
+            result: resultWithTrace(<Map<String, String>>[
+              <String, String>{
+                'name': '当たっていた → 当たる',
+                'description': '',
+              },
+            ]),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('当たっていた → 当たる'), findsOneWidget);
+    // 单条标签不需要分隔符。
+    expect(find.text('«'), findsNothing);
+
+    await tester.tap(find.text('当たっていた → 当たる'));
+    await tester.pumpAndSettle();
+
+    // 没有对话框弹出——标签根本不可点。
+    expect(find.byType(Dialog), findsNothing);
   });
 }

--- a/native/fushidicts/fushidicts_src/popup_json.cpp
+++ b/native/fushidicts/fushidicts_src/popup_json.cpp
@@ -31,6 +31,39 @@ static void json_escape(std::ostringstream& os, const std::string& s) {
   os << '"';
 }
 
+// 词形变化链 → 弹窗的 `deinflectionTrace` 数组。
+//
+// 与 Dart 侧 buildDeinflectionTags（fushi_dictionary/lib/src/language/language.dart）
+// 逐字段对齐——两条弹窗路径必须给出同一份 JSON，parity 由 Dart 侧的
+// dictionary_popup_webview_test 锁住。语义详见该函数的文档注释：
+//   * trace 的压栈顺序是**剥离顺序**（最外层的变形最先被剥），显示要的是**接续
+//     顺序**，所以整体反转：`当たっていた` 的 trace `[-た, -いる, -て]` 显示成
+//     `-て « -いる « -た`。
+//   * trace 为空而 matched != deinflected，说明这是 lookup.cpp 里的**文本变体归一**
+//     （colour→color 一类），它不经过任何变形规则，故没有语法说明，只回落成一条
+//     `matched → deinflected`。这条分支不能删。
+static void write_deinflection_tags(std::ostringstream& os,
+                                    const std::string& matched,
+                                    const std::string& deinflected,
+                                    const std::vector<TransformGroup>& trace) {
+  os << '[';
+  if (!trace.empty()) {
+    for (size_t i = trace.size(); i-- > 0;) {
+      if (i + 1 != trace.size()) os << ',';
+      os << R"({"name":)";
+      json_escape(os, trace[i].name);
+      os << R"(,"description":)";
+      json_escape(os, trace[i].description);
+      os << '}';
+    }
+  } else if (matched != deinflected && !deinflected.empty()) {
+    os << R"({"name":)";
+    json_escape(os, matched + " \xe2\x86\x92 " + deinflected);
+    os << R"(,"description":""})";
+  }
+  os << ']';
+}
+
 std::string build_popup_json(const std::vector<LookupResult>& results,
                              int max_terms) {
   struct GroupData {
@@ -38,6 +71,7 @@ std::string build_popup_json(const std::vector<LookupResult>& results,
     std::string reading;
     std::string matched;
     std::string deinflected;
+    std::vector<TransformGroup> trace;
     std::vector<FrequencyEntry> frequencies;
     std::vector<PitchEntry> pitches;
     std::set<std::string> seen_freqs;
@@ -69,11 +103,13 @@ std::string build_popup_json(const std::vector<LookupResult>& results,
         gd.reading = r.term.reading;
         gd.matched = r.matched;
         gd.deinflected = r.deinflected;
+        gd.trace = r.trace;
         it = groups.find(key);
       } else if (it->second.matched == it->second.expression &&
                  r.matched != r.term.expression) {
         it->second.matched = r.matched;
         it->second.deinflected = r.deinflected;
+        it->second.trace = r.trace;
       }
 
       auto& gd = it->second;
@@ -154,17 +190,7 @@ done:
     os << R"(,"matched":)";
     json_escape(os, gd.matched);
     os << R"(,"rules":[],"deinflectionTrace":)";
-
-    if (gd.matched != gd.deinflected && !gd.deinflected.empty()) {
-      os << R"([{"name":)";
-      std::string trace_name = gd.matched;
-      trace_name += " → ";
-      trace_name += gd.deinflected;
-      json_escape(os, trace_name);
-      os << R"(,"description":""}])";
-    } else {
-      os << "[]";
-    }
+    write_deinflection_tags(os, gd.matched, gd.deinflected, gd.trace);
 
     os << R"(,"glossaries":[)";
     for (size_t j = 0; j < gd.glossaries.size(); j++) {

--- a/native/fushidicts/tests/CMakeLists.txt
+++ b/native/fushidicts/tests/CMakeLists.txt
@@ -56,6 +56,8 @@ add_fushi_test(word_scan_test word_scan_test.cpp
 add_fushi_test(text_processor_test text_processor_test.cpp
     "${FUSHI_SRC}/text_processor"
     "${FUSHI_ROOT}/fushidicts_external/utfcpp/source")
+# 弹窗 deinflectionTrace：纯内存，直接喂 LookupResult 给 build_popup_json。
+add_fushi_test(popup_json_deinflection_test popup_json_deinflection_test.cpp)
 # zip64 includes "zip/zip.hpp" -> root at fushidicts_src/.
 add_fushi_test(zip64_central_dir_test zip64_central_dir_test.cpp
     "${FUSHI_SRC}")

--- a/native/fushidicts/tests/popup_json_deinflection_test.cpp
+++ b/native/fushidicts/tests/popup_json_deinflection_test.cpp
@@ -1,0 +1,128 @@
+// 弹窗 JSON 的 deinflectionTrace：词形变化链 + 每一层的语法说明。
+//
+// 这条链早就全线铺好——assets/transforms/<lang>.json 里每个 transform 都带
+// Yomitan 的语法说明，deinflector 解析进 TransformGroup{name, description}，
+// lookup 把整条 trace 挂在 LookupResult 上——唯独 build_popup_json 以前把 trace
+// 丢了，改用一条现编的 "matched → deinflected" 且 description 恒为空串，于是
+// 弹窗里永远没有语法说明。
+//
+// 本测试锁住 build_popup_json 的输出，并与 Dart 侧 buildDeinflectionTags
+// （packages/fushi_dictionary/lib/src/language/language.dart）逐字节对齐——两条
+// 弹窗路径必须给出同一份 JSON。Dart 侧对应用例见
+// fushi/test/dictionary/deinflection_grammar_tags_test.dart。
+//
+// Usage: popup_json_deinflection_test   (无参，纯内存断言)  Exit 0=PASS, 非零=FAIL
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "fushidicts/popup_json.hpp"
+
+static int g_fail = 0;
+
+static void expect_contains(const char* name, const std::string& haystack,
+                            const std::string& needle) {
+  if (haystack.find(needle) == std::string::npos) {
+    std::fprintf(stderr, "FAIL %s:\n  want substring: %s\n  in: %s\n", name,
+                 needle.c_str(), haystack.c_str());
+    ++g_fail;
+  }
+}
+
+static void expect_absent(const char* name, const std::string& haystack,
+                          const std::string& needle) {
+  if (haystack.find(needle) != std::string::npos) {
+    std::fprintf(stderr, "FAIL %s:\n  unwanted substring: %s\n  in: %s\n", name,
+                 needle.c_str(), haystack.c_str());
+    ++g_fail;
+  }
+}
+
+static LookupResult make(const std::string& matched,
+                         const std::string& deinflected,
+                         std::vector<TransformGroup> trace) {
+  LookupResult r;
+  r.matched = matched;
+  r.deinflected = deinflected;
+  r.trace = std::move(trace);
+  r.preprocessor_steps = 0;
+  r.term.expression = "\xe5\xbd\x93\xe3\x81\x9f\xe3\x82\x8b";  // 当たる
+  r.term.reading = "\xe3\x81\x82\xe3\x81\x9f\xe3\x82\x8b";     // あたる
+  r.term.rules = "";
+  GlossaryEntry g;
+  g.dict_name = "JMdict";
+  g.glossary = "[\"to hit\"]";
+  g.definition_tags = "";
+  g.term_tags = "";
+  r.term.glossaries.push_back(g);
+  return r;
+}
+
+int main() {
+  // 引擎压栈顺序 = 剥离顺序：当たっていた 先剥最外层的 -た，再剥 -いる，最后 -て。
+  const std::vector<TransformGroup> trace = {
+      {"-\xe3\x81\x9f", "Indicates the past."},                 // -た
+      {"-\xe3\x81\x84\xe3\x82\x8b", "Indicates continuation."},  // -いる
+      {"-\xe3\x81\xa6", "\xe3\x81\xa6-form."},                   // -て
+  };
+  const std::string atteita =
+      "\xe5\xbd\x93\xe3\x81\x9f\xe3\x81\xa3\xe3\x81\xa6\xe3\x81\x84\xe3\x81\x9f";  // 当たっていた
+  const std::string ataru = "\xe5\xbd\x93\xe3\x81\x9f\xe3\x82\x8b";                // 当たる
+
+  // ① 有 trace：整体反转成接续顺序（-て « -いる « -た），语法说明逐条带上。
+  //    这一串必须与 Dart 侧 buildPopupJsonFromLookup 的输出逐字节相同。
+  {
+    std::vector<LookupResult> results = {make(atteita, ataru, trace)};
+    const std::string json = build_popup_json(results, 100);
+    expect_contains(
+        "trace-reversed-with-descriptions", json,
+        "\"deinflectionTrace\":["
+        "{\"name\":\"-\xe3\x81\xa6\",\"description\":\"\xe3\x81\xa6-form.\"},"
+        "{\"name\":\"-\xe3\x81\x84\xe3\x82\x8b\",\"description\":\"Indicates continuation.\"},"
+        "{\"name\":\"-\xe3\x81\x9f\",\"description\":\"Indicates the past.\"}]");
+    // 有真实变形链时不该再退回那条没有语法说明的合并标签。
+    expect_absent("no-synthetic-step-when-trace-present", json,
+                  "\xe2\x86\x92");  // →
+  }
+
+  // ② 无 trace 但 matched != deinflected：文本变体归一（colour→color 一类），
+  //    不经过任何变形规则，故只回落成一条、且没有语法说明。这条分支不能删。
+  {
+    std::vector<LookupResult> results = {make("colour", "color", {})};
+    const std::string json = build_popup_json(results, 100);
+    expect_contains("variant-fallback", json,
+                    "\"deinflectionTrace\":[{\"name\":\"colour \xe2\x86\x92 "
+                    "color\",\"description\":\"\"}]");
+  }
+
+  // ③ 原形直查（matched == deinflected）→ 空数组，不生成自指标签。
+  {
+    std::vector<LookupResult> results = {make(ataru, ataru, {})};
+    const std::string json = build_popup_json(results, 100);
+    expect_contains("no-self-step", json, "\"deinflectionTrace\":[]");
+  }
+
+  // ④ 引擎未回填 deinflected（空串）→ 同样空数组，不生成「x → 」残缺标签。
+  {
+    std::vector<LookupResult> results = {make(atteita, "", {})};
+    const std::string json = build_popup_json(results, 100);
+    expect_contains("no-partial-step", json, "\"deinflectionTrace\":[]");
+  }
+
+  // ⑤ 单层 trace：反转是恒等，但语法说明照样要带上。
+  {
+    std::vector<LookupResult> results = {
+        make(atteita, ataru, {{"-\xe3\x81\xa6", "\xe3\x81\xa6-form."}})};
+    const std::string json = build_popup_json(results, 100);
+    expect_contains("single-step", json,
+                    "\"deinflectionTrace\":[{\"name\":\"-\xe3\x81\xa6\","
+                    "\"description\":\"\xe3\x81\xa6-form.\"}]");
+  }
+
+  if (g_fail != 0) {
+    std::fprintf(stderr, "popup_json_deinflection_test: %d failure(s)\n", g_fail);
+    return 1;
+  }
+  std::printf("popup_json_deinflection_test: PASS\n");
+  return 0;
+}

--- a/packages/fushi_dictionary/lib/src/language/language.dart
+++ b/packages/fushi_dictionary/lib/src/language/language.dart
@@ -409,12 +409,88 @@ abstract class Language {
   }
 }
 
+/// 弹窗上的一枚词形变化标签：变形名（`-て`）+ 该变形的语法说明。
+typedef DeinflectionTag = ({String name, String description});
+
+/// 词形变化链 → 弹窗标签序列。**这是全 app 唯一一处生成变形标签的地方**，
+/// 三条弹窗路径（[buildPopupJsonFromLookup] / `buildLookupEntriesJson` /
+/// 原生弹窗）和 C++ 的 `build_popup_json` 都必须走这套语义，不允许各自再拼。
+///
+/// `trace` 是唯一真相：引擎每剥掉一层变形就往里压一个 [FushiTransformGroup]，
+/// 带着变形名和 `assets/transforms/<lang>.json` 里的语法说明。压栈顺序是**剥离
+/// 顺序**（最外层的变形最先被剥），而用户要看的是**接续顺序**——从词典形出发依
+/// 次接上了哪些变形，所以显示时整体反转：`当たっていた` 的 trace 是
+/// `[-た, -いる, -て]`，显示成 `-て « -いる « -た`（与 Yomitan 一致）。
+///
+/// trace 为空、而 matched 又确实不等于 deinflected 时，回落成单条
+/// `matched → deinflected`：那是 `lookup.cpp` 的**文本变体归一**（colour→color
+/// 一类），不经过任何变形规则，所以既没有 trace 也没有语法说明。这条回落分支
+/// 不能删——删了这类查询就完全不提示词形变化了。
+List<DeinflectionTag> buildDeinflectionTags({
+  required String matched,
+  required String deinflected,
+  required List<FushiTransformGroup> trace,
+}) {
+  if (trace.isNotEmpty) {
+    return <DeinflectionTag>[
+      for (final FushiTransformGroup t in trace.reversed)
+        (name: t.name, description: t.description),
+    ];
+  }
+  if (matched != deinflected && deinflected.isNotEmpty) {
+    return <DeinflectionTag>[
+      (name: '$matched → $deinflected', description: '')
+    ];
+  }
+  return const <DeinflectionTag>[];
+}
+
+/// [buildDeinflectionTags] 的结果 → 弹窗 JSON 里的 `deinflectionTrace` 数组。
+List<Map<String, String>> deinflectionTagsToJson(List<DeinflectionTag> tags) {
+  return <Map<String, String>>[
+    for (final DeinflectionTag t in tags)
+      <String, String>{'name': t.name, 'description': t.description},
+  ];
+}
+
+/// 从 [buildLookupEntryExtra] 写出的 extra 里读回变形标签。
+///
+/// extra 里存的已经是 [buildDeinflectionTags] 的成品（含回落），所以这里**只解析、
+/// 不再判断**——回落语义只有一份。老 extra（没有 `deinflectionTrace` 键）才走末尾
+/// 的兼容分支，靠 matched/deinflected 现算。
+List<DeinflectionTag> deinflectionTagsFromExtra(Map<String, dynamic> extra) {
+  final Object? raw = extra['deinflectionTrace'];
+  if (raw is List) {
+    return <DeinflectionTag>[
+      for (final Object? item in raw)
+        if (item is Map)
+          (
+            name: (item['name'] ?? '').toString(),
+            description: (item['description'] ?? '').toString(),
+          ),
+    ];
+  }
+  return buildDeinflectionTags(
+    matched: (extra['matched'] ?? '').toString(),
+    deinflected: (extra['deinflected'] ?? '').toString(),
+    trace: const <FushiTransformGroup>[],
+  );
+}
+
 String buildLookupEntryExtra(FushiLookupResult r, FushiGlossaryEntry g) {
   return jsonEncode({
     'definitionTags': g.definitionTags,
     'termTags': g.termTags,
     'matched': r.matched,
     'deinflected': r.deinflected,
+    // 变形链带着语法说明一起随 entry 走。走 extra 的两条弹窗路径（原生弹窗、
+    // buildLookupEntriesJson）本来只能看到 matched/deinflected，只好现编一条
+    // 「matched → deinflected」且说明恒空——语法说明就是断在这里的。
+    'deinflectionTrace': deinflectionTagsToJson(buildDeinflectionTags(
+      matched: r.matched,
+      deinflected: r.deinflected,
+      trace: r.trace,
+    )),
     'frequencies': r.term.frequencies
         .map((f) => {
               'dictName': f.dictName,
@@ -506,6 +582,7 @@ String buildPopupJsonFromLookup({
   final groupReading = <String, String>{};
   final groupMatched = <String, String>{};
   final groupDeinflected = <String, String>{};
+  final groupTrace = <String, List<FushiTransformGroup>>{};
   final groupFrequencies = <String, List<FushiFrequencyEntry>>{};
   final groupPitches = <String, List<FushiPitchEntry>>{};
   final seenFreqs = <String, Set<String>>{};
@@ -543,6 +620,7 @@ String buildPopupJsonFromLookup({
         groupReading[key] = r.term.reading;
         groupMatched[key] = r.matched;
         groupDeinflected[key] = r.deinflected;
+        groupTrace[key] = r.trace;
         groupFrequencies[key] = [];
         groupPitches[key] = [];
         seenFreqs[key] = {};
@@ -555,6 +633,7 @@ String buildPopupJsonFromLookup({
         // and trace stay consistent on the same FushiLookupResult.
         groupMatched[key] = r.matched;
         groupDeinflected[key] = r.deinflected;
+        groupTrace[key] = r.trace;
       }
 
       for (final f in r.term.frequencies) {
@@ -600,15 +679,11 @@ String buildPopupJsonFromLookup({
     sb.write(',"matched":');
     sb.write(jsonEncode(groupMatched[key]));
     sb.write(',"rules":[],"deinflectionTrace":');
-    final matched = groupMatched[key]!;
-    final deinflected = groupDeinflected[key]!;
-    if (matched != deinflected && deinflected.isNotEmpty) {
-      sb.write('[{"name":');
-      sb.write(jsonEncode('$matched → $deinflected'));
-      sb.write(',"description":""}]');
-    } else {
-      sb.write('[]');
-    }
+    sb.write(jsonEncode(deinflectionTagsToJson(buildDeinflectionTags(
+      matched: groupMatched[key]!,
+      deinflected: groupDeinflected[key]!,
+      trace: groupTrace[key] ?? const <FushiTransformGroup>[],
+    ))));
     sb.write(',"glossaries":[');
     final gl = groupGlossaries[key]!;
     for (var j = 0; j < gl.length; j++) {

--- a/test/js/popup_grammar_tooltip.test.mjs
+++ b/test/js/popup_grammar_tooltip.test.mjs
@@ -1,0 +1,214 @@
+// 词形变化标签的语法说明浮层（jsdom 真 DOM）。
+//
+// 弹窗把每一层词形变化渲染成一枚 .deinflection-tag，说明文本来自
+// assets/transforms/<lang>.json（经 deinflectionTrace 送达）。桌面上悬停出浮层，
+// 触屏上点开 .overlay —— Dart 侧的源码守卫只能看文本，管不到这里的运行时语义：
+// 视口收敛算不算对、触屏会不会把浮层粘死在屏幕上，只有真 DOM 能问出来。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+
+const POPUP_URL = new URL("../../fushi/assets/popup/popup.js", import.meta.url);
+const popupSrc = readFileSync(POPUP_URL, "utf8");
+
+const VIEWPORT_W = 800;
+const VIEWPORT_H = 600;
+const TOOLTIP_W = 300;
+const TOOLTIP_H = 120;
+
+/// 起一个装好 popup.js 的窗口。
+///
+/// anchorRect 是被悬停的那枚标签的位置；浮层自身的尺寸固定成
+/// TOOLTIP_W×TOOLTIP_H，这样「往左收」「翻到上方」这两条分支才有确定的期望值。
+function createPopup(anchorRect) {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><body>
+      <div class="overlay" style="display:none"><div class="overlay-content"></div></div>
+      <div id="entries-container"></div>
+    </body>`,
+    { runScripts: "outside-only", pretendToBeVisual: true },
+  );
+  const win = dom.window;
+
+  win.flutter_inappwebview = { callHandler: () => {} };
+  win.innerWidth = VIEWPORT_W;
+  win.innerHeight = VIEWPORT_H;
+  // jsdom 的 matchMedia 恒 matches:false，会把每个设备都判成触屏。默认按「能悬停
+  // 的桌面」处理，触屏分支由用例自己改回来。
+  win.matchMedia = (query) => ({
+    media: query,
+    matches: query.includes("hover: hover"),
+    addListener() {},
+    removeListener() {},
+  });
+
+  // jsdom 不排版，getBoundingClientRect 恒为 0。按 class 分派出确定的几何：
+  // 浮层报固定尺寸，标签报调用方给的锚点位置。
+  win.HTMLElement.prototype.getBoundingClientRect = function () {
+    if (this.classList.contains("grammar-tooltip")) {
+      return {
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: TOOLTIP_W,
+        bottom: TOOLTIP_H,
+        width: TOOLTIP_W,
+        height: TOOLTIP_H,
+      };
+    }
+    return anchorRect;
+  };
+
+  win.eval(popupSrc);
+  return win;
+}
+
+function rect(left, top, width = 40, height = 16) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+  };
+}
+
+test("有语法说明的标签才可点/可悬停", () => {
+  const win = createPopup(rect(10, 10));
+
+  const withDescription = win.createDeinflectionTag({
+    name: "-て",
+    description: "て-form.",
+  });
+  assert.ok(withDescription.classList.contains("has-description"));
+  assert.equal(withDescription.getAttribute("data-description"), "て-form.");
+  assert.equal(typeof withDescription.onclick, "function");
+  assert.equal(typeof withDescription.onmouseenter, "function");
+
+  // 文本变体归一的回落标签没有说明：不加 has-description（CSS 据此不给指针
+  // 手型），也不挂任何处理器，免得点开一个空框。
+  const withoutDescription = win.createDeinflectionTag({
+    name: "colour → color",
+    description: "",
+  });
+  assert.equal(withoutDescription.classList.contains("has-description"), false);
+  assert.equal(withoutDescription.getAttribute("data-description"), null);
+  assert.equal(withoutDescription.onclick, null);
+  assert.equal(withoutDescription.onmouseenter, null);
+});
+
+test("悬停显示浮层并填入说明，移开后隐藏", () => {
+  const win = createPopup(rect(10, 10));
+  const tag = win.createDeinflectionTag({
+    name: "-て",
+    description: "て-form.\nUsage: attach て…",
+  });
+  win.document.body.appendChild(tag);
+
+  assert.equal(win.document.querySelector(".grammar-tooltip"), null);
+
+  tag.onmouseenter.call(tag);
+  const tooltip = win.document.querySelector(".grammar-tooltip");
+  assert.ok(tooltip, "浮层应在首次悬停时懒创建");
+  assert.equal(tooltip.textContent, "て-form.\nUsage: attach て…");
+  assert.equal(tooltip.style.display, "block");
+
+  tag.onmouseleave.call(tag);
+  assert.equal(tooltip.style.display, "none");
+});
+
+test("浮层懒创建只建一个，重复悬停复用同一节点", () => {
+  const win = createPopup(rect(10, 10));
+  const first = win.createDeinflectionTag({ name: "-て", description: "A" });
+  const second = win.createDeinflectionTag({ name: "-た", description: "B" });
+  win.document.body.append(first, second);
+
+  first.onmouseenter.call(first);
+  second.onmouseenter.call(second);
+
+  assert.equal(win.document.querySelectorAll(".grammar-tooltip").length, 1);
+  assert.equal(win.document.querySelector(".grammar-tooltip").textContent, "B");
+});
+
+test("靠右的标签：浮层往左收，不越出视口右缘", () => {
+  // 锚点左缘 700 + 浮层宽 300 = 1000 > 视口 800，必须收到 800-300-8 = 492。
+  const win = createPopup(rect(700, 100));
+  const tag = win.createDeinflectionTag({ name: "-て", description: "A" });
+  win.document.body.appendChild(tag);
+
+  tag.onmouseenter.call(tag);
+  const tooltip = win.document.querySelector(".grammar-tooltip");
+
+  assert.equal(tooltip.style.left, "492px");
+  // 下方放得下（100+16+6+120 = 242 < 600-8），维持在标签下方。
+  assert.equal(tooltip.style.top, "122px");
+});
+
+test("贴近底部的标签：浮层翻到上方", () => {
+  // 锚点 top 520 / bottom 536：下方 536+6+120 = 662 > 600-8，翻到上方
+  // 520-120-6 = 394。
+  const win = createPopup(rect(100, 520));
+  const tag = win.createDeinflectionTag({ name: "-て", description: "A" });
+  win.document.body.appendChild(tag);
+
+  tag.onmouseenter.call(tag);
+  const tooltip = win.document.querySelector(".grammar-tooltip");
+
+  assert.equal(tooltip.style.top, "394px");
+});
+
+test("上下都放不下时维持在下方，不顶出视口外", () => {
+  // 一枚比视口还高的锚点：上方 -6-120 < 8 放不下，只能维持在下方并截断。
+  const win = createPopup(rect(100, 0, 40, VIEWPORT_H));
+  const tag = win.createDeinflectionTag({ name: "-て", description: "A" });
+  win.document.body.appendChild(tag);
+
+  tag.onmouseenter.call(tag);
+  const tooltip = win.document.querySelector(".grammar-tooltip");
+
+  assert.equal(tooltip.style.top, `${VIEWPORT_H + 6}px`);
+});
+
+test("触屏（不能悬停）不显示浮层——否则没有 mouseleave 来收它", () => {
+  const win = createPopup(rect(10, 10));
+  win.matchMedia = (query) => ({
+    media: query,
+    matches: false, // (hover: hover) 不成立 = 触屏
+    addListener() {},
+    removeListener() {},
+  });
+
+  const tag = win.createDeinflectionTag({ name: "-て", description: "A" });
+  win.document.body.appendChild(tag);
+
+  tag.onmouseenter.call(tag);
+
+  assert.equal(
+    win.document.querySelector(".grammar-tooltip"),
+    null,
+    "触屏 tap 会补发 mouseenter，浮层一旦显示就再没有 mouseleave 收它",
+  );
+});
+
+test("点击走全屏 overlay（触屏上唯一的查看路径）", () => {
+  const win = createPopup(rect(10, 10));
+  const tag = win.createDeinflectionTag({
+    name: "-て",
+    description: "て-form.",
+  });
+  win.document.body.appendChild(tag);
+
+  tag.onclick.call(tag);
+
+  const overlay = win.document.querySelector(".overlay");
+  assert.equal(overlay.style.display, "block");
+  assert.equal(
+    win.document.querySelector(".overlay-content").textContent,
+    "て-form.",
+  );
+});

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -575,6 +575,42 @@
     color: inherit;
 }
 
+/* 「«」读作「来自」：右边那层变形接在左边这层之上，`-て « -いる « -た` 即
+   词典形先接て、再接いる、最后接た。与 Yomitan 同一种读法。分隔符走 ::before
+   而不是插 DOM 节点，选区复制时不会把它一起带走。 */
+.deinflection-tag:not(:first-child)::before {
+    content: '«';
+    margin-right: 4px;
+    margin-left: 2px;
+    opacity: 0.55;
+}
+
+/* 只有带语法说明的标签可点/可 hover（见 popup.js 的 createDeinflectionTag）。 */
+.deinflection-tag.has-description {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+/* 词形变化的语法说明浮层（桌面 hover；触屏走 .overlay）。位置由 JS 按锚点算好
+   写进 left/top，这里只管观感。 */
+.grammar-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 728;
+    max-width: 460px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-color);
+    background: var(--surface-container-high);
+    border: 1px solid var(--outline-variant);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
 .frequency-group {
     display: inline-flex;
     font-size: 11px;

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -634,6 +634,42 @@ html.global-lookup .mine-button:not(:disabled) {
     color: inherit;
 }
 
+/* 「«」读作「来自」：右边那层变形接在左边这层之上，`-て « -いる « -た` 即
+   词典形先接て、再接いる、最后接た。与 Yomitan 同一种读法。分隔符走 ::before
+   而不是插 DOM 节点，选区复制时不会把它一起带走。 */
+.deinflection-tag:not(:first-child)::before {
+    content: '«';
+    margin-right: 4px;
+    margin-left: 2px;
+    opacity: 0.55;
+}
+
+/* 只有带语法说明的标签可点/可 hover（见 popup.js 的 createDeinflectionTag）。 */
+.deinflection-tag.has-description {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+/* 词形变化的语法说明浮层（桌面 hover；触屏走 .overlay）。位置由 JS 按锚点算好
+   写进 left/top，这里只管观感。 */
+.grammar-tooltip {
+    display: none;
+    position: fixed;
+    z-index: 728;
+    max-width: 460px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    color: var(--text-color);
+    background: var(--surface-container-high);
+    border: 1px solid var(--outline-variant);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
 .frequency-group {
     display: inline-flex;
     font-size: 11px;

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -507,6 +507,62 @@ function closeOverlay() {
     __fushiRootNode().querySelector('.overlay').style.display = 'none';
 }
 
+/* 词形变化标签的语法说明浮层（桌面 hover）。
+   点击走 showDescription 的全屏 overlay——触屏上没有 hover，且窄屏放不下这块浮层。
+   浮层是懒创建的，挂在 __fushiOverlayParent()（shadow root 或 document.body）下，
+   这样扩展注入到宿主页面时也不会跑到词典的 Shadow DOM 外面去。 */
+function ensureGrammarTooltip() {
+    const root = __fushiRootNode();
+    let tooltip = root.querySelector('.grammar-tooltip');
+    if (!tooltip) {
+        tooltip = el('div', { className: 'grammar-tooltip' });
+        __fushiOverlayParent().appendChild(tooltip);
+    }
+    return tooltip;
+}
+
+function showGrammarTooltip(element) {
+    /* 只有能 hover 的指针设备才显示。触屏浏览器会在 tap 时补发一次 mouseenter，
+       那样浮层会一直粘在屏幕上没人收（没有后续的 mouseleave）。 */
+    try {
+        if (window.matchMedia && !window.matchMedia('(hover: hover)').matches) return;
+    } catch (_) { /* matchMedia 不可用时按可 hover 处理 */ }
+
+    const description = element.getAttribute('data-description');
+    if (!description) return;
+
+    const tooltip = ensureGrammarTooltip();
+    tooltip.textContent = description;
+    tooltip.style.display = 'block';
+    /* 先落地再量：宽度受 CSS max-width 约束，量完才知道该往哪边收。 */
+    tooltip.style.left = '0px';
+    tooltip.style.top = '0px';
+
+    const anchor = element.getBoundingClientRect();
+    const box = tooltip.getBoundingClientRect();
+    const margin = 8;
+
+    let left = anchor.left;
+    const maxLeft = window.innerWidth - box.width - margin;
+    if (left > maxLeft) left = maxLeft;
+    if (left < margin) left = margin;
+
+    let top = anchor.bottom + 6;
+    if (top + box.height > window.innerHeight - margin) {
+        const above = anchor.top - box.height - 6;
+        /* 上方也放不下就维持在下方：宁可截断底部，也不要顶出视口外够不着。 */
+        if (above >= margin) top = above;
+    }
+
+    tooltip.style.left = left + 'px';
+    tooltip.style.top = top + 'px';
+}
+
+function hideGrammarTooltip() {
+    const tooltip = __fushiRootNode().querySelector('.grammar-tooltip');
+    if (tooltip) tooltip.style.display = 'none';
+}
+
 // https://github.com/yomidevs/yomitan/blob/c24d4c9b39ceec1b5fd133df774c41972e9ebbdc/ext/js/language/ja/japanese.js#L171
 function createFuriganaSegment(text, reading) {
     return {text, reading};
@@ -2070,12 +2126,28 @@ function renderTaggedTermPairs(parent, pairs) {
 }
 
 function createDeinflectionTag(tag) {
+    // 语法说明来自 assets/transforms/<lang>.json，随 deinflectionTrace 一起送到。
+    // 文本变体归一的回落标签（colour → color）没有说明，这时不加 has-description：
+    // 不给指针手型、不挂 hover/click，免得点开一个空框。
+    const hasDescription = !!tag.description;
+    if (!hasDescription) {
+        return el('span', {
+            className: 'deinflection-tag',
+            textContent: tag.name
+        });
+    }
     return el('span', {
-        className: 'deinflection-tag',
+        className: 'deinflection-tag has-description',
         textContent: tag.name,
         'data-description': tag.description,
         onclick() {
             showDescription(this);
+        },
+        onmouseenter() {
+            showGrammarTooltip(this);
+        },
+        onmouseleave() {
+            hideGrammarTooltip();
         }
     });
 }


### PR DESCRIPTION
Discord 上有用户问能不能在 Fushi 里加 Yomitan 那种**语法查询**——查词弹窗里词形变化链的每一层可点/可悬停，弹出该变形的语法说明。

## 这不是新功能，是接通最后一米

链路早就全线铺好，只在拼弹窗 JSON 时被**四份互相拷贝的伪造代码**切断：

| 环节 | 位置 | 修前 |
|---|---|---|
| 语法说明数据 | `assets/transforms/ja.json`（54 条 transform，53 条带说明） | 已随包 |
| 解析进引擎 | `deinflector.cpp` → `TransformGroup{name, description}` | 已有 |
| 挂到查词结果 | `lookup.cpp` `.trace = deinflection.trace` | 已有 |
| FFI 透出 | `fushidicts_ffi.cpp` name+description 都 dup 出来 | 已有 |
| **拼弹窗 JSON** | **四处** | ❌ **全丢弃 trace，现编一条 `matched → deinflected`，`description` 硬编码 `""`** |
| 标签渲染 | `popup.js` `data-description` + `onclick` | 已有 |
| 说明展示 | `popup.js` `showDescription()` → overlay | 已有 |

截图里那段 tooltip 文字（"て-form. It has a myriad of meanings…"）**逐字就是 `ja.json` 里 `-て` 的 description**。

## 改法

四份伪造是同一个特殊情况写了四遍。收口成 `buildDeinflectionTags` 一处生成，四个消费点只读不拼：

- trace 反转成**接续顺序**（引擎压栈是剥离顺序）：`当たっていた` 显示成 `-て « -いる « -た`，与 Yomitan 同序
- **保留**文本变体归一（colour→color）的回落分支：那条路径本就不经过变形规则，没有 trace 也没有说明，删了这类查询会完全不提示词形变化
- `extra` 里存的是**成品**，消费点只解析不再判断——回落语义只有一份

UI：桌面 hover 出说明浮层（视口边界自动收敛），点击走全屏 overlay（触屏唯一路径；触屏刻意不 hover——tap 补发的 mouseenter 没有 mouseleave 来收它）；原生弹窗标签可点弹说明。没有说明的回落标签不可点，不弹空框。

## 验证

- 本地全量 `FLUTTER TEST VERDICT: PASSED - 19957 tests ran`
- 目录枚举型守卫整批 250 tests（首轮抓到我自己写的裸 `fontSize:`，已改走 textTheme）
- 新增测试：Dart 12 条 + C++ ctest 1 条 + jsdom 8 条 + 原生弹窗 widget 2 条
- 三条源码守卫**经变异实测**：M1/M2/M3 如期变红、还原逐字节 SHA 无损、基线复绿
- `flutter analyze` 两处（app + 词典包）均 No issues found
- popup 三镜像逐字节一致 + `content.css` 重生成并 `--check` 通过

## 已知边界

- 语法说明是 Yomitan 英文原文（Yomitan 自身也是英文），未翻译
- 各语言覆盖率：日语 53/54，另有 ar/en/eo/es/fr 等 11 种 100%；ko (1/450)、eu (0/75)、grc (0/21) 几乎没有说明——这些语言的标签正常显示变形名但不可点，是设计内的降级
- 未做真机验证（按既定规则不做）
