### PR TITLE
feat(manga): 漫画页接入手柄（手柄重设计 P1）

### DIFF
--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -46,8 +46,15 @@ import 'package:fushi/src/media/manga/reader/manga_rescan_result_sheet.dart';
 import 'package:fushi/src/media/manga/reader/manga_volume_key_paging_controller.dart';
 import 'package:fushi/src/media/manga/reader/manga_zoom_preference_debouncer.dart';
 import 'package:fushi/src/focus/page_focus_ownership.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart'
+    show GamepadButtonIntent;
 import 'package:fushi/src/shortcuts/input_binding.dart'
-    show InputBinding, ModifierKey, MouseBinding, activeModifierKeys;
+    show
+        GamepadButton,
+        InputBinding,
+        ModifierKey,
+        MouseBinding,
+        activeModifierKeys;
 import 'package:fushi/src/shortcuts/manga_arrow_override.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
@@ -114,7 +121,7 @@ enum MangaReaderInputAction {
 /// 一次键盘平移移动的视口比例。按比例而非像素，1080p 与 4K 手感一致。
 const double kMangaPanStepFraction = 0.15;
 
-enum _MangaReaderInputSource { flutter, nativeWebView, volumeKey }
+enum _MangaReaderInputSource { flutter, nativeWebView, volumeKey, gamepad }
 
 /// Serializes burst page-turn input across asynchronous WebView window loads.
 ///
@@ -348,13 +355,14 @@ class MangaFushiPage extends BaseSourcePage {
   /// 再由 [resolveMangaArrowPageTurn] 按跨页方向校正——两步都在调用侧完成，本函数
   /// 只负责「拿到动作之后，当前上下文该不该执行它」这层门控。
   ///
-  /// [horizontalArrow] = 触发键是否为左/右方向键。它们是**跨页步进**语义，两道
-  /// 门控都不适用：webtoon 的纵向滚动不影响左右翻页；词典弹窗可见时也要「关弹窗
+  /// [crossPageStep] = 触发键是否为**跨页步进**语义（左/右方向键、D-pad 左右与
+  /// 手柄翻页键 RB/LB），两道门控都不适用：webtoon 的纵向滚动不影响跨页步进
+  /// （手柄没有原生滚动路径，webtoon 也用锚点跳页）；词典弹窗可见时也要「关弹窗
   /// 并翻页」（本页与阅读器的关键差异）。其余前进/后退键则要让位——弹窗可见时空格
   /// 归词典自己，webtoon 模式下纵向键归 WebView 原生滚动。
   static MangaReaderInputAction? inputActionForShortcut({
     required ShortcutAction? action,
-    required bool horizontalArrow,
+    required bool crossPageStep,
     required bool dictionaryShown,
     required MangaReadingMode mode,
   }) {
@@ -383,7 +391,7 @@ class MangaFushiPage extends BaseSourcePage {
       _ => null,
     };
     if (pan != null) return pan;
-    if (!horizontalArrow) {
+    if (!crossPageStep) {
       if (dictionaryShown) return null;
       if (mode == MangaReadingMode.webtoon) return null;
     }
@@ -2160,11 +2168,56 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         bound;
     return MangaFushiPage.inputActionForShortcut(
       action: corrected,
-      horizontalArrow: key == LogicalKeyboardKey.arrowLeft ||
+      crossPageStep: key == LogicalKeyboardKey.arrowLeft ||
           key == LogicalKeyboardKey.arrowRight,
       dictionaryShown: isDictionaryShown,
       mode: _mode,
     );
+  }
+
+  /// 手柄按钮 → 本页输入动作（桌面轮询 [GamepadButtonIntent] 与 Android 原生
+  /// gameButton* 键事件汇合到同一入口，与阅读器 `_handleGamepadButton` 同构）。
+  ///
+  /// 解析阶梯与键盘路径一致：manga scope 优先，未命中兜底 universal（「返回上一
+  /// 级」，默认手柄 B）——所以手柄 B 走的是与 Esc 相同的两级阶梯（弹窗可见先关
+  /// 弹窗、没弹窗才退出漫画），而不是 GamepadService 的全局 maybePop 兜底直接退页。
+  /// D-pad 左/右经 [resolveMangaDpadPageTurn] 按跨页方向（日漫默认 rtl）校正。
+  ///
+  /// 手柄翻页键一律**跨页步进**语义（crossPageStep: true）：手柄没有原生滚动路径，
+  /// webtoon 模式下也该用锚点跳页；弹窗可见时关弹窗并翻页。
+  MangaReaderInputAction? _resolveMangaGamepadAction(GamepadButton button) {
+    final FushiShortcutRegistry registry = appModel.shortcutRegistry;
+    final ShortcutAction? bound = registry.resolveGamepad(
+          button,
+          scope: ShortcutScope.manga,
+        ) ??
+        registry.resolveGamepad(
+          button,
+          scope: ShortcutScope.universal,
+        );
+    final ShortcutAction? corrected = resolveMangaDpadPageTurn(
+          button: button,
+          rtl: _spreadDirection == 'rtl',
+          boundAction: bound,
+        ) ??
+        bound;
+    return MangaFushiPage.inputActionForShortcut(
+      action: corrected,
+      crossPageStep: true,
+      dictionaryShown: isDictionaryShown,
+      mode: _mode,
+    );
+  }
+
+  /// 消费一枚手柄按钮；false 交回 GamepadService 的兜底（A=激活、dpad=移焦）。
+  bool _handleGamepadButton(GamepadButton button) {
+    final MangaReaderInputAction? action = _resolveMangaGamepadAction(button);
+    if (action == null) return false;
+    _executeReaderInputAction(
+      action,
+      source: _MangaReaderInputSource.gamepad,
+    );
+    return true;
   }
 
   void _handleNativeNavigationKey(String key) {
@@ -3246,43 +3299,56 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         // 滚动的子树。
         // 键盘兜底必须包住正文、chrome 和词典弹层。旧结构只包正文 WebView，
         // 词典 WebView 获得焦点后变成 sibling，左右键/Escape 不再经过本处理器。
-        body: Focus(
-          focusNode: _focusNode,
-          autofocus: true,
-          onKeyEvent: _handleReaderKey,
-          child: Stack(
-            fit: StackFit.expand,
-            children: <Widget>[
-              Positioned.fill(child: _buildBody()),
-              // 查词弹窗层：必须在同一个键盘 Focus 子树里，否则原生词典
-              // WebView 持焦后会吞掉翻页键。
-              Positioned.fill(
-                key: const ValueKey<String>('manga_dictionary_host'),
-                child: buildDictionary(),
-              ),
-              if (_bookRow != null && !_loadFailed)
-                Positioned(
-                  top: 0,
-                  left: 0,
-                  child: SafeArea(
-                    child: IconButton(
-                      key: const ValueKey<String>('manga_reader_back_button'),
-                      tooltip:
-                          MaterialLocalizations.of(context).backButtonTooltip,
-                      color: Colors.white,
-                      icon: const Icon(Icons.arrow_back_ios_new),
-                      onPressed: () => Navigator.of(context).maybePop(),
+        //
+        // 手柄同理：桌面轮询路径把 GamepadButtonIntent 派给 primaryFocus 所在
+        // 子树的 Actions，Android 的 gameButton* 键事件经全局 wrapper 转成同一
+        // Intent——Actions 必须是正文 WebView 与词典弹层的共同祖先，词典 WebView
+        // 持焦时手柄键才仍经过本页（先关弹窗再退页的两级阶梯，而非全局 maybePop）。
+        body: Actions(
+          actions: <Type, Action<Intent>>{
+            GamepadButtonIntent: CallbackAction<GamepadButtonIntent>(
+              onInvoke: (GamepadButtonIntent intent) =>
+                  _handleGamepadButton(intent.button),
+            ),
+          },
+          child: Focus(
+            focusNode: _focusNode,
+            autofocus: true,
+            onKeyEvent: _handleReaderKey,
+            child: Stack(
+              fit: StackFit.expand,
+              children: <Widget>[
+                Positioned.fill(child: _buildBody()),
+                // 查词弹窗层：必须在同一个键盘 Focus 子树里，否则原生词典
+                // WebView 持焦后会吞掉翻页键。
+                Positioned.fill(
+                  key: const ValueKey<String>('manga_dictionary_host'),
+                  child: buildDictionary(),
+                ),
+                if (_bookRow != null && !_loadFailed)
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    child: SafeArea(
+                      child: IconButton(
+                        key: const ValueKey<String>('manga_reader_back_button'),
+                        tooltip:
+                            MaterialLocalizations.of(context).backButtonTooltip,
+                        color: Colors.white,
+                        icon: const Icon(Icons.arrow_back_ios_new),
+                        onPressed: () => Navigator.of(context).maybePop(),
+                      ),
                     ),
                   ),
-                ),
-              // 顶部 chrome：页码指示 + 阅读模式切换。
-              if (_bookRow != null && !_loadFailed)
-                Positioned(
-                  top: 0,
-                  right: 0,
-                  child: SafeArea(child: _buildTopChrome()),
-                ),
-            ],
+                // 顶部 chrome：页码指示 + 阅读模式切换。
+                if (_bookRow != null && !_loadFailed)
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: SafeArea(child: _buildTopChrome()),
+                  ),
+              ],
+            ),
           ),
         ),
       ),

--- a/fushi/lib/src/shortcuts/manga_arrow_override.dart
+++ b/fushi/lib/src/shortcuts/manga_arrow_override.dart
@@ -31,7 +31,32 @@ ShortcutAction? resolveMangaArrowPageTurn({
   final bool isLeft = key == LogicalKeyboardKey.arrowLeft;
   final bool isRight = key == LogicalKeyboardKey.arrowRight;
   if (!isLeft && !isRight) return null;
-  // rtl（日漫默认）：下一页在左 → 左键前进。ltr：下一页在右 → 右键前进。
+  return _directionalPageTurn(isLeft: isLeft, rtl: rtl);
+}
+
+/// 漫画手柄 D-pad 左/右的跨页方向校正——[resolveMangaArrowPageTurn] 的手柄同构。
+///
+/// 语义完全一致：注册表存**页序语义**，dpadLeft/dpadRight 的物理朝向按书的跨页
+/// 方向（日漫默认 rtl）翻成 forward/backward；只在该按钮**当前仍绑定到翻页动作**时
+/// 介入（[boundAction] 判据），用户改绑/解绑后完全让路。RB/LB 等非方向按钮不参与
+/// 校正——它们与 PageDown/空格同属页序语义，任何排版下都一致。
+ShortcutAction? resolveMangaDpadPageTurn({
+  required GamepadButton button,
+  required bool rtl,
+  required ShortcutAction? boundAction,
+}) {
+  if (boundAction != ShortcutAction.mangaPageForward &&
+      boundAction != ShortcutAction.mangaPageBackward) {
+    return null;
+  }
+  final bool isLeft = button == GamepadButton.dpadLeft;
+  final bool isRight = button == GamepadButton.dpadRight;
+  if (!isLeft && !isRight) return null;
+  return _directionalPageTurn(isLeft: isLeft, rtl: rtl);
+}
+
+/// 物理左/右 → 页序动作。rtl（日漫默认）：下一页在左 → 左 = 前进。
+ShortcutAction _directionalPageTurn({required bool isLeft, required bool rtl}) {
   final bool leftIsForward = rtl;
   if (isLeft) {
     return leftIsForward

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -167,13 +167,16 @@ enum ShortcutScope {
       // 提供的，故只开键盘。
       case globalExternal:
         return const <ShortcutChannel>{ShortcutChannel.keyboard};
-      // 漫画页只有键盘解析入口：`_resolveMangaKeyAction` 走 `resolveKeyboard`，
-      // 滚轮翻页是硬编码的 `wheelInputAction`（不查注册表），手柄则完全没接
-      // （既无 `resolveGamepad`，也无 `GamepadButtonIntent` 的 Action）。开着手柄/
-      // 鼠标通道 = 设置页给出能配却按了没反应的入口，比没有这个选项更糟。
-      // 接上对应解析入口（照 reader `_handleGamepadButton`）并真机验证后再开。
+      // 漫画页：键盘走 `_resolveMangaKeyAction`（resolveKeyboard），手柄走
+      // `_handleGamepadButton`（resolveGamepad manga → universal，桌面轮询的
+      // GamepadButtonIntent 与 Android gameButton* 键事件汇合到同一入口，与
+      // reader 同构）。滚轮翻页是硬编码的 `wheelInputAction`（不查注册表），
+      // 鼠标依旧没有解析入口，不开。
       case manga:
-        return const <ShortcutChannel>{ShortcutChannel.keyboard};
+        return const <ShortcutChannel>{
+          ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
+        };
       // 查词弹窗：滚轮（上/下一个词条）+ 键盘（制卡）。两者都不经 resolveKeyboard —— 绑定
       // 由 popup_settings_injection 序列化后注入给 popup.js，命中判定在 JS 侧（弹窗内容是
       // WebView，输入事件先到它的 JS）。键盘通道的取用点同样是

--- a/fushi/lib/src/shortcuts/shortcut_defaults.dart
+++ b/fushi/lib/src/shortcuts/shortcut_defaults.dart
@@ -334,22 +334,30 @@ class ShortcutDefaults {
     // 朝向再由 resolveMangaArrowPageTurn 按跨页方向（日漫默认 rtl）校正，所以这里
     // 存的是**页序语义**而非物理方向。
     //
-    // **只有键盘绑定**：漫画页至今没有手柄解析入口（既无 `resolveGamepad`，也无
-    // `GamepadButtonIntent` 的 Action，Android 的 gameButton* 键事件同样匹配不到
-    // 纯键盘绑定）。曾在这里配过 RB/LB/dpad/B，效果是用户在设置里能配、按下去毫无
-    // 反应——比压根没有这个选项更糟，用户会以为自己手柄坏了。要加回来必须先照
-    // reader `_handleGamepadButton` 接上解析入口并真机验证；`manga` scope 的
-    // `channels` 也相应只开键盘，`shortcut_channel_wiring_guard_test` 会盯住两者一致。
+    // 手柄默认与 reader 翻页同构（RB/dpad右=前进、LB/dpad左=后退）：漫画页现在有
+    // 真实的手柄解析入口（`_handleGamepadButton` → resolveGamepad manga →
+    // universal，桌面轮询与 Android gameButton* 汇合同一入口），dpad 左/右再由
+    // resolveMangaDpadPageTurn 按跨页方向校正——与键盘方向键同一套页序语义。
+    // B **刻意不绑**：退出/关弹窗归 universal 的 globalBack（手柄 B 默认在
+    // universal），在 manga scope 再绑一个 B 会把两级阶梯永久遮蔽
+    // （`universal_back_test` 盯着）。此前「配过 RB/LB/dpad/B 但没有解析入口」的
+    // 死通道教训见 `shortcut_channel_wiring_guard_test`——通道与入口必须同增同减。
     ShortcutAction.mangaPageForward: _kb([
       _key(LogicalKeyboardKey.pageDown),
       _key(LogicalKeyboardKey.arrowRight),
       _key(LogicalKeyboardKey.arrowDown),
       _key(LogicalKeyboardKey.space),
+    ], [
+      _gRB,
+      _gDpadRight
     ]),
     ShortcutAction.mangaPageBackward: _kb([
       _key(LogicalKeyboardKey.pageUp),
       _key(LogicalKeyboardKey.arrowLeft),
       _key(LogicalKeyboardKey.arrowUp),
+    ], [
+      _gLB,
+      _gDpadLeft
     ]),
     // 「只关词典、绝不退出」（漫画版）：**默认空绑定**，理由与 readerDismissDict
     // 完全相同——Esc 归 universal 的 globalBack 一键阶梯。

--- a/fushi/lib/src/shortcuts/shortcut_registry.dart
+++ b/fushi/lib/src/shortcuts/shortcut_registry.dart
@@ -16,7 +16,7 @@ import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
 /// 过快捷键设置的用户，其快照里该 action 仍是「旧版本的完整默认」（仅 F），覆盖后新键
 /// （F12）永久丢失 —— 表现为「按 F12 没反应」。迁移只对「用户从未动过该 action（键集
 /// 恰等于旧默认全集）」的快照补回新键，绝不碰用户主动改/删过的绑定。
-const int kShortcutSchemaVersion = 8;
+const int kShortcutSchemaVersion = 9;
 
 /// 持久化 JSON 里记录写入时 schema 版本的保留 key（不是某个 action 的绑定，故单独
 /// 处理，不进 _unknownEntries，也不会被 [ShortcutAction.fromKey] 误解析）。
@@ -233,6 +233,17 @@ class FushiShortcutRegistry extends ChangeNotifier {
         ],
       );
     }
+    // v8 -> v9（手柄全功能重设计 P1，漫画页接手柄）：给两个**已存在**的 manga 翻页
+    // 动作新增手柄默认（RB/dpad右=前进、LB/dpad左=后退）。老快照里它们已有键盘绑定
+    // 但手柄为空，快照整体覆盖默认 ⇒ 不迁移则新手柄键永久丢失（BUG-318 同型，与
+    // v4→v5 的 video 手柄批完全同构）。只新增手柄、不改键盘默认，故用「键盘未动过」
+    // 判据。B 不在此列——退出/关弹窗归 universal globalBack 的手柄 B（v1→v2 已补）。
+    if (from < 9) {
+      _restoreGamepadDefaultIfKeyboardUntouched(
+          ShortcutAction.mangaPageForward, defaults);
+      _restoreGamepadDefaultIfKeyboardUntouched(
+          ShortcutAction.mangaPageBackward, defaults);
+    }
   }
 
   /// v8：把 [action] 的**键盘**绑定清空，仅当它恰等于 [oldDefaultKeyboard]（证明
@@ -277,10 +288,10 @@ class FushiShortcutRegistry extends ChangeNotifier {
     } catch (_) {
       return; // 损坏的条目：丢弃即可，绝不因此打断整段迁移。
     }
-    final bool keyboardUntouched =
-        _sameBindings<InputBinding>(legacy.keyboardBindings, oldDefaultKeyboard);
-    final bool gamepadUntouched =
-        _sameBindings<GamepadBinding>(legacy.gamepadBindings, oldDefaultGamepad);
+    final bool keyboardUntouched = _sameBindings<InputBinding>(
+        legacy.keyboardBindings, oldDefaultKeyboard);
+    final bool gamepadUntouched = _sameBindings<GamepadBinding>(
+        legacy.gamepadBindings, oldDefaultGamepad);
     if (keyboardUntouched && gamepadUntouched) return;
 
     final ShortcutBindingSet back = bindingsFor(ShortcutAction.globalBack);

--- a/fushi/test/pages/manga_fushi_page_test.dart
+++ b/fushi/test/pages/manga_fushi_page_test.dart
@@ -460,7 +460,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaPageForward,
-          horizontalArrow: true,
+          crossPageStep: true,
           dictionaryShown: true,
           mode: MangaReadingMode.spread,
         ),
@@ -473,7 +473,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaDismissDict,
-          horizontalArrow: false,
+          crossPageStep: false,
           dictionaryShown: true,
           mode: MangaReadingMode.spread,
         ),
@@ -482,7 +482,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaDismissDict,
-          horizontalArrow: false,
+          crossPageStep: false,
           dictionaryShown: false,
           mode: MangaReadingMode.spread,
         ),
@@ -495,7 +495,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaPageForward,
-          horizontalArrow: false,
+          crossPageStep: false,
           dictionaryShown: true,
           mode: MangaReadingMode.spread,
         ),
@@ -508,7 +508,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaPageForward,
-          horizontalArrow: false,
+          crossPageStep: false,
           dictionaryShown: false,
           mode: MangaReadingMode.webtoon,
         ),
@@ -518,7 +518,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.mangaPageForward,
-          horizontalArrow: true,
+          crossPageStep: true,
           dictionaryShown: false,
           mode: MangaReadingMode.webtoon,
         ),
@@ -531,7 +531,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: null,
-          horizontalArrow: true,
+          crossPageStep: true,
           dictionaryShown: false,
           mode: MangaReadingMode.spread,
         ),
@@ -540,7 +540,7 @@ void main() {
       expect(
         MangaFushiPage.inputActionForShortcut(
           action: ShortcutAction.readerPageForward,
-          horizontalArrow: false,
+          crossPageStep: false,
           dictionaryShown: false,
           mode: MangaReadingMode.spread,
         ),

--- a/fushi/test/shortcuts/manga_arrow_override_test.dart
+++ b/fushi/test/shortcuts/manga_arrow_override_test.dart
@@ -79,4 +79,55 @@ void main() {
       }
     });
   });
+
+  group('resolveMangaDpadPageTurn（手柄 D-pad 的同构校正）', () {
+    ShortcutAction? call(
+      GamepadButton button, {
+      required bool rtl,
+      ShortcutAction? bound = ShortcutAction.mangaPageForward,
+    }) =>
+        resolveMangaDpadPageTurn(button: button, rtl: rtl, boundAction: bound);
+
+    test('rtl（日漫默认）：dpad左前进、dpad右后退；ltr 相反', () {
+      expect(call(GamepadButton.dpadLeft, rtl: true),
+          ShortcutAction.mangaPageForward);
+      expect(call(GamepadButton.dpadRight, rtl: true),
+          ShortcutAction.mangaPageBackward);
+      expect(call(GamepadButton.dpadRight, rtl: false),
+          ShortcutAction.mangaPageForward);
+      expect(call(GamepadButton.dpadLeft, rtl: false),
+          ShortcutAction.mangaPageBackward);
+    });
+
+    test('校正只看物理方向 + 排版方向，与原绑定的前进/后退无关（键盘同款不变式）', () {
+      expect(
+        call(GamepadButton.dpadLeft,
+            rtl: true, bound: ShortcutAction.mangaPageBackward),
+        ShortcutAction.mangaPageForward,
+      );
+    });
+
+    test('已改绑成非翻页动作 / 未绑定 → 不覆写，交回注册表', () {
+      expect(
+        call(GamepadButton.dpadLeft,
+            rtl: true, bound: ShortcutAction.mangaDismissDict),
+        isNull,
+      );
+      expect(call(GamepadButton.dpadLeft, rtl: true, bound: null), isNull);
+    });
+
+    test('非 D-pad 左右按钮不参与校正（RB/LB 是页序语义，任何排版下一致）', () {
+      for (final GamepadButton button in <GamepadButton>[
+        GamepadButton.rb,
+        GamepadButton.lb,
+        GamepadButton.dpadUp,
+        GamepadButton.dpadDown,
+        GamepadButton.a,
+        GamepadButton.b,
+      ]) {
+        expect(call(button, rtl: true), isNull,
+            reason: '${button.label} 不该被方向校正');
+      }
+    });
+  });
 }

--- a/fushi/test/shortcuts/manga_gamepad_mapping_test.dart
+++ b/fushi/test/shortcuts/manga_gamepad_mapping_test.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/manga_reading_mode.dart';
+import 'package:fushi/src/media/manga/reader/manga_fushi_page.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+/// 手柄全功能重设计 P1（漫画页接手柄）的映射与迁移测试，与
+/// `video_gamepad_mapping_test.dart` 的 v4→v5 组同构。
+void main() {
+  group('manga 手柄默认映射', () {
+    late FushiShortcutRegistry registry;
+
+    setUp(() {
+      registry = FushiShortcutRegistry();
+      registry.loadDefaults(TargetPlatform.windows);
+    });
+
+    test('RB/dpad右 → 前进，LB/dpad左 → 后退（页序语义，方向校正在页面侧）', () {
+      expect(
+        registry.resolveGamepad(GamepadButton.rb, scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageForward,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadRight,
+            scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageForward,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.lb, scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageBackward,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadLeft,
+            scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageBackward,
+      );
+    });
+
+    test('B 在 manga scope 无绑定，兜底 universal 解析成 globalBack', () {
+      // 这正是「弹窗开着按手柄 B 直接退页」bug 的根因修复形态：manga scope 不占
+      // B，页面解析兜底 universal 拿到 globalBack，再走与 Esc 相同的两级阶梯。
+      expect(
+        registry.resolveGamepad(GamepadButton.b, scope: ShortcutScope.manga),
+        isNull,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.b,
+            scope: ShortcutScope.universal),
+        ShortcutAction.globalBack,
+      );
+    });
+  });
+
+  group('手柄动作的上下文门控（crossPageStep 语义）', () {
+    test('globalBack 两级阶梯：弹窗可见先关弹窗，否则退出漫画', () {
+      expect(
+        MangaFushiPage.inputActionForShortcut(
+          action: ShortcutAction.globalBack,
+          crossPageStep: true,
+          dictionaryShown: true,
+          mode: MangaReadingMode.spread,
+        ),
+        MangaReaderInputAction.dismissDictionary,
+      );
+      expect(
+        MangaFushiPage.inputActionForShortcut(
+          action: ShortcutAction.globalBack,
+          crossPageStep: true,
+          dictionaryShown: false,
+          mode: MangaReadingMode.spread,
+        ),
+        MangaReaderInputAction.backOrExit,
+      );
+    });
+
+    test('手柄翻页是跨页步进：webtoon 也用锚点跳页、弹窗可见关弹窗并翻页', () {
+      // 手柄没有原生滚动路径——键盘的「webtoon 让位原生滚动」「弹窗可见让位」两道
+      // 门控都不适用（crossPageStep: true），否则 webtoon 模式下手柄完全翻不了页。
+      for (final bool dictionaryShown in <bool>[true, false]) {
+        for (final MangaReadingMode mode in MangaReadingMode.values) {
+          expect(
+            MangaFushiPage.inputActionForShortcut(
+              action: ShortcutAction.mangaPageForward,
+              crossPageStep: true,
+              dictionaryShown: dictionaryShown,
+              mode: mode,
+            ),
+            MangaReaderInputAction.next,
+            reason: 'dict=$dictionaryShown mode=$mode 手柄前进必须可用',
+          );
+        }
+      }
+    });
+  });
+
+  group('schema migration v8 → v9（漫画翻页手柄默认补发）', () {
+    /// v8 时代的快照：manga 动作已有键盘默认但手柄为空。
+    Map<String, dynamic> v8Snapshot({
+      Map<ShortcutAction, ShortcutBindingSet> overrides = const {},
+    }) {
+      final Map<ShortcutAction, ShortcutBindingSet> defaults =
+          ShortcutDefaults.forPlatform(TargetPlatform.windows);
+      final Map<String, dynamic> json = <String, dynamic>{
+        kShortcutSchemaVersionKey: 8,
+      };
+      for (final MapEntry<ShortcutAction, ShortcutBindingSet> entry
+          in defaults.entries) {
+        final ShortcutAction action = entry.key;
+        if (overrides.containsKey(action)) {
+          json[action.key] = overrides[action]!.toJson();
+          continue;
+        }
+        final List<GamepadBinding> gamepad = action.scope == ShortcutScope.manga
+            ? const <GamepadBinding>[]
+            : entry.value.gamepadBindings;
+        json[action.key] = ShortcutBindingSet(
+          keyboardBindings: entry.value.keyboardBindings,
+          gamepadBindings: gamepad,
+          mouseBindings: entry.value.mouseBindings,
+          wheelBindings: entry.value.wheelBindings,
+        ).toJson();
+      }
+      return json;
+    }
+
+    test('没动过键盘的老快照升级后补回手柄默认', () {
+      final FushiShortcutRegistry registry = FushiShortcutRegistry();
+      registry.loadFromJsonString(
+        jsonEncode(v8Snapshot()),
+        TargetPlatform.windows,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.rb, scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageForward,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.lb, scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageBackward,
+      );
+    });
+
+    test('用户改过键盘的动作绝不强行恢复（不覆写用户编辑）', () {
+      final FushiShortcutRegistry registry = FushiShortcutRegistry();
+      registry.loadFromJsonString(
+        jsonEncode(
+          v8Snapshot(
+            overrides: <ShortcutAction, ShortcutBindingSet>{
+              ShortcutAction.mangaPageForward: const ShortcutBindingSet(
+                keyboardBindings: <InputBinding>[
+                  InputBinding(key: LogicalKeyboardKey.keyN),
+                ],
+              ),
+            },
+          ),
+        ),
+        TargetPlatform.windows,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.rb, scope: ShortcutScope.manga),
+        isNull,
+        reason: '改过键盘的 mangaPageForward 不得被迁移覆写',
+      );
+      // 没动过的兄弟动作照常补发。
+      expect(
+        registry.resolveGamepad(GamepadButton.lb, scope: ShortcutScope.manga),
+        ShortcutAction.mangaPageBackward,
+      );
+    });
+  });
+}

--- a/fushi/test/shortcuts/shortcut_channel_wiring_guard_test.dart
+++ b/fushi/test/shortcuts/shortcut_channel_wiring_guard_test.dart
@@ -196,11 +196,18 @@ void main() {
     );
   });
 
-  test('漫画 scope 只开放键盘，且默认表不含手柄绑定', () {
-    // 回归钉：这三个 action 曾带着 RB/LB/dpad/B 默认绑定发出去，而漫画页没有任何
-    // 手柄解析入口。要恢复必须先照 reader `_handleGamepadButton` 接上入口并真机验证。
+  test('漫画 scope 开放键盘+手柄，翻页动作双通道默认齐全', () {
+    // 历史教训（原「只开放键盘」回归钉的反转）：这批 action 曾带着 RB/LB/dpad/B
+    // 默认绑定发出去而页面没有任何手柄解析入口——「设置里能配、按了没反应」。
+    // 现在漫画页有真实入口（`_handleGamepadButton` → resolveGamepad manga →
+    // universal，见 manga_fushi_page.dart），通道随之打开；本测试钉住新不变式：
+    //   · 通道恰为 keyboard+gamepad（鼠标依旧没有解析入口，不得开）；
+    //   · 翻页动作必须键盘+手柄默认双全（RB/dpad右=前进、LB/dpad左=后退）；
+    //   · **不得**有任何 manga 动作默认绑手柄 B——退出/关弹窗归 universal
+    //     globalBack 的 B，两级阶梯不许被 manga scope 遮蔽（universal_back_test）。
     expect(ShortcutScope.manga.channels, <ShortcutChannel>{
       ShortcutChannel.keyboard,
+      ShortcutChannel.gamepad,
     });
     for (final TargetPlatform platform in <TargetPlatform>[
       TargetPlatform.windows,
@@ -211,8 +218,13 @@ void main() {
           ShortcutDefaults.forPlatform(platform);
       for (final ShortcutAction action in ShortcutAction.values
           .where((ShortcutAction a) => a.scope == ShortcutScope.manga)) {
-        expect(table[action]!.gamepadBindings, isEmpty,
-            reason: '$platform ${action.key} 不得有手柄默认绑定（漫画页没接手柄）');
+        expect(
+            table[action]!
+                .gamepadBindings
+                .where((GamepadBinding b) => b.button == GamepadButton.b),
+            isEmpty,
+            reason: '$platform ${action.key} 不得默认绑手柄 B'
+                '（B 归 universal globalBack 的两级阶梯）');
         // mangaDismissDict 是**有意**留空的可选动作：Esc 已归全 app 唯一的
         // 「返回上一级」(globalBack)，它在这里再绑一个键盘默认就会在 manga scope
         // 先命中，把「无弹窗时退出漫画」那一级永久遮蔽（v8 统一的核心不变式，
@@ -220,6 +232,14 @@ void main() {
         if (action == ShortcutAction.mangaDismissDict) continue;
         expect(table[action]!.keyboardBindings, isNotEmpty,
             reason: '$platform ${action.key} 必须有键盘默认绑定');
+      }
+      for (final ShortcutAction action in const <ShortcutAction>[
+        ShortcutAction.mangaPageForward,
+        ShortcutAction.mangaPageBackward,
+      ]) {
+        expect(table[action]!.gamepadBindings, isNotEmpty,
+            reason: '$platform ${action.key} 必须有手柄默认绑定'
+                '（v8→v9 迁移补发的就是这组，删了老用户就拿不到）');
       }
     }
   });

--- a/fushi/test/shortcuts/universal_back_test.dart
+++ b/fushi/test/shortcuts/universal_back_test.dart
@@ -116,10 +116,11 @@ void main() {
     test('手柄侧同理，且已登记的有意例外只有有声书的 B', () {
       final Map<ShortcutAction, ShortcutBindingSet> defaults =
           ShortcutDefaults.forPlatform(TargetPlatform.windows);
-      final Set<GamepadButton> backButtons = defaults[ShortcutAction.globalBack]!
-          .gamepadBindings
-          .map((GamepadBinding b) => b.button)
-          .toSet();
+      final Set<GamepadButton> backButtons =
+          defaults[ShortcutAction.globalBack]!
+              .gamepadBindings
+              .map((GamepadBinding b) => b.button)
+              .toSet();
       for (final ShortcutAction action in ShortcutAction.values) {
         if (action.scope == ShortcutScope.universal) continue;
         for (final GamepadBinding gp in defaults[action]!.gamepadBindings) {
@@ -378,7 +379,8 @@ void main() {
       expect(
         'scope: ShortcutScope.universal'.allMatches(code).length,
         2,
-        reason: '键盘 (_resolveReaderKeyboardShortcut) 与手柄 (_handleGamepadButton) '
+        reason:
+            '键盘 (_resolveReaderKeyboardShortcut) 与手柄 (_handleGamepadButton) '
             '各一处兜底解析；少一处就有一条通道退不出书',
       );
     });
@@ -388,8 +390,13 @@ void main() {
       final String code = maskComments(File(path).readAsStringSync());
       expect(code.contains('MangaReaderInputAction.backOrExit'), isTrue,
           reason: '漫画必须有「退出」这个落点动作');
-      expect(code.contains('scope: ShortcutScope.universal'), isTrue,
-          reason: '解析必须兜底 universal，否则 Esc 仍解析不到任何动作');
+      expect(
+        'scope: ShortcutScope.universal'.allMatches(code).length,
+        2,
+        reason: '键盘 (_resolveMangaKeyAction) 与手柄 (_resolveMangaGamepadAction) '
+            '各一处兜底解析 universal；少一处就有一条通道退不出漫画'
+            '（手柄那条缺席时 B 会走全局 maybePop 兜底，弹窗开着直接退页）',
+      );
       final int idx = code.indexOf('if (action == ShortcutAction.globalBack)');
       expect(idx, greaterThanOrEqualTo(0));
       final String slice = code.substring(idx, idx + 260);


### PR DESCRIPTION
手柄全功能重设计 P1/5（后续 P2 弹窗手柄、P3 视频浮层焦点、P4 游戏库、P5 游戏内浮窗另开 PR）。

## 改动
- 漫画页新增 `Actions<GamepadButtonIntent>` + `_handleGamepadButton`（桌面轮询与 Android gameButton* 汇合同一入口，与 reader 同构）
- 解析阶梯 `resolveGamepad(manga) → universal`：**根治手柄 B 语义分叉**——此前漫画页无手柄入口，B 落到 GamepadService 全局 maybePop 兜底，查词弹窗开着直接退页；现在与 Esc 同走两级阶梯（先关弹窗、再退出）
- 默认绑定：RB/D-pad右=下一页、LB/D-pad左=上一页；D-pad 左右经新增 `resolveMangaDpadPageTurn` 按跨页方向（日漫默认 rtl）校正
- `inputActionForShortcut` 参数 `horizontalArrow` 更名 `crossPageStep`：手柄翻页一律跨页步进语义（webtoon 锚点跳页、弹窗可见关弹窗并翻页）
- manga scope 通道开 keyboard+gamepad（设置页自动渲染手柄章节）
- schema v8→v9 迁移：老快照按「键盘未动过」判据补发手柄默认（BUG-318 同型，照 v4→v5 video 批）

## 守卫
- `shortcut_channel_wiring_guard_test` 回归钉反转：钉双通道 + 翻页手柄默认齐全 + 禁绑 B
- `universal_back_test` 漫画条强化：键盘/手柄各一处 universal 兜底（count==2）
- 新增 `manga_gamepad_mapping_test`（默认映射 + 门控语义 + v8→v9 迁移双向）
- 三条守卫均已变异实测（通道回退/兜底缺席/迁移失效 → 对应测试红）

## 验证
- `flutter analyze` 全量 0 issue
- `flutter test test/shortcuts test/pages/manga_fushi_page_test.dart` 559 项全绿
- 缺口：未做 Windows 真机手柄复测（按既定流程跳过，合入前如需可补）