### PR TITLE
feat(popup): 查词弹窗接手柄 + 右摇杆滚动（手柄重设计 P2）

### DIFF
--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -3018,6 +3018,27 @@ window.fushiPopupMineFirstEntry = async function() {
     return true;
 };
 
+// 手柄（Dart 侧 dictionaryPopup scope 派发，默认 Y）：播放第一个可见词条的发音。
+// 与 fushiPopupMineFirstEntry 同模板：点既有按钮复用其全部音源解析/回退/提示逻辑，
+// 绝不另起第二条音频桥。
+window.fushiPopupPlayFirstAudio = async function() {
+    const audioButton = __fushiRootNode().querySelector('.audio-button');
+    if (!audioButton || audioButton.disabled) {
+        return false;
+    }
+    audioButton.click();
+    return true;
+};
+
+// 手柄右摇杆（Dart 侧连续派发）：滚动弹窗内容 dy CSS 像素（正=向下）。不走 wheel
+// 事件——那条路挂着词条导航绑定判定（__fushiEntryWheelBindings），纯滚动直接动
+// 文档滚动元素即可。
+window.fushiPopupScrollBy = function(dy) {
+    const el = document.scrollingElement || document.documentElement;
+    el.scrollBy(0, dy);
+    return true;
+};
+
 // 查词弹窗的键盘快捷键（用户请求：「点那个加号的动作」要能用键盘触发）。
 // 实际覆盖面：app 内弹窗、浏览器扩展、以及 app 外**已获得焦点的剪贴板面板**。app 外的
 // 瞬态查词覆盖窗带 WS_EX_NOACTIVATE、永不接收键盘焦点（且 runner 无键盘转发），本监听在
@@ -3038,8 +3059,9 @@ const FUSHI_POPUP_KEY_DEFAULT_BINDINGS = {
     mine: [{ key: 'enter', mods: ['ctrl'] }],
     next: [],
     prev: [],
+    audio: [],
 };
-// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / null。判据与滚轮那套同构：
+// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / 'audio' / null。判据与滚轮那套同构：
 // 键名归一后相等，且当前按下的修饰键集合与某条绑定**全等**（故 Ctrl+Enter 绝不会被
 // Ctrl+Shift+Enter 误触）。
 function fushiPopupKeyAction(e) {
@@ -3061,6 +3083,7 @@ function fushiPopupKeyAction(e) {
     if (matches(cfg.mine)) return 'mine';
     if (matches(cfg.next)) return 'next';
     if (matches(cfg.prev)) return 'prev';
+    if (matches(cfg.audio)) return 'audio';
     return null;
 }
 // 扩展场景下本监听常驻在**宿主页面**的 document 上（弹窗是注入宿主页的 DOM，不是独立文档），
@@ -3085,6 +3108,8 @@ window.__fushiPopupKeyListener = async function(e) {
     try {
         if (action === 'mine') {
             handled = (await window.fushiPopupMineFirstEntry()) === true;
+        } else if (action === 'audio') {
+            handled = (await window.fushiPopupPlayFirstAudio()) === true;
         } else if (typeof window.fushiFocusDictionaryEntryMove === 'function') {
             // 与 Alt+滚轮同一执行体：只有焦点真的移动了才算接管；单词条 / 已到首尾时返回
             // 'blocked'，这一帧交还给页面（不吞按键）。

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -3018,6 +3018,27 @@ window.fushiPopupMineFirstEntry = async function() {
     return true;
 };
 
+// 手柄（Dart 侧 dictionaryPopup scope 派发，默认 Y）：播放第一个可见词条的发音。
+// 与 fushiPopupMineFirstEntry 同模板：点既有按钮复用其全部音源解析/回退/提示逻辑，
+// 绝不另起第二条音频桥。
+window.fushiPopupPlayFirstAudio = async function() {
+    const audioButton = __fushiRootNode().querySelector('.audio-button');
+    if (!audioButton || audioButton.disabled) {
+        return false;
+    }
+    audioButton.click();
+    return true;
+};
+
+// 手柄右摇杆（Dart 侧连续派发）：滚动弹窗内容 dy CSS 像素（正=向下）。不走 wheel
+// 事件——那条路挂着词条导航绑定判定（__fushiEntryWheelBindings），纯滚动直接动
+// 文档滚动元素即可。
+window.fushiPopupScrollBy = function(dy) {
+    const el = document.scrollingElement || document.documentElement;
+    el.scrollBy(0, dy);
+    return true;
+};
+
 // 查词弹窗的键盘快捷键（用户请求：「点那个加号的动作」要能用键盘触发）。
 // 实际覆盖面：app 内弹窗、浏览器扩展、以及 app 外**已获得焦点的剪贴板面板**。app 外的
 // 瞬态查词覆盖窗带 WS_EX_NOACTIVATE、永不接收键盘焦点（且 runner 无键盘转发），本监听在
@@ -3038,8 +3059,9 @@ const FUSHI_POPUP_KEY_DEFAULT_BINDINGS = {
     mine: [{ key: 'enter', mods: ['ctrl'] }],
     next: [],
     prev: [],
+    audio: [],
 };
-// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / null。判据与滚轮那套同构：
+// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / 'audio' / null。判据与滚轮那套同构：
 // 键名归一后相等，且当前按下的修饰键集合与某条绑定**全等**（故 Ctrl+Enter 绝不会被
 // Ctrl+Shift+Enter 误触）。
 function fushiPopupKeyAction(e) {
@@ -3061,6 +3083,7 @@ function fushiPopupKeyAction(e) {
     if (matches(cfg.mine)) return 'mine';
     if (matches(cfg.next)) return 'next';
     if (matches(cfg.prev)) return 'prev';
+    if (matches(cfg.audio)) return 'audio';
     return null;
 }
 // 扩展场景下本监听常驻在**宿主页面**的 document 上（弹窗是注入宿主页的 DOM，不是独立文档），
@@ -3085,6 +3108,8 @@ window.__fushiPopupKeyListener = async function(e) {
     try {
         if (action === 'mine') {
             handled = (await window.fushiPopupMineFirstEntry()) === true;
+        } else if (action === 'audio') {
+            handled = (await window.fushiPopupPlayFirstAudio()) === true;
         } else if (typeof window.fushiFocusDictionaryEntryMove === 'function') {
             // 与 Alt+滚轮同一执行体：只有焦点真的移动了才算接管；单词条 / 已到首尾时返回
             // 'blocked'，这一帧交还给页面（不吞按键）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62169 (3657 per locale)
+/// Strings: 62186 (3658 per locale)
 ///
-/// Built on 2026-08-20 at 05:33 UTC
+/// Built on 2026-08-20 at 17:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4972,6 +4972,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Folder added as a library source and scanned.';
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -13452,6 +13453,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -21997,6 +22000,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -30558,6 +30563,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -39131,6 +39138,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -47634,6 +47643,8 @@ class _StringsId extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -56181,6 +56192,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -64545,6 +64558,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -72916,6 +72931,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -81443,6 +81460,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -89982,6 +90001,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -98508,6 +98529,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -106982,6 +107005,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -115487,6 +115512,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -123978,6 +124005,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 // Path: <root>
@@ -131829,6 +131858,8 @@ class _StringsZhCn extends _StringsEn {
   String get drag_drop_folder_source_added => '已把文件夹添加为来源并开始扫描';
   @override
   String get drag_drop_folder_source_exists => '该文件夹已经是来源了';
+  @override
+  String get shortcut_action_popup_play_audio => '播放单词发音';
 }
 
 // Path: <root>
@@ -140116,6 +140147,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get drag_drop_folder_source_exists =>
       'That folder is already a library source.';
+  @override
+  String get shortcut_action_popup_play_audio => 'Play word audio';
 }
 
 /// Flat map(s) containing all translations.
@@ -147622,6 +147655,8 @@ extension on _StringsEn {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -155126,6 +155161,8 @@ extension on _StringsAr {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -162652,6 +162689,8 @@ extension on _StringsDe {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -170177,6 +170216,8 @@ extension on _StringsEs {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -177708,6 +177749,8 @@ extension on _StringsFr {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -185221,6 +185264,8 @@ extension on _StringsId {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -192748,6 +192793,8 @@ extension on _StringsIt {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -200237,6 +200284,8 @@ extension on _StringsJa {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -207730,6 +207779,8 @@ extension on _StringsKo {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -215251,6 +215302,8 @@ extension on _StringsNl {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -222769,6 +222822,8 @@ extension on _StringsPtBr {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -230292,6 +230347,8 @@ extension on _StringsRu {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -237798,6 +237855,8 @@ extension on _StringsTh {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -245313,6 +245372,8 @@ extension on _StringsTr {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -252824,6 +252885,8 @@ extension on _StringsVi {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }
@@ -260276,6 +260339,8 @@ extension on _StringsZhCn {
         return '已把文件夹添加为来源并开始扫描';
       case 'drag_drop_folder_source_exists':
         return '该文件夹已经是来源了';
+      case 'shortcut_action_popup_play_audio':
+        return '播放单词发音';
       default:
         return null;
     }
@@ -267760,6 +267825,8 @@ extension on _StringsZhHk {
         return 'Folder added as a library source and scanned.';
       case 'drag_drop_folder_source_exists':
         return 'That folder is already a library source.';
+      case 'shortcut_action_popup_play_audio':
+        return 'Play word audio';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "向左平移",
   "shortcut_action_manga_pan_right": "向右平移",
   "drag_drop_folder_source_added": "已把文件夹添加为来源并开始扫描",
-  "drag_drop_folder_source_exists": "该文件夹已经是来源了"
+  "drag_drop_folder_source_exists": "该文件夹已经是来源了",
+  "shortcut_action_popup_play_audio": "播放单词发音"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3655,5 +3655,6 @@
   "shortcut_action_manga_pan_left": "Pan left",
   "shortcut_action_manga_pan_right": "Pan right",
   "drag_drop_folder_source_added": "Folder added as a library source and scanned.",
-  "drag_drop_folder_source_exists": "That folder is already a library source."
+  "drag_drop_folder_source_exists": "That folder is already a library source.",
+  "shortcut_action_popup_play_audio": "Play word audio"
 }

--- a/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:flutter/widgets.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
 
 /// Shared empty result used to mount the popup WebView during the search phase
 /// (BUG-080), so popup.html + JS + CSS cold-load in parallel with the FFI
@@ -71,7 +72,33 @@ class DictionaryPopupController extends ChangeNotifier {
   DictionaryPopupController({
     required this.lowMemory,
     this.onLookupStackDepthChanged,
-  });
+  }) {
+    // 手柄重设计 P2：每个弹窗栈 controller 把自己登记为 dictionaryPopup scope 手柄
+    // 动作的执行体（GamepadService 在页面 Actions 未消费后按可见性取用）。7 个宿主
+    // （书内/漫画/视频/首页词典/独立查词/歌词浮窗/texthooker）由此免逐个接线。
+    // 纯回调对象，不引入 UI 依赖，controller 保持纯逻辑可测。
+    _gamepadHooks = DictionaryPopupGamepadHooks(
+      hasVisiblePopup: () => hasVisiblePopup,
+      entryMove: (bool forward) async =>
+          _topVisibleWebViewState?.focusEntryMove(forward),
+      mineFirstEntry: () async =>
+          _topVisibleWebViewState?.mineFirstVisibleEntry(),
+      playFirstAudio: () async =>
+          _topVisibleWebViewState?.playFirstVisibleAudio(),
+      scrollBy: (double dy) async =>
+          _topVisibleWebViewState?.scrollContentBy(dy),
+    );
+    DictionaryPopupGamepadRegistry.push(_gamepadHooks);
+  }
+
+  late final DictionaryPopupGamepadHooks _gamepadHooks;
+
+  /// 栈顶**可见**层的 WebView 状态（热槽隐身层不算）；无可见层或 WebView 未挂载
+  /// 返回 null（钩子就地变 no-op，不抛）。
+  DictionaryPopupWebViewState? get _topVisibleWebViewState {
+    final int index = lastVisibleIndex;
+    return index < 0 ? null : _entries[index].webViewKey.currentState;
+  }
 
   /// TODO-607 P0-2：查词栈「可见深度」变化时的注入回调（书内 / 视频 / 首页 / 安卓独立
   /// 查词窗各宿主在创建时注入 `ErrorLogService.instance.markLookupStackDepth`）。
@@ -415,6 +442,7 @@ class DictionaryPopupController extends ChangeNotifier {
 
   @override
   void dispose() {
+    DictionaryPopupGamepadRegistry.pop(_gamepadHooks);
     // 防泄漏：销毁时取消所有挂起的兜底 Timer。
     for (final Timer t in _revealFailsafeTimers.values) {
       t.cancel();

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -696,6 +696,23 @@ JSON.stringify((function(){
     );
   }
 
+  /// 手柄（dictionaryPopup scope）：播放第一个可见词条的发音——点既有发音按钮，
+  /// 复用其全部音源解析/回退逻辑（与制卡同一「点按钮不另起桥」纪律）。
+  Future<void> playFirstVisibleAudio() async {
+    await _controller?.evaluateJavascript(
+      source: 'window.fushiPopupPlayFirstAudio'
+          ' ? window.fushiPopupPlayFirstAudio() : false',
+    );
+  }
+
+  /// 手柄右摇杆：连续滚动弹窗内容 [dy] CSS 像素（正=向下）。
+  Future<void> scrollContentBy(double dy) async {
+    await _controller?.evaluateJavascript(
+      source: 'window.fushiPopupScrollBy'
+          ' ? window.fushiPopupScrollBy(${dy.round()}) : false',
+    );
+  }
+
   /// BUG-763/766：确认「制卡前调整」原生对话框时，回 WebView 精确点中第 [idx] 个词条
   /// （`:scope > .entry` DOM 序）的制卡按钮，复用其全部制卡/查重/覆写逻辑（Dart 侧无
   /// 「制卡指定词条」直接入口——mineEntry 契约要求 JS 先构造 payload）。

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -475,7 +475,7 @@ String _webKeyName(LogicalKeyboardKey key) {
 /// {"mine":[{"key":"enter","mods":["ctrl"]}],"next":[],"prev":[]}
 /// ```
 ///
-/// 覆盖本 scope **全部三个动作**（制卡 + 上/下一个词条），而不只是制卡——因为
+/// 覆盖本 scope **全部动作**（制卡 + 上/下一个词条 + 播放发音），而不只是制卡——因为
 /// [ShortcutScope.channels] 是按 scope 而非按 action 开通道的：只要这个 scope 开了键盘，
 /// 设置页就会给它名下每个动作都渲染出「添加键盘快捷键」入口。若只有制卡真能用，词条导航
 /// 那两个入口就成了「能配、按了没反应」的死绑定（`shortcut_channel_wiring_guard_test`
@@ -509,6 +509,10 @@ String popupKeyBindingsJson(
     'mine': encode(ShortcutAction.popupMineEntry),
     'next': encode(ShortcutAction.popupNextEntry),
     'prev': encode(ShortcutAction.popupPrevEntry),
+    // P2 新增「播放发音」：键盘默认为空（默认只有手柄 Y），但 scope 开着键盘通道，
+    // 用户绑上后 app 外裸 WebView2 表面照样要生效——注入表必须与 scope 动作全集
+    // 同步（popup_mine_key_binding_test 钉着）。
+    'audio': encode(ShortcutAction.popupPlayAudio),
   });
 }
 

--- a/fushi/lib/src/shortcuts/dictionary_popup_gamepad.dart
+++ b/fushi/lib/src/shortcuts/dictionary_popup_gamepad.dart
@@ -1,0 +1,73 @@
+/// dictionaryPopup scope 的手柄执行钩子与进程级登记处（手柄重设计 P2）。
+///
+/// 为什么在 shortcuts 层放一个纯回调对象、而不是直接引用
+/// `DictionaryPopupController` / `DictionaryPopupWebViewState`：
+/// GamepadService（shortcuts 层）是消费方，弹窗栈与 WebView 状态在 pages 层——
+/// 依赖必须单向（pages → shortcuts）。controller 在自己那侧构造好钩子注册进来，
+/// 服务侧只见函数，不见弹窗类型。
+///
+/// 分发次序（`GamepadService._dispatchButton` / `wrapWithGlobalNavigation`）：
+/// **页面 Actions 永远优先**，弹窗解析只吃页面没消费的按钮——与 universal
+/// 「返回上一级」同一哲学（页面专属键优先，兜底才轮到跨页面能力）。因此
+/// dictionaryPopup 的手柄默认键必须挑各媒体页没占用的位（dpad上下/X/Y 会被
+/// video 的音量与字幕句跳转先吃掉，那是**有意**的让位，不是 bug——视频页
+/// 弹窗内导航走字幕选字光标）。
+library;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// 一组由弹窗宿主（`DictionaryPopupController`）提供的执行回调。全部指向
+/// **栈顶可见**弹窗；无可见弹窗时 [hasVisiblePopup] 为 false，登记处直接跳过。
+class DictionaryPopupGamepadHooks {
+  const DictionaryPopupGamepadHooks({
+    required this.hasVisiblePopup,
+    required this.entryMove,
+    required this.mineFirstEntry,
+    required this.playFirstAudio,
+    required this.scrollBy,
+  });
+
+  /// 当前栈里是否有可见弹窗（常驻隐藏热槽不算）。
+  final bool Function() hasVisiblePopup;
+
+  /// 词条焦点移到下/上一个词条并滚进视口（popup.js
+  /// `fushiFocusDictionaryEntryMove`，与 Alt+滚轮同一执行体）。
+  final Future<void> Function(bool forward) entryMove;
+
+  /// 制卡：点第一个可见词条的加号（`fushiPopupMineFirstEntry`，单一制卡桥）。
+  final Future<void> Function() mineFirstEntry;
+
+  /// 发音：点第一个可见词条的发音按钮（`fushiPopupPlayFirstAudio`）。
+  final Future<void> Function() playFirstAudio;
+
+  /// 右摇杆连续滚动弹窗内容 [dy] CSS 像素（正=内容向下滚）。
+  final Future<void> Function(double dy) scrollBy;
+}
+
+/// 进程级登记栈（与 `PageScrollRegistry` 同构）：每个弹窗 controller 构造时
+/// push、dispose 时 pop。[current] 取**最近注册且当前有可见弹窗**的一组钩子——
+/// 同一时刻现实中只有活跃路由的弹窗可见，可见性过滤天然消掉「首页 controller
+/// 常驻但视频页在顶」的歧义。
+class DictionaryPopupGamepadRegistry {
+  DictionaryPopupGamepadRegistry._();
+
+  static final List<DictionaryPopupGamepadHooks> _stack =
+      <DictionaryPopupGamepadHooks>[];
+
+  static void push(DictionaryPopupGamepadHooks hooks) => _stack.add(hooks);
+
+  static void pop(DictionaryPopupGamepadHooks hooks) => _stack.remove(hooks);
+
+  static DictionaryPopupGamepadHooks? get current {
+    for (int i = _stack.length - 1; i >= 0; i--) {
+      if (_stack[i].hasVisiblePopup()) return _stack[i];
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  static void debugClear() => _stack.clear();
+
+  @visibleForTesting
+  static int get debugDepth => _stack.length;
+}

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -12,9 +12,45 @@ import 'package:gamepads/gamepads.dart' as gp;
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
+import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+/// dictionaryPopup scope 的手柄兜底（手柄重设计 P2）：页面 Actions **未消费**的
+/// 按钮，在有可见查词弹窗时按弹窗绑定解析并执行（词条导航/制卡/发音）。桌面轮询
+/// （[GamepadService._dispatchButton]）与 Android 键事件链
+/// （`wrapWithGlobalNavigation`）共用这一个入口——页面专属键永远优先，弹窗只吃
+/// 页面没占的按钮，与 universal「返回上一级」同一哲学。
+bool tryDictionaryPopupGamepadButton(
+  FushiShortcutRegistry? registry,
+  GamepadButton button,
+) {
+  if (registry == null) return false;
+  final DictionaryPopupGamepadHooks? hooks =
+      DictionaryPopupGamepadRegistry.current;
+  if (hooks == null) return false;
+  final ShortcutAction? action = registry.resolveGamepad(
+    button,
+    scope: ShortcutScope.dictionaryPopup,
+  );
+  switch (action) {
+    case ShortcutAction.popupNextEntry:
+      unawaited(hooks.entryMove(true));
+      return true;
+    case ShortcutAction.popupPrevEntry:
+      unawaited(hooks.entryMove(false));
+      return true;
+    case ShortcutAction.popupMineEntry:
+      unawaited(hooks.mineFirstEntry());
+      return true;
+    case ShortcutAction.popupPlayAudio:
+      unawaited(hooks.playFirstAudio());
+      return true;
+    default:
+      return false;
+  }
+}
 
 /// Intent dispatched for a physical gamepad button on platforms where Flutter
 /// does NOT deliver `gameButton*` key events (desktop / Apple). The active page
@@ -353,6 +389,7 @@ class GamepadService {
         onButton: _dispatchButton,
         onLongPress: _dispatchLongPress,
         onStickMove: _dispatchStickMove,
+        onRightStickScroll: _dispatchRightStickScroll,
       ),
     )..start();
   }
@@ -385,6 +422,11 @@ class GamepadService {
         ) ==
         true;
     if (handled) return;
+
+    // 手柄重设计 P2：页面没消费的按钮，弹窗可见时先按 dictionaryPopup scope 解析
+    // （词条导航/制卡/发音）。排在页面之后 = 页面专属键永远优先；排在滚动/焦点
+    // 兜底之前 = 弹窗可见时 dpad 上下先导航词条，而不是把焦点从弹窗底下移走。
+    if (tryDictionaryPopupGamepadButton(registry, button)) return;
 
     // The page didn't consume the button: LB/RB (or whatever the user bound to
     // the global scroll-page actions) page-scrolls the current page's primary
@@ -465,6 +507,19 @@ class GamepadService {
     if (ctx == null) return;
     _setHighlightForHardwareNav();
     gamepadMoveFocusInDirection(ctx, dir);
+  }
+
+  /// 每 tick 满偏时滚动的 CSS 像素（60ms 一 tick ≈ 满偏 400px/s，半偏减半）。
+  static const double _kRightStickScrollPxPerTick = 24;
+
+  /// 手柄重设计 P2：右摇杆连续滚动**可见查词弹窗**的内容。无弹窗时不做事——
+  /// 页面滚动已有 LB/RB 整页滚（globalScrollPage*）与左摇杆焦点滚动兜底，右摇杆
+  /// 现阶段专职弹窗，避免同一根摇杆在不同页面语义漂移。
+  void _dispatchRightStickScroll(double dyNorm) {
+    final DictionaryPopupGamepadHooks? hooks =
+        DictionaryPopupGamepadRegistry.current;
+    if (hooks == null) return;
+    unawaited(hooks.scrollBy(dyNorm * _kRightStickScrollPxPerTick));
   }
 
   /// LB/RB page-scroll fallback: if [button] is bound to a global scroll-page
@@ -815,7 +870,18 @@ class GamepadFrameProcessor {
     required this.onButton,
     this.onLongPress,
     this.onStickMove,
+    this.onRightStickScroll,
   });
+
+  /// 手柄重设计 P2：右摇杆的**连续滚动**通道。每个采样 tick（60ms）在死区外都
+  /// 发一次归一化纵向偏移（-1..1，**向下为正**——插件轴 +Y=上，滚动语义相反，
+  /// 这里翻好号），消费方按偏移量滚动查词弹窗内容。与左摇杆（焦点导航）刻意
+  /// 分开：左手移焦点、右手滚内容，互不抢通道。Null（未接线/单元测试）= no-op。
+  final void Function(double dyNorm)? onRightStickScroll;
+
+  /// 右摇杆滚动死区（约 24% 满偏）：比左摇杆的方向滞回门槛（stickEnter）低——
+  /// 滚动是连续量不怕抖动误触发，门槛太高反而丢慢速微调。
+  static const int rightStickDeadZone = 8000;
 
   /// Emits a discrete [GamepadButton] press. TODO-700 T6: the D-pad emits here
   /// (dpad* buttons, routed through the shortcut registry as bindable triggers);
@@ -907,6 +973,8 @@ class GamepadFrameProcessor {
     required int stickX,
     required int stickY,
     required int nowMs,
+    int rightStickX = 0,
+    int rightStickY = 0,
   }) {
     // Edge-detected discrete buttons. A is handled separately below when
     // long-press is supported (decided on release), so skip it here to avoid a
@@ -970,6 +1038,13 @@ class GamepadFrameProcessor {
       _updateHeldStickDirection(stickDir, nowMs: nowMs);
     } else {
       _heldStickDir = null;
+    }
+
+    // 右摇杆连续滚动（P2）：无边沿检测、无自动重复——它是速度量，每 tick 在死区
+    // 外都发（横轴暂不消费，只采纵轴）。
+    final void Function(double dyNorm)? scrollEmit = onRightStickScroll;
+    if (scrollEmit != null && rightStickY.abs() > rightStickDeadZone) {
+      scrollEmit(-rightStickY / GamepadFrameBits.axisMax);
     }
   }
 
@@ -1070,6 +1145,8 @@ class GamepadFrameState {
   int rightTrigger = 0;
   int stickX = 0; // -axisMax..axisMax
   int stickY = 0;
+  int rightStickX = 0; // -axisMax..axisMax（P2：右摇杆滚动通道）
+  int rightStickY = 0;
 
   // Normalized gamepads button -> frame bitmask (only the directional/face/
   // shoulder/thumb/menu buttons the processor understands; home/touchpad are
@@ -1111,6 +1188,10 @@ class GamepadFrameState {
       stickX = (value * GamepadFrameBits.axisMax).round();
     } else if (axis == gp.GamepadAxis.leftStickY) {
       stickY = (value * GamepadFrameBits.axisMax).round();
+    } else if (axis == gp.GamepadAxis.rightStickX) {
+      rightStickX = (value * GamepadFrameBits.axisMax).round();
+    } else if (axis == gp.GamepadAxis.rightStickY) {
+      rightStickY = (value * GamepadFrameBits.axisMax).round();
     } else if (axis == gp.GamepadAxis.leftTrigger) {
       leftTrigger = (value * GamepadFrameBits.triggerMax).round();
     } else if (axis == gp.GamepadAxis.rightTrigger) {
@@ -1156,6 +1237,8 @@ class _PluginGamepadPoller {
         rightTrigger: _state.rightTrigger,
         stickX: _state.stickX,
         stickY: _state.stickY,
+        rightStickX: _state.rightStickX,
+        rightStickY: _state.rightStickY,
         nowMs: _clock.elapsedMilliseconds,
       );
     });

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -15,7 +15,8 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
         arrowFocusMoveDirection,
         dispatchNativeGamepadButtonIntent,
         focusedEditableText,
-        gamepadMoveFocusInDirection;
+        gamepadMoveFocusInDirection,
+        tryDictionaryPopupGamepadButton;
 
 /// 顶层路由是不是一个**弹层**（对话框 / 下拉 / bottom sheet）。
 ///
@@ -448,6 +449,16 @@ Widget wrapWithGlobalNavigation({
       final KeyEventResult gamepadResult =
           dispatchNativeGamepadButtonIntent(event);
       if (gamepadResult == KeyEventResult.handled) return gamepadResult;
+      // 手柄重设计 P2（Android 键事件链）：页面 Actions 没消费的手柄按钮，弹窗
+      // 可见时按 dictionaryPopup scope 解析（词条导航/制卡/发音）——与桌面轮询
+      // 路径 GamepadService._dispatchButton 的弹窗兜底同一入口、同一次序。
+      if (event is KeyDownEvent) {
+        final GamepadButton? nativeButton = GamepadButton.fromKeyEvent(event);
+        if (nativeButton != null &&
+            tryDictionaryPopupGamepadButton(registry, nativeButton)) {
+          return KeyEventResult.handled;
+        }
+      }
       if (focusNavigationEnabled) {
         final KeyEventResult arrowResult =
             _handleGlobalArrowFocus(navigatorKey, event);

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -177,14 +177,18 @@ enum ShortcutScope {
           ShortcutChannel.keyboard,
           ShortcutChannel.gamepad,
         };
-      // 查词弹窗：滚轮（上/下一个词条）+ 键盘（制卡）。两者都不经 resolveKeyboard —— 绑定
-      // 由 popup_settings_injection 序列化后注入给 popup.js，命中判定在 JS 侧（弹窗内容是
-      // WebView，输入事件先到它的 JS）。键盘通道的取用点同样是
-      // `bindingsFor(popupMineEntry).keyboardBindings`。
+      // 查词弹窗：滚轮（上/下一个词条）+ 键盘（制卡）+ 手柄。滚轮/键盘不经
+      // resolveKeyboard —— 绑定由 popup_settings_injection 序列化后注入给 popup.js，
+      // 命中判定在 JS 侧（弹窗内容是 WebView，输入事件先到它的 JS）；键盘通道的
+      // 取用点同样是 `bindingsFor(popupMineEntry).keyboardBindings`。
+      // 手柄（P2）走 Dart 侧：GamepadService 在页面 Actions 未消费后按
+      // `resolveGamepad(scope: dictionaryPopup)` 解析，经
+      // DictionaryPopupGamepadRegistry 的钩子调进弹窗 JS（词条导航/制卡/发音）。
       case dictionaryPopup:
         return const <ShortcutChannel>{
           ShortcutChannel.wheel,
           ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
         };
     }
   }
@@ -453,7 +457,12 @@ enum ShortcutAction {
   // 不可能触发**。galgame 场景焦点通常在游戏上，不先点面板就按不到。要覆盖瞬态窗只有两条
   // 路（去掉 NOACTIVATE = 抢游戏焦点、违背它的设计初衷；或上全局 RegisterHotKey），都是
   // 产品取舍，未做——别把这里的实现说成「app 内 / app 外 / 浏览器都能用」。
-  popupMineEntry(ShortcutScope.dictionaryPopup, 'popup_mine_entry');
+  popupMineEntry(ShortcutScope.dictionaryPopup, 'popup_mine_entry'),
+
+  // 手柄重设计 P2：播放第一个可见词条的发音（点既有 `.audio-button`，与制卡同一
+  // 「点按钮不另起桥」纪律，JS 入口 `fushiPopupPlayFirstAudio`）。默认只有手柄 Y
+  // ——键盘上鼠标点按钮已经够近，而手柄用户没有任何非光标模式的发音入口。
+  popupPlayAudio(ShortcutScope.dictionaryPopup, 'popup_play_audio');
 
   const ShortcutAction(this.scope, this.key);
 

--- a/fushi/lib/src/shortcuts/shortcut_defaults.dart
+++ b/fushi/lib/src/shortcuts/shortcut_defaults.dart
@@ -456,15 +456,21 @@ class ShortcutDefaults {
     // 手感）。裸滚轮永远滚动弹窗内容，故必须带修饰键；Alt 在 WebView 里没有默认滚轮
     // 语义（Ctrl+滚轮是缩放、Shift+滚轮是横向滚动，都不能占）。dictionaryPopup 是独立
     // co-active 组，与任何页面键位不冲突。
+    // 手柄默认（P2）：dpad 下/上 = 下/上一个词条。执行链是 GamepadService 的弹窗
+    // 兜底（页面 Actions 未消费 → resolveGamepad(dictionaryPopup) → 钩子调 JS），
+    // **页面专属键永远优先**：视频页 dpad 上下被音量占用，弹窗里照旧调音量——那是
+    // 有意让位（视频弹窗导航走字幕选字光标），不要为此给弹窗改绑更冲的键。
     ShortcutAction.popupNextEntry: const ShortcutBindingSet(
       wheelBindings: <WheelBinding>[
         WheelBinding(WheelDirection.down, modifiers: {ModifierKey.alt}),
       ],
+      gamepadBindings: <GamepadBinding>[_gDpadDown],
     ),
     ShortcutAction.popupPrevEntry: const ShortcutBindingSet(
       wheelBindings: <WheelBinding>[
         WheelBinding(WheelDirection.up, modifiers: {ModifierKey.alt}),
       ],
+      gamepadBindings: <GamepadBinding>[_gDpadUp],
     ),
     // 制卡（= 点弹窗里的「＋」）。默认 Ctrl+Enter，与阅读器既有的
     // readerCreateCardFromPopup 同键：两者是同一件事在不同焦点归属下的两条执行路径，
@@ -475,6 +481,16 @@ class ShortcutDefaults {
       keyboardBindings: <InputBinding>[
         _key(LogicalKeyboardKey.enter, {ModifierKey.ctrl}),
       ],
+      // 手柄 X = 制卡（P2，Dart 侧弹窗兜底派发）。reader 的 X=书签、video 的
+      // X=上一句在各自页面先命中——弹窗可见时它们仍优先，这是「页面专属键优先」
+      // 的既定哲学；漫画/首页词典/独立查词页没占 X，弹窗制卡直达。
+      gamepadBindings: const <GamepadBinding>[_gX],
+    ),
+    // 发音（P2 新增）：默认只有手柄 Y——键盘/鼠标用户点按钮已经够近，而手柄用户
+    // 此前没有任何非光标模式的发音入口。执行体是点第一个可见词条的发音按钮
+    // （fushiPopupPlayFirstAudio，与制卡同一「点按钮不另起桥」纪律）。
+    ShortcutAction.popupPlayAudio: const ShortcutBindingSet(
+      gamepadBindings: <GamepadBinding>[_gY],
     ),
   };
 
@@ -544,9 +560,12 @@ class ShortcutDefaults {
           // 弹窗宿主（Android 悬浮词典 / 独立查词页）都是 Flutter 宿主、没有 Dart 侧接线，
           // 给了绑定也永不触发——「设置里能配、按了没反应」比没有这个选项更糟。
           // 与 globalExternal 在移动端返回空绑定同理。
+          // 手柄绑定（P2）移动端保留：Android 的手柄键经页面 Actions →
+          // 全局 wrapper 的弹窗兜底同样走 Dart 派发，与桌面同一条链。
           case ShortcutScope.dictionaryPopup:
             return ShortcutBindingSet(
               wheelBindings: desktop.wheelBindings,
+              gamepadBindings: desktop.gamepadBindings,
             );
         }
       }(),

--- a/fushi/lib/src/shortcuts/shortcut_labels.dart
+++ b/fushi/lib/src/shortcuts/shortcut_labels.dart
@@ -171,6 +171,8 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_popup_prev_entry;
       case ShortcutAction.popupMineEntry:
         return t.shortcut_action_popup_mine_entry;
+      case ShortcutAction.popupPlayAudio:
+        return t.shortcut_action_popup_play_audio;
     }
   }
 }

--- a/fushi/lib/src/shortcuts/shortcut_registry.dart
+++ b/fushi/lib/src/shortcuts/shortcut_registry.dart
@@ -16,7 +16,7 @@ import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
 /// 过快捷键设置的用户，其快照里该 action 仍是「旧版本的完整默认」（仅 F），覆盖后新键
 /// （F12）永久丢失 —— 表现为「按 F12 没反应」。迁移只对「用户从未动过该 action（键集
 /// 恰等于旧默认全集）」的快照补回新键，绝不碰用户主动改/删过的绑定。
-const int kShortcutSchemaVersion = 9;
+const int kShortcutSchemaVersion = 10;
 
 /// 持久化 JSON 里记录写入时 schema 版本的保留 key（不是某个 action 的绑定，故单独
 /// 处理，不进 _unknownEntries，也不会被 [ShortcutAction.fromKey] 误解析）。
@@ -244,6 +244,37 @@ class FushiShortcutRegistry extends ChangeNotifier {
       _restoreGamepadDefaultIfKeyboardUntouched(
           ShortcutAction.mangaPageBackward, defaults);
     }
+    // v9 -> v10（手柄全功能重设计 P2，查词弹窗接手柄）：给三个**已存在**的
+    // dictionaryPopup 动作新增手柄默认（dpad下/上=词条导航、X=制卡）。不能用
+    // 「键盘未动过」判据整组还原——popupNext/PrevEntry 的主通道是**滚轮**，整组
+    // 还原会把用户自定义的滚轮绑定一并抹掉。该 scope 此前根本没开手柄通道，快照
+    // 里 gamepad 恒为空 ⇒ 「gamepad 为空」本身就是「用户不可能动过」的精确判据，
+    // 只补 gamepad、其余通道分毫不碰。（popupPlayAudio 是全新 action，老快照无
+    // 其 key，loadDefaults 已播种，无需迁移。）
+    if (from < 10) {
+      for (final ShortcutAction action in const <ShortcutAction>[
+        ShortcutAction.popupNextEntry,
+        ShortcutAction.popupPrevEntry,
+        ShortcutAction.popupMineEntry,
+      ]) {
+        _seedGamepadDefaultIfUnset(action, defaults);
+      }
+    }
+  }
+
+  /// v10：仅当 [action] 的手柄绑定**为空**时，把当前默认表的手柄绑定播种进去；
+  /// 其余通道（键盘/鼠标/滚轮）原样保留。适用于「该 scope 此前从未开过手柄通道」
+  /// 的迁移——空手柄集不可能是用户自定义，播种零误伤。
+  void _seedGamepadDefaultIfUnset(
+    ShortcutAction action,
+    Map<ShortcutAction, ShortcutBindingSet> defaults,
+  ) {
+    final ShortcutBindingSet current = bindingsFor(action);
+    if (current.gamepadBindings.isNotEmpty) return;
+    final List<GamepadBinding> seeded =
+        defaults[action]?.gamepadBindings ?? const <GamepadBinding>[];
+    if (seeded.isEmpty) return;
+    _bindings[action] = current.copyWith(gamepadBindings: seeded);
   }
 
   /// v8：把 [action] 的**键盘**绑定清空，仅当它恰等于 [oldDefaultKeyboard]（证明

--- a/fushi/test/shortcuts/popup_entry_wheel_binding_test.dart
+++ b/fushi/test/shortcuts/popup_entry_wheel_binding_test.dart
@@ -127,20 +127,22 @@ void main() {
       );
     });
 
-    test('dictionaryPopup 是独立 co-active 组，开滚轮 + 键盘两个通道', () {
+    test('dictionaryPopup 是独立 co-active 组，开滚轮 + 键盘 + 手柄三个通道', () {
       expect(ShortcutScope.dictionaryPopup.coactiveScopes,
           <ShortcutScope>[ShortcutScope.dictionaryPopup]);
-      // 契约变更（制卡快捷键）：本 scope 早先只开滚轮，因为唯一的动作是词条导航。加入
-      // popupMineEntry（= 点弹窗里的「＋」）后键盘通道有了真实消费者——
-      // popup_settings_injection 把 `bindingsFor(popupMineEntry).keyboardBindings`
-      // 序列化注入给 popup.js（app 外裸 WebView2 表面），视频页另按同一绑定在 Dart 侧派发。
-      // 故这里从「只开滚轮」放宽成两通道；但**不是**放开成三通道：手柄/鼠标仍无解析入口。
+      // 契约变更史：最早只开滚轮（唯一动作是词条导航）；加入 popupMineEntry 后键盘
+      // 通道有了真实消费者（popup_settings_injection 注入 popup.js + 视频页 Dart 侧
+      // 派发）；手柄重设计 P2 再开手柄——GamepadService 的弹窗兜底按
+      // `resolveGamepad(scope: dictionaryPopup)` 解析，经 DictionaryPopupGamepadRegistry
+      // 的钩子调进弹窗 JS。鼠标仍无解析入口，**不得**放开成四通道。
       expect(
         ShortcutScope.dictionaryPopup.channels,
-        <ShortcutChannel>{ShortcutChannel.wheel, ShortcutChannel.keyboard},
+        <ShortcutChannel>{
+          ShortcutChannel.wheel,
+          ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
+        },
       );
-      expect(ShortcutScope.dictionaryPopup.channels,
-          isNot(contains(ShortcutChannel.gamepad)));
       expect(ShortcutScope.dictionaryPopup.channels,
           isNot(contains(ShortcutChannel.mouse)));
       // 其它 scope 保持键盘/手柄/鼠标三通道（不因新通道枚举而改变既有行为）。

--- a/fushi/test/shortcuts/popup_gamepad_mapping_test.dart
+++ b/fushi/test/shortcuts/popup_gamepad_mapping_test.dart
@@ -1,0 +1,312 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gamepads/gamepads.dart' as gp;
+import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 手柄全功能重设计 P2：查词弹窗手柄通道（默认映射 / 兜底派发 / v9→v10 迁移）
+/// 与右摇杆滚动采集。
+void main() {
+  tearDown(DictionaryPopupGamepadRegistry.debugClear);
+
+  DictionaryPopupGamepadHooks recordingHooks(
+    List<String> calls, {
+    bool visible = true,
+  }) {
+    return DictionaryPopupGamepadHooks(
+      hasVisiblePopup: () => visible,
+      entryMove: (bool forward) async =>
+          calls.add(forward ? 'entry:next' : 'entry:prev'),
+      mineFirstEntry: () async => calls.add('mine'),
+      playFirstAudio: () async => calls.add('audio'),
+      scrollBy: (double dy) async => calls.add('scroll:$dy'),
+    );
+  }
+
+  group('dictionaryPopup 手柄默认映射', () {
+    late FushiShortcutRegistry registry;
+
+    setUp(() {
+      registry = FushiShortcutRegistry();
+      registry.loadDefaults(TargetPlatform.windows);
+    });
+
+    test('dpad下/上=词条导航、X=制卡、Y=发音', () {
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadDown,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupNextEntry,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadUp,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupPrevEntry,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.x,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupMineEntry,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.y,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupPlayAudio,
+      );
+    });
+
+    test('移动端默认表也带手柄绑定（Android 键事件链同一执行路）', () {
+      final Map<ShortcutAction, ShortcutBindingSet> mobile =
+          ShortcutDefaults.forPlatform(TargetPlatform.android);
+      expect(
+          mobile[ShortcutAction.popupNextEntry]!.gamepadBindings, isNotEmpty);
+      expect(
+          mobile[ShortcutAction.popupPlayAudio]!.gamepadBindings, isNotEmpty);
+    });
+  });
+
+  group('tryDictionaryPopupGamepadButton（弹窗兜底派发）', () {
+    late FushiShortcutRegistry registry;
+
+    setUp(() {
+      registry = FushiShortcutRegistry();
+      registry.loadDefaults(TargetPlatform.windows);
+    });
+
+    test('弹窗可见：四个默认按钮各自派发到对应钩子', () {
+      final List<String> calls = <String>[];
+      DictionaryPopupGamepadRegistry.push(recordingHooks(calls));
+      expect(tryDictionaryPopupGamepadButton(registry, GamepadButton.dpadDown),
+          isTrue);
+      expect(tryDictionaryPopupGamepadButton(registry, GamepadButton.dpadUp),
+          isTrue);
+      expect(
+          tryDictionaryPopupGamepadButton(registry, GamepadButton.x), isTrue);
+      expect(
+          tryDictionaryPopupGamepadButton(registry, GamepadButton.y), isTrue);
+      expect(calls, <String>['entry:next', 'entry:prev', 'mine', 'audio']);
+    });
+
+    test('未绑定按钮返回 false（交回滚动/焦点兜底），不误吞', () {
+      final List<String> calls = <String>[];
+      DictionaryPopupGamepadRegistry.push(recordingHooks(calls));
+      expect(
+          tryDictionaryPopupGamepadButton(registry, GamepadButton.a), isFalse);
+      expect(
+          tryDictionaryPopupGamepadButton(registry, GamepadButton.b), isFalse);
+      expect(
+          tryDictionaryPopupGamepadButton(registry, GamepadButton.rb), isFalse);
+      expect(calls, isEmpty);
+    });
+
+    test('无可见弹窗：登记了钩子也不吃任何按钮', () {
+      final List<String> calls = <String>[];
+      DictionaryPopupGamepadRegistry.push(
+          recordingHooks(calls, visible: false));
+      expect(tryDictionaryPopupGamepadButton(registry, GamepadButton.dpadDown),
+          isFalse);
+      expect(calls, isEmpty);
+    });
+
+    test('取最近注册且可见的钩子（首页常驻 controller 不抢活跃路由的弹窗）', () {
+      final List<String> homeCalls = <String>[];
+      final List<String> videoCalls = <String>[];
+      DictionaryPopupGamepadRegistry.push(
+          recordingHooks(homeCalls, visible: false));
+      DictionaryPopupGamepadRegistry.push(recordingHooks(videoCalls));
+      expect(tryDictionaryPopupGamepadButton(registry, GamepadButton.dpadDown),
+          isTrue);
+      expect(homeCalls, isEmpty);
+      expect(videoCalls, <String>['entry:next']);
+    });
+
+    test('registry 为 null（测试宿主）时安全返回 false', () {
+      DictionaryPopupGamepadRegistry.push(recordingHooks(<String>[]));
+      expect(tryDictionaryPopupGamepadButton(null, GamepadButton.dpadDown),
+          isFalse);
+    });
+  });
+
+  group('右摇杆滚动采集', () {
+    test('GamepadFrameState 采集 rightStickX/Y 轴', () {
+      final GamepadFrameState state = GamepadFrameState();
+      state.applyAxis(gp.GamepadAxis.rightStickY, 0.5);
+      expect(state.rightStickY, (0.5 * GamepadFrameBits.axisMax).round());
+      state.applyAxis(gp.GamepadAxis.rightStickX, -1.0);
+      expect(state.rightStickX, -GamepadFrameBits.axisMax);
+    });
+
+    test('处理器：死区内不发、死区外每 tick 发归一化偏移且向下为正', () {
+      final List<double> emitted = <double>[];
+      final GamepadFrameProcessor processor = GamepadFrameProcessor(
+        onButton: (_) {},
+        onRightStickScroll: emitted.add,
+      );
+      // 死区内（|8000| 不超过阈值）：不发。
+      processor.processFrame(
+        buttons: 0,
+        leftTrigger: 0,
+        rightTrigger: 0,
+        stickX: 0,
+        stickY: 0,
+        rightStickY: GamepadFrameProcessor.rightStickDeadZone,
+        nowMs: 0,
+      );
+      expect(emitted, isEmpty);
+      // 推杆向上（插件 +Y=上）→ 滚动向上 = 负值。
+      processor.processFrame(
+        buttons: 0,
+        leftTrigger: 0,
+        rightTrigger: 0,
+        stickX: 0,
+        stickY: 0,
+        rightStickY: GamepadFrameBits.axisMax,
+        nowMs: 60,
+      );
+      expect(emitted.single, -1.0);
+      // 推杆向下 → 正值，连续 tick 连续发（无边沿检测）。
+      processor.processFrame(
+        buttons: 0,
+        leftTrigger: 0,
+        rightTrigger: 0,
+        stickX: 0,
+        stickY: 0,
+        rightStickY: -GamepadFrameBits.axisMax ~/ 2,
+        nowMs: 120,
+      );
+      processor.processFrame(
+        buttons: 0,
+        leftTrigger: 0,
+        rightTrigger: 0,
+        stickX: 0,
+        stickY: 0,
+        rightStickY: -GamepadFrameBits.axisMax ~/ 2,
+        nowMs: 180,
+      );
+      expect(emitted.length, 3);
+      expect(emitted[1], greaterThan(0));
+      expect(emitted[2], emitted[1]);
+    });
+  });
+
+  group(
+      '派发接线源码守卫（单测只测 tryDictionaryPopupGamepadButton 本体，'
+      '接线被删时它们照样绿——这两条钉住两条真实调用链）', () {
+    test('桌面轮询：_dispatchButton 在页面 Actions 之后调弹窗兜底', () {
+      final String code = maskComments(
+          File('lib/src/shortcuts/gamepad_service.dart').readAsStringSync());
+      expect(
+        code.contains('if (tryDictionaryPopupGamepadButton(registry, button)) '
+            'return;'),
+        isTrue,
+        reason: '桌面轮询链丢失弹窗兜底：手柄在弹窗上只剩焦点/滚动兜底',
+      );
+    });
+
+    test('Android 键事件链：全局 wrapper 调同一入口', () {
+      final String code = maskComments(
+          File('lib/src/shortcuts/global_navigation.dart').readAsStringSync());
+      expect(
+        code.contains(
+            'tryDictionaryPopupGamepadButton(registry, nativeButton)'),
+        isTrue,
+        reason: 'Android 链丢失弹窗兜底：手柄弹窗操作变桌面 only',
+      );
+    });
+  });
+
+  group('schema migration v9 → v10（弹窗手柄默认播种）', () {
+    /// v9 时代的快照：dictionaryPopup 动作有滚轮/键盘绑定但手柄恒空
+    /// （该 scope 当时根本没开手柄通道），popupPlayAudio 尚不存在。
+    Map<String, dynamic> v9Snapshot({
+      Map<ShortcutAction, ShortcutBindingSet> overrides = const {},
+    }) {
+      final Map<ShortcutAction, ShortcutBindingSet> defaults =
+          ShortcutDefaults.forPlatform(TargetPlatform.windows);
+      final Map<String, dynamic> json = <String, dynamic>{
+        kShortcutSchemaVersionKey: 9,
+      };
+      for (final MapEntry<ShortcutAction, ShortcutBindingSet> entry
+          in defaults.entries) {
+        final ShortcutAction action = entry.key;
+        if (action == ShortcutAction.popupPlayAudio) continue; // v9 没有它
+        if (overrides.containsKey(action)) {
+          json[action.key] = overrides[action]!.toJson();
+          continue;
+        }
+        final List<GamepadBinding> gamepad =
+            action.scope == ShortcutScope.dictionaryPopup
+                ? const <GamepadBinding>[]
+                : entry.value.gamepadBindings;
+        json[action.key] = ShortcutBindingSet(
+          keyboardBindings: entry.value.keyboardBindings,
+          gamepadBindings: gamepad,
+          mouseBindings: entry.value.mouseBindings,
+          wheelBindings: entry.value.wheelBindings,
+        ).toJson();
+      }
+      return json;
+    }
+
+    test('老快照升级后补上弹窗手柄默认；新动作 popupPlayAudio 天然拿默认', () {
+      final FushiShortcutRegistry registry = FushiShortcutRegistry();
+      registry.loadFromJsonString(
+        jsonEncode(v9Snapshot()),
+        TargetPlatform.windows,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadDown,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupNextEntry,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.x,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupMineEntry,
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.y,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupPlayAudio,
+      );
+    });
+
+    test('用户自定义的滚轮绑定原样保留（播种只动 gamepad，绝不整组还原）', () {
+      // 用户把「下一个词条」改成 Ctrl+滚轮下：迁移后滚轮保持用户值，同时手柄补上。
+      final FushiShortcutRegistry registry = FushiShortcutRegistry();
+      const WheelBinding userWheel = WheelBinding(
+        WheelDirection.down,
+        modifiers: <ModifierKey>{ModifierKey.ctrl},
+      );
+      registry.loadFromJsonString(
+        jsonEncode(
+          v9Snapshot(
+            overrides: <ShortcutAction, ShortcutBindingSet>{
+              ShortcutAction.popupNextEntry: const ShortcutBindingSet(
+                wheelBindings: <WheelBinding>[userWheel],
+              ),
+            },
+          ),
+        ),
+        TargetPlatform.windows,
+      );
+      expect(
+        registry.bindingsFor(ShortcutAction.popupNextEntry).wheelBindings,
+        <WheelBinding>[userWheel],
+      );
+      expect(
+        registry.resolveGamepad(GamepadButton.dpadDown,
+            scope: ShortcutScope.dictionaryPopup),
+        ShortcutAction.popupNextEntry,
+      );
+    });
+  });
+}

--- a/fushi/test/shortcuts/popup_mine_key_binding_test.dart
+++ b/fushi/test/shortcuts/popup_mine_key_binding_test.dart
@@ -56,7 +56,7 @@ void main() {
         registryFor(TargetPlatform.windows),
         TargetPlatform.windows,
       ));
-      expect(cfg.keys.toSet(), <String>{'mine', 'next', 'prev'});
+      expect(cfg.keys.toSet(), <String>{'mine', 'next', 'prev', 'audio'});
       expect(
         ShortcutAction.actionsForScope(ShortcutScope.dictionaryPopup).length,
         cfg.keys.length,

--- a/fushi/test/shortcuts/shortcut_wheel_binding_capture_test.dart
+++ b/fushi/test/shortcuts/shortcut_wheel_binding_capture_test.dart
@@ -204,15 +204,18 @@ void main() {
     resetPlatform();
   });
 
-  testWidgets('弹窗 scope 给滚轮 + 键盘入口，不给手柄/鼠标入口（不造死绑定）',
+  testWidgets('弹窗 scope 给滚轮 + 键盘 + 手柄入口，不给鼠标入口（不造死绑定）',
       (WidgetTester tester) async {
-    // 契约变更（制卡快捷键）：本 scope 早先只开滚轮。加入 popupMineEntry（= 点弹窗里的
-    // 「＋」，默认 Ctrl+Enter）后键盘通道有了真实消费者，故键盘入口出现。
+    // 契约变更史：本 scope 早先只开滚轮；加入 popupMineEntry（= 点弹窗里的「＋」，
+    // 默认 Ctrl+Enter）后键盘通道有了真实消费者，键盘入口出现；手柄重设计 P2 再开
+    // 手柄——GamepadService 的弹窗兜底（tryDictionaryPopupGamepadButton）按本 scope
+    // 解析并经钩子调进弹窗 JS，手柄入口随之出现。
     //
     // 关键点是「不造死绑定」这个约束本身没有松动，只是满足方式变了：通道是按 **scope**
-    // 开的，所以开键盘就等于给本 scope 每个动作都开。为此 popup_settings_injection 的
-    // 键盘绑定表覆盖三个动作（mine/next/prev）、popup.js 统一分派——词条导航同样能绑键盘
-    // 并真的生效，而不是渲染出一个按了没反应的入口。手柄/鼠标仍无解析入口，保持不给。
+    // 开的，所以开一个通道就等于给本 scope 每个动作都开。键盘侧
+    // popup_settings_injection 的绑定表覆盖全部动作（mine/next/prev/audio）、popup.js
+    // 统一分派；手柄侧全部动作都进 tryDictionaryPopupGamepadButton 的分派表。
+    // 鼠标仍无解析入口，保持不给。
     usePlatform(TargetPlatform.windows);
     final FushiShortcutRegistry registry =
         buildRegistry(TargetPlatform.windows);
@@ -224,7 +227,7 @@ void main() {
 
     expect(find.byKey(const Key('shortcut_add_wheel')), findsOneWidget);
     expect(find.text(t.shortcut_keyboard), findsWidgets);
-    expect(find.text(t.shortcut_gamepad), findsNothing);
+    expect(find.text(t.shortcut_gamepad), findsWidgets);
     expect(find.byKey(const Key('shortcut_add_mouse')), findsNothing);
 
     resetPlatform();

--- a/tools/browser-extension/popup-mine-key.test.js
+++ b/tools/browser-extension/popup-mine-key.test.js
@@ -34,16 +34,18 @@ function loadKeyListener(bindings) {
 
   const mineCalls = [];
   const moveCalls = [];
+  const audioCalls = [];
   const win = {
     fushiPopupMineFirstEntry: async () => { mineCalls.push(1); return true; },
     fushiFocusDictionaryEntryMove: (dir) => { moveCalls.push(dir); return 'moved'; },
+    fushiPopupPlayFirstAudio: async () => { audioCalls.push(1); return true; },
   };
   if (bindings !== undefined) win.__fushiPopupKeyBindings = bindings;
   const ctx = { window: win, document: { addEventListener() {} } };
   ctx.globalThis = ctx;
   vm.createContext(ctx);
   vm.runInContext(slice, ctx);
-  return { win, mineCalls, moveCalls };
+  return { win, mineCalls, moveCalls, audioCalls };
 }
 
 function ev(over) {
@@ -137,4 +139,13 @@ test('没命中任何绑定时不吞按键（网页自己的快捷键照常工�
   const e = ev({ key: 'a', ctrlKey: true });
   await win.__fushiPopupKeyListener(e);
   assert.strictEqual(e._prevented, false, '未命中就必须原样交还给页面');
+});
+
+test('播放发音绑定命中时走 fushiPopupPlayFirstAudio，不碰制卡/导航（P2）', async () => {
+  const cfg = { mine: [], next: [], prev: [], audio: [{ key: 'p', mods: [] }] };
+  const { win, mineCalls, moveCalls, audioCalls } = loadKeyListener(cfg);
+  await win.__fushiPopupKeyListener(ev({ key: 'p', ctrlKey: false }));
+  assert.strictEqual(audioCalls.length, 1);
+  assert.strictEqual(mineCalls.length, 0);
+  assert.strictEqual(moveCalls.length, 0);
 });

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3018,6 +3018,27 @@ window.fushiPopupMineFirstEntry = async function() {
     return true;
 };
 
+// 手柄（Dart 侧 dictionaryPopup scope 派发，默认 Y）：播放第一个可见词条的发音。
+// 与 fushiPopupMineFirstEntry 同模板：点既有按钮复用其全部音源解析/回退/提示逻辑，
+// 绝不另起第二条音频桥。
+window.fushiPopupPlayFirstAudio = async function() {
+    const audioButton = __fushiRootNode().querySelector('.audio-button');
+    if (!audioButton || audioButton.disabled) {
+        return false;
+    }
+    audioButton.click();
+    return true;
+};
+
+// 手柄右摇杆（Dart 侧连续派发）：滚动弹窗内容 dy CSS 像素（正=向下）。不走 wheel
+// 事件——那条路挂着词条导航绑定判定（__fushiEntryWheelBindings），纯滚动直接动
+// 文档滚动元素即可。
+window.fushiPopupScrollBy = function(dy) {
+    const el = document.scrollingElement || document.documentElement;
+    el.scrollBy(0, dy);
+    return true;
+};
+
 // 查词弹窗的键盘快捷键（用户请求：「点那个加号的动作」要能用键盘触发）。
 // 实际覆盖面：app 内弹窗、浏览器扩展、以及 app 外**已获得焦点的剪贴板面板**。app 外的
 // 瞬态查词覆盖窗带 WS_EX_NOACTIVATE、永不接收键盘焦点（且 runner 无键盘转发），本监听在
@@ -3038,8 +3059,9 @@ const FUSHI_POPUP_KEY_DEFAULT_BINDINGS = {
     mine: [{ key: 'enter', mods: ['ctrl'] }],
     next: [],
     prev: [],
+    audio: [],
 };
-// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / null。判据与滚轮那套同构：
+// 本次 keydown 命中哪个弹窗动作：'mine' / 'next' / 'prev' / 'audio' / null。判据与滚轮那套同构：
 // 键名归一后相等，且当前按下的修饰键集合与某条绑定**全等**（故 Ctrl+Enter 绝不会被
 // Ctrl+Shift+Enter 误触）。
 function fushiPopupKeyAction(e) {
@@ -3061,6 +3083,7 @@ function fushiPopupKeyAction(e) {
     if (matches(cfg.mine)) return 'mine';
     if (matches(cfg.next)) return 'next';
     if (matches(cfg.prev)) return 'prev';
+    if (matches(cfg.audio)) return 'audio';
     return null;
 }
 // 扩展场景下本监听常驻在**宿主页面**的 document 上（弹窗是注入宿主页的 DOM，不是独立文档），
@@ -3085,6 +3108,8 @@ window.__fushiPopupKeyListener = async function(e) {
     try {
         if (action === 'mine') {
             handled = (await window.fushiPopupMineFirstEntry()) === true;
+        } else if (action === 'audio') {
+            handled = (await window.fushiPopupPlayFirstAudio()) === true;
         } else if (typeof window.fushiFocusDictionaryEntryMove === 'function') {
             // 与 Alt+滚轮同一执行体：只有焦点真的移动了才算接管；单词条 / 已到首尾时返回
             // 'blocked'，这一帧交还给页面（不吞按键）。


### PR DESCRIPTION
手柄全功能重设计 P2/5，**堆叠在 #922（P1）之上**——P1 合入后本 PR base 会自动落到 develop。

## 改动
- **dictionaryPopup scope 开手柄通道**：GamepadService 在页面 Actions 未消费后按 `resolveGamepad(dictionaryPopup)` 解析（`tryDictionaryPopupGamepadButton`）；Android 键事件链在全局 wrapper 同一入口。**页面专属键永远优先**（与 universal 返回同哲学）——video 的 dpad 上下/X/Y 被音量/字幕句占用属有意让位（视频弹窗导航走字幕 caret）。
- **执行体注册**：`DictionaryPopupGamepadRegistry`（纯回调钩子，shortcuts 层，依赖单向）+ `DictionaryPopupController` 构造自注册/dispose 注销——书内/漫画/视频/首页词典/独立查词/歌词浮窗/texthooker 七个宿主免逐个接线。
- **默认绑定**：dpad下/上=词条导航、X=制卡、Y=发音。新动作 `popupPlayAudio`（点既有发音按钮，不另起桥）；键盘注入表与 popup.js 分派同步补 `audio`（scope 级通道承诺完整，扩展 vendor 镜像同步）。
- **右摇杆采集**（此前桌面轮询完全不采）：`GamepadFrameState/Processor` 采 rightStickX/Y，死区外每 tick 发归一化偏移，连续滚动可见弹窗内容。Android 无此通道（引擎无 MotionEvent 轴路径，既有不对称）。
- **schema v9→v10**：`_seedGamepadDefaultIfUnset`——gamepad 为空才播种，绝不整组还原（保住用户自定义滚轮/键盘绑定；与 v5 的整组还原判据刻意不同，理由见迁移注释）。

## 守卫
- 新增 `popup_gamepad_mapping_test`：默认映射 / 兜底派发（含可见性过滤、最近注册优先） / 右摇杆死区与符号 / v9→v10 双向迁移 / **两条派发接线源码守卫**（桌面轮询链 + Android 链）
- `popup_entry_wheel_binding_test` / `popup_mine_key_binding_test` / `shortcut_wheel_binding_capture_test` 契约反转更新
- 扩展 node 测试补 audio 行为用例（11/11 绿）
- 变异实测 3 条：删派发接线 / 迁移失效 / JS audio 分派失效 → 对应测试红

## 验证
- `flutter analyze` 全量 0 issue；`flutter test test/shortcuts + manga_fushi_page_test` 570 项全绿
- 缺口：未做 Windows 真机手柄复测（按既定流程跳过）