### PR TITLE
feat(video): 浮层面板焦点体系（手柄重设计 P3）

### DIFF
--- a/fushi/lib/src/focus/panel_focus_scope.dart
+++ b/fushi/lib/src/focus/panel_focus_scope.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/widgets.dart';
+
+/// 浮层面板的焦点圈地（手柄重设计 P3）。
+///
+/// 解决的问题：视频页的剧集轨 / 字幕列表 / 侧栏面板打开后，焦点仍停在页面级
+/// `_videoFocusNode` 上——手柄 D-pad 的通用移焦兜底从那里出发找不到面板内的行，
+/// 面板对手柄用户等于不存在。本组件把面板包成一个 [FocusScope] +
+/// [FocusTraversalGroup]，在 [visible] 变真（或以可见状态挂载）时把焦点领进面板
+/// 的第一个可遍历节点；面板关闭（变假或卸载）时把焦点还给 [restoreFocus]（宿主
+/// 页面焦点节点），播放快捷键随之恢复。
+///
+/// 两种宿主形态都覆盖：
+///   · 常驻挂载 + FadingChromeGate 显隐（剧集轨）：跟 [didUpdateWidget] 的
+///     visible 边沿走；
+///   · 只在打开时挂载（字幕列表 / 侧栏）：跟 [initState] / [dispose] 走，
+///     visible 恒 true 即可。
+///
+/// 若面板内有子节点自带 `autofocus`（如选中集卡片），后帧检查发现焦点已在面板内
+/// 就不再抢——autofocus 的更精准落点优先。
+class PanelFocusScope extends StatefulWidget {
+  const PanelFocusScope({
+    required this.visible,
+    required this.child,
+    this.restoreFocus,
+    super.key,
+  });
+
+  /// 面板当前是否可见。常驻挂载的面板传真实显隐；随开关挂卸的面板传 true。
+  final bool visible;
+
+  /// 面板关闭后把焦点还给谁（通常是宿主页面的键盘焦点节点）。null = 不归还。
+  final FocusNode? restoreFocus;
+
+  final Widget child;
+
+  @override
+  State<PanelFocusScope> createState() => _PanelFocusScopeState();
+}
+
+class _PanelFocusScopeState extends State<PanelFocusScope> {
+  final FocusScopeNode _scope = FocusScopeNode(debugLabel: 'PanelFocusScope');
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.visible) _claimFocusNextFrame();
+  }
+
+  @override
+  void didUpdateWidget(PanelFocusScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible && !oldWidget.visible) {
+      _claimFocusNextFrame();
+    } else if (!widget.visible && oldWidget.visible) {
+      _restoreHostFocus();
+    }
+  }
+
+  @override
+  void dispose() {
+    // 面板随关闭卸载（字幕列表 / 侧栏）：焦点若还圈在面板里，归还宿主。
+    if (widget.visible && _scope.hasFocus) _restoreHostFocus();
+    _scope.dispose();
+    super.dispose();
+  }
+
+  /// 后帧认领：等本帧布局完成（FadingChromeGate 的 ExcludeFocus 已放开）再进。
+  void _claimFocusNextFrame() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !widget.visible) return;
+      // 子节点 autofocus 已落在面板内 → 尊重更精准的落点，不抢。
+      if (_scope.hasFocus) return;
+      _scope.requestFocus();
+      if (_scope.focusedChild == null) _scope.nextFocus();
+    });
+  }
+
+  void _restoreHostFocus() {
+    final FocusNode? host = widget.restoreFocus;
+    if (host == null) return;
+    if (host.canRequestFocus) host.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusScope(
+      node: _scope,
+      child: FocusTraversalGroup(child: widget.child),
+    );
+  }
+}

--- a/fushi/lib/src/media/video/video_player_shortcuts.dart
+++ b/fushi/lib/src/media/video/video_player_shortcuts.dart
@@ -9,7 +9,8 @@ import 'package:flutter/services.dart'
         PhysicalKeyboardKey;
 import 'package:flutter/widgets.dart';
 
-import 'package:fushi/src/shortcuts/input_binding.dart' show ModifierKey;
+import 'package:fushi/src/shortcuts/input_binding.dart'
+    show GamepadButton, ModifierKey;
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 
@@ -598,4 +599,22 @@ bool keyDownMatchesHoldSpeed(
         physicalKey: event.physicalKey,
       ) ==
       ShortcutAction.videoHoldSpeed;
+}
+
+/// 手柄重设计 P3：浮层面板（字幕列表 / 剧集轨 / 侧栏）打开时**让位给通用焦点导航**
+/// 的按钮集合——D-pad 移焦、A 激活聚焦行（视频页把这些按钮直接交回 GamepadService
+/// 兜底，而不是解析成音量 / seek / 播放暂停）。其余按钮照常解析 video scope
+/// （LB/RB seek、Y 下一句等在面板开着时仍可用），B 经 universal globalBack 走既有
+/// 逐级退出阶梯关面板。
+bool isVideoPanelFocusNavButton(GamepadButton button) {
+  switch (button) {
+    case GamepadButton.dpadUp:
+    case GamepadButton.dpadDown:
+    case GamepadButton.dpadLeft:
+    case GamepadButton.dpadRight:
+    case GamepadButton.a:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/fushi/lib/src/pages/implementations/video_fushi/episode.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/episode.part.dart
@@ -294,17 +294,24 @@ extension _VideoEpisode on _VideoFushiPageState {
           child: _withSidePanelOpaqueCursor(
             SafeArea(
               top: false,
-              child: VideoEpisodePanel(
-                key: const ValueKey<String>('video-episode-panel'),
-                episodes: _episodePanelEntries(),
-                currentIndex: _currentEpisode,
-                onTapEpisode: _handleEpisodeListTap,
-                onClose: _closeEpisodeList,
-                colorScheme: cs,
-                title: t.video_episode_list,
-                emptyHint: t.video_episode_list_empty,
-                fontSize: 14 * _videoUiScale,
-                height: panelHeight,
+              // 手柄重设计 P3：轨道打开即把焦点领进面板（关闭还给页面焦点），
+              // D-pad 才能选集——本面板常驻挂载靠 FadingChromeGate 显隐，认领
+              // 必须跟 visible 边沿走而非挂载。
+              child: PanelFocusScope(
+                visible: visible,
+                restoreFocus: _videoFocusNode,
+                child: VideoEpisodePanel(
+                  key: const ValueKey<String>('video-episode-panel'),
+                  episodes: _episodePanelEntries(),
+                  currentIndex: _currentEpisode,
+                  onTapEpisode: _handleEpisodeListTap,
+                  onClose: _closeEpisodeList,
+                  colorScheme: cs,
+                  title: t.video_episode_list,
+                  emptyHint: t.video_episode_list_empty,
+                  fontSize: 14 * _videoUiScale,
+                  height: panelHeight,
+                ),
               ),
             ),
           ),

--- a/fushi/lib/src/pages/implementations/video_fushi/side_panel.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/side_panel.part.dart
@@ -135,9 +135,15 @@ extension _VideoSidePanel on _VideoFushiPageState {
           __,
         ) {
           if (panelState == null) return const SizedBox.shrink();
-          final Widget panelContent = _buildVideoSidePanelContent(
-            panelState,
-            controller,
+          // 手柄重设计 P3：侧栏随打开挂载，挂载即领焦点进面板、卸载还给页面
+          // 焦点——D-pad 才能在速度/设置/章节/画质行间移动。
+          final Widget panelContent = PanelFocusScope(
+            visible: true,
+            restoreFocus: _videoFocusNode,
+            child: _buildVideoSidePanelContent(
+              panelState,
+              controller,
+            ),
           );
           // BUG-254：面板打开时在面板「后面 / 左侧空白」铺一层全屏不可见 barrier，
           // 点面板之外任意位置 → [_hideVideoSidePanel] 关闭面板。barrier 用

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -1435,61 +1435,69 @@ extension _VideoSubtitle on _VideoFushiPageState {
                     // 在字幕列表上可见。`opaque:false` 不阻断指针下探（cue 行点击 / 查词 /
                     // 滚动照常）；仅桌面有 OS 光标语义才挂（移动端透传，零开销）。
                     child: _withSubtitleListCursorReveal(
-                      SafeArea(
-                        left: false,
-                        // BUG-877：面板叠一层左边缘拖拽把手（[_subtitleListResizeHandle]）
-                        // 改宽度并持久化；Stack 让把手浮在面板左边缘、不占面板内容宽度。
-                        child: Stack(
-                          children: <Widget>[
-                            VideoSubtitleJumpPanel(
-                              key: const ValueKey<String>(
-                                  'video-subtitle-jump-panel'),
-                              controller: controller,
-                              onTapCue: _handleSubtitleJumpTap,
-                              onLookupCue: _handleSubtitleListLookup,
-                              // BUG-874：把命中句柄绑给面板，查词浮层 dismiss barrier 据此把
-                              // 「点列表下一个词」切换查词而非吞成关闭浮层。
-                              hitTester: _subtitleListHitTester,
-                              onCopyCue: _copyCueText,
-                              onFavoriteCue: _toggleFavoriteCueForVideo,
-                              isCueFavorited: _isCueFavorited,
-                              // TODO-613：自动滚动开关初值从 Drift preferences 读，切换时落盘。
-                              initialAutoScroll:
-                                  appModel.videoSubtitleListAutoScroll,
-                              onAutoScrollChanged: (bool value) => unawaited(
-                                appModel.setVideoSubtitleListAutoScroll(value),
-                              ),
-                              // BUG-878：行字号档位初值从 Drift preferences 读，A+/A- 或
-                              // Ctrl+滚轮调节时落盘，跨开关 / 跨重启记住。
-                              initialFontScaleIndex:
-                                  appModel.videoSubtitleListFontScaleIndex,
-                              onFontScaleIndexChanged: (int value) => unawaited(
-                                appModel
-                                    .setVideoSubtitleListFontScaleIndex(value),
-                              ),
-                              // BUG-879：列表行文本 Shift-悬停查词门控，与画面字幕同源。
-                              hoverAutoLookupEnabled:
-                                  ReaderFushiSource.instance.hoverAutoLookup,
-                              onClose: _closeSubtitleJumpList,
-                              colorScheme: cs,
-                              title: t.video_subtitle_list,
-                              emptyHint: t.video_subtitle_list_empty,
-                              loadingHint: t.video_subtitle_list_loading,
-                              fontSize: 14 * _videoUiScale,
-                              width: panelWidth,
-                            ),
-                            Positioned(
-                              left: 0,
-                              top: 0,
-                              bottom: 0,
-                              child: _subtitleListResizeHandle(
-                                currentWidth: panelWidth,
-                                minWidth: minPanelWidth,
-                                maxWidth: maxPanelWidth,
+                      // 手柄重设计 P3：列表随打开挂载，挂载即领焦点进面板、卸载
+                      // 还给页面焦点——D-pad 才能在 cue 行间移动。
+                      PanelFocusScope(
+                        visible: true,
+                        restoreFocus: _videoFocusNode,
+                        child: SafeArea(
+                          left: false,
+                          // BUG-877：面板叠一层左边缘拖拽把手（[_subtitleListResizeHandle]）
+                          // 改宽度并持久化；Stack 让把手浮在面板左边缘、不占面板内容宽度。
+                          child: Stack(
+                            children: <Widget>[
+                              VideoSubtitleJumpPanel(
+                                key: const ValueKey<String>(
+                                    'video-subtitle-jump-panel'),
+                                controller: controller,
+                                onTapCue: _handleSubtitleJumpTap,
+                                onLookupCue: _handleSubtitleListLookup,
+                                // BUG-874：把命中句柄绑给面板，查词浮层 dismiss barrier 据此把
+                                // 「点列表下一个词」切换查词而非吞成关闭浮层。
+                                hitTester: _subtitleListHitTester,
+                                onCopyCue: _copyCueText,
+                                onFavoriteCue: _toggleFavoriteCueForVideo,
+                                isCueFavorited: _isCueFavorited,
+                                // TODO-613：自动滚动开关初值从 Drift preferences 读，切换时落盘。
+                                initialAutoScroll:
+                                    appModel.videoSubtitleListAutoScroll,
+                                onAutoScrollChanged: (bool value) => unawaited(
+                                  appModel
+                                      .setVideoSubtitleListAutoScroll(value),
+                                ),
+                                // BUG-878：行字号档位初值从 Drift preferences 读，A+/A- 或
+                                // Ctrl+滚轮调节时落盘，跨开关 / 跨重启记住。
+                                initialFontScaleIndex:
+                                    appModel.videoSubtitleListFontScaleIndex,
+                                onFontScaleIndexChanged: (int value) =>
+                                    unawaited(
+                                  appModel.setVideoSubtitleListFontScaleIndex(
+                                      value),
+                                ),
+                                // BUG-879：列表行文本 Shift-悬停查词门控，与画面字幕同源。
+                                hoverAutoLookupEnabled:
+                                    ReaderFushiSource.instance.hoverAutoLookup,
+                                onClose: _closeSubtitleJumpList,
                                 colorScheme: cs,
+                                title: t.video_subtitle_list,
+                                emptyHint: t.video_subtitle_list_empty,
+                                loadingHint: t.video_subtitle_list_loading,
+                                fontSize: 14 * _videoUiScale,
+                                width: panelWidth,
                               ),
-                            ),
-                          ],
+                              Positioned(
+                                left: 0,
+                                top: 0,
+                                bottom: 0,
+                                child: _subtitleListResizeHandle(
+                                  currentWidth: panelWidth,
+                                  minWidth: minPanelWidth,
+                                  maxWidth: maxPanelWidth,
+                                  colorScheme: cs,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -83,6 +83,7 @@ import 'package:fushi/src/media/video/video_player_controller.dart';
 import 'package:fushi/src/media/video/video_screenshot_filename.dart';
 import 'package:fushi/src/startup/exit_flush_registry.dart';
 import 'package:fushi/src/focus/page_focus_ownership.dart';
+import 'package:fushi/src/focus/panel_focus_scope.dart';
 import 'package:fushi/src/media/video/video_player_shortcuts.dart';
 // TODO-1342：视频播放器手柄映射。GamepadButtonIntent（桌面轮询派发）+ GamepadButton
 // （原生按键归一）+ ShortcutAction/ShortcutScope（video 作用域绑定解析）。
@@ -3796,6 +3797,14 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _episodeListVisible.value ||
       _videoControlEditMode.value;
 
+  /// 手柄重设计 P3：可用 D-pad 逐行浏览的三类面板任一打开（字幕列表 / 剧集轨 /
+  /// 侧栏）。与 [_hasVideoOverlay] 刻意不同集：控件 popover 与控制条编辑模式不是
+  /// 「行浏览」表面，D-pad 在那里仍按 video scope 解析。
+  bool get _videoNavigablePanelOpen =>
+      _subtitleListVisible.value ||
+      _episodeListVisible.value ||
+      _videoSidePanel.value != null;
+
   // BUG-371：字幕跳转列表是 **push-aside** 侧栏（[_videoWithSubtitlePanel] 的
   // `Row[Expanded(video), 面板列]`，TODO-314），把画面挤窄到左侧、**不遮挡**叠在画面上
   // 的左 / 右浮动操作 rail。故强压制门控**不含**字幕列表显隐——开字幕列表时左 / 右控制
@@ -4730,6 +4739,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // （阅读器 caret.part 同款 contextual 路由）；未激活返回 false 走正常解析
     // （进入光标本身是注册表动作 videoEnterCaret，经下方 callback 执行）。
     if (_handleCaretGamepadButton(button)) return true;
+    // 手柄重设计 P3：浮层面板打开时，D-pad/A 让位给通用焦点导航（面板内选行）——
+    // 返回 false 交给 GamepadService 的 dpad=移焦 / A=激活兜底，而不是解析成
+    // 音量 / seek / 播放暂停。焦点由 PanelFocusScope 在面板打开时领进面板；其余
+    // 按钮照常解析（LB/RB seek 仍可用），B 经下方 universal 兜底走逐级退出关面板。
+    if (_videoNavigablePanelOpen && isVideoPanelFocusNavButton(button)) {
+      return false;
+    }
     final ShortcutAction? action = appModel.shortcutRegistry.resolveGamepad(
           button,
           scope: ShortcutScope.video,

--- a/fushi/test/focus/panel_focus_scope_test.dart
+++ b/fushi/test/focus/panel_focus_scope_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/panel_focus_scope.dart';
+
+/// 手柄重设计 P3：浮层面板焦点圈地的行为测试。
+void main() {
+  Widget host({
+    required bool visible,
+    required FocusNode hostNode,
+    bool autofocusSecond = false,
+    Key? firstKey,
+    Key? secondKey,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: <Widget>[
+            Focus(focusNode: hostNode, child: const SizedBox(height: 10)),
+            PanelFocusScope(
+              visible: visible,
+              restoreFocus: hostNode,
+              child: Column(
+                children: <Widget>[
+                  TextButton(
+                    key: firstKey ?? const Key('panel-row-1'),
+                    onPressed: () {},
+                    child: const Text('row1'),
+                  ),
+                  TextButton(
+                    key: secondKey ?? const Key('panel-row-2'),
+                    autofocus: autofocusSecond,
+                    onPressed: () {},
+                    child: const Text('row2'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool nodeHasFocus(WidgetTester tester, Key key) =>
+      Focus.of(tester.element(find.byKey(key))).hasFocus;
+
+  testWidgets('visible 边沿（常驻挂载形态）：打开领第一个可遍历节点，关闭还宿主',
+      (WidgetTester tester) async {
+    final FocusNode hostNode = FocusNode(debugLabel: 'host');
+    addTearDown(hostNode.dispose);
+    await tester.pumpWidget(host(visible: false, hostNode: hostNode));
+    hostNode.requestFocus();
+    await tester.pump();
+    expect(hostNode.hasFocus, isTrue);
+
+    // 打开：后帧认领 → 面板第一行获焦，宿主失焦。
+    await tester.pumpWidget(host(visible: true, hostNode: hostNode));
+    await tester.pump();
+    expect(nodeHasFocus(tester, const Key('panel-row-1')), isTrue);
+    expect(hostNode.hasFocus, isFalse);
+
+    // 关闭：焦点还给宿主。
+    await tester.pumpWidget(host(visible: false, hostNode: hostNode));
+    await tester.pump();
+    expect(hostNode.hasFocus, isTrue);
+  });
+
+  testWidgets('子节点 autofocus 优先：认领发现焦点已在面板内就不抢', (WidgetTester tester) async {
+    final FocusNode hostNode = FocusNode(debugLabel: 'host');
+    addTearDown(hostNode.dispose);
+    await tester.pumpWidget(
+        host(visible: false, hostNode: hostNode, autofocusSecond: true));
+    hostNode.requestFocus();
+    await tester.pump();
+
+    await tester.pumpWidget(
+        host(visible: true, hostNode: hostNode, autofocusSecond: true));
+    await tester.pump();
+    // autofocus 的第二行拿到焦点，认领不把它抢到第一行。
+    expect(nodeHasFocus(tester, const Key('panel-row-2')), isTrue);
+  });
+
+  testWidgets('挂载即可见形态（visible 恒 true）：挂载领焦点、卸载还宿主',
+      (WidgetTester tester) async {
+    final FocusNode hostNode = FocusNode(debugLabel: 'host');
+    addTearDown(hostNode.dispose);
+
+    Widget build({required bool mounted}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              Focus(focusNode: hostNode, child: const SizedBox(height: 10)),
+              if (mounted)
+                PanelFocusScope(
+                  visible: true,
+                  restoreFocus: hostNode,
+                  child: TextButton(
+                    key: const Key('panel-row-1'),
+                    onPressed: () {},
+                    child: const Text('row1'),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(mounted: false));
+    hostNode.requestFocus();
+    await tester.pump();
+    expect(hostNode.hasFocus, isTrue);
+
+    await tester.pumpWidget(build(mounted: true));
+    await tester.pump();
+    expect(nodeHasFocus(tester, const Key('panel-row-1')), isTrue);
+
+    await tester.pumpWidget(build(mounted: false));
+    await tester.pump();
+    expect(hostNode.hasFocus, isTrue);
+  });
+}

--- a/fushi/test/shortcuts/video_panel_focus_nav_test.dart
+++ b/fushi/test/shortcuts/video_panel_focus_nav_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 手柄重设计 P3：视频浮层面板的焦点导航让位（分类器 + 接线源码守卫）。
+void main() {
+  group('isVideoPanelFocusNavButton', () {
+    test('dpad 四向 + A 让位给焦点导航', () {
+      for (final GamepadButton button in <GamepadButton>[
+        GamepadButton.dpadUp,
+        GamepadButton.dpadDown,
+        GamepadButton.dpadLeft,
+        GamepadButton.dpadRight,
+        GamepadButton.a,
+      ]) {
+        expect(isVideoPanelFocusNavButton(button), isTrue,
+            reason: '${button.label} 应在面板打开时让位');
+      }
+    });
+
+    test('播放控制按钮不让位（LB/RB seek、B 退出阶梯、X/Y 字幕句在面板开着时仍可用）', () {
+      for (final GamepadButton button in <GamepadButton>[
+        GamepadButton.lb,
+        GamepadButton.rb,
+        GamepadButton.lt,
+        GamepadButton.rt,
+        GamepadButton.b,
+        GamepadButton.x,
+        GamepadButton.y,
+        GamepadButton.start,
+        GamepadButton.select,
+        GamepadButton.thumbLeft,
+        GamepadButton.thumbRight,
+      ]) {
+        expect(isVideoPanelFocusNavButton(button), isFalse,
+            reason: '${button.label} 不该被面板抢走');
+      }
+    });
+  });
+
+  group('接线源码守卫（分类器单测抓不到「闸门被删」）', () {
+    test('视频手柄处理器在注册表解析之前放行面板焦点导航按钮', () {
+      final String code = maskComments(
+          File('lib/src/pages/implementations/video_fushi_page.dart')
+              .readAsStringSync());
+      expect(
+        code.contains(
+            'if (_videoNavigablePanelOpen && isVideoPanelFocusNavButton(button)) {'),
+        isTrue,
+        reason: '闸门缺席：面板打开时 D-pad 仍会被解析成音量/seek，手柄进不了面板',
+      );
+    });
+
+    test('三类面板都包了 PanelFocusScope（焦点领进面板的唯一入口）', () {
+      const Map<String, String> panels = <String, String>{
+        'lib/src/pages/implementations/video_fushi/episode.part.dart': '剧集轨',
+        'lib/src/pages/implementations/video_fushi/subtitle.part.dart': '字幕列表',
+        'lib/src/pages/implementations/video_fushi/side_panel.part.dart': '侧栏',
+      };
+      panels.forEach((String path, String label) {
+        final String code = maskComments(File(path).readAsStringSync());
+        expect(code.contains('PanelFocusScope('), isTrue,
+            reason: '$label（$path）没包 PanelFocusScope：打开后焦点留在页面节点，'
+                'D-pad 让位了也没有可移动的焦点');
+      });
+    });
+  });
+}


### PR DESCRIPTION
手柄全功能重设计 P3/5，堆叠在 #925（P2）之上。

## 问题
视频页手柄映射本身已全（38 动作），但剧集轨/字幕列表/侧栏面板**没有焦点体系**：面板打开后焦点仍在页面级 `_videoFocusNode`，且 D-pad 被音量/seek 占满——手柄用户进不了任何面板。

## 改动
- **新增 `PanelFocusScope`**（`lib/src/focus/panel_focus_scope.dart`）：FocusScope+FocusTraversalGroup；面板打开（visible 边沿或挂载）后帧把焦点领进第一个可遍历节点，关闭/卸载还给宿主焦点；子节点 autofocus 更精准时不抢。覆盖两种宿主形态（FadingChromeGate 常驻挂载 / 随开挂载）。
- **三处面板包上**：剧集轨（episode.part）、字幕跳转列表（subtitle.part）、侧栏（side_panel.part，速度/设置/章节/画质共用）。面板内行本就是 InkWell/ListTile 可聚焦件，缺的只是「焦点进得去」。
- **上下文 D-pad 路由**：`_videoNavigablePanelOpen`（与 `_hasVideoOverlay` 刻意不同集——popover/控件编辑不是行浏览面板）时，D-pad/A 让位给 GamepadService 通用兜底（移焦+激活）；LB/RB seek 等其余按钮照常；B 经 universal globalBack 既有逐级退出阶梯关面板。分类器 `isVideoPanelFocusNavButton` 独立可测。

## 守卫与测试
- `panel_focus_scope_test`：三形态真实焦点行为（widget 测试）
- `video_panel_focus_nav_test`：分类器全按钮枚举 + 闸门/三面板接线源码守卫
- 变异实测 2 条：删闸门 / 摘除面板包裹 → 守卫红

## 验证
- `flutter analyze` 0 issue；`test/shortcuts + test/focus` 625 项全绿
- 缺口：未做 Windows 真机手柄复测（按既定流程跳过）