### PR TITLE
feat(games): 游戏库卡片手柄补齐（手柄重设计 P4）

### DIFF
--- a/fushi/lib/src/pages/implementations/games_library_page.dart
+++ b/fushi/lib/src/pages/implementations/games_library_page.dart
@@ -7,6 +7,9 @@ import 'package:fushi_core/fushi_core.dart';
 
 import 'package:fushi/models.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart'
+    show GamepadButtonIntent;
+import 'package:fushi/src/shortcuts/input_binding.dart' show GamepadButton;
 import 'package:fushi/src/media/collections/add_to_collection_dialog.dart';
 import 'package:fushi/src/media/collections/collection_context_dialog.dart';
 import 'package:fushi/src/media/collections/collection_grouping.dart';
@@ -1641,16 +1644,29 @@ class _GameCard extends StatelessWidget {
     // 竖版海报卡（对齐 ReinaManager 库页观感）：封面 3:4 + 标题居中 + 底部排序
     // 浮层 + hover 放大 + 主色选中环，全部由共享组件 [GalgamePosterCard] 负责。
     // focusId 沿用 `game-card-<id>`（手柄/键盘可 requestById 聚焦，focus 测试守）。
-    return GalgamePosterCard(
-      cover: GameCoverThumb(game: game),
-      title: game.displayName,
-      overlayText: sort,
-      focusId: FushiFocusId('game-card-${game.id}'),
-      onTap: onTap,
-      onLongPress: () => unawaited(_showContextMenu(context)),
-      onSecondaryTap: () => unawaited(_showContextMenu(context)),
-      trailing: _menuButton(context, colors, tokens),
-      semanticLabel: game.displayName,
+    //
+    // 手柄重设计 P4：卡片聚焦时 Y = 打开详情（A=启动、长按 A=上下文菜单在
+    // GalgamePosterCard 内）。用 isEnabled 门控而非 CallbackAction 返回 false——
+    // Actions 停在第一个 **enabled** 的 action，返回 false 仍会终止向上查找，
+    // 把 home scope 的 LT/RT 换 tab 等外层解析静默吞掉（settings_shared /
+    // adaptive_navigation 同款既定模式）。
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        GamepadButtonIntent: _GameCardDetailGamepadAction(
+          onDetail: onDetail,
+        ),
+      },
+      child: GalgamePosterCard(
+        cover: GameCoverThumb(game: game),
+        title: game.displayName,
+        overlayText: sort,
+        focusId: FushiFocusId('game-card-${game.id}'),
+        onTap: onTap,
+        onLongPress: () => unawaited(_showContextMenu(context)),
+        onSecondaryTap: () => unawaited(_showContextMenu(context)),
+        trailing: _menuButton(context, colors, tokens),
+        semanticLabel: game.displayName,
+      ),
     );
   }
 
@@ -1713,5 +1729,25 @@ class GameCoverThumb extends StatelessWidget {
       return ShelfFileCover(path: cover, placeholder: placeholder);
     }
     return placeholder;
+  }
+}
+
+/// 手柄重设计 P4：游戏卡聚焦时 Y = 打开详情。用 [isEnabled] 只认 Y——其余按钮
+/// 保持 disabled，Actions 查找继续向上冒泡（home scope 的 LT/RT 换 tab 等外层
+/// 解析不被遮蔽；这是 settings_shared / adaptive_navigation 的既定放行模式，
+/// CallbackAction 返回 false 做不到——它恒 enabled，查找到它就停）。
+class _GameCardDetailGamepadAction extends Action<GamepadButtonIntent> {
+  _GameCardDetailGamepadAction({required this.onDetail});
+
+  final VoidCallback onDetail;
+
+  @override
+  bool isEnabled(GamepadButtonIntent intent) =>
+      intent.button == GamepadButton.y;
+
+  @override
+  Object? invoke(GamepadButtonIntent intent) {
+    onDetail();
+    return true;
   }
 }

--- a/fushi/lib/src/utils/components/galgame_poster_card.dart
+++ b/fushi/lib/src/utils/components/galgame_poster_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart'
+    show GamepadLongPressActions;
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_hover_lift.dart';
 import 'package:fushi/src/utils/components/shelf_card_widgets.dart';
@@ -141,18 +143,23 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
         FushiFocusRoot.maybeControllerOf(context) == null) {
       return semantic;
     }
-    return Actions(
-      actions: <Type, Action<Intent>>{
-        ActivateIntent: CallbackAction<ActivateIntent>(
-          onInvoke: (_) {
-            widget.onTap?.call();
-            return null;
-          },
+    // 手柄重设计 P4：长按 A = 鼠标长按/右键同一入口（onLongPress，游戏卡上是
+    // 上下文菜单）。[GamepadLongPressActions] 对 null onLongPress 透明。
+    return GamepadLongPressActions(
+      onLongPress: widget.onLongPress,
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (_) {
+              widget.onTap?.call();
+              return null;
+            },
+          ),
+        },
+        child: FushiFocusTarget(
+          id: widget.focusId ?? _fallbackFocusId,
+          child: semantic,
         ),
-      },
-      child: FushiFocusTarget(
-        id: widget.focusId ?? _fallbackFocusId,
-        child: semantic,
       ),
     );
   }

--- a/fushi/test/pages/games_library_gamepad_guard_test.dart
+++ b/fushi/test/pages/games_library_gamepad_guard_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 手柄重设计 P4：游戏库卡片手柄接线的源码守卫（页面依赖太重，widget 测试不现实；
+/// GalgamePosterCard 侧的长按 A 行为由 galgame_poster_card_test 真实驱动）。
+void main() {
+  const String path = 'lib/src/pages/implementations/games_library_page.dart';
+
+  test('游戏卡包了 Y=详情 的 GamepadButtonIntent Action', () {
+    final String code = maskComments(File(path).readAsStringSync());
+    expect(code.contains('_GameCardDetailGamepadAction('), isTrue,
+        reason: '卡片没挂 Y=详情 action：手柄用户只能启动、进不了详情页');
+    // isEnabled 只认 Y 的门控必须在：CallbackAction 返回 false 会把 home scope
+    // 的 LT/RT 换 tab 等外层解析静默吞掉（Actions 停在第一个 enabled 的 action）。
+    final int classIdx = code.indexOf('class _GameCardDetailGamepadAction');
+    expect(classIdx, greaterThanOrEqualTo(0));
+    final String slice = code.substring(classIdx);
+    expect(slice.contains('bool isEnabled(GamepadButtonIntent intent)'), isTrue,
+        reason: '必须用 isEnabled 门控放行非 Y 按钮');
+    expect(slice.contains('intent.button == GamepadButton.y'), isTrue,
+        reason: 'Y 是详情键的唯一判据');
+  });
+}

--- a/fushi/test/widgets/galgame_poster_card_test.dart
+++ b/fushi/test/widgets/galgame_poster_card_test.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart'
+    show GamepadLongPressIntent;
+import 'package:fushi/src/shortcuts/input_binding.dart' show GamepadButton;
 import 'package:fushi/src/utils/components/galgame_poster_card.dart';
 
 Widget _host(Widget child) => MaterialApp(
@@ -24,8 +28,7 @@ void main() {
     expect(ar.aspectRatio, 3 / 4);
   });
 
-  testWidgets('overlayText 有值时显示排序浮层，空时不显示',
-      (WidgetTester tester) async {
+  testWidgets('overlayText 有值时显示排序浮层，空时不显示', (WidgetTester tester) async {
     await tester.pumpWidget(_host(
       const GalgamePosterCard(
         cover: ColoredBox(color: Colors.blue),
@@ -99,5 +102,62 @@ void main() {
       ),
     ));
     expect(find.byIcon(Icons.more_vert), findsOneWidget);
+  });
+
+  // 手柄重设计 P4：焦点根下长按 A（GamepadLongPressIntent）= onLongPress
+  // （游戏卡上是上下文菜单），与鼠标长按/右键同一入口。
+  testWidgets('手柄长按 A 触发 onLongPress（焦点根下）', (WidgetTester tester) async {
+    int longPresses = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: FushiFocusRoot(
+          child: Center(
+            child: SizedBox(
+              width: 160,
+              child: GalgamePosterCard(
+                cover: const ColoredBox(color: Colors.blue),
+                title: 'G',
+                onTap: () {},
+                onLongPress: () => longPresses++,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+    final BuildContext cardContext =
+        tester.element(find.text('G'));
+    final Object? handled = Actions.maybeInvoke<GamepadLongPressIntent>(
+      cardContext,
+      const GamepadLongPressIntent(GamepadButton.a),
+    );
+    expect(handled, isTrue);
+    expect(longPresses, 1);
+  });
+
+  testWidgets('无 onLongPress 时长按包装透明（不拦截 intent）', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: FushiFocusRoot(
+          child: Center(
+            child: SizedBox(
+              width: 160,
+              child: GalgamePosterCard(
+                cover: const ColoredBox(color: Colors.blue),
+                title: 'G',
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+    final BuildContext cardContext =
+        tester.element(find.text('G'));
+    final Object? handled = Actions.maybeInvoke<GamepadLongPressIntent>(
+      cardContext,
+      const GamepadLongPressIntent(GamepadButton.a),
+    );
+    expect(handled, isNull, reason: '透明包装：intent 应继续向上查找');
   });
 }


### PR DESCRIPTION
手柄全功能重设计 P4/5，堆叠在 #926（P3）之上。

## 现状与改动
游戏库/首页的焦点站点早已布好（`FushiFocusId game-card-<id>`），D-pad 移焦 + A 激活（=启动）本就走通用兜底。本 PR 补齐缺口：

- **手柄长按 A = 上下文菜单**：`GalgamePosterCard` 包 `GamepadLongPressActions`（与鼠标长按/右键同一入口 onLongPress），改状态/刮削/封面/标签等全部菜单操作由此可达；null 时透明。共用组件（库页/合集详情/游戏首页）全体受益。
- **Y = 打开详情**：游戏卡挂 `_GameCardDetailGamepadAction`，用 `isEnabled` 只认 Y——其余按钮保持 disabled 让 Actions 查找继续向上，home scope 的 LT/RT 换 tab 等外层解析不被遮蔽（settings_shared/adaptive_navigation 既定放行模式；CallbackAction 返回 false 会静默吞掉外层）。

## 测试
- `galgame_poster_card_test` 补两条真实 GamepadLongPressIntent 派发行为测试
- `games_library_gamepad_guard_test` 源码守卫（Y action 接线 + isEnabled 门控判据）
- 变异实测 2 条：长按接线摘除 / Y 判据改 X → 对应测试红
- `flutter analyze` 0 issue

## 缺口
未做 Windows 真机手柄复测（按既定流程跳过）。