### PR TITLE
feat(gal): 游戏内查词卡片接手柄——独占路由（手柄重设计 P5）

### DIFF
--- a/fushi/assets/popup/global_lookup_host.js
+++ b/fushi/assets/popup/global_lookup_host.js
@@ -2496,6 +2496,55 @@
     return frameSources.has(iframe) ? frameSources.get(iframe) : null;
   }
 
+  // 手柄重设计 P5 — Dart 侧手柄独占路由（GamepadService → native gamepadAction
+  // → 本 host）：把动作转发进**顶层**卡片帧的 popup.js 既有入口，与滚轮/键盘
+  // 同一批执行体（fushiFocusDictionaryEntryMove / fushiPopupMineFirstEntry /
+  // fushiPopupPlayFirstAudio / fushiPopupScrollBy），不另起桥。帧不可用 /
+  // 入口缺席一律返回 false（no-op），绝不抛——本函数由 fire-and-forget 的
+  // ExecuteScript 调用，异常只会淹死在 WebView 控制台里。
+  function gamepadAction(action, dy) {
+    var record = null;
+    var id = topPopupId();
+    if (id !== null) {
+      record = frames.get(id);
+    }
+    var win = frameWindowOf(record);
+    if (!win) {
+      return false;
+    }
+    try {
+      if (action === 'next' || action === 'prev') {
+        return typeof win.fushiFocusDictionaryEntryMove === 'function' &&
+            win.fushiFocusDictionaryEntryMove(action) === 'moved';
+      }
+      if (action === 'mine') {
+        if (typeof win.fushiPopupMineFirstEntry !== 'function') return false;
+        win.fushiPopupMineFirstEntry();
+        return true;
+      }
+      if (action === 'audio') {
+        if (typeof win.fushiPopupPlayFirstAudio !== 'function') return false;
+        win.fushiPopupPlayFirstAudio();
+        return true;
+      }
+      if (action === 'scroll') {
+        if (typeof win.fushiPopupScrollBy === 'function') {
+          win.fushiPopupScrollBy(dy || 0);
+          return true;
+        }
+        var el = win.document &&
+            (win.document.scrollingElement || win.document.documentElement);
+        if (el && typeof el.scrollBy === 'function') {
+          el.scrollBy(0, dy || 0);
+          return true;
+        }
+      }
+    } catch (e) {
+      return false;
+    }
+    return false;
+  }
+
   // 剪贴板面板：把 ROOT 帧的滚动位置复位到顶部。面板的 root iframe 是**复用**的
   // （renderStack 只换 #entries-container innerHTML，iframe / 其滚动容器不重建），
   // 故上一句被滚动过的 scrollTop 会跨渲染保留——一条更长的新剪贴板内容渲染进来时
@@ -2767,6 +2816,7 @@
     handleGlobalWheel: handleGlobalWheel,
     armGalFrameDirty: requestGalFrameDirty,
     requestGalFrameDirty: requestGalFrameDirty,
+    gamepadAction: gamepadAction,
     measureAndReport: measureAndReport,
     commitLayerShift: commitLayerShift,
     commitLayerShiftAndArmCapture: commitLayerShiftAndArmCapture,

--- a/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
+++ b/fushi/lib/src/lookup/gal_ingame_lookup_controller.dart
@@ -36,6 +36,7 @@ import 'package:fushi/src/mining/galgame_window_gif.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/platform/gal_hook_text_overlay_channel.dart';
+import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
 
 /// 偏好读取口。与 `GalHookPreferenceReader` 同形——独立声明只为不让台词浮窗控制器与
 /// 本控制器互相 import 成环，语义完全一致（key + 默认值，测试可注入替身）。
@@ -192,10 +193,34 @@ class GalIngameLookupController {
       unawaited(_onOverlayHidden(route));
     };
     overlay.onRoutedDirty = markRoutedDirty;
+    // 手柄重设计 P5：会话期把游戏内卡片登记为手柄的**独占**路由。卡片可见
+    // （_activeRoute 非空）时 GamepadService 把弹窗动作转发进卡片、吞掉其余
+    // 按钮——绝不让游戏里的手柄输入驱动后台 app 的页面/焦点/返回。
+    GalIngameLookupGamepadRoute.set(DictionaryPopupGamepadHooks(
+      hasVisiblePopup: () => _started && _enabledNow && _activeRoute != null,
+      entryMove: (bool forward) =>
+          _dispatchGamepadAction(forward ? 'next' : 'prev'),
+      mineFirstEntry: () => _dispatchGamepadAction('mine'),
+      playFirstAudio: () => _dispatchGamepadAction('audio'),
+      scrollBy: (double dy) => _dispatchGamepadAction('scroll', dy: dy),
+    ));
+  }
+
+  /// 手柄动作 → 卡片窗 host（native gamepadAction → 顶层帧 popup.js 入口）。
+  /// 必须在**当前卡片 route 的 zone**里下发，channel 才会把调用送到 galCard
+  /// 窗口而不是桌面查词窗；route 已失效时静默丢弃（瞬时输入，不排队）。
+  Future<void> _dispatchGamepadAction(String action, {double dy = 0}) async {
+    final GlobalLookupRoute? route = _activeRoute;
+    if (route == null || !GlobalLookupChannel.isRouteValid(route)) return;
+    await GlobalLookupChannel.runWithRoute(
+      route,
+      () => GlobalLookupChannel.gamepadAction(action, dy: dy),
+    );
   }
 
   @visibleForTesting
   Future<void> stopForTesting() async {
+    GalIngameLookupGamepadRoute.set(null);
     _sessionActive = false;
     await _terminateCurrentLookup();
     final Future<void>? lookupDrain = _drainCompleter?.future;

--- a/fushi/lib/src/lookup/global_lookup_channel.dart
+++ b/fushi/lib/src/lookup/global_lookup_channel.dart
@@ -98,6 +98,11 @@ abstract final class GlobalLookupChannel {
 
   static Future<void> render(String popupJson) => _impl.render(popupJson);
 
+  /// 手柄重设计 P5：转发一枚手柄动作到当前路由的 overlay host（见
+  /// [OverlayWindowChannel.gamepadAction]）。
+  static Future<void> gamepadAction(String action, {double dy = 0}) =>
+      _impl.gamepadAction(action, dy: dy);
+
   static Future<void> resize({required int width, required int height}) =>
       _impl.resize(width: width, height: height);
 

--- a/fushi/lib/src/lookup/overlay_window_channel.dart
+++ b/fushi/lib/src/lookup/overlay_window_channel.dart
@@ -214,6 +214,16 @@ class OverlayWindowChannel {
         'json': popupJson,
       });
 
+  /// 手柄重设计 P5：把一枚 Dart 侧解析好的手柄动作转发进 host
+  /// （window.__globalLookupHost.gamepadAction → 顶层卡片帧的 popup.js 入口）。
+  /// [action] 只接受 native 白名单里的 'next'/'prev'/'mine'/'audio'/'scroll'；
+  /// [dy] 仅 scroll 用（CSS 像素，正=向下）。
+  Future<void> gamepadAction(String action, {double dy = 0}) =>
+      _invoke<void>('gamepadAction', <String, Object?>{
+        'action': action,
+        'dy': dy,
+      });
+
   /// Resizes the overlay window (physical px), clamped to the work area by
   /// native. Keeps the current top-left anchor.
   Future<void> resize({required int width, required int height}) =>

--- a/fushi/lib/src/shortcuts/dictionary_popup_gamepad.dart
+++ b/fushi/lib/src/shortcuts/dictionary_popup_gamepad.dart
@@ -71,3 +71,31 @@ class DictionaryPopupGamepadRegistry {
   @visibleForTesting
   static int get debugDepth => _stack.length;
 }
+
+/// 手柄重设计 P5：游戏内查词卡片的**独占**手柄路由（仅 Windows galgame 链路）。
+///
+/// 与 [DictionaryPopupGamepadRegistry]（app 内弹窗的兜底路由）语义相反：游戏在
+/// 前台、卡片可见时，手柄绝不能驱动后台 app 的页面 Actions / 焦点移动 / 返回
+/// ——按到 B 把后台 app 退了一页是灾难。所以 GamepadService 在分发**最前端**
+/// 检查本路由：命中弹窗动作（词条导航/制卡/发音）就经钩子转发进卡片 WebView2，
+/// 未命中的按钮也一律吞掉（卡片可见期间手柄专属卡片；游戏自己经原生输入照常
+/// 收到手柄，本路由只管 app 进程这一份轮询）。
+///
+/// 由 gal 游戏内查词 controller 在卡片显示时设置、隐藏/会话结束时清除。
+class GalIngameLookupGamepadRoute {
+  GalIngameLookupGamepadRoute._();
+
+  static DictionaryPopupGamepadHooks? _current;
+
+  /// 当前独占钩子；卡片不可见（或未设置）返回 null，分发照常走 app 路径。
+  static DictionaryPopupGamepadHooks? get current {
+    final DictionaryPopupGamepadHooks? hooks = _current;
+    if (hooks == null || !hooks.hasVisiblePopup()) return null;
+    return hooks;
+  }
+
+  static void set(DictionaryPopupGamepadHooks? hooks) => _current = hooks;
+
+  @visibleForTesting
+  static void debugClear() => _current = null;
+}

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -26,10 +26,21 @@ bool tryDictionaryPopupGamepadButton(
   FushiShortcutRegistry? registry,
   GamepadButton button,
 ) {
-  if (registry == null) return false;
   final DictionaryPopupGamepadHooks? hooks =
       DictionaryPopupGamepadRegistry.current;
   if (hooks == null) return false;
+  return dispatchDictionaryPopupGamepadButton(hooks, registry, button);
+}
+
+/// 按 dictionaryPopup scope 解析 [button] 并在 [hooks] 上执行。
+/// [tryDictionaryPopupGamepadButton]（app 内弹窗兜底）与 P5 的游戏内卡片独占
+/// 路由（[GalIngameLookupGamepadRoute]）共用这一个解析/执行体。
+bool dispatchDictionaryPopupGamepadButton(
+  DictionaryPopupGamepadHooks hooks,
+  FushiShortcutRegistry? registry,
+  GamepadButton button,
+) {
+  if (registry == null) return false;
   final ShortcutAction? action = registry.resolveGamepad(
     button,
     scope: ShortcutScope.dictionaryPopup,
@@ -412,6 +423,16 @@ class GamepadService {
   /// reader's registry page-turn bindings (e.g. D-pad-right → page forward)
   /// fire; when unbound in the active scope they fall back to directional focus.
   void _dispatchButton(GamepadButton button) {
+    // 手柄重设计 P5：游戏内查词卡片可见时**独占**手柄——命中弹窗动作转发进
+    // 卡片 WebView2，未命中也一律吞掉，绝不驱动后台 app 的页面/焦点/返回
+    // （游戏本身经原生输入照常收到手柄；这里只管 app 进程的这份轮询）。
+    // 不碰焦点高亮策略：app 在后台，别为游戏里的按键点亮 app 的焦点环。
+    final DictionaryPopupGamepadHooks? galHooks =
+        GalIngameLookupGamepadRoute.current;
+    if (galHooks != null) {
+      dispatchDictionaryPopupGamepadButton(galHooks, registry, button);
+      return;
+    }
     final BuildContext? ctx = _dispatchContext;
     if (ctx == null) return;
     _setHighlightForHardwareNav();
@@ -503,6 +524,9 @@ class GamepadService {
   /// focus ring like an arrow key; whatever is focused is then activated by a
   /// SEPARATE explicit press (A / the rebindable enter-caret key).
   void _dispatchStickMove(TraversalDirection dir) {
+    // P5：游戏内卡片独占期间左摇杆也吞掉——后台 app 的焦点不能被游戏里的
+    // 摇杆悄悄挪走。
+    if (GalIngameLookupGamepadRoute.current != null) return;
     final BuildContext? ctx = _dispatchContext;
     if (ctx == null) return;
     _setHighlightForHardwareNav();
@@ -516,8 +540,10 @@ class GamepadService {
   /// 页面滚动已有 LB/RB 整页滚（globalScrollPage*）与左摇杆焦点滚动兜底，右摇杆
   /// 现阶段专职弹窗，避免同一根摇杆在不同页面语义漂移。
   void _dispatchRightStickScroll(double dyNorm) {
+    // P5：游戏内卡片可见时右摇杆滚动卡片内容（独占路由优先）。
     final DictionaryPopupGamepadHooks? hooks =
-        DictionaryPopupGamepadRegistry.current;
+        GalIngameLookupGamepadRoute.current ??
+            DictionaryPopupGamepadRegistry.current;
     if (hooks == null) return;
     unawaited(hooks.scrollBy(dyNorm * _kRightStickScrollPxPerTick));
   }
@@ -554,6 +580,8 @@ class GamepadService {
   /// A widget that supports long-press maps the intent to the same callback its
   /// `onLongPress` uses; if nothing handles it, the long-press is a no-op.
   void _dispatchLongPress(GamepadButton button) {
+    // P5：游戏内卡片独占期间长按也吞掉（后台 app 的长按语义不该被游戏触发）。
+    if (GalIngameLookupGamepadRoute.current != null) return;
     final BuildContext? ctx = _dispatchContext;
     if (ctx == null) return;
     _setHighlightForHardwareNav();

--- a/fushi/test/lookup/gal_ingame_gamepad_route_test.dart
+++ b/fushi/test/lookup/gal_ingame_gamepad_route_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 手柄重设计 P5：游戏内查词卡片的独占手柄路由（行为 + 三层接线源码守卫）。
+void main() {
+  tearDown(() {
+    GalIngameLookupGamepadRoute.debugClear();
+    DictionaryPopupGamepadRegistry.debugClear();
+  });
+
+  DictionaryPopupGamepadHooks recordingHooks(
+    List<String> calls, {
+    bool Function()? visible,
+  }) {
+    return DictionaryPopupGamepadHooks(
+      hasVisiblePopup: visible ?? () => true,
+      entryMove: (bool forward) async =>
+          calls.add(forward ? 'entry:next' : 'entry:prev'),
+      mineFirstEntry: () async => calls.add('mine'),
+      playFirstAudio: () async => calls.add('audio'),
+      scrollBy: (double dy) async => calls.add('scroll:$dy'),
+    );
+  }
+
+  group('GalIngameLookupGamepadRoute', () {
+    test('卡片可见性门控：不可见 / 未设置 / 清除后 current 均为 null', () {
+      expect(GalIngameLookupGamepadRoute.current, isNull);
+      bool visible = false;
+      GalIngameLookupGamepadRoute.set(
+          recordingHooks(<String>[], visible: () => visible));
+      expect(GalIngameLookupGamepadRoute.current, isNull);
+      visible = true;
+      expect(GalIngameLookupGamepadRoute.current, isNotNull);
+      GalIngameLookupGamepadRoute.set(null);
+      expect(GalIngameLookupGamepadRoute.current, isNull);
+    });
+
+    test('dispatchDictionaryPopupGamepadButton 对独占钩子按弹窗绑定派发', () {
+      final FushiShortcutRegistry registry = FushiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+      final List<String> calls = <String>[];
+      final DictionaryPopupGamepadHooks hooks = recordingHooks(calls);
+      expect(
+          dispatchDictionaryPopupGamepadButton(
+              hooks, registry, GamepadButton.dpadDown),
+          isTrue);
+      expect(
+          dispatchDictionaryPopupGamepadButton(
+              hooks, registry, GamepadButton.y),
+          isTrue);
+      // 未绑定按钮返回 false——独占吞掉与否由 GamepadService 的前置步骤决定，
+      // 不由本函数决定（app 内兜底路径要靠 false 放行滚动/焦点兜底）。
+      expect(
+          dispatchDictionaryPopupGamepadButton(
+              hooks, registry, GamepadButton.b),
+          isFalse);
+      expect(calls, <String>['entry:next', 'audio']);
+    });
+  });
+
+  group('接线源码守卫', () {
+    test('GamepadService 四条分发通道都过独占路由（按钮吞掉一切/摇杆吞掉/右摇杆优先卡片）', () {
+      final String code = maskComments(
+          File('lib/src/shortcuts/gamepad_service.dart').readAsStringSync());
+      // 按钮：独占命中后 return（吞掉一切，绝不落到页面 Actions / 焦点 / 返回）。
+      expect(
+        code.contains('dispatchDictionaryPopupGamepadButton('
+            'galHooks, registry, button);'),
+        isTrue,
+        reason: '按钮通道缺独占前置：游戏里按手柄会驱动后台 app UI',
+      );
+      // 左摇杆与长按：独占期间直接吞掉。
+      expect(
+        RegExp(r'void _dispatchStickMove\([\s\S]{0,200}'
+                r'GalIngameLookupGamepadRoute\.current != null\) return;')
+            .hasMatch(code),
+        isTrue,
+        reason: '左摇杆通道缺独占吞噬：后台 app 焦点会被游戏里的摇杆挪走',
+      );
+      expect(
+        RegExp(r'void _dispatchLongPress\([\s\S]{0,200}'
+                r'GalIngameLookupGamepadRoute\.current != null\) return;')
+            .hasMatch(code),
+        isTrue,
+        reason: '长按通道缺独占吞噬',
+      );
+      // 右摇杆：独占路由优先于 app 内弹窗登记栈。
+      expect(
+        code.contains('GalIngameLookupGamepadRoute.current ??'),
+        isTrue,
+        reason: '右摇杆通道没有优先卡片：游戏内卡片滚不动',
+      );
+    });
+
+    test('host JS 暴露 gamepadAction 且转发到 popup.js 既有入口', () {
+      final String js =
+          File('assets/popup/global_lookup_host.js').readAsStringSync();
+      expect(js.contains('gamepadAction: gamepadAction,'), isTrue,
+          reason: 'host 未导出 gamepadAction：native ExecuteScript 打不到');
+      for (final String entry in <String>[
+        'fushiFocusDictionaryEntryMove',
+        'fushiPopupMineFirstEntry',
+        'fushiPopupPlayFirstAudio',
+        'fushiPopupScrollBy',
+      ]) {
+        expect(js.contains(entry), isTrue,
+            reason: 'gamepadAction 必须复用既有入口 $entry，不另起桥');
+      }
+    });
+
+    test('native 两侧接线：方法分发 + 动作白名单', () {
+      final String fw =
+          File('windows/runner/flutter_window.cpp').readAsStringSync();
+      expect(fw.contains('method == "gamepadAction"'), isTrue,
+          reason: 'MethodChannel 缺 gamepadAction 分发');
+      final String glw =
+          File('windows/runner/global_lookup_window.cpp').readAsStringSync();
+      expect(glw.contains('kAllowedActions'), isTrue,
+          reason: '动作名必须走白名单再拼 ExecuteScript');
+      expect(glw.contains('window.__globalLookupHost.gamepadAction('), isTrue);
+    });
+
+    test('gal 控制器：会话 start 登记独占路由、stop 清除', () {
+      final String code = maskComments(
+          File('lib/src/lookup/gal_ingame_lookup_controller.dart')
+              .readAsStringSync());
+      expect(code.contains('GalIngameLookupGamepadRoute.set('), isTrue);
+      expect(code.contains('GalIngameLookupGamepadRoute.set(null);'), isTrue,
+          reason: '会话结束不清路由 = 手柄永久被吞');
+      expect(code.contains("_dispatchGamepadAction('mine')"), isTrue);
+    });
+  });
+}

--- a/fushi/test/lookup/gal_ingame_gamepad_route_test.dart
+++ b/fushi/test/lookup/gal_ingame_gamepad_route_test.dart
@@ -123,8 +123,25 @@ void main() {
           reason: 'MethodChannel 缺 gamepadAction 分发');
       final String glw =
           File('windows/runner/global_lookup_window.cpp').readAsStringSync();
-      expect(glw.contains('kAllowedActions'), isTrue,
+      // 只查符号存在不够（改名/删执行都可能漏）：切出 DispatchGamepadAction 函数
+      // 体，白名单数组与「未命中即 return」的执行判据必须都在其中。
+      final int fnIdx =
+          glw.indexOf('void GlobalLookupWindow::DispatchGamepadAction');
+      expect(fnIdx, greaterThanOrEqualTo(0),
+          reason: 'DispatchGamepadAction 实现缺席');
+      // 终点锚用真实调用 `webview_->ExecuteScript`（裸 'ExecuteScript' 会被
+      // 函数体注释里的同词提前截断）。
+      final int endIdx = glw.indexOf('webview_->ExecuteScript', fnIdx);
+      expect(endIdx, greaterThan(fnIdx),
+          reason: 'DispatchGamepadAction 里没有真实的 ExecuteScript 调用');
+      final String fnSlice = glw.substring(fnIdx, endIdx);
+      expect(fnSlice.contains('kAllowedActions'), isTrue,
           reason: '动作名必须走白名单再拼 ExecuteScript');
+      expect(
+        RegExp(r'if \(!allowed\) \{\s*return;\s*\}').hasMatch(fnSlice),
+        isTrue,
+        reason: '白名单必须真的拦截（未命中即 return），不能只是摆着的数组',
+      );
       expect(glw.contains('window.__globalLookupHost.gamepadAction('), isTrue);
     });
 

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -1508,6 +1508,12 @@ void FlutterWindow::RegisterGlobalLookupChannel() {
         } else if (method == "render") {
           win->RenderJson(StringFromValue(args, "json", ""));
           result->Success();
+        } else if (method == "gamepadAction") {
+          // 手柄重设计 P5：Dart 侧 GamepadService 独占路由 → host gamepadAction
+          // （词条导航/制卡/发音/滚动，动作名白名单在 window 实现里钉死）。
+          win->DispatchGamepadAction(StringFromValue(args, "action", ""),
+                                     DoubleFromValue(args, "dy", 0.0));
+          result->Success();
         } else if (method == "resize") {
           if (win == gal_lookup_card_window_.get()) {
             win->ResizeOffscreen(IntFromValue(args, "width", 0),

--- a/fushi/windows/runner/global_lookup_window.cpp
+++ b/fushi/windows/runner/global_lookup_window.cpp
@@ -2303,6 +2303,32 @@ void GlobalLookupWindow::ConfigureWebView() {
       nullptr);
 }
 
+void GlobalLookupWindow::DispatchGamepadAction(const std::string& action,
+                                               double dy) {
+  if (recovering_ || !webview_ready_ || !webview_) {
+    return;
+  }
+  // 动作名白名单：本方法把字符串拼进 ExecuteScript，绝不透传任意输入。
+  static const char* const kAllowedActions[] = {"next", "prev", "mine", "audio",
+                                                "scroll"};
+  bool allowed = false;
+  for (const char* const candidate : kAllowedActions) {
+    if (action == candidate) {
+      allowed = true;
+      break;
+    }
+  }
+  if (!allowed) {
+    return;
+  }
+  const std::wstring action_w(action.begin(), action.end());
+  const std::wstring script =
+      L"window.__globalLookupHost && "
+      L"window.__globalLookupHost.gamepadAction('" + action_w + L"', " +
+      std::to_wstring(dy) + L");";
+  webview_->ExecuteScript(script.c_str(), nullptr);
+}
+
 void GlobalLookupWindow::RenderJson(const std::string& full_script) {
   // full_script is the complete JS built in Dart (settings + lookupEntries +
   // renderPopup), mirroring dictionary_popup_webview._pushResults. Cached until

--- a/fushi/windows/runner/global_lookup_window.h
+++ b/fushi/windows/runner/global_lookup_window.h
@@ -139,6 +139,12 @@ class GlobalLookupWindow {
   // WebView2 finishes initial navigation if called too early.
   void RenderJson(const std::string& popup_json);
 
+  // 手柄重设计 P5：把一枚 Dart 侧解析好的手柄动作转发进 host
+  // (window.__globalLookupHost.gamepadAction)。动作名走实现里的白名单，
+  // 绝不把任意字符串拼进 ExecuteScript；WebView 未就绪时静默丢弃
+  // （手柄动作是瞬时输入，不做 pending 缓存）。
+  void DispatchGamepadAction(const std::string& action, double dy);
+
   // Resolves a deferred JS bridge promise. |json_value| is a JSON literal
   // (e.g. "\"file:///a.mp3\"", "true", "null") passed straight to
   // window.__fushiBridgeResolve(id, json_value). Used by the audio handlers,


### PR DESCRIPTION
手柄全功能重设计 P5/5（终篇），堆叠在 #927（P4）之上。

## 关键设计
游戏内卡片的 WebView2 属 **app 进程**（帧才 memcpy 进游戏 Layer），手柄轮询（GameInput）也在 app 进程——**不动 hook 的 `InjectLookupInput` IPC 契约**（static_assert 的 5 种鼠标 kind 原样），全部走 app 内部三层：

- **native**：`GlobalLookupWindow::DispatchGamepadAction`（动作名白名单后才拼 ExecuteScript）+ MethodChannel `gamepadAction` 分发（gal 卡片窗与桌面查词窗共用同一 handler）
- **host JS**：`__globalLookupHost.gamepadAction` 把动作转发进**顶层**卡片帧的 popup.js 既有入口（词条导航/制卡/发音/滚动，不另起桥）
- **Dart**：`GalIngameLookupGamepadRoute` **独占**路由——卡片可见时 GamepadService 在分发最前端把弹窗动作（dpad上下/X/Y/右摇杆）转发进卡片，**其余按钮/左摇杆/长按一律吞掉**：绝不让游戏里的手柄输入驱动后台 app 的页面/焦点/返回（按到 B 把后台 app 退一页是灾难）。gal 控制器 start 登记、stop 清除；动作经卡片 route zone 下发（channel 才选中 galCard 窗）。

## 守卫与验证
- `gal_ingame_gamepad_route_test`：可见性门控 + 派发行为 + 四条分发通道/host 导出/native 白名单（切函数体断言真实拦截）/控制器登记清除 的接线源码守卫
- 变异实测 3 条全部转红：删独占前置 / 删 host 导出 / 删白名单拦截分支（第三条曾暴露守卫「只查符号存在」+「注释同词截断切片」两个弱点，已强化）
- `flutter analyze` 0 issue；shortcuts+focus+lookup+相关页 **1284 项全绿**；`flutter build windows --debug` 真绿（√ Built fushi.exe，exit 0）

## 诚实边界
**capability = implemented_unverified**：未做「真实手柄 + 真实游戏」E2E（app 后台时 GameInput 是否继续送帧、独占吞噬体感、卡片滚动手感均未真机验证），不宣称已支持；engine-support.yaml 未动（这不是引擎能力）。已知取舍：游戏本身仍会收到手柄原生输入（本路由只管 app 进程的轮询份）。

另：随本链修复 P2 漏同步的第三份 popup.js 镜像（assets/browser_extension/vendor，三镜像守卫红），已在 #925 补提交并前滚合并至 P3/P4/P5。