### PR TITLE
fix(reader): 有声书跟随读到下一页第一句时不翻页 (BUG-1764)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1633 条。点号进各自文件。
+> 共 1634 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1764](bugs/BUG-1764-audiobook-next-page-first-cue-no-turn.md) | ✅ | ✅ | 有声书跟随：下一页第一句不自动翻页 |
 | [BUG-1755](bugs/BUG-1755-ass-wrap-width-anchored-to-window.md) | ✅ | ✅ | 字幕换行宽度锚在窗口而非视频画面，最大化后排版突变（BUG-1730 续） |
 | [BUG-1754](bugs/BUG-1754-drop-video-folder-ignored.md) | ✅ | ✅ | 视频页拖入文件夹完全静默 |
 | [BUG-1753](bugs/BUG-1753-drop-multi-video-only-first.md) | ✅ | ✅ | 拖入多个视频只导入第一个 |

--- a/docs/bugs/BUG-1764-audiobook-next-page-first-cue-no-turn.md
+++ b/docs/bugs/BUG-1764-audiobook-next-page-first-cue-no-turn.md
@@ -1,0 +1,73 @@
+## BUG-1764 · 有声书跟随：下一页第一句不自动翻页
+
+- **报告**：2026-08-21（用户反馈：有声书读到下一页的第一句话时不会自动翻页）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/reader/reader_pagination_scripts.dart:2193`（修复前的
+  `if (startEdge >= 0 && startEdge < context.viewportExtent) return false;`），更深一层在
+  `alignToPage`（同文件 `:2151`）缺分页网格相位。
+
+### 症状
+
+有声书跟随播放（`followAudio` 开）时，音频推进到下一页的第一句，页面不翻；要等到第二句
+（或更靠后的句子）才翻过去。翻过去之后落页位置是对的，所以表现为「下一页开头那一两句被跳过」。
+
+### 根因
+
+分页 cue 跟随的唯一落页路径是 `scrollToRange`：取句首起始边（竖排 `rect.top` / 横排 `rect.left`）
+加当前滚动量得到 anchor，再 `alignToPage`(floor) 落页。
+
+**滚动坐标的原点是 body 的 padding box 起始边，而列内容从 content box 起始边开始**，两者恰差一个
+turn 轴起始 padding。所以列 j 的起始滚动坐标是 `contentStart + j*pageStep`，不是 `j*pageStep`。
+旧 `alignToPage` 用裸 `floor(anchor/pageStep)`，等于把整个列网格平移了 `contentStart`，两个方向
+各错一次：
+
+1. `contentStart > column-gap` 时，每列末尾 `contentStart − gap` 那段被判进下一列 → 有声书读到
+   「句首是行尾单字」的 cue 时凭空前翻一页、下一句又翻回 = 抖动。这就是 **BUG-875**。
+2. BUG-875 当时的修法不是补相位，而是在 `scrollToRange` 加一条
+   `startEdge < context.viewportExtent` 的「已可见即不翻」短路。而 client 视口
+   （`body.clientWidth/Height`，body 是 `border-box`、margin/border 皆 0）比一页真正的内容宽出
+   turn 轴**两侧** padding：
+
+   ```
+   viewportExtent − pageStep = (contentStart + contentBox + contentEnd) − (contentBox + gap)
+                             = contentStart + contentEnd − gap
+   ```
+
+   下一页第一句的起始边恰好是 `contentStart + pageStep`，于是短路命中的充要条件塌成
+   **`contentEnd > column-gap`**（turn 轴结束边 padding 大于列间距，`column-gap` 恒 22px）：
+
+   - 横排：`contentEnd = padding-right = margin-right vw = 0.02·W` → **窗口宽 > 1100px 必现**
+     （1280px → 25.6 > 22；1920px → 38.4 > 22）。桌面默认横排就中招。
+   - 竖排：`contentEnd = padding-bottom = margin-bottom vh + fontSize + --chrome-bottom-inset`
+     → 字号 > 22、或底栏「挤压」模式占位（+56·scale）、或移动端系统底部 inset > 0 时必现。
+
+   命中即 `return false` → 该翻不翻。
+
+两个场景的 `startEdge` 与 `targetScroll` 取值**完全相同**，单一阈值结构上区分不了它们——说明判据
+维度本身就错了，可见性短路只是用一条带宽把相位误差盖住，代价是把下一页开头等宽的一段一起吞掉。
+
+### 修复
+
+- `getScrollContext` 暴露 `contentStart`（turn 轴起始 padding：竖排 `paddingTop`＝含
+  `--chrome-top-inset`，横排 `paddingLeft`），与落页锚的取轴严格同源。
+- `alignToPage` 改为 `floor((offset − contentStart)/pageSize)*pageSize`，成为精确的列号函数。
+  返回值仍落在 `j*pageSize` 的滚动网格上，**网格本身零变化**（`paginate` / `pageStepPosition` /
+  `minScroll` 不受影响）。
+- 删掉 `scrollToRange` 里的 `viewportExtent` 可见性短路：补相位后
+  `targetScroll === currentScroll` 已经精确表达「句首就在本页」，BUG-875 与本 bug 同时消失，
+  不再需要任何特例分支。
+
+顺带修正的同源错判：跳到下一页**后半段**的句子，旧裸网格会翻过头整整一页（`scrollToProgressPaged`
+/ `alignToFragmentTarget` / `scrollToCharOffset` 共用 `alignToPage`，一并变正确）。
+
+- **[x] ① 已修复** — `fushi/lib/src/reader/reader_pagination_scripts.dart`：`getScrollContext`
+  增 `contentStart`、`alignToPage` 减相位、`scrollToRange` 删可见性短路；Dart 影子
+  `revealAnchorTargetScrollForTesting` / `revealScrollTargetForTesting` 同步。提交见分支
+  `worktree-fix-audiobook-next-page-first-cue`。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reveal_viewport_visible_no_flip_test.dart`
+  重写为「reveal 落页网格相位」契约：BUG-1764 组（下一页首句必须翻、翻一页不翻两页）+ BUG-875 组
+  （行尾单字不得前翻，双向锁）+ 边界回归 + 源码守卫（`getScrollContext` 必须暴露 `contentStart`、
+  `alignToPage` 必须减相位、`scrollToRange` 不得复活 `viewportExtent` 短路）。两轮变异实测：移除
+  JS 相位 → 守卫红；移除 Dart 影子相位 → 3 条行为用例红。
+- **备注**：本 bug 是 BUG-875 修法引入的回归，两者共享同一根因，故合并在同一份契约测试里守，
+  避免未来两处几何漂移。未做真机复测（无对应设备取证），相位关系由 CSS 生成器
+  `reader_content_styles.dart` 的 body 规则代数推导 + 纯函数影子锁定。

--- a/fushi/lib/src/reader/reader_pagination_scripts.dart
+++ b/fushi/lib/src/reader/reader_pagination_scripts.dart
@@ -219,44 +219,50 @@ class ReaderPaginationScripts {
   /// 语义被 `restoreToCharOffset` :706 / `jumpToFragment` 锁定，**不自创轴向**）。
   /// 起始边锚恒等于「这句开头所在那一页」，不越界。
   ///
-  /// 返回 floor 对齐后的目标滚动量（`alignToPage`：`floor(anchor/pageSize)*pageSize`，
-  /// anchor 先 clamp 到 >=0）。
+  /// 返回 floor 对齐后的目标滚动量（`alignToPage`：
+  /// `floor((anchor − contentStart)/pageSize)*pageSize`，差先 clamp 到 >=0）。
+  ///
+  /// [contentStart] 是分页网格的**相位** —— turn 轴起始 padding（竖排 `padding-top`、
+  /// 横排 `padding-left`）。滚动坐标原点是 body 的 padding box，列内容却从 content box
+  /// 起始边开始，故列 j 的起始滚动坐标 = `contentStart + j*pageSize`。不减相位就等于把
+  /// 网格整体平移了 contentStart，见 `alignToPage` 注释与 BUG-1764/BUG-875。
   @visibleForTesting
   static double revealAnchorTargetScrollForTesting({
     required double rectStart,
     required double currentScroll,
     required double pageSize,
+    double contentStart = 0,
   }) {
     if (pageSize <= 0) return currentScroll;
-    final double anchor = rectStart + currentScroll;
+    final double anchor = rectStart + currentScroll - contentStart;
     final double safe = anchor < 0 ? 0 : anchor;
     return (safe / pageSize).floorToDouble() * pageSize;
   }
 
-  /// JS `scrollToRange` reveal 决策的纯 Dart 影子（BUG-875）。
+  /// JS `scrollToRange` reveal 决策的纯 Dart 影子（BUG-875 / BUG-1764）。
   ///
-  /// 返回值：`null` = 不翻页（句首已在本页可见 / pageSize 非法 / 目标==当前）；
-  /// 非空 = 应翻到的目标 scroll。
+  /// 返回值：`null` = 不翻页（句首就在本页 / pageSize 非法）；非空 = 应翻到的目标 scroll。
   ///
-  /// 根因：`pageSize`（列周期）因 chrome inset / body padding 可比 client
-  /// `viewportExtent` 小最多半页。竖排一句 cue 句首若是行尾单字（列底），其起始边
-  /// `rectStart`(=rect.top) 落在 `[pageSize, viewportExtent)` 带内 —— 视觉仍在本页底部、
-  /// 却已越过 pitch 网格边界 → 旧 floor 判进下一页 → 有声书读到该句凭空前翻、下一句又
-  /// 翻回 = 抖动。修复：起始边落在真实 client 视口 `[0, viewportExtent)` 内即「已可见」，
-  /// 不翻页。`rectStart<0`（句首滚出视口首边）或 `>=viewportExtent`（句首真在下一页）
-  /// 才照常 floor 落页。
+  /// 判据只有一条：句首所属的那一页是不是当前页（`alignToPage` 减相位后就是精确的列号
+  /// 函数，见 [revealAnchorTargetScrollForTesting] 的 [contentStart]）。历史上这里还有
+  /// 一条 `rectStart < viewportExtent` 的「已可见即不翻」短路（BUG-875 的旧修法）：
+  /// client 视口比一页真正的内容宽出 turn 轴两侧 padding，于是**结束边** padding >
+  /// column-gap 时（横排宽屏、竖排大字号/底栏占位/移动端系统 inset），下一页开头那段
+  /// 落进 `[pageSize, viewportExtent)` 带被误判成「本页可见」→ 有声书跟随读到下一页第一句
+  /// 时不翻页（BUG-1764）。而 BUG-875 的行尾单字与它在 `rectStart` / `targetScroll` 上取值
+  /// 完全相同，同一条阈值无法区分 —— 根因不在可见性判据而在网格相位，补相位后两者同时消失。
   static double? revealScrollTargetForTesting({
     required double rectStart,
     required double currentScroll,
     required double pageSize,
-    required double viewportExtent,
+    double contentStart = 0,
   }) {
     if (pageSize <= 0) return null;
-    if (rectStart >= 0 && rectStart < viewportExtent) return null;
     final double target = revealAnchorTargetScrollForTesting(
       rectStart: rectStart,
       currentScroll: currentScroll,
       pageSize: pageSize,
+      contentStart: contentStart,
     );
     if (target == currentScroll) return null;
     return target;
@@ -2081,13 +2087,24 @@ $_sharedJs
     // 只用于最后一张无法整页对齐的 terminal clamp。
     var viewportExtent = vertical ? scrollEl.clientHeight : scrollEl.clientWidth;
     var physicalMaxScroll = Math.max(0, totalSize - viewportExtent);
+    // BUG-1764（有声书下一页第一句不翻页）/ BUG-875（竖排行尾单字凭空前翻）的共同根因：
+    // 分页网格的**相位**。滚动坐标原点是 body 的 padding box 起始边，而列内容从 content box
+    // 起始边开始 —— 两者恰差一个 turn 轴起始 padding。故列 j 的起始滚动坐标恒为
+    // contentStart + j*pageStep，而不是 j*pageStep。判「某个 anchor 属于第几列」必须先减掉
+    // contentStart 再除 pageStep（见 alignToPage）。turn 轴由 vertical 决定：竖排（vertical-rl
+    // 的 inline 轴竖直、列向下堆叠、滚 scrollTop）取 paddingTop，横排取 paddingLeft，与
+    // getPagePosition / 各落页锚的起始边取轴严格同源。
+    var contentStart = vertical
+      ? (parseFloat(cs.paddingTop) || 0)
+      : (parseFloat(cs.paddingLeft) || 0);
     return {
       vertical: vertical,
       scrollEl: scrollEl,
       pageSize: pageStep,
       maxScroll: maxScroll,
       physicalMaxScroll: physicalMaxScroll,
-      viewportExtent: viewportExtent
+      viewportExtent: viewportExtent,
+      contentStart: contentStart
     };
   },
   getPagePosition: function(context) {
@@ -2149,7 +2166,17 @@ $_sharedJs
     }, { passive: true });
   },
   alignToPage: function(context, offset) {
-    return Math.floor(Math.max(0, offset) / context.pageSize) * context.pageSize;
+    // 相位修正（BUG-1764/BUG-875 同源根因）：列 j 的起始滚动坐标 = contentStart + j*pageSize
+    // （见 getScrollContext 的 contentStart），所以列号 = floor((anchor − contentStart)/pageSize)。
+    // 裸 floor(anchor/pageSize) 相当于把网格整体平移了 contentStart：
+    //   · contentStart > gap 时，每列末尾 (contentStart − gap) 那段内容被判进下一列 → 落页前翻
+    //     一页（BUG-875 竖排行尾单字凭空翻页的真正来源）；
+    //   · 反过来下一列开头那段被判成仍属本列 → 该翻不翻（BUG-1764）。
+    // 减相位后 alignToPage 就是精确的列号函数，两个方向的错判同时消失，不需要任何可见性特例。
+    // 返回值仍落在 j*pageSize 的滚动网格上（页对齐后内容起始边露出 contentStart 的页边距，
+    // 与 paginate / pageStepPosition / minScroll 的网格严格同源，网格本身零变化）。
+    var phase = context.contentStart || 0;
+    return Math.floor(Math.max(0, offset - phase) / context.pageSize) * context.pageSize;
   },
   alignContentStartToPage: function(context, offset) {
     // TODO-1179：章首落点只能向下偏置到「包含首行内容边」的那一页。firstContentEdge
@@ -2179,18 +2206,17 @@ $_sharedJs
     var startEdge = context.vertical ? rect.top : rect.left;
     var anchor = startEdge + currentScroll;
     var targetScroll = this.alignToPage(context, anchor);
-    // BUG-875（竖排行尾单字凭空翻页根因修复）：pageStep（列周期 = N×(used 列宽+gap)）
-    // 因 chrome inset / body padding 可比 client 视口 extent 小最多半页（见 getScrollContext
-    // 的 physicalMaxScroll 注释「两者因此可相差半页」）。当一句 cue 的**句首**是一行的**行尾
-    // 单字**（竖排=列底），其首段 rect 的起始边 rect.top 落在 [pageStep, viewportExtent) 这条
-    // 「视觉仍在本页底部、却已越过 pitch 网格边界」的带内 → 旧 floor 网格把它判进下一 pitch
-    // 页 → 有声书读到该句凭空前翻一页、下一句句首起始边回到 [0,pageStep) 又翻回 = 来回抖动。
-    // 起始边只要落在真实 client 视口内即「已在本页可见」，reveal 原语不该再翻页（与
-    // scrollToTarget「已可见即 return false」同哲学，但分页模式整页对齐无需 15% 安全边距：
-    // 句子落在本页任意位置都是合法阅读位）。用真实 viewportExtent 作可见判据，从根上消除
-    // pitch 网格与 client 视口在页底的坐标失配，不引入延迟/特例分支。startEdge<0（句首已滚出
-    // 视口首边）或 >=viewportExtent（句首在下一页、真需翻页）时不短路，照常 floor 落页。
-    if (startEdge >= 0 && startEdge < context.viewportExtent) return false;
+    // BUG-1764（有声书跟随读到下一页第一句时不翻页）：这里曾有一条
+    // `if (startEdge >= 0 && startEdge < context.viewportExtent) return false;` 的
+    // 「已可见即不翻」短路，是 BUG-875（竖排行尾单字凭空前翻）的旧修法。它用 client 视口
+    // extent 当可见判据，而 client 视口比一页真正的内容（contentBox）宽出 turn 轴两侧 padding：
+    // 只要**结束边** padding > column-gap（横排 W>1100px 的宽屏、竖排字号>22 或底栏占位 /
+    // 移动端系统 inset），下一页开头那段就落在 [pageStep, viewportExtent) 带内被判成「本页可见」
+    // → 该翻不翻，要等到再下一句才翻，表现为「下一页第一句不自动翻页」。
+    // 而 BUG-875 的行尾单字与本 bug 的下一页首句在 startEdge / targetScroll 上取值完全相同，
+    // 单一阈值结构上区分不了两者 —— 说明判据维度本身就错了。真正的根因是 alignToPage 缺列
+    // 网格相位（见那里的注释）：补上相位后，`targetScroll === currentScroll` 已经精确表达
+    // 「句首就在本页」，两个方向的错判同时消失，这条特例短路不再需要，删除。
     if (targetScroll === currentScroll) return false;
     this.setPagePosition(context, targetScroll);
     var self = this;

--- a/fushi/test/reader/reveal_viewport_visible_no_flip_test.dart
+++ b/fushi/test/reader/reveal_viewport_visible_no_flip_test.dart
@@ -9,111 +9,209 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/reader/reader_pagination_scripts.dart';
 
-/// BUG-875：竖排有声书读到「句首是行尾单字」的 cue 时凭空前翻一页、下一句又翻回。
+/// 分页 reveal 落页的**网格相位**契约：BUG-875 与 BUG-1764 是同一个缺陷的两面。
 ///
-/// 根因：`reader_pagination_scripts.dart` 的 `scrollToRange`（cue-follow +
-/// search-highlight 共用落页路径）用起始边 `rect.top`（竖排）`alignToPage`(floor) 落页，
-/// 但 `pageStep`（列周期 = N×(used 列宽+gap)）因 chrome inset / body padding 可比 client
-/// `viewportExtent` 小最多半页（见 getScrollContext 的 physicalMaxScroll 注释）。句首是行尾
-/// 单字（竖排=列底）时，其 rect.top 落在 `[pageStep, viewportExtent)` 这条「视觉仍在本页
-/// 底部、却已越过 pitch 网格边界」的带内 → floor 判进下一 pitch 页 → 前翻；下一句句首起始边
-/// 回到 `[0,pageStep)` → 翻回 = 抖动。
+/// `scrollToRange` 是 cue-follow + search-highlight 共用的落页路径：取句首起始边
+/// （竖排 `rect.top`、横排 `rect.left`）+ 当前滚动量得到 anchor，再 `alignToPage` 落页。
 ///
-/// 修复：起始边落在真实 client 视口 `[0, viewportExtent)` 内即「已在本页可见」，reveal 不翻页。
+/// 滚动坐标的原点是 body 的 **padding box** 起始边，而列内容从 **content box** 起始边
+/// 开始，两者恰差一个 turn 轴起始 padding（竖排 `padding-top`＝含 `--chrome-top-inset`，
+/// 横排 `padding-left`＝`margin-left vw`）。所以列 j 的起始滚动坐标是
+/// `contentStart + j*pageStep`，**不是** `j*pageStep`。裸 `floor(anchor/pageStep)` 等于把
+/// 网格整体平移了 contentStart，两个方向各错一次：
 ///
-/// 这是 JS `window.fushiReader.scrollToRange` 落页决策的纯 Dart 影子（headless WebView 不可用，
-/// 按项目测试范式：纯函数单测 + 源码守卫）。
+/// - `contentStart > column-gap` → 每列末尾 `contentStart − gap` 那段被判进下一列：
+///   有声书读到「句首是行尾单字」的 cue 时凭空前翻一页、下一句又翻回 = 抖动（**BUG-875**）。
+/// - 旧修法给 `scrollToRange` 加了一条 `rectStart < viewportExtent` 的「已可见即不翻」
+///   短路。client 视口比一页真正的内容宽出 turn 轴**两侧** padding，于是**结束边** padding
+///   > gap 时（横排 W>1100px 的宽屏、竖排字号>22 / 底栏占位 / 移动端系统 inset），下一页
+///   开头那段落进 `[pageStep, viewportExtent)` 带、被判成「本页可见」→ 该翻不翻，要等下一句
+///   才翻，用户感知就是「有声书下一页的第一句话不会自动翻页」（**BUG-1764**）。
+///
+/// 两个场景的 `rectStart` / `targetScroll` 取值完全相同，单一阈值结构上区分不了 —— 判据
+/// 维度本身就错了。根因修复是给 `alignToPage` 补上相位，之后 `targetScroll == currentScroll`
+/// 已经精确表达「句首就在本页」，可见性特例短路不再需要。
+///
+/// 这是 JS `window.fushiReader.scrollToRange` 落页决策的纯 Dart 影子（headless WebView
+/// 不可用，按项目测试范式：纯函数单测 + 源码守卫）。
 void main() {
-  // pageStep 比视口 extent 小半页：真实设备上 chrome inset / body padding 造成的失配。
-  const double pageSize = 1000.0;
-  const double viewportExtent = 1500.0; // pageStep < viewportExtent（相差半页）
+  // 一组自洽的真实几何（量纲取自 reader_content_styles.dart 的 body 规则）：
+  //   column-gap 恒 22px；列周期 pageStep = contentBox + gap；
+  //   client 视口 extent = contentStart + contentBox + contentEnd（body 是 border-box、
+  //   margin/border 皆 0，故 client == padding box）。
+  // contentStart=60 取「竖排移动端状态栏 + 顶部进度挤压」量级（> gap，BUG-875 的成立条件）；
+  // contentEnd=100 取「字号 22px + 底栏占位」量级（> gap，BUG-1764 的成立条件）。
+  const double gap = 22.0;
+  const double contentBox = 978.0;
+  const double pageSize = contentBox + gap; // 1000
+  const double contentStart = 60.0;
+  const double contentEnd = 100.0;
+  const double viewportExtent = contentStart + contentBox + contentEnd; // 1138
+  const double fontSize = 22.0;
 
-  double? target({
-    required double rectStart,
-    required double currentScroll,
-  }) =>
+  // 当前停在第 2 页（页网格恒为 j*pageStep）。
+  const double currentScroll = 2 * pageSize;
+
+  double? target(double rectStart) =>
       ReaderPaginationScripts.revealScrollTargetForTesting(
         rectStart: rectStart,
         currentScroll: currentScroll,
         pageSize: pageSize,
-        viewportExtent: viewportExtent,
+        contentStart: contentStart,
       );
 
-  group('BUG-875 句首落在 client 视口内即不翻页（消除页底 pitch/视口失配）', () {
-    test('句首行尾单字：rect.top 落 [pageStep, viewportExtent) 带内 → 不翻页（原症状页）', () {
-      // 停在第 2 页（currentScroll=2000）。句首单字在列底：rect.top=1200，越过
-      // pageStep(1000) 但仍在 viewportExtent(1500) 内 = 视觉在本页底部。
-      // 旧 floor：anchor=1200+2000=3200 → 落 3000（前翻一页，症状）。
-      final double old =
-          ReaderPaginationScripts.revealAnchorTargetScrollForTesting(
-        rectStart: 1200,
-        currentScroll: 2000,
-        pageSize: pageSize,
-      );
-      expect(old, 3000, reason: '旧 floor 网格把页底可见句首判进下一 pitch 页 → 前翻（症状）');
+  /// 补相位前的裸网格（旧 `alignToPage`），仅用于证明症状真实存在。
+  double legacyTarget(double rectStart) =>
+      ((rectStart + currentScroll) / pageSize).floorToDouble() * pageSize;
 
-      expect(target(rectStart: 1200, currentScroll: 2000), isNull,
-          reason: '句首已在 client 视口内 → reveal 不翻页');
+  /// 旧的「已可见即不翻」短路（BUG-875 旧修法），仅用于证明它吞掉了下一页开头。
+  bool legacyVisibleShortCircuit(double rectStart) =>
+      rectStart >= 0 && rectStart < viewportExtent;
+
+  group('BUG-1764 下一页第一句必须翻页（旧 client 视口短路吞掉了下一页开头）', () {
+    // 列 j 起始滚动坐标 = contentStart + j*pageStep，故停在第 2 页时下一页（列 3）
+    // 的第一句句首起始边 = contentStart + pageStep。
+    const double nextPageFirstCue = contentStart + pageSize; // 1060
+
+    test('症状复现：下一页首句起始边落在旧短路带内 → 旧实现判「已可见」不翻页', () {
+      expect(nextPageFirstCue, greaterThanOrEqualTo(pageSize),
+          reason: '句首已越过列周期边界 = 真的在下一页');
+      expect(nextPageFirstCue, lessThan(viewportExtent),
+          reason: '但仍落在 client 视口内 → 旧短路把它当成本页可见');
+      expect(legacyVisibleShortCircuit(nextPageFirstCue), isTrue,
+          reason: '旧 rectStart<viewportExtent 短路命中 → 该翻不翻（BUG-1764 症状）');
     });
 
-    test('句首落 [0, pageStep) 常规区：本就同页 → 不翻页（回归保护）', () {
-      expect(target(rectStart: 300, currentScroll: 2000), isNull);
+    test('修复后：下一页首句落到下一页网格线上，翻页', () {
+      expect(target(nextPageFirstCue), currentScroll + pageSize);
     });
 
-    test('句首恰在视口底边 viewportExtent：仍在本页 → 不翻页', () {
-      expect(
-          target(rectStart: viewportExtent - 1, currentScroll: 2000), isNull);
+    test('下一页首句之后的整页内容都落同一页，不会翻过头', () {
+      // 下一页（列 3）内容的滚动坐标范围 = [contentStart+3*pageStep, +contentBox]。
+      // 相对当前滚动的起始边 = contentStart+pageStep .. contentStart+pageStep+contentBox。
+      for (final double offsetInPage in <double>[0, 1, 300, contentBox - 1]) {
+        expect(
+            target(nextPageFirstCue + offsetInPage), currentScroll + pageSize,
+            reason: '列内偏移 $offsetInPage 仍属下一页，不该翻两页');
+      }
+      // 裸网格在这里会翻过头整整一页（相位缺失的第二个症状）。
+      expect(legacyTarget(nextPageFirstCue + contentBox - 1),
+          currentScroll + 2 * pageSize,
+          reason: '旧网格把下一页后半段判进再下一页');
+    });
+  });
+
+  group('BUG-875 本页行尾单字不得凭空前翻（相位修正后无需可见性特例）', () {
+    // 竖排一句 cue 的句首是行尾单字 = 落在列的 inline 轴末端，其起始边（字的顶边）
+    // = contentStart + contentBox − 字高。
+    const double lineTailChar = contentStart + contentBox - fontSize; // 1016
+
+    test('症状复现：裸网格把列末尾 (contentStart − gap) 那段判进下一列 → 前翻', () {
+      expect(contentStart, greaterThan(gap),
+          reason: 'contentStart > gap 是 BUG-875 的成立条件');
+      expect(lineTailChar, greaterThanOrEqualTo(pageSize),
+          reason: '视觉仍在本页列底，却已越过裸网格的页边界');
+      expect(legacyTarget(lineTailChar), currentScroll + pageSize,
+          reason: '旧裸网格前翻一页（BUG-875 症状）');
     });
 
-    test('句首真在下一页（rect.top >= viewportExtent）：照常 floor 翻页', () {
-      // rect.top=1600 越过视口 → 句首不可见、真需翻页。anchor=1600+2000=3600 → 落 3000。
-      expect(target(rectStart: 1600, currentScroll: 2000), 3000);
+    test('修复后：行尾单字仍属本页 → 不翻页', () {
+      expect(target(lineTailChar), isNull);
     });
 
-    test('句首已滚出视口首边（rect.top<0）：照常 floor 回翻', () {
-      // 停在第 2 页，句首在上一页：rect.top=-200 → anchor=1800 → floor 落 1000。
-      expect(target(rectStart: -200, currentScroll: 2000), 1000);
+    test('列内任意位置都属本页（相邻句不再在翻/不翻之间摆动）', () {
+      for (final double edge in <double>[
+        contentStart, // 列首
+        contentStart + 1,
+        contentStart + contentBox / 2,
+        contentStart + contentBox - 1, // 列末最后一像素
+      ]) {
+        expect(target(edge), isNull, reason: '起始边 $edge 仍在本页列内');
+      }
+    });
+  });
+
+  group('reveal 落页的其余边界（回归保护）', () {
+    test('句首已滚出视口首边（rectStart<0）：回翻到句首所在页', () {
+      // 句首在上一页列内：相对起始边 = contentStart + contentBox − pageStep − 200。
+      const double prevPage = contentStart - pageSize + contentBox - 200;
+      expect(prevPage, lessThan(0));
+      expect(target(prevPage), currentScroll - pageSize);
     });
 
-    test('pageSize<=0：不翻页', () {
+    test('句首恰在本页内容起始边：不翻页', () {
+      expect(target(contentStart), isNull);
+    });
+
+    test('pageSize<=0：不翻页（与 JS 早退一致）', () {
       expect(
         ReaderPaginationScripts.revealScrollTargetForTesting(
-          rectStart: 1200,
-          currentScroll: 2000,
+          rectStart: contentStart + pageSize,
+          currentScroll: currentScroll,
           pageSize: 0,
-          viewportExtent: viewportExtent,
+          contentStart: contentStart,
         ),
         isNull,
       );
     });
+
+    test('contentStart 省略时退化为裸网格（连续/VN 等无相位场景零行为变化）', () {
+      expect(
+        ReaderPaginationScripts.revealScrollTargetForTesting(
+          rectStart: pageSize,
+          currentScroll: currentScroll,
+          pageSize: pageSize,
+        ),
+        currentScroll + pageSize,
+      );
+    });
   });
 
-  group('BUG-875 源码守卫：scrollToRange 必须有 client 视口可见短路', () {
+  group('源码守卫：落页网格必须带相位，且不得复活 client 视口可见短路', () {
     final String scripts = File(
       'lib/src/reader/reader_pagination_scripts.dart',
     ).readAsStringSync();
 
-    String scrollToRangeBody() {
-      final int start = scripts.indexOf('scrollToRange: function(range)');
-      expect(start, greaterThanOrEqualTo(0), reason: '找不到 scrollToRange 定义');
-      final int end = scripts.indexOf('notifyRestoreComplete: function', start);
+    String functionBody(String signature, String nextSignature) {
+      final int start = scripts.indexOf(signature);
+      expect(start, greaterThanOrEqualTo(0), reason: '找不到 $signature');
+      final int end = scripts.indexOf(nextSignature, start);
       return scripts.substring(start, end >= 0 ? end : scripts.length);
     }
 
-    test('getScrollContext 暴露 viewportExtent', () {
+    test('getScrollContext 暴露 contentStart（turn 轴起始 padding）', () {
       expect(
-        RegExp(r'viewportExtent\s*:\s*viewportExtent').hasMatch(scripts),
+        RegExp(r'contentStart\s*:\s*contentStart').hasMatch(scripts),
         isTrue,
-        reason: 'scrollToRange 需从 context 读真实 client 视口 extent',
+        reason: 'alignToPage 需要从 context 读列网格相位',
+      );
+      expect(
+        RegExp(r'contentStart\s*=\s*vertical\s*\?\s*\(parseFloat\(cs\.paddingTop\)')
+            .hasMatch(scripts),
+        isTrue,
+        reason: '相位必须按 turn 轴取 paddingTop/paddingLeft，与落页锚同源',
       );
     });
 
-    test('scrollToRange 用 startEdge < viewportExtent 的可见短路', () {
-      final String body = scrollToRangeBody();
+    test('alignToPage 先减相位再 floor', () {
+      final String body = functionBody('alignToPage: function(context, offset)',
+          'alignContentStartToPage: function');
       expect(
-        RegExp(r'startEdge\s*<\s*context\.viewportExtent').hasMatch(body),
+        RegExp(r'offset\s*-\s*phase').hasMatch(body),
         isTrue,
-        reason: '页底 pitch/视口失配的可见短路缺失 → BUG-875 竖排行尾单字翻页抖动回归',
+        reason: '缺相位 → BUG-875 前翻 / BUG-1764 该翻不翻同时回归',
+      );
+    });
+
+    test('scrollToRange 不得再用 client 视口 extent 作可见短路', () {
+      final String body = functionBody(
+          'scrollToRange: function(range)', 'notifyRestoreComplete: function');
+      expect(
+        RegExp(r'^\s*if\s*\([^\n]*startEdge\s*<\s*context\.viewportExtent',
+                multiLine: true)
+            .hasMatch(body),
+        isFalse,
+        reason: 'client 视口比一页内容宽出两侧 padding，该短路会吞掉下一页开头（BUG-1764）',
       );
     });
   });


### PR DESCRIPTION
用户反馈：有声书播放跟随时，读到**下一页的第一句**不会自动翻页，要等到第二句才翻。

## 根因

分页落页网格缺**相位**。BUG-875 与本 bug 是同一缺陷的两面。

滚动坐标的原点是 body 的 padding box 起始边，而列内容从 content box 起始边开始，两者恰差一个
turn 轴起始 padding。所以列 j 的起始滚动坐标是 `contentStart + j*pageStep`，而旧 `alignToPage`
用裸 `floor(anchor/pageStep)`，等于把整个列网格平移了 `contentStart`：

1. `contentStart > column-gap` 时每列末尾那段被判进下一列 → 行尾单字凭空前翻（**BUG-875**）。
2. BUG-875 当时的修法不是补相位，而是给 `scrollToRange` 加了
   `startEdge < context.viewportExtent` 的「已可见即不翻」短路。client 视口
   （body 是 border-box、margin/border 皆 0）比一页真正的内容宽出 turn 轴**两侧** padding：

   ```
   viewportExtent − pageStep = contentStart + contentEnd − gap
   ```

   下一页第一句的起始边恰是 `contentStart + pageStep`，于是命中条件塌成 **`contentEnd > column-gap`**
   （`column-gap` 恒 22px）：
   - 横排 `contentEnd = 0.02·W` → **窗口宽 > 1100px 必现**（1280→25.6，1920→38.4）；
   - 竖排 `contentEnd = margin-bottom vh + fontSize + --chrome-bottom-inset` → 字号>22、底栏挤压
     占位、或移动端系统底部 inset > 0 时必现。

   命中即 `return false` → 该翻不翻。

两个场景的 `startEdge` / `targetScroll` 取值**完全相同**，单一阈值结构上区分不了 —— 判据维度本身
就错了，可见性短路只是用一条带宽盖住相位误差，代价是把下一页开头等宽的一段一起吞掉。

## 修复

- `getScrollContext` 暴露 `contentStart`（竖排 `paddingTop`／横排 `paddingLeft`，与落页锚同轴）。
- `alignToPage` 先减相位再 floor，成为精确的列号函数；返回值仍落在 `j*pageSize` 网格上，
  **翻页网格本身零变化**（`paginate` / `pageStepPosition` / `minScroll` 不受影响）。
- 删掉 `scrollToRange` 的 `viewportExtent` 短路 —— 补相位后 `targetScroll === currentScroll`
  已精确表达「句首就在本页」，两个方向的错判同时消失，无需任何特例分支。

顺带修正同源错判：跳到下一页**后半段**的句子，旧网格会翻过头整整一页
（`scrollToProgressPaged` / `alignToFragmentTarget` / `scrollToCharOffset` 共用 `alignToPage`）。

## 测试

`fushi/test/reader/reveal_viewport_visible_no_flip_test.dart` 重写为「落页网格相位」契约：
BUG-1764 组（下一页首句必须翻、翻一页不翻两页）+ BUG-875 组（行尾单字不得前翻，双向锁）+
边界回归 + 三条源码守卫。

**两轮变异实测**：移除 JS 相位 → 守卫红；移除 Dart 影子相位 → 3 条行为用例红；还原后源文件
sha256 逐字节一致。

- `flutter analyze`（含 test）：No issues found
- `test/reader` 1397 条全绿；`test/media/audiobook` + `test/pages` 3838 条全绿（7 skip）

## 未覆盖

未做真机复测（无对应设备取证）。相位关系由 `reader_content_styles.dart` 的 body 规则代数推导
＋纯函数影子锁定。

文档：`docs/bugs/BUG-1764-audiobook-next-page-first-cue-no-turn.md`

https://claude.ai/code/session_01XhmcCXseR5F7ku6NeWPUHj