### PR TITLE
feat(downloads): 下载页批次A——删冗余入口/手动添加任务/任务排序搜索/MD3优先级菜单

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1633 条。点号进各自文件。
+> 共 1635 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1766](bugs/BUG-1766-download-priority-menu-not-md3.md) | ✅ | ✅ | 排队优先级菜单未走MD3共享原语 |
+| [BUG-1765](bugs/BUG-1765-download-source-subtitle-row-misaligned.md) | ✅ | ✅ | 下载来源与字幕下拉底边不对齐 |
 | [BUG-1755](bugs/BUG-1755-ass-wrap-width-anchored-to-window.md) | ✅ | ✅ | 字幕换行宽度锚在窗口而非视频画面，最大化后排版突变（BUG-1730 续） |
 | [BUG-1754](bugs/BUG-1754-drop-video-folder-ignored.md) | ✅ | ✅ | 视频页拖入文件夹完全静默 |
 | [BUG-1753](bugs/BUG-1753-drop-multi-video-only-first.md) | ✅ | ✅ | 拖入多个视频只导入第一个 |

--- a/docs/bugs/BUG-1765-download-source-subtitle-row-misaligned.md
+++ b/docs/bugs/BUG-1765-download-source-subtitle-row-misaligned.md
@@ -1,0 +1,6 @@
+## BUG-1765 · 下载来源与字幕下拉底边不对齐
+- **报告**：2026-08-21（用户截图：下载页资源面板「默认受管视频来源」与「附带字幕」两个下拉底边错位）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart:1180`——BUG-1713 给左侧来源下拉加了 `helperText`（1191）而右侧字幕下拉没有，两个 `InputDecorator` 总高度不同；外层 `Row` 用默认 `CrossAxisAlignment.center`，右框被向下挤半个 helper 高度，底边错位。
+- **[x] ① 已修复** — 该 Row 显式 `crossAxisAlignment: CrossAxisAlignment.start`：两个输入框同高顶对齐（底边自然齐），helper 挂在左框下方不再影响右框。随 worktree-downloads-page-batch-a 批次提交。
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `fushi/test/pages/video_discovery_option_row_alignment_guard_test.dart`（该 Row 埋在需要完整 registry/sources 装配的 surface 深处，源扫描是最强可落地层）。已变异实测：删掉对齐行守卫变红，还原经 sha256 逐字节核对。
+- **备注**：settings 页同一对 key 的消费（`video_external_provider_settings_section.dart:769`）是纵向单列布局，不受影响。

--- a/docs/bugs/BUG-1766-download-priority-menu-not-md3.md
+++ b/docs/bugs/BUG-1766-download-priority-menu-not-md3.md
@@ -1,0 +1,6 @@
+## BUG-1766 · 排队优先级菜单未走MD3共享原语
+- **报告**：2026-08-21（用户截图：任务卡「排队」优先级弹出菜单是裸 Material 默认样式，未走 MD3）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/video_download_jobs_panel.dart:750`（旧行号）——优先级菜单裸用 `PopupMenuButton<int>`，没吃 `FushiDesignTokens` 的 menuRadius/overlay 色/动画，也进不了手柄焦点体系；本仓业务页面菜单的约定原语是 `FushiOverflowMenu`（`fushi_material_components.dart:2500`）。
+- **[x] ① 已修复** — 换 `FushiOverflowMenu<int>` + `FushiPopupMenuItem`（当前档位 selected 高亮），busy 态单独渲染禁用按钮脸；同批新增的任务排序菜单同走该原语。随 worktree-downloads-page-batch-a 批次提交。
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `fushi/test/pages/video_download_jobs_panel_md3_guard_test.dart`（正则禁裸 `PopupMenuButton(`/`PopupMenuButton<T>(` 构造 + 必须出现 `FushiOverflowMenu<`）。已变异实测：先发现 `contains('PopupMenuButton(')` 会被泛型形态逃过、改正则后变异双向验证通过；行为层由 `video_download_jobs_panel_test.dart` 既有优先级点击测试兜住。
+- **备注**：全仓 md3 静态守卫（`md3_design_system_static_test.dart`）此前未覆盖本文件，故补文件级守卫。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62237 (3661 per locale)
+/// Strings: 62424 (3672 per locale)
 ///
-/// Built on 2026-08-20 at 09:30 UTC
+/// Built on 2026-08-21 at 12:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -257,8 +257,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anime_download_search_failed =>
       'Search failed or timed out. Tap retry.';
   String get anime_download_search_hint => 'Anime title';
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   String get anime_download_sort_date => 'Published';
   String get anime_download_sort_seeders => 'Seeders';
   String get anime_download_sort_size => 'Size';
@@ -4979,6 +4977,20 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The peer isn\'t using HTTPS on this port. Use an http:// address.';
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  String get download_task_add => 'Add task';
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  String get download_task_add_title_label => 'Title';
+  String get download_task_add_content_kind => 'Content type';
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  String get download_task_add_submitted => 'Task added';
+  String get download_task_search_hint => 'Search tasks';
+  String get download_task_sort_created => 'Date added';
+  String get download_task_sort_progress => 'Progress';
+  String get download_task_sort_status => 'Status';
+  String get download_task_no_match => 'No matching tasks';
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -5125,9 +5137,6 @@ class _StringsAr extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -13470,6 +13479,32 @@ class _StringsAr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -13616,9 +13651,6 @@ class _StringsDe extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -22026,6 +22058,32 @@ class _StringsDe extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -22172,9 +22230,6 @@ class _StringsEs extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -30598,6 +30653,32 @@ class _StringsEs extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -30744,9 +30825,6 @@ class _StringsFr extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -39182,6 +39260,32 @@ class _StringsFr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -39328,9 +39432,6 @@ class _StringsId extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -47696,6 +47797,32 @@ class _StringsId extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -47842,9 +47969,6 @@ class _StringsIt extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -56254,6 +56378,32 @@ class _StringsIt extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -56400,9 +56550,6 @@ class _StringsJa extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -64629,6 +64776,32 @@ class _StringsJa extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -64775,9 +64948,6 @@ class _StringsKo extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -73011,6 +73181,32 @@ class _StringsKo extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -73157,9 +73353,6 @@ class _StringsNl extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -81549,6 +81742,32 @@ class _StringsNl extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -81695,9 +81914,6 @@ class _StringsPtBr extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -90099,6 +90315,32 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -90245,9 +90487,6 @@ class _StringsRu extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -98636,6 +98875,32 @@ class _StringsRu extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -98782,9 +99047,6 @@ class _StringsTh extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -107121,6 +107383,32 @@ class _StringsTh extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -107267,9 +107555,6 @@ class _StringsTr extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -115637,6 +115922,32 @@ class _StringsTr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -115783,9 +116094,6 @@ class _StringsVi extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -124139,6 +124447,32 @@ class _StringsVi extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 // Path: <root>
@@ -124278,8 +124612,6 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_search_failed => '搜索失败或超时，请点重试';
   @override
   String get anime_download_search_hint => '番剧名';
-  @override
-  String get anime_download_search_start_hint => '在上方搜索番剧名，自动匹配种子与字幕。';
   @override
   String get anime_download_sort_date => '发布时间';
   @override
@@ -131999,6 +132331,31 @@ class _StringsZhCn extends _StringsEn {
   String get sync_pair_peer_not_https => '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
   @override
   String get sync_pair_not_fushi_discovered => '此地址未找到 Fushi 设备。';
+  @override
+  String get download_task_add => '添加任务';
+  @override
+  String get download_task_add_pick_torrent => '选择种子文件';
+  @override
+  String get download_task_add_title_label => '标题';
+  @override
+  String get download_task_add_content_kind => '内容类型';
+  @override
+  String get download_task_add_invalid => '无法识别的磁力链接或种子文件';
+  @override
+  String get download_task_add_submitted => '已添加任务';
+  @override
+  String get download_task_search_hint => '搜索任务';
+  @override
+  String get download_task_sort_created => '添加时间';
+  @override
+  String get download_task_sort_progress => '进度';
+  @override
+  String get download_task_sort_status => '状态';
+  @override
+  String get download_task_no_match => '没有匹配的任务';
+  @override
+  String get anime_download_search_start_hint =>
+      '在上方搜索作品名，自动匹配种子与字幕。下载不限视频：书籍、漫画、有声书、游戏也会自动入库。';
 }
 
 // Path: <root>
@@ -132145,9 +132502,6 @@ class _StringsZhHk extends _StringsEn {
       'Search failed or timed out. Tap retry.';
   @override
   String get anime_download_search_hint => 'Anime title';
-  @override
-  String get anime_download_search_start_hint =>
-      'Search an anime title above — torrents and subtitles are matched automatically.';
   @override
   String get anime_download_sort_date => 'Published';
   @override
@@ -140297,6 +140651,32 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String get download_task_add => 'Add task';
+  @override
+  String get download_task_add_pick_torrent => 'Choose torrent file';
+  @override
+  String get download_task_add_title_label => 'Title';
+  @override
+  String get download_task_add_content_kind => 'Content type';
+  @override
+  String get download_task_add_invalid =>
+      'Unrecognized magnet link or torrent file';
+  @override
+  String get download_task_add_submitted => 'Task added';
+  @override
+  String get download_task_search_hint => 'Search tasks';
+  @override
+  String get download_task_sort_created => 'Date added';
+  @override
+  String get download_task_sort_progress => 'Progress';
+  @override
+  String get download_task_sort_status => 'Status';
+  @override
+  String get download_task_no_match => 'No matching tasks';
+  @override
+  String get anime_download_search_start_hint =>
+      'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
 }
 
 /// Flat map(s) containing all translations.
@@ -140404,8 +140784,6 @@ extension on _StringsEn {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -147811,6 +148189,30 @@ extension on _StringsEn {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -147919,8 +148321,6 @@ extension on _StringsAr {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -155323,6 +155723,30 @@ extension on _StringsAr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -155431,8 +155855,6 @@ extension on _StringsDe {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -162857,6 +163279,30 @@ extension on _StringsDe {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -162965,8 +163411,6 @@ extension on _StringsEs {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -170390,6 +170834,30 @@ extension on _StringsEs {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -170498,8 +170966,6 @@ extension on _StringsFr {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -177929,6 +178395,30 @@ extension on _StringsFr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -178037,8 +178527,6 @@ extension on _StringsId {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -185450,6 +185938,30 @@ extension on _StringsId {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -185558,8 +186070,6 @@ extension on _StringsIt {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -192985,6 +193495,30 @@ extension on _StringsIt {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -193093,8 +193627,6 @@ extension on _StringsJa {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -200482,6 +201014,30 @@ extension on _StringsJa {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -200590,8 +201146,6 @@ extension on _StringsKo {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -207983,6 +208537,30 @@ extension on _StringsKo {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -208091,8 +208669,6 @@ extension on _StringsNl {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -215512,6 +216088,30 @@ extension on _StringsNl {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -215620,8 +216220,6 @@ extension on _StringsPtBr {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -223038,6 +223636,30 @@ extension on _StringsPtBr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -223146,8 +223768,6 @@ extension on _StringsRu {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -230569,6 +231189,30 @@ extension on _StringsRu {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -230677,8 +231321,6 @@ extension on _StringsTh {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -238083,6 +238725,30 @@ extension on _StringsTh {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -238191,8 +238857,6 @@ extension on _StringsTr {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -245606,6 +246270,30 @@ extension on _StringsTr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -245714,8 +246402,6 @@ extension on _StringsVi {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -253125,6 +253811,30 @@ extension on _StringsVi {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }
@@ -253230,8 +253940,6 @@ extension on _StringsZhCn {
         return '搜索失败或超时，请点重试';
       case 'anime_download_search_hint':
         return '番剧名';
-      case 'anime_download_search_start_hint':
-        return '在上方搜索番剧名，自动匹配种子与字幕。';
       case 'anime_download_sort_date':
         return '发布时间';
       case 'anime_download_sort_seeders':
@@ -260585,6 +261293,30 @@ extension on _StringsZhCn {
         return '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
       case 'sync_pair_not_fushi_discovered':
         return '此地址未找到 Fushi 设备。';
+      case 'download_task_add':
+        return '添加任务';
+      case 'download_task_add_pick_torrent':
+        return '选择种子文件';
+      case 'download_task_add_title_label':
+        return '标题';
+      case 'download_task_add_content_kind':
+        return '内容类型';
+      case 'download_task_add_invalid':
+        return '无法识别的磁力链接或种子文件';
+      case 'download_task_add_submitted':
+        return '已添加任务';
+      case 'download_task_search_hint':
+        return '搜索任务';
+      case 'download_task_sort_created':
+        return '添加时间';
+      case 'download_task_sort_progress':
+        return '进度';
+      case 'download_task_sort_status':
+        return '状态';
+      case 'download_task_no_match':
+        return '没有匹配的任务';
+      case 'anime_download_search_start_hint':
+        return '在上方搜索作品名，自动匹配种子与字幕。下载不限视频：书籍、漫画、有声书、游戏也会自动入库。';
       default:
         return null;
     }
@@ -260693,8 +261425,6 @@ extension on _StringsZhHk {
         return 'Search failed or timed out. Tap retry.';
       case 'anime_download_search_hint':
         return 'Anime title';
-      case 'anime_download_search_start_hint':
-        return 'Search an anime title above — torrents and subtitles are matched automatically.';
       case 'anime_download_sort_date':
         return 'Published';
       case 'anime_download_sort_seeders':
@@ -268077,6 +268807,30 @@ extension on _StringsZhHk {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'download_task_add':
+        return 'Add task';
+      case 'download_task_add_pick_torrent':
+        return 'Choose torrent file';
+      case 'download_task_add_title_label':
+        return 'Title';
+      case 'download_task_add_content_kind':
+        return 'Content type';
+      case 'download_task_add_invalid':
+        return 'Unrecognized magnet link or torrent file';
+      case 'download_task_add_submitted':
+        return 'Task added';
+      case 'download_task_search_hint':
+        return 'Search tasks';
+      case 'download_task_sort_created':
+        return 'Date added';
+      case 'download_task_sort_progress':
+        return 'Progress';
+      case 'download_task_sort_status':
+        return 'Status';
+      case 'download_task_no_match':
+        return 'No matching tasks';
+      case 'anime_download_search_start_hint':
+        return 'Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。",
   "anime_download_search_failed": "搜索失败或超时，请点重试",
   "anime_download_search_hint": "番剧名",
-  "anime_download_search_start_hint": "在上方搜索番剧名，自动匹配种子与字幕。",
   "anime_download_sort_date": "发布时间",
   "anime_download_sort_seeders": "做种数",
   "anime_download_sort_size": "体积",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "地址格式无效",
   "sync_pair_peer_requires_https": "该设备只接受 HTTPS，请改用 https:// 开头的地址。",
   "sync_pair_peer_not_https": "对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。",
-  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。"
+  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。",
+  "download_task_add": "添加任务",
+  "download_task_add_pick_torrent": "选择种子文件",
+  "download_task_add_title_label": "标题",
+  "download_task_add_content_kind": "内容类型",
+  "download_task_add_invalid": "无法识别的磁力链接或种子文件",
+  "download_task_add_submitted": "已添加任务",
+  "download_task_search_hint": "搜索任务",
+  "download_task_sort_created": "添加时间",
+  "download_task_sort_progress": "进度",
+  "download_task_sort_status": "状态",
+  "download_task_no_match": "没有匹配的任务",
+  "anime_download_search_start_hint": "在上方搜索作品名，自动匹配种子与字幕。下载不限视频：书籍、漫画、有声书、游戏也会自动入库。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -47,7 +47,6 @@
   "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
   "anime_download_search_failed": "Search failed or timed out. Tap retry.",
   "anime_download_search_hint": "Anime title",
-  "anime_download_search_start_hint": "Search an anime title above — torrents and subtitles are matched automatically.",
   "anime_download_sort_date": "Published",
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
@@ -3659,5 +3658,17 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "download_task_add": "Add task",
+  "download_task_add_pick_torrent": "Choose torrent file",
+  "download_task_add_title_label": "Title",
+  "download_task_add_content_kind": "Content type",
+  "download_task_add_invalid": "Unrecognized magnet link or torrent file",
+  "download_task_add_submitted": "Task added",
+  "download_task_search_hint": "Search tasks",
+  "download_task_sort_created": "Date added",
+  "download_task_sort_progress": "Progress",
+  "download_task_sort_status": "Status",
+  "download_task_no_match": "No matching tasks",
+  "anime_download_search_start_hint": "Search a title above - torrents and subtitles are matched automatically. Downloads are not limited to video: books, manga, audiobooks and games are imported too."
 }

--- a/fushi/lib/src/media/torrent/torrent_metainfo.dart
+++ b/fushi/lib/src/media/torrent/torrent_metainfo.dart
@@ -29,6 +29,7 @@ class InspectedTorrentMetainfo {
     required this.torrentId,
     required this.v1InfoHash,
     required this.v2InfoHash,
+    this.suggestedName,
   }) : bytes = Uint8List.fromList(bytes);
 
   final Uint8List bytes;
@@ -38,6 +39,10 @@ class InspectedTorrentMetainfo {
   final String torrentId;
   final String? v1InfoHash;
   final String? v2InfoHash;
+
+  /// `info.name`（优先 `name.utf-8`）的展示名；缺失/非文本返回 null。
+  /// 手动添加任务用它预填标题。
+  final String? suggestedName;
 
   TorrentMetainfoPayload toPayload({required String fileName}) =>
       TorrentMetainfoPayload(
@@ -108,11 +113,19 @@ InspectedTorrentMetainfo inspectTorrentMetainfo(
     );
   }
 
+  String? suggestedName;
+  final Object? rawName = info['name.utf-8'] ?? info['name'];
+  if (rawName is Uint8List && rawName.isNotEmpty) {
+    final String decoded = utf8.decode(rawName, allowMalformed: true).trim();
+    if (decoded.isNotEmpty) suggestedName = decoded;
+  }
+
   return InspectedTorrentMetainfo(
     bytes: bytes,
     torrentId: torrentId,
     v1InfoHash: v1InfoHash,
     v2InfoHash: v2InfoHash,
+    suggestedName: suggestedName,
   );
 }
 

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -8,12 +8,19 @@ import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart'
+    show DiscoveryImportOutcome;
+import 'package:fushi/src/media/discovery/discovery_models.dart'
+    show DiscoveryMediaKind;
+import 'package:fushi/src/media/discovery/import/discovery_import_plan.dart'
+    show DiscoveryImportBlockedException;
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/metadata/credential_redaction.dart';
 import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/magnet_utils.dart';
 import 'package:fushi/src/media/torrent/torrent_add_coordinator.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
+import 'package:fushi/src/media/torrent/torrent_metainfo.dart';
 import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
@@ -80,6 +87,58 @@ class VideoDownloadEnqueueRequest {
   final int priority;
   final int maxAttempts;
   final String? coverUrl;
+}
+
+/// 手动添加任务的 `resourceProvider` 值：这类任务没有发现身份，payload 来自
+/// 用户粘贴的磁力（`magnetUri` 列）或落盘的 .torrent 元数据文件。
+const String kManualVideoDownloadResourceProvider = 'manual';
+
+/// 手动「按域入库」任务的 organizationPolicy 前缀。完整值形如
+/// `discovery-novel`：organize 阶段只把文件解析成本机绝对路径（不重命名、不
+/// 进受管视频来源），import 阶段整包交给发现导入执行器按域入库。
+const String kManualDiscoveryPolicyPrefix = 'discovery-';
+
+/// [kind] 域的手动任务 organizationPolicy 值。
+String manualDiscoveryOrganizationPolicy(DiscoveryMediaKind kind) =>
+    '$kManualDiscoveryPolicyPrefix${kind.name}';
+
+/// 从 organizationPolicy 还原发现域；非 `discovery-*` 策略返回 null。
+DiscoveryMediaKind? discoveryKindOfOrganizationPolicy(String policy) {
+  if (!policy.startsWith(kManualDiscoveryPolicyPrefix)) return null;
+  return DiscoveryMediaKind.values
+      .asNameMap()[policy.substring(kManualDiscoveryPolicyPrefix.length)];
+}
+
+/// 手动添加任务（磁力链接 / .torrent 文件）。[magnetUri] 与 [metainfo] 恰好
+/// 传一个。[discoveryKind] 为 null 表示视频任务（走完整 organize/subtitle/
+/// import 视频流程，需要 [targetSourceId]）；非 null 表示按该域入库（书/漫画/
+/// 有声书/游戏，文件留在下载目录原地入库）。
+class VideoDownloadManualEnqueueRequest {
+  const VideoDownloadManualEnqueueRequest({
+    required this.title,
+    required this.backendIdentity,
+    this.magnetUri,
+    this.metainfo,
+    this.discoveryKind,
+    this.mediaKind = VideoMetadataMediaKind.movie,
+    this.targetSourceId,
+    this.subtitlePolicy = VideoDownloadSubtitlePolicy.none,
+    this.priority = 0,
+    this.maxAttempts = 6,
+  });
+
+  final String title;
+  final VideoDownloadBackendIdentity backendIdentity;
+  final String? magnetUri;
+  final InspectedTorrentMetainfo? metainfo;
+  final DiscoveryMediaKind? discoveryKind;
+
+  /// 视频任务的组织形态：movie = 单文件；tv = 按季/集组织。
+  final VideoMetadataMediaKind mediaKind;
+  final int? targetSourceId;
+  final VideoDownloadSubtitlePolicy subtitlePolicy;
+  final int priority;
+  final int maxAttempts;
 }
 
 class VideoDownloadBackendBinding {
@@ -391,6 +450,11 @@ Future<void> deletePersistedVideoDownloadJob({
 typedef VideoDownloadBackendResolver = Future<VideoDownloadBackendBinding?>
     Function(VideoDownloadJobRow job);
 
+/// 手动「按域入库」任务完成下载后的整包导入端口（AppModel 接线
+/// `DiscoveryImportExecutor.importPaths`；null = 本设备不支持该类任务）。
+typedef VideoDownloadDiscoveryImporter = Future<DiscoveryImportOutcome>
+    Function(DiscoveryMediaKind kind, List<String> absolutePaths);
+
 /// Resume ids that remain owned by the v78 pipeline after legacy JSON files
 /// have been archived. New library jobs keep completed torrents alive so upload
 /// policy, seeding and task metrics continue across restarts. Legacy imports
@@ -523,6 +587,8 @@ class VideoDownloadPipelineService {
     this.onBackendTaskAdded,
     this.subtitleRegistry,
     this.defaultContentLanguage,
+    this.discoveryImporter,
+    this.manualTorrentDirectory,
     Iterable<String> preferredSubtitleLanguages = const <String>[],
     String? workerId,
     this.pollInterval = const Duration(seconds: 5),
@@ -546,6 +612,13 @@ class VideoDownloadPipelineService {
   final VideoDownloadBackendResolver backendResolver;
   final VideoSourceScrapeCoordinator scrapeCoordinator;
   final Future<void> Function(VideoDownloadJobRow job)? onBackendTaskAdded;
+
+  /// 见 [VideoDownloadDiscoveryImporter]。
+  final VideoDownloadDiscoveryImporter? discoveryImporter;
+
+  /// 手动任务 .torrent 元数据的落盘目录（`<jobId>.torrent`）。null 时手动
+  /// 任务只接受磁力链接。
+  final Directory? manualTorrentDirectory;
   final String workerId;
   final Duration pollInterval;
   final Duration leaseDuration;
@@ -591,6 +664,106 @@ class VideoDownloadPipelineService {
         targetSourceId: Value<int?>(request.targetSourceId),
         organizationPolicy: const Value<String>('library'),
         subtitlePolicy: Value<String>(request.subtitlePolicy.name),
+        lifecycle: const Value<String>(VideoDownloadJobLifecycle.active),
+        stage: const Value<String>(VideoDownloadJobStage.enqueue),
+        priority: Value<int>(request.priority),
+        maxAttempts: Value<int>(request.maxAttempts),
+        createdAt: Value<int>(now),
+        updatedAt: Value<int>(now),
+      ),
+    );
+    wake();
+    return jobId;
+  }
+
+  /// 手动添加任务：与搜索出的资源同走本管线（同任务列表、同优先级/重试/删除
+  /// 操作）。视频任务走完整 organize/subtitle/import 流程；[DiscoveryMediaKind]
+  /// 任务下载后整包交给 [discoveryImporter] 按域入库。没有发现身份，故完成后
+  /// 不进 scrape 阶段。
+  Future<String> enqueueManual(
+    VideoDownloadManualEnqueueRequest request,
+  ) async {
+    final String? magnet = request.magnetUri?.trim();
+    final InspectedTorrentMetainfo? metainfo = request.metainfo;
+    if ((magnet == null || magnet.isEmpty) == (metainfo == null)) {
+      throw ArgumentError(
+        'exactly one of magnetUri and metainfo must be provided',
+      );
+    }
+    final String? hash =
+        metainfo?.torrentId ?? parseMagnetInfoHash(magnet ?? '');
+    if (hash == null || hash.isEmpty) {
+      throw const VideoDownloadPipelineActionRequired(
+        'The magnet link has no verifiable info hash',
+      );
+    }
+    final String title = request.title.trim();
+    if (title.isEmpty) {
+      throw ArgumentError.value(request.title, 'title');
+    }
+    if (request.maxAttempts <= 0) {
+      throw ArgumentError.value(request.maxAttempts, 'maxAttempts');
+    }
+    final DiscoveryMediaKind? discoveryKind = request.discoveryKind;
+    final bool video = discoveryKind == null;
+    if (video) {
+      final MediaSourceRow? source = request.targetSourceId == null
+          ? null
+          : await database.getMediaSourceById(request.targetSourceId!);
+      _validateManagedSource(source);
+    } else if (discoveryImporter == null) {
+      throw const VideoDownloadPipelineActionRequired(
+        'Importing this content kind is not supported on this device',
+      );
+    }
+    final String jobId = generateVideoDownloadInstallationId();
+    if (metainfo != null) {
+      final Directory? directory = manualTorrentDirectory;
+      if (directory == null) {
+        throw const VideoDownloadPipelineActionRequired(
+          'Torrent file storage is not configured on this device',
+        );
+      }
+      // 元数据字节先落盘再建任务行：任务在任何后续阶段重启后都能从
+      // `<jobId>.torrent` 重新物化 payload（对齐 magnet 走 magnetUri 列）。
+      await directory.create(recursive: true);
+      await File(p.join(directory.path, '$jobId.torrent'))
+          .writeAsBytes(metainfo.bytes, flush: true);
+    }
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    await database.upsertVideoDownloadJob(
+      VideoDownloadJobsCompanion(
+        jobId: Value<String>(jobId),
+        resourceProvider:
+            const Value<String>(kManualVideoDownloadResourceProvider),
+        selectedResourceId: Value<String>(hash),
+        resourceTitle: Value<String?>(title),
+        torrentHash: Value<String?>(hash.toLowerCase()),
+        magnetUri: Value<String?>(magnet),
+        metadataProvider: const Value<String?>(null),
+        externalId: const Value<String?>(null),
+        // mediaKind 的值域按 organizationPolicy 分治：视频任务放
+        // VideoMetadataMediaKind.name（organize/import 消费），discovery 任务放
+        // DiscoveryMediaKind.name（仅展示与 import 阶段消费，二者不交叉读）。
+        mediaKind: Value<String>(
+          video ? request.mediaKind.name : discoveryKind.name,
+        ),
+        discoveryCategory: const Value<String?>(null),
+        title: Value<String>(title),
+        year: const Value<int?>(null),
+        backendKind: Value<String>(request.backendIdentity.kind),
+        backendProfileId: Value<String?>(request.backendIdentity.profileId),
+        fingerprint: Value<String>(request.backendIdentity.fingerprint),
+        category: Value<String?>(request.backendIdentity.category),
+        targetSourceId: Value<int?>(video ? request.targetSourceId : null),
+        organizationPolicy: Value<String>(
+          video ? 'library' : manualDiscoveryOrganizationPolicy(discoveryKind),
+        ),
+        subtitlePolicy: Value<String>(
+          // 非视频内容没有字幕概念；强制 none 免得 subtitle 阶段空转。
+          (video ? request.subtitlePolicy : VideoDownloadSubtitlePolicy.none)
+              .name,
+        ),
         lifecycle: const Value<String>(VideoDownloadJobLifecycle.active),
         stage: const Value<String>(VideoDownloadJobStage.enqueue),
         priority: Value<int>(request.priority),
@@ -982,6 +1155,20 @@ class VideoDownloadPipelineService {
       }
     }
 
+    // 手动 .torrent 任务的元数据文件随任务一起清（best-effort；文件极小，
+    // 删失败不阻塞任务行删除）。
+    final Directory? manualDirectory = manualTorrentDirectory;
+    if (manualDirectory != null &&
+        job.resourceProvider == kManualVideoDownloadResourceProvider) {
+      try {
+        final File metainfoFile =
+            File(p.join(manualDirectory.path, '${job.jobId}.torrent'));
+        if (await metainfoFile.exists()) await metainfoFile.delete();
+      } on Object {
+        // 忽略：孤儿 .torrent 文件无害。
+      }
+    }
+
     try {
       await deletePersistedVideoDownloadJob(
         database: database,
@@ -1263,6 +1450,11 @@ class VideoDownloadPipelineService {
         ),
       );
     }
+    // 手动 .torrent 任务：payload 从入队时落盘的元数据文件重新物化（带
+    // 期望 hash 复核，文件被换掉会显式失败而不是下错种子）。
+    if (job.resourceProvider == kManualVideoDownloadResourceProvider) {
+      return _resolveManualMetainfoPayload(job);
+    }
     return resourceRegistry.resolveSelection(
       selection: VideoResourceSelection(
         providerId: job.resourceProvider,
@@ -1275,6 +1467,32 @@ class VideoDownloadPipelineService {
         season: job.season,
       ),
     );
+  }
+
+  /// 读取 `<manualTorrentDirectory>/<jobId>.torrent` 并复核 info hash。
+  Future<TorrentAddPayload> _resolveManualMetainfoPayload(
+    VideoDownloadJobRow job,
+  ) async {
+    final Directory? directory = manualTorrentDirectory;
+    if (directory == null) {
+      throw const VideoDownloadPipelineActionRequired(
+        'Torrent file storage is not configured on this device',
+      );
+    }
+    final File file = File(p.join(directory.path, '${job.jobId}.torrent'));
+    if (!await file.exists()) {
+      throw const VideoDownloadPipelineActionRequired(
+        'The torrent file recorded for this task is no longer available',
+      );
+    }
+    try {
+      return inspectTorrentMetainfo(
+        await file.readAsBytes(),
+        expectedInfoHash: job.torrentHash,
+      ).toPayload(fileName: p.basename(file.path));
+    } on TorrentMetainfoException catch (error) {
+      throw VideoDownloadPipelineActionRequired(error.message);
+    }
   }
 
   Future<void> _observeDownload(VideoDownloadJobRow job) async {
@@ -1407,6 +1625,10 @@ class VideoDownloadPipelineService {
       await _reconcileLegacyDownload(job);
       return;
     }
+    if (discoveryKindOfOrganizationPolicy(job.organizationPolicy) != null) {
+      await _resolveDiscoveryDownloadPaths(job);
+      return;
+    }
     final MediaSourceRow source = await _managedSource(job);
     final VideoDownloadBackendBinding binding = await _binding(job);
     final String hash = job.backendTaskId ?? job.torrentHash ?? '';
@@ -1485,6 +1707,80 @@ class VideoDownloadPipelineService {
     rows = await database.getVideoDownloadJobFiles(job.jobId);
     await _markFilesOrganized(rows);
     await _advanceToSubtitle(job, rows);
+  }
+
+  /// 手动「按域入库」任务的 organize：不重命名、不搬进受管视频来源，只把后端
+  /// 报告的文件解析成本机绝对路径并核对存在性/体积，随后直接跳到 import 阶段
+  /// （这类内容没有字幕概念，subtitle 阶段整段不进）。
+  Future<void> _resolveDiscoveryDownloadPaths(VideoDownloadJobRow job) async {
+    final VideoDownloadBackendBinding binding = await _binding(job);
+    final String hash = job.backendTaskId ?? job.torrentHash ?? '';
+    if (hash.isEmpty) {
+      throw const VideoDownloadPipelineActionRequired('Torrent id is missing');
+    }
+    final List<VideoDownloadPathMapping> mappings = _effectivePathMappings(
+      binding,
+      observedSavePath: job.observedSavePath,
+    );
+    final ({VideoDownloadPathMapping mapping, String localPath}) saveRoot =
+        await _validateObservedSavePath(job, mappings);
+    final List<TorrentFileEntry> backendFiles =
+        await binding.backend.listFiles(hash);
+    _ensureLeaseHeld();
+    if (backendFiles.isEmpty) {
+      throw const VideoDownloadPipelineActionRequired(
+        'The download has no visible files',
+      );
+    }
+    await _ensureDownloadedFileRows(job, backendFiles);
+    final Map<int, TorrentFileEntry> byIndex = <int, TorrentFileEntry>{
+      for (final TorrentFileEntry file in backendFiles) file.index: file,
+    };
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    for (final VideoDownloadJobFileRow row
+        in await database.getVideoDownloadJobFiles(job.jobId)) {
+      _ensureLeaseHeld();
+      final TorrentFileEntry? backendFile =
+          row.backendFileIndex == null ? null : byIndex[row.backendFileIndex!];
+      if (backendFile == null) continue;
+      final String? absolutePath = _resolveBackendFileLocalPath(
+        remoteSavePath: job.observedSavePath!,
+        relativePath: backendFile.name,
+        mapping: saveRoot.mapping,
+        localSaveRoot: saveRoot.localPath,
+      );
+      if (absolutePath == null) {
+        throw VideoDownloadPipelineActionRequired(
+          'A downloaded file is outside the observed save path: '
+          '${backendFile.name}',
+        );
+      }
+      final File localFile = File(absolutePath);
+      if (!await localFile.exists()) {
+        throw VideoDownloadPipelineActionRequired(
+          'A downloaded file is not accessible on this device: '
+          '${backendFile.name}',
+        );
+      }
+      if (backendFile.size > 0 &&
+          await localFile.length() != backendFile.size) {
+        throw VideoDownloadPipelineActionRequired(
+          'A downloaded file size does not match: ${backendFile.name}',
+        );
+      }
+      await database.updateVideoDownloadJobFile(
+        row.id,
+        VideoDownloadJobFilesCompanion(
+          currentRelativePath: Value<String>(backendFile.name),
+          finalAbsolutePath: Value<String?>(absolutePath),
+          sizeBytes: Value<int?>(backendFile.size),
+          status: const Value<String>(VideoDownloadJobFileStatus.organized),
+          error: const Value<String?>(null),
+          updatedAt: Value<int>(now),
+        ),
+      );
+    }
+    await _advance(job, VideoDownloadJobStage.import);
   }
 
   /// Reconciles a pre-v78 plan against its original backend location. Legacy
@@ -2306,6 +2602,12 @@ class VideoDownloadPipelineService {
 
   Future<void> _importMedia(VideoDownloadJobRow job) async {
     _ensureLeaseHeld();
+    final DiscoveryMediaKind? discoveryKind =
+        discoveryKindOfOrganizationPolicy(job.organizationPolicy);
+    if (discoveryKind != null) {
+      await _importDiscoveryMedia(job, discoveryKind);
+      return;
+    }
     final bool legacy = job.organizationPolicy == 'legacy';
     final MediaSourceRow? source = legacy ? null : await _managedSource(job);
     final List<VideoDownloadJobFileRow> files = (await database
@@ -2429,7 +2731,10 @@ class VideoDownloadPipelineService {
       );
     }
     database.notifyVideoLibraryChanged();
-    if (legacy) {
+    // 没有确认过的发现身份（手动任务）时 scrape 阶段永远不可能成功——那一步
+    // 的第一件事就是要求 provider/externalId。直接完成，别把任务钉在
+    // needsAttention 上让用户困惑。
+    if (legacy || job.metadataProvider == null || job.externalId == null) {
       await _releaseLeaseWith(
         () => database.completeVideoDownloadJob(
           jobId: job.jobId,
@@ -2440,6 +2745,63 @@ class VideoDownloadPipelineService {
       return;
     }
     await _advance(job, VideoDownloadJobStage.scrape, nowAt: now);
+  }
+
+  /// 手动「按域入库」任务的 import：整包绝对路径交给 [discoveryImporter]
+  /// （分类 → 需要时解压 → 各域既有导入原语），成功即完成任务。
+  Future<void> _importDiscoveryMedia(
+    VideoDownloadJobRow job,
+    DiscoveryMediaKind kind,
+  ) async {
+    final VideoDownloadDiscoveryImporter? importer = discoveryImporter;
+    if (importer == null) {
+      throw const VideoDownloadPipelineActionRequired(
+        'Importing this content kind is not supported on this device',
+      );
+    }
+    final List<VideoDownloadJobFileRow> rows =
+        await database.getVideoDownloadJobFiles(job.jobId);
+    final List<String> paths = <String>[
+      for (final VideoDownloadJobFileRow row in rows)
+        if (row.finalAbsolutePath?.trim().isNotEmpty ?? false)
+          row.finalAbsolutePath!,
+    ];
+    if (paths.isEmpty) {
+      throw const VideoDownloadPipelineActionRequired(
+        'No downloaded files are available for import',
+      );
+    }
+    _ensureLeaseHeld();
+    final DiscoveryImportOutcome outcome;
+    try {
+      outcome = await importer(kind, paths);
+    } on DiscoveryImportBlockedException catch (error) {
+      // 分类不出/解压失败是内容问题，不是可重试的环境问题。
+      throw VideoDownloadPipelineActionRequired(error.toString());
+    }
+    _ensureLeaseHeld();
+    debugPrint('[manual-download] imported ${outcome.importedCount} item(s) '
+        'as ${kind.name}${outcome.summary == null ? '' : ': ${outcome.summary}'}');
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    // importedCount == 0（库里已有同一本）也算完成：文件就位、库里可见，用户
+    // 无事可做。真正的失败在上面以异常表达。
+    for (final VideoDownloadJobFileRow row in rows) {
+      if (row.finalAbsolutePath == null) continue;
+      await database.updateVideoDownloadJobFile(
+        row.id,
+        VideoDownloadJobFilesCompanion(
+          status: const Value<String>(VideoDownloadJobFileStatus.imported),
+          updatedAt: Value<int>(now),
+        ),
+      );
+    }
+    await _releaseLeaseWith(
+      () => database.completeVideoDownloadJob(
+        jobId: job.jobId,
+        workerId: workerId,
+        completedAt: now,
+      ),
+    );
   }
 
   Future<void> _scrapeMedia(VideoDownloadJobRow job) async {

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3995,6 +3995,12 @@ class AppModel with ChangeNotifier {
       backendResolver: _resolveVideoDownloadBackend,
       scrapeCoordinator: scrape,
       onBackendTaskAdded: _checkpointEmbeddedVideoDownload,
+      // 手动添加任务（下载页「添加任务」）：非视频内容整包交发现导入执行器
+      // 按域入库；.torrent 元数据落 app 目录随任务持久化。
+      discoveryImporter: (DiscoveryMediaKind kind, List<String> paths) =>
+          discoveryImportExecutor.importPaths(kind, paths),
+      manualTorrentDirectory:
+          Directory(path.join(appDirectory.path, 'manual_torrents')),
     )..start();
     _videoDownloadPipelineService = pipeline;
     _videoDownloadSubscriptionService = VideoDownloadSubscriptionService(

--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -3,14 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 
-import 'package:fushi/src/media/manga/manga_module.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_tasks_section.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
 import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
 import 'package:fushi/src/media/video/download/video_resource_registry.dart';
 import 'package:fushi/src/models/app_model.dart';
-import 'package:fushi/src/pages/implementations/airing_calendar_page.dart';
 import 'package:fushi/src/pages/implementations/anime_download_dialog.dart';
+import 'package:fushi/src/pages/implementations/manual_download_task_dialog.dart';
 import 'package:fushi/src/pages/implementations/downloads_resource_gap.dart';
 import 'package:fushi/src/pages/implementations/media_sources_dialog.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
@@ -23,10 +22,11 @@ import 'package:fushi_core/fushi_core.dart'
     show MediaSourceRow, VideoDownloadJobRow;
 
 /// 独立「下载」页（顶层底栏 tab）＝统一下载中心：番剧下载流程 **直接内联**
-/// 铺在页面上（搜番 → 选种 → 配字幕 → 推送 + 通用磁力 + 下载任务），任务 tab
-/// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列；页头另有在线目录入口。
-/// 右上角齿轮切到「下载设置」（后端/限速/上传/做种/内存）。完成后按内容类型
-/// 自动入库（视频→视频库、epub→阅读库，见 AnimeDownloadService；漫画卷→
+/// 铺在页面上（搜番 → 选种 → 配字幕 → 推送 + 下载任务），任务 tab 同时列出
+/// 漫画「在线目录」（mokuro.moe）的卷下载队列；页头「添加任务」支持手动粘贴
+/// 磁力 / 选 .torrent 文件入队（[ManualDownloadTaskDialog]）。设置 tab 配置
+/// 后端/限速/上传/做种/内存。完成后按内容类型自动入库（视频→视频库、书籍/
+/// 漫画/游戏/有声书→各域导入器，见 VideoDownloadPipelineService；漫画卷→
 /// 书架，见 MokuroMoeDownloadQueue）。
 class DownloadsPage extends ConsumerStatefulWidget {
   const DownloadsPage({
@@ -201,34 +201,12 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     );
   }
 
-  /// 漫画「在线目录」入口（统一下载中心：书/漫画获取入口与 torrent 并列）。
-  ///
-  /// 书架页与书籍导入框的旧入口已收敛到这里，故本页是
-  /// [MangaModule.openOnlineCatalog] 的唯一消费方——目录弹窗的构造统一收在
-  /// 漫画模块里，不在页面层直接 new 它。
-  Future<void> _openMangaCatalog() async {
-    await MangaModule.openOnlineCatalog(
+  /// 手动添加任务（磁力链接 / .torrent 文件）：与搜索出的资源同走 v78 持久
+  /// 管线，任务出现在任务 tab、同一套排序/搜索/优先级/删除操作。
+  Future<void> _openManualTaskDialog() async {
+    await showManualDownloadTaskDialog(
       context: context,
-      db: ref.read(appProvider).database,
-    );
-  }
-
-  /// 放送日历整页入口（TODO-2487）。[tabContext] 必须来自 DefaultTabController
-  /// 之下（AppBar actions 里的 Builder），日历页点「订阅中」条目 pop 回来后
-  /// 用它把本页 tab 切到订阅。
-  void _openAiringCalendar(BuildContext tabContext) {
-    final TabController tabController = DefaultTabController.of(tabContext);
-    Navigator.push<void>(
-      context,
-      adaptivePageRoute<void>(
-        context: context,
-        builder: (_) => AiringCalendarPage(
-          onOpenSubscriptions: () {
-            if (!mounted) return;
-            tabController.animateTo(2);
-          },
-        ),
-      ),
+      appModel: ref.read(appProvider),
     );
   }
 
@@ -278,18 +256,15 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
               onChanged: select,
             ),
           ),
+          // 页头动作只留「添加任务」（2026-08-21 用户点名）：旧「放送日历」
+          // 「在线目录」入口都不是下载动作，前者迁往发现页（独立改造），后者
+          // 在漫画库页「浏览」视图仍然可达。
           actions: <Widget>[
             FushiIconButton(
-              icon: Icons.calendar_month_outlined,
-              tooltip: t.download_airing_calendar_title,
-              label: t.download_airing_calendar_title,
-              onTap: () => _openAiringCalendar(tabContext),
-            ),
-            FushiIconButton(
-              icon: Icons.menu_book_outlined,
-              tooltip: t.manga_online_catalog_title,
-              label: t.manga_online_catalog_title,
-              onTap: _openMangaCatalog,
+              icon: Icons.add,
+              tooltip: t.download_task_add,
+              label: t.download_task_add,
+              onTap: _openManualTaskDialog,
             ),
           ],
         );

--- a/fushi/lib/src/pages/implementations/manual_download_task_dialog.dart
+++ b/fushi/lib/src/pages/implementations/manual_download_task_dialog.dart
@@ -1,0 +1,427 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart'
+    show DiscoveryMediaKind;
+import 'package:fushi/src/media/torrent/magnet_utils.dart';
+import 'package:fushi/src/media/torrent/torrent_metainfo.dart';
+import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataMediaKind;
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/utils.dart';
+import 'package:fushi_core/fushi_core.dart' show MediaSourceRow;
+
+/// 手动添加下载任务的唯一入口（下载页页头「添加任务」）。
+///
+/// 前置条件（后端可达 + 身份可解析）在开框前解析好：解析失败给一条可读提示，
+/// 不让用户填完表单才发现后端没配。
+Future<void> showManualDownloadTaskDialog({
+  required BuildContext context,
+  required AppModel appModel,
+}) async {
+  final VideoDownloadPipelineService? pipeline =
+      appModel.videoDownloadPipelineService;
+  if (pipeline == null) {
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text(t.download_backend_not_configured)),
+    );
+    return;
+  }
+  final VideoDownloadBackendIdentity identity;
+  try {
+    identity = await appModel.currentVideoDownloadBackendIdentity();
+  } on Object catch (error) {
+    if (context.mounted) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text('$error')),
+      );
+    }
+    return;
+  }
+  final List<MediaSourceRow> sources =
+      await appModel.getManagedVideoDownloadSources();
+  if (!context.mounted) return;
+  await showAppDialog<void>(
+    context: context,
+    builder: (BuildContext _) => ManualDownloadTaskDialog(
+      pipeline: pipeline,
+      identity: identity,
+      sources: sources,
+      defaultSourceId: appModel.prefsRepo.videoDownloadTargetSourceId,
+    ),
+  );
+}
+
+/// 粘贴磁力 / 选 .torrent 文件 → [VideoDownloadPipelineService.enqueueManual]。
+///
+/// 内容类型决定入库路径：视频走完整视频流程（需要目标受管来源），小说/漫画/
+/// 有声书/游戏在下载完成后整包交发现导入执行器按域入库。
+class ManualDownloadTaskDialog extends StatefulWidget {
+  const ManualDownloadTaskDialog({
+    required this.pipeline,
+    required this.identity,
+    required this.sources,
+    required this.defaultSourceId,
+    super.key,
+  });
+
+  final VideoDownloadPipelineService pipeline;
+  final VideoDownloadBackendIdentity identity;
+  final List<MediaSourceRow> sources;
+  final int? defaultSourceId;
+
+  @override
+  State<ManualDownloadTaskDialog> createState() =>
+      _ManualDownloadTaskDialogState();
+}
+
+class _ManualDownloadTaskDialogState extends State<ManualDownloadTaskDialog> {
+  final TextEditingController _magnetController = TextEditingController();
+  final TextEditingController _titleController = TextEditingController();
+
+  InspectedTorrentMetainfo? _metainfo;
+  String? _metainfoFileName;
+
+  /// null = 视频（默认）；其余按域入库。
+  DiscoveryMediaKind? _discoveryKind;
+  VideoMetadataMediaKind _mediaKind = VideoMetadataMediaKind.movie;
+  int? _sourceId;
+  VideoDownloadSubtitlePolicy _subtitlePolicy =
+      VideoDownloadSubtitlePolicy.none;
+  bool _submitting = false;
+
+  /// 标题框最近一次被自动预填的值：用户改过就不再覆盖。
+  String _autoFilledTitle = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _sourceId = widget.defaultSourceId ??
+        (widget.sources.isEmpty ? null : widget.sources.first.id);
+  }
+
+  @override
+  void dispose() {
+    _magnetController.dispose();
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  String? get _magnetHash => parseMagnetInfoHash(_magnetController.text);
+
+  bool get _hasPayload => _metainfo != null || _magnetHash != null;
+
+  bool get _isVideo => _discoveryKind == null;
+
+  bool get _canSubmit =>
+      !_submitting &&
+      _hasPayload &&
+      _titleController.text.trim().isNotEmpty &&
+      (!_isVideo || _sourceId != null);
+
+  void _prefillTitle(String? candidate) {
+    final String value = candidate?.trim() ?? '';
+    if (value.isEmpty) return;
+    final String current = _titleController.text.trim();
+    if (current.isNotEmpty && current != _autoFilledTitle) return;
+    _titleController.text = value;
+    _autoFilledTitle = value;
+  }
+
+  void _onMagnetChanged(String value) {
+    setState(() {
+      if (value.trim().isNotEmpty) {
+        // 磁力与 .torrent 文件互斥：以最后编辑的一方为准。
+        _metainfo = null;
+        _metainfoFileName = null;
+      }
+      _prefillTitle(parseMagnetDisplayName(value));
+    });
+  }
+
+  Future<void> _pickTorrentFile() async {
+    final FilePickerResult? picked = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: <String>['torrent'],
+      withData: true,
+    );
+    if (picked == null || picked.files.isEmpty) return;
+    final PlatformFile file = picked.files.first;
+    Uint8List? bytes = file.bytes;
+    if (bytes == null && file.path != null) {
+      try {
+        bytes = await File(file.path!).readAsBytes();
+      } on Object {
+        bytes = null;
+      }
+    }
+    if (!mounted) return;
+    if (bytes == null || bytes.isEmpty) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(t.download_task_add_invalid)),
+      );
+      return;
+    }
+    final InspectedTorrentMetainfo metainfo;
+    try {
+      metainfo = inspectTorrentMetainfo(bytes);
+    } on TorrentMetainfoException {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(t.download_task_add_invalid)),
+      );
+      return;
+    }
+    setState(() {
+      _metainfo = metainfo;
+      _metainfoFileName = file.name;
+      _magnetController.clear();
+      _prefillTitle(metainfo.suggestedName ?? file.name);
+    });
+  }
+
+  Future<void> _submit() async {
+    if (!_canSubmit) return;
+    setState(() => _submitting = true);
+    try {
+      await widget.pipeline.enqueueManual(
+        VideoDownloadManualEnqueueRequest(
+          title: _titleController.text.trim(),
+          backendIdentity: widget.identity,
+          magnetUri: _metainfo == null ? _magnetController.text.trim() : null,
+          metainfo: _metainfo,
+          discoveryKind: _discoveryKind,
+          mediaKind: _mediaKind,
+          targetSourceId: _isVideo ? _sourceId : null,
+          subtitlePolicy: _subtitlePolicy,
+        ),
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+        SnackBar(content: Text(t.download_task_add_submitted)),
+      );
+    } on Object catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          SnackBar(
+            content: Text(t.download_task_action_failed(error: '$error')),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return AlertDialog(
+      title: Text(t.download_task_add),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              TextField(
+                key: const ValueKey<String>('manual-task-magnet'),
+                controller: _magnetController,
+                decoration: InputDecoration(
+                  labelText: t.anime_download_generic_hint,
+                  prefixIcon: const Icon(Icons.link),
+                ),
+                maxLines: 1,
+                onChanged: _onMagnetChanged,
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              Row(
+                children: <Widget>[
+                  OutlinedButton.icon(
+                    key: const ValueKey<String>('manual-task-pick-torrent'),
+                    onPressed: _submitting ? null : _pickTorrentFile,
+                    icon: const Icon(Icons.file_open_outlined, size: 18),
+                    label: Text(t.download_task_add_pick_torrent),
+                  ),
+                  SizedBox(width: tokens.spacing.gap),
+                  Expanded(
+                    child: Text(
+                      _metainfoFileName ?? '',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              TextField(
+                key: const ValueKey<String>('manual-task-title'),
+                controller: _titleController,
+                decoration: InputDecoration(
+                  labelText: t.download_task_add_title_label,
+                ),
+                maxLines: 1,
+                onChanged: (_) => setState(() {}),
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              DropdownButtonFormField<DiscoveryMediaKind?>(
+                key: const ValueKey<String>('manual-task-content-kind'),
+                initialValue: _discoveryKind,
+                decoration: InputDecoration(
+                  labelText: t.download_task_add_content_kind,
+                ),
+                items: <DropdownMenuItem<DiscoveryMediaKind?>>[
+                  DropdownMenuItem<DiscoveryMediaKind?>(
+                    value: null,
+                    child: Text(t.anime_download_kind_video),
+                  ),
+                  DropdownMenuItem<DiscoveryMediaKind?>(
+                    value: DiscoveryMediaKind.novel,
+                    child: Text(t.discovery_kind_novel),
+                  ),
+                  DropdownMenuItem<DiscoveryMediaKind?>(
+                    value: DiscoveryMediaKind.manga,
+                    child: Text(t.discovery_kind_manga),
+                  ),
+                  DropdownMenuItem<DiscoveryMediaKind?>(
+                    value: DiscoveryMediaKind.audiobook,
+                    child: Text(t.discovery_kind_audiobook),
+                  ),
+                  DropdownMenuItem<DiscoveryMediaKind?>(
+                    value: DiscoveryMediaKind.game,
+                    child: Text(t.games),
+                  ),
+                ],
+                onChanged: _submitting
+                    ? null
+                    : (DiscoveryMediaKind? value) =>
+                        setState(() => _discoveryKind = value),
+              ),
+              if (_isVideo) ...<Widget>[
+                SizedBox(height: tokens.spacing.gap),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                      child: DropdownButtonFormField<VideoMetadataMediaKind>(
+                        key: const ValueKey<String>('manual-task-media-kind'),
+                        initialValue: _mediaKind,
+                        decoration: InputDecoration(
+                          labelText: t.media_tracking_kind,
+                        ),
+                        items: <DropdownMenuItem<VideoMetadataMediaKind>>[
+                          DropdownMenuItem<VideoMetadataMediaKind>(
+                            value: VideoMetadataMediaKind.movie,
+                            child: Text(t.collection_relation_movie),
+                          ),
+                          DropdownMenuItem<VideoMetadataMediaKind>(
+                            value: VideoMetadataMediaKind.tv,
+                            child: Text(t.series),
+                          ),
+                        ],
+                        onChanged: _submitting
+                            ? null
+                            : (VideoMetadataMediaKind? value) {
+                                if (value != null) {
+                                  setState(() => _mediaKind = value);
+                                }
+                              },
+                      ),
+                    ),
+                    SizedBox(width: tokens.spacing.gap),
+                    Expanded(
+                      child:
+                          DropdownButtonFormField<VideoDownloadSubtitlePolicy>(
+                        key: const ValueKey<String>(
+                          'manual-task-subtitle-policy',
+                        ),
+                        initialValue: _subtitlePolicy,
+                        decoration: InputDecoration(
+                          labelText: t.anime_download_include_subs,
+                        ),
+                        items: <DropdownMenuItem<VideoDownloadSubtitlePolicy>>[
+                          DropdownMenuItem<VideoDownloadSubtitlePolicy>(
+                            value: VideoDownloadSubtitlePolicy.none,
+                            child: Text(t.anime_download_no_subs),
+                          ),
+                          DropdownMenuItem<VideoDownloadSubtitlePolicy>(
+                            value: VideoDownloadSubtitlePolicy.bestEffort,
+                            child: Text(t.anime_download_include_subs),
+                          ),
+                        ],
+                        onChanged: _submitting
+                            ? null
+                            : (VideoDownloadSubtitlePolicy? value) {
+                                if (value != null) {
+                                  setState(() => _subtitlePolicy = value);
+                                }
+                              },
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: tokens.spacing.gap),
+                if (widget.sources.isEmpty)
+                  Text(
+                    t.download_no_managed_video_source,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                  )
+                else
+                  DropdownButtonFormField<int>(
+                    key: const ValueKey<String>('manual-task-source'),
+                    initialValue: _sourceId,
+                    isExpanded: true,
+                    decoration: InputDecoration(
+                      labelText: t.video_download_target_source_title,
+                    ),
+                    items: widget.sources
+                        .map(
+                          (MediaSourceRow source) => DropdownMenuItem<int>(
+                            value: source.id,
+                            child: Text(
+                              source.label,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        )
+                        .toList(growable: false),
+                    onChanged: _submitting
+                        ? null
+                        : (int? value) => setState(() => _sourceId = value),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.of(context).pop(),
+          child: Text(t.dialog_cancel),
+        ),
+        FilledButton.icon(
+          key: const ValueKey<String>('manual-task-submit'),
+          onPressed: _canSubmit ? () => unawaited(_submit()) : null,
+          icon: _submitting
+              ? const SizedBox.square(
+                  dimension: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.add),
+          label: Text(t.download_task_add),
+        ),
+      ],
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
@@ -1178,6 +1178,10 @@ class _VideoResourceSearchSurfaceState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         Row(
+          // 左侧带 helperText、右侧没有：默认的居中对齐会把右侧输入框往下挤
+          // 半个 helper 高（两个框底边错位）。顶对齐让两个框同高齐边，helper
+          // 自然挂在左框下方。
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Expanded(
               child: DropdownButtonFormField<int>(

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -12,6 +12,7 @@ import 'package:fushi_core/fushi_core.dart'
         VideoDownloadJobStage;
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
 import 'package:fushi/src/media/torrent/torrent_task_display.dart';
 import 'package:fushi/src/media/video/download/video_download_error_presentation.dart';
@@ -64,6 +65,76 @@ typedef VideoDownloadJobPriorityAction = Future<void> Function(
   VideoDownloadJobRow job,
   int priority,
 );
+
+/// 任务列表的排序维度（会话级，不落偏好——列表通常几十条，切换成本为零）。
+enum VideoDownloadJobSort { createdDesc, titleAsc, progressDesc, statusGroup }
+
+/// [VideoDownloadJobSort.statusGroup] 的分组次序：越需要用户看的越靠前。
+int videoDownloadLifecycleRank(String lifecycle) => switch (lifecycle) {
+      VideoDownloadJobLifecycle.needsAttention => 0,
+      VideoDownloadJobLifecycle.failed => 1,
+      VideoDownloadJobLifecycle.active => 2,
+      VideoDownloadJobLifecycle.cancelled => 3,
+      VideoDownloadJobLifecycle.completed => 4,
+      _ => 5,
+    };
+
+/// 任务在没有实时后端快照时的可比进度：完成恒 1，否则用持久的阶段进度。
+double videoDownloadJobComparableProgress(VideoDownloadJobRow job) =>
+    job.lifecycle == VideoDownloadJobLifecycle.completed
+        ? 1
+        : job.stageProgress.clamp(0, 1).toDouble();
+
+/// 按 [sort] 返回新的有序列表。纯函数，稳定 tiebreak 用 createdAt 倒序 + jobId。
+List<VideoDownloadJobRow> sortedVideoDownloadJobs(
+  List<VideoDownloadJobRow> jobs,
+  VideoDownloadJobSort sort,
+) {
+  int byCreatedDesc(VideoDownloadJobRow a, VideoDownloadJobRow b) {
+    final int byCreated = b.createdAt.compareTo(a.createdAt);
+    return byCreated != 0 ? byCreated : a.jobId.compareTo(b.jobId);
+  }
+
+  final List<VideoDownloadJobRow> out = List<VideoDownloadJobRow>.of(jobs);
+  switch (sort) {
+    case VideoDownloadJobSort.createdDesc:
+      out.sort(byCreatedDesc);
+    case VideoDownloadJobSort.titleAsc:
+      out.sort((VideoDownloadJobRow a, VideoDownloadJobRow b) {
+        final int byTitle =
+            a.title.toLowerCase().compareTo(b.title.toLowerCase());
+        return byTitle != 0 ? byTitle : byCreatedDesc(a, b);
+      });
+    case VideoDownloadJobSort.progressDesc:
+      out.sort((VideoDownloadJobRow a, VideoDownloadJobRow b) {
+        final int byProgress = videoDownloadJobComparableProgress(b)
+            .compareTo(videoDownloadJobComparableProgress(a));
+        return byProgress != 0 ? byProgress : byCreatedDesc(a, b);
+      });
+    case VideoDownloadJobSort.statusGroup:
+      out.sort((VideoDownloadJobRow a, VideoDownloadJobRow b) {
+        final int byRank = videoDownloadLifecycleRank(a.lifecycle)
+            .compareTo(videoDownloadLifecycleRank(b.lifecycle));
+        return byRank != 0 ? byRank : byCreatedDesc(a, b);
+      });
+  }
+  return out;
+}
+
+/// 搜索过滤：标题与资源发布名任一命中即留（与库页同一套归一化口径，全角/
+/// 片假名/标点差异不挡命中）。纯函数。
+List<VideoDownloadJobRow> filterVideoDownloadJobs(
+  List<VideoDownloadJobRow> jobs,
+  String query,
+) =>
+    filterByMediaSearch(
+      jobs,
+      query,
+      (VideoDownloadJobRow job) => <String>[
+        job.title,
+        if (job.resourceTitle?.trim().isNotEmpty ?? false) job.resourceTitle!,
+      ],
+    );
 
 /// Compact task surface for schema-v78 durable video downloads.
 ///
@@ -147,11 +218,22 @@ class VideoDownloadJobsPanel extends StatefulWidget {
 class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
   late Stream<List<VideoDownloadJobRow>> _jobs;
   final Set<String> _busyJobIds = <String>{};
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  String _searchQuery = '';
+  VideoDownloadJobSort _sort = VideoDownloadJobSort.createdDesc;
 
   @override
   void initState() {
     super.initState();
     _jobs = widget.store.watchJobs();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
   }
 
   @override
@@ -293,56 +375,127 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
               message: t.anime_download_no_tasks,
             );
           }
-          return _VideoDownloadJobList(
-            jobs: jobs,
-            metricsLoader: widget.metricsLoader,
-            selectedSizeLoader: widget.selectedSizeLoader,
-            itemBuilder: (
-              BuildContext context,
-              VideoDownloadJobRow job,
-              TorrentSnapshot? snapshot,
-              int? selectedSizeBytes,
-            ) =>
-                _VideoDownloadJobCard(
-              key: ValueKey<String>(
-                'video-download-job-${job.jobId}',
+          final List<VideoDownloadJobRow> visible = sortedVideoDownloadJobs(
+            filterVideoDownloadJobs(jobs, _searchQuery),
+            _sort,
+          );
+          return Column(
+            children: <Widget>[
+              _buildToolbar(),
+              Expanded(
+                child: visible.isEmpty
+                    ? _MessageState(
+                        icon: Icons.search_off,
+                        message: t.download_task_no_match,
+                      )
+                    : _buildJobList(visible),
               ),
-              job: job,
-              snapshot: snapshot,
-              selectedSizeBytes: selectedSizeBytes,
-              busy: _busyJobIds.contains(job.jobId),
-              onRetry: widget.onRetry == null
-                  ? null
-                  : () => _runAction(job, widget.onRetry!),
-              onResume: widget.onResume == null
-                  ? null
-                  : () => _runAction(job, widget.onResume!),
-              onCancel: widget.onCancel == null
-                  ? null
-                  : () => _runAction(job, widget.onCancel!),
-              onOpenDetails: widget.onOpenDetails == null
-                  ? null
-                  : () => _runAction(job, widget.onOpenDetails!),
-              onSetPriority: widget.onSetPriority == null
-                  ? null
-                  : (int priority) => _runAction(
-                        job,
-                        (VideoDownloadJobRow row) =>
-                            widget.onSetPriority!(row, priority),
-                      ),
-              // Mobile has no file-manager reveal contract; the action would
-              // always fail, so it is not offered there.
-              onOpenLocation: widget.locationLoader == null ||
-                      currentVideoDownloadRevealHost() == null
-                  ? null
-                  : () => _openLocation(job),
-              onDelete:
-                  widget.onDelete == null ? null : () => _confirmDelete(job),
-              lifecycleLabel: widget.lifecycleLabel,
-              stageLabel: widget.stageLabel,
-            ),
+            ],
           );
         },
+      ),
+    );
+  }
+
+  /// 任务列表上方的搜索 + 排序工具条（只在真有任务时出现）。
+  Widget _buildToolbar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: FushiSearchField(
+              fieldKey: const ValueKey<String>('video-download-job-search'),
+              controller: _searchController,
+              focusNode: _searchFocusNode,
+              hintText: t.download_task_search_hint,
+              onChanged: (String value) => setState(() => _searchQuery = value),
+              onSubmitted: (String value) =>
+                  setState(() => _searchQuery = value),
+              onClear: () => setState(() => _searchQuery = ''),
+            ),
+          ),
+          const SizedBox(width: 8),
+          FushiOverflowMenu<VideoDownloadJobSort>(
+            key: const ValueKey<String>('video-download-job-sort'),
+            tooltip: t.sort_by,
+            onSelected: (VideoDownloadJobSort value) =>
+                setState(() => _sort = value),
+            items: <PopupMenuEntry<VideoDownloadJobSort>>[
+              for (final VideoDownloadJobSort value
+                  in VideoDownloadJobSort.values)
+                FushiPopupMenuItem<VideoDownloadJobSort>(
+                  value: value,
+                  label: _sortLabel(value),
+                  selected: _sort == value,
+                ),
+            ],
+            child: OutlinedButton.icon(
+              // 外层菜单接管点击；onPressed 必须为 null 才不吞菜单手势。
+              onPressed: null,
+              icon: const Icon(Icons.sort, size: 18),
+              label: Text(_sortLabel(_sort)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _sortLabel(VideoDownloadJobSort sort) => switch (sort) {
+        VideoDownloadJobSort.createdDesc => t.download_task_sort_created,
+        VideoDownloadJobSort.titleAsc => t.sort_title,
+        VideoDownloadJobSort.progressDesc => t.download_task_sort_progress,
+        VideoDownloadJobSort.statusGroup => t.download_task_sort_status,
+      };
+
+  Widget _buildJobList(List<VideoDownloadJobRow> jobs) {
+    return _VideoDownloadJobList(
+      jobs: jobs,
+      metricsLoader: widget.metricsLoader,
+      selectedSizeLoader: widget.selectedSizeLoader,
+      itemBuilder: (
+        BuildContext context,
+        VideoDownloadJobRow job,
+        TorrentSnapshot? snapshot,
+        int? selectedSizeBytes,
+      ) =>
+          _VideoDownloadJobCard(
+        key: ValueKey<String>(
+          'video-download-job-${job.jobId}',
+        ),
+        job: job,
+        snapshot: snapshot,
+        selectedSizeBytes: selectedSizeBytes,
+        busy: _busyJobIds.contains(job.jobId),
+        onRetry: widget.onRetry == null
+            ? null
+            : () => _runAction(job, widget.onRetry!),
+        onResume: widget.onResume == null
+            ? null
+            : () => _runAction(job, widget.onResume!),
+        onCancel: widget.onCancel == null
+            ? null
+            : () => _runAction(job, widget.onCancel!),
+        onOpenDetails: widget.onOpenDetails == null
+            ? null
+            : () => _runAction(job, widget.onOpenDetails!),
+        onSetPriority: widget.onSetPriority == null
+            ? null
+            : (int priority) => _runAction(
+                  job,
+                  (VideoDownloadJobRow row) =>
+                      widget.onSetPriority!(row, priority),
+                ),
+        // Mobile has no file-manager reveal contract; the action would
+        // always fail, so it is not offered there.
+        onOpenLocation: widget.locationLoader == null ||
+                currentVideoDownloadRevealHost() == null
+            ? null
+            : () => _openLocation(job),
+        onDelete: widget.onDelete == null ? null : () => _confirmDelete(job),
+        lifecycleLabel: widget.lifecycleLabel,
+        stageLabel: widget.stageLabel,
       ),
     );
   }
@@ -747,40 +900,35 @@ class _VideoDownloadJobCard extends StatelessWidget {
                   // 优先级只对「还在排队/还没做完」的任务有意义：已完成或已取消
                   // 的任务再调也不会被重新取走，给了只会让人以为能插队。
                   if (onSetPriority != null && _canSetPriority)
-                    PopupMenuButton<int>(
-                      key: ValueKey<String>(
-                        'video-download-job-priority-${job.jobId}',
-                      ),
-                      enabled: !busy,
-                      tooltip: t.download_task_priority,
-                      initialValue: job.priority,
-                      onSelected: onSetPriority,
-                      itemBuilder: (BuildContext context) =>
-                          <PopupMenuEntry<int>>[
-                        PopupMenuItem<int>(
-                          value: 1,
-                          child: Text(t.download_task_priority_high),
-                        ),
-                        PopupMenuItem<int>(
-                          value: 0,
-                          child: Text(t.download_task_priority_normal),
-                        ),
-                        PopupMenuItem<int>(
-                          value: -1,
-                          child: Text(t.download_task_priority_low),
-                        ),
-                      ],
-                      child: OutlinedButton.icon(
-                        // 外层 PopupMenuButton 已接管点击；这里只借用按钮外观，
-                        // onPressed 必须为 null 才不会吞掉菜单的手势。
-                        onPressed: null,
-                        icon: const Icon(Icons.low_priority, size: 18),
-                        label: Text(
-                          '${t.download_task_priority} · '
-                          '${_priorityLabel(job.priority)}',
-                        ),
-                      ),
-                    ),
+                    busy
+                        ? _priorityButtonFace()
+                        // 走共享 MD3 菜单原语（圆角/浮层色/焦点可进），不再裸用
+                        // PopupMenuButton（用户截图：裸菜单没走 MD3 样式）。
+                        : FushiOverflowMenu<int>(
+                            key: ValueKey<String>(
+                              'video-download-job-priority-${job.jobId}',
+                            ),
+                            tooltip: t.download_task_priority,
+                            onSelected: onSetPriority!,
+                            items: <PopupMenuEntry<int>>[
+                              FushiPopupMenuItem<int>(
+                                value: 1,
+                                label: t.download_task_priority_high,
+                                selected: job.priority > 0,
+                              ),
+                              FushiPopupMenuItem<int>(
+                                value: 0,
+                                label: t.download_task_priority_normal,
+                                selected: job.priority == 0,
+                              ),
+                              FushiPopupMenuItem<int>(
+                                value: -1,
+                                label: t.download_task_priority_low,
+                                selected: job.priority < 0,
+                              ),
+                            ],
+                            child: _priorityButtonFace(),
+                          ),
                   if (onOpenLocation != null)
                     OutlinedButton.icon(
                       key: ValueKey<String>(
@@ -810,6 +958,16 @@ class _VideoDownloadJobCard extends StatelessWidget {
       ),
     );
   }
+
+  /// 优先级按钮的外观（真正的点击由外层菜单接管，onPressed 恒 null；busy 时
+  /// 直接单独渲染这张脸当禁用态）。
+  Widget _priorityButtonFace() => OutlinedButton.icon(
+        onPressed: null,
+        icon: const Icon(Icons.low_priority, size: 18),
+        label: Text(
+          '${t.download_task_priority} · ${_priorityLabel(job.priority)}',
+        ),
+      );
 
   /// Shows the untouched raw `lastError` diagnostics in a copyable dialog.
   Future<void> _showErrorDetail(BuildContext context) async {

--- a/fushi/test/media/video/download/video_download_pipeline_service_test.dart
+++ b/fushi/test/media/video/download/video_download_pipeline_service_test.dart
@@ -1,12 +1,18 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/discovery/discovery_download_queue.dart'
+    show DiscoveryImportOutcome;
+import 'package:fushi/src/media/discovery/discovery_models.dart'
+    show DiscoveryMediaKind;
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
+import 'package:fushi/src/media/torrent/torrent_metainfo.dart';
 import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
@@ -1353,7 +1359,232 @@ void main() {
       throwsA(isA<VideoDownloadPipelineActionRequired>()),
     );
   });
+
+  // 手动添加任务（2026-08-21 用户点名「用户没办法手动导入任务」）。
+  group('enqueueManual', () {
+    const String manualMagnet = 'magnet:?xt=urn:btih:$_torrentHash&dn=Manual';
+
+    test('organizationPolicy 与发现域互相换算，未知策略返回 null', () {
+      for (final DiscoveryMediaKind kind in DiscoveryMediaKind.values) {
+        expect(
+          discoveryKindOfOrganizationPolicy(
+            manualDiscoveryOrganizationPolicy(kind),
+          ),
+          kind,
+        );
+      }
+      expect(discoveryKindOfOrganizationPolicy('library'), isNull);
+      expect(discoveryKindOfOrganizationPolicy('legacy'), isNull);
+      expect(discoveryKindOfOrganizationPolicy('discovery-unknown'), isNull);
+    });
+
+    test('磁力视频任务落 manual 行：无发现身份、策略 library', () async {
+      final _PipelineEnvironment environment =
+          await _PipelineEnvironment.create(backend: _FakeTorrentBackend());
+      addTearDown(environment.close);
+
+      final String jobId = await environment.service.enqueueManual(
+        VideoDownloadManualEnqueueRequest(
+          title: 'Manual Movie',
+          backendIdentity: _expectedIdentity,
+          magnetUri: manualMagnet,
+          targetSourceId: environment.sourceId,
+        ),
+      );
+      final VideoDownloadJobRow? job =
+          await environment.database.getVideoDownloadJob(jobId);
+      expect(job, isNotNull);
+      expect(job!.resourceProvider, kManualVideoDownloadResourceProvider);
+      expect(job.magnetUri, manualMagnet);
+      expect(job.torrentHash, _torrentHash);
+      expect(job.metadataProvider, isNull,
+          reason: '手动任务没有发现身份，import 后必须直接完成而不是进 scrape');
+      expect(job.externalId, isNull);
+      expect(job.mediaKind, VideoMetadataMediaKind.movie.name);
+      expect(job.organizationPolicy, 'library');
+      expect(job.subtitlePolicy, VideoDownloadSubtitlePolicy.none.name);
+      expect(job.targetSourceId, environment.sourceId);
+      expect(job.title, 'Manual Movie');
+    });
+
+    test('入参校验：双 payload / 零 payload / 无 hash 磁力 / 视频缺来源', () async {
+      final _PipelineEnvironment environment =
+          await _PipelineEnvironment.create(backend: _FakeTorrentBackend());
+      addTearDown(environment.close);
+      final InspectedTorrentMetainfo metainfo =
+          inspectTorrentMetainfo(_manualV1Metainfo());
+
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'x',
+            backendIdentity: _expectedIdentity,
+            magnetUri: manualMagnet,
+            metainfo: metainfo,
+            targetSourceId: environment.sourceId,
+          ),
+        ),
+        throwsArgumentError,
+        reason: '磁力与 .torrent 恰好二选一',
+      );
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'x',
+            backendIdentity: _expectedIdentity,
+            targetSourceId: environment.sourceId,
+          ),
+        ),
+        throwsArgumentError,
+      );
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'x',
+            backendIdentity: _expectedIdentity,
+            magnetUri: 'magnet:?dn=no-hash',
+            targetSourceId: environment.sourceId,
+          ),
+        ),
+        throwsA(isA<VideoDownloadPipelineActionRequired>()),
+      );
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'x',
+            backendIdentity: _expectedIdentity,
+            magnetUri: manualMagnet,
+          ),
+        ),
+        throwsA(isA<VideoDownloadPipelineActionRequired>()),
+        reason: '视频任务必须有受管来源',
+      );
+    });
+
+    test('.torrent 任务：元数据先落盘（<jobId>.torrent），hash 取自 metainfo', () async {
+      final Directory manualDir =
+          await Directory.systemTemp.createTemp('fushi-manual-torrents-');
+      addTearDown(() async {
+        if (await manualDir.exists()) await manualDir.delete(recursive: true);
+      });
+      final _PipelineEnvironment environment =
+          await _PipelineEnvironment.create(backend: _FakeTorrentBackend());
+      addTearDown(environment.close);
+      final VideoDownloadPipelineService service = VideoDownloadPipelineService(
+        database: environment.database,
+        resourceRegistry: environment.resourceRegistry,
+        backendResolver: (_) async => VideoDownloadBackendBinding(
+          backend: environment.backend,
+          identity: _expectedIdentity,
+        ),
+        scrapeCoordinator: environment.scrapeCoordinator,
+        manualTorrentDirectory: manualDir,
+        workerId: 'manual-metainfo-worker',
+        pollInterval: const Duration(hours: 1),
+      );
+      addTearDown(service.dispose);
+      final InspectedTorrentMetainfo metainfo =
+          inspectTorrentMetainfo(_manualV1Metainfo());
+
+      final String jobId = await service.enqueueManual(
+        VideoDownloadManualEnqueueRequest(
+          title: 'Manual Torrent',
+          backendIdentity: _expectedIdentity,
+          metainfo: metainfo,
+          targetSourceId: environment.sourceId,
+        ),
+      );
+
+      expect(
+        File(p.join(manualDir.path, '$jobId.torrent')).existsSync(),
+        isTrue,
+        reason: '重启后 payload 从这份落盘元数据重新物化',
+      );
+      final VideoDownloadJobRow? job =
+          await environment.database.getVideoDownloadJob(jobId);
+      expect(job!.torrentHash, metainfo.torrentId);
+      expect(job.magnetUri, isNull);
+    });
+
+    test('.torrent 任务在未配置落盘目录时显式拒绝', () async {
+      final _PipelineEnvironment environment =
+          await _PipelineEnvironment.create(backend: _FakeTorrentBackend());
+      addTearDown(environment.close);
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'x',
+            backendIdentity: _expectedIdentity,
+            metainfo: inspectTorrentMetainfo(_manualV1Metainfo()),
+            targetSourceId: environment.sourceId,
+          ),
+        ),
+        throwsA(isA<VideoDownloadPipelineActionRequired>()),
+      );
+    });
+
+    test('发现域任务：策略 discovery-<kind>、无字幕、无目标来源；无 importer 拒绝', () async {
+      final _PipelineEnvironment environment =
+          await _PipelineEnvironment.create(backend: _FakeTorrentBackend());
+      addTearDown(environment.close);
+
+      await expectLater(
+        environment.service.enqueueManual(
+          VideoDownloadManualEnqueueRequest(
+            title: 'A Novel',
+            backendIdentity: _expectedIdentity,
+            magnetUri: manualMagnet,
+            discoveryKind: DiscoveryMediaKind.novel,
+          ),
+        ),
+        throwsA(isA<VideoDownloadPipelineActionRequired>()),
+        reason: '本设备没接发现导入执行器时不能默默收下书任务',
+      );
+
+      final VideoDownloadPipelineService service = VideoDownloadPipelineService(
+        database: environment.database,
+        resourceRegistry: environment.resourceRegistry,
+        backendResolver: (_) async => VideoDownloadBackendBinding(
+          backend: environment.backend,
+          identity: _expectedIdentity,
+        ),
+        scrapeCoordinator: environment.scrapeCoordinator,
+        discoveryImporter:
+            (DiscoveryMediaKind kind, List<String> paths) async =>
+                const DiscoveryImportOutcome(importedCount: 1),
+        workerId: 'manual-discovery-worker',
+        pollInterval: const Duration(hours: 1),
+      );
+      addTearDown(service.dispose);
+
+      final String jobId = await service.enqueueManual(
+        VideoDownloadManualEnqueueRequest(
+          title: 'A Novel',
+          backendIdentity: _expectedIdentity,
+          magnetUri: manualMagnet,
+          discoveryKind: DiscoveryMediaKind.novel,
+          // 故意同时给字幕策略与来源：发现域任务必须把它们归零。
+          subtitlePolicy: VideoDownloadSubtitlePolicy.bestEffort,
+          targetSourceId: environment.sourceId,
+        ),
+      );
+      final VideoDownloadJobRow? job =
+          await environment.database.getVideoDownloadJob(jobId);
+      expect(job!.organizationPolicy, 'discovery-novel');
+      expect(job.subtitlePolicy, VideoDownloadSubtitlePolicy.none.name,
+          reason: '非视频内容没有字幕概念');
+      expect(job.targetSourceId, isNull, reason: '发现域任务不进受管视频来源');
+      expect(job.mediaKind, DiscoveryMediaKind.novel.name);
+    });
+  });
 }
+
+/// 与 torrent_metainfo_test 同款的最小 v1 metainfo（单文件 name=test）。
+Uint8List _manualV1Metainfo() => Uint8List.fromList(
+      utf8.encode(
+        'd4:infod6:lengthi1e4:name4:test6:pieces20:aaaaaaaaaaaaaaaaaaaaee',
+      ),
+    );
 
 TorrentSnapshot _downloadingSnapshot({required double progress}) =>
     TorrentSnapshot(

--- a/fushi/test/pages/video_discovery_option_row_alignment_guard_test.dart
+++ b/fushi/test/pages/video_discovery_option_row_alignment_guard_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1765：资源/订阅面板的「默认受管视频来源 / 附带字幕」两个下拉并排，
+/// 左侧带 helperText（BUG-1713 加的）而右侧没有。Row 默认居中对齐时右框会被
+/// 往下挤半个 helper 高度，两个输入框底边错位（用户 2026-08-21 截图）。
+///
+/// 守卫钉死：包着 `video-resource-source` 的那个 Row 必须显式顶对齐。
+/// 用源码扫描而不是 widget 测试，因为该 Row 埋在需要完整 registry/sources
+/// 装配的 surface 深处，而回归形态就是「有人删掉那一行 crossAxisAlignment」。
+void main() {
+  test('来源/字幕下拉的 Row 顶对齐（helperText 不再挤歪右框）', () {
+    final File f = File(
+      'lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart',
+    );
+    expect(f.existsSync(), isTrue,
+        reason: '找不到 video_discovery_acquisition_dialogs.dart'
+            '（路径变了要同步本守卫）');
+    final String code = maskCommentsAndScriptLines(f.readAsStringSync());
+
+    final int keyIndex = code.indexOf("'video-resource-source'");
+    expect(keyIndex, greaterThan(0), reason: '来源下拉的 ValueKey 变了要同步本守卫');
+    final int rowIndex = code.lastIndexOf('Row(', keyIndex);
+    expect(rowIndex, greaterThan(0));
+    final String rowHead = code.substring(rowIndex, keyIndex);
+    expect(
+      rowHead,
+      contains('crossAxisAlignment: CrossAxisAlignment.start'),
+      reason: '左侧下拉带 helperText、右侧没有：Row 不顶对齐时两个输入框底边'
+          '错位（BUG-1765）。删这行前先想清 helper 高度差怎么消。',
+    );
+  });
+}

--- a/fushi/test/pages/video_download_jobs_panel_md3_guard_test.dart
+++ b/fushi/test/pages/video_download_jobs_panel_md3_guard_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1766：任务卡「排队优先级」此前裸用 [PopupMenuButton]，弹出的菜单没有
+/// MD3 圆角/浮层色/焦点可进（用户 2026-08-21 截图）。业务页面必须走共享原语
+/// `FushiOverflowMenu`（内部统一 shape/color/animation，手柄焦点也接了）。
+///
+/// 守卫钉死：任务面板源码不再出现裸 `PopupMenuButton(` 构造。
+/// `PopupMenuEntry` / `FushiPopupMenuItem` 类型引用不在禁用之列。
+void main() {
+  test('任务面板菜单走 FushiOverflowMenu，不裸用 PopupMenuButton', () {
+    final File f = File(
+      'lib/src/pages/implementations/video_download_jobs_panel.dart',
+    );
+    expect(f.existsSync(), isTrue,
+        reason: '找不到 video_download_jobs_panel.dart（路径变了要同步本守卫）');
+    final String code = maskCommentsAndScriptLines(f.readAsStringSync());
+
+    // 裸构造带不带泛型都算（`PopupMenuButton(` / `PopupMenuButton<int>(`）；
+    // 类型引用（PopupMenuEntry / PopupMenuButtonState）不在禁用之列。
+    expect(
+      RegExp(r'PopupMenuButton(<[^>]*>)?\s*\(').hasMatch(code),
+      isFalse,
+      reason: '裸 PopupMenuButton 菜单没走 MD3 设计令牌（BUG-1766），'
+          '用共享原语 FushiOverflowMenu。',
+    );
+    expect(code, contains('FushiOverflowMenu<'),
+        reason: '优先级/排序菜单应经共享 MD3 菜单原语渲染。');
+  });
+}

--- a/fushi/test/pages/video_download_jobs_panel_test.dart
+++ b/fushi/test/pages/video_download_jobs_panel_test.dart
@@ -748,4 +748,122 @@ void main() {
       reason: '给一个不会再被取走的任务露出「优先级」，等于骗用户能插队。',
     );
   });
+
+  // 任务列表搜索 + 排序（2026-08-21 用户点名：任务缺排序、缺搜索）。
+  group('sort & search', () {
+    test('sortedVideoDownloadJobs 四个维度各按预期排序', () {
+      final List<VideoDownloadJobRow> jobs = <VideoDownloadJobRow>[
+        _job(id: 'a', title: 'Beta', progress: 0.2)
+            .copyWith(createdAt: 100, priority: 0),
+        _job(
+          id: 'b',
+          title: 'Alpha',
+          lifecycle: VideoDownloadJobLifecycle.completed,
+          progress: 1,
+        ).copyWith(createdAt: 50),
+        _job(
+          id: 'c',
+          title: 'Gamma',
+          lifecycle: VideoDownloadJobLifecycle.needsAttention,
+          progress: 0.7,
+        ).copyWith(createdAt: 75),
+      ];
+      List<String> ids(VideoDownloadJobSort sort) =>
+          sortedVideoDownloadJobs(jobs, sort)
+              .map((VideoDownloadJobRow row) => row.jobId)
+              .toList();
+
+      expect(ids(VideoDownloadJobSort.createdDesc), <String>['a', 'c', 'b'],
+          reason: '默认最新添加在前');
+      expect(ids(VideoDownloadJobSort.titleAsc), <String>['b', 'a', 'c'],
+          reason: '名称字典序');
+      expect(ids(VideoDownloadJobSort.progressDesc), <String>['b', 'c', 'a'],
+          reason: '完成恒 1 排最前，其余按阶段进度');
+      expect(ids(VideoDownloadJobSort.statusGroup), <String>['c', 'a', 'b'],
+          reason: 'needsAttention 最需要用户看、排最前，完成最后');
+    });
+
+    test('filterVideoDownloadJobs 与库页同一套归一化（全角/大小写不挡命中）', () {
+      final List<VideoDownloadJobRow> jobs = <VideoDownloadJobRow>[
+        _job(id: 'a', title: 'Fate／stay night'),
+        _job(id: 'b', title: 'Other Show'),
+      ];
+      expect(filterVideoDownloadJobs(jobs, ''), hasLength(2), reason: '空查询不过滤');
+      final List<VideoDownloadJobRow> hit =
+          filterVideoDownloadJobs(jobs, 'fate stay');
+      expect(hit, hasLength(1));
+      expect(hit.single.jobId, 'a');
+      // resourceTitle 也可搜（用户记得住的常是发布名）。
+      expect(
+        filterVideoDownloadJobs(jobs, 'A-Rather-Long-Release-Group'),
+        hasLength(2),
+      );
+    });
+
+    testWidgets('搜索框过滤任务卡片，无命中给空态', (WidgetTester tester) async {
+      final _MemoryJobsStore store = _MemoryJobsStore();
+      addTearDown(store.close);
+      await _pumpPanel(
+        tester,
+        panel: VideoDownloadJobsPanel(store: store),
+      );
+      store.emit(<VideoDownloadJobRow>[
+        _job(id: 'a', title: 'Alpha Show'),
+        _job(id: 'b', title: 'Beta Show'),
+      ]);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('video-download-job-a')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('video-download-job-b')),
+          findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('video-download-job-search')),
+        'alpha',
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('video-download-job-a')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('video-download-job-b')),
+          findsNothing);
+
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('video-download-job-search')),
+        'zzz-no-match',
+      );
+      await tester.pumpAndSettle();
+      expect(find.text(t.download_task_no_match), findsOneWidget,
+          reason: '无命中要说清是搜索没命中，不能复用「没有任务」空态');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('排序菜单切到名称序后卡片顺序变化', (WidgetTester tester) async {
+      final _MemoryJobsStore store = _MemoryJobsStore();
+      addTearDown(store.close);
+      await _pumpPanel(
+        tester,
+        panel: VideoDownloadJobsPanel(store: store),
+      );
+      store.emit(<VideoDownloadJobRow>[
+        _job(id: 'new', title: 'Zeta Newest').copyWith(createdAt: 200),
+        _job(id: 'old', title: 'Alpha Oldest').copyWith(createdAt: 10),
+      ]);
+      await tester.pumpAndSettle();
+
+      double topOf(String id) => tester
+          .getTopLeft(find.byKey(ValueKey<String>('video-download-job-$id')))
+          .dy;
+      expect(topOf('new') < topOf('old'), isTrue, reason: '默认按添加时间倒序，最新在上');
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('video-download-job-sort')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.sort_title).last);
+      await tester.pumpAndSettle();
+      expect(topOf('old') < topOf('new'), isTrue,
+          reason: '名称序 Alpha 在 Zeta 之上');
+      expect(tester.takeException(), isNull);
+    });
+  });
 }

--- a/fushi/test/torrent/torrent_metainfo_test.dart
+++ b/fushi/test/torrent/torrent_metainfo_test.dart
@@ -42,6 +42,10 @@ void main() {
       expect(inspected.torrentId, inspected.v2InfoHash!.substring(0, 40));
     });
 
+    test('exposes info.name as suggestedName（手动添加任务预填标题用）', () {
+      expect(inspectTorrentMetainfo(_v1Metainfo()).suggestedName, 'test');
+    });
+
     test('rejects a declared hash mismatch', () {
       expect(
         () => inspectTorrentMetainfo(


### PR DESCRIPTION
用户 2026-08-21 下载页反馈批次 A（决策记录：放送日历后续在发现页重做；手动任务走新管线；B1-B4 大改造另开 PR）。

## 改动
- **删页头「放送日历」「在线目录」入口**：日历迁发现页（独立 PR 跟进重做），在线目录漫画库「浏览」视图仍可达；页头动作位换成「添加任务」。
- **手动添加任务（磁力 / .torrent）进新管线**：`VideoDownloadPipelineService.enqueueManual`
  - 视频任务：完整 organize/subtitle/import 流程（选电影/剧集、目标受管来源、字幕策略）；
  - 小说/漫画/有声书/游戏：`organizationPolicy = discovery-<kind>`，下载完成整包交 `DiscoveryImportExecutor` 按域入库（不重命名、不进受管视频来源）；
  - `.torrent` 元数据入队即落 `manual_torrents/<jobId>.torrent`，重启后 payload 重新物化并复核 infohash；
  - 手动任务无发现身份 → import 后直接完成，不再进注定失败的 scrape 阶段（该修复同时惠及所有无身份任务）。
- **任务列表搜索 + 排序**：搜索走库页同一套归一化（全角/片假名/标点不挡命中），排序四维（添加时间/名称/进度/状态），纯函数可测。
- **BUG-1765** 来源/字幕下拉底边错位：左侧 helperText 高度差 + Row 默认居中对齐 → 改顶对齐；源码守卫已变异实测。
- **BUG-1766** 优先级菜单未走 MD3：裸 `PopupMenuButton` → `FushiOverflowMenu` + `FushiPopupMenuItem`（当前档位高亮）；守卫变异实测时抓到泛型逃逸，已改正则。
- **资源 tab 空态文案**：说明下载不限视频（书/漫画/有声书/游戏自动入库），17 语言 i18n_sync 重建。

## 验证
- `flutter analyze` 全量绿（No issues found）。
- 定向测试 65+99 全绿：任务面板（含新排序/搜索 widget 测试）、管线（新增 enqueueManual 6 例）、metainfo、下载页门头/inset 守卫、订阅面板、MD3 静态守卫、i18n 完整性。
- 两条新源码守卫做了变异实测（注入回归→红→sha256 逐字节还原→绿）。
- `dart run tool/bug.dart check` 通过（1635 条，号唯一）。

https://claude.ai/code/session_01NiDoGenLF9eanzXqxaWYAG