### PR TITLE
feat(subtitle): B1 字幕搜索重做——两级版本聚类选择器 + 正文语言检测

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62237 (3661 per locale)
+/// Strings: 62339 (3667 per locale)
 ///
-/// Built on 2026-08-20 at 09:30 UTC
+/// Built on 2026-08-21 at 14:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4979,6 +4979,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The peer isn\'t using HTTPS on this port. Use an http:// address.';
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  String get subtitle_version_ai_translated => 'AI translated';
+  String get subtitle_version_content_language => 'Content';
+  String get subtitle_version_show_files => 'Show files';
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -13470,6 +13477,19 @@ class _StringsAr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -22026,6 +22046,19 @@ class _StringsDe extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -30598,6 +30631,19 @@ class _StringsEs extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -39182,6 +39228,19 @@ class _StringsFr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -47696,6 +47755,19 @@ class _StringsId extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -56254,6 +56326,19 @@ class _StringsIt extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -64629,6 +64714,19 @@ class _StringsJa extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -73011,6 +73109,19 @@ class _StringsKo extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -81549,6 +81660,19 @@ class _StringsNl extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -90099,6 +90223,19 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -98636,6 +98773,19 @@ class _StringsRu extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -107121,6 +107271,19 @@ class _StringsTh extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -115637,6 +115800,19 @@ class _StringsTr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -124139,6 +124315,19 @@ class _StringsVi extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -131999,6 +132188,18 @@ class _StringsZhCn extends _StringsEn {
   String get sync_pair_peer_not_https => '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
   @override
   String get sync_pair_not_fushi_discovered => '此地址未找到 Fushi 设备。';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '共 ${n} 集';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) => '${n} 个未编号';
+  @override
+  String get subtitle_version_ai_translated => '机翻';
+  @override
+  String get subtitle_version_content_language => '正文';
+  @override
+  String get subtitle_version_show_files => '展开文件';
+  @override
+  String get subtitle_version_view_files => '文件视图';
 }
 
 // Path: <root>
@@ -140297,6 +140498,19 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 /// Flat map(s) containing all translations.
@@ -147811,6 +148025,18 @@ extension on _StringsEn {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -155323,6 +155549,18 @@ extension on _StringsAr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -162857,6 +163095,18 @@ extension on _StringsDe {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -170390,6 +170640,18 @@ extension on _StringsEs {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -177929,6 +178191,18 @@ extension on _StringsFr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -185450,6 +185724,18 @@ extension on _StringsId {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -192985,6 +193271,18 @@ extension on _StringsIt {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -200482,6 +200780,18 @@ extension on _StringsJa {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -207983,6 +208293,18 @@ extension on _StringsKo {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -215512,6 +215834,18 @@ extension on _StringsNl {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -223038,6 +223372,18 @@ extension on _StringsPtBr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -230569,6 +230915,18 @@ extension on _StringsRu {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -238083,6 +238441,18 @@ extension on _StringsTh {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -245606,6 +245976,18 @@ extension on _StringsTr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -253125,6 +253507,18 @@ extension on _StringsVi {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -260585,6 +260979,18 @@ extension on _StringsZhCn {
         return '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
       case 'sync_pair_not_fushi_discovered':
         return '此地址未找到 Fushi 设备。';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '共 ${n} 集';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} 个未编号';
+      case 'subtitle_version_ai_translated':
+        return '机翻';
+      case 'subtitle_version_content_language':
+        return '正文';
+      case 'subtitle_version_show_files':
+        return '展开文件';
+      case 'subtitle_version_view_files':
+        return '文件视图';
       default:
         return null;
     }
@@ -268077,6 +268483,18 @@ extension on _StringsZhHk {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "地址格式无效",
   "sync_pair_peer_requires_https": "该设备只接受 HTTPS，请改用 https:// 开头的地址。",
   "sync_pair_peer_not_https": "对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。",
-  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。"
+  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。",
+  "subtitle_version_episode_count": "共 $n 集",
+  "subtitle_version_unnumbered_count": "$n 个未编号",
+  "subtitle_version_ai_translated": "机翻",
+  "subtitle_version_content_language": "正文",
+  "subtitle_version_show_files": "展开文件",
+  "subtitle_version_view_files": "文件视图"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -27,11 +27,16 @@ class JimakuFile {
     required this.name,
     required this.url,
     this.size,
+    this.lastModifiedMs,
   });
 
   final String name;
   final String url;
   final int? size;
+
+  /// API `last_modified`（ISO-8601）解析成的 epoch 毫秒；缺失/不可解析为
+  /// null。版本选择器的「N 天前」与最新文件判定用。
+  final int? lastModifiedMs;
 
   /// 文件扩展名（小写，不含点）；用于选解析器（srt/ass/vtt）。
   String get extension {
@@ -314,6 +319,7 @@ List<JimakuFile> parseJimakuFiles(String body, {bool strict = false}) {
         name: name,
         url: url,
         size: f['size'] is int ? f['size'] as int : null,
+        lastModifiedMs: parseJimakuTimestampMs(f['last_modified']),
       ));
     }
     return out;
@@ -328,6 +334,13 @@ List<JimakuFile> parseJimakuFiles(String body, {bool strict = false}) {
     }
     return const <JimakuFile>[];
   }
+}
+
+/// 解析 Jimaku 的 `last_modified`（ISO-8601 字符串）为 epoch 毫秒。
+/// 非字符串/不可解析 → null（时间只是增强信息，绝不让它挡住文件本身）。
+int? parseJimakuTimestampMs(Object? raw) {
+  if (raw is! String || raw.trim().isEmpty) return null;
+  return DateTime.tryParse(raw.trim())?.toUtc().millisecondsSinceEpoch;
 }
 
 /// Jimaku 请求失败。默认客户端路径仍可 fail-open；需要向用户区分「零结果」与「请求

--- a/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
@@ -143,6 +143,9 @@ class _JimakuSubtitleCandidate extends VideoSubtitleCandidate {
           season: season,
           episode: file.episode,
           fileSize: file.size,
+          uploadedAtMs: file.lastModifiedMs,
+          collectionId: '${entry.id}',
+          collectionLabel: entry.name,
         );
 
   final JimakuEntry entry;

--- a/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
+++ b/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
@@ -115,6 +115,9 @@ class OpenSubtitlesSearchRecord {
     this.downloadCount = 0,
     this.hearingImpaired = false,
     this.fps,
+    this.uploadedAtMs,
+    this.aiTranslated = false,
+    this.fromTrusted = false,
   });
 
   final int fileId;
@@ -126,6 +129,15 @@ class OpenSubtitlesSearchRecord {
   final int downloadCount;
   final bool hearingImpaired;
   final double? fps;
+
+  /// `attributes.upload_date`（ISO-8601）→ epoch 毫秒；缺失/不可解析 null。
+  final int? uploadedAtMs;
+
+  /// `attributes.ai_translated`：机翻标记（排序降权，UI 明示）。
+  final bool aiTranslated;
+
+  /// `attributes.from_trusted`：可信上传者。
+  final bool fromTrusted;
 }
 
 List<OpenSubtitlesSearchRecord> parseOpenSubtitlesSearchResponse(String body) {
@@ -165,6 +177,13 @@ List<OpenSubtitlesSearchRecord> parseOpenSubtitlesSearchResponse(String body) {
           downloadCount: _int(attributes['download_count']) ?? 0,
           hearingImpaired: attributes['hearing_impaired'] == true,
           fps: _double(attributes['fps']),
+          uploadedAtMs: attributes['upload_date'] is String
+              ? DateTime.tryParse(attributes['upload_date']! as String)
+                  ?.toUtc()
+                  .millisecondsSinceEpoch
+              : null,
+          aiTranslated: attributes['ai_translated'] == true,
+          fromTrusted: attributes['from_trusted'] == true,
         ),
       );
     }
@@ -644,6 +663,9 @@ class _OpenSubtitlesCandidate extends VideoSubtitleCandidate {
           downloadCount: record.downloadCount,
           hearingImpaired: record.hearingImpaired,
           fps: record.fps,
+          uploadedAtMs: record.uploadedAtMs,
+          aiTranslated: record.aiTranslated,
+          fromTrusted: record.fromTrusted,
         );
 
   final OpenSubtitlesSearchRecord record;

--- a/fushi/lib/src/media/video/subtitle/subtitle_content_language.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_content_language.dart
@@ -1,0 +1,159 @@
+/// 字幕**正文**语言检测（纯函数）。
+///
+/// 文件名标签（`[JPN]` / `[CHS]`）经常是错的——上传者复制模板、打包改名都会
+/// 留下错标签；正文才是权威（参照 RSS-Subtitle-Manager 的同名判据）。本模块
+/// 只看对白文本：ASS 取 `Dialogue:` 行第 10 字段起，SRT/VTT 去序号与时间轴，
+/// 再剥 `{...}` / `<...>` 标签后统计假名 / 汉字 / 拉丁字母。
+///
+/// 判定规则（阈值与 RSS-Subtitle-Manager 对齐，全部有单测）：
+/// - 假名 ≥ 8 → 日语；其中「无假名且汉字 ≥ 2 的行」≥ 3 行、且这些行的汉字量
+///   ≥ max(12, 总汉字/5) → 中日双语（`日文行\N中文行` 的典型形态）。
+/// - 否则汉字 ≥ 8 → 按简/繁判别字符集计数分简体/繁体。
+/// - 否则拉丁字母 ≥ 30 → 英语。
+/// - 都不够 → 未知（**不猜**）。
+library;
+
+/// 检测结果。粗粒度语言码投影见 [coarseLanguageCode]。
+enum SubtitleContentLanguage {
+  japanese,
+  simplifiedChinese,
+  traditionalChinese,
+
+  /// 中日双语（同屏两行，学日语用户的高价值版本，单列一类不并入 zh）。
+  bilingualJaZh,
+  english,
+  unknown,
+}
+
+/// 投影到既有 `ja/zh/en/ko` 粗码（`kJimakuLanguageCodes` 同一值域）；
+/// unknown → null。双语归 zh（含中文即可被「中文」筛选命中；细分标签由
+/// [subtitleContentLanguageNativeLabel] 展示）。
+String? coarseLanguageCode(SubtitleContentLanguage language) =>
+    switch (language) {
+      SubtitleContentLanguage.japanese => 'ja',
+      SubtitleContentLanguage.simplifiedChinese ||
+      SubtitleContentLanguage.traditionalChinese ||
+      SubtitleContentLanguage.bilingualJaZh =>
+        'zh',
+      SubtitleContentLanguage.english => 'en',
+      SubtitleContentLanguage.unknown => null,
+    };
+
+/// 母语写法显示名（与 `jimakuLanguageLabel` 同姿态：不随界面语言变，不走 i18n）。
+String? subtitleContentLanguageNativeLabel(SubtitleContentLanguage language) =>
+    switch (language) {
+      SubtitleContentLanguage.japanese => '日本語',
+      SubtitleContentLanguage.simplifiedChinese => '简体中文',
+      SubtitleContentLanguage.traditionalChinese => '繁體中文',
+      SubtitleContentLanguage.bilingualJaZh => '中日双语',
+      SubtitleContentLanguage.english => 'English',
+      SubtitleContentLanguage.unknown => null,
+    };
+
+/// 简体判别集：只在简体文本出现、繁体文本写作另一形的常用字。
+const String _kSimplifiedOnlyChars = '们这对时东乐买卖医还见观说话读书写马鸟龙风'
+    '电开关门问间众优传体华单卫压发变经给绝统继绿网义习学为点让边远运进军农'
+    '动劳办务历层岁带帮广应张当录隐忆态怀恶悬爱战抢护报担拟拥挂币帅师归';
+
+/// 繁体判别集：与 [_kSimplifiedOnlyChars] 一一对应的繁体形。
+const String _kTraditionalOnlyChars = '們這對時東樂買賣醫還見觀說話讀書寫馬鳥龍風'
+    '電開關門問間眾優傳體華單衛壓發變經給絕統繼綠網義習學為點讓邊遠運進軍農'
+    '動勞辦務歷層歲帶幫廣應張當錄隱憶態懷惡懸愛戰搶護報擔擬擁掛幣帥師歸';
+
+final Set<int> _simplifiedOnly = _kSimplifiedOnlyChars.runes.toSet();
+final Set<int> _traditionalOnly = _kTraditionalOnlyChars.runes.toSet();
+
+bool _isKana(int rune) =>
+    (rune >= 0x3041 && rune <= 0x3096) || // 平假名
+    (rune >= 0x30A1 && rune <= 0x30FA); // 片假名（不含长音符/中点等标点）
+
+bool _isHan(int rune) =>
+    (rune >= 0x4E00 && rune <= 0x9FFF) ||
+    (rune >= 0x3400 && rune <= 0x4DBF) ||
+    rune == 0x3005; // 々
+
+bool _isLatinLetter(int rune) =>
+    (rune >= 0x41 && rune <= 0x5A) || (rune >= 0x61 && rune <= 0x7A);
+
+/// 从字幕全文提取「对白行」列表（纯函数，便于单测）。
+///
+/// - ASS/SSA：只取 `Dialogue:` 行的第 10 个逗号字段起（Text 字段本身可含逗号），
+///   `\N`/`\n` 内联换行拆成多行（双语字幕的典型形态就在这一步现形）。
+/// - SRT/VTT：丢纯序号行、时间轴行（含 `-->`）与 `WEBVTT` 头。
+/// - 通用：剥 `{...}`（ASS 覆写块）与 `<...>`（HTML 风格标签）。
+List<String> extractSubtitleDialogueLines(String text) {
+  final List<String> out = <String>[];
+  final bool looksAss = text.contains('Dialogue:');
+  for (final String rawLine in text.split(RegExp(r'\r?\n'))) {
+    String line = rawLine.trim();
+    if (line.isEmpty) continue;
+    if (looksAss) {
+      if (!line.startsWith('Dialogue:')) continue;
+      final List<String> parts = line.split(',');
+      if (parts.length < 10) continue;
+      line = parts.sublist(9).join(',');
+    } else {
+      if (line.contains('-->')) continue;
+      if (RegExp(r'^\d+$').hasMatch(line)) continue;
+      if (line == 'WEBVTT' || line.startsWith('NOTE ')) continue;
+    }
+    for (final String piece in line.split(RegExp(r'\\[Nn]'))) {
+      final String cleaned = piece
+          .replaceAll(RegExp(r'\{[^}]*\}'), '')
+          .replaceAll(RegExp(r'<[^>]*>'), '')
+          .trim();
+      if (cleaned.isNotEmpty) out.add(cleaned);
+    }
+  }
+  return out;
+}
+
+/// 见 library doc。输入是**解码后的全文**（字节 → 文本用既有
+/// `decodeTextBytes`，本模块不管编码）。
+SubtitleContentLanguage detectSubtitleContentLanguage(String text) {
+  final List<String> lines = extractSubtitleDialogueLines(text);
+  int totalKana = 0;
+  int totalHan = 0;
+  int totalLatin = 0;
+  int hanOnlyLines = 0;
+  int hanOnlyHan = 0;
+  int simplifiedHits = 0;
+  int traditionalHits = 0;
+  for (final String line in lines) {
+    int lineKana = 0;
+    int lineHan = 0;
+    for (final int rune in line.runes) {
+      if (_isKana(rune)) {
+        lineKana++;
+      } else if (_isHan(rune)) {
+        lineHan++;
+        if (_simplifiedOnly.contains(rune)) simplifiedHits++;
+        if (_traditionalOnly.contains(rune)) traditionalHits++;
+      } else if (_isLatinLetter(rune)) {
+        totalLatin++;
+      }
+    }
+    totalKana += lineKana;
+    totalHan += lineHan;
+    if (lineKana == 0 && lineHan >= 2) {
+      hanOnlyLines++;
+      hanOnlyHan += lineHan;
+    }
+  }
+  if (totalKana >= 8) {
+    // 纯日语字幕里也有汉字拟声/汉字词行（「物音」），要求「无假名汉字行」既有
+    // 行数又有总量，才判双语——单个拟声行不构成中文轨。
+    final int bilingualFloor = totalHan ~/ 5 > 12 ? totalHan ~/ 5 : 12;
+    if (hanOnlyLines >= 3 && hanOnlyHan >= bilingualFloor) {
+      return SubtitleContentLanguage.bilingualJaZh;
+    }
+    return SubtitleContentLanguage.japanese;
+  }
+  if (totalHan >= 8) {
+    return traditionalHits > simplifiedHits
+        ? SubtitleContentLanguage.traditionalChinese
+        : SubtitleContentLanguage.simplifiedChinese;
+  }
+  if (totalLatin >= 30) return SubtitleContentLanguage.english;
+  return SubtitleContentLanguage.unknown;
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_version_groups.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_version_groups.dart
@@ -1,0 +1,195 @@
+/// 字幕候选的两级「版本」聚类（纯函数，参照 RSS-Subtitle-Manager 的
+/// 版本选择器）：文件名流水账 → 少数几张可决策的版本卡。
+///
+/// 第一级 = 来源合集（Jimaku entry / OpenSubtitles 整体）；第二级 = 同一合集内
+/// 的「变体」：格式 + 语言 + 发布组标签 + CC/机翻标记。同版本的几十个集数文件
+/// 折进一张卡，用户选一次版本，具体某集由 [pickGroupCandidateForEpisode] 解析。
+library;
+
+import 'package:fushi/src/media/video/jimaku_client.dart'
+    show jimakuLanguageLabel, jimakuLanguageRank;
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+/// 文件名开头的发布组标签（`[SubsPlease] xxx` → `SubsPlease`）。
+/// 8 位 hex（CRC）、分辨率、纯语言 token 不算组名；认不出返回 null。
+String? subtitleReleaseGroupTag(String fileName) {
+  final RegExpMatch? match =
+      RegExp(r'^\s*[\[【]([^\]】]{2,30})[\]】]').firstMatch(fileName);
+  if (match == null) return null;
+  final String tag = match.group(1)!.trim();
+  if (tag.isEmpty) return null;
+  if (RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(tag)) return null;
+  if (RegExp(r'^\d{3,4}[pP]$').hasMatch(tag)) return null;
+  const Set<String> languageTokens = <String>{
+    'ja', 'jp', 'jpn', 'zh', 'chs', 'cht', 'sc', 'tc', 'en', 'eng', 'ko',
+    'kor', // 语言标签是变体维度，不是组名
+  };
+  if (languageTokens.contains(tag.toLowerCase())) return null;
+  return tag;
+}
+
+/// 小写扩展名（不含点）；认不出为空串。
+String subtitleFormatOf(String fileName) {
+  final int dot = fileName.lastIndexOf('.');
+  return dot < 0 ? '' : fileName.substring(dot + 1).toLowerCase();
+}
+
+/// 一张「版本卡」：同一来源合集下、同格式同语言同发布组的候选集合。
+class SubtitleVersionGroup {
+  SubtitleVersionGroup._({
+    required this.key,
+    required this.collectionLabel,
+    required this.members,
+  });
+
+  final String key;
+
+  /// 第一级标签：Jimaku entry 名 / 无合集概念的来源用 providerId。
+  final String collectionLabel;
+
+  /// 集号升序（无集号殿后），同集按文件名。
+  final List<VideoSubtitleCandidate> members;
+
+  VideoSubtitleCandidate get representative => latest;
+
+  String get providerId => members.first.providerId;
+  String get language => members.first.language;
+  String get format => subtitleFormatOf(members.first.fileName);
+  String? get releaseGroupTag =>
+      subtitleReleaseGroupTag(members.first.fileName);
+  bool get hearingImpaired => members.first.hearingImpaired;
+  bool get aiTranslated => members.first.aiTranslated;
+  bool get fromTrusted => members.any(
+        (VideoSubtitleCandidate candidate) => candidate.fromTrusted,
+      );
+
+  /// 第二级标签的组成部分（UI 逐段拼、缺段跳过）：格式大写、语言母语名、组名。
+  List<String> get variantParts => <String>[
+        if (format.isNotEmpty) format.toUpperCase(),
+        if (language.isNotEmpty) jimakuLanguageLabel(language),
+        if (releaseGroupTag != null) releaseGroupTag!,
+      ];
+
+  Set<int> get episodes => <int>{
+        for (final VideoSubtitleCandidate candidate in members)
+          if (candidate.episode != null) candidate.episode!,
+      };
+
+  int get unnumberedCount => members
+      .where((VideoSubtitleCandidate candidate) => candidate.episode == null)
+      .length;
+
+  int? get latestUploadedAtMs {
+    int? latest;
+    for (final VideoSubtitleCandidate candidate in members) {
+      final int? at = candidate.uploadedAtMs;
+      if (at != null && (latest == null || at > latest)) latest = at;
+    }
+    return latest;
+  }
+
+  /// 「最新」文件：上传时间最大者；全部无时间时取集号最大者（近似最新一集）。
+  VideoSubtitleCandidate get latest {
+    VideoSubtitleCandidate best = members.first;
+    for (final VideoSubtitleCandidate candidate in members.skip(1)) {
+      final int? bestAt = best.uploadedAtMs;
+      final int? at = candidate.uploadedAtMs;
+      if (at != null && (bestAt == null || at > bestAt)) {
+        best = candidate;
+        continue;
+      }
+      if (at == null && bestAt == null) {
+        final int bestEp = best.episode ?? -1;
+        final int ep = candidate.episode ?? -1;
+        if (ep > bestEp) best = candidate;
+      }
+    }
+    return best;
+  }
+
+  int get totalDownloadCount => members.fold(
+        0,
+        (int sum, VideoSubtitleCandidate candidate) =>
+            sum + candidate.downloadCount,
+      );
+}
+
+String _groupKeyOf(VideoSubtitleCandidate candidate) => <String>[
+      candidate.providerId,
+      candidate.collectionId ?? '',
+      subtitleFormatOf(candidate.fileName),
+      candidate.language,
+      subtitleReleaseGroupTag(candidate.fileName) ?? '',
+      candidate.hearingImpaired ? 'hi' : '',
+      candidate.aiTranslated ? 'ai' : '',
+    ].join('\u001f');
+
+int _compareMembers(VideoSubtitleCandidate a, VideoSubtitleCandidate b) {
+  final int byEpisode = (a.episode ?? 1 << 30).compareTo(b.episode ?? 1 << 30);
+  return byEpisode != 0 ? byEpisode : a.fileName.compareTo(b.fileName);
+}
+
+/// 聚类 + 排序。组间排序：语言权重（[preferredLanguage] 最前）→ 机翻殿后 →
+/// 最新上传时间降序（无时间殿后）→ 累计下载量 → key（稳定）。
+List<SubtitleVersionGroup> buildSubtitleVersionGroups(
+  Iterable<VideoSubtitleCandidate> candidates, {
+  String? preferredLanguage,
+}) {
+  final Map<String, List<VideoSubtitleCandidate>> byKey =
+      <String, List<VideoSubtitleCandidate>>{};
+  for (final VideoSubtitleCandidate candidate in candidates) {
+    byKey
+        .putIfAbsent(_groupKeyOf(candidate), () => <VideoSubtitleCandidate>[])
+        .add(candidate);
+  }
+  final List<SubtitleVersionGroup> groups = <SubtitleVersionGroup>[
+    for (final MapEntry<String, List<VideoSubtitleCandidate>> entry
+        in byKey.entries)
+      SubtitleVersionGroup._(
+        key: entry.key,
+        collectionLabel:
+            entry.value.first.collectionLabel ?? entry.value.first.providerId,
+        members: List<VideoSubtitleCandidate>.unmodifiable(
+          entry.value..sort(_compareMembers),
+        ),
+      ),
+  ];
+  groups.sort((SubtitleVersionGroup a, SubtitleVersionGroup b) {
+    final int byLanguage = jimakuLanguageRank(
+      a.language.isEmpty ? null : a.language,
+      preferred: preferredLanguage,
+    ).compareTo(jimakuLanguageRank(
+      b.language.isEmpty ? null : b.language,
+      preferred: preferredLanguage,
+    ));
+    if (byLanguage != 0) return byLanguage;
+    if (a.aiTranslated != b.aiTranslated) return a.aiTranslated ? 1 : -1;
+    final int aAt = a.latestUploadedAtMs ?? -1;
+    final int bAt = b.latestUploadedAtMs ?? -1;
+    if (aAt != bAt) return bAt.compareTo(aAt);
+    final int byDownloads =
+        b.totalDownloadCount.compareTo(a.totalDownloadCount);
+    return byDownloads != 0 ? byDownloads : a.key.compareTo(b.key);
+  });
+  return List<SubtitleVersionGroup>.unmodifiable(groups);
+}
+
+/// 从版本卡解析「用户要的那一集」：
+/// - [episode] 非空：精确集号命中 → 该文件；无命中但组里恰有 1 个无集号文件
+///   （剧场版/整季包常态）→ 那一个；否则 null（UI 展开让用户手选）。
+/// - [episode] 为空：组里只有 1 个文件 → 它；否则 null。
+VideoSubtitleCandidate? pickGroupCandidateForEpisode(
+  SubtitleVersionGroup group,
+  int? episode,
+) {
+  if (episode != null) {
+    for (final VideoSubtitleCandidate candidate in group.members) {
+      if (candidate.episode == episode) return candidate;
+    }
+    final List<VideoSubtitleCandidate> unnumbered = group.members
+        .where((VideoSubtitleCandidate candidate) => candidate.episode == null)
+        .toList(growable: false);
+    return unnumbered.length == 1 ? unnumbered.single : null;
+  }
+  return group.members.length == 1 ? group.members.single : null;
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_version_language_probe.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_version_language_probe.dart
@@ -1,0 +1,57 @@
+/// 版本组代表文件的正文语言探测（增强信息，绝不阻塞、绝不抛）。
+///
+/// 文件名认不出语言的版本组，下载其代表文件（字幕通常几十 KB）解码后用
+/// [detectSubtitleContentLanguage] 判正文语言。结果只用于展示（「正文：简体
+/// 中文」），不改变分组——探测是异步补充，卡片不因它重排。
+///
+/// 纪律（对来源站的礼貌，参照 RSS-Subtitle-Manager 的 4 并发 + 缓存）：
+/// 结果按 identityKey 进程内缓存；超过 [maxProbeBytes] 的文件不探（整季包
+/// 没必要为标签下几 MB）；任何失败静默返回 null。
+library;
+
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
+
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+class SubtitleVersionLanguageProbe {
+  SubtitleVersionLanguageProbe({
+    required Future<VideoSubtitleDownload> Function(
+      VideoSubtitleCandidate candidate,
+    ) download,
+    this.maxProbeBytes = 2 * 1024 * 1024,
+  }) : _download = download;
+
+  final Future<VideoSubtitleDownload> Function(
+    VideoSubtitleCandidate candidate,
+  ) _download;
+  final int maxProbeBytes;
+
+  final Map<String, SubtitleContentLanguage?> _cache =
+      <String, SubtitleContentLanguage?>{};
+
+  /// 探测 [candidate] 的正文语言；不可用/失败/unknown → null。
+  Future<SubtitleContentLanguage?> probe(
+    VideoSubtitleCandidate candidate,
+  ) async {
+    final String key = candidate.identityKey;
+    if (_cache.containsKey(key)) return _cache[key];
+    final int? size = candidate.fileSize;
+    if (size != null && size > maxProbeBytes) {
+      return _cache[key] = null;
+    }
+    try {
+      final VideoSubtitleDownload download = await _download(candidate);
+      if (download.bytes.isEmpty || download.bytes.length > maxProbeBytes) {
+        return _cache[key] = null;
+      }
+      final String text = await decodeTextBytes(download.bytes);
+      final SubtitleContentLanguage detected =
+          detectSubtitleContentLanguage(text);
+      return _cache[key] =
+          detected == SubtitleContentLanguage.unknown ? null : detected;
+    } on Object {
+      return _cache[key] = null;
+    }
+  }
+}

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
@@ -59,6 +59,11 @@ abstract class VideoSubtitleCandidate {
     this.downloadCount = 0,
     this.hearingImpaired = false,
     this.fps,
+    this.uploadedAtMs,
+    this.collectionId,
+    this.collectionLabel,
+    this.aiTranslated = false,
+    this.fromTrusted = false,
   });
 
   final String providerId;
@@ -73,6 +78,23 @@ abstract class VideoSubtitleCandidate {
   final int downloadCount;
   final bool hearingImpaired;
   final double? fps;
+
+  /// 上传/最后修改时刻（epoch 毫秒）。版本选择器的「N 天前」与「最新文件」
+  /// 判定用；来源没给（旧响应）为 null。
+  final int? uploadedAtMs;
+
+  /// 来源侧的「合集」身份（Jimaku entry id / OpenSubtitles 无此概念为 null）。
+  /// 两级版本聚类的第一级分组键；此前只藏在 remoteId 前缀里，UI 拿不到。
+  final String? collectionId;
+
+  /// [collectionId] 的展示名（Jimaku entry 名）。
+  final String? collectionLabel;
+
+  /// 来源明确标注的机翻（OpenSubtitles `ai_translated`）。质量信号，排序降权。
+  final bool aiTranslated;
+
+  /// 来源明确标注的可信上传者（OpenSubtitles `from_trusted`）。
+  final bool fromTrusted;
 
   String get identityKey => '$providerId:$remoteId';
 }

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -11,9 +12,13 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_language_probe.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
+import 'package:fushi/src/pages/implementations/subtitle_version_group_list.dart';
 import 'package:fushi/utils.dart';
 
 /// 一条可下载的在线字幕候选：来源条目/发布名 + 文件名 + 回给来源 provider 的句柄。
@@ -249,7 +254,20 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   bool _searching = false;
   bool _searched = false;
   String? _busyName; // 正在下载的文件名
+  String? _busySourceKey; // 正在下载的候选 identityKey（版本卡视图用）
   List<JimakuCandidate> _candidates = const <JimakuCandidate>[];
+
+  /// true = 平铺文件列表（旧视图）；false（默认）= 版本卡视图。候选缺 source
+  /// （测试预置样本）时强制文件视图。
+  bool _showFileView = false;
+
+  /// 版本组正文语言探测结果（group.key → 检测值），展示用。
+  Map<String, SubtitleContentLanguage> _probedGroupLanguages =
+      <String, SubtitleContentLanguage>{};
+
+  /// 每轮搜索递增，丢弃迟到的旧探测结果。
+  int _probeGeneration = 0;
+  SubtitleVersionLanguageProbe? _probe;
 
   /// API key 输入区是否折叠（配好 key 且已有候选结果后默认收起腾出列表空间）。
   bool _apiKeyCollapsed = false;
@@ -454,11 +472,49 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         _searched = true;
         _searchedWithEpisode = episode != null;
         _selectedSeriesId = anilistId;
+        _probedGroupLanguages = <String, SubtitleContentLanguage>{};
         // 记忆语言 / 上轮类型本次无候选 → 退回「全部」，不空屏（保底）。
         _reconcileSelectedFilters();
         // 配好 key 且搜出结果后，默认收起 API key 输入区腾出列表空间
         // （用户：「apikey 配完是不是可以缩小显示」）。用户仍可点「修改」展开。
         _apiKeyCollapsed = sorted.isNotEmpty;
+      });
+      unawaited(_probeUnknownLanguageGroups(registry));
+    }
+  }
+
+  /// 文件名认不出语言的版本组：后台下载代表文件探正文语言（展示增强，见
+  /// [SubtitleVersionLanguageProbe] 的纪律）。最多探 4 组、逐个串行；结果按
+  /// generation 丢弃迟到者。
+  Future<void> _probeUnknownLanguageGroups(
+    VideoSubtitleRegistry registry,
+  ) async {
+    final int generation = ++_probeGeneration;
+    final List<VideoSubtitleCandidate> sources = <VideoSubtitleCandidate>[
+      for (final JimakuCandidate candidate in _candidates)
+        if (candidate.source != null) candidate.source!,
+    ];
+    if (sources.isEmpty) return;
+    final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+      sources,
+      preferredLanguage: _selectedLanguage,
+    );
+    final SubtitleVersionLanguageProbe probe =
+        _probe ??= SubtitleVersionLanguageProbe(download: registry.download);
+    int probed = 0;
+    for (final SubtitleVersionGroup group in groups) {
+      if (group.language.isNotEmpty) continue;
+      if (probed >= 4) break;
+      probed++;
+      final SubtitleContentLanguage? detected =
+          await probe.probe(group.representative);
+      if (!mounted || generation != _probeGeneration) return;
+      if (detected == null) continue;
+      setState(() {
+        _probedGroupLanguages = <String, SubtitleContentLanguage>{
+          ..._probedGroupLanguages,
+          group.key: detected,
+        };
       });
     }
   }
@@ -477,9 +533,19 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// （[ExternalProviderFailure]）是给管线重试用的，对用户只有「没下来」一种语义。
   Future<void> _download(JimakuCandidate candidate) async {
     final VideoSubtitleCandidate? source = candidate.source;
+    if (source == null) return;
+    await _downloadSource(source);
+  }
+
+  /// 下载真实来源候选（文件视图与版本卡视图共用）：registry 按 providerId
+  /// 分派，落盘后 pop 回本地路径。
+  Future<void> _downloadSource(VideoSubtitleCandidate source) async {
     final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
-    if (source == null || registry == null) return;
-    setState(() => _busyName = candidate.name);
+    if (registry == null) return;
+    setState(() {
+      _busyName = source.fileName;
+      _busySourceKey = source.identityKey;
+    });
     try {
       final VideoSubtitleDownload download = await registry.download(source);
       if (download.bytes.isEmpty) {
@@ -495,7 +561,12 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     } on Object {
       _snack(t.video_jimaku_download_failed);
     } finally {
-      if (mounted) setState(() => _busyName = null);
+      if (mounted) {
+        setState(() {
+          _busyName = null;
+          _busySourceKey = null;
+        });
+      }
     }
   }
 
@@ -707,6 +778,21 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
               ),
               onChanged: (String v) => setState(() => _filter = v),
             ),
+            // 版本卡视图默认开；想直接翻原始文件列表的用户在这里切换。
+            if (_candidates
+                .any((JimakuCandidate c) => c.source != null)) ...<Widget>[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: FilterChip(
+                  key: const ValueKey<String>('jimaku-file-view-toggle'),
+                  label: Text(t.subtitle_version_view_files),
+                  selected: _showFileView,
+                  onSelected: (bool value) =>
+                      setState(() => _showFileView = value),
+                ),
+              ),
+            ],
           ],
         ],
       ),
@@ -750,14 +836,40 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         ),
       );
     }
-    // 先按语言筛选（_selectedLanguage）、再按类型筛选（_selectedFormat），最后交给
-    // 列表做关键词二次筛选。三层各自独立、顺序不影响结果集。
-    return JimakuCandidateList(
-      candidates: filterCandidatesByFormat(
+    // 先按语言筛选（_selectedLanguage）、再按类型筛选（_selectedFormat）、再做
+    // 关键词二次筛选。三层各自独立、顺序不影响结果集。
+    final List<JimakuCandidate> filtered = filterByMediaSearch(
+      filterCandidatesByFormat(
         filterCandidatesByLanguage(_candidates, _selectedLanguage),
         _selectedFormat,
       ),
-      filter: _filter,
+      _filter,
+      (JimakuCandidate c) => <String>[c.name, c.entryName],
+    );
+    // 版本卡视图（默认）：候选全部带真实来源时按「合集 › 格式+语言+组」聚类，
+    // 文件名流水账折进卡内（RSS-Subtitle-Manager 式版本选择器）。测试预置样本
+    // （source == null）或用户显式切文件视图时走旧平铺列表。
+    final List<VideoSubtitleCandidate> sources = <VideoSubtitleCandidate>[
+      for (final JimakuCandidate candidate in filtered)
+        if (candidate.source != null) candidate.source!,
+    ];
+    final bool canGroup =
+        sources.isNotEmpty && sources.length == filtered.length;
+    if (canGroup && !_showFileView) {
+      return SubtitleVersionGroupList(
+        groups: buildSubtitleVersionGroups(
+          sources,
+          preferredLanguage: _selectedLanguage,
+        ),
+        requestedEpisode: int.tryParse(_episodeCtrl.text.trim()),
+        busyIdentityKey: _busySourceKey,
+        onPickCandidate: _busyName == null ? _downloadSource : null,
+        probedLanguages: _probedGroupLanguages,
+      );
+    }
+    return JimakuCandidateList(
+      candidates: filtered,
+      filter: '',
       busyName: _busyName,
       onDownload: _busyName == null ? _download : null,
     );

--- a/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
+++ b/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/video/jimaku_client.dart'
+    show jimakuLanguageLabel;
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/activity_feed.dart'
+    show ActivityRelativeTime, ActivityRelativeUnit, activityRelativeTime;
+import 'package:fushi/utils.dart';
+
+/// 字幕「版本卡」列表（参照 RSS-Subtitle-Manager 的版本选择器）：一张卡 =
+/// 一个来源合集下的一个变体（格式+语言+发布组），几十个集数文件折进卡内。
+///
+/// 交互：点卡片 → 有明确目标集时直接下载该集文件（[requestedEpisode] +
+/// [pickGroupCandidateForEpisode]），解析不出唯一文件则展开卡片让用户手选；
+/// 右侧 chevron 恒可手动展开。每行/每卡的下载动作都回 [onPickCandidate]。
+class SubtitleVersionGroupList extends StatefulWidget {
+  const SubtitleVersionGroupList({
+    required this.groups,
+    required this.requestedEpisode,
+    required this.busyIdentityKey,
+    required this.onPickCandidate,
+    this.probedLanguages = const <String, SubtitleContentLanguage>{},
+    super.key,
+  });
+
+  final List<SubtitleVersionGroup> groups;
+
+  /// 用户在集数框里要的那一集；null = 没指定。
+  final int? requestedEpisode;
+
+  /// 正在下载的候选 identityKey；null = 空闲。非空时所有动作禁用。
+  final String? busyIdentityKey;
+
+  /// 用户最终选定某个文件（下载动作由宿主执行）。null = 全部禁用。
+  final void Function(VideoSubtitleCandidate candidate)? onPickCandidate;
+
+  /// 正文语言探测结果（group.key → 检测值）：文件名认不出语言的组，宿主可
+  /// 后台探测正文后回填，本组件只展示（`正文：简体中文`），不参与分组。
+  final Map<String, SubtitleContentLanguage> probedLanguages;
+
+  @override
+  State<SubtitleVersionGroupList> createState() =>
+      _SubtitleVersionGroupListState();
+}
+
+class _SubtitleVersionGroupListState extends State<SubtitleVersionGroupList> {
+  final Set<String> _expanded = <String>{};
+
+  bool get _busy => widget.busyIdentityKey != null;
+
+  void _onCardTap(SubtitleVersionGroup group) {
+    if (_busy || widget.onPickCandidate == null) return;
+    final VideoSubtitleCandidate? picked =
+        pickGroupCandidateForEpisode(group, widget.requestedEpisode);
+    if (picked != null) {
+      widget.onPickCandidate!(picked);
+      return;
+    }
+    setState(() {
+      if (!_expanded.add(group.key)) _expanded.remove(group.key);
+    });
+  }
+
+  String _relativeLabel(int epochMs) {
+    final ActivityRelativeTime rel =
+        activityRelativeTime(epochMs, DateTime.now());
+    return switch (rel.unit) {
+      ActivityRelativeUnit.justNow => t.activity_just_now,
+      ActivityRelativeUnit.minutesAgo => t.activity_minutes_ago(n: rel.value),
+      ActivityRelativeUnit.hoursAgo => t.activity_hours_ago(n: rel.value),
+      ActivityRelativeUnit.daysAgo => t.activity_days_ago(n: rel.value),
+    };
+  }
+
+  /// 卡片第三行：覆盖集数 · 相对时间 · 大小 · 下载量。缺段跳过。
+  String _metaLine(SubtitleVersionGroup group) {
+    final Set<int> episodes = group.episodes;
+    final List<String> parts = <String>[];
+    if (episodes.isNotEmpty) {
+      final int first = episodes.reduce((int a, int b) => a < b ? a : b);
+      final int last = episodes.reduce((int a, int b) => a > b ? a : b);
+      final String range =
+          episodes.length == 1 ? 'EP$first' : 'EP$first–EP$last';
+      parts.add(
+        '${t.subtitle_version_episode_count(n: episodes.length)} ($range)',
+      );
+    }
+    if (group.unnumberedCount > 0) {
+      parts.add(
+        t.subtitle_version_unnumbered_count(n: group.unnumberedCount),
+      );
+    }
+    final int? latestAt = group.latestUploadedAtMs;
+    if (latestAt != null) parts.add(_relativeLabel(latestAt));
+    final int? size = group.latest.fileSize;
+    if (size != null) parts.add(FushiByteFormat.bytes(size));
+    if (group.totalDownloadCount > 0) {
+      parts.add('${group.totalDownloadCount}↓');
+    }
+    return parts.join(' · ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListView.separated(
+      itemCount: widget.groups.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (BuildContext context, int index) {
+        final SubtitleVersionGroup group = widget.groups[index];
+        return _buildCard(theme, group);
+      },
+    );
+  }
+
+  Widget _buildCard(ThemeData theme, SubtitleVersionGroup group) {
+    final bool expanded = _expanded.contains(group.key);
+    final SubtitleContentLanguage? probed = widget.probedLanguages[group.key];
+    final String? probedLabel =
+        probed == null ? null : subtitleContentLanguageNativeLabel(probed);
+    final String variant = group.variantParts.join(' · ');
+    return FushiCard(
+      key: ValueKey<String>('subtitle-version-${group.key}'),
+      padding: const EdgeInsets.all(12),
+      onTap: () => _onCardTap(group),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      variant.isEmpty
+                          ? group.collectionLabel
+                          : '${group.collectionLabel} › $variant',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      group.latest.fileName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _metaLine(group),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (widget.busyIdentityKey != null &&
+                  group.members.any((VideoSubtitleCandidate candidate) =>
+                      candidate.identityKey == widget.busyIdentityKey))
+                const Padding(
+                  padding: EdgeInsets.all(8),
+                  child: SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              else
+                FushiIconButton(
+                  icon: expanded ? Icons.expand_less : Icons.expand_more,
+                  tooltip: t.subtitle_version_show_files,
+                  onTap: _busy
+                      ? null
+                      : () => setState(() {
+                            if (!_expanded.add(group.key)) {
+                              _expanded.remove(group.key);
+                            }
+                          }),
+                ),
+            ],
+          ),
+          if (group.aiTranslated ||
+              group.hearingImpaired ||
+              probedLabel != null) ...<Widget>[
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: <Widget>[
+                if (probedLabel != null)
+                  FushiTagChip(
+                    label:
+                        '${t.subtitle_version_content_language}: $probedLabel',
+                    tone: FushiTagChipTone.surface,
+                  ),
+                if (group.aiTranslated)
+                  FushiTagChip(
+                    label: t.subtitle_version_ai_translated,
+                    color: theme.colorScheme.tertiary,
+                    tone: FushiTagChipTone.surface,
+                  ),
+                if (group.hearingImpaired)
+                  const FushiTagChip(
+                    label: 'CC',
+                    tone: FushiTagChipTone.surface,
+                  ),
+              ],
+            ),
+          ],
+          if (expanded) ...<Widget>[
+            const SizedBox(height: 4),
+            for (final VideoSubtitleCandidate candidate in group.members)
+              _buildFileRow(theme, group, candidate),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFileRow(
+    ThemeData theme,
+    SubtitleVersionGroup group,
+    VideoSubtitleCandidate candidate,
+  ) {
+    final bool busyThis = widget.busyIdentityKey == candidate.identityKey;
+    final bool highlight = widget.requestedEpisode != null &&
+        candidate.episode == widget.requestedEpisode;
+    final List<String> meta = <String>[
+      if (candidate.episode != null) 'EP${candidate.episode}',
+      if (candidate.language.isNotEmpty)
+        jimakuLanguageLabel(candidate.language),
+      if (candidate.fileSize != null) FushiByteFormat.bytes(candidate.fileSize),
+      if (candidate.uploadedAtMs != null)
+        _relativeLabel(candidate.uploadedAtMs!),
+    ];
+    return FushiListItem(
+      key: ValueKey<String>('subtitle-file-${candidate.identityKey}'),
+      density: FushiListDensity.compact,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      selected: highlight,
+      onTap: _busy || widget.onPickCandidate == null
+          ? null
+          : () => widget.onPickCandidate!(candidate),
+      title: Text(
+        candidate.fileName,
+        maxLines: 2,
+        softWrap: true,
+        overflow: TextOverflow.fade,
+      ),
+      titleMaxLines: 2,
+      subtitle: meta.isEmpty ? null : Text(meta.join(' · ')),
+      trailing: busyThis
+          ? const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.download, size: 18),
+    );
+  }
+}

--- a/fushi/test/media/video/jimaku_client_test.dart
+++ b/fushi/test/media/video/jimaku_client_test.dart
@@ -59,14 +59,21 @@ void main() {
   group('parseJimakuFiles + JimakuFile', () {
     test('解析文件，缺 name/url 的跳过', () {
       const String body = '''
-[{"name":"ep01.ja.srt","url":"https://x/ep01.srt","size":1234},
+[{"name":"ep01.ja.srt","url":"https://x/ep01.srt","size":1234,
+  "last_modified":"2026-08-01T12:00:00Z"},
  {"name":"ep02.ass","url":"https://x/ep02.ass"},
  {"url":"https://x/no-name"}]''';
       final List<JimakuFile> files = parseJimakuFiles(body);
       expect(files, hasLength(2));
       expect(files[0].name, 'ep01.ja.srt');
       expect(files[0].size, 1234);
+      expect(
+        files[0].lastModifiedMs,
+        DateTime.utc(2026, 8, 1, 12).millisecondsSinceEpoch,
+        reason: 'B1 版本卡的「N 天前」来自 last_modified，此前该字段被丢弃',
+      );
       expect(files[1].url, 'https://x/ep02.ass');
+      expect(files[1].lastModifiedMs, isNull, reason: '缺失/坏时间不挡文件');
     });
 
     test('extension / isTextSubtitle', () {

--- a/fushi/test/media/video/open_subtitles_client_test.dart
+++ b/fushi/test/media/video/open_subtitles_client_test.dart
@@ -502,6 +502,38 @@ void main() {
       expect(result.failures.single.kind, testCase.kind);
     });
   }
+
+  test('B1：解析 upload_date / ai_translated / from_trusted（版本卡信号）', () {
+    final List<OpenSubtitlesSearchRecord> records =
+        parseOpenSubtitlesSearchResponse(jsonEncode(<String, Object?>{
+      'data': <Object?>[
+        <String, Object?>{
+          'attributes': <String, Object?>{
+            'language': 'en',
+            'upload_date': '2026-08-02T03:04:05Z',
+            'ai_translated': true,
+            'from_trusted': true,
+            'files': <Object?>[
+              <String, Object?>{'file_id': 1, 'file_name': 'a.srt'},
+            ],
+          },
+        },
+      ],
+    }));
+    final OpenSubtitlesSearchRecord record = records.single;
+    expect(
+      record.uploadedAtMs,
+      DateTime.utc(2026, 8, 2, 3, 4, 5).millisecondsSinceEpoch,
+    );
+    expect(record.aiTranslated, isTrue);
+    expect(record.fromTrusted, isTrue);
+
+    final List<OpenSubtitlesSearchRecord> defaults =
+        parseOpenSubtitlesSearchResponse(jsonEncode(_searchResponse));
+    expect(defaults.single.uploadedAtMs, isNull);
+    expect(defaults.single.aiTranslated, isFalse);
+    expect(defaults.single.fromTrusted, isFalse);
+  });
 }
 
 const Map<String, Object?> _emptySearch = <String, Object?>{

--- a/fushi/test/media/video/subtitle_content_language_test.dart
+++ b/fushi/test/media/video/subtitle_content_language_test.dart
@@ -1,0 +1,135 @@
+// B1 字幕搜索重做：正文语言检测纯函数。文件名标签常错（上传者复制模板/打包
+// 改名），正文是权威——阈值与 RSS-Subtitle-Manager 对齐，逐条规则单测。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+
+String _srt(List<String> lines) {
+  final StringBuffer sb = StringBuffer();
+  for (int i = 0; i < lines.length; i++) {
+    sb
+      ..writeln(i + 1)
+      ..writeln('00:0$i:00,000 --> 00:0$i:02,000')
+      ..writeln(lines[i])
+      ..writeln();
+  }
+  return sb.toString();
+}
+
+String _ass(List<String> lines) {
+  final StringBuffer sb = StringBuffer()
+    ..writeln('[Script Info]')
+    ..writeln('Title: x')
+    ..writeln('[Events]')
+    ..writeln('Format: Layer, Start, End, Style, Name, MarginL, MarginR, '
+        'MarginV, Effect, Text');
+  for (final String line in lines) {
+    sb.writeln('Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,$line');
+  }
+  return sb.toString();
+}
+
+void main() {
+  group('extractSubtitleDialogueLines', () {
+    test('SRT 丢序号/时间轴，保对白', () {
+      final List<String> lines = extractSubtitleDialogueLines(
+        _srt(<String>['こんにちは', 'Hello there']),
+      );
+      expect(lines, <String>['こんにちは', 'Hello there']);
+    });
+
+    test('ASS 取 Dialogue 第 10 字段起，Text 内逗号不截断，\\N 拆行、剥标签', () {
+      final List<String> lines = extractSubtitleDialogueLines(
+        _ass(<String>[r'{\an8}おはよう、世界\N你好，世界', '<i>styled</i>']),
+      );
+      expect(lines, <String>['おはよう、世界', '你好，世界', 'styled']);
+    });
+  });
+
+  group('detectSubtitleContentLanguage', () {
+    test('假名足量 → 日语', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'こんにちは、世界',
+          '今日はいい天気ですね',
+        ])),
+        SubtitleContentLanguage.japanese,
+      );
+    });
+
+    test('日语字幕里的汉字拟声行不构成双语（行数与总量双门槛）', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'それでは、始めましょう',
+          'あの音は何だろう',
+          '物音', // 单个无假名汉字行：不是中文轨
+          'きっと風の音ですよ',
+        ])),
+        SubtitleContentLanguage.japanese,
+      );
+    });
+
+    test('逐行日文+中文（\\N 双语）→ 中日双语', () {
+      expect(
+        detectSubtitleContentLanguage(_ass(<String>[
+          r'おはようございます\N早上好各位观众朋友们',
+          r'今日はいい天気ですね\N今天天气真不错啊朋友',
+          r'それでは始めましょう\N那么我们现在就开始吧',
+        ])),
+        SubtitleContentLanguage.bilingualJaZh,
+      );
+    });
+
+    test('简体正文 → 简体中文', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          '这个时间点我们还没开始',
+          '他们说这样也可以',
+        ])),
+        SubtitleContentLanguage.simplifiedChinese,
+      );
+    });
+
+    test('繁体正文 → 繁體中文', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          '這個時間點我們還沒開始',
+          '他們說這樣也可以',
+        ])),
+        SubtitleContentLanguage.traditionalChinese,
+      );
+    });
+
+    test('拉丁字母足量 → 英语', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'The quick brown fox jumps over the lazy dog',
+        ])),
+        SubtitleContentLanguage.english,
+      );
+    });
+
+    test('样本不足 → unknown（不猜）', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>['ok'])),
+        SubtitleContentLanguage.unknown,
+      );
+      expect(
+        detectSubtitleContentLanguage(''),
+        SubtitleContentLanguage.unknown,
+      );
+    });
+  });
+
+  test('coarse 投影与母语标签', () {
+    expect(coarseLanguageCode(SubtitleContentLanguage.japanese), 'ja');
+    expect(coarseLanguageCode(SubtitleContentLanguage.bilingualJaZh), 'zh');
+    expect(coarseLanguageCode(SubtitleContentLanguage.unknown), isNull);
+    expect(
+      subtitleContentLanguageNativeLabel(
+        SubtitleContentLanguage.simplifiedChinese,
+      ),
+      '简体中文',
+    );
+  });
+}

--- a/fushi/test/media/video/subtitle_version_groups_test.dart
+++ b/fushi/test/media/video/subtitle_version_groups_test.dart
@@ -1,0 +1,173 @@
+// B1 字幕搜索重做：两级版本聚类纯函数。分组键 = 来源合集 × (格式+语言+发布组
+// +CC+机翻)；卡内按集号升序；组间排序 语言→机翻殿后→最新→下载量。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({
+    required super.remoteId,
+    required super.fileName,
+    super.providerId = 'jimaku',
+    super.language = 'ja',
+    super.providerPriority = 100,
+    super.episode,
+    super.uploadedAtMs,
+    super.collectionId,
+    super.collectionLabel,
+    super.aiTranslated,
+  });
+}
+
+void main() {
+  group('subtitleReleaseGroupTag', () {
+    test('取开头方括号组名；CRC/分辨率/语言标签不算', () {
+      expect(
+          subtitleReleaseGroupTag('[SubsPlease] Show - 01.ass'), 'SubsPlease');
+      expect(subtitleReleaseGroupTag('【喵萌奶茶屋】剧集 01.srt'), '喵萌奶茶屋');
+      expect(subtitleReleaseGroupTag('[A1B2C3D4] Show - 01.ass'), isNull);
+      expect(subtitleReleaseGroupTag('[1080p] Show.ass'), isNull);
+      expect(subtitleReleaseGroupTag('[CHS] Show.ass'), isNull);
+      expect(subtitleReleaseGroupTag('Show - 01.ass'), isNull);
+    });
+  });
+
+  group('buildSubtitleVersionGroups', () {
+    test('同合集同变体折成一张卡；不同格式/组分开', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          for (int ep = 1; ep <= 3; ep++)
+            _FakeCandidate(
+              remoteId: '9:[SubsPlease] Show - 0$ep.ass',
+              fileName: '[SubsPlease] Show - 0$ep.ass',
+              episode: ep,
+              collectionId: '9',
+              collectionLabel: 'Show (Jimaku)',
+            ),
+          _FakeCandidate(
+            remoteId: '9:[SubsPlease] Show - 01.srt',
+            fileName: '[SubsPlease] Show - 01.srt',
+            episode: 1,
+            collectionId: '9',
+            collectionLabel: 'Show (Jimaku)',
+          ),
+        ],
+      );
+      expect(groups, hasLength(2), reason: 'ass 与 srt 是两个版本');
+      final SubtitleVersionGroup ass = groups
+          .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+      expect(ass.members, hasLength(3));
+      expect(ass.episodes, <int>{1, 2, 3});
+      expect(ass.collectionLabel, 'Show (Jimaku)');
+      expect(ass.releaseGroupTag, 'SubsPlease');
+      expect(ass.variantParts, contains('ASS'));
+    });
+
+    test('卡内按集号升序；latest 按上传时间，无时间退化取集号最大', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(
+            remoteId: 'a:2',
+            fileName: 'Show - 02.ass',
+            episode: 2,
+            collectionId: 'a',
+            uploadedAtMs: 2000,
+          ),
+          _FakeCandidate(
+            remoteId: 'a:1',
+            fileName: 'Show - 01.ass',
+            episode: 1,
+            collectionId: 'a',
+            uploadedAtMs: 5000,
+          ),
+        ],
+      );
+      final SubtitleVersionGroup group = groups.single;
+      expect(group.members.first.episode, 1);
+      expect(group.latest.uploadedAtMs, 5000);
+      expect(group.latestUploadedAtMs, 5000);
+
+      final SubtitleVersionGroup noTime = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(remoteId: 'b:1', fileName: 'X - 01.ass', episode: 1),
+          _FakeCandidate(remoteId: 'b:3', fileName: 'X - 03.ass', episode: 3),
+        ],
+      ).single;
+      expect(noTime.latest.episode, 3);
+    });
+
+    test('组间排序：优先语言最前、机翻殿后、最新在前', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(
+            remoteId: 'os:1',
+            providerId: 'opensubtitles',
+            fileName: 'Show.en.srt',
+            language: 'en',
+            uploadedAtMs: 9000,
+          ),
+          _FakeCandidate(
+            remoteId: 'j:1',
+            fileName: 'Show.ja.ass',
+            language: 'ja',
+            uploadedAtMs: 1000,
+          ),
+          _FakeCandidate(
+            remoteId: 'os:2',
+            providerId: 'opensubtitles',
+            fileName: 'Show.ai.en.srt',
+            language: 'en',
+            uploadedAtMs: 9999,
+            aiTranslated: true,
+          ),
+          _FakeCandidate(
+            remoteId: 'j:2',
+            fileName: 'Show.zh.ass',
+            language: 'zh',
+            uploadedAtMs: 8000,
+          ),
+        ],
+        preferredLanguage: 'zh',
+      );
+      expect(
+        groups.map((SubtitleVersionGroup group) => group.language).toList(),
+        <String>['zh', 'ja', 'en', 'en'],
+        reason: '偏好语言最前，其后按 ja/zh/en/ko 权重',
+      );
+      expect(groups[2].aiTranslated, isFalse);
+      expect(groups[3].aiTranslated, isTrue, reason: '同语言下机翻殿后');
+    });
+  });
+
+  group('pickGroupCandidateForEpisode', () {
+    SubtitleVersionGroup group(List<VideoSubtitleCandidate> members) =>
+        buildSubtitleVersionGroups(members).single;
+
+    test('精确集号命中', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:1', fileName: 'S - 01.ass', episode: 1),
+        _FakeCandidate(remoteId: 'a:2', fileName: 'S - 02.ass', episode: 2),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, 2)!.episode, 2);
+      expect(pickGroupCandidateForEpisode(g, 5), isNull,
+          reason: '没有那一集 → 交还 UI 展开');
+    });
+
+    test('无命中但恰有 1 个未编号文件（剧场版/整季包）→ 那一个', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:m', fileName: 'Movie.ass'),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, 7)!.fileName, 'Movie.ass');
+      expect(pickGroupCandidateForEpisode(g, null)!.fileName, 'Movie.ass');
+    });
+
+    test('未指定集且多文件 → null（不猜）', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:1', fileName: 'S - 01.ass', episode: 1),
+        _FakeCandidate(remoteId: 'a:2', fileName: 'S - 02.ass', episode: 2),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, null), isNull);
+    });
+  });
+}

--- a/fushi/test/pages/subtitle_version_group_list_test.dart
+++ b/fushi/test/pages/subtitle_version_group_list_test.dart
@@ -1,0 +1,180 @@
+// B1 字幕搜索重做：版本卡列表 widget + 对话框版本视图集成。
+// 锁住四条契约：① 聚类后一版本一卡；② 指定集数点卡直接命中该集文件；
+// ③ 解析不出唯一文件时点卡展开文件行；④ 对话框默认版本视图、可切文件视图。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/src/pages/implementations/subtitle_version_group_list.dart';
+import 'package:fushi/utils.dart';
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({
+    required super.remoteId,
+    required super.fileName,
+    super.providerId = 'jimaku',
+    super.language = 'ja',
+    super.providerPriority = 100,
+    super.episode,
+    super.fileSize,
+    super.collectionId,
+    super.collectionLabel,
+  });
+}
+
+List<VideoSubtitleCandidate> _seasonPack() => <VideoSubtitleCandidate>[
+      for (int ep = 1; ep <= 3; ep++)
+        _FakeCandidate(
+          remoteId: '9:[SubsPlease] Show - 0$ep.ass',
+          fileName: '[SubsPlease] Show - 0$ep.ass',
+          episode: ep,
+          fileSize: 30000 + ep,
+          collectionId: '9',
+          collectionLabel: 'Show (2026)',
+        ),
+      _FakeCandidate(
+        remoteId: '9:[MoeSubs] Show - 01.srt',
+        fileName: '[MoeSubs] Show - 01.srt',
+        language: 'zh',
+        episode: 1,
+        collectionId: '9',
+        collectionLabel: 'Show (2026)',
+      ),
+    ];
+
+void main() {
+  Future<void> pumpList(
+    WidgetTester tester, {
+    required List<SubtitleVersionGroup> groups,
+    int? requestedEpisode,
+    required void Function(VideoSubtitleCandidate) onPick,
+  }) async {
+    tester.view.physicalSize = const Size(1000, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SubtitleVersionGroupList(
+            groups: groups,
+            requestedEpisode: requestedEpisode,
+            busyIdentityKey: null,
+            onPickCandidate: onPick,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('一版本一卡：ass 与 srt 两组各渲染一张卡', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    await pumpList(tester, groups: groups, onPick: (_) {});
+    expect(find.byType(FushiCard), findsNWidgets(2));
+    expect(find.textContaining('Show (2026) › ASS'), findsOneWidget);
+    expect(find.textContaining('SubsPlease'), findsWidgets);
+  });
+
+  testWidgets('指定集数点卡 → 直接选中该集文件', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    VideoSubtitleCandidate? picked;
+    await pumpList(
+      tester,
+      groups: groups,
+      requestedEpisode: 2,
+      onPick: (VideoSubtitleCandidate candidate) => picked = candidate,
+    );
+    final SubtitleVersionGroup assGroup = groups
+        .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+    await tester.tap(
+      find.byKey(ValueKey<String>('subtitle-version-${assGroup.key}')),
+    );
+    await tester.pumpAndSettle();
+    expect(picked, isNotNull);
+    expect(picked!.episode, 2, reason: '集数框写 2，点卡就该拿第 2 集');
+  });
+
+  testWidgets('无法解析唯一文件 → 点卡展开文件行，点行选中', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    VideoSubtitleCandidate? picked;
+    await pumpList(
+      tester,
+      groups: groups,
+      // 不指定集数 + 组内多文件 → 点卡应展开而不是瞎选。
+      onPick: (VideoSubtitleCandidate candidate) => picked = candidate,
+    );
+    final SubtitleVersionGroup assGroup = groups
+        .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+    await tester.tap(
+      find.byKey(ValueKey<String>('subtitle-version-${assGroup.key}')),
+    );
+    await tester.pumpAndSettle();
+    expect(picked, isNull);
+    final Finder fileRow = find.byKey(
+      ValueKey<String>(
+        'subtitle-file-${assGroup.members[1].identityKey}',
+      ),
+    );
+    expect(fileRow, findsOneWidget, reason: '展开后逐文件可选');
+    await tester.tap(fileRow);
+    await tester.pumpAndSettle();
+    expect(picked!.episode, 2);
+  });
+
+  testWidgets('对话框：带来源候选默认版本视图，可切回文件视图', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final List<JimakuCandidate> seeded = <JimakuCandidate>[
+      for (final VideoSubtitleCandidate source in _seasonPack())
+        JimakuCandidate(
+          entryName: source.collectionLabel ?? '',
+          name: source.fileName,
+          language: source.language,
+          source: source,
+        ),
+    ];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: 'Show',
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  debugInitialCandidates: seeded,
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SubtitleVersionGroupList), findsOneWidget,
+        reason: '带真实来源的候选默认走版本卡视图');
+    expect(find.byType(JimakuCandidateList), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('jimaku-file-view-toggle')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(JimakuCandidateList), findsOneWidget,
+        reason: '文件视图开关切回旧平铺列表');
+  });
+}


### PR DESCRIPTION
用户 2026-08-21：「咱们整体的字幕搜索极其不好用」。参照 RSS-Subtitle-Manager（用户决策「有什么好的都可以抄」+ 批次 B 全做）的两项核心设计：**版本聚类选择器**与**正文语言判据**。独立于 #931/#932，可任意顺序合并。

## 难用的根因与对策
旧字幕搜索把原始文件名流水账直接抛给用户（一部番几十行 `ListTile`，行内连语言/集号/大小都不显示）。三个「窄口」修掉：
1. **模型层**：`VideoSubtitleCandidate` 补 `uploadedAtMs` / `collectionId`+`Label`（Jimaku entry 身份）/ `aiTranslated` / `fromTrusted`——这些聚类与排序信号此前在 `jimaku_client` / `open_subtitles_client` 解析层被丢弃。
2. **聚类层**（纯函数）：`buildSubtitleVersionGroups` 把候选聚成「来源合集 › 格式+语言+发布组+CC/机翻」版本卡；组间按 语言权重（偏好最前）→ 机翻殿后 → 最新上传 → 下载量 排序；`pickGroupCandidateForEpisode` 三态解析目标集。
3. **UI 层**：`JimakuSubtitleDialog` 默认版本卡视图——每卡三行（版本名 / 最新文件名 / 覆盖集数+相对时间+大小+下载量），指定集数时**点卡即下载该集**；解析不出唯一文件展开逐文件选。保留文件视图开关。

**正文语言检测**（RSM 同款判据）：文件名 `[JPN]` 标签常错，正文才是权威。ASS/SRT 对白提取 → 假名/汉字/拉丁统计 → 日/简/繁/中日双语/英分类（双语要行数+总量双门槛，纯日语字幕的汉字拟声行不误判）。文件名认不出语言的版本组后台探测代表文件（≤4 组、进程内缓存、静默失败），卡上展示「正文：简体中文」。

## 验证
- 全量 `flutter analyze` 零问题。
- 新增 63 例（检测/聚类/解析新字段/版本卡 widget/对话框集成）+ 相邻既有字幕测试 100 例全绿。
- 既有对话框测试全部原样通过（debug 预置样本自动走旧文件视图）。
- 缺口如实说明：正文探测走真网络，未对真实 Jimaku 站点实测；对话框视觉未截图复核。

https://claude.ai/code/session_01NiDoGenLF9eanzXqxaWYAG