### PR TITLE
feat(discovery): B2 资源选版——下载模式「发布组›清晰度」版本卡

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62339 (3667 per locale)
+/// Strings: 62373 (3669 per locale)
 ///
-/// Built on 2026-08-21 at 14:16 UTC
+/// Built on 2026-08-21 at 14:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4986,6 +4986,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get subtitle_version_content_language => 'Content';
   String get subtitle_version_show_files => 'Show files';
   String get subtitle_version_view_files => 'File list';
+  String get resource_version_batch => 'Batch';
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -13490,6 +13492,10 @@ class _StringsAr extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -22059,6 +22065,10 @@ class _StringsDe extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -30644,6 +30654,10 @@ class _StringsEs extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -39241,6 +39255,10 @@ class _StringsFr extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -47768,6 +47786,10 @@ class _StringsId extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -56339,6 +56361,10 @@ class _StringsIt extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -64727,6 +64753,10 @@ class _StringsJa extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -73122,6 +73152,10 @@ class _StringsKo extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -81673,6 +81707,10 @@ class _StringsNl extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -90236,6 +90274,10 @@ class _StringsPtBr extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -98786,6 +98828,10 @@ class _StringsRu extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -107284,6 +107330,10 @@ class _StringsTh extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -115813,6 +115863,10 @@ class _StringsTr extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -124328,6 +124382,10 @@ class _StringsVi extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 // Path: <root>
@@ -132200,6 +132258,10 @@ class _StringsZhCn extends _StringsEn {
   String get subtitle_version_show_files => '展开文件';
   @override
   String get subtitle_version_view_files => '文件视图';
+  @override
+  String get resource_version_batch => '合集';
+  @override
+  String get resource_version_view_flat => '全部条目';
 }
 
 // Path: <root>
@@ -140511,6 +140573,10 @@ class _StringsZhHk extends _StringsEn {
   String get subtitle_version_show_files => 'Show files';
   @override
   String get subtitle_version_view_files => 'File list';
+  @override
+  String get resource_version_batch => 'Batch';
+  @override
+  String get resource_version_view_flat => 'All releases';
 }
 
 /// Flat map(s) containing all translations.
@@ -148037,6 +148103,10 @@ extension on _StringsEn {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -155561,6 +155631,10 @@ extension on _StringsAr {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -163107,6 +163181,10 @@ extension on _StringsDe {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -170652,6 +170730,10 @@ extension on _StringsEs {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -178203,6 +178285,10 @@ extension on _StringsFr {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -185736,6 +185822,10 @@ extension on _StringsId {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -193283,6 +193373,10 @@ extension on _StringsIt {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -200792,6 +200886,10 @@ extension on _StringsJa {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -208305,6 +208403,10 @@ extension on _StringsKo {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -215846,6 +215948,10 @@ extension on _StringsNl {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -223384,6 +223490,10 @@ extension on _StringsPtBr {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -230927,6 +231037,10 @@ extension on _StringsRu {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -238453,6 +238567,10 @@ extension on _StringsTh {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -245988,6 +246106,10 @@ extension on _StringsTr {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -253519,6 +253641,10 @@ extension on _StringsVi {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }
@@ -260991,6 +261117,10 @@ extension on _StringsZhCn {
         return '展开文件';
       case 'subtitle_version_view_files':
         return '文件视图';
+      case 'resource_version_batch':
+        return '合集';
+      case 'resource_version_view_flat':
+        return '全部条目';
       default:
         return null;
     }
@@ -268495,6 +268625,10 @@ extension on _StringsZhHk {
         return 'Show files';
       case 'subtitle_version_view_files':
         return 'File list';
+      case 'resource_version_batch':
+        return 'Batch';
+      case 'resource_version_view_flat':
+        return 'All releases';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62237 (3661 per locale)
+/// Strings: 62339 (3667 per locale)
 ///
-/// Built on 2026-08-20 at 09:30 UTC
+/// Built on 2026-08-21 at 14:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4979,6 +4979,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The peer isn\'t using HTTPS on this port. Use an http:// address.';
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  String get subtitle_version_ai_translated => 'AI translated';
+  String get subtitle_version_content_language => 'Content';
+  String get subtitle_version_show_files => 'Show files';
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -13470,6 +13477,19 @@ class _StringsAr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -22026,6 +22046,19 @@ class _StringsDe extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -30598,6 +30631,19 @@ class _StringsEs extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -39182,6 +39228,19 @@ class _StringsFr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -47696,6 +47755,19 @@ class _StringsId extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -56254,6 +56326,19 @@ class _StringsIt extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -64629,6 +64714,19 @@ class _StringsJa extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -73011,6 +73109,19 @@ class _StringsKo extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -81549,6 +81660,19 @@ class _StringsNl extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -90099,6 +90223,19 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -98636,6 +98773,19 @@ class _StringsRu extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -107121,6 +107271,19 @@ class _StringsTh extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -115637,6 +115800,19 @@ class _StringsTr extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -124139,6 +124315,19 @@ class _StringsVi extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 // Path: <root>
@@ -131999,6 +132188,18 @@ class _StringsZhCn extends _StringsEn {
   String get sync_pair_peer_not_https => '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
   @override
   String get sync_pair_not_fushi_discovered => '此地址未找到 Fushi 设备。';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '共 ${n} 集';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) => '${n} 个未编号';
+  @override
+  String get subtitle_version_ai_translated => '机翻';
+  @override
+  String get subtitle_version_content_language => '正文';
+  @override
+  String get subtitle_version_show_files => '展开文件';
+  @override
+  String get subtitle_version_view_files => '文件视图';
 }
 
 // Path: <root>
@@ -140297,6 +140498,19 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get sync_pair_not_fushi_discovered =>
       'No Fushi device found at this address.';
+  @override
+  String subtitle_version_episode_count({required Object n}) => '${n} episodes';
+  @override
+  String subtitle_version_unnumbered_count({required Object n}) =>
+      '${n} unnumbered';
+  @override
+  String get subtitle_version_ai_translated => 'AI translated';
+  @override
+  String get subtitle_version_content_language => 'Content';
+  @override
+  String get subtitle_version_show_files => 'Show files';
+  @override
+  String get subtitle_version_view_files => 'File list';
 }
 
 /// Flat map(s) containing all translations.
@@ -147811,6 +148025,18 @@ extension on _StringsEn {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -155323,6 +155549,18 @@ extension on _StringsAr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -162857,6 +163095,18 @@ extension on _StringsDe {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -170390,6 +170640,18 @@ extension on _StringsEs {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -177929,6 +178191,18 @@ extension on _StringsFr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -185450,6 +185724,18 @@ extension on _StringsId {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -192985,6 +193271,18 @@ extension on _StringsIt {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -200482,6 +200780,18 @@ extension on _StringsJa {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -207983,6 +208293,18 @@ extension on _StringsKo {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -215512,6 +215834,18 @@ extension on _StringsNl {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -223038,6 +223372,18 @@ extension on _StringsPtBr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -230569,6 +230915,18 @@ extension on _StringsRu {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -238083,6 +238441,18 @@ extension on _StringsTh {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -245606,6 +245976,18 @@ extension on _StringsTr {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -253125,6 +253507,18 @@ extension on _StringsVi {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }
@@ -260585,6 +260979,18 @@ extension on _StringsZhCn {
         return '对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。';
       case 'sync_pair_not_fushi_discovered':
         return '此地址未找到 Fushi 设备。';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '共 ${n} 集';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} 个未编号';
+      case 'subtitle_version_ai_translated':
+        return '机翻';
+      case 'subtitle_version_content_language':
+        return '正文';
+      case 'subtitle_version_show_files':
+        return '展开文件';
+      case 'subtitle_version_view_files':
+        return '文件视图';
       default:
         return null;
     }
@@ -268077,6 +268483,18 @@ extension on _StringsZhHk {
         return 'The peer isn\'t using HTTPS on this port. Use an http:// address.';
       case 'sync_pair_not_fushi_discovered':
         return 'No Fushi device found at this address.';
+      case 'subtitle_version_episode_count':
+        return ({required Object n}) => '${n} episodes';
+      case 'subtitle_version_unnumbered_count':
+        return ({required Object n}) => '${n} unnumbered';
+      case 'subtitle_version_ai_translated':
+        return 'AI translated';
+      case 'subtitle_version_content_language':
+        return 'Content';
+      case 'subtitle_version_show_files':
+        return 'Show files';
+      case 'subtitle_version_view_files':
+        return 'File list';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "地址格式无效",
   "sync_pair_peer_requires_https": "该设备只接受 HTTPS，请改用 https:// 开头的地址。",
   "sync_pair_peer_not_https": "对端在该端口未启用 HTTPS，请改用 http:// 开头的地址。",
-  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。"
+  "sync_pair_not_fushi_discovered": "此地址未找到 Fushi 设备。",
+  "subtitle_version_episode_count": "共 $n 集",
+  "subtitle_version_unnumbered_count": "$n 个未编号",
+  "subtitle_version_ai_translated": "机翻",
+  "subtitle_version_content_language": "正文",
+  "subtitle_version_show_files": "展开文件",
+  "subtitle_version_view_files": "文件视图"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "机翻",
   "subtitle_version_content_language": "正文",
   "subtitle_version_show_files": "展开文件",
-  "subtitle_version_view_files": "文件视图"
+  "subtitle_version_view_files": "文件视图",
+  "resource_version_batch": "合集",
+  "resource_version_view_flat": "全部条目"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3659,5 +3659,11 @@
   "sync_pair_invalid_url": "Invalid address format",
   "sync_pair_peer_requires_https": "This device only accepts HTTPS. Use an https:// address.",
   "sync_pair_peer_not_https": "The peer isn't using HTTPS on this port. Use an http:// address.",
-  "sync_pair_not_fushi_discovered": "No Fushi device found at this address."
+  "sync_pair_not_fushi_discovered": "No Fushi device found at this address.",
+  "subtitle_version_episode_count": "$n episodes",
+  "subtitle_version_unnumbered_count": "$n unnumbered",
+  "subtitle_version_ai_translated": "AI translated",
+  "subtitle_version_content_language": "Content",
+  "subtitle_version_show_files": "Show files",
+  "subtitle_version_view_files": "File list"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3665,5 +3665,7 @@
   "subtitle_version_ai_translated": "AI translated",
   "subtitle_version_content_language": "Content",
   "subtitle_version_show_files": "Show files",
-  "subtitle_version_view_files": "File list"
+  "subtitle_version_view_files": "File list",
+  "resource_version_batch": "Batch",
+  "resource_version_view_flat": "All releases"
 }

--- a/fushi/lib/src/media/video/download/video_resource_version_groups.dart
+++ b/fushi/lib/src/media/video/download/video_resource_version_groups.dart
@@ -1,0 +1,220 @@
+/// 下载模式资源候选的「版本」聚类（纯函数，参照 RSS-Subtitle-Manager 的
+/// Nyaa 版本选择器）：几十条发布流水账 → 少数几张「发布组 › 清晰度」版本卡。
+///
+/// 订阅模式已有按订阅生效单位的聚合（`groupVideoSubscriptionCandidates`，
+/// BUG-1590）；本模块服务**下载模式**：用户最终要挑的是一条具体发布，聚类只
+/// 负责把「哪个组哪个清晰度」这层决策折起来，选组后再展开挑集。
+library;
+
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+
+/// 从发布标题解析集号（`S01E05` / `Title - 05 [1080p]` 两种主流形态）。
+/// 认不出返回 null。纯函数（原居 acquisition dialogs，聚类需要后下沉到此，
+/// dialogs 侧 re-export 保源兼容）。
+int? episodeNumberFromReleaseTitle(String title) {
+  final RegExpMatch? seasonEpisode = RegExp(
+    r'\bS\d{1,3}[ ._-]*E(\d{1,4})(?:v\d+)?\b',
+    caseSensitive: false,
+  ).firstMatch(title);
+  if (seasonEpisode != null) return int.tryParse(seasonEpisode.group(1)!);
+  final RegExpMatch? anime = RegExp(
+    r'(?:^|\s)-\s*(\d{1,4})(?:v\d+)?(?=\s*(?:\[|\(|$))',
+    caseSensitive: false,
+  ).firstMatch(title);
+  return anime == null ? null : int.tryParse(anime.group(1)!);
+}
+
+/// 标题开头的发布组标签（`[SubsPlease] xxx` → `SubsPlease`）。
+/// candidate.releaseGroup 缺失时的回退；CRC/分辨率不算组名。
+String? releaseGroupTagFromTitle(String title) {
+  final RegExpMatch? match =
+      RegExp(r'^\s*[\[【]([^\]】]{2,30})[\]】]').firstMatch(title);
+  if (match == null) return null;
+  final String tag = match.group(1)!.trim();
+  if (tag.isEmpty) return null;
+  if (RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(tag)) return null;
+  if (RegExp(r'^\d{3,4}[pP]$').hasMatch(tag)) return null;
+  return tag;
+}
+
+/// 标题里的清晰度（candidate.resolution 缺失时的回退）。
+String? resolutionFromTitle(String title) => RegExp(
+      r'\b(2160|1440|1080|720|576|480)[pP]\b',
+    ).firstMatch(title)?.group(0)?.toLowerCase();
+
+/// 这条发布是不是整季合集（batch）。判据（保守，全部对应真实发布形态）：
+/// - 显式关键词：batch / complete / 合集 / 全集；
+/// - 带界定符的集数区间：`[01-12]` / `第01-12话` / `(01~24 Fin)` ——要求区间
+///   由 第/括号 引导**或**以 话/集/END/Fin/完 收尾，两端 1..300 且递增，避免
+///   把 `2023-08` 日期、分辨率误判成区间。
+bool isLikelyBatchVideoRelease(String title) {
+  if (RegExp(r'\b(batch|complete)\b', caseSensitive: false).hasMatch(title)) {
+    return true;
+  }
+  if (title.contains('合集') || title.contains('全集')) return true;
+  for (final RegExpMatch match in RegExp(
+    r'(?:(?<lead>第|\[|\(|【|（)\s*)?(\d{1,3})\s*[-~〜]\s*(\d{1,3})\s*'
+    r'(?<tail>话|話|集|END|Fin|完)?',
+    caseSensitive: false,
+  ).allMatches(title)) {
+    if (match.namedGroup('lead') == null && match.namedGroup('tail') == null) {
+      continue;
+    }
+    final int? first = int.tryParse(match.group(2)!);
+    final int? last = int.tryParse(match.group(3)!);
+    if (first == null || last == null) continue;
+    if (first >= 1 && last <= 300 && last > first) return true;
+  }
+  return false;
+}
+
+/// 一张资源「版本卡」：同来源实例、同发布组、同清晰度、同 trusted 的发布集合。
+class VideoResourceVersionGroup {
+  VideoResourceVersionGroup._({
+    required this.key,
+    required this.members,
+  });
+
+  final String key;
+
+  /// 集号升序（认不出的殿后），同集按发布时间降序。
+  final List<VideoResourceCandidate> members;
+
+  String get providerId => members.first.providerId;
+  bool get trusted => members.first.trusted;
+
+  String? get releaseGroup =>
+      members.first.releaseGroup ??
+      releaseGroupTagFromTitle(members.first.title);
+
+  String? get resolution =>
+      members.first.resolution ?? resolutionFromTitle(members.first.title);
+
+  /// 卡标题的组成部分（缺段跳过）：组名、清晰度、来源。
+  List<String> get labelParts => <String>[
+        if (releaseGroup != null) releaseGroup!,
+        if (resolution != null) resolution!,
+        providerId,
+      ];
+
+  Set<int> get episodes => <int>{
+        for (final VideoResourceCandidate member in members)
+          if (episodeNumberFromReleaseTitle(member.title) != null)
+            episodeNumberFromReleaseTitle(member.title)!,
+      };
+
+  int get batchCount => members
+      .where((VideoResourceCandidate member) =>
+          isLikelyBatchVideoRelease(member.title))
+      .length;
+
+  DateTime? get latestPublishedAt {
+    DateTime? latest;
+    for (final VideoResourceCandidate member in members) {
+      final DateTime? at = member.publishedAt;
+      if (at != null && (latest == null || at.isAfter(latest))) latest = at;
+    }
+    return latest;
+  }
+
+  int get bestSeeders => members.fold(
+        0,
+        (int best, VideoResourceCandidate member) =>
+            member.seeders > best ? member.seeders : best,
+      );
+
+  /// 代表条：做种最多 → 最新 → 标题（全序，渲染稳定）。
+  VideoResourceCandidate get representative {
+    final List<VideoResourceCandidate> sorted =
+        List<VideoResourceCandidate>.of(members)..sort(_bySeedersDesc);
+    return sorted.first;
+  }
+}
+
+int _bySeedersDesc(VideoResourceCandidate a, VideoResourceCandidate b) {
+  final int bySeeders = b.seeders.compareTo(a.seeders);
+  if (bySeeders != 0) return bySeeders;
+  final DateTime? pa = a.publishedAt;
+  final DateTime? pb = b.publishedAt;
+  if (pa != null && pb != null) {
+    final int byDate = pb.compareTo(pa);
+    if (byDate != 0) return byDate;
+  } else if (pa != pb) {
+    return pa == null ? 1 : -1;
+  }
+  return a.title.compareTo(b.title);
+}
+
+String _groupKeyOf(VideoResourceCandidate candidate) => <String>[
+      candidate.providerId,
+      candidate.providerInstanceId,
+      (candidate.releaseGroup ??
+              releaseGroupTagFromTitle(candidate.title) ??
+              '')
+          .toLowerCase(),
+      (candidate.resolution ?? resolutionFromTitle(candidate.title) ?? '')
+          .toLowerCase(),
+      candidate.trusted ? 'trusted' : '',
+    ].join('\u001f');
+
+int _byEpisodeAsc(VideoResourceCandidate a, VideoResourceCandidate b) {
+  final int episodeA = episodeNumberFromReleaseTitle(a.title) ?? (1 << 30);
+  final int episodeB = episodeNumberFromReleaseTitle(b.title) ?? (1 << 30);
+  if (episodeA != episodeB) return episodeA.compareTo(episodeB);
+  return _bySeedersDesc(a, b);
+}
+
+/// 聚类 + 排序。组间：最高做种数降序 → 最新发布降序 → key（稳定）。
+List<VideoResourceVersionGroup> buildVideoResourceVersionGroups(
+  Iterable<VideoResourceCandidate> candidates,
+) {
+  final Map<String, List<VideoResourceCandidate>> byKey =
+      <String, List<VideoResourceCandidate>>{};
+  for (final VideoResourceCandidate candidate in candidates) {
+    byKey
+        .putIfAbsent(_groupKeyOf(candidate), () => <VideoResourceCandidate>[])
+        .add(candidate);
+  }
+  final List<VideoResourceVersionGroup> groups = <VideoResourceVersionGroup>[
+    for (final MapEntry<String, List<VideoResourceCandidate>> entry
+        in byKey.entries)
+      VideoResourceVersionGroup._(
+        key: entry.key,
+        members: List<VideoResourceCandidate>.unmodifiable(
+          entry.value..sort(_byEpisodeAsc),
+        ),
+      ),
+  ];
+  groups.sort((VideoResourceVersionGroup a, VideoResourceVersionGroup b) {
+    final int bySeeders = b.bestSeeders.compareTo(a.bestSeeders);
+    if (bySeeders != 0) return bySeeders;
+    final DateTime? pa = a.latestPublishedAt;
+    final DateTime? pb = b.latestPublishedAt;
+    if (pa != null && pb != null) {
+      final int byDate = pb.compareTo(pa);
+      if (byDate != 0) return byDate;
+    } else if (pa != pb) {
+      return pa == null ? 1 : -1;
+    }
+    return a.key.compareTo(b.key);
+  });
+  return List<VideoResourceVersionGroup>.unmodifiable(groups);
+}
+
+/// 从版本卡解析「用户要的那一集」：
+/// - [episode] 非空：集号精确命中 → 该发布（同集多条取代表序最优）；否则 null；
+/// - [episode] 为空：组里恰 1 条 → 它；否则 null（UI 展开手选）。
+VideoResourceCandidate? pickResourceVersionCandidate(
+  VideoResourceVersionGroup group, {
+  int? episode,
+}) {
+  if (episode != null) {
+    final List<VideoResourceCandidate> hits = group.members
+        .where((VideoResourceCandidate member) =>
+            episodeNumberFromReleaseTitle(member.title) == episode)
+        .toList()
+      ..sort(_bySeedersDesc);
+    return hits.isEmpty ? null : hits.first;
+  }
+  return group.members.length == 1 ? group.members.single : null;
+}

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -27,11 +27,16 @@ class JimakuFile {
     required this.name,
     required this.url,
     this.size,
+    this.lastModifiedMs,
   });
 
   final String name;
   final String url;
   final int? size;
+
+  /// API `last_modified`（ISO-8601）解析成的 epoch 毫秒；缺失/不可解析为
+  /// null。版本选择器的「N 天前」与最新文件判定用。
+  final int? lastModifiedMs;
 
   /// 文件扩展名（小写，不含点）；用于选解析器（srt/ass/vtt）。
   String get extension {
@@ -314,6 +319,7 @@ List<JimakuFile> parseJimakuFiles(String body, {bool strict = false}) {
         name: name,
         url: url,
         size: f['size'] is int ? f['size'] as int : null,
+        lastModifiedMs: parseJimakuTimestampMs(f['last_modified']),
       ));
     }
     return out;
@@ -328,6 +334,13 @@ List<JimakuFile> parseJimakuFiles(String body, {bool strict = false}) {
     }
     return const <JimakuFile>[];
   }
+}
+
+/// 解析 Jimaku 的 `last_modified`（ISO-8601 字符串）为 epoch 毫秒。
+/// 非字符串/不可解析 → null（时间只是增强信息，绝不让它挡住文件本身）。
+int? parseJimakuTimestampMs(Object? raw) {
+  if (raw is! String || raw.trim().isEmpty) return null;
+  return DateTime.tryParse(raw.trim())?.toUtc().millisecondsSinceEpoch;
 }
 
 /// Jimaku 请求失败。默认客户端路径仍可 fail-open；需要向用户区分「零结果」与「请求

--- a/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
@@ -143,6 +143,9 @@ class _JimakuSubtitleCandidate extends VideoSubtitleCandidate {
           season: season,
           episode: file.episode,
           fileSize: file.size,
+          uploadedAtMs: file.lastModifiedMs,
+          collectionId: '${entry.id}',
+          collectionLabel: entry.name,
         );
 
   final JimakuEntry entry;

--- a/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
+++ b/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
@@ -115,6 +115,9 @@ class OpenSubtitlesSearchRecord {
     this.downloadCount = 0,
     this.hearingImpaired = false,
     this.fps,
+    this.uploadedAtMs,
+    this.aiTranslated = false,
+    this.fromTrusted = false,
   });
 
   final int fileId;
@@ -126,6 +129,15 @@ class OpenSubtitlesSearchRecord {
   final int downloadCount;
   final bool hearingImpaired;
   final double? fps;
+
+  /// `attributes.upload_date`（ISO-8601）→ epoch 毫秒；缺失/不可解析 null。
+  final int? uploadedAtMs;
+
+  /// `attributes.ai_translated`：机翻标记（排序降权，UI 明示）。
+  final bool aiTranslated;
+
+  /// `attributes.from_trusted`：可信上传者。
+  final bool fromTrusted;
 }
 
 List<OpenSubtitlesSearchRecord> parseOpenSubtitlesSearchResponse(String body) {
@@ -165,6 +177,13 @@ List<OpenSubtitlesSearchRecord> parseOpenSubtitlesSearchResponse(String body) {
           downloadCount: _int(attributes['download_count']) ?? 0,
           hearingImpaired: attributes['hearing_impaired'] == true,
           fps: _double(attributes['fps']),
+          uploadedAtMs: attributes['upload_date'] is String
+              ? DateTime.tryParse(attributes['upload_date']! as String)
+                  ?.toUtc()
+                  .millisecondsSinceEpoch
+              : null,
+          aiTranslated: attributes['ai_translated'] == true,
+          fromTrusted: attributes['from_trusted'] == true,
         ),
       );
     }
@@ -644,6 +663,9 @@ class _OpenSubtitlesCandidate extends VideoSubtitleCandidate {
           downloadCount: record.downloadCount,
           hearingImpaired: record.hearingImpaired,
           fps: record.fps,
+          uploadedAtMs: record.uploadedAtMs,
+          aiTranslated: record.aiTranslated,
+          fromTrusted: record.fromTrusted,
         );
 
   final OpenSubtitlesSearchRecord record;

--- a/fushi/lib/src/media/video/subtitle/subtitle_content_language.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_content_language.dart
@@ -1,0 +1,159 @@
+/// 字幕**正文**语言检测（纯函数）。
+///
+/// 文件名标签（`[JPN]` / `[CHS]`）经常是错的——上传者复制模板、打包改名都会
+/// 留下错标签；正文才是权威（参照 RSS-Subtitle-Manager 的同名判据）。本模块
+/// 只看对白文本：ASS 取 `Dialogue:` 行第 10 字段起，SRT/VTT 去序号与时间轴，
+/// 再剥 `{...}` / `<...>` 标签后统计假名 / 汉字 / 拉丁字母。
+///
+/// 判定规则（阈值与 RSS-Subtitle-Manager 对齐，全部有单测）：
+/// - 假名 ≥ 8 → 日语；其中「无假名且汉字 ≥ 2 的行」≥ 3 行、且这些行的汉字量
+///   ≥ max(12, 总汉字/5) → 中日双语（`日文行\N中文行` 的典型形态）。
+/// - 否则汉字 ≥ 8 → 按简/繁判别字符集计数分简体/繁体。
+/// - 否则拉丁字母 ≥ 30 → 英语。
+/// - 都不够 → 未知（**不猜**）。
+library;
+
+/// 检测结果。粗粒度语言码投影见 [coarseLanguageCode]。
+enum SubtitleContentLanguage {
+  japanese,
+  simplifiedChinese,
+  traditionalChinese,
+
+  /// 中日双语（同屏两行，学日语用户的高价值版本，单列一类不并入 zh）。
+  bilingualJaZh,
+  english,
+  unknown,
+}
+
+/// 投影到既有 `ja/zh/en/ko` 粗码（`kJimakuLanguageCodes` 同一值域）；
+/// unknown → null。双语归 zh（含中文即可被「中文」筛选命中；细分标签由
+/// [subtitleContentLanguageNativeLabel] 展示）。
+String? coarseLanguageCode(SubtitleContentLanguage language) =>
+    switch (language) {
+      SubtitleContentLanguage.japanese => 'ja',
+      SubtitleContentLanguage.simplifiedChinese ||
+      SubtitleContentLanguage.traditionalChinese ||
+      SubtitleContentLanguage.bilingualJaZh =>
+        'zh',
+      SubtitleContentLanguage.english => 'en',
+      SubtitleContentLanguage.unknown => null,
+    };
+
+/// 母语写法显示名（与 `jimakuLanguageLabel` 同姿态：不随界面语言变，不走 i18n）。
+String? subtitleContentLanguageNativeLabel(SubtitleContentLanguage language) =>
+    switch (language) {
+      SubtitleContentLanguage.japanese => '日本語',
+      SubtitleContentLanguage.simplifiedChinese => '简体中文',
+      SubtitleContentLanguage.traditionalChinese => '繁體中文',
+      SubtitleContentLanguage.bilingualJaZh => '中日双语',
+      SubtitleContentLanguage.english => 'English',
+      SubtitleContentLanguage.unknown => null,
+    };
+
+/// 简体判别集：只在简体文本出现、繁体文本写作另一形的常用字。
+const String _kSimplifiedOnlyChars = '们这对时东乐买卖医还见观说话读书写马鸟龙风'
+    '电开关门问间众优传体华单卫压发变经给绝统继绿网义习学为点让边远运进军农'
+    '动劳办务历层岁带帮广应张当录隐忆态怀恶悬爱战抢护报担拟拥挂币帅师归';
+
+/// 繁体判别集：与 [_kSimplifiedOnlyChars] 一一对应的繁体形。
+const String _kTraditionalOnlyChars = '們這對時東樂買賣醫還見觀說話讀書寫馬鳥龍風'
+    '電開關門問間眾優傳體華單衛壓發變經給絕統繼綠網義習學為點讓邊遠運進軍農'
+    '動勞辦務歷層歲帶幫廣應張當錄隱憶態懷惡懸愛戰搶護報擔擬擁掛幣帥師歸';
+
+final Set<int> _simplifiedOnly = _kSimplifiedOnlyChars.runes.toSet();
+final Set<int> _traditionalOnly = _kTraditionalOnlyChars.runes.toSet();
+
+bool _isKana(int rune) =>
+    (rune >= 0x3041 && rune <= 0x3096) || // 平假名
+    (rune >= 0x30A1 && rune <= 0x30FA); // 片假名（不含长音符/中点等标点）
+
+bool _isHan(int rune) =>
+    (rune >= 0x4E00 && rune <= 0x9FFF) ||
+    (rune >= 0x3400 && rune <= 0x4DBF) ||
+    rune == 0x3005; // 々
+
+bool _isLatinLetter(int rune) =>
+    (rune >= 0x41 && rune <= 0x5A) || (rune >= 0x61 && rune <= 0x7A);
+
+/// 从字幕全文提取「对白行」列表（纯函数，便于单测）。
+///
+/// - ASS/SSA：只取 `Dialogue:` 行的第 10 个逗号字段起（Text 字段本身可含逗号），
+///   `\N`/`\n` 内联换行拆成多行（双语字幕的典型形态就在这一步现形）。
+/// - SRT/VTT：丢纯序号行、时间轴行（含 `-->`）与 `WEBVTT` 头。
+/// - 通用：剥 `{...}`（ASS 覆写块）与 `<...>`（HTML 风格标签）。
+List<String> extractSubtitleDialogueLines(String text) {
+  final List<String> out = <String>[];
+  final bool looksAss = text.contains('Dialogue:');
+  for (final String rawLine in text.split(RegExp(r'\r?\n'))) {
+    String line = rawLine.trim();
+    if (line.isEmpty) continue;
+    if (looksAss) {
+      if (!line.startsWith('Dialogue:')) continue;
+      final List<String> parts = line.split(',');
+      if (parts.length < 10) continue;
+      line = parts.sublist(9).join(',');
+    } else {
+      if (line.contains('-->')) continue;
+      if (RegExp(r'^\d+$').hasMatch(line)) continue;
+      if (line == 'WEBVTT' || line.startsWith('NOTE ')) continue;
+    }
+    for (final String piece in line.split(RegExp(r'\\[Nn]'))) {
+      final String cleaned = piece
+          .replaceAll(RegExp(r'\{[^}]*\}'), '')
+          .replaceAll(RegExp(r'<[^>]*>'), '')
+          .trim();
+      if (cleaned.isNotEmpty) out.add(cleaned);
+    }
+  }
+  return out;
+}
+
+/// 见 library doc。输入是**解码后的全文**（字节 → 文本用既有
+/// `decodeTextBytes`，本模块不管编码）。
+SubtitleContentLanguage detectSubtitleContentLanguage(String text) {
+  final List<String> lines = extractSubtitleDialogueLines(text);
+  int totalKana = 0;
+  int totalHan = 0;
+  int totalLatin = 0;
+  int hanOnlyLines = 0;
+  int hanOnlyHan = 0;
+  int simplifiedHits = 0;
+  int traditionalHits = 0;
+  for (final String line in lines) {
+    int lineKana = 0;
+    int lineHan = 0;
+    for (final int rune in line.runes) {
+      if (_isKana(rune)) {
+        lineKana++;
+      } else if (_isHan(rune)) {
+        lineHan++;
+        if (_simplifiedOnly.contains(rune)) simplifiedHits++;
+        if (_traditionalOnly.contains(rune)) traditionalHits++;
+      } else if (_isLatinLetter(rune)) {
+        totalLatin++;
+      }
+    }
+    totalKana += lineKana;
+    totalHan += lineHan;
+    if (lineKana == 0 && lineHan >= 2) {
+      hanOnlyLines++;
+      hanOnlyHan += lineHan;
+    }
+  }
+  if (totalKana >= 8) {
+    // 纯日语字幕里也有汉字拟声/汉字词行（「物音」），要求「无假名汉字行」既有
+    // 行数又有总量，才判双语——单个拟声行不构成中文轨。
+    final int bilingualFloor = totalHan ~/ 5 > 12 ? totalHan ~/ 5 : 12;
+    if (hanOnlyLines >= 3 && hanOnlyHan >= bilingualFloor) {
+      return SubtitleContentLanguage.bilingualJaZh;
+    }
+    return SubtitleContentLanguage.japanese;
+  }
+  if (totalHan >= 8) {
+    return traditionalHits > simplifiedHits
+        ? SubtitleContentLanguage.traditionalChinese
+        : SubtitleContentLanguage.simplifiedChinese;
+  }
+  if (totalLatin >= 30) return SubtitleContentLanguage.english;
+  return SubtitleContentLanguage.unknown;
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_version_groups.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_version_groups.dart
@@ -1,0 +1,195 @@
+/// 字幕候选的两级「版本」聚类（纯函数，参照 RSS-Subtitle-Manager 的
+/// 版本选择器）：文件名流水账 → 少数几张可决策的版本卡。
+///
+/// 第一级 = 来源合集（Jimaku entry / OpenSubtitles 整体）；第二级 = 同一合集内
+/// 的「变体」：格式 + 语言 + 发布组标签 + CC/机翻标记。同版本的几十个集数文件
+/// 折进一张卡，用户选一次版本，具体某集由 [pickGroupCandidateForEpisode] 解析。
+library;
+
+import 'package:fushi/src/media/video/jimaku_client.dart'
+    show jimakuLanguageLabel, jimakuLanguageRank;
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+/// 文件名开头的发布组标签（`[SubsPlease] xxx` → `SubsPlease`）。
+/// 8 位 hex（CRC）、分辨率、纯语言 token 不算组名；认不出返回 null。
+String? subtitleReleaseGroupTag(String fileName) {
+  final RegExpMatch? match =
+      RegExp(r'^\s*[\[【]([^\]】]{2,30})[\]】]').firstMatch(fileName);
+  if (match == null) return null;
+  final String tag = match.group(1)!.trim();
+  if (tag.isEmpty) return null;
+  if (RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(tag)) return null;
+  if (RegExp(r'^\d{3,4}[pP]$').hasMatch(tag)) return null;
+  const Set<String> languageTokens = <String>{
+    'ja', 'jp', 'jpn', 'zh', 'chs', 'cht', 'sc', 'tc', 'en', 'eng', 'ko',
+    'kor', // 语言标签是变体维度，不是组名
+  };
+  if (languageTokens.contains(tag.toLowerCase())) return null;
+  return tag;
+}
+
+/// 小写扩展名（不含点）；认不出为空串。
+String subtitleFormatOf(String fileName) {
+  final int dot = fileName.lastIndexOf('.');
+  return dot < 0 ? '' : fileName.substring(dot + 1).toLowerCase();
+}
+
+/// 一张「版本卡」：同一来源合集下、同格式同语言同发布组的候选集合。
+class SubtitleVersionGroup {
+  SubtitleVersionGroup._({
+    required this.key,
+    required this.collectionLabel,
+    required this.members,
+  });
+
+  final String key;
+
+  /// 第一级标签：Jimaku entry 名 / 无合集概念的来源用 providerId。
+  final String collectionLabel;
+
+  /// 集号升序（无集号殿后），同集按文件名。
+  final List<VideoSubtitleCandidate> members;
+
+  VideoSubtitleCandidate get representative => latest;
+
+  String get providerId => members.first.providerId;
+  String get language => members.first.language;
+  String get format => subtitleFormatOf(members.first.fileName);
+  String? get releaseGroupTag =>
+      subtitleReleaseGroupTag(members.first.fileName);
+  bool get hearingImpaired => members.first.hearingImpaired;
+  bool get aiTranslated => members.first.aiTranslated;
+  bool get fromTrusted => members.any(
+        (VideoSubtitleCandidate candidate) => candidate.fromTrusted,
+      );
+
+  /// 第二级标签的组成部分（UI 逐段拼、缺段跳过）：格式大写、语言母语名、组名。
+  List<String> get variantParts => <String>[
+        if (format.isNotEmpty) format.toUpperCase(),
+        if (language.isNotEmpty) jimakuLanguageLabel(language),
+        if (releaseGroupTag != null) releaseGroupTag!,
+      ];
+
+  Set<int> get episodes => <int>{
+        for (final VideoSubtitleCandidate candidate in members)
+          if (candidate.episode != null) candidate.episode!,
+      };
+
+  int get unnumberedCount => members
+      .where((VideoSubtitleCandidate candidate) => candidate.episode == null)
+      .length;
+
+  int? get latestUploadedAtMs {
+    int? latest;
+    for (final VideoSubtitleCandidate candidate in members) {
+      final int? at = candidate.uploadedAtMs;
+      if (at != null && (latest == null || at > latest)) latest = at;
+    }
+    return latest;
+  }
+
+  /// 「最新」文件：上传时间最大者；全部无时间时取集号最大者（近似最新一集）。
+  VideoSubtitleCandidate get latest {
+    VideoSubtitleCandidate best = members.first;
+    for (final VideoSubtitleCandidate candidate in members.skip(1)) {
+      final int? bestAt = best.uploadedAtMs;
+      final int? at = candidate.uploadedAtMs;
+      if (at != null && (bestAt == null || at > bestAt)) {
+        best = candidate;
+        continue;
+      }
+      if (at == null && bestAt == null) {
+        final int bestEp = best.episode ?? -1;
+        final int ep = candidate.episode ?? -1;
+        if (ep > bestEp) best = candidate;
+      }
+    }
+    return best;
+  }
+
+  int get totalDownloadCount => members.fold(
+        0,
+        (int sum, VideoSubtitleCandidate candidate) =>
+            sum + candidate.downloadCount,
+      );
+}
+
+String _groupKeyOf(VideoSubtitleCandidate candidate) => <String>[
+      candidate.providerId,
+      candidate.collectionId ?? '',
+      subtitleFormatOf(candidate.fileName),
+      candidate.language,
+      subtitleReleaseGroupTag(candidate.fileName) ?? '',
+      candidate.hearingImpaired ? 'hi' : '',
+      candidate.aiTranslated ? 'ai' : '',
+    ].join('\u001f');
+
+int _compareMembers(VideoSubtitleCandidate a, VideoSubtitleCandidate b) {
+  final int byEpisode = (a.episode ?? 1 << 30).compareTo(b.episode ?? 1 << 30);
+  return byEpisode != 0 ? byEpisode : a.fileName.compareTo(b.fileName);
+}
+
+/// 聚类 + 排序。组间排序：语言权重（[preferredLanguage] 最前）→ 机翻殿后 →
+/// 最新上传时间降序（无时间殿后）→ 累计下载量 → key（稳定）。
+List<SubtitleVersionGroup> buildSubtitleVersionGroups(
+  Iterable<VideoSubtitleCandidate> candidates, {
+  String? preferredLanguage,
+}) {
+  final Map<String, List<VideoSubtitleCandidate>> byKey =
+      <String, List<VideoSubtitleCandidate>>{};
+  for (final VideoSubtitleCandidate candidate in candidates) {
+    byKey
+        .putIfAbsent(_groupKeyOf(candidate), () => <VideoSubtitleCandidate>[])
+        .add(candidate);
+  }
+  final List<SubtitleVersionGroup> groups = <SubtitleVersionGroup>[
+    for (final MapEntry<String, List<VideoSubtitleCandidate>> entry
+        in byKey.entries)
+      SubtitleVersionGroup._(
+        key: entry.key,
+        collectionLabel:
+            entry.value.first.collectionLabel ?? entry.value.first.providerId,
+        members: List<VideoSubtitleCandidate>.unmodifiable(
+          entry.value..sort(_compareMembers),
+        ),
+      ),
+  ];
+  groups.sort((SubtitleVersionGroup a, SubtitleVersionGroup b) {
+    final int byLanguage = jimakuLanguageRank(
+      a.language.isEmpty ? null : a.language,
+      preferred: preferredLanguage,
+    ).compareTo(jimakuLanguageRank(
+      b.language.isEmpty ? null : b.language,
+      preferred: preferredLanguage,
+    ));
+    if (byLanguage != 0) return byLanguage;
+    if (a.aiTranslated != b.aiTranslated) return a.aiTranslated ? 1 : -1;
+    final int aAt = a.latestUploadedAtMs ?? -1;
+    final int bAt = b.latestUploadedAtMs ?? -1;
+    if (aAt != bAt) return bAt.compareTo(aAt);
+    final int byDownloads =
+        b.totalDownloadCount.compareTo(a.totalDownloadCount);
+    return byDownloads != 0 ? byDownloads : a.key.compareTo(b.key);
+  });
+  return List<SubtitleVersionGroup>.unmodifiable(groups);
+}
+
+/// 从版本卡解析「用户要的那一集」：
+/// - [episode] 非空：精确集号命中 → 该文件；无命中但组里恰有 1 个无集号文件
+///   （剧场版/整季包常态）→ 那一个；否则 null（UI 展开让用户手选）。
+/// - [episode] 为空：组里只有 1 个文件 → 它；否则 null。
+VideoSubtitleCandidate? pickGroupCandidateForEpisode(
+  SubtitleVersionGroup group,
+  int? episode,
+) {
+  if (episode != null) {
+    for (final VideoSubtitleCandidate candidate in group.members) {
+      if (candidate.episode == episode) return candidate;
+    }
+    final List<VideoSubtitleCandidate> unnumbered = group.members
+        .where((VideoSubtitleCandidate candidate) => candidate.episode == null)
+        .toList(growable: false);
+    return unnumbered.length == 1 ? unnumbered.single : null;
+  }
+  return group.members.length == 1 ? group.members.single : null;
+}

--- a/fushi/lib/src/media/video/subtitle/subtitle_version_language_probe.dart
+++ b/fushi/lib/src/media/video/subtitle/subtitle_version_language_probe.dart
@@ -1,0 +1,57 @@
+/// 版本组代表文件的正文语言探测（增强信息，绝不阻塞、绝不抛）。
+///
+/// 文件名认不出语言的版本组，下载其代表文件（字幕通常几十 KB）解码后用
+/// [detectSubtitleContentLanguage] 判正文语言。结果只用于展示（「正文：简体
+/// 中文」），不改变分组——探测是异步补充，卡片不因它重排。
+///
+/// 纪律（对来源站的礼貌，参照 RSS-Subtitle-Manager 的 4 并发 + 缓存）：
+/// 结果按 identityKey 进程内缓存；超过 [maxProbeBytes] 的文件不探（整季包
+/// 没必要为标签下几 MB）；任何失败静默返回 null。
+library;
+
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
+
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+class SubtitleVersionLanguageProbe {
+  SubtitleVersionLanguageProbe({
+    required Future<VideoSubtitleDownload> Function(
+      VideoSubtitleCandidate candidate,
+    ) download,
+    this.maxProbeBytes = 2 * 1024 * 1024,
+  }) : _download = download;
+
+  final Future<VideoSubtitleDownload> Function(
+    VideoSubtitleCandidate candidate,
+  ) _download;
+  final int maxProbeBytes;
+
+  final Map<String, SubtitleContentLanguage?> _cache =
+      <String, SubtitleContentLanguage?>{};
+
+  /// 探测 [candidate] 的正文语言；不可用/失败/unknown → null。
+  Future<SubtitleContentLanguage?> probe(
+    VideoSubtitleCandidate candidate,
+  ) async {
+    final String key = candidate.identityKey;
+    if (_cache.containsKey(key)) return _cache[key];
+    final int? size = candidate.fileSize;
+    if (size != null && size > maxProbeBytes) {
+      return _cache[key] = null;
+    }
+    try {
+      final VideoSubtitleDownload download = await _download(candidate);
+      if (download.bytes.isEmpty || download.bytes.length > maxProbeBytes) {
+        return _cache[key] = null;
+      }
+      final String text = await decodeTextBytes(download.bytes);
+      final SubtitleContentLanguage detected =
+          detectSubtitleContentLanguage(text);
+      return _cache[key] =
+          detected == SubtitleContentLanguage.unknown ? null : detected;
+    } on Object {
+      return _cache[key] = null;
+    }
+  }
+}

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
@@ -59,6 +59,11 @@ abstract class VideoSubtitleCandidate {
     this.downloadCount = 0,
     this.hearingImpaired = false,
     this.fps,
+    this.uploadedAtMs,
+    this.collectionId,
+    this.collectionLabel,
+    this.aiTranslated = false,
+    this.fromTrusted = false,
   });
 
   final String providerId;
@@ -73,6 +78,23 @@ abstract class VideoSubtitleCandidate {
   final int downloadCount;
   final bool hearingImpaired;
   final double? fps;
+
+  /// 上传/最后修改时刻（epoch 毫秒）。版本选择器的「N 天前」与「最新文件」
+  /// 判定用；来源没给（旧响应）为 null。
+  final int? uploadedAtMs;
+
+  /// 来源侧的「合集」身份（Jimaku entry id / OpenSubtitles 无此概念为 null）。
+  /// 两级版本聚类的第一级分组键；此前只藏在 remoteId 前缀里，UI 拿不到。
+  final String? collectionId;
+
+  /// [collectionId] 的展示名（Jimaku entry 名）。
+  final String? collectionLabel;
+
+  /// 来源明确标注的机翻（OpenSubtitles `ai_translated`）。质量信号，排序降权。
+  final bool aiTranslated;
+
+  /// 来源明确标注的可信上传者（OpenSubtitles `from_trusted`）。
+  final bool fromTrusted;
 
   String get identityKey => '$providerId:$remoteId';
 }

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -11,9 +12,13 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_language_probe.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
+import 'package:fushi/src/pages/implementations/subtitle_version_group_list.dart';
 import 'package:fushi/utils.dart';
 
 /// 一条可下载的在线字幕候选：来源条目/发布名 + 文件名 + 回给来源 provider 的句柄。
@@ -249,7 +254,20 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   bool _searching = false;
   bool _searched = false;
   String? _busyName; // 正在下载的文件名
+  String? _busySourceKey; // 正在下载的候选 identityKey（版本卡视图用）
   List<JimakuCandidate> _candidates = const <JimakuCandidate>[];
+
+  /// true = 平铺文件列表（旧视图）；false（默认）= 版本卡视图。候选缺 source
+  /// （测试预置样本）时强制文件视图。
+  bool _showFileView = false;
+
+  /// 版本组正文语言探测结果（group.key → 检测值），展示用。
+  Map<String, SubtitleContentLanguage> _probedGroupLanguages =
+      <String, SubtitleContentLanguage>{};
+
+  /// 每轮搜索递增，丢弃迟到的旧探测结果。
+  int _probeGeneration = 0;
+  SubtitleVersionLanguageProbe? _probe;
 
   /// API key 输入区是否折叠（配好 key 且已有候选结果后默认收起腾出列表空间）。
   bool _apiKeyCollapsed = false;
@@ -454,11 +472,49 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         _searched = true;
         _searchedWithEpisode = episode != null;
         _selectedSeriesId = anilistId;
+        _probedGroupLanguages = <String, SubtitleContentLanguage>{};
         // 记忆语言 / 上轮类型本次无候选 → 退回「全部」，不空屏（保底）。
         _reconcileSelectedFilters();
         // 配好 key 且搜出结果后，默认收起 API key 输入区腾出列表空间
         // （用户：「apikey 配完是不是可以缩小显示」）。用户仍可点「修改」展开。
         _apiKeyCollapsed = sorted.isNotEmpty;
+      });
+      unawaited(_probeUnknownLanguageGroups(registry));
+    }
+  }
+
+  /// 文件名认不出语言的版本组：后台下载代表文件探正文语言（展示增强，见
+  /// [SubtitleVersionLanguageProbe] 的纪律）。最多探 4 组、逐个串行；结果按
+  /// generation 丢弃迟到者。
+  Future<void> _probeUnknownLanguageGroups(
+    VideoSubtitleRegistry registry,
+  ) async {
+    final int generation = ++_probeGeneration;
+    final List<VideoSubtitleCandidate> sources = <VideoSubtitleCandidate>[
+      for (final JimakuCandidate candidate in _candidates)
+        if (candidate.source != null) candidate.source!,
+    ];
+    if (sources.isEmpty) return;
+    final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+      sources,
+      preferredLanguage: _selectedLanguage,
+    );
+    final SubtitleVersionLanguageProbe probe =
+        _probe ??= SubtitleVersionLanguageProbe(download: registry.download);
+    int probed = 0;
+    for (final SubtitleVersionGroup group in groups) {
+      if (group.language.isNotEmpty) continue;
+      if (probed >= 4) break;
+      probed++;
+      final SubtitleContentLanguage? detected =
+          await probe.probe(group.representative);
+      if (!mounted || generation != _probeGeneration) return;
+      if (detected == null) continue;
+      setState(() {
+        _probedGroupLanguages = <String, SubtitleContentLanguage>{
+          ..._probedGroupLanguages,
+          group.key: detected,
+        };
       });
     }
   }
@@ -477,9 +533,19 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// （[ExternalProviderFailure]）是给管线重试用的，对用户只有「没下来」一种语义。
   Future<void> _download(JimakuCandidate candidate) async {
     final VideoSubtitleCandidate? source = candidate.source;
+    if (source == null) return;
+    await _downloadSource(source);
+  }
+
+  /// 下载真实来源候选（文件视图与版本卡视图共用）：registry 按 providerId
+  /// 分派，落盘后 pop 回本地路径。
+  Future<void> _downloadSource(VideoSubtitleCandidate source) async {
     final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
-    if (source == null || registry == null) return;
-    setState(() => _busyName = candidate.name);
+    if (registry == null) return;
+    setState(() {
+      _busyName = source.fileName;
+      _busySourceKey = source.identityKey;
+    });
     try {
       final VideoSubtitleDownload download = await registry.download(source);
       if (download.bytes.isEmpty) {
@@ -495,7 +561,12 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     } on Object {
       _snack(t.video_jimaku_download_failed);
     } finally {
-      if (mounted) setState(() => _busyName = null);
+      if (mounted) {
+        setState(() {
+          _busyName = null;
+          _busySourceKey = null;
+        });
+      }
     }
   }
 
@@ -707,6 +778,21 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
               ),
               onChanged: (String v) => setState(() => _filter = v),
             ),
+            // 版本卡视图默认开；想直接翻原始文件列表的用户在这里切换。
+            if (_candidates
+                .any((JimakuCandidate c) => c.source != null)) ...<Widget>[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: FilterChip(
+                  key: const ValueKey<String>('jimaku-file-view-toggle'),
+                  label: Text(t.subtitle_version_view_files),
+                  selected: _showFileView,
+                  onSelected: (bool value) =>
+                      setState(() => _showFileView = value),
+                ),
+              ),
+            ],
           ],
         ],
       ),
@@ -750,14 +836,40 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         ),
       );
     }
-    // 先按语言筛选（_selectedLanguage）、再按类型筛选（_selectedFormat），最后交给
-    // 列表做关键词二次筛选。三层各自独立、顺序不影响结果集。
-    return JimakuCandidateList(
-      candidates: filterCandidatesByFormat(
+    // 先按语言筛选（_selectedLanguage）、再按类型筛选（_selectedFormat）、再做
+    // 关键词二次筛选。三层各自独立、顺序不影响结果集。
+    final List<JimakuCandidate> filtered = filterByMediaSearch(
+      filterCandidatesByFormat(
         filterCandidatesByLanguage(_candidates, _selectedLanguage),
         _selectedFormat,
       ),
-      filter: _filter,
+      _filter,
+      (JimakuCandidate c) => <String>[c.name, c.entryName],
+    );
+    // 版本卡视图（默认）：候选全部带真实来源时按「合集 › 格式+语言+组」聚类，
+    // 文件名流水账折进卡内（RSS-Subtitle-Manager 式版本选择器）。测试预置样本
+    // （source == null）或用户显式切文件视图时走旧平铺列表。
+    final List<VideoSubtitleCandidate> sources = <VideoSubtitleCandidate>[
+      for (final JimakuCandidate candidate in filtered)
+        if (candidate.source != null) candidate.source!,
+    ];
+    final bool canGroup =
+        sources.isNotEmpty && sources.length == filtered.length;
+    if (canGroup && !_showFileView) {
+      return SubtitleVersionGroupList(
+        groups: buildSubtitleVersionGroups(
+          sources,
+          preferredLanguage: _selectedLanguage,
+        ),
+        requestedEpisode: int.tryParse(_episodeCtrl.text.trim()),
+        busyIdentityKey: _busySourceKey,
+        onPickCandidate: _busyName == null ? _downloadSource : null,
+        probedLanguages: _probedGroupLanguages,
+      );
+    }
+    return JimakuCandidateList(
+      candidates: filtered,
+      filter: '',
       busyName: _busyName,
       onDownload: _busyName == null ? _download : null,
     );

--- a/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
+++ b/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/video/jimaku_client.dart'
+    show jimakuLanguageLabel;
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/activity_feed.dart'
+    show ActivityRelativeTime, ActivityRelativeUnit, activityRelativeTime;
+import 'package:fushi/utils.dart';
+
+/// 字幕「版本卡」列表（参照 RSS-Subtitle-Manager 的版本选择器）：一张卡 =
+/// 一个来源合集下的一个变体（格式+语言+发布组），几十个集数文件折进卡内。
+///
+/// 交互：点卡片 → 有明确目标集时直接下载该集文件（[requestedEpisode] +
+/// [pickGroupCandidateForEpisode]），解析不出唯一文件则展开卡片让用户手选；
+/// 右侧 chevron 恒可手动展开。每行/每卡的下载动作都回 [onPickCandidate]。
+class SubtitleVersionGroupList extends StatefulWidget {
+  const SubtitleVersionGroupList({
+    required this.groups,
+    required this.requestedEpisode,
+    required this.busyIdentityKey,
+    required this.onPickCandidate,
+    this.probedLanguages = const <String, SubtitleContentLanguage>{},
+    super.key,
+  });
+
+  final List<SubtitleVersionGroup> groups;
+
+  /// 用户在集数框里要的那一集；null = 没指定。
+  final int? requestedEpisode;
+
+  /// 正在下载的候选 identityKey；null = 空闲。非空时所有动作禁用。
+  final String? busyIdentityKey;
+
+  /// 用户最终选定某个文件（下载动作由宿主执行）。null = 全部禁用。
+  final void Function(VideoSubtitleCandidate candidate)? onPickCandidate;
+
+  /// 正文语言探测结果（group.key → 检测值）：文件名认不出语言的组，宿主可
+  /// 后台探测正文后回填，本组件只展示（`正文：简体中文`），不参与分组。
+  final Map<String, SubtitleContentLanguage> probedLanguages;
+
+  @override
+  State<SubtitleVersionGroupList> createState() =>
+      _SubtitleVersionGroupListState();
+}
+
+class _SubtitleVersionGroupListState extends State<SubtitleVersionGroupList> {
+  final Set<String> _expanded = <String>{};
+
+  bool get _busy => widget.busyIdentityKey != null;
+
+  void _onCardTap(SubtitleVersionGroup group) {
+    if (_busy || widget.onPickCandidate == null) return;
+    final VideoSubtitleCandidate? picked =
+        pickGroupCandidateForEpisode(group, widget.requestedEpisode);
+    if (picked != null) {
+      widget.onPickCandidate!(picked);
+      return;
+    }
+    setState(() {
+      if (!_expanded.add(group.key)) _expanded.remove(group.key);
+    });
+  }
+
+  String _relativeLabel(int epochMs) {
+    final ActivityRelativeTime rel =
+        activityRelativeTime(epochMs, DateTime.now());
+    return switch (rel.unit) {
+      ActivityRelativeUnit.justNow => t.activity_just_now,
+      ActivityRelativeUnit.minutesAgo => t.activity_minutes_ago(n: rel.value),
+      ActivityRelativeUnit.hoursAgo => t.activity_hours_ago(n: rel.value),
+      ActivityRelativeUnit.daysAgo => t.activity_days_ago(n: rel.value),
+    };
+  }
+
+  /// 卡片第三行：覆盖集数 · 相对时间 · 大小 · 下载量。缺段跳过。
+  String _metaLine(SubtitleVersionGroup group) {
+    final Set<int> episodes = group.episodes;
+    final List<String> parts = <String>[];
+    if (episodes.isNotEmpty) {
+      final int first = episodes.reduce((int a, int b) => a < b ? a : b);
+      final int last = episodes.reduce((int a, int b) => a > b ? a : b);
+      final String range =
+          episodes.length == 1 ? 'EP$first' : 'EP$first–EP$last';
+      parts.add(
+        '${t.subtitle_version_episode_count(n: episodes.length)} ($range)',
+      );
+    }
+    if (group.unnumberedCount > 0) {
+      parts.add(
+        t.subtitle_version_unnumbered_count(n: group.unnumberedCount),
+      );
+    }
+    final int? latestAt = group.latestUploadedAtMs;
+    if (latestAt != null) parts.add(_relativeLabel(latestAt));
+    final int? size = group.latest.fileSize;
+    if (size != null) parts.add(FushiByteFormat.bytes(size));
+    if (group.totalDownloadCount > 0) {
+      parts.add('${group.totalDownloadCount}↓');
+    }
+    return parts.join(' · ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListView.separated(
+      itemCount: widget.groups.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (BuildContext context, int index) {
+        final SubtitleVersionGroup group = widget.groups[index];
+        return _buildCard(theme, group);
+      },
+    );
+  }
+
+  Widget _buildCard(ThemeData theme, SubtitleVersionGroup group) {
+    final bool expanded = _expanded.contains(group.key);
+    final SubtitleContentLanguage? probed = widget.probedLanguages[group.key];
+    final String? probedLabel =
+        probed == null ? null : subtitleContentLanguageNativeLabel(probed);
+    final String variant = group.variantParts.join(' · ');
+    return FushiCard(
+      key: ValueKey<String>('subtitle-version-${group.key}'),
+      padding: const EdgeInsets.all(12),
+      onTap: () => _onCardTap(group),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      variant.isEmpty
+                          ? group.collectionLabel
+                          : '${group.collectionLabel} › $variant',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      group.latest.fileName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _metaLine(group),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (widget.busyIdentityKey != null &&
+                  group.members.any((VideoSubtitleCandidate candidate) =>
+                      candidate.identityKey == widget.busyIdentityKey))
+                const Padding(
+                  padding: EdgeInsets.all(8),
+                  child: SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              else
+                FushiIconButton(
+                  icon: expanded ? Icons.expand_less : Icons.expand_more,
+                  tooltip: t.subtitle_version_show_files,
+                  onTap: _busy
+                      ? null
+                      : () => setState(() {
+                            if (!_expanded.add(group.key)) {
+                              _expanded.remove(group.key);
+                            }
+                          }),
+                ),
+            ],
+          ),
+          if (group.aiTranslated ||
+              group.hearingImpaired ||
+              probedLabel != null) ...<Widget>[
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: <Widget>[
+                if (probedLabel != null)
+                  FushiTagChip(
+                    label:
+                        '${t.subtitle_version_content_language}: $probedLabel',
+                    tone: FushiTagChipTone.surface,
+                  ),
+                if (group.aiTranslated)
+                  FushiTagChip(
+                    label: t.subtitle_version_ai_translated,
+                    color: theme.colorScheme.tertiary,
+                    tone: FushiTagChipTone.surface,
+                  ),
+                if (group.hearingImpaired)
+                  const FushiTagChip(
+                    label: 'CC',
+                    tone: FushiTagChipTone.surface,
+                  ),
+              ],
+            ),
+          ],
+          if (expanded) ...<Widget>[
+            const SizedBox(height: 4),
+            for (final VideoSubtitleCandidate candidate in group.members)
+              _buildFileRow(theme, group, candidate),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFileRow(
+    ThemeData theme,
+    SubtitleVersionGroup group,
+    VideoSubtitleCandidate candidate,
+  ) {
+    final bool busyThis = widget.busyIdentityKey == candidate.identityKey;
+    final bool highlight = widget.requestedEpisode != null &&
+        candidate.episode == widget.requestedEpisode;
+    final List<String> meta = <String>[
+      if (candidate.episode != null) 'EP${candidate.episode}',
+      if (candidate.language.isNotEmpty)
+        jimakuLanguageLabel(candidate.language),
+      if (candidate.fileSize != null) FushiByteFormat.bytes(candidate.fileSize),
+      if (candidate.uploadedAtMs != null)
+        _relativeLabel(candidate.uploadedAtMs!),
+    ];
+    return FushiListItem(
+      key: ValueKey<String>('subtitle-file-${candidate.identityKey}'),
+      density: FushiListDensity.compact,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      selected: highlight,
+      onTap: _busy || widget.onPickCandidate == null
+          ? null
+          : () => widget.onPickCandidate!(candidate),
+      title: Text(
+        candidate.fileName,
+        maxLines: 2,
+        softWrap: true,
+        overflow: TextOverflow.fade,
+      ),
+      titleMaxLines: 2,
+      subtitle: meta.isEmpty ? null : Text(meta.join(' · ')),
+      trailing: busyThis
+          ? const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.download, size: 18),
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/media/torrent/video_resource_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
 import 'package:fushi/src/media/video/download/video_resource_registry.dart';
+import 'package:fushi/src/media/video/download/video_resource_version_groups.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
@@ -23,6 +24,12 @@ import 'package:fushi_core/fushi_core.dart'
         VideoDownloadJobRow,
         VideoDownloadJobStage;
 import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/pages/implementations/video_resource_version_group_list.dart';
+
+// 集数解析下沉后的源兼容出口（订阅聚合与既有测试从本文件 import 它）。
+export 'package:fushi/src/media/video/download/video_resource_version_groups.dart'
+    show episodeNumberFromReleaseTitle;
 
 typedef VideoDiscoveryDownloadSubmit = Future<void> Function(
   VideoDiscoveryDownloadSelection selection,
@@ -339,18 +346,9 @@ List<VideoSubscriptionCandidateGroup> groupVideoSubscriptionCandidates(
   return <VideoSubscriptionCandidateGroup>[...grouped, ...ungroupable];
 }
 
-int? episodeNumberFromReleaseTitle(String title) {
-  final RegExpMatch? seasonEpisode = RegExp(
-    r'\bS\d{1,3}[ ._-]*E(\d{1,4})(?:v\d+)?\b',
-    caseSensitive: false,
-  ).firstMatch(title);
-  if (seasonEpisode != null) return int.tryParse(seasonEpisode.group(1)!);
-  final RegExpMatch? anime = RegExp(
-    r'(?:^|\s)-\s*(\d{1,4})(?:v\d+)?(?=\s*(?:\[|\(|$))',
-    caseSensitive: false,
-  ).firstMatch(title);
-  return anime == null ? null : int.tryParse(anime.group(1)!);
-}
+// `episodeNumberFromReleaseTitle` 已下沉到 video_resource_version_groups.dart
+// （下载模式版本聚类需要），此处 re-export 保源兼容（订阅聚合与测试仍从本文件
+// import）。
 
 String videoDiscoverySubscriptionId(VideoMediaReference reference) {
   final String digest = sha256
@@ -705,6 +703,9 @@ class _VideoResourceSearchSurfaceState
       _loading = false;
     });
   }
+
+  /// 下载模式：true = 平铺全部条目（旧视图）；false（默认）= 版本卡视图。
+  bool _flatResourceView = false;
 
   void _select(VideoResourceCandidate candidate) {
     setState(() {
@@ -1114,10 +1115,54 @@ class _VideoResourceSearchSurfaceState
       return Center(child: Text(t.video_discovery_empty));
     }
     // 订阅模式下行单位 = 订阅生效单位（见 groupVideoSubscriptionCandidates 的
-    // 文档）；下载模式仍是一集一行，用户要挑的就是具体那一个发布。
+    // 文档）；下载模式默认「发布组 › 清晰度」版本卡（B2，参照
+    // RSS-Subtitle-Manager）——挑组一次、组内挑集，几十条发布不再平铺；
+    // 「全部条目」开关随时切回平铺视图。
     final List<VideoSubscriptionCandidateGroup>? groups = widget.subscription
         ? groupVideoSubscriptionCandidates(result.items)
         : null;
+    if (groups == null) {
+      final Widget toggle = Align(
+        alignment: AlignmentDirectional.centerEnd,
+        child: FilterChip(
+          key: const ValueKey<String>('video-resource-flat-toggle'),
+          label: Text(t.resource_version_view_flat),
+          selected: _flatResourceView,
+          onSelected: (bool value) => setState(() => _flatResourceView = value),
+        ),
+      );
+      if (!_flatResourceView) {
+        return Column(
+          children: <Widget>[
+            toggle,
+            const SizedBox(height: 4),
+            Expanded(
+              child: VideoResourceVersionGroupList(
+                groups: buildVideoResourceVersionGroups(result.items),
+                selectedIdentityKey: _selected?.identityKey,
+                onSelect: _select,
+                compact: !widget.pageMode,
+              ),
+            ),
+          ],
+        );
+      }
+      return Column(
+        children: <Widget>[
+          toggle,
+          const SizedBox(height: 4),
+          Expanded(child: _buildFlatResults(result, groups)),
+        ],
+      );
+    }
+    return _buildFlatResults(result, groups);
+  }
+
+  /// 平铺列表（订阅模式恒用；下载模式经「全部条目」开关可切回）。
+  Widget _buildFlatResults(
+    ProviderBatchResult<VideoResourceCandidate> result,
+    List<VideoSubscriptionCandidateGroup>? groups,
+  ) {
     return ListView.builder(
       key: const ValueKey<String>('video-resource-results'),
       itemCount: groups?.length ?? result.items.length,

--- a/fushi/lib/src/pages/implementations/video_resource_version_group_list.dart
+++ b/fushi/lib/src/pages/implementations/video_resource_version_group_list.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+import 'package:fushi/src/media/video/download/video_resource_version_groups.dart';
+import 'package:fushi/src/pages/implementations/activity_feed.dart'
+    show ActivityRelativeTime, ActivityRelativeUnit, activityRelativeTime;
+import 'package:fushi/utils.dart';
+
+/// 下载模式的资源「版本卡」列表：一张卡 = 一个「发布组 › 清晰度」版本，
+/// 组内逐集发布折在卡内展开。点卡：恰 1 条发布 → 直接选中；否则展开。
+/// 点发布行 → 选中（选中态与外层提交按钮共用既有 `_selected` 模型）。
+class VideoResourceVersionGroupList extends StatefulWidget {
+  const VideoResourceVersionGroupList({
+    required this.groups,
+    required this.selectedIdentityKey,
+    required this.onSelect,
+    this.compact = false,
+    super.key,
+  });
+
+  final List<VideoResourceVersionGroup> groups;
+
+  /// 当前选中发布的 identityKey（外层 `_selected`）；null = 未选。
+  final String? selectedIdentityKey;
+
+  final void Function(VideoResourceCandidate candidate)? onSelect;
+
+  /// 对话框态用紧凑密度（与旧平铺列表同参数语义）。
+  final bool compact;
+
+  @override
+  State<VideoResourceVersionGroupList> createState() =>
+      _VideoResourceVersionGroupListState();
+}
+
+class _VideoResourceVersionGroupListState
+    extends State<VideoResourceVersionGroupList> {
+  final Set<String> _expanded = <String>{};
+
+  void _toggleExpanded(String key) {
+    setState(() {
+      if (!_expanded.add(key)) _expanded.remove(key);
+    });
+  }
+
+  void _onCardTap(VideoResourceVersionGroup group) {
+    final VideoResourceCandidate? picked = pickResourceVersionCandidate(group);
+    if (picked != null && widget.onSelect != null) {
+      widget.onSelect!(picked);
+      return;
+    }
+    _toggleExpanded(group.key);
+  }
+
+  String _relativeLabel(DateTime at) {
+    final ActivityRelativeTime rel = activityRelativeTime(
+      at.millisecondsSinceEpoch,
+      DateTime.now(),
+    );
+    return switch (rel.unit) {
+      ActivityRelativeUnit.justNow => t.activity_just_now,
+      ActivityRelativeUnit.minutesAgo => t.activity_minutes_ago(n: rel.value),
+      ActivityRelativeUnit.hoursAgo => t.activity_hours_ago(n: rel.value),
+      ActivityRelativeUnit.daysAgo => t.activity_days_ago(n: rel.value),
+    };
+  }
+
+  String _metaLine(VideoResourceVersionGroup group) {
+    final Set<int> episodes = group.episodes;
+    final List<String> parts = <String>[];
+    if (episodes.isNotEmpty) {
+      final int first = episodes.reduce((int a, int b) => a < b ? a : b);
+      final int last = episodes.reduce((int a, int b) => a > b ? a : b);
+      final String range =
+          episodes.length == 1 ? 'EP$first' : 'EP$first–EP$last';
+      parts.add(
+        '${t.subtitle_version_episode_count(n: episodes.length)} ($range)',
+      );
+    }
+    final DateTime? latest = group.latestPublishedAt;
+    if (latest != null) parts.add(_relativeLabel(latest));
+    final int? size = group.representative.sizeBytes;
+    if (size != null) parts.add(FushiByteFormat.bytes(size));
+    parts.add('${group.bestSeeders}↑');
+    return parts.join(' · ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListView.separated(
+      key: const ValueKey<String>('video-resource-version-groups'),
+      itemCount: widget.groups.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (BuildContext context, int index) =>
+          _buildCard(theme, widget.groups[index]),
+    );
+  }
+
+  Widget _buildCard(ThemeData theme, VideoResourceVersionGroup group) {
+    final bool expanded = _expanded.contains(group.key);
+    final bool containsSelection = widget.selectedIdentityKey != null &&
+        group.members.any((VideoResourceCandidate member) =>
+            member.identityKey == widget.selectedIdentityKey);
+    return FushiCard(
+      key: ValueKey<String>('resource-version-${group.key}'),
+      padding: const EdgeInsets.all(12),
+      selected: containsSelection,
+      onTap: widget.onSelect == null ? null : () => _onCardTap(group),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(
+                group.trusted
+                    ? Icons.verified_rounded
+                    : Icons.cloud_download_outlined,
+                size: 20,
+                color: group.trusted
+                    ? theme.colorScheme.primary
+                    : theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      group.labelParts.join(' · '),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      group.representative.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _metaLine(group),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (group.batchCount > 0)
+                Padding(
+                  padding: const EdgeInsets.only(right: 4),
+                  child: FushiTagChip(
+                    label: t.resource_version_batch,
+                    tone: FushiTagChipTone.surface,
+                  ),
+                ),
+              FushiIconButton(
+                icon: expanded ? Icons.expand_less : Icons.expand_more,
+                tooltip: t.subtitle_version_show_files,
+                onTap: () => _toggleExpanded(group.key),
+              ),
+            ],
+          ),
+          if (expanded) ...<Widget>[
+            const SizedBox(height: 4),
+            for (final VideoResourceCandidate member in group.members)
+              _buildMemberRow(theme, member),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMemberRow(ThemeData theme, VideoResourceCandidate member) {
+    final int? episode = episodeNumberFromReleaseTitle(member.title);
+    final List<String> meta = <String>[
+      if (episode != null) 'EP$episode',
+      if (member.sizeBytes != null) FushiByteFormat.bytes(member.sizeBytes),
+      '${member.seeders}↑ ${member.leechers}↓',
+      if (member.publishedAt != null) _relativeLabel(member.publishedAt!),
+    ];
+    return FushiListItem(
+      key: ValueKey<String>('resource-release-${member.identityKey}'),
+      density:
+          widget.compact ? FushiListDensity.compact : FushiListDensity.standard,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      selected: widget.selectedIdentityKey == member.identityKey,
+      onTap: widget.onSelect == null ? null : () => widget.onSelect!(member),
+      title: Text(
+        member.title,
+        maxLines: 2,
+        softWrap: true,
+        overflow: TextOverflow.fade,
+      ),
+      titleMaxLines: 2,
+      subtitle: Text(meta.join(' · ')),
+    );
+  }
+}

--- a/fushi/test/media/video/jimaku_client_test.dart
+++ b/fushi/test/media/video/jimaku_client_test.dart
@@ -59,14 +59,21 @@ void main() {
   group('parseJimakuFiles + JimakuFile', () {
     test('解析文件，缺 name/url 的跳过', () {
       const String body = '''
-[{"name":"ep01.ja.srt","url":"https://x/ep01.srt","size":1234},
+[{"name":"ep01.ja.srt","url":"https://x/ep01.srt","size":1234,
+  "last_modified":"2026-08-01T12:00:00Z"},
  {"name":"ep02.ass","url":"https://x/ep02.ass"},
  {"url":"https://x/no-name"}]''';
       final List<JimakuFile> files = parseJimakuFiles(body);
       expect(files, hasLength(2));
       expect(files[0].name, 'ep01.ja.srt');
       expect(files[0].size, 1234);
+      expect(
+        files[0].lastModifiedMs,
+        DateTime.utc(2026, 8, 1, 12).millisecondsSinceEpoch,
+        reason: 'B1 版本卡的「N 天前」来自 last_modified，此前该字段被丢弃',
+      );
       expect(files[1].url, 'https://x/ep02.ass');
+      expect(files[1].lastModifiedMs, isNull, reason: '缺失/坏时间不挡文件');
     });
 
     test('extension / isTextSubtitle', () {

--- a/fushi/test/media/video/open_subtitles_client_test.dart
+++ b/fushi/test/media/video/open_subtitles_client_test.dart
@@ -502,6 +502,38 @@ void main() {
       expect(result.failures.single.kind, testCase.kind);
     });
   }
+
+  test('B1：解析 upload_date / ai_translated / from_trusted（版本卡信号）', () {
+    final List<OpenSubtitlesSearchRecord> records =
+        parseOpenSubtitlesSearchResponse(jsonEncode(<String, Object?>{
+      'data': <Object?>[
+        <String, Object?>{
+          'attributes': <String, Object?>{
+            'language': 'en',
+            'upload_date': '2026-08-02T03:04:05Z',
+            'ai_translated': true,
+            'from_trusted': true,
+            'files': <Object?>[
+              <String, Object?>{'file_id': 1, 'file_name': 'a.srt'},
+            ],
+          },
+        },
+      ],
+    }));
+    final OpenSubtitlesSearchRecord record = records.single;
+    expect(
+      record.uploadedAtMs,
+      DateTime.utc(2026, 8, 2, 3, 4, 5).millisecondsSinceEpoch,
+    );
+    expect(record.aiTranslated, isTrue);
+    expect(record.fromTrusted, isTrue);
+
+    final List<OpenSubtitlesSearchRecord> defaults =
+        parseOpenSubtitlesSearchResponse(jsonEncode(_searchResponse));
+    expect(defaults.single.uploadedAtMs, isNull);
+    expect(defaults.single.aiTranslated, isFalse);
+    expect(defaults.single.fromTrusted, isFalse);
+  });
 }
 
 const Map<String, Object?> _emptySearch = <String, Object?>{

--- a/fushi/test/media/video/subtitle_content_language_test.dart
+++ b/fushi/test/media/video/subtitle_content_language_test.dart
@@ -1,0 +1,135 @@
+// B1 字幕搜索重做：正文语言检测纯函数。文件名标签常错（上传者复制模板/打包
+// 改名），正文是权威——阈值与 RSS-Subtitle-Manager 对齐，逐条规则单测。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_content_language.dart';
+
+String _srt(List<String> lines) {
+  final StringBuffer sb = StringBuffer();
+  for (int i = 0; i < lines.length; i++) {
+    sb
+      ..writeln(i + 1)
+      ..writeln('00:0$i:00,000 --> 00:0$i:02,000')
+      ..writeln(lines[i])
+      ..writeln();
+  }
+  return sb.toString();
+}
+
+String _ass(List<String> lines) {
+  final StringBuffer sb = StringBuffer()
+    ..writeln('[Script Info]')
+    ..writeln('Title: x')
+    ..writeln('[Events]')
+    ..writeln('Format: Layer, Start, End, Style, Name, MarginL, MarginR, '
+        'MarginV, Effect, Text');
+  for (final String line in lines) {
+    sb.writeln('Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,$line');
+  }
+  return sb.toString();
+}
+
+void main() {
+  group('extractSubtitleDialogueLines', () {
+    test('SRT 丢序号/时间轴，保对白', () {
+      final List<String> lines = extractSubtitleDialogueLines(
+        _srt(<String>['こんにちは', 'Hello there']),
+      );
+      expect(lines, <String>['こんにちは', 'Hello there']);
+    });
+
+    test('ASS 取 Dialogue 第 10 字段起，Text 内逗号不截断，\\N 拆行、剥标签', () {
+      final List<String> lines = extractSubtitleDialogueLines(
+        _ass(<String>[r'{\an8}おはよう、世界\N你好，世界', '<i>styled</i>']),
+      );
+      expect(lines, <String>['おはよう、世界', '你好，世界', 'styled']);
+    });
+  });
+
+  group('detectSubtitleContentLanguage', () {
+    test('假名足量 → 日语', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'こんにちは、世界',
+          '今日はいい天気ですね',
+        ])),
+        SubtitleContentLanguage.japanese,
+      );
+    });
+
+    test('日语字幕里的汉字拟声行不构成双语（行数与总量双门槛）', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'それでは、始めましょう',
+          'あの音は何だろう',
+          '物音', // 单个无假名汉字行：不是中文轨
+          'きっと風の音ですよ',
+        ])),
+        SubtitleContentLanguage.japanese,
+      );
+    });
+
+    test('逐行日文+中文（\\N 双语）→ 中日双语', () {
+      expect(
+        detectSubtitleContentLanguage(_ass(<String>[
+          r'おはようございます\N早上好各位观众朋友们',
+          r'今日はいい天気ですね\N今天天气真不错啊朋友',
+          r'それでは始めましょう\N那么我们现在就开始吧',
+        ])),
+        SubtitleContentLanguage.bilingualJaZh,
+      );
+    });
+
+    test('简体正文 → 简体中文', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          '这个时间点我们还没开始',
+          '他们说这样也可以',
+        ])),
+        SubtitleContentLanguage.simplifiedChinese,
+      );
+    });
+
+    test('繁体正文 → 繁體中文', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          '這個時間點我們還沒開始',
+          '他們說這樣也可以',
+        ])),
+        SubtitleContentLanguage.traditionalChinese,
+      );
+    });
+
+    test('拉丁字母足量 → 英语', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>[
+          'The quick brown fox jumps over the lazy dog',
+        ])),
+        SubtitleContentLanguage.english,
+      );
+    });
+
+    test('样本不足 → unknown（不猜）', () {
+      expect(
+        detectSubtitleContentLanguage(_srt(<String>['ok'])),
+        SubtitleContentLanguage.unknown,
+      );
+      expect(
+        detectSubtitleContentLanguage(''),
+        SubtitleContentLanguage.unknown,
+      );
+    });
+  });
+
+  test('coarse 投影与母语标签', () {
+    expect(coarseLanguageCode(SubtitleContentLanguage.japanese), 'ja');
+    expect(coarseLanguageCode(SubtitleContentLanguage.bilingualJaZh), 'zh');
+    expect(coarseLanguageCode(SubtitleContentLanguage.unknown), isNull);
+    expect(
+      subtitleContentLanguageNativeLabel(
+        SubtitleContentLanguage.simplifiedChinese,
+      ),
+      '简体中文',
+    );
+  });
+}

--- a/fushi/test/media/video/subtitle_version_groups_test.dart
+++ b/fushi/test/media/video/subtitle_version_groups_test.dart
@@ -1,0 +1,173 @@
+// B1 字幕搜索重做：两级版本聚类纯函数。分组键 = 来源合集 × (格式+语言+发布组
+// +CC+机翻)；卡内按集号升序；组间排序 语言→机翻殿后→最新→下载量。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({
+    required super.remoteId,
+    required super.fileName,
+    super.providerId = 'jimaku',
+    super.language = 'ja',
+    super.providerPriority = 100,
+    super.episode,
+    super.uploadedAtMs,
+    super.collectionId,
+    super.collectionLabel,
+    super.aiTranslated,
+  });
+}
+
+void main() {
+  group('subtitleReleaseGroupTag', () {
+    test('取开头方括号组名；CRC/分辨率/语言标签不算', () {
+      expect(
+          subtitleReleaseGroupTag('[SubsPlease] Show - 01.ass'), 'SubsPlease');
+      expect(subtitleReleaseGroupTag('【喵萌奶茶屋】剧集 01.srt'), '喵萌奶茶屋');
+      expect(subtitleReleaseGroupTag('[A1B2C3D4] Show - 01.ass'), isNull);
+      expect(subtitleReleaseGroupTag('[1080p] Show.ass'), isNull);
+      expect(subtitleReleaseGroupTag('[CHS] Show.ass'), isNull);
+      expect(subtitleReleaseGroupTag('Show - 01.ass'), isNull);
+    });
+  });
+
+  group('buildSubtitleVersionGroups', () {
+    test('同合集同变体折成一张卡；不同格式/组分开', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          for (int ep = 1; ep <= 3; ep++)
+            _FakeCandidate(
+              remoteId: '9:[SubsPlease] Show - 0$ep.ass',
+              fileName: '[SubsPlease] Show - 0$ep.ass',
+              episode: ep,
+              collectionId: '9',
+              collectionLabel: 'Show (Jimaku)',
+            ),
+          _FakeCandidate(
+            remoteId: '9:[SubsPlease] Show - 01.srt',
+            fileName: '[SubsPlease] Show - 01.srt',
+            episode: 1,
+            collectionId: '9',
+            collectionLabel: 'Show (Jimaku)',
+          ),
+        ],
+      );
+      expect(groups, hasLength(2), reason: 'ass 与 srt 是两个版本');
+      final SubtitleVersionGroup ass = groups
+          .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+      expect(ass.members, hasLength(3));
+      expect(ass.episodes, <int>{1, 2, 3});
+      expect(ass.collectionLabel, 'Show (Jimaku)');
+      expect(ass.releaseGroupTag, 'SubsPlease');
+      expect(ass.variantParts, contains('ASS'));
+    });
+
+    test('卡内按集号升序；latest 按上传时间，无时间退化取集号最大', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(
+            remoteId: 'a:2',
+            fileName: 'Show - 02.ass',
+            episode: 2,
+            collectionId: 'a',
+            uploadedAtMs: 2000,
+          ),
+          _FakeCandidate(
+            remoteId: 'a:1',
+            fileName: 'Show - 01.ass',
+            episode: 1,
+            collectionId: 'a',
+            uploadedAtMs: 5000,
+          ),
+        ],
+      );
+      final SubtitleVersionGroup group = groups.single;
+      expect(group.members.first.episode, 1);
+      expect(group.latest.uploadedAtMs, 5000);
+      expect(group.latestUploadedAtMs, 5000);
+
+      final SubtitleVersionGroup noTime = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(remoteId: 'b:1', fileName: 'X - 01.ass', episode: 1),
+          _FakeCandidate(remoteId: 'b:3', fileName: 'X - 03.ass', episode: 3),
+        ],
+      ).single;
+      expect(noTime.latest.episode, 3);
+    });
+
+    test('组间排序：优先语言最前、机翻殿后、最新在前', () {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        <VideoSubtitleCandidate>[
+          _FakeCandidate(
+            remoteId: 'os:1',
+            providerId: 'opensubtitles',
+            fileName: 'Show.en.srt',
+            language: 'en',
+            uploadedAtMs: 9000,
+          ),
+          _FakeCandidate(
+            remoteId: 'j:1',
+            fileName: 'Show.ja.ass',
+            language: 'ja',
+            uploadedAtMs: 1000,
+          ),
+          _FakeCandidate(
+            remoteId: 'os:2',
+            providerId: 'opensubtitles',
+            fileName: 'Show.ai.en.srt',
+            language: 'en',
+            uploadedAtMs: 9999,
+            aiTranslated: true,
+          ),
+          _FakeCandidate(
+            remoteId: 'j:2',
+            fileName: 'Show.zh.ass',
+            language: 'zh',
+            uploadedAtMs: 8000,
+          ),
+        ],
+        preferredLanguage: 'zh',
+      );
+      expect(
+        groups.map((SubtitleVersionGroup group) => group.language).toList(),
+        <String>['zh', 'ja', 'en', 'en'],
+        reason: '偏好语言最前，其后按 ja/zh/en/ko 权重',
+      );
+      expect(groups[2].aiTranslated, isFalse);
+      expect(groups[3].aiTranslated, isTrue, reason: '同语言下机翻殿后');
+    });
+  });
+
+  group('pickGroupCandidateForEpisode', () {
+    SubtitleVersionGroup group(List<VideoSubtitleCandidate> members) =>
+        buildSubtitleVersionGroups(members).single;
+
+    test('精确集号命中', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:1', fileName: 'S - 01.ass', episode: 1),
+        _FakeCandidate(remoteId: 'a:2', fileName: 'S - 02.ass', episode: 2),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, 2)!.episode, 2);
+      expect(pickGroupCandidateForEpisode(g, 5), isNull,
+          reason: '没有那一集 → 交还 UI 展开');
+    });
+
+    test('无命中但恰有 1 个未编号文件（剧场版/整季包）→ 那一个', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:m', fileName: 'Movie.ass'),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, 7)!.fileName, 'Movie.ass');
+      expect(pickGroupCandidateForEpisode(g, null)!.fileName, 'Movie.ass');
+    });
+
+    test('未指定集且多文件 → null（不猜）', () {
+      final SubtitleVersionGroup g = group(<VideoSubtitleCandidate>[
+        _FakeCandidate(remoteId: 'a:1', fileName: 'S - 01.ass', episode: 1),
+        _FakeCandidate(remoteId: 'a:2', fileName: 'S - 02.ass', episode: 2),
+      ]);
+      expect(pickGroupCandidateForEpisode(g, null), isNull);
+    });
+  });
+}

--- a/fushi/test/media/video/video_resource_version_groups_test.dart
+++ b/fushi/test/media/video/video_resource_version_groups_test.dart
@@ -1,0 +1,115 @@
+// B2 资源选版：下载模式「发布组›清晰度」聚类纯函数。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+import 'package:fushi/src/media/video/download/video_resource_version_groups.dart';
+
+class _FakeResource extends VideoResourceCandidate {
+  _FakeResource({
+    required super.remoteId,
+    required super.title,
+    super.providerId = 'nyaa',
+    super.providerInstanceId = 'nyaa',
+    super.providerPriority = 100,
+    super.releaseGroup,
+    super.resolution,
+    super.seeders,
+    super.publishedAt,
+  });
+}
+
+void main() {
+  group('isLikelyBatchVideoRelease', () {
+    test('关键词与带界定符的区间判合集', () {
+      expect(isLikelyBatchVideoRelease('[SubsPlease] Show (01-12) (Batch)'),
+          isTrue);
+      expect(isLikelyBatchVideoRelease('Show Complete Series 1080p'), isTrue);
+      expect(isLikelyBatchVideoRelease('【喵萌】剧场版+TV全集'), isTrue);
+      expect(isLikelyBatchVideoRelease('[Sub] Show [01-24 Fin]'), isTrue);
+      expect(isLikelyBatchVideoRelease('第01-12话 合集'), isTrue);
+    });
+
+    test('日期/分辨率/单集不误判', () {
+      expect(
+          isLikelyBatchVideoRelease('[SubsPlease] Show - 05 (1080p)'), isFalse);
+      expect(isLikelyBatchVideoRelease('Show 2023-08 Special'), isFalse,
+          reason: '裸日期区间没有 第/括号引导也没有话/集收尾');
+      expect(isLikelyBatchVideoRelease('Show S01E05 720p'), isFalse);
+    });
+  });
+
+  group('buildVideoResourceVersionGroups', () {
+    List<VideoResourceCandidate> items() => <VideoResourceCandidate>[
+          for (int ep = 1; ep <= 3; ep++)
+            _FakeResource(
+              remoteId: 'sp$ep',
+              title: '[SubsPlease] Show - 0$ep (1080p) [ABCD123$ep]',
+              releaseGroup: 'SubsPlease',
+              resolution: '1080p',
+              seeders: 10 * ep,
+              publishedAt: DateTime.utc(2026, 8, ep),
+            ),
+          _FakeResource(
+            remoteId: 'er1',
+            title: '[Erai-raws] Show - 01 [720p]',
+            releaseGroup: 'Erai-raws',
+            resolution: '720p',
+            seeders: 5,
+            publishedAt: DateTime.utc(2026, 8, 10),
+          ),
+        ];
+
+    test('同组同清晰度折一张卡；组间按最高做种数排序', () {
+      final List<VideoResourceVersionGroup> groups =
+          buildVideoResourceVersionGroups(items());
+      expect(groups, hasLength(2));
+      expect(groups.first.releaseGroup, 'SubsPlease',
+          reason: 'bestSeeders 30 > 5');
+      expect(groups.first.episodes, <int>{1, 2, 3});
+      expect(groups.first.members.first.remoteId, 'sp1', reason: '卡内集号升序');
+      expect(groups.first.representative.remoteId, 'sp3', reason: '代表条 = 做种最多');
+      expect(groups.first.labelParts, contains('1080p'));
+    });
+
+    test('结构化字段缺失时从标题回退组名/清晰度', () {
+      final List<VideoResourceVersionGroup> groups =
+          buildVideoResourceVersionGroups(<VideoResourceCandidate>[
+        _FakeResource(
+          remoteId: 'a',
+          title: '[VCB-Studio] Show - 01 [1080p]',
+        ),
+        _FakeResource(
+          remoteId: 'b',
+          title: '[VCB-Studio] Show - 02 [1080p]',
+        ),
+      ]);
+      final VideoResourceVersionGroup group = groups.single;
+      expect(group.releaseGroup, 'VCB-Studio');
+      expect(group.resolution, '1080p');
+    });
+  });
+
+  group('pickResourceVersionCandidate', () {
+    test('指定集精确命中；未指定且多条 → null；单条 → 它', () {
+      final VideoResourceVersionGroup group = buildVideoResourceVersionGroups(
+        <VideoResourceCandidate>[
+          _FakeResource(remoteId: 'a', title: '[G] S - 01 [1080p]', seeders: 3),
+          _FakeResource(remoteId: 'b', title: '[G] S - 02 [1080p]', seeders: 9),
+        ],
+      ).single;
+      expect(
+        pickResourceVersionCandidate(group, episode: 2)!.remoteId,
+        'b',
+      );
+      expect(pickResourceVersionCandidate(group, episode: 9), isNull);
+      expect(pickResourceVersionCandidate(group), isNull);
+
+      final VideoResourceVersionGroup single = buildVideoResourceVersionGroups(
+        <VideoResourceCandidate>[
+          _FakeResource(remoteId: 'm', title: '[G] Movie [1080p]'),
+        ],
+      ).single;
+      expect(pickResourceVersionCandidate(single)!.remoteId, 'm');
+    });
+  });
+}

--- a/fushi/test/pages/subtitle_version_group_list_test.dart
+++ b/fushi/test/pages/subtitle_version_group_list_test.dart
@@ -1,0 +1,180 @@
+// B1 字幕搜索重做：版本卡列表 widget + 对话框版本视图集成。
+// 锁住四条契约：① 聚类后一版本一卡；② 指定集数点卡直接命中该集文件；
+// ③ 解析不出唯一文件时点卡展开文件行；④ 对话框默认版本视图、可切文件视图。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/subtitle/subtitle_version_groups.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/src/pages/implementations/subtitle_version_group_list.dart';
+import 'package:fushi/utils.dart';
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({
+    required super.remoteId,
+    required super.fileName,
+    super.providerId = 'jimaku',
+    super.language = 'ja',
+    super.providerPriority = 100,
+    super.episode,
+    super.fileSize,
+    super.collectionId,
+    super.collectionLabel,
+  });
+}
+
+List<VideoSubtitleCandidate> _seasonPack() => <VideoSubtitleCandidate>[
+      for (int ep = 1; ep <= 3; ep++)
+        _FakeCandidate(
+          remoteId: '9:[SubsPlease] Show - 0$ep.ass',
+          fileName: '[SubsPlease] Show - 0$ep.ass',
+          episode: ep,
+          fileSize: 30000 + ep,
+          collectionId: '9',
+          collectionLabel: 'Show (2026)',
+        ),
+      _FakeCandidate(
+        remoteId: '9:[MoeSubs] Show - 01.srt',
+        fileName: '[MoeSubs] Show - 01.srt',
+        language: 'zh',
+        episode: 1,
+        collectionId: '9',
+        collectionLabel: 'Show (2026)',
+      ),
+    ];
+
+void main() {
+  Future<void> pumpList(
+    WidgetTester tester, {
+    required List<SubtitleVersionGroup> groups,
+    int? requestedEpisode,
+    required void Function(VideoSubtitleCandidate) onPick,
+  }) async {
+    tester.view.physicalSize = const Size(1000, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SubtitleVersionGroupList(
+            groups: groups,
+            requestedEpisode: requestedEpisode,
+            busyIdentityKey: null,
+            onPickCandidate: onPick,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('一版本一卡：ass 与 srt 两组各渲染一张卡', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    await pumpList(tester, groups: groups, onPick: (_) {});
+    expect(find.byType(FushiCard), findsNWidgets(2));
+    expect(find.textContaining('Show (2026) › ASS'), findsOneWidget);
+    expect(find.textContaining('SubsPlease'), findsWidgets);
+  });
+
+  testWidgets('指定集数点卡 → 直接选中该集文件', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    VideoSubtitleCandidate? picked;
+    await pumpList(
+      tester,
+      groups: groups,
+      requestedEpisode: 2,
+      onPick: (VideoSubtitleCandidate candidate) => picked = candidate,
+    );
+    final SubtitleVersionGroup assGroup = groups
+        .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+    await tester.tap(
+      find.byKey(ValueKey<String>('subtitle-version-${assGroup.key}')),
+    );
+    await tester.pumpAndSettle();
+    expect(picked, isNotNull);
+    expect(picked!.episode, 2, reason: '集数框写 2，点卡就该拿第 2 集');
+  });
+
+  testWidgets('无法解析唯一文件 → 点卡展开文件行，点行选中', (WidgetTester tester) async {
+    final List<SubtitleVersionGroup> groups =
+        buildSubtitleVersionGroups(_seasonPack());
+    VideoSubtitleCandidate? picked;
+    await pumpList(
+      tester,
+      groups: groups,
+      // 不指定集数 + 组内多文件 → 点卡应展开而不是瞎选。
+      onPick: (VideoSubtitleCandidate candidate) => picked = candidate,
+    );
+    final SubtitleVersionGroup assGroup = groups
+        .firstWhere((SubtitleVersionGroup group) => group.format == 'ass');
+    await tester.tap(
+      find.byKey(ValueKey<String>('subtitle-version-${assGroup.key}')),
+    );
+    await tester.pumpAndSettle();
+    expect(picked, isNull);
+    final Finder fileRow = find.byKey(
+      ValueKey<String>(
+        'subtitle-file-${assGroup.members[1].identityKey}',
+      ),
+    );
+    expect(fileRow, findsOneWidget, reason: '展开后逐文件可选');
+    await tester.tap(fileRow);
+    await tester.pumpAndSettle();
+    expect(picked!.episode, 2);
+  });
+
+  testWidgets('对话框：带来源候选默认版本视图，可切回文件视图', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final List<JimakuCandidate> seeded = <JimakuCandidate>[
+      for (final VideoSubtitleCandidate source in _seasonPack())
+        JimakuCandidate(
+          entryName: source.collectionLabel ?? '',
+          name: source.fileName,
+          language: source.language,
+          source: source,
+        ),
+    ];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: 'Show',
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  debugInitialCandidates: seeded,
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SubtitleVersionGroupList), findsOneWidget,
+        reason: '带真实来源的候选默认走版本卡视图');
+    expect(find.byType(JimakuCandidateList), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('jimaku-file-view-toggle')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(JimakuCandidateList), findsOneWidget,
+        reason: '文件视图开关切回旧平铺列表');
+  });
+}

--- a/fushi/test/pages/video_resource_version_group_list_test.dart
+++ b/fushi/test/pages/video_resource_version_group_list_test.dart
@@ -1,0 +1,190 @@
+// B2 资源选版：版本卡列表 widget + 下载模式 surface 集成。
+// 契约：① 下载模式默认版本卡视图；② 单条组点卡直接选中；③ 多条组点卡展开、
+// 点行选中并使提交可用；④「全部条目」开关切回平铺列表。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/download/video_resource_registry.dart';
+import 'package:fushi/src/media/video/download/video_resource_version_groups.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/pages/implementations/video_discovery_acquisition_dialogs.dart';
+import 'package:fushi/src/media/torrent/torrent_backend.dart'
+    show TorrentAddPayload;
+import 'package:fushi_core/fushi_core.dart' show MediaSourceRow;
+
+class _FakeResource extends VideoResourceCandidate {
+  _FakeResource({
+    required super.remoteId,
+    required super.title,
+    super.providerId = 'nyaa',
+    super.providerInstanceId = 'nyaa',
+    super.providerPriority = 100,
+    super.releaseGroup,
+    super.resolution,
+    super.seeders,
+  });
+}
+
+class _SeededProvider implements VideoResourceProvider {
+  _SeededProvider(this.items);
+
+  final List<VideoResourceCandidate> items;
+
+  @override
+  String get id => 'nyaa';
+
+  @override
+  Set<VideoDiscoveryCategory> get categories =>
+      const <VideoDiscoveryCategory>{};
+
+  @override
+  int get priority => 10;
+
+  @override
+  Future<ProviderBatchResult<VideoResourceCandidate>> search(
+    VideoResourceSearchRequest request,
+  ) async =>
+      ProviderBatchResult<VideoResourceCandidate>.success(items);
+
+  @override
+  Future<TorrentAddPayload> resolve(VideoResourceCandidate candidate) async =>
+      throw UnimplementedError();
+
+  @override
+  void close() {}
+}
+
+List<VideoResourceCandidate> _items() => <VideoResourceCandidate>[
+      for (int ep = 1; ep <= 3; ep++)
+        _FakeResource(
+          remoteId: 'sp$ep',
+          title: '[SubsPlease] Show - 0$ep (1080p)',
+          releaseGroup: 'SubsPlease',
+          resolution: '1080p',
+          seeders: 30,
+        ),
+      _FakeResource(
+        remoteId: 'movie',
+        title: '[Erai-raws] Show Movie [720p]',
+        releaseGroup: 'Erai-raws',
+        resolution: '720p',
+        seeders: 5,
+      ),
+    ];
+
+VideoDiscoveryItem _item() => VideoDiscoveryItem(
+      reference: VideoMediaReference(
+        providerId: 'anilist',
+        mediaId: '42',
+        mediaKind: VideoMetadataMediaKind.tv,
+        discoveryCategory: VideoDiscoveryCategory.anime,
+        title: 'Show',
+        anilistId: 42,
+      ),
+    );
+
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  Future<void> pumpSurface(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1100, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: VideoDiscoveryResourceSearchDialog(
+              item: _item(),
+              registry: VideoResourceRegistry(
+                <VideoResourceProvider>[_SeededProvider(_items())],
+              ),
+              sources: const <MediaSourceRow>[
+                MediaSourceRow(
+                  id: 1,
+                  label: 'videos',
+                  mediaKind: 'video',
+                  transport: 'local',
+                  rootPath: r'D:\media',
+                  mediaCount: 0,
+                  recursive: true,
+                  sortOrder: 0,
+                  createdAt: 1,
+                ),
+              ],
+              defaultSourceId: 1,
+              onSubmit: (VideoDiscoveryDownloadSelection selection) async {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('下载模式默认版本卡；单条组点卡直选；提交可用', (WidgetTester tester) async {
+    await pumpSurface(tester);
+    expect(
+      find.byKey(const ValueKey<String>('video-resource-version-groups')),
+      findsOneWidget,
+      reason: '下载模式默认走版本卡视图',
+    );
+    final List<VideoResourceVersionGroup> groups =
+        buildVideoResourceVersionGroups(_items());
+    final VideoResourceVersionGroup movie = groups.firstWhere(
+      (VideoResourceVersionGroup group) => group.releaseGroup == 'Erai-raws',
+    );
+    await tester.tap(
+      find.byKey(ValueKey<String>('resource-version-${movie.key}')),
+    );
+    await tester.pumpAndSettle();
+    final FilledButton submit = tester.widget<FilledButton>(
+      find.byKey(const ValueKey<String>('video-resource-submit')),
+    );
+    expect(submit.onPressed, isNotNull, reason: '选中即可提交');
+  });
+
+  testWidgets('多条组点卡展开、点行选中', (WidgetTester tester) async {
+    await pumpSurface(tester);
+    final List<VideoResourceVersionGroup> groups =
+        buildVideoResourceVersionGroups(_items());
+    final VideoResourceVersionGroup sp = groups.firstWhere(
+      (VideoResourceVersionGroup group) => group.releaseGroup == 'SubsPlease',
+    );
+    await tester.tap(
+      find.byKey(ValueKey<String>('resource-version-${sp.key}')),
+    );
+    await tester.pumpAndSettle();
+    final Finder row = find.byKey(
+      ValueKey<String>('resource-release-${sp.members[1].identityKey}'),
+    );
+    expect(row, findsOneWidget, reason: '多条组点卡应展开而不是瞎选');
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+    final FilledButton submit = tester.widget<FilledButton>(
+      find.byKey(const ValueKey<String>('video-resource-submit')),
+    );
+    expect(submit.onPressed, isNotNull, reason: '点行选中后提交可用');
+  });
+
+  testWidgets('「全部条目」开关切回平铺列表', (WidgetTester tester) async {
+    await pumpSurface(tester);
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-resource-flat-toggle')),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey<String>('video-resource-results')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('video-resource-version-groups')),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
> **堆叠在 #933（B1）之上**；#933 合入后本 PR diff 收敛为 B2 改动。

用户 2026-08-21 批次 B「全做」之二，参照 RSS-Subtitle-Manager 的 Nyaa 版本选择器。订阅模式已有按订阅生效单位的聚合（BUG-1590）；本 PR 补齐**下载模式**：几十条发布平铺流水账 → 少数「发布组 › 清晰度」版本卡，挑组一次、组内挑集。

## 改动
- **纯函数**（`video_resource_version_groups.dart`）：聚类键 = 来源实例×发布组×清晰度×trusted（结构化字段缺失从标题回退取开头方括号组名/分辨率 token）；组间按最高做种数→最新发布排序；**合集检测** `isLikelyBatchVideoRelease`（batch/complete/合集/全集 关键词 + 带界定符的集数区间；`2023-08` 日期与分辨率不误判）；`episodeNumberFromReleaseTitle` 下沉至此、dialogs re-export 保源兼容。
- **UI**（`VideoResourceVersionGroupList`）：卡三行（组›清晰度›来源 / 代表发布名 / 覆盖集数+相对时间+体积+做种数↑）、trusted 徽标、「合集」警示 chip；点卡恰 1 条发布直接选中，多条展开逐集挑；选中态与既有 `_selected`/提交模型共用；「全部条目」开关切回旧平铺视图（订阅模式不受影响）。

## 验证
- 全量 `flutter analyze` 零问题。
- 新增 15 例（合集判据正反/聚类/标题回退/选集三态/surface 集成：默认版本卡、点选后提交可用、开关切换）+ 相邻资源/订阅测试 27 例全绿。
- 缺口：真实 Nyaa 结果的聚类效果未实测；视觉未截图复核。

https://claude.ai/code/session_01NiDoGenLF9eanzXqxaWYAG