### PR TITLE
fix(manga): 点开漫画作品报 RUNTIME_FAILURE（详情增量被当完整条目读 lateinit url）· BUG-1767

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1643 条。点号进各自文件。
+> 共 1644 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1767](bugs/BUG-1767-manga-detail-lateinit-url.md) | ✅ | ✅ | 点开漫画作品报 RUNTIME_FAILURE：详情解析结果被当完整条目读 lateinit url |
 | [BUG-1766](bugs/BUG-1766-download-priority-menu-not-md3.md) | ✅ | ✅ | 排队优先级菜单未走MD3共享原语 |
 | [BUG-1765](bugs/BUG-1765-download-source-subtitle-row-misaligned.md) | ✅ | ✅ | 下载来源与字幕下拉底边不对齐 |
 | [BUG-1764](bugs/BUG-1764-audiobook-next-page-first-cue-no-turn.md) | ✅ | ✅ | 有声书跟随：下一页第一句不自动翻页 |

--- a/docs/bugs/BUG-1767-manga-detail-lateinit-url.md
+++ b/docs/bugs/BUG-1767-manga-detail-lateinit-url.md
@@ -1,0 +1,62 @@
+## BUG-1767 · 点开漫画作品报 RUNTIME_FAILURE：详情解析结果被当完整条目读 lateinit url
+- **报告**：2026-08-22（用户：Android debug 通道 APK，Manga Mura 源，作品「ONE PIECE学園」）
+- **现象**：漫画源能装、源浏览页的作品网格能正常加载出封面和标题；点进任意作品，详情页只显示一行
+  `MihonRuntimeException(RUNTIME_FAILURE): Mihon extension operation failed`，无重试、无更多信息。
+- **真实性**：✅ 真 bug。根因 `fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonChannelHandler.kt:273-285`
+  （旧代码 `.manga.also { result -> loaded.mangaCache[cacheKey(source, result.url)] = result }.toBridgeMap()`）。
+
+### 根因
+
+Mihon 的 `mangaDetailsParse()` 返回的是**增量**，不是完整条目：扩展 `SManga.create()` 一个新对象，
+只填元数据（title / thumbnail_url / genre / description / author / artist / status），**从不回填 `url`**——
+`url` 是条目身份，上游官方 app 只把元数据 merge 回已存条目，永远不读返回值的 `url`。
+`HttpSource.fetchMangaDetails` 也原样返回该对象，只额外置 `initialized = true`
+（mihon `fdb223d6` `source-api/.../online/HttpSource.kt:245-251`）。
+
+而 `SMangaImpl.url` / `title` 是 `lateinit var`（同 commit `source-api/.../model/SMangaImpl.kt:9-11`）。
+Fushi 的桥接层把这个增量对象当完整条目用，缓存 key 和 `toBridgeMap()` 都第一行就读 `url`：
+
+- `MihonChannelHandler.kt` `getDetailsManga` 分支：`cacheKey(source, result.url)`
+- `MihonModelBridge.kt:9` `SManga.toBridgeMap()`：`"url" to url`
+
+⇒ `kotlin.UninitializedPropertyAccessException: lateinit property url has not been initialized`。
+它是 `RuntimeException`、不是 `IllegalArgumentException`，正好落进 `MihonChannelHandler` 的
+`catch (_: Throwable)` 兜底桶 → `RUNTIME_FAILURE` + 固定文案。
+
+**为什么列表不炸**：列表/搜索解析走 `setUrlWithoutDomain(...)`，`url` 有值；`chapterListParse` 也
+调 `setUrlWithoutDomain` + `setName`。**只有详情**返回未初始化 `url` 的对象。所以这不是 Manga Mura
+专属——凡是 `mangaDetailsParse` 不回填 `url`（Mihon 扩展的普遍写法）都会中招。
+
+同族缺陷（桌面）：`third_party/m_extension_server` 的 `ResponseModels.kt:88-99` 用
+`runCatching { this.url }.getOrDefault("")` 读同一个字段，**不崩但把 url 静默变成空串**，
+接下来拿空 url 去拉章节。所以身份收敛必须做在 Dart 侧才能同时覆盖两个后端。
+
+### 放大伤害的第二个缺陷：桥接层把异常抹干净
+
+`MihonChannelHandler.kt` 的 `catch (_: Throwable)` 把原始 `Throwable` 整个丢弃——不打日志、
+不进 message、`details` 传 `null`。而扩展是第三方 dex，失败原因（缺类 / 网络 / 站点改版）**只存在于
+cause 链**。Dart 侧 `MihonRuntimeException.toString()` 又不输出 cause，全仓无一处读
+`PlatformException.details`；详情页 `_load()` 的 catch 也不记日志。三层叠加的结果是：
+这个 bug 从用户截图到 ErrorLogService 都读不出任何可行动信息。
+
+- **[x] ① 已修复** — 三处：
+  1. `MihonModelBridge.kt` 新增 `SManga.mergedWithDetails()`：身份取入参，只有元数据走「新值覆盖旧值」；
+     `MihonChannelHandler.kt` 的 `getDetailsManga` 改用它，不再读详情结果的 `url`。
+  2. `MihonManga.mergedWithDetails()`（`mihon_models.dart`）+ `MihonBridgeRuntime.getDetails` 在 Dart 侧
+     再收敛一次身份，覆盖桌面 sidecar 回传空 url 的同族缺陷。
+  3. 诊断链路：`MihonDiagnostics.kt`（`describeCauseChain` / `diagnosticDetails`）+ 兜底改为
+     `catch (error: Throwable)`，回传 `Mihon <method>/<inner> failed: <cause 链>` 与堆栈（`details`），
+     并 `Log.e("MihonChannel", …)`；`MihonRuntimeException` 增加 `details`/`diagnostics`；
+     详情页记录失败阶段（details / chapters / library）、写 ErrorLogService、渲染带「重试 + 查看详情」的失败态。
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/media/manga/mihon_detail_identity_test.dart`：Dart 合并语义 + 空 url 回传时身份不丢 +
+    Kotlin 源码守卫（`getDetailsManga` 不得读详情结果的 `url`、兜底不得再吞 `Throwable`）。
+    守卫扫描前先剥注释——本文件自己注释里就写过 `update.url`，直扫原文会被自己的注释骗。
+  - `fushi/test/media/manga/android_mihon_runtime_error_test.dart`：`PlatformException` 的
+    code/message/details 三者透传。
+  - `fushi/test/media/manga/mihon_source_browse_page_test.dart`：详情页失败态渲染 + 诊断对话框 + 重试复原。
+  - 四条变异实测全部让守卫变红、且文件逐字节还原。
+- **备注**：真机复测缺口——本机当前无连接设备/可用模拟器 NAT 到 Manga Mura 的验证环境，
+  修复是沿真实代码路径静态确证（上游 `SMangaImpl` lateinit + `MangaReader.mangaDetailsParse` 不设 url，
+  两处均从源仓核对过原文）+ 单测/守卫覆盖，未做真机端到端。装上新 debug 通道包后，
+  若仍失败，`adb logcat -s MihonChannel:E` 或详情页的「查看详情」会直接给出真实 cause。

--- a/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonChannelHandler.kt
+++ b/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonChannelHandler.kt
@@ -3,6 +3,7 @@ package app.fushi.reader.mihon
 import android.app.Application
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.Source
@@ -86,16 +87,19 @@ class MihonChannelHandler(private val app: Application) {
                 try {
                     val value = handle(call)
                     mainHandler.post { result.success(value) }
-                } catch (error: MihonHostException) {
-                    mainHandler.post { result.error(error.code, error.message, null) }
-                } catch (error: IllegalArgumentException) {
-                    mainHandler.post {
-                        result.error("INVALID_ARGUMENT", error.message ?: "Invalid argument", null)
+                } catch (error: Throwable) {
+                    val operation = describeOperation(call)
+                    val code = when (error) {
+                        is MihonHostException -> error.code
+                        is IllegalArgumentException -> "INVALID_ARGUMENT"
+                        else -> "RUNTIME_FAILURE"
                     }
-                } catch (_: Throwable) {
-                    mainHandler.post {
-                        result.error("RUNTIME_FAILURE", "Mihon extension operation failed", null)
-                    }
+                    // 不能把真实异常换成一句固定文案：扩展跑在第三方 dex 里，
+                    // 失败原因（缺类 / 网络 / 站点改版）只存在于 cause 链，丢了就无从诊断。
+                    val message = "Mihon $operation failed: ${describeCauseChain(error)}"
+                    Log.e(TAG, message, error)
+                    val details = diagnosticDetails(error)
+                    mainHandler.post { result.error(code, message, details) }
                 } finally {
                     requestId?.let(activeImageRequests::remove)
                 }
@@ -270,14 +274,17 @@ class MihonChannelHandler(private val app: Application) {
                 val input = arguments.requiredMap("mangaData")
                 val manga = loaded.mangaCache[cacheKey(source, input.requiredString("url"))]
                     ?: mangaFromBridge(input)
-                source.getMangaUpdate(
+                val update = source.getMangaUpdate(
                     manga = manga,
                     chapters = emptyList(),
                     fetchDetails = true,
                     fetchChapters = false,
-                ).manga.also { result ->
-                    loaded.mangaCache[cacheKey(source, result.url)] = result
-                }.toBridgeMap()
+                ).manga
+                // 详情结果是增量：身份（url）只能来自入参，读 update.url 会踩
+                // 未初始化的 lateinit。见 SManga.mergedWithDetails。
+                val merged = manga.mergedWithDetails(update)
+                loaded.mangaCache[cacheKey(source, merged.url)] = merged
+                merged.toBridgeMap()
             }
             "getChapterList" -> runBlocking {
                 val input = arguments.requiredMap("mangaData")
@@ -418,7 +425,20 @@ class MihonChannelHandler(private val app: Application) {
                 value as? Map<String, Any?>
             }
 
+    /**
+     * 把失败归到具体操作上。
+     *
+     * 漫画详情页会连着发 `getDetailsManga` 和 `getChapterList` 两次
+     * `invoke`，两者失败时原本回的 code/message 完全一样，用户和日志
+     * 都分不出断在哪一步。内层 `method` 必须跟着错误一起回去。
+     */
+    private fun describeOperation(call: MethodCall): String {
+        val inner = (call.arguments as? Map<*, *>)?.get("method")?.toString()
+        return if (inner.isNullOrEmpty()) call.method else "${call.method}/$inner"
+    }
+
     companion object {
         private const val MAX_APK_BYTES = 100L * 1024L * 1024L
+        private const val TAG = "MihonChannel"
     }
 }

--- a/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonDiagnostics.kt
+++ b/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonDiagnostics.kt
@@ -1,0 +1,44 @@
+package app.fushi.reader.mihon
+
+/**
+ * 扩展宿主的错误描述工具。
+ *
+ * Mihon 扩展是第三方 dex，失败原因几乎全在异常的 **cause 链最深一层**
+ * （`NoClassDefFoundError` 指出宿主缺哪个类、`IOException` 指出网络/Cloudflare、
+ * `NullPointerException` 指出站点改版后选择器落空）。反射调用还会再包一层
+ * `InvocationTargetException`，只看最外层等于什么都没看到。
+ *
+ * 所以桥接层往 Flutter 回传错误时，必须把整条链渲染出来，而不是替换成一句
+ * 「操作失败」——那句话对用户和维护者都是零信息。
+ */
+internal fun describeCauseChain(error: Throwable): String {
+    val parts = mutableListOf<String>()
+    var current: Throwable? = error
+    val seen = HashSet<Throwable>()
+    while (current != null && seen.add(current) && parts.size < MAX_CAUSE_LINKS) {
+        val label = current.javaClass.simpleName.ifBlank { current.javaClass.name }
+        val message = current.message?.trim().orEmpty()
+        parts += if (message.isEmpty()) label else "$label: $message"
+        current = current.cause
+    }
+    return parts.joinToString(" ← ")
+}
+
+/**
+ * MethodChannel `details` 字段承载的完整堆栈。
+ *
+ * 消息体要短到能进 toast/标题，堆栈则留给「复制详情」对话框和日志上传，因此分开
+ * 两路而不是把堆栈塞进 message。做长度上限是因为 platform channel 的每次回包都要
+ * 整段序列化过去，跑飞的链路能产出几百 KB。
+ */
+internal fun diagnosticDetails(error: Throwable): String =
+    error.stackTraceToString().let { trace ->
+        if (trace.length <= MAX_DETAILS_CHARS) {
+            trace
+        } else {
+            trace.take(MAX_DETAILS_CHARS) + "\n… (truncated)"
+        }
+    }
+
+private const val MAX_CAUSE_LINKS = 6
+private const val MAX_DETAILS_CHARS = 8000

--- a/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonExtensionLoader.kt
+++ b/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonExtensionLoader.kt
@@ -173,25 +173,6 @@ internal class MihonExtensionLoader(private val context: Context) {
         return LoadedMihonExtension(inspection, sources, classLoader)
     }
 
-    /**
-     * Walks the whole cause chain and renders it as
-     * `Outer: msg ← Cause: msg ← Root: msg`, capped so a runaway chain can't
-     * bloat the surfaced message. The deepest link is usually the actionable
-     * one (which class/method the extension needs but the host lacks).
-     */
-    private fun describeCauseChain(error: Throwable): String {
-        val parts = mutableListOf<String>()
-        var current: Throwable? = error
-        val seen = HashSet<Throwable>()
-        while (current != null && seen.add(current) && parts.size < 6) {
-            val label = current.javaClass.simpleName.ifBlank { current.javaClass.name }
-            val message = current.message?.trim().orEmpty()
-            parts += if (message.isEmpty()) label else "$label: $message"
-            current = current.cause
-        }
-        return parts.joinToString(" ← ")
-    }
-
     @Suppress("DEPRECATION")
     private fun packageInfo(file: File): PackageInfo? = packageManager.getPackageArchiveInfo(
         file.absolutePath,

--- a/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonModelBridge.kt
+++ b/fushi/android/app/src/main/kotlin/app/fushi/reader/mihon/MihonModelBridge.kt
@@ -18,6 +18,47 @@ internal fun SManga.toBridgeMap(): Map<String, Any?> = mapOf(
     "initialized" to initialized,
 )
 
+/**
+ * 把详情解析结果合进已知条目。
+ *
+ * Mihon 的 `mangaDetailsParse` 返回的是**增量**，不是完整条目：它
+ * `SManga.create()` 一个新对象，只填元数据，**从不回填 `url`**——因为
+ * `url` 是条目身份，上游官方 app 只把元数据 merge 回已存条目，永远不读
+ * 返回值的 `url`。而 `SMangaImpl.url` / `title` 是 `lateinit var`，所以谁把
+ * 这个增量对象当完整条目读，谁就吃
+ * `UninitializedPropertyAccessException`（BUG-1767：漫画列表能开、点进去必报
+ * RUNTIME_FAILURE）。
+ *
+ * 所以身份永远取自入参，只有元数据走“新值覆盖旧值”。
+ */
+internal fun SManga.mergedWithDetails(update: SManga): SManga = SManga.create().apply {
+    val base = this@mergedWithDetails
+    url = base.url
+    title = lateinitOrNull { update.title }?.takeIf { value -> value.isNotEmpty() }
+        ?: base.title
+    thumbnail_url = update.thumbnail_url ?: base.thumbnail_url
+    artist = update.artist ?: base.artist
+    author = update.author ?: base.author
+    description = update.description ?: base.description
+    genre = update.genre ?: base.genre
+    status = if (update.status != SManga.UNKNOWN) update.status else base.status
+    initialized = update.initialized || base.initialized
+}
+
+/**
+ * 读一个可能未初始化的 `lateinit` 属性。
+ *
+ * 类外部拿不到 `::title.isInitialized`，而第三方扩展能否赋值不在宕主
+ * 控制范围内，因此只能捕获。只接 [UninitializedPropertyAccessException]，
+ * 其他异常照旧往上抛——这里存在为了识别“没赋值”这一个信号，
+ * 不是为了吞错。
+ */
+private inline fun <T> lateinitOrNull(read: () -> T): T? = try {
+    read()
+} catch (_: UninitializedPropertyAccessException) {
+    null
+}
+
 internal fun mangaFromBridge(value: Map<String, Any?>): SManga = SManga.create().apply {
     url = value["url"]?.toString().orEmpty()
     title = value["title"]?.toString().orEmpty()

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 62577 (3681 per locale)
+/// Strings: 62611 (3683 per locale)
 ///
-/// Built on 2026-08-21 at 13:05 UTC
+/// Built on 2026-08-21 at 16:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5003,6 +5003,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_sort_progress => 'Progress';
   String get download_task_sort_status => 'Status';
   String get download_task_no_match => 'No matching tasks';
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -13538,6 +13540,10 @@ class _StringsAr extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -22138,6 +22144,10 @@ class _StringsDe extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -30754,6 +30764,10 @@ class _StringsEs extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -39382,6 +39396,10 @@ class _StringsFr extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -47940,6 +47958,10 @@ class _StringsId extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -56542,6 +56564,10 @@ class _StringsIt extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -64961,6 +64987,10 @@ class _StringsJa extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -73388,6 +73418,10 @@ class _StringsKo extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -81970,6 +82004,10 @@ class _StringsNl extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -90564,6 +90602,10 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -99145,6 +99187,10 @@ class _StringsRu extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -107674,6 +107720,10 @@ class _StringsTh extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -116234,6 +116284,10 @@ class _StringsTr extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -124780,6 +124834,10 @@ class _StringsVi extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 // Path: <root>
@@ -132682,6 +132740,10 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_sort_status => '状态';
   @override
   String get download_task_no_match => '没有匹配的任务';
+  @override
+  String get manga_online_detail_load_failed => '无法载入这部漫画。';
+  @override
+  String get manga_online_error_view_detail => '查看详情';
 }
 
 // Path: <root>
@@ -141026,6 +141088,10 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_sort_status => 'Status';
   @override
   String get download_task_no_match => 'No matching tasks';
+  @override
+  String get manga_online_detail_load_failed => 'Could not load this manga.';
+  @override
+  String get manga_online_error_view_detail => 'View details';
 }
 
 /// Flat map(s) containing all translations.
@@ -148580,6 +148646,10 @@ extension on _StringsEn {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -156132,6 +156202,10 @@ extension on _StringsAr {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -163706,6 +163780,10 @@ extension on _StringsDe {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -171279,6 +171357,10 @@ extension on _StringsEs {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -178858,6 +178940,10 @@ extension on _StringsFr {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -186419,6 +186505,10 @@ extension on _StringsId {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -193994,6 +194084,10 @@ extension on _StringsIt {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -201531,6 +201625,10 @@ extension on _StringsJa {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -209072,6 +209170,10 @@ extension on _StringsKo {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -216641,6 +216743,10 @@ extension on _StringsNl {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -224207,6 +224313,10 @@ extension on _StringsPtBr {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -231778,6 +231888,10 @@ extension on _StringsRu {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -239332,6 +239446,10 @@ extension on _StringsTh {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -246895,6 +247013,10 @@ extension on _StringsTr {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -254454,6 +254576,10 @@ extension on _StringsVi {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }
@@ -261954,6 +262080,10 @@ extension on _StringsZhCn {
         return '状态';
       case 'download_task_no_match':
         return '没有匹配的任务';
+      case 'manga_online_detail_load_failed':
+        return '无法载入这部漫画。';
+      case 'manga_online_error_view_detail':
+        return '查看详情';
       default:
         return null;
     }
@@ -269486,6 +269616,10 @@ extension on _StringsZhHk {
         return 'Status';
       case 'download_task_no_match':
         return 'No matching tasks';
+      case 'manga_online_detail_load_failed':
+        return 'Could not load this manga.';
+      case 'manga_online_error_view_detail':
+        return 'View details';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "添加时间",
   "download_task_sort_progress": "进度",
   "download_task_sort_status": "状态",
-  "download_task_no_match": "没有匹配的任务"
+  "download_task_no_match": "没有匹配的任务",
+  "manga_online_detail_load_failed": "无法载入这部漫画。",
+  "manga_online_error_view_detail": "查看详情"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3679,5 +3679,7 @@
   "download_task_sort_created": "Date added",
   "download_task_sort_progress": "Progress",
   "download_task_sort_status": "Status",
-  "download_task_no_match": "No matching tasks"
+  "download_task_no_match": "No matching tasks",
+  "manga_online_detail_load_failed": "Could not load this manga.",
+  "manga_online_error_view_detail": "View details"
 }

--- a/fushi/lib/src/media/manga/mihon/android_mihon_runtime.dart
+++ b/fushi/lib/src/media/manga/mihon/android_mihon_runtime.dart
@@ -192,6 +192,7 @@ class AndroidMihonRuntime extends MihonBridgeRuntime
         error.code,
         error.message ?? 'Android Mihon runtime failed',
         cause: error,
+        details: error.details?.toString(),
       );
     } on MissingPluginException catch (error) {
       throw MihonRuntimeException(

--- a/fushi/lib/src/media/manga/mihon/mihon_bridge_runtime.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_bridge_runtime.dart
@@ -121,19 +121,21 @@ abstract class MihonBridgeRuntime implements MihonRuntime {
     MihonSource source,
     MihonManga manga, {
     List<MihonPreference> preferences = const <MihonPreference>[],
-  }) async =>
-      MihonManga.fromJson(
-        _asMap(
-          await invokeBridge(
-            extension,
-            'getDetailsManga',
-            <String, Object?>{
-              ..._sourceArguments(source, preferences),
-              'mangaData': manga.toJson(),
-            },
-          ),
+  }) async {
+    final MihonManga parsed = MihonManga.fromJson(
+      _asMap(
+        await invokeBridge(
+          extension,
+          'getDetailsManga',
+          <String, Object?>{
+            ..._sourceArguments(source, preferences),
+            'mangaData': manga.toJson(),
+          },
         ),
-      );
+      ),
+    );
+    return manga.mergedWithDetails(parsed);
+  }
 
   @override
   Future<List<MihonChapter>> getChapters(

--- a/fushi/lib/src/media/manga/mihon/mihon_models.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_models.dart
@@ -147,6 +147,26 @@ class MihonManga {
   final int status;
   final bool initialized;
 
+  /// 把一次详情拉取的结果合回本条目。
+  ///
+  /// Mihon 的详情解析返回的是**增量**：`url` 是条目身份，扩展从不
+  /// 回填，上游官方 app 也从不读它。两个后端各自暴露了这个假设：
+  /// Android 原生桥直接读 `lateinit url` 而崩（RUNTIME_FAILURE），桌面
+  /// sidecar 则把它静默读成空串，导致接下来拉章节用空 url（BUG-1767）。
+  ///
+  /// 所以身份统一在这里收敛：新值只能覆盖元数据，覆盖不了 `url`。
+  MihonManga mergedWithDetails(MihonManga update) => MihonManga(
+        url: url,
+        title: update.title.isNotEmpty ? update.title : title,
+        coverUrl: update.coverUrl ?? coverUrl,
+        artist: update.artist ?? artist,
+        author: update.author ?? author,
+        description: update.description ?? description,
+        genre: update.genre ?? genre,
+        status: update.status != 0 ? update.status : status,
+        initialized: update.initialized || initialized,
+      );
+
   Map<String, Object?> toJson() => <String, Object?>{
         'url': url,
         'title': title,
@@ -410,11 +430,30 @@ class MihonPreference {
 }
 
 class MihonRuntimeException implements Exception {
-  const MihonRuntimeException(this.code, this.message, {this.cause});
+  const MihonRuntimeException(
+    this.code,
+    this.message, {
+    this.cause,
+    this.details,
+  });
 
   final String code;
   final String message;
   final Object? cause;
+
+  /// 原生侧回传的完整堆栈（`PlatformException.details`）。
+  ///
+  /// 不进 [toString]：它会被直接渲染到页面上，几 KB 堆栈堆到
+  /// 屏幕上反而把真正可操作的 [message] 顶掉。堆栈只走诊断对话框
+  /// 和日志（见 [diagnostics]）。
+  final String? details;
+
+  /// 诊断通道（可复制对话框 / 日志）用的全文。
+  String get diagnostics {
+    final String? stack = details;
+    if (stack == null || stack.isEmpty) return toString();
+    return '${toString()}\n\n$stack';
+  }
 
   @override
   String toString() => 'MihonRuntimeException($code): $message';

--- a/fushi/lib/src/media/manga/mihon/mihon_source_browse_page.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_source_browse_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_online_reader_page.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_runtime.dart';
+import 'package:fushi/src/utils/misc/error_details_dialog.dart';
 import 'package:fushi/utils.dart';
 
 enum _MihonBrowseMode { popular, latest, search }
@@ -380,6 +381,7 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
   MihonLibraryEntry? _libraryEntry;
   bool _libraryBusy = false;
   Object? _error;
+  String? _errorStage;
 
   @override
   void initState() {
@@ -388,6 +390,8 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
   }
 
   Future<void> _load() async {
+    if (_error != null) setState(() => _error = null);
+    String stage = 'details';
     try {
       final MihonManga details = await widget.manager.runtime.getDetails(
         widget.sourceContext.extension,
@@ -395,6 +399,7 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
         widget.manga,
         preferences: widget.sourceContext.preferences,
       );
+      stage = 'chapters';
       final List<MihonChapter> chapters =
           await widget.manager.runtime.getChapters(
         widget.sourceContext.extension,
@@ -402,6 +407,7 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
         details,
         preferences: widget.sourceContext.preferences,
       );
+      stage = 'library';
       final MihonLibraryService library = MihonLibraryService(widget.manager);
       EpubBookRow? shelfBook =
           await library.find(widget.sourceContext, details);
@@ -423,8 +429,21 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
           _libraryEntry = MihonLibraryEntry.tryParse(shelfBook?.sourceMetadata);
         });
       }
-    } on Object catch (error) {
-      if (mounted) setState(() => _error = error);
+    } on Object catch (error, stack) {
+      // 三个阶段共用一个 catch，不记 stage 就分不出断在拉详情、拉章节
+      // 还是写书架，而桥接层对三者返回的 code 可能完全一样。
+      ErrorLogService.instance.log(
+        'MihonMangaDetailPage.load[$stage][${widget.sourceContext.source.name}]',
+        error,
+        stack,
+      );
+      debugPrint('[Mihon] detail load failed at $stage: $error');
+      if (mounted) {
+        setState(() {
+          _error = error;
+          _errorStage = stage;
+        });
+      }
     }
   }
 
@@ -496,6 +515,62 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
     );
   }
 
+  /// 失败态不能只扔一行异常文本。
+  ///
+  /// 这里的失败几乎全是环境性的（站点抽风、Cloudflare、网络），
+  /// 所以重试是真正有用的动作；而排障需要的堆栈太长，只能进可复制的
+  /// 诊断对话框（[showErrorDetails]），不能铺在页面上。
+  Widget _buildErrorView(BuildContext context, Object error) {
+    final String diagnostics = <String>[
+      'stage: ${_errorStage ?? 'unknown'}',
+      'source: ${widget.sourceContext.source.name}',
+      'manga: ${widget.manga.url}',
+      '',
+      error is MihonRuntimeException ? error.diagnostics : '$error',
+    ].join('\n');
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              t.manga_online_detail_load_failed,
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            SelectableText(
+              '$error',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              alignment: WrapAlignment.center,
+              children: <Widget>[
+                FilledButton(
+                  onPressed: () => unawaited(_load()),
+                  child: Text(t.retry),
+                ),
+                TextButton(
+                  key: const ValueKey<String>('mihon_detail_error_details'),
+                  onPressed: () => unawaited(showErrorDetails(
+                    context,
+                    title: t.mihon_extension_error,
+                    error: diagnostics,
+                  )),
+                  child: Text(t.manga_online_error_view_detail),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final MihonManga details = _details ?? widget.manga;
@@ -503,7 +578,7 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
       title: details.title,
       subtitle: widget.sourceContext.source.name,
       body: _error != null
-          ? Center(child: Text('$_error'))
+          ? _buildErrorView(context, _error!)
           : _details == null
               ? Center(child: adaptiveIndicator(context: context))
               : ListView(

--- a/fushi/test/media/manga/android_mihon_runtime_error_test.dart
+++ b/fushi/test/media/manga/android_mihon_runtime_error_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/mihon/android_mihon_runtime.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+
+/// 原生桥回传的诊断信息必须一路活到 UI。
+///
+/// 之前 Android 侧把任意 `Throwable` 换成一句固定的
+/// `Mihon extension operation failed`，Dart 侧又从不读 `PlatformException.details`，
+/// 于是「点开漫画报错」在两端都查不出原因（BUG-1767）。这条用例把 code / message /
+/// details 三者的透传钉死。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('app.fushi.reader/mihon');
+  const MihonExtensionRef extension = MihonExtensionRef(
+    packageName: 'org.example.fixture',
+    apkPath: 'extensions/org.example.fixture.ext',
+  );
+  const MihonSource source = MihonSource(
+    extensionPackage: 'org.example.fixture',
+    id: '1',
+    name: 'Fixture',
+    language: 'en',
+    baseUrl: 'https://example.test',
+  );
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('platform failures keep their code, message and native stack', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      throw PlatformException(
+        code: 'RUNTIME_FAILURE',
+        message: 'Mihon invoke/getDetailsManga failed: '
+            'NoClassDefFoundError: kotlin.LazyKt',
+        details: 'java.lang.NoClassDefFoundError\n\tat fixture.Stack',
+      );
+    });
+
+    final AndroidMihonRuntime runtime = AndroidMihonRuntime();
+    await expectLater(
+      runtime.getDetails(
+        extension,
+        source,
+        const MihonManga(url: '/manga/fixture', title: 'Fixture'),
+      ),
+      throwsA(
+        isA<MihonRuntimeException>()
+            .having(
+                (MihonRuntimeException e) => e.code, 'code', 'RUNTIME_FAILURE')
+            .having((MihonRuntimeException e) => e.message, 'message',
+                contains('getDetailsManga'))
+            .having((MihonRuntimeException e) => e.details, 'details',
+                contains('at fixture.Stack'))
+            .having((MihonRuntimeException e) => e.diagnostics, 'diagnostics',
+                allOf(contains('kotlin.LazyKt'), contains('at fixture.Stack'))),
+      ),
+    );
+  });
+
+  test('a failure without native details still renders its message', () {
+    const MihonRuntimeException error =
+        MihonRuntimeException('IMAGE_HTTP', 'Source image request failed');
+    expect(error.details, isNull);
+    expect(error.diagnostics, error.toString());
+    expect(
+      error.toString(),
+      'MihonRuntimeException(IMAGE_HTTP): Source image request failed',
+    );
+  });
+}

--- a/fushi/test/media/manga/mihon_detail_identity_test.dart
+++ b/fushi/test/media/manga/mihon_detail_identity_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/mihon/android_mihon_runtime.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+
+import '../../helpers/source_guard.dart';
+
+/// BUG-1767 守卫：漫画详情返回的是**增量**，条目身份（`url`）只能来自入参。
+///
+/// Mihon 扩展的 `mangaDetailsParse` 会 `SManga.create()` 一个只填元数据的新对象，
+/// 从不回填 `url`（上游官方 app 也从不读它）。而 `SMangaImpl.url` / `title` 是
+/// `lateinit var`，于是两个后端各自暴露了同一个错误假设：
+///
+/// * Android 原生桥直接读 `update.url` → `UninitializedPropertyAccessException`
+///   → 兜底成 `RUNTIME_FAILURE`，表现为「漫画列表能开、点进作品必报错」；
+/// * 桌面 sidecar 用 `runCatching{}.getOrDefault("")` 读，不崩但把 `url` 变成空串，
+///   接下来拿空 url 去拉章节。
+///
+/// 所以身份收敛统一放在 Dart 侧（[MihonManga.mergedWithDetails]），原生侧的合并
+/// 只是让它在崩之前就不再读那个字段。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('详情增量合并', () {
+    const MihonManga base = MihonManga(
+      url: '/manga/one-piece-gakuen',
+      title: 'ONE PIECE学園',
+      coverUrl: 'https://example.test/cover.jpg',
+      status: 1,
+    );
+
+    test('缺 url 的增量不会把身份抹掉', () {
+      const MihonManga update = MihonManga(
+        url: '',
+        title: 'ONE PIECE学園',
+        author: '尾田栄一郎',
+        description: '本文',
+        initialized: true,
+      );
+
+      final MihonManga merged = base.mergedWithDetails(update);
+
+      expect(merged.url, '/manga/one-piece-gakuen');
+      expect(merged.author, '尾田栄一郎');
+      expect(merged.description, '本文');
+      expect(merged.initialized, isTrue);
+    });
+
+    test('增量没带的字段回落到已知值，带了的覆盖', () {
+      const MihonManga update = MihonManga(
+        url: '/somewhere/else',
+        title: '',
+        genre: 'Comedy',
+        status: 2,
+      );
+
+      final MihonManga merged = base.mergedWithDetails(update);
+
+      // url 永远不被详情更新，哪怕增量里非空。
+      expect(merged.url, '/manga/one-piece-gakuen');
+      expect(merged.title, 'ONE PIECE学園');
+      expect(merged.coverUrl, 'https://example.test/cover.jpg');
+      expect(merged.genre, 'Comedy');
+      expect(merged.status, 2);
+    });
+  });
+
+  test('原生桥回传空 url 时 getDetails 仍然保住入参身份', () async {
+    const MethodChannel channel = MethodChannel('app.fushi.reader/mihon');
+    Map<Object?, Object?>? sentDetailArguments;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      sentDetailArguments = call.arguments as Map<Object?, Object?>;
+      return <String, Object?>{
+        // 桌面 sidecar 对未初始化 lateinit 的真实产物就是空串。
+        'url': '',
+        'title': 'ONE PIECE学園',
+        'author': '尾田栄一郎',
+        'initialized': true,
+      };
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    final MihonManga details = await AndroidMihonRuntime().getDetails(
+      const MihonExtensionRef(
+        packageName: 'eu.kanade.tachiyomi.extension.ja.mangamura',
+        apkPath: 'extensions/mangamura.ext',
+      ),
+      const MihonSource(
+        extensionPackage: 'eu.kanade.tachiyomi.extension.ja.mangamura',
+        id: '1006356371941619891',
+        name: 'Manga Mura',
+        language: 'ja',
+        baseUrl: 'https://mangamura.test',
+      ),
+      const MihonManga(
+        url: '/manga/one-piece-gakuen',
+        title: 'ONE PIECE学園',
+      ),
+    );
+
+    expect(details.url, '/manga/one-piece-gakuen');
+    expect(details.author, '尾田栄一郎');
+    expect(
+      (sentDetailArguments!['mangaData']! as Map<Object?, Object?>)['url'],
+      '/manga/one-piece-gakuen',
+    );
+  });
+
+  group('Android 原生桥的详情合并', () {
+    late final String handler = File(
+      'android/app/src/main/kotlin/app/fushi/reader/mihon/MihonChannelHandler.kt',
+    ).readAsStringSync();
+    late final String modelBridge = File(
+      'android/app/src/main/kotlin/app/fushi/reader/mihon/MihonModelBridge.kt',
+    ).readAsStringSync();
+
+    test('MihonModelBridge 提供 mergedWithDetails', () {
+      expect(
+        maskComments(modelBridge).contains('fun SManga.mergedWithDetails('),
+        isTrue,
+        reason: 'MihonModelBridge.kt 少了 mergedWithDetails；'
+            '详情增量就会重新被当成完整条目读 lateinit url。',
+      );
+    });
+
+    test('getDetailsManga 不读详情结果的 url，改走 mergedWithDetails', () {
+      // 必须先去注释：本文件自己就在注释里写过 `update.url`，
+      // 直扫原文会被自己的注释骗成假红/假绿。
+      final String branch = maskComments(_getDetailsMangaBranch(handler));
+      expect(
+        branch.contains('mergedWithDetails'),
+        isTrue,
+        reason: 'getDetailsManga 分支没有调用 mergedWithDetails：\n$branch',
+      );
+      expect(
+        RegExp(r'(result|update|detailedManga)\s*\.\s*url').hasMatch(branch),
+        isFalse,
+        reason: 'getDetailsManga 分支又开始读详情结果的 url 了，'
+            '那是未初始化的 lateinit，必报 RUNTIME_FAILURE：\n$branch',
+      );
+    });
+  });
+
+  test('原生桥失败时必须回传真实原因而不是固定文案', () {
+    final String handler = File(
+      'android/app/src/main/kotlin/app/fushi/reader/mihon/MihonChannelHandler.kt',
+    ).readAsStringSync();
+    expect(
+      maskComments(handler).contains('catch (_: Throwable)'),
+      isFalse,
+      reason: 'MethodChannel 兜底又开始丢弃 Throwable 了；'
+          '扩展失败原因只存在于 cause 链，丢了就无从诊断。',
+    );
+    expect(
+      maskComments(handler).contains('describeCauseChain('),
+      isTrue,
+      reason: '兜底分支必须把 cause 链渲染进 message。',
+    );
+    expect(
+      maskComments(handler).contains('diagnosticDetails('),
+      isTrue,
+      reason: '兜底分支必须把堆栈放进 MethodChannel 的 details 字段。',
+    );
+  });
+}
+
+/// 截出 `"getDetailsManga" ->` 到下一个 `"..." ->` 之间的分支体。
+String _getDetailsMangaBranch(String source) {
+  const String marker = '"getDetailsManga" ->';
+  final int start = source.indexOf(marker);
+  if (start < 0) {
+    fail('MihonChannelHandler.kt 里找不到 "getDetailsManga" 分支');
+  }
+  final int next =
+      source.indexOf(RegExp('"[A-Za-z]+" ->'), start + marker.length);
+  return source.substring(start, next < 0 ? source.length : next);
+}

--- a/fushi/test/media/manga/mihon_source_browse_page_test.dart
+++ b/fushi/test/media/manga/mihon_source_browse_page_test.dart
@@ -130,6 +130,65 @@ void main() {
     },
   );
 
+  testWidgets(
+    'a failed detail load surfaces the real cause and can be retried',
+    (WidgetTester tester) async {
+      // 原本这里只会渲染一行光秃的异常文本，既没重试也拿不到
+      // 堆栈（BUG-1767）。这条用例盯住三件事：原因可见、诊断入口存在、
+      // 重试真的会重新发请求并恢复正常页面。
+      await tester.binding.setSurfaceSize(const Size(1400, 1000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      runtime.detailsFailure = const MihonRuntimeException(
+        'RUNTIME_FAILURE',
+        'Mihon invoke/getDetailsManga failed: '
+            'NoClassDefFoundError: kotlin.LazyKt',
+        details: 'java.lang.NoClassDefFoundError\n\tat fixture.Stack',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(useMaterial3: true),
+          home: MihonSourceBrowsePage(
+            manager: manager,
+            target: MihonInstalledTarget(manager.sources.single),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.tap(find.text('Raw Otaku fixture'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+      expect(runtime.detailsCalls, 1);
+      expect(find.text('Could not load this manga.'), findsOneWidget);
+      expect(
+        find.textContaining('NoClassDefFoundError: kotlin.LazyKt'),
+        findsOneWidget,
+      );
+
+      // 诊断对话框里必须能拿到原生堆栈和失败阶段。
+      await tester.tap(
+        find.byKey(const ValueKey<String>('mihon_detail_error_details')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('stage: details'), findsOneWidget);
+      expect(find.textContaining('at fixture.Stack'), findsOneWidget);
+      await tester.tap(find.text('CLOSE'));
+      await tester.pumpAndSettle();
+
+      runtime.detailsFailure = null;
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(runtime.detailsCalls, 2);
+      expect(find.text('Could not load this manga.'), findsNothing);
+      expect(find.text('Chapter 1'), findsOneWidget);
+    },
+  );
+
   testWidgets('a stale initial response cannot replace a newer search result',
       (WidgetTester tester) async {
     runtime.popularGate = Completer<MihonMangaPage>();
@@ -213,6 +272,10 @@ class _BrowseRuntime extends Fake implements MihonRuntime {
   Completer<MihonMangaPage>? searchGate;
   Map<int, MihonMangaPage>? popularPages;
 
+  /// 非空时 [getDetails] 抛它，用来驱动详情页的失败态。
+  Exception? detailsFailure;
+  int detailsCalls = 0;
+
   @override
   Future<List<MihonFilter>> getFilters(
     MihonExtensionRef extension,
@@ -254,14 +317,18 @@ class _BrowseRuntime extends Fake implements MihonRuntime {
     MihonSource source,
     MihonManga manga, {
     List<MihonPreference> preferences = const <MihonPreference>[],
-  }) async =>
-      const MihonManga(
-        url: '/manga/fixture',
-        title: 'Raw Otaku fixture',
-        author: 'Fixture author',
-        description: 'Fixture description',
-        initialized: true,
-      );
+  }) async {
+    detailsCalls++;
+    final Exception? failure = detailsFailure;
+    if (failure != null) throw failure;
+    return const MihonManga(
+      url: '/manga/fixture',
+      title: 'Raw Otaku fixture',
+      author: 'Fixture author',
+      description: 'Fixture description',
+      initialized: true,
+    );
+  }
 
   @override
   Future<List<MihonChapter>> getChapters(


### PR DESCRIPTION
## 症状

Android debug 通道包，漫画源能装、作品网格能正常加载；**点进任意作品**，详情页只显示一行
`MihonRuntimeException(RUNTIME_FAILURE): Mihon extension operation failed`，无重试、无更多信息。
用户现场：Manga Mura 源 /「ONE PIECE学園」。

## 根因

Mihon 的 `mangaDetailsParse()` 返回的是**增量**：扩展 `SManga.create()` 一个新对象，只填元数据，
**从不回填 `url`**——`url` 是条目身份，上游官方 app 只把元数据 merge 回已存条目，永远不读返回值的 `url`。
`HttpSource.fetchMangaDetails` 也原样返回它，只额外置 `initialized = true`。

而 `SMangaImpl.url` / `title` 是 `lateinit var`。Fushi 的桥接层把这个增量对象当完整条目用：

- `MihonChannelHandler.getDetailsManga`：`cacheKey(source, result.url)`
- `MihonModelBridge.toBridgeMap()`：`"url" to url`

⇒ `UninitializedPropertyAccessException`。它是 `RuntimeException` 而非 `IllegalArgumentException`，
正好落进 `catch (_: Throwable)` 兜底桶 → `RUNTIME_FAILURE` + 固定文案。

**为什么列表不炸**：列表/搜索解析走 `setUrlWithoutDomain(...)`，`chapterListParse` 也设 url+name；
只有详情返回未初始化 `url` 的对象。所以这不是 Manga Mura 专属——凡是 `mangaDetailsParse` 不回填
`url`（Mihon 扩展的普遍写法）都会中招。

同族缺陷（桌面）：`third_party/m_extension_server` 的 `ResponseModels.kt` 用
`runCatching { this.url }.getOrDefault("")` 读同一字段，**不崩但把 url 静默变成空串**，
接下来拿空 url 去拉章节。所以身份收敛必须同时做在 Dart 侧。

## 放大伤害的第二个缺陷

`catch (_: Throwable)` 把原始异常整个丢弃——不打日志、不进 message、`details` 传 `null`；
Dart 的 `MihonRuntimeException.toString()` 不输出 cause，全仓无一处读 `PlatformException.details`；
详情页 catch 也不记日志。三层叠加，这个 bug 从用户截图到 ErrorLogService 都读不出任何可行动信息。

## 改动

1. `MihonModelBridge.kt` 新增 `SManga.mergedWithDetails()`（身份取入参，元数据新值覆盖旧值；
   用只接 `UninitializedPropertyAccessException` 的 `lateinitOrNull` 探测未初始化的 `title`），
   `getDetailsManga` 改用它。
2. `MihonManga.mergedWithDetails()` + `MihonBridgeRuntime.getDetails` 在 Dart 侧再收敛一次身份。
3. 诊断链路：新增 `MihonDiagnostics.kt`（`describeCauseChain` / `diagnosticDetails`），兜底改为
   回传 `Mihon <method>/<inner> failed: <cause 链>` + 堆栈（`details`）并 `Log.e("MihonChannel", …)`；
   `MihonRuntimeException` 增加 `details`/`diagnostics`；详情页记录失败阶段（details/chapters/library）、
   写 ErrorLogService、渲染带「重试 + 查看详情（可复制）」的失败态。
4. 新增 i18n：`manga_online_detail_load_failed` / `manga_online_error_view_detail`（走 `i18n_sync`，17 语言）。

## 验证

- `dart analyze`（fushi 全量，含 test）：No issues found
- `flutter test test/media/manga`：**471 passed**
- 目录枚举型守卫整批：`FLUTTER TEST VERDICT: PASSED - 250 tests ran`（与文档基线一致）
- `flutter build apk --debug --target-platform android-arm64`：exit 0，Kotlin 改动编译通过
- 新守卫四条变异实测：每条变异都让守卫变红，文件逐字节还原（sha256 比对）

## 未做

真机端到端未跑：本机当前无连接设备。修复是沿真实代码路径静态确证（上游 `SMangaImpl` 的 lateinit
与 `MangaReader.mangaDetailsParse` 不设 url，两处均从源仓核对原文）+ 单测/守卫覆盖。
装上新包后若仍失败，`adb logcat -s MihonChannel:E` 或详情页「查看详情」会直接给出真实 cause。

https://claude.ai/code/session_01QVfY1WZxuVw4P11BfRE9wC
