### PR TITLE
fix(update): 全新下载不再显示「续传：未续传」

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 63172 (3716 per locale)
+/// Strings: 63155 (3715 per locale)
 ///
-/// Built on 2026-08-21 at 21:02 UTC
+/// Built on 2026-08-22 at 05:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2760,7 +2760,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Debug channel builds may be unstable. Use at your own risk.';
   String get update_download => 'Download';
   String get update_download_failed => 'Download failed';
-  String get update_download_not_resumed => 'not resumed';
   String get update_download_restarted_from_zero => 'restarted from zero';
   String update_download_resume_status({required Object status}) =>
       'Resume: ${status}';
@@ -9712,8 +9711,6 @@ class _StringsAr extends _StringsEn {
   String get update_download => 'تنزيل';
   @override
   String get update_download_failed => 'فشل التنزيل';
-  @override
-  String get update_download_not_resumed => 'لم يُستأنف';
   @override
   String get update_download_restarted_from_zero => 'أُعيد التنزيل من الصفر';
   @override
@@ -18373,8 +18370,6 @@ class _StringsDe extends _StringsEn {
   String get update_download => 'Herunterladen';
   @override
   String get update_download_failed => 'Download fehlgeschlagen';
-  @override
-  String get update_download_not_resumed => 'nicht fortgesetzt';
   @override
   String get update_download_restarted_from_zero => 'von vorn begonnen';
   @override
@@ -27063,8 +27058,6 @@ class _StringsEs extends _StringsEn {
   String get update_download => 'Descargar';
   @override
   String get update_download_failed => 'Error al descargar';
-  @override
-  String get update_download_not_resumed => 'no reanudada';
   @override
   String get update_download_restarted_from_zero => 'reiniciada desde cero';
   @override
@@ -35771,8 +35764,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get update_download_failed => 'échec du téléchargement';
   @override
-  String get update_download_not_resumed => 'non repris';
-  @override
   String get update_download_restarted_from_zero => 'redémarré de zéro';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -44414,8 +44405,6 @@ class _StringsId extends _StringsEn {
   String get update_download => 'Unduh';
   @override
   String get update_download_failed => 'Unduhan gagal';
-  @override
-  String get update_download_not_resumed => 'tidak dilanjutkan';
   @override
   String get update_download_restarted_from_zero => 'diulang dari nol';
   @override
@@ -53086,8 +53075,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get update_download_failed => 'Download fallito';
   @override
-  String get update_download_not_resumed => 'non ripreso';
-  @override
   String get update_download_restarted_from_zero => 'riavviato da zero';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -61628,8 +61615,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get update_download_failed => 'ダウンロードに失敗しました';
   @override
-  String get update_download_not_resumed => 'レジュームせず';
-  @override
   String get update_download_restarted_from_zero => '最初からやり直し';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -70128,8 +70113,6 @@ class _StringsKo extends _StringsEn {
   String get update_download => '다운로드';
   @override
   String get update_download_failed => '다운로드 실패';
-  @override
-  String get update_download_not_resumed => '이어받지 않음';
   @override
   String get update_download_restarted_from_zero => '처음부터 다시 받음';
   @override
@@ -78751,8 +78734,6 @@ class _StringsNl extends _StringsEn {
   String get update_download => 'Downloaden';
   @override
   String get update_download_failed => 'Download mislukt';
-  @override
-  String get update_download_not_resumed => 'niet hervat';
   @override
   String get update_download_restarted_from_zero =>
       'opnieuw begonnen vanaf nul';
@@ -87417,8 +87398,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get update_download_failed => 'Falha no download';
   @override
-  String get update_download_not_resumed => 'não retomado';
-  @override
   String get update_download_restarted_from_zero => 'reiniciado do zero';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -96081,8 +96060,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get update_download_failed => 'Ошибка загрузки';
   @override
-  String get update_download_not_resumed => 'не продолжена';
-  @override
   String get update_download_restarted_from_zero => 'начата заново';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -104697,8 +104674,6 @@ class _StringsTh extends _StringsEn {
   String get update_download => 'ดาวน์โหลด';
   @override
   String get update_download_failed => 'ดาวน์โหลดล้มเหลว';
-  @override
-  String get update_download_not_resumed => 'ไม่ได้ดาวน์โหลดต่อ';
   @override
   String get update_download_restarted_from_zero =>
       'เริ่มดาวน์โหลดใหม่ตั้งแต่ต้น';
@@ -113328,8 +113303,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get update_download_failed => 'İndirme başarısız';
   @override
-  String get update_download_not_resumed => 'sürdürülmedi';
-  @override
   String get update_download_restarted_from_zero =>
       'sıfırdan yeniden başlatıldı';
   @override
@@ -121955,8 +121928,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get update_download_failed => 'Tải xuống thất bại';
   @override
-  String get update_download_not_resumed => 'không tiếp tục';
-  @override
   String get update_download_restarted_from_zero => 'đã tải lại từ đầu';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -130269,8 +130240,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get update_download_failed => '下载失败';
   @override
-  String get update_download_not_resumed => '未续传';
-  @override
   String get update_download_restarted_from_zero => '已从零重下';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -138401,8 +138370,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get update_download_failed => '下載失敗';
   @override
-  String get update_download_not_resumed => '未續傳';
-  @override
   String get update_download_restarted_from_zero => '已從頭重下';
   @override
   String update_download_resume_status({required Object status}) =>
@@ -146508,8 +146475,6 @@ extension on _StringsEn {
         return 'Download';
       case 'update_download_failed':
         return 'Download failed';
-      case 'update_download_not_resumed':
-        return 'not resumed';
       case 'update_download_restarted_from_zero':
         return 'restarted from zero';
       case 'update_download_resume_status':
@@ -154130,8 +154095,6 @@ extension on _StringsAr {
         return 'تنزيل';
       case 'update_download_failed':
         return 'فشل التنزيل';
-      case 'update_download_not_resumed':
-        return 'لم يُستأنف';
       case 'update_download_restarted_from_zero':
         return 'أُعيد التنزيل من الصفر';
       case 'update_download_resume_status':
@@ -161771,8 +161734,6 @@ extension on _StringsDe {
         return 'Herunterladen';
       case 'update_download_failed':
         return 'Download fehlgeschlagen';
-      case 'update_download_not_resumed':
-        return 'nicht fortgesetzt';
       case 'update_download_restarted_from_zero':
         return 'von vorn begonnen';
       case 'update_download_resume_status':
@@ -169413,8 +169374,6 @@ extension on _StringsEs {
         return 'Descargar';
       case 'update_download_failed':
         return 'Error al descargar';
-      case 'update_download_not_resumed':
-        return 'no reanudada';
       case 'update_download_restarted_from_zero':
         return 'reiniciada desde cero';
       case 'update_download_resume_status':
@@ -177060,8 +177019,6 @@ extension on _StringsFr {
         return 'Télécharger';
       case 'update_download_failed':
         return 'échec du téléchargement';
-      case 'update_download_not_resumed':
-        return 'non repris';
       case 'update_download_restarted_from_zero':
         return 'redémarré de zéro';
       case 'update_download_resume_status':
@@ -184696,8 +184653,6 @@ extension on _StringsId {
         return 'Unduh';
       case 'update_download_failed':
         return 'Unduhan gagal';
-      case 'update_download_not_resumed':
-        return 'tidak dilanjutkan';
       case 'update_download_restarted_from_zero':
         return 'diulang dari nol';
       case 'update_download_resume_status':
@@ -192335,8 +192290,6 @@ extension on _StringsIt {
         return 'Scarica';
       case 'update_download_failed':
         return 'Download fallito';
-      case 'update_download_not_resumed':
-        return 'non ripreso';
       case 'update_download_restarted_from_zero':
         return 'riavviato da zero';
       case 'update_download_resume_status':
@@ -199953,8 +199906,6 @@ extension on _StringsJa {
         return 'ダウンロード';
       case 'update_download_failed':
         return 'ダウンロードに失敗しました';
-      case 'update_download_not_resumed':
-        return 'レジュームせず';
       case 'update_download_restarted_from_zero':
         return '最初からやり直し';
       case 'update_download_resume_status':
@@ -207563,8 +207514,6 @@ extension on _StringsKo {
         return '다운로드';
       case 'update_download_failed':
         return '다운로드 실패';
-      case 'update_download_not_resumed':
-        return '이어받지 않음';
       case 'update_download_restarted_from_zero':
         return '처음부터 다시 받음';
       case 'update_download_resume_status':
@@ -215194,8 +215143,6 @@ extension on _StringsNl {
         return 'Downloaden';
       case 'update_download_failed':
         return 'Download mislukt';
-      case 'update_download_not_resumed':
-        return 'niet hervat';
       case 'update_download_restarted_from_zero':
         return 'opnieuw begonnen vanaf nul';
       case 'update_download_resume_status':
@@ -222832,8 +222779,6 @@ extension on _StringsPtBr {
         return 'Baixar';
       case 'update_download_failed':
         return 'Falha no download';
-      case 'update_download_not_resumed':
-        return 'não retomado';
       case 'update_download_restarted_from_zero':
         return 'reiniciado do zero';
       case 'update_download_resume_status':
@@ -230472,8 +230417,6 @@ extension on _StringsRu {
         return 'Скачать';
       case 'update_download_failed':
         return 'Ошибка загрузки';
-      case 'update_download_not_resumed':
-        return 'не продолжена';
       case 'update_download_restarted_from_zero':
         return 'начата заново';
       case 'update_download_resume_status':
@@ -238099,8 +238042,6 @@ extension on _StringsTh {
         return 'ดาวน์โหลด';
       case 'update_download_failed':
         return 'ดาวน์โหลดล้มเหลว';
-      case 'update_download_not_resumed':
-        return 'ไม่ได้ดาวน์โหลดต่อ';
       case 'update_download_restarted_from_zero':
         return 'เริ่มดาวน์โหลดใหม่ตั้งแต่ต้น';
       case 'update_download_resume_status':
@@ -245729,8 +245670,6 @@ extension on _StringsTr {
         return 'İndir';
       case 'update_download_failed':
         return 'İndirme başarısız';
-      case 'update_download_not_resumed':
-        return 'sürdürülmedi';
       case 'update_download_restarted_from_zero':
         return 'sıfırdan yeniden başlatıldı';
       case 'update_download_resume_status':
@@ -253360,8 +253299,6 @@ extension on _StringsVi {
         return 'Tải xuống';
       case 'update_download_failed':
         return 'Tải xuống thất bại';
-      case 'update_download_not_resumed':
-        return 'không tiếp tục';
       case 'update_download_restarted_from_zero':
         return 'đã tải lại từ đầu';
       case 'update_download_resume_status':
@@ -260954,8 +260891,6 @@ extension on _StringsZhCn {
         return '下载';
       case 'update_download_failed':
         return '下载失败';
-      case 'update_download_not_resumed':
-        return '未续传';
       case 'update_download_restarted_from_zero':
         return '已从零重下';
       case 'update_download_resume_status':
@@ -268540,8 +268475,6 @@ extension on _StringsZhHk {
         return '下載';
       case 'update_download_failed':
         return '下載失敗';
-      case 'update_download_not_resumed':
-        return '未續傳';
       case 'update_download_restarted_from_zero':
         return '已從頭重下';
       case 'update_download_resume_status':

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Debug channel builds may be unstable. Use at your own risk.",
   "update_download": "Download",
   "update_download_failed": "Download failed",
-  "update_download_not_resumed": "not resumed",
   "update_download_restarted_from_zero": "restarted from zero",
   "update_download_resume_status": "Resume: $status",
   "update_download_resumed": "resumed",

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "إصدارات قناة التصحيح قد تكون غير مستقرة. استخدمها على مسؤوليتك.",
   "update_download": "تنزيل",
   "update_download_failed": "فشل التنزيل",
-  "update_download_not_resumed": "لم يُستأنف",
   "update_download_restarted_from_zero": "أُعيد التنزيل من الصفر",
   "update_download_resume_status": "الاستئناف: $status",
   "update_download_resumed": "تم الاستئناف",

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Debug-Kanal-Builds können instabil sein. Verwendung auf eigene Gefahr.",
   "update_download": "Herunterladen",
   "update_download_failed": "Download fehlgeschlagen",
-  "update_download_not_resumed": "nicht fortgesetzt",
   "update_download_restarted_from_zero": "von vorn begonnen",
   "update_download_resume_status": "Fortsetzen: $status",
   "update_download_resumed": "fortgesetzt",

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Las compilaciones del canal de depuración pueden ser inestables. Úselas bajo su propio riesgo.",
   "update_download": "Descargar",
   "update_download_failed": "Error al descargar",
-  "update_download_not_resumed": "no reanudada",
   "update_download_restarted_from_zero": "reiniciada desde cero",
   "update_download_resume_status": "Reanudación: $status",
   "update_download_resumed": "reanudada",

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Les builds du canal de débogage peuvent être instables. Utilisez-les à vos risques et périls.",
   "update_download": "Télécharger",
   "update_download_failed": "échec du téléchargement",
-  "update_download_not_resumed": "non repris",
   "update_download_restarted_from_zero": "redémarré de zéro",
   "update_download_resume_status": "Reprise : $status",
   "update_download_resumed": "repris",

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Build kanal debug mungkin tidak stabil. Gunakan dengan risiko sendiri.",
   "update_download": "Unduh",
   "update_download_failed": "Unduhan gagal",
-  "update_download_not_resumed": "tidak dilanjutkan",
   "update_download_restarted_from_zero": "diulang dari nol",
   "update_download_resume_status": "Lanjut: $status",
   "update_download_resumed": "dilanjutkan",

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Le build del canale di debug possono essere instabili. Usare a proprio rischio.",
   "update_download": "Scarica",
   "update_download_failed": "Download fallito",
-  "update_download_not_resumed": "non ripreso",
   "update_download_restarted_from_zero": "riavviato da zero",
   "update_download_resume_status": "Ripresa: $status",
   "update_download_resumed": "ripreso",

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "デバッグチャンネルのビルドは不安定な場合があります。自己責任でご使用ください。",
   "update_download": "ダウンロード",
   "update_download_failed": "ダウンロードに失敗しました",
-  "update_download_not_resumed": "レジュームせず",
   "update_download_restarted_from_zero": "最初からやり直し",
   "update_download_resume_status": "レジューム：$status",
   "update_download_resumed": "レジューム済み",

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "디버그 채널 빌드는 불안정할 수 있습니다. 본인 책임하에 사용하세요.",
   "update_download": "다운로드",
   "update_download_failed": "다운로드 실패",
-  "update_download_not_resumed": "이어받지 않음",
   "update_download_restarted_from_zero": "처음부터 다시 받음",
   "update_download_resume_status": "이어받기: $status",
   "update_download_resumed": "이어받음",

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Builds van het debug-kanaal kunnen instabiel zijn. Gebruik op eigen risico.",
   "update_download": "Downloaden",
   "update_download_failed": "Download mislukt",
-  "update_download_not_resumed": "niet hervat",
   "update_download_restarted_from_zero": "opnieuw begonnen vanaf nul",
   "update_download_resume_status": "Hervatten: $status",
   "update_download_resumed": "hervat",

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Builds do canal de depuração podem ser instáveis. Use por sua conta e risco.",
   "update_download": "Baixar",
   "update_download_failed": "Falha no download",
-  "update_download_not_resumed": "não retomado",
   "update_download_restarted_from_zero": "reiniciado do zero",
   "update_download_resume_status": "Retomada: $status",
   "update_download_resumed": "retomado",

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Сборки отладочного канала могут быть нестабильными. Используйте на свой риск.",
   "update_download": "Скачать",
   "update_download_failed": "Ошибка загрузки",
-  "update_download_not_resumed": "не продолжена",
   "update_download_restarted_from_zero": "начата заново",
   "update_download_resume_status": "Докачка: $status",
   "update_download_resumed": "продолжена",

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "เวอร์ชันช่องดีบักอาจไม่เสถียร ใช้ความเสี่ยงของคุณเอง",
   "update_download": "ดาวน์โหลด",
   "update_download_failed": "ดาวน์โหลดล้มเหลว",
-  "update_download_not_resumed": "ไม่ได้ดาวน์โหลดต่อ",
   "update_download_restarted_from_zero": "เริ่มดาวน์โหลดใหม่ตั้งแต่ต้น",
   "update_download_resume_status": "การดาวน์โหลดต่อ: $status",
   "update_download_resumed": "ดาวน์โหลดต่อแล้ว",

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Hata ayıklama kanalı sürümleri kararsız olabilir. Riski size aittir.",
   "update_download": "İndir",
   "update_download_failed": "İndirme başarısız",
-  "update_download_not_resumed": "sürdürülmedi",
   "update_download_restarted_from_zero": "sıfırdan yeniden başlatıldı",
   "update_download_resume_status": "Sürdürme: $status",
   "update_download_resumed": "sürdürüldü",

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "Bản dựng kênh gỡ lỗi có thể không ổn định. Sử dụng theo rủi ro của bạn.",
   "update_download": "Tải xuống",
   "update_download_failed": "Tải xuống thất bại",
-  "update_download_not_resumed": "không tiếp tục",
   "update_download_restarted_from_zero": "đã tải lại từ đầu",
   "update_download_resume_status": "Tiếp tục: $status",
   "update_download_resumed": "đã tiếp tục",

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "调试通道的构建可能不稳定。使用风险自负。",
   "update_download": "下载",
   "update_download_failed": "下载失败",
-  "update_download_not_resumed": "未续传",
   "update_download_restarted_from_zero": "已从零重下",
   "update_download_resume_status": "续传：$status",
   "update_download_resumed": "已续传",

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2059,7 +2059,6 @@
   "update_debug_channel_warning": "偵錯頻道的建置版本可能不穩定。使用風險自負。",
   "update_download": "下載",
   "update_download_failed": "下載失敗",
-  "update_download_not_resumed": "未續傳",
   "update_download_restarted_from_zero": "已從頭重下",
   "update_download_resume_status": "續傳：$status",
   "update_download_resumed": "已續傳",

--- a/fushi/lib/src/utils/misc/resumable_downloader.dart
+++ b/fushi/lib/src/utils/misc/resumable_downloader.dart
@@ -61,14 +61,30 @@ class ResumableDownloadState {
   }
 }
 
+/// 一次下载相对已有 `.part` 断点的**实际处置**，三态互斥。
+///
+/// 之前用 `resumed` / `restartedFromZero` 两个 bool 编码，`false/false` 同时表示
+/// 「本来就没断点可续」和「结论还没出来」，消费端无法把「没这回事」与「续传失败」
+/// 分开，UI 于是把全新下载渲染成「未续传」。收成一个枚举后 [none] 就是明确的
+/// 「本次没有可报的续传事实」，UI 据此整行不渲染。
+enum DownloadResumeOutcome {
+  /// 没有可续的 `.part`（或首响应尚未到达、结论未定）：本次不涉及续传。
+  none,
+
+  /// 服务器接受了 Range（206 且起点匹配）：真正从断点续上。
+  resumed,
+
+  /// 请求了 Range 但服务器忽略（200 / 416）：旧 part 已丢弃，从 0 全量重写。
+  restartedFromZero,
+}
+
 @immutable
 class ResumableDownloadMetaInfo {
   const ResumableDownloadMetaInfo({
     required this.etag,
     required this.lastModified,
     required this.totalBytes,
-    required this.resumed,
-    required this.restartedFromZero,
+    required this.resumeOutcome,
     required this.writeOffset,
   });
 
@@ -76,11 +92,8 @@ class ResumableDownloadMetaInfo {
   final String? lastModified;
   final int? totalBytes;
 
-  /// 本次接受了 Range 续传（服务器返回 206 且起点匹配）。
-  final bool resumed;
-
-  /// 本次请求了 Range 但服务器忽略（返回 200 / 416），已丢弃旧 part 从 0 全量重写。
-  final bool restartedFromZero;
+  /// 本次相对已有断点的实际处置。
+  final DownloadResumeOutcome resumeOutcome;
 
   /// body 实际写入的起始偏移（续传 = resumeOffset；全量重写 = 0）。
   final int writeOffset;
@@ -155,8 +168,11 @@ class ResumableDownloader {
     final ResumableDownloadResponse response = await opened;
 
     int writeOffset = resumeOffset;
-    var resumed = false;
-    var restartedFromZero = restarted;
+    // restarted=true 只可能来自本函数因 416 / 坏 Content-Range 的一次自我重入，
+    // 那次 resumeOffset 已清成 0，处置就是「从零重下」。
+    var outcome = restarted
+        ? DownloadResumeOutcome.restartedFromZero
+        : DownloadResumeOutcome.none;
     if (requestedRange &&
         response.statusCode == HttpStatus.requestedRangeNotSatisfiable &&
         !restarted) {
@@ -174,12 +190,12 @@ class ResumableDownloader {
         if (!restarted) return _run(resumeOffset: 0, restarted: true);
         throw HttpException('invalid content-range for resume: $url');
       }
-      resumed = true;
+      outcome = DownloadResumeOutcome.resumed;
     } else if (response.statusCode == HttpStatus.ok) {
       if (requestedRange) {
         await _deleteFile(partFile);
         writeOffset = 0;
-        restartedFromZero = true;
+        outcome = DownloadResumeOutcome.restartedFromZero;
       }
     } else if (response.statusCode != HttpStatus.partialContent) {
       await response.stream.drain<void>();
@@ -191,8 +207,7 @@ class ResumableDownloader {
       etag: response.header(HttpHeaders.etagHeader),
       lastModified: response.header(HttpHeaders.lastModifiedHeader),
       totalBytes: expectedSize ?? total,
-      resumed: resumed,
-      restartedFromZero: restartedFromZero,
+      resumeOutcome: outcome,
       writeOffset: writeOffset,
     ));
 

--- a/fushi/lib/src/utils/misc/update_checker_download.dart
+++ b/fushi/lib/src/utils/misc/update_checker_download.dart
@@ -45,8 +45,7 @@ class UpdateDownloadDiagnostics {
     required this.receivedBytes,
     required this.totalBytes,
     required this.bytesPerSecond,
-    required this.resumed,
-    required this.restartedFromZero,
+    required this.resumeOutcome,
   });
 
   final String sourceUrl;
@@ -54,8 +53,10 @@ class UpdateDownloadDiagnostics {
   final int receivedBytes;
   final int? totalBytes;
   final double? bytesPerSecond;
-  final bool resumed;
-  final bool restartedFromZero;
+
+  /// 本次下载相对已有 `.part` 断点的处置。[DownloadResumeOutcome.none] 表示
+  /// 「没有可报的续传事实」（全新下载 / 首响应未到），UI 据此不渲染续传行。
+  final DownloadResumeOutcome resumeOutcome;
 }
 
 final Map<String, Future<File>> _activeUpdateDownloads =
@@ -731,8 +732,10 @@ Future<File> _downloadCandidateSingle({
   final Stopwatch diagnosticsStopwatch = Stopwatch()..start();
   var lastDiagnosticsElapsed = -_kDownloadDiagnosticsInterval.inMilliseconds;
   var speedStartBytes = resumeOffset;
-  var resumed = false;
-  var restartedFromZero = restarted;
+  // 首响应到达前结论未定：先按 none 报（UI 不渲染续传行），onMeta 到了再改写。
+  var resumeOutcome = restarted
+      ? DownloadResumeOutcome.restartedFromZero
+      : DownloadResumeOutcome.none;
 
   void reportDiagnostics({
     required int receivedBytes,
@@ -759,8 +762,7 @@ Future<File> _downloadCandidateSingle({
           receivedBytes: receivedBytes,
           elapsed: diagnosticsStopwatch.elapsed,
         ),
-        resumed: resumed,
-        restartedFromZero: restartedFromZero,
+        resumeOutcome: resumeOutcome,
       ),
     );
   }
@@ -814,9 +816,10 @@ Future<File> _downloadCandidateSingle({
     firstByteTimeout: _kFirstByteTimeout,
     bodyTimeout: _kPerAttemptTimeout,
     onMeta: (ResumableDownloadMetaInfo info) {
-      resumed = info.resumed;
-      restartedFromZero = info.restartedFromZero;
-      if (info.restartedFromZero) speedStartBytes = 0;
+      resumeOutcome = info.resumeOutcome;
+      if (info.resumeOutcome == DownloadResumeOutcome.restartedFromZero) {
+        speedStartBytes = 0;
+      }
       pendingMetadataWrite = persistStagingMetadata(info);
       final int? total = asset.sizeBytes ?? info.totalBytes;
       if (total != null && total > 0) {
@@ -1038,8 +1041,9 @@ Future<File?> _downloadSegmented({
           receivedBytes: receivedTotal,
           elapsed: stopwatch.elapsed,
         ),
-        resumed: false,
-        restartedFromZero: false,
+        // 分片路径开工先 _cleanupSegmentFiles，跨次续传在这条路上不存在（段级续传
+        // 只在本次运行内的重试里生效），且门控要求 resumeOffset == 0 —— 恒 none。
+        resumeOutcome: DownloadResumeOutcome.none,
       ),
     );
   }

--- a/fushi/lib/src/utils/misc/update_checker_ui.dart
+++ b/fushi/lib/src/utils/misc/update_checker_ui.dart
@@ -566,11 +566,14 @@ class _DownloadDiagnosticsPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final TextStyle? style = Theme.of(context).textTheme.bodySmall;
-    final String resumeStatus = value.restartedFromZero
-        ? t.update_download_restarted_from_zero
-        : value.resumed
-            ? t.update_download_resumed
-            : t.update_download_not_resumed;
+    // 续传行只在「确实发生了续传相关的事」时出现：全新下载（none）没有可报的
+    // 续传事实，多显示一行「未续传」是把「没这回事」说成「这事没成」。
+    final String? resumeStatus = switch (value.resumeOutcome) {
+      DownloadResumeOutcome.resumed => t.update_download_resumed,
+      DownloadResumeOutcome.restartedFromZero =>
+        t.update_download_restarted_from_zero,
+      DownloadResumeOutcome.none => null,
+    };
     return DefaultTextStyle.merge(
       style: style,
       child: Column(
@@ -593,10 +596,12 @@ class _DownloadDiagnosticsPanel extends StatelessWidget {
               speed: formatUpdateDownloadSpeed(value.bytesPerSecond),
             ),
           ),
-          SizedBox(height: tokens.spacing.gap / 2),
-          _DiagnosticLine(
-            text: t.update_download_resume_status(status: resumeStatus),
-          ),
+          if (resumeStatus != null) ...<Widget>[
+            SizedBox(height: tokens.spacing.gap / 2),
+            _DiagnosticLine(
+              text: t.update_download_resume_status(status: resumeStatus),
+            ),
+          ],
         ],
       ),
     );

--- a/fushi/test/utils/misc/resumable_downloader_test.dart
+++ b/fushi/test/utils/misc/resumable_downloader_test.dart
@@ -129,7 +129,7 @@ void main() {
       final List<int> body = payload();
       await part().writeAsBytes(<int>[7, 7, 7], flush: true);
 
-      final List<bool> restarted = <bool>[];
+      final List<DownloadResumeOutcome> restarted = <DownloadResumeOutcome>[];
       final File file = await ResumableDownloader(
         url: 'http://host/stream',
         destination: dest(),
@@ -137,7 +137,7 @@ void main() {
         expectedSize: body.length,
         resumeState: const ResumableDownloadState(lastModified: 'yesterday'),
         onMeta: (ResumableDownloadMetaInfo info) =>
-            restarted.add(info.restartedFromZero),
+            restarted.add(info.resumeOutcome),
         open: (Uri uri, Map<String, String> headers) async {
           expect(headers[HttpHeaders.rangeHeader], 'bytes=3-');
           return ResumableDownloadResponse.bytes(
@@ -150,7 +150,8 @@ void main() {
         },
       ).download();
 
-      expect(restarted, <bool>[true]);
+      expect(restarted,
+          <DownloadResumeOutcome>[DownloadResumeOutcome.restartedFromZero]);
       expect(await file.readAsBytes(), body);
     });
 
@@ -202,17 +203,18 @@ void main() {
       expect(part().existsSync(), isFalse);
     });
 
-    test('reports resumed=true on accepted 206 resume', () async {
+    test('reports resumed outcome on accepted 206 resume', () async {
       final List<int> body = payload();
       await part().writeAsBytes(body.sublist(0, 6), flush: true);
-      final List<bool> resumedFlags = <bool>[];
+      final List<DownloadResumeOutcome> resumedFlags =
+          <DownloadResumeOutcome>[];
       await ResumableDownloader(
         url: 'http://host/stream',
         destination: dest(),
         partFile: part(),
         expectedSize: body.length,
         onMeta: (ResumableDownloadMetaInfo info) =>
-            resumedFlags.add(info.resumed),
+            resumedFlags.add(info.resumeOutcome),
         open: (Uri uri, Map<String, String> headers) async =>
             ResumableDownloadResponse.bytes(
           statusCode: HttpStatus.partialContent,
@@ -223,7 +225,8 @@ void main() {
           },
         ),
       ).download();
-      expect(resumedFlags, <bool>[true]);
+      expect(
+          resumedFlags, <DownloadResumeOutcome>[DownloadResumeOutcome.resumed]);
     });
   });
 }

--- a/fushi/test/utils/misc/update_checker_dialog_test.dart
+++ b/fushi/test/utils/misc/update_checker_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
 import 'package:fushi/src/utils/misc/show_app_dialog.dart';
 import 'package:fushi/src/utils/misc/update_handoff.dart';
 import 'package:fushi/src/utils/misc/update_checker.dart';
@@ -104,8 +105,7 @@ void main() {
         receivedBytes: 1234567,
         totalBytes: 987654321,
         bytesPerSecond: 123456,
-        resumed: false,
-        restartedFromZero: false,
+        resumeOutcome: DownloadResumeOutcome.none,
       ),
     );
     addTearDown(progress.dispose);
@@ -131,7 +131,68 @@ void main() {
     expect(find.textContaining('ghproxy.net'), findsOneWidget);
     expect(find.textContaining('1.2 MB'), findsOneWidget);
     expect(find.textContaining('120.6 KB/s'), findsOneWidget);
-    expect(find.textContaining(t.update_download_not_resumed), findsOneWidget);
+    // 全新下载没有可报的续传事实：整行不出现（不再显示「续传：未续传」）。
+    expect(
+      find.textContaining(t.update_download_resume_status(status: '')),
+      findsNothing,
+      reason: '无断点可续时不得渲染续传行',
+    );
+  });
+
+  testWidgets('download diagnostics only shows the resume line when it resumed',
+      (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(420, 520);
+    addTearDown(tester.view.reset);
+
+    final ValueNotifier<double> progress = ValueNotifier<double>(0.42);
+    final ValueNotifier<String> status =
+        ValueNotifier<String>(t.update_downloading);
+    final ValueNotifier<UpdateDownloadDiagnostics?> diagnostics =
+        ValueNotifier<UpdateDownloadDiagnostics?>(
+      const UpdateDownloadDiagnostics(
+        sourceUrl: 'https://example.com/hibiki-9.9.9-windows-setup.exe',
+        sourceHost: 'example.com',
+        receivedBytes: 1234567,
+        totalBytes: 987654321,
+        bytesPerSecond: 123456,
+        resumeOutcome: DownloadResumeOutcome.resumed,
+      ),
+    );
+    addTearDown(progress.dispose);
+    addTearDown(status.dispose);
+    addTearDown(diagnostics.dispose);
+
+    await tester.pumpWidget(
+      buildApp(
+        Stack(
+          children: <Widget>[
+            buildUpdateDownloadOverlayForTest(
+              progress: progress,
+              status: status,
+              diagnostics: diagnostics,
+              onHide: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.textContaining(t.update_download_resumed), findsOneWidget);
+
+    diagnostics.value = const UpdateDownloadDiagnostics(
+      sourceUrl: 'https://example.com/hibiki-9.9.9-windows-setup.exe',
+      sourceHost: 'example.com',
+      receivedBytes: 1234567,
+      totalBytes: 987654321,
+      bytesPerSecond: 123456,
+      resumeOutcome: DownloadResumeOutcome.restartedFromZero,
+    );
+    await tester.pump();
+    expect(
+      find.textContaining(t.update_download_restarted_from_zero),
+      findsOneWidget,
+    );
   });
 
   // TODO-738: the download overlay exposes a Cancel escape hatch that fires the

--- a/fushi/test/utils/misc/update_checker_download_resume_test.dart
+++ b/fushi/test/utils/misc/update_checker_download_resume_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/misc/platform_updater.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
 import 'package:fushi/src/utils/misc/update_checker.dart';
 
 void main() {
@@ -131,8 +132,7 @@ void main() {
       expect(last.receivedBytes, payload.length);
       expect(last.totalBytes, payload.length);
       expect(last.bytesPerSecond, isNotNull);
-      expect(last.resumed, isFalse);
-      expect(last.restartedFromZero, isFalse);
+      expect(last.resumeOutcome, DownloadResumeOutcome.none);
     });
 
     test('reports diagnostics for accepted resume and restart-from-zero',
@@ -173,10 +173,9 @@ void main() {
               (UpdateDownloadDiagnostics d) =>
                   d.receivedBytes == payload.length,
             )
-            .resumed,
-        isTrue,
+            .resumeOutcome,
+        DownloadResumeOutcome.resumed,
       );
-      expect(resumedDiagnostics.last.restartedFromZero, isFalse);
 
       final Directory restartDir =
           await Directory.systemTemp.createTemp('hibiki-update-restart');
@@ -211,8 +210,8 @@ void main() {
       final UpdateDownloadDiagnostics restartLast = restartDiagnostics.last;
       expect(restartLast.receivedBytes, payload.length);
       expect(restartLast.totalBytes, payload.length);
-      expect(restartLast.resumed, isFalse);
-      expect(restartLast.restartedFromZero, isTrue);
+      expect(
+          restartLast.resumeOutcome, DownloadResumeOutcome.restartedFromZero);
     });
 
     test('formats diagnostic byte sizes, speeds, and speed samples', () {


### PR DESCRIPTION
## 用户反馈

> 下载的续传没续传不用显示出来。然后这个续传不续传判断有点怪。

## 根因

续传状态本质是**三态**：没断点可续 / 真的续上了 / 请求了 Range 但服务器不认（200/416）从零重下。之前用 `resumed` + `restartedFromZero` **两个 bool** 编码，`false/false` 同时表示「本来就没断点」和「首响应还没到、结论未定」。UI（`_DownloadDiagnosticsPanel`）把这个默认坑渲染成「续传：未续传」——把「没这回事」说成「这事没成」。绝大多数下载都是全新的，所以这行噪音恒亮，这就是「判断有点怪」的来源。

## 改动

- 新增 `DownloadResumeOutcome { none, resumed, restartedFromZero }`，引擎 `ResumableDownloadMetaInfo` 与诊断 `UpdateDownloadDiagnostics` 共用同一枚举，两个 bool 全部删除。
- UI 对 `none` **整行不渲染**；`resumed` / `restartedFromZero` 照常显示。
- 分片下载路径：开工即 `_cleanupSegmentFiles`、门控又要求 `resumeOffset == 0`，跨次续传在那条路上根本不存在（段级续传只在本次运行内的重试生效），显式标 `none` 并注明理由，取代原来无注释的硬编码 `false/false`。
- 删掉已无消费方的 i18n key `update_download_not_resumed`（走 `i18n_sync --remove`，17 语言同步 + `dart run slang` 重生成）。

## 守卫

- `update_checker_dialog_test`：原来断言「必须出现『未续传』」→ 翻成「无断点时续传行不得出现」，并新增一条 `resumed` / `restartedFromZero` 各自正常显示的正向断言。
- `resumable_downloader_test` / `update_checker_download_resume_test`：bool 断言换成枚举断言，三态各有覆盖。

## 验证

- `flutter analyze`（含 test）：No issues found。
- `dart run tool/flutter_test_failures.dart --no-pub test/utils/misc test/sync/interconnect_download_manager_test.dart test/sync/interconnect_download_failure_surface_test.dart` → `FLUTTER TEST VERDICT: PASSED - 756 tests ran`。

https://claude.ai/code/session_01SY1xuzLZP6YqhDUYq3HCHb
