### PR TITLE
存储页：数据存储位置移入、全类目可展开、去掉可选模块区

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 63138 (3714 per locale)
 ///
-/// Built on 2026-08-22 at 08:55 UTC
+/// Built on 2026-08-22 at 09:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4858,8 +4858,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Shortcut ${index}';
   String get video_control_custom_action_none => 'Not assigned';
   String get settings_destination_storage => 'Storage';
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
   String get storage_overview_section => 'Disk usage';
   String get storage_overview_total => 'Total';
   String get storage_overview_refresh => 'Rescan';
@@ -5043,6 +5041,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_online_error_view_detail => 'View details';
   String get discovery_sources_unavailable => 'All sources are unavailable';
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -13332,9 +13332,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -13651,6 +13648,9 @@ class _StringsAr extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -22005,9 +22005,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -22324,6 +22321,9 @@ class _StringsDe extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -30694,9 +30694,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -31013,6 +31010,9 @@ class _StringsEs extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -39395,9 +39395,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -39714,6 +39711,9 @@ class _StringsFr extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -48026,9 +48026,6 @@ class _StringsId extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -48345,6 +48342,9 @@ class _StringsId extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -56701,9 +56701,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -57020,6 +57017,9 @@ class _StringsIt extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -65193,9 +65193,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -65512,6 +65509,9 @@ class _StringsJa extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -73693,9 +73693,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -74012,6 +74009,9 @@ class _StringsKo extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -82348,9 +82348,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -82667,6 +82664,9 @@ class _StringsNl extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -91015,9 +91015,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -91334,6 +91331,9 @@ class _StringsPtBr extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -99669,9 +99669,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -99988,6 +99985,9 @@ class _StringsRu extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -108271,9 +108271,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -108590,6 +108587,9 @@ class _StringsTh extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -116904,9 +116904,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -117223,6 +117220,9 @@ class _StringsTr extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -125523,9 +125523,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -125842,6 +125839,9 @@ class _StringsVi extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 // Path: <root>
@@ -133526,8 +133526,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get settings_destination_storage => '存储';
   @override
-  String get settings_destination_storage_summary => '磁盘占用与可清理模块';
-  @override
   String get storage_overview_section => '磁盘占用';
   @override
   String get storage_overview_total => '总计';
@@ -133811,6 +133809,8 @@ class _StringsZhCn extends _StringsEn {
   String get discovery_sources_unavailable => '全部来源都不可用';
   @override
   String get storage_shaders_delete_anime4k => '删除 Anime4K 着色器';
+  @override
+  String get settings_destination_storage_summary => '数据位置与磁盘占用';
 }
 
 // Path: <root>
@@ -141909,9 +141909,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get settings_destination_storage => 'Storage';
   @override
-  String get settings_destination_storage_summary =>
-      'Disk usage and reclaimable modules';
-  @override
   String get storage_overview_section => 'Disk usage';
   @override
   String get storage_overview_total => 'Total';
@@ -142228,6 +142225,9 @@ class _StringsZhHk extends _StringsEn {
   String get discovery_sources_unavailable => 'All sources are unavailable';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  @override
+  String get settings_destination_storage_summary =>
+      'Data location and disk usage';
 }
 
 /// Flat map(s) containing all translations.
@@ -149576,8 +149576,6 @@ extension on _StringsEn {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -149848,6 +149846,8 @@ extension on _StringsEn {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -157194,8 +157194,6 @@ extension on _StringsAr {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -157466,6 +157464,8 @@ extension on _StringsAr {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -164834,8 +164834,6 @@ extension on _StringsDe {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -165106,6 +165104,8 @@ extension on _StringsDe {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -172473,8 +172473,6 @@ extension on _StringsEs {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -172745,6 +172743,8 @@ extension on _StringsEs {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -180118,8 +180118,6 @@ extension on _StringsFr {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -180390,6 +180388,8 @@ extension on _StringsFr {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -187745,8 +187745,6 @@ extension on _StringsId {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -188017,6 +188015,8 @@ extension on _StringsId {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -195386,8 +195386,6 @@ extension on _StringsIt {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -195658,6 +195656,8 @@ extension on _StringsIt {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -202989,8 +202989,6 @@ extension on _StringsJa {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -203261,6 +203259,8 @@ extension on _StringsJa {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -210596,8 +210596,6 @@ extension on _StringsKo {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -210868,6 +210866,8 @@ extension on _StringsKo {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -218231,8 +218231,6 @@ extension on _StringsNl {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -218503,6 +218501,8 @@ extension on _StringsNl {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -225863,8 +225863,6 @@ extension on _StringsPtBr {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -226135,6 +226133,8 @@ extension on _StringsPtBr {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -233500,8 +233500,6 @@ extension on _StringsRu {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -233772,6 +233770,8 @@ extension on _StringsRu {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -241120,8 +241120,6 @@ extension on _StringsTh {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -241392,6 +241390,8 @@ extension on _StringsTh {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -248749,8 +248749,6 @@ extension on _StringsTr {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -249021,6 +249019,8 @@ extension on _StringsTr {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -256374,8 +256374,6 @@ extension on _StringsVi {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -256646,6 +256644,8 @@ extension on _StringsVi {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }
@@ -263940,8 +263940,6 @@ extension on _StringsZhCn {
         return '不绑定';
       case 'settings_destination_storage':
         return '存储';
-      case 'settings_destination_storage_summary':
-        return '磁盘占用与可清理模块';
       case 'storage_overview_section':
         return '磁盘占用';
       case 'storage_overview_total':
@@ -264212,6 +264210,8 @@ extension on _StringsZhCn {
         return '全部来源都不可用';
       case 'storage_shaders_delete_anime4k':
         return '删除 Anime4K 着色器';
+      case 'settings_destination_storage_summary':
+        return '数据位置与磁盘占用';
       default:
         return null;
     }
@@ -271538,8 +271538,6 @@ extension on _StringsZhHk {
         return 'Not assigned';
       case 'settings_destination_storage':
         return 'Storage';
-      case 'settings_destination_storage_summary':
-        return 'Disk usage and reclaimable modules';
       case 'storage_overview_section':
         return 'Disk usage';
       case 'storage_overview_total':
@@ -271810,6 +271808,8 @@ extension on _StringsZhHk {
         return 'All sources are unavailable';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'settings_destination_storage_summary':
+        return 'Data location and disk usage';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 63155 (3715 per locale)
+/// Strings: 63138 (3714 per locale)
 ///
-/// Built on 2026-08-22 at 05:47 UTC
+/// Built on 2026-08-22 at 08:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4886,13 +4886,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get storage_entry_delete_done => 'Deleted';
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
-  String get storage_modules_section => 'Optional modules';
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   String get storage_modules_anime4k_hint =>
       'Can be downloaded again anytime in video settings';
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  String get storage_modules_not_installed => 'Not installed';
   String get storage_bundled_section => 'Bundled components';
   String get storage_bundled_hint =>
       'Shipped with the installer; deleted files come back on the next update, listed for reference only.';
@@ -5044,6 +5042,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_online_detail_load_failed => 'Could not load this manga.';
   String get manga_online_error_view_detail => 'View details';
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -13383,8 +13382,6 @@ class _StringsAr extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -13392,8 +13389,6 @@ class _StringsAr extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -13654,6 +13649,8 @@ class _StringsAr extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -22058,8 +22055,6 @@ class _StringsDe extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -22067,8 +22062,6 @@ class _StringsDe extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -22329,6 +22322,8 @@ class _StringsDe extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -30749,8 +30744,6 @@ class _StringsEs extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -30758,8 +30751,6 @@ class _StringsEs extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -31020,6 +31011,8 @@ class _StringsEs extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -39452,8 +39445,6 @@ class _StringsFr extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -39461,8 +39452,6 @@ class _StringsFr extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -39723,6 +39712,8 @@ class _StringsFr extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -48085,8 +48076,6 @@ class _StringsId extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -48094,8 +48083,6 @@ class _StringsId extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -48356,6 +48343,8 @@ class _StringsId extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -56762,8 +56751,6 @@ class _StringsIt extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -56771,8 +56758,6 @@ class _StringsIt extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -57033,6 +57018,8 @@ class _StringsIt extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -65256,8 +65243,6 @@ class _StringsJa extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -65265,8 +65250,6 @@ class _StringsJa extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -65527,6 +65510,8 @@ class _StringsJa extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -73758,8 +73743,6 @@ class _StringsKo extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -73767,8 +73750,6 @@ class _StringsKo extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -74029,6 +74010,8 @@ class _StringsKo extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -82415,8 +82398,6 @@ class _StringsNl extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -82424,8 +82405,6 @@ class _StringsNl extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -82686,6 +82665,8 @@ class _StringsNl extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -91084,8 +91065,6 @@ class _StringsPtBr extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -91093,8 +91072,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -91355,6 +91332,8 @@ class _StringsPtBr extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -99740,8 +99719,6 @@ class _StringsRu extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -99749,8 +99726,6 @@ class _StringsRu extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -100011,6 +99986,8 @@ class _StringsRu extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -108344,8 +108321,6 @@ class _StringsTh extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -108353,8 +108328,6 @@ class _StringsTh extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -108615,6 +108588,8 @@ class _StringsTh extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -116979,8 +116954,6 @@ class _StringsTr extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -116988,8 +116961,6 @@ class _StringsTr extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -117250,6 +117221,8 @@ class _StringsTr extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -125600,8 +125573,6 @@ class _StringsVi extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -125609,8 +125580,6 @@ class _StringsVi extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -125871,6 +125840,8 @@ class _StringsVi extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 // Path: <root>
@@ -133603,16 +133574,12 @@ class _StringsZhCn extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       '删除失败：${reason}';
   @override
-  String get storage_modules_section => '可选模块';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K 着色器';
   @override
   String get storage_modules_anime4k_hint => '可随时在视频设置的画质增强里重新下载';
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       '已删除 ${n} 个着色器文件';
-  @override
-  String get storage_modules_not_installed => '未安装';
   @override
   String get storage_bundled_section => '随包组件';
   @override
@@ -133842,6 +133809,8 @@ class _StringsZhCn extends _StringsEn {
   String get manga_online_error_view_detail => '查看详情';
   @override
   String get discovery_sources_unavailable => '全部来源都不可用';
+  @override
+  String get storage_shaders_delete_anime4k => '删除 Anime4K 着色器';
 }
 
 // Path: <root>
@@ -141990,8 +141959,6 @@ class _StringsZhHk extends _StringsEn {
   String storage_entry_delete_failed({required Object reason}) =>
       'Delete failed: ${reason}';
   @override
-  String get storage_modules_section => 'Optional modules';
-  @override
   String get storage_modules_anime4k_title => 'Anime4K shaders';
   @override
   String get storage_modules_anime4k_hint =>
@@ -141999,8 +141966,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String storage_modules_anime4k_delete_done({required Object n}) =>
       'Deleted ${n} shader files';
-  @override
-  String get storage_modules_not_installed => 'Not installed';
   @override
   String get storage_bundled_section => 'Bundled components';
   @override
@@ -142261,6 +142226,8 @@ class _StringsZhHk extends _StringsEn {
   String get manga_online_error_view_detail => 'View details';
   @override
   String get discovery_sources_unavailable => 'All sources are unavailable';
+  @override
+  String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
 }
 
 /// Flat map(s) containing all translations.
@@ -149654,16 +149621,12 @@ extension on _StringsEn {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -149883,6 +149846,8 @@ extension on _StringsEn {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -157274,16 +157239,12 @@ extension on _StringsAr {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -157503,6 +157464,8 @@ extension on _StringsAr {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -164916,16 +164879,12 @@ extension on _StringsDe {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -165145,6 +165104,8 @@ extension on _StringsDe {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -172557,16 +172518,12 @@ extension on _StringsEs {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -172786,6 +172743,8 @@ extension on _StringsEs {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -180204,16 +180163,12 @@ extension on _StringsFr {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -180433,6 +180388,8 @@ extension on _StringsFr {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -187833,16 +187790,12 @@ extension on _StringsId {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -188062,6 +188015,8 @@ extension on _StringsId {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -195476,16 +195431,12 @@ extension on _StringsIt {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -195705,6 +195656,8 @@ extension on _StringsIt {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -203081,16 +203034,12 @@ extension on _StringsJa {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -203310,6 +203259,8 @@ extension on _StringsJa {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -210690,16 +210641,12 @@ extension on _StringsKo {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -210919,6 +210866,8 @@ extension on _StringsKo {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -218327,16 +218276,12 @@ extension on _StringsNl {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -218556,6 +218501,8 @@ extension on _StringsNl {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -225961,16 +225908,12 @@ extension on _StringsPtBr {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -226190,6 +226133,8 @@ extension on _StringsPtBr {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -233600,16 +233545,12 @@ extension on _StringsRu {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -233829,6 +233770,8 @@ extension on _StringsRu {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -241222,16 +241165,12 @@ extension on _StringsTh {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -241451,6 +241390,8 @@ extension on _StringsTh {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -248853,16 +248794,12 @@ extension on _StringsTr {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -249082,6 +249019,8 @@ extension on _StringsTr {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -256480,16 +256419,12 @@ extension on _StringsVi {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -256709,6 +256644,8 @@ extension on _StringsVi {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }
@@ -264048,16 +263985,12 @@ extension on _StringsZhCn {
         return '已删除';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => '删除失败：${reason}';
-      case 'storage_modules_section':
-        return '可选模块';
       case 'storage_modules_anime4k_title':
         return 'Anime4K 着色器';
       case 'storage_modules_anime4k_hint':
         return '可随时在视频设置的画质增强里重新下载';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => '已删除 ${n} 个着色器文件';
-      case 'storage_modules_not_installed':
-        return '未安装';
       case 'storage_bundled_section':
         return '随包组件';
       case 'storage_bundled_hint':
@@ -264277,6 +264210,8 @@ extension on _StringsZhCn {
         return '查看详情';
       case 'discovery_sources_unavailable':
         return '全部来源都不可用';
+      case 'storage_shaders_delete_anime4k':
+        return '删除 Anime4K 着色器';
       default:
         return null;
     }
@@ -271648,16 +271583,12 @@ extension on _StringsZhHk {
         return 'Deleted';
       case 'storage_entry_delete_failed':
         return ({required Object reason}) => 'Delete failed: ${reason}';
-      case 'storage_modules_section':
-        return 'Optional modules';
       case 'storage_modules_anime4k_title':
         return 'Anime4K shaders';
       case 'storage_modules_anime4k_hint':
         return 'Can be downloaded again anytime in video settings';
       case 'storage_modules_anime4k_delete_done':
         return ({required Object n}) => 'Deleted ${n} shader files';
-      case 'storage_modules_not_installed':
-        return 'Not installed';
       case 'storage_bundled_section':
         return 'Bundled components';
       case 'storage_bundled_hint':
@@ -271877,6 +271808,8 @@ extension on _StringsZhHk {
         return 'View details';
       case 'discovery_sources_unavailable':
         return 'All sources are unavailable';
+      case 'storage_shaders_delete_anime4k':
+        return 'Delete Anime4K shaders';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "将删除该词典及其已导入数据。",
   "storage_entry_delete_done": "已删除",
   "storage_entry_delete_failed": "删除失败：$reason",
-  "storage_modules_section": "可选模块",
   "storage_modules_anime4k_title": "Anime4K 着色器",
   "storage_modules_anime4k_hint": "可随时在视频设置的画质增强里重新下载",
   "storage_modules_anime4k_delete_done": "已删除 $n 个着色器文件",
-  "storage_modules_not_installed": "未安装",
   "storage_bundled_section": "随包组件",
   "storage_bundled_hint": "随安装包携带，删除后下次更新会自动恢复，此处仅展示。",
   "storage_dictionary_delete_incomplete": "词典删除未完成、条目仍在，详见错误日志",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "显示文件",
   "manga_online_detail_load_failed": "无法载入这部漫画。",
   "manga_online_error_view_detail": "查看详情",
-  "discovery_sources_unavailable": "全部来源都不可用"
+  "discovery_sources_unavailable": "全部来源都不可用",
+  "storage_shaders_delete_anime4k": "删除 Anime4K 着色器"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "快捷键 $index",
   "video_control_custom_action_none": "不绑定",
   "settings_destination_storage": "存储",
-  "settings_destination_storage_summary": "磁盘占用与可清理模块",
   "storage_overview_section": "磁盘占用",
   "storage_overview_total": "总计",
   "storage_overview_refresh": "重新扫描",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "无法载入这部漫画。",
   "manga_online_error_view_detail": "查看详情",
   "discovery_sources_unavailable": "全部来源都不可用",
-  "storage_shaders_delete_anime4k": "删除 Anime4K 着色器"
+  "storage_shaders_delete_anime4k": "删除 Anime4K 着色器",
+  "settings_destination_storage_summary": "数据位置与磁盘占用"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3600,11 +3600,9 @@
   "storage_entry_delete_dictionary_confirm_body": "This removes the dictionary and its imported data.",
   "storage_entry_delete_done": "Deleted",
   "storage_entry_delete_failed": "Delete failed: $reason",
-  "storage_modules_section": "Optional modules",
   "storage_modules_anime4k_title": "Anime4K shaders",
   "storage_modules_anime4k_hint": "Can be downloaded again anytime in video settings",
   "storage_modules_anime4k_delete_done": "Deleted $n shader files",
-  "storage_modules_not_installed": "Not installed",
   "storage_bundled_section": "Bundled components",
   "storage_bundled_hint": "Shipped with the installer; deleted files come back on the next update, listed for reference only.",
   "storage_dictionary_delete_incomplete": "Dictionary still present after deletion, see error log",
@@ -3713,5 +3711,6 @@
   "resource_version_show_files": "Show files",
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
-  "discovery_sources_unavailable": "All sources are unavailable"
+  "discovery_sources_unavailable": "All sources are unavailable",
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3578,7 +3578,6 @@
   "video_control_custom_action": "Shortcut $index",
   "video_control_custom_action_none": "Not assigned",
   "settings_destination_storage": "Storage",
-  "settings_destination_storage_summary": "Disk usage and reclaimable modules",
   "storage_overview_section": "Disk usage",
   "storage_overview_total": "Total",
   "storage_overview_refresh": "Rescan",
@@ -3712,5 +3711,6 @@
   "manga_online_detail_load_failed": "Could not load this manga.",
   "manga_online_error_view_detail": "View details",
   "discovery_sources_unavailable": "All sources are unavailable",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "settings_destination_storage_summary": "Data location and disk usage"
 }

--- a/fushi/lib/src/pages/implementations/storage_usage_view.dart
+++ b/fushi/lib/src/pages/implementations/storage_usage_view.dart
@@ -4,19 +4,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/src/media/video/video_shader_downloader.dart';
-import 'package:fushi/src/ocr/manga_ocr_service.dart';
 import 'package:fushi/src/storage/storage_usage_service.dart';
 import 'package:fushi/utils.dart';
 
 /// 设置 →「存储」目的地正文（经 [SettingsDestination.body] 逃生口渲染）。
 ///
-/// 三块：
+/// 两块：
 /// 1. 磁盘占用总览——[StorageUsageService.scanCategories] 逐类目渐进出结果，
-///    书籍/词典类目可展开明细并单条删除；
-/// 2. 可选模块——漫画 OCR 模型（删除/下载，接 [MangaOcrService] 既有原语）与
-///    Anime4K 着色器（只删清单内文件，恢复走视频设置既有下载入口）；
-/// 3. 随包组件——安装目录内随包携带的大件，**只展示**：更新 = 安装器整体重写
+///    **每个类目都可展开明细**：书籍/词典是 DB 已知条目（可单条删除），其余
+///    类目是类目根下的直接子项（只读，看清是哪个文件在吃盘）；着色器类目行
+///    额外挂 Anime4K 预设删除（只删清单内文件，恢复走视频设置既有下载入口）；
+/// 2. 随包组件——安装目录内随包携带的大件，**只展示**：更新 = 安装器整体重写
 ///    安装目录，删掉的必然回来，做删除按钮是假动作。
+///
+/// 漫画 OCR 模型的下载/删除**不在这里**：入口在漫画 OCR 设置区
+/// （`manga_ocr_settings_section.dart`），存储页只如实显示它占多少。
 ///
 /// 删除一律复用各域既有路径（见 [StorageUsageService] 头注释），本文件零裸
 /// `Directory.delete`。所有依赖经构造参数注入（服务/取数/删除回调），
@@ -24,7 +26,6 @@ import 'package:fushi/utils.dart';
 class StorageUsageView extends ConsumerStatefulWidget {
   const StorageUsageView({
     required this.service,
-    required this.ocrService,
     required this.booksProvider,
     required this.dictionaryNamesProvider,
     required this.deleteBook,
@@ -35,9 +36,6 @@ class StorageUsageView extends ConsumerStatefulWidget {
   });
 
   final StorageUsageService service;
-
-  /// 漫画 OCR 服务（与漫画 OCR 设置区同一单例；测试注 fake）。
-  final MangaOcrService ocrService;
 
   /// 书籍清单取数（真实现读 `epub_books` 表）。
   final Future<List<StorageBookRef>> Function() booksProvider;
@@ -84,11 +82,6 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
 
   List<BundledComponentUsage> _bundled = const <BundledComponentUsage>[];
 
-  MangaOcrModelStatus? _ocrStatus;
-  bool _ocrBusy = false;
-  double? _ocrDownloadProgress;
-  StreamSubscription<MangaOcrDownloadEvent>? _ocrSub;
-
   int _anime4kBytes = 0;
   bool _anime4kBusy = false;
 
@@ -101,7 +94,6 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
   @override
   void dispose() {
     unawaited(_scanSub?.cancel());
-    unawaited(_ocrSub?.cancel());
     super.dispose();
   }
 
@@ -111,7 +103,7 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
       _scanning = true;
       _usage.clear();
     });
-    unawaited(_loadModules());
+    unawaited(_loadExtras());
     List<StorageBookRef> books = const <StorageBookRef>[];
     List<String> dictNames = const <String>[];
     try {
@@ -140,13 +132,9 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     );
   }
 
-  Future<void> _loadModules() async {
-    try {
-      final MangaOcrModelStatus ocr = await widget.ocrService.modelStatus();
-      if (mounted) setState(() => _ocrStatus = ocr);
-    } catch (e) {
-      debugPrint('[storage] ocr status failed: $e');
-    }
+  /// 总览之外的附加信息：Anime4K 预设占用（决定着色器类目行给不给删除按钮）
+  /// 与随包组件清单。与类目扫描并行跑，慢的一方不挡另一方。
+  Future<void> _loadExtras() async {
     try {
       final int bytes = await widget.anime4kBytesProvider();
       if (mounted) setState(() => _anime4kBytes = bytes);
@@ -222,72 +210,7 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     }
   }
 
-  // ── OCR 模型模块 ────────────────────────────────────────────────────
-
-  Future<void> _ocrDownload() async {
-    if (_ocrBusy) return;
-    setState(() {
-      _ocrBusy = true;
-      _ocrDownloadProgress = null;
-    });
-    await _ocrSub?.cancel();
-    _ocrSub = widget.ocrService.downloadModels().listen(
-      (MangaOcrDownloadEvent e) {
-        if (!mounted) return;
-        setState(() {
-          _ocrDownloadProgress =
-              e.totalBytes > 0 ? e.receivedBytes / e.totalBytes : null;
-        });
-      },
-      onError: (Object e) async {
-        debugPrint('[storage] ocr download failed: $e');
-        if (!mounted) return;
-        setState(() => _ocrBusy = false);
-        await _loadModules();
-      },
-      onDone: () async {
-        if (!mounted) return;
-        setState(() => _ocrBusy = false);
-        await _loadModules();
-        // 下载完成后总览里的 OCR 类目行同步长回来（与删除路径对称，审查 L3）。
-        await _rescan();
-      },
-    );
-  }
-
-  Future<void> _ocrDelete() async {
-    if (_ocrBusy) return;
-    if (!await _confirmDelete(
-      t.storage_category_ocr_models,
-      t.manga_ocr_delete_confirm_message,
-    )) {
-      return;
-    }
-    setState(() => _ocrBusy = true);
-    try {
-      await widget.ocrService.deleteModels();
-    } catch (e) {
-      // Windows 上模型文件被占用（推理还挂着）时 delete 会抛：如实报错，
-      // 不能静默吞成未处理异步异常（审查 L2）。
-      if (mounted) {
-        FushiToast.show(
-          msg: t.storage_entry_delete_failed(reason: '$e'),
-          severity: ToastSeverity.error,
-        );
-      }
-      return;
-    } finally {
-      if (mounted) setState(() => _ocrBusy = false);
-    }
-    if (!mounted) return;
-    FushiToast.show(
-      msg: t.manga_ocr_delete_done,
-      severity: ToastSeverity.success,
-    );
-    await _loadModules();
-    // OCR 类目行也要跟着归零。
-    await _rescan();
-  }
+  // ── Anime4K 预设删除 ────────────────────────────────────────────────
 
   Future<void> _anime4kDeleteAction() async {
     if (_anime4kBusy) return;
@@ -317,7 +240,7 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
       msg: t.storage_modules_anime4k_delete_done(n: deleted.length),
       severity: ToastSeverity.success,
     );
-    await _loadModules();
+    await _loadExtras();
     await _rescan();
   }
 
@@ -371,8 +294,6 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         _buildOverviewSection(),
-        const SizedBox(height: 12),
-        _buildModulesSection(),
         if (_bundled.isNotEmpty) ...<Widget>[
           const SizedBox(height: 12),
           _buildBundledSection(),
@@ -424,6 +345,11 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     // 显示占位。
     final bool expandable = usage != null && usage.entries.isNotEmpty;
     final bool expanded = _expanded.contains(id);
+    // Anime4K 预设是唯一「删了还能一键装回来」的着色器资产，而删除原语只此一处
+    //（视频设置的画质增强只有下载入口）：挂在着色器类目行上，只删清单内文件，
+    // 用户自己导入的同目录 .glsl 不碰。
+    final bool showAnime4kDelete =
+        id == StorageCategoryId.shaders && _anime4kBytes > 0;
     return <Widget>[
       FushiListItem(
         title: Text(_categoryTitle(id)),
@@ -431,6 +357,21 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
+            if (showAnime4kDelete)
+              _anime4kBusy
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 8),
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : IconButton(
+                      tooltip: t.storage_shaders_delete_anime4k,
+                      icon: const Icon(Icons.auto_fix_off_outlined, size: 18),
+                      onPressed: _anime4kDeleteAction,
+                    ),
             Text(usage == null ? '…' : formatStorageBytes(usage.bytes)),
             if (expandable) ...<Widget>[
               const SizedBox(width: 4),
@@ -452,6 +393,11 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     StorageCategoryId id,
     StorageCategoryUsage usage,
   ) {
+    // 只有书籍/词典明细接得上既有删除原语（`deleteBook` / `deleteDictionary`）；
+    // 其余类目的明细是磁盘子项，删它就是裸 `Directory.delete`——会绕过墓碑/
+    // 引用护栏，也可能删掉主库文件，故一律只读展示。
+    final bool deletable =
+        id == StorageCategoryId.books || id == StorageCategoryId.dictionaries;
     final List<StorageEntryUsage> visible =
         usage.entries.take(kMaxVisibleEntries).toList(growable: false);
     final List<StorageEntryUsage> rest =
@@ -465,19 +411,21 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
           subtitle: Text(formatStorageBytes(entry.bytes)),
           padding: const EdgeInsetsDirectional.only(start: 32, end: 8),
           density: FushiListDensity.compact,
-          trailing: _busyEntryId == entry.id
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : IconButton(
-                  tooltip: t.dialog_delete,
-                  icon: const Icon(Icons.delete_outline, size: 18),
-                  onPressed: _busyEntryId != null
-                      ? null
-                      : () => _deleteEntry(id, entry),
-                ),
+          trailing: !deletable
+              ? null
+              : (_busyEntryId == entry.id
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : IconButton(
+                      tooltip: t.dialog_delete,
+                      icon: const Icon(Icons.delete_outline, size: 18),
+                      onPressed: _busyEntryId != null
+                          ? null
+                          : () => _deleteEntry(id, entry),
+                    )),
         ),
       if (rest.isNotEmpty)
         FushiListItem(
@@ -489,74 +437,6 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
           density: FushiListDensity.compact,
         ),
     ];
-  }
-
-  Widget _buildModulesSection() {
-    final MangaOcrModelStatus? ocr = _ocrStatus;
-    final bool ocrReady = ocr?.allReady ?? false;
-    final bool ocrPartial = !ocrReady && (ocr?.hasAnyFiles ?? false);
-    return AdaptiveSettingsSection(
-      title: t.storage_modules_section,
-      children: <Widget>[
-        // 漫画 OCR 模型：删除/下载接既有原语（与漫画 OCR 设置区同一 service）。
-        AdaptiveSettingsRow(
-          title: t.storage_category_ocr_models,
-          subtitle: ocr == null
-              ? null
-              : (ocrReady || ocrPartial
-                  ? formatStorageBytes(ocr.diskBytes)
-                  : t.storage_modules_not_installed),
-          icon: Icons.document_scanner_outlined,
-          showIcon: true,
-          trailing: _ocrBusy && _ocrDownloadProgress != null
-              ? SizedBox(
-                  width: 80,
-                  child: LinearProgressIndicator(value: _ocrDownloadProgress),
-                )
-              : (_ocrBusy
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : (ocrReady || ocrPartial
-                      ? IconButton(
-                          tooltip: t.manga_ocr_delete,
-                          icon: const Icon(Icons.delete_outline),
-                          onPressed: _ocrDelete,
-                        )
-                      : IconButton(
-                          tooltip: t.manga_ocr_download,
-                          icon: const Icon(Icons.download_outlined),
-                          onPressed: _ocrDownload,
-                        ))),
-        ),
-        // Anime4K 着色器：只删清单内文件（用户自导入的同目录着色器不碰）；
-        // 恢复走视频设置 → 画质增强的既有预设下载入口。
-        AdaptiveSettingsRow(
-          title: t.storage_modules_anime4k_title,
-          subtitle: _anime4kBytes > 0
-              ? '${formatStorageBytes(_anime4kBytes)} · '
-                  '${t.storage_modules_anime4k_hint}'
-              : t.storage_modules_not_installed,
-          icon: Icons.auto_awesome_outlined,
-          showIcon: true,
-          trailing: _anime4kBusy
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : (_anime4kBytes > 0
-                  ? IconButton(
-                      tooltip: t.dialog_delete,
-                      icon: const Icon(Icons.delete_outline),
-                      onPressed: _anime4kDeleteAction,
-                    )
-                  : null),
-        ),
-      ],
-    );
   }
 
   Widget _buildBundledSection() {

--- a/fushi/lib/src/settings/settings_schema_storage.dart
+++ b/fushi/lib/src/settings/settings_schema_storage.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
-import 'package:fushi/src/media/manga/manga_ocr_provider.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi/src/pages/implementations/storage_usage_view.dart';
 import 'package:fushi/src/pages/implementations/tag_filter_sheet.dart'
@@ -10,10 +9,17 @@ import 'package:fushi/src/pages/implementations/tag_filter_sheet.dart'
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/storage/storage_usage_service.dart';
+import 'package:fushi/src/sync/sync_settings_schema.dart'
+    show buildDataStorageLocationSection;
 import 'package:fushi/utils.dart';
 
-/// 「存储」一级设置分类：磁盘占用总览（书/词典可展开单条删除）+ 可选模块
-/// （OCR 模型 / Anime4K 着色器删除恢复）+ 随包组件展示。
+/// 「存储」一级设置分类：数据存储位置（数据根在哪）+ 磁盘占用总览（每个类目
+/// 都可展开明细，书/词典可单条删除）+ 随包组件展示。
+///
+/// 「数据存储位置」是本页唯一的 schema section（历史上挂过同步备份、后来挪到
+/// 「系统」）：它回答「数据放哪」，与下面「占了多少」是同一个问题的两半，放在
+/// 一起才成一页；item id 仍是 'sync.data_storage_location'，构建函数留在
+/// sync_settings_schema（行 widget 是该库私有 part）。
 ///
 /// 正文经 [SettingsDestination.body] 逃生口渲染 [StorageUsageView]；所有删除
 /// 都在这里接到各域既有路径（书 `ReaderFushiSource.deleteBook`、词典
@@ -24,10 +30,9 @@ SettingsDestination buildStorageDestination() {
     title: t.settings_destination_storage,
     summary: t.settings_destination_storage_summary,
     icon: Icons.sd_storage_outlined,
-    sections: const <SettingsSection>[],
+    sections: <SettingsSection>[buildDataStorageLocationSection()],
     body: (SettingsContext c) => StorageUsageView(
       service: StorageUsageService(),
-      ocrService: c.ref.read(mangaOcrServiceProvider),
       booksProvider: () async {
         final List<EpubBookRow> rows =
             await c.appModel.database.getAllEpubBooks();
@@ -97,10 +102,10 @@ SettingsDestination buildStorageDestination() {
         subtitle: t.storage_overview_total,
       ),
       SettingsBodySearchEntry(
-        id: 'storage.modules',
-        title: t.storage_modules_section,
-        subtitle: '${t.storage_category_ocr_models} · '
-            '${t.storage_modules_anime4k_title}',
+        id: 'storage.shaders',
+        title: t.storage_category_shaders,
+        subtitle: '${t.storage_modules_anime4k_title} · '
+            '${t.storage_shaders_delete_anime4k}',
       ),
       SettingsBodySearchEntry(
         id: 'storage.bundled',

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -5,8 +5,6 @@ import 'package:fushi/pages.dart';
 import 'package:fushi/src/settings/settings_actions.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
-import 'package:fushi/src/sync/sync_settings_schema.dart'
-    show buildDataStorageLocationSection;
 import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/sync/sync_http.dart';
 import 'package:fushi/src/utils/misc/crash_dump_locator.dart';
@@ -217,10 +215,6 @@ SettingsDestination buildSystemDestination() {
           ),
         ],
       ),
-      // 「数据存储位置」从同步备份大类挪来（用户拍板：数据根是设备级存储配置，
-      // 与备份无关）。构建函数在 sync_settings_schema（行 widget 是该库私有 part），
-      // item id 'sync.data_storage_location' 不变。
-      buildDataStorageLocationSection(),
       SettingsSection(
         title: t.section_update,
         // 更新分区在所有平台可见（至少能「检查→打开发布页」）；自动安装开关

--- a/fushi/lib/src/storage/storage_usage_service.dart
+++ b/fushi/lib/src/storage/storage_usage_service.dart
@@ -24,6 +24,9 @@ import 'package:fushi/src/storage/export_directory.dart'
 /// `storage_usage_service_test.dart`），support 根整体归「数据库与内部数据」，
 /// 其中 OCR 模型子目录单独拆出（它是唯一可删可恢复的 support 子项）。
 ///
+/// 每个类目都出明细：书籍/词典的条目来自 DB（有标题、接既有删除原语），其余
+/// 类目的条目就是类目根下的直接子项（`_childEntriesSync`，只读展示）。
+///
 /// 目录求和递归 stat 整棵树（词典是 GB 级），全部经 [Isolate.run] 隔离跑，
 /// 绝不在 UI isolate 同步扫。
 enum StorageCategoryId {
@@ -57,14 +60,15 @@ enum StorageCategoryId {
   /// 导出文件：`fushiExport` + `hibikiExport`。
   exports,
 
-  /// 数据库与内部数据：support 根整体减去 OCR 模型子目录。
+  /// 数据库与内部数据：support 根的直接子项减去 OCR 模型子目录（主库
+  /// `fushi.db`、本地发音库副本 `local_audio_*.db` 等都在明细里）。
   database,
 
   /// 漫画 OCR 模型：`<support>/ocr_models`（可删可恢复）。
   ocrModels,
 }
 
-/// 一个类目内的单条可展开条目（一本书 / 一部词典）。
+/// 一个类目内的单条可展开条目（一本书 / 一部词典 / 类目根下的一个子项）。
 class StorageEntryUsage {
   const StorageEntryUsage({
     required this.id,
@@ -73,10 +77,10 @@ class StorageEntryUsage {
     required this.paths,
   });
 
-  /// 域内主键（书 = bookKey，词典 = 词典名）。
+  /// 域内主键（书 = bookKey，词典 = 词典名，通用子项 = 绝对路径）。
   final String id;
 
-  /// 显示名（书名 / 词典名）。
+  /// 显示名（书名 / 词典名 / `<顶层目录>/<子项名>`）。
   final String label;
 
   /// 该条目占用字节数（多个目录求和）。
@@ -96,11 +100,13 @@ class StorageCategoryUsage {
 
   final StorageCategoryId id;
 
-  /// 类目总字节数（**目录整树**求和——可能大于 [entries] 之和：孤儿目录、
-  /// 未入库残留也如实计入，不做「只算已知条目」的假账）。
+  /// 类目总字节数。书籍/词典类目按**目录整树**求和——可能大于 [entries] 之和：
+  /// 孤儿目录、未入库残留也如实计入，不做「只算已知条目」的假账；其余类目的
+  /// 明细就是根目录的全部直接子项，两者恒相等。
   final int bytes;
 
-  /// 可展开明细（书籍/词典类目非空，其余为空）。按字节数降序。
+  /// 可展开明细，按字节数降序。书籍/词典是 DB 已知条目（带删除原语），其余
+  /// 类目是类目根下的直接子项（只读展示）。
   final List<StorageEntryUsage> entries;
 }
 
@@ -228,6 +234,37 @@ int _pathsSizeSync(final List<String> paths) {
   return total;
 }
 
+/// isolate 入口：列出多个根目录的**直接子项**并逐个求大小。
+///
+/// 这是除书籍/词典（有 DB 标题与既有删除原语，见 `_scanBooks` / `_scanDictionaries`）
+/// 之外所有类目的明细来源：类目根下每个文件/子目录一条，label 带顶层目录名前缀
+/// （`videos/Foo.mkv`、`mpv_shaders/Anime4K_Clamp.glsl`），跨根重名不会混淆。
+///
+/// 子项之和恒等于整树之和（根目录自身不占字节），所以类目总量直接由明细求和得出，
+/// 不再额外扫一遍整树。
+List<Map<String, Object>> _childEntriesSync(final List<String> roots) {
+  final List<Map<String, Object>> out = <Map<String, Object>>[];
+  for (final String root in roots) {
+    final Directory dir = Directory(root);
+    if (!dir.existsSync()) continue;
+    List<FileSystemEntity> children;
+    try {
+      children = dir.listSync(followLinks: false);
+    } on FileSystemException {
+      // 整树列举失败（并发删除/无权限）：该根跳过。
+      continue;
+    }
+    for (final FileSystemEntity child in children) {
+      out.add(<String, Object>{
+        'label': '${p.basename(root)}/${p.basename(child.path)}',
+        'path': child.path,
+        'bytes': directorySizeSync(child.path),
+      });
+    }
+  }
+  return out;
+}
+
 /// 有声书 persist 目录的纯派生（**不创建**，与
 /// `AudiobookStorage.ensurePersistDir` 同口径：`fnv1a32Hex(utf8(key))`；
 /// 该口径已固化进持久目录名，不得漂移——上游金标在 fushi_core
@@ -276,16 +313,15 @@ class StorageUsageService {
         case StorageCategoryId.database:
           yield await _scanDatabase(support);
         case StorageCategoryId.ocrModels:
-          final int bytes = await sizeOfPaths(
-              <String>[p.join(support.path, kOcrModelsSupportChild)]);
-          yield StorageCategoryUsage(id: id, bytes: bytes);
+          yield await _scanGeneric(id, <String>[
+            p.join(support.path, kOcrModelsSupportChild),
+          ]);
         default:
           final List<String> children =
               kStorageCategoryDocumentsChildren[id] ?? const <String>[];
-          final int bytes = await sizeOfPaths(<String>[
+          yield await _scanGeneric(id, <String>[
             for (final String child in children) p.join(docs.path, child),
           ]);
-          yield StorageCategoryUsage(id: id, bytes: bytes);
       }
     }
   }
@@ -369,13 +405,40 @@ class StorageUsageService {
   }
 
   Future<StorageCategoryUsage> _scanDatabase(final Directory support) async {
-    // support 根整体减去 OCR 模型子目录（后者单列一类）。
-    final String root = support.path;
-    final String ocr = p.join(root, kOcrModelsSupportChild);
-    final List<int> sizes = await _run(
-        () => <int>[directorySizeSync(root), directorySizeSync(ocr)]);
-    final int bytes = (sizes[0] - sizes[1]).clamp(0, sizes[0]);
-    return StorageCategoryUsage(id: StorageCategoryId.database, bytes: bytes);
+    // support 根的直接子项，减去 OCR 模型子目录（后者单列一类）。明细里因此
+    // 能看到主库 `fushi.db`、本地发音库副本 `local_audio_*.db` 等具体大件。
+    return _scanGeneric(
+      StorageCategoryId.database,
+      <String>[support.path],
+      excludePaths: <String>{p.join(support.path, kOcrModelsSupportChild)},
+    );
+  }
+
+  /// 通用类目扫描：类目根下每个直接子项一条明细，类目总量 = 明细求和。
+  /// [excludePaths] 里的子项既不计入明细也不计入总量（被别的类目单列时用）。
+  Future<StorageCategoryUsage> _scanGeneric(
+    final StorageCategoryId id,
+    final List<String> roots, {
+    final Set<String> excludePaths = const <String>{},
+  }) async {
+    final List<Map<String, Object>> raw =
+        await _run(() => _childEntriesSync(roots));
+    final List<StorageEntryUsage> entries = <StorageEntryUsage>[
+      for (final Map<String, Object> e in raw)
+        if (!excludePaths.contains(e['path'] as String))
+          StorageEntryUsage(
+            // 通用明细没有域内主键，用绝对路径当身份（UI 只拿它做展开/去重，
+            // 不接删除原语——通用条目一律只读展示）。
+            id: e['path'] as String,
+            label: e['label'] as String,
+            bytes: e['bytes'] as int,
+            paths: <String>[e['path'] as String],
+          ),
+    ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
+        b.bytes.compareTo(a.bytes));
+    final int bytes =
+        entries.fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes);
+    return StorageCategoryUsage(id: id, bytes: bytes, entries: entries);
   }
 
   /// 随包组件占用（桌面端安装目录内、随安装包携带；**只展示不可删**——

--- a/fushi/lib/src/sync/sync_settings_schema.dart
+++ b/fushi/lib/src/sync/sync_settings_schema.dart
@@ -408,9 +408,11 @@ SettingsDestination buildSyncBackupDestination() {
 }
 
 /// 桌面端「数据存储位置」小节（TODO-935 E2）。历史上挂在同步备份大类尾部，
-/// 2026-07-26 用户拍板挪到「系统」大类展示——数据根是设备级存储配置，与备份无关。
+/// 2026-07-26 用户拍板挪出同步备份（数据根是设备级存储配置，与备份无关），
+/// 2026-08-22「存储」大类落地后再从「系统」挪到「存储」——与磁盘占用同页：
+/// 数据放哪 + 占了多少是同一个问题的两半。
 /// 构建函数留在本库（[_DataRootWidget] 是本库私有 part），由
-/// `settings_schema_system.dart` 调用；item id 保持 'sync.data_storage_location'
+/// `settings_schema_storage.dart` 调用；item id 保持 'sync.data_storage_location'
 /// 不变（历史命名前缀，搜索/导航锚点，仅换展示分类）。移动端沙箱固定，整个
 /// section 用 isDesktopPlatform 门控隐藏；桌面选新目录后走已实现的
 /// DataRootMigrator 整目录迁移 + 迁移成功后自动重启。

--- a/fushi/test/pages/storage_usage_view_test.dart
+++ b/fushi/test/pages/storage_usage_view_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -6,56 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
-import 'package:fushi/src/ocr/manga_ocr_service.dart';
 import 'package:fushi/src/pages/implementations/storage_usage_view.dart';
 import 'package:fushi/src/storage/storage_usage_service.dart';
 import 'package:fushi/utils.dart';
-
-/// Fake OCR 服务：状态可编程，删除翻转状态。
-class _FakeOcrService implements MangaOcrService {
-  _FakeOcrService({this.ready = true});
-
-  bool ready;
-  int deleteCalls = 0;
-
-  @override
-  bool get isSupportedPlatform => true;
-
-  @override
-  Future<MangaOcrModelStatus> modelStatus() async => MangaOcrModelStatus(
-        detectorReady: ready,
-        recognizerReady: ready,
-        diskBytes: ready ? 40 * 1024 * 1024 : 0,
-        totalBytes: 40 * 1024 * 1024,
-      );
-
-  @override
-  Stream<MangaOcrDownloadEvent> downloadModels() async* {
-    ready = true;
-    yield const MangaOcrDownloadEvent(
-      fileName: 'detector.onnx',
-      receivedBytes: 20,
-      totalBytes: 20,
-      done: true,
-    );
-  }
-
-  @override
-  Future<int> deleteModels() async {
-    deleteCalls++;
-    final bool had = ready;
-    ready = false;
-    // 契约是「返回实际释放的字节数」，与 modelStatus 报的 diskBytes 对齐。
-    return had ? 40 * 1024 * 1024 : 0;
-  }
-
-  @override
-  Stream<MangaOcrVolumeEvent> ocrFolder({
-    required String imageDirPath,
-    String? volumeTitle,
-  }) =>
-      const Stream<MangaOcrVolumeEvent>.empty();
-}
 
 void main() {
   late Directory tempRoot;
@@ -101,19 +53,19 @@ void main() {
 
   StorageUsageView view({
     required StorageUsageService service,
-    required _FakeOcrService ocr,
     Future<List<StorageBookRef>> Function()? books,
     Future<String?> Function(String bookKey)? deleteBook,
+    Future<int> Function()? anime4kBytes,
+    Future<List<String>> Function()? anime4kDelete,
   }) {
     return StorageUsageView(
       service: service,
-      ocrService: ocr,
       booksProvider: books ?? () async => const <StorageBookRef>[],
       dictionaryNamesProvider: () async => const <String>[],
       deleteBook: deleteBook ?? (String _) async => null,
       deleteDictionary: (String _) async => null,
-      anime4kBytesProvider: () async => 0,
-      anime4kDelete: () async => const <String>[],
+      anime4kBytesProvider: anime4kBytes ?? () async => 0,
+      anime4kDelete: anime4kDelete ?? () async => const <String>[],
     );
   }
 
@@ -122,7 +74,6 @@ void main() {
 
     await tester.pumpWidget(wrap(view(
       service: service(),
-      ocr: _FakeOcrService(),
       books: () async => <StorageBookRef>[
         StorageBookRef(
           bookKey: 'keyA',
@@ -147,7 +98,6 @@ void main() {
 
     await tester.pumpWidget(wrap(view(
       service: service(),
-      ocr: _FakeOcrService(),
       books: () async => <StorageBookRef>[
         StorageBookRef(
           bookKey: 'keyA',
@@ -195,44 +145,83 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
 
-  testWidgets('OCR 模型行：已安装显示删除，确认后调 service.deleteModels',
-      (WidgetTester tester) async {
-    final _FakeOcrService ocr = _FakeOcrService(ready: true);
-    await tester.pumpWidget(wrap(view(service: service(), ocr: ocr)));
+  testWidgets('非书籍类目也能展开：明细列出磁盘子项，且不给删除按钮', (WidgetTester tester) async {
+    writeFile(p.join(docs.path, 'custom_fonts', 'NotoSerif.ttf'), 4096);
+
+    await tester.pumpWidget(wrap(view(service: service())));
     await tester.pumpAndSettle();
 
-    expect(find.text(t.storage_category_ocr_models), findsWidgets);
-    // 模块区在长类目列表下方、默认视口外：先滚到可见再点。
-    await tester.ensureVisible(find.byTooltip(t.manga_ocr_delete));
+    // 展开前明细不在树上。
+    expect(find.text('custom_fonts/NotoSerif.ttf'), findsNothing);
+
+    await tester.ensureVisible(find.text(t.storage_category_custom_fonts));
     await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip(t.manga_ocr_delete));
+    await tester.tap(find.text(t.storage_category_custom_fonts));
+    await tester.pumpAndSettle();
+
+    expect(find.text('custom_fonts/NotoSerif.ttf'), findsOneWidget);
+    // 通用明细接不上域内删除原语，一律只读——不得出现删除按钮。
+    expect(find.byTooltip(t.dialog_delete), findsNothing);
+  });
+
+  testWidgets('可选模块区已移除：OCR 模型只剩占用行，没有下载/删除按钮', (WidgetTester tester) async {
+    writeFile(
+        p.join(support.path, kOcrModelsSupportChild, 'manga', 'a.onnx'), 300);
+
+    await tester.pumpWidget(wrap(view(service: service())));
+    await tester.pumpAndSettle();
+
+    // 类目行还在（如实显示占用），但下载/删除入口已回归漫画 OCR 设置区。
+    expect(find.text(t.storage_category_ocr_models), findsOneWidget);
+    expect(find.byTooltip(t.manga_ocr_delete), findsNothing);
+    expect(find.byTooltip(t.manga_ocr_download), findsNothing);
+  });
+
+  testWidgets('着色器类目行挂 Anime4K 删除：确认后走注入的删除原语并重扫', (WidgetTester tester) async {
+    writeFile(p.join(docs.path, 'mpv_shaders', 'Anime4K_Clamp.glsl'), 512);
+    int deleteCalls = 0;
+
+    await tester.pumpWidget(wrap(view(
+      service: service(),
+      anime4kBytes: () async => deleteCalls == 0 ? 512 : 0,
+      anime4kDelete: () async {
+        deleteCalls++;
+        File(p.join(docs.path, 'mpv_shaders', 'Anime4K_Clamp.glsl'))
+            .deleteSync();
+        return const <String>['Anime4K_Clamp.glsl'];
+      },
+    )));
+    await tester.pumpAndSettle();
+
+    final Finder deleteButton =
+        find.byTooltip(t.storage_shaders_delete_anime4k);
+    await tester.ensureVisible(deleteButton);
+    await tester.pumpAndSettle();
+    await tester.tap(deleteButton);
     await tester.pumpAndSettle();
     await tester.tap(find.widgetWithText(FilledButton, t.dialog_delete));
-    for (int i = 0; i < 50; i++) {
-      await tester.pump(const Duration(milliseconds: 100));
-      if (ocr.deleteCalls > 0 &&
+    for (int i = 0; i < 20; i++) {
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 20)));
+      await tester.pump();
+      if (deleteCalls > 0 &&
           find.byType(CircularProgressIndicator).evaluate().isEmpty) {
         break;
       }
     }
 
-    expect(ocr.deleteCalls, 1);
-    expect(ocr.ready, isFalse);
+    expect(deleteCalls, 1);
+    // 删完预设后按钮自行消失（_anime4kBytes 归零）。
+    expect(find.byTooltip(t.storage_shaders_delete_anime4k), findsNothing);
   });
 
-  testWidgets('OCR 模型行：未安装显示下载，点击后走下载流并翻绿', (WidgetTester tester) async {
-    final _FakeOcrService ocr = _FakeOcrService(ready: false);
-    await tester.pumpWidget(wrap(view(service: service(), ocr: ocr)));
+  testWidgets('无 Anime4K 预设时着色器行不给删除按钮', (WidgetTester tester) async {
+    writeFile(p.join(docs.path, 'mpv_shaders', 'mine.glsl'), 128);
+
+    await tester.pumpWidget(wrap(view(service: service())));
     await tester.pumpAndSettle();
 
-    await tester.ensureVisible(find.byTooltip(t.manga_ocr_download));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip(t.manga_ocr_download));
-    for (int i = 0; i < 50 && !ocr.ready; i++) {
-      await tester.pump(const Duration(milliseconds: 100));
-    }
-    await tester.pump(const Duration(milliseconds: 200));
-
-    expect(ocr.ready, isTrue);
+    expect(find.text(t.storage_category_shaders), findsOneWidget);
+    expect(find.byTooltip(t.storage_shaders_delete_anime4k), findsNothing);
   });
 }

--- a/fushi/test/storage/storage_usage_service_test.dart
+++ b/fushi/test/storage/storage_usage_service_test.dart
@@ -181,6 +181,63 @@ void main() {
           300);
     });
 
+    test('通用类目：明细 = 类目根下直接子项，label 带顶层目录前缀，总量 = 明细之和', () async {
+      writeFile(p.join(docs.path, 'videos', 'a.mkv'), 700);
+      writeFile(p.join(docs.path, 'remote_videos', 'series', 'ep1.mp4'), 300);
+      writeFile(p.join(docs.path, 'mpv_shaders', 'Anime4K_Clamp.glsl'), 12);
+      writeFile(p.join(docs.path, 'custom_fonts', 'NotoSerif.ttf'), 55);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: const <StorageBookRef>[],
+        dictionaryNames: const <String>[],
+      ).toList();
+
+      final StorageCategoryUsage video = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.videoDownloads);
+      // 跨 4 个根（videos / remote_videos / anime_downloads / manual_torrents）
+      // 的直接子项合成一张明细，按字节降序。
+      expect(video.bytes, 1000);
+      expect(video.entries.map((StorageEntryUsage e) => e.label).toList(),
+          <String>['videos/a.mkv', 'remote_videos/series']);
+      expect(video.entries[0].bytes, 700);
+      expect(video.entries[1].bytes, 300);
+      // 通用条目的 id 是绝对路径（没有域内主键）。
+      expect(video.entries[0].id, p.join(docs.path, 'videos', 'a.mkv'));
+
+      final StorageCategoryUsage shaders = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.shaders);
+      expect(shaders.entries.single.label, 'mpv_shaders/Anime4K_Clamp.glsl');
+      expect(shaders.bytes, 12);
+
+      final StorageCategoryUsage fonts = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.customFonts);
+      expect(fonts.entries.single.label, 'custom_fonts/NotoSerif.ttf');
+      expect(fonts.bytes, 55);
+    });
+
+    test('database 明细列出 support 根子项，且不含被单列的 OCR 模型目录', () async {
+      writeFile(p.join(support.path, 'fushi.sqlite'), 1000);
+      writeFile(p.join(support.path, 'local_audio_1.db'), 20);
+      writeFile(
+          p.join(support.path, kOcrModelsSupportChild, 'manga', 'a.onnx'), 300);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: const <StorageBookRef>[],
+        dictionaryNames: const <String>[],
+      ).toList();
+
+      final StorageCategoryUsage db = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.database);
+      expect(db.bytes, 1020);
+      expect(db.entries.map((StorageEntryUsage e) => e.label).toList(),
+          <String>['support/fushi.sqlite', 'support/local_audio_1.db']);
+
+      final StorageCategoryUsage ocr = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.ocrModels);
+      expect(ocr.entries.single.label, 'ocr_models/manga');
+      expect(ocr.bytes, 300);
+    });
+
     test('每个类目恰好产出一次结果', () async {
       final List<StorageCategoryUsage> all = await service().scanCategories(
         books: const <StorageBookRef>[],

--- a/fushi/test/sync/sync_settings_visibility_test.dart
+++ b/fushi/test/sync/sync_settings_visibility_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/settings/settings_schema_card_creation.dart';
+import 'package:fushi/src/settings/settings_schema_storage.dart';
 import 'package:fushi/src/settings/settings_schema_system.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_settings_schema.dart';
@@ -40,7 +41,7 @@ void main() {
     test('regroups into four intent-based sections', () {
       // 互联（client 配置 / LAN 发现 / host 模式）已拆到独立的
       // buildInterconnectDestination（见下方 group），「数据存储位置」已挪到
-      // 「系统」大类展示（buildDataStorageLocationSection，见下方 group），
+      // 「存储」大类展示（buildDataStorageLocationSection，见下方 group），
       // 同步分类剩：method / content / actions / backup。
       expect(dest.sections, hasLength(4));
       expect(
@@ -284,9 +285,10 @@ void main() {
   });
 
   group('buildDataStorageLocationSection placement', () {
-    test('the data-storage section now lives in the system destination', () {
-      // 用户拍板（2026-07-26）：数据根是设备级存储配置，与备份无关，从同步备份
-      // 大类挪到「系统」展示；item id 'sync.data_storage_location' 保持不变
+    test('the data-storage section now lives in the storage destination', () {
+      // 用户拍板：数据根是设备级存储配置，与备份无关（2026-07-26 从同步备份挪到
+      // 「系统」），「存储」大类落地后再挪进「存储」（2026-08-22）——「数据放哪」
+      // 与「占了多少」同页；item id 'sync.data_storage_location' 保持不变
       // （历史命名前缀，搜索/导航锚点）。
       final SettingsSection section = buildDataStorageLocationSection();
       expect(section.visible, isNotNull,
@@ -295,13 +297,22 @@ void main() {
         section.items.map((SettingsItem i) => i.id),
         <String>['sync.data_storage_location'],
       );
+      final SettingsDestination storage = buildStorageDestination();
+      expect(
+        storage.sections
+            .expand((SettingsSection s) => s.items)
+            .where((SettingsItem i) => i.id == 'sync.data_storage_location'),
+        hasLength(1),
+        reason: '存储大类必须恰好承载一份数据存储位置行',
+      );
+      // 系统大类不得再残留一份（两处都挂 = 搜索出双份、改一处另一处不动）。
       final SettingsDestination system = buildSystemDestination();
       expect(
         system.sections
             .expand((SettingsSection s) => s.items)
             .where((SettingsItem i) => i.id == 'sync.data_storage_location'),
-        hasLength(1),
-        reason: '系统大类必须恰好承载一份数据存储位置行',
+        isEmpty,
+        reason: '数据存储位置不再挂在系统大类',
       );
     });
   });


### PR DESCRIPTION
用户三条反馈：数据存储位置从「系统」移到「存储」；视频 / 自定义字体 / 音频数据库 / 着色器等类目也要能展开；下面的「可选模块」区去掉。

## 改了什么

1. **数据存储位置搬家**：`buildDataStorageLocationSection()` 从 `settings_schema_system.dart` 挪到 `settings_schema_storage.dart` 的 sections（渲染在磁盘占用上方）。item id `sync.data_storage_location` 不变，搜索/导航锚点不动。守卫测试改咬新放置，并加断言「系统大类不再残留一份」。

2. **每个类目都能展开**：原来只有书籍/词典有明细（各自专用扫描 + DB 标题）。新增通用扫描 `_childEntriesSync`：类目根下每个直接子项一条，label 带顶层目录前缀（`videos/Foo.mkv`、`mpv_shaders/Anime4K_Clamp.glsl`、`custom_fonts/NotoSans.ttf`）。
   - 「数据库与内部数据」也随之出明细：主库 `fushi.db`、本地发音库副本 `local_audio_*.db` 各占多少一眼可见（用户说的「音频数据库」就在这里）。
   - 子项之和恒等于整树之和，所以类目总量直接由明细求和，比原来少扫一遍整树。
   - **通用明细一律只读**：接不上域内删除原语的条目不给删除按钮——裸 `Directory.delete` 会绕过墓碑/引用护栏，database 类目里更可能直接删掉主库文件。

3. **删掉「可选模块」区**：
   - OCR 模型的下载/删除本来就在漫画 OCR 设置区（`manga_ocr_settings_section.dart`），存储页只保留占用行，能力不丢。
   - Anime4K 预设删除是**只此一处**的能力（视频设置的画质增强只有下载入口），下沉到着色器类目行的删除按钮，仍走 `deleteAnime4kShaderFiles`（只删清单内文件，用户自导入的 .glsl 不碰），删完按钮自行消失。
   - 「随包组件」区保留（用户只点名了可选模块）。

4. i18n：`+storage_shaders_delete_anime4k`，`-storage_modules_section`、`-storage_modules_not_installed`，经 `i18n_sync` 落 17 语言 + `dart run slang` 重生成。

## 验证

- `flutter analyze`（含 test）：No issues found。
- `dart run tool/flutter_test_failures.dart --no-pub`：
  - 存储服务 / 存储页 / 同步设置放置 / 数据根设置 → `PASSED - 59 tests ran`
  - `test/settings` + `test/i18n` → `PASSED - 375 tests ran`
- 未做真机复测（纯设置页结构与只读扫描改动；删除路径均复用既有原语，未新增磁盘写）。

https://claude.ai/code/session_01HgVkFQJKw21YfvMmg3nzjy