### PR TITLE
fix(galgame): 隔离 XAudio2 codec trampoline

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1650 条。点号进各自文件。
+> 共 1651 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1774](bugs/BUG-1774-xaudio-codec-trampoline-collision.md) | ✅ | ✅ | XAudio2 WMA Hook 覆盖 ADPCM trampoline 导致游戏静音 |
 | [BUG-1773](bugs/BUG-1773-phrase-lookup-truncated-at-word-end.md) | ✅ | ✅ | 点英文单词查词把查询串截到词尾导致短语词条永不匹配 |
 | [BUG-1772](bugs/BUG-1772-libtorrent-2-1-drift-breaks-native-build.md) | ✅ | ✅ | vcpkg 未钉版，libtorrent 2.0→2.1 漂移打断 Windows DLL 与 Android .so 构建 |
 | [BUG-1771](bugs/BUG-1771-alist-search-parent-base-path.md) | ✅ | ✅ | AList 搜索结果路径带 base_path 前缀，目录打不开、文件下不了 |

--- a/docs/bugs/BUG-1774-xaudio-codec-trampoline-collision.md
+++ b/docs/bugs/BUG-1774-xaudio-codec-trampoline-collision.md
@@ -1,0 +1,6 @@
+## BUG-1774 · XAudio2 WMA Hook 覆盖 ADPCM trampoline 导致游戏静音
+- **报告**：2026-08-22（用户报告）
+- **真实性**：✅ 真 bug。`windows_audio_adapter.inc:1289,1392` 的 `SubmitSourceBuffer` / `FlushSourceBuffers` 在不同 codec voice 上可出现不同 vtable target，旧实现却把 trampoline 写进单个全局 original；后安装者覆盖前者，前一个 detour 随后会调用错误实现。
+- **[x] ① 已修复** — `dll_main.cpp:355` 仅为这两个多 target 方法维护各自独立的 target → trampoline 注册表；普通 `HookFn` 保持历史去重语义，避免不同 detour 被错误合并。
+- **[x] ② 已加自动化测试** — `hook_original_registry_test.cpp` 验证多 target 发布、重复发布、容量与清除；`adapter_structure_test.py` 锁定两个方法必须按当前 vtable slot 查找 original。
+- **备注**：初版修复曾把全 DLL 的 Hook 都迁进一个共享注册表，SGRE 启动后稳定触发 BEX64 `0xc0000005`；真机 A/B 证明精确 HEAD DLL 可稳定运行，而共享表版本约 9 秒崩溃。因此注册表必须按 detour 收窄，不能改变全局 Hook 编排。

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fushi
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.2.1+1222
+version: 2.2.1+1223
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(fushi_voice_hook SHARED
   "hook/dll_main.cpp"
   "hook/adapter.h"
   "hook/ffmpeg_runtime.h"
+  "hook/hook_original_registry.h"
   "hook/xaudio_resource_dispatch.h"
   "hook/bgi_arc.h"
   "hook/artemis_pfs.h"
@@ -117,6 +118,13 @@ target_compile_definitions(fushi_xaudio_source_format_test
   PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
 add_test(NAME fushi_xaudio_source_format_test
   COMMAND fushi_xaudio_source_format_test)
+
+add_executable(fushi_hook_original_registry_test
+  "tests/hook_original_registry_test.cpp"
+)
+target_include_directories(fushi_hook_original_registry_test PRIVATE "hook")
+add_test(NAME fushi_hook_original_registry_test
+  COMMAND fushi_hook_original_registry_test)
 
 add_executable(fushi_xaudio_trace_export_test
   "tests/xaudio_trace_export_test.cpp"

--- a/native/galgame_hook/hook/adapters/windows_audio_adapter.inc
+++ b/native/galgame_hook/hook/adapters/windows_audio_adapter.inc
@@ -1104,7 +1104,11 @@ HRESULT STDMETHODCALLTYPE Detour_FlushSourceBuffers(
   trace.detail0 = static_cast<uint32_t>(
       registered ? fushi_voice_hook::XAudioTraceLookupResult::kRegistered
                  : fushi_voice_hook::XAudioTraceLookupResult::kMissing);
-  const HRESULT hr = g_orig_FlushSourceBuffers(self);
+  const FlushSourceBuffers_t original =
+      OriginalHookForVtableSlot<FlushSourceBuffers_t>(
+          self, kIdxFlushSourceBuffers, g_flush_source_buffers_originals);
+  const HRESULT hr =
+      original != nullptr ? original(self) : XAUDIO2_E_INVALID_CALL;
   trace.hresult = static_cast<int32_t>(hr);
   if (SUCCEEDED(hr) && registered) {
     if (g_xaudio_formats.AdvanceQueueGeneration(source.source,
@@ -1285,7 +1289,12 @@ HRESULT STDMETHODCALLTYPE Detour_SubmitSourceBuffer(
   }
   trace.detail1 = static_cast<uint32_t>(rejection);
 
-  const HRESULT hr = g_orig_SubmitSourceBuffer(self, pBuffer, pBufferWMA);
+  const SubmitSourceBuffer_t original =
+      OriginalHookForVtableSlot<SubmitSourceBuffer_t>(
+          self, kIdxSubmitSourceBuffer, g_submit_source_buffer_originals);
+  const HRESULT hr = original != nullptr
+                         ? original(self, pBuffer, pBufferWMA)
+                         : XAUDIO2_E_INVALID_CALL;
   trace.hresult = static_cast<int32_t>(hr);
   if (FAILED(hr)) {
     if (staged != nullptr) ReleaseXAudioCaptureJob(staged);
@@ -1383,18 +1392,20 @@ HRESULT STDMETHODCALLTYPE Detour_CreateSourceVoice(
       IncrementXAudioCounter(&g_xaudio_capture_counters.unsupported_format);
       SetXAudioDiagnostic(fushi_voice_hook::kXAudioDiagUnsupportedFormat);
     }
-    HookFn(VtableSlot(*ppSourceVoice, kIdxSubmitSourceBuffer),
-           reinterpret_cast<void*>(&Detour_SubmitSourceBuffer),
-           reinterpret_cast<void**>(&g_orig_SubmitSourceBuffer));
+    HookFnWithOriginalRegistry(
+        VtableSlot(*ppSourceVoice, kIdxSubmitSourceBuffer),
+        reinterpret_cast<void*>(&Detour_SubmitSourceBuffer),
+        &g_submit_source_buffer_originals);
     HookFn(VtableSlot(*ppSourceVoice, kIdxSourceVoiceStart),
            reinterpret_cast<void*>(&Detour_SourceVoiceStart),
            reinterpret_cast<void**>(&g_orig_SourceVoiceStart));
     HookFn(VtableSlot(*ppSourceVoice, kIdxSourceVoiceStop),
            reinterpret_cast<void*>(&Detour_SourceVoiceStop),
            reinterpret_cast<void**>(&g_orig_SourceVoiceStop));
-    HookFn(VtableSlot(*ppSourceVoice, kIdxFlushSourceBuffers),
-           reinterpret_cast<void*>(&Detour_FlushSourceBuffers),
-           reinterpret_cast<void**>(&g_orig_FlushSourceBuffers));
+    HookFnWithOriginalRegistry(
+        VtableSlot(*ppSourceVoice, kIdxFlushSourceBuffers),
+        reinterpret_cast<void*>(&Detour_FlushSourceBuffers),
+        &g_flush_source_buffers_originals);
     HookFn(VtableSlot(*ppSourceVoice, kIdxDestroyVoice),
            reinterpret_cast<void*>(&Detour_DestroyVoice),
            reinterpret_cast<void**>(&g_orig_DestroyVoice));

--- a/native/galgame_hook/hook/dll_main.cpp
+++ b/native/galgame_hook/hook/dll_main.cpp
@@ -47,6 +47,7 @@
 #include "catsystem2_int.h"
 #include "malie_lib.h"
 #include "ffmpeg_runtime.h"
+#include "hook_original_registry.h"
 #include "siglus_ovk.h"
 #include "siglus_text.h"
 #include "text_thread_identity.h"
@@ -151,14 +152,17 @@ uint8_t* g_clip_base = nullptr;
 uint8_t* g_lb_ring_base = nullptr;
 uint8_t* g_lb_marker_base = nullptr;
 
-// MinHook 去重集：同一 SubmitSourceBuffer/CreateSourceVoice 实现常被多个实例共享同一 vtable，
-// 对同一函数地址只 MH_CreateHook 一次（重复 create 会报 MH_ERROR_ALREADY_CREATED）。
+// MinHook 去重集：普通 hook 仍保持历史语义。只有确实会因 codec 出现多个 vtable target
+// 的 XAudio2 方法使用下面两个独立 trampoline 注册表；不能把全 DLL 的不同 detour 混进
+// 一个仅按 target 索引的表，否则共享实现地址会把某个 detour 绑定到别的 trampoline。
 CRITICAL_SECTION g_cs;
 bool g_cs_ready = false;
 CRITICAL_SECTION g_text_cs;
 bool g_text_cs_ready = false;
 void* g_hooked_fns[64] = {nullptr};
 int g_hooked_count = 0;
+fushi_voice_hook::HookOriginalRegistry<16> g_submit_source_buffer_originals;
+fushi_voice_hook::HookOriginalRegistry<16> g_flush_source_buffers_originals;
 
 // 原始语音流落盘的共用出口（KiriKiri 与 Siglus 都写同一目录，供 Dart 按 tick 配对）。
 std::wstring VoiceBaseName(const wchar_t* storagename) {
@@ -246,10 +250,8 @@ typedef HRESULT(STDMETHODCALLTYPE* CommitChanges_t)(IXAudio2* self,
 XAudio2Create_t g_orig_XAudio2Create9 = nullptr;
 XAudio2Create_t g_orig_XAudio2Create8 = nullptr;
 CreateSourceVoice_t g_orig_CreateSourceVoice = nullptr;
-SubmitSourceBuffer_t g_orig_SubmitSourceBuffer = nullptr;
 SourceVoiceStartStop_t g_orig_SourceVoiceStart = nullptr;
 SourceVoiceStartStop_t g_orig_SourceVoiceStop = nullptr;
-FlushSourceBuffers_t g_orig_FlushSourceBuffers = nullptr;
 DestroyVoice_t g_orig_DestroyVoice = nullptr;
 CommitChanges_t g_orig_CommitChanges = nullptr;
 
@@ -351,6 +353,43 @@ bool HookFn(void* target, void* detour, void** original) {
   }
   LeaveCriticalSection(&g_cs);
   return ok;
+}
+
+// 多 codec XAudio2 方法专用：一个 detour 可以对应多个 target，每个 target 必须保留自己的
+// trampoline。注册表按 detour 分开，避免普通 HookFn 的跨适配器 target 去重语义被改写。
+template <size_t Capacity>
+bool HookFnWithOriginalRegistry(
+    void* target, void* detour,
+    fushi_voice_hook::HookOriginalRegistry<Capacity>* originals) {
+  if (target == nullptr || originals == nullptr || !g_cs_ready) return false;
+  bool ok = false;
+  EnterCriticalSection(&g_cs);
+  void* trampoline = originals->Lookup(target);
+  if (trampoline != nullptr) {
+    ok = true;
+  } else {
+    const MH_STATUS created = MH_CreateHook(target, detour, &trampoline);
+    if (created == MH_OK && originals->Publish(target, trampoline)) {
+      const MH_STATUS enabled = MH_EnableHook(target);
+      if (enabled == MH_OK || enabled == MH_ERROR_ENABLED) {
+        ok = true;
+      } else {
+        originals->Erase(target, trampoline);
+        MH_RemoveHook(target);
+      }
+    } else if (created == MH_OK) {
+      MH_RemoveHook(target);
+    }
+  }
+  LeaveCriticalSection(&g_cs);
+  return ok;
+}
+
+template <typename Function, size_t Capacity>
+Function OriginalHookForVtableSlot(
+    void* com_obj, size_t idx,
+    const fushi_voice_hook::HookOriginalRegistry<Capacity>& originals) {
+  return reinterpret_cast<Function>(originals.Lookup(VtableSlot(com_obj, idx)));
 }
 
 // 首次拿到可发布的 PCM 格式：block_align 最后写，作为跨进程「格式就绪」完成标记。

--- a/native/galgame_hook/hook/hook_original_registry.h
+++ b/native/galgame_hook/hook/hook_original_registry.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+
+namespace fushi_voice_hook {
+
+// MinHook detours that can be reached through more than one COM vtable target
+// must call the trampoline that belongs to the current target.  Publication is
+// serialized by HookFnWithOriginalRegistry; Lookup stays lock-free for
+// real-time audio callbacks.
+template <size_t Capacity>
+class HookOriginalRegistry {
+ public:
+  bool Publish(void* target, void* original) {
+    if (target == nullptr || original == nullptr) return false;
+    for (auto& entry : entries_) {
+      if (entry.target.load(std::memory_order_acquire) == target) {
+        return entry.original.load(std::memory_order_acquire) == original;
+      }
+    }
+    for (auto& entry : entries_) {
+      if (entry.target.load(std::memory_order_acquire) != nullptr) continue;
+      entry.original.store(original, std::memory_order_relaxed);
+      entry.target.store(target, std::memory_order_release);
+      return true;
+    }
+    return false;
+  }
+
+  void* Lookup(void* target) const {
+    if (target == nullptr) return nullptr;
+    for (const auto& entry : entries_) {
+      if (entry.target.load(std::memory_order_acquire) == target) {
+        return entry.original.load(std::memory_order_acquire);
+      }
+    }
+    return nullptr;
+  }
+
+  bool Erase(void* target, void* original) {
+    for (auto& entry : entries_) {
+      if (entry.target.load(std::memory_order_acquire) != target) continue;
+      if (entry.original.load(std::memory_order_acquire) != original) {
+        return false;
+      }
+      entry.target.store(nullptr, std::memory_order_release);
+      entry.original.store(nullptr, std::memory_order_relaxed);
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  struct Entry {
+    std::atomic<void*> target{nullptr};
+    std::atomic<void*> original{nullptr};
+  };
+
+  std::array<Entry, Capacity> entries_{};
+};
+
+}  // namespace fushi_voice_hook

--- a/native/galgame_hook/tests/adapter_structure_test.py
+++ b/native/galgame_hook/tests/adapter_structure_test.py
@@ -139,11 +139,20 @@ class AdapterStructureTest(unittest.TestCase):
         submit = submit.split("Detour_CreateSourceVoice", 1)[0]
         self.assertLess(
             submit.index("PrepareXAudioCaptureJob("),
-            submit.index("g_orig_SubmitSourceBuffer("),
+            submit.index("OriginalHookForVtableSlot<SubmitSourceBuffer_t>"),
         )
         self.assertLess(
-            submit.index("g_orig_SubmitSourceBuffer("),
+            submit.index("OriginalHookForVtableSlot<SubmitSourceBuffer_t>"),
             submit.index("PublishXAudioCaptureJob("),
+        )
+        self.assertNotIn("g_orig_SubmitSourceBuffer", main)
+        self.assertNotIn("g_orig_FlushSourceBuffers", main)
+        self.assertIn("g_submit_source_buffer_originals", main)
+        self.assertIn("g_flush_source_buffers_originals", main)
+        self.assertIn("originals.Lookup(VtableSlot(com_obj, idx))", main)
+        self.assertLess(
+            main.index("originals->Publish(target, trampoline)"),
+            main.index("MH_EnableHook(target)"),
         )
         failed = submit.split("if (FAILED(hr))", 1)[1]
         failed = failed.split("return hr;", 1)[0]

--- a/native/galgame_hook/tests/hook_original_registry_test.cpp
+++ b/native/galgame_hook/tests/hook_original_registry_test.cpp
@@ -1,0 +1,49 @@
+#include <cstdint>
+#include <cstdio>
+
+#include "hook_original_registry.h"
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool condition, const char* message) {
+  if (condition) return;
+  std::fprintf(stderr, "FAIL: %s\n", message);
+  ++g_failures;
+}
+
+void* Address(uintptr_t value) { return reinterpret_cast<void*>(value); }
+
+}  // namespace
+
+int main() {
+  fushi_voice_hook::HookOriginalRegistry<2> registry;
+  void* const wave_target = Address(0x1000);
+  void* const wave_original = Address(0x2000);
+  void* const wma_target = Address(0x3000);
+  void* const wma_original = Address(0x4000);
+
+  Check(registry.Publish(wave_target, wave_original),
+        "wave target must publish");
+  Check(registry.Publish(wma_target, wma_original),
+        "WMA target must publish independently");
+  Check(registry.Lookup(wave_target) == wave_original,
+        "wave target must keep its own trampoline after WMA publication");
+  Check(registry.Lookup(wma_target) == wma_original,
+        "WMA target must resolve its own trampoline");
+  Check(registry.Lookup(Address(0x5000)) == nullptr,
+        "unknown target must not fall back to the latest trampoline");
+  Check(!registry.Publish(wave_target, wma_original),
+        "a target must not be rebound to a different trampoline");
+  Check(!registry.Publish(Address(0x5000), Address(0x6000)),
+        "full registry must reject an untracked hook");
+  Check(!registry.Erase(wave_target, wma_original),
+        "rollback must require the matching trampoline");
+  Check(registry.Erase(wave_target, wave_original),
+        "matching hook publication must be removable before enable");
+  Check(registry.Lookup(wave_target) == nullptr,
+        "erased target must not resolve");
+
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## 概要

- 为 XAudio2 `SubmitSourceBuffer` / `FlushSourceBuffers` 按 codec vtable target 保存各自 trampoline，避免 WMA/ADPCM voice 互相覆盖 original。
- 保留普通 `HookFn` 的历史去重语义；撤销会把不同 detour 混入单一共享表、导致 SGRE 启动后 BEX64 `0xc0000005` 的初版实现。
- 登记 BUG-1774、补充 registry/结构守卫，并将 Windows 运行行为变更的 build number 升至 `2.2.1+1223`。

## 运行时证据

- 原始 SGRE x64 启动路径：问题版稳定约 9 秒崩溃，Windows WER 为 BEX64 / `0xc0000005`。
- 精确 HEAD 基线 DLL 在相同 injector/命令下运行超过 30 秒；最终隔离注册表版本同样运行超过 30 秒且无新增崩溃事件。
- Debug Fushi 实际暂存并加载的 Hook DLL SHA-256：`1AE847DC2B493C4B8FABD6F72CDF6FC672578840B9BCB6737C683EA3A2AC0A0E`。
- Fushi 启动真实游戏后进程持续存活，文本线程重新出现 `UserHook1`，并观测到 3 行、其中 1 行带音频；用户已确认验证通过。

## 构建与检查

- `cmake --build native/galgame_hook/build/x64 --config Release --target fushi_voice_hook --parallel`：成功。
- `native/galgame_hook/tools/build_distribution.ps1`（未传 `-RunTests`）：x64/x86 helper 归档成功。
- `flutter build windows --debug --no-pub`：成功。
- `dart run tool/bug.dart check --strict`：退出码 0，BUG-1774 唯一、索引同步。
- `git diff --check` / `git diff --cached --check`：通过。

按用户要求，本次未执行 CTest、Dart/Flutter 单元测试或全量测试；由 PR CI 运行正式测试门。