### PR TITLE
fix(download): 入队持久化候选磁链 + TV 整理无集号文件进 Extras (BUG-1784, BUG-1785)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1654 条。点号进各自文件。
+> 共 1656 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1785](bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md) | ✅ | ✅ | TV 整理被无集号特典文件整批卡死 |
+| [BUG-1784](bugs/BUG-1784-download-nyaa-retry-loses-magnet.md) | ✅ | ✅ | 下载重试丢失已选 magnet 致 nyaa notFound |
 | [BUG-1777](bugs/BUG-1777-emphatic-full-collapse-phantom-match.md) | ✅ | ✅ | 查词促音丢失：强调折叠full模式常开产生吞字幻影匹配压过原形 |
 | [BUG-1776](bugs/BUG-1776-subtitle-list-adjacent-chain-dup.md) | ✅ | ✅ | 字幕列表不折叠同文本时间相接的卡拉OK交替事件 |
 | [BUG-1775](bugs/BUG-1775-ass-clip-cue-frame-anchor.md) | ✅ | ✅ | 带clip的ASS事件按容器基线定位与帧空间裁剪几何脱节 |

--- a/docs/bugs/BUG-1784-download-nyaa-retry-loses-magnet.md
+++ b/docs/bugs/BUG-1784-download-nyaa-retry-loses-magnet.md
@@ -1,0 +1,6 @@
+## BUG-1784 · 下载重试丢失已选 magnet 致 nyaa notFound
+- **报告**：2026-08-23（用户：任务出错 `ExternalProviderFailure(provider=nyaa:nyaa.si, operation=resolve, kind=notFound): selected resource is no longer available`，点重试仍失败）
+- **真实性**：✅ 真 bug。根因：搜索入队路径不持久化候选磁链——nyaa 候选选中时 magnet 已在内存（`fushi/lib/src/media/torrent/nyaa_resource_provider.dart` 的 `resolve` 直接返回 `torrent.magnet`），但 `enqueue()`（`fushi/lib/src/media/video/download/video_download_pipeline_service.dart`）不写 `magnetUri` 列（全仓唯一写入点是 `video_download_legacy_importer.dart` 与 `enqueueManual`）。任务在 enqueue 阶段重启/重试时 `_resolvePayload` 掉进 `resolveSelection`，拿完整发布名（`[Airota&VCB-Studio] Gekijouban … [MOVIE]`）回 nyaa 分词重搜，搜不中即在 `video_resource_registry.dart` 的 `resolveSelection` 末尾抛 notFound——资源还在，钥匙被自己扔了；重试走同一条重搜路径，必然复现。
+- **[x] ① 已修复** — `VideoResourceCandidate` 增持久 `magnetUri` 字段（nyaa/apibay/knaben 直传构造磁链，torznab 仅在 `magnet:` 前缀且 hash 与搜索结果一致时传）；`enqueue()` 随任务落 `magnetUri` 列；`_resolvePayload` 重搜成功解析出磁链时写回任务行，重搜失败时对公共索引器任务（nyaa/apibay/knaben）用任务行里的 info hash + 各家固定 tracker 集离线重建磁链（存量任务行的兜底），私有 Torznab 保持原失败语义。提交：见本 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/video_download_pipeline_service_test.dart`：入队持久化候选磁链断言 + 存量 nyaa 任务行（无 magnet、重搜空结果）经离线重建成功进入 download 阶段。
+- **备注**：新入队任务从此不再依赖索引器可用性物化 payload；存量失败任务点「重试」即走重建路径恢复。

--- a/docs/bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md
+++ b/docs/bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md
@@ -1,0 +1,6 @@
+## BUG-1785 · TV 整理被无集号特典文件整批卡死
+- **报告**：2026-08-23（用户：`unable to determine episode number: [VCB-Studio] Hibike! Euphonium 2 [Ma10p_1080p]\Previews\[VCB-Studio] Hibike! Euphonium 2 [WEB Preview02][Ma10p_1080p][x265_flac].mkv`，种子 100% 完成后卡在「整理」任务出错）
+- **真实性**：✅ 真 bug。根因：`fushi/lib/src/media/video/download/video_download_organizer.dart` 的 `plan()` 中 episodic 分支对**每一个**视频文件硬解析集号，解析不出直接 `throw FormatException`，整批整理失败；movie 分支却有 Extras 兜底（非正片全进 `Extras/`）。VCB-Studio 类 BDRip 标配 `Previews/`、`SPs/`、`Menus/` 目录，预告/特典/菜单天生无集号（`[WEB Preview02]`、`[NCOP]` 均不匹配纯数字集数块），一个特典文件即拖死全部正片入库。
+- **[x] ① 已修复** — episodic 与 movie 共用同一条 Extras 规则：认得出集号的进 `Season NN/`，其余镜像种子内目录结构（剥共享发布根目录）进 `Extras/`——路径天然唯一，不同子目录同名特典不互顶；下游 `kind: 'extra'` 是既有概念，直接兼容。一集都认不出仍显式失败（kind 误标不静默入库）。同时把 `p.basename` 换成平台无关切段（内置引擎在 Windows 报 `\` 分隔路径，Linux 上 `p.basename` 不认）。提交：见本 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/video_download_organizer_test.dart`：VCB 布局（正片 + Previews/SPs 特典 + 反斜杠路径）出计划不抛错、特典镜像进 Extras；全无集号仍失败的既有用例保留。
+- **备注**：与 BUG-1784 同一条用户报告链（同一批響け！ユーフォニアム下载任务）。

--- a/fushi/lib/src/media/torrent/nyaa_resource_provider.dart
+++ b/fushi/lib/src/media/torrent/nyaa_resource_provider.dart
@@ -166,6 +166,7 @@ class _NyaaResourceCandidate extends VideoResourceCandidate {
           releaseGroup: torrent.releaseGroup,
           trusted: torrent.trusted,
           detailsUrl: torrent.pageUrl,
+          magnetUri: torrent.magnet,
         );
 
   final NyaaTorrent torrent;

--- a/fushi/lib/src/media/torrent/public_video_index_provider.dart
+++ b/fushi/lib/src/media/torrent/public_video_index_provider.dart
@@ -42,6 +42,7 @@ class PublicVideoIndexCandidate extends VideoResourceCandidate {
           resolution: torrent.resolution,
           releaseGroup: torrent.releaseGroup,
           detailsUrl: torrent.detailsUrl,
+          magnetUri: torrent.magnet,
         );
 
   final PublicVideoIndexTorrent torrent;

--- a/fushi/lib/src/media/torrent/torznab_client.dart
+++ b/fushi/lib/src/media/torrent/torznab_client.dart
@@ -892,10 +892,28 @@ class _TorznabResourceCandidate extends VideoResourceCandidate {
           publishedAt: item.publishedAt,
           category: item.category,
           detailsUrl: item.detailsUrl,
+          magnetUri: _persistableMagnet(item),
         );
 
   final TorznabIndexerConfig config;
   final TorznabSearchItem item;
+
+  /// 可随任务落库的磁链：必须 `magnet:` 前缀且（两边都有 hash 时）与搜索结果
+  /// 的 info hash 一致——与 `resolve` 的 integrity 检查同判据，提前到构造期，
+  /// 持久化路径就不会绕过它。
+  static String? _persistableMagnet(TorznabSearchItem item) {
+    final String? magnet = item.magnetUri;
+    if (magnet == null || !magnet.toLowerCase().startsWith('magnet:')) {
+      return null;
+    }
+    final String? parsedHash = parseMagnetInfoHash(magnet);
+    if (parsedHash != null &&
+        item.infoHash != null &&
+        parsedHash != item.infoHash) {
+      return null;
+    }
+    return magnet;
+  }
 }
 
 class _TorznabSearchWindow {

--- a/fushi/lib/src/media/torrent/video_resource_provider.dart
+++ b/fushi/lib/src/media/torrent/video_resource_provider.dart
@@ -46,6 +46,7 @@ abstract class VideoResourceCandidate {
     this.releaseGroup,
     this.trusted = false,
     this.detailsUrl,
+    this.magnetUri,
   });
 
   final String providerId;
@@ -64,6 +65,12 @@ abstract class VideoResourceCandidate {
   final String? releaseGroup;
   final bool trusted;
   final String? detailsUrl;
+
+  /// 选择时刻就已在手的持久磁力链接（`magnet:` 前缀），入队时随任务落库
+  /// （BUG-1784）：重启/重试解析 payload 不再依赖回索引器重搜——发布名分词
+  /// 搜不回或条目被下架都会让「资源还在、钥匙丢了」变成 notFound。只有
+  /// 临时 URL（Torznab .torrent 下载链）的 provider 留 null，走重搜兜底。
+  final String? magnetUri;
 
   /// Cross-indexer dedupe uses the info hash; provider-local identity is a
   /// safe fallback when an indexer does not expose one.

--- a/fushi/lib/src/media/video/download/video_download_organizer.dart
+++ b/fushi/lib/src/media/video/download/video_download_organizer.dart
@@ -107,45 +107,46 @@ class VideoDownloadOrganizer {
                       b.size.compareTo(a.size)))
                 .first
             : null;
+    final String? sharedRoot = _sharedRootSegment(videoFiles);
     final Set<String> targetKeys = <String>{};
     final List<VideoOrganizationFilePlan> planned =
         <VideoOrganizationFilePlan>[];
+    var recognizedEpisodes = 0;
     for (final TorrentFileEntry file in videoFiles) {
       final String extension = p.extension(file.name).toLowerCase();
       late final String relative;
       int? seasonNumber;
       int? episodeNumber;
-      if (request.kind == VideoOrganizationKind.movie) {
-        if (identical(file, mainMovie)) {
-          relative = _portableJoin(<String>[
-            displayRoot,
-            '$displayRoot$extension',
-          ]);
-        } else {
-          final String extraName = _safeSegment(
-            p.basenameWithoutExtension(file.name),
-          );
-          relative = _portableJoin(<String>[
-            displayRoot,
-            'Extras',
-            '$extraName$extension',
-          ]);
-        }
-      } else {
-        final VideoNameInfo parsed = parseVideoFilename(p.basename(file.name));
+      // 剧集与电影共用同一条 Extras 规则：认得出集号的进 Season 目录，其余
+      // 一律镜像进 Extras（预告/特典/菜单等，BUG-1785），下游 `kind: 'extra'`
+      // 已是既有概念。电影额外把最大文件抬成正片。
+      if (request.kind == VideoOrganizationKind.episodic) {
+        final VideoNameInfo parsed =
+            parseVideoFilename(_segments(file.name).last);
         episodeNumber = parsed.episode;
-        if (episodeNumber == null) {
-          throw FormatException(
-            'unable to determine episode number: ${file.name}',
-          );
+        if (episodeNumber != null) {
+          seasonNumber = parsed.season ?? request.defaultSeasonNumber;
         }
-        seasonNumber = parsed.season ?? request.defaultSeasonNumber;
+      }
+      if (episodeNumber != null) {
+        recognizedEpisodes += 1;
         final String season = seasonNumber.toString().padLeft(2, '0');
         final String episode = episodeNumber.toString().padLeft(2, '0');
         relative = _portableJoin(<String>[
           displayRoot,
           'Season $season',
           '$displayRoot - S${season}E$episode$extension',
+        ]);
+      } else if (identical(file, mainMovie)) {
+        relative = _portableJoin(<String>[
+          displayRoot,
+          '$displayRoot$extension',
+        ]);
+      } else {
+        relative = _portableJoin(<String>[
+          displayRoot,
+          'Extras',
+          ..._extraSegments(file.name, sharedRoot: sharedRoot),
         ]);
       }
       final String targetKey =
@@ -165,6 +166,14 @@ class VideoDownloadOrganizer {
         seasonNumber: seasonNumber,
         episodeNumber: episodeNumber,
       ));
+    }
+    // 一集都认不出说明种子与「剧集」判定不符（比如误标 kind），全 Extras 的
+    // 静默入库只会把问题藏起来，仍然显式失败。
+    if (request.kind == VideoOrganizationKind.episodic &&
+        recognizedEpisodes == 0) {
+      throw FormatException(
+        'unable to determine episode number: ${videoFiles.first.name}',
+      );
     }
     return VideoOrganizationPlan(remoteSourceRoot: remoteRoot, files: planned);
   }
@@ -257,4 +266,42 @@ class VideoDownloadOrganizer {
 
   static String _normalizeRelative(String value) =>
       value.replaceAll('\\', '/').replaceFirst(RegExp(r'^/+'), '');
+
+  /// 种子内相对路径切段（`/` 与 `\` 都认：qBittorrent 返回 `/`，内置引擎在
+  /// Windows 上返回 `\`）。
+  static List<String> _segments(String name) => name
+      .split(RegExp(r'[\\/]+'))
+      .where((String s) => s.trim().isNotEmpty)
+      .toList(growable: false);
+
+  /// 单根种子的发布目录名（所有视频文件共享的第一段）；平铺种子返回 null。
+  /// Extras 镜像时剥掉它，免得多出一层 `[Group] Title [1080p]` 噪音目录。
+  static String? _sharedRootSegment(List<TorrentFileEntry> files) {
+    String? root;
+    for (final TorrentFileEntry file in files) {
+      final List<String> segments = _segments(file.name);
+      if (segments.length < 2) return null;
+      if (root == null) {
+        root = segments.first;
+      } else if (segments.first != root) {
+        return null;
+      }
+    }
+    return root;
+  }
+
+  /// Extras 目标段：镜像种子内目录结构（剥共享根），路径天然唯一，不同子目录
+  /// 里的同名特典不会互相顶掉。每段过 [_safeSegment]，末段扩展名统一小写。
+  static List<String> _extraSegments(String name, {String? sharedRoot}) {
+    final List<String> segments = _segments(name);
+    final List<String> inner = sharedRoot != null && segments.length > 1
+        ? segments.sublist(1)
+        : segments;
+    final String extension = p.extension(inner.last).toLowerCase();
+    final String stem = _safeSegment(p.basenameWithoutExtension(inner.last));
+    return <String>[
+      ...inner.sublist(0, inner.length - 1).map(_safeSegment),
+      '$stem$extension',
+    ];
+  }
 }

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -18,6 +18,11 @@ import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/metadata/credential_redaction.dart';
 import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/magnet_utils.dart';
+import 'package:fushi/src/media/torrent/nyaa_client.dart' show kNyaaTrackers;
+import 'package:fushi/src/media/torrent/public_video_index_client.dart'
+    show kPublicVideoIndexTrackers;
+import 'package:fushi/src/media/torrent/public_video_index_provider.dart'
+    show kApibayResourceProviderId, kKnabenResourceProviderId;
 import 'package:fushi/src/media/torrent/torrent_add_coordinator.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
 import 'package:fushi/src/media/torrent/torrent_metainfo.dart';
@@ -649,6 +654,10 @@ class VideoDownloadPipelineService {
         selectedResourceId: Value<String>(request.resource.remoteId),
         resourceTitle: Value<String?>(request.resource.title),
         torrentHash: Value<String?>(request.resource.infoHash?.toLowerCase()),
+        // 候选自带的持久磁链随任务落库（BUG-1784）：重启/重试直接用它物化
+        // payload，不再依赖回索引器重搜发布名——搜不回条目会把还活着的资源
+        // 误报成 notFound。
+        magnetUri: Value<String?>(_persistableMagnetOf(request.resource)),
         metadataProvider: Value<String?>(request.media.providerId),
         externalId: Value<String?>(request.media.mediaId),
         mediaKind: Value<String>(request.media.mediaKind.name),
@@ -1440,14 +1449,12 @@ class VideoDownloadPipelineService {
     );
   }
 
-  Future<TorrentAddPayload> _resolvePayload(VideoDownloadJobRow job) {
+  Future<TorrentAddPayload> _resolvePayload(VideoDownloadJobRow job) async {
     final String? magnet = job.magnetUri;
     if (magnet != null && magnet.isNotEmpty) {
-      return Future<TorrentAddPayload>.value(
-        TorrentMagnetPayload(
-          magnetUri: magnet,
-          torrentId: parseMagnetInfoHash(magnet) ?? job.torrentHash,
-        ),
+      return TorrentMagnetPayload(
+        magnetUri: magnet,
+        torrentId: parseMagnetInfoHash(magnet) ?? job.torrentHash,
       );
     }
     // 手动 .torrent 任务：payload 从入队时落盘的元数据文件重新物化（带
@@ -1455,18 +1462,80 @@ class VideoDownloadPipelineService {
     if (job.resourceProvider == kManualVideoDownloadResourceProvider) {
       return _resolveManualMetainfoPayload(job);
     }
-    return resourceRegistry.resolveSelection(
-      selection: VideoResourceSelection(
-        providerId: job.resourceProvider,
-        remoteId: job.selectedResourceId,
-        title: job.resourceTitle ?? job.title,
-      ),
-      request: VideoResourceSearchRequest(
-        media: _mediaReference(job),
-        query: job.resourceTitle ?? job.title,
-        season: job.season,
-      ),
+    final TorrentAddPayload payload;
+    try {
+      payload = await resourceRegistry.resolveSelection(
+        selection: VideoResourceSelection(
+          providerId: job.resourceProvider,
+          remoteId: job.selectedResourceId,
+          title: job.resourceTitle ?? job.title,
+        ),
+        request: VideoResourceSearchRequest(
+          media: _mediaReference(job),
+          query: job.resourceTitle ?? job.title,
+          season: job.season,
+        ),
+      );
+    } on Object {
+      // 重搜找不回（条目下架/发布名分词搜不中/索引器故障）不代表资源没了：
+      // 公共索引器（nyaa/apibay/knaben）的磁链本就是 info hash + 固定
+      // tracker 现场拼出来的，任务行里的 hash 就够重建（BUG-1784 存量行）。
+      final TorrentMagnetPayload? recovered = _recoverPublicMagnetPayload(job);
+      if (recovered == null) rethrow;
+      await _persistResolvedMagnet(job, recovered.magnetUri);
+      return recovered;
+    }
+    // 重搜成功解析出的磁链写回任务行：下次重启/重试不再吃索引器可用性。
+    if (payload is TorrentMagnetPayload) {
+      await _persistResolvedMagnet(job, payload.magnetUri);
+    }
+    return payload;
+  }
+
+  /// 公共索引器任务的离线磁链重建：`magnet:?xt=urn:btih:<hash>` + 该索引器
+  /// 的固定 tracker 集。私有 Torznab（DHT 关闭、需 .torrent 凭据）返回 null，
+  /// 保持原失败语义。
+  TorrentMagnetPayload? _recoverPublicMagnetPayload(VideoDownloadJobRow job) {
+    final String provider = job.resourceProvider;
+    bool isProvider(String id) =>
+        provider == id || provider.startsWith('$id:');
+    final List<String>? trackers = isProvider('nyaa')
+        ? kNyaaTrackers
+        : isProvider(kApibayResourceProviderId) ||
+                isProvider(kKnabenResourceProviderId)
+            ? kPublicVideoIndexTrackers
+            : null;
+    if (trackers == null) return null;
+    final String hash =
+        (job.torrentHash ?? job.selectedResourceId).toLowerCase();
+    if (!RegExp(r'^[0-9a-f]{40}$').hasMatch(hash)) return null;
+    final StringBuffer magnet = StringBuffer('magnet:?xt=urn:btih:$hash');
+    final String name = (job.resourceTitle ?? job.title).trim();
+    if (name.isNotEmpty) {
+      magnet.write('&dn=${Uri.encodeQueryComponent(name)}');
+    }
+    for (final String tracker in trackers) {
+      magnet.write('&tr=${Uri.encodeQueryComponent(tracker)}');
+    }
+    return TorrentMagnetPayload(magnetUri: magnet.toString(), torrentId: hash);
+  }
+
+  Future<void> _persistResolvedMagnet(
+    VideoDownloadJobRow job,
+    String magnetUri,
+  ) async {
+    if (!magnetUri.startsWith('magnet:')) return;
+    await database.updateVideoDownloadJob(
+      job.jobId,
+      VideoDownloadJobsCompanion(magnetUri: Value<String?>(magnetUri)),
     );
+  }
+
+  /// 入队时可落库的候选磁链（DB CHECK 约束要求 `magnet:` 前缀）。
+  static String? _persistableMagnetOf(VideoResourceCandidate resource) {
+    final String? magnet = resource.magnetUri?.trim();
+    if (magnet == null || !magnet.startsWith('magnet:')) return null;
+    return magnet;
   }
 
   /// 读取 `<manualTorrentDirectory>/<jobId>.torrent` 并复核 info hash。

--- a/fushi/test/media/video/download/video_download_organizer_test.dart
+++ b/fushi/test/media/video/download/video_download_organizer_test.dart
@@ -138,6 +138,78 @@ void main() {
     );
   });
 
+  test('episodic organizer routes unnumbered specials to Extras (BUG-1785)',
+      () async {
+    final Directory root = await Directory.systemTemp.createTemp(
+      'fushi-organizer-extras-',
+    );
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+    const String releaseRoot = '[VCB-Studio] Hibike! Euphonium 2 [Ma10p_1080p]';
+    final VideoOrganizationPlan plan = const VideoDownloadOrganizer().plan(
+      VideoOrganizationRequest(
+        torrentId: 'hash',
+        title: '響け！ユーフォニアム 2',
+        year: 2016,
+        kind: VideoOrganizationKind.episodic,
+        defaultSeasonNumber: 2,
+        sourceRoot: root.path,
+        pathMapping: VideoDownloadPathMapping(
+          remoteRoot: '/library',
+          localRoot: root.path,
+        ),
+      ),
+      <TorrentFileEntry>[
+        const TorrentFileEntry(
+          name: '$releaseRoot/'
+              '[VCB-Studio] Hibike! Euphonium 2 [01][Ma10p_1080p][x265_flac].mkv',
+          size: 900,
+          progress: 1,
+          index: 0,
+        ),
+        // 内置引擎在 Windows 上报反斜杠路径（用户原始报错原样）。
+        const TorrentFileEntry(
+          name: '$releaseRoot\\Previews\\'
+              '[VCB-Studio] Hibike! Euphonium 2 [WEB Preview02][Ma10p_1080p][x265_flac].mkv',
+          size: 30,
+          progress: 1,
+          index: 1,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/SPs/'
+              '[VCB-Studio] Hibike! Euphonium 2 [NCOP][Ma10p_1080p][x265_flac].mkv',
+          size: 40,
+          progress: 1,
+          index: 2,
+        ),
+      ],
+    );
+
+    final Map<int, VideoOrganizationFilePlan> byIndex =
+        <int, VideoOrganizationFilePlan>{
+      for (final VideoOrganizationFilePlan file in plan.files)
+        file.backendFileIndex: file,
+    };
+    expect(
+      byIndex[0]!.targetRelativePath,
+      '響け！ユーフォニアム 2 (2016)/Season 02/'
+      '響け！ユーフォニアム 2 (2016) - S02E01.mkv',
+    );
+    expect(byIndex[0]!.episodeNumber, 1);
+    expect(
+      byIndex[1]!.targetRelativePath,
+      '響け！ユーフォニアム 2 (2016)/Extras/Previews/'
+      '[VCB-Studio] Hibike! Euphonium 2 [WEB Preview02][Ma10p_1080p][x265_flac].mkv',
+    );
+    expect(byIndex[1]!.episodeNumber, isNull);
+    expect(
+      byIndex[2]!.targetRelativePath,
+      '響け！ユーフォニアム 2 (2016)/Extras/SPs/'
+      '[VCB-Studio] Hibike! Euphonium 2 [NCOP][Ma10p_1080p][x265_flac].mkv',
+    );
+  });
+
   test('unparseable episodic filename blocks before backend mutation',
       () async {
     final Directory root = await Directory.systemTemp.createTemp(

--- a/fushi/test/media/video/download/video_download_pipeline_service_test.dart
+++ b/fushi/test/media/video/download/video_download_pipeline_service_test.dart
@@ -144,6 +144,64 @@ void main() {
     expect(jobAtCheckpoint!.torrentHash, _torrentHash);
   });
 
+  test('enqueue persists the candidate magnet and skips re-search (BUG-1784)',
+      () async {
+    const String candidateMagnet =
+        'magnet:?xt=urn:btih:$_torrentHash&dn=Show+S01E01'
+        '&tr=udp%3A%2F%2Ftracker.example%3A1337%2Fannounce';
+    final _FakeTorrentBackend backend = _FakeTorrentBackend(
+      snapshots: <TorrentSnapshot>[_downloadingSnapshot(progress: 0.25)],
+    );
+    final _PipelineEnvironment environment = await _PipelineEnvironment.create(
+      backend: backend,
+      candidateMagnetUri: candidateMagnet,
+    );
+    addTearDown(environment.close);
+
+    final String jobId = await environment.service.enqueue(
+      environment.enqueueRequest(),
+    );
+    final VideoDownloadJobRow downloading = await _waitForJob(
+      environment.database,
+      jobId,
+      (VideoDownloadJobRow row) => row.stage == VideoDownloadJobStage.download,
+    );
+
+    expect(downloading.magnetUri, candidateMagnet);
+    // payload 从任务行磁链物化，物化不回索引器重搜/重解析。
+    expect(environment.provider.searchCalls, 0);
+    expect(environment.provider.resolveCalls, 0);
+    expect(backend.addCalls, 1);
+  });
+
+  test('legacy job without magnet recovers offline from its info hash '
+      'when re-search misses (BUG-1784)', () async {
+    final _FakeTorrentBackend backend = _FakeTorrentBackend(
+      snapshots: <TorrentSnapshot>[_downloadingSnapshot(progress: 0.25)],
+    );
+    final _PipelineEnvironment environment = await _PipelineEnvironment.create(
+      backend: backend,
+    );
+    addTearDown(environment.close);
+    // 存量任务行形态：入队时没落磁链，且条目已从索引器搜不回。
+    environment.provider.returnEmptySearch = true;
+
+    final String jobId = await environment.service.enqueue(
+      environment.enqueueRequest(),
+    );
+    final VideoDownloadJobRow downloading = await _waitForJob(
+      environment.database,
+      jobId,
+      (VideoDownloadJobRow row) => row.stage == VideoDownloadJobStage.download,
+    );
+
+    // 离线重建的磁链（info hash + 该索引器固定 tracker）落回任务行。
+    expect(downloading.magnetUri, startsWith('magnet:?xt=urn:btih:'));
+    expect(downloading.magnetUri, contains(_torrentHash));
+    expect(environment.provider.resolveCalls, 0);
+    expect(backend.addCalls, 1);
+  });
+
   test('long enqueue renews its lease and cannot be claimed by another worker',
       () async {
     final _FakeTorrentBackend backend = _FakeTorrentBackend(
@@ -1654,6 +1712,7 @@ class _PipelineEnvironment {
     Future<void> Function(VideoDownloadJobRow job)? onBackendTaskAdded,
     Duration leaseDuration = const Duration(minutes: 1),
     Duration pollInterval = const Duration(hours: 1),
+    String? candidateMagnetUri,
   }) async {
     final FushiDatabase database =
         FushiDatabase.forTesting(NativeDatabase.memory());
@@ -1667,7 +1726,8 @@ class _PipelineEnvironment {
         createdAt: 1,
       ),
     );
-    final _FakeResourceProvider provider = _FakeResourceProvider();
+    final _FakeResourceProvider provider =
+        _FakeResourceProvider(candidateMagnetUri: candidateMagnetUri);
     final VideoResourceRegistry resourceRegistry =
         VideoResourceRegistry(<VideoResourceProvider>[provider]);
     final VideoSubtitleRegistry? subtitleRegistry = subtitleProvider == null
@@ -1830,7 +1890,7 @@ VideoMediaReference _mediaReference() => VideoMediaReference(
     );
 
 class _FakeResourceCandidate extends VideoResourceCandidate {
-  _FakeResourceCandidate()
+  _FakeResourceCandidate({String? magnetUri})
       : super(
           providerId: 'nyaa',
           providerInstanceId: 'test-instance',
@@ -1838,6 +1898,7 @@ class _FakeResourceCandidate extends VideoResourceCandidate {
           title: 'Show S01E01',
           providerPriority: 0,
           infoHash: _torrentHash,
+          magnetUri: magnetUri,
         );
 }
 
@@ -1899,11 +1960,15 @@ class _FakeSubtitleProvider implements VideoSubtitleProvider {
 }
 
 class _FakeResourceProvider implements VideoResourceProvider {
-  _FakeResourceProvider() : candidate = _FakeResourceCandidate();
+  _FakeResourceProvider({String? candidateMagnetUri})
+      : candidate = _FakeResourceCandidate(magnetUri: candidateMagnetUri);
 
   final _FakeResourceCandidate candidate;
   int searchCalls = 0;
   int resolveCalls = 0;
+
+  /// true = 重搜找不回已选条目（条目下架/发布名搜不中），search 返回空成功。
+  bool returnEmptySearch = false;
 
   @override
   String get id => 'nyaa';
@@ -1923,7 +1988,9 @@ class _FakeResourceProvider implements VideoResourceProvider {
   ) async {
     searchCalls += 1;
     return ProviderBatchResult<VideoResourceCandidate>.success(
-      <VideoResourceCandidate>[candidate],
+      returnEmptySearch
+          ? const <VideoResourceCandidate>[]
+          : <VideoResourceCandidate>[candidate],
     );
   }
 


### PR DESCRIPTION
## 摘要

同一条用户报告链（響け！ユーフォニアム 下载任务）里的两个下载中心根因修复：

### BUG-1784 · 下载重试丢失已选 magnet 致 nyaa notFound
- **症状**：任务出错 `ExternalProviderFailure(provider=nyaa:nyaa.si, operation=resolve, kind=notFound): selected resource is no longer available`，点重试仍失败。
- **根因**：搜索入队路径不持久化候选磁链——选中时 magnet 已在内存，`enqueue()` 却不写 `magnetUri` 列。任务重启/重试时被迫拿完整发布名回索引器分词重搜，搜不中即把还活着的资源误报成 notFound。
- **修复**：`VideoResourceCandidate` 增持久 `magnetUri` 字段（nyaa/apibay/knaben 直传，torznab 仅在 `magnet:` 前缀且 hash 一致时传）；`enqueue()` 随任务落库；`_resolvePayload` 重搜成功写回磁链，重搜失败时对公共索引器任务用任务行 info hash + 各家固定 tracker 离线重建（存量失败任务点「重试」即恢复）；私有 Torznab 保持原失败语义。

### BUG-1785 · TV 整理被无集号特典文件整批卡死
- **症状**：种子 100% 完成后整理阶段 `unable to determine episode number: ...\Previews\[VCB-Studio] ... [WEB Preview02]...mkv`。
- **根因**：episodic 整理对每个视频文件硬解析集号，解析不出直接抛错整批失败；movie 分支却有 Extras 兜底。VCB 类 BDRip 标配 Previews/SPs/Menus，特典天生无集号。
- **修复**：episodic 与 movie 共用同一条 Extras 规则——认得出集号的进 `Season NN/`，其余镜像种子目录结构（剥共享发布根）进 `Extras/`，路径天然唯一；下游 `kind: 'extra'` 是既有概念直接兼容。一集都认不出仍显式失败。顺带把 `p.basename` 换成平台无关切段（内置引擎在 Windows 报反斜杠路径，Linux 上 `p.basename` 不认）。

## 验证

- `flutter analyze`：No issues found
- `flutter test test/media/video/download test/torrent --no-pub`：436 passed（含 4 个新用例：入队持久化磁链跳过重搜、存量行离线重建、VCB 布局特典进 Extras、全无集号仍失败）
- `dart run tool/bug.dart check`：号唯一、索引同步、跨源无撞号

https://claude.ai/code/session_01A5jEbNmpqhkVJZ8i2UqFRw