### PR TITLE
feat(lookup): 弹窗窗体观感对齐 Niratan——伴随投影窗 + 纯表面 + 系统灰描边 + 悬停滚动条

### DIFF
--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -127,37 +127,59 @@
     padding: 0 10px 10px;
 }
 
-/* Themed scrollbar (mirrors reader_content_styles.dart / lyrics_mode_html.dart).
-   The track stays transparent so it shows the popup background; the thumb takes
-   --text-color (onSurface, injected by dictionary_popup_webview _themeVariablesJs),
-   so dark themes get a light thumb and light themes a dark one. The standard
-   props cover Firefox/Chromium 121+; the -webkit pseudo-elements cover Android
-   WebView / Windows WebView2 / macOS WKWebView. color-scheme is pinned per theme
-   in the html[data-theme] blocks below -- WebView2's Fluent overlay scrollbar
-   ignores ::-webkit-scrollbar and only follows the UA color-scheme. */
-:where(#entries-container) {
-    scrollbar-width: thin;
-    scrollbar-color: var(--text-color) transparent;
-}
-
-:where(#entries-container) ::-webkit-scrollbar {
+/* Themed scrollbar — Niratan 对齐（2026-08-23，取代 TODO-789 的常驻细滚动条）。
+   静止时完全隐形；鼠标落在文档上（:hover）或滚动进行中（popup.js 的滚动监听给
+   根节点加 .popup-scroll-active，900ms 衰减，覆盖触屏无 hover 的情形）才浮现
+   胶囊 thumb —— 逐字对齐 Niratan popup.css 的 overlay 滚动条（宽 8px、透明
+   track、999px 胶囊、2px 内缩 content-box、min-height 36px）。
+   有意不再设标准 scrollbar-width / scrollbar-color：Chromium 121+ 一旦标准
+   属性生效会整族禁用 ::-webkit-scrollbar 伪元素（BUG-753 记录的引擎行为），
+   而「静止隐形、悬停浮现」只有伪元素表达得出来。副作用一并消化：没有标准
+   thin 属性后 WebView2 可能回到 Fluent overlay 滚动条（忽略伪元素、只认 UA
+   color-scheme）——那形态本来就是静止隐形的浮层，与本设计同向；color-scheme
+   仍按主题钉在 html[data-theme] 块里。gutter 消失不影响圆角：TODO-893 的
+   右上/右下方角根因已由 html.global-lookup 的透明渐变背景根治，不再依赖
+   「内容右缘与 shell 右缘重合」。thumb 颜色变量在 html[data-theme] 块按主题
+   定义，不再用 --text-color 实心色（黑/白实心太扎眼，Niratan 用半透明灰）。 */
+:where(#entries-container, #entries-container *)::-webkit-scrollbar {
     width: 8px;
     height: 8px;
-}
-
-:where(#entries-container) ::-webkit-scrollbar-track {
     background: transparent;
 }
 
-:where(#entries-container) ::-webkit-scrollbar-thumb {
-    background-color: var(--text-color);
-    background-clip: padding-box;
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-track,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-track-piece,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-corner {
+    background: transparent;
+    border: 0;
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb {
+    min-height: 36px;
     border: 2px solid transparent;
-    border-radius: 8px;
+    border-radius: 999px;
+    background-color: transparent;
+    background-clip: content-box;
 }
 
-:where(#entries-container) ::-webkit-scrollbar-corner {
-    background: transparent;
+/* 通用形（不枚举 html/body/.overlay）：任一滚动容器被悬停、或被 popup.js 打上
+   .popup-scroll-active，就显形**它自己**的 thumb。比 Niratan 的枚举式更简，且
+   content.css 生成器把 `*` 前缀重根为 #entries-container 及其后代后，扩展里
+   无论真正的滚动容器是哪层都被覆盖（枚举 html/body 在扩展里会失配）。 */
+:where(#entries-container, #entries-container *):hover::-webkit-scrollbar-thumb,
+:where(#entries-container, #entries-container *).popup-scroll-active::-webkit-scrollbar-thumb {
+    background-color: var(--popup-scrollbar-thumb, rgba(128, 128, 128, 0.42));
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb:hover,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb:active {
+    background-color: var(--popup-scrollbar-thumb-active, rgba(128, 128, 128, 0.64));
 }
 
 .entry {
@@ -1382,6 +1404,9 @@
     --background-color: #fff;
     --background-color-light: #fff;
     --text-color: #000;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明灰，非实心）。 */
+    --popup-scrollbar-thumb: rgba(80, 80, 80, 0.42);
+    --popup-scrollbar-thumb-active: rgba(80, 80, 80, 0.64);
     /* Prefer the MD3 ColorScheme values Dart injects (--md-*); the per-theme
        literals stay as fallbacks for hosts that don't inject (Android native). */
     --surface-container: var(--md-surface-container, #F0F1EC);
@@ -1396,6 +1421,9 @@
     --background-color: #000;
     --background-color-light: #000;
     --text-color: #fff;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明白）。 */
+    --popup-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+    --popup-scrollbar-thumb-active: rgba(255, 255, 255, 0.56);
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
     --text-color-light3: #888888;

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -172,37 +172,59 @@ body {
     padding: 0 10px 10px;
 }
 
-/* Themed scrollbar (mirrors reader_content_styles.dart / lyrics_mode_html.dart).
-   The track stays transparent so it shows the popup background; the thumb takes
-   --text-color (onSurface, injected by dictionary_popup_webview _themeVariablesJs),
-   so dark themes get a light thumb and light themes a dark one. The standard
-   props cover Firefox/Chromium 121+; the -webkit pseudo-elements cover Android
-   WebView / Windows WebView2 / macOS WKWebView. color-scheme is pinned per theme
-   in the html[data-theme] blocks below -- WebView2's Fluent overlay scrollbar
-   ignores ::-webkit-scrollbar and only follows the UA color-scheme. */
-html {
-    scrollbar-width: thin;
-    scrollbar-color: var(--text-color) transparent;
-}
-
+/* Themed scrollbar — Niratan 对齐（2026-08-23，取代 TODO-789 的常驻细滚动条）。
+   静止时完全隐形；鼠标落在文档上（:hover）或滚动进行中（popup.js 的滚动监听给
+   根节点加 .popup-scroll-active，900ms 衰减，覆盖触屏无 hover 的情形）才浮现
+   胶囊 thumb —— 逐字对齐 Niratan popup.css 的 overlay 滚动条（宽 8px、透明
+   track、999px 胶囊、2px 内缩 content-box、min-height 36px）。
+   有意不再设标准 scrollbar-width / scrollbar-color：Chromium 121+ 一旦标准
+   属性生效会整族禁用 ::-webkit-scrollbar 伪元素（BUG-753 记录的引擎行为），
+   而「静止隐形、悬停浮现」只有伪元素表达得出来。副作用一并消化：没有标准
+   thin 属性后 WebView2 可能回到 Fluent overlay 滚动条（忽略伪元素、只认 UA
+   color-scheme）——那形态本来就是静止隐形的浮层，与本设计同向；color-scheme
+   仍按主题钉在 html[data-theme] 块里。gutter 消失不影响圆角：TODO-893 的
+   右上/右下方角根因已由 html.global-lookup 的透明渐变背景根治，不再依赖
+   「内容右缘与 shell 右缘重合」。thumb 颜色变量在 html[data-theme] 块按主题
+   定义，不再用 --text-color 实心色（黑/白实心太扎眼，Niratan 用半透明灰）。 */
 ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
+    background: transparent;
 }
 
-::-webkit-scrollbar-track {
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-track-piece,
+::-webkit-scrollbar-corner {
     background: transparent;
+    border: 0;
+}
+
+::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
 }
 
 ::-webkit-scrollbar-thumb {
-    background-color: var(--text-color);
-    background-clip: padding-box;
+    min-height: 36px;
     border: 2px solid transparent;
-    border-radius: 8px;
+    border-radius: 999px;
+    background-color: transparent;
+    background-clip: content-box;
 }
 
-::-webkit-scrollbar-corner {
-    background: transparent;
+/* 通用形（不枚举 html/body/.overlay）：任一滚动容器被悬停、或被 popup.js 打上
+   .popup-scroll-active，就显形**它自己**的 thumb。比 Niratan 的枚举式更简，且
+   content.css 生成器把 `*` 前缀重根为 #entries-container 及其后代后，扩展里
+   无论真正的滚动容器是哪层都被覆盖（枚举 html/body 在扩展里会失配）。 */
+*:hover::-webkit-scrollbar-thumb,
+*.popup-scroll-active::-webkit-scrollbar-thumb {
+    background-color: var(--popup-scrollbar-thumb, rgba(128, 128, 128, 0.42));
+}
+
+::-webkit-scrollbar-thumb:hover,
+::-webkit-scrollbar-thumb:active {
+    background-color: var(--popup-scrollbar-thumb-active, rgba(128, 128, 128, 0.64));
 }
 
 .entry {
@@ -1441,6 +1463,9 @@ html[data-theme="light"] {
     --background-color: #fff;
     --background-color-light: #fff;
     --text-color: #000;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明灰，非实心）。 */
+    --popup-scrollbar-thumb: rgba(80, 80, 80, 0.42);
+    --popup-scrollbar-thumb-active: rgba(80, 80, 80, 0.64);
     /* Prefer the MD3 ColorScheme values Dart injects (--md-*); the per-theme
        literals stay as fallbacks for hosts that don't inject (Android native). */
     --surface-container: var(--md-surface-container, #F0F1EC);
@@ -1455,6 +1480,9 @@ html[data-theme="dark"] {
     --background-color: #000;
     --background-color-light: #000;
     --text-color: #fff;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明白）。 */
+    --popup-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+    --popup-scrollbar-thumb-active: rgba(255, 255, 255, 0.56);
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
     --text-color-light3: #888888;
@@ -1579,19 +1607,24 @@ html[data-theme="dark"] {
  * grid — and only style the bare WebView2 lookup window.
  *
  * Card chrome ports hoshi's reader-popup-host.js `.fushi-reader-popup-shell`
- * (border 1px rgba(120,120,128,0.36) / radius 10px). The opaque, NON-layered
- * WebView2 window (see global_lookup_window.cpp: "No WS_EX_LAYERED") cannot
- * carry a real drop-shadow inside CSS — that is a platform limitation, not an
- * omission; the true rounded-corner + shadow is supplied by the native window
- * region (SetWindowRgn) instead. The CSS here gives the content a clean inset
+ * (radius 10px；描边 2026-08-23 起改系统分隔线灰 #D1D1D6/#3A3A3C，对齐
+ * Niratan)。The opaque, NON-layered WebView2 window (see
+ * global_lookup_window.cpp: "No WS_EX_LAYERED") cannot carry a real
+ * drop-shadow inside CSS — that platform limitation stands; the rounded corner
+ * is supplied by the native window region (SetWindowRgn) and the drop shadow
+ * by the companion layered shadow window (global_lookup_shadow.cpp,
+ * 2026-08-23). The CSS here gives the content a clean inset
  * border so it reads as a card, not raw text flush to the window edge.
  * ===================================================================== */
 
 html.global-lookup body {
-    /* hoshi shell border (light). The dark variant follows below. Inset padding
-       lifts the content off the hard window edge so the border reads as a card
-       frame rather than a hairline glued to the glass. */
-    border: 1px solid rgba(120, 120, 128, 0.36);
+    /* Niratan 对齐（2026-08-23）— 外壳描边改用系统分隔线灰（Niratan
+       DictionaryPopupMaterial.GetOutlineColor 的 #D1D1D6 / #3A3A3C 实色），
+       取代原 hoshi 的 rgba(120,120,128,0.36) 半透明描边：与原生 Win11 hairline
+       同色，配伴随投影窗（global_lookup_shadow.cpp）后观感即 Niratan 弹窗。
+       Inset padding lifts the content off the hard window edge so the border
+       reads as a card frame rather than a hairline glued to the glass. */
+    border: 1px solid #D1D1D6;
     border-radius: 10px;
     padding: 8px 10px 10px;
     min-height: 100%;
@@ -1607,7 +1640,7 @@ html.global-lookup body {
 }
 
 html.global-lookup[data-theme="dark"] body {
-    border-color: rgba(255, 255, 255, 0.34);
+    border-color: #3A3A3C;
 }
 
 /* 用户「词典方框怎么能左右动，Niratan 不会」根因修：app 外全局查词 / 浏览器扩展原本

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -5030,3 +5030,34 @@ document.addEventListener('mousemove', function(e) {
         window.fushiSelection.selectText(e.clientX, e.clientY, 20);
     }
 }, {passive: true});
+
+// Niratan 对齐（2026-08-23）— 滚动条静止隐形、滚动时浮现。popup.css 的
+// ::-webkit-scrollbar-thumb 静止透明，靠 :hover 或 .popup-scroll-active 显形；
+// hover 只覆盖桌面鼠标，这里补触屏/键盘滚动：任意滚动事件给根节点 + body +
+// 事件目标挂 .popup-scroll-active，900ms 无滚动后整体清除（与 Niratan
+// setPopupScrollIndicatorActive 同法同参）。capture:true 才收得到内部滚动容器
+// （.overlay / .expression-scroll 等）的 scroll（scroll 不冒泡）。
+var __fushiPopupScrollIndicatorTimer = 0;
+document.addEventListener('scroll', function (event) {
+    var root = document.documentElement;
+    var body = document.body;
+    var activeClass = 'popup-scroll-active';
+    root.classList.add(activeClass);
+    if (body) body.classList.add(activeClass);
+    var scrollTarget = event.target && event.target.nodeType === Node.ELEMENT_NODE
+        ? event.target
+        : null;
+    if (scrollTarget && scrollTarget.classList) {
+        scrollTarget.classList.add(activeClass);
+    }
+    if (__fushiPopupScrollIndicatorTimer) {
+        clearTimeout(__fushiPopupScrollIndicatorTimer);
+    }
+    __fushiPopupScrollIndicatorTimer = setTimeout(function () {
+        root.classList.remove(activeClass);
+        if (body) body.classList.remove(activeClass);
+        document.querySelectorAll('.' + activeClass).forEach(function (element) {
+            element.classList.remove(activeClass);
+        });
+    }, 900);
+}, { passive: true, capture: true });

--- a/fushi/assets/popup/global_lookup_host.js
+++ b/fushi/assets/popup/global_lookup_host.js
@@ -436,12 +436,16 @@
     // onto the window's own transparent (=hard dark) surface as an ~11px DARK
     // HALO ringing the card's corners/edges, which the native rounded window
     // region (SetWindowRgn) cannot clip away. That halo is exactly the "black
-    // border outside the rounded corners" the user reported. A real drop-shadow
+    // border outside the rounded corners" the user reported. A CSS drop-shadow
     // is physically impossible on a non-layered WebView2 window (the design
-    // already conceded this), so the shell casts none: the rounded silhouette
-    // comes from SetWindowRgn + the body's 1px card border, with nothing painted
-    // outside the card. All rules scoped to .global-lookup-frame-shell -> the
-    // in-app popup (no host.js) is never touched.
+    // already conceded this), so the shell casts none IN CSS: the rounded
+    // silhouette comes from SetWindowRgn + the body's 1px card border, with
+    // nothing painted outside the card. The real per-card soft shadow is drawn
+    // NATIVELY by the companion layered shadow window (global_lookup_shadow.cpp,
+    // 2026-08-23) sitting right below this HWND — do NOT reintroduce a CSS
+    // box-shadow here on top of it. All rules scoped to
+    // .global-lookup-frame-shell -> the in-app popup (no host.js) is never
+    // touched.
     // D1 reveal gate: a shell paints only when BOTH data-* flags are 'true'.
     style.textContent =
         // D1 reveal gate FIRST (kept as its own rule so the gate contract stays

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -172,37 +172,59 @@ body {
     padding: 0 10px 10px;
 }
 
-/* Themed scrollbar (mirrors reader_content_styles.dart / lyrics_mode_html.dart).
-   The track stays transparent so it shows the popup background; the thumb takes
-   --text-color (onSurface, injected by dictionary_popup_webview _themeVariablesJs),
-   so dark themes get a light thumb and light themes a dark one. The standard
-   props cover Firefox/Chromium 121+; the -webkit pseudo-elements cover Android
-   WebView / Windows WebView2 / macOS WKWebView. color-scheme is pinned per theme
-   in the html[data-theme] blocks below -- WebView2's Fluent overlay scrollbar
-   ignores ::-webkit-scrollbar and only follows the UA color-scheme. */
-html {
-    scrollbar-width: thin;
-    scrollbar-color: var(--text-color) transparent;
-}
-
+/* Themed scrollbar — Niratan 对齐（2026-08-23，取代 TODO-789 的常驻细滚动条）。
+   静止时完全隐形；鼠标落在文档上（:hover）或滚动进行中（popup.js 的滚动监听给
+   根节点加 .popup-scroll-active，900ms 衰减，覆盖触屏无 hover 的情形）才浮现
+   胶囊 thumb —— 逐字对齐 Niratan popup.css 的 overlay 滚动条（宽 8px、透明
+   track、999px 胶囊、2px 内缩 content-box、min-height 36px）。
+   有意不再设标准 scrollbar-width / scrollbar-color：Chromium 121+ 一旦标准
+   属性生效会整族禁用 ::-webkit-scrollbar 伪元素（BUG-753 记录的引擎行为），
+   而「静止隐形、悬停浮现」只有伪元素表达得出来。副作用一并消化：没有标准
+   thin 属性后 WebView2 可能回到 Fluent overlay 滚动条（忽略伪元素、只认 UA
+   color-scheme）——那形态本来就是静止隐形的浮层，与本设计同向；color-scheme
+   仍按主题钉在 html[data-theme] 块里。gutter 消失不影响圆角：TODO-893 的
+   右上/右下方角根因已由 html.global-lookup 的透明渐变背景根治，不再依赖
+   「内容右缘与 shell 右缘重合」。thumb 颜色变量在 html[data-theme] 块按主题
+   定义，不再用 --text-color 实心色（黑/白实心太扎眼，Niratan 用半透明灰）。 */
 ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
+    background: transparent;
 }
 
-::-webkit-scrollbar-track {
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-track-piece,
+::-webkit-scrollbar-corner {
     background: transparent;
+    border: 0;
+}
+
+::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
 }
 
 ::-webkit-scrollbar-thumb {
-    background-color: var(--text-color);
-    background-clip: padding-box;
+    min-height: 36px;
     border: 2px solid transparent;
-    border-radius: 8px;
+    border-radius: 999px;
+    background-color: transparent;
+    background-clip: content-box;
 }
 
-::-webkit-scrollbar-corner {
-    background: transparent;
+/* 通用形（不枚举 html/body/.overlay）：任一滚动容器被悬停、或被 popup.js 打上
+   .popup-scroll-active，就显形**它自己**的 thumb。比 Niratan 的枚举式更简，且
+   content.css 生成器把 `*` 前缀重根为 #entries-container 及其后代后，扩展里
+   无论真正的滚动容器是哪层都被覆盖（枚举 html/body 在扩展里会失配）。 */
+*:hover::-webkit-scrollbar-thumb,
+*.popup-scroll-active::-webkit-scrollbar-thumb {
+    background-color: var(--popup-scrollbar-thumb, rgba(128, 128, 128, 0.42));
+}
+
+::-webkit-scrollbar-thumb:hover,
+::-webkit-scrollbar-thumb:active {
+    background-color: var(--popup-scrollbar-thumb-active, rgba(128, 128, 128, 0.64));
 }
 
 .entry {
@@ -1441,6 +1463,9 @@ html[data-theme="light"] {
     --background-color: #fff;
     --background-color-light: #fff;
     --text-color: #000;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明灰，非实心）。 */
+    --popup-scrollbar-thumb: rgba(80, 80, 80, 0.42);
+    --popup-scrollbar-thumb-active: rgba(80, 80, 80, 0.64);
     /* Prefer the MD3 ColorScheme values Dart injects (--md-*); the per-theme
        literals stay as fallbacks for hosts that don't inject (Android native). */
     --surface-container: var(--md-surface-container, #F0F1EC);
@@ -1455,6 +1480,9 @@ html[data-theme="dark"] {
     --background-color: #000;
     --background-color-light: #000;
     --text-color: #fff;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明白）。 */
+    --popup-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+    --popup-scrollbar-thumb-active: rgba(255, 255, 255, 0.56);
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
     --text-color-light3: #888888;
@@ -1579,19 +1607,24 @@ html[data-theme="dark"] {
  * grid — and only style the bare WebView2 lookup window.
  *
  * Card chrome ports hoshi's reader-popup-host.js `.fushi-reader-popup-shell`
- * (border 1px rgba(120,120,128,0.36) / radius 10px). The opaque, NON-layered
- * WebView2 window (see global_lookup_window.cpp: "No WS_EX_LAYERED") cannot
- * carry a real drop-shadow inside CSS — that is a platform limitation, not an
- * omission; the true rounded-corner + shadow is supplied by the native window
- * region (SetWindowRgn) instead. The CSS here gives the content a clean inset
+ * (radius 10px；描边 2026-08-23 起改系统分隔线灰 #D1D1D6/#3A3A3C，对齐
+ * Niratan)。The opaque, NON-layered WebView2 window (see
+ * global_lookup_window.cpp: "No WS_EX_LAYERED") cannot carry a real
+ * drop-shadow inside CSS — that platform limitation stands; the rounded corner
+ * is supplied by the native window region (SetWindowRgn) and the drop shadow
+ * by the companion layered shadow window (global_lookup_shadow.cpp,
+ * 2026-08-23). The CSS here gives the content a clean inset
  * border so it reads as a card, not raw text flush to the window edge.
  * ===================================================================== */
 
 html.global-lookup body {
-    /* hoshi shell border (light). The dark variant follows below. Inset padding
-       lifts the content off the hard window edge so the border reads as a card
-       frame rather than a hairline glued to the glass. */
-    border: 1px solid rgba(120, 120, 128, 0.36);
+    /* Niratan 对齐（2026-08-23）— 外壳描边改用系统分隔线灰（Niratan
+       DictionaryPopupMaterial.GetOutlineColor 的 #D1D1D6 / #3A3A3C 实色），
+       取代原 hoshi 的 rgba(120,120,128,0.36) 半透明描边：与原生 Win11 hairline
+       同色，配伴随投影窗（global_lookup_shadow.cpp）后观感即 Niratan 弹窗。
+       Inset padding lifts the content off the hard window edge so the border
+       reads as a card frame rather than a hairline glued to the glass. */
+    border: 1px solid #D1D1D6;
     border-radius: 10px;
     padding: 8px 10px 10px;
     min-height: 100%;
@@ -1607,7 +1640,7 @@ html.global-lookup body {
 }
 
 html.global-lookup[data-theme="dark"] body {
-    border-color: rgba(255, 255, 255, 0.34);
+    border-color: #3A3A3C;
 }
 
 /* 用户「词典方框怎么能左右动，Niratan 不会」根因修：app 外全局查词 / 浏览器扩展原本

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -5030,3 +5030,34 @@ document.addEventListener('mousemove', function(e) {
         window.fushiSelection.selectText(e.clientX, e.clientY, 20);
     }
 }, {passive: true});
+
+// Niratan 对齐（2026-08-23）— 滚动条静止隐形、滚动时浮现。popup.css 的
+// ::-webkit-scrollbar-thumb 静止透明，靠 :hover 或 .popup-scroll-active 显形；
+// hover 只覆盖桌面鼠标，这里补触屏/键盘滚动：任意滚动事件给根节点 + body +
+// 事件目标挂 .popup-scroll-active，900ms 无滚动后整体清除（与 Niratan
+// setPopupScrollIndicatorActive 同法同参）。capture:true 才收得到内部滚动容器
+// （.overlay / .expression-scroll 等）的 scroll（scroll 不冒泡）。
+var __fushiPopupScrollIndicatorTimer = 0;
+document.addEventListener('scroll', function (event) {
+    var root = document.documentElement;
+    var body = document.body;
+    var activeClass = 'popup-scroll-active';
+    root.classList.add(activeClass);
+    if (body) body.classList.add(activeClass);
+    var scrollTarget = event.target && event.target.nodeType === Node.ELEMENT_NODE
+        ? event.target
+        : null;
+    if (scrollTarget && scrollTarget.classList) {
+        scrollTarget.classList.add(activeClass);
+    }
+    if (__fushiPopupScrollIndicatorTimer) {
+        clearTimeout(__fushiPopupScrollIndicatorTimer);
+    }
+    __fushiPopupScrollIndicatorTimer = setTimeout(function () {
+        root.classList.remove(activeClass);
+        if (body) body.classList.remove(activeClass);
+        document.querySelectorAll('.' + activeClass).forEach(function (element) {
+            element.classList.remove(activeClass);
+        });
+    }, 900);
+}, { passive: true, capture: true });

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2891,7 +2891,10 @@ class AppModel with ChangeNotifier {
   Map<String, String> browserExtensionThemeColors() {
     final ColorScheme s = themeNotifier.buildColorScheme(
         themeNotifier.isDarkMode ? Brightness.dark : Brightness.light);
-    final Color bgColor = _overrideDictionaryColor ?? s.surface;
+    // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑（popupCardSurface），
+    // 不再用 tinted scheme.surface；override 优先级不变。
+    final Color bgColor =
+        popupCardSurface(scheme: s, override: _overrideDictionaryColor);
     // BUG-736：核心色/圆角/列数变量的取值统一来自 buildPopupThemeCssVars——与 in-app
     // 弹窗注入器（popup_settings_injection / dictionary_popup_webview）同一真源，
     // 根除「扩展漏抄一处、退化成灰高亮/白字/直角」的手抄漂移。

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -905,7 +905,9 @@ JSON.stringify((function(){
     // popup CSS 在属性缺席时回退 1（经典单列不受影响）。
     final Map<String, String> vars = buildPopupThemeCssVars(
       scheme: scheme,
-      backgroundColor: appModel.overrideDictionaryColor ?? scheme.surface,
+      // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑，override 优先级不变。
+      backgroundColor: popupCardSurface(
+          scheme: scheme, override: appModel.overrideDictionaryColor),
       surfaceContainerHigh: scheme.surfaceContainerHigh,
       dictionaryColumns: appModel.popupDictionaryColumns,
     );
@@ -1307,8 +1309,11 @@ JSON.stringify((function(){
     );
     final t = Translations.of(context);
     final appModel = ref.read(appProvider);
-    final Color bgColor = appModel.overrideDictionaryColor ??
-        Theme.of(context).colorScheme.surface;
+    // Niratan 对齐（2026-08-23）：初始 HTML 底色与主题注入器同源纯白/纯黑，
+    // 避免「先 tinted 后纯色」的一帧闪变。
+    final Color bgColor = popupCardSurface(
+        scheme: Theme.of(context).colorScheme,
+        override: appModel.overrideDictionaryColor);
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final String bgHex = _colorToHex(bgColor);
     final String themeAttr = isDark ? 'dark' : 'light';

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -84,7 +84,9 @@ String _themeVariablesJs({
   final ColorScheme scheme = theme.colorScheme;
   final Map<String, String> vars = buildPopupThemeCssVars(
     scheme: scheme,
-    backgroundColor: appModel.overrideDictionaryColor ?? scheme.surface,
+    // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑，override 优先级不变。
+    backgroundColor: popupCardSurface(
+        scheme: scheme, override: appModel.overrideDictionaryColor),
     surfaceContainerHigh: scheme.surfaceContainerHigh,
     dictionaryColumns: appModel.popupDictionaryColumns,
   );

--- a/fushi/lib/src/utils/popup_theme_css.dart
+++ b/fushi/lib/src/utils/popup_theme_css.dart
@@ -28,10 +28,23 @@ String cssRgbTriplet(Color c) => '${(c.r * 255.0).round().clamp(0, 255)}, '
 /// [c] 的 `rgba(r, g, b, 0.35)` 串——查到词高亮色（primary @0.35 alpha）的固定配方。
 String cssRgba035(Color c) => 'rgba(${cssRgbTriplet(c)}, 0.35)';
 
+/// Niratan 对齐（2026-08-23）：弹窗卡面默认**纯白/纯黑**，不再用 MD3 tinted
+/// `scheme.surface`。Niratan 的弹窗表面就是 #FFF/#000
+/// （DictionaryPopupMaterial.GetOpaqueSurfaceColor），MD3 种子色染出的
+/// surface（浅色偏米/偏绿、深色偏灰）正是「我们的弹窗观感发闷」的来源之一。
+/// 用户手动指定的词典底色 [override]（overrideDictionaryColor）优先级不变；
+/// 四个消费方（AppModel 扩展 theme map、两个 in-app 注入器、热槽 WebView
+/// 初始 HTML）统一走本 helper，防再漂移（BUG-688/736 同型教训）。
+Color popupCardSurface({required ColorScheme scheme, Color? override}) =>
+    override ??
+    (scheme.brightness == Brightness.dark
+        ? const Color(0xFF000000)
+        : const Color(0xFFFFFFFF));
+
 /// 三个弹窗表面共用的核心主题变量（变量名 → CSS 值，保序）。
 ///
 /// 调用点差异通过参数表达，不在此分支：
-/// - [backgroundColor]：`overrideDictionaryColor ?? scheme.surface`（词典底色覆盖）；
+/// - [backgroundColor]：`popupCardSurface(...)`（默认纯白/纯黑，词典底色覆盖优先）；
 /// - [surfaceContainerHigh]：in-app 两个注入器传 `scheme.surfaceContainerHigh`，
 ///   浏览器扩展侧历史行为是 `overrideDictionaryColor ?? scheme.surfaceContainerHigh`；
 /// - [dictionaryColumns]：`popupDictionaryColumns` 偏好。

--- a/fushi/test/build/browser_extension_popup_parity_guard_test.dart
+++ b/fushi/test/build/browser_extension_popup_parity_guard_test.dart
@@ -120,7 +120,9 @@ void main() {
         // BUG-752: the scope must be the specificity-neutral `:where(...)` form.
         for (final String scoped in const <String>[
           ':where(#entries-container) ::selection',
-          ':where(#entries-container) ::-webkit-scrollbar',
+          // Niratan 对齐（2026-08-23）：滚动条伪元素改「容器自身 + 后代」重根
+          // （旧的纯后代形漏掉 #entries-container 自己作为滚动容器的场景）。
+          ':where(#entries-container, #entries-container *)::-webkit-scrollbar',
           ':where(#entries-container)[data-theme="dark"]',
         ]) {
           expect(content.contains(scoped), isTrue,

--- a/fushi/test/dictionary/popup_css_scrollbar_theme_guard_test.dart
+++ b/fushi/test/dictionary/popup_css_scrollbar_theme_guard_test.dart
@@ -1,46 +1,94 @@
-// TODO-789 static guard: the shared dictionary-popup WebView surface (used by
-// the lookup overlay AND the home lookup search page) must theme its scrollbar
-// the same way the reader body and lyrics mode do — otherwise desktop WebView2
-// shows its default arrowed grey scrollbar regardless of the app theme.
+// TODO-789 → 2026-08-23 Niratan 对齐改版 static guard：查词弹窗滚动条为
+// 「静止隐形、悬停/滚动浮现」的 overlay 胶囊滚动条（对齐 Niratan popup.css），
+// 不再是常驻的 --text-color 实心细滚动条。
 //
-// Root cause: assets/popup/popup.css had no body/html-level scrollbar rules at
-// all (only `.expression-scroll::-webkit-scrollbar{display:none}`, which hides
-// an unrelated horizontal expression bar). reader_content_styles.dart and
-// lyrics_mode_html.dart already carry the full rule set; popup.css was the only
-// themed WebView surface missing it.
+// 钉住的不变式：
+// 1. 静止态 thumb 透明（::-webkit-scrollbar-thumb 基础规则 background-color:
+//    transparent + 999px 胶囊 + 2px content-box 内缩）；
+// 2. 悬停 / .popup-scroll-active（popup.js 滚动监听打的类，覆盖触屏无 hover）
+//    时 thumb 才取 --popup-scrollbar-thumb 显形；
+// 3. **不得**重新引入标准 scrollbar-color / 根级 scrollbar-width: thin ——
+//    Chromium 121+ 一旦标准滚动条属性生效会整族禁用 ::-webkit-scrollbar
+//    伪元素（BUG-753 记录的引擎行为），悬停显隐立即失效退化回常驻滚动条；
+//    （.expression-scroll 的 scrollbar-width: none 是 BUG-753 的既有修复，保留）
+// 4. 两个主题块定义 --popup-scrollbar-thumb 变量；
+// 5. color-scheme 仍按主题钉住（WebView2 Fluent overlay 滚动条只认 UA
+//    color-scheme 的兜底路径）。
+// 6. popup.js 带 popup-scroll-active 滚动监听（900ms 衰减）。
 //
-// Layer rationale: the scrollbar appearance is pure CSS in a static asset, so a
-// file-text scan is the strongest landable guard — it pins the exact rules and
-// the per-theme `color-scheme` (WebView2's Fluent overlay scrollbar ignores
-// ::-webkit-scrollbar and only follows the UA color-scheme).
+// Layer rationale: 滚动条外观是静态资产里的纯 CSS，文件文本扫描是能落地的
+// 最强守卫层。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('popup.css themed scrollbar (TODO-789)', () {
+  group('popup.css overlay scrollbar (Niratan 对齐 2026-08-23)', () {
     late final String css;
+    late final String js;
 
     setUpAll(() {
       final File file = File('assets/popup/popup.css');
       expect(file.existsSync(), isTrue,
           reason: 'popup.css not found at ${file.absolute.path}');
       css = file.readAsStringSync();
+      final File jsFile = File('assets/popup/popup.js');
+      expect(jsFile.existsSync(), isTrue,
+          reason: 'popup.js not found at ${jsFile.absolute.path}');
+      js = jsFile.readAsStringSync();
     });
 
-    test('emits webkit scrollbar thumb + standard scrollbar props', () {
-      expect(css, contains('::-webkit-scrollbar-thumb'),
-          reason: 'scrollbar thumb pseudo-element rule must exist');
-      expect(css, contains('::-webkit-scrollbar-track'),
-          reason: 'scrollbar track pseudo-element rule must exist');
-      expect(css, contains('scrollbar-width: thin;'));
-      expect(css, contains('scrollbar-color: var(--text-color) transparent;'),
-          reason: 'thumb must reuse the injected --text-color (onSurface)');
+    test('rest-state thumb is transparent pill', () {
+      final int idx = css.indexOf('::-webkit-scrollbar-thumb {');
+      expect(idx, greaterThanOrEqualTo(0),
+          reason: 'base scrollbar thumb rule must exist');
+      final String block = css.substring(idx, css.indexOf('}', idx));
+      expect(block, contains('background-color: transparent;'),
+          reason: '静止态 thumb 必须透明（静止隐形是本设计的核心）');
+      expect(block, contains('border-radius: 999px;'),
+          reason: '胶囊形 thumb（Niratan 同参）');
+      expect(block, contains('background-clip: content-box;'),
+          reason: '2px 透明 border + content-box 内缩形成悬浮胶囊');
     });
 
-    test('thumb colour follows the injected --text-color', () {
-      expect(css, contains('background-color: var(--text-color);'),
-          reason: 'webkit thumb colour must reuse --text-color, not a literal');
+    test('thumb reveals on hover and on popup-scroll-active', () {
+      expect(css, contains('*:hover::-webkit-scrollbar-thumb'),
+          reason: '桌面鼠标悬停显形（通用形，任一滚动容器自身悬停即显形）');
+      expect(css, contains('*.popup-scroll-active::-webkit-scrollbar-thumb'),
+          reason: '滚动进行中显形（触屏/键盘滚动无 hover，靠 popup.js 打类）');
+      final int idx = css.indexOf('*:hover::-webkit-scrollbar-thumb');
+      final String block = css.substring(idx, css.indexOf('}', idx));
+      expect(block, contains('var(--popup-scrollbar-thumb'),
+          reason: '显形色走主题变量，非字面量');
+    });
+
+    test('standard scrollbar props must NOT come back (Chromium 121+ 全族禁用)',
+        () {
+      // 声明级匹配（行首缩进 + 属性名 + 冒号），注释里提到属性名不算。
+      expect(RegExp(r'^\s*scrollbar-color\s*:', multiLine: true).hasMatch(css),
+          isFalse,
+          reason: '标准 scrollbar-color 声明一出现，Chromium 121+ 即禁用全部 '
+              '::-webkit-scrollbar 伪元素，悬停显隐失效（BUG-753 行为）');
+      final Iterable<RegExpMatch> widthDecls =
+          RegExp(r'^\s*scrollbar-width\s*:\s*(\S+?)\s*;', multiLine: true)
+              .allMatches(css);
+      for (final RegExpMatch m in widthDecls) {
+        expect(m.group(1), 'none',
+            reason: 'scrollbar-width 只允许 none（.expression-scroll 的 '
+                'BUG-753 修复）；thin/auto 会让 Chromium 121+ 禁用 '
+                '::-webkit-scrollbar 全族');
+      }
+    });
+
+    test('theme blocks define the thumb variable', () {
+      for (final String theme in <String>['light', 'dark']) {
+        final int idx = css.indexOf('html[data-theme="$theme"] {');
+        expect(idx, greaterThanOrEqualTo(0),
+            reason: '$theme theme block must exist');
+        final String block = css.substring(idx, css.indexOf('}', idx));
+        expect(block, contains('--popup-scrollbar-thumb:'),
+            reason: '$theme 主题必须定义滚动条胶囊色变量');
+      }
     });
 
     test('light theme block pins color-scheme: light', () {
@@ -63,6 +111,13 @@ void main() {
       expect(darkBlock, contains('color-scheme: dark;'),
           reason:
               'WebView2 Fluent overlay scrollbar only follows color-scheme');
+    });
+
+    test('popup.js carries the popup-scroll-active toggler', () {
+      expect(js, contains("'popup-scroll-active'"),
+          reason: 'popup.js 必须有滚动监听给根节点打 .popup-scroll-active');
+      expect(js, contains('900'),
+          reason: '900ms 无滚动后衰减（Niratan 同参）');
     });
   });
 }

--- a/fushi/test/lookup/global_lookup_popup_style_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_popup_style_guard_test.dart
@@ -204,8 +204,9 @@ void main() {
       expect(css.contains('html.global-lookup body {'), isTrue);
       final int bodyAt = css.indexOf('html.global-lookup body {');
       final String bodyRule = css.substring(bodyAt, css.indexOf('}', bodyAt));
-      expect(bodyRule.contains('border: 1px solid rgba(120, 120, 128, 0.36)'),
-          isTrue,
+      // Niratan 对齐（2026-08-23）：描边改系统分隔线灰 #D1D1D6（暗色 #3A3A3C
+      // 在 html.global-lookup[data-theme="dark"] body 覆盖）。
+      expect(bodyRule.contains('border: 1px solid #D1D1D6'), isTrue,
           reason: 'the iframe body owns the one visible card border');
     });
 

--- a/fushi/test/lookup/global_lookup_popup_style_test.mjs
+++ b/fushi/test/lookup/global_lookup_popup_style_test.mjs
@@ -66,8 +66,10 @@ assert.strictEqual(glGroup.length, 0,
 const glShell = find('html.global-lookup body');
 assert.strictEqual(glShell.length, 1, 'card chrome must be on html.global-lookup body');
 assert.ok(/border-radius:\s*10px/.test(glShell[0].body), 'hoshi 10px radius');
-assert.ok(/border:\s*1px solid rgba\(120, 120, 128, 0\.36\)/.test(glShell[0].body),
-  'hoshi shell border spec');
+// Niratan 对齐（2026-08-23）：描边=系统分隔线灰 #D1D1D6（暗色 #3A3A3C 由
+// html.global-lookup[data-theme="dark"] body 覆盖）。
+assert.ok(/border:\s*1px solid #D1D1D6/.test(glShell[0].body),
+  'Niratan outline border spec (#D1D1D6)');
 // The bare global `body { ... }` rule must NOT carry the card chrome (in-app
 // uses the bare body and must stay transparent/flush).
 const bareBody = find('body');

--- a/fushi/test/lookup/global_lookup_shadow_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_shadow_guard_test.dart
@@ -1,0 +1,96 @@
+// 2026-08-23 弹窗观感（Niratan 对齐）— 伴随投影窗源码扫描守卫。
+//
+// 背景：查词浮窗/剪贴板面板是 windowed WebView2 + SetWindowRgn 裁形的窗口，
+// 拿不到 DWM 系统投影；投影由伴随的 layered 影子窗（global_lookup_shadow.cpp）
+// 自绘。这里钉住四条会静默退化的结构不变式（无法用 flutter test 驱动真窗口，
+// 故源码扫描是能落地的最强层；窗口真观感由 Windows 构建 + 真机复测兜底）：
+// 1. 影子窗必须点击穿透 + 不可激活 + 无任务栏项（WS_EX_TRANSPARENT |
+//    WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_LAYERED）——少任何一个都会
+//    出现「影子吃点击/抢焦点/任务栏幽灵项」级别的回归；
+// 2. WM_WINDOWPOSCHANGED 漏斗必须调 SyncShadow 且把消息交回 DefWindowProc
+//    （WM_SIZE/WM_MOVE 由它派生，吞掉=窗口一动内容就不跟）；
+// 3. Reveal/RevealStack 在 revealed_ 置位后必须显式补 SyncShadow——
+//    SetWindowPos 触发漏斗时 revealed_ 还是 false，不补首帧无影；
+// 4. 投影位图必须对卡矩形内部 punch-out（面板整窗 LWA_ALPHA 半透明时，
+//    不打洞黑影会从卡片底下透出来压暗内容）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late final String shadowCpp;
+  late final String windowCpp;
+  late final String cmake;
+
+  setUpAll(() {
+    final File shadow = File('windows/runner/global_lookup_shadow.cpp');
+    expect(shadow.existsSync(), isTrue,
+        reason: 'global_lookup_shadow.cpp 应存在: ${shadow.path}');
+    shadowCpp = shadow.readAsStringSync();
+    final File window = File('windows/runner/global_lookup_window.cpp');
+    expect(window.existsSync(), isTrue);
+    windowCpp = window.readAsStringSync();
+    cmake = File('windows/runner/CMakeLists.txt').readAsStringSync();
+  });
+
+  group('伴随投影窗（global_lookup_shadow）结构不变式', () {
+    test('影子窗 ex-style：layered + 点击穿透 + 不可激活 + 无任务栏项', () {
+      expect(
+        shadowCpp.contains(
+            'WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE | '
+            'WS_EX_TOOLWINDOW'),
+        isTrue,
+        reason: '缺 TRANSPARENT=影子环吃掉底下应用的点击（BUG-749 同型回归）；'
+            '缺 NOACTIVATE=抢焦点；缺 TOOLWINDOW=任务栏幽灵项；'
+            '缺 LAYERED=UpdateLayeredWindow 直接失效',
+      );
+    });
+
+    test('WM_WINDOWPOSCHANGED 漏斗：SyncShadow + 交回 DefWindowProc', () {
+      final int caseAt = windowCpp.indexOf('case WM_WINDOWPOSCHANGED:');
+      expect(caseAt, greaterThanOrEqualTo(0),
+          reason: '投影同步单漏斗必须挂在 WM_WINDOWPOSCHANGED');
+      final int nextCase = windowCpp.indexOf('case ', caseAt + 10);
+      final String block = windowCpp.substring(caseAt, nextCase);
+      expect(block, contains('SyncShadow();'),
+          reason: '漏斗内必须同步投影（移动/缩放/显隐/Z 序变化全经此处）');
+      expect(block, contains('return DefWindowProc('),
+          reason: 'WM_SIZE/WM_MOVE 由 DefWindowProc 从本消息派生，'
+              '吞掉后 WebView bounds/region 全不再跟随窗口');
+    });
+
+    test('Reveal 与 RevealStack 在标志置位后显式补 SyncShadow（首帧有影）', () {
+      for (final String fn in <String>[
+        'GlobalLookupWindow::Reveal(',
+        'GlobalLookupWindow::RevealStack(',
+      ]) {
+        final int fnAt = windowCpp.indexOf('void $fn');
+        expect(fnAt, greaterThanOrEqualTo(0), reason: '$fn 应存在');
+        final int fnEnd = windowCpp.indexOf('\nvoid GlobalLookupWindow::',
+            fnAt + 1);
+        final String body = windowCpp.substring(
+            fnAt, fnEnd > 0 ? fnEnd : windowCpp.length);
+        final int revealedAt = body.indexOf('revealed_ = true;');
+        final int syncAt = body.lastIndexOf('SyncShadow();');
+        expect(revealedAt, greaterThanOrEqualTo(0),
+            reason: '$fn 应置位 revealed_');
+        expect(syncAt, greaterThan(revealedAt),
+            reason: '$fn 必须在 revealed_ 置位之后补 SyncShadow——SetWindowPos '
+                '触发漏斗那一刻 revealed_ 还是 false，不补则首帧无影');
+      }
+    });
+
+    test('投影位图对卡矩形内部 punch-out', () {
+      expect(shadowCpp, contains('punch-out'),
+          reason: '卡内 alpha 必须清零：面板整窗半透明时黑影会从卡片底下透出');
+      // punch 循环的实际形状：卡内 (d <= 0) 像素置 0。
+      expect(shadowCpp.contains('row[px] = 0;'), isTrue,
+          reason: 'punch-out 循环必须真的清像素，不是只留注释');
+    });
+
+    test('CMakeLists 把 global_lookup_shadow.cpp 编入 runner', () {
+      expect(cmake, contains('"global_lookup_shadow.cpp"'),
+          reason: '源文件不进 add_executable 就是悄悄不生效');
+    });
+  });
+}

--- a/fushi/windows/runner/CMakeLists.txt
+++ b/fushi/windows/runner/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "floating_lyric_window.cpp"
   "foreground_selection.cpp"
+  "global_lookup_shadow.cpp"
   "global_lookup_window.cpp"
   "hook_toolbar_window.cpp"
   "ime_association_guard.cpp"

--- a/fushi/windows/runner/global_lookup_shadow.cpp
+++ b/fushi/windows/runner/global_lookup_shadow.cpp
@@ -1,0 +1,297 @@
+#include "global_lookup_shadow.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+constexpr wchar_t kShadowClassName[] = L"FushiLookupShadowWindow";
+
+// 投影形状参数（CSS px，运行时按锚窗 DPI 换算成物理 px）。
+// 双瓣近似 Win11 flyout 阴影：
+// - ambient：贴边紧瓣，d→0 处最深，负责"落地感"并在视觉上柔化 region 锯齿边；
+// - key：向下偏移的大瓣，负责"浮起感"。
+constexpr double kMarginCss = 30.0;        // 投影窗四周超出锚窗的边距
+constexpr double kAmbientSigmaCss = 7.0;   // ambient 高斯宽度
+constexpr double kAmbientAlpha = 0.26;     // ambient 峰值不透明度
+constexpr double kKeySigmaCss = 16.0;      // key 高斯宽度
+constexpr double kKeyAlpha = 0.20;         // key 峰值不透明度
+constexpr double kKeyOffsetYCss = 4.0;     // key 瓣向下偏移
+
+// 圆角矩形有符号距离（外正内负）。[rect]=l,t,w,h；[r] 圆角半径。
+double RoundedRectDistance(double px, double py,
+                           const std::array<double, 4>& rect, double r) {
+  const double cx = rect[0] + rect[2] / 2.0;
+  const double cy = rect[1] + rect[3] / 2.0;
+  const double bx = rect[2] / 2.0 - r;
+  const double by = rect[3] / 2.0 - r;
+  const double qx = std::abs(px - cx) - (bx > 0 ? bx : 0);
+  const double qy = std::abs(py - cy) - (by > 0 ? by : 0);
+  const double ax = qx > 0 ? qx : 0;
+  const double ay = qy > 0 ? qy : 0;
+  const double outside = std::sqrt(ax * ax + ay * ay);
+  const double inside = std::min(std::max(qx, qy), 0.0);
+  return outside + inside - r;
+}
+
+}  // namespace
+
+LookupShadowWindow::~LookupShadowWindow() {
+  if (hwnd_ != nullptr) {
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+  }
+  // 类注册进程级共享（瞬态查词窗 + 剪贴板面板各持一个投影窗），不在此注销，
+  // 与 GlobalLookupWindow 的窗口类同一纪律：进程退出时由 OS 回收。
+}
+
+LRESULT CALLBACK LookupShadowWindow::WndProc(HWND hwnd, UINT message,
+                                             WPARAM wparam,
+                                             LPARAM lparam) noexcept {
+  // 纯展示窗：WS_EX_TRANSPARENT 已保证鼠标穿透，这里不需要任何自定义行为。
+  return DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+void LookupShadowWindow::EnsureWindow() {
+  if (hwnd_ != nullptr && IsWindow(hwnd_)) {
+    return;
+  }
+  hwnd_ = nullptr;
+  static bool s_class_registered = false;
+  if (!s_class_registered) {
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = LookupShadowWindow::WndProc;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = kShadowClassName;
+    RegisterClassExW(&wc);
+    s_class_registered = true;
+  }
+  // WS_EX_TRANSPARENT：命中测试永远穿透（影子环绝不吃底下应用的点击）；
+  // WS_EX_NOACTIVATE + WS_DISABLED：绝不参与激活/焦点；
+  // WS_EX_TOOLWINDOW：无任务栏项/Alt-Tab 项；
+  // WS_EX_LAYERED：UpdateLayeredWindow 逐像素 alpha 的前提。
+  // 不带 WS_EX_TOPMOST：Z 序全程由 Sync 里 insertAfter=anchor 钉在锚窗正下，
+  // 锚窗在哪个 Z 带、影子就跟到哪个 Z 带（面板未 pin 时在非置顶带同样成立）。
+  hwnd_ = CreateWindowExW(
+      WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW,
+      kShadowClassName, L"", WS_POPUP | WS_DISABLED, 0, 0, 1, 1, nullptr,
+      nullptr, GetModuleHandle(nullptr), nullptr);
+  if (hwnd_ != nullptr && block_capture_) {
+    SetWindowDisplayAffinity(hwnd_, WDA_EXCLUDEFROMCAPTURE);
+  }
+  // 强制下次 Sync 重画（新窗口还没有内容）。
+  last_w_ = 0;
+  last_h_ = 0;
+  last_cards_px_.clear();
+}
+
+void LookupShadowWindow::SetBlockCapture(bool block) {
+  block_capture_ = block;
+  if (hwnd_ != nullptr && IsWindow(hwnd_)) {
+    SetWindowDisplayAffinity(hwnd_,
+                             block ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE);
+  }
+}
+
+void LookupShadowWindow::Hide() {
+  if (hwnd_ != nullptr && IsWindow(hwnd_)) {
+    ShowWindow(hwnd_, SW_HIDE);
+  }
+}
+
+void LookupShadowWindow::Sync(
+    HWND anchor, bool show,
+    const std::vector<std::array<double, 4>>& cards_css, int radius_css,
+    bool defer_repaint) {
+  if (anchor == nullptr || !IsWindow(anchor) || !show) {
+    Hide();
+    return;
+  }
+  RECT wr{};
+  if (!GetWindowRect(anchor, &wr)) {
+    Hide();
+    return;
+  }
+  const int anchor_w = wr.right - wr.left;
+  const int anchor_h = wr.bottom - wr.top;
+  if (anchor_w <= 0 || anchor_h <= 0) {
+    Hide();
+    return;
+  }
+  UINT dpi = GetDpiForWindow(anchor);
+  if (dpi == 0) {
+    dpi = 96;
+  }
+  const double dpr = static_cast<double>(dpi) / 96.0;
+  const int margin = static_cast<int>(std::lround(kMarginCss * dpr));
+  const int radius_px = static_cast<int>(std::lround(radius_css * dpr));
+
+  // 卡矩形 CSS px → 投影窗本地物理 px（投影窗原点 = 锚窗原点 − margin）。
+  std::vector<std::array<double, 4>> cards_px;
+  if (cards_css.empty()) {
+    cards_px.push_back({static_cast<double>(margin),
+                        static_cast<double>(margin),
+                        static_cast<double>(anchor_w),
+                        static_cast<double>(anchor_h)});
+  } else {
+    cards_px.reserve(cards_css.size());
+    for (const std::array<double, 4>& r : cards_css) {
+      if (r[2] <= 0 || r[3] <= 0) {
+        continue;
+      }
+      cards_px.push_back({r[0] * dpr + margin, r[1] * dpr + margin,
+                          r[2] * dpr, r[3] * dpr});
+    }
+    if (cards_px.empty()) {
+      Hide();
+      return;
+    }
+  }
+
+  const int win_w = anchor_w + 2 * margin;
+  const int win_h = anchor_h + 2 * margin;
+  const int win_x = wr.left - margin;
+  const int win_y = wr.top - margin;
+
+  EnsureWindow();
+  if (hwnd_ == nullptr) {
+    return;
+  }
+
+  const bool dirty = win_w != last_w_ || win_h != last_h_ ||
+                     radius_px != last_radius_px_ ||
+                     cards_px != last_cards_px_;
+  if (dirty) {
+    if (defer_repaint) {
+      // 模态 resize 循环中每帧重画会拖慢拖拽：先藏起来，
+      // WM_EXITSIZEMOVE 后的下一次 Sync 再恢复。
+      Hide();
+      return;
+    }
+    if (!Paint(win_x, win_y, win_w, win_h, cards_px, radius_px, dpr)) {
+      Hide();
+      return;
+    }
+    last_w_ = win_w;
+    last_h_ = win_h;
+    last_radius_px_ = radius_px;
+    last_cards_px_ = cards_px;
+  }
+  // 纯移动（内容没变）：layered 窗口内容随窗而动，SetWindowPos 免重画；
+  // 同一调用顺带把 Z 序钉回锚窗正下方并确保可见。SWP_NOACTIVATE：绝不抢焦点。
+  SetWindowPos(hwnd_, anchor, win_x, win_y, 0, 0,
+               SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+}
+
+bool LookupShadowWindow::Paint(
+    int x, int y, int width, int height,
+    const std::vector<std::array<double, 4>>& cards_px, int radius_px,
+    double dpr) {
+  if (width <= 0 || height <= 0) {
+    return false;
+  }
+  BITMAPINFO bmi = {};
+  bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  bmi.bmiHeader.biWidth = width;
+  bmi.bmiHeader.biHeight = -height;  // top-down
+  bmi.bmiHeader.biPlanes = 1;
+  bmi.bmiHeader.biBitCount = 32;
+  bmi.bmiHeader.biCompression = BI_RGB;
+
+  void* bits = nullptr;
+  HDC screen_dc = GetDC(nullptr);
+  HBITMAP dib =
+      CreateDIBSection(screen_dc, &bmi, DIB_RGB_COLORS, &bits, nullptr, 0);
+  if (dib == nullptr || bits == nullptr) {
+    if (dib != nullptr) {
+      DeleteObject(dib);
+    }
+    ReleaseDC(nullptr, screen_dc);
+    return false;
+  }
+  HDC mem_dc = CreateCompatibleDC(screen_dc);
+  HGDIOBJ old_bitmap = SelectObject(mem_dc, dib);
+
+  const double sigma_a = kAmbientSigmaCss * dpr;
+  const double sigma_k = kKeySigmaCss * dpr;
+  const double key_dy = kKeyOffsetYCss * dpr;
+  // 高斯尾部按 margin 截断即可；margin(30css) > 2σk(16css) 有足够余量。
+  auto* pixels = static_cast<uint32_t*>(bits);
+  std::fill(pixels, pixels + static_cast<size_t>(width) * height, 0u);
+
+  for (const std::array<double, 4>& card : cards_px) {
+    // 只扫本卡影响的包围盒（卡矩形外扩 margin），级联多卡时避免整图 × 卡数。
+    const int margin_px =
+        static_cast<int>(std::lround(kMarginCss * dpr));
+    const int x0 = std::max(0, static_cast<int>(std::floor(card[0])) - margin_px);
+    const int y0 = std::max(0, static_cast<int>(std::floor(card[1])) - margin_px);
+    const int x1 = std::min(
+        width, static_cast<int>(std::ceil(card[0] + card[2])) + margin_px);
+    const int y1 = std::min(
+        height, static_cast<int>(std::ceil(card[1] + card[3])) + margin_px);
+    for (int py = y0; py < y1; ++py) {
+      uint32_t* row = pixels + static_cast<size_t>(py) * width;
+      for (int px = x0; px < x1; ++px) {
+        const double fx = px + 0.5;
+        const double fy = py + 0.5;
+        const double d = RoundedRectDistance(fx, fy, card, radius_px);
+        if (d <= 0) {
+          continue;  // 卡内不画（punch-out 在下面统一做）
+        }
+        const double dk =
+            RoundedRectDistance(fx, fy - key_dy, card, radius_px);
+        const double ambient =
+            kAmbientAlpha * std::exp(-(d * d) / (sigma_a * sigma_a));
+        const double key =
+            dk <= 0 ? kKeyAlpha
+                    : kKeyAlpha * std::exp(-(dk * dk) / (sigma_k * sigma_k));
+        const double alpha = 1.0 - (1.0 - ambient) * (1.0 - key);
+        const uint32_t a =
+            static_cast<uint32_t>(std::lround(std::clamp(alpha, 0.0, 1.0) * 255.0));
+        if (a == 0) {
+          continue;
+        }
+        // 多卡重叠区取较深者（max）——比相加更接近真实阴影且不会过曝。
+        const uint32_t existing = row[px] >> 24;
+        if (a > existing) {
+          // 纯黑影：预乘 ARGB = (a, 0, 0, 0)。
+          row[px] = a << 24;
+        }
+      }
+    }
+  }
+  // punch-out：任何卡矩形内部一律 alpha=0。面板可开整窗 LWA_ALPHA 半透明，
+  // 不打洞的话黑影会从半透明卡片底下透出来把内容压暗；级联相邻卡的影子落进
+  // 另一张卡的矩形同理清掉（那块像素本来也被不透明卡片盖住，防御性一致）。
+  for (const std::array<double, 4>& card : cards_px) {
+    const int x0 = std::max(0, static_cast<int>(std::floor(card[0])));
+    const int y0 = std::max(0, static_cast<int>(std::floor(card[1])));
+    const int x1 = std::min(width, static_cast<int>(std::ceil(card[0] + card[2])));
+    const int y1 = std::min(height, static_cast<int>(std::ceil(card[1] + card[3])));
+    for (int py = y0; py < y1; ++py) {
+      uint32_t* row = pixels + static_cast<size_t>(py) * width;
+      for (int px = x0; px < x1; ++px) {
+        const double d = RoundedRectDistance(px + 0.5, py + 0.5, card,
+                                             radius_px);
+        if (d <= 0) {
+          row[px] = 0;
+        }
+      }
+    }
+  }
+
+  POINT dst = {x, y};
+  SIZE size = {width, height};
+  POINT src = {0, 0};
+  BLENDFUNCTION blend = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+  const BOOL ok = UpdateLayeredWindow(hwnd_, screen_dc, &dst, &size, mem_dc,
+                                      &src, 0, &blend, ULW_ALPHA);
+
+  SelectObject(mem_dc, old_bitmap);
+  DeleteDC(mem_dc);
+  DeleteObject(dib);
+  ReleaseDC(nullptr, screen_dc);
+  return ok != FALSE;
+}

--- a/fushi/windows/runner/global_lookup_shadow.h
+++ b/fushi/windows/runner/global_lookup_shadow.h
@@ -1,0 +1,81 @@
+#ifndef RUNNER_GLOBAL_LOOKUP_SHADOW_H_
+#define RUNNER_GLOBAL_LOOKUP_SHADOW_H_
+
+#include <windows.h>
+
+#include <array>
+#include <vector>
+
+// 查词弹窗投影窗（2026-08-23，对齐 Niratan 弹窗观感）。
+//
+// 背景：查词浮窗/剪贴板面板是 windowed WebView2 宿主 —— 不能带 WS_EX_LAYERED
+// （与 WebView2 合成面互斥，见 global_lookup_window.cpp ShowAt 注释），圆角只能
+// 靠 SetWindowRgn 硬裁，而带 region 的窗口拿不到 DWM 系统投影。Niratan 的弹窗
+// 是 WinUI3 context-menu presenter，投影是系统白送的；我们这边等价物只能自绘。
+//
+// 方案：每个 GlobalLookupWindow 配一个伴随的 layered 投影窗（本类）。
+// - WS_EX_LAYERED + UpdateLayeredWindow 逐像素 alpha 画柔和投影（黑色双瓣：
+//   贴边 ambient + 下偏 key，近似 Win11 flyout 阴影）；
+// - WS_EX_TRANSPARENT + WS_EX_NOACTIVATE：投影环绝不吃鼠标点击、绝不参与激活
+//   —— 这正是选「伴随窗」而不是「region 扩边 + CSS 画影」的原因（后者的影子
+//   环会吞掉本应穿透到底下应用的点击，等于把 BUG-749 修过的问题再引回来）；
+// - Z 序钉在锚窗正下方（SetWindowPos insertAfter=anchor），锚窗每次
+//   WM_WINDOWPOSCHANGED（移动/缩放/显隐/置顶重申）由 GlobalLookupWindow::
+//   SyncShadow 单漏斗重新同步；
+// - 级联多卡：按 shellRects（BUG-749 已有的卡矩形真相源）逐卡画影，卡间空隙
+//   照常穿透——视觉上等价「每卡一窗各自带影」，但不拆单 WebView 架构；
+// - 卡矩形内部 alpha 一律打 0（punch-out）：面板可开整窗 LWA_ALPHA 半透明，
+//   不打洞的话黑影会从半透明卡片底下透出来把内容压暗。
+//
+// 贴边 ambient 瓣在 d→0 处 alpha 最高，紧贴 GDI region 裁出的锯齿边缘形成
+// 深色渐变过渡，顺带显著弱化 region 圆角无抗锯齿的观感（真 AA 需要逐像素
+// 透明合成，而 composition 路线有真机「透明像素合成成黑」前科，见
+// flutter_window.cpp RegisterClipboardPanelChannel 注释——修好 DComp 黑底前
+// 不走那条路）。
+class LookupShadowWindow {
+ public:
+  LookupShadowWindow() = default;
+  ~LookupShadowWindow();
+
+  LookupShadowWindow(const LookupShadowWindow&) = delete;
+  LookupShadowWindow& operator=(const LookupShadowWindow&) = delete;
+
+  // 把投影窗同步到 [anchor] 当前几何/可见性/Z 序之下。
+  // [show]=false 或 anchor 无效 → 隐藏（窗口保留复用）。
+  // [cards_css]：锚窗内各卡矩形（窗口相对 CSS px，即 shellRects 原样）；空 =
+  // 整窗一张卡（面板 / 拖拽期兜底）。[radius_css]：卡圆角（CSS px，与
+  // ApplyRoundedRegion 的 10px 同源）。
+  // [defer_repaint]=true（模态 resize 循环中）：几何变了但不重画——每帧重画会
+  // 拖慢拖拽；此时直接隐藏，WM_EXITSIZEMOVE 后的下一次 Sync 恢复。纯移动
+  // （尺寸/卡矩形不变）永远走免重画的快路径，面板拖动全程影随窗走。
+  void Sync(HWND anchor, bool show,
+            const std::vector<std::array<double, 4>>& cards_css,
+            int radius_css, bool defer_repaint);
+
+  // 立即隐藏（锚窗 Hide/ForgetDeadWindow 用；窗口保留复用）。
+  void Hide();
+
+  // 防截屏与锚窗联动：面板开 WDA_EXCLUDEFROMCAPTURE 时投影也必须排除，否则
+  // 录屏里会出现一圈"凭空的影子"泄露卡片轮廓。
+  void SetBlockCapture(bool block);
+
+ private:
+  static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam,
+                                  LPARAM lparam) noexcept;
+  void EnsureWindow();
+  // 重画投影位图并经 UpdateLayeredWindow 提交（同时落位置+尺寸+内容）。
+  // [cards_px]：投影窗本地物理 px 卡矩形；[radius_px] 物理 px 圆角。
+  bool Paint(int x, int y, int width, int height,
+             const std::vector<std::array<double, 4>>& cards_px, int radius_px,
+             double dpr);
+
+  HWND hwnd_ = nullptr;
+  bool block_capture_ = false;
+  // 上次成功提交的几何指纹——纯移动免重画的判据。
+  int last_w_ = 0;
+  int last_h_ = 0;
+  int last_radius_px_ = 0;
+  std::vector<std::array<double, 4>> last_cards_px_;
+};
+
+#endif  // RUNNER_GLOBAL_LOOKUP_SHADOW_H_

--- a/fushi/windows/runner/global_lookup_window.cpp
+++ b/fushi/windows/runner/global_lookup_window.cpp
@@ -771,6 +771,8 @@ void GlobalLookupWindow::ForgetDeadWindow() {
   revealed_ = false;
   offscreen_active_ = false;
   shell_rects_css_.clear();  // BUG-749 — stale rects must not clip a rebuild.
+  // 锚窗已死，投影窗不能留在桌面上变成"孤儿影子"。
+  shadow_.Hide();
 }
 
 bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
@@ -933,6 +935,9 @@ void GlobalLookupWindow::Reveal(int width, int height) {
     fushi::ArmLowLevelMouseHook(hwnd_);
     mouse_hook_armed_ = true;
   }
+  // 投影：上面 SetWindowPos 触发的 WM_WINDOWPOSCHANGED 到达时 revealed_ 还是
+  // false（置位在其后），漏斗那次同步判为隐藏——首帧必须在标志置位后显式补一次。
+  SyncShadow();
 }
 
 void GlobalLookupWindow::RevealStack(int dx, int dy, int width, int height,
@@ -1017,6 +1022,9 @@ void GlobalLookupWindow::RevealStack(int dx, int dy, int width, int height,
     fushi::ArmLowLevelMouseHook(hwnd_);
     mouse_hook_armed_ = true;
   }
+  // 投影：与 Reveal 同因——上面 SetWindowPos 触发漏斗时 revealed_ 还是 false，
+  // 标志置位后显式补一次，首帧才有影。
+  SyncShadow();
 }
 
 void GlobalLookupWindow::ResizeTo(int width, int height) {
@@ -1263,6 +1271,8 @@ void GlobalLookupWindow::ApplyBlockCapture() {
   if (hwnd_ == nullptr) {
     return;
   }
+  // 投影窗与锚窗联动排除捕获：录屏里"凭空一圈影子"同样泄露卡片轮廓。
+  shadow_.SetBlockCapture(block_capture_);
   // WDA_EXCLUDEFROMCAPTURE：窗口对用户可见但从截图 / 录屏 / 屏幕共享里排除
   // （查词内容不外泄）。Win10<2004 该值不被支持 -> API 失败，回退 WDA_MONITOR
   // （被捕获处画成黑块，同样不泄露内容）。关闭时 WDA_NONE 恢复正常可截。
@@ -1333,6 +1343,9 @@ void GlobalLookupWindow::Hide(bool notify) {
   shell_rects_css_.clear();
   ReleaseDismissHooks();
   StopTopmostGuard();
+  // 投影窗随卡片同步隐藏（WM_WINDOWPOSCHANGED 也会兜到，这里显式先藏，
+  // 避免"卡没了影子晚一拍"）。
+  shadow_.Hide();
   if (hwnd_ != nullptr) {
     ShowWindow(hwnd_, SW_HIDE);
   }
@@ -2514,6 +2527,26 @@ void GlobalLookupWindow::ApplyRoundedRegion() {
   }
 }
 
+// 2026-08-23 弹窗观感 — 投影同步单漏斗（调用点：WM_WINDOWPOSCHANGED /
+// SetShellRectsFromCsv / WM_EXITSIZEMOVE；Hide 与 ForgetDeadWindow 直接
+// shadow_.Hide()）。
+//
+// 可见性判据 = revealed_ && visible_：离屏渲染（ShowAt 的 OffscreenX 停靠、
+// PrewarmWebView、gal 采集面 ResizeOffscreen）全程不带影；卡片真正上屏
+// （Reveal/RevealStack 置位）后影子才出现。卡矩形用 shellRects（BUG-749 的
+// 卡片几何真相源，瞬态级联逐卡画影）；面板实例 shellRects 恒空 → 整窗一影。
+// 模态 resize 循环（resizing_）中卡矩形已失真且每帧重画会拖慢拖拽：传
+// defer_repaint 让影子窗"几何脏了就先藏"，WM_EXITSIZEMOVE 复原。半径 10
+// 与 ApplyRoundedRegion 的 10 逻辑 px（diameter 20）同源，两者必须一起改。
+void GlobalLookupWindow::SyncShadow() {
+  const bool show = revealed_ && visible_ && hwnd_ != nullptr &&
+                    IsWindowVisible(hwnd_);
+  shadow_.Sync(hwnd_, show,
+               resizing_ ? std::vector<std::array<double, 4>>{}
+                         : shell_rects_css_,
+               10, resizing_);
+}
+
 // BUG-749 — parse {handler:'shellRects', args:['l,t,w,h;l,t,w,h;…']} (window-
 // relative CSS px, numbers only — produced by global_lookup_host.js
 // measureAndReport) and re-apply the window region. A malformed payload (or a
@@ -2567,6 +2600,8 @@ void GlobalLookupWindow::SetShellRectsFromCsv(const std::string& body) {
   }
   shell_rects_css_ = std::move(rects);
   ApplyRoundedRegion();
+  // 2026-08-23 弹窗观感 — 卡矩形变了（级联增删卡/卡尺寸变化），投影跟着重画。
+  SyncShadow();
 }
 
 void GlobalLookupWindow::ForwardGlobalClickToHost(int screen_x, int screen_y) {
@@ -2620,6 +2655,13 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       HandleGlobalWheel(fushi::UnpackMouseHookPoint(wparam),
                         fushi::UnpackMouseHookWheel(lparam));
       return 0;
+    case WM_WINDOWPOSCHANGED:
+      // 2026-08-23 弹窗观感 — 投影同步单漏斗：移动/缩放/显隐/Z 序变化（含
+      // ReassertTopmost 的置顶重申与 Reveal/ResizeTo 的每一次 SetWindowPos）
+      // 全部经过本消息，投影窗在此一处跟随，杜绝散落的手工同步点漂移。
+      // 必须交回 DefWindowProc：WM_SIZE / WM_MOVE 是它在这里派生的。
+      SyncShadow();
+      return DefWindowProc(hwnd_, message, wparam, lparam);
     case WM_SIZE:
       if (controller_) {
         RECT rc;
@@ -2707,6 +2749,8 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       // Phase C — 先复原 resize 期间临时挂起的 shell 区域裁剪（resizing_ 归零后重算）。
       resizing_ = false;
       ApplyRoundedRegion();
+      // 拖拽期间投影因防掉帧被隐藏（见 SyncShadow），拖完立刻恢复。
+      SyncShadow();
       if (message_cb_ && hwnd_ != nullptr) {
         RECT r{};
         GetWindowRect(hwnd_, &r);

--- a/fushi/windows/runner/global_lookup_window.h
+++ b/fushi/windows/runner/global_lookup_window.h
@@ -40,6 +40,9 @@
 
 // BUG-1166 — 滚轮载荷类型（fushi::MouseHookWheel）来自钩子线程的消息契约。
 #include "low_level_mouse_hook.h"
+// 2026-08-23 弹窗观感 — layered 伴随投影窗（region 窗口拿不到 DWM 系统投影，
+// 见 global_lookup_shadow.h 头注释）。
+#include "global_lookup_shadow.h"
 
 class GlobalLookupWindow {
  public:
@@ -389,6 +392,11 @@ class GlobalLookupWindow {
   std::wstring LoadAdapterScript() const;
   // TODO-867 P3c — reads global_lookup_host.js for top-level injection.
   std::wstring LoadHostScript() const;
+  // 2026-08-23 弹窗观感 — 投影同步单漏斗：锚窗每次 WM_WINDOWPOSCHANGED
+  // （移动/缩放/显隐/置顶重申都会经过）+ shellRects 更新 + Hide 显式调用。
+  // 投影可见性 = revealed_ && visible_（离屏渲染/预热/gal 采集面绝不带影）；
+  // 模态 resize 循环中（resizing_）几何脏时不重画只隐藏，防拖拽掉帧。
+  void SyncShadow();
 
   HWND hwnd_ = nullptr;
   HWINEVENTHOOK foreground_hook_ = nullptr;
@@ -469,6 +477,10 @@ class GlobalLookupWindow {
   // composition 模式下 WebView2 请求的光标（add_CursorChanged 回调更新）；
   // WM_SETCURSOR 据此 SetCursor，让 hover 链接/文本时光标形状正确。
   HCURSOR composition_cursor_ = nullptr;
+
+  // 2026-08-23 弹窗观感 — 伴随投影窗（每实例一个：瞬态查词窗按 shellRects
+  // 逐卡画影，面板整窗一影）。生命周期随本实例；显隐由 SyncShadow 驱动。
+  LookupShadowWindow shadow_;
 
   MediaResolver media_resolver_;
   MessageCallback message_cb_;

--- a/tools/browser-extension/scripts/generate-content-css.mjs
+++ b/tools/browser-extension/scripts/generate-content-css.mjs
@@ -103,9 +103,22 @@ function transformSelector(raw) {
   // 收进 `:where(#entries-container)` 后代，特异性仍是 (0,1,0)，与 app 内一致。
   if (/^:lang\(/.test(p)) return ':where(#entries-container) ' + p;
   if (p === 'body') return ':where(#entries-container)';
-  if (/^html([.[ ]|$)/.test(p)) return ':where(#entries-container)' + p.slice(4);
+  // Niratan 对齐（2026-08-23）滚动条悬停/滚动显形：`*:hover` /
+  // `*.popup-scroll-active` 这类 `*` 前缀选择器重根为「容器自身 + 全部后代」
+  // （零特异性 :where 包容器，:hover/.popup-scroll-active 部分原样保留），
+  // 与顶部 `*` 通配 reset 的重根策略同源。
+  if (p.startsWith('*') && p.length > 1) {
+    return ':where(#entries-container, #entries-container *)' + p.slice(1);
+  }
+  if (/^body([.:])/.test(p)) return ':where(#entries-container)' + p.slice(4);
+  if (/^html([.[: ]|$)/.test(p)) return ':where(#entries-container)' + p.slice(4);
   if (p === '::selection') return ':where(#entries-container) ::selection';
-  if (p.startsWith('::-webkit-scrollbar')) return ':where(#entries-container) ' + p;
+  // 滚动条伪元素：覆盖「容器自身 + 全部后代」的滚动条（旧映射只带后代，
+  // #entries-container 自己作为滚动容器时其 thumb 落 UA 默认样式——静止隐形
+  // 设计下会退化成常驻灰滚动条）。
+  if (p.startsWith('::-webkit-scrollbar')) {
+    return ':where(#entries-container, #entries-container *)' + p;
+  }
   if (/^(hr|a)$/.test(p)) return ':where(#entries-container) ' + p;
   throw new Error(
     `[generate-content-css] UNKNOWN document-level selector ${JSON.stringify(p)}: ` +

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -127,37 +127,59 @@
     padding: 0 10px 10px;
 }
 
-/* Themed scrollbar (mirrors reader_content_styles.dart / lyrics_mode_html.dart).
-   The track stays transparent so it shows the popup background; the thumb takes
-   --text-color (onSurface, injected by dictionary_popup_webview _themeVariablesJs),
-   so dark themes get a light thumb and light themes a dark one. The standard
-   props cover Firefox/Chromium 121+; the -webkit pseudo-elements cover Android
-   WebView / Windows WebView2 / macOS WKWebView. color-scheme is pinned per theme
-   in the html[data-theme] blocks below -- WebView2's Fluent overlay scrollbar
-   ignores ::-webkit-scrollbar and only follows the UA color-scheme. */
-:where(#entries-container) {
-    scrollbar-width: thin;
-    scrollbar-color: var(--text-color) transparent;
-}
-
-:where(#entries-container) ::-webkit-scrollbar {
+/* Themed scrollbar — Niratan 对齐（2026-08-23，取代 TODO-789 的常驻细滚动条）。
+   静止时完全隐形；鼠标落在文档上（:hover）或滚动进行中（popup.js 的滚动监听给
+   根节点加 .popup-scroll-active，900ms 衰减，覆盖触屏无 hover 的情形）才浮现
+   胶囊 thumb —— 逐字对齐 Niratan popup.css 的 overlay 滚动条（宽 8px、透明
+   track、999px 胶囊、2px 内缩 content-box、min-height 36px）。
+   有意不再设标准 scrollbar-width / scrollbar-color：Chromium 121+ 一旦标准
+   属性生效会整族禁用 ::-webkit-scrollbar 伪元素（BUG-753 记录的引擎行为），
+   而「静止隐形、悬停浮现」只有伪元素表达得出来。副作用一并消化：没有标准
+   thin 属性后 WebView2 可能回到 Fluent overlay 滚动条（忽略伪元素、只认 UA
+   color-scheme）——那形态本来就是静止隐形的浮层，与本设计同向；color-scheme
+   仍按主题钉在 html[data-theme] 块里。gutter 消失不影响圆角：TODO-893 的
+   右上/右下方角根因已由 html.global-lookup 的透明渐变背景根治，不再依赖
+   「内容右缘与 shell 右缘重合」。thumb 颜色变量在 html[data-theme] 块按主题
+   定义，不再用 --text-color 实心色（黑/白实心太扎眼，Niratan 用半透明灰）。 */
+:where(#entries-container, #entries-container *)::-webkit-scrollbar {
     width: 8px;
     height: 8px;
-}
-
-:where(#entries-container) ::-webkit-scrollbar-track {
     background: transparent;
 }
 
-:where(#entries-container) ::-webkit-scrollbar-thumb {
-    background-color: var(--text-color);
-    background-clip: padding-box;
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-track,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-track-piece,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-corner {
+    background: transparent;
+    border: 0;
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb {
+    min-height: 36px;
     border: 2px solid transparent;
-    border-radius: 8px;
+    border-radius: 999px;
+    background-color: transparent;
+    background-clip: content-box;
 }
 
-:where(#entries-container) ::-webkit-scrollbar-corner {
-    background: transparent;
+/* 通用形（不枚举 html/body/.overlay）：任一滚动容器被悬停、或被 popup.js 打上
+   .popup-scroll-active，就显形**它自己**的 thumb。比 Niratan 的枚举式更简，且
+   content.css 生成器把 `*` 前缀重根为 #entries-container 及其后代后，扩展里
+   无论真正的滚动容器是哪层都被覆盖（枚举 html/body 在扩展里会失配）。 */
+:where(#entries-container, #entries-container *):hover::-webkit-scrollbar-thumb,
+:where(#entries-container, #entries-container *).popup-scroll-active::-webkit-scrollbar-thumb {
+    background-color: var(--popup-scrollbar-thumb, rgba(128, 128, 128, 0.42));
+}
+
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb:hover,
+:where(#entries-container, #entries-container *)::-webkit-scrollbar-thumb:active {
+    background-color: var(--popup-scrollbar-thumb-active, rgba(128, 128, 128, 0.64));
 }
 
 .entry {
@@ -1382,6 +1404,9 @@
     --background-color: #fff;
     --background-color-light: #fff;
     --text-color: #000;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明灰，非实心）。 */
+    --popup-scrollbar-thumb: rgba(80, 80, 80, 0.42);
+    --popup-scrollbar-thumb-active: rgba(80, 80, 80, 0.64);
     /* Prefer the MD3 ColorScheme values Dart injects (--md-*); the per-theme
        literals stay as fallbacks for hosts that don't inject (Android native). */
     --surface-container: var(--md-surface-container, #F0F1EC);
@@ -1396,6 +1421,9 @@
     --background-color: #000;
     --background-color-light: #000;
     --text-color: #fff;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明白）。 */
+    --popup-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+    --popup-scrollbar-thumb-active: rgba(255, 255, 255, 0.56);
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
     --text-color-light3: #888888;

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -172,37 +172,59 @@ body {
     padding: 0 10px 10px;
 }
 
-/* Themed scrollbar (mirrors reader_content_styles.dart / lyrics_mode_html.dart).
-   The track stays transparent so it shows the popup background; the thumb takes
-   --text-color (onSurface, injected by dictionary_popup_webview _themeVariablesJs),
-   so dark themes get a light thumb and light themes a dark one. The standard
-   props cover Firefox/Chromium 121+; the -webkit pseudo-elements cover Android
-   WebView / Windows WebView2 / macOS WKWebView. color-scheme is pinned per theme
-   in the html[data-theme] blocks below -- WebView2's Fluent overlay scrollbar
-   ignores ::-webkit-scrollbar and only follows the UA color-scheme. */
-html {
-    scrollbar-width: thin;
-    scrollbar-color: var(--text-color) transparent;
-}
-
+/* Themed scrollbar — Niratan 对齐（2026-08-23，取代 TODO-789 的常驻细滚动条）。
+   静止时完全隐形；鼠标落在文档上（:hover）或滚动进行中（popup.js 的滚动监听给
+   根节点加 .popup-scroll-active，900ms 衰减，覆盖触屏无 hover 的情形）才浮现
+   胶囊 thumb —— 逐字对齐 Niratan popup.css 的 overlay 滚动条（宽 8px、透明
+   track、999px 胶囊、2px 内缩 content-box、min-height 36px）。
+   有意不再设标准 scrollbar-width / scrollbar-color：Chromium 121+ 一旦标准
+   属性生效会整族禁用 ::-webkit-scrollbar 伪元素（BUG-753 记录的引擎行为），
+   而「静止隐形、悬停浮现」只有伪元素表达得出来。副作用一并消化：没有标准
+   thin 属性后 WebView2 可能回到 Fluent overlay 滚动条（忽略伪元素、只认 UA
+   color-scheme）——那形态本来就是静止隐形的浮层，与本设计同向；color-scheme
+   仍按主题钉在 html[data-theme] 块里。gutter 消失不影响圆角：TODO-893 的
+   右上/右下方角根因已由 html.global-lookup 的透明渐变背景根治，不再依赖
+   「内容右缘与 shell 右缘重合」。thumb 颜色变量在 html[data-theme] 块按主题
+   定义，不再用 --text-color 实心色（黑/白实心太扎眼，Niratan 用半透明灰）。 */
 ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
+    background: transparent;
 }
 
-::-webkit-scrollbar-track {
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-track-piece,
+::-webkit-scrollbar-corner {
     background: transparent;
+    border: 0;
+}
+
+::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
 }
 
 ::-webkit-scrollbar-thumb {
-    background-color: var(--text-color);
-    background-clip: padding-box;
+    min-height: 36px;
     border: 2px solid transparent;
-    border-radius: 8px;
+    border-radius: 999px;
+    background-color: transparent;
+    background-clip: content-box;
 }
 
-::-webkit-scrollbar-corner {
-    background: transparent;
+/* 通用形（不枚举 html/body/.overlay）：任一滚动容器被悬停、或被 popup.js 打上
+   .popup-scroll-active，就显形**它自己**的 thumb。比 Niratan 的枚举式更简，且
+   content.css 生成器把 `*` 前缀重根为 #entries-container 及其后代后，扩展里
+   无论真正的滚动容器是哪层都被覆盖（枚举 html/body 在扩展里会失配）。 */
+*:hover::-webkit-scrollbar-thumb,
+*.popup-scroll-active::-webkit-scrollbar-thumb {
+    background-color: var(--popup-scrollbar-thumb, rgba(128, 128, 128, 0.42));
+}
+
+::-webkit-scrollbar-thumb:hover,
+::-webkit-scrollbar-thumb:active {
+    background-color: var(--popup-scrollbar-thumb-active, rgba(128, 128, 128, 0.64));
 }
 
 .entry {
@@ -1441,6 +1463,9 @@ html[data-theme="light"] {
     --background-color: #fff;
     --background-color-light: #fff;
     --text-color: #000;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明灰，非实心）。 */
+    --popup-scrollbar-thumb: rgba(80, 80, 80, 0.42);
+    --popup-scrollbar-thumb-active: rgba(80, 80, 80, 0.64);
     /* Prefer the MD3 ColorScheme values Dart injects (--md-*); the per-theme
        literals stay as fallbacks for hosts that don't inject (Android native). */
     --surface-container: var(--md-surface-container, #F0F1EC);
@@ -1455,6 +1480,9 @@ html[data-theme="dark"] {
     --background-color: #000;
     --background-color-light: #000;
     --text-color: #fff;
+    /* Niratan 对齐（2026-08-23）— 悬停浮现滚动条的胶囊色（半透明白）。 */
+    --popup-scrollbar-thumb: rgba(255, 255, 255, 0.34);
+    --popup-scrollbar-thumb-active: rgba(255, 255, 255, 0.56);
     --text-color-light1: #aaaaaa;
     --text-color-light2: #999999;
     --text-color-light3: #888888;
@@ -1579,19 +1607,24 @@ html[data-theme="dark"] {
  * grid — and only style the bare WebView2 lookup window.
  *
  * Card chrome ports hoshi's reader-popup-host.js `.fushi-reader-popup-shell`
- * (border 1px rgba(120,120,128,0.36) / radius 10px). The opaque, NON-layered
- * WebView2 window (see global_lookup_window.cpp: "No WS_EX_LAYERED") cannot
- * carry a real drop-shadow inside CSS — that is a platform limitation, not an
- * omission; the true rounded-corner + shadow is supplied by the native window
- * region (SetWindowRgn) instead. The CSS here gives the content a clean inset
+ * (radius 10px；描边 2026-08-23 起改系统分隔线灰 #D1D1D6/#3A3A3C，对齐
+ * Niratan)。The opaque, NON-layered WebView2 window (see
+ * global_lookup_window.cpp: "No WS_EX_LAYERED") cannot carry a real
+ * drop-shadow inside CSS — that platform limitation stands; the rounded corner
+ * is supplied by the native window region (SetWindowRgn) and the drop shadow
+ * by the companion layered shadow window (global_lookup_shadow.cpp,
+ * 2026-08-23). The CSS here gives the content a clean inset
  * border so it reads as a card, not raw text flush to the window edge.
  * ===================================================================== */
 
 html.global-lookup body {
-    /* hoshi shell border (light). The dark variant follows below. Inset padding
-       lifts the content off the hard window edge so the border reads as a card
-       frame rather than a hairline glued to the glass. */
-    border: 1px solid rgba(120, 120, 128, 0.36);
+    /* Niratan 对齐（2026-08-23）— 外壳描边改用系统分隔线灰（Niratan
+       DictionaryPopupMaterial.GetOutlineColor 的 #D1D1D6 / #3A3A3C 实色），
+       取代原 hoshi 的 rgba(120,120,128,0.36) 半透明描边：与原生 Win11 hairline
+       同色，配伴随投影窗（global_lookup_shadow.cpp）后观感即 Niratan 弹窗。
+       Inset padding lifts the content off the hard window edge so the border
+       reads as a card frame rather than a hairline glued to the glass. */
+    border: 1px solid #D1D1D6;
     border-radius: 10px;
     padding: 8px 10px 10px;
     min-height: 100%;
@@ -1607,7 +1640,7 @@ html.global-lookup body {
 }
 
 html.global-lookup[data-theme="dark"] body {
-    border-color: rgba(255, 255, 255, 0.34);
+    border-color: #3A3A3C;
 }
 
 /* 用户「词典方框怎么能左右动，Niratan 不会」根因修：app 外全局查词 / 浏览器扩展原本

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -5030,3 +5030,34 @@ document.addEventListener('mousemove', function(e) {
         window.fushiSelection.selectText(e.clientX, e.clientY, 20);
     }
 }, {passive: true});
+
+// Niratan 对齐（2026-08-23）— 滚动条静止隐形、滚动时浮现。popup.css 的
+// ::-webkit-scrollbar-thumb 静止透明，靠 :hover 或 .popup-scroll-active 显形；
+// hover 只覆盖桌面鼠标，这里补触屏/键盘滚动：任意滚动事件给根节点 + body +
+// 事件目标挂 .popup-scroll-active，900ms 无滚动后整体清除（与 Niratan
+// setPopupScrollIndicatorActive 同法同参）。capture:true 才收得到内部滚动容器
+// （.overlay / .expression-scroll 等）的 scroll（scroll 不冒泡）。
+var __fushiPopupScrollIndicatorTimer = 0;
+document.addEventListener('scroll', function (event) {
+    var root = document.documentElement;
+    var body = document.body;
+    var activeClass = 'popup-scroll-active';
+    root.classList.add(activeClass);
+    if (body) body.classList.add(activeClass);
+    var scrollTarget = event.target && event.target.nodeType === Node.ELEMENT_NODE
+        ? event.target
+        : null;
+    if (scrollTarget && scrollTarget.classList) {
+        scrollTarget.classList.add(activeClass);
+    }
+    if (__fushiPopupScrollIndicatorTimer) {
+        clearTimeout(__fushiPopupScrollIndicatorTimer);
+    }
+    __fushiPopupScrollIndicatorTimer = setTimeout(function () {
+        root.classList.remove(activeClass);
+        if (body) body.classList.remove(activeClass);
+        document.querySelectorAll('.' + activeClass).forEach(function (element) {
+            element.classList.remove(activeClass);
+        });
+    }, 900);
+}, { passive: true, capture: true });


### PR DESCRIPTION
## 背景
用户对比 W1ght/Niratan-win 后点名三项差距全改：阴影、圆角观感、CSS 表面细节。Niratan 弹窗是 WinUI3 context-menu presenter（系统白送 DWM 投影+AA 圆角）；我们的查词窗是 windowed WebView2 + SetWindowRgn 裁形，拿不到系统投影。

## 改动
1. **伴随投影窗** `global_lookup_shadow.{h,cpp}`：WS_EX_LAYERED|TRANSPARENT|NOACTIVATE 影子窗，UpdateLayeredWindow 自绘双瓣柔影（近似 Win11 flyout），按 shellRects 逐卡画影（级联=每卡独立投影）、点击穿透、卡内 punch-out（面板整窗半透明不透黑）、防截屏联动；`WM_WINDOWPOSCHANGED` 单漏斗同步，Reveal/RevealStack 首帧显式补同步，拖拽 resize 期间防掉帧隐藏。贴边 ambient 瓣同时显著弱化 GDI region 锯齿圆角观感。
2. **纯表面**：弹窗卡面默认纯白/纯黑（`popupCardSurface` 单一真源，AppModel 扩展 theme map + 两个 in-app 注入器 + 热槽初始 HTML 四点统一），override 词典底色优先级不变。
3. **系统灰描边**：外壳 hairline 改 #D1D1D6/#3A3A3C（Niratan GetOutlineColor 同色）。
4. **悬停滚动条**：静止完全隐形，:hover / .popup-scroll-active（popup.js 滚动监听，900ms 衰减）浮现胶囊 thumb；去标准 scrollbar-* 防 Chromium 121+ 全族禁用伪元素；content.css 生成器补 `*`/html/body 变体重根映射（含滚动条伪元素改「容器+后代」双覆盖）。

## 明确不做（有真机前科/失配陷阱）
- 瞬态窗切 composition 拿真 AA 圆角：DComp 透明像素真机合成成黑（flutter_window.cpp:1620 注释），修好黑底前不走。
- 面板 DWMWCP_ROUND：DWM ~8px 与 CSS 10px 圆角失配会在四角露底色条。
- 每卡一顶层窗：等于每卡一个 WebView2 实例，拆掉单 WebView 级联架构，回归面不成比例。

## 验证
- `flutter analyze` 全量 0 issue；popup/theme/parity/滚动条守卫 + 新增 `global_lookup_shadow_guard_test` 全绿；守卫全部变异实测（改坏转红、精确还原）。
- `flutter build windows --debug` 全绿（√ Built fushi.exe，0 error，含三个 C++ 构建期门测试）。注意：Git Bash 环境 PATH 无独立 CMake 时 flutter 落到 VS 自带 CMake，INSTALL 步骤会把 prefix 烙成 C:/Program Files/fushi 而失败——环境问题非代码问题，PATH 前置 `C:\Program Files\CMake\bin` 即绿。
- 三镜像 byte-identical + content.css 重生成 `--check` 通过。
- 缺口：投影/滚动条真实观感未上真机复测（影子窗形状/浓度参数可能需按真机观感微调）。

https://claude.ai/code/session_01So3PtK4v6iatZHufHAZUwv