### PR TITLE
fix(video,subtitle): 用户报告三条——章节标记基准分叉 + Jimaku 静默降级 (BUG-1782/1783)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1654 条。点号进各自文件。
+> 共 1656 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1783](bugs/BUG-1783-chapter-markers-safearea-basis-mismatch.md) | ✅ | ✅ | 移动端章节标记与进度条基准分叉：标记层多套一层 SafeArea，刘海横屏下整排斜切错位 |
+| [BUG-1782](bugs/BUG-1782-jimaku-anilist-silent-degrade-cross-season.md) | ✅ | ✅ | Jimaku 搜索时好时坏：AniList 失败被静默吞成空结果，退化成跨季文本搜索 |
 | [BUG-1777](bugs/BUG-1777-emphatic-full-collapse-phantom-match.md) | ✅ | ✅ | 查词促音丢失：强调折叠full模式常开产生吞字幻影匹配压过原形 |
 | [BUG-1776](bugs/BUG-1776-subtitle-list-adjacent-chain-dup.md) | ✅ | ✅ | 字幕列表不折叠同文本时间相接的卡拉OK交替事件 |
 | [BUG-1775](bugs/BUG-1775-ass-clip-cue-frame-anchor.md) | ✅ | ✅ | 带clip的ASS事件按容器基线定位与帧空间裁剪几何脱节 |

--- a/docs/bugs/BUG-1782-jimaku-anilist-silent-degrade-cross-season.md
+++ b/docs/bugs/BUG-1782-jimaku-anilist-silent-degrade-cross-season.md
@@ -1,0 +1,60 @@
+## BUG-1782 · Jimaku 搜索时好时坏：AniList 失败被静默吞成空结果，退化成跨季文本搜索
+
+- **报告**：2026-08-23（用户：截图两张 + 「更新之后筛选怎么坏了 之前没问题的」，紧接着「起了怪了，现在又行了 不知如何触发」；Windows debug rolling `12067-075d4f3`）
+- **真实性**：✅ 真 bug（根因不是「更新引入」，是一条**一直存在**的静默降级路径；用户观察到的「时好时坏」正是它的指纹）
+
+### 症状
+
+「获取字幕（Jimaku）」搜 `Yuru Yuri`，结果区把四个不同季/系列的 entry 平铺在一起（`Yuru Yuri` / `Yuru Yuri San Hai!` / `Yuru Yuri♪♪` / `Yuru Yuri Nachuyachumi!+`），按 E01/E02/E03 交替排列。过一会儿又自己好了，用户找不到触发条件。
+
+jimaku.cc 上这五个 entry 确实各自独立存在，所以多 entry 是数据侧的真实情况——问题在于**这次搜索本该用 anilist_id 直查、只命中一个 entry**。
+
+### 根因
+
+`fushi/lib/src/media/video/anilist_client.dart:270-294`（修前）的 `searchAnime`：
+
+- `:284` `if (res.statusCode != 200) continue;` —— 含 **429 rate limit**；
+- `:290` `catch (_) {}` —— 裸吞，连日志都不打；
+- `:294` 最终 `return const <AniListMedia>[]`。
+
+于是**「AniList 说没有这部番」与「这次根本没问上」共用同一个空列表**，调用方无从区分。链条：
+
+```
+AniList 挂/被限流 → searchAnime 返回 []
+  → _search() 传 anilistId: media.isNotEmpty ? media.first.id : null  = null
+  → provider searchEntries(anilistId: null)
+  → JimakuClient.searchByQuery("Yuru Yuri")   ← 文本回退
+  → jimaku.cc 上 5 个 entry 全量平铺
+AniList 恢复 → searchByAnilistId → 单 entry → 「现在又行了」
+```
+
+同一份代码两种结果，**无任何用户可见信号，也无日志可查**——这就是「不知如何触发」。
+
+限流预算的现实来源：`AniListClient` 被放送日历页共用（`airing_calendar_page.dart`），它按 `perPage: 50` 翻页拉 airingSchedules。讽刺的是同一个 client 里 `fetchAiringSchedulePage` **明确不吞 429 并上抛**（`anilist_client.dart:178`/`:322` 的注释把这个「有意不同」写死了），于是日历烧掉配额、字幕搜索静默降级。
+
+截图侧佐证：AniList 空 ⇒ `_seriesMatches` 空 ⇒ 系列消歧区不渲染（要求 ≥2 条）。用户截图左栏正没有系列列表，是 AniList 空的指纹。而这意味着**用户在最需要消歧的那一刻，恰恰拿不到任何消歧手段**。
+
+同族第二触发条件（此时系列列表**会**出现）：AniList 有结果，但盲取的 `media.first` 那一季的 Jimaku entry 没挂 anilist_id → `searchByAnilistId` 空 → 同样回退文本 → 同样平铺。
+
+**已排除的假设**（逐条给了依据，见调查记录）：`_selectedSeriesId` 未重置（`_search()` 开头就清，且对话框每次 `showDialog` 新建）；候选被缓存（搜索路径无任何缓存层）；手敲番名 vs 元数据带入走不同分支（两者都只是 `_queryCtrl` 的值）；Jimaku `anime` 硬过滤（BUG-1694）相关（Yuru Yuri 是动画不会被滤）。
+
+### 修复
+
+- **[x] ① 已修复** — commit `<填>`
+  - `anilist_client.dart` 新增 `AniListSearchOutcome{media, failure}`；`searchAnime` 改为返回它，**空结果与失败不再共用同一个返回值**。失败判定按「**所有**候选查询都没能给出成功响应」（`anySuccess` 而不是 `lastFailure` 决定）：只要有一次拿到 200 并解析成功，哪怕结果为空也算「AniList 明确答了没有」，避免把「先答了没有、后一个保守回退词 429」误报成降级。
+  - `jimaku_subtitle_dialog.dart`：降级时记 `ErrorLogService.logDiagnostic`（与 Jimaku 侧既有诊断口径一致，此前**这条路径零日志**），并在结果区顶部如实告知「这次没能确认系列，结果可能混入同系列其他季」+ 就地重试。**不改结果本身**——回退结果仍然有用，总比什么都不给强；只是不再让降级和正常长得一模一样。只有降级时才多包一层，正常路径 widget 树与改动前一致，不碰 BUG-279 的有界高度/滚动不变量。
+  - `anime_download_dialog.dart`：非 200（含 429）此前被吞成空列表、走不到它自己的 catch，于是**限流被显示成「无结果」**；现在如实并入既有失败态，用户拿到重试 + 原因。这是同一根因在另一个入口的第二个受害者。
+  - `jimaku_batch_dialog.dart`：同样在降级回退前留诊断日志。
+  - i18n 经 `i18n_sync --add` 加 1 键 × 17 语言 + `dart run slang` 重生成。
+- **[x] ② 已加自动化测试** — commit `<填>`
+  - `fushi/test/media/video/anilist_client_test.dart` 新增 5 条：`200 空结果 = 明确答了没有，不是降级` / `429 限流 = 降级且带得出原因` / `网络异常 = 降级` / `先失败后成功：只要有一次问上了就不报降级` / `先成功答没有、后一个回退查询 429：仍不报降级`（后两条正是锁 `anySuccess` 语义）。
+  - `fushi/test/pages/jimaku_series_lookup_degraded_test.dart` 新增 2 条 widget 用例（候选复刻用户截图的跨季混排）：降级时提示条 + 重试可见且**不顶掉结果列表**；正常时不显示提示（不吓唬用户）。为此加了 `debugInitialSeriesLookupFailed` 注入点，与既有 `debugInitialCandidates` / `debugInitialSeriesMatches` 同款。
+  - **变异实测**：① 把 `searchAnime` 的非 200 分支改回 `continue`（旧的静默吞）→「429 限流 = 降级」精确转红，还原后 `anilist_client.dart` sha256 `ecebe9598acd9a58afd6c6a3c314aca5eec2d363f148352d8c8523cbe6ed9437` 一致；② 把提示条条件改成 `if (true || …)` → 降级用例转红，还原后 `jimaku_subtitle_dialog.dart` sha256 `8a666cb95a476c679cd1c6a1ef6def9130ba18279ee94ecc332d99662698ca40` 一致。
+  - 邻域回归：10 个 Jimaku / AniList 测试文件经 `flutter_test_failures.dart` 跑出 `VERDICT: PASSED - 71 tests ran`。
+
+### 备注（本次未修，但同一条链上的真实缺口）
+
+1. **入口就把身份扔了**（治本项，值得独立 PR）。`_jimakuQuery()`（`fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart:672-689`）只从 `parseVideoFilename(basename).series` 取**文本**，`JimakuSubtitleDialog` 构造器压根没有 `anilistId` 参数——明明库里存着刮削身份（`video_metadata_works` + `video_metadata_provider_identities`，已有 DAO `getVideoMetadataProviderIdentities(workId:)`），手动入口还要拿文件名去 AniList 猜一遍。**带上 anilistId 后 AniList 挂掉也不影响这条路径**，比本次的「让降级可见」更根治。
+   对照组：自动补字幕路径做对了——`scrapedMediaReference`（`fushi/lib/src/media/video/subtitle/scraped_subtitle_targets.dart:68-100`）原样带 anilistId / originalTitle / discoveryCategory，其文档注释写着「缺一件准确率就塌一层」。**两条路径对同一问题给了相反的答案。**
+2. **整条字幕链零相关度排序**。`deduplicateVideoSubtitles` 只按 providerPriority → downloadCount；`buildSubtitleVersionGroups` 只按语言 → 机翻 → 上传时间 → 下载量，**没有任何标题/季号贴合度**。所以即使有了 B1 的版本卡，错季的卡照样能压在正确季前面。现成可复用：BUG-1548 已为资源搜索造了同形状的 `parseVideoResourceIdentity` / `rankVideoResourcesByRelevance`（`fushi/lib/src/media/torrent/video_resource_relevance.dart`），从未接进字幕链路。
+3. 用户说的「更新之后坏了」是归因不是事实：`for (entry in entries)` 的平铺从 2026-06-05 首版就在，`v2.0.0..v2.1.1` 之间这几个文件零改动。真正变的是 AniList 那边通不通。

--- a/docs/bugs/BUG-1783-chapter-markers-safearea-basis-mismatch.md
+++ b/docs/bugs/BUG-1783-chapter-markers-safearea-basis-mismatch.md
@@ -1,0 +1,54 @@
+## BUG-1783 · 移动端章节标记与进度条基准分叉：标记层多套一层 SafeArea，刘海横屏下整排斜切错位
+
+- **报告**：2026-08-23（用户：截图一张 + 「手机上的章节标记有问题」；安卓 debug rolling `12067-075d4f3`，横屏 2532×1170，`[VCB-Studio] Yuru Yuri [05]` 23:56）
+- **真实性**：✅ 真 bug（纯移动端；桌面两条路径都恰好等价，从不暴露）
+
+### 症状
+
+进度条上方那排章节竖线整体对不上轨道：首章明显右偏、末章左偏，中间某处反而是准的。用户主观描述成「右边两条溢出轨道」，但像素数据不支持溢出——实测最右一条在 x≈2350，轨道右端在 x≈2478，是**被压在轨道内侧**。
+
+### 根因
+
+`fushi/lib/src/pages/implementations/video_fushi/chapter.part.dart:98`（修前）的 `SafeArea`。
+
+标记层与 seek bar 轨道用了**两个不同的水平基准**：
+
+| | 水平基准 |
+|---|---|
+| 标记层（修前） | `padding.left + 16 + f·(W − 32 − padding.left − padding.right)` |
+| 真实轨道（vendored fork `third_party/media_kit_video/.../controls/material.dart:1210-1216` + `seekBarMargin`） | `16 + f·(W − 32)`，**不含任何安全区** |
+
+误差 `Δ(f) = padding.left − f·(padding.left + padding.right)` 随比例线性变化——**不是整体平移而是仿射斜切**：左端右推、右端左拉、中间 `f = P_l/(P_l+P_r)` 处恰好蒙对。这正是它长期没被一眼看出的原因。
+
+两个前提缺一不可，而移动端两个都满足：
+
+1. **轨道恒零内缩**：fork 的真相源是 `_theme(context).padding ?? (isFullscreen(context) ? MediaQuery.padding : EdgeInsets.zero)`。Hibiki 的移动 / 桌面 controls theme 都没设 `padding` 字段，而移动端视频**永不进 media_kit 全屏路由**（BUG-221，`_toggleVideoFullscreen` 移动端 no-op），于是恒走 `EdgeInsets.zero` 分支。
+2. **`MediaQuery.padding` 非零**：`fushi/android/app/src/main/res/values*/styles.xml:9` 全局 `windowLayoutInDisplayCutoutMode=shortEdges` → 画面画进刘海区，**横屏时 cutout 落在左 / 右短边**。Scaffold body 之上没有任何 SafeArea/removePadding，padding 原样到达标记层。
+
+而 `SafeArea` 恒吃 `MediaQuery.padding`，只在「真的处于全屏路由」时才与上式等价。桌面窗口态 padding=0（SafeArea 空转）、桌面全屏走 media_kit 全屏路由（两边都吃 `MediaQuery.padding`）——**桌面两条路径恰好都等价，所以这个 bug 只在移动端存在**，与用户说的「手机上」吻合。修前注释（`chapter.part.dart:80-81`）写的「与 media_kit 控制条 padding 对齐，保证窗口 / 全屏两条路径都不错位」只在桌面成立。
+
+**坐标反算佐证**：按错误基准反推 `padding.left ≈ 45` 逻辑 px 时，6 条线落在 `0:00 / 1:25 / 2:51 / 11:00 / 21:39 / 23:27`——序 + OP（86s，标准 90s）+ A パート + B パート + ED + 次回预告，教科书式动画章节表；按「无 bug」假设反推则是 `1:21 / 2:37 / 3:55 / 11:19 / 20:59 / 22:37`，**没有 0:00 章**（BD/TV remux 的 mkv 第一章恒为 `00:00:00.000`），且多出一个来路不明的 3:55。前者远更自洽。
+
+**同源的第二处**：`_buildThumbnailPreviewOverlay`（同文件）有一模一样的 `SafeArea`，其文档声明「几何与章节刻度层同源」。它目前桌面 only 所以没暴露，但声明同源就不能两处各写一套。
+
+**次要同源缺陷（一并消除）**：竖直方向 `band.bottom` 里的 `_videoBottomSystemInset()` 已经算过一次 `viewPadding.bottom`，`SafeArea` 又扣一次 `padding.bottom` → 系统栏可见时**双重计数**，标记会浮到轨道上方。同一个 `SafeArea` 拿掉后一并消失。
+
+### 修复
+
+- **[x] ① 已修复** — commit `<填>`
+  - 新增纯函数 `videoControlsChromeInsets`（`fushi/lib/src/media/video/video_subtitle_style.dart`，与 `videoSeekBarTrackBand` 同处）：把 fork 的 `_theme.padding ?? (isFullscreen ? MediaQuery.padding : EdgeInsets.zero)` 收成**页面与测试同源的单一真相**，消掉「控制条侧和刻度侧各写一遍、迟早分叉」这个特殊情况。
+  - 新增 `_isVideoFullscreenRoute` / `_videoControlsChromeInsets()`（`fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart`）：刻度层是 controls Builder 的**兄弟**、拿不到 media_kit 的 Fullscreen InheritedWidget，只能经 `_videoControlsContext` 反查；移动端按 BUG-221 直接短路 `false`，避开「兄弟层在同帧早于 Builder 回调执行、只能读到上一帧 context」的时序依赖——移动端恰恰是唯一暴露面，不能让它的正确性挂在帧序上。
+  - `chapter.part.dart` 两处 `SafeArea` → `Padding(padding: _videoControlsChromeInsets())`。
+- **[x] ② 已加自动化测试** — commit `<填>`
+  - `fushi/test/media/video/video_chapter_markers_test.dart` 新增 `videoControlsChromeInsets (BUG-1783)` 4 条：非全屏路由水平贡献恒零 / 全屏路由吃系统安全区 / theme 显式 padding 两条路径都以它为准 / **刘海横屏下刻度层与轨道左右边界逐像素相等**（把 bug 的数学形式直接写成断言，`f ∈ {0, .25, .5, .75, 1}` 逐点比对，而不是断言某个字面量存在）。
+  - 同文件源码守卫新增一条：两个兄弟层（刻度 + 缩略图预览）都**不得**出现 `SafeArea`、且必须走 `_videoControlsChromeInsets()`。
+  - **变异实测（双向）**：
+    ① 把纯函数改成 `themePadding ?? systemPadding`（= SafeArea 语义）→ 2 条转红，含「逐像素相等」；还原后 `video_subtitle_style.dart` sha256 `b4ec1cba9520ec175974dc4eac9c4e3f46074006dab732aed4733ffd653ee157` 与变异前一致。
+    ② 把刻度层 `Padding(padding: _videoControlsChromeInsets())` 改回 `SafeArea(` → 源码守卫那条转红；还原后 `chapter.part.dart` sha256 `bd2ea808b19f99d0d220a215611cff9fe52f16709d0a5eceaf5a3d89996d8cf2` 与变异前一致。还原后 18 条全绿。
+  - **写守卫时踩到并已修掉的两个坑**（都真实红过，不是假设）：① 裸 `contains('SafeArea')` 会命中**修复自己的注释**（注释里必须解释「原本是 SafeArea」），故断言前 `maskComments`；② 用「下一个方法签名」做切片，会因两个 builder 的先后顺序而把整段剩余语料吞进 body，负向断言随即失效——改用 `methodBody()` 自己做花括号配对。
+
+### 备注
+
+- 「左边挤 3 条」不是 bug：无论按哪种基准反算，这三条都落在 0:00–4:00，就是「序 + OP + A パート」的正常密度。数据本身如此。
+- 章节数据链本身没问题：`video_player_controller.dart:2259 refreshChapters()` 逐条读 libmpv `chapter-list`，交给纯函数 `parseChapterList`，时间戳是容器原值不经换算，且 `_refreshChaptersWhenDurationReady` 保证 `duration > 0` 后才读。
+- **旧守卫为什么是假绿**：`fushi/test/media/video/video_chapter_markers_test.dart:239-268` 的源码守卫断言 builder 体里出现字符串 `left: 16` / `right: 16`——`SafeArea` 就叠在它外面，字符串照样命中。「看起来对齐了」的字符串守卫拦不住基准分叉，补测必须断言**两侧基准相等**而不是某个字面量存在。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -57,6 +57,8 @@ enum AppLocale with BaseAppLocale<AppLocale, _StringsEn> {
 
   /// Gets current instance managed by [LocaleSettings].
   _StringsEn get translations => LocaleSettings.instance.translationMap[this]!;
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 /// Method A: Simple
@@ -90,6 +92,8 @@ class Translations {
 
   static _StringsEn of(BuildContext context) =>
       InheritedLocaleData.of<AppLocale, _StringsEn>(context).translations;
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 /// The provider for method B
@@ -100,6 +104,8 @@ class TranslationProvider
 
   static InheritedLocaleData<AppLocale, _StringsEn> of(BuildContext context) =>
       InheritedLocaleData.of<AppLocale, _StringsEn>(context);
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 /// Method B shorthand via [BuildContext] extension method.
@@ -109,6 +115,8 @@ class TranslationProvider
 /// context.t.someKey.anotherKey
 extension BuildContextTranslationsExtension on BuildContext {
   _StringsEn get t => TranslationProvider.of(this).translations;
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 /// Manages all translation instances and the current locale
@@ -143,6 +151,8 @@ class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, _StringsEn> {
         cardinalResolver: cardinalResolver,
         ordinalResolver: ordinalResolver,
       );
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 /// Provides utility functions without any side effects.
@@ -165,6 +175,8 @@ class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, _StringsEn> {
   static AppLocale findDeviceLocale() => instance.findDeviceLocale();
   static List<Locale> get supportedLocales => instance.supportedLocales;
   static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // translations
@@ -5075,6 +5087,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -13739,6 +13753,8 @@ class _StringsAr extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -22468,6 +22484,8 @@ class _StringsDe extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -31213,6 +31231,8 @@ class _StringsEs extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -39970,6 +39990,8 @@ class _StringsFr extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -48657,6 +48679,8 @@ class _StringsId extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -57388,6 +57412,8 @@ class _StringsIt extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -65936,6 +65962,8 @@ class _StringsJa extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -74492,6 +74520,8 @@ class _StringsKo extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -83203,6 +83233,8 @@ class _StringsNl extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      '这次没能在 AniList 上确认系列，下面是按标题直接搜出来的结果，可能混入同系列其他季。';
 }
 
 // Path: <root>
@@ -91926,6 +91958,8 @@ class _StringsPtBr extends _StringsEn {
       'Adjust the background corner radius.';
   @override
   String get storage_shaders_delete_anime4k => 'Delete Anime4K shaders';
+  String get video_jimaku_series_lookup_degraded =>
+      'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
 }
 
 // Path: <root>
@@ -150816,6 +150850,8 @@ extension on _StringsEn {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -158482,6 +158518,8 @@ extension on _StringsAr {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -166170,6 +166208,8 @@ extension on _StringsDe {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -173857,6 +173897,8 @@ extension on _StringsEs {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -181550,6 +181592,8 @@ extension on _StringsFr {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -189225,6 +189269,8 @@ extension on _StringsId {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -196914,6 +196960,8 @@ extension on _StringsIt {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -204565,6 +204613,8 @@ extension on _StringsJa {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -212220,6 +212270,8 @@ extension on _StringsKo {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -219903,6 +219955,8 @@ extension on _StringsNl {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -227583,6 +227637,8 @@ extension on _StringsPtBr {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -235268,6 +235324,8 @@ extension on _StringsRu {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -242936,6 +242994,8 @@ extension on _StringsTh {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -250613,6 +250673,8 @@ extension on _StringsTr {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -258286,6 +258348,8 @@ extension on _StringsVi {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }
@@ -265900,6 +265964,8 @@ extension on _StringsZhCn {
         return '调整窗口背景的圆角半径。';
       case 'storage_shaders_delete_anime4k':
         return '删除 Anime4K 着色器';
+      case 'video_jimaku_series_lookup_degraded':
+        return '这次没能在 AniList 上确认系列，下面是按标题直接搜出来的结果，可能混入同系列其他季。';
       default:
         return null;
     }
@@ -273546,6 +273612,8 @@ extension on _StringsZhHk {
         return 'Adjust the background corner radius.';
       case 'storage_shaders_delete_anime4k':
         return 'Delete Anime4K shaders';
+      case 'video_jimaku_series_lookup_degraded':
+        return 'Couldn\'t confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "让文字与窗口边缘和缩放手柄保持距离。",
   "gal_hook_text_corner_radius": "窗口圆角",
   "gal_hook_text_corner_radius_hint": "调整窗口背景的圆角半径。",
-  "storage_shaders_delete_anime4k": "删除 Anime4K 着色器"
+  "storage_shaders_delete_anime4k": "删除 Anime4K 着色器",
+  "video_jimaku_series_lookup_degraded": "这次没能在 AniList 上确认系列，下面是按标题直接搜出来的结果，可能混入同系列其他季。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3736,5 +3736,6 @@
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
   "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
-  "storage_shaders_delete_anime4k": "Delete Anime4K shaders"
+  "storage_shaders_delete_anime4k": "Delete Anime4K shaders",
+  "video_jimaku_series_lookup_degraded": "Couldn't confirm the series on AniList this time, so these results come from a plain title search and may mix in other seasons of the same series."
 }

--- a/fushi/lib/src/media/video/anilist_client.dart
+++ b/fushi/lib/src/media/video/anilist_client.dart
@@ -188,6 +188,31 @@ class AniListRequestException implements Exception {
   String toString() => 'AniList HTTP $statusCode: $message';
 }
 
+/// [AniListClient.searchAnime] 的结果（BUG-1782）。
+///
+/// **为什么不能只返回 `List<AniListMedia>`**：空列表此前同时表示「AniList 说没有这部番」
+/// 和「这次根本没问上（网络挂 / 429 限流 / 解析失败）」两件完全不同的事，调用方无从区分，
+/// 只能一律当「没搜到」处理。下游 Jimaku 因此在 AniList 被限流时静默退化成纯文本搜索，
+/// 把同系列所有季的字幕平铺给用户，而 AniList 恢复后又自己好了——用户报「更新之后筛选
+/// 怎么坏了」「起了怪了，现在又行了，不知如何触发」。把失败**带出来**是这条链能被诊断的
+/// 前提，也是 UI 能如实告诉用户「结果不可靠」而不是假装一切正常的前提。
+class AniListSearchOutcome {
+  const AniListSearchOutcome.ok(this.media) : failure = null;
+
+  const AniListSearchOutcome.failed(String this.failure)
+      : media = const <AniListMedia>[];
+
+  final List<AniListMedia> media;
+
+  /// 非 null = 搜索链路发生过失败，此时 [media] 为空**不代表**查无此番。
+  final String? failure;
+
+  /// 搜索没能给出可信答案（调用方据此决定要不要把降级说给用户听）。
+  bool get degraded => failure != null;
+
+  bool get isEmpty => media.isEmpty;
+}
+
 /// 解析 airingSchedules GraphQL 响应。纯函数，结构不符 → 空页（HTTP 层错误
 /// 由 [AniListClient.fetchAiringSchedulePage] 以 [AniListRequestException] 上抛）。
 AniListAiringPage parseAniListAiringResponse(String body) {
@@ -263,11 +288,20 @@ query ($search: String) {
   }
 }''';
 
-  /// 按 [title] 搜索番剧。网络/解析失败返回空列表（不抛，调用方按空处理）。
+  /// 按 [title] 搜索番剧。**不抛**，但会经 [AniListSearchOutcome.failure] 如实带回
+  /// 「这次没问上」（BUG-1782）——空结果与失败不再共用同一个返回值。
+  ///
   /// 搜索词先做 macron 归一化（见 [normalizeAniListSearch]），让带官方 romaji
   /// 长音（ū ō…）的输入也能命中 AniList；全标题无结果时再尝试逗号前的主标题，
   /// 兼容罗马字连写/分写别名差异。
-  Future<List<AniListMedia>> searchAnime(String title) async {
+  ///
+  /// 失败判定按「**所有**候选查询都没能给出成功响应」：只要有一次拿到 200 并解析成功，
+  /// 哪怕结果为空，都算「AniList 明确答了没有」（`ok`）；一次成功都没有才是 `failed`。
+  /// 429 尤其要算失败——放送日历页共用同一个 client 按 `perPage: 50` 翻页拉 airingSchedules，
+  /// 配额被它烧掉时字幕搜索这边此前是静默降级的。
+  Future<AniListSearchOutcome> searchAnime(String title) async {
+    String? lastFailure;
+    bool anySuccess = false;
     for (final String query in aniListSearchQueries(title)) {
       try {
         final http.Response res = await _client.post(
@@ -281,17 +315,26 @@ query ($search: String) {
             'variables': <String, dynamic>{'search': query},
           }),
         );
-        if (res.statusCode != 200) continue;
+        if (res.statusCode != 200) {
+          lastFailure = 'HTTP ${res.statusCode}';
+          continue;
+        }
         // 显式 UTF-8 解码（res.body 无 charset 时按 latin1 → 日文/罗马音乱码）。
         final List<AniListMedia> matches = parseAniListSearchResponse(
           utf8.decode(res.bodyBytes, allowMalformed: true),
         );
-        if (matches.isNotEmpty) return matches;
-      } catch (_) {
-        // Try the next conservative fallback; callers still receive [].
+        anySuccess = true;
+        if (matches.isNotEmpty) return AniListSearchOutcome.ok(matches);
+        // 200 且解析成功但结果为空 = AniList 明确答了「没有」，继续试下一个更保守的
+        // 查询词。只要有过这么一次，就说明链路是通的，末尾不再报降级。
+      } catch (e) {
+        lastFailure = e.toString();
       }
     }
-    return const <AniListMedia>[];
+    if (!anySuccess && lastFailure != null) {
+      return AniListSearchOutcome.failed(lastFailure);
+    }
+    return const AniListSearchOutcome.ok(<AniListMedia>[]);
   }
 
   static const String _airingQuery = r'''

--- a/fushi/lib/src/media/video/video_subtitle_style.dart
+++ b/fushi/lib/src/media/video/video_subtitle_style.dart
@@ -168,6 +168,34 @@ double videoSubtitleControlsTopReserve({
   return (bottom: trackCenter - tickHeight / 2, height: tickHeight);
 }
 
+/// media_kit 控制条自身的**外层 padding**（BUG-1783）。叠在控制条 Stack 上的兄弟层
+/// （章节刻度、缩略图预览浮层……）必须用**同一个**值做水平基准，否则刻度与轨道分叉。
+///
+/// 真相源是 fork `third_party/media_kit_video/.../controls/material.dart` 的
+/// `_theme(context).padding ?? (isFullscreen(context) ? MediaQuery.padding : EdgeInsets.zero)`。
+/// Hibiki 的移动 / 桌面 theme 都**没有**设 `padding` 字段，故恒走后半段。
+///
+/// **为什么不能图省事写 `SafeArea`**：`SafeArea` 恒吃 `MediaQuery.padding`，与上式只在
+/// 「真的处于 media_kit 全屏路由」时才等价。而移动端视频**永不进 media_kit 全屏路由**
+/// （BUG-221，`_toggleVideoFullscreen` 移动端 no-op），轨道恒走 `EdgeInsets.zero` 分支；
+/// 与此同时 Android 全局 `windowLayoutInDisplayCutoutMode=shortEdges`
+/// （`fushi/android/app/src/main/res/values*/styles.xml`）让横屏刘海落在**左 / 右短边**、
+/// `padding.left/right` 非零。于是刻度层比轨道多缩一段，误差
+/// `Δ(f) = padding.left − f·(padding.left + padding.right)` 随比例线性变化——不是整体平移
+/// 而是**仿射斜切**：首章右偏、末章左偏、中间某点恰好蒙对，最难被一眼看出。用户报
+/// 「手机上的章节标记有问题」即此。
+///
+/// 纯函数（页面与测试同源）。[themePadding] 传 controls theme 的 `padding` 字段（当前两套
+/// 主题均为 null，留参数是为了主题哪天真设了值时两侧仍不分叉）。
+EdgeInsets videoControlsChromeInsets({
+  required bool isFullscreenRoute,
+  required EdgeInsets systemPadding,
+  EdgeInsets? themePadding,
+}) {
+  return themePadding ??
+      (isFullscreenRoute ? systemPadding : EdgeInsets.zero);
+}
+
 /// 字幕字号的**屏幕自适应因子**（TODO-1199）。
 ///
 /// 问题：字幕字号此前把用户设置的固定值（[VideoSubtitleStyle.fontSize]）原样喂给

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -364,11 +364,20 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       anilist = AniListClient(
         client: await ref.read(appProvider).createDownloadHttpClient(),
       );
-      final List<AniListMedia> media =
+      final AniListSearchOutcome outcome =
           await anilist.searchAnime(query).timeout(kDownloadDiscoveryTimeout);
       if (!mounted) return;
+      // BUG-1782：非 200（含 429 限流）此前被 searchAnime 内部吞成空列表，走不到下面的
+      // catch，于是限流被显示成「无结果」。现在如实并入既有失败态，用户拿到重试 + 原因。
+      if (outcome.degraded) {
+        setState(() {
+          _animeSearchError = true;
+          _animeSearchErrorDetail = outcome.failure;
+        });
+        return;
+      }
       setState(() {
-        _animeMatches = media;
+        _animeMatches = outcome.media;
         _searchedAnime = true;
       });
     } catch (error) {

--- a/fushi/lib/src/pages/implementations/jimaku_batch_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_batch_dialog.dart
@@ -143,8 +143,9 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
       anilist = AniListClient(
         client: await _createHttpClient(),
       );
-      final List<AniListMedia> media = await anilist.searchAnime(query);
+      final AniListSearchOutcome outcome = await anilist.searchAnime(query);
       if (!mounted || generation != _seriesResolutionGeneration) return;
+      final List<AniListMedia> media = outcome.media;
       setState(() => _seriesMatches = media);
       if (media.isNotEmpty) {
         await _selectSeries(
@@ -154,6 +155,15 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
         );
       } else {
         // AniList 无命中 → 用文本直接搜 Jimaku 条目（无 anilist 绑定）。
+        // BUG-1782：`degraded` 时这不是「无命中」而是「没问上」，回退结果会横跨同系列
+        // 各季。留一条诊断日志，否则事后无从判断某次批量搜的是不是这个降级路径。
+        if (outcome.degraded) {
+          ErrorLogService.instance.logDiagnostic(
+            'JimakuBatchDialog.searchAnime',
+            'AniList 搜索降级（${outcome.failure}）：「$query」退化为纯文本条目搜索，'
+                '结果可能横跨同系列多季',
+          );
+        }
         await _resolveEntriesByQuery(query, generation: generation);
       }
     } finally {

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -197,6 +197,7 @@ class JimakuSubtitleDialog extends StatefulWidget {
     this.httpClientFactory,
     this.debugInitialCandidates,
     this.debugInitialSeriesMatches,
+    this.debugInitialSeriesLookupFailed = false,
     super.key,
   });
 
@@ -238,6 +239,11 @@ class JimakuSubtitleDialog extends StatefulWidget {
   @visibleForTesting
   final List<AniListMedia>? debugInitialSeriesMatches;
 
+  /// 仅测试用：预置「上一次 AniList 系列解析没问上」（BUG-1782），免去为验证降级提示
+  /// 条而搭一整套 429 HTTP + registry 桩。与上面两个注入点同款。
+  @visibleForTesting
+  final bool debugInitialSeriesLookupFailed;
+
   @override
   State<JimakuSubtitleDialog> createState() => _JimakuSubtitleDialogState();
 }
@@ -253,6 +259,10 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
 
   bool _searching = false;
   bool _searched = false;
+
+  /// BUG-1782：上一次 AniList 系列解析**没问上**（网络 / 429 限流），而不是「查无此番」。
+  /// 为真时本次结果是纯文本回退搜出来的，可能横跨同系列多季，结果区据此如实告知。
+  bool _seriesLookupFailed = false;
   String? _busyName; // 正在下载的文件名
   String? _busySourceKey; // 正在下载的候选 identityKey（版本卡视图用）
   List<JimakuCandidate> _candidates = const <JimakuCandidate>[];
@@ -309,6 +319,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       _seriesMatches = List<AniListMedia>.unmodifiable(seedSeries);
       _selectedSeriesId = seedSeries.first.id;
     }
+    _seriesLookupFailed = widget.debugInitialSeriesLookupFailed;
   }
 
   /// 把记忆/选中的筛选（语言 + 类型）与当前候选对齐：本次结果里没出现的值 → 退回
@@ -359,6 +370,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       _candidates = const <JimakuCandidate>[];
       _seriesMatches = const <AniListMedia>[];
       _selectedSeriesId = null;
+      _seriesLookupFailed = false;
     });
     // BUG-1509：先让「按钮禁用 + 结果区 loading」完整绘制一帧，再做偏好写入、
     // 代理 client 初始化和联网。旧顺序先 await onApiKeyChanged，慢磁盘/数据库下点击后
@@ -378,11 +390,26 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       );
       // ① 先经 AniList 把番名解析成候选系列（romaji/english/native 都能匹上）；存全部
       //   候选供用户消歧，默认取首条（相关度最高）。② AniList 无命中时回退文本直接搜。
-      final List<AniListMedia> media = await anilist.searchAnime(query);
+      final AniListSearchOutcome outcome = await anilist.searchAnime(query);
       if (!mounted) return;
-      setState(() => _seriesMatches = media);
+      // BUG-1782：`degraded` 时 media 为空**不代表**查无此番，只代表这次没问上（网络 /
+      // 429 限流；放送日历页共用同一个 client 翻页拉 airingSchedules，很容易把配额烧掉）。
+      // 此前两种情况共用空列表，回退路径把同系列所有季平铺给用户，且既无提示也无日志——
+      // 用户看到的就是「筛选时好时坏、不知怎么触发」。这里如实分开：留诊断日志 + 记状态
+      // 供结果区如实告知，用户可重试而不是对着一堆跨季结果发懵。
+      if (outcome.degraded) {
+        ErrorLogService.instance.logDiagnostic(
+          'JimakuSubtitleDialog.searchAnime',
+          'AniList 搜索降级（${outcome.failure}）：「$query」退化为纯文本条目搜索，'
+              '结果可能横跨同系列多季',
+        );
+      }
+      setState(() {
+        _seriesMatches = outcome.media;
+        _seriesLookupFailed = outcome.degraded;
+      });
       await _fetchCandidates(
-        anilistId: media.isNotEmpty ? media.first.id : null,
+        anilistId: outcome.media.isNotEmpty ? outcome.media.first.id : null,
         queryFallback: query,
         episode: episode,
       );
@@ -823,10 +850,57 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     );
   }
 
-  /// 结果区（宽屏右栏 / 窄屏下段）：搜索中 spinner → 无结果提示（含「显示全部集」
+  /// 结果区外壳：AniList 系列解析降级时在正文**上方**加一条如实说明（BUG-1782）。
+  ///
+  /// 降级下拿到的候选是纯文本搜出来的，会横跨同系列各季（`Yuru Yuri` 搜出 `San Hai!` /
+  /// `♪♪` / `Nachuyachumi!+`）。此前这与「正常搜到一季」在 UI 上完全无法区分，用户只能
+  /// 观察到「筛选时好时坏」。这里不改结果本身（回退结果仍然有用，总比什么都没有强），
+  /// 只把「这批结果为什么不可靠 + 可以重试」讲清楚。
+  ///
+  /// 只有降级时才多包一层：正常路径的 widget 树与改动前逐字节一致，不碰 BUG-279 的
+  /// 有界高度 / ListView 滚动不变量。
+  Widget _buildResultsArea(ThemeData theme) {
+    final Widget body = _buildResultsBody(theme);
+    if (!_seriesLookupFailed || _searching) return body;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(
+                Icons.warning_amber_outlined,
+                size: 18,
+                color: theme.colorScheme.error,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  t.video_jimaku_series_lookup_degraded,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.error),
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: _searching ? null : _search,
+                child: Text(t.retry),
+              ),
+            ],
+          ),
+        ),
+        Expanded(child: body),
+      ],
+    );
+  }
+
+  /// 结果区正文（宽屏右栏 / 窄屏下段）：搜索中 spinner → 无结果提示（含「显示全部集」
   /// 逃生口）→ 候选列表。列表由外层给定有界高度、内部普通（非 shrinkWrap）ListView
   /// 滚动，保留 BUG-279 不变量。
-  Widget _buildResultsArea(ThemeData theme) {
+  Widget _buildResultsBody(ThemeData theme) {
     if (_searching) {
       return buildLoading();
     }

--- a/fushi/lib/src/pages/implementations/video_fushi/chapter.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/chapter.part.dart
@@ -77,8 +77,11 @@ extension _VideoChapter on _VideoFushiPageState {
   /// 总时长换算成 `[0,1)` 比例画线（[chapterMarkerFractions]）。
   ///
   /// 仅当前视频有内封章节（[_hasChapters]）时挂；可见性随控制条（[_videoControlsVisible]）
-  /// 与 seek bar 同步淡入淡出。SafeArea 吃全屏路由的系统安全区，与 media_kit 控制条
-  /// `padding`（全屏 = MediaQuery.padding）对齐，保证窗口 / 全屏两条路径都不错位。
+  /// 与 seek bar 同步淡入淡出。外层 padding 走 [_videoControlsChromeInsets]，与 media_kit
+  /// 控制条**同一条真相**（BUG-1783：此处原本是 `SafeArea`，它恒吃 `MediaQuery.padding`，
+  /// 只在真的处于全屏路由时才与控制条等价；移动端因 BUG-221 永不进全屏路由，轨道恒零内缩，
+  /// 而 `shortEdges` 刘海让横屏 `padding.left/right` 非零 → 刻度层比轨道多缩一段，误差随
+  /// 比例斜切，首章右偏、末章左偏）。
   Widget _buildChapterMarkersOverlay(VideoPlayerController controller) {
     if (!_hasChapters) return const SizedBox.shrink();
     // 刻度竖线高度：比轨道再高一截（约轨道高 + 8px×缩放），让标记探出轨道上下、清晰可见，
@@ -95,8 +98,10 @@ extension _VideoChapter on _VideoFushiPageState {
       tickHeight: tickHeight,
     );
     return Positioned.fill(
-      child: SafeArea(
-        // 全屏安全区与 media_kit 控制条 padding 对齐；窗口态安全区为 0 不影响。
+      child: Padding(
+        // 与 media_kit 控制条同源的外层 padding（BUG-1783）；移动端 / 桌面窗口态恒为零，
+        // 只有真的进了全屏路由才吃系统安全区——和轨道逐像素对齐。
+        padding: _videoControlsChromeInsets(),
         child: ValueListenableBuilder<bool>(
           valueListenable: _videoControlsVisible,
           builder: (BuildContext _, bool controlsVisible, __) {
@@ -168,7 +173,10 @@ extension _VideoChapter on _VideoFushiPageState {
         band.bottom + band.height + 6.0 * _videoUiScale;
     final ColorScheme cs = _videoChromeColorScheme(context);
     return Positioned.fill(
-      child: SafeArea(
+      child: Padding(
+        // 与刻度层同源（BUG-1783）：本层目前桌面 only，SafeArea 的分叉在此没暴露，但几何
+        // 声明「与章节刻度层同源」，就不能两处各写一套——一并收敛到同一条真相。
+        padding: _videoControlsChromeInsets(),
         child: ValueListenableBuilder<bool>(
           valueListenable: _videoControlsVisible,
           builder: (BuildContext _, bool controlsVisible, __) {

--- a/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
@@ -34,6 +34,28 @@ part of '../video_fushi_page.dart';
 /// controls_theme.part.dart in batch11) is left untouched in the main shell — it
 /// is a batch11 leftover, not part of this fullscreen block, so it is not moved.
 extension _VideoFullscreen on _VideoFushiPageState {
+  /// 当前是否真的处于 **media_kit 全屏路由**（BUG-1783）。
+  ///
+  /// 给叠在控制条 Stack 上的**兄弟层**（章节刻度 / 缩略图预览）判断该不该吃系统安全区用：
+  /// 它们不在 controls 子树里，拿不到 media_kit 的 Fullscreen InheritedWidget，只能经
+  /// [_videoControlsContext]（controls 子树内 Builder 捕获）反查。
+  ///
+  /// 移动端**直接短路 false**：BUG-221 已把移动端全屏路由统一 no-op 掉，横屏沉浸态是唯一
+  /// 形态。短路同时避开「兄弟层在同帧早于 Builder 回调执行、只能读到上一帧 context」的时序
+  /// 依赖——移动端恰恰是本 bug 的唯一暴露面，不能让它的正确性挂在帧序上。
+  bool get _isVideoFullscreenRoute {
+    if (isMobilePlatform) return false;
+    final BuildContext? ctx = _videoControlsContext;
+    return ctx != null && ctx.mounted && isFullscreen(ctx);
+  }
+
+  /// 控制条兄弟层与 media_kit 控制条**同源**的外层 padding（BUG-1783）。
+  /// 几何收敛进纯函数 [videoControlsChromeInsets]，页面与测试同源调用。
+  EdgeInsets _videoControlsChromeInsets() => videoControlsChromeInsets(
+        isFullscreenRoute: _isVideoFullscreenRoute,
+        systemPadding: MediaQuery.of(context).padding,
+      );
+
   Future<void> _toggleVideoFullscreen(BuildContext context) {
     // BUG-221: 移动端永不进 media_kit 全屏路由（横屏沉浸态即唯一形态）。统一在此单一收口
     // no-op，杜绝任何入口（双击 / 全屏按钮 / 快捷键 / 右键菜单）把移动端推进全屏路由——

--- a/fushi/test/media/video/anilist_client_test.dart
+++ b/fushi/test/media/video/anilist_client_test.dart
@@ -5,6 +5,7 @@
 // 结果。normalizeAniListSearch 把 macron 展开成双元音（Chūnibyō→Chuunibyou）让其命中。
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' show Response;
@@ -85,13 +86,103 @@ void main() {
         );
       });
       final AniListClient client = AniListClient(client: mock);
-      final List<AniListMedia> matches =
+      final AniListSearchOutcome outcome =
           await client.searchAnime('Watashi o Tabetai, Hito de Nashi');
-      expect(matches.single.id, 183385);
+      expect(outcome.media.single.id, 183385);
+      expect(outcome.degraded, isFalse);
       expect(requested, <String>[
         'Watashi o Tabetai, Hito de Nashi',
         'Watashi o Tabetai',
       ]);
+      client.close();
+    });
+  });
+
+  // BUG-1782：「AniList 说没有这部番」与「这次根本没问上」此前共用同一个空列表，
+  // 调用方只能一律当「没搜到」。下游 Jimaku 因此在限流时静默退化成纯文本搜索，把同
+  // 系列所有季平铺给用户；AniList 恢复后又自己好了——用户报「更新之后筛选怎么坏了」
+  // 「起了怪了，现在又行了，不知如何触发」。这一组锁住两者不再等价。
+  group('AniListSearchOutcome 区分「查无此番」与「没问上」(BUG-1782)', () {
+    Response ok(List<Map<String, dynamic>> media) => Response(
+          jsonEncode(<String, dynamic>{
+            'data': <String, dynamic>{
+              'Page': <String, dynamic>{'media': media},
+            },
+          }),
+          200,
+        );
+
+    test('200 空结果 = AniList 明确答了没有，不是降级', () async {
+      final AniListClient client = AniListClient(
+        client: MockClient((_) async => ok(<Map<String, dynamic>>[])),
+      );
+      final AniListSearchOutcome outcome = await client.searchAnime('Yuru Yuri');
+      expect(outcome.media, isEmpty);
+      expect(outcome.degraded, isFalse,
+          reason: '真的没这部番时不该报降级，否则每次搜不到都在吓唬用户');
+      client.close();
+    });
+
+    test('429 限流 = 降级，且带得出原因', () async {
+      final AniListClient client = AniListClient(
+        client: MockClient((_) async => Response('rate limited', 429)),
+      );
+      final AniListSearchOutcome outcome = await client.searchAnime('Yuru Yuri');
+      expect(outcome.media, isEmpty);
+      expect(outcome.degraded, isTrue,
+          reason: '429 此前被吞成空列表，与「查无此番」无法区分——正是本 bug 的根因；'
+              '放送日历页共用同一个 client 按 perPage:50 翻页，很容易把配额烧掉');
+      expect(outcome.failure, contains('429'));
+      client.close();
+    });
+
+    test('网络异常 = 降级', () async {
+      final AniListClient client = AniListClient(
+        client: MockClient((_) async => throw const SocketException('offline')),
+      );
+      final AniListSearchOutcome outcome = await client.searchAnime('Yuru Yuri');
+      expect(outcome.degraded, isTrue);
+      client.close();
+    });
+
+    test('先失败后成功：只要有一次问上了就不报降级', () async {
+      // 第一个查询词 500，回退查询词 200 且有结果 → 链路是通的，不该吓唬用户。
+      int calls = 0;
+      final AniListClient client = AniListClient(
+        client: MockClient((_) async {
+          calls++;
+          if (calls == 1) return Response('boom', 500);
+          return ok(<Map<String, dynamic>>[
+            <String, dynamic>{
+              'id': 10495,
+              'title': <String, dynamic>{'romaji': 'Yuru Yuri'},
+            },
+          ]);
+        }),
+      );
+      final AniListSearchOutcome outcome =
+          await client.searchAnime('Yuru Yuri, Nachuyachumi');
+      expect(outcome.media.single.id, 10495);
+      expect(outcome.degraded, isFalse);
+      client.close();
+    });
+
+    test('先成功答没有、后一个回退查询 429：仍不报降级', () async {
+      // anySuccess 而不是 lastFailure 决定：AniList 已经明确答过一次「没有」，
+      // 后续保守回退词的失败不该被翻译成「结果不可信」。
+      int calls = 0;
+      final AniListClient client = AniListClient(
+        client: MockClient((_) async {
+          calls++;
+          if (calls == 1) return ok(<Map<String, dynamic>>[]);
+          return Response('rate limited', 429);
+        }),
+      );
+      final AniListSearchOutcome outcome =
+          await client.searchAnime('Yuru Yuri, Nachuyachumi');
+      expect(calls, greaterThan(1), reason: '这条用例要求真的走到第二个回退查询词');
+      expect(outcome.media, isEmpty);
+      expect(outcome.degraded, isFalse);
       client.close();
     });
   });

--- a/fushi/test/media/video/video_chapter_markers_test.dart
+++ b/fushi/test/media/video/video_chapter_markers_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/source_guard.dart';
 import '../../pages/video_fushi_page_source_corpus.dart';
 import 'package:fushi/src/media/video/video_chapter_markers.dart';
 import 'package:fushi/src/media/video/video_player_controller.dart';
@@ -229,6 +230,73 @@ void main() {
     });
   });
 
+  // BUG-1783：刻度层与 seek bar 轨道的**水平基准**必须同源。这一组直接编码 bug 的数学
+  // 形式——旧守卫只断言 builder 体里出现字符串 `left: 16` / `right: 16`，而当年的 SafeArea
+  // 就叠在那个 Padding 外面，字符串照样命中、守卫恒绿。字面量存在 ≠ 基准一致。
+  group('videoControlsChromeInsets (BUG-1783)', () {
+    // 横屏刘海机：`shortEdges` 让 cutout 落在左 / 右短边（实测反算 padding.left ≈ 45）。
+    const EdgeInsets cutout = EdgeInsets.only(left: 45, right: 30);
+
+    test('非全屏路由：系统安全区再大，控制条外层 padding 也恒为零', () {
+      expect(
+        videoControlsChromeInsets(
+          isFullscreenRoute: false,
+          systemPadding: cutout,
+        ),
+        EdgeInsets.zero,
+        reason: 'fork 窗口态走 EdgeInsets.zero 分支；移动端因 BUG-221 永远落在这一支，'
+            '刻度层多缩一段就会与轨道分叉',
+      );
+    });
+
+    test('全屏路由：与 media_kit 一样吃系统安全区', () {
+      expect(
+        videoControlsChromeInsets(
+          isFullscreenRoute: true,
+          systemPadding: cutout,
+        ),
+        cutout,
+      );
+    });
+
+    test('controls theme 显式设了 padding 时以它为准（两条路径都是）', () {
+      const EdgeInsets themed = EdgeInsets.all(4);
+      for (final bool fullscreen in <bool>[false, true]) {
+        expect(
+          videoControlsChromeInsets(
+            isFullscreenRoute: fullscreen,
+            systemPadding: cutout,
+            themePadding: themed,
+          ),
+          themed,
+        );
+      }
+    });
+
+    test('刘海横屏下刻度层与轨道左右边界逐像素相等', () {
+      // 用户那台机：2532×1170 @ DPR 3 → 844 逻辑宽。
+      const double w = 844;
+      final EdgeInsets insets = videoControlsChromeInsets(
+        isFullscreenRoute: false,
+        systemPadding: cutout,
+      );
+      // 轨道（fork material.dart 窗口态 + seekBarMargin 16）：不含任何安全区。
+      double trackX(double f) => 16 + f * (w - 32);
+      // 刻度层：控制条外层 padding + 同样的 16，内部按剩余宽线性。
+      double markerX(double f) =>
+          insets.left + 16 + f * (w - 32 - insets.horizontal);
+      for (final double f in <double>[0, 0.25, 0.5, 0.75, 1]) {
+        expect(
+          markerX(f),
+          closeTo(trackX(f), 0.001),
+          reason: 'f=$f 处刻度与轨道错位——修前的 SafeArea 让误差 '
+              'Δ(f)=padding.left−f·padding.horizontal 随比例斜切：'
+              '首章右偏、末章左偏、中间某点恰好蒙对',
+        );
+      }
+    });
+  });
+
   // media_kit 的 seek bar 无法在无头 libmpv 下驱动真实渲染，故页面层「刻度叠在 seek bar
   // 同一几何上」的接线用源码守卫锁定不变量（几何纯函数由上面的 widget/单元测试覆盖）。
   group('video_fushi_page wires chapter markers onto seek bar (TODO-432)', () {
@@ -265,6 +333,33 @@ void main() {
       // 纯视觉层不拦指针，不破坏 seek bar 拖动。
       expect(body.contains('IgnorePointer'), isTrue,
           reason: '刻度层必须 IgnorePointer，否则会拦掉 seek bar 拖动');
+    });
+
+    // BUG-1783：两个叠在 controls Stack 上的兄弟层都不许自己吃系统安全区。
+    //
+    // 用 methodBody 而不是「下一个方法签名」做切片：两个 builder 在文件里的先后顺序
+    // 一变，手写的结束锚点就会把整段剩余语料吞进 body，负向断言随即失去意义（实测正是
+    // 这样先红的）。methodBody 自己做花括号配对并掩掉注释——后者同样必要：修复本身在
+    // 注释里解释了「原本是 SafeArea、为什么不能用」，裸 contains 会把说明当违规命中。
+    test('刻度层与缩略图预览层都走 _videoControlsChromeInsets，不再套 SafeArea', () {
+      for (final (String name, String signature) in <(String, String)>[
+        ('章节刻度层', 'Widget _buildChapterMarkersOverlay('),
+        ('缩略图预览层', 'Widget _buildThumbnailPreviewOverlay('),
+      ]) {
+        final String body = maskComments(methodBody(src, signature));
+        expect(
+          body.contains('SafeArea'),
+          isFalse,
+          reason: '$name 不得套 SafeArea：它恒吃 MediaQuery.padding，而 media_kit 轨道在'
+              '非全屏路由下恒零内缩（移动端因 BUG-221 永远是非全屏），两者基准会分叉',
+        );
+        expect(
+          body.contains('_videoControlsChromeInsets()'),
+          isTrue,
+          reason: '$name 的外层 padding 必须走 _videoControlsChromeInsets()，'
+              '与 media_kit 控制条同一条真相',
+        );
+      }
     });
   });
 }

--- a/fushi/test/pages/jimaku_series_lookup_degraded_test.dart
+++ b/fushi/test/pages/jimaku_series_lookup_degraded_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/utils.dart';
+
+/// BUG-1782：AniList 系列解析降级时，结果区必须**如实告知**结果可能横跨同系列多季。
+///
+/// 用户报的是「更新之后筛选怎么坏了 / 起了怪了，现在又行了，不知如何触发」——搜
+/// `Yuru Yuri` 却把 `San Hai!` / `♪♪` / `Nachuyachumi!+` 一起平铺出来，过一会儿又正常。
+/// 根因在 `AniListClient.searchAnime` 把 429 / 网络失败吞成空列表（见
+/// `test/media/video/anilist_client_test.dart` 那组），此处只锁 UI 侧的契约：降级路径
+/// 与正常路径在界面上**不能长得一模一样**，否则用户永远只能观察到「时好时坏」。
+void main() {
+  List<JimakuCandidate> crossSeasonCandidates() => const <JimakuCandidate>[
+        // 复刻用户截图：同一次搜索里混着四个不同 entry 的文件。
+        JimakuCandidate(
+          entryName: 'Yuru Yuri',
+          name: 'ゆるゆり.S01E01.中学デビュー!.WEBRip.Netflix.ja[cc].srt',
+        ),
+        JimakuCandidate(
+          entryName: 'Yuru Yuri San Hai!',
+          name: 'ゆるゆり さん ハイ!.S01E01.WEBRip.Netflix.ja[cc].srt',
+        ),
+        JimakuCandidate(
+          entryName: 'Yuru Yuri Nachuyachumi!+',
+          name: 'ゆるゆり なちゅやちゅみ＋.S01E01.WEBRip.Netflix.ja[cc].srt',
+        ),
+      ];
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required bool degraded,
+  }) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        key: UniqueKey(),
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext ctx) => ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: 'Yuru Yuri',
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  debugInitialCandidates: crossSeasonCandidates(),
+                  debugInitialSeriesLookupFailed: degraded,
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('AniList 没问上时，结果区如实告知可能混入其他季 + 给重试',
+      (WidgetTester tester) async {
+    await pump(tester, degraded: true);
+    expect(tester.takeException(), isNull);
+
+    expect(
+      find.text(t.video_jimaku_series_lookup_degraded),
+      findsOneWidget,
+      reason: '降级路径必须说出来——否则用户只能观察到「筛选时好时坏」，'
+          '而这正是本 bug 无法自查的原因',
+    );
+    expect(find.text(t.retry), findsOneWidget, reason: '降级是暂时的，必须能就地重试');
+    // 提示不该顶掉结果本身：回退结果仍然有用，总比什么都不给强。
+    expect(find.byType(JimakuCandidateList), findsOneWidget);
+  });
+
+  testWidgets('正常搜到时不显示降级提示（不吓唬用户）', (WidgetTester tester) async {
+    await pump(tester, degraded: false);
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.video_jimaku_series_lookup_degraded), findsNothing);
+    expect(find.byType(JimakuCandidateList), findsOneWidget);
+  });
+}


### PR DESCRIPTION
2026-08-23 用户群反馈（debug rolling `12067-075d4f3`，即 develop HEAD）四张截图，验真后拆成三条，其中两条在本 PR，第三条已并入他人分支。

## BUG-1783 · 移动端章节标记与进度条基准分叉

用户：「手机上的章节标记有问题」（安卓横屏 2532×1170）。

刻度层套了一层 `SafeArea`（恒吃 `MediaQuery.padding`），而 fork 的真实轨道走 `_theme.padding ?? (isFullscreen ? MediaQuery.padding : EdgeInsets.zero)`。两者只在真的处于 media_kit 全屏路由时等价——移动端因 BUG-221 永不进全屏路由（轨道恒零内缩），同时 Android 全局 `shortEdges` 让横屏刘海落在左右短边。误差 `Δ(f) = padding.left − f·padding.horizontal` 随比例**斜切**而非平移：首章右偏、末章左偏、中间某点恰好蒙对，所以长期没被一眼看出。桌面两条路径恰好都等价，从不暴露。

修法是把 fork 那条表达式收成纯函数 `videoControlsChromeInsets`，两侧共用一条真相；顺带消除竖直方向的双重计数（`band.bottom` 已含 `viewPadding.bottom`，`SafeArea` 又扣一次）。

## BUG-1782 · Jimaku 搜索时好时坏，退化成跨季文本搜索

用户：「更新之后筛选怎么坏了 之前没问题的」→ 紧接着「起了怪了，现在又行了 不知如何触发」。搜 `Yuru Yuri` 把 `San Hai!` / `♪♪` / `Nachuyachumi!+` 一起平铺。

`searchAnime` 让「AniList 说没有这部番」与「这次根本没问上」共用同一个空列表（非 200 含 429 直接 continue、异常裸 `catch(_)` 零日志）。于是 `anilistId=null` → Jimaku 从 id 直查退化成文本搜索 → 5 个 entry 全平铺；AniList 恢复后又自己好了。同一份代码两种结果、无信号、无日志——正是「不知如何触发」。同一个 client 里 `fetchAiringSchedulePage` 明确不吞 429，而放送日历页正共用它按 `perPage:50` 翻页烧配额。

**注意**：「更新之后坏了」是用户归因，不是代码事实——平铺逻辑从 2026-06-05 首版就在，`v2.0.0..v2.1.1` 之间这几个文件零改动。变的是 AniList 那边通不通。

顺带修好同一根因在番剧下载对话框的第二个受害者：非 200 此前被吞成空列表、走不到它自己的 catch，限流被显示成「无结果」。

## 验证

- 全量 `flutter analyze`（含 test）：No issues found
- 36 条目录枚举型守卫：`VERDICT: PASSED - 250 tests ran`（与文档基线一致）
- Jimaku/AniList 邻域 10 个文件：`VERDICT: PASSED - 71 tests ran`
- 章节标记：18 条全绿
- **变异实测（4 次，双向）**：改纯函数 / 把刻度层改回 `SafeArea` / 把 429 分支改回 `continue` / 把提示条条件改成 `if(true||…)`，各自精确转红；4 次还原后源码 sha256 均与变异前逐字节一致

## 第三条：已并入他人分支，不在本 PR

「下载 OCR 模型的地方点不开了」查出两道墙：Android 平台闸门（`defaultPlatformSupport()` 排除 Android，却被拿去 gating 下载 UI），以及出厂默认引擎 `google_lens` 让模型块整块 `SizedBox.shrink()`。前者已有 BUG-1780 在做，我把后者（含「守卫恒绿是因为测试回退值 `auto` 与生产默认 `google_lens` 分叉」）转给该分支，已被核实并一起修完提交（`40ad94fe04`）。原占位号 BUG-1781 已删除，不占号。

## 未修，已记进 bug 文档

手动入口 `_jimakuQuery()` 只取文件名文本、不带库里已有的刮削 `anilistId`（自动补字幕路径的 `scrapedMediaReference` 做对了，两条路径对同一问题给了相反答案）；以及整条字幕链零相关度排序。带上身份后 AniList 挂掉也不影响这条路径，比「让降级可见」更根治，值得独立 PR。

https://claude.ai/code/session_016qkYWkNhdrpcXGsYkrJV23