### PR TITLE
feat(onboarding): 推荐包分片并发下载 + 多镜像

### DIFF
--- a/fushi/lib/src/onboarding/recommended_pack.dart
+++ b/fushi/lib/src/onboarding/recommended_pack.dart
@@ -319,6 +319,33 @@ class RecommendedPackDownloader {
 
   File get _importedFlagFile => File(p.join(_packDir.path, 'imported.flag'));
 
+  /// 单流路径的服务端校验子（ETag / Last-Modified）落盘处，供跨进程续传带
+  /// `If-Range`。分片路径把校验子记在自己的进度文件里，不用这个。
+  File get _partValidatorFile =>
+      File(p.join(_packDir.path, '$_fileName.part.etag'));
+
+  String? _readSingleStreamValidator() {
+    try {
+      if (!_partValidatorFile.existsSync()) return null;
+      final String value = _partValidatorFile.readAsStringSync().trim();
+      return value.isEmpty ? null : value;
+    } on FileSystemException {
+      return null;
+    }
+  }
+
+  void _writeSingleStreamValidator(String? value) {
+    try {
+      if (value == null || value.isEmpty) {
+        if (_partValidatorFile.existsSync()) _partValidatorFile.deleteSync();
+        return;
+      }
+      _partValidatorFile.writeAsStringSync(value);
+    } on FileSystemException {
+      // 校验子写不下只影响续传安全性判定，不该中断下载。
+    }
+  }
+
   bool get hasCompletedFile => packFile.existsSync();
 
   /// 已下字节（两条路合一）。分片路的 `.mpart` 是**预分配**的完整大小，长度不代表
@@ -505,6 +532,11 @@ class RecommendedPackDownloader {
     CancelToken? cancelToken,
   }) async {
     int existing = _partFile.existsSync() ? _partFile.lengthSync() : 0;
+    // 续传必须带 If-Range：这条路会在「探针因网络抖动失败」时接手一台其实支持
+    // Range 的服务器，没有校验子就会把旧断点续到**换过的新包**上，只能靠末尾
+    // sha256 事后打回——代价是白下一整个 9.5 GB。
+    final String? validator =
+        existing > 0 ? _readSingleStreamValidator() : null;
     final Response<ResponseBody> response = await dio.get<ResponseBody>(
       url,
       cancelToken: cancelToken,
@@ -512,15 +544,20 @@ class RecommendedPackDownloader {
         responseType: ResponseType.stream,
         headers: <String, Object?>{
           if (existing > 0) 'range': 'bytes=$existing-',
+          if (validator != null) 'if-range': validator,
         },
         validateStatus: (int? status) => status == 200 || status == 206,
       ),
     );
     if (existing > 0 && response.statusCode == 200) {
-      // 服务器忽略 Range（回整文件）：append 会拼出坏包，只能丢半截从头写。
+      // 服务器忽略 Range 或校验子过期（服务端换包）：append 会拼出坏包，只能丢
+      // 半截从头写。
       existing = 0;
       if (_partFile.existsSync()) _partFile.deleteSync();
     }
+    _writeSingleStreamValidator(
+      response.headers.value('etag') ?? response.headers.value('last-modified'),
+    );
     final int? remaining =
         int.tryParse(response.headers.value('content-length') ?? '');
     final int? total = remaining == null ? null : existing + remaining;
@@ -551,11 +588,13 @@ class RecommendedPackDownloader {
       if (digest.toString() != sha256Hex) {
         // 坏包不留：删掉半截，下次从头下（续传一个已知坏的文件没有意义）。
         _partFile.deleteSync();
+        _writeSingleStreamValidator(null);
         throw Exception('recommended pack sha256 mismatch: '
             'got $digest, expected $sha256Hex');
       }
     }
     _partFile.renameSync(packFile.path);
+    _writeSingleStreamValidator(null);
     return packFile;
   }
 }

--- a/fushi/lib/src/onboarding/recommended_pack.dart
+++ b/fushi/lib/src/onboarding/recommended_pack.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:fushi/src/utils/misc/download_plan.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+import 'package:fushi/src/utils/misc/segmented_downloader.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 import 'package:path/path.dart' as p;
 
@@ -20,14 +23,42 @@ const String kRecommendedPackGoogleDriveUrl =
 /// 格式（字段见 [RecommendedPackManifest]）：
 /// `{"version":"2026-08-14","url":"https://dl.wrds.xyz/….fushi.zip",`
 /// `"sha256":"<hex>","size_bytes":10200000000}`
+///
+/// 分片分发（可选，见 [RecommendedPackManifest.toDownloadPlan]）再加：
+/// `"mirrors":[…整包镜像…]`、`"part_size_bytes":268435456`，或物理切片的
+/// `"parts":[{"name":…,"offset":…,"length":…,"sha256":…}]` + `"part_base_urls":[…]`。
 const String kRecommendedPackManifestUrl =
     'https://dl.wrds.xyz/fushi-recommended-manifest.json';
 
 /// 展示用体积标签（近似值，随包更新；清单带 size_bytes 时以清单为准展示）。
 const String kRecommendedPackSizeLabel = '9.5 GB';
 
+/// 清单没给 `part_size_bytes` 时，整包 Range 模式的默认切段大小。
+///
+/// 64 MiB：9.5 GB 约 152 段——段够多才能在几个镜像间摊开、单段失败重下的代价也小；
+/// 再小则请求数与进度落盘开销开始压过收益。
+const int kRecommendedPackDefaultPartSize = 64 * 1024 * 1024;
+
+/// 单片切片的来源。
+@immutable
+class RecommendedPackPart {
+  const RecommendedPackPart({
+    required this.name,
+    required this.offset,
+    required this.length,
+    this.sha256,
+  });
+
+  /// 切片文件名，拼在 `part_base_urls` 后面。
+  final String name;
+  final int offset;
+  final int length;
+  final String? sha256;
+}
+
 /// 推荐包清单：稳定 URL 下发的当前包指针。[url] 必填；[sha256]（小写 hex，可选）
-/// 提供时下载完成后做完整性校验；[sizeBytes]（可选）用于展示。
+/// 提供时下载完成后做完整性校验；[sizeBytes]（可选）用于展示，也是**开启分片并发
+/// 下载的前提**（没有总长就没法切段）。
 @immutable
 class RecommendedPackManifest {
   const RecommendedPackManifest({
@@ -35,12 +66,94 @@ class RecommendedPackManifest {
     this.version,
     this.sha256,
     this.sizeBytes,
+    this.mirrors = const <String>[],
+    this.parts = const <RecommendedPackPart>[],
+    this.partBaseUrls = const <String>[],
+    this.partSizeBytes,
   });
 
   final String url;
   final String? version;
   final String? sha256;
   final int? sizeBytes;
+
+  /// 整包镜像（与 [url] 同内容的其它主机），Range 模式下与 [url] 一起轮换。
+  final List<String> mirrors;
+
+  /// 物理切片表（可选）。给出时每片各自是一个可独立下载的资源，可以撒在多台主机上
+  /// ——单片 ≤2 GB 时 GitHub Release 也装得下。
+  final List<RecommendedPackPart> parts;
+
+  /// 切片所在目录（可多个互为镜像），与 [RecommendedPackPart.name] 拼成完整 URL。
+  final List<String> partBaseUrls;
+
+  /// 整包 Range 模式的切段大小；缺省用 [kRecommendedPackDefaultPartSize]。
+  final int? partSizeBytes;
+
+  /// 整包来源列表：主 URL 在前，镜像在后。
+  List<String> get wholeFileUrls => <String>[url, ...mirrors];
+
+  /// 把清单翻成分片下载计划。信息不足（不知道总长）时返回 null，调用方回退到
+  /// 「探测总长」或单流下载。
+  ///
+  /// 两种形态最终都落成同一个 [DownloadPlan]：物理切片给每片挂切片 URL
+  /// （`remoteOffset` = 0），整包镜像再作为**额外来源**挂上去（`remoteOffset` =
+  /// 该片偏移）——于是「GitHub 放切片、CF 放整包」可以互为镜像，下载器不需要知道
+  /// 这回事。
+  DownloadPlan? toDownloadPlan() {
+    if (parts.isNotEmpty && partBaseUrls.isNotEmpty) {
+      final DownloadPlan? sliced = _slicedPlan();
+      if (sliced != null) return sliced;
+    }
+    final int? total = sizeBytes;
+    if (total == null || total <= 0) return null;
+    return DownloadPlan.ranged(
+      urls: wholeFileUrls,
+      totalBytes: total,
+      partSize: partSizeBytes ?? kRecommendedPackDefaultPartSize,
+      sha256: sha256,
+      version: version,
+    );
+  }
+
+  DownloadPlan? _slicedPlan() {
+    int total = 0;
+    for (final RecommendedPackPart part in parts) {
+      total += part.length;
+    }
+    // 清单自相矛盾（切片总长 ≠ 声明总长）时不猜，退回整包 Range 模式。
+    if (sizeBytes != null && sizeBytes != total) return null;
+    final List<DownloadPart> planParts = <DownloadPart>[];
+    for (int i = 0; i < parts.length; i++) {
+      final RecommendedPackPart part = parts[i];
+      planParts.add(DownloadPart(
+        index: i,
+        offset: part.offset,
+        length: part.length,
+        sha256: part.sha256,
+        sources: <DownloadSource>[
+          for (final String base in partBaseUrls)
+            DownloadSource(url: _joinUrl(base, part.name)),
+          for (final String whole in wholeFileUrls)
+            DownloadSource(url: whole, remoteOffset: part.offset),
+        ],
+      ));
+    }
+    try {
+      return DownloadPlan(
+        totalBytes: total,
+        parts: planParts,
+        sha256: sha256,
+        version: version,
+      );
+    } on ArgumentError {
+      // 切片表有缝/重叠：宁可退回整包 Range，也不下一个注定拼错的包。
+      return null;
+    }
+  }
+
+  static String _joinUrl(String base, String name) =>
+      base.endsWith('/') ? '$base$name' : '$base/$name';
 }
 
 /// 解析清单 json（纯函数，便于单测）。结构不合法 / url 缺失或非 https 时返回
@@ -55,21 +168,67 @@ RecommendedPackManifest? parseRecommendedPackManifest(String jsonText) {
   if (decoded is! Map<String, dynamic>) return null;
   final Object? url = decoded['url'];
   if (url is! String || !url.startsWith('https://')) return null;
-  final Object? sha256Raw = decoded['sha256'];
-  final String? sha256Hex = sha256Raw is String && sha256Raw.isNotEmpty
-      ? sha256Raw.toLowerCase()
-      : null;
-  if (sha256Hex != null && !RegExp(r'^[0-9a-f]{64}$').hasMatch(sha256Hex)) {
+  final String? sha256Hex = _parseSha256(decoded['sha256']);
+  if (decoded['sha256'] is String &&
+      (decoded['sha256'] as String).isNotEmpty &&
+      sha256Hex == null) {
     return null;
   }
   final Object? sizeBytes = decoded['size_bytes'];
   final Object? version = decoded['version'];
+  final Object? partSize = decoded['part_size_bytes'];
   return RecommendedPackManifest(
     url: url,
     version: version is String ? version : null,
     sha256: sha256Hex,
     sizeBytes: sizeBytes is int && sizeBytes > 0 ? sizeBytes : null,
+    mirrors: _parseHttpsList(decoded['mirrors']),
+    partBaseUrls: _parseHttpsList(decoded['part_base_urls']),
+    parts: _parseParts(decoded['parts']),
+    partSizeBytes: partSize is int && partSize > 0 ? partSize : null,
   );
+}
+
+String? _parseSha256(Object? raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  final String lower = raw.toLowerCase();
+  return RegExp(r'^[0-9a-f]{64}$').hasMatch(lower) ? lower : null;
+}
+
+List<String> _parseHttpsList(Object? raw) {
+  if (raw is! List) return const <String>[];
+  return <String>[
+    for (final Object? item in raw)
+      if (item is String && item.startsWith('https://')) item,
+  ];
+}
+
+List<RecommendedPackPart> _parseParts(Object? raw) {
+  if (raw is! List) return const <RecommendedPackPart>[];
+  final List<RecommendedPackPart> parsed = <RecommendedPackPart>[];
+  for (final Object? item in raw) {
+    if (item is! Map<String, dynamic>) return const <RecommendedPackPart>[];
+    final Object? name = item['name'];
+    final Object? offset = item['offset'];
+    final Object? length = item['length'];
+    if (name is! String ||
+        name.isEmpty ||
+        name.contains('/') ||
+        offset is! int ||
+        offset < 0 ||
+        length is! int ||
+        length <= 0) {
+      // 一条坏记录就整表作废：半张切片表比没有更危险。
+      return const <RecommendedPackPart>[];
+    }
+    parsed.add(RecommendedPackPart(
+      name: name,
+      offset: offset,
+      length: length,
+      sha256: _parseSha256(item['sha256']),
+    ));
+  }
+  return parsed;
 }
 
 /// 拉取稳定清单；网络失败 / 超时 / 内容不合法一律返回 null（回退内置直链）。
@@ -92,8 +251,12 @@ Future<RecommendedPackManifest?> fetchRecommendedPackManifest() async {
   }
 }
 
-/// 推荐包断点续传下载器。半截文件落 `<name>.part`，完成后原子改名为最终文件名；
-/// 再次调用 [download] 会带 `Range` 续传（服务器忽略 Range 时自动从头重下）。
+/// 推荐包下载器。优先**分片并发 + 多镜像**（[SegmentedDownloader]）：一次开
+/// [SegmentedDownloader.kDefaultDownloadConcurrency] 条连接分头取，单片失败只重下
+/// 该片并轮换镜像，进度落 `<name>.mpart.json` 跨进程可续。
+///
+/// 服务器不支持 Range（探测拿不到总长）时退回**单流续传**旧路径——那条路一直在，
+/// 不因为新增并发而丢掉任何一种能下成的场景。
 ///
 /// 导入推荐包会走备份导入流程并**重启进程**，没有机会在导入成功后删包——所以
 /// [markImportStarted] 在启动导入前落一个 flag 文件，重启回来后由
@@ -104,7 +267,23 @@ class RecommendedPackDownloader {
     required Directory packDir,
     this.url = kRecommendedPackCloudflareUrl,
     this.sha256Hex,
+    this.manifest,
+    this.concurrency = SegmentedDownloader.kDefaultDownloadConcurrency,
   }) : _packDir = packDir;
+
+  /// 从清单构造：URL / sha256 / 分片计划一起跟着清单走。
+  factory RecommendedPackDownloader.fromManifest({
+    required Directory packDir,
+    required RecommendedPackManifest manifest,
+    int concurrency = SegmentedDownloader.kDefaultDownloadConcurrency,
+  }) =>
+      RecommendedPackDownloader(
+        packDir: packDir,
+        url: manifest.url,
+        sha256Hex: manifest.sha256,
+        manifest: manifest,
+        concurrency: concurrency,
+      );
 
   final Directory _packDir;
 
@@ -116,21 +295,58 @@ class RecommendedPackDownloader {
   /// 不符即删档报错——坏包/被截断的包不进备份导入。
   final String? sha256Hex;
 
+  /// 清单（可选）。带分片信息时走分片并发；为 null 时按内置直链探测。
+  final RecommendedPackManifest? manifest;
+
+  /// 并发段数。
+  final int concurrency;
+
   String get _fileName => Uri.parse(url).pathSegments.last;
 
   /// 下载完成的推荐包文件（可能尚不存在）。
   File get packFile => File(p.join(_packDir.path, _fileName));
 
+  /// 单流续传的半截文件。
   File get _partFile => File(p.join(_packDir.path, '$_fileName.part'));
+
+  /// 分片下载的半截文件（预分配到完整大小）。与单流的 `.part` **分开命名**：两条
+  /// 路的半截文件语义不同（一个是「已下这么多字节」，一个是「预分配好、按片填」），
+  /// 共用一个名字会让另一条路把对方的半截当成自己的断点。
+  File get _multiPartFile => File(p.join(_packDir.path, '$_fileName.mpart'));
+
+  File get _multiPartProgressFile =>
+      File(p.join(_packDir.path, '$_fileName.mpart.json'));
 
   File get _importedFlagFile => File(p.join(_packDir.path, 'imported.flag'));
 
   bool get hasCompletedFile => packFile.existsSync();
 
+  /// 已下字节（两条路合一）。分片路的 `.mpart` 是**预分配**的完整大小，长度不代表
+  /// 进度，必须读进度文件——否则 UI 一进来就显示「已下 9.5 GB」。
   int get partialBytes {
     try {
+      if (_multiPartProgressFile.existsSync()) {
+        return _receivedFromProgressFile();
+      }
       return _partFile.existsSync() ? _partFile.lengthSync() : 0;
     } on FileSystemException {
+      return 0;
+    }
+  }
+
+  int _receivedFromProgressFile() {
+    try {
+      final Object? decoded =
+          json.decode(_multiPartProgressFile.readAsStringSync());
+      if (decoded is! Map<String, dynamic>) return 0;
+      final Object? parts = decoded['parts'];
+      if (parts is! Map<String, dynamic>) return 0;
+      int sum = 0;
+      for (final Object? value in parts.values) {
+        if (value is int && value > 0) sum += value;
+      }
+      return sum;
+    } catch (_) {
       return 0;
     }
   }
@@ -168,7 +384,127 @@ class RecommendedPackDownloader {
     final Dio dio = createAppDio(
       options: BaseOptions(followRedirects: true, maxRedirects: 5),
     );
-    int existing = partialBytes;
+    try {
+      final DownloadPlan? plan = await _resolvePlan(dio, cancelToken);
+      if (plan != null) {
+        return await _downloadSegmented(
+          plan: plan,
+          dio: dio,
+          progress: progress,
+          receivedBytes: receivedBytes,
+          cancelToken: cancelToken,
+        );
+      }
+      return await _downloadSingleStream(
+        dio: dio,
+        progress: progress,
+        receivedBytes: receivedBytes,
+        cancelToken: cancelToken,
+      );
+    } finally {
+      dio.close();
+    }
+  }
+
+  /// 定分片计划：清单能直接给出就用清单；否则探一次总长（顺带验服务器支不支持
+  /// Range）。拿不到就返回 null → 单流路径。
+  Future<DownloadPlan?> _resolvePlan(Dio dio, CancelToken? cancelToken) async {
+    final DownloadPlan? fromManifest = manifest?.toDownloadPlan();
+    if (fromManifest != null) return fromManifest;
+
+    final int? total = await _probeTotalBytes(dio, cancelToken);
+    if (total == null || total <= 0) return null;
+    return DownloadPlan.ranged(
+      urls: manifest?.wholeFileUrls ?? <String>[url],
+      totalBytes: total,
+      partSize: manifest?.partSizeBytes ?? kRecommendedPackDefaultPartSize,
+      sha256: sha256Hex,
+      version: manifest?.version,
+    );
+  }
+
+  /// `Range: bytes=0-0` 探针：只要 1 个字节，从 `Content-Range` 读总长。
+  /// 服务器回 200（忽略 Range）就说明不支持断点，返回 null 走单流。
+  Future<int?> _probeTotalBytes(Dio dio, CancelToken? cancelToken) async {
+    try {
+      final Response<ResponseBody> response = await dio.get<ResponseBody>(
+        url,
+        cancelToken: cancelToken,
+        options: Options(
+          responseType: ResponseType.stream,
+          headers: <String, Object?>{'range': 'bytes=0-0'},
+          validateStatus: (int? status) => status == 200 || status == 206,
+        ),
+      );
+      final ResponseBody? body = response.data;
+      // 探针的 body 至多 1 字节（206）；若服务器忽略 Range 回了 200，body 是整个
+      // 9.5 GB——必须断连，绝不 drain。
+      if (body != null) {
+        await body.stream.listen(null, cancelOnError: true).cancel();
+      }
+      if (response.statusCode != 206) return null;
+      final String? contentRange = response.headers.value('content-range');
+      if (contentRange == null) return null;
+      final RegExpMatch? match =
+          RegExp(r'^bytes\s+\d+-\d+/(\d+)$').firstMatch(contentRange.trim());
+      if (match == null) return null;
+      return int.tryParse(match.group(1)!);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<File> _downloadSegmented({
+    required DownloadPlan plan,
+    required Dio dio,
+    required ValueNotifier<double> progress,
+    required ValueNotifier<int> receivedBytes,
+    CancelToken? cancelToken,
+  }) async {
+    final SegmentedDownloader downloader = SegmentedDownloader(
+      plan: plan,
+      destination: packFile,
+      partFile: _multiPartFile,
+      progressFile: _multiPartProgressFile,
+      concurrency: concurrency,
+      isCancelled: () => cancelToken?.isCancelled ?? false,
+      onProgress: (int received, int total) {
+        receivedBytes.value = received;
+        if (total > 0) progress.value = received / total;
+      },
+      open: (Uri uri, Map<String, String> headers) async {
+        final Response<ResponseBody> response = await dio.get<ResponseBody>(
+          uri.toString(),
+          cancelToken: cancelToken,
+          options: Options(
+            responseType: ResponseType.stream,
+            headers: <String, Object?>{...headers},
+            validateStatus: (int? status) =>
+                status != null && status >= 200 && status < 400,
+          ),
+        );
+        return ResumableDownloadResponse(
+          statusCode: response.statusCode ?? 0,
+          headers: <String, String>{
+            for (final MapEntry<String, List<String>> entry
+                in response.headers.map.entries)
+              entry.key: entry.value.join(','),
+          },
+          stream: response.data!.stream,
+        );
+      },
+    );
+    return downloader.download();
+  }
+
+  /// 单流续传旧路径：服务器不支持 Range 时的兜底。行为与引入分片前逐字一致。
+  Future<File> _downloadSingleStream({
+    required Dio dio,
+    required ValueNotifier<double> progress,
+    required ValueNotifier<int> receivedBytes,
+    CancelToken? cancelToken,
+  }) async {
+    int existing = _partFile.existsSync() ? _partFile.lengthSync() : 0;
     final Response<ResponseBody> response = await dio.get<ResponseBody>(
       url,
       cancelToken: cancelToken,

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -189,10 +189,9 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
         final RecommendedPackManifest? manifest =
             await fetchRecommendedPackManifest();
         if (manifest != null) {
-          _manifestDownloader = RecommendedPackDownloader(
+          _manifestDownloader = RecommendedPackDownloader.fromManifest(
             packDir: _packDir,
-            url: manifest.url,
-            sha256Hex: manifest.sha256,
+            manifest: manifest,
           );
         }
       }

--- a/fushi/lib/src/utils/misc/download_plan.dart
+++ b/fushi/lib/src/utils/misc/download_plan.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/foundation.dart';
+
+/// 一片数据的**一个来源**。
+///
+/// [remoteOffset] 是「本片的第一个字节，在该 URL 所指资源内部的偏移」——这一个字段
+/// 就把两种分发形态收成同一个结构，消费端不需要 mode 分支：
+///
+/// - **整包 + HTTP Range**（服务端零改动）：URL 指向完整包，[remoteOffset] == 本片在
+///   目标文件中的偏移。取本片就是 `Range: bytes=<remoteOffset>-<remoteOffset+len-1>`。
+/// - **物理切片**（分片撒在多主机）：URL 指向切好的那一片，[remoteOffset] == 0。
+///   取本片就是整个资源。
+///
+/// 同一片可以同时挂两种来源（CF 整包 + GitHub 切片互为镜像），失败时轮换。
+@immutable
+class DownloadSource {
+  const DownloadSource({required this.url, this.remoteOffset = 0})
+      : assert(remoteOffset >= 0, 'remoteOffset 不能为负');
+
+  final String url;
+
+  /// 本片首字节在该 URL 资源内的偏移；整包来源为该片的绝对偏移，切片来源为 0。
+  final int remoteOffset;
+
+  @override
+  bool operator ==(Object other) =>
+      other is DownloadSource &&
+      other.url == url &&
+      other.remoteOffset == remoteOffset;
+
+  @override
+  int get hashCode => Object.hash(url, remoteOffset);
+
+  @override
+  String toString() => 'DownloadSource($url @$remoteOffset)';
+}
+
+/// 目标文件的一片：写到目标文件 [offset] 处的 [length] 个字节。
+///
+/// [sha256] 可选，只有物理切片清单能给出（Range 模式无法预先知道每片摘要）；给出时
+/// 边下边算、单片校验失败只重下该片，不用等整包下完才发现坏了。
+@immutable
+class DownloadPart {
+  const DownloadPart({
+    required this.index,
+    required this.offset,
+    required this.length,
+    required this.sources,
+    this.sha256,
+  })  : assert(offset >= 0, 'offset 不能为负'),
+        assert(length > 0, 'length 必须为正');
+
+  final int index;
+
+  /// 本片在**目标文件**中的起始偏移。
+  final int offset;
+  final int length;
+
+  /// 可用来源，按序轮换（首个为首选）。
+  final List<DownloadSource> sources;
+
+  /// 本片内容的 sha256（小写 hex），可选。
+  final String? sha256;
+
+  /// 本片的结束偏移（**独占**）。
+  int get end => offset + length;
+
+  @override
+  String toString() => 'DownloadPart(#$index $offset+$length)';
+}
+
+/// 分片下载计划：一个目标文件 + 一组互不重叠、恰好铺满 `[0, totalBytes)` 的片。
+///
+/// 构造时校验铺砖（[_validateTiling]）：有缝或重叠都会当场抛 [ArgumentError]，而不是
+/// 下完 9.5 GB 才在 sha256 上发现包是坏的。
+@immutable
+class DownloadPlan {
+  DownloadPlan({
+    required this.totalBytes,
+    required this.parts,
+    this.sha256,
+    this.version,
+  }) {
+    _validateTiling(totalBytes, parts);
+  }
+
+  /// 整包 + Range 模式：把 [totalBytes] 按 [partSize] 切段，每段挂上全部 [urls]。
+  ///
+  /// 服务端零改动——只要主机支持 Range，现有直链立刻能并发下载。
+  factory DownloadPlan.ranged({
+    required List<String> urls,
+    required int totalBytes,
+    required int partSize,
+    String? sha256,
+    String? version,
+  }) {
+    if (urls.isEmpty) {
+      throw ArgumentError.value(urls, 'urls', '至少要有一个来源');
+    }
+    if (totalBytes <= 0) {
+      throw ArgumentError.value(totalBytes, 'totalBytes', '必须为正');
+    }
+    if (partSize <= 0) {
+      throw ArgumentError.value(partSize, 'partSize', '必须为正');
+    }
+    final List<DownloadPart> parts = <DownloadPart>[];
+    int offset = 0;
+    int index = 0;
+    while (offset < totalBytes) {
+      final int length =
+          offset + partSize > totalBytes ? totalBytes - offset : partSize;
+      parts.add(DownloadPart(
+        index: index,
+        offset: offset,
+        length: length,
+        sources: <DownloadSource>[
+          for (final String url in urls)
+            DownloadSource(url: url, remoteOffset: offset),
+        ],
+      ));
+      offset += length;
+      index += 1;
+    }
+    return DownloadPlan(
+      totalBytes: totalBytes,
+      parts: parts,
+      sha256: sha256,
+      version: version,
+    );
+  }
+
+  /// 单流退化计划：整个文件一片。服务器不支持 Range 时的兜底形态，让消费端仍然
+  /// 只认识 [DownloadPlan] 一种输入。
+  factory DownloadPlan.single({
+    required List<String> urls,
+    required int totalBytes,
+    String? sha256,
+    String? version,
+  }) =>
+      DownloadPlan.ranged(
+        urls: urls,
+        totalBytes: totalBytes,
+        partSize: totalBytes,
+        sha256: sha256,
+        version: version,
+      );
+
+  /// 目标文件总字节数。
+  final int totalBytes;
+
+  final List<DownloadPart> parts;
+
+  /// 整包 sha256（小写 hex，可选）。每片都带 [DownloadPart.sha256] 时，逐片校验已
+  /// 严格强于整包校验，消费端可跳过整包重读。
+  final String? sha256;
+
+  /// 包版本标识（清单里的 `version`）。进度文件靠它判断「服务端换包了」。
+  final String? version;
+
+  /// 是否每片都带摘要——是则无需整包重读校验。
+  bool get hasPerPartDigests =>
+      parts.isNotEmpty && parts.every((DownloadPart p) => p.sha256 != null);
+
+  static void _validateTiling(int totalBytes, List<DownloadPart> parts) {
+    if (totalBytes <= 0) {
+      throw ArgumentError.value(totalBytes, 'totalBytes', '必须为正');
+    }
+    if (parts.isEmpty) {
+      throw ArgumentError.value(parts, 'parts', '不能为空');
+    }
+    final List<DownloadPart> sorted = <DownloadPart>[...parts]
+      ..sort((DownloadPart a, DownloadPart b) => a.offset.compareTo(b.offset));
+    int expected = 0;
+    for (final DownloadPart part in sorted) {
+      if (part.sources.isEmpty) {
+        throw ArgumentError('片 #${part.index} 没有任何来源');
+      }
+      if (part.offset != expected) {
+        throw ArgumentError(
+          '分片不连续：期望 offset=$expected，实到 ${part.offset}'
+          '（片 #${part.index}）',
+        );
+      }
+      expected = part.end;
+    }
+    if (expected != totalBytes) {
+      throw ArgumentError(
+        '分片总长 $expected 与 totalBytes $totalBytes 不符',
+      );
+    }
+    final Set<int> indices = parts.map((DownloadPart p) => p.index).toSet();
+    if (indices.length != parts.length) {
+      throw ArgumentError('片 index 重复');
+    }
+  }
+}

--- a/fushi/lib/src/utils/misc/segmented_downloader.dart
+++ b/fushi/lib/src/utils/misc/segmented_downloader.dart
@@ -1,0 +1,574 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:crypto/crypto.dart';
+import 'package:fushi/src/utils/misc/download_plan.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+
+/// 打开一次请求。与 [ResumableDownloadOpen] 同形（复用 [ResumableDownloadResponse]），
+/// 让单流与分片两条路共享同一套注入点和测试替身。
+typedef SegmentedDownloadOpen = ResumableDownloadOpen;
+
+/// 已收字节 / 总字节。
+typedef SegmentedDownloadProgress = void Function(int received, int total);
+
+/// 用户主动取消。与真实失败区分开：取消不重试、不删半截（下次可续）。
+class SegmentedDownloadCancelledException implements Exception {
+  const SegmentedDownloadCancelledException();
+  @override
+  String toString() => 'SegmentedDownloadCancelledException';
+}
+
+/// 某一片把所有来源都试完仍拿不到。
+class SegmentedDownloadPartException implements Exception {
+  const SegmentedDownloadPartException(this.partIndex, this.cause);
+  final int partIndex;
+  final Object cause;
+  @override
+  String toString() =>
+      'SegmentedDownloadPartException(片 #$partIndex 全部来源失败: $cause)';
+}
+
+/// 分片并发下载器：把 [DownloadPlan] 的每一片并发取回，按各自偏移写进**同一个**
+/// 预分配的 `.part` 文件，全部完成并校验后原子改名为 [destination]。
+///
+/// ## 为什么不是「分卷压缩」
+///
+/// 分卷（`.zip.001`）下完必须再解出一个完整包才能导入，落地要 2× 磁盘——9.5 GB 的包
+/// 在手机上就是 19 GB。按**字节**分片则是并发写进同一个目标文件，下完即是原封不动的
+/// 原文件，消费端（备份导入）一行不用改，磁盘只要 1×。
+///
+/// ## 断点与换包
+///
+/// 每片的已收字节记在 [progressFile]，跨进程可续。服务端换包由两道闸拦住：进度文件
+/// 记了计划的 `version`/`totalBytes`/`sha256`，对不上直接清空重来；续传请求还带
+/// `If-Range`，服务器自己会把过期断点降级成 200（本类据此丢弃该片重下），不会拼出
+/// 一个下完 9.5 GB 才在 sha256 上发现是坏的包。
+///
+/// ## 取够就断
+///
+/// 一片取到 [DownloadPart.length] 字节就跳出 `await for`（取消订阅断连），绝不把整包
+/// 读完——否则一个忽略 Range 的服务器会让每一片都去下整个 9.5 GB。
+class SegmentedDownloader {
+  SegmentedDownloader({
+    required this.plan,
+    required this.destination,
+    required this.partFile,
+    required this.progressFile,
+    required this.open,
+    this.concurrency = kDefaultDownloadConcurrency,
+    this.maxAttemptsPerPart = 3,
+    this.onProgress,
+    this.bodyTimeout,
+    this.firstByteTimeout,
+    this.isCancelled,
+    this.flushInterval = kDefaultFlushInterval,
+  })  : assert(concurrency > 0, 'concurrency 必须为正'),
+        assert(maxAttemptsPerPart > 0, 'maxAttemptsPerPart 必须为正');
+
+  /// 并发段数默认值：国内下 CF 单连接常被限速，多连接叠加是主要提速手段；再大对
+  /// 移动端内存/CDN 都不友好。
+  static const int kDefaultDownloadConcurrency = 4;
+
+  /// 每写满这么多字节就 flush 一次并落一次进度（崩溃最多丢这么多）。
+  static const int kDefaultFlushInterval = 8 * 1024 * 1024;
+
+  final DownloadPlan plan;
+  final File destination;
+  final File partFile;
+  final File progressFile;
+  final SegmentedDownloadOpen open;
+  final int concurrency;
+  final int maxAttemptsPerPart;
+  final SegmentedDownloadProgress? onProgress;
+
+  /// 两个数据块之间的最大间隔（不是整片总时长）。
+  final Duration? bodyTimeout;
+
+  /// 首字节（连接 + 响应头）预算。
+  final Duration? firstByteTimeout;
+
+  /// 取消判定；返回 true 时正在跑的片尽快退出，半截保留供下次续传。
+  final bool Function()? isCancelled;
+
+  final int flushInterval;
+
+  late RandomAccessFile _raf;
+  final _AsyncLock _ioLock = _AsyncLock();
+  late _ProgressStore _store;
+  int _receivedTotal = 0;
+
+  /// 服务端校验子（ETag / Last-Modified），首个成功响应捕获，之后续传带 `If-Range`。
+  String? _validator;
+
+  Future<File> download() async {
+    if (await destination.exists()) return destination;
+    await partFile.parent.create(recursive: true);
+
+    _store = await _ProgressStore.load(progressFile, plan);
+    _validator = _store.validator;
+    await _preparePartFile();
+    _receivedTotal = _store.receivedTotal(plan);
+    onProgress?.call(_receivedTotal, plan.totalBytes);
+
+    final List<DownloadPart> pending = plan.parts
+        .where((DownloadPart p) => _store.receivedOf(p.index) < p.length)
+        .toList();
+
+    if (pending.isNotEmpty) {
+      _raf = await _openPartFile();
+      try {
+        await _runWorkers(pending);
+      } finally {
+        try {
+          await _raf.flush();
+        } catch (_) {
+          // flush 失败不能盖住上面真正的错误；下面 close 仍要跑。
+        }
+        await _raf.close();
+      }
+    }
+
+    await _verifyOrThrow();
+    return _promote();
+  }
+
+  // ── 文件准备 ────────────────────────────────────────────────────────
+
+  /// 确保 `.part` 存在且长度**恰好**是 totalBytes（预分配）。空间不够就在这里当场
+  /// 失败，而不是下到 90% 才写不进去。
+  Future<void> _preparePartFile() async {
+    final bool exists = await partFile.exists();
+    if (!exists) {
+      final RandomAccessFile raf = await partFile.open(mode: FileMode.write);
+      try {
+        await raf.truncate(plan.totalBytes);
+      } finally {
+        await raf.close();
+      }
+      return;
+    }
+    final int length = await partFile.length();
+    if (length == plan.totalBytes) return;
+    final RandomAccessFile raf = await partFile.open(mode: FileMode.append);
+    try {
+      await raf.truncate(plan.totalBytes);
+    } finally {
+      await raf.close();
+    }
+  }
+
+  /// 以 append 模式打开做随机写：`write` 会截断已下内容，只有 `append` 既不截断又能
+  /// `setPosition` 随机写。该语义由 `segmented_downloader_test.dart` 的平台守卫钉住
+  /// （某平台若按 `O_APPEND` 强制追加，测试当场红，而不是把 9.5 GB 写成乱序垃圾）。
+  Future<RandomAccessFile> _openPartFile() =>
+      partFile.open(mode: FileMode.append);
+
+  // ── 并发调度 ────────────────────────────────────────────────────────
+
+  Future<void> _runWorkers(List<DownloadPart> pending) async {
+    final Queue<DownloadPart> queue = Queue<DownloadPart>.of(pending);
+    Object? failure;
+    StackTrace? failureStack;
+
+    Future<void> worker() async {
+      while (queue.isNotEmpty) {
+        if (failure != null) return;
+        _throwIfCancelled();
+        final DownloadPart part = queue.removeFirst();
+        try {
+          await _fetchPart(part);
+        } catch (e, st) {
+          // 先到的错误胜出；其余 worker 看到 failure 后收工（快速失败：一片彻底
+          // 拿不到，整包就不可能完成，没必要让别的片继续烧流量）。
+          failure ??= e;
+          failureStack ??= st;
+          queue.clear();
+          return;
+        }
+      }
+    }
+
+    final int workerCount = math.min(concurrency, pending.length);
+    await Future.wait<void>(
+      List<Future<void>>.generate(workerCount, (_) => worker()),
+    );
+    if (failure != null) {
+      Error.throwWithStackTrace(failure!, failureStack!);
+    }
+  }
+
+  /// 取一片：按序轮换来源，直到取到或试满 [maxAttemptsPerPart] 次。
+  Future<void> _fetchPart(DownloadPart part) async {
+    Object? lastError;
+    StackTrace? lastStack;
+    for (int attempt = 0; attempt < maxAttemptsPerPart; attempt++) {
+      _throwIfCancelled();
+      final DownloadSource source = part.sources[attempt % part.sources.length];
+      try {
+        await _fetchPartFrom(part, source);
+        return;
+      } on SegmentedDownloadCancelledException {
+        rethrow;
+      } catch (e, st) {
+        lastError = e;
+        lastStack = st;
+      }
+    }
+    Error.throwWithStackTrace(
+      SegmentedDownloadPartException(part.index, lastError!),
+      lastStack!,
+    );
+  }
+
+  Future<void> _fetchPartFrom(DownloadPart part, DownloadSource source) async {
+    int done = _store.receivedOf(part.index);
+    if (done >= part.length) return;
+
+    final int start = source.remoteOffset + done;
+    final int end = source.remoteOffset + part.length - 1;
+    final Map<String, String> headers = <String, String>{
+      HttpHeaders.rangeHeader: 'bytes=$start-$end',
+    };
+    final String? validator = _validator;
+    if (done > 0 && validator != null && validator.isNotEmpty) {
+      headers[HttpHeaders.ifRangeHeader] = validator;
+    }
+
+    Future<ResumableDownloadResponse> opened =
+        open(Uri.parse(source.url), headers);
+    if (firstByteTimeout != null) {
+      opened = opened.timeout(firstByteTimeout!);
+    }
+    final ResumableDownloadResponse response = await opened;
+
+    if (response.statusCode == HttpStatus.partialContent) {
+      // 206 必须带可解析的 Content-Range（RFC 9110）。缺了或看不懂就**不猜**——
+      // 猜错就是把别处的字节写进本片偏移，最后只体现为一个 sha256 不符的坏包。
+      final int? gotStart =
+          _contentRangeStart(response.header(HttpHeaders.contentRangeHeader));
+      if (gotStart != start) {
+        await _abort(response);
+        throw HttpException(
+          'content-range 起点不符：要 $start 实到 $gotStart',
+          uri: Uri.parse(source.url),
+        );
+      }
+    } else if (response.statusCode == HttpStatus.ok) {
+      // 服务器忽略了 Range，body 从**资源第 0 字节**开始。
+      if (source.remoteOffset != 0) {
+        // 整包来源：这条 body 是整个包，不是本片。绝不能消费（会下满 9.5 GB），
+        // 直接断连换下一个来源。
+        await _abort(response);
+        throw HttpException(
+          '来源忽略 Range，整包来源无法定位片 #${part.index}',
+          uri: Uri.parse(source.url),
+        );
+      }
+      // 切片来源：body 就是本片，从头重写（旧的半截作废）。
+      done = 0;
+      await _ioLock.run(() async {
+        _receivedTotal -= _store.receivedOf(part.index);
+        _store.setReceived(part.index, 0);
+      });
+    } else {
+      await _abort(response);
+      throw HttpException(
+        'download failed (${response.statusCode})',
+        uri: Uri.parse(source.url),
+      );
+    }
+
+    _validator ??= response.header(HttpHeaders.etagHeader) ??
+        response.header(HttpHeaders.lastModifiedHeader);
+
+    await _consumePart(part: part, response: response, alreadyDone: done);
+  }
+
+  /// 消费一片的 body：边写盘边算摘要，取够 [DownloadPart.length] 立刻跳出。
+  Future<void> _consumePart({
+    required DownloadPart part,
+    required ResumableDownloadResponse response,
+    required int alreadyDone,
+  }) async {
+    final String? expected = part.sha256;
+    ByteConversionSink? hasher;
+    _DigestSink? digestSink;
+    if (expected != null) {
+      digestSink = _DigestSink();
+      hasher = sha256.startChunkedConversion(digestSink);
+      if (alreadyDone > 0) {
+        await _seedHasher(hasher, part, alreadyDone);
+      }
+    }
+
+    int written = alreadyDone;
+    int sinceFlush = 0;
+
+    Stream<List<int>> body = response.stream;
+    if (bodyTimeout != null) body = body.timeout(bodyTimeout!);
+
+    await for (final List<int> chunk in body) {
+      if (isCancelled?.call() ?? false) {
+        await _flushAndPersist(part.index, written);
+        throw const SegmentedDownloadCancelledException();
+      }
+      if (chunk.isEmpty) continue;
+      // 服务器多给了就只取够（忽略 Range 的 200 会一路送到文件末尾）。
+      final int take = math.min(chunk.length, part.length - written);
+      if (take <= 0) break;
+
+      final int writeAt = part.offset + written;
+      await _ioLock.run(() async {
+        await _raf.setPosition(writeAt);
+        await _raf.writeFrom(chunk, 0, take);
+      });
+      hasher?.addSlice(chunk, 0, take, false);
+
+      written += take;
+      sinceFlush += take;
+      _receivedTotal += take;
+      onProgress?.call(_receivedTotal, plan.totalBytes);
+
+      if (sinceFlush >= flushInterval) {
+        await _flushAndPersist(part.index, written);
+        sinceFlush = 0;
+      }
+      if (written >= part.length) break; // 取够就断连，不读整包
+    }
+
+    if (written < part.length) {
+      await _flushAndPersist(part.index, written);
+      throw HttpException(
+        '片 #${part.index} 提前结束：$written / ${part.length}',
+      );
+    }
+
+    if (expected != null) {
+      hasher!.close();
+      final String actual = digestSink!.value.toString();
+      if (actual != expected) {
+        // 坏片不留：已收清零，下次重下这一片（整包其余片不受影响）。
+        await _ioLock.run(() async {
+          _receivedTotal -= _store.receivedOf(part.index);
+          _store.setReceived(part.index, 0);
+        });
+        await _store.persist(progressFile, plan, _validator);
+        throw ResumableDownloadIntegrityException(
+          '片 #${part.index} sha256 不符：得 $actual 期望 $expected',
+        );
+      }
+    }
+
+    await _flushAndPersist(part.index, written);
+  }
+
+  /// 续传时把已落盘的前缀喂给摘要器，免得为了校验再整片重读一遍。
+  Future<void> _seedHasher(
+    ByteConversionSink hasher,
+    DownloadPart part,
+    int prefixLength,
+  ) async {
+    final RandomAccessFile reader = await partFile.open(mode: FileMode.read);
+    try {
+      await reader.setPosition(part.offset);
+      int remaining = prefixLength;
+      const int bufferSize = 1 << 20;
+      while (remaining > 0) {
+        final int want = math.min(bufferSize, remaining);
+        final List<int> bytes = await reader.read(want);
+        if (bytes.isEmpty) {
+          throw ResumableDownloadIntegrityException(
+            '片 #${part.index} 前缀读取提前结束',
+          );
+        }
+        hasher.addSlice(bytes, 0, bytes.length, false);
+        remaining -= bytes.length;
+      }
+    } finally {
+      await reader.close();
+    }
+  }
+
+  Future<void> _flushAndPersist(int partIndex, int received) async {
+    await _ioLock.run(() async {
+      await _raf.flush();
+      _store.setReceived(partIndex, received);
+    });
+    await _store.persist(progressFile, plan, _validator);
+  }
+
+  /// 断开一条不要的响应流：**不能**用 `drain`——整包来源的 body 是 9.5 GB。
+  Future<void> _abort(ResumableDownloadResponse response) async {
+    try {
+      final StreamSubscription<List<int>> sub =
+          response.stream.listen(null, cancelOnError: true);
+      await sub.cancel();
+    } catch (_) {
+      // best-effort：断连失败不该盖住真正的失败原因。
+    }
+  }
+
+  void _throwIfCancelled() {
+    if (isCancelled?.call() ?? false) {
+      throw const SegmentedDownloadCancelledException();
+    }
+  }
+
+  // ── 收尾 ────────────────────────────────────────────────────────────
+
+  Future<void> _verifyOrThrow() async {
+    final int length = await partFile.length();
+    if (length != plan.totalBytes) {
+      throw ResumableDownloadIntegrityException(
+        '大小不符：得 $length 期望 ${plan.totalBytes}',
+      );
+    }
+    final String? expected = plan.sha256;
+    // 每片都验过摘要时，逐片校验已严格强于整包校验，省掉一次 9.5 GB 重读。
+    if (expected == null || plan.hasPerPartDigests) return;
+    final Digest digest = await sha256.bind(partFile.openRead()).first;
+    if (digest.toString() != expected) {
+      await _deleteQuietly(partFile);
+      await _deleteQuietly(progressFile);
+      throw ResumableDownloadIntegrityException(
+        '整包 sha256 不符：得 $digest 期望 $expected',
+      );
+    }
+  }
+
+  Future<File> _promote() async {
+    await destination.parent.create(recursive: true);
+    if (await destination.exists()) await _deleteQuietly(destination);
+    final File promoted = await partFile.rename(destination.path);
+    await _deleteQuietly(progressFile);
+    return promoted;
+  }
+
+  static Future<void> _deleteQuietly(File file) async {
+    try {
+      if (await file.exists()) await file.delete();
+    } catch (_) {
+      // best-effort
+    }
+  }
+
+  static int? _contentRangeStart(String? value) {
+    if (value == null) return null;
+    final RegExpMatch? match =
+        RegExp(r'^bytes\s+(\d+)-(\d+)/(\d+|\*)$').firstMatch(value.trim());
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
+  }
+}
+
+/// 串行化写盘：多个片并发到达，但只有一个 [RandomAccessFile]，`setPosition` +
+/// `writeFrom` 必须成对地不被打断，否则两片会写到彼此的偏移上。
+///
+/// 用锁而不是「每片开一个 fd」是有意的：瓶颈在网络不在盘，一把锁最笨也最不会错。
+class _AsyncLock {
+  Future<void> _tail = Future<void>.value();
+
+  Future<T> run<T>(Future<T> Function() body) {
+    final Completer<void> gate = Completer<void>();
+    final Future<void> previous = _tail;
+    _tail = gate.future;
+    return previous.then((_) => body()).whenComplete(gate.complete);
+  }
+}
+
+class _DigestSink implements Sink<Digest> {
+  late Digest value;
+
+  @override
+  void add(Digest data) => value = data;
+
+  @override
+  void close() {}
+}
+
+/// 各片已收字节的持久化。与计划的 `version` / `totalBytes` / `sha256` 绑定：任何一项
+/// 对不上说明服务端换包了，整份进度作废（而不是把新旧两个包的字节拼在一起）。
+class _ProgressStore {
+  _ProgressStore._(this._received, this.validator);
+
+  static const int _formatVersion = 1;
+
+  final Map<int, int> _received;
+  String? validator;
+
+  static Future<_ProgressStore> load(File file, DownloadPlan plan) async {
+    try {
+      if (!await file.exists()) return _ProgressStore._(<int, int>{}, null);
+      final Object? decoded = json.decode(await file.readAsString());
+      if (decoded is! Map<String, dynamic>) {
+        return _ProgressStore._(<int, int>{}, null);
+      }
+      if (decoded['version'] != _formatVersion ||
+          decoded['totalBytes'] != plan.totalBytes ||
+          decoded['planVersion'] != plan.version ||
+          decoded['sha256'] != plan.sha256) {
+        return _ProgressStore._(<int, int>{}, null);
+      }
+      final Object? parts = decoded['parts'];
+      final Map<int, int> received = <int, int>{};
+      if (parts is Map<String, dynamic>) {
+        for (final MapEntry<String, dynamic> entry in parts.entries) {
+          final int? index = int.tryParse(entry.key);
+          final Object? value = entry.value;
+          if (index == null || value is! int || value < 0) continue;
+          received[index] = value;
+        }
+      }
+      // 越界的记录（片表变了）一律丢弃，避免把已收字节记到不存在的偏移上。
+      final Map<int, int> clamped = <int, int>{};
+      for (final DownloadPart part in plan.parts) {
+        final int? got = received[part.index];
+        if (got == null || got <= 0) continue;
+        clamped[part.index] = math.min(got, part.length);
+      }
+      final Object? validator = decoded['validator'];
+      return _ProgressStore._(
+        clamped,
+        validator is String && validator.isNotEmpty ? validator : null,
+      );
+    } catch (_) {
+      return _ProgressStore._(<int, int>{}, null);
+    }
+  }
+
+  int receivedOf(int index) => _received[index] ?? 0;
+
+  void setReceived(int index, int value) => _received[index] = value;
+
+  int receivedTotal(DownloadPlan plan) {
+    int sum = 0;
+    for (final DownloadPart part in plan.parts) {
+      sum += math.min(receivedOf(part.index), part.length);
+    }
+    return sum;
+  }
+
+  Future<void> persist(File file, DownloadPlan plan, String? validator) async {
+    this.validator = validator;
+    try {
+      await file.parent.create(recursive: true);
+      await file.writeAsString(json.encode(<String, Object?>{
+        'version': _formatVersion,
+        'totalBytes': plan.totalBytes,
+        'planVersion': plan.version,
+        'sha256': plan.sha256,
+        'validator': validator,
+        'parts': <String, int>{
+          for (final MapEntry<int, int> e in _received.entries)
+            if (e.value > 0) '${e.key}': e.value,
+        },
+      }));
+    } catch (_) {
+      // 进度落盘失败只影响续传效率，不该中断正在进行的下载。
+    }
+  }
+}

--- a/fushi/lib/src/utils/misc/segmented_downloader.dart
+++ b/fushi/lib/src/utils/misc/segmented_downloader.dart
@@ -66,6 +66,7 @@ class SegmentedDownloader {
     this.firstByteTimeout,
     this.isCancelled,
     this.flushInterval = kDefaultFlushInterval,
+    this.retryBackoff,
   })  : assert(concurrency > 0, 'concurrency 必须为正'),
         assert(maxAttemptsPerPart > 0, 'maxAttemptsPerPart 必须为正');
 
@@ -95,6 +96,16 @@ class SegmentedDownloader {
   final bool Function()? isCancelled;
 
   final int flushInterval;
+
+  /// 第 [attempt] 次失败后等多久再试下一个来源。默认指数退避（1s / 2s / 4s…，
+  /// 上限 30s）：移动网络抖动时背靠背重试三次基本是三次一起失败，退避才有意义。
+  /// 单测注入 [Duration.zero] 免得空等。
+  final Duration Function(int attempt)? retryBackoff;
+
+  static Duration _defaultBackoff(int attempt) {
+    final int seconds = 1 << (attempt > 4 ? 4 : attempt);
+    return Duration(seconds: seconds > 30 ? 30 : seconds);
+  }
 
   late RandomAccessFile _raf;
   final _AsyncLock _ioLock = _AsyncLock();
@@ -216,6 +227,13 @@ class SegmentedDownloader {
       } catch (e, st) {
         lastError = e;
         lastStack = st;
+        if (attempt + 1 < maxAttemptsPerPart) {
+          final Duration wait = (retryBackoff ?? _defaultBackoff)(attempt);
+          if (wait > Duration.zero) {
+            await Future<void>.delayed(wait);
+            _throwIfCancelled();
+          }
+        }
       }
     }
     Error.throwWithStackTrace(

--- a/fushi/test/onboarding/recommended_pack_manifest_test.dart
+++ b/fushi/test/onboarding/recommended_pack_manifest_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/onboarding/recommended_pack.dart';
+import 'package:fushi/src/utils/misc/download_plan.dart';
 
 void main() {
   group('parseRecommendedPackManifest', () {
@@ -47,6 +48,172 @@ void main() {
     test('malformed json / non-object returns null', () {
       expect(parseRecommendedPackManifest('not json'), isNull);
       expect(parseRecommendedPackManifest('[1,2,3]'), isNull);
+    });
+
+    test('mirrors / part_base_urls 只收 https，杂项被丢掉', () {
+      final RecommendedPackManifest? m = parseRecommendedPackManifest(
+        '{"url":"https://dl.wrds.xyz/a.zip",'
+        '"mirrors":["https://m1/a.zip","http://insecure/a.zip",7],'
+        '"part_base_urls":["https://gh/dl/"]}',
+      );
+      expect(m, isNotNull);
+      expect(m!.mirrors, <String>['https://m1/a.zip']);
+      expect(m.partBaseUrls, <String>['https://gh/dl/']);
+      expect(m.wholeFileUrls,
+          <String>['https://dl.wrds.xyz/a.zip', 'https://m1/a.zip']);
+    });
+
+    test('parts 里有一条坏记录就整表作废（半张切片表比没有更危险）', () {
+      final RecommendedPackManifest? m = parseRecommendedPackManifest(
+        '{"url":"https://dl.wrds.xyz/a.zip",'
+        '"part_base_urls":["https://gh/dl/"],'
+        '"parts":[{"name":"a.000","offset":0,"length":100},'
+        '{"name":"a.001","offset":100,"length":-5}]}',
+      );
+      expect(m, isNotNull);
+      expect(m!.parts, isEmpty);
+    });
+
+    test('切片名不得带路径分隔符（防止拼出目录穿越 URL）', () {
+      final RecommendedPackManifest? m = parseRecommendedPackManifest(
+        '{"url":"https://dl.wrds.xyz/a.zip",'
+        '"part_base_urls":["https://gh/dl/"],'
+        '"parts":[{"name":"../../evil","offset":0,"length":100}]}',
+      );
+      expect(m!.parts, isEmpty);
+    });
+  });
+
+  group('toDownloadPlan', () {
+    test('只有 size_bytes 时按 Range 模式切段，整包镜像一起挂上', () {
+      final RecommendedPackManifest m = RecommendedPackManifest(
+        url: 'https://dl.wrds.xyz/a.zip',
+        mirrors: const <String>['https://m1/a.zip'],
+        sizeBytes: 250,
+        partSizeBytes: 100,
+        version: 'v1',
+      );
+      final DownloadPlan? plan = m.toDownloadPlan();
+      expect(plan, isNotNull);
+      expect(plan!.parts.length, 3);
+      expect(plan.version, 'v1');
+      expect(plan.parts.first.sources.length, 2);
+      expect(plan.parts[1].sources.first.remoteOffset, 100);
+    });
+
+    test('没有总长时返回 null（调用方去探测或走单流）', () {
+      const RecommendedPackManifest m =
+          RecommendedPackManifest(url: 'https://dl.wrds.xyz/a.zip');
+      expect(m.toDownloadPlan(), isNull);
+    });
+
+    test('切片模式：切片 URL remoteOffset=0，整包镜像作为额外来源', () {
+      final RecommendedPackManifest m = RecommendedPackManifest(
+        url: 'https://dl.wrds.xyz/a.zip',
+        sizeBytes: 200,
+        partBaseUrls: const <String>['https://gh/dl/'],
+        parts: const <RecommendedPackPart>[
+          RecommendedPackPart(name: 'a.000', offset: 0, length: 100),
+          RecommendedPackPart(name: 'a.001', offset: 100, length: 100),
+        ],
+      );
+      final DownloadPlan? plan = m.toDownloadPlan();
+      expect(plan, isNotNull);
+      expect(plan!.parts.length, 2);
+      // 切片来源在前（首选），整包来源垫底当镜像。
+      expect(plan.parts[1].sources.first,
+          const DownloadSource(url: 'https://gh/dl/a.001'));
+      expect(
+          plan.parts[1].sources.last,
+          const DownloadSource(
+              url: 'https://dl.wrds.xyz/a.zip', remoteOffset: 100));
+    });
+
+    test('切片总长与声明总长打架时退回 Range 模式，不拿矛盾清单下包', () {
+      final RecommendedPackManifest m = RecommendedPackManifest(
+        url: 'https://dl.wrds.xyz/a.zip',
+        sizeBytes: 999,
+        partSizeBytes: 500,
+        partBaseUrls: const <String>['https://gh/dl/'],
+        parts: const <RecommendedPackPart>[
+          RecommendedPackPart(name: 'a.000', offset: 0, length: 100),
+        ],
+      );
+      final DownloadPlan? plan = m.toDownloadPlan();
+      expect(plan, isNotNull);
+      expect(plan!.totalBytes, 999, reason: '应按声明总长走 Range，而不是按切片表');
+      expect(plan.parts.first.sources.first.url, 'https://dl.wrds.xyz/a.zip');
+    });
+
+    test('tool/make_download_manifest.dart 的真实产物能被解析成计划（slice）', () {
+      // 这份 JSON 逐字来自 `dart run tool/make_download_manifest.dart --mode slice`
+      // 的实际输出。生成器与消费端的字段名一旦分叉，只会在生产上体现为「清单拉到了
+      // 却还是单流下载」，这条往返测试把契约钉住。
+      const String emitted = '''
+{
+  "version": "demo-1",
+  "url": "https://dl.wrds.xyz/demo.fushi.zip",
+  "sha256": "0c5a99b4b3ff2f25f5eeba1f85d2584bd6b314ff7eca44cc35e7492d010fa533",
+  "size_bytes": 307200,
+  "part_size_bytes": 102400,
+  "part_base_urls": ["https://gh/dl/pack-demo"],
+  "parts": [
+    {"name":"demo.fushi.zip.000","offset":0,"length":102400,
+     "sha256":"10a1048cb17d595dacb38c932b92afb52eb04a4eb904aa711274bce721176de7"},
+    {"name":"demo.fushi.zip.001","offset":102400,"length":102400,
+     "sha256":"b67a6c8e49dfd07213dd5a74f0100b63fe8db5a145219fb26de728a156f7b95f"},
+    {"name":"demo.fushi.zip.002","offset":204800,"length":102400,
+     "sha256":"35e379de3fdbf4ab685d42bdf671d866da5a530fa201cf0d0d7bd25316f80baf"}
+  ]
+}
+''';
+      final RecommendedPackManifest? m = parseRecommendedPackManifest(emitted);
+      expect(m, isNotNull);
+      final DownloadPlan? plan = m!.toDownloadPlan();
+      expect(plan, isNotNull);
+      expect(plan!.totalBytes, 307200);
+      expect(plan.parts.length, 3);
+      expect(plan.hasPerPartDigests, isTrue, reason: '切片清单带逐片摘要，才能省掉整包重读');
+      expect(plan.parts.first.sources.first.url,
+          'https://gh/dl/pack-demo/demo.fushi.zip.000');
+    });
+
+    test('tool/make_download_manifest.dart 的真实产物能被解析成计划（range）', () {
+      const String emitted = '''
+{
+  "version": "demo-1",
+  "url": "https://dl.wrds.xyz/demo.fushi.zip",
+  "sha256": "0c5a99b4b3ff2f25f5eeba1f85d2584bd6b314ff7eca44cc35e7492d010fa533",
+  "size_bytes": 307200,
+  "mirrors": ["https://m1/demo.fushi.zip"],
+  "part_size_bytes": 67108864
+}
+''';
+      final RecommendedPackManifest? m = parseRecommendedPackManifest(emitted);
+      final DownloadPlan? plan = m!.toDownloadPlan();
+      expect(plan, isNotNull);
+      // 段大小 64 MiB > 总长 → 退化成一片，但仍带上镜像。
+      expect(plan!.parts.length, 1);
+      expect(plan.parts.single.sources.length, 2);
+      expect(plan.hasPerPartDigests, isFalse);
+      expect(plan.sha256, isNotNull, reason: 'range 模式靠整包摘要兜底');
+    });
+
+    test('切片表有缝时退回 Range 模式而不是抛异常', () {
+      final RecommendedPackManifest m = RecommendedPackManifest(
+        url: 'https://dl.wrds.xyz/a.zip',
+        sizeBytes: 200,
+        partSizeBytes: 200,
+        partBaseUrls: const <String>['https://gh/dl/'],
+        parts: const <RecommendedPackPart>[
+          RecommendedPackPart(name: 'a.000', offset: 0, length: 50),
+          // 50..100 是个洞
+          RecommendedPackPart(name: 'a.001', offset: 100, length: 150),
+        ],
+      );
+      final DownloadPlan? plan = m.toDownloadPlan();
+      expect(plan, isNotNull);
+      expect(plan!.parts.length, 1, reason: '退回整包 Range 单段');
     });
   });
 }

--- a/fushi/test/utils/download_plan_test.dart
+++ b/fushi/test/utils/download_plan_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/download_plan.dart';
+
+void main() {
+  group('DownloadPlan.ranged', () {
+    test('按段大小铺满，末段取余数', () {
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/x.zip'],
+        totalBytes: 250,
+        partSize: 100,
+      );
+      expect(plan.parts.length, 3);
+      expect(plan.parts.map((DownloadPart p) => p.offset), <int>[0, 100, 200]);
+      expect(plan.parts.map((DownloadPart p) => p.length), <int>[100, 100, 50]);
+      expect(plan.parts.last.end, 250);
+    });
+
+    test('整包来源的 remoteOffset 等于该片绝对偏移', () {
+      // 这一条就是「Range 模式」的全部：URL 指的是整包，所以片在资源内的偏移
+      // 与它在目标文件中的偏移相同。
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/x.zip', 'https://b/x.zip'],
+        totalBytes: 200,
+        partSize: 100,
+      );
+      expect(plan.parts[1].sources, <DownloadSource>[
+        const DownloadSource(url: 'https://a/x.zip', remoteOffset: 100),
+        const DownloadSource(url: 'https://b/x.zip', remoteOffset: 100),
+      ]);
+    });
+
+    test('段大于总长时退化成一片', () {
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/x.zip'],
+        totalBytes: 50,
+        partSize: 1000,
+      );
+      expect(plan.parts.length, 1);
+      expect(plan.parts.single.length, 50);
+    });
+
+    test('参数非法时当场拒绝', () {
+      expect(
+        () => DownloadPlan.ranged(
+            urls: const <String>[], totalBytes: 10, partSize: 5),
+        throwsArgumentError,
+      );
+      expect(
+        () => DownloadPlan.ranged(
+            urls: const <String>['https://a'], totalBytes: 0, partSize: 5),
+        throwsArgumentError,
+      );
+      expect(
+        () => DownloadPlan.ranged(
+            urls: const <String>['https://a'], totalBytes: 10, partSize: 0),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('铺砖校验', () {
+    DownloadPart part(int index, int offset, int length) => DownloadPart(
+          index: index,
+          offset: offset,
+          length: length,
+          sources: const <DownloadSource>[DownloadSource(url: 'https://a')],
+        );
+
+    test('有缝隙就拒绝（下完会是个中间带洞的坏包）', () {
+      expect(
+        () => DownloadPlan(
+          totalBytes: 200,
+          parts: <DownloadPart>[part(0, 0, 50), part(1, 100, 100)],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('有重叠就拒绝', () {
+      expect(
+        () => DownloadPlan(
+          totalBytes: 150,
+          parts: <DownloadPart>[part(0, 0, 100), part(1, 50, 100)],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('总长对不上就拒绝', () {
+      expect(
+        () => DownloadPlan(
+          totalBytes: 999,
+          parts: <DownloadPart>[part(0, 0, 100)],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('片 index 重复就拒绝（进度会互相覆盖）', () {
+      expect(
+        () => DownloadPlan(
+          totalBytes: 200,
+          parts: <DownloadPart>[part(0, 0, 100), part(0, 100, 100)],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('片没有来源就拒绝', () {
+      expect(
+        () => DownloadPlan(
+          totalBytes: 100,
+          parts: const <DownloadPart>[
+            DownloadPart(
+              index: 0,
+              offset: 0,
+              length: 100,
+              sources: <DownloadSource>[],
+            ),
+          ],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('乱序给片也接受（按 offset 排序后校验）', () {
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 200,
+        parts: <DownloadPart>[part(1, 100, 100), part(0, 0, 100)],
+      );
+      expect(plan.parts.length, 2);
+    });
+  });
+
+  group('hasPerPartDigests', () {
+    test('全带摘要为 true，缺一片为 false', () {
+      DownloadPart withSha(int i, int off, String? sha) => DownloadPart(
+            index: i,
+            offset: off,
+            length: 100,
+            sha256: sha,
+            sources: const <DownloadSource>[DownloadSource(url: 'https://a')],
+          );
+      expect(
+        DownloadPlan(
+          totalBytes: 200,
+          parts: <DownloadPart>[
+            withSha(0, 0, 'a' * 64),
+            withSha(1, 100, 'b' * 64)
+          ],
+        ).hasPerPartDigests,
+        isTrue,
+      );
+      expect(
+        DownloadPlan(
+          totalBytes: 200,
+          parts: <DownloadPart>[withSha(0, 0, 'a' * 64), withSha(1, 100, null)],
+        ).hasPerPartDigests,
+        isFalse,
+      );
+    });
+  });
+}

--- a/fushi/test/utils/segmented_downloader_test.dart
+++ b/fushi/test/utils/segmented_downloader_test.dart
@@ -1,0 +1,726 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/download_plan.dart';
+import 'package:fushi/src/utils/misc/resumable_downloader.dart';
+import 'package:fushi/src/utils/misc/segmented_downloader.dart';
+
+/// 假服务器：按 URL 路由资源，支持 Range，可注入「忽略 Range」「超发字节」「404」
+/// 「首字节后断流」等真实世界里会遇到的坏行为。
+class _FakeHost {
+  _FakeHost();
+
+  final Map<String, Uint8List> resources = <String, Uint8List>{};
+
+  /// 这些 URL 一律 404（模拟镜像挂掉）。
+  final Set<String> dead = <String>{};
+
+  /// 这些 URL 忽略 Range，永远从第 0 字节回 200。
+  final Set<String> ignoresRange = <String>{};
+
+  /// 这些 URL 回 206 但多发字节（发到资源结尾），考验「取够就断」。
+  final Set<String> overSends = <String>{};
+
+  /// 这些 URL 回 206 但不带 Content-Range（畸形响应）。
+  final Set<String> omitsContentRange = <String>{};
+
+  /// 每个 URL 收到的 Range 头，按序记录。
+  final List<MapEntry<String, String?>> requests =
+      <MapEntry<String, String?>>[];
+
+  String etag = '"v1"';
+  int chunkSize = 7;
+
+  /// 已开始但被调用方主动取消的响应数——用来证明「整包 body 没有被读完」。
+  int cancelledStreams = 0;
+
+  /// 实际投递出去的字节总数。若下载器不在取够时断连，忽略 range-end 的服务器会让
+  /// **每一片**都把整包读完，这个数会翻成 N 倍——这是分片下载最贵的失效方式。
+  int deliveredBytes = 0;
+
+  Future<ResumableDownloadResponse> open(
+    Uri uri,
+    Map<String, String> headers,
+  ) async {
+    final String url = uri.toString();
+    final String? range = headers['range'] ?? headers['Range'];
+    requests.add(MapEntry<String, String?>(url, range));
+
+    if (dead.contains(url)) {
+      return ResumableDownloadResponse.bytes(
+        statusCode: 404,
+        body: const <int>[],
+      );
+    }
+    final Uint8List? body = resources[url];
+    if (body == null) {
+      return ResumableDownloadResponse.bytes(
+        statusCode: 404,
+        body: const <int>[],
+      );
+    }
+
+    if (range == null || ignoresRange.contains(url)) {
+      return ResumableDownloadResponse(
+        statusCode: 200,
+        headers: <String, String>{
+          'etag': etag,
+          'content-length': '${body.length}',
+        },
+        stream: _chunked(body, 0, body.length),
+      );
+    }
+
+    final RegExpMatch match = RegExp(r'^bytes=(\d+)-(\d*)$').firstMatch(range)!;
+    final int start = int.parse(match.group(1)!);
+    final int end = match.group(2)!.isEmpty
+        ? body.length - 1
+        : math.min(int.parse(match.group(2)!), body.length - 1);
+    final int sendEnd = overSends.contains(url) ? body.length - 1 : end;
+    return ResumableDownloadResponse(
+      statusCode: 206,
+      headers: <String, String>{
+        'etag': etag,
+        if (!omitsContentRange.contains(url))
+          'content-range': 'bytes $start-$end/${body.length}',
+      },
+      stream: _chunked(body, start, sendEnd + 1),
+    );
+  }
+
+  /// 分块投递，**遵守背压**：订阅被 pause（`await for` 的循环体正在跑）时停止投递，
+  /// resume 后继续，cancel 后彻底停。真实 HTTP 流就是这样——消费端不读，服务端就
+  /// 不会继续往下发。假服务器若无脑往缓冲区猛塞，[deliveredBytes] 量到的是生产者
+  /// 而不是真实网络消耗，「取够就断」这类带宽断言会变成空的。
+  Stream<List<int>> _chunked(Uint8List body, int start, int endExclusive) {
+    final StreamController<List<int>> controller =
+        StreamController<List<int>>();
+    bool cancelled = false;
+    Completer<void>? paused;
+
+    controller.onPause = () => paused ??= Completer<void>();
+    controller.onResume = () {
+      paused?.complete();
+      paused = null;
+    };
+    controller.onCancel = () {
+      if (!cancelled) {
+        cancelled = true;
+        cancelledStreams += 1;
+      }
+      paused?.complete();
+      paused = null;
+    };
+    controller.onListen = () async {
+      int at = start;
+      while (at < endExclusive && !cancelled) {
+        final Completer<void>? gate = paused;
+        if (gate != null) {
+          await gate.future;
+          continue;
+        }
+        final int stop = math.min(at + chunkSize, endExclusive);
+        controller.add(body.sublist(at, stop));
+        deliveredBytes += stop - at;
+        at = stop;
+        // 让出事件循环，使取消/暂停/并发调度有机会发生。
+        await Future<void>.delayed(Duration.zero);
+      }
+      if (!cancelled) await controller.close();
+    };
+    return controller.stream;
+  }
+}
+
+Uint8List _payload(int length) {
+  final Uint8List bytes = Uint8List(length);
+  for (int i = 0; i < length; i++) {
+    bytes[i] = (i * 31 + 7) & 0xff;
+  }
+  return bytes;
+}
+
+String _sha256Of(List<int> bytes) => sha256.convert(bytes).toString();
+
+void main() {
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('segmented_dl_test');
+  });
+
+  tearDown(() {
+    try {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    } on FileSystemException {
+      // Windows 上偶发占用，不影响断言。
+    }
+  });
+
+  File dest() => File('${tmp.path}/pack.zip');
+  File part() => File('${tmp.path}/pack.zip.mpart');
+  File progress() => File('${tmp.path}/pack.zip.mpart.json');
+
+  SegmentedDownloader build(
+    DownloadPlan plan,
+    _FakeHost host, {
+    int concurrency = 4,
+    bool Function()? isCancelled,
+    int maxAttemptsPerPart = 3,
+  }) =>
+      SegmentedDownloader(
+        plan: plan,
+        destination: dest(),
+        partFile: part(),
+        progressFile: progress(),
+        open: host.open,
+        concurrency: concurrency,
+        maxAttemptsPerPart: maxAttemptsPerPart,
+        isCancelled: isCancelled,
+        flushInterval: 64,
+      );
+
+  group('平台前提', () {
+    test('FileMode.append + setPosition 必须是随机写，不是强制追加', () async {
+      // 分片并发写盘的**全部正确性**都压在这条语义上：`write` 会截断已下内容，只有
+      // `append` 既不截断又能 setPosition 随机写。某个平台若按 O_APPEND 语义把写
+      // 强行落到文件末尾，9.5 GB 会被写成乱序垃圾、且只有最后 sha256 才发现。
+      // 这条守卫让那种平台在 CI 上当场红。
+      final File f = File('${tmp.path}/probe.bin');
+      RandomAccessFile raf = await f.open(mode: FileMode.write);
+      await raf.writeFrom(List<int>.filled(16, 0x41));
+      await raf.close();
+
+      raf = await f.open(mode: FileMode.append);
+      await raf.setPosition(4);
+      await raf.writeFrom(List<int>.filled(4, 0x42));
+      await raf.close();
+
+      final List<int> bytes = f.readAsBytesSync();
+      expect(bytes.length, 16, reason: 'append 不该改变文件长度');
+      expect(bytes.sublist(4, 8), <int>[0x42, 0x42, 0x42, 0x42],
+          reason: 'setPosition 指定的偏移必须被真正写到');
+      expect(bytes.sublist(8), List<int>.filled(8, 0x41), reason: '不得越界覆盖后续字节');
+    });
+
+    test('truncate 能把新文件预分配到指定大小', () async {
+      final File f = File('${tmp.path}/prealloc.bin');
+      final RandomAccessFile raf = await f.open(mode: FileMode.write);
+      await raf.truncate(4096);
+      await raf.close();
+      expect(f.lengthSync(), 4096);
+    });
+  });
+
+  group('并发分片下载', () {
+    test('多片并发下完的字节与原文件逐字节一致', () async {
+      final Uint8List body = _payload(1000);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+        sha256: _sha256Of(body),
+      );
+      expect(plan.parts.length, 10);
+
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body);
+      expect(part().existsSync(), isFalse, reason: '半截文件应已改名');
+      expect(progress().existsSync(), isFalse, reason: '进度文件应随完成删除');
+    });
+
+    test('并发度不超过片数，且每片只请求自己的区间', () async {
+      final Uint8List body = _payload(300);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+
+      await build(plan, host, concurrency: 8).download();
+
+      expect(host.requests.length, 3);
+      final Set<String?> ranges =
+          host.requests.map((MapEntry<String, String?> e) => e.value).toSet();
+      expect(
+        ranges,
+        <String>{'bytes=0-99', 'bytes=100-199', 'bytes=200-299'},
+      );
+    });
+
+    test('进度回调单调递增并终于总字节', () async {
+      final Uint8List body = _payload(500);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: body.length,
+        partSize: 125,
+      );
+      final List<int> seen = <int>[];
+      await SegmentedDownloader(
+        plan: plan,
+        destination: dest(),
+        partFile: part(),
+        progressFile: progress(),
+        open: host.open,
+        onProgress: (int received, int total) {
+          expect(total, body.length);
+          seen.add(received);
+        },
+      ).download();
+
+      expect(seen, isNotEmpty);
+      expect(seen.last, body.length);
+      for (int i = 1; i < seen.length; i++) {
+        expect(seen[i], greaterThanOrEqualTo(seen[i - 1]));
+      }
+    });
+  });
+
+  group('镜像与坏服务器', () {
+    test('镜像 404 时自动轮换到下一个来源', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://good/pack.zip'] = body
+        ..dead.add('https://dead/pack.zip');
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://dead/pack.zip', 'https://good/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body);
+      expect(
+        host.requests.any(
+            (MapEntry<String, String?> e) => e.key == 'https://dead/pack.zip'),
+        isTrue,
+        reason: '首选来源应被试过',
+      );
+    });
+
+    test('切片来源忽略 Range（回 200）时按整片重写，结果仍正确', () async {
+      // 物理切片：URL 指向的就是这一片，200 回的整个 body 正好是本片内容。
+      final Uint8List body = _payload(240);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://s/part-0'] = Uint8List.sublistView(body, 0, 120)
+        ..resources['https://s/part-1'] = Uint8List.sublistView(body, 120, 240)
+        ..ignoresRange.addAll(<String>['https://s/part-0', 'https://s/part-1']);
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 240,
+        parts: const <DownloadPart>[
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 120,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://s/part-0'),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 120,
+            length: 120,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://s/part-1'),
+            ],
+          ),
+        ],
+      );
+
+      final File out = await build(plan, host).download();
+      expect(out.readAsBytesSync(), body);
+    });
+
+    test('整包来源忽略 Range 时必须断连换源，绝不消费整包', () async {
+      // 这是最贵的坏行为：整包来源回 200 意味着 body 是整个 9.5 GB。若照单全收，
+      // 每一片都会把整包下一遍。要求：立刻断连（cancelledStreams 增加）并换源。
+      final Uint8List body = _payload(300);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://bad/pack.zip'] = body
+        ..resources['https://good/pack.zip'] = body
+        ..ignoresRange.add('https://bad/pack.zip');
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 300,
+        parts: const <DownloadPart>[
+          // 只造一片且偏移 > 0，好让「整包来源」的判定生效。
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 100,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://good/pack.zip', remoteOffset: 0),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 100,
+            length: 200,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://bad/pack.zip', remoteOffset: 100),
+              DownloadSource(url: 'https://good/pack.zip', remoteOffset: 100),
+            ],
+          ),
+        ],
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body, reason: '换源后内容必须正确');
+      expect(host.cancelledStreams, greaterThan(0),
+          reason: '忽略 Range 的整包响应必须被断连，而不是读完');
+    });
+
+    test('206 缺 Content-Range 视为畸形响应，换源而不是照写', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://weird/pack.zip'] = body
+        ..resources['https://good/pack.zip'] = body
+        ..omitsContentRange.add('https://weird/pack.zip');
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://weird/pack.zip', 'https://good/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+
+      final File out = await build(plan, host).download();
+      expect(out.readAsBytesSync(), body);
+    });
+
+    test('服务器忽略 range-end 时取够即断，不让每片都把整包读完', () async {
+      // 最贵的失效方式：服务器认 range 起点但一路发到 EOF。若不在取够时断连，
+      // 3 片会各自读到文件尾 = 600 字节（9.5 GB 的包就是每片下整包）。
+      final Uint8List body = _payload(300);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://over/pack.zip'] = body
+        ..overSends.add('https://over/pack.zip');
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://over/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body);
+      expect(out.lengthSync(), 300, reason: '超发不得把文件撑大');
+      expect(
+        host.deliveredBytes,
+        lessThan(400),
+        reason: '取够就该断连；读满 600 说明每片都把整包读完了',
+      );
+    });
+
+    test('切片源比声明的片长时不得写过界（末片超发会把文件撑大）', () async {
+      // 切片资源自身比清单声明的 length 长（上传错版本 / 服务端拼接错）。写过界
+      // 会把预分配好的目标文件撑大，成品就不再是原文件。
+      final Uint8List body = _payload(200);
+      final Uint8List longTail = Uint8List(80)
+        ..setRange(0, 50, body.sublist(150, 200))
+        ..fillRange(50, 80, 0xee);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://s/part-0'] = Uint8List.sublistView(body, 0, 150)
+        ..resources['https://s/part-1'] = longTail
+        // 切片源忽略 Range（回 200 整个资源）——只有这样才会真的超发；老实响应
+        // Range 的切片源永远只发被要的那段，测不到写过界。
+        ..ignoresRange.add('https://s/part-1');
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 200,
+        parts: const <DownloadPart>[
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 150,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://s/part-0'),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 150,
+            length: 50,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://s/part-1'),
+            ],
+          ),
+        ],
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.lengthSync(), 200, reason: '成品长度必须等于计划总长');
+      expect(out.readAsBytesSync(), body);
+    });
+
+    test('所有来源都挂时抛 SegmentedDownloadPartException 且不产出成品', () async {
+      final _FakeHost host = _FakeHost()..dead.add('https://dead/pack.zip');
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://dead/pack.zip'],
+        totalBytes: 200,
+        partSize: 100,
+      );
+
+      await expectLater(
+        build(plan, host).download(),
+        throwsA(isA<SegmentedDownloadPartException>()),
+      );
+      expect(dest().existsSync(), isFalse);
+    });
+  });
+
+  group('断点续传', () {
+    test('中断后重跑只补未完成的片', () async {
+      final Uint8List body = _payload(400);
+      final _FakeHost first = _FakeHost()
+        ..resources['https://a/pack.zip'] = body
+        // 后两片的来源挂掉，前两片能下完。
+        ..dead.add('https://b/pack.zip');
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 400,
+        version: 'v1',
+        parts: const <DownloadPart>[
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 100,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 0),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 100,
+            length: 100,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 100),
+            ],
+          ),
+          DownloadPart(
+            index: 2,
+            offset: 200,
+            length: 100,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://b/pack.zip', remoteOffset: 200),
+            ],
+          ),
+          DownloadPart(
+            index: 3,
+            offset: 300,
+            length: 100,
+            sources: <DownloadSource>[
+              DownloadSource(url: 'https://b/pack.zip', remoteOffset: 300),
+            ],
+          ),
+        ],
+      );
+
+      await expectLater(
+        build(plan, first, concurrency: 1).download(),
+        throwsA(isA<SegmentedDownloadPartException>()),
+      );
+      expect(progress().existsSync(), isTrue, reason: '进度必须留下供续传');
+      expect(part().lengthSync(), 400, reason: '半截文件是预分配的完整大小');
+
+      // 第二轮：全部来源健康。
+      final _FakeHost second = _FakeHost()
+        ..resources['https://a/pack.zip'] = body
+        ..resources['https://b/pack.zip'] = body;
+      final DownloadPlan plan2 = DownloadPlan(
+        totalBytes: 400,
+        version: 'v1',
+        parts: plan.parts,
+      );
+
+      final File out = await build(plan2, second, concurrency: 1).download();
+
+      expect(out.readAsBytesSync(), body);
+      final Set<String?> retried =
+          second.requests.map((MapEntry<String, String?> e) => e.value).toSet();
+      expect(retried.contains('bytes=0-99'), isFalse,
+          reason: '第 0 片上一轮已完成，不该重下');
+      expect(retried.contains('bytes=100-199'), isFalse,
+          reason: '第 1 片上一轮已完成，不该重下');
+    });
+
+    test('计划版本变了（服务端换包）时进度整份作废', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      // 预置一份「旧包」的进度。
+      progress().writeAsStringSync(json.encode(<String, Object?>{
+        'version': 1,
+        'totalBytes': 200,
+        'planVersion': 'OLD',
+        'sha256': null,
+        'parts': <String, int>{'0': 100},
+      }));
+
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: 200,
+        partSize: 100,
+        version: 'NEW',
+      );
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body);
+      final Set<String?> ranges =
+          host.requests.map((MapEntry<String, String?> e) => e.value).toSet();
+      expect(ranges.contains('bytes=0-99'), isTrue,
+          reason: '换包后第 0 片必须重下，不能把旧包字节当断点');
+    });
+  });
+
+  group('完整性', () {
+    test('单片 sha256 不符时清零该片并最终失败，不产出成品', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 200,
+        parts: <DownloadPart>[
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 100,
+            sha256: _sha256Of(body.sublist(0, 100)),
+            sources: const <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 0),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 100,
+            length: 100,
+            // 故意写错的摘要。
+            sha256: 'f' * 64,
+            sources: const <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 100),
+            ],
+          ),
+        ],
+      );
+
+      await expectLater(
+        build(plan, host).download(),
+        throwsA(isA<SegmentedDownloadPartException>()),
+      );
+      expect(dest().existsSync(), isFalse);
+    });
+
+    test('整包 sha256 不符时删档并抛完整性异常', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: 200,
+        partSize: 100,
+        sha256: 'a' * 64,
+      );
+
+      await expectLater(
+        build(plan, host).download(),
+        throwsA(isA<ResumableDownloadIntegrityException>()),
+      );
+      expect(dest().existsSync(), isFalse);
+      expect(part().existsSync(), isFalse, reason: '坏包不留');
+      expect(progress().existsSync(), isFalse);
+    });
+
+    test('每片都带摘要时跳过整包重读（逐片校验已更强）', () async {
+      final Uint8List body = _payload(200);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan(
+        totalBytes: 200,
+        // 整包摘要故意写错：逐片摘要全对时不该再读一遍 9.5 GB 去核它。
+        sha256: 'b' * 64,
+        parts: <DownloadPart>[
+          DownloadPart(
+            index: 0,
+            offset: 0,
+            length: 100,
+            sha256: _sha256Of(body.sublist(0, 100)),
+            sources: const <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 0),
+            ],
+          ),
+          DownloadPart(
+            index: 1,
+            offset: 100,
+            length: 100,
+            sha256: _sha256Of(body.sublist(100, 200)),
+            sources: const <DownloadSource>[
+              DownloadSource(url: 'https://a/pack.zip', remoteOffset: 100),
+            ],
+          ),
+        ],
+      );
+
+      final File out = await build(plan, host).download();
+      expect(out.readAsBytesSync(), body);
+    });
+  });
+
+  group('取消', () {
+    test('取消时抛取消异常、保留半截与进度、不产出成品', () async {
+      final Uint8List body = _payload(1000);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+      bool cancelled = false;
+      final Future<File> future = build(
+        plan,
+        host,
+        concurrency: 1,
+        isCancelled: () => cancelled,
+      ).download();
+      // 让第一片开跑再取消。
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      cancelled = true;
+
+      await expectLater(
+        future,
+        throwsA(isA<SegmentedDownloadCancelledException>()),
+      );
+      expect(dest().existsSync(), isFalse);
+      expect(part().existsSync(), isTrue, reason: '半截保留供下次续传');
+    });
+  });
+
+  group('已完成', () {
+    test('成品已存在时直接返回，不发任何请求', () async {
+      final Uint8List body = _payload(100);
+      dest().writeAsBytesSync(body);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://a/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://a/pack.zip'],
+        totalBytes: body.length,
+        partSize: 50,
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.path, dest().path);
+      expect(host.requests, isEmpty);
+    });
+  });
+}

--- a/fushi/test/utils/segmented_downloader_test.dart
+++ b/fushi/test/utils/segmented_downloader_test.dart
@@ -172,6 +172,7 @@ void main() {
     int concurrency = 4,
     bool Function()? isCancelled,
     int maxAttemptsPerPart = 3,
+    Duration Function(int attempt)? retryBackoff,
   }) =>
       SegmentedDownloader(
         plan: plan,
@@ -183,6 +184,8 @@ void main() {
         maxAttemptsPerPart: maxAttemptsPerPart,
         isCancelled: isCancelled,
         flushInterval: 64,
+        // 单测不空等真实退避。
+        retryBackoff: retryBackoff ?? (int _) => Duration.zero,
       );
 
   group('平台前提', () {
@@ -462,6 +465,33 @@ void main() {
 
       expect(out.lengthSync(), 200, reason: '成品长度必须等于计划总长');
       expect(out.readAsBytesSync(), body);
+    });
+
+    test('换源之间按 attempt 退避，最后一次失败后不再空等', () async {
+      // 背靠背重试三次在抖动的移动网络上基本是三次一起失败；退避得真的被调用，
+      // 且不该在「已经没有下一次」之后还等一轮。
+      final _FakeHost host = _FakeHost()..dead.add('https://dead/pack.zip');
+      final List<int> attempts = <int>[];
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://dead/pack.zip'],
+        totalBytes: 100,
+        partSize: 100,
+      );
+
+      await expectLater(
+        build(
+          plan,
+          host,
+          maxAttemptsPerPart: 3,
+          retryBackoff: (int attempt) {
+            attempts.add(attempt);
+            return Duration.zero;
+          },
+        ).download(),
+        throwsA(isA<SegmentedDownloadPartException>()),
+      );
+
+      expect(attempts, <int>[0, 1], reason: '3 次尝试之间只有 2 段等待，末次失败后直接报错');
     });
 
     test('所有来源都挂时抛 SegmentedDownloadPartException 且不产出成品', () async {

--- a/fushi/tool/make_download_manifest.dart
+++ b/fushi/tool/make_download_manifest.dart
@@ -1,0 +1,300 @@
+// 推荐包分发清单生成器。
+//
+// 两种形态，对应 `RecommendedPackManifest.toDownloadPlan()` 的两条路：
+//
+//   range  只算总长 + sha256，产出一份指向**现有整包直链**的清单。服务端零改动、
+//          不用重新上传任何东西，客户端立刻获得并发分段 + 断点续传。
+//   slice  额外把包切成固定大小的分片文件，可以撒在多台主机上（单片 ≤2 GB 时
+//          GitHub Release 也装得下），清单里带每片 sha256。
+//
+// 用法（在 `fushi/` 下）：
+//   dart run tool/make_download_manifest.dart \
+//     --input D:\packs\fushi-recommended-2026-08-14.fushi.zip \
+//     --whole-url https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip \
+//     --mode range --version 2026-08-14
+//
+//   dart run tool/make_download_manifest.dart \
+//     --input ...zip --mode slice --part-size 1GiB --out-dir D:\packs\slices \
+//     --whole-url https://dl.wrds.xyz/....zip \
+//     --part-base-url https://github.com/hajisensai/Fushi/releases/download/pack-2026-08-14 \
+//     --mirror https://mirror2.example/....zip
+//
+// 切片文件名固定为 `<包名>.NNN`（三位十进制，从 000 起），与清单里的 `name` 对应。
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+const int _kDefaultPartSize = 64 * 1024 * 1024;
+const int _kReadChunk = 1 << 20;
+
+void main(List<String> argv) async {
+  final _Args args;
+  try {
+    args = _Args.parse(argv);
+  } on FormatException catch (e) {
+    stderr.writeln('参数错误：${e.message}\n');
+    stderr.writeln(_usage);
+    exitCode = 2;
+    return;
+  }
+
+  final File input = File(args.input);
+  if (!input.existsSync()) {
+    stderr.writeln('找不到输入文件：${args.input}');
+    exitCode = 2;
+    return;
+  }
+
+  final int totalBytes = input.lengthSync();
+  final String packName = _basename(args.input);
+  stdout.writeln('输入：$packName（$totalBytes 字节，${_human(totalBytes)}）');
+  stdout.writeln('模式：${args.slice ? 'slice（切片）' : 'range（整包 + Range）'}');
+
+  final List<Map<String, Object?>> parts = <Map<String, Object?>>[];
+  final Directory? outDir = args.slice ? Directory(args.outDir!) : null;
+  if (outDir != null && !outDir.existsSync()) {
+    outDir.createSync(recursive: true);
+  }
+
+  // 整包摘要边读边算；切片模式下同一遍读顺手把片写出去 + 算片摘要。
+  final ByteConversionSink wholeSink =
+      sha256.startChunkedConversion(_DigestSink((Digest d) => _whole = d));
+
+  final RandomAccessFile reader = await input.open();
+  try {
+    int offset = 0;
+    int partIndex = 0;
+    while (offset < totalBytes) {
+      final int partLength = offset + args.partSize > totalBytes
+          ? totalBytes - offset
+          : args.partSize;
+      final String partName =
+          '$packName.${partIndex.toString().padLeft(3, '0')}';
+
+      Digest? partDigest;
+      final ByteConversionSink partSink = sha256
+          .startChunkedConversion(_DigestSink((Digest d) => partDigest = d));
+
+      IOSink? sliceSink;
+      if (outDir != null) {
+        sliceSink = File('${outDir.path}${Platform.pathSeparator}$partName')
+            .openWrite();
+      }
+
+      int remaining = partLength;
+      while (remaining > 0) {
+        final int want = remaining < _kReadChunk ? remaining : _kReadChunk;
+        final Uint8List bytes = await reader.read(want);
+        if (bytes.isEmpty) {
+          throw StateError('读取提前结束：偏移 ${offset + partLength - remaining}');
+        }
+        wholeSink.addSlice(bytes, 0, bytes.length, false);
+        partSink.addSlice(bytes, 0, bytes.length, false);
+        sliceSink?.add(bytes);
+        remaining -= bytes.length;
+      }
+      partSink.close();
+      if (sliceSink != null) {
+        await sliceSink.flush();
+        await sliceSink.close();
+      }
+
+      parts.add(<String, Object?>{
+        'name': partName,
+        'offset': offset,
+        'length': partLength,
+        'sha256': partDigest.toString(),
+      });
+      stdout.writeln(
+        '  片 ${partIndex.toString().padLeft(3, '0')}  '
+        '偏移 $offset  长度 $partLength  ${partDigest.toString().substring(0, 12)}…',
+      );
+
+      offset += partLength;
+      partIndex += 1;
+    }
+  } finally {
+    await reader.close();
+  }
+  wholeSink.close();
+
+  final Map<String, Object?> manifest = <String, Object?>{
+    'version': args.version,
+    'url': args.wholeUrl,
+    'sha256': _whole.toString(),
+    'size_bytes': totalBytes,
+    if (args.mirrors.isNotEmpty) 'mirrors': args.mirrors,
+    'part_size_bytes': args.partSize,
+    if (args.slice) ...<String, Object?>{
+      'part_base_urls': args.partBaseUrls,
+      'parts': parts,
+    },
+  };
+
+  final String outPath = args.manifestPath ??
+      (args.slice
+          ? '${outDir!.path}${Platform.pathSeparator}$packName.manifest.json'
+          : '${input.parent.path}${Platform.pathSeparator}$packName.manifest.json');
+  File(outPath).writeAsStringSync(
+    const JsonEncoder.withIndent('  ').convert(manifest),
+  );
+
+  stdout.writeln('\n整包 sha256：$_whole');
+  stdout.writeln('清单写入：$outPath');
+  if (args.slice && args.partBaseUrls.isEmpty) {
+    stdout.writeln(
+      '警告：slice 模式没给 --part-base-url，清单里的切片来源为空，'
+      '客户端只会退回整包 Range 模式。',
+    );
+  }
+  stdout.writeln(
+    '\n下一步：把清单上传到 kRecommendedPackManifestUrl 指向的地址'
+    '${args.slice ? '，并把切片上传到 --part-base-url 指向的目录' : ''}。',
+  );
+}
+
+late Digest _whole;
+
+class _DigestSink implements Sink<Digest> {
+  _DigestSink(this._onDigest);
+  final void Function(Digest) _onDigest;
+  @override
+  void add(Digest data) => _onDigest(data);
+  @override
+  void close() {}
+}
+
+class _Args {
+  _Args({
+    required this.input,
+    required this.wholeUrl,
+    required this.version,
+    required this.partSize,
+    required this.slice,
+    required this.outDir,
+    required this.mirrors,
+    required this.partBaseUrls,
+    required this.manifestPath,
+  });
+
+  final String input;
+  final String wholeUrl;
+  final String version;
+  final int partSize;
+  final bool slice;
+  final String? outDir;
+  final List<String> mirrors;
+  final List<String> partBaseUrls;
+  final String? manifestPath;
+
+  static _Args parse(List<String> argv) {
+    final Map<String, String> single = <String, String>{};
+    final List<String> mirrors = <String>[];
+    final List<String> partBaseUrls = <String>[];
+
+    for (int i = 0; i < argv.length; i++) {
+      final String flag = argv[i];
+      if (!flag.startsWith('--')) {
+        throw FormatException('无法识别的参数 $flag');
+      }
+      if (i + 1 >= argv.length) {
+        throw FormatException('$flag 缺少取值');
+      }
+      final String value = argv[++i];
+      switch (flag) {
+        case '--mirror':
+          mirrors.add(value);
+        case '--part-base-url':
+          partBaseUrls.add(value);
+        default:
+          single[flag] = value;
+      }
+    }
+
+    final String? input = single['--input'];
+    if (input == null) throw const FormatException('--input 必填');
+    final String? wholeUrl = single['--whole-url'];
+    if (wholeUrl == null) throw const FormatException('--whole-url 必填');
+    if (!wholeUrl.startsWith('https://')) {
+      throw const FormatException('--whole-url 必须是 https');
+    }
+    for (final String url in <String>[...mirrors, ...partBaseUrls]) {
+      if (!url.startsWith('https://')) {
+        throw FormatException('镜像/切片地址必须是 https：$url');
+      }
+    }
+
+    final String mode = single['--mode'] ?? 'slice';
+    if (mode != 'slice' && mode != 'range') {
+      throw FormatException('--mode 只能是 slice 或 range，实到 $mode');
+    }
+    final bool slice = mode == 'slice';
+    final String? outDir = single['--out-dir'];
+    if (slice && outDir == null) {
+      throw const FormatException('slice 模式必须给 --out-dir');
+    }
+
+    return _Args(
+      input: input,
+      wholeUrl: wholeUrl,
+      version: single['--version'] ?? _basename(input),
+      partSize: _parseSize(single['--part-size']) ?? _kDefaultPartSize,
+      slice: slice,
+      outDir: outDir,
+      mirrors: mirrors,
+      partBaseUrls: partBaseUrls,
+      manifestPath: single['--manifest-out'],
+    );
+  }
+}
+
+/// 支持 `1073741824` / `1GiB` / `64MiB` / `512KiB` 三种写法。
+int? _parseSize(String? raw) {
+  if (raw == null) return null;
+  final RegExpMatch? match =
+      RegExp(r'^(\d+)(B|KiB|MiB|GiB)?$', caseSensitive: false).firstMatch(raw);
+  if (match == null) {
+    throw FormatException('看不懂的大小：$raw');
+  }
+  final int value = int.parse(match.group(1)!);
+  switch (match.group(2)?.toUpperCase()) {
+    case 'KIB':
+      return value * 1024;
+    case 'MIB':
+      return value * 1024 * 1024;
+    case 'GIB':
+      return value * 1024 * 1024 * 1024;
+    default:
+      return value;
+  }
+}
+
+String _basename(String path) =>
+    path.split(RegExp(r'[\\/]')).where((String s) => s.isNotEmpty).last;
+
+String _human(int bytes) {
+  if (bytes >= 1 << 30) {
+    return '${(bytes / (1 << 30)).toStringAsFixed(2)} GiB';
+  }
+  if (bytes >= 1 << 20) {
+    return '${(bytes / (1 << 20)).toStringAsFixed(2)} MiB';
+  }
+  return '$bytes B';
+}
+
+const String _usage = '''
+用法：dart run tool/make_download_manifest.dart --input <包> --whole-url <https 直链> [选项]
+
+  --input <path>           要分发的包（必填）
+  --whole-url <url>        整包直链，写进清单 url 字段（必填，https）
+  --mode range|slice       range=只出清单（零重传）；slice=同时切片（默认 slice）
+  --out-dir <path>         slice 模式的切片输出目录（slice 必填）
+  --part-size <size>       切段大小，支持 64MiB / 1GiB 写法（默认 64MiB）
+  --mirror <url>           整包镜像，可重复
+  --part-base-url <url>    切片所在目录，可重复（slice 模式）
+  --version <str>          包版本标识（默认取输入文件名）
+  --manifest-out <path>    清单输出路径（默认与切片/输入同目录）
+''';


### PR DESCRIPTION
## 问题

9.5 GB 推荐包此前只有**单流单源**一条路：一条连接下整包，只有 CF / Google Drive 两个来源。国内下 CF 单连接常被限速，单一主机不可达时无路可走。

## 改了什么

**数据结构先行**——`DownloadSource.remoteOffset` 一个字段把两种分发形态收成同一个结构，消费端没有 mode 分支：

- 整包 + Range（服务端零改动）：`remoteOffset` = 该片在目标文件中的偏移
- 物理切片（撒多主机）：`remoteOffset` = 0

于是「GitHub 放切片、CF 放整包」可以互为同一片的镜像，下载器不需要知道这回事。

- `DownloadPlan`：构造即校验铺砖，有缝 / 重叠 / index 重复 / 片无来源当场 `ArgumentError`。
- `SegmentedDownloader`：4 段并发、单片失败只重下该片并轮换镜像、指数退避、每片已收字节落 `<name>.mpart.json` 跨进程可续、逐片摘要边下边算（续传时读回前缀补种，不整片重读）。
- **按字节分片而非分卷压缩**：并发写进同一个预分配文件，下完即原封不动的原包，备份导入（`restoreBackup` 本就是流式）一行未改，磁盘 1× 而不是 2×（9.5 GB 的包在手机上就是 19 GB 的差别）。
- 坏服务器三条：取够本片即断连（否则忽略 range-end 的服务器会让**每片都下整包**）；整包来源回 200 立即断连换源，绝不消费整包；206 缺 Content-Range 视为畸形，换源而不是照写。
- 换包防护：进度绑 `version`/`totalBytes`/`sha256`，对不上整份作废；续传带 `If-Range`（**单流兜底路径此前完全没有**，会把旧断点续到新包上，只能靠末尾 sha256 事后打回——代价是白下一整个 9.5 GB）。
- 清单扩展 `mirrors` / `parts` / `part_base_urls` / `part_size_bytes`，换包仍零发版；服务器不支持 Range 时退回原单流路径，一种能下成的场景都没丢。
- `fushi/tool/make_download_manifest.dart`：`range` 模式只出清单（**零重传**，对现有直链立刻生效），`slice` 模式另切分片（单片 ≤2 GB 时 GitHub Release 装得下）。

## 验证

- 全量套件（`dart run tool/flutter_test_failures.dart --no-pub`）在第一个提交上 `PASSED - 20287 tests ran`。
- 定向 424 条绿（新测试 + 全部目录枚举型守卫）；全量 `flutter analyze` 零 issue。
- **变异实测三轮**均被杀掉：去掉取值截断 / 去掉两处「取够就断」（`deliveredBytes` 从 <400 变 600，正是每片都读整包）/ 去掉「最后一次不等」（退避序列从 `[0,1]` 变 `[0,1,2]`）。第一轮变异**没红**，暴露出我的假服务器不遵守背压、断言是空的——改成遵守 pause/resume 后才测得住。
- 切片脚本端到端实测：逐片 sha256 与独立 `sha256sum` 逐字节一致，拼回原文件摘要与原包一致。
- 跨平台前提有守卫钉住：`FileMode.append` + `setPosition` 必须是随机写（某平台若按 `O_APPEND` 语义强制追加，会把 9.5 GB 写成乱序垃圾且只有末尾 sha256 才发现）。

## 合入前请注意

最后一次全量跑在**第二个提交**上报 FAILED，2 个 error 事件同属 `test/models/dict_engine_max_results_alignment_test.dart`，报 "Connection closed before test suite loaded"——装载期 IPC 断连的并发伪红；该 suite 单独跑 16 条全过，且与本改动（下载器）无关。确认用的复跑被中断，**合入 develop 前建议再取一次干净的 `flutter_test_failures` 全量绿**。

未做：真机 / 真实网络下的分片下载验证（需要一台支持 Range 的真实主机 + 大文件）。

https://claude.ai/code/session_0155KNKD9PBZGUsjnDkNqBpQ
