### PR TITLE
feat(subtitle): Jimaku 真人剧检索 + OpenSubtitles 语言码归一（孤儿分支重新落地）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1651](bugs/BUG-1651-opensubtitles-zh-language-code.md) | 🚧 | 🚧 | OpenSubtitles 搜索传裸 zh 语言码，中文字幕永远搜不到 |
+| [BUG-1651](bugs/BUG-1651-opensubtitles-zh-language-code.md) | ✅ | ✅ | OpenSubtitles 搜索传裸 zh 语言码，中文字幕永远搜不到 |
 | [BUG-1646](bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md) | ✅ | 🚧 | 魔法少女的魔女审判切换场景后字幕线程断开 |
 | [BUG-1645](bugs/BUG-1645-nested-latin-lookup.md) | ✅ | ✅ | 嵌套查词查不了英语单词（跨节点粘连成拉丁串） |
 | [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1532 条。点号进各自文件。
+> 共 1533 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1656](bugs/BUG-1656-playlist-subtitle-restore-no-fallback.md) | ✅ | ✅ | 合集里下载的字幕退出再进就没了：恢复链只走一支、零兜底 |
 | [BUG-1654](bugs/BUG-1654-jimaku-download-error-hidden-behind-dialog.md) | ✅ | ✅ | 下载失败提示被对话框盖住且没有原因 |
 | [BUG-1653](bugs/BUG-1653-jimaku-series-list-cleared-before-refetch.md) | ✅ | ✅ | 填集数再搜后系列列表消失且搜不出结果 |
 | [BUG-1652](bugs/BUG-1652-jimaku-search-uses-display-name.md) | ✅ | ✅ | Jimaku 搜索拿中文显示名去猜，刮削存下的 AniList ID 从没被用过 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1529 条。点号进各自文件。
+> 共 1532 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1654](bugs/BUG-1654-jimaku-download-error-hidden-behind-dialog.md) | ✅ | ✅ | 下载失败提示被对话框盖住且没有原因 |
+| [BUG-1653](bugs/BUG-1653-jimaku-series-list-cleared-before-refetch.md) | ✅ | ✅ | 填集数再搜后系列列表消失且搜不出结果 |
+| [BUG-1652](bugs/BUG-1652-jimaku-search-uses-display-name.md) | ✅ | ✅ | Jimaku 搜索拿中文显示名去猜，刮削存下的 AniList ID 从没被用过 |
 | [BUG-1651](bugs/BUG-1651-opensubtitles-zh-language-code.md) | ✅ | ✅ | OpenSubtitles 搜索传裸 zh 语言码，中文字幕永远搜不到 |
 | [BUG-1646](bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md) | ✅ | 🚧 | 魔法少女的魔女审判切换场景后字幕线程断开 |
 | [BUG-1645](bugs/BUG-1645-nested-latin-lookup.md) | ✅ | ✅ | 嵌套查词查不了英语单词（跨节点粘连成拉丁串） |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1528 条。点号进各自文件。
+> 共 1529 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1651](bugs/BUG-1651-opensubtitles-zh-language-code.md) | 🚧 | 🚧 | OpenSubtitles 搜索传裸 zh 语言码，中文字幕永远搜不到 |
 | [BUG-1646](bugs/BUG-1646-manosaba-scene-switch-subtitle-lane.md) | ✅ | 🚧 | 魔法少女的魔女审判切换场景后字幕线程断开 |
 | [BUG-1645](bugs/BUG-1645-nested-latin-lookup.md) | ✅ | ✅ | 嵌套查词查不了英语单词（跨节点粘连成拉丁串） |
 | [BUG-1644](bugs/BUG-1644-d3d11va-zero-copy-interop.md) | ✅ | ✅ | Windows 视频硬解走 d3d11va-copy：ANGLE 用自己的隐藏 D3D11 device，mpv d3d11-egl interop 加载不了 |

--- a/docs/bugs/BUG-1651-opensubtitles-zh-language-code.md
+++ b/docs/bugs/BUG-1651-opensubtitles-zh-language-code.md
@@ -1,0 +1,44 @@
+## BUG-1651 · OpenSubtitles 搜索传裸 zh 语言码，中文字幕永远搜不到
+- **报告**：2026-08-15（用户：接入 OpenSubtitles 时自查发现，非用户报告）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/media/video/subtitle/open_subtitles_client.dart:503`
+  （`'languages': request.languages.join(',')` 把 Hibiki 的大类语言码原样透传给 API）
+- **[ ] ① 未修复** —
+- **[ ] ② 未加自动化测试** —
+- **备注**：
+
+### 根因
+
+Hibiki 内部的字幕语言值域是**大类码** `ja` / `zh` / `en` / `ko`
+（`fushi/lib/src/media/video/jimaku_client.dart` 的 `kJimakuLanguageCodes`，Jimaku 侧靠文件名
+启发式识别，只分到大类）。这套值域经设置项「默认字幕语言」
+（`video.subtitle.jimaku_default_language`）流进下载流水线：
+
+`app_model.dart` → `VideoDownloadPipelineService(preferredSubtitleLanguages: [...])`
+→ `video_download_pipeline_service.dart:1711` `languages: preferredSubtitleLanguages`
+→ `open_subtitles_client.dart:503` `'languages': request.languages.join(',')`
+
+而 OpenSubtitles REST API v1 的语言值域是 **BCP-47**，其官方语言表
+（`GET https://api.opensubtitles.com/api/v1/infos/languages`，无需 API key 即可读，实测
+105 个码）**不存在裸 `zh`**，只有 `zh-cn` / `zh-tw` / `zh-ca`。
+
+因此用户把默认字幕语言设成中文后，OpenSubtitles 这一路的搜索恒定拿不到中文结果。
+`ja` / `en` / `ko` 都在表内，所以只有中文这一档坏——这也是它长期没被发现的原因。
+
+实测确认（一手证据，2026-08-15）：语言表里带地区码的家族只有
+`az-az` / `az-zb` / `pt-br` / `pt-pt` / `tm-td` / `zh-ca` / `zh-cn` / `zh-tw`；
+`ja` `en` `ko` `es` `fr` `de` `it` `ru` `th` `vi` `id` `ar` `nl` `tr` 均有裸码。
+对 Hibiki 现有值域只有 `zh` 需要映射（`pt` 目前不在字幕语言值域内，一并归一以防将来踩）。
+
+### 影响范围
+
+- 下载流水线自动配字幕阶段（既有路径，本 bug 早已存在）。
+- 播放页新增的「在线获取字幕」入口（同一个 client，见同批次接入改动）。
+
+不影响 Jimaku：它没有服务端语言过滤，语言是客户端按文件名识别的。
+
+### 修复方向
+
+在 `OpenSubtitlesClient` 内部做一次语言码归一（单一真相源，两个调用方都受益），而不是在
+各调用方分别转换：client 最清楚自己 API 的值域。`zh` → `zh-cn,zh-tw`，`pt` → `pt-br,pt-pt`，
+其余原样透传（未知码交给服务端裁决，不在客户端擅自丢弃）；结果去重并排序——API 对未规范化
+的 query 会回 301 重定向到规范 URL，排序能省掉这次多余往返。

--- a/docs/bugs/BUG-1651-opensubtitles-zh-language-code.md
+++ b/docs/bugs/BUG-1651-opensubtitles-zh-language-code.md
@@ -2,8 +2,14 @@
 - **报告**：2026-08-15（用户：接入 OpenSubtitles 时自查发现，非用户报告）
 - **真实性**：✅ 真 bug — 根因 `fushi/lib/src/media/video/subtitle/open_subtitles_client.dart:503`
   （`'languages': request.languages.join(',')` 把 Hibiki 的大类语言码原样透传给 API）
-- **[ ] ① 未修复** —
-- **[ ] ② 未加自动化测试** —
+- **[x] ① 已修复** — `fushi/lib/src/media/video/subtitle/open_subtitles_client.dart`
+  新增 `normalizeOpenSubtitlesLanguages` + `kOpenSubtitlesLanguageExpansions`，在 client 内部
+  单点归一（两个调用方——下载流水线与播放页在线检索——都受益），`_searchQueries` 改用归一结果。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/open_subtitles_client_test.dart`
+  新增 group「语言码归一（BUG-1651）」4 例：zh/pt 展开、裸码透传、去重去空排序、搜索请求真的
+  带上归一后的码。既有用例 `falls back in separate hash, IMDb, TMDB, then title requests` 里
+  断言 `languages == 'ja,zh'` 的那行同步改成 `'ja,zh-cn,zh-tw'`——它锁的正是本 bug 的缺陷行为。
+  变异实测：删掉 zh 映射后 3 例转红，还原后文件 sha256 与变异前一致。
 - **备注**：
 
 ### 根因

--- a/docs/bugs/BUG-1652-jimaku-search-uses-display-name.md
+++ b/docs/bugs/BUG-1652-jimaku-search-uses-display-name.md
@@ -1,0 +1,47 @@
+## BUG-1652 · Jimaku 搜索拿中文显示名去猜，刮削存下的 AniList ID 从没被用过
+- **报告**：2026-08-15（用户实测，原话「这里字幕轨搜索的时候没有根据罗马音/英语搜索」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart`
+  的 `_jimakuQuery()`（只回一个显示名字符串）+ `jimaku_subtitle_dialog.dart` 的 `_search()`
+  （拿这个字符串去 `AniListClient.searchAnime`）
+- **[x] ① 已修复** — commit `9bfe4cdd95`
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/jimaku_search_seed_test.dart`（7 例）+
+  `fushi/test/pages/jimaku_search_identity_test.dart`（4 例）
+- **备注**：与 [BUG-1653] / [BUG-1654] 同一批用户实测反馈，同一个对话框。
+
+### 复现
+
+播放 Re:Zero 第四季（库里显示名是中文「Re：从零开始的异世界生活 第四季 丧失篇」）→ 字幕菜单
+→「获取字幕（Jimaku）」→ 番剧名预填为该中文串 → 搜索 → 0 结果。
+用户手动把番剧名改成日文「Re:ゼロから始める異世界生活」后立刻搜到（截图里 7 个系列、满屏候选）。
+
+### 根因
+
+不是「中文搜不了」——实测 AniList 用纯中文「从零开始的异世界生活」**能**命中（靠 synonyms）；
+但「译名 + 季度 + 篇名」的整串匹配不上：
+
+| 查询串 | AniList 结果 |
+|---|---|
+| `从零开始的异世界生活` | 命中 Re:Zero 系列 |
+| `Re：从零开始的异世界生活 第四季 丧失篇` | **0 条** |
+
+真正的问题是**拿显示名去猜**：`_jimakuQuery()` 用 `parseVideoFilename(basename).series`，
+那个解析器是针对西文/日文发布名写的，中文标题里的「第四季 丧失篇」和全角冒号剥不掉，整串原样
+丢给 AniList；AniList 空 → 没有 anilist_id → 退回文本搜 Jimaku（Jimaku 条目名只有 romaji/英文/
+日文，中文同样搜不到）→ 双双落空，且**没有任何降级重试**。
+
+而这个视频**刮削过**：`video_metadata_provider_identities` 里存着 `provider='anilist'` 的
+`externalId`，`video_metadata_works` 里存着 `originalTitle`（日文原名）。播放页从未读过它们
+（全页 + 18 个 part 里 grep 不到任何 `getVideoMetadataWorkBy*`）。
+
+### 修复
+
+新增 `fushi/lib/src/media/video/jimaku_search_seed.dart` 的 `JimakuSearchSeed` + 播放页
+`_buildJimakuSeed`：
+
+- 有外部 ID 就**直接按 `anilist_id` / `tmdb_id` 检索 Jimaku**，完全跳过文本匹配这一环；
+- 搜索词优先级改为「日文原名 → 刮削作品名 → 显示名 → 合集名」（Jimaku 是日语字幕站，条目名与
+  上传文件名基本是日文或罗马音，中文译名命中率最低）；
+- 用户手动改过番名则一律按他的词搜，不再套用刮削 ID。
+
+归属坑（表 CHECK 约束）：合集里的一集，元数据挂在**合集**上，用该集 bookUid 查恒为 null，必须走
+`widget.playlistCollectionId`。元数据读不到一律降级为纯文本检索（= 旧行为），不挡住搜索。

--- a/docs/bugs/BUG-1653-jimaku-series-list-cleared-before-refetch.md
+++ b/docs/bugs/BUG-1653-jimaku-series-list-cleared-before-refetch.md
@@ -1,0 +1,34 @@
+## BUG-1653 · 填集数再搜后系列列表消失且搜不出结果
+- **报告**：2026-08-15（用户实测，原话「选择集数以后没办法选择系列了。而且搜索不出来结果」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart`
+  的 `_search()`：先 `setState` 清空 `_seriesMatches` / `_selectedSeriesId`，再 `await` 一次
+  AniList 往返才回填
+- **[x] ① 已修复** — commit `9bfe4cdd95`
+- **[x] ② 已加自动化测试** — `fushi/test/pages/jimaku_search_identity_test.dart`
+  「AniList 这一跳空手而归时，已有的系列列表不被清空」
+- **备注**：与 [BUG-1652] / [BUG-1654] 同一批用户实测反馈，同一个对话框。
+
+### 根因
+
+系列列表的显示条件是 `_seriesMatches.length >= 2`，与结果多少无关。问题在**清空与取数的次序**：
+
+```dart
+setState(() { _seriesMatches = const []; _selectedSeriesId = null; });  // 先清空
+final media = await anilist.searchAnime(query);                          // 再去拿
+```
+
+中间只要这一跳没拿到东西，用户就**永久失去**系列选择面：既搜不到，又换不了系列，只能关掉重开。
+而 `AniListClient.searchAnime` 是 fail-open 的（网络/非 200/解析失败一律返回空列表，
+`anilist_client.dart:277,283-287`），AniList 本身又有限流——连续点几次搜索很容易触发。
+
+叠加 [BUG-1652]：拿不到 anilist_id 就退回文本搜，而预填的是中文译名，于是「搜不出结果」与
+「系列没了」同时发生，看起来像是「选了集数导致的」。
+
+### 修复
+
+- 清空只跟着「换了番名」走：新增 `_seriesQuery` 记录当前系列列表对应哪个番名，
+  `sameSeriesQuery` 时保留列表与选中项；
+- AniList 返回空**不再覆盖**已有列表（空既可能是查无此番，也可能是限流/抖动，后者不该擦掉用户已有的）；
+- 已选定系列且番名没变（典型：只改了集数）→ 直接在该系列内重列文件，不再重跑 AniList
+  （省一次往返，也少一次限流机会）；
+- `debugInitialSeriesMatches` 预置时同步写 `_seriesQuery`，与真实搜索路径保持一致。

--- a/docs/bugs/BUG-1654-jimaku-download-error-hidden-behind-dialog.md
+++ b/docs/bugs/BUG-1654-jimaku-download-error-hidden-behind-dialog.md
@@ -1,0 +1,31 @@
+## BUG-1654 · 下载失败提示被对话框盖住且没有原因
+- **报告**：2026-08-15（用户实测，原话「下载失败报错在弹窗底下。而不是弹窗上面，而且没有详细信息」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart`
+  旧 `_snack()` 走 `ScaffoldMessenger.of(context).showSnackBar`
+- **[x] ① 已修复** — commit `9bfe4cdd95`
+- **[x] ② 已加自动化测试** — `fushi/test/pages/jimaku_search_identity_test.dart`
+  「下载失败的原因显示在对话框内部，并带上 HTTP 状态码」
+- **备注**：与 [BUG-1652] / [BUG-1653] 同一批用户实测反馈，同一个对话框。
+
+### 根因
+
+两个独立缺陷叠在一起：
+
+1. **位置**：本对话框是全屏 modal，而 `ScaffoldMessenger` 的 SnackBar 挂在它**底下那层页面**的
+   Scaffold 上，正好被对话框整个盖住。用户看到的就是「点了没反应」，失败原因一次都没露过面。
+   受影响的不止下载失败——`video_jimaku_no_key`（没填 API key）走的是同一条路。
+2. **内容**：`downloadFile` 默认 fail-open 吞成 `null`，调用点只弹一句写死的「下载失败」。
+   key 过期（401）、被限流（429）、文件下架（404）在用户眼里长得一模一样，无从下手。
+
+搜索路径同样吃这个亏：条目检索失败与「真的没有这部番」都被吞成空列表，用户只看到「没有找到字幕」，
+于是继续换关键词瞎试——而真实原因可能是 key 过期，换多少次关键词都不会好。
+
+### 修复
+
+- 新增对话框内部的错误条（`ValueKey('jimaku-error-banner')`，errorContainer 底色，恒置顶于结果区），
+  `_snack` 全部改为 `_showError`；
+- 下载与条目检索都开 `throwOnError: true`，经新增纯函数 `describeJimakuFailure`
+  （`jimaku_client.dart`）拼成「基础文案（HTTP <状态码>）」；拿不到状态码（DNS/超时/代理挂了）
+  时原样返回基础文案，不编造细节；
+- `listFiles` 保持 fail-open：某个条目列不出文件不该让其它条目的结果一起消失；
+- 新增 i18n key `video_jimaku_search_failed`，让「搜索失败」与「真的没有字幕」在 UI 上可区分。

--- a/docs/bugs/BUG-1656-playlist-subtitle-restore-no-fallback.md
+++ b/docs/bugs/BUG-1656-playlist-subtitle-restore-no-fallback.md
@@ -1,0 +1,65 @@
+## BUG-1656 · 合集里下载的字幕退出再进就没了：恢复链只走一支、零兜底
+- **报告**：2026-08-15（用户实测，原话「下载的字幕退出进来以后又没了」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/pages/implementations/video_fushi_page.dart`
+  `_loadSingle` 的字幕恢复 else-if 链（兜底三层全挂在链尾，前一支失败即空手收场）
+- **[x] ① 已修复** — 兜底链改为独立判据 + 放宽 sidecar 门 + 释放无效外挂路径
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_subtitle_restore_fallback_guard_test.dart`（4 例，变异实测）
+- **备注**：与 [BUG-1652] / [BUG-1653] / [BUG-1654] 同一批用户实测反馈。
+  另见下方「同批查出、本轮未修」两条。
+
+### 实证（用户真实库，只读查询）
+
+数据根 `D:\APP\HIBIKI_date`：
+
+- 合集 77「Re：从零开始的异世界生活 第四季 丧失篇 (2026)」，`collection_type='playlist'`，
+  三个成员各自是独立 `video_books` 行（S04E10/E11/E12）。
+- 只有 **S04E12** 有 `subtitle_source`，指向 `documents\video_subtitles\` 下当晚 00:33 下载的
+  ABEMA `.srt`；**该文件在磁盘上存在，按 SrtParser 规则可解析出 406 条 cue**。
+- 但该行 **`audio_cues` 条数 = 0**。
+- 41 行带外挂字幕的 `subtitle_source` 全部在磁盘上存在（排除「文件被清掉」）。
+
+⇒ 「写错行」「文件没了」「双语 `.ja-en.ass` 解析不了」三个最像的假设**全部被证伪**。
+
+### 根因
+
+合集里的每一集**只落字幕源指针、不落 cue**（`_selectSubtitleSource` 的 `_episodes.isEmpty`
+分支，BUG-081 有意为之）。于是 `_loadSingle` 的恢复链成了单点故障：
+
+1. `externalSub` 在一开始就被赋成持久化路径（非空）。
+2. 分支是 **else-if 链**：只要路径存在且扩展名对（`rehydratePath != null`），就只走「重解析磁盘
+   档案」这一支；解析没拿到 cue 时按注释「保留 DB 缓存 cues」——**而合集这一集的缓存恒为空**。
+3. 后面的「持久化源精确恢复」挂在同一条链的 `else if (cues.isEmpty)` 上，**永远轮不到**。
+4. 即便轮到，sidecar 兜底的门是 `cues.isEmpty && externalSub == null`，被第 1 步那个非空值挡掉。
+5. 最后 `_applyLoad` 把非空 `externalSubtitlePath` 传给 controller，而
+   `VideoPlayerController.load` 的「无外挂 + 无 cue 才后台抽内封文本轨」判据同样被它挡掉。
+
+⇒ **一次解析就是全部：失败 = 零字幕 + 零兜底 + 零提示**（恢复路径全程只有 `debugPrint`）。
+单视频有 `loadCues` 这层 DB cue 安全网，合集没有——这就是「单视频没事、合集必现」的不对称根源，
+也是用户「只能重新下载一次」的直接原因。
+
+原注释里「播放列表换集走 `_restorePersistedSubtitle` 已是重解析，故只需修单视频路径」的前提，
+在统一合集 Phase 3（换集改为 `pushReplacement` 重建、每集都走 `_loadSingle`）之后已经失效。
+
+### 修复
+
+把兜底从 else-if 链里拆出来，改成「只要还没拿到 cue 就逐级往下试」：
+
+- 独立判据 `if (!subtitleExplicitlyOff && cues.isEmpty)`，上面任何一支「试过但没成功」都能落进来；
+- sidecar 门只看 `cues.isEmpty`（去掉 `externalSub == null`）——「有持久化源但它恢复不出内容」时
+  也该试 sidecar；
+- 最终仍无 cue 且源不是内嵌轨 → 释放 `externalSub`，让 controller 的内封轨自动加载兜底。
+  **只影响本次加载，不回写 DB**，用户选过的源仍在库里，下次仍会先试它。
+- TODO-818（用户显式关闭字幕）仍然短路整条兜底，判据自身也带 `!subtitleExplicitlyOff` 双保险。
+
+### 同批查出、本轮未修（各自待立项）
+
+1. **内封轨自动加载不落库**：`_handleEmbeddedSubtitleAutoLoad` 只 `setState(_currentSubtitleSource)`
+   从不写 DB；而 `_selectSubtitleSource` 在解析失败时早退，早退发生在 `controller.setCues` 之前，
+   屏幕上原有的（自动加载的内封）字幕不会被清掉。⇒「下载 → 应用 → 屏幕上确实有字幕」完全可能是
+   「这次下载其实没成功，你看到的是内封轨」，退出重进自然「我下的字幕没了」。用户当晚 7 分钟内连下
+   三个不同来源的字幕（00:26/00:31/00:33），符合这种反复试探。
+2. **跨集字幕继承是死代码**：`crossEpisode: true` 在 lib 里一次都没被传过（两个调用点都是 false），
+   `pickEpisodeSubtitleSource` / `shouldReusePersistedSubtitleAcrossEpisode` 在生产路径上不可达。
+   合集「继续观看」打开的下一集 `subtitle_source` 为 NULL，⇒ 每集都得手动下一次字幕。
+   （`docs/bugs/BUG-1288` 末尾把「字幕记录也无了得重新选」列为未定根因、待单独立项；本次调查补上了
+   它缺的那一环——不是没写，是读回时没有兜底。）

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57715 (3395 per locale)
+/// Strings: 57783 (3399 per locale)
 ///
-/// Built on 2026-08-14 at 15:34 UTC
+/// Built on 2026-08-14 at 15:52 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4593,6 +4593,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_jimaku_category_anime => 'Anime';
   String get video_jimaku_category_live_action => 'Live action';
   String get video_jimaku_category_all => 'All';
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  String get video_subtitle_online_title => 'Title';
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -12431,6 +12436,15 @@ class _StringsAr extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -20336,6 +20350,15 @@ class _StringsDe extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -28257,6 +28280,15 @@ class _StringsEs extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -36190,6 +36222,15 @@ class _StringsFr extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -44051,6 +44092,15 @@ class _StringsId extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -51958,6 +52008,15 @@ class _StringsIt extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -59679,6 +59738,15 @@ class _StringsJa extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -67407,6 +67475,15 @@ class _StringsKo extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -75294,6 +75371,15 @@ class _StringsNl extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -83193,6 +83279,15 @@ class _StringsPtBr extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -91078,6 +91173,15 @@ class _StringsRu extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -98911,6 +99015,15 @@ class _StringsTh extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -106775,6 +106888,15 @@ class _StringsTr extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -114624,6 +114746,15 @@ class _StringsVi extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 // Path: <root>
@@ -121902,6 +122033,14 @@ class _StringsZhCn extends _StringsEn {
   String get video_jimaku_category_live_action => '真人';
   @override
   String get video_jimaku_category_all => '全部';
+  @override
+  String get video_subtitle_online_fetch => '在线获取字幕';
+  @override
+  String get video_subtitle_online_title => '标题';
+  @override
+  String get video_subtitle_online_no_source => '尚未配置在线字幕来源，请先在设置中添加。';
+  @override
+  String get video_subtitle_online_hash_matched => '按文件哈希精确匹配';
 }
 
 // Path: <root>
@@ -129546,6 +129685,15 @@ class _StringsZhHk extends _StringsEn {
   String get video_jimaku_category_live_action => 'Live action';
   @override
   String get video_jimaku_category_all => 'All';
+  @override
+  String get video_subtitle_online_fetch => 'Fetch subtitles (online)';
+  @override
+  String get video_subtitle_online_title => 'Title';
+  @override
+  String get video_subtitle_online_no_source =>
+      'No online subtitle source is configured. Add one in Settings.';
+  @override
+  String get video_subtitle_online_hash_matched => 'Matched by file hash';
 }
 
 /// Flat map(s) containing all translations.
@@ -136518,6 +136666,14 @@ extension on _StringsEn {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -143488,6 +143644,14 @@ extension on _StringsAr {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -150480,6 +150644,14 @@ extension on _StringsDe {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -157471,6 +157643,14 @@ extension on _StringsEs {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -164468,6 +164648,14 @@ extension on _StringsFr {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -171447,6 +171635,14 @@ extension on _StringsId {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -178440,6 +178636,14 @@ extension on _StringsIt {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -185395,6 +185599,14 @@ extension on _StringsJa {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -192354,6 +192566,14 @@ extension on _StringsKo {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -199341,6 +199561,14 @@ extension on _StringsNl {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -206325,6 +206553,14 @@ extension on _StringsPtBr {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -213314,6 +213550,14 @@ extension on _StringsRu {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -220286,6 +220530,14 @@ extension on _StringsTh {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -227267,6 +227519,14 @@ extension on _StringsTr {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -234244,6 +234504,14 @@ extension on _StringsVi {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }
@@ -241163,6 +241431,14 @@ extension on _StringsZhCn {
         return '真人';
       case 'video_jimaku_category_all':
         return '全部';
+      case 'video_subtitle_online_fetch':
+        return '在线获取字幕';
+      case 'video_subtitle_online_title':
+        return '标题';
+      case 'video_subtitle_online_no_source':
+        return '尚未配置在线字幕来源，请先在设置中添加。';
+      case 'video_subtitle_online_hash_matched':
+        return '按文件哈希精确匹配';
       default:
         return null;
     }
@@ -248113,6 +248389,14 @@ extension on _StringsZhHk {
         return 'Live action';
       case 'video_jimaku_category_all':
         return 'All';
+      case 'video_subtitle_online_fetch':
+        return 'Fetch subtitles (online)';
+      case 'video_subtitle_online_title':
+        return 'Title';
+      case 'video_subtitle_online_no_source':
+        return 'No online subtitle source is configured. Add one in Settings.';
+      case 'video_subtitle_online_hash_matched':
+        return 'Matched by file hash';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57647 (3391 per locale)
+/// Strings: 57715 (3395 per locale)
 ///
-/// Built on 2026-08-14 at 13:06 UTC
+/// Built on 2026-08-14 at 15:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4589,6 +4589,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Drag a subtitle up or down to reposition it';
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  String get video_jimaku_category => 'Category';
+  String get video_jimaku_category_anime => 'Anime';
+  String get video_jimaku_category_live_action => 'Live action';
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -12419,6 +12423,14 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -20316,6 +20328,14 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -28229,6 +28249,14 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -36154,6 +36182,14 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -44007,6 +44043,14 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -51906,6 +51950,14 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -59619,6 +59671,14 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -67339,6 +67399,14 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -75218,6 +75286,14 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -83109,6 +83185,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -90986,6 +91070,14 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -98811,6 +98903,14 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -106667,6 +106767,14 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -114508,6 +114616,14 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 // Path: <root>
@@ -121778,6 +121894,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
+  @override
+  String get video_jimaku_category => '分类';
+  @override
+  String get video_jimaku_category_anime => '动画';
+  @override
+  String get video_jimaku_category_live_action => '真人';
+  @override
+  String get video_jimaku_category_all => '全部';
 }
 
 // Path: <root>
@@ -129414,6 +129538,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get video_jimaku_category => 'Category';
+  @override
+  String get video_jimaku_category_anime => 'Anime';
+  @override
+  String get video_jimaku_category_live_action => 'Live action';
+  @override
+  String get video_jimaku_category_all => 'All';
 }
 
 /// Flat map(s) containing all translations.
@@ -136378,6 +136510,14 @@ extension on _StringsEn {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -143340,6 +143480,14 @@ extension on _StringsAr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -150324,6 +150472,14 @@ extension on _StringsDe {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -157307,6 +157463,14 @@ extension on _StringsEs {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -164296,6 +164460,14 @@ extension on _StringsFr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -171267,6 +171439,14 @@ extension on _StringsId {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -178252,6 +178432,14 @@ extension on _StringsIt {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -185199,6 +185387,14 @@ extension on _StringsJa {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -192150,6 +192346,14 @@ extension on _StringsKo {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -199129,6 +199333,14 @@ extension on _StringsNl {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -206105,6 +206317,14 @@ extension on _StringsPtBr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -213086,6 +213306,14 @@ extension on _StringsRu {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -220050,6 +220278,14 @@ extension on _StringsTh {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -227023,6 +227259,14 @@ extension on _StringsTr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -233992,6 +234236,14 @@ extension on _StringsVi {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }
@@ -240903,6 +241155,14 @@ extension on _StringsZhCn {
         return '上下拖动字幕调整位置';
       case 'anki_connect_mobile_disabled_key_cleared':
         return '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
+      case 'video_jimaku_category':
+        return '分类';
+      case 'video_jimaku_category_anime':
+        return '动画';
+      case 'video_jimaku_category_live_action':
+        return '真人';
+      case 'video_jimaku_category_all':
+        return '全部';
       default:
         return null;
     }
@@ -247845,6 +248105,14 @@ extension on _StringsZhHk {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'video_jimaku_category':
+        return 'Category';
+      case 'video_jimaku_category_anime':
+        return 'Anime';
+      case 'video_jimaku_category_live_action':
+        return 'Live action';
+      case 'video_jimaku_category_all':
+        return 'All';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57783 (3399 per locale)
+/// Strings: 57800 (3400 per locale)
 ///
-/// Built on 2026-08-14 at 15:52 UTC
+/// Built on 2026-08-14 at 16:44 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4598,6 +4598,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_subtitle_online_no_source =>
       'No online subtitle source is configured. Add one in Settings.';
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -12445,6 +12446,8 @@ class _StringsAr extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -20359,6 +20362,8 @@ class _StringsDe extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -28289,6 +28294,8 @@ class _StringsEs extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -36231,6 +36238,8 @@ class _StringsFr extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -44101,6 +44110,8 @@ class _StringsId extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -52017,6 +52028,8 @@ class _StringsIt extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -59747,6 +59760,8 @@ class _StringsJa extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -67484,6 +67499,8 @@ class _StringsKo extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -75380,6 +75397,8 @@ class _StringsNl extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -83288,6 +83307,8 @@ class _StringsPtBr extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -91182,6 +91203,8 @@ class _StringsRu extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -99024,6 +99047,8 @@ class _StringsTh extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -106897,6 +106922,8 @@ class _StringsTr extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -114755,6 +114782,8 @@ class _StringsVi extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 // Path: <root>
@@ -122041,6 +122070,8 @@ class _StringsZhCn extends _StringsEn {
   String get video_subtitle_online_no_source => '尚未配置在线字幕来源，请先在设置中添加。';
   @override
   String get video_subtitle_online_hash_matched => '按文件哈希精确匹配';
+  @override
+  String get video_jimaku_search_failed => '搜索失败';
 }
 
 // Path: <root>
@@ -129694,6 +129725,8 @@ class _StringsZhHk extends _StringsEn {
       'No online subtitle source is configured. Add one in Settings.';
   @override
   String get video_subtitle_online_hash_matched => 'Matched by file hash';
+  @override
+  String get video_jimaku_search_failed => 'Search failed';
 }
 
 /// Flat map(s) containing all translations.
@@ -136674,6 +136707,8 @@ extension on _StringsEn {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -143652,6 +143687,8 @@ extension on _StringsAr {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -150652,6 +150689,8 @@ extension on _StringsDe {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -157651,6 +157690,8 @@ extension on _StringsEs {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -164656,6 +164697,8 @@ extension on _StringsFr {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -171643,6 +171686,8 @@ extension on _StringsId {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -178644,6 +178689,8 @@ extension on _StringsIt {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -185607,6 +185654,8 @@ extension on _StringsJa {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -192574,6 +192623,8 @@ extension on _StringsKo {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -199569,6 +199620,8 @@ extension on _StringsNl {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -206561,6 +206614,8 @@ extension on _StringsPtBr {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -213558,6 +213613,8 @@ extension on _StringsRu {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -220538,6 +220595,8 @@ extension on _StringsTh {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -227527,6 +227586,8 @@ extension on _StringsTr {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -234512,6 +234573,8 @@ extension on _StringsVi {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }
@@ -241439,6 +241502,8 @@ extension on _StringsZhCn {
         return '尚未配置在线字幕来源，请先在设置中添加。';
       case 'video_subtitle_online_hash_matched':
         return '按文件哈希精确匹配';
+      case 'video_jimaku_search_failed':
+        return '搜索失败';
       default:
         return null;
     }
@@ -248397,6 +248462,8 @@ extension on _StringsZhHk {
         return 'No online subtitle source is configured. Add one in Settings.';
       case 'video_subtitle_online_hash_matched':
         return 'Matched by file hash';
+      case 'video_jimaku_search_failed':
+        return 'Search failed';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "分类",
   "video_jimaku_category_anime": "动画",
   "video_jimaku_category_live_action": "真人",
-  "video_jimaku_category_all": "全部"
+  "video_jimaku_category_all": "全部",
+  "video_subtitle_online_fetch": "在线获取字幕",
+  "video_subtitle_online_title": "标题",
+  "video_subtitle_online_no_source": "尚未配置在线字幕来源，请先在设置中添加。",
+  "video_subtitle_online_hash_matched": "按文件哈希精确匹配"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "顶部",
   "video_setting_subtitle_drag_adjust": "拖拽调整位置",
   "video_subtitle_drag_adjust_hint": "上下拖动字幕调整位置",
-  "anki_connect_mobile_disabled_key_cleared": "移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。"
+  "anki_connect_mobile_disabled_key_cleared": "移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。",
+  "video_jimaku_category": "分类",
+  "video_jimaku_category_anime": "动画",
+  "video_jimaku_category_live_action": "真人",
+  "video_jimaku_category_all": "全部"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "在线获取字幕",
   "video_subtitle_online_title": "标题",
   "video_subtitle_online_no_source": "尚未配置在线字幕来源，请先在设置中添加。",
-  "video_subtitle_online_hash_matched": "按文件哈希精确匹配"
+  "video_subtitle_online_hash_matched": "按文件哈希精确匹配",
+  "video_jimaku_search_failed": "搜索失败"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3397,5 +3397,6 @@
   "video_subtitle_online_fetch": "Fetch subtitles (online)",
   "video_subtitle_online_title": "Title",
   "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
-  "video_subtitle_online_hash_matched": "Matched by file hash"
+  "video_subtitle_online_hash_matched": "Matched by file hash",
+  "video_jimaku_search_failed": "Search failed"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3393,5 +3393,9 @@
   "video_jimaku_category": "Category",
   "video_jimaku_category_anime": "Anime",
   "video_jimaku_category_live_action": "Live action",
-  "video_jimaku_category_all": "All"
+  "video_jimaku_category_all": "All",
+  "video_subtitle_online_fetch": "Fetch subtitles (online)",
+  "video_subtitle_online_title": "Title",
+  "video_subtitle_online_no_source": "No online subtitle source is configured. Add one in Settings.",
+  "video_subtitle_online_hash_matched": "Matched by file hash"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3389,5 +3389,9 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "video_jimaku_category": "Category",
+  "video_jimaku_category_anime": "Anime",
+  "video_jimaku_category_live_action": "Live action",
+  "video_jimaku_category_all": "All"
 }

--- a/fushi/lib/src/media/video/download/video_subtitle_registry.dart
+++ b/fushi/lib/src/media/video/download/video_subtitle_registry.dart
@@ -17,13 +17,10 @@ class VideoSubtitleRegistry {
   ) async {
     final bool anime =
         request.media?.discoveryCategory == VideoDiscoveryCategory.anime;
-    final List<VideoSubtitleProvider> applicable = providers
-        .where(
-          (VideoSubtitleProvider provider) => anime
-              ? provider.id == 'jimaku' || provider.id == 'opensubtitles'
-              : provider.id == 'opensubtitles',
-        )
-        .toList()
+    // 每个 provider 自己决定能否服务这次检索（Jimaku 会按分类切 anime/live-action
+    // 范围），注册表不再用 id 白名单替它们做可用性判断——那行白名单曾把 Jimaku 的整个
+    // 真人剧库挡在非动漫检索之外。排序仍保留「动漫优先 Jimaku」的既有意图。
+    final List<VideoSubtitleProvider> applicable = providers.toList()
       ..sort((VideoSubtitleProvider a, VideoSubtitleProvider b) {
         if (anime && a.id != b.id) {
           if (a.id == 'jimaku') return -1;

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -8,17 +8,124 @@ import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 
+/// Jimaku 条目的分类范围：动画 / 真人（Live Action）/ 全部。
+///
+/// Jimaku 站点把这两类拆成两个页面（`jimaku.cc` 与 `jimaku.cc/dramas`），API 侧对应
+/// `/entries/search?anime=<bool>`。**这个参数是硬相等过滤而不是「偏好」**：服务端实现
+/// （`src/routes/api/entries.rs`）第一行就是
+/// `if self.anime != entry.flags.is_anime() { return None }`，且 `anime` 缺省为 `true`。
+///
+/// 两个后果决定了本枚举的存在：
+/// 1. 不显式传 `anime=false` 就永远搜不到任何真人剧条目；
+/// 2. 服务端**没有**「不限分类」这个取值，所以 [all] 只能靠发两次请求再合并去重实现
+///    （见 [jimakuScopeAnimeFlags]）。
+///
+/// 另注：`anilist_id` / `tmdb_id` 的精确匹配也排在上面那句分类过滤之后，因此按 TMDB ID
+/// 查真人剧时必须同时带 `anime=false`，否则命中率恒为 0。
+enum JimakuSearchScope {
+  /// 只搜动画条目（= 旧行为，服务端缺省值）。
+  anime,
+
+  /// 只搜真人条目（日剧/电影等，对应站点的 Live Action 页）。
+  liveAction,
+
+  /// 两类都搜：客户端发两次请求后按条目 id 合并去重。
+  all,
+}
+
+/// 把 [scope] 展开成需要依次请求的 `anime=` 取值序列。
+///
+/// 单分类是「长度 1 的普通情况」，[JimakuSearchScope.all] 是「长度 2」——调用方统一按
+/// 列表循环即可，不需要为「全部」写特例分支。
+List<bool> jimakuScopeAnimeFlags(JimakuSearchScope scope) {
+  switch (scope) {
+    case JimakuSearchScope.anime:
+      return const <bool>[true];
+    case JimakuSearchScope.liveAction:
+      return const <bool>[false];
+    case JimakuSearchScope.all:
+      return const <bool>[true, false];
+  }
+}
+
+/// Jimaku 条目标记位。
+///
+/// API 层把服务端内部的 u32 bitfield 展开成 JSON 对象再返回（服务端 `models.rs` 注释
+/// 原文：*At the API level, we expand the flags to a dict*），故此处按对象解析；字段缺失
+/// 一律按 `false`（与服务端 `#[serde(default)]` 同语义）。
+class JimakuEntryFlags {
+  const JimakuEntryFlags({
+    this.anime = false,
+    this.unverified = false,
+    this.external = false,
+    this.movie = false,
+    this.adult = false,
+  });
+
+  /// 该条目属于动画。
+  final bool anime;
+
+  /// 尚未经编辑审核。
+  final bool unverified;
+
+  /// 条目来自外部来源（如 kitsunekko/jpsubbers 镜像）。
+  final bool external;
+
+  /// 该条目是电影（而非剧集）。
+  final bool movie;
+
+  /// 面向成人受众。
+  final bool adult;
+
+  /// 是否为真人条目：`anime` 位取反。UI 用它给条目打「真人」标。
+  bool get isLiveAction => !anime;
+}
+
+/// 解析 Jimaku entry 的 `flags` 字段；非对象（或缺失）返回全 false 的默认值。
+///
+/// 只认对象形态：API 只会返回对象，站点页面里内嵌的 u32 bitfield 不是本客户端的输入，
+/// 不为不存在的情况写解析分支。
+JimakuEntryFlags parseJimakuEntryFlags(Object? raw) {
+  if (raw is! Map) return const JimakuEntryFlags();
+  bool read(String key) => raw[key] == true;
+  return JimakuEntryFlags(
+    anime: read('anime'),
+    unverified: read('unverified'),
+    external: read('external'),
+    movie: read('movie'),
+    adult: read('adult'),
+  );
+}
+
+/// 按 Jimaku 的 TMDB ID 编码拼串：`tv:<id>` / `movie:<id>`。
+///
+/// 编码来自服务端 schema 的 `pattern = (tv|movie):(\d+)`；Hibiki 侧的 TMDB 元数据
+/// （`TmdbVideoMetadataProvider`）只给出裸数字 id + 媒体类型，需经此函数转换。
+String jimakuTmdbId({required bool movie, required int tmdbId}) =>
+    '${movie ? 'movie' : 'tv'}:$tmdbId';
+
 /// Jimaku（jimaku.cc）字幕条目：一个番剧/作品。
 class JimakuEntry {
   const JimakuEntry({
     required this.id,
     required this.name,
     this.anilistId,
+    this.tmdbId,
+    this.japaneseName,
+    this.flags = const JimakuEntryFlags(),
   });
 
   final int id;
   final String name;
   final int? anilistId;
+
+  /// `tv:<id>` / `movie:<id>` 形态的 TMDB ID；动画条目通常为 null。
+  final String? tmdbId;
+
+  /// 日文（含汉字假名）名。真人剧的用户输入常是日文原名，服务端模糊搜索也会匹配此字段。
+  final String? japaneseName;
+
+  final JimakuEntryFlags flags;
 }
 
 /// Jimaku 条目下的一个字幕文件。
@@ -139,14 +246,21 @@ List<JimakuEntry> parseJimakuEntries(String body, {bool strict = false}) {
       }
       final String primaryName = (e['name'] as String?)?.trim() ?? '';
       final String englishName = (e['english_name'] as String?)?.trim() ?? '';
+      final String japaneseName = (e['japanese_name'] as String?)?.trim() ?? '';
+      final String tmdbId = (e['tmdb_id'] as String?)?.trim() ?? '';
       out.add(JimakuEntry(
         id: id,
         name: primaryName.isNotEmpty
             ? primaryName
             : englishName.isNotEmpty
                 ? englishName
-                : '#$id',
+                : japaneseName.isNotEmpty
+                    ? japaneseName
+                    : '#$id',
         anilistId: e['anilist_id'] as int?,
+        tmdbId: tmdbId.isEmpty ? null : tmdbId,
+        japaneseName: japaneseName.isEmpty ? null : japaneseName,
+        flags: parseJimakuEntryFlags(e['flags']),
       ));
     }
     return out;
@@ -359,6 +473,26 @@ Uri buildListFilesUri(String base, int entryId, {int? episode}) {
   return uri.replace(queryParameters: <String, String>{'episode': '$episode'});
 }
 
+/// 构造 `/api/entries/search` 请求 URI。纯函数，便于单测断言分类与检索键拼参。
+///
+/// [anime] 恒显式拼进 query：服务端缺省 `true`，靠缺省值等于把真人剧永久挡在门外，
+/// 所以这里不做「等于缺省就省略」的优化——显式才是可读且可断言的。
+Uri buildSearchEntriesUri(
+  String base, {
+  required bool anime,
+  int? anilistId,
+  String? tmdbId,
+  String? query,
+}) {
+  final Map<String, String> params = <String, String>{
+    'anime': anime ? 'true' : 'false',
+    if (anilistId != null) 'anilist_id': '$anilistId',
+    if (tmdbId != null && tmdbId.trim().isNotEmpty) 'tmdb_id': tmdbId.trim(),
+    if (query != null && query.trim().isNotEmpty) 'query': query,
+  };
+  return Uri.parse('$base/entries/search').replace(queryParameters: params);
+}
+
 /// Jimaku API 客户端（参照 asbplayer 的 Jimaku 集成）。需用户在设置/对话框填 API key。
 ///
 /// 端点：`/api/entries/search`（按 anilist_id 或 query 搜条目）、`/api/entries/<id>/files`
@@ -378,24 +512,49 @@ class JimakuClient {
       };
 
   /// 按 AniList id 搜 Jimaku 条目。
+  ///
+  /// 不开放 scope：AniList ID 是动画专属标识，配 `anime=false` 恒返回空，没有可用取值。
   Future<List<JimakuEntry>> searchByAnilistId(
     int anilistId, {
     bool throwOnError = false,
   }) async {
     return _searchEntries(
-      <String, String>{'anilist_id': '$anilistId'},
+      anilistId: anilistId,
+      scope: JimakuSearchScope.anime,
+      throwOnError: throwOnError,
+    );
+  }
+
+  /// 按 TMDB ID（`tv:<id>` / `movie:<id>`，见 [jimakuTmdbId]）精确搜条目。
+  ///
+  /// 真人剧的权威关联键。默认 [JimakuSearchScope.all]：TMDB 既可能挂在真人条目上，也可能
+  /// 挂在动画剧场版上，而分类过滤先于 ID 匹配执行，只查一边会漏。
+  Future<List<JimakuEntry>> searchByTmdbId(
+    String tmdbId, {
+    JimakuSearchScope scope = JimakuSearchScope.all,
+    bool throwOnError = false,
+  }) async {
+    if (tmdbId.trim().isEmpty) return const <JimakuEntry>[];
+    return _searchEntries(
+      tmdbId: tmdbId,
+      scope: scope,
       throwOnError: throwOnError,
     );
   }
 
   /// 按文本搜 Jimaku 条目（AniList 匹配不到时的回退）。
+  ///
+  /// [scope] 决定搜动画还是真人；缺省 [JimakuSearchScope.anime] = 旧行为。服务端模糊匹配
+  /// 覆盖 romaji / 英文 / 日文三种名字，故日文原名可直接作为 [query]。
   Future<List<JimakuEntry>> searchByQuery(
     String query, {
+    JimakuSearchScope scope = JimakuSearchScope.anime,
     bool throwOnError = false,
   }) async {
     if (query.trim().isEmpty) return const <JimakuEntry>[];
     return _searchEntries(
-      <String, String>{'query': query},
+      query: query,
+      scope: scope,
       throwOnError: throwOnError,
     );
   }
@@ -407,20 +566,31 @@ class JimakuClient {
   /// 「其实有字幕却报无字幕」。纯委托，便于用 fake [http.Client] 单测。
   Future<List<JimakuEntry>> searchEntries({
     int? anilistId,
+    String? tmdbId,
     List<String> queryFallbacks = const <String>[],
+    JimakuSearchScope scope = JimakuSearchScope.anime,
     bool throwOnError = false,
   }) async {
-    if (anilistId != null) {
+    if (anilistId != null && scope != JimakuSearchScope.liveAction) {
       final List<JimakuEntry> byId = await searchByAnilistId(
         anilistId,
         throwOnError: throwOnError,
       );
       if (byId.isNotEmpty) return byId;
     }
+    if (tmdbId != null && tmdbId.trim().isNotEmpty) {
+      final List<JimakuEntry> byTmdb = await searchByTmdbId(
+        tmdbId,
+        scope: scope,
+        throwOnError: throwOnError,
+      );
+      if (byTmdb.isNotEmpty) return byTmdb;
+    }
     for (final String query in queryFallbacks) {
       if (query.trim().isEmpty) continue;
       final List<JimakuEntry> byQuery = await searchByQuery(
         query,
+        scope: scope,
         throwOnError: throwOnError,
       );
       if (byQuery.isNotEmpty) return byQuery;
@@ -428,27 +598,47 @@ class JimakuClient {
     return const <JimakuEntry>[];
   }
 
-  Future<List<JimakuEntry>> _searchEntries(
-    Map<String, String> params, {
+  /// 单次或多次（[JimakuSearchScope.all]）请求 `/entries/search` 并按条目 id 去重合并。
+  ///
+  /// 保序：先请求的分类排前（`all` 时动画在前、真人在后），同 id 只保留首次出现，服务端
+  /// 已按模糊匹配得分降序返回，合并不会打乱各自内部次序。
+  Future<List<JimakuEntry>> _searchEntries({
+    required JimakuSearchScope scope,
     required bool throwOnError,
+    int? anilistId,
+    String? tmdbId,
+    String? query,
   }) async {
     try {
-      final Uri uri =
-          Uri.parse('$_base/entries/search').replace(queryParameters: params);
-      final http.Response res = await _client.get(uri, headers: _headers);
-      if (res.statusCode != 200) {
-        if (throwOnError) {
-          throw JimakuRequestException(
-            'search entries failed',
-            statusCode: res.statusCode,
-          );
+      final List<JimakuEntry> merged = <JimakuEntry>[];
+      final Set<int> seen = <int>{};
+      for (final bool anime in jimakuScopeAnimeFlags(scope)) {
+        final Uri uri = buildSearchEntriesUri(
+          _base,
+          anime: anime,
+          anilistId: anilistId,
+          tmdbId: tmdbId,
+          query: query,
+        );
+        final http.Response res = await _client.get(uri, headers: _headers);
+        if (res.statusCode != 200) {
+          if (throwOnError) {
+            throw JimakuRequestException(
+              'search entries failed',
+              statusCode: res.statusCode,
+            );
+          }
+          continue;
         }
-        return const <JimakuEntry>[];
+        final List<JimakuEntry> page = parseJimakuEntries(
+          utf8.decode(res.bodyBytes, allowMalformed: true),
+          strict: throwOnError,
+        );
+        for (final JimakuEntry entry in page) {
+          if (seen.add(entry.id)) merged.add(entry);
+        }
       }
-      return parseJimakuEntries(
-        utf8.decode(res.bodyBytes, allowMalformed: true),
-        strict: throwOnError,
-      );
+      return merged;
     } catch (e, stack) {
       // fail-open：预期可失败的网络路径，返回空列表（同旧行为），补 diagnostic。
       ErrorLogService.instance.logDiagnostic('JimakuClient.searchEntries', e);

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -464,6 +464,18 @@ class JimakuRequestException implements Exception {
   }
 }
 
+/// 把一次 Jimaku 失败拼成**用户能据以行动**的一句话：`<基础文案>（HTTP <状态码>）`。
+///
+/// 纯函数，便于单测。失败原因必须落到 UI 上——401（key 过期/写错）、429（被限流，等会
+/// 儿再试）、404（文件下架）对用户是完全不同的三件事，一律显示「下载失败」等于什么都
+/// 没说。拿不到状态码（DNS/超时/代理挂了）时原样返回基础文案，不编造细节。
+String describeJimakuFailure(String baseMessage, Object? error) {
+  if (error is! JimakuRequestException) return baseMessage;
+  final int? status = error.statusCode;
+  if (status == null) return baseMessage;
+  return '$baseMessage（HTTP $status）';
+}
+
 /// 构造 `/api/entries/<id>/files` 请求 URI。纯函数，便于单测断言 episode 拼参。
 ///
 /// [episode] 非空时附 `episode=<n>`，否则 URI 不带任何 query（= 旧行为）。

--- a/fushi/lib/src/media/video/jimaku_search_seed.dart
+++ b/fushi/lib/src/media/video/jimaku_search_seed.dart
@@ -1,0 +1,84 @@
+import 'package:fushi/src/media/video/jimaku_client.dart';
+
+/// 打开在线字幕检索时的**检索种子**：把 app 早就知道的身份信息（刮削得到的外部 ID、
+/// 日文原名）摆在「拿界面上的显示名去模糊搜」前面。
+///
+/// 存在的理由是一个真实故障：用户库里的《Re:Zero》第四季显示名是中文
+/// 「Re：从零开始的异世界生活 第四季 丧失篇」，而 Jimaku 的条目名只有罗马音/英文/日文，
+/// AniList 也匹配不上这种「中文译名 + 季度 + 篇名」的长串（实测：光「从零开始的异世界
+/// 生活」能命中，整串 0 结果）。于是搜索必然空手而归——**尽管这个视频刮削过，库里明明
+/// 白白存着它的 AniList ID 和日文原名**。有身份就别再去猜名字。
+class JimakuSearchSeed {
+  const JimakuSearchSeed({
+    this.anilistId,
+    this.tmdbId,
+    this.queries = const <String>[],
+  });
+
+  /// 刮削得到的 AniList 作品 id；非空时可直接按 `anilist_id` 检索 Jimaku，
+  /// 完全跳过文本匹配这一环。
+  final int? anilistId;
+
+  /// 刮削得到的 TMDB id，已按 Jimaku 的 `tv:<id>` / `movie:<id>` 编码。
+  final String? tmdbId;
+
+  /// 候选搜索词，按命中概率降序。第一项用于预填输入框。
+  final List<String> queries;
+
+  /// 预填输入框用的搜索词；一个都没有时为空串。
+  String get primaryQuery => queries.isEmpty ? '' : queries.first;
+
+  /// 除主搜索词以外的备选（主词搜空后依次再试）。
+  List<String> get fallbackQueries =>
+      queries.length <= 1 ? const <String>[] : queries.sublist(1);
+
+  /// 是否带有可直接检索的强身份（无需靠名字猜）。
+  bool get hasStrongIdentity => anilistId != null || tmdbId != null;
+}
+
+/// 组装 [JimakuSearchSeed]。纯函数，不碰数据库，便于单测。
+///
+/// [externalIds] 是 `provider → externalId`（provider 名小写，见
+/// `video_metadata_provider_identities.provider`：AniList 写 `anilist`、TMDB 写 `tmdb`）。
+///
+/// 搜索词优先级——**日文原名排第一**：Jimaku 是日语字幕站，条目名是罗马音/英文/日文，
+/// 上传的字幕文件名也基本是日文或罗马音；而库里的显示名很可能是中文译名，拿它去搜命中率
+/// 最低。依次为：日文原名 → 刮削作品名 → 显示名（文件名解析结果）→ 合集名。
+/// 去空白、去重，保持上述先后。
+JimakuSearchSeed buildJimakuSearchSeed({
+  String? originalTitle,
+  String? metadataTitle,
+  String? displayTitle,
+  String? collectionTitle,
+  Map<String, String> externalIds = const <String, String>{},
+  bool isMovie = false,
+}) {
+  final List<String> queries = <String>[];
+  void add(String? value) {
+    final String trimmed = value?.trim() ?? '';
+    if (trimmed.isEmpty) return;
+    if (queries.contains(trimmed)) return;
+    queries.add(trimmed);
+  }
+
+  add(originalTitle);
+  add(metadataTitle);
+  add(displayTitle);
+  add(collectionTitle);
+
+  final String? rawAnilist = externalIds['anilist']?.trim();
+  final String? rawTmdb = externalIds['tmdb']?.trim();
+  final int? anilistId = rawAnilist == null || rawAnilist.isEmpty
+      ? null
+      : int.tryParse(rawAnilist);
+  final int? tmdbNumeric =
+      rawTmdb == null || rawTmdb.isEmpty ? null : int.tryParse(rawTmdb);
+
+  return JimakuSearchSeed(
+    anilistId: anilistId,
+    tmdbId: tmdbNumeric == null
+        ? null
+        : jimakuTmdbId(movie: isMovie, tmdbId: tmdbNumeric),
+    queries: List<String>.unmodifiable(queries),
+  );
+}

--- a/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
@@ -1,5 +1,7 @@
 import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 
 class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
@@ -19,6 +21,31 @@ class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
   @override
   String get id => 'jimaku';
 
+  /// 把发现层的分类映射成 Jimaku 的检索范围。
+  ///
+  /// Jimaku 站点把动画与真人拆成两个互斥集合（`anime` 是硬相等过滤），所以这里必须给出
+  /// 明确范围而不能"都不说"——不说等于只搜动画。分类未知（无 media 引用，例如播放页对
+  /// 一个本地文件搜字幕）时取 [JimakuSearchScope.all]：宁可多发一次请求，也不要因为默
+  /// 认动画而把日剧字幕整片藏起来。
+  static JimakuSearchScope scopeFor(VideoMediaReference? media) {
+    if (media == null) return JimakuSearchScope.all;
+    return media.discoveryCategory == VideoDiscoveryCategory.anime
+        ? JimakuSearchScope.anime
+        : JimakuSearchScope.liveAction;
+  }
+
+  /// 把发现层的裸 TMDB 数字 id 编码成 Jimaku 的 `tv:<id>` / `movie:<id>`。
+  ///
+  /// TMDB 的电影与剧集是两个独立号段，媒体种类必须一起编码，否则会张冠李戴。
+  static String? tmdbIdFor(VideoMediaReference? media) {
+    final int? tmdbId = media?.tmdbId;
+    if (tmdbId == null) return null;
+    return jimakuTmdbId(
+      movie: media!.mediaKind == VideoMetadataMediaKind.movie,
+      tmdbId: tmdbId,
+    );
+  }
+
   @override
   Future<ProviderBatchResult<VideoSubtitleCandidate>> search(
     VideoSubtitleSearchRequest request,
@@ -31,7 +58,9 @@ class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
     try {
       final List<JimakuEntry> entries = await _client.searchEntries(
         anilistId: request.media?.anilistId,
+        tmdbId: tmdbIdFor(request.media),
         queryFallbacks: fallbacks,
+        scope: scopeFor(request.media),
         throwOnError: true,
       );
       final List<VideoSubtitleCandidate> candidates =

--- a/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
+++ b/fushi/lib/src/media/video/subtitle/open_subtitles_client.dart
@@ -12,6 +12,43 @@ import 'package:fushi/src/utils/net/app_http.dart';
 
 const int kMaximumSubtitleDownloadBytes = 64 * 1024 * 1024;
 
+/// Hibiki 的大类语言码 → OpenSubtitles 认得的 BCP-47 码（BUG-1651）。
+///
+/// Hibiki 内部字幕语言只分到大类（`ja`/`zh`/`en`/`ko`，见 `kJimakuLanguageCodes`——
+/// Jimaku 侧靠文件名启发式识别，本来就分不了地区）。而 OpenSubtitles 的语言表
+/// （`GET /infos/languages`，105 个码）里**没有裸 `zh`**，只有 `zh-cn` / `zh-tw` /
+/// `zh-ca`：把大类码原样发过去，中文字幕恒定搜不到。
+///
+/// 只有带地区码的语言家族需要展开——实测该表里带地区的仅 `az` / `pt` / `tm` / `zh`
+/// 四族，`ja` `en` `ko` `es` `fr` `de` `it` `ru` `th` `vi` `id` `ar` `nl` `tr` 均有裸码，
+/// 原样透传即可。这里只登记 Hibiki 可能产生的那两族，其余交给服务端裁决。
+const Map<String, List<String>> kOpenSubtitlesLanguageExpansions =
+    <String, List<String>>{
+  'zh': <String>['zh-cn', 'zh-tw'],
+  'pt': <String>['pt-br', 'pt-pt'],
+};
+
+/// 把语言偏好归一成 OpenSubtitles 能接受的值域。纯函数，便于单测。
+///
+/// 大类码展开成该族的具体地区码（`zh` → `zh-cn,zh-tw`），其余小写后原样保留；结果去重
+/// 并**排序**——API 对未规范化的 query 会回 301 重定向到规范 URL，排好序能省掉这次多余
+/// 往返（实测 `languages=zh-CN&query=X` 会被 301 到全小写且参数有序的 URL）。
+List<String> normalizeOpenSubtitlesLanguages(Iterable<String> languages) {
+  final Set<String> out = <String>{};
+  for (final String raw in languages) {
+    final String code = raw.trim().toLowerCase();
+    if (code.isEmpty) continue;
+    final List<String>? expansion = kOpenSubtitlesLanguageExpansions[code];
+    if (expansion == null) {
+      out.add(code);
+    } else {
+      out.addAll(expansion);
+    }
+  }
+  final List<String> sorted = out.toList()..sort();
+  return List<String>.unmodifiable(sorted);
+}
+
 class OpenSubtitlesConfig {
   OpenSubtitlesConfig({
     required this.apiKey,
@@ -497,10 +534,12 @@ class OpenSubtitlesClient implements VideoSubtitleProvider {
       RegExp(r'^tt', caseSensitive: false),
       '',
     );
+    // 归一后再发：Hibiki 内部是大类码，OpenSubtitles 要 BCP-47（BUG-1651）。
+    final List<String> languages =
+        normalizeOpenSubtitlesLanguages(request.languages);
     final Map<String, String> common = <String, String>{
       'page': '${request.page}',
-      if (request.languages.isNotEmpty)
-        'languages': request.languages.join(','),
+      if (languages.isNotEmpty) 'languages': languages.join(','),
     };
     final Map<String, String> episode = <String, String>{
       if (request.effectiveSeason != null)

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -130,8 +130,20 @@ List<String> availableFormats(List<JimakuCandidate> candidates) {
 // `jimakuLanguageLabel` 已下沉到 jimaku_client.dart（数据层单一真相源，设置页也要用）。
 // 四处共用（本对话框 / 下载对话框 / 批量对话框 / 设置页），各自直接 import 数据层。
 
-/// 「自动获取字幕（Jimaku）」对话框（参照 asbplayer）：填 API key → 用番名经 AniList
-/// 找 anilist_id → Jimaku 列字幕文件 → 选一个下载到 [saveDirectory] → pop 回本地路径。
+/// 分类筛选 chip 的稳定 key（动画 / 真人 / 全部）。
+///
+/// 分类「全部」与语言「全部」在多数语言里译文同字，靠文本定位会互相撞上；给两组 chip
+/// 各自的稳定 key，测试与无障碍工具才能无歧义指到具体那一个。
+Key jimakuCategoryChipKey(JimakuSearchScope scope) =>
+    ValueKey<String>('jimaku-category-${scope.name}');
+
+/// 语言筛选 chip 的稳定 key；[lang] 为 null 表示「全部」。
+Key jimakuLanguageChipKey(String? lang) =>
+    ValueKey<String>('jimaku-language-${lang ?? 'all'}');
+
+/// 「自动获取字幕（Jimaku）」对话框（参照 asbplayer）：填 API key → 选分类（动画 /
+/// 真人）→ 用番名经 AniList 找 anilist_id（仅动画）→ Jimaku 列字幕文件 → 选一个下载到
+/// [saveDirectory] → pop 回本地路径。
 ///
 /// 网络/解析失败一律降级为「无结果」，不抛。API key 变化经 [onApiKeyChanged] 持久化。
 /// 真实拉取需有效 key + 联网（device/network 验证待用户）。
@@ -222,6 +234,13 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// 解析（纯文本回退）。
   int? _selectedSeriesId;
 
+  /// 检索分类：Jimaku 把动画与真人（站点的 Anime / Live Action 两页）拆成互斥集合，
+  /// 服务端 `anime` 是硬相等过滤且缺省 true——不给出分类就等于只搜动画，日剧永远搜不到。
+  ///
+  /// 缺省保持 [JimakuSearchScope.anime]（= 旧行为）。这不是本地筛选而是服务端检索参数，
+  /// 故切换分类必须重搜，不能像语言/类型 chip 那样只过滤现有候选。
+  JimakuSearchScope _scope = JimakuSearchScope.anime;
+
   @override
   void initState() {
     super.initState();
@@ -288,6 +307,21 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     if (!mounted) return;
     await widget.onApiKeyChanged(apiKey);
 
+    // 真人分类不经 AniList：它的 GraphQL 写死 `type: ANIME`，日剧/电影在那儿永远查
+    // 不到，白等一次网络往返还会把系列 chip 区填上一堆同名动画误导用户。
+    if (_scope != JimakuSearchScope.anime) {
+      try {
+        await _fetchCandidates(
+          anilistId: null,
+          queryFallback: query,
+          episode: episode,
+        );
+      } finally {
+        if (mounted) setState(() => _searching = false);
+      }
+      return;
+    }
+
     AniListClient? anilist;
     try {
       anilist = AniListClient(
@@ -352,7 +386,8 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         entries.addAll(await jimaku.searchByAnilistId(anilistId));
       }
       if (entries.isEmpty) {
-        entries.addAll(await jimaku.searchByQuery(queryFallback));
+        entries
+            .addAll(await jimaku.searchByQuery(queryFallback, scope: _scope));
       }
 
       final List<JimakuCandidate> candidates = <JimakuCandidate>[];
@@ -530,18 +565,62 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     );
   }
 
+  /// 切换检索分类。
+  ///
+  /// 与语言/类型 chip 不同，分类是服务端检索参数而非本地过滤：换了分类，现有候选整批
+  /// 失效，必须重搜。已经搜过（或已输入番名）就顺手重搜，省掉用户再点一次搜索。
+  Future<void> _selectScope(JimakuSearchScope scope) async {
+    if (_scope == scope || _searching) return;
+    setState(() {
+      _scope = scope;
+      // 真人分类下 AniList 系列 chip 无意义（AniList 只有动画），一并清掉避免误导。
+      if (scope != JimakuSearchScope.anime) {
+        _seriesMatches = const <AniListMedia>[];
+        _selectedSeriesId = null;
+      }
+    });
+    if (_apiKeyCtrl.text.trim().isEmpty || _queryCtrl.text.trim().isEmpty) {
+      return;
+    }
+    await _search();
+  }
+
+  /// 分类筛选分区（动画 / 真人 / 全部）：恒显示。
+  ///
+  /// 这是 Jimaku 站点 Anime / Live Action 两页在 app 内的对应物。恒显示而不是「有结果
+  /// 才显示」——搜不到恰恰是用户最需要换分类的时候，把入口藏在结果后面等于没有。
+  Widget _buildCategoryChips() {
+    return _chipSection(t.video_jimaku_category, <Widget>[
+      for (final JimakuSearchScope scope in JimakuSearchScope.values)
+        ChoiceChip(
+          // 分类「全部」与语言「全部」译文同字，纯文本定位会两边撞；key 让测试与
+          // 无障碍工具都能无歧义指到具体那一个。
+          key: jimakuCategoryChipKey(scope),
+          label: Text(switch (scope) {
+            JimakuSearchScope.anime => t.video_jimaku_category_anime,
+            JimakuSearchScope.liveAction => t.video_jimaku_category_live_action,
+            JimakuSearchScope.all => t.video_jimaku_category_all,
+          }),
+          selected: _scope == scope,
+          onSelected: (_) => _selectScope(scope),
+        ),
+    ]);
+  }
+
   /// 语言筛选分区（含「全部」）：仅在搜出结果里出现 ≥1 个可识别语言时显示。
   Widget _buildLanguageChips() {
     final List<String> langs = availableLanguages(_candidates);
     if (langs.isEmpty) return const SizedBox.shrink();
     return _chipSection(t.video_jimaku_language, <Widget>[
       ChoiceChip(
+        key: jimakuLanguageChipKey(null),
         label: Text(t.video_jimaku_language_all),
         selected: _selectedLanguage == null,
         onSelected: (_) => _selectLanguage(null),
       ),
       for (final String lang in langs)
         ChoiceChip(
+          key: jimakuLanguageChipKey(lang),
           label: Text(jimakuLanguageLabel(lang)),
           selected: _selectedLanguage == lang,
           onSelected: (_) => _selectLanguage(lang),
@@ -588,6 +667,9 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         children: <Widget>[
           _buildApiKeySection(),
           const SizedBox(height: 8),
+          // 分类在番名之前：它决定这次检索去哪半个库找，属于「搜什么」而不是
+          // 「搜到之后怎么筛」，所以不与语言/类型筛选放在一起。
+          _buildCategoryChips(),
           TextField(
             controller: _queryCtrl,
             decoration: InputDecoration(labelText: t.video_jimaku_query),

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/media/video/anilist_client.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/jimaku_search_seed.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
 import 'package:fushi/utils.dart';
@@ -156,6 +157,7 @@ class JimakuSubtitleDialog extends StatefulWidget {
     this.initialPreferredLanguage,
     this.onPreferredLanguageChanged,
     this.httpClientFactory,
+    this.seed = const JimakuSearchSeed(),
     this.debugInitialCandidates,
     this.debugInitialSeriesMatches,
     super.key,
@@ -163,6 +165,13 @@ class JimakuSubtitleDialog extends StatefulWidget {
 
   /// 预填的搜索词（由视频文件名解析出的番名）。
   final String initialQuery;
+
+  /// 该视频**已知的身份**（刮削得到的 AniList / TMDB id 与备选搜索词）。
+  ///
+  /// 有强身份（[JimakuSearchSeed.hasStrongIdentity]）且用户没改过输入框时，直接按 id
+  /// 检索 Jimaku，跳过「显示名 → AniList 模糊匹配 → anilist_id」这条链——中文译名在那条
+  /// 链上匹配不到，而 id 是确定的。缺省是空种子（= 旧行为，纯文本搜）。
+  final JimakuSearchSeed seed;
 
   /// 预填的 Jimaku API key。
   final String initialApiKey;
@@ -234,6 +243,17 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// 解析（纯文本回退）。
   int? _selectedSeriesId;
 
+  /// 产生当前 [_seriesMatches] 的番名。用于判断「这次搜索是不是还在搜同一部番」——
+  /// 只有换了番名才该丢弃已解析出的系列列表。
+  String? _seriesQuery;
+
+  /// 对话框内的错误信息（搜索/下载失败）；null = 无错。
+  ///
+  /// **必须显示在对话框内部**：本对话框是全屏 modal，而 `ScaffoldMessenger` 的 SnackBar
+  /// 挂在底下那层页面的 Scaffold 上，正好被对话框整个盖住——用户只会看到「点了没反应」，
+  /// 失败原因一次也没露过面。
+  String? _error;
+
   /// 检索分类：Jimaku 把动画与真人（站点的 Anime / Live Action 两页）拆成互斥集合，
   /// 服务端 `anime` 是硬相等过滤且缺省 true——不给出分类就等于只搜动画，日剧永远搜不到。
   ///
@@ -256,6 +276,9 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     if (seedSeries != null && seedSeries.isNotEmpty) {
       _seriesMatches = List<AniListMedia>.unmodifiable(seedSeries);
       _selectedSeriesId = seedSeries.first.id;
+      // 记下这批系列对应哪个番名：否则下一次搜索会把它判成「换了番」而清空，
+      // 与真实搜索路径（_search 里同时写 _seriesMatches 和 _seriesQuery）不一致。
+      _seriesQuery = widget.initialQuery;
     }
   }
 
@@ -284,7 +307,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     final String apiKey = _apiKeyCtrl.text.trim();
     final String query = _queryCtrl.text.trim();
     if (apiKey.isEmpty) {
-      _snack(t.video_jimaku_no_key);
+      _showError(t.video_jimaku_no_key);
       return;
     }
     if (query.isEmpty) return;
@@ -292,12 +315,22 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     final int? episode = int.tryParse(_episodeCtrl.text.trim());
 
     FocusManager.instance.primaryFocus?.unfocus();
+    // 番名没变（典型场景：只在集数框填了个数字再点搜索）就保留已解析出的系列列表与
+    // 当前选中项。旧实现在这里无条件清空，而系列列表要等一次网络往返才回填——AniList
+    // 限流（429，客户端 fail-open 静默返回空）或任何抖动都会让用户**永久失去**系列
+    // 选择面：既搜不到又换不了系列，只能关掉重开。清空必须跟着「换了番名」走。
+    final bool sameSeriesQuery = query == _seriesQuery;
+    final int? keepSelectedSeriesId =
+        sameSeriesQuery ? _selectedSeriesId : null;
     setState(() {
       _searching = true;
       _searched = false;
+      _error = null;
       _candidates = const <JimakuCandidate>[];
-      _seriesMatches = const <AniListMedia>[];
-      _selectedSeriesId = null;
+      if (!sameSeriesQuery) {
+        _seriesMatches = const <AniListMedia>[];
+        _selectedSeriesId = null;
+      }
     });
     // BUG-1509：先让「按钮禁用 + 结果区 loading」完整绘制一帧，再做偏好写入、
     // 代理 client 初始化和联网。旧顺序先 await onApiKeyChanged，慢磁盘/数据库下点击后
@@ -322,6 +355,33 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       return;
     }
 
+    // 用户已经选定系列、番名又没变（只改了集数）：直接在该系列里重列文件。重跑一遍
+    // AniList 既白等一次往返、又平白多一次限流机会，还可能把系列面清空。
+    //
+    // 用户没手动改过番名时，刮削得到的 AniList id 同样是「已经选定的系列」——它比拿显示
+    // 名去 AniList 模糊匹配可靠得多（中文译名在那儿根本匹配不到）。
+    final int? directSeriesId = keepSelectedSeriesId ??
+        (query == widget.initialQuery ? widget.seed.anilistId : null);
+    if (directSeriesId != null) {
+      // _fetchCandidates 自己吃掉异常并落 _error，这里不需要 try/finally。
+      await _fetchCandidates(
+        anilistId: directSeriesId,
+        queryFallback: query,
+        episode: episode,
+      );
+      if (!mounted) return;
+      // 用户手选的系列即便零结果也到此为止——他明确指定了这一个，不该被偷偷换成文本搜。
+      // 而刮削推断出的 id 只是「最可能」，零结果时继续往下走文本回退，别让强身份反倒
+      // 把回退路堵死。
+      final bool settled = keepSelectedSeriesId != null ||
+          _candidates.isNotEmpty ||
+          _error != null;
+      if (settled) {
+        setState(() => _searching = false);
+        return;
+      }
+    }
+
     AniListClient? anilist;
     try {
       anilist = AniListClient(
@@ -331,7 +391,14 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       //   候选供用户消歧，默认取首条（相关度最高）。② AniList 无命中时回退文本直接搜。
       final List<AniListMedia> media = await anilist.searchAnime(query);
       if (!mounted) return;
-      setState(() => _seriesMatches = media);
+      setState(() {
+        // 只在真拿到东西时替换：AniList 空结果既可能是「查无此番」，也可能是限流/网络
+        // 抖动，后者绝不该把用户已有的系列列表擦掉。
+        if (media.isNotEmpty) {
+          _seriesMatches = media;
+          _seriesQuery = query;
+        }
+      });
       await _fetchCandidates(
         anilistId: media.isNotEmpty ? media.first.id : null,
         queryFallback: query,
@@ -381,14 +448,25 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         apiKey: _apiKeyCtrl.text.trim(),
         client: await _createHttpClient(),
       );
-      final List<JimakuEntry> entries = <JimakuEntry>[];
-      if (anilistId != null) {
-        entries.addAll(await jimaku.searchByAnilistId(anilistId));
-      }
-      if (entries.isEmpty) {
-        entries
-            .addAll(await jimaku.searchByQuery(queryFallback, scope: _scope));
-      }
+      // 检索键按可靠度递降交给客户端统一收敛：anilist_id（动画强身份）→ tmdb_id
+      // （真人强身份）→ 文本。备选文本词来自刮削（日文原名等），只在用户没手动改过输入
+      // 框时才用——他改了就说明要按自己的词搜。
+      //
+      // throwOnError：条目检索失败必须与「真的没有这部番」区分开。两者都吞成空列表时
+      // 用户只看到「没有找到字幕」，于是继续换关键词瞎试，而真实原因可能是 key 过期或
+      // 被限流——换多少次关键词都不会好。listFiles 保持 fail-open：某个条目列不出文件
+      // 不该让其它条目的结果一起消失。
+      final List<JimakuEntry> entries = await jimaku.searchEntries(
+        anilistId: anilistId,
+        tmdbId: widget.seed.tmdbId,
+        queryFallbacks: <String>[
+          queryFallback,
+          if (_queryCtrl.text.trim() == widget.initialQuery)
+            ...widget.seed.fallbackQueries,
+        ],
+        scope: _scope,
+        throwOnError: true,
+      );
 
       final List<JimakuCandidate> candidates = <JimakuCandidate>[];
       for (final JimakuEntry entry in entries) {
@@ -416,6 +494,13 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         // （用户：「apikey 配完是不是可以缩小显示」）。用户仍可点「修改」展开。
         _apiKeyCollapsed = sorted.isNotEmpty;
       });
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _searched = true;
+        _searchedWithEpisode = episode != null;
+        _error = describeJimakuFailure(t.video_jimaku_search_failed, error);
+      });
     } finally {
       jimaku?.close();
     }
@@ -431,16 +516,25 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   Future<void> _download(JimakuCandidate candidate) async {
     final String apiKey = _apiKeyCtrl.text.trim();
     if (apiKey.isEmpty) return;
-    setState(() => _busyName = candidate.file.name);
+    setState(() {
+      _busyName = candidate.file.name;
+      _error = null;
+    });
     JimakuClient? jimaku;
     try {
       jimaku = JimakuClient(
         apiKey: apiKey,
         client: await _createHttpClient(),
       );
-      final Uint8List? bytes = await jimaku.downloadFile(candidate.file.url);
-      if (bytes == null) {
-        _snack(t.video_jimaku_download_failed);
+      // throwOnError：下载失败必须能说出**为什么**。旧路径吞成 null 后只弹一句
+      // 「下载失败」，key 过期（401）、被限流（429）、文件下架（404）在用户眼里长
+      // 得一模一样，无从下手。
+      final Uint8List? bytes = await jimaku.downloadFile(
+        candidate.file.url,
+        throwOnError: true,
+      );
+      if (bytes == null || bytes.isEmpty) {
+        _showError(t.video_jimaku_download_failed);
         return;
       }
       final Directory dir = Directory(widget.saveDirectory);
@@ -449,16 +543,21 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       await File(dest).writeAsBytes(bytes);
       if (!mounted) return;
       Navigator.pop(context, dest);
+    } on Object catch (error) {
+      _showError(describeJimakuFailure(t.video_jimaku_download_failed, error));
     } finally {
       jimaku?.close();
       if (mounted) setState(() => _busyName = null);
     }
   }
 
-  void _snack(String message) {
+  /// 把失败原因显示在**对话框内部**。
+  ///
+  /// 曾经走 [ScaffoldMessenger]：本对话框是全屏 modal，SnackBar 挂在它底下那层页面的
+  /// Scaffold 上，被整个盖住——用户看到的就是「点了没反应」，失败原因一次都没露过面。
+  void _showError(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    setState(() => _error = message);
   }
 
   /// API key 输入区：未折叠时为完整密码框（含获取链接提示）；折叠时为一行紧凑
@@ -719,7 +818,50 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// 结果区（宽屏右栏 / 窄屏下段）：搜索中 spinner → 无结果提示（含「显示全部集」
   /// 逃生口）→ 候选列表。列表由外层给定有界高度、内部普通（非 shrinkWrap）ListView
   /// 滚动，保留 BUG-279 不变量。
+  /// 结果区外壳：错误条恒置顶，正文在下。
+  ///
+  /// 错误必须与结果同屏而不是弹在别处——本对话框是全屏 modal，SnackBar 会被它盖住。
   Widget _buildResultsArea(ThemeData theme) {
+    final String? error = _error;
+    if (error == null) return _buildResultsBody(theme);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Material(
+            key: const ValueKey<String>('jimaku-error-banner'),
+            color: theme.colorScheme.errorContainer,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              child: Row(
+                children: <Widget>[
+                  Icon(
+                    Icons.error_outline,
+                    size: 18,
+                    color: theme.colorScheme.onErrorContainer,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      error,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Expanded(child: _buildResultsBody(theme)),
+      ],
+    );
+  }
+
+  Widget _buildResultsBody(ThemeData theme) {
     if (_searching) {
       return buildLoading();
     }

--- a/fushi/lib/src/pages/implementations/online_subtitle_search_dialog.dart
+++ b/fushi/lib/src/pages/implementations/online_subtitle_search_dialog.dart
@@ -1,0 +1,304 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/fushi_page_placeholders.dart';
+import 'package:fushi/utils.dart';
+
+/// 在线字幕搜索对话框（provider 无关）：走 [VideoSubtitleRegistry] 一次问遍所有已配置
+/// 的在线字幕源，选一条下载到 [saveDirectory]，pop 回本地绝对路径。
+///
+/// 与 `JimakuSubtitleDialog` 的分工：那个是 Jimaku 专用的精细控制台（条目消歧、集号、
+/// 语言/格式筛选）；这个是「一把搜全部源」的通道，OpenSubtitles 之类只有标题/哈希两种
+/// 检索键的源走这里。**两者 pop 契约相同**（都返回下载好的本地路径），所以播放页的落地
+/// 与挂轨逻辑一份即可，不需要为新源再写一遍。
+///
+/// [videoPath] 指向本地视频文件时会算 OSDb movie hash 一并发出去——这是 OpenSubtitles
+/// 最强的检索键（按文件本身而不是标题匹配，能直接命中该压制版本的字幕）。
+class OnlineSubtitleSearchDialog extends StatefulWidget {
+  const OnlineSubtitleSearchDialog({
+    required this.registry,
+    required this.initialQuery,
+    required this.saveDirectory,
+    this.videoPath,
+    this.season,
+    this.episode,
+    this.preferredLanguages = const <String>[],
+    this.debugInitialResult,
+    super.key,
+  });
+
+  final VideoSubtitleRegistry registry;
+
+  /// 预填的标题（播放页由文件名/远端标题解析而来）。
+  final String initialQuery;
+
+  /// 下载落盘目录（绝对路径，函数内确保存在）。
+  final String saveDirectory;
+
+  /// 本地视频文件绝对路径；非空且存在时用于计算文件指纹做精确匹配。远端流为 null。
+  final String? videoPath;
+
+  final int? season;
+  final int? episode;
+
+  /// 语言偏好（空 = 不限），直接透传给各 provider。
+  final List<String> preferredLanguages;
+
+  /// 仅测试用：预置搜索结果，免联网即可验证列表渲染与下载路径。
+  @visibleForTesting
+  final ProviderBatchResult<VideoSubtitleCandidate>? debugInitialResult;
+
+  @override
+  State<OnlineSubtitleSearchDialog> createState() =>
+      _OnlineSubtitleSearchDialogState();
+}
+
+class _OnlineSubtitleSearchDialogState extends State<OnlineSubtitleSearchDialog>
+    with FushiPagePlaceholders<OnlineSubtitleSearchDialog> {
+  late final TextEditingController _queryCtrl =
+      TextEditingController(text: widget.initialQuery);
+
+  bool _searching = false;
+  bool _searched = false;
+  String? _busyId;
+  ProviderBatchResult<VideoSubtitleCandidate>? _result;
+
+  /// 本次搜索是否真的带上了文件指纹（用于给结果区标「按文件哈希精确匹配」）。
+  bool _usedFingerprint = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final ProviderBatchResult<VideoSubtitleCandidate>? seed =
+        widget.debugInitialResult;
+    if (seed != null) {
+      _result = seed;
+      _searched = true;
+      return;
+    }
+    if (widget.initialQuery.trim().isNotEmpty) {
+      // 进来即搜：调用方已经把标题解析好了，再让用户点一次「搜索」纯属多余。
+      WidgetsBinding.instance.addPostFrameCallback((_) => _search());
+    }
+  }
+
+  @override
+  void dispose() {
+    _queryCtrl.dispose();
+    super.dispose();
+  }
+
+  /// 计算本地视频的指纹（OSDb movie hash + 体积 + 文件名）；无本地文件或读失败 → null。
+  ///
+  /// 失败一律降级为「没有指纹」而不是报错：指纹只是让匹配更准的加分项，拿不到就退回按
+  /// 标题搜，绝不因此让整次搜索失败。
+  Future<LocalVideoFingerprint?> _fingerprint() async {
+    final String? path = widget.videoPath;
+    if (path == null || path.trim().isEmpty) return null;
+    try {
+      final File file = File(path);
+      if (!await file.exists()) return null;
+      return LocalVideoFingerprint(
+        fileSize: await file.length(),
+        openSubtitlesMovieHash: await computeOpenSubtitlesMovieHash(path),
+        fileName: p.basename(path),
+      );
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<void> _search() async {
+    final String query = _queryCtrl.text.trim();
+    if (_searching) return;
+    FocusManager.instance.primaryFocus?.unfocus();
+    setState(() {
+      _searching = true;
+      _searched = false;
+      _result = null;
+    });
+    // 先让 loading 完整绘制一帧再做磁盘哈希与联网（与 Jimaku 对话框同一条
+    // paint-before-work 约束：慢磁盘下点完没有任何反馈会看起来像卡死）。
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    try {
+      final LocalVideoFingerprint? fingerprint = await _fingerprint();
+      if (!mounted) return;
+      final ProviderBatchResult<VideoSubtitleCandidate> result =
+          await widget.registry.search(
+        VideoSubtitleSearchRequest(
+          query: query,
+          languages: widget.preferredLanguages,
+          season: widget.season,
+          episode: widget.episode,
+          fingerprint: fingerprint,
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _result = result;
+        _searched = true;
+        _usedFingerprint = fingerprint?.openSubtitlesMovieHash != null;
+      });
+    } finally {
+      if (mounted) setState(() => _searching = false);
+    }
+  }
+
+  Future<void> _download(VideoSubtitleCandidate candidate) async {
+    if (_busyId != null) return;
+    setState(() => _busyId = candidate.identityKey);
+    try {
+      final VideoSubtitleDownload download =
+          await widget.registry.download(candidate);
+      final Directory dir = Directory(widget.saveDirectory);
+      if (!dir.existsSync()) dir.createSync(recursive: true);
+      // 只取 basename：provider 给的文件名来自远端，不能让它带路径分隔符逃出目录。
+      final String leaf = p.basename(download.fileName.trim());
+      final String dest =
+          p.join(dir.path, leaf.isEmpty ? 'subtitle.srt' : leaf);
+      await File(dest).writeAsBytes(download.bytes);
+      if (!mounted) return;
+      Navigator.pop(context, dest);
+    } on ExternalProviderFailure catch (failure) {
+      if (mounted) _snack(failure.message);
+    } on Object {
+      if (mounted) _snack(t.video_jimaku_download_failed);
+    } finally {
+      if (mounted) setState(() => _busyId = null);
+    }
+  }
+
+  void _snack(String message) {
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  /// 一条候选的副标题：来源 · 语言 · 季集 · 下载量。缺的字段直接不显示，不占位。
+  String _subtitleFor(VideoSubtitleCandidate candidate) {
+    final List<String> parts = <String>[
+      candidate.providerId,
+      if (candidate.language.trim().isNotEmpty) candidate.language,
+      if (candidate.season != null && candidate.episode != null)
+        'S${candidate.season}E${candidate.episode}'
+      else if (candidate.episode != null)
+        'E${candidate.episode}',
+      if (candidate.downloadCount > 0) '↓${candidate.downloadCount}',
+      if (candidate.hearingImpaired) 'HI',
+    ];
+    return parts.join(' · ');
+  }
+
+  Widget _buildResults(ThemeData theme) {
+    if (_searching) return buildLoading();
+    final ProviderBatchResult<VideoSubtitleCandidate>? result = _result;
+    if (result == null) {
+      return Center(
+        child: Icon(
+          Icons.subtitles_outlined,
+          size: 48,
+          color: theme.colorScheme.outlineVariant,
+        ),
+      );
+    }
+    if (result.items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              _searched
+                  ? t.video_jimaku_no_results
+                  : t.video_subtitle_online_no_source,
+              textAlign: TextAlign.center,
+            ),
+            // provider 级失败单独列出来：「一个源挂了」和「真的没有字幕」对用户是
+            // 两件事，混成一句「没找到」会让人白等下去。
+            for (final ExternalProviderFailure failure in result.failures)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  '${failure.providerId}: ${failure.message}',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.error),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+    return ListView.builder(
+      itemCount: result.items.length,
+      itemBuilder: (BuildContext context, int index) {
+        final VideoSubtitleCandidate candidate = result.items[index];
+        final bool busy = _busyId == candidate.identityKey;
+        return ListTile(
+          leading: const Icon(Icons.subtitles_outlined),
+          title: Text(candidate.fileName, maxLines: 2),
+          subtitle: Text(_subtitleFor(candidate)),
+          trailing: busy
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.download_outlined),
+          enabled: _busyId == null,
+          onTap: _busyId == null ? () => _download(candidate) : null,
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(t.video_subtitle_online_fetch),
+      content: SizedBox(
+        width: 560,
+        height: 460,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            TextField(
+              controller: _queryCtrl,
+              decoration: InputDecoration(
+                labelText: t.video_subtitle_online_title,
+                isDense: true,
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: _searching ? null : _search,
+                ),
+              ),
+              onSubmitted: (_) => _search(),
+            ),
+            if (_usedFingerprint)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  t.video_subtitle_online_hash_matched,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.primary),
+                ),
+              ),
+            const SizedBox(height: 8),
+            Expanded(child: _buildResults(theme)),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(t.dialog_cancel),
+        ),
+      ],
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/online_subtitle_search_dialog.dart
+++ b/fushi/lib/src/pages/implementations/online_subtitle_search_dialog.dart
@@ -238,9 +238,12 @@ class _OnlineSubtitleSearchDialogState extends State<OnlineSubtitleSearchDialog>
       itemBuilder: (BuildContext context, int index) {
         final VideoSubtitleCandidate candidate = result.items[index];
         final bool busy = _busyId == candidate.identityKey;
-        return ListTile(
+        // 走共享 MD3 行组件而不是裸 ListTile：普通页面的视觉外壳统一由共享组件决定
+        // （md3_design_system_static_test 的「ordinary page chrome」守卫）。
+        return FushiListItem(
           leading: const Icon(Icons.subtitles_outlined),
-          title: Text(candidate.fileName, maxLines: 2),
+          title: Text(candidate.fileName),
+          titleMaxLines: 2,
           subtitle: Text(_subtitleFor(candidate)),
           trailing: busy
               ? const SizedBox(
@@ -249,7 +252,6 @@ class _OnlineSubtitleSearchDialogState extends State<OnlineSubtitleSearchDialog>
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.download_outlined),
-          enabled: _busyId == null,
           onTap: _busyId == null ? () => _download(candidate) : null,
         );
       },

--- a/fushi/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/torrent_settings_section.dart
@@ -669,7 +669,15 @@ class _TorrentSettingsSectionState
             ),
           ],
         ],
-        const VideoExternalProviderSettingsSection(),
+        // OpenSubtitles 那一组不在这儿：它是字幕来源，归「设置 → 视频 → 字幕」，与
+        // Jimaku 的 API key 并列。留在下载设置里的是种子索引器与下载落地相关的三组。
+        const VideoExternalProviderSettingsSection(
+          groups: <VideoExternalSettingsGroup>{
+            VideoExternalSettingsGroup.torznab,
+            VideoExternalSettingsGroup.pathMappings,
+            VideoExternalSettingsGroup.targetSource,
+          },
+        ),
       ],
     );
     if (!widget.constrainWidth) {

--- a/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/video_external_provider_settings_section.dart
@@ -142,16 +142,51 @@ class AppVideoExternalSettingsStore implements VideoExternalSettingsStore {
       appModel.setJimakuDefaultLanguage(language);
 }
 
+/// 本组件里彼此独立的四组设置。
+///
+/// 它们原本焊死在一个 Column 里、整块挂在「设置 → 下载」下。但 OpenSubtitles 是**字幕
+/// 来源**而不是下载器配置：把它和种子索引器摆在一起，用户在「视频 → 字幕」里只看得到
+/// Jimaku 的 API key，自然会以为 app 根本没接 OpenSubtitles。分组让同一份表单能按归属
+/// 拆到该去的地方，配置本身仍是同一份（同一个偏好键、同一套校验与防抖保存）。
+enum VideoExternalSettingsGroup {
+  /// Torznab 种子索引器。
+  torznab,
+
+  /// OpenSubtitles 在线字幕源。
+  openSubtitles,
+
+  /// 下载后端路径映射。
+  pathMappings,
+
+  /// 下载落地的目标媒体库。
+  targetSource,
+}
+
 /// 发现/下载闭环所依赖的设备本地外部配置。
 ///
 /// 密钥字段始终遮罩；端点只有通过 provider 自身的 HTTPS/loopback 安全校验后才写入
 /// Preferences。表单错误只显示稳定的本地化提示，不把含密钥的 URL 或异常正文写进
 /// snack、日志或诊断导出。
+///
+/// 渲染哪几组由 [groups] 决定：同一份配置按归属拆到「设置 → 下载」与「设置 → 视频 →
+/// 字幕」两处，见 [VideoExternalSettingsGroup]。
 class VideoExternalProviderSettingsSection extends ConsumerStatefulWidget {
-  const VideoExternalProviderSettingsSection({super.key, this.store});
+  const VideoExternalProviderSettingsSection({
+    super.key,
+    this.store,
+    this.groups = const <VideoExternalSettingsGroup>{
+      VideoExternalSettingsGroup.torznab,
+      VideoExternalSettingsGroup.openSubtitles,
+      VideoExternalSettingsGroup.pathMappings,
+      VideoExternalSettingsGroup.targetSource,
+    },
+  });
 
   /// 测试注入口；生产路径从 [AppModel] 构造设备本地 store。
   final VideoExternalSettingsStore? store;
+
+  /// 要渲染哪几组设置。缺省全渲染（= 旧行为）。
+  final Set<VideoExternalSettingsGroup> groups;
 
   @override
   ConsumerState<VideoExternalProviderSettingsSection> createState() =>
@@ -713,105 +748,117 @@ class _VideoExternalProviderSettingsSectionState
               ),
             ),
           ),
-        _sectionHeading(
-          theme,
-          t.video_torznab_settings_title,
-          t.video_torznab_settings_hint,
-          icon: Icons.travel_explore_outlined,
-        ),
-        for (int index = 0; index < _torznab.length; index++)
-          _torznabCard(theme, index),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: OutlinedButton.icon(
-            key: const ValueKey<String>('video-torznab-add'),
-            onPressed: () => setState(
-              () => _torznab.add(_TorznabDraft.empty(_newDraftId('torznab'))),
-            ),
-            icon: const Icon(Icons.add),
-            label: Text(t.video_torznab_add),
+        if (widget.groups
+            .contains(VideoExternalSettingsGroup.torznab)) ...<Widget>[
+          _sectionHeading(
+            theme,
+            t.video_torznab_settings_title,
+            t.video_torznab_settings_hint,
+            icon: Icons.travel_explore_outlined,
           ),
-        ),
-        const Divider(height: 32),
-        _sectionHeading(
-          theme,
-          t.video_opensubtitles_settings_title,
-          t.video_opensubtitles_settings_hint,
-          icon: Icons.subtitles_outlined,
-        ),
-        _openSubtitlesFields(),
-        const Divider(height: 32),
-        _sectionHeading(
-          theme,
-          t.video_download_path_mappings_title,
-          t.video_download_path_mappings_hint,
-          icon: Icons.route_outlined,
-        ),
-        for (int index = 0; index < _mappings.length; index++)
-          _mappingCard(index),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: OutlinedButton.icon(
-            key: const ValueKey<String>('video-path-mapping-add'),
-            onPressed: () => setState(
-              () => _mappings.add(_PathMappingDraft.empty(
-                _newDraftId('mapping'),
-                suggestedBackendProfileId: _suggestedBackendProfileId,
-              )),
-            ),
-            icon: const Icon(Icons.add),
-            label: Text(t.video_download_path_mapping_add),
-          ),
-        ),
-        const Divider(height: 32),
-        _sectionHeading(
-          theme,
-          t.video_download_target_source_title,
-          t.video_download_target_source_hint,
-          icon: Icons.video_library_outlined,
-        ),
-        if (_sources.isEmpty)
-          Text(
-            t.video_download_target_source_empty,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          )
-        else
-          DropdownButtonFormField<int>(
-            key: ValueKey<String>(
-              'video-target-source-${_targetSourceId ?? 'none'}',
-            ),
-            initialValue: _targetSourceId ?? 0,
-            decoration: InputDecoration(
-              labelText: t.video_download_target_source_none,
-              isDense: true,
-              border: const OutlineInputBorder(),
-            ),
-            isExpanded: true,
-            items: <DropdownMenuItem<int>>[
-              DropdownMenuItem<int>(
-                value: 0,
-                child: Text(t.video_download_target_source_none),
+          for (int index = 0; index < _torznab.length; index++)
+            _torznabCard(theme, index),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              key: const ValueKey<String>('video-torznab-add'),
+              onPressed: () => setState(
+                () => _torznab.add(_TorznabDraft.empty(_newDraftId('torznab'))),
               ),
-              for (final ManagedVideoSourceOption source in _sources)
-                DropdownMenuItem<int>(
-                  value: source.id,
-                  child: Text(
-                    '${source.label} — ${source.rootPath}',
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-            ],
-            onChanged: (int? sourceId) {
-              final int? selected = sourceId == 0 ? null : sourceId;
-              setState(() => _targetSourceId = selected);
-              _save(
-                (VideoExternalSettingsStore store) =>
-                    store.saveTargetSourceId(selected),
-              );
-            },
+              icon: const Icon(Icons.add),
+              label: Text(t.video_torznab_add),
+            ),
           ),
+          const Divider(height: 32),
+        ],
+        if (widget.groups
+            .contains(VideoExternalSettingsGroup.openSubtitles)) ...<Widget>[
+          _sectionHeading(
+            theme,
+            t.video_opensubtitles_settings_title,
+            t.video_opensubtitles_settings_hint,
+            icon: Icons.subtitles_outlined,
+          ),
+          _openSubtitlesFields(),
+          const Divider(height: 32),
+        ],
+        if (widget.groups
+            .contains(VideoExternalSettingsGroup.pathMappings)) ...<Widget>[
+          _sectionHeading(
+            theme,
+            t.video_download_path_mappings_title,
+            t.video_download_path_mappings_hint,
+            icon: Icons.route_outlined,
+          ),
+          for (int index = 0; index < _mappings.length; index++)
+            _mappingCard(index),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              key: const ValueKey<String>('video-path-mapping-add'),
+              onPressed: () => setState(
+                () => _mappings.add(_PathMappingDraft.empty(
+                  _newDraftId('mapping'),
+                  suggestedBackendProfileId: _suggestedBackendProfileId,
+                )),
+              ),
+              icon: const Icon(Icons.add),
+              label: Text(t.video_download_path_mapping_add),
+            ),
+          ),
+          const Divider(height: 32),
+        ],
+        if (widget.groups
+            .contains(VideoExternalSettingsGroup.targetSource)) ...<Widget>[
+          _sectionHeading(
+            theme,
+            t.video_download_target_source_title,
+            t.video_download_target_source_hint,
+            icon: Icons.video_library_outlined,
+          ),
+          if (_sources.isEmpty)
+            Text(
+              t.video_download_target_source_empty,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            DropdownButtonFormField<int>(
+              key: ValueKey<String>(
+                'video-target-source-${_targetSourceId ?? 'none'}',
+              ),
+              initialValue: _targetSourceId ?? 0,
+              decoration: InputDecoration(
+                labelText: t.video_download_target_source_none,
+                isDense: true,
+                border: const OutlineInputBorder(),
+              ),
+              isExpanded: true,
+              items: <DropdownMenuItem<int>>[
+                DropdownMenuItem<int>(
+                  value: 0,
+                  child: Text(t.video_download_target_source_none),
+                ),
+                for (final ManagedVideoSourceOption source in _sources)
+                  DropdownMenuItem<int>(
+                    value: source.id,
+                    child: Text(
+                      '${source.label} — ${source.rootPath}',
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+              onChanged: (int? sourceId) {
+                final int? selected = sourceId == 0 ? null : sourceId;
+                setState(() => _targetSourceId = selected);
+                _save(
+                  (VideoExternalSettingsStore store) =>
+                      store.saveTargetSourceId(selected),
+                );
+              },
+            ),
+        ],
         const SizedBox(height: 8),
       ],
     );

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -142,6 +142,17 @@ extension _VideoSubtitle on _VideoFushiPageState {
               ? null
               : () => unawaited(_openJimakuDialog(controller)),
         ),
+      // 在线源（OpenSubtitles 等）此前只在发现页/下载流水线可达，播放页完全看不到；
+      // 这里补上入口，走 registry 一次搜全部已配置源。仅在真有配置好的源时显示。
+      if (appModel.videoSubtitleRegistry?.providers.isNotEmpty ?? false)
+        ListTile(
+          leading: const Icon(Icons.travel_explore_outlined),
+          title: Text(t.video_subtitle_online_fetch),
+          enabled: !_subtitleLoadingShown,
+          onTap: _subtitleLoadingShown
+              ? null
+              : () => unawaited(_openOnlineSubtitleDialog(controller)),
+        ),
       ListTile(
         leading: const Icon(Icons.file_open_outlined),
         title: Text(t.video_subtitle_import_file),
@@ -726,6 +737,21 @@ extension _VideoSubtitle on _VideoFushiPageState {
     );
     // Jimaku 对话框内含联网搜索/下载，会夺焦；关闭后把焦点还给 Video。
     _focusOwnership.reclaim(FocusReclaimCause.overlayClosed);
+    await _applyDownloadedSubtitle(controller, downloaded);
+  }
+
+  /// 把在线对话框下载好的字幕文件应用到当前视频。
+  ///
+  /// 所有在线字幕来源共用这一条落地路径——对话框的契约就是「pop 回一个本地绝对路径」，
+  /// 至于它是 Jimaku 还是 OpenSubtitles 下来的，这里不需要也不应该知道。
+  ///
+  /// - 本地视频：构造外挂 [SubtitleSource] 经 [_selectSubtitleSource] 持久化链路应用。
+  /// - 远端视频（[_isRemote]）：没有本地 DB 行，按远端契约只在内存里应用，经
+  ///   [_applyRemoteSubtitle]（与远端「本地导入字幕」同一不落 DB 的链路）。
+  Future<void> _applyDownloadedSubtitle(
+    VideoPlayerController controller,
+    String? downloaded,
+  ) async {
     if (downloaded == null || !context.mounted) return;
     if (_isRemote) {
       // 远端：内存应用，不写本地 DB（_applyRemoteSubtitle 自带 cue 为空时的失败提示
@@ -747,6 +773,44 @@ extension _VideoSubtitle on _VideoFushiPageState {
     if (applied && mounted) {
       _showOsd(t.video_jimaku_downloaded, severity: ToastSeverity.success);
     }
+  }
+
+  /// 打开「在线获取字幕」对话框：走 [AppModel.videoSubtitleRegistry] 一次问遍所有已
+  /// 配置的在线字幕源（OpenSubtitles 等），下载后与 Jimaku 同一条落地路径应用。
+  ///
+  /// 与 Jimaku 专用入口并存而不是取代它：Jimaku 那个是条目/集号/语言的精细控制台，这个
+  /// 是「一把搜全部源」的通道。本地视频会一并带上 OSDb 文件哈希（OpenSubtitles 据此
+  /// 直接命中该压制版本的字幕，比按标题搜准得多）。
+  Future<void> _openOnlineSubtitleDialog(
+    VideoPlayerController controller,
+  ) async {
+    final VideoSubtitleRegistry? registry = appModel.videoSubtitleRegistry;
+    if (registry == null || registry.providers.isEmpty) {
+      _showOsd(t.video_subtitle_online_no_source);
+      return;
+    }
+    final String query = _jimakuQuery() ?? '';
+    final String saveDir = (await AppPaths.videoSubtitlesDirectory()).path;
+    if (!context.mounted) return;
+    final String? videoPath = _currentVideoPath;
+    final VideoNameInfo? parsed =
+        videoPath == null ? null : parseVideoFilename(p.basename(videoPath));
+    final String? preferred = appModel.jimakuDefaultLanguageOrNull;
+    final String? downloaded = await showDialog<String>(
+      context: context,
+      builder: (_) => OnlineSubtitleSearchDialog(
+        registry: registry,
+        initialQuery: query,
+        saveDirectory: saveDir,
+        videoPath: videoPath,
+        season: parsed?.season,
+        episode: parsed?.episode,
+        preferredLanguages: <String>[if (preferred != null) preferred],
+      ),
+    );
+    // 对话框内含联网搜索/下载，会夺焦；关闭后把焦点还给 Video。
+    _focusOwnership.reclaim(FocusReclaimCause.overlayClosed);
+    await _applyDownloadedSubtitle(controller, downloaded);
   }
 
   /// 弹系统文件选择器挑一个字幕文件（srt/ass/ssa/vtt）→ 经 [_importExternalSubtitle]

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -700,6 +700,51 @@ extension _VideoSubtitle on _VideoFushiPageState {
     return null;
   }
 
+  /// 组装在线字幕检索的**身份种子**：优先用刮削早就存下的外部 ID 与日文原名，而不是
+  /// 界面上的显示名。
+  ///
+  /// 根因背景：库里的显示名可能是中文译名（如「Re：从零开始的异世界生活 第四季 丧失篇」），
+  /// 而 Jimaku 的条目名只有罗马音/英文/日文，AniList 也匹配不上这种「中文译名 + 季度 +
+  /// 篇名」的长串——于是搜索必然空手而归，**尽管这个视频刮削过、库里明明存着它的 AniList
+  /// ID 和日文原名**。有身份就别再去猜名字。
+  ///
+  /// 归属规则（`video_metadata_works` 的 CHECK 约束）：合集里的一集，元数据挂在
+  /// **合集**上而不是该集的 bookUid 上，故有 [VideoFushiPage.playlistCollectionId] 时必须
+  /// 走合集口，否则恒查不到。读不到元数据一律降级为纯文本检索（= 旧行为），绝不因此挡住
+  /// 搜索。
+  Future<JimakuSearchSeed> _buildJimakuSeed(String fallbackTitle) async {
+    try {
+      final FushiDatabase db = appModel.database;
+      final int? collectionId = widget.playlistCollectionId;
+      final VideoMetadataWorkRow? work = collectionId != null
+          ? await db.getVideoMetadataWorkByCollection(collectionId)
+          : await db.getVideoMetadataWorkByBook(widget.bookUid);
+      final Map<String, String> externalIds = <String, String>{};
+      if (work != null) {
+        final List<VideoMetadataProviderIdentityRow> identities =
+            await db.getVideoMetadataProviderIdentities(workId: work.id);
+        for (final VideoMetadataProviderIdentityRow row in identities) {
+          externalIds[row.provider] = row.externalId;
+        }
+      }
+      return buildJimakuSearchSeed(
+        originalTitle: work?.originalTitle,
+        metadataTitle: work?.title,
+        displayTitle: fallbackTitle,
+        collectionTitle: _playlistTitle,
+        externalIds: externalIds,
+        isMovie: work?.mediaType == 'movie',
+      );
+    } on Object catch (error) {
+      ErrorLogService.instance
+          .logDiagnostic('VideoFushiPage._buildJimakuSeed', error);
+      return buildJimakuSearchSeed(
+        displayTitle: fallbackTitle,
+        collectionTitle: _playlistTitle,
+      );
+    }
+  }
+
   /// 打开「自动获取字幕（Jimaku）」对话框：用番名（[_jimakuQuery]）搜 → 下载到
   /// `<appDocs>/video_subtitles/` → 应用。
   ///
@@ -722,10 +767,15 @@ extension _VideoSubtitle on _VideoFushiPageState {
     final String? preferredLanguage =
         appModel.jimakuPreferredLanguages[seriesKey] ??
             appModel.jimakuDefaultLanguageOrNull;
+    // 身份种子（外部 ID + 日文原名）；seriesKey 仍按原 query 算，免得预填词一换就把
+    // 用户此前的语言记忆全对不上。
+    final JimakuSearchSeed seed = await _buildJimakuSeed(query);
+    if (!context.mounted) return;
     final String? downloaded = await showDialog<String>(
       context: context,
       builder: (_) => JimakuSubtitleDialog(
-        initialQuery: query,
+        seed: seed,
+        initialQuery: seed.primaryQuery.isEmpty ? query : seed.primaryQuery,
         initialApiKey: appModel.jimakuApiKey,
         onApiKeyChanged: (String key) => appModel.setJimakuApiKey(key),
         saveDirectory: saveDir,

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -2748,6 +2748,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         cues = reparsed;
       }
       // reparsed 为空（档案被删/损坏）：保留上面的 DB 缓存 cues，仅缺样式不缺内容。
+      // **但缓存本身可能就是空的**——合集里的每一集只落字幕源指针、不落 cue
+      // （见 _selectSubtitleSource 的 `_episodes.isEmpty` 分支），所以这条支路解析
+      // 失败时 cues 恒为空。下面那组兜底因此**不能**继续挂在同一条 else-if 链上，
+      // 否则「解析一次没成功」就等于零字幕、零兜底、零提示（用户报：下载的字幕退出
+      // 再进就没了，只能重下一次）。
     } else if (rehydrateEmbedded) {
       // 内嵌文本轨：重解析已抽取的缓存档案恢复 cue 级 / 行内样式 markup（TODO-1246）。
       final ({
@@ -2764,7 +2769,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         externalSub = restored.persisted;
       }
       // restored 为空（缓存被清 / 容器不可读）：保留 DB 缓存 cues，仅缺样式不缺内容。
-    } else if (cues.isEmpty) {
+    }
+
+    // 兜底链：只要**还没拿到 cue** 就逐级往下试。这里刻意独立于上面那条 else-if 链
+    // ——上面任何一支「试过但没成功」都必须能落到这里。合集里的每一集没有 DB cue 缓存
+    // 兜底（只落字幕源指针），一旦挂在同一条链上，「解析一次没成功」就直接空手收场。
+    if (!subtitleExplicitlyOff && cues.isEmpty) {
       // ① 优先恢复持久化的字幕源（精确匹配本视频的同一源）。
       if (paths.subtitleSource != null && paths.subtitleSource!.isNotEmpty) {
         final ({
@@ -2782,14 +2792,21 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
           graphicStreamIndex = restored.graphicStreamIndex;
         }
       }
-      // ② 无持久化 / 无匹配：退默认 sidecar 探测。
-      if (cues.isEmpty && externalSub == null) {
+      // ② 仍为空：退默认 sidecar 探测。判据只看「还没有 cue」——旧判据额外要求
+      // `externalSub == null`，于是「有持久化源、但它恢复不出内容」时连 sidecar 都不试。
+      if (cues.isEmpty) {
         final ({String path, List<AudioCue> cues})? sidecar =
             await _detectSidecar(paths.videoPath, widget.bookUid);
         if (sidecar != null) {
           cues = sidecar.cues;
           externalSub = sidecar.path;
         }
+      }
+      // ③ 还是空：别拿一个恢复不出任何内容的外挂源去挡住播放器的内封轨自动加载
+      // （`VideoPlayerController.load` 只在「无外挂路径 + 无 cue」时才后台抽内封文本轨）。
+      // 只影响本次加载，**不回写 DB**——用户选过的源仍在库里，下次仍会先试它。
+      if (cues.isEmpty && !SubtitleSource.isEmbeddedPersisted(externalSub)) {
+        externalSub = null;
       }
     }
     await _applyLoad(

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -107,6 +107,7 @@ import 'package:fushi/src/media/video/video_subtitle_style.dart';
 import 'package:fushi/src/media/video/video_thumbnail_preview_controller.dart';
 import 'package:fushi/src/media/video/video_thumbnail_preview_overlay.dart';
 import 'package:fushi/src/media/video/video_watch_tracker.dart';
+import 'package:fushi/src/media/video/jimaku_search_seed.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 import 'package:fushi/src/pages/implementations/online_subtitle_search_dialog.dart';
 import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -108,6 +108,8 @@ import 'package:fushi/src/media/video/video_thumbnail_preview_controller.dart';
 import 'package:fushi/src/media/video/video_thumbnail_preview_overlay.dart';
 import 'package:fushi/src/media/video/video_watch_tracker.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/src/pages/implementations/online_subtitle_search_dialog.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
 import 'package:fushi/src/media/video/video_quick_settings_host.dart';
 import 'package:fushi/src/media/video/video_quick_settings_sheet.dart';
 import 'package:fushi/src/media/video/video_sidecar.dart';

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
 import 'package:fushi/src/media/video/scraper/tmdb_default_key.dart';
 import 'package:fushi/src/media/video/video_subtitle_style.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/video_external_provider_settings_section.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/utils.dart';
@@ -1169,6 +1170,22 @@ SettingsDestination buildVideoDestination() {
             onChanged: (SettingsContext settingsContext, String code) async {
               await settingsContext.appModel.setJimakuDefaultLanguage(code);
             },
+          ),
+          // ── OpenSubtitles（另一个在线字幕源）──────────────────────────────
+          // 这块表单本来整块挂在「设置 → 下载」里，和 Torznab 种子索引器摆一起：
+          // OpenSubtitles 是**字幕来源**，放在那儿等于藏起来——用户在字幕设置里只看得到
+          // Jimaku 的 API key，自然以为 app 根本没接它。同一份配置（同一个偏好键、同一套
+          // 校验与防抖保存），只是渲染到它该在的位置。
+          SettingsCustomItem(
+            id: 'video.subtitle.opensubtitles',
+            icon: Icons.subtitles_outlined,
+            searchTitle: t.video_opensubtitles_settings_title,
+            builder: (SettingsContext settingsContext) =>
+                const VideoExternalProviderSettingsSection(
+              groups: <VideoExternalSettingsGroup>{
+                VideoExternalSettingsGroup.openSubtitles,
+              },
+            ),
           ),
         ],
       ),

--- a/fushi/test/media/video/download/video_subtitle_registry_test.dart
+++ b/fushi/test/media/video/download/video_subtitle_registry_test.dart
@@ -1,0 +1,150 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+
+/// 只记录「有没有被叫到、以什么顺序」的假 provider。
+class _RecordingProvider implements VideoSubtitleProvider {
+  _RecordingProvider(this.id, this.priority, this.log);
+
+  @override
+  final String id;
+
+  @override
+  final int priority;
+
+  final List<String> log;
+
+  @override
+  Future<ProviderBatchResult<VideoSubtitleCandidate>> search(
+    VideoSubtitleSearchRequest request,
+  ) async {
+    log.add(id);
+    return ProviderBatchResult<VideoSubtitleCandidate>.success(
+      <VideoSubtitleCandidate>[
+        _FakeCandidate(providerId: id, providerPriority: priority),
+      ],
+    );
+  }
+
+  @override
+  Future<VideoSubtitleDownload> download(
+      VideoSubtitleCandidate candidate) async {
+    log.add('download:$id');
+    return VideoSubtitleDownload(
+      bytes: Uint8List.fromList(<int>[1]),
+      fileName: '$id.srt',
+      language: 'ja',
+    );
+  }
+
+  @override
+  void close() {}
+}
+
+class _FakeCandidate extends VideoSubtitleCandidate {
+  _FakeCandidate({required String providerId, required int providerPriority})
+      : super(
+          providerId: providerId,
+          remoteId: 'r',
+          fileName: '$providerId.srt',
+          language: 'ja',
+          providerPriority: providerPriority,
+        );
+}
+
+VideoMediaReference _reference(VideoDiscoveryCategory category) =>
+    VideoMediaReference(
+      providerId: 'tmdb',
+      mediaId: '1',
+      mediaKind: VideoMetadataMediaKind.tv,
+      discoveryCategory: category,
+      title: '最愛',
+    );
+
+void main() {
+  group('VideoSubtitleRegistry provider 路由', () {
+    test('非动漫检索也要问 Jimaku（真人剧字幕接入）', () async {
+      final List<String> log = <String>[];
+      final VideoSubtitleRegistry registry = VideoSubtitleRegistry(
+        <VideoSubtitleProvider>[
+          _RecordingProvider('jimaku', 100, log),
+          _RecordingProvider('opensubtitles', 200, log),
+        ],
+      );
+
+      await registry.search(
+        VideoSubtitleSearchRequest(
+          media: _reference(VideoDiscoveryCategory.tv),
+          query: '最愛',
+        ),
+      );
+
+      // 旧实现在这里只放行 opensubtitles，Jimaku 的真人剧库整片不可见。
+      expect(log, containsAll(<String>['jimaku', 'opensubtitles']));
+    });
+
+    test('动漫检索合并两家结果，顺序由 provider 优先级决定', () async {
+      final List<String> log = <String>[];
+      // 用默认优先级：Jimaku 100 先于 OpenSubtitles 200。候选的最终顺序只由
+      // providerPriority 决定（deduplicateVideoSubtitles），与 fan-out 的启动
+      // 顺序无关，故此处断言结果而不是调用次序。
+      final VideoSubtitleRegistry registry = VideoSubtitleRegistry(
+        <VideoSubtitleProvider>[
+          _RecordingProvider('opensubtitles', 200, log),
+          _RecordingProvider('jimaku', 100, log),
+        ],
+      );
+
+      final ProviderBatchResult<VideoSubtitleCandidate> result =
+          await registry.search(
+        VideoSubtitleSearchRequest(
+          media: _reference(VideoDiscoveryCategory.anime),
+          query: 'frieren',
+        ),
+      );
+
+      expect(log, containsAll(<String>['jimaku', 'opensubtitles']));
+      expect(
+        result.items.map((VideoSubtitleCandidate c) => c.providerId).toList(),
+        <String>['jimaku', 'opensubtitles'],
+      );
+    });
+
+    test('无媒体引用时全部 provider 参与', () async {
+      final List<String> log = <String>[];
+      final VideoSubtitleRegistry registry = VideoSubtitleRegistry(
+        <VideoSubtitleProvider>[
+          _RecordingProvider('jimaku', 100, log),
+          _RecordingProvider('opensubtitles', 200, log),
+        ],
+      );
+
+      await registry.search(VideoSubtitleSearchRequest(query: '半沢直樹'));
+
+      expect(log, containsAll(<String>['jimaku', 'opensubtitles']));
+    });
+
+    test('download 按候选的 providerId 回到原 provider', () async {
+      final List<String> log = <String>[];
+      final VideoSubtitleRegistry registry = VideoSubtitleRegistry(
+        <VideoSubtitleProvider>[
+          _RecordingProvider('jimaku', 100, log),
+          _RecordingProvider('opensubtitles', 200, log),
+        ],
+      );
+
+      final VideoSubtitleDownload download = await registry.download(
+        _FakeCandidate(providerId: 'opensubtitles', providerPriority: 200),
+      );
+
+      expect(download.fileName, 'opensubtitles.srt');
+      expect(log, <String>['download:opensubtitles']);
+    });
+  });
+}

--- a/fushi/test/media/video/jimaku_client_test.dart
+++ b/fushi/test/media/video/jimaku_client_test.dart
@@ -256,6 +256,183 @@ void main() {
     });
   });
 
+  group('JimakuSearchScope（Live Action 接入）', () {
+    test('scope 展开成 anime= 取值序列；all = 两次请求', () {
+      expect(jimakuScopeAnimeFlags(JimakuSearchScope.anime), <bool>[true]);
+      expect(
+          jimakuScopeAnimeFlags(JimakuSearchScope.liveAction), <bool>[false]);
+      // 服务端没有「不限分类」取值（anime 是硬相等过滤），故全部 = 两类各查一次。
+      expect(jimakuScopeAnimeFlags(JimakuSearchScope.all), <bool>[true, false]);
+    });
+
+    test('buildSearchEntriesUri 恒显式拼 anime=，缺省值也不省略', () {
+      final Uri anime = buildSearchEntriesUri('https://jimaku.cc/api',
+          anime: true, query: 'x');
+      expect(anime.queryParameters['anime'], 'true');
+      expect(anime.path, '/api/entries/search');
+
+      final Uri live = buildSearchEntriesUri('https://jimaku.cc/api',
+          anime: false, query: '半沢直樹');
+      expect(live.queryParameters['anime'], 'false');
+      expect(live.queryParameters['query'], '半沢直樹');
+    });
+
+    test('buildSearchEntriesUri 只拼有值的检索键，空串忽略', () {
+      final Uri uri = buildSearchEntriesUri(
+        'https://jimaku.cc/api',
+        anime: false,
+        anilistId: 21,
+        tmdbId: '  tv:12345  ',
+        query: '   ',
+      );
+      expect(uri.queryParameters['anilist_id'], '21');
+      expect(uri.queryParameters['tmdb_id'], 'tv:12345'); // 已 trim
+      expect(uri.queryParameters.containsKey('query'), isFalse);
+    });
+
+    test('jimakuTmdbId 按服务端 (tv|movie):(\\d+) 编码', () {
+      expect(jimakuTmdbId(movie: false, tmdbId: 12345), 'tv:12345');
+      expect(jimakuTmdbId(movie: true, tmdbId: 669204), 'movie:669204');
+    });
+
+    test('parseJimakuEntryFlags 解析对象，缺字段/非对象 → false', () {
+      final JimakuEntryFlags flags = parseJimakuEntryFlags(<String, Object?>{
+        'anime': false,
+        'movie': true,
+        'adult': false,
+      });
+      expect(flags.anime, isFalse);
+      expect(flags.movie, isTrue);
+      expect(flags.unverified, isFalse); // 缺字段
+      expect(flags.isLiveAction, isTrue);
+
+      const JimakuEntryFlags empty = JimakuEntryFlags();
+      expect(parseJimakuEntryFlags(null).anime, empty.anime);
+      expect(parseJimakuEntryFlags(8).movie, isFalse); // 不解析 bitfield 形态
+    });
+
+    test('parseJimakuEntries 解析 tmdb_id / japanese_name / flags', () {
+      const String body = '''
+[{"id":6270,"name":"\\"Kakure Bitch\\" Yattemashita","japanese_name":"かくれビッチやってました",
+  "tmdb_id":"movie:669204","flags":{"anime":false,"movie":true,"adult":false,
+  "external":false,"unverified":false}}]''';
+      final List<JimakuEntry> entries = parseJimakuEntries(body);
+      final JimakuEntry entry = entries.single;
+      expect(entry.tmdbId, 'movie:669204');
+      expect(entry.japaneseName, 'かくれビッチやってました');
+      expect(entry.flags.isLiveAction, isTrue);
+      expect(entry.flags.movie, isTrue);
+    });
+
+    test('name 空时回退 japanese_name（真人条目常无 romaji 名）', () {
+      final List<JimakuEntry> entries = parseJimakuEntries(
+        '[{"id":9,"name":"","english_name":"","japanese_name":"最愛"}]',
+      );
+      expect(entries.single.name, '最愛');
+    });
+
+    test('scope=liveAction → 请求带 anime=false（真人剧接入的核心守卫）', () async {
+      final List<String> seen = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        seen.add(req.url.queryParameters['anime'] ?? '<missing>');
+        return http.Response.bytes(
+            utf8.encode('[{"id":1,"name":"半沢直樹"}]'), 200);
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      final List<JimakuEntry> entries = await jc.searchByQuery(
+        '半沢直樹',
+        scope: JimakuSearchScope.liveAction,
+      );
+      expect(entries.single.name, '半沢直樹');
+      expect(seen, <String>['false']);
+    });
+
+    test('默认 scope 仍是 anime=true（不回归旧行为）', () async {
+      final List<String> seen = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        seen.add(req.url.queryParameters['anime'] ?? '<missing>');
+        return http.Response('[]', 200);
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      await jc.searchByQuery('frieren');
+      await jc.searchByAnilistId(154587);
+      expect(seen, <String>['true', 'true']);
+    });
+
+    test('scope=all → 两次请求（动画在前）并按 id 去重合并', () async {
+      final List<String> seen = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        final String anime = req.url.queryParameters['anime']!;
+        seen.add(anime);
+        // 两类各返回一条，其中 id=5 重复出现，必须只保留一次。
+        return http.Response(
+          anime == 'true'
+              ? '[{"id":5,"name":"dup"},{"id":1,"name":"a"}]'
+              : '[{"id":5,"name":"dup"},{"id":2,"name":"b"}]',
+          200,
+        );
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      final List<JimakuEntry> entries =
+          await jc.searchByQuery('x', scope: JimakuSearchScope.all);
+      expect(seen, <String>['true', 'false']);
+      expect(entries.map((JimakuEntry e) => e.id).toList(), <int>[5, 1, 2]);
+    });
+
+    test('scope=all 时一类失败不吞掉另一类结果', () async {
+      final MockClient client = MockClient((http.Request req) async {
+        return req.url.queryParameters['anime'] == 'true'
+            ? http.Response('boom', 500)
+            : http.Response('[{"id":3,"name":"live"}]', 200);
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      final List<JimakuEntry> entries =
+          await jc.searchByQuery('x', scope: JimakuSearchScope.all);
+      expect(entries.single.name, 'live');
+    });
+
+    test('searchByTmdbId 默认查两类（分类过滤先于 ID 匹配）', () async {
+      final List<String> seen = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        seen.add(
+            '${req.url.queryParameters['anime']}:${req.url.queryParameters['tmdb_id']}');
+        return http.Response('[]', 200);
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      await jc.searchByTmdbId('tv:12345');
+      expect(seen, <String>['true:tv:12345', 'false:tv:12345']);
+    });
+
+    test('searchEntries 在 liveAction 下跳过 anilist_id、按 tmdb → 文本回退', () async {
+      final List<String> calls = <String>[];
+      final MockClient client = MockClient((http.Request req) async {
+        final Map<String, String> p = req.url.queryParameters;
+        if (p.containsKey('anilist_id')) {
+          calls.add('anilist');
+          return http.Response.bytes(
+              utf8.encode('[{"id":99,"name":"不该被用到"}]'), 200);
+        }
+        if (p.containsKey('tmdb_id')) {
+          calls.add('tmdb:${p['anime']}');
+          return http.Response('[]', 200);
+        }
+        calls.add('query:${p['query']}:${p['anime']}');
+        // 必须走 utf8 字节：http.Response 的 String 构造按 latin1 编码，日文直接炸。
+        return http.Response.bytes(utf8.encode('[{"id":4,"name":"最愛"}]'), 200);
+      });
+      final JimakuClient jc = JimakuClient(apiKey: 'k', client: client);
+      final List<JimakuEntry> entries = await jc.searchEntries(
+        anilistId: 21,
+        tmdbId: 'tv:126991',
+        queryFallbacks: <String>['最愛'],
+        scope: JimakuSearchScope.liveAction,
+      );
+      expect(entries.single.name, '最愛');
+      // AniList 是动画专属键，真人范围下不得发这个请求。
+      expect(calls, <String>['tmdb:false', 'query:最愛:false']);
+    });
+  });
+
   group('JimakuClient.listFiles strict availability check', () {
     test('默认保持 fail-open，预检查严格模式保留 HTTP 状态码', () async {
       final JimakuClient jc = JimakuClient(

--- a/fushi/test/media/video/jimaku_search_seed_test.dart
+++ b/fushi/test/media/video/jimaku_search_seed_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/jimaku_search_seed.dart';
+
+/// 在线字幕检索的身份种子。
+///
+/// 真实故障：库里《Re:Zero》第四季的显示名是中文「Re：从零开始的异世界生活 第四季
+/// 丧失篇」，Jimaku 的条目名只有罗马音/英文/日文，AniList 也匹配不上这种长串（实测
+/// 只有「从零开始的异世界生活」能命中，整串 0 结果）——于是搜索必然空手而归，尽管这个
+/// 视频刮削过、库里存着它的 AniList ID 和日文原名。
+void main() {
+  group('buildJimakuSearchSeed', () {
+    test('日文原名排在最前，其次刮削名、显示名、合集名', () {
+      final JimakuSearchSeed seed = buildJimakuSearchSeed(
+        originalTitle: 'Re:ゼロから始める異世界生活',
+        metadataTitle: 'Re:Zero kara Hajimeru Isekai Seikatsu',
+        displayTitle: 'Re：从零开始的异世界生活 第四季 丧失篇',
+        collectionTitle: 'Re:Zero',
+      );
+      expect(seed.queries, <String>[
+        'Re:ゼロから始める異世界生活',
+        'Re:Zero kara Hajimeru Isekai Seikatsu',
+        'Re：从零开始的异世界生活 第四季 丧失篇',
+        'Re:Zero',
+      ]);
+      // 预填框用第一条；其余作为主词搜空后的备选。
+      expect(seed.primaryQuery, 'Re:ゼロから始める異世界生活');
+      expect(
+          seed.fallbackQueries.first, 'Re:Zero kara Hajimeru Isekai Seikatsu');
+    });
+
+    test('去空白、去重、跳过空值', () {
+      final JimakuSearchSeed seed = buildJimakuSearchSeed(
+        originalTitle: '  ',
+        metadataTitle: 'Bocchi the Rock!',
+        displayTitle: 'Bocchi the Rock!',
+        collectionTitle: null,
+      );
+      expect(seed.queries, <String>['Bocchi the Rock!']);
+      expect(seed.fallbackQueries, isEmpty);
+    });
+
+    test('AniList / TMDB 外部 ID 被解析成强身份', () {
+      final JimakuSearchSeed seed = buildJimakuSearchSeed(
+        displayTitle: '最愛',
+        externalIds: const <String, String>{
+          'anilist': '21355',
+          'tmdb': '126991',
+        },
+      );
+      expect(seed.anilistId, 21355);
+      // 剧集编码成 tv:，电影编码成 movie:（TMDB 两个号段互不相通）。
+      expect(seed.tmdbId, 'tv:126991');
+      expect(seed.hasStrongIdentity, isTrue);
+    });
+
+    test('电影用 movie: 前缀', () {
+      final JimakuSearchSeed seed = buildJimakuSearchSeed(
+        displayTitle: 'x',
+        externalIds: const <String, String>{'tmdb': '669204'},
+        isMovie: true,
+      );
+      expect(seed.tmdbId, 'movie:669204');
+    });
+
+    test('没有元数据时退化成纯文本种子（= 旧行为）', () {
+      final JimakuSearchSeed seed =
+          buildJimakuSearchSeed(displayTitle: 'Some Anime');
+      expect(seed.hasStrongIdentity, isFalse);
+      expect(seed.anilistId, isNull);
+      expect(seed.tmdbId, isNull);
+      expect(seed.primaryQuery, 'Some Anime');
+    });
+
+    test('外部 ID 不是数字时当作没有，不硬塞给 API', () {
+      final JimakuSearchSeed seed = buildJimakuSearchSeed(
+        displayTitle: 'x',
+        externalIds: const <String, String>{'anilist': 'abc', 'tmdb': ''},
+      );
+      expect(seed.anilistId, isNull);
+      expect(seed.tmdbId, isNull);
+      expect(seed.hasStrongIdentity, isFalse);
+    });
+
+    test('空种子（缺省构造）不带任何检索键', () {
+      const JimakuSearchSeed seed = JimakuSearchSeed();
+      expect(seed.primaryQuery, '');
+      expect(seed.fallbackQueries, isEmpty);
+      expect(seed.hasStrongIdentity, isFalse);
+    });
+  });
+}

--- a/fushi/test/media/video/open_subtitles_client_test.dart
+++ b/fushi/test/media/video/open_subtitles_client_test.dart
@@ -333,6 +333,54 @@ void main() {
         reason: 'the 65th MiB crosses the cap; chunk 66 stays unread');
   });
 
+  group('语言码归一（BUG-1651）', () {
+    test('大类 zh 展开成 OpenSubtitles 真有的地区码', () {
+      // 官方语言表（/infos/languages，105 个码）里没有裸 zh，只有 zh-cn/zh-tw/zh-ca：
+      // 原样发过去中文字幕恒定搜不到。
+      expect(normalizeOpenSubtitlesLanguages(<String>['zh']),
+          <String>['zh-cn', 'zh-tw']);
+      expect(normalizeOpenSubtitlesLanguages(<String>['pt']),
+          <String>['pt-br', 'pt-pt']);
+    });
+
+    test('本来就有裸码的语言原样透传', () {
+      expect(normalizeOpenSubtitlesLanguages(<String>['ja']), <String>['ja']);
+      expect(normalizeOpenSubtitlesLanguages(<String>['en', 'ko']),
+          <String>['en', 'ko']);
+    });
+
+    test('去重、去空、小写化，并排序', () {
+      // API 对未规范化的 query 会 301 到规范 URL；排好序省掉这次多余往返。
+      expect(
+        normalizeOpenSubtitlesLanguages(<String>['ZH', ' ja ', '', 'zh', 'ja']),
+        <String>['ja', 'zh-cn', 'zh-tw'],
+      );
+    });
+
+    test('搜索请求真的带上归一后的语言码', () async {
+      final List<Map<String, String>> queries = <Map<String, String>>[];
+      final OpenSubtitlesClient client = OpenSubtitlesClient(
+        config: OpenSubtitlesConfig(
+          apiKey: 'api-secret',
+          baseUrl: Uri.parse('http://localhost/api/v1'),
+        ),
+        client: MockClient((http.Request request) async {
+          queries.add(request.url.queryParameters);
+          return http.Response(
+              jsonEncode(<String, Object?>{'data': <Object?>[]}), 200);
+        }),
+        closesClient: false,
+      );
+
+      await client.search(
+        VideoSubtitleSearchRequest(query: '最愛', languages: <String>['zh']),
+      );
+
+      expect(queries.single['languages'], 'zh-cn,zh-tw',
+          reason: '裸 zh 发过去等于放弃全部中文字幕');
+    });
+  });
+
   test('does not issue an unbounded search with only language filters',
       () async {
     final OpenSubtitlesClient client = OpenSubtitlesClient(
@@ -429,7 +477,9 @@ void main() {
     expect(queries[3], isNot(contains('parent_tmdb_id')));
     for (final Map<String, String> query in queries) {
       expect(query['page'], '3');
-      expect(query['languages'], 'ja,zh');
+      // BUG-1651：入参仍是 Hibiki 的大类码 ja/zh，但发出去必须是 OpenSubtitles
+      // 认得的 BCP-47——它的语言表里没有裸 zh。旧断言锁的正是那个缺陷行为。
+      expect(query['languages'], 'ja,zh-cn,zh-tw');
     }
   });
 

--- a/fushi/test/media/video/video_subtitle_preference_test.dart
+++ b/fushi/test/media/video/video_subtitle_preference_test.dart
@@ -180,6 +180,49 @@ void main() {
       );
     });
   });
+  group('isImportedExternalSubtitlePath（真实下载文件名，用户报「退出再进字幕没了」）', () {
+    // 用户实测截图里的 Jimaku 候选文件名：带括号、CRC、双语后缀。恢复捷径靠这个判据
+    // 决定「要不要按路径直接加载」——它一旦认不出，重进就会掉回「只扫视频同目录」的
+    // 分支，而下载的字幕根本不住在那儿，字幕就此消失。
+    test('括号 / CRC / 双语后缀都不影响识别', () {
+      for (final String name in <String>[
+        '(Hi10)_Re_Zero_-_01_(BD_720p)_(BlurayDesuYo)_(DB3C1337).ja-en.ass',
+        '[Kamigami] Re Zero kara Hajimeru Isekai Seikatsu - 01v3 '
+            '[1920x1080 x265 Ma10p AAC][JPN].ass',
+        'Re_ゼロから始める異世界生活.新編集版.S01E01.WEBRip.Netflix.ja[cc].srt',
+        'Re Life in a different world from zero.S01E01.WEBRip.ja[cc].srt',
+      ]) {
+        expect(
+          isImportedExternalSubtitlePath(
+            '/home/u/Documents/app/video_subtitles/$name',
+          ),
+          isTrue,
+          reason: '认不出就等于重进后字幕消失：$name',
+        );
+      }
+    });
+
+    test('内嵌源与非字幕扩展名仍然不认', () {
+      expect(isImportedExternalSubtitlePath('embedded:2'), isFalse);
+      expect(isImportedExternalSubtitlePath(''), isFalse);
+      expect(
+        isImportedExternalSubtitlePath('/x/video_subtitles/subs.zip'),
+        isFalse,
+      );
+    });
+
+    test('这些文件名跨集也认得住在别处（不被当成同目录 sidecar）', () {
+      expect(
+        shouldReusePersistedSubtitleAcrossEpisode(
+          '/home/u/Documents/app/video_subtitles/'
+              '(Hi10)_Re_Zero_-_01_(BD_720p).ja-en.ass',
+          '/media/Anime/Re Zero/S04E02.mkv',
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('shouldReusePersistedSubtitleAcrossEpisode（换集是否沿用导入字幕）', () {
     // 真正的导入/下载字幕：住在 <appDocs>/video_subtitles/，与剧集目录无关 → 沿用。
     test('导入字幕（异目录）→ true（跨集沿用）', () {

--- a/fushi/test/pages/jimaku_dialog_scroll_test.dart
+++ b/fushi/test/pages/jimaku_dialog_scroll_test.dart
@@ -365,8 +365,8 @@ void main() {
       (WidgetTester tester) async {
     await pumpLangDialog(tester);
     // 「全部」+ ja + zh chip 渲染；ko/en 不渲染（候选里没有）。
-    expect(find.widgetWithText(ChoiceChip, t.video_jimaku_language_all),
-        findsOneWidget);
+    // 按 key 定位：分类区也有一个同字的「全部」chip，纯文本会撞上。
+    expect(find.byKey(jimakuLanguageChipKey(null)), findsOneWidget);
     expect(find.widgetWithText(ChoiceChip, '日本語'), findsOneWidget);
     expect(find.widgetWithText(ChoiceChip, '中文'), findsOneWidget);
     expect(find.widgetWithText(ChoiceChip, 'English'), findsNothing);
@@ -402,8 +402,8 @@ void main() {
     // 记忆 ko，但候选里没有 ko → 退回「全部」，不空屏。
     await pumpLangDialog(tester, initialPreferredLanguage: 'ko');
     expect(shownCandidateCount(tester), 4, reason: '退回全部，列全部候选');
-    final ChoiceChip allChip = tester
-        .widget(find.widgetWithText(ChoiceChip, t.video_jimaku_language_all));
+    final ChoiceChip allChip =
+        tester.widget(find.byKey(jimakuLanguageChipKey(null)));
     expect(allChip.selected, isTrue, reason: '无候选的记忆语言退回「全部」');
   });
 

--- a/fushi/test/pages/jimaku_live_action_test.dart
+++ b/fushi/test/pages/jimaku_live_action_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/utils.dart';
+
+/// Jimaku 自动获取字幕对话框的「分类」（动画 / 真人 / 全部）行为。
+///
+/// 根因回顾：Jimaku 服务端把 `anime` 当硬相等过滤且缺省 `true`，而对话框此前从不传这个
+/// 参数，于是站点 Live Action 页上的真人剧字幕在 app 内一条都取不到；同时它无条件先查
+/// AniList（GraphQL 写死 `type: ANIME`），对日剧纯属白等一次网络往返。
+void main() {
+  /// 记录本次用例发出的所有请求 URL。
+  late List<String> requests;
+
+  MockClient makeClient() => MockClient((http.Request request) async {
+        requests.add(request.url.toString());
+        if (request.url.host.contains('anilist')) {
+          return http.Response('{"data":{"Page":{"media":[]}}}', 200);
+        }
+        if (request.url.path.endsWith('/entries/search')) {
+          return http.Response.bytes(
+            utf8.encode('[{"id":4,"name":"最愛","tmdb_id":"tv:126991",'
+                '"flags":{"anime":false}}]'),
+            200,
+          );
+        }
+        return http.Response.bytes(
+          utf8.encode('[{"name":"最愛 - 01.ja.srt","url":"https://x/1"}]'),
+          200,
+        );
+      });
+
+  Future<void> pumpDialog(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: '最愛',
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  httpClientFactory: () async => makeClient(),
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() => requests = <String>[]);
+
+  testWidgets('分类 chip 恒显示，默认选中动画', (WidgetTester tester) async {
+    await pumpDialog(tester);
+
+    expect(find.text(t.video_jimaku_category), findsOneWidget);
+    // 搜不到恰恰是最需要换分类的时候，入口不能藏在「有结果」之后。
+    expect(find.text(t.video_jimaku_category_live_action), findsOneWidget);
+
+    final ChoiceChip animeChip = tester.widget<ChoiceChip>(
+      find.byKey(jimakuCategoryChipKey(JimakuSearchScope.anime)),
+    );
+    expect(animeChip.selected, isTrue);
+  });
+
+  testWidgets('选真人 → 重搜时带 anime=false 且不再问 AniList',
+      (WidgetTester tester) async {
+    await pumpDialog(tester);
+
+    await tester
+        .tap(find.byKey(jimakuCategoryChipKey(JimakuSearchScope.liveAction)));
+    await tester.pumpAndSettle();
+
+    final List<String> searches = requests
+        .where((String url) => url.contains('/entries/search'))
+        .toList();
+    expect(searches, isNotEmpty, reason: '切换分类必须重搜，分类是服务端检索参数');
+    expect(searches.every((String url) => url.contains('anime=false')), isTrue,
+        reason: '真人分类必须显式传 anime=false，否则服务端按缺省只回动画');
+    // AniList 只有动画，真人分类下问它是白等一次往返、还会拿同名动画误导用户。
+    expect(requests.any((String url) => url.contains('anilist')), isFalse);
+  });
+
+  testWidgets('默认动画分类仍先问 AniList 且搜 anime=true（不回归旧行为）',
+      (WidgetTester tester) async {
+    await pumpDialog(tester);
+
+    await tester.tap(find.text(t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    expect(requests.any((String url) => url.contains('anilist')), isTrue);
+    final List<String> searches = requests
+        .where((String url) => url.contains('/entries/search'))
+        .toList();
+    expect(searches, isNotEmpty);
+    expect(searches.every((String url) => url.contains('anime=true')), isTrue);
+  });
+
+  testWidgets('选全部 → 动画与真人各查一次', (WidgetTester tester) async {
+    await pumpDialog(tester);
+
+    await tester.tap(find.byKey(jimakuCategoryChipKey(JimakuSearchScope.all)));
+    await tester.pumpAndSettle();
+
+    final List<String> searches = requests
+        .where((String url) => url.contains('/entries/search'))
+        .toList();
+    // 服务端没有「不限分类」取值，只能两类各发一次。
+    expect(searches.where((String u) => u.contains('anime=true')), isNotEmpty);
+    expect(searches.where((String u) => u.contains('anime=false')), isNotEmpty);
+  });
+}

--- a/fushi/test/pages/jimaku_search_identity_test.dart
+++ b/fushi/test/pages/jimaku_search_identity_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fushi/src/media/video/anilist_client.dart';
+import 'package:fushi/src/media/video/jimaku_search_seed.dart';
+import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:fushi/utils.dart';
+
+/// Jimaku 对话框的**身份优先检索**与**失败可见性**。
+///
+/// 三个真实故障：
+/// 1. 库里显示名是中文译名时搜不到——app 明明存着这个视频的 AniList ID，却还在拿显示名
+///    去 AniList 模糊匹配（中文长串匹配不上）。
+/// 2. 填了集数再点搜索，系列列表整个消失且搜不出结果——`_search` 先清空系列列表、再等一次
+///    网络往返回填，中间任何失败（AniList 限流 fail-open）都会让用户永久失去系列选择面。
+/// 3. 下载失败的提示弹在对话框**底下**（SnackBar 挂在被 modal 盖住的页面 Scaffold 上），
+///    而且只有一句「下载失败」，401/429/404 长得一模一样。
+void main() {
+  late List<String> requests;
+
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    required MockClient client,
+    JimakuSearchSeed seed = const JimakuSearchSeed(),
+    String initialQuery = 'Re:ゼロから始める異世界生活',
+    List<AniListMedia>? series,
+  }) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: initialQuery,
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  seed: seed,
+                  httpClientFactory: () async => client,
+                  debugInitialSeriesMatches: series,
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() => requests = <String>[]);
+
+  MockClient recordingClient({
+    String entriesBody =
+        '[{"id":7,"name":"Re:Zero kara Hajimeru Isekai Seikatsu"}]',
+    String filesBody =
+        '[{"name":"Re Zero - 01.ja.srt","url":"https://jimaku.cc/file/1"}]',
+    String anilistBody = '{"data":{"Page":{"media":[]}}}',
+    int filesStatus = 200,
+  }) =>
+      MockClient((http.Request request) async {
+        requests.add(request.url.toString());
+        if (request.url.host.contains('anilist')) {
+          return http.Response.bytes(utf8.encode(anilistBody), 200);
+        }
+        if (request.url.path.endsWith('/entries/search')) {
+          return http.Response.bytes(utf8.encode(entriesBody), 200);
+        }
+        return http.Response.bytes(utf8.encode(filesBody), filesStatus);
+      });
+
+  testWidgets('已知 AniList id 时直接按 id 检索，完全不碰 AniList 文本匹配',
+      (WidgetTester tester) async {
+    await pumpDialog(
+      tester,
+      client: recordingClient(),
+      seed: const JimakuSearchSeed(
+        anilistId: 21355,
+        queries: <String>['Re:ゼロから始める異世界生活'],
+      ),
+    );
+
+    await tester.tap(find.text(t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    // 中文译名在 AniList 上匹配不到，而 id 是确定的——有 id 就别再去猜名字。
+    expect(requests.any((String u) => u.contains('anilist.co')), isFalse);
+    expect(
+      requests.any((String u) => u.contains('anilist_id=21355')),
+      isTrue,
+      reason: '刮削存下来的 AniList id 必须直接用于检索 Jimaku',
+    );
+  });
+
+  testWidgets('用户改过番名后不再套用刮削 id（按他自己的词搜）', (WidgetTester tester) async {
+    await pumpDialog(
+      tester,
+      client: recordingClient(),
+      seed: const JimakuSearchSeed(
+        anilistId: 21355,
+        queries: <String>['Re:ゼロから始める異世界生活'],
+      ),
+    );
+
+    await tester.enterText(
+        find.widgetWithText(TextField, t.video_jimaku_query), '別のアニメ');
+    await tester.tap(find.text(t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    expect(requests.any((String u) => u.contains('anilist.co')), isTrue,
+        reason: '用户自己改了番名，应按他的词重新解析系列');
+  });
+
+  testWidgets('AniList 这一跳空手而归时，已有的系列列表不被清空', (WidgetTester tester) async {
+    // 预置两个系列（= 用户已经搜过一次的状态），再让 AniList 返回空（限流/抖动）。
+    await pumpDialog(
+      tester,
+      client: recordingClient(anilistBody: '{"data":{"Page":{"media":[]}}}'),
+      series: const <AniListMedia>[
+        AniListMedia(
+            id: 21355, romaji: 'Re:Zero kara Hajimeru Isekai Seikatsu'),
+        AniListMedia(id: 119661, romaji: 'Re:Zero 2nd Season Part 2'),
+      ],
+    );
+    expect(find.text('Re:Zero 2nd Season Part 2'), findsOneWidget);
+
+    // 只在集数框填个数字再搜（用户报的正是这一步之后系列没了）。
+    await tester.enterText(
+        find.widgetWithText(TextField, t.video_jimaku_episode), '4');
+    await tester.tap(find.text(t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Re:Zero 2nd Season Part 2'),
+      findsOneWidget,
+      reason: '系列列表要等一次网络往返才回填，提前清空会让用户在失败时永久失去选择面',
+    );
+  });
+
+  testWidgets('下载失败的原因显示在对话框内部，并带上 HTTP 状态码', (WidgetTester tester) async {
+    final MockClient client = MockClient((http.Request request) async {
+      requests.add(request.url.toString());
+      if (request.url.host.contains('anilist')) {
+        return http.Response('{"data":{"Page":{"media":[]}}}', 200);
+      }
+      if (request.url.path.endsWith('/entries/search')) {
+        return http.Response.bytes(
+            utf8.encode('[{"id":7,"name":"Re:Zero"}]'), 200);
+      }
+      if (request.url.path.endsWith('/files')) {
+        return http.Response.bytes(
+          utf8.encode('[{"name":"ep01.ja.srt","url":"https://jimaku.cc/f/1"}]'),
+          200,
+        );
+      }
+      // 文件下载本身失败（key 过期）。
+      return http.Response('forbidden', 403);
+    });
+
+    await pumpDialog(tester, client: client);
+    await tester.tap(find.text(t.video_jimaku_search));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('ep01.ja.srt'));
+    await tester.pumpAndSettle();
+
+    // 对话框是全屏 modal，SnackBar 会被它整个盖住——错误必须画在对话框内部。
+    expect(find.byKey(const ValueKey<String>('jimaku-error-banner')),
+        findsOneWidget);
+    expect(find.textContaining('403'), findsOneWidget,
+        reason: '401/429/404 是完全不同的三件事，只说「下载失败」等于什么都没说');
+  });
+}

--- a/fushi/test/pages/online_subtitle_search_dialog_test.dart
+++ b/fushi/test/pages/online_subtitle_search_dialog_test.dart
@@ -20,23 +20,21 @@ class _StubCandidate extends VideoSubtitleCandidate {
     super.remoteId = 'r1',
     super.language = 'ja',
     super.providerPriority = 200,
-    super.downloadCount = 0,
     super.episode,
   });
 }
 
 class _StubProvider implements VideoSubtitleProvider {
-  _StubProvider({
-    required this.id,
-    required this.downloadFileName,
-    this.bytes = const <int>[1, 2, 3],
-  });
+  _StubProvider({required this.id, required this.downloadFileName});
 
   @override
   final String id;
 
   final String downloadFileName;
-  final List<int> bytes;
+
+  /// 落盘内容的固定探针字节，用于断言「写下去的就是 provider 给的那份」。
+  static const List<int> bytes = <int>[1, 2, 3];
+
   int downloadCalls = 0;
 
   @override

--- a/fushi/test/pages/online_subtitle_search_dialog_test.dart
+++ b/fushi/test/pages/online_subtitle_search_dialog_test.dart
@@ -1,0 +1,236 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/video/download/video_subtitle_registry.dart';
+import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi/src/pages/implementations/online_subtitle_search_dialog.dart';
+
+/// 在线字幕对话框（provider 无关）：OpenSubtitles 等只有标题/哈希两种检索键的源，此前
+/// 只在发现页/下载流水线可达，播放页完全没有入口。本对话框补上那条路，并与 Jimaku 专用
+/// 对话框共用同一个 pop 契约（返回下载好的本地绝对路径），播放页落地逻辑因此只需一份。
+class _StubCandidate extends VideoSubtitleCandidate {
+  _StubCandidate({
+    required super.providerId,
+    required super.fileName,
+    super.remoteId = 'r1',
+    super.language = 'ja',
+    super.providerPriority = 200,
+    super.downloadCount = 0,
+    super.episode,
+  });
+}
+
+class _StubProvider implements VideoSubtitleProvider {
+  _StubProvider({
+    required this.id,
+    required this.downloadFileName,
+    this.bytes = const <int>[1, 2, 3],
+  });
+
+  @override
+  final String id;
+
+  final String downloadFileName;
+  final List<int> bytes;
+  int downloadCalls = 0;
+
+  @override
+  int get priority => 200;
+
+  @override
+  Future<ProviderBatchResult<VideoSubtitleCandidate>> search(
+    VideoSubtitleSearchRequest request,
+  ) async =>
+      ProviderBatchResult<VideoSubtitleCandidate>.success(
+          const <VideoSubtitleCandidate>[]);
+
+  @override
+  Future<VideoSubtitleDownload> download(
+      VideoSubtitleCandidate candidate) async {
+    downloadCalls++;
+    return VideoSubtitleDownload(
+      bytes: Uint8List.fromList(bytes),
+      fileName: downloadFileName,
+      language: candidate.language,
+    );
+  }
+
+  @override
+  void close() {}
+}
+
+void main() {
+  late Directory saveDir;
+
+  /// 对话框 pop 出来的值。必须是外层变量而不是 `pumpDialog` 的返回值——pop 发生在点击
+  /// 之后，按值返回只会拿到点击前的 null 快照。
+  String? popped;
+
+  setUp(() {
+    saveDir = Directory.systemTemp.createTempSync('online_subs_test');
+    popped = null;
+  });
+
+  tearDown(() {
+    try {
+      if (saveDir.existsSync()) saveDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      // 临时目录清理失败不该盖掉真正的断言失败（Windows 上句柄释放有延迟）。
+    }
+  });
+
+  /// 点一条候选并等真实落盘完成。
+  ///
+  /// 下载路径里有真实文件 IO，而 widget test 默认跑在 FakeAsync 区域——`pumpAndSettle`
+  /// 推不动真实事件循环，`File.writeAsBytes` 的 Future 永远不完成。必须在 [runAsync]
+  /// 里驱动，否则一定超时。
+  Future<void> tapAndSettleIo(WidgetTester tester, String label) async {
+    await tester.runAsync(() async {
+      await tester.tap(find.text(label));
+      for (int i = 0; i < 50; i++) {
+        await tester.pump(const Duration(milliseconds: 10));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        if (find.byType(OnlineSubtitleSearchDialog).evaluate().isEmpty) break;
+      }
+    });
+    await tester.pump();
+  }
+
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    required VideoSubtitleRegistry registry,
+    required ProviderBatchResult<VideoSubtitleCandidate> seed,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () async {
+                popped = await showDialog<String>(
+                  context: ctx,
+                  builder: (_) => OnlineSubtitleSearchDialog(
+                    registry: registry,
+                    initialQuery: '最愛',
+                    saveDirectory: saveDir.path,
+                    debugInitialResult: seed,
+                  ),
+                );
+              },
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('候选按「文件名 + 来源·语言」渲染', (WidgetTester tester) async {
+    final _StubProvider provider = _StubProvider(
+      id: 'opensubtitles',
+      downloadFileName: 'saiai.ja.srt',
+    );
+    await pumpDialog(
+      tester,
+      registry: VideoSubtitleRegistry(<VideoSubtitleProvider>[provider]),
+      seed: ProviderBatchResult<VideoSubtitleCandidate>.success(
+        <VideoSubtitleCandidate>[
+          _StubCandidate(
+            providerId: 'opensubtitles',
+            fileName: 'saiai.ja.srt',
+            episode: 1,
+          ),
+        ],
+      ),
+    );
+
+    expect(find.text('saiai.ja.srt'), findsOneWidget);
+    // 来源必须可见：同一列表里混着多个源的结果，看不出出处就没法判断可信度。
+    expect(find.textContaining('opensubtitles'), findsOneWidget);
+  });
+
+  testWidgets('点候选 → 下载落盘并 pop 回本地路径', (WidgetTester tester) async {
+    final _StubProvider provider = _StubProvider(
+      id: 'opensubtitles',
+      downloadFileName: 'saiai.ja.srt',
+    );
+    await pumpDialog(
+      tester,
+      registry: VideoSubtitleRegistry(<VideoSubtitleProvider>[provider]),
+      seed: ProviderBatchResult<VideoSubtitleCandidate>.success(
+        <VideoSubtitleCandidate>[
+          _StubCandidate(
+            providerId: 'opensubtitles',
+            fileName: 'saiai.ja.srt',
+          ),
+        ],
+      ),
+    );
+
+    await tapAndSettleIo(tester, 'saiai.ja.srt');
+
+    expect(provider.downloadCalls, 1);
+    final File written = File(p.join(saveDir.path, 'saiai.ja.srt'));
+    expect(written.existsSync(), isTrue);
+    expect(written.readAsBytesSync(), <int>[1, 2, 3]);
+    // pop 契约与 Jimaku 对话框一致：返回本地绝对路径，播放页据此走同一条落地路径。
+    expect(popped, written.path);
+  });
+
+  testWidgets('远端文件名带路径分隔符时只取 basename（不逃出保存目录）', (WidgetTester tester) async {
+    final _StubProvider provider = _StubProvider(
+      id: 'opensubtitles',
+      downloadFileName: '../../evil.srt',
+    );
+    await pumpDialog(
+      tester,
+      registry: VideoSubtitleRegistry(<VideoSubtitleProvider>[provider]),
+      seed: ProviderBatchResult<VideoSubtitleCandidate>.success(
+        <VideoSubtitleCandidate>[
+          _StubCandidate(providerId: 'opensubtitles', fileName: 'shown.srt'),
+        ],
+      ),
+    );
+
+    await tapAndSettleIo(tester, 'shown.srt');
+
+    expect(File(p.join(saveDir.path, 'evil.srt')).existsSync(), isTrue);
+    expect(
+      File(p.join(saveDir.parent.path, 'evil.srt')).existsSync(),
+      isFalse,
+      reason: '文件名来自远端，绝不能带着 ../ 写到保存目录之外',
+    );
+  });
+
+  testWidgets('零结果时把 provider 失败原因单独显示出来', (WidgetTester tester) async {
+    final _StubProvider provider = _StubProvider(
+      id: 'opensubtitles',
+      downloadFileName: 'x.srt',
+    );
+    await pumpDialog(
+      tester,
+      registry: VideoSubtitleRegistry(<VideoSubtitleProvider>[provider]),
+      seed: ProviderBatchResult<VideoSubtitleCandidate>.failure(
+        const ExternalProviderFailure(
+          providerId: 'opensubtitles',
+          operation: 'search',
+          kind: ExternalProviderFailureKind.unauthorized,
+          message: 'OpenSubtitles API key is not configured',
+        ),
+      ),
+    );
+
+    // 「源挂了」和「真没有字幕」是两件事，混成一句「没找到」会让用户白等下去。
+    expect(
+      find.textContaining('OpenSubtitles API key is not configured'),
+      findsOneWidget,
+    );
+  });
+}

--- a/fushi/test/pages/video_online_subtitle_entry_guard_test.dart
+++ b/fushi/test/pages/video_online_subtitle_entry_guard_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+import 'video_fushi_page_source_corpus.dart';
+
+/// 播放页「在线获取字幕」入口的静态守卫。
+///
+/// 背景：OpenSubtitles 早就有完整 provider 实现（`open_subtitles_client.dart`）和设置
+/// 表单，但只挂在发现页 / 下载流水线一侧；播放页的字幕菜单是硬编码直连 Jimaku 的，用户
+/// 在播放器里根本看不到它。这里锁住补上的那条入口——播放器要 media_kit 真跑起来才能做
+/// widget 测试，故按本仓既有范式落静态守卫。
+///
+/// 全部是「要求型」断言，判据一律剥注释（[containsCodeLine] / [containsIdentifierCall]）：
+/// 裸 contains 下「把实现删掉、把字面量留在注释里」是能骗绿的。
+void main() {
+  final String src = readVideoFushiSource();
+
+  test('字幕菜单里有在线获取入口，且按已配置的源门控', () {
+    expect(containsCodeLine(src, 't.video_subtitle_online_fetch'), isTrue,
+        reason: '播放页字幕菜单必须有「在线获取字幕」入口，否则 OpenSubtitles 等源在'
+            '播放器里永远不可达；注释里写着这句不算实现');
+    expect(
+      containsCodeLine(
+          src, 'appModel.videoSubtitleRegistry?.providers.isNotEmpty'),
+      isTrue,
+      reason: '入口必须按「真有配置好的在线源」门控，一个源都没配时不该显示',
+    );
+  });
+
+  test('入口走 registry 而不是再硬编码一个 provider', () {
+    final String body =
+        methodBody(src, 'Future<void> _openOnlineSubtitleDialog(');
+    expect(containsIdentifierCall(body, 'OnlineSubtitleSearchDialog'), isTrue,
+        reason: '在线入口必须打开 provider 无关的对话框');
+    expect(containsCodeLine(body, 'registry: registry'), isTrue,
+        reason: '对话框必须吃 VideoSubtitleRegistry：加新字幕源不该再改播放页');
+    expect(containsCodeLine(body, 'videoPath: videoPath'), isTrue,
+        reason: '必须把本地视频路径传下去——OpenSubtitles 按文件哈希匹配才能命中该压制'
+            '版本的字幕，只按标题搜准度差一个数量级');
+  });
+
+  test('Jimaku 与在线两条下载路径共用同一条落地逻辑', () {
+    final String jimaku = methodBody(src, 'Future<void> _openJimakuDialog(');
+    final String online =
+        methodBody(src, 'Future<void> _openOnlineSubtitleDialog(');
+    expect(containsIdentifierCall(jimaku, '_applyDownloadedSubtitle'), isTrue,
+        reason: 'Jimaku 下载完必须走共用落地路径');
+    expect(containsIdentifierCall(online, '_applyDownloadedSubtitle'), isTrue,
+        reason: '在线源下载完必须走同一条落地路径：本地/远端分流、并入字幕轨列表、'
+            '成功提示都在那里，各写一份迟早漂开');
+  });
+
+  test('共用落地路径仍保留远端分流与轨列表登记', () {
+    final String body =
+        methodBody(src, 'Future<void> _applyDownloadedSubtitle(');
+    expect(containsIdentifierCall(body, '_applyRemoteSubtitle'), isTrue,
+        reason: '远端视频没有本地 DB 行，必须走只在内存应用的远端链路');
+    expect(
+        containsIdentifierCall(body, '_registerImportedSubtitleSource'), isTrue,
+        reason: 'BUG-1329：下载的新档要当场并入字幕轨列表，且不按 applied 门控');
+  });
+}

--- a/fushi/test/pages/video_subtitle_restore_fallback_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_restore_fallback_guard_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+import 'video_fushi_page_source_corpus.dart';
+
+/// `_loadSingle` 字幕恢复兜底链的静态守卫（BUG-1655）。
+///
+/// 用户实测：在合集里用 Jimaku 下载并应用了字幕，退出再进就没了，只能重新下。
+/// 排查到的真实数据（用户库 `D:\APP\HIBIKI_date`）：那一集的 `subtitle_source` 写对了、
+/// 文件在磁盘上、能解析出 406 条 cue，但该行 `audio_cues` 条数为 **0**——合集里的每一集
+/// 只落字幕源指针、不落 cue（`_selectSubtitleSource` 的 `_episodes.isEmpty` 分支）。
+///
+/// 于是恢复链的 else-if 结构成了单点故障：`rehydratePath != null` 这一支「试过但没解析出
+/// 东西」时，`cues` 保持 DB 缓存（恒空），而后续的「持久化源精确恢复 / sidecar 探测 /
+/// 内封轨自动加载」三层兜底全挂在同一条链的后面，一个都轮不到 ⇒ 零字幕、零兜底、零提示。
+/// 单视频有 `loadCues` 那层 DB cue 安全网，所以只在合集里必现。
+///
+/// 播放页要 media_kit 真跑起来才能 widget 测，故按本仓既有范式落静态守卫；判据一律剥注释
+/// （[containsCodeLine]），避免「把实现删掉、字面量留在注释里」骗绿。
+void main() {
+  final String src = readVideoFushiSource();
+  final String body = methodBody(src, 'Future<void> _loadSingle(');
+
+  test('兜底链独立于 else-if 链：任何一支没成功都必须能落到兜底', () {
+    expect(
+      containsCodeLine(body, 'if (!subtitleExplicitlyOff && cues.isEmpty) {'),
+      isTrue,
+      reason: '兜底必须是独立判据（「还没拿到 cue 就继续试」），而不是挂在 else-if 链尾',
+    );
+    expect(
+      containsCodeLine(body, '} else if (cues.isEmpty) {'),
+      isFalse,
+      reason: '一旦兜底重新变成 else-if 分支，前面任一支「试过但失败」就会直接空手收场'
+          '——这正是用户报「下载的字幕退出再进就没了」的结构性根因',
+    );
+  });
+
+  test('sidecar 探测的门只看「还没有 cue」，不再要求没有持久化源', () {
+    expect(
+      containsCodeLine(body, 'if (cues.isEmpty && externalSub == null) {'),
+      isFalse,
+      reason: '旧判据下「有持久化源但它恢复不出内容」时连 sidecar 都不试，'
+          '等于把唯一还能救的一层也关掉了',
+    );
+    expect(
+      containsIdentifierCall(body, '_detectSidecar'),
+      isTrue,
+      reason: 'sidecar 探测这层兜底必须还在',
+    );
+  });
+
+  test('恢复不出内容的外挂源不得挡住内封轨自动加载', () {
+    // VideoPlayerController.load 只在「无外挂路径 + 无 cue」时才后台抽内封文本轨；
+    // 留着一个解析不出东西的路径 = 连最后这层兜底也被挡掉。
+    expect(
+      containsCodeLine(body, 'externalSub = null;'),
+      isTrue,
+      reason: '最终仍无 cue 时必须放掉这个外挂路径，否则内封轨兜底永远不触发',
+    );
+    expect(
+      containsCodeLine(body,
+          'if (cues.isEmpty && !SubtitleSource.isEmbeddedPersisted(externalSub)) {'),
+      isTrue,
+      reason: '只在「确实没恢复出 cue」且源不是内嵌轨时才放掉；内嵌轨要保留给下游解析',
+    );
+  });
+
+  test('显式关闭字幕仍然短路整条兜底（TODO-818 不倒退）', () {
+    expect(
+      containsCodeLine(body, 'if (subtitleExplicitlyOff) {'),
+      isTrue,
+      reason: '用户显式关过字幕就不该被任何一层兜底重新打开',
+    );
+    // 兜底判据自身也带 !subtitleExplicitlyOff，双保险。
+    expect(
+      containsCodeLine(body, 'if (!subtitleExplicitlyOff && cues.isEmpty) {'),
+      isTrue,
+    );
+  });
+}

--- a/fushi/test/torrent/external_provider_adapters_test.dart
+++ b/fushi/test/torrent/external_provider_adapters_test.dart
@@ -146,6 +146,113 @@ void main() {
     );
     expect(result.failures.single.statusCode, 401);
   });
+
+  group('Jimaku Live Action 接入', () {
+    VideoMediaReference reference({
+      required VideoDiscoveryCategory category,
+      VideoMetadataMediaKind kind = VideoMetadataMediaKind.tv,
+      int? tmdbId,
+    }) =>
+        VideoMediaReference(
+          providerId: 'tmdb',
+          mediaId: '${tmdbId ?? 0}',
+          mediaKind: kind,
+          discoveryCategory: category,
+          title: '最愛',
+          tmdbId: tmdbId,
+        );
+
+    test('分类 → 检索范围：动漫查动画、其余查真人、未知查两类', () {
+      expect(
+        JimakuVideoSubtitleProvider.scopeFor(
+            reference(category: VideoDiscoveryCategory.anime)),
+        JimakuSearchScope.anime,
+      );
+      expect(
+        JimakuVideoSubtitleProvider.scopeFor(
+            reference(category: VideoDiscoveryCategory.tv)),
+        JimakuSearchScope.liveAction,
+      );
+      expect(
+        JimakuVideoSubtitleProvider.scopeFor(
+            reference(category: VideoDiscoveryCategory.movie)),
+        JimakuSearchScope.liveAction,
+      );
+      // 分类未知（播放页对本地文件搜字幕）不得默认成动画，否则日剧字幕整片消失。
+      expect(
+        JimakuVideoSubtitleProvider.scopeFor(null),
+        JimakuSearchScope.all,
+      );
+    });
+
+    test('TMDB id 按媒体种类编码（电影/剧集是两个号段）', () {
+      expect(
+        JimakuVideoSubtitleProvider.tmdbIdFor(reference(
+          category: VideoDiscoveryCategory.tv,
+          tmdbId: 126991,
+        )),
+        'tv:126991',
+      );
+      expect(
+        JimakuVideoSubtitleProvider.tmdbIdFor(reference(
+          category: VideoDiscoveryCategory.movie,
+          kind: VideoMetadataMediaKind.movie,
+          tmdbId: 669204,
+        )),
+        'movie:669204',
+      );
+      expect(
+        JimakuVideoSubtitleProvider.tmdbIdFor(
+            reference(category: VideoDiscoveryCategory.tv)),
+        isNull,
+      );
+    });
+
+    test('真人剧检索发 anime=false 且带 tmdb_id，不发 anilist_id', () async {
+      final List<String> searches = <String>[];
+      final JimakuVideoSubtitleProvider provider = JimakuVideoSubtitleProvider(
+        client: JimakuClient(
+          apiKey: 'k',
+          client: MockClient((http.Request request) async {
+            if (request.url.path.endsWith('/entries/search')) {
+              final Map<String, String> p = request.url.queryParameters;
+              searches.add('anime=${p['anime']}'
+                  ' tmdb=${p['tmdb_id']}'
+                  ' anilist=${p['anilist_id']}'
+                  ' query=${p['query']}');
+              return http.Response.bytes(
+                utf8.encode('[{"id":4,"name":"最愛","tmdb_id":"tv:126991",'
+                    '"flags":{"anime":false}}]'),
+                200,
+              );
+            }
+            return http.Response.bytes(
+              utf8.encode('[{"name":"最愛 - 01.ja.srt","url":"https://x/1"}]'),
+              200,
+            );
+          }),
+        ),
+      );
+
+      final ProviderBatchResult<VideoSubtitleCandidate> result =
+          await provider.search(
+        VideoSubtitleSearchRequest(
+          media: reference(
+            category: VideoDiscoveryCategory.tv,
+            tmdbId: 126991,
+          ),
+          query: '最愛',
+        ),
+      );
+
+      expect(result.failures, isEmpty);
+      expect(result.items, hasLength(1));
+      // TMDB 精确键命中即停，且分类恒为真人；AniList 是动画专属键，此处不得出现。
+      expect(searches, <String>[
+        'anime=false tmdb=tv:126991 anilist=null query=null',
+      ]);
+    });
+  });
 }
 
 const String _nyaaFeed = '''


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：本分支的 14 个新增文件在 `develop` 上**一个都不存在**，10 条提交主题在 `develop` 日志里也全部找不到。工作做完了，但从没开过 PR。

## 内容

Jimaku 真人剧检索 + OpenSubtitles 可达性/语言码归一 + 播放页在线字幕入口。未落地代码约 **+3170 行 / 25 个文件**。

## ⚠ 合并前必做

分支里的 `BUG-1651` ~ `BUG-1656` 六个号**已被 `develop` 上别的 bug 占用**。直接合会让 per-file 守卫测试 CI 变红。必须先跑：

    dart run tool/bug.dart renumber <old> <new>

（该工具会同时改文件名、正文 H2、代码引用、测试名四处并 reindex；只改文件名不改正文 H2 会让守卫测试红。）

## 风险

基底是 2026-08-15，`develop` 此后走了大量提交，预计有实质冲突，需人工 rebase。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
