### PR TITLE
fix(galgame): 在作者 720802ce 之上补齐 PR #938 剩余根因修复（从未开 PR）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 63580 (3740 per locale)
+/// Strings: 63597 (3741 per locale)
 ///
-/// Built on 2026-08-22 at 04:11 UTC
+/// Built on 2026-08-22 at 06:17 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5077,6 +5077,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get gal_hook_text_corner_radius => 'Window corner radius';
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -13745,6 +13747,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -22478,6 +22483,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -31227,6 +31235,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -39988,6 +39999,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -48679,6 +48693,9 @@ class _StringsId extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -57414,6 +57431,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -65966,6 +65986,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -74526,6 +74549,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -83241,6 +83267,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -91968,6 +91997,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -100682,6 +100714,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -109344,6 +109379,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -118037,6 +118075,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -126716,6 +126757,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 // Path: <root>
@@ -134737,6 +134781,9 @@ class _StringsZhCn extends _StringsEn {
   String get gal_hook_text_corner_radius => '窗口圆角';
   @override
   String get gal_hook_text_corner_radius_hint => '调整窗口背景的圆角半径。';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
 }
 
 // Path: <root>
@@ -143214,6 +143261,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get gal_hook_text_corner_radius_hint =>
       'Adjust the background corner radius.';
+  @override
+  String get game_hook_reason_capability_probe_failed =>
+      'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -150886,6 +150936,8 @@ extension on _StringsEn {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -158556,6 +158608,8 @@ extension on _StringsAr {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -166248,6 +166302,8 @@ extension on _StringsDe {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -173939,6 +173995,8 @@ extension on _StringsEs {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -181636,6 +181694,8 @@ extension on _StringsFr {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -189315,6 +189375,8 @@ extension on _StringsId {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -197008,6 +197070,8 @@ extension on _StringsIt {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -204663,6 +204727,8 @@ extension on _StringsJa {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -212322,6 +212388,8 @@ extension on _StringsKo {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -220009,6 +220077,8 @@ extension on _StringsNl {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -227693,6 +227763,8 @@ extension on _StringsPtBr {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -235382,6 +235454,8 @@ extension on _StringsRu {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -243054,6 +243128,8 @@ extension on _StringsTh {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -250735,6 +250811,8 @@ extension on _StringsTr {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -258412,6 +258490,8 @@ extension on _StringsVi {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }
@@ -266030,6 +266110,8 @@ extension on _StringsZhCn {
         return '窗口圆角';
       case 'gal_hook_text_corner_radius_hint':
         return '调整窗口背景的圆角半径。';
+      case 'game_hook_reason_capability_probe_failed':
+        return '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
       default:
         return null;
     }
@@ -273680,6 +273762,8 @@ extension on _StringsZhHk {
         return 'Window corner radius';
       case 'gal_hook_text_corner_radius_hint':
         return 'Adjust the background corner radius.';
+      case 'game_hook_reason_capability_probe_failed':
+        return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "文字左右边距",
   "gal_hook_text_padding_hint": "让文字与窗口边缘和缩放手柄保持距离。",
   "gal_hook_text_corner_radius": "窗口圆角",
-  "gal_hook_text_corner_radius_hint": "调整窗口背景的圆角半径。"
+  "gal_hook_text_corner_radius_hint": "调整窗口背景的圆角半径。",
+  "game_hook_reason_capability_probe_failed": "捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3738,5 +3738,6 @@
   "gal_hook_text_padding": "Horizontal text padding",
   "gal_hook_text_padding_hint": "Keep text away from the window edges and resize grip.",
   "gal_hook_text_corner_radius": "Window corner radius",
-  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius."
+  "gal_hook_text_corner_radius_hint": "Adjust the background corner radius.",
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
 }

--- a/fushi/lib/src/mining/gal_hook_failure_text.dart
+++ b/fushi/lib/src/mining/gal_hook_failure_text.dart
@@ -40,6 +40,8 @@ String? galHookFailureLabel(GalHookInjectorFailure failure) =>
         t.game_hook_reason_shared_memory_unavailable,
       GalHookInjectorFailure.protocolMismatch =>
         t.game_hook_reason_protocol_mismatch,
+      GalHookInjectorFailure.capabilityProbeFailed =>
+        t.game_hook_reason_capability_probe_failed,
       GalHookInjectorFailure.handshakeTimeout =>
         t.game_hook_reason_handshake_timeout,
     };

--- a/fushi/lib/src/mining/gal_hook_session_controller.dart
+++ b/fushi/lib/src/mining/gal_hook_session_controller.dart
@@ -2953,7 +2953,18 @@ class GalHookSessionController extends ChangeNotifier {
     return null;
   }
 
-  Future<void> _applyNativeLoopbackPolicyToLiveEngines({
+  /// 把 native loopback 策略推给所有活跃引擎，返回**有多少个没确认**。
+  ///
+  /// 两处根因修复（原实现用 `throw StateError` 表示未确认）：
+  ///   (1) 抛出会当场中断循环，后面的引擎连一次 deny 请求都收不到——而 deny 是隐私门，
+  ///       漏掉任何一个引擎就意味着那个游戏进程里的 loopback 还在录。所以这里逐个都发，
+  ///       单个引擎失败或抛出只累计计数，不打断其余引擎。
+  ///   (2) 那个 StateError 被 [SerialJobQueue] 的 buildFailure 吞成 `false`，而调用方
+  ///       `.then<void>((bool _) {})` 把它丢掉，于是 fail-closed 契约在用户那边表现为
+  ///       fail-open：UI 一声不响，用户以为回环已经关了。计数返回给调用方，由它落进
+  ///       可见状态。
+  Future<({int unacknowledged, bool superseded})>
+      _applyNativeLoopbackPolicyToLiveEngines({
     required GalNativeLoopbackPolicy policy,
     required int sessionGeneration,
     required int policyRevision,
@@ -2966,18 +2977,45 @@ class GalHookSessionController extends ChangeNotifier {
     if (starting != null) engines.add(starting);
     if (active != null) engines.add(active);
     if (audio is EngineHookGalAudioSource) engines.add(audio);
+    int unacknowledged = 0;
     for (final EngineHookGalAudioSource engine in engines) {
-      final bool applied = await engine.requestNativeLoopbackPolicy(policy);
+      bool applied = false;
+      try {
+        applied = await engine.requestNativeLoopbackPolicy(policy);
+      } on Object {
+        applied = false;
+      }
       if (sessionGeneration != _operationGeneration ||
           policyRevision != _audioFallbackPolicyRevision) {
-        return;
+        return (unacknowledged: unacknowledged, superseded: true);
       }
-      if (!applied) {
-        throw StateError(
-          'native loopback policy ${policy.cliValue} was not acknowledged',
-        );
-      }
+      if (!applied) unacknowledged++;
     }
+    return (unacknowledged: unacknowledged, superseded: false);
+  }
+
+  /// 策略没能全部落地时，必须让用户看见——尤其是 deny：没确认就等于那个游戏进程里的
+  /// 回环可能还在录，而 UI 上策略已经显示成「干净源」了。
+  void _reportNativeLoopbackPolicyUnacknowledged({
+    required GalNativeLoopbackPolicy policy,
+    required int unacknowledged,
+  }) {
+    final String message = policy == GalNativeLoopbackPolicy.deny
+        ? 'Process loopback capture could not be confirmed stopped in '
+            '$unacknowledged running game(s); restart the game to be sure'
+        : 'Process loopback capture could not be re-enabled in '
+            '$unacknowledged running game(s)';
+    _setState(_state.copyWith(lastError: message));
+    _record(
+      GalHookEventSeverity.error,
+      'audio',
+      'audio.native_loopback_policy_unacknowledged',
+      message,
+      details: <String, Object?>{
+        'policy': policy.cliValue,
+        'unacknowledged': unacknowledged,
+      },
+    );
   }
 
   /// 用户切换降级策略：立即生效 + 按游戏记住。
@@ -3007,9 +3045,13 @@ class GalHookSessionController extends ChangeNotifier {
             sessionGeneration != _operationGeneration) {
           return true;
         }
+        final GalNativeLoopbackPolicy native = policy.allowsLoopback
+            ? GalNativeLoopbackPolicy.allow
+            : GalNativeLoopbackPolicy.deny;
+        final ({int unacknowledged, bool superseded}) result;
         if (policy.allowsLoopback) {
-          await _applyNativeLoopbackPolicyToLiveEngines(
-            policy: GalNativeLoopbackPolicy.allow,
+          result = await _applyNativeLoopbackPolicyToLiveEngines(
+            policy: native,
             sessionGeneration: sessionGeneration,
             policyRevision: revision,
           );
@@ -3025,11 +3067,19 @@ class GalHookSessionController extends ChangeNotifier {
             sessionGeneration: sessionGeneration,
             policyRevision: revision,
           );
-          await _applyNativeLoopbackPolicyToLiveEngines(
-            policy: GalNativeLoopbackPolicy.deny,
+          result = await _applyNativeLoopbackPolicyToLiveEngines(
+            policy: native,
             sessionGeneration: sessionGeneration,
             policyRevision: revision,
           );
+        }
+        if (result.superseded) return true;
+        if (result.unacknowledged > 0) {
+          _reportNativeLoopbackPolicyUnacknowledged(
+            policy: native,
+            unacknowledged: result.unacknowledged,
+          );
+          return false;
         }
         return true;
       },

--- a/fushi/lib/src/mining/galgame_audio_source.dart
+++ b/fushi/lib/src/mining/galgame_audio_source.dart
@@ -281,6 +281,13 @@ enum GalHookInjectorFailure {
   /// injector 已 hooked、共享内存已开，但超时内既没有 PCM 格式也没有文本 hook。
   handshakeTimeout,
 
+  /// capability 探测没能给出答案：helper 拉不起来、崩了、或超时没退出。
+  ///
+  /// 与 [protocolMismatch] 分开是因为**处置相反**：那条是组件比本体旧、只能换版本；
+  /// 这条是这台机器上 helper 根本没跑起来或没响应（多为杀软删档/锁定、权限不足、
+  /// 进程挂住），换多少个版本都不会好。
+  capabilityProbeFailed,
+
   /// 有失败但无法归类（保留原始 stderr 尾巴供诊断）。
   unknown,
 }
@@ -1009,9 +1016,32 @@ typedef GalHookProcessStarter = Future<Process> Function(
   List<String> arguments,
 );
 
+/// capability 探测的三态结果。
+///
+/// 「答了但没这个能力」和「根本没答上来」必须分开：前者是组件版本旧、只能换版本；
+/// 后者是这台机器上 helper 拉不起来或没响应（杀软删档/权限不足/进程挂住），换版本
+/// 一点用没有。合成一个 bool 就只能二选一地误报，而误报的那一半会把用户引向一个
+/// 做了也没用的动作。
+enum GalHookCapabilityProbeResult {
+  /// helper 跑起来了，并明确应答了 v16 capability。
+  supported,
+
+  /// helper 跑起来也答了，但答案里没有这个 capability——组件比本体旧。
+  unsupported,
+
+  /// helper 没能给出答案：拉不起来、崩了、或超时没退出。
+  probeFailed,
+}
+
+/// capability 探测的硬上限。探测是**目标无关**的一次性子进程调用，正常在毫秒级返回；
+/// 没有这个上限，helper 一挂住 `start()` 就永不返回，`_audioFallbackPolicyQueue`
+/// 随之永久堵死（串行队列在等这一个 job）。
+const Duration kGalHookCapabilityProbeTimeout = Duration(seconds: 5);
+
 /// Whether the installed injector proves the v16 fail-closed native loopback
 /// contract without opening or injecting any target process.
-typedef GalHookCapabilitiesProbe = Future<bool> Function(String executable);
+typedef GalHookCapabilitiesProbe = Future<GalHookCapabilityProbeResult>
+    Function(String executable);
 
 enum GalNativeLoopbackPolicy {
   deny,
@@ -1033,19 +1063,42 @@ bool hasGalNativeLoopbackPolicyCapability({
     stdout is String &&
     stdout.trim() == kGalNativeLoopbackPolicyCapability;
 
-Future<bool> _probeGalHookCapabilities(String executable) async {
+Future<GalHookCapabilityProbeResult> _probeGalHookCapabilities(
+  String executable,
+) async {
+  final Process process;
   try {
-    final ProcessResult result = await Process.run(
+    process = await Process.start(
       executable,
       const <String>['--capabilities'],
       runInShell: false,
     );
-    return hasGalNativeLoopbackPolicyCapability(
-      exitCode: result.exitCode,
-      stdout: result.stdout,
-    );
   } on ProcessException {
-    return false;
+    return GalHookCapabilityProbeResult.probeFailed;
+  }
+  // 必须自己起进程而不是用 Process.run：`Process.run(...).timeout(...)` 只是放弃
+  // 等待，子进程照样活着、管道照样被引用，挂住的 helper 会一直挂着。这里超时后
+  // 真的把它杀掉。
+  final Future<String> stdoutText =
+      process.stdout.transform(utf8.decoder).join();
+  final Future<void> drainedStderr = process.stderr.drain<void>();
+  try {
+    final int exitCode =
+        await process.exitCode.timeout(kGalHookCapabilityProbeTimeout);
+    final String stdout =
+        await stdoutText.timeout(kGalHookCapabilityProbeTimeout);
+    await drainedStderr.timeout(kGalHookCapabilityProbeTimeout);
+    return hasGalNativeLoopbackPolicyCapability(
+      exitCode: exitCode,
+      stdout: stdout,
+    )
+        ? GalHookCapabilityProbeResult.supported
+        : GalHookCapabilityProbeResult.unsupported;
+  } on TimeoutException {
+    process.kill(ProcessSignal.sigkill);
+    return GalHookCapabilityProbeResult.probeFailed;
+  } on ProcessException {
+    return GalHookCapabilityProbeResult.probeFailed;
   }
 }
 
@@ -1475,16 +1528,26 @@ class EngineHookGalAudioSource implements GalAudioSource {
     // Safety gate: old helpers silently ignore unknown flags. Prove the exact
     // v16 capability in a target-free process before we ever spawn an
     // injection command; no capability means no launch, attach, or retry.
-    var supportsNativeLoopbackPolicy = false;
+    GalHookCapabilityProbeResult capability =
+        GalHookCapabilityProbeResult.probeFailed;
     try {
-      supportsNativeLoopbackPolicy = await _capabilitiesProbe(path);
+      capability = await _capabilitiesProbe(path);
     } on Object {
-      supportsNativeLoopbackPolicy = false;
+      // 探测器自身抛出（含注入的测试替身）也只是「没答上来」，不是「组件太老」。
+      // 兜住异常是为了不毒化调用它的串行队列，但兜住之后必须如实归类。
+      capability = GalHookCapabilityProbeResult.probeFailed;
     }
-    if (!supportsNativeLoopbackPolicy) {
-      _lastFailure = const GalHookInjectorDiagnostics(
-        failure: GalHookInjectorFailure.protocolMismatch,
-        stderrTail: 'injector capability native_loopback_policy_v1 unavailable',
+    if (capability != GalHookCapabilityProbeResult.supported) {
+      final bool tooOld =
+          capability == GalHookCapabilityProbeResult.unsupported;
+      _lastFailure = GalHookInjectorDiagnostics(
+        // 处置相反：unsupported 只能换版本；probeFailed 要查杀软/权限/挂住的进程。
+        failure: tooOld
+            ? GalHookInjectorFailure.protocolMismatch
+            : GalHookInjectorFailure.capabilityProbeFailed,
+        stderrTail: tooOld
+            ? 'injector capability native_loopback_policy_v1 unavailable'
+            : 'injector capability probe produced no answer',
       );
       _finishStartWait(opened: false);
       return null;

--- a/fushi/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/fushi/lib/src/pages/implementations/custom_fonts_page.dart
@@ -658,7 +658,12 @@ class _CustomFontsPageState extends BasePageState {
     }
     await _settings!.refreshFromDb();
     await appModel.refreshAppFont();
-    await GalHookTextOverlayController.instance.applyFontFromSettings();
+    // 平台门在**取单例之前**：GalHookTextOverlayController.instance 会把整套 galgame
+    // 单例图（含 GalIngameLookupController 与它挂上去、永不释放的监听器）建起来。
+    // 非 Windows 用户只是存了一次字体，不该因此拉起一整个 Windows 专属子系统。
+    if (GalHookTextOverlayController.isSupported) {
+      await GalHookTextOverlayController.instance.applyFontFromSettings();
+    }
     ReaderFushiSource.onSettingsChangedLive?.call();
   }
 
@@ -1455,7 +1460,7 @@ class _CustomFontCatalogTileState extends State<CustomFontCatalogTile> {
 
   /// 折叠态摘要：把已启用的用途拼成一行，用户不展开也能一眼看到该字体用在哪。
   String get _rolesSummary => <String>[
-        for (final FontTarget target in FontTarget.values)
+        for (final FontTarget target in visibleFontTargets)
           if (widget.targets.contains(target)) _targetLabel(target),
       ].join(' · ');
 
@@ -1590,7 +1595,10 @@ class _CustomFontCatalogTileState extends State<CustomFontCatalogTile> {
                 spacing: tokens.spacing.gap,
                 runSpacing: tokens.spacing.gap,
                 children: [
-                  for (final FontTarget target in FontTarget.values)
+                  // 只列当前平台真的存在的用途：游戏查词浮窗是 Windows 专属，
+                  // 在安卓/iOS/macOS/Linux 上多出这一枚 chip 是一个点了没有任何
+                  // 效果的开关。持久化不按平台裁剪（见 visibleFontTargets）。
+                  for (final FontTarget target in visibleFontTargets)
                     FilterChip(
                       label: Text(_targetLabel(target)),
                       selected: widget.targets.contains(target),

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -35,6 +35,22 @@ enum FontTarget {
   gameLookup,
 }
 
+extension FontTargetAvailability on FontTarget {
+  /// 这个用途在当前平台上是否**存在**。
+  ///
+  /// 只用来决定 UI 列不列。持久化一律遍历 [FontTarget.values]：同一份 profile 会跨端
+  /// 同步，按平台裁剪读写就等于「在安卓上打开一次字体页，Windows 上配好的游戏查词
+  /// 字体被抹掉」。
+  bool get isAvailableOnThisPlatform =>
+      this != FontTarget.gameLookup || Platform.isWindows;
+}
+
+/// UI 里应当列出的字体用途。见 [FontTargetAvailability.isAvailableOnThisPlatform]。
+List<FontTarget> get visibleFontTargets => <FontTarget>[
+      for (final FontTarget target in FontTarget.values)
+        if (target.isAvailableOnThisPlatform) target,
+    ];
+
 /// All reader display/behavior settings, decoupled from the media source.
 ///
 /// Reads/writes share the same Drift `preferences` table keys as

--- a/fushi/test/build/gal_overlay_appearance_guard_test.dart
+++ b/fushi/test/build/gal_overlay_appearance_guard_test.dart
@@ -7,6 +7,8 @@ void main() {
       File('windows/runner/floating_lyric_window.h').readAsStringSync();
   final String runner =
       File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+  final String prefs =
+      File('lib/src/models/preferences_repository.dart').readAsStringSync();
   final String channel =
       File('windows/runner/flutter_window.cpp').readAsStringSync();
 
@@ -51,5 +53,26 @@ void main() {
     expect(runner.contains('style_.outline_width'), isTrue);
     expect(runner.contains('style_.text_padding'), isTrue);
     expect(runner.contains('style_.corner_radius'), isTrue);
+  });
+
+  test('a corner radius of 0 really means 0 (no default-value sentinel)', () {
+    // 圆角偏好的下限就是 0（直角）。绘制点如果把 0 当作「用平台默认」，用户把滑块
+    // 拖到 0 什么都不会发生，而且现象上完全看不出原因。历史默认必须由 Style 的默认
+    // 值承担，绘制点不得有 `corner_radius > 0 ? ... : 默认` 这种哨兵分支。
+    expect(
+      RegExp(r'style_\.corner_radius\s*>\s*0').hasMatch(runner),
+      isFalse,
+      reason: '0 是合法圆角取值，不能同时当作「用默认」的哨兵',
+    );
+    expect(
+      header.contains('double corner_radius = 14.0;'),
+      isTrue,
+      reason: '历史默认 14dp 必须写在 Style 的默认值上',
+    );
+    expect(
+      prefs.contains('galHookTextCornerRadiusMin = 0.0'),
+      isTrue,
+      reason: '偏好下限是 0，这条守卫的前提',
+    );
   });
 }

--- a/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
+++ b/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
@@ -21,17 +21,36 @@ void main() {
   final String controller =
       File('lib/src/lookup/gal_hook_text_overlay_controller.dart')
           .readAsStringSync();
+  final String prefs =
+      File('lib/src/models/preferences_repository.dart').readAsStringSync();
+  final String windowHeader =
+      File('windows/runner/floating_lyric_window.h').readAsStringSync();
 
   test('① 描边/投影是同一 text_layout_ 的偏移多遍绘制', () {
+    // 描边半径从固定常量 kLyricOutlineRadiusDip 改成了用户可配的 style_.outline_width，
+    // 所以这里不再钉常量名，而是钉「半径来自 style_ 且被夹在合法区间」——常量名没了不等于
+    // 渲染没接上，但取值不夹区间就是能把描边拉到吃掉整块文字。
     expect(
-      window.contains('kLyricOutlineRadiusDip'),
+      window.contains('std::clamp(style_.outline_width, 0.0, 8.0)'),
       isTrue,
-      reason: '描边半径常量必须存在，否则桌面歌词渲染根本没接上',
+      reason: '描边半径必须取自 style_.outline_width 并夹在 [0,8]',
     );
     expect(
       window.contains('kLyricShadowOffsetDip'),
       isTrue,
       reason: '投影偏移常量必须存在',
+    );
+    // 可配置化不得顺手改观感：默认值必须逐位等于改造前的硬编码值，否则所有没动过
+    // 这个设置的用户会在一次升级后发现描边变了，而 diff 里看不出任何「观感改动」。
+    expect(
+      prefs.contains('galHookTextOutlineWidthDefault = 1.6'),
+      isTrue,
+      reason: '描边默认值必须等于原 kLyricOutlineRadiusDip = 1.6f',
+    );
+    expect(
+      windowHeader.contains('bool bold = true;'),
+      isTrue,
+      reason: '半粗默认必须为真：改造前 hook 模式无条件半粗',
     );
     // 描边环必须把 text_layout_ 自己再画一遍（同一几何），而不是另建排版。
     expect(
@@ -60,11 +79,13 @@ void main() {
       reason: '注音描边遍必须被 hook_text_mode_ 门住',
     );
     expect(
-      RegExp(r'hook_text_mode_\s*\?\s*DWRITE_FONT_WEIGHT_SEMI_BOLD'
+      RegExp(r'hook_text_mode_ && style_\.bold\s*\?\s*'
+              r'DWRITE_FONT_WEIGHT_SEMI_BOLD'
               r'\s*:\s*DWRITE_FONT_WEIGHT_NORMAL')
           .hasMatch(window),
       isTrue,
-      reason: '半粗字重同样只允许在 hook 模式启用',
+      reason: '半粗字重同样只允许在 hook 模式启用（现在还叠一个用户开关，'
+          '但 hook_text_mode_ 这一层门不能被去掉——去掉就会改到歌词条/剪贴板窗）',
     );
   });
 

--- a/fushi/test/build/overlay_ruby_render_guard_test.dart
+++ b/fushi/test/build/overlay_ruby_render_guard_test.dart
@@ -23,6 +23,8 @@ void main() {
       File('windows/runner/floating_lyric_window.h').readAsStringSync();
   final String channelHost =
       File('windows/runner/flutter_window.cpp').readAsStringSync();
+  final String prefs =
+      File('lib/src/models/preferences_repository.dart').readAsStringSync();
 
   test('① 注音几何复用 HitTestTextRange，不自建排版', () {
     expect(
@@ -74,12 +76,31 @@ void main() {
       isTrue,
       reason: '必须有一个统一的 has_ruby 门，空注音时行距与绘制都不动',
     );
+    // 行距门现在有两个入口：注音（has_ruby）和 hook 模式下用户自定的行高。两个入口
+    // 都必须在同一个 if 里，且必须都是有条件的——无条件改行距会让所有老浮窗观感变化。
+    final Match? spacingGate = RegExp(
+      r'if \(text_layout_ != nullptr &&\s*\(has_ruby \|\|'
+      r'[\s\S]{0,80}?hook_text_mode_ &&[\s\S]{0,80}?style_\.line_height'
+      r'[\s\S]{0,900}?SetLineSpacing',
+    ).firstMatch(window);
     expect(
-      RegExp(r'if \(has_ruby && text_layout_ != nullptr\)[\s\S]{0,600}?'
-              r'SetLineSpacing')
+      spacingGate,
+      isNotNull,
+      reason: '加高行距必须同时挂在 has_ruby 与 hook_text_mode_ 两个门后；'
+          '任一入口无条件化都会改到歌词条 / 剪贴板窗',
+    );
+    // 可配置化不得顺手改观感：默认行高必须是 1.0（恒等），没动过这个设置的用户
+    // 排版逐像素等于改造前。守卫只放宽正则不补这条，就是给「默认值悄悄变了」开门。
+    expect(
+      prefs.contains('galHookTextLineHeightDefault = 1.0'),
+      isTrue,
+      reason: '行高默认必须是恒等值 1.0',
+    );
+    expect(
+      RegExp(r'std::clamp\(\s*style_\.line_height,\s*0\.8,\s*2\.0\s*\)')
           .hasMatch(window),
       isTrue,
-      reason: '加高行距必须挂在 has_ruby 门后；无条件改行距会让所有老浮窗观感变化',
+      reason: '行高必须夹在 [0.8,2.0]，否则能把整块文字推出可视区',
     );
     expect(
       RegExp(r'if \(has_ruby && ruby_format_ != nullptr\)').hasMatch(window),

--- a/fushi/test/media/audiobook/floating_lyric_click_through_guard_test.dart
+++ b/fushi/test/media/audiobook/floating_lyric_click_through_guard_test.dart
@@ -103,13 +103,24 @@ void main() {
     });
 
     test('padlock glyphs are drawn as full UTF-16 strings', () {
+      // 这条守卫原本把缩进写死在断言里（负向断言匹配的是 'DrawTextW(' + 换行 +
+      // 10 个空格 + 'glyph, 1,'）。后来新增的 hook 工具栏把同样的调用写成单行，
+      // 于是整个从它旁边溜了过去。改成「按调用点计数」：任何一个 glyph 绘制不走
+      // GlyphLength 就红，与缩进、换行、参数换行位置全部无关。
       expect(cpp.contains('GlyphLength'), isTrue,
           reason: 'Emoji glyphs need their full UTF-16 code-unit length.');
-      expect(cpp.contains('DrawTextW(\n          glyph, GlyphLength(glyph),'),
-          isTrue,
-          reason: 'DrawTextW must not truncate surrogate-pair glyphs.');
-      expect(cpp.contains('DrawTextW(\n          glyph, 1,'), isFalse,
-          reason: 'Length 1 truncates U+1F512/U+1F513 padlock glyphs.');
+      final Iterable<RegExpMatch> glyphDraws =
+          RegExp(r'DrawTextW\(\s*glyph,\s*([^,]+),').allMatches(cpp);
+      expect(glyphDraws, isNotEmpty,
+          reason: 'The glyph draw call must still exist.');
+      for (final RegExpMatch m in glyphDraws) {
+        expect(
+          m.group(1)!.trim(),
+          'GlyphLength(glyph)',
+          reason: 'Every glyph DrawTextW must pass the full UTF-16 length; a '
+              'literal length truncates U+1F512/U+1F513-class glyphs.',
+        );
+      }
     });
   });
 

--- a/fushi/test/mining/gal_shm_open_error_test.dart
+++ b/fushi/test/mining/gal_shm_open_error_test.dart
@@ -165,7 +165,8 @@ void main() {
       final EngineHookGalAudioSource source = EngineHookGalAudioSource(
         targetPid: 4321,
         injectorPath: injector.path,
-        capabilitiesProbe: (String _) async => true,
+        capabilitiesProbe: (String _) async =>
+            GalHookCapabilityProbeResult.supported,
         processStarter: (String executable, List<String> arguments) async {
           scheduleMicrotask(() {
             process.stdoutController.add(injectorStdout.codeUnits);

--- a/fushi/test/mining/galgame_audio_test.dart
+++ b/fushi/test/mining/galgame_audio_test.dart
@@ -458,7 +458,7 @@ void main() {
         injectorPath: injector.path,
         capabilitiesProbe: (String executable) async {
           expect(executable, injector.path);
-          return false;
+          return GalHookCapabilityProbeResult.unsupported;
         },
         processStarter: (String executable, List<String> arguments) async {
           injectionStarts++;
@@ -476,6 +476,80 @@ void main() {
         await source.stop();
         await temp.delete(recursive: true);
       }
+    });
+
+    test('capability 探测答不上来时报「探测失败」而不是「组件太老」', () async {
+      // 两种失败的处置相反：unsupported 只能换版本，probeFailed 要查杀软/权限/
+      // 挂住的进程。旧实现用一个 bool + `on Object` 把任意错误都翻成
+      // protocolMismatch（「组件太老」），把用户引向一个做了也没用的动作。
+      final Directory temp = await Directory.systemTemp.createTemp(
+        'hibiki_helper_capability_probe_failed_test_',
+      );
+      final File injector =
+          File('${temp.path}${Platform.pathSeparator}fake.exe');
+      await injector.writeAsBytes(const <int>[0]);
+      var injectionStarts = 0;
+      final EngineHookGalAudioSource source = EngineHookGalAudioSource(
+        targetPid: 2468,
+        injectorPath: injector.path,
+        capabilitiesProbe: (String _) async =>
+            GalHookCapabilityProbeResult.probeFailed,
+        processStarter: (String executable, List<String> arguments) async {
+          injectionStarts++;
+          throw StateError('injection must not start');
+        },
+      );
+      try {
+        expect(await source.start(), isNull);
+        expect(injectionStarts, 0, reason: '仍然 fail closed，绝不启动注入');
+        expect(
+          source.lastFailure.failure,
+          GalHookInjectorFailure.capabilityProbeFailed,
+        );
+        expect(
+          source.lastFailure.failure,
+          isNot(GalHookInjectorFailure.protocolMismatch),
+        );
+      } finally {
+        await source.stop();
+        await temp.delete(recursive: true);
+      }
+    });
+
+    test('capability 探测抛异常也归类成探测失败，且不毒化调用方', () async {
+      final Directory temp = await Directory.systemTemp.createTemp(
+        'hibiki_helper_capability_probe_throw_test_',
+      );
+      final File injector =
+          File('${temp.path}${Platform.pathSeparator}fake.exe');
+      await injector.writeAsBytes(const <int>[0]);
+      final EngineHookGalAudioSource source = EngineHookGalAudioSource(
+        targetPid: 2468,
+        injectorPath: injector.path,
+        capabilitiesProbe: (String _) async =>
+            throw StateError('probe blew up'),
+        processStarter: (String executable, List<String> arguments) async =>
+            throw StateError('injection must not start'),
+      );
+      try {
+        // start() 必须正常返回 null（异常不能穿出去把串行队列毒死），
+        // 同时诊断必须如实说是探测失败。
+        expect(await source.start(), isNull);
+        expect(
+          source.lastFailure.failure,
+          GalHookInjectorFailure.capabilityProbeFailed,
+        );
+      } finally {
+        await source.stop();
+        await temp.delete(recursive: true);
+      }
+    });
+
+    test('capability 探测有硬超时上限（不会让 start() 永不返回）', () {
+      // 探测是目标无关的一次性子进程调用；没有上限，helper 一挂住整条
+      // _audioFallbackPolicyQueue 就永久堵死。
+      expect(kGalHookCapabilityProbeTimeout.inSeconds, greaterThan(0));
+      expect(kGalHookCapabilityProbeTimeout.inMinutes, lessThan(1));
     });
 
     test('capability stdout 只接受退出码 0 的 exact single token', () {
@@ -548,7 +622,8 @@ void main() {
       final EngineHookGalAudioSource source = EngineHookGalAudioSource(
         launchExe: game.path,
         injectorPath: injector.path,
-        capabilitiesProbe: (String _) async => true,
+        capabilitiesProbe: (String _) async =>
+            GalHookCapabilityProbeResult.supported,
         processStarter: (String executable, List<String> arguments) async {
           expect(executable, injector.path);
           expect(
@@ -653,7 +728,8 @@ void main() {
       final EngineHookGalAudioSource source = EngineHookGalAudioSource(
         targetPid: 2468,
         injectorPath: injector.path,
-        capabilitiesProbe: (String _) async => true,
+        capabilitiesProbe: (String _) async =>
+            GalHookCapabilityProbeResult.supported,
         processStarter: (String executable, List<String> arguments) async {
           expect(executable, injector.path);
           expect(arguments, containsAllInOrder(<String>['--pid', '2468']));
@@ -738,7 +814,8 @@ void main() {
       final EngineHookGalAudioSource source = EngineHookGalAudioSource(
         targetPid: 2468,
         injectorPath: injector.path,
-        capabilitiesProbe: (String _) async => true,
+        capabilitiesProbe: (String _) async =>
+            GalHookCapabilityProbeResult.supported,
         processStarter: (String executable, List<String> arguments) async {
           expect(
             arguments,

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -72,6 +72,32 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // 连控件都不该渲染。由四层专项测试咬住：Dart 侧命中→定位→投帧的契约测试、native
   // 侧 v14 契约测试（区寻址 + 帧闸门 + ShouldApplyLookupFrame 真值表）、会话 replay
   // （7 个变异体实测全红），以及禁止把查词链路搬回游戏进程的源码扫描守卫。
+  // galgame 台词浮窗的九项外观设置（PR#938）。写 prefsRepo（changed=true），生效点
+  // 全部在 runner 自有的 Win32 分层窗里：Direct2D/DirectWrite 直绘，widget harness
+  // 既没有那个 HWND 也没有渲染目标，没有任何可探的渲染输入；而且整条 Windows-only，
+  // CI（Linux）连控件都不该渲染。由三层源码守卫咬住：
+  //   ① appearance 守卫：每个字段都真的过 MethodChannel 落进 native style，并被
+  //      对应的绘制点消费（不是「接进来了但没人读」）；
+  //   ② lyric-style 守卫：描边/字重的门控与**默认值等于改造前硬编码值**；
+  //   ③ ruby-render 守卫：行距门控与默认行高恒等 1.0。
+  // ②③ 那两条默认值断言是这批登记的前提：可配置化如果顺手改了默认观感，
+  // 「没探针」就会变成「没人发现所有老用户的浮窗都变样了」。
+  'game/Galgame caption font size':
+      'test/build/gal_overlay_appearance_guard_test.dart',
+  'game/Letter spacing': 'test/build/gal_overlay_appearance_guard_test.dart',
+  'game/Line height': 'test/build/gal_overlay_appearance_guard_test.dart + '
+      'test/build/overlay_ruby_render_guard_test.dart',
+  'game/Bold text': 'test/build/gal_overlay_appearance_guard_test.dart + '
+      'test/build/gal_overlay_lyric_style_guard_test.dart',
+  'game/Text alignment': 'test/build/gal_overlay_appearance_guard_test.dart',
+  'game/Window background opacity':
+      'test/build/gal_overlay_appearance_guard_test.dart',
+  'game/Outline width': 'test/build/gal_overlay_appearance_guard_test.dart + '
+      'test/build/gal_overlay_lyric_style_guard_test.dart',
+  'game/Horizontal text padding':
+      'test/build/gal_overlay_appearance_guard_test.dart',
+  'game/Window corner radius':
+      'test/build/gal_overlay_appearance_guard_test.dart',
   'game/In-game dictionary lookup':
       'test/lookup/gal_ingame_lookup_contract_test.dart + '
           'native/galgame_hook/tests/lookup_ipc_contract_test.cpp + '

--- a/fushi/test/tools/gal_hook_overlay_buttons_guard_test.dart
+++ b/fushi/test/tools/gal_hook_overlay_buttons_guard_test.dart
@@ -48,9 +48,13 @@ void main() {
     // 字形表必须覆盖 0..N-1（default 分支只是兜底，不算覆盖）。
     final String toolbarSource = toolbar.readAsStringSync();
     final int glyphStart = toolbarSource.indexOf('const wchar_t* SlotGlyph');
-    final int glyphEnd = toolbarSource.indexOf('bool SlotActive', glyphStart);
     expect(glyphStart, greaterThan(0), reason: '找不到 SlotGlyph 定义');
-    expect(glyphEnd, greaterThan(glyphStart));
+    // 切片终点取**本函数**在第 0 列的收尾大括号，不要拿相邻函数当分隔符：
+    // 原实现以 'bool SlotActive' 为终点，SlotActive 被挪到 SlotGlyph 之前时
+    // indexOf 返回 -1，守卫直接崩在切片上而不是报出真正的问题。
+    final int glyphEnd = toolbarSource.indexOf('\n}', glyphStart);
+    expect(glyphEnd, greaterThan(glyphStart),
+        reason: 'SlotGlyph 必须有第 0 列的收尾大括号');
     final String glyphBody = toolbarSource.substring(glyphStart, glyphEnd);
     final List<int> glyphCases = RegExp(r'case (\d+):')
         .allMatches(glyphBody)

--- a/fushi/test/tools/gal_overlay_shift_hover_pin_guard_test.dart
+++ b/fushi/test/tools/gal_overlay_shift_hover_pin_guard_test.dart
@@ -236,16 +236,24 @@ void main() {
       );
     });
 
-    test('按钮状态：📌 字形 + 真实 topmost 高亮 + 状态参与重绘比对', () {
+    test('按钮状态：push_pin 字形 + 真实 topmost 高亮 + 状态参与重绘比对', () {
       expect(
         toolbarHeader.contains('bool topmost = true;'),
         isTrue,
         reason: 'States 必须带上 topmost，独立工具条窗才画得出高亮',
       );
+      // 字形从 emoji 📌(U+1F4CC) 换成了 Material Symbols Rounded 的 push_pin
+      // (U+F10D)：整条工具栏统一走图标字体。断言跟着换码点，同时把**矢量兜底**
+      // 一起钉住——图标字体加载失败时若没有兜底，用户看到的是一整排空按钮。
       expect(
-        toolbar.contains(r'return L"\U0001F4CC";'),
+        toolbar.contains(r'return L"\uF10D";'),
         isTrue,
-        reason: '置顶槽必须有 📌 字形',
+        reason: '置顶槽必须有 push_pin 字形（Material Symbols U+F10D）',
+      );
+      expect(
+        toolbar.contains('void DrawSlotIcon('),
+        isTrue,
+        reason: '图标字体缺失时必须还有矢量兜底，否则整排按钮画不出来',
       );
       expect(
         toolbar.contains('return states.topmost;'),
@@ -280,7 +288,7 @@ void main() {
       );
     });
 
-    test('最小宽度跟着槽数走（9 槽 = 350dip 行宽，下限必须更大）', () {
+    test('最小宽度跟着槽数走（下限必须不小于真实工具栏行宽）', () {
       final Match? declared =
           RegExp(r'kSlotCount\s*=\s*(\d+)\s*;').firstMatch(toolbarHeader);
       expect(declared, isNotNull);
@@ -289,8 +297,17 @@ void main() {
           RegExp(r'kHookTextMinStripWidthDip = ([\d.]+)f;').firstMatch(window);
       expect(minWidth, isNotNull);
       final double floor = double.parse(minWidth!.group(1)!);
-      // 行宽 = N * 按钮 30dip + (N-1) * 间隙 10dip。
-      final double rowWidth = slots * 30.0 + (slots - 1) * 10.0;
+      // 行宽 = N * 按钮 + (N-1) * 间隙。两个尺寸必须**从源码读**：守卫自抄一份
+      // 数字，就会在源码把 30/10 调成 32/4 时继续用旧值算，算出的下限既不是
+      // 真实行宽、也没人发现它已经不看真实值了。
+      final Match? btn =
+          RegExp(r'kHookTextButtonSizeDip = ([\d.]+)f;').firstMatch(window);
+      final Match? gap =
+          RegExp(r'kHookTextButtonGapDip = ([\d.]+)f;').firstMatch(window);
+      expect(btn, isNotNull, reason: '找不到 kHookTextButtonSizeDip');
+      expect(gap, isNotNull, reason: '找不到 kHookTextButtonGapDip');
+      final double rowWidth = slots * double.parse(btn!.group(1)!) +
+          (slots - 1) * double.parse(gap!.group(1)!);
       expect(
         floor,
         greaterThanOrEqualTo(rowWidth),

--- a/fushi/test/tools/voice_hook_ipc_contract_test.dart
+++ b/fushi/test/tools/voice_hook_ipc_contract_test.dart
@@ -35,8 +35,10 @@ void main() {
       expect(source, contains('constexpr uint32_t $bit ='),
           reason: '$bit 没在契约头里定义');
     }
-    // v15：保留 v14 的 hit/input/frame 查词区，并只追加截图抑制 applied-seq 确认。
-    expect(source, contains('constexpr uint32_t kSharedVersion = 15;'));
+    // v16：在 v15 之上纯尾部追加 injected WASAPI loopback 的 fail-closed 控制/确认。
+    // 这个数字必须钉死：它是 wire identity，写错一位就是「旧 helper 静默绕过默认
+    // deny」。改它必须同时改契约头顶部的版本沿革说明。
+    expect(source, contains('constexpr uint32_t kSharedVersion = 16;'));
   });
 
   test('v15：截图抑制必须 exact-match，且普通帧不能推进 applied ack', () {

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -1188,10 +1188,13 @@ void FloatingLyricWindow::Render() {
   render_target_->BeginDraw();
   render_target_->Clear(D2D1::ColorF(0, 0, 0, 0));
 
-  // TODO-708 P2: 圆角半径可调。style_.corner_radius > 0 时用设置值，否则回退历史 14dp。
-  const float corner_dip = style_.corner_radius > 0.0
-                               ? static_cast<float>(style_.corner_radius)
-                               : kCornerRadiusDip;
+  // TODO-708 P2: 圆角半径可调。0 是合法取值（直角），所以这里**没有**哨兵分支——
+  // 历史默认由 Style::corner_radius 的默认值承担（见头文件）。夹区间是防畸形负载：
+  // 上界与偏好侧 galHookTextCornerRadiusMax 同值。
+  static_assert(kCornerRadiusDip == 14.0f,
+                "Style::corner_radius 的默认值必须与之同源");
+  const float corner_dip =
+      static_cast<float>(std::clamp(style_.corner_radius, 0.0, 40.0));
   const float corner = ScaleForDpi(corner_dip);
   D2D1_ROUNDED_RECT bg_rect = D2D1::RoundedRect(
       D2D1::RectF(0, 0, static_cast<float>(width), static_cast<float>(height)),
@@ -1697,8 +1700,11 @@ void FloatingLyricWindow::Render() {
               D2D1::RectF(bx, t_top, bx + t_btn, t_top + t_btn);
           if (icon_format != nullptr) {
             const wchar_t* glyph = hook_toolbar::SlotGlyph(slot, tb_states);
-            render_target_->DrawTextW(glyph, 1, icon_format.Get(), icon_rect,
-                                      icon_brush);
+            // 长度一律走 GlyphLength：写死 1 会把任何代理对字形（U+1F512 等）截半，
+            // 画出一个替换方块。当前这些字形恰好都在 BMP，所以写死 1 也看不出问题
+            // ——正因如此它才会一路溜到发布，必须在源头堵死而不是靠「现在没事」。
+            render_target_->DrawTextW(glyph, GlyphLength(glyph),
+                                      icon_format.Get(), icon_rect, icon_brush);
           } else {
             hook_toolbar::DrawSlotIcon(render_target_.Get(), d2d_factory_.Get(),
                                        slot, tb_states, icon_rect, icon_brush);

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -90,9 +90,14 @@ class FloatingLyricWindow {
     uint32_t button_bg_color = 0x33000000;
     uint32_t highlight_color = 0x80FFD54F;
     uint32_t active_color = 0xFFFFD54F;
-    // TODO-708 P2: 圆角半径 / 窗宽（逻辑 dp）。0 = 平台原生默认（14dp 圆角 / 720dip 起始
-    // 宽 + 可拖拽），>0 时按该 dp 覆盖，保证默认零观感变化。
-    double corner_radius = 0.0;
+    // TODO-708 P2: 窗宽/窗高仍用 0 = 平台原生默认（720dip 起始宽 + 可拖拽）：0 宽窗
+    // 不是合法用户取值，拿它当哨兵没有歧义。
+    //
+    // 圆角**不能**这么做：0 是合法取值（直角），偏好里 min 就是 0。原实现让绘制点
+    // 读到 0 就回退 14dp，于是用户把圆角拖到 0 什么都不会发生，而且看不出为什么。
+    // 这里直接把历史默认写成默认值，绘制点不再有哨兵分支——0 就是 0。
+    // 数值与 floating_lyric_window.cpp 的 kCornerRadiusDip 由 static_assert 钉死同源。
+    double corner_radius = 14.0;
     double window_width = 0.0;
     double window_height = 0.0;
   };

--- a/native/galgame_hook/docs/engine-support.md
+++ b/native/galgame_hook/docs/engine-support.md
@@ -21,6 +21,7 @@
 | `malie_libp` | Malie System / LIBP CFI | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | malie_libp_cfi_voice_resource (verified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `qlie_filepack` | QLIE / FilePack | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | qlie_wuvorbis_per_source_pcm (verified)；qlie_wuvorbis_float_per_source_pcm (implemented_unverified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `unity_il2cpp` | Unity IL2CPP | `verified` | luna_pc_hooks (verified)；unity_tmp_events (verified)；unity_legacy_text_events (implemented_unverified) | unity_audioclip_resource (verified)；xaudio2_source_voice_pcm (verified)；process_loopback (verified) | 1 |
+| `sgre` | M2 wind3d11 runtime (STEINS;GATE RE:BOOT) | `implemented_unverified` | — | engine_archive_resource (implemented_unverified) | 0 |
 
 ## 识别与能力明细
 
@@ -571,6 +572,44 @@ Tests：`tests/qlie_pack_test.cpp`、`tests/adapter_structure_test.py`
 Fixtures：尚无（P5 补齐）
 
 Tests：`tests/unity_event_cursor_test.cpp`、`tests/il2cpp_thread_scope_test.cpp`、`tests/resource_audio_ready_test.cpp`、`tests/adapter_structure_test.py`
+
+### M2 wind3d11 runtime (STEINS;GATE RE:BOOT) (`sgre`)
+
+- 状态：`implemented_unverified`
+- 别名：SGRE、STEINS;GATE RE:BOOT、wind3d11
+- 家族：`m2_wind3d11`（M2 wind3d11 audio-archive runtime）
+- 当前 adapter：`hook/adapters/sgre_adapter.inc`
+- 进程策略：launch=`create_suspended_preferred`，attach=`supported_for_objects_created_after_attach`，follow-child=`false`
+
+识别签名（所有非空项均带真实样本或运行时观察证据）：
+
+- `pe_architectures`：x64；证据：runtime_observation — Luna text profile config/luna_hook_profiles.tsv:5 records an x64 Steam build; the audio path has no independent hashed sample yet.
+- `directory_files_all`：wind3d11data/voice_body.bin；证据：runtime_observation — MatchesSgreProfile requires the archive to exist next to the hashed executable; character voices live in voice_body.bin.
+- `hashes`：75A83A0E2A7E22055417AE0474B47BE98418C4E42C695C548B558705C404B9D8；证据：runtime_observation — Same executable SHA-256 the Luna text profile keys on, so text and audio identity cannot drift apart silently.
+
+文本能力：
+
+- 不适用；文本由具体引擎 profile / Luna 线程处理。
+- codepage：not_applicable
+- 线程提示：Text comes from the Luna profile keyed by the same executable SHA-256, not from this adapter.
+
+音频优先级：
+
+1. `engine_archive_resource` — `implemented_unverified`；格式：xWMA chunks taken verbatim from wind3d11data/voice_body.bin；clean voice：yes
+
+真实样本证据：
+
+
+已知限制：
+
+- No real-game session has been run against this adapter: process_found through card_e2e are all not_run.
+- Archive membership is the role proof, and it only holds while the runtime keeps character voice in a separate voice_body.bin.
+- The emitted .xwma file is not byte-identical to an archive entry: the RIFF envelope is synthesised here. Only the fmt/dpds/payload chunks are verbatim.
+- Identity is the executable SHA-256, so a game patch disables both text and audio capture at once. That is deliberate -- it prevents a silent text/audio mismatch -- but it does mean a patched build stops working until the hash is re-measured.
+
+Fixtures：尚无（P5 补齐）
+
+Tests：`tests/sgre_adapter_test.cpp`
 
 ## 状态定义
 

--- a/native/galgame_hook/engine-support.yaml
+++ b/native/galgame_hook/engine-support.yaml
@@ -17,43 +17,60 @@
     {
       "id": "siglus",
       "display_name": "SiglusEngine",
-      "aliases": ["Siglus 3", "VisualArt's Siglus"],
+      "aliases": [
+        "Siglus 3",
+        "VisualArt's Siglus"
+      ],
       "family": {
         "id": "visualarts",
         "relation": "VisualArt's / Key 系引擎"
       },
       "detection": {
         "executable_names": {
-          "values": ["SiglusEngine.exe"],
+          "values": [
+            "SiglusEngine.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "anemoi 正式版，hibiki handoff 2026-07-19"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "anemoi SiglusEngine 1.1.141.3"
           }
         },
         "directory_files_all": {
-          "values": ["Gameexe.dat", "Scene.pck"],
+          "values": [
+            "Gameexe.dat",
+            "Scene.pck"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "renamed Siglus executable regression fixed by hibiki-hook d1601b9"
           }
         },
-        "pe_imports": {"values": [], "evidence": null},
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["dsound.dll"],
+          "values": [
+            "dsound.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "anemoi used DirectSound through CoCreateInstance"
           }
         },
         "resource_extensions": {
-          "values": [".ovk"],
+          "values": [
+            ".ovk"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "anemoi koe/*.ovk entries exported byte-identically"
@@ -148,7 +165,10 @@
     {
       "id": "elf_ai6",
       "display_name": "elf AI6",
-      "aliases": ["AI6WIN", "elf AI6"],
+      "aliases": [
+        "AI6WIN",
+        "elf AI6"
+      ],
       "family": {
         "id": "elf",
         "relation": "elf AI6 archive-based engine"
@@ -166,7 +186,10 @@
           "values": [],
           "evidence": null
         },
-        "pe_imports": {"values": [], "evidence": null},
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
           "values": [],
           "evidence": null
@@ -242,25 +265,48 @@
     {
       "id": "reallive",
       "display_name": "RealLive / old VisualArt's",
-      "aliases": ["RealLive", "VisualArt's RealLive"],
+      "aliases": [
+        "RealLive",
+        "VisualArt's RealLive"
+      ],
       "family": {
         "id": "visualarts",
         "relation": "older sibling of the verified Siglus OVK path"
       },
       "detection": {
-        "executable_names": {"values": [], "evidence": null},
-        "pe_architectures": {"values": [], "evidence": null},
-        "directory_files_all": {"values": [], "evidence": null},
-        "pe_imports": {"values": [], "evidence": null},
-        "runtime_modules": {"values": [], "evidence": null},
+        "executable_names": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_architectures": {
+          "values": [],
+          "evidence": null
+        },
+        "directory_files_all": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
+        "runtime_modules": {
+          "values": [],
+          "evidence": null
+        },
         "resource_extensions": {
-          "values": [".ovk"],
+          "values": [
+            ".ovk"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "anemoi VisualArt's/Siglus koe/*.ovk proves the shared container path only; it is not RealLive compatibility evidence"
           }
         },
-        "hashes": {"values": [], "evidence": null}
+        "hashes": {
+          "values": [],
+          "evidence": null
+        }
       },
       "process_strategy": {
         "launch": "profile_pending_real_sample",
@@ -312,47 +358,78 @@
         "A real original-path run must add executable/module hashes, text-thread evidence and byte-identity proof before promotion."
       ],
       "adapter_path": "hook/adapters/reallive_adapter.inc",
-      "fixture_paths": ["tests/fixtures/reallive_replay.json"],
-      "test_paths": ["tests/reallive_adapter_test.cpp"]
+      "fixture_paths": [
+        "tests/fixtures/reallive_replay.json"
+      ],
+      "test_paths": [
+        "tests/reallive_adapter_test.cpp"
+      ]
     },
     {
       "id": "kirikiri_z",
       "display_name": "KiriKiri2 / KiriKiriZ",
-      "aliases": ["吉里吉里2", "Kirikiri 2", "吉里吉里Z", "Kirikiri Z"],
-      "family": {"id": "kirikiri", "relation": "KiriKiri family"},
+      "aliases": [
+        "吉里吉里2",
+        "Kirikiri 2",
+        "吉里吉里Z",
+        "Kirikiri Z"
+      ],
+      "family": {
+        "id": "kirikiri",
+        "relation": "KiriKiri family"
+      },
       "detection": {
         "executable_names": {
-          "values": ["otomeki.exe", "isekai-elf-sample.exe"],
+          "values": [
+            "otomeki.exe",
+            "isekai-elf-sample.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "otomeki.exe KiriKiriZ run (2026-07-18) and official BABEL KiriKiri2 experience version run (2026-07-23)"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Both recorded KiriKiriZ and KiriKiri2 samples are x86"
           }
         },
-        "directory_files_all": {"values": [], "evidence": null},
-        "pe_imports": {"values": [], "evidence": null},
+        "directory_files_all": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["dsound.dll", "wuvorbis.dll"],
+          "values": [
+            "dsound.dll",
+            "wuvorbis.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "DirectSound was observed in otomeki.exe; the official BABEL experience version loaded wuvorbis.dll from the KiriKiri temp plugin directory"
           }
         },
         "resource_extensions": {
-          "values": [".xp3", ".ogg"],
+          "values": [
+            ".xp3",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "The official BABEL experience version ships data.xp3/plugin.xp3 and opens Ogg through wuvorbis"
           }
         },
         "hashes": {
-          "values": ["2280115774277789CA15760CD25E29E82560B928FC7994763F7EBEBF7461D92A"],
+          "values": [
+            "2280115774277789CA15760CD25E29E82560B928FC7994763F7EBEBF7461D92A"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "SHA-256 of isekai-elf-sample.exe from the developer-hosted experience version"
@@ -440,7 +517,9 @@
         "Text-thread choice is not free on this engine: the same game exposes one EmbedKrkrZ thread carrying whole-string-doubled dialogue (folded correctly by the block-level normaliser) and several KiriKiriZ threads carrying per-character doubled/tripled strings that the artifact gate correctly drops. Selecting a KiriKiriZ thread leaves the workbench with zero lines forever and makes in-game mining fail silently. Tracked as BUG-1733/1734/1735; the native filtering is correct and must not be relaxed."
       ],
       "adapter_path": "hook/adapters/kirikiri_adapter.inc",
-      "fixture_paths": ["tests/fixtures/kirikiri_lookup_replay.tsv"],
+      "fixture_paths": [
+        "tests/fixtures/kirikiri_lookup_replay.tsv"
+      ],
       "test_paths": [
         "tests/resource_audio_ready_test.cpp",
         "tests/lookup_ipc_contract_test.cpp",
@@ -451,28 +530,57 @@
     {
       "id": "xaudio2_directsound",
       "display_name": "XAudio2 / DirectSound generic capture",
-      "aliases": ["XAudio2", "DirectSound", "Windows source PCM"],
-      "family": {"id": "windows_audio_api", "relation": "generic audio backend"},
+      "aliases": [
+        "XAudio2",
+        "DirectSound",
+        "Windows source PCM"
+      ],
+      "family": {
+        "id": "windows_audio_api",
+        "relation": "generic audio backend"
+      },
       "detection": {
-        "executable_names": {"values": [], "evidence": null},
+        "executable_names": {
+          "values": [],
+          "evidence": null
+        },
         "pe_architectures": {
-          "values": ["x86", "x64"],
+          "values": [
+            "x86",
+            "x64"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "Both helper architectures build; x86 KiriKiriZ/Siglus paths were exercised on real games."
           }
         },
-        "directory_files_all": {"values": [], "evidence": null},
-        "pe_imports": {"values": [], "evidence": null},
+        "directory_files_all": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["xaudio2_9.dll", "xaudio2_8.dll", "dsound.dll"],
+          "values": [
+            "xaudio2_9.dll",
+            "xaudio2_8.dll",
+            "dsound.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "The shipped generic adapters resolve these loaded modules; DirectSound was observed on the recorded x86 samples."
           }
         },
-        "resource_extensions": {"values": [], "evidence": null},
-        "hashes": {"values": [], "evidence": null}
+        "resource_extensions": {
+          "values": [],
+          "evidence": null
+        },
+        "hashes": {
+          "values": [],
+          "evidence": null
+        }
       },
       "process_strategy": {
         "launch": "create_suspended_preferred",
@@ -521,39 +629,68 @@
       ],
       "adapter_path": "hook/adapters/windows_audio_adapter.inc",
       "fixture_paths": [],
-      "test_paths": ["tests/session_reuse_test.cpp"]
+      "test_paths": [
+        "tests/session_reuse_test.cpp"
+      ]
     },
     {
       "id": "renpy_ffmpeg",
       "display_name": "Ren'Py / FFmpeg",
-      "aliases": ["Ren'Py", "libavcodec", "libavformat", "FFmpeg 54"],
-      "family": {"id": "renpy", "relation": "versioned FFmpeg runtime"},
+      "aliases": [
+        "Ren'Py",
+        "libavcodec",
+        "libavformat",
+        "FFmpeg 54"
+      ],
+      "family": {
+        "id": "renpy",
+        "relation": "versioned FFmpeg runtime"
+      },
       "detection": {
         "executable_names": {
-          "values": ["Sakura Swim Club.exe"],
+          "values": [
+            "Sakura Swim Club.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Sakura Swim Club full-card run recorded in hibiki handoff 2026-07-18"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "Recorded Ren'Py sample launches a child python.exe targeted by the legacy hook"
           }
         },
-        "directory_files_all": {"values": [], "evidence": null},
-        "pe_imports": {"values": [], "evidence": null},
+        "directory_files_all": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["avcodec-54.dll", "avformat-54.dll"],
+          "values": [
+            "avcodec-54.dll",
+            "avformat-54.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "The existing adapter targets the recorded legacy Ren'Py/FFmpeg runtime; the sample did not produce an adapter hit"
           }
         },
-        "resource_extensions": {"values": [], "evidence": null},
-        "hashes": {"values": [], "evidence": null}
+        "resource_extensions": {
+          "values": [],
+          "evidence": null
+        },
+        "hashes": {
+          "values": [],
+          "evidence": null
+        }
       },
       "process_strategy": {
         "launch": "launcher_then_scored_game_child",
@@ -615,7 +752,9 @@
         "The real sample fell back to loopback; no clean decoder-level voice claim is made."
       ],
       "adapter_path": "hook/adapters/renpy_adapter.inc",
-      "fixture_paths": ["tests/fixtures/workflow_replay.json"],
+      "fixture_paths": [
+        "tests/fixtures/workflow_replay.json"
+      ],
       "test_paths": [
         "tests/ffmpeg_runtime_test.cpp",
         "tests/child_process_policy_test.cpp",
@@ -625,40 +764,62 @@
     {
       "id": "tyrano_nwjs",
       "display_name": "TyranoScript / NW.js",
-      "aliases": ["TyranoScript 5", "TyranoBuilder", "NW.js"],
-      "family": {"id": "tyrano", "relation": "NW.js packaged TyranoScript runtime"},
+      "aliases": [
+        "TyranoScript 5",
+        "TyranoBuilder",
+        "NW.js"
+      ],
+      "family": {
+        "id": "tyrano",
+        "relation": "NW.js packaged TyranoScript runtime"
+      },
       "detection": {
         "executable_names": {
-          "values": ["kaerimichi.exe"],
+          "values": [
+            "kaerimichi.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "かえりみち official free Windows release from novelgame.jp, verified 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x64"],
+          "values": [
+            "x64"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "kaerimichi.exe PE/COFF x86-64 runtime observation"
           }
         },
         "directory_files_all": {
-          "values": ["resources/app.asar", "ffmpeg.dll"],
+          "values": [
+            "resources/app.asar",
+            "ffmpeg.dll"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official sample package layout and live module inventory"
           }
         },
-        "pe_imports": {"values": [], "evidence": null},
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["ffmpeg.dll"],
+          "values": [
+            "ffmpeg.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "Monolithic Chromium FFmpeg exports avformat_open_input and is loaded in the visible NW.js process"
           }
         },
         "resource_extensions": {
-          "values": [".ogg", ".m4a"],
+          "values": [
+            ".ogg",
+            ".m4a"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "app.asar contains paired OGG/M4A voice members under data/sound/v_*"
@@ -740,40 +901,63 @@
     {
       "id": "bgi_ethornell",
       "display_name": "BGI / Ethornell",
-      "aliases": ["BURIKO General Interpreter", "Ethornell"],
-      "family": {"id": "bgi", "relation": "BURIKO ARC20 runtime"},
+      "aliases": [
+        "BURIKO General Interpreter",
+        "Ethornell"
+      ],
+      "family": {
+        "id": "bgi",
+        "relation": "BURIKO ARC20 runtime"
+      },
       "detection": {
         "executable_names": {
-          "values": ["BGI.exe"],
+          "values": [
+            "BGI.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "AUGUST official 千の刃濤、桃花染の皇姫 Web trial, inspected 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial BGI.exe PE/COFF static probe"
           }
         },
         "directory_files_all": {
-          "values": ["BGI.exe", "BGI.hvl", "data03110.arc"],
+          "values": [
+            "BGI.exe",
+            "BGI.hvl",
+            "data03110.arc"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial package layout"
           }
         },
         "pe_imports": {
-          "values": ["DSOUND.dll", "KERNEL32.dll"],
+          "values": [
+            "DSOUND.dll",
+            "KERNEL32.dll"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial BGI.exe import table"
           }
         },
-        "runtime_modules": {"values": [], "evidence": null},
+        "runtime_modules": {
+          "values": [],
+          "evidence": null
+        },
         "resource_extensions": {
-          "values": [".arc", ".ogg"],
+          "values": [
+            ".arc",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "data03110.arc has a BURIKO ARC20 index and 146 bw-wrapped Ogg members"
@@ -848,46 +1032,68 @@
     {
       "id": "artemis_pfs",
       "display_name": "Artemis Engine / PF8",
-      "aliases": ["Artemis Engine", "Artemis", "PF8"],
-      "family": {"id": "artemis", "relation": "iarsys runtime with PF6/PF8 archives"},
+      "aliases": [
+        "Artemis Engine",
+        "Artemis",
+        "PF8"
+      ],
+      "family": {
+        "id": "artemis",
+        "relation": "iarsys runtime with PF6/PF8 archives"
+      },
       "detection": {
         "executable_names": {
-          "values": ["アマナツ体験版.exe"],
+          "values": [
+            "アマナツ体験版.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "あざらしそふと official アマナツ trial, verified 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x64"],
+          "values": [
+            "x64"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial executable PE/COFF x86-64 static and live observation"
           }
         },
         "directory_files_all": {
-          "values": ["iarsys64.dll", "*.pfs"],
+          "values": [
+            "iarsys64.dll",
+            "*.pfs"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial portable package contains iarsys64.dll and a same-title PF8 archive"
           }
         },
         "pe_imports": {
-          "values": ["DSOUND.dll", "KERNEL32.dll"],
+          "values": [
+            "DSOUND.dll",
+            "KERNEL32.dll"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official trial executable import table"
           }
         },
         "runtime_modules": {
-          "values": ["iarsys64.dll"],
+          "values": [
+            "iarsys64.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "Official trial launched through the x64 Hibiki injector and exposed the Artemis runtime next to the executable"
           }
         },
         "resource_extensions": {
-          "values": [".pfs", ".ogg"],
+          "values": [
+            ".pfs",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "PF8 index contains 797 Ogg voice members under sound/vo and sound/sysse/vo"
@@ -971,34 +1177,58 @@
     {
       "id": "catsystem2",
       "display_name": "CatSystem2 / KIF INT",
-      "aliases": ["CatSystem2", "CS2", "KIF INT"],
-      "family": {"id": "catsystem2", "relation": "ARES ADV runtime and KIF archives"},
+      "aliases": [
+        "CatSystem2",
+        "CS2",
+        "KIF INT"
+      ],
+      "family": {
+        "id": "catsystem2",
+        "relation": "ARES ADV runtime and KIF archives"
+      },
       "detection": {
         "executable_names": {
-          "values": ["cs2_open.exe", "cs2.exe"],
+          "values": [
+            "cs2_open.exe",
+            "cs2.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "ARES official CatSystem2 starter kit v3.01, verified 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official cs2_open.exe PE/COFF i386 static and live observation"
           }
         },
         "directory_files_all": {
-          "values": ["config/startup.xml", "*.int"],
+          "values": [
+            "config/startup.xml",
+            "*.int"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official packaged starter-kit replay layout"
           }
         },
-        "pe_imports": {"values": [], "evidence": null},
-        "runtime_modules": {"values": [], "evidence": null},
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
+        "runtime_modules": {
+          "values": [],
+          "evidence": null
+        },
         "resource_extensions": {
-          "values": [".int", ".ogg"],
+          "values": [
+            ".int",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official MakeInt.exe produced pcm_d.int with a named Ogg member that cs2_open.exe played through the pcm command"
@@ -1082,28 +1312,42 @@
     {
       "id": "malie_libp",
       "display_name": "Malie System / LIBP CFI",
-      "aliases": ["Malie", "Malie System", "LIBP", "CFI"],
+      "aliases": [
+        "Malie",
+        "Malie System",
+        "LIBP",
+        "CFI"
+      ],
       "family": {
         "id": "malie",
         "relation": "Greenwood Malie runtime and title-keyed LIBP archives"
       },
       "detection": {
         "executable_names": {
-          "values": ["malie.exe", "malie_dsp.exe", "malie_fabla.exe"],
+          "values": [
+            "malie.exe",
+            "malie_dsp.exe",
+            "malie_fabla.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Steam app 644540 build 21665074, verified 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official malie.exe PE/COFF i386, Malie System 1.0.0.5"
           }
         },
         "directory_files_all": {
-          "values": ["malie.exe", "data2.dat"],
+          "values": [
+            "malie.exe",
+            "data2.dat"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Official Steam free common-route installation"
@@ -1122,9 +1366,15 @@
             "reference": "malie.exe import table and live file-I/O diagnostics"
           }
         },
-        "runtime_modules": {"values": [], "evidence": null},
+        "runtime_modules": {
+          "values": [],
+          "evidence": null
+        },
         "resource_extensions": {
-          "values": [".dat", ".ogg"],
+          "values": [
+            ".dat",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "data2.dat contains 20,434 CFI-encrypted data\\voice\\*.ogg members"
@@ -1209,28 +1459,39 @@
     {
       "id": "qlie_filepack",
       "display_name": "QLIE / FilePack",
-      "aliases": ["QLIE", "FilePackVer3.1", "wuvorbis QLIE"],
+      "aliases": [
+        "QLIE",
+        "FilePackVer3.1",
+        "wuvorbis QLIE"
+      ],
       "family": {
         "id": "qlie",
         "relation": "Warmth / AMUSE CRAFT QLIE runtime and FilePack archives"
       },
       "detection": {
         "executable_names": {
-          "values": ["美少女万華鏡_体験版.exe"],
+          "values": [
+            "美少女万華鏡_体験版.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "美少女万華鏡 -理と迷宮の少女- 体験版 1.01, verified 2026-07-23"
           }
         },
         "pe_architectures": {
-          "values": ["x86"],
+          "values": [
+            "x86"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Measured trial executable PE/COFF i386"
           }
         },
         "directory_files_all": {
-          "values": ["DLL/wuvorbis.dll", "GameData/data0.pack"],
+          "values": [
+            "DLL/wuvorbis.dll",
+            "GameData/data0.pack"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "Measured trial directory; data0.pack tail contains FilePackVer3.1"
@@ -1241,14 +1502,19 @@
           "evidence": null
         },
         "runtime_modules": {
-          "values": ["wuvorbis.dll"],
+          "values": [
+            "wuvorbis.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "Live x86 process invoked wu_ov_open_callbacks and wu_ov_read; the wu_ov_read_float export was present and its detour reached hook-ready state"
           }
         },
         "resource_extensions": {
-          "values": [".pack", ".ogg"],
+          "values": [
+            ".pack",
+            ".ogg"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "GameData/data*.pack with GARbro-extracted character voice Ogg members"
@@ -1343,18 +1609,29 @@
     {
       "id": "unity_il2cpp",
       "display_name": "Unity IL2CPP",
-      "aliases": ["Unity", "UnityPlayer IL2CPP"],
-      "family": {"id": "unity", "relation": "IL2CPP runtime"},
+      "aliases": [
+        "Unity",
+        "UnityPlayer IL2CPP"
+      ],
+      "family": {
+        "id": "unity",
+        "relation": "IL2CPP runtime"
+      },
       "detection": {
         "executable_names": {
-          "values": ["manosaba.exe", "Sasasa.exe"],
+          "values": [
+            "manosaba.exe",
+            "Sasasa.exe"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "manosaba_game and 最悪なる災厄人間に捧ぐ runtime observations"
           }
         },
         "pe_architectures": {
-          "values": ["x64"],
+          "values": [
+            "x64"
+          ],
           "evidence": {
             "kind": "real_sample",
             "reference": "manosaba_game Unity IL2CPP sample"
@@ -1371,16 +1648,28 @@
             "reference": "manosaba_game directory inspection recorded in hibiki-hook README"
           }
         },
-        "pe_imports": {"values": [], "evidence": null},
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
         "runtime_modules": {
-          "values": ["UnityPlayer.dll", "GameAssembly.dll"],
+          "values": [
+            "UnityPlayer.dll",
+            "GameAssembly.dll"
+          ],
           "evidence": {
             "kind": "runtime_observation",
             "reference": "manosaba_game Unity IL2CPP sample"
           }
         },
-        "resource_extensions": {"values": [], "evidence": null},
-        "hashes": {"values": [], "evidence": null}
+        "resource_extensions": {
+          "values": [],
+          "evidence": null
+        },
+        "hashes": {
+          "values": [],
+          "evidence": null
+        }
       },
       "process_strategy": {
         "launch": "create_suspended_early_injection",
@@ -1456,6 +1745,100 @@
         "tests/il2cpp_thread_scope_test.cpp",
         "tests/resource_audio_ready_test.cpp",
         "tests/adapter_structure_test.py"
+      ]
+    },
+    {
+      "id": "sgre",
+      "display_name": "M2 wind3d11 runtime (STEINS;GATE RE:BOOT)",
+      "aliases": [
+        "SGRE",
+        "STEINS;GATE RE:BOOT",
+        "wind3d11"
+      ],
+      "family": {
+        "id": "m2_wind3d11",
+        "relation": "M2 wind3d11 audio-archive runtime"
+      },
+      "detection": {
+        "executable_names": {
+          "values": [],
+          "evidence": null
+        },
+        "pe_architectures": {
+          "values": [
+            "x64"
+          ],
+          "evidence": {
+            "kind": "runtime_observation",
+            "reference": "Luna text profile config/luna_hook_profiles.tsv:5 records an x64 Steam build; the audio path has no independent hashed sample yet."
+          }
+        },
+        "directory_files_all": {
+          "values": [
+            "wind3d11data/voice_body.bin"
+          ],
+          "evidence": {
+            "kind": "runtime_observation",
+            "reference": "MatchesSgreProfile requires the archive to exist next to the hashed executable; character voices live in voice_body.bin."
+          }
+        },
+        "pe_imports": {
+          "values": [],
+          "evidence": null
+        },
+        "runtime_modules": {
+          "values": [],
+          "evidence": null
+        },
+        "resource_extensions": {
+          "values": [],
+          "evidence": null
+        },
+        "hashes": {
+          "values": [
+            "75A83A0E2A7E22055417AE0474B47BE98418C4E42C695C548B558705C404B9D8"
+          ],
+          "evidence": {
+            "kind": "runtime_observation",
+            "reference": "Same executable SHA-256 the Luna text profile keys on, so text and audio identity cannot drift apart silently."
+          }
+        }
+      },
+      "process_strategy": {
+        "launch": "create_suspended_preferred",
+        "attach": "supported_for_objects_created_after_attach",
+        "follow_child_processes": false,
+        "notes": [
+          "The adapter registers a compressed-resource handler on the shared XAudio worker seam; the generic middleware holds no engine-specific knowledge."
+        ]
+      },
+      "text": {
+        "capabilities": [],
+        "codepage": "not_applicable",
+        "thread_selection_hint": "Text comes from the Luna profile keyed by the same executable SHA-256, not from this adapter."
+      },
+      "audio": {
+        "priority": [
+          {
+            "kind": "engine_archive_resource",
+            "format": "xWMA chunks taken verbatim from wind3d11data/voice_body.bin",
+            "status": "implemented_unverified",
+            "clean_voice": "yes"
+          }
+        ]
+      },
+      "verified_games": [],
+      "current_status": "implemented_unverified",
+      "known_limitations": [
+        "No real-game session has been run against this adapter: process_found through card_e2e are all not_run.",
+        "Archive membership is the role proof, and it only holds while the runtime keeps character voice in a separate voice_body.bin.",
+        "The emitted .xwma file is not byte-identical to an archive entry: the RIFF envelope is synthesised here. Only the fmt/dpds/payload chunks are verbatim.",
+        "Identity is the executable SHA-256, so a game patch disables both text and audio capture at once. That is deliberate -- it prevents a silent text/audio mismatch -- but it does mean a patched build stops working until the hash is re-measured."
+      ],
+      "adapter_path": "hook/adapters/sgre_adapter.inc",
+      "fixture_paths": [],
+      "test_paths": [
+        "tests/sgre_adapter_test.cpp"
       ]
     }
   ]

--- a/native/galgame_hook/hook/adapters/windows_audio_adapter.inc
+++ b/native/galgame_hook/hook/adapters/windows_audio_adapter.inc
@@ -793,6 +793,9 @@ void ProcessPendingXAudioCaptureJobs() {
   DrainXAudioControlEvents();
   std::vector<uint8_t> encoded;
   std::vector<int16_t> decoded;
+  // 复用同一个缓冲跨作业：这条循环跑在 HookWorker 上，每作业新建一个 vector 只会
+  // 把分配器打得更热，没有任何收益。
+  std::vector<uint8_t> resource;
   for (XAudioCaptureJob& job : g_xaudio_capture_jobs) {
     // Claim before reading producer-owned fields.  Interlocked exchange is the
     // publication/acquire edge for the descriptor and its page chain.
@@ -871,12 +874,55 @@ void ProcessPendingXAudioCaptureJobs() {
             encoded.data() + job.encoded_bytes;
         submission.packet_count = job.wma_packet_count;
         submission.playback_timestamp_ms = playback_timestamp;
-        g_xaudio_compressed_resource_dispatch.Dispatch(submission);
+        if (g_xaudio_compressed_resource_dispatch.available()) {
+          // 有引擎 profile 认领了这条 seam：判决**完全**归它。归档没命中就是
+          // 「这不是角色语音」，不能再拿通用回退去兜——那会把 BGM/SE 也当资源发出去，
+          // 正好抹掉归档路径唯一比时长判据强的地方。
+          g_xaudio_compressed_resource_dispatch.Dispatch(submission);
+        } else {
+          // 没有任何引擎 profile 认领这条 seam。
+          //
+          // 丢弃**不是**合法出路：xWMA 是这类引擎语音的唯一出口，本进程里没有 WMA
+          // 解码器，下面的 legacy job 路径（ADPCM 解码 / PCM 直通）对它无能为力。
+          // 丢掉就等于「任何其它用 xWMA 语音的引擎，语音在制卡链路上彻底消失」。
+          //
+          // 这里重建的 RIFF/XWMA 全部取自**这次提交自己**：fmt 由 XAudio2 报的源格式
+          // 合成、dpds 用 XAUDIO2_BUFFER_WMA 的原表、压缩负载逐字节原样。不解码、不
+          // 重分类、不读任何引擎专属资产——共享中间件的边界没有被越过。
+          //
+          // 时长预筛把逐块流入的 BGM/SE 挡在外面：没有归档可比对时，它是唯一还能
+          // 区分「一整句」和「一小块背景音」的判据。
+          uint32_t decoded_bytes = 0;
+          std::memcpy(&decoded_bytes,
+                      submission.packet_cumulative_bytes +
+                          (static_cast<size_t>(job.wma_packet_count) - 1u) * 4u,
+                      sizeof(decoded_bytes));
+          if (fushi_voice_hook::IsLikelyVoiceWmaSubmission(
+                  job.source.format, job.wma_packet_count, decoded_bytes) &&
+              fushi_voice_hook::BuildXwmaResource(
+                  job.source.format, encoded.data(), job.encoded_bytes,
+                  submission.packet_cumulative_bytes, job.wma_packet_count,
+                  &resource) &&
+              resource.size() <= std::numeric_limits<uint32_t>::max()) {
+            wchar_t storage_name[128] = {};
+            swprintf_s(storage_name, L"xwma-%p-%llu-%llu-%llu.xwma",
+                       reinterpret_cast<void*>(job.source.source),
+                       static_cast<unsigned long long>(job.source.generation),
+                       static_cast<unsigned long long>(
+                           job.source.queue_generation),
+                       static_cast<unsigned long long>(playback_timestamp));
+            if (WriteVoiceOggAt(resource.data(),
+                                static_cast<uint32_t>(resource.size()),
+                                storage_name, playback_timestamp)) {
+              SetXAudioDiagnostic(
+                  fushi_voice_hook::kXAudioDiagRuntimeXwmaPublished);
+            }
+          }
+        }
       }
-      // Compressed WMA is never decoded or reclassified in shared middleware.
-      // An explicitly matched engine profile either proves and publishes an
-      // original resource through the worker seam or leaves the submission
-      // unknown; there is no PCM downgrade here.
+      // 压缩 WMA 在共享中间件里既不解码也不重新分类：认领它的引擎 profile 通过 worker
+      // seam 证明并发布原始资源，没人认领就退回上面那条纯运行时重建。两条路都不产出
+      // PCM——把压缩字节当 PCM 送进环形缓冲只会得到噪声。
       ReleaseXAudioCaptureJob(&job);
       continue;
     }

--- a/native/galgame_hook/hook/xwma_resource.h
+++ b/native/galgame_hook/hook/xwma_resource.h
@@ -117,6 +117,26 @@ inline bool BuildXwmaResource(
                                      encoded, encoded_bytes, output);
 }
 
+// 时长判据：这次 xWMA 提交解码后是否长到像一句台词（>=700ms）。
+//
+// 这**不是**角色身份证明，只是一道便宜的预筛。没有引擎归档可用时，通用路径靠它把
+// 逐块流入的 BGM/SE 挡在资源发布之外——否则每一小块 BGM 都会落成一个资源文件，既
+// 撑爆 dump 目录，也会在按时间戳配对时和真语音抢。
+inline bool IsLikelyVoiceWmaSubmission(const XAudioSourceFormat& format,
+                                       uint32_t packet_count,
+                                       uint32_t decoded_bytes) {
+  // WAVEFORMATEX 对 WMAUDIO2 通常填 wBitsPerSample=16，但不是所有引擎都填。填 0 时
+  // 直接算会让 bytes_per_second 恒为 0、判据恒假 —— 那是一条**静默丢弃**路径，比
+  // 判错更糟。WMA 解码输出按定义是 16-bit PCM，所以缺值时按 16 算，而不是放弃。
+  const uint32_t bits =
+      format.bits_per_sample != 0 ? format.bits_per_sample : 16u;
+  const uint64_t bytes_per_second =
+      static_cast<uint64_t>(format.sample_rate) * format.channels * bits / 8u;
+  return format.encoding == XAudioSourceEncoding::kWmaudio2 &&
+         packet_count != 0 && decoded_bytes != 0 && bytes_per_second != 0 &&
+         static_cast<uint64_t>(decoded_bytes) * 1000u >=
+             bytes_per_second * 700u;
+}
 }  // namespace fushi_voice_hook
 
 #endif  // FUSHI_VOICE_HOOK_XWMA_RESOURCE_H_

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -225,11 +225,20 @@ constexpr uint32_t kXAudioDiagUnsupportedFormat = 0x00008000u;
 constexpr uint32_t kXAudioDiagRegistryExhausted = 0x00010000u;
 constexpr uint32_t kXAudioDiagCommitFailed = 0x00020000u;
 constexpr uint32_t kXAudioDiagCommitQueueExhausted = 0x00040000u;
-// At least one byte-exact compressed game voice resource was published by the
-// XAudio2 path.  Unlike kXAudioDiagPcmPublished, this is a resource-audio
-// readiness proof and lets the host prefer the original file even when no PCM
-// clip was active at the matching text timestamp (SGRE xWMA).
+// 至少发布过一条**取自引擎归档**的压缩语音资源（当前只有 SGRE 的 voice_body.bin）。
+// 与 kXAudioDiagPcmPublished 不同，这是 resource-audio 就绪证据：即使配对时刻没有
+// 活跃 PCM clip，host 也可以优先用它。
+//
+// 「byte-exact」到什么层次，必须说准（SOP 第 7 节的 hash_verified 是按这个判的）：
+//   * fmt / dpds / 压缩负载三块**逐字节**取自归档，与源 entry 一致；
+//   * 但发布出去的 `.xwma` **文件**不逐字节等于归档里的任何一段——归档存的是无头
+//     chunk，RIFF 外壳是本进程合成的。所以能宣称的是「负载哈希一致」，不是「文件
+//     哈希一致」；要上 hash_verified 必须比对负载而不是整文件。
 constexpr uint32_t kXAudioDiagGameResourcePublished = 0x00080000u;
+// 由运行时 fmt/dpds 重建并发布的**通用** xWMA 资源（没有引擎归档可比对的引擎）。
+// 与上面那位分开的理由：那位能宣称负载逐字节等于源 entry，这一位不能——fmt 是本
+// 进程按 XAudio2 报的源格式合成的。混成一位，台账上就分不出这两级证据。
+constexpr uint32_t kXAudioDiagRuntimeXwmaPublished = 0x00100000u;
 
 // reserved_luna 的资源音频诊断位。KiriKiriZ 的 TVPCreateStream hook 直接导出当前播放的
 // 已解密 Ogg；Siglus 从 OVK 索引导出逐句 Ogg。它们只代表“资源捕获链已安装”，不要求 PCM

--- a/native/galgame_hook/tests/adapter_contract_test.cpp
+++ b/native/galgame_hook/tests/adapter_contract_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 

--- a/native/galgame_hook/tests/adapter_structure_test.py
+++ b/native/galgame_hook/tests/adapter_structure_test.py
@@ -606,5 +606,87 @@ class AdapterStructureTest(unittest.TestCase):
         self.assertIn("return 1;", source[rejection:polling])
 
 
+    def test_sgre_archive_stays_out_of_shared_middleware(self) -> None:
+        adapter = (
+            ROOT / "hook" / "adapters" / "windows_audio_adapter.inc"
+        ).read_text(encoding="utf-8")
+        profile = (ROOT / "hook" / "adapters" / "sgre_profile.h").read_text(
+            encoding="utf-8"
+        )
+        sgre = (ROOT / "hook" / "adapters" / "sgre_adapter.inc").read_text(
+            encoding="utf-8"
+        )
+        # The generic XAudio middleware must hold no engine-specific knowledge:
+        # it only offers submissions through the registration seam.
+        for forbidden in ("Sgre", "sgre", "voice_body"):
+            self.assertNotIn(forbidden, adapter, forbidden)
+        self.assertIn("RegisterXAudioCompressedResourceHandler", sgre)
+        # Identity is the executable hash, i.e. the same anchor the Luna text
+        # profile keys on, so text and audio identity cannot drift apart.
+        # An executable *file name* would be a distribution property, not an
+        # engine identity, and CLAUDE.md forbids enabling shared middleware on
+        # that kind of match.
+        self.assertIn("kSgreExecutableSha256", profile)
+        self.assertNotIn("sgre_steam.exe", profile)
+        self.assertNotIn("sgre_steam.exe", adapter)
+
+    def test_unclaimed_xwma_submissions_are_published_not_dropped(self) -> None:
+        adapter = (
+            ROOT / "hook" / "adapters" / "windows_audio_adapter.inc"
+        ).read_text(encoding="utf-8")
+        branch = adapter.split("XAudioSourceEncoding::kWmaudio2) {", 1)[1]
+        branch = branch.split("const bool is_adpcm", 1)[0]
+        # xWMA is the only voice outlet for these engines and this process has
+        # no WMA decoder, so a submission no engine profile claims must still
+        # be published as a compressed resource rebuilt from its own runtime
+        # fmt + dpds. Dropping it removes that engine's voice from the card
+        # pipeline entirely.
+        # An engine profile that claims the seam owns the verdict entirely;
+        # the generic rebuild only applies when nothing claims it, so an
+        # archive miss still means "not voice" for that engine.
+        self.assertIn("if (g_xaudio_compressed_resource_dispatch.available())",
+                      branch)
+        self.assertIn("BuildXwmaResource(", branch)
+        self.assertIn("kXAudioDiagRuntimeXwmaPublished", branch)
+        # Without an archive to compare against, the duration prefilter is the
+        # only thing separating a whole line from a chunk of streaming BGM.
+        self.assertIn("IsLikelyVoiceWmaSubmission", branch)
+        # Byte-exact and runtime-rebuilt resources must not share one
+        # diagnostic bit: only the archive path may claim payload hash
+        # identity with a source entry.
+        self.assertNotIn("kXAudioDiagGameResourcePublished", branch)
+
+    def test_hook_worker_contract_gate_covers_the_poll_pump(self) -> None:
+        main = (ROOT / "hook" / "dll_main.cpp").read_text(encoding="utf-8")
+        worker = main.split("DWORD WINAPI HookWorker", 1)[1]
+        # Whitespace-normalised so the assertion pins the control flow, not the
+        # formatter. A bare "there is a return somewhere between gate and pump"
+        # check is vacuous: SignalReady's own early return already satisfies it.
+        compact = " ".join(worker.split())
+        gate = compact.index("g_header->version != kSharedVersion")
+        self.assertLess(gate, compact.index("registry.Poll();"))
+        # Take the gate's own block by brace matching. A bare "there is a
+        # return somewhere between gate and pump" check is vacuous: SignalReady's
+        # own early return already satisfies it. What must hold is that the
+        # mismatch branch itself cannot fall through to the pump.
+        open_at = compact.index("{", gate)
+        depth = 0
+        close_at = -1
+        for i in range(open_at, len(compact)):
+            if compact[i] == "{":
+                depth += 1
+            elif compact[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    close_at = i
+                    break
+        self.assertGreater(close_at, open_at, "contract gate has no block")
+        self.assertIn("return 1;", compact[open_at:close_at])
+        registry = (ROOT / "hook" / "adapter_registry.inc").read_text(
+            encoding="utf-8"
+        )
+        poll = registry.split("void Poll() {", 1)[1]
+        self.assertIn("loopback_.PollPolicy();", poll)
+
 if __name__ == "__main__":
     unittest.main()

--- a/native/galgame_hook/tests/assert_liveness_guard_test.py
+++ b/native/galgame_hook/tests/assert_liveness_guard_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Every native test must keep its assertions alive under --config Release.
+
+MSVC defines NDEBUG in Release, which compiles bare `assert(...)` out entirely.
+CI builds these tests with `--config Release`, so a test file without
+`#undef NDEBUG` is green no matter what it claims to check -- the same
+"zero execution masquerading as a pass" family as BUG-1157.
+
+This guard is a source scan rather than a runtime check on purpose: a runtime
+check would itself be an assert, and would therefore be the first thing the
+defect deletes.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AssertLivenessGuardTest(unittest.TestCase):
+    def test_every_native_test_undefines_ndebug_before_including_anything(
+        self,
+    ) -> None:
+        tests = sorted((ROOT / "tests").glob("*_test.cpp"))
+        self.assertGreater(len(tests), 20, "test discovery looks broken")
+        for path in tests:
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("#undef NDEBUG", text, path.name)
+            # Order matters, but only against the includes that can bind
+            # assert(): <cassert>/<assert.h>, and any project header that might
+            # pull one of them in. Platform headers such as <windows.h> ahead of
+            # the undef are fine, and forcing them below it would be a pointless
+            # churn -- so pin the real invariant, not "line 1".
+            undef_at = text.index("#undef NDEBUG")
+            for marker in ('#include <cassert>', '#include <assert.h>',
+                           '#include "'):
+                at = text.find(marker)
+                if at >= 0:
+                    self.assertLess(undef_at, at, f"{path.name}: {marker}")
+
+    def test_new_adapter_scaffolding_emits_the_undef(self) -> None:
+        # galhook.py `new` writes a native test file; if its template forgets the
+        # undef, every future engine adapter starts life with dead assertions.
+        tool = (ROOT / "tools" / "galhook.py").read_text(encoding="utf-8")
+        native_test_template = tool.split("native_test.write_text(", 1)[1]
+        native_test_template = native_test_template.split(
+            "encoding=", 1
+        )[0]
+        self.assertIn("#undef NDEBUG", native_test_template)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/native/galgame_hook/tests/child_process_policy_test.cpp
+++ b/native/galgame_hook/tests/child_process_policy_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include "child_process_policy.h"
 
 #include <cassert>

--- a/native/galgame_hook/tests/directsound_format_registry_test.cpp
+++ b/native/galgame_hook/tests/directsound_format_registry_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 

--- a/native/galgame_hook/tests/elf_ai6_adapter_test.cpp
+++ b/native/galgame_hook/tests/elf_ai6_adapter_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/native/galgame_hook/tests/ffmpeg_runtime_test.cpp
+++ b/native/galgame_hook/tests/ffmpeg_runtime_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include "ffmpeg_runtime.h"
 
 #include <cassert>

--- a/native/galgame_hook/tests/il2cpp_thread_scope_test.cpp
+++ b/native/galgame_hook/tests/il2cpp_thread_scope_test.cpp
@@ -5,6 +5,11 @@
 // IL2CPP 线程 API 固定四条路径：已注册免 attach、未注册则 attach+detach 且句柄配平、attach
 // 失败或 API 缺失时判定为不安全并放弃。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdio>
 
 #include "il2cpp_thread_scope.h"

--- a/native/galgame_hook/tests/kirikiri_launch_profile_test.cpp
+++ b/native/galgame_hook/tests/kirikiri_launch_profile_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include "kirikiri_launch_profile.h"
 
 #include <cstdio>

--- a/native/galgame_hook/tests/launch_command_line_test.cpp
+++ b/native/galgame_hook/tests/launch_command_line_test.cpp
@@ -5,6 +5,11 @@
 //   2. 真的把组装结果喂给 `CommandLineToArgvW` 反解，逐 token 比对 —— 这才是子进程
 //      实际看到的东西，光比对字符串证明不了转义是对的。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <windows.h>
 // WIN32_LEAN_AND_MEAN 把 CommandLineToArgvW 挡在 windows.h 之外，必须显式引入。
 #include <shellapi.h>

--- a/native/galgame_hook/tests/launch_failure_policy_test.cpp
+++ b/native/galgame_hook/tests/launch_failure_policy_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstring>
 
@@ -8,6 +13,11 @@ int main() {
   using fushi_voice_hook::LaunchedProcessDisposition;
   using fushi_voice_hook::LaunchFailureReason;
   using fushi_voice_hook::LaunchFailureToken;
+  // 这三个 using 是补上的：`#undef NDEBUG` 之前，用到它们的 assert 整条被预处理器
+  // 删掉，编译器从没见过这些标识符。也就是说这些断言从来没有被编译过，更谈不上执行。
+  using fushi_voice_hook::LaunchedProcessIsSuspended;
+  using fushi_voice_hook::MustResumeAfterInjection;
+  using fushi_voice_hook::SuspendedStartupWaitBudgetMs;
 
   // 根因回归：CREATE_SUSPENDED 拉起的游戏在 ResumeThread 之前失败时，绝不允许把进程
   // 留在挂起态。旧实现对「就绪事件超时」「旧映射不可复用」这两条（都在 Resume 之前

--- a/native/galgame_hook/tests/launcher_layout_test.cpp
+++ b/native/galgame_hook/tests/launcher_layout_test.cpp
@@ -5,6 +5,11 @@
 // 自己那一层，于是把 hook 下在启动器上，启动器拉起 SiglusEngine.exe 后自己退出，
 // 文本/音频一条都不来。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdio>
 #include <set>
 #include <string>

--- a/native/galgame_hook/tests/locale_emulator_launch_test.cpp
+++ b/native/galgame_hook/tests/locale_emulator_launch_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include "locale_emulator_launch.h"
 
 #include <cstddef>

--- a/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
+++ b/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
@@ -17,6 +17,11 @@
 // 与 text_lane_ipc_test.cpp 同一套做法：在进程内摆一块按真实布局排好的假共享内存，
 // 直接跑契约头里的那份寻址实现（不复制一份到测试里）。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/native/galgame_hook/tests/lookup_overlay_geometry_test.cpp
+++ b/native/galgame_hook/tests/lookup_overlay_geometry_test.cpp
@@ -3,6 +3,11 @@
 // 这层要挡住的是「卡片飘到游戏窗口外面」这一类症状：用户看不见卡片，与「host 压根没投帧」
 // 在现象上完全同形，真机上分不开。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdio>
 
 #include "lookup_overlay_geometry.h"

--- a/native/galgame_hook/tests/lookup_session_replay_test.cpp
+++ b/native/galgame_hook/tests/lookup_session_replay_test.cpp
@@ -27,6 +27,11 @@
 //     adapter 那个 .inc 依赖 MinHook/TJS/游戏进程上下文，不能独立编译进测试。它与
 //     adapter 一致由 tests/kirikiri_lookup_source_guard_test.py 从源码侧另行钉住。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/native/galgame_hook/tests/luna_bridge_abi_test.cpp
+++ b/native/galgame_hook/tests/luna_bridge_abi_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <type_traits>
 
 #include "luna_bridge.h"

--- a/native/galgame_hook/tests/luna_hook_config_test.cpp
+++ b/native/galgame_hook/tests/luna_hook_config_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <array>
 #include <cstdio>
 

--- a/native/galgame_hook/tests/luna_text_replay_test.cpp
+++ b/native/galgame_hook/tests/luna_text_replay_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/native/galgame_hook/tests/native_loopback_policy_test.cpp
+++ b/native/galgame_hook/tests/native_loopback_policy_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/native/galgame_hook/tests/qlie_pack_test.cpp
+++ b/native/galgame_hook/tests/qlie_pack_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/native/galgame_hook/tests/reallive_adapter_test.cpp
+++ b/native/galgame_hook/tests/reallive_adapter_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstring>
 #include <vector>

--- a/native/galgame_hook/tests/resource_audio_ready_test.cpp
+++ b/native/galgame_hook/tests/resource_audio_ready_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 

--- a/native/galgame_hook/tests/session_reuse_test.cpp
+++ b/native/galgame_hook/tests/session_reuse_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 

--- a/native/galgame_hook/tests/siglus_launch_test.cpp
+++ b/native/galgame_hook/tests/siglus_launch_test.cpp
@@ -5,6 +5,11 @@
 // engine.launch_or_inject_failed。改为按 Gameexe.dat + Scene.pck 文件夹签名识别后即使 exe
 // 改名也能判为 Siglus 从而延迟附着。本测试用假文件表固定“两签名齐全才判定、缺一不误报”。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdio>
 #include <set>
 #include <string>

--- a/native/galgame_hook/tests/siglus_ovk_test.cpp
+++ b/native/galgame_hook/tests/siglus_ovk_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>

--- a/native/galgame_hook/tests/siglus_text_test.cpp
+++ b/native/galgame_hook/tests/siglus_text_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstdio>
 #include <vector>

--- a/native/galgame_hook/tests/steam_launch_test.cpp
+++ b/native/galgame_hook/tests/steam_launch_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <string>
 

--- a/native/galgame_hook/tests/text_lane_ipc_test.cpp
+++ b/native/galgame_hook/tests/text_lane_ipc_test.cpp
@@ -5,6 +5,11 @@
 // system_loopback（BUG-1159 的失败链）。分道之后覆盖只发生在道内，这条失败链在结构上
 // 不存在——本测试就是钉死这个"结构上"。
 
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>

--- a/native/galgame_hook/tests/thread_preview_ipc_test.cpp
+++ b/native/galgame_hook/tests/thread_preview_ipc_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <array>
 #include <atomic>
 #include <cstdint>

--- a/native/galgame_hook/tests/unity_event_cursor_test.cpp
+++ b/native/galgame_hook/tests/unity_event_cursor_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 

--- a/native/galgame_hook/tests/unity_text_mesh_reassembler_test.cpp
+++ b/native/galgame_hook/tests/unity_text_mesh_reassembler_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <cstdint>
 #include <cwchar>

--- a/native/galgame_hook/tests/utterance_window_test.cpp
+++ b/native/galgame_hook/tests/utterance_window_test.cpp
@@ -7,6 +7,11 @@
 //
 // 不用 assert：本目录的测试目标没有关掉 NDEBUG，Release 配置下 assert 会被整条编掉，
 // 那样的「测试」永远绿。这里用显式检查 + 非零退出码。
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cstdint>
 #include <cstdio>
 #include <vector>

--- a/native/galgame_hook/tests/voice_clip_energy_test.cpp
+++ b/native/galgame_hook/tests/voice_clip_energy_test.cpp
@@ -9,6 +9,11 @@
 // 选源就不会因为格式而失效。
 //
 // 不用 assert：本目录测试目标没关 NDEBUG，Release 下 assert 会被整条编掉，那样永远绿。
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cmath>
 #include <cstdint>
 #include <cstdio>

--- a/native/galgame_hook/tests/voice_hook_ipc_name_test.cpp
+++ b/native/galgame_hook/tests/voice_hook_ipc_name_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include "voice_hook_ipc.h"
 
 #include <cassert>

--- a/native/galgame_hook/tests/voice_resource_filename_test.cpp
+++ b/native/galgame_hook/tests/voice_resource_filename_test.cpp
@@ -1,3 +1,8 @@
+// CI 走 `--config Release`，MSVC 在该配置下定义 NDEBUG，裸 assert 会被整条编译掉，
+// 于是这个测试无论断言对不对都恒绿——与 BUG-1157「零测试执行伪装成通过」同一族。
+// 必须在任何 include 之前撤销它。守卫：tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
 #include <cassert>
 #include <string>
 

--- a/native/galgame_hook/tools/galhook.py
+++ b/native/galgame_hook/tools/galhook.py
@@ -294,7 +294,12 @@ class {class_name}Adapter final : public fushi_voice_hook::EngineAdapter {{
         encoding="utf-8",
     )
     native_test.write_text(
-        f'''#include "../hook/adapters/{engine_id}_profile.h"
+        f'''// CI builds with --config Release, where MSVC defines NDEBUG and compiles
+// bare assert() out entirely. Undefine it before any include or this test is
+// green no matter what it checks. Guard: tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
+#include "../hook/adapters/{engine_id}_profile.h"
 int main() {{ return fushi_voice_hook::Matches{class_name}Profile(nullptr) ? 1 : 0; }}
 ''',
         encoding="utf-8",


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：`native/galgame_hook/tests/assert_liveness_guard_test.py` 在 `develop` 上不存在，提交主题也找不到。从没开过 PR。

## 内容

在作者提交 720802ce 之上补齐 PR #938 剩余根因修复。未落地约 **+855 行 / 57 个文件**。

## ⚠ 与 fix/pr938-rootcause 重叠

两条分支都在修 PR #938 的后续根因问题，内容有重叠。请一并审，不要各合一半。

## 平台边界

galgame hook 相关只做 Windows 端；合并前对照 `docs/agent/galgame-hooking.md` 的阶段证据门。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
