### PR TITLE
feat(gal): hook 浮窗白卡样式 + 工具条悬停提示（从未开 PR）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57664 (3392 per locale)
+/// Strings: 57681 (3393 per locale)
 ///
-/// Built on 2026-08-13 at 17:40 UTC
+/// Built on 2026-08-14 at 11:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4590,6 +4590,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Drag a subtitle up or down to reposition it';
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -12422,6 +12423,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -20321,6 +20324,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -28236,6 +28241,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -36163,6 +36170,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -44018,6 +44027,8 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -51919,6 +51930,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -59634,6 +59647,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -67356,6 +67371,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -75237,6 +75254,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -83130,6 +83149,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -91009,6 +91030,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -98836,6 +98859,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -106694,6 +106719,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -114537,6 +114564,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 // Path: <root>
@@ -121809,6 +121838,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
+  @override
+  String get font_target_gal_hook => '游戏台词字体';
 }
 
 // Path: <root>
@@ -129447,6 +129478,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+  @override
+  String get font_target_gal_hook => 'Game dialogue font';
 }
 
 /// Flat map(s) containing all translations.
@@ -136413,6 +136446,8 @@ extension on _StringsEn {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -143377,6 +143412,8 @@ extension on _StringsAr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -150363,6 +150400,8 @@ extension on _StringsDe {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -157348,6 +157387,8 @@ extension on _StringsEs {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -164339,6 +164380,8 @@ extension on _StringsFr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -171312,6 +171355,8 @@ extension on _StringsId {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -178299,6 +178344,8 @@ extension on _StringsIt {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -185248,6 +185295,8 @@ extension on _StringsJa {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -192201,6 +192250,8 @@ extension on _StringsKo {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -199182,6 +199233,8 @@ extension on _StringsNl {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -206160,6 +206213,8 @@ extension on _StringsPtBr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -213143,6 +213198,8 @@ extension on _StringsRu {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -220109,6 +220166,8 @@ extension on _StringsTh {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -227084,6 +227143,8 @@ extension on _StringsTr {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -234055,6 +234116,8 @@ extension on _StringsVi {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }
@@ -240968,6 +241031,8 @@ extension on _StringsZhCn {
         return '上下拖动字幕调整位置';
       case 'anki_connect_mobile_disabled_key_cleared':
         return '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
+      case 'font_target_gal_hook':
+        return '游戏台词字体';
       default:
         return null;
     }
@@ -247912,6 +247977,8 @@ extension on _StringsZhHk {
         return 'Drag a subtitle up or down to reposition it';
       case 'anki_connect_mobile_disabled_key_cleared':
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
+      case 'font_target_gal_hook':
+        return 'Game dialogue font';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57681 (3393 per locale)
+/// Strings: 57834 (3402 per locale)
 ///
-/// Built on 2026-08-14 at 11:31 UTC
+/// Built on 2026-08-14 at 13:01 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4591,6 +4591,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_connect_mobile_disabled_key_cleared =>
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   String get font_target_gal_hook => 'Game dialogue font';
+  String get game_hook_btn_replay => 'Replay line audio';
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  String get game_hook_btn_follow => 'Follow latest line';
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  String get game_hook_btn_transparency => 'Toggle background';
+  String get game_hook_btn_lock => 'Lock position';
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  String get game_hook_btn_topmost => 'Always on top';
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -12425,6 +12434,24 @@ class _StringsAr extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -20326,6 +20353,24 @@ class _StringsDe extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -28243,6 +28288,24 @@ class _StringsEs extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -36172,6 +36235,24 @@ class _StringsFr extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -44029,6 +44110,24 @@ class _StringsId extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -51932,6 +52031,24 @@ class _StringsIt extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -59649,6 +59766,24 @@ class _StringsJa extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -67373,6 +67508,24 @@ class _StringsKo extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -75256,6 +75409,24 @@ class _StringsNl extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -83151,6 +83322,24 @@ class _StringsPtBr extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -91032,6 +91221,24 @@ class _StringsRu extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -98861,6 +99068,24 @@ class _StringsTh extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -106721,6 +106946,24 @@ class _StringsTr extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -114566,6 +114809,24 @@ class _StringsVi extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 // Path: <root>
@@ -121840,6 +122101,24 @@ class _StringsZhCn extends _StringsEn {
       '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
   @override
   String get font_target_gal_hook => '游戏台词字体';
+  @override
+  String get game_hook_btn_replay => '重播本句语音';
+  @override
+  String get game_hook_btn_recapture => '补录本句语音';
+  @override
+  String get game_hook_btn_follow => '跟随最新台词';
+  @override
+  String get game_hook_btn_passthrough => '鼠标穿透到游戏';
+  @override
+  String get game_hook_btn_transparency => '切换背景底板';
+  @override
+  String get game_hook_btn_lock => '锁定位置';
+  @override
+  String get game_hook_btn_workbench => '打开捕获工作台';
+  @override
+  String get game_hook_btn_topmost => '窗口置顶';
+  @override
+  String get game_hook_btn_close => '关闭浮窗';
 }
 
 // Path: <root>
@@ -129480,6 +129759,24 @@ class _StringsZhHk extends _StringsEn {
       'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
   @override
   String get font_target_gal_hook => 'Game dialogue font';
+  @override
+  String get game_hook_btn_replay => 'Replay line audio';
+  @override
+  String get game_hook_btn_recapture => 'Recapture line audio';
+  @override
+  String get game_hook_btn_follow => 'Follow latest line';
+  @override
+  String get game_hook_btn_passthrough => 'Mouse pass-through to game';
+  @override
+  String get game_hook_btn_transparency => 'Toggle background';
+  @override
+  String get game_hook_btn_lock => 'Lock position';
+  @override
+  String get game_hook_btn_workbench => 'Open capture workbench';
+  @override
+  String get game_hook_btn_topmost => 'Always on top';
+  @override
+  String get game_hook_btn_close => 'Close overlay';
 }
 
 /// Flat map(s) containing all translations.
@@ -136448,6 +136745,24 @@ extension on _StringsEn {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -143414,6 +143729,24 @@ extension on _StringsAr {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -150402,6 +150735,24 @@ extension on _StringsDe {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -157389,6 +157740,24 @@ extension on _StringsEs {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -164382,6 +164751,24 @@ extension on _StringsFr {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -171357,6 +171744,24 @@ extension on _StringsId {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -178346,6 +178751,24 @@ extension on _StringsIt {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -185297,6 +185720,24 @@ extension on _StringsJa {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -192252,6 +192693,24 @@ extension on _StringsKo {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -199235,6 +199694,24 @@ extension on _StringsNl {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -206215,6 +206692,24 @@ extension on _StringsPtBr {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -213200,6 +213695,24 @@ extension on _StringsRu {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -220168,6 +220681,24 @@ extension on _StringsTh {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -227145,6 +227676,24 @@ extension on _StringsTr {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -234118,6 +234667,24 @@ extension on _StringsVi {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }
@@ -241033,6 +241600,24 @@ extension on _StringsZhCn {
         return '移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。';
       case 'font_target_gal_hook':
         return '游戏台词字体';
+      case 'game_hook_btn_replay':
+        return '重播本句语音';
+      case 'game_hook_btn_recapture':
+        return '补录本句语音';
+      case 'game_hook_btn_follow':
+        return '跟随最新台词';
+      case 'game_hook_btn_passthrough':
+        return '鼠标穿透到游戏';
+      case 'game_hook_btn_transparency':
+        return '切换背景底板';
+      case 'game_hook_btn_lock':
+        return '锁定位置';
+      case 'game_hook_btn_workbench':
+        return '打开捕获工作台';
+      case 'game_hook_btn_topmost':
+        return '窗口置顶';
+      case 'game_hook_btn_close':
+        return '关闭浮窗';
       default:
         return null;
     }
@@ -247979,6 +248564,24 @@ extension on _StringsZhHk {
         return 'AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.';
       case 'font_target_gal_hook':
         return 'Game dialogue font';
+      case 'game_hook_btn_replay':
+        return 'Replay line audio';
+      case 'game_hook_btn_recapture':
+        return 'Recapture line audio';
+      case 'game_hook_btn_follow':
+        return 'Follow latest line';
+      case 'game_hook_btn_passthrough':
+        return 'Mouse pass-through to game';
+      case 'game_hook_btn_transparency':
+        return 'Toggle background';
+      case 'game_hook_btn_lock':
+        return 'Lock position';
+      case 'game_hook_btn_workbench':
+        return 'Open capture workbench';
+      case 'game_hook_btn_topmost':
+        return 'Always on top';
+      case 'game_hook_btn_close':
+        return 'Close overlay';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "顶部",
   "video_setting_subtitle_drag_adjust": "拖拽调整位置",
   "video_subtitle_drag_adjust_hint": "上下拖动字幕调整位置",
-  "anki_connect_mobile_disabled_key_cleared": "移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。"
+  "anki_connect_mobile_disabled_key_cleared": "移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。",
+  "font_target_gal_hook": "游戏台词字体"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "拖拽调整位置",
   "video_subtitle_drag_adjust_hint": "上下拖动字幕调整位置",
   "anki_connect_mobile_disabled_key_cleared": "移动端使用 AnkiConnect 必须填 API key，清空后已自动关闭该开关，Anki 改回走内置后端。",
-  "font_target_gal_hook": "游戏台词字体"
+  "font_target_gal_hook": "游戏台词字体",
+  "game_hook_btn_replay": "重播本句语音",
+  "game_hook_btn_recapture": "补录本句语音",
+  "game_hook_btn_follow": "跟随最新台词",
+  "game_hook_btn_passthrough": "鼠标穿透到游戏",
+  "game_hook_btn_transparency": "切换背景底板",
+  "game_hook_btn_lock": "锁定位置",
+  "game_hook_btn_workbench": "打开捕获工作台",
+  "game_hook_btn_topmost": "窗口置顶",
+  "game_hook_btn_close": "关闭浮窗"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3390,5 +3390,6 @@
   "video_subtitle_anchor_top": "Top",
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
-  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again."
+  "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
+  "font_target_gal_hook": "Game dialogue font"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3391,5 +3391,14 @@
   "video_setting_subtitle_drag_adjust": "Drag to adjust position",
   "video_subtitle_drag_adjust_hint": "Drag a subtitle up or down to reposition it",
   "anki_connect_mobile_disabled_key_cleared": "AnkiConnect needs an API key on mobile, so clearing it turned the switch back off. Anki now goes through the built-in backend again.",
-  "font_target_gal_hook": "Game dialogue font"
+  "font_target_gal_hook": "Game dialogue font",
+  "game_hook_btn_replay": "Replay line audio",
+  "game_hook_btn_recapture": "Recapture line audio",
+  "game_hook_btn_follow": "Follow latest line",
+  "game_hook_btn_passthrough": "Mouse pass-through to game",
+  "game_hook_btn_transparency": "Toggle background",
+  "game_hook_btn_lock": "Lock position",
+  "game_hook_btn_workbench": "Open capture workbench",
+  "game_hook_btn_topmost": "Always on top",
+  "game_hook_btn_close": "Close overlay"
 }

--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -131,6 +131,11 @@ class GalHookTextOverlayController extends ChangeNotifier {
   double _opacity = _defaultOpacity;
   double _lastNonZeroOpacity = _defaultRestoreOpacity;
   double _fontSize = kGalHookTextFontSize;
+
+  /// 台词字体（字体库 FontTarget.galHookText 的第一条启用项）。null = 未设置，
+  /// native 回退内置字族。path 为 null 表示系统字体（native 按 family 名解析）。
+  String? _fontFamily;
+  String? _fontPath;
   GalHookTextWindowRect? _savedRect;
 
   static bool get isSupported =>
@@ -270,6 +275,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
     _opacity = stored.clamp(0.0, 1.0);
     if (_opacity > 0) _lastNonZeroOpacity = _opacity;
     _fontSize = _readFontSizePreference();
+    _readHookFontPreference();
     final Object? storedRect = read(_rectPreferenceKey, '');
     final String encoded = storedRect is String ? storedRect : '';
     if (encoded.isEmpty) return;
@@ -389,6 +395,8 @@ class GalHookTextOverlayController extends ChangeNotifier {
         rect: _savedRect,
         fontSize: _fontSize,
         bgColor: _backgroundColor,
+        fontFamily: _fontFamily,
+        fontPath: _fontPath,
         following: _following,
         passThrough: _passThrough,
         locked: _locked,
@@ -472,6 +480,8 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GalHookTextOverlayChannel.updateStyle(
       bgColor: _backgroundColor,
       fontSize: _fontSize,
+      fontFamily: _fontFamily,
+      fontPath: _fontPath,
     );
     notifyListeners();
   }
@@ -492,6 +502,45 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GalHookTextOverlayChannel.updateStyle(
       bgColor: _backgroundColor,
       fontSize: next,
+      fontFamily: _fontFamily,
+      fontPath: _fontPath,
+    );
+    notifyListeners();
+  }
+
+  /// 读台词字体（字体库 `FontTarget.galHookText` 用途）：取第一条启用项的
+  /// `{name, path}` 进 [_fontFamily] / [_fontPath]。真值在
+  /// [ReaderFushiSource.readerSettings]（app 初始化时挂上）；未挂 / 未设置时
+  /// 双双置 null → native 回退内置字族。
+  void _readHookFontPreference() {
+    _fontFamily = null;
+    _fontPath = null;
+    final settings = ReaderFushiSource.readerSettings;
+    if (settings == null) return;
+    for (final Map<String, dynamic> font in settings.galHookFonts) {
+      if (font['enabled'] == false) continue;
+      final Object? name = font['name'];
+      if (name is! String || name.isEmpty) continue;
+      _fontFamily = name;
+      final Object? path = font['path'];
+      _fontPath = path is String && path.isNotEmpty ? path : null;
+      return;
+    }
+  }
+
+  /// 字体库改动后调用：重读台词字体并立刻推给已开着的 native 浮窗。与
+  /// [applyFontSizeFromPreferences] 同款纪律——漏掉这步只落盘，浮窗要重开才生效。
+  Future<void> applyFontFromPreferences() async {
+    if (!_started) return;
+    final String? prevFamily = _fontFamily;
+    final String? prevPath = _fontPath;
+    _readHookFontPreference();
+    if (prevFamily == _fontFamily && prevPath == _fontPath) return;
+    await GalHookTextOverlayChannel.updateStyle(
+      bgColor: _backgroundColor,
+      fontSize: _fontSize,
+      fontFamily: _fontFamily,
+      fontPath: _fontPath,
     );
     notifyListeners();
   }

--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -80,11 +80,14 @@ class GalHookTextOverlayController extends ChangeNotifier {
   static const String _rectPreferenceKey = 'gal_hook_text_window_rect';
   static const String _opacityPreferenceKey = 'gal_hook_text_window_bg_opacity';
 
-  /// 桌面歌词式重写：native 侧 hook 模式文字已自带描边 + 投影，可读性不再依赖
-  /// 底板，默认背景与音乐播放器桌面歌词一致——全透明。存过偏好的用户保持原值
-  /// （never break userspace）；`◐` 一键切底板时恢复到 [_defaultRestoreOpacity]。
-  static const double _defaultOpacity = 0.0;
-  static const double _defaultRestoreOpacity = 0.6;
+  /// 浮窗两态（`◐` 一键切换）：
+  /// - 底板不透明 = **白色磨砂卡**（默认）：奶白圆角卡片 + 深色文字，参考桌面
+  ///   翻译器的浅色浮窗；
+  /// - 底板全透明 = 桌面歌词式：白字直接压在游戏画面上，native 自动加描边 +
+  ///   投影自证可读性。
+  /// 存过透明度偏好的用户保持原值（never break userspace）。
+  static const double _defaultOpacity = 0.92;
+  static const double _defaultRestoreOpacity = 0.92;
 
   /// BUG-1095：台词字号的持久化 key。与 [_rectPreferenceKey]（窗口几何）严格分开——
   /// 这两件事以前被 native 的「字号 = 基准 × 窗高比例」耦成一件，正是「放不下拖高
@@ -395,8 +398,13 @@ class GalHookTextOverlayController extends ChangeNotifier {
         rect: _savedRect,
         fontSize: _fontSize,
         bgColor: _backgroundColor,
+        textColor: _textColor,
+        buttonTextColor: _buttonTextColor,
+        buttonBgColor: _buttonBgColor,
+        activeColor: _activeColor,
         fontFamily: _fontFamily,
         fontPath: _fontPath,
+        slotTooltips: _slotTooltips,
         following: _following,
         passThrough: _passThrough,
         locked: _locked,
@@ -426,10 +434,34 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await _syncVoiceState();
   }
 
+  /// 白卡模式判据：底板可见即走浅色卡片调色板（深字浅底），全透明走桌面歌词
+  /// 调色板（白字，native 按底板 alpha 自动决定要不要描边）。
+  bool get _isCardMode => _opacity > 0;
+
   int get _backgroundColor {
     final int alpha = (_opacity.clamp(0.0, 1.0) * 255).round();
-    return alpha << 24;
+    // 卡片模式奶白底（FAFAFC）；透明模式底色无意义，保持纯黑基底以复用
+    // native 的 BUG-1046 可点性 alpha 地板。
+    return _isCardMode ? (alpha << 24) | 0x00FAFAFC : alpha << 24;
   }
+
+  int get _textColor => _isCardMode ? 0xFF23262B : 0xFFFFFFFF;
+  int get _buttonTextColor => _isCardMode ? 0xFF3C4046 : 0xFFFFFFFF;
+  int get _buttonBgColor => _isCardMode ? 0x12000000 : 0x552D2340;
+  int get _activeColor => _isCardMode ? 0xFF7B1FA2 : 0xFFCE93D8;
+
+  /// 工具条槽位悬停提示文案，与 native `hook_toolbar::kSlotActions` 同下标。
+  List<String> get _slotTooltips => <String>[
+        t.game_hook_btn_replay,
+        t.game_hook_btn_recapture,
+        t.game_hook_btn_follow,
+        t.game_hook_btn_passthrough,
+        t.game_hook_btn_transparency,
+        t.game_hook_btn_lock,
+        t.game_hook_btn_workbench,
+        t.game_hook_btn_topmost,
+        t.game_hook_btn_close,
+      ];
 
   Future<void> showManually() async {
     if (!_started) return;
@@ -480,6 +512,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GalHookTextOverlayChannel.updateStyle(
       bgColor: _backgroundColor,
       fontSize: _fontSize,
+      textColor: _textColor,
+      buttonTextColor: _buttonTextColor,
+      buttonBgColor: _buttonBgColor,
+      activeColor: _activeColor,
       fontFamily: _fontFamily,
       fontPath: _fontPath,
     );
@@ -502,6 +538,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GalHookTextOverlayChannel.updateStyle(
       bgColor: _backgroundColor,
       fontSize: next,
+      textColor: _textColor,
+      buttonTextColor: _buttonTextColor,
+      buttonBgColor: _buttonBgColor,
+      activeColor: _activeColor,
       fontFamily: _fontFamily,
       fontPath: _fontPath,
     );
@@ -539,6 +579,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GalHookTextOverlayChannel.updateStyle(
       bgColor: _backgroundColor,
       fontSize: _fontSize,
+      textColor: _textColor,
+      buttonTextColor: _buttonTextColor,
+      buttonBgColor: _buttonBgColor,
+      activeColor: _activeColor,
       fontFamily: _fontFamily,
       fontPath: _fontPath,
     );

--- a/fushi/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/fushi/lib/src/pages/implementations/custom_fonts_page.dart
@@ -7,6 +7,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/pages.dart';
+import 'package:fushi/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/reader/font_catalog.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
@@ -656,6 +657,11 @@ class _CustomFontsPageState extends BasePageState {
     }
     await _settings!.refreshFromDb();
     await appModel.refreshAppFont();
+    // gal hook 台词浮窗字体（FontTarget.galHookText）不经 Flutter engine，走
+    // gal_hook_text channel 直推 native；与 BUG-1095 字号的「写偏好 → 立刻推
+    // native」同款纪律，漏掉这步要重开浮窗才生效。非 Windows / 浮窗未启动时
+    // 是空操作。
+    await GalHookTextOverlayController.instance.applyFontFromPreferences();
     ReaderFushiSource.onSettingsChangedLive?.call();
   }
 
@@ -1438,8 +1444,9 @@ class CustomFontCatalogTile extends StatefulWidget {
 }
 
 class _CustomFontCatalogTileState extends State<CustomFontCatalogTile> {
-  // 4 个字体用途开关（System UI / Novel Text / Dictionary / Video Subtitle）
-  // 默认折叠：每行不再被四枚 FilterChip 撑高，一屏能看到更多字体。展开后才显示。
+  // 字体用途开关（System UI / Novel Text / Dictionary / Video Subtitle /
+  // Game dialogue）默认折叠：每行不被整排 FilterChip 撑高，一屏能看到更多
+  // 字体。展开后才显示。
   bool _rolesExpanded = false;
 
   String _targetLabel(FontTarget target) => switch (target) {
@@ -1447,6 +1454,7 @@ class _CustomFontCatalogTileState extends State<CustomFontCatalogTile> {
         FontTarget.body => t.font_target_body,
         FontTarget.dictionary => t.font_target_dictionary,
         FontTarget.videoSubtitle => t.font_target_video_subtitle,
+        FontTarget.galHookText => t.font_target_gal_hook,
       };
 
   /// 折叠态摘要：把已启用的用途拼成一行，用户不展开也能一眼看到该字体用在哪。

--- a/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -394,6 +394,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     double fontSize = kGalHookTextFontSize,
     int textColor = 0xFFFFFFFF,
     int bgColor = 0xE0000000,
+    String? fontFamily,
+    String? fontPath,
     bool following = true,
     bool passThrough = false,
     bool locked = false,
@@ -401,6 +403,10 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   }) {
     return _instance.showImpl(<String, Object?>{
       'fontSize': fontSize,
+      // 自定义台词字体（字体库 FontTarget.galHookText 的第一条启用项）。缺省 /
+      // 老 native 不识别时回退内置字族（Yu Gothic），never break。
+      if (fontFamily != null && fontFamily.isNotEmpty) 'fontFamily': fontFamily,
+      if (fontPath != null && fontPath.isNotEmpty) 'fontPath': fontPath,
       'textColor': textColor,
       'bgColor': bgColor,
       'buttonTextColor': 0xFFFFFFFF,
@@ -446,12 +452,16 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     required int bgColor,
     int textColor = 0xFFFFFFFF,
     double fontSize = kGalHookTextFontSize,
+    String? fontFamily,
+    String? fontPath,
   }) async {
     if (!_instance.isSupported) return;
     await _instance.channel.invokeMethod<void>('updateStyle', <String, Object?>{
       'fontSize': fontSize,
       'bgColor': bgColor,
       'textColor': textColor,
+      if (fontFamily != null && fontFamily.isNotEmpty) 'fontFamily': fontFamily,
+      if (fontPath != null && fontPath.isNotEmpty) 'fontPath': fontPath,
       'buttonTextColor': 0xFFFFFFFF,
       'buttonBgColor': 0x552D2340,
       'activeColor': 0xFFCE93D8,

--- a/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/fushi/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -394,8 +394,12 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     double fontSize = kGalHookTextFontSize,
     int textColor = 0xFFFFFFFF,
     int bgColor = 0xE0000000,
+    int buttonTextColor = 0xFFFFFFFF,
+    int buttonBgColor = 0x552D2340,
+    int activeColor = 0xFFCE93D8,
     String? fontFamily,
     String? fontPath,
+    List<String>? slotTooltips,
     bool following = true,
     bool passThrough = false,
     bool locked = false,
@@ -407,11 +411,14 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
       // 老 native 不识别时回退内置字族（Yu Gothic），never break。
       if (fontFamily != null && fontFamily.isNotEmpty) 'fontFamily': fontFamily,
       if (fontPath != null && fontPath.isNotEmpty) 'fontPath': fontPath,
+      // 工具条槽位悬停提示，与 native hook_toolbar::kSlotActions 同下标。
+      if (slotTooltips != null && slotTooltips.isNotEmpty)
+        'slotTooltips': slotTooltips,
       'textColor': textColor,
       'bgColor': bgColor,
-      'buttonTextColor': 0xFFFFFFFF,
-      'buttonBgColor': 0x552D2340,
-      'activeColor': 0xFFCE93D8,
+      'buttonTextColor': buttonTextColor,
+      'buttonBgColor': buttonBgColor,
+      'activeColor': activeColor,
       'windowWidth': 900.0,
       'windowHeight': 140.0,
       'clickLookupEnabled': true,
@@ -452,6 +459,9 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     required int bgColor,
     int textColor = 0xFFFFFFFF,
     double fontSize = kGalHookTextFontSize,
+    int buttonTextColor = 0xFFFFFFFF,
+    int buttonBgColor = 0x552D2340,
+    int activeColor = 0xFFCE93D8,
     String? fontFamily,
     String? fontPath,
   }) async {
@@ -462,9 +472,9 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
       'textColor': textColor,
       if (fontFamily != null && fontFamily.isNotEmpty) 'fontFamily': fontFamily,
       if (fontPath != null && fontPath.isNotEmpty) 'fontPath': fontPath,
-      'buttonTextColor': 0xFFFFFFFF,
-      'buttonBgColor': 0x552D2340,
-      'activeColor': 0xFFCE93D8,
+      'buttonTextColor': buttonTextColor,
+      'buttonBgColor': buttonBgColor,
+      'activeColor': activeColor,
     });
   }
 

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -28,6 +28,11 @@ enum FontTarget {
   /// not libmpv — Hibiki renders text subtitles in the Flutter layer). New in
   /// TODO-864.
   videoSubtitle,
+
+  /// Windows galgame hook 台词浮窗字体。消费方是 native DirectWrite（浮窗是
+  /// runner 自绘的分层窗，不走 Flutter engine），所以这个 target 只取
+  /// `{name, path}` 经 gal_hook_text channel 下发，不经 [AppFontLoader] 注册。
+  galHookText,
 }
 
 /// All reader display/behavior settings, decoupled from the media source.
@@ -554,6 +559,10 @@ class ReaderSettings {
   /// Sibling of the other `*_fonts` keys; backs [FontTarget.videoSubtitle].
   static const String fontKeyVideoSubtitle = 'video_sub_fonts';
 
+  /// Persistence key for the galgame hook overlay font list.
+  /// Sibling of the other `*_fonts` keys; backs [FontTarget.galHookText].
+  static const String fontKeyGalHookText = 'gal_hook_fonts';
+
   /// Persistence key for the shared font catalog.
   static const String fontCatalogKey = 'font_catalog';
 
@@ -565,6 +574,7 @@ class ReaderSettings {
     fontKeyAppUi,
     fontKeyDictionary,
     fontKeyVideoSubtitle,
+    fontKeyGalHookText,
   ];
 
   bool get _hasAnyFontPrefs =>
@@ -598,6 +608,8 @@ class ReaderSettings {
         fontKeyDictionary: _legacyFontListForKey(fontKeyDictionary),
       if (_cache.containsKey(fontKeyVideoSubtitle))
         fontKeyVideoSubtitle: _legacyFontListForKey(fontKeyVideoSubtitle),
+      if (_cache.containsKey(fontKeyGalHookText))
+        fontKeyGalHookText: _legacyFontListForKey(fontKeyGalHookText),
     };
   }
 
@@ -734,6 +746,7 @@ class ReaderSettings {
     // their compat seed.
     if (key != fontKeyBody &&
         key != fontKeyVideoSubtitle &&
+        key != fontKeyGalHookText &&
         !state.hasTarget(key) &&
         state.hasTarget(fontKeyBody)) {
       final FontCatalogState seeded = state.withTargetFonts(
@@ -763,6 +776,11 @@ class ReaderSettings {
   List<Map<String, dynamic>> get videoSubtitleFonts =>
       _fontListForTargetKey(fontKeyVideoSubtitle);
 
+  /// Galgame hook 台词浮窗字体列表。未设置 = 空列表 → native 回退默认字族
+  /// （Yu Gothic）。与 [videoSubtitleFonts] 同规矩：不继承正文列表。
+  List<Map<String, dynamic>> get galHookFonts =>
+      _fontListForTargetKey(fontKeyGalHookText);
+
   /// Resolves the persisted font list for a [FontTarget].
   List<Map<String, dynamic>> fontsForTarget(FontTarget target) =>
       switch (target) {
@@ -770,6 +788,7 @@ class ReaderSettings {
         FontTarget.appUi => appUiFonts,
         FontTarget.dictionary => dictionaryFonts,
         FontTarget.videoSubtitle => videoSubtitleFonts,
+        FontTarget.galHookText => galHookFonts,
       };
 
   /// CSS font-family string and @font-face declarations for the BODY fonts.
@@ -808,6 +827,7 @@ class ReaderSettings {
         FontTarget.appUi => fontKeyAppUi,
         FontTarget.dictionary => fontKeyDictionary,
         FontTarget.videoSubtitle => fontKeyVideoSubtitle,
+        FontTarget.galHookText => fontKeyGalHookText,
       };
 
   /// Persists the whole list for [target]. The body convenience overload

--- a/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
+++ b/fushi/test/build/gal_overlay_lyric_style_guard_test.dart
@@ -43,21 +43,31 @@ void main() {
     );
   });
 
-  test('② 描边只在 hook 模式生效，其余浮窗逐像素不变', () {
+  test('② 描边只在「hook 模式 × 近透明底板」生效，其余浮窗逐像素不变', () {
+    // fx 判据必须以 hook_text_mode_ 为第一门（歌词条 / 剪贴板窗永远进不来），
+    // 第二门是底板 alpha（白卡模式深字无描边）+ 穿透强制清底。
+    expect(
+      RegExp(r'lyric_text_fx =\s*hook_text_mode_ &&\s*'
+              r'\(pass_through_ \|\| \(style_\.bg_color >> 24\) < '
+              r'kLyricTextFxBgAlphaMax\)')
+          .hasMatch(window),
+      isTrue,
+      reason: '描边开关必须是 hook 模式 && (穿透 || 底板近透明)；'
+          '任何一门被拆掉，白卡会脏描边或歌词条被改观感',
+    );
     // 主文本门与注音门分别锁：两处同形门若只锁其一，另一处被拆掉时守卫不响。
     expect(
-      RegExp(r'if \(hook_text_mode_ && lyric_outline != nullptr &&\s*'
+      RegExp(r'if \(lyric_text_fx && lyric_outline != nullptr &&\s*'
               r'lyric_shadow != nullptr\)')
           .hasMatch(window),
       isTrue,
-      reason: '主文本描边/投影遍必须被 hook_text_mode_ 门住；'
-          '歌词条 / 剪贴板窗不许被改观感',
+      reason: '主文本描边/投影遍必须被 lyric_text_fx 门住',
     );
     expect(
-      RegExp(r'if \(hook_text_mode_ && lyric_outline != nullptr\) \{')
+      RegExp(r'if \(lyric_text_fx && lyric_outline != nullptr\) \{')
           .hasMatch(window),
       isTrue,
-      reason: '注音描边遍必须被 hook_text_mode_ 门住',
+      reason: '注音描边遍必须被 lyric_text_fx 门住',
     );
     expect(
       RegExp(r'hook_text_mode_\s*\?\s*DWRITE_FONT_WEIGHT_SEMI_BOLD'
@@ -78,11 +88,14 @@ void main() {
     );
   });
 
-  test('④ Dart 默认底板全透明，◐ 恢复值非零', () {
+  test('④ Dart 两态调色板：白卡默认非零、◐ 恢复值非零、透明态白字', () {
+    final RegExp def = RegExp(r'_defaultOpacity = (\d+(?:\.\d+)?);');
+    final Match? dm = def.firstMatch(controller);
+    expect(dm, isNotNull, reason: '默认底板常量必须存在');
     expect(
-      controller.contains('_defaultOpacity = 0.0'),
-      isTrue,
-      reason: '桌面歌词式默认无底板；可读性由 native 描边承担',
+      double.parse(dm!.group(1)!),
+      greaterThan(0),
+      reason: '默认是白色磨砂卡（参考桌面翻译器浅色浮窗），不是透明',
     );
     final RegExp restore = RegExp(r'_defaultRestoreOpacity = (\d+(?:\.\d+)?);');
     final Match? m = restore.firstMatch(controller);
@@ -92,5 +105,47 @@ void main() {
       greaterThan(0),
       reason: '恢复值为 0 会让 ◐ 在 0 ↔ 0 之间空转',
     );
+    // 两态文字色必须跟着底板走：白卡深字 / 透明白字。任何一半被写死，另一态
+    // 就是白字白底或黑字黑底。
+    expect(
+      RegExp(r'_textColor => _isCardMode \? 0xFF[0-9A-Fa-f]{6} : 0xFFFFFFFF')
+          .hasMatch(controller),
+      isTrue,
+      reason: '文字颜色必须按 _isCardMode 分派：卡片深字、透明白字',
+    );
+  });
+
+  test('⑤ 工具条悬停提示：文案条数 == 槽位数，两个工具条窗共用一张表', () {
+    final String toolbarHeader =
+        File('windows/runner/hook_toolbar_window.h').readAsStringSync();
+    final String toolbarImpl =
+        File('windows/runner/hook_toolbar_window.cpp').readAsStringSync();
+    final RegExp slotCount = RegExp(r'constexpr int kSlotCount = (\d+);');
+    final Match? sc = slotCount.firstMatch(toolbarHeader);
+    expect(sc, isNotNull, reason: '共享槽位表必须存在');
+    final int slots = int.parse(sc!.group(1)!);
+    // Dart 下发的文案条数必须与槽位数一致——差一条就是「按错位的提示」，比
+    // 没有提示更糟。
+    expect(
+      RegExp(r't\.game_hook_btn_\w+').allMatches(controller).length,
+      slots,
+      reason: '控制器 _slotTooltips 的条数必须等于 native kSlotCount（$slots）',
+    );
+    // 两个工具条窗都必须从共享表取词并真的接了悬停事件。
+    expect(
+      toolbarHeader.contains('void SetSlotTooltips('),
+      isTrue,
+      reason: '共享文案入口必须在 hook_toolbar 命名空间（单一真相）',
+    );
+    for (final (String file, String src) in <(String, String)>[
+      ('floating_lyric_window.cpp', window),
+      ('hook_toolbar_window.cpp', toolbarImpl),
+    ]) {
+      expect(
+        RegExp(r'(slot_)?tooltip_\.Update\(hwnd_, slot').hasMatch(src),
+        isTrue,
+        reason: '$file 的鼠标移动路径必须驱动槽位提示（两窗不许只接一半）',
+      );
+    }
   });
 }

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -66,6 +66,10 @@ constexpr float kLyricOutlineRadiusDip = 1.6f;
 constexpr float kLyricShadowOffsetDip = 2.0f;
 constexpr uint32_t kLyricOutlineColor = 0xE0000000;  // 88% 黑描边
 constexpr uint32_t kLyricShadowColor = 0x59000000;   // 35% 黑投影
+// 描边/投影只在「近透明底板」时开：底板 alpha 低于此值（≈25%）文字直接压在游戏
+// 画面上，需要描边自证可读性；卡片模式（白色磨砂底）用深色文字，描边反而脏。
+// 穿透模式强制清底（BUG-1480），恒走描边分支。
+constexpr uint32_t kLyricTextFxBgAlphaMax = 0x40;
 // Base logical font size the lyric text was authored at; the rendered font
 // scales with the bar height so growing the bar enlarges the text too.
 constexpr float kBaseStripHeightForFontDip = 96.0f;
@@ -378,6 +382,7 @@ void FloatingLyricWindow::Hide() {
   visible_ = false;
   hovered_ = false;
   tracking_mouse_leave_ = false;
+  slot_tooltip_.Hide();
   // BUG-1471: a hidden window never receives the WM_LBUTTONUP that would end an
   // in-flight press. Clearing only `dragging_` here left `pressed_` stuck true
   // across the hide, and MaybeHoverLookup bails on `pressed_` -- hover lookup
@@ -938,6 +943,18 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // onShiftHover 同语义）。命中新字才派发一次，见 MaybeHoverLookup。
       MaybeHoverLookup(static_cast<float>(GET_X_LPARAM(lparam)),
                        static_cast<float>(GET_Y_LPARAM(lparam)));
+      // 工具条槽位悬停提示（hook 模式）：按钮只在 hovered_ 时可见/可点
+      // （ControlActionAt 同门），提示同门；拖拽/按压途中不冒提示。
+      if (hook_text_mode_ && !pressed_ && !dragging_) {
+        const int slot = hovered_
+                             ? HookToolbarSlotAt(
+                                   static_cast<float>(GET_X_LPARAM(lparam)),
+                                   static_cast<float>(GET_Y_LPARAM(lparam)))
+                             : -1;
+        POINT cursor;
+        GetCursorPos(&cursor);
+        slot_tooltip_.Update(hwnd_, slot, cursor.x + 12, cursor.y + 22);
+      }
       return 0;
     }
     case WM_TIMER: {
@@ -967,6 +984,7 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       tracking_mouse_leave_ = false;
       StopHoverLookupPolling();
       ResetHoverLookupAnchor();
+      slot_tooltip_.Hide();
       if (hovered_ && !dragging_) {
         hovered_ = false;
         RequestRender();
@@ -974,6 +992,7 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       return 0;
     }
     case WM_LBUTTONDOWN: {
+      slot_tooltip_.Hide();
       const float x = static_cast<float>(GET_X_LPARAM(lparam));
       const float y = static_cast<float>(GET_Y_LPARAM(lparam));
 
@@ -1413,15 +1432,18 @@ void FloatingLyricWindow::Render() {
       // 再画投影，最后回到原点画填充。所有遍都在上面的 text_clip 之内。
       // hook 的 UpdateText 恒传 current_line_start=-1，不存在 per-range dim
       // drawing effect，因此描边遍不会被 SetDrawingEffect 换色。
+      const bool lyric_text_fx =
+          hook_text_mode_ &&
+          (pass_through_ || (style_.bg_color >> 24) < kLyricTextFxBgAlphaMax);
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> lyric_outline;
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> lyric_shadow;
-      if (hook_text_mode_) {
+      if (lyric_text_fx) {
         render_target_->CreateSolidColorBrush(
             ColorFromArgb(kLyricOutlineColor), lyric_outline.GetAddressOf());
         render_target_->CreateSolidColorBrush(
             ColorFromArgb(kLyricShadowColor), lyric_shadow.GetAddressOf());
       }
-      if (hook_text_mode_ && lyric_outline != nullptr &&
+      if (lyric_text_fx && lyric_outline != nullptr &&
           lyric_shadow != nullptr) {
         const float shadow_off = ScaleForDpi(kLyricShadowOffsetDip);
         render_target_->DrawTextLayout(
@@ -1474,7 +1496,7 @@ void FloatingLyricWindow::Render() {
               text_rect_.left + box.left + box.width,
               text_origin_y + box.top + ruby_gap_px);
           // 注音的桌面歌词描边：字小，半径收到 0.75 倍、不画投影。
-          if (hook_text_mode_ && lyric_outline != nullptr) {
+          if (lyric_text_fx && lyric_outline != nullptr) {
             const float rr = ScaleForDpi(kLyricOutlineRadiusDip * 0.75f);
             const float rd = rr * 0.7071f;
             const D2D1_POINT_2F ruby_ring[8] = {
@@ -1806,6 +1828,31 @@ void FloatingLyricWindow::DispatchControlAction(const std::string& action) {
   }
 }
 
+int FloatingLyricWindow::HookToolbarSlotAt(float x, float y) const {
+  if (hwnd_ == nullptr || !hook_text_mode_) {
+    return -1;
+  }
+  RECT rc;
+  GetClientRect(hwnd_, &rc);
+  const float width = static_cast<float>(rc.right - rc.left);
+  const float btn = ScaleForDpi(kButtonSizeDip);
+  const float gap = ScaleForDpi(kButtonGapDip);
+  const float ctrl_top = ScaleForDpi(kControlsTopDip);
+  if (y < ctrl_top || y > ctrl_top + btn) {
+    return -1;
+  }
+  const float controls_total = btn * kHookTextControlSlotCount +
+                               gap * (kHookTextControlSlotCount - 1);
+  const float left = (width - controls_total) / 2.0f;
+  for (int slot = 0; slot < kHookTextControlSlotCount; ++slot) {
+    const float bx = left + slot * (btn + gap);
+    if (x >= bx && x <= bx + btn) {
+      return slot;
+    }
+  }
+  return -1;
+}
+
 std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
   if (text_only_) {
     // Text-only Luna toolbar: only the lock + one-click-transparency buttons are
@@ -1826,19 +1873,11 @@ std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
       return std::string();
     }
     if (hook_text_mode_) {
-      const float controls_total =
-          btn * kHookTextControlSlotCount +
-          gap * (kHookTextControlSlotCount - 1);
-      const float left = (width - controls_total) / 2.0f;
-      for (int slot = 0; slot < kHookTextControlSlotCount; ++slot) {
-        const float bx = left + slot * (btn + gap);
-        if (x < bx || x > bx + btn) continue;
-        // Shared slot table (hook_toolbar::kSlotActions): the standalone
-        // pass-through toolbar indexes the very same array, so the two windows
-        // physically cannot disagree about what a button does.
-        return hook_toolbar::kSlotActions[slot];
-      }
-      return std::string();
+      // Shared slot table (hook_toolbar::kSlotActions): the standalone
+      // pass-through toolbar indexes the very same array, so the two windows
+      // physically cannot disagree about what a button does.
+      const int slot = HookToolbarSlotAt(x, y);
+      return slot >= 0 ? hook_toolbar::kSlotActions[slot] : std::string();
     }
     const float lock_x = width - pad - btn;
     const float top_x = lock_x - gap - btn;

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -439,6 +439,70 @@ void FloatingLyricWindow::Highlight(int start, int length) {
   RequestRender();
 }
 
+// 自定义台词字体解析（hook 模式，字体库下发）。
+//
+// 私有集合走 IDWriteFactory5 的 FontSetBuilder（Win10 1703+；老系统 As() 失败
+// 直接回退内置字族）。集合按文件路径缓存：**尝试过**就记路径，成败都不再对同
+// 一路径做第二次文件 IO——Render 每帧都会来问，失败重试等于每帧读盘。
+// family 名以文件内的第一族为准：Dart 侧字体库存的 name 是导入时的展示名，与
+// 字体内部 family 不保证一致，拿它去 CreateTextFormat 匹配不上会静默掉进系统
+// fallback，看起来就是「选了字体没生效」。
+FloatingLyricWindow::ResolvedFont FloatingLyricWindow::ResolveTextFont(
+    const wchar_t* fallback_family) {
+  ResolvedFont resolved;
+  resolved.family = fallback_family;
+  if (style_.font_file.empty()) {
+    // 没有文件：family 名非空时按系统集合解析（系统字体条目），空则内置字族。
+    if (!style_.font_family.empty()) resolved.family = style_.font_family;
+    return resolved;
+  }
+  if (style_.font_file != custom_font_collection_file_) {
+    custom_font_collection_file_ = style_.font_file;
+    custom_font_collection_.Reset();
+    custom_font_collection_family_.clear();
+    Microsoft::WRL::ComPtr<IDWriteFactory5> factory5;
+    if (dwrite_factory_ != nullptr &&
+        SUCCEEDED(dwrite_factory_.As(&factory5))) {
+      Microsoft::WRL::ComPtr<IDWriteFontFile> file;
+      Microsoft::WRL::ComPtr<IDWriteFontSetBuilder1> builder;
+      Microsoft::WRL::ComPtr<IDWriteFontSet> font_set;
+      Microsoft::WRL::ComPtr<IDWriteFontCollection1> collection;
+      if (SUCCEEDED(factory5->CreateFontFileReference(
+              style_.font_file.c_str(), nullptr, file.GetAddressOf())) &&
+          SUCCEEDED(factory5->CreateFontSetBuilder(builder.GetAddressOf())) &&
+          SUCCEEDED(builder->AddFontFile(file.Get())) &&
+          SUCCEEDED(builder->CreateFontSet(font_set.GetAddressOf())) &&
+          SUCCEEDED(factory5->CreateFontCollectionFromFontSet(
+              font_set.Get(), collection.GetAddressOf())) &&
+          collection != nullptr && collection->GetFontFamilyCount() > 0) {
+        Microsoft::WRL::ComPtr<IDWriteFontFamily1> family;
+        Microsoft::WRL::ComPtr<IDWriteLocalizedStrings> names;
+        UINT32 length = 0;
+        if (SUCCEEDED(collection->GetFontFamily(0, family.GetAddressOf())) &&
+            SUCCEEDED(family->GetFamilyNames(names.GetAddressOf())) &&
+            names->GetCount() > 0 &&
+            SUCCEEDED(names->GetStringLength(0, &length))) {
+          std::wstring name(length + 1, L'\0');
+          if (SUCCEEDED(names->GetString(0, name.data(), length + 1))) {
+            name.resize(length);
+            custom_font_collection_ = collection;
+            custom_font_collection_family_ = name;
+          }
+        }
+      }
+    }
+  }
+  if (custom_font_collection_ != nullptr &&
+      !custom_font_collection_family_.empty()) {
+    resolved.collection = custom_font_collection_.Get();
+    resolved.family = custom_font_collection_family_;
+  } else if (!style_.font_family.empty()) {
+    // 建集失败：还剩 family 名可试系统集合（同名字体恰好装过时仍能生效）。
+    resolved.family = style_.font_family;
+  }
+  return resolved;
+}
+
 void FloatingLyricWindow::UpdateStyle(const Style& style) {
   style_ = style;
   text_format_.Reset();
@@ -1158,9 +1222,15 @@ void FloatingLyricWindow::Render() {
   const DWRITE_FONT_WEIGHT text_weight = hook_text_mode_
                                              ? DWRITE_FONT_WEIGHT_SEMI_BOLD
                                              : DWRITE_FONT_WEIGHT_NORMAL;
+  // 字族也分模式：Yu Gothic UI 是界面字体，假名被压窄（约 8 成宽）只适合标签；
+  // hook 台词是正文排版，默认全宽假名的 Yu Gothic，且可被字体库的「游戏台词」
+  // 用途覆盖（ResolveTextFont：自定义文件走私有集合）。其余浮窗保持 UI 字族。
+  const ResolvedFont resolved_font =
+      hook_text_mode_ ? ResolveTextFont(L"Yu Gothic")
+                      : ResolvedFont{nullptr, L"Yu Gothic UI"};
   if (text_format_ == nullptr) {
     dwrite_factory_->CreateTextFormat(
-        L"Yu Gothic UI", nullptr, text_weight,
+        resolved_font.family.c_str(), resolved_font.collection, text_weight,
         DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         static_cast<float>(ScaleForDpi(scaled_font)),
         L"", text_format_.GetAddressOf());
@@ -1179,7 +1249,7 @@ void FloatingLyricWindow::Render() {
   // PushAxisAlignedClip 把一切文字绘制框在 text_rect_ 里，绝不会画到控件带上）。
   if (has_ruby && ruby_format_ == nullptr) {
     dwrite_factory_->CreateTextFormat(
-        L"Yu Gothic UI", nullptr, text_weight,
+        resolved_font.family.c_str(), resolved_font.collection, text_weight,
         DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, ruby_font_px,
         L"", ruby_format_.GetAddressOf());
     if (ruby_format_ != nullptr) {

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -244,6 +244,11 @@ class FloatingLyricWindow {
   // Returns the control action at the client point, or empty when none.
   std::string ControlActionAt(float x, float y);
 
+  // hook 模式：client 点落在工具条第几槽（-1 = 不在任何按钮上）。几何与
+  // Render() 的按钮绘制完全同源；ControlActionAt 与悬停提示共用这一个入口，
+  // 命中判定与提示永远指同一颗按钮。
+  int HookToolbarSlotAt(float x, float y) const;
+
   // 把 client 点上的那个字送去查词（回调带屏幕逻辑 px 的词矩形）。点击查词与
   // Shift-悬停查词共用这一个出口，两条路径的取词、坐标换算、载荷永远同形。
   // 返回是否真的派发了一次查词。
@@ -460,6 +465,9 @@ class FloatingLyricWindow {
   // BUG-951: the always-clickable toolbar used while the body is click-through.
   // Only ever created / shown for hook_text_mode_ instances in pass-through.
   HookToolbarWindow pass_through_toolbar_;
+
+  // hook 模式正文内工具条的悬停提示（文案共享 hook_toolbar::SlotTooltip 表）。
+  hook_toolbar::SlotTooltipHost slot_tooltip_;
 
   LookupCallback on_lookup_;
   ContextLookupCallback on_context_lookup_;

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -5,6 +5,7 @@
 
 #include <d2d1.h>
 #include <dwrite.h>
+#include <dwrite_3.h>
 #include <wrl/client.h>
 
 #include <cstdint>
@@ -86,6 +87,12 @@ class FloatingLyricWindow {
     double corner_radius = 0.0;
     double window_width = 0.0;
     double window_height = 0.0;
+    // 自定义台词字体（hook 模式，来自 app 字体库）。family 空 = 用内置字族；
+    // file 非空 = 从该字体文件建 DirectWrite 私有集合（family 名以文件内为准，
+    // Dart 给的 family 匹配不上时取文件第一族）。老 payload 缺字段 → 双空 →
+    // 逐像素回到内置字族（never break）。
+    std::wstring font_family;
+    std::wstring font_file;
   };
 
   struct Labels {
@@ -206,6 +213,15 @@ class FloatingLyricWindow {
   bool EnsureDeviceResources();
   void DiscardDeviceResources();
   bool EnsureTextResources();
+
+  // 自定义台词字体：按 style_.font_file 惰性建（并缓存）DirectWrite 私有字体
+  // 集合，返回排版应使用的 (collection, family)。file 为空 / 建集失败时返回
+  // (nullptr, 内置字族)——失败按文件路径记忆，不会每帧重试 IO。
+  struct ResolvedFont {
+    IDWriteFontCollection* collection = nullptr;  // nullptr = 系统集合
+    std::wstring family;
+  };
+  ResolvedFont ResolveTextFont(const wchar_t* fallback_family);
   void Render();
   void RequestRender();
 
@@ -429,6 +445,11 @@ class FloatingLyricWindow {
   // Direct2D / DirectWrite.
   Microsoft::WRL::ComPtr<ID2D1Factory> d2d_factory_;
   Microsoft::WRL::ComPtr<IDWriteFactory> dwrite_factory_;
+  // 自定义字体私有集合缓存（见 ResolveTextFont）。collection_file_ 记的是**已
+  // 尝试**的文件路径（无论成败），路径不变绝不重建；失败时 collection_ 为空。
+  Microsoft::WRL::ComPtr<IDWriteFontCollection1> custom_font_collection_;
+  std::wstring custom_font_collection_file_;
+  std::wstring custom_font_collection_family_;
   Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> render_target_;
   Microsoft::WRL::ComPtr<IDWriteTextFormat> text_format_;
   // 振假名用的小号 format（居中、不换行）。与 text_format_ 同生命周期：字号 /

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -645,6 +645,18 @@ std::wstring WideFromValue(const flutter::EncodableMap* args, const char* key,
   return result;
 }
 
+std::wstring WideFromUtf8(const std::string& s) {
+  if (s.empty()) {
+    return std::wstring();
+  }
+  int size = MultiByteToWideChar(CP_UTF8, 0, s.data(),
+                                 static_cast<int>(s.size()), nullptr, 0);
+  std::wstring result(size, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
+                      result.data(), size);
+  return result;
+}
+
 std::string StringFromValue(const flutter::EncodableMap* args, const char* key,
                             const std::string& fallback) {
   if (args == nullptr) {
@@ -1129,6 +1141,26 @@ void FlutterWindow::RegisterGalHookTextChannel() {
               IntFromValue(args, "left", 0), IntFromValue(args, "top", 0),
               IntFromValue(args, "width", 0),
               IntFromValue(args, "height", 0));
+          // 工具条槽位悬停提示（与 hook_toolbar::kSlotActions 同下标的本地化
+          // 文案）。老 payload 缺字段就保持上次的表——文案只随 locale 变，不随
+          // 会话变。
+          if (args != nullptr) {
+            const auto tips_it =
+                args->find(flutter::EncodableValue("slotTooltips"));
+            if (tips_it != args->end()) {
+              if (const auto* list =
+                      std::get_if<flutter::EncodableList>(&tips_it->second)) {
+                std::vector<std::wstring> tooltips;
+                tooltips.reserve(list->size());
+                for (const flutter::EncodableValue& value : *list) {
+                  const auto* text = std::get_if<std::string>(&value);
+                  tooltips.push_back(text != nullptr ? WideFromUtf8(*text)
+                                                     : std::wstring());
+                }
+                hook_toolbar::SetSlotTooltips(std::move(tooltips));
+              }
+            }
+          }
           result->Success(
               flutter::EncodableValue(gal_hook_text_window_->Show(GetHandle())));
         } else if (method == "hide") {

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -712,6 +712,10 @@ FloatingLyricWindow::Style StyleFromArgs(const flutter::EncodableMap* args) {
   style.window_width = DoubleFromValue(args, "windowWidth", style.window_width);
   style.window_height =
       DoubleFromValue(args, "windowHeight", style.window_height);
+  // 自定义台词字体（gal hook 浮窗，字体库下发）。旧 payload 缺字段 → 双空 →
+  // native 用内置字族，逐像素不变。
+  style.font_family = WideFromValue(args, "fontFamily", L"");
+  style.font_file = WideFromValue(args, "fontPath", L"");
   return style;
 }
 

--- a/fushi/windows/runner/hook_toolbar_window.cpp
+++ b/fushi/windows/runner/hook_toolbar_window.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 
+#pragma comment(lib, "comctl32.lib")
 #pragma comment(lib, "d2d1.lib")
 #pragma comment(lib, "dwrite.lib")
 
@@ -109,6 +110,102 @@ bool SlotActive(int slot, const States& states) {
     default:
       return false;
   }
+}
+
+namespace {
+
+std::vector<std::wstring>& SlotTooltipStore() {
+  static std::vector<std::wstring> store;
+  return store;
+}
+
+}  // namespace
+
+void SetSlotTooltips(std::vector<std::wstring> tooltips) {
+  SlotTooltipStore() = std::move(tooltips);
+}
+
+const std::wstring& SlotTooltip(int slot) {
+  static const std::wstring empty;
+  const std::vector<std::wstring>& store = SlotTooltipStore();
+  if (slot < 0 || slot >= static_cast<int>(store.size())) {
+    return empty;
+  }
+  return store[static_cast<size_t>(slot)];
+}
+
+SlotTooltipHost::~SlotTooltipHost() {
+  if (hwnd_ != nullptr) {
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+  }
+}
+
+bool SlotTooltipHost::EnsureWindow(HWND owner) {
+  if (hwnd_ != nullptr) {
+    return true;
+  }
+  // TOOLTIPS_CLASS 归 comctl32 管；tooltip 与 tab 同属 ICC_TAB_CLASSES。只需
+  // 初始化一次，失败（极老系统）就当没有 tooltip，功能静默降级不崩。
+  static const bool common_controls_ready = [] {
+    INITCOMMONCONTROLSEX icc = {sizeof(INITCOMMONCONTROLSEX),
+                                ICC_TAB_CLASSES};
+    return InitCommonControlsEx(&icc) != FALSE;
+  }();
+  if (!common_controls_ready) {
+    return false;
+  }
+  hwnd_ = CreateWindowExW(WS_EX_TOPMOST | WS_EX_NOACTIVATE, TOOLTIPS_CLASSW,
+                          nullptr, WS_POPUP | TTS_ALWAYSTIP | TTS_NOPREFIX,
+                          CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                          CW_USEDEFAULT, owner, nullptr,
+                          GetModuleHandleW(nullptr), nullptr);
+  if (hwnd_ == nullptr) {
+    return false;
+  }
+  tool_ = {};
+  tool_.cbSize = sizeof(tool_);
+  // TTF_TRACK|TTF_ABSOLUTE：位置完全由宿主的 TTM_TRACKPOSITION 决定——宿主窗
+  // 是 WS_EX_NOACTIVATE 的自绘分层窗，标准的矩形工具 + 子类化在这里拿不到可靠
+  // 的鼠标节奏，手动追踪反而最简单。
+  tool_.uFlags = TTF_TRACK | TTF_ABSOLUTE;
+  tool_.hwnd = owner;
+  tool_.uId = 1;
+  tool_.lpszText = const_cast<wchar_t*>(L"");
+  SendMessageW(hwnd_, TTM_ADDTOOLW, 0, reinterpret_cast<LPARAM>(&tool_));
+  return true;
+}
+
+void SlotTooltipHost::Update(HWND owner, int slot, int screen_x,
+                             int screen_y) {
+  const std::wstring& text = SlotTooltip(slot);
+  if (slot < 0 || text.empty() || owner == nullptr) {
+    Hide();
+    return;
+  }
+  if (slot == active_slot_) {
+    return;  // 同一颗按钮上抖动不重摆位置，提示钉在初次进入处。
+  }
+  if (!EnsureWindow(owner)) {
+    return;
+  }
+  active_slot_ = slot;
+  tool_.lpszText = const_cast<wchar_t*>(text.c_str());
+  SendMessageW(hwnd_, TTM_UPDATETIPTEXTW, 0, reinterpret_cast<LPARAM>(&tool_));
+  SendMessageW(hwnd_, TTM_TRACKPOSITION, 0,
+               MAKELPARAM(static_cast<WORD>(screen_x),
+                          static_cast<WORD>(screen_y)));
+  SendMessageW(hwnd_, TTM_TRACKACTIVATE, TRUE,
+               reinterpret_cast<LPARAM>(&tool_));
+}
+
+void SlotTooltipHost::Hide() {
+  active_slot_ = -1;
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  SendMessageW(hwnd_, TTM_TRACKACTIVATE, FALSE,
+               reinterpret_cast<LPARAM>(&tool_));
 }
 
 }  // namespace hook_toolbar
@@ -221,6 +318,7 @@ void HookToolbarWindow::Hide() {
   visible_ = false;
   hovered_ = false;
   tracking_mouse_leave_ = false;
+  tooltip_.Hide();
   CancelPointerGesture();
   if (hwnd_ != nullptr) {
     ShowWindow(hwnd_, SW_HIDE);
@@ -334,11 +432,22 @@ LRESULT HookToolbarWindow::HandleMessage(UINT message, WPARAM wparam,
             static_cast<int>(kDragThresholdPx * kDragThresholdPx)) {
           dragging_ = true;
         }
+        return 0;
+      }
+      {
+        // 槽位悬停提示：提示摆在光标右下（不遮按钮本身）。文案表与正文内工具
+        // 条共用（hook_toolbar::SlotTooltip），空文案 / 空槽自动隐藏。
+        const int slot = SlotAt(static_cast<float>(GET_X_LPARAM(lparam)),
+                                static_cast<float>(GET_Y_LPARAM(lparam)));
+        POINT cursor;
+        GetCursorPos(&cursor);
+        tooltip_.Update(hwnd_, slot, cursor.x + 12, cursor.y + 22);
       }
       return 0;
     }
     case WM_MOUSELEAVE: {
       tracking_mouse_leave_ = false;
+      tooltip_.Hide();
       if (hovered_ && !dragging_) {
         hovered_ = false;
         Render();
@@ -346,6 +455,7 @@ LRESULT HookToolbarWindow::HandleMessage(UINT message, WPARAM wparam,
       return 0;
     }
     case WM_LBUTTONDOWN: {
+      tooltip_.Hide();
       const float x = static_cast<float>(GET_X_LPARAM(lparam));
       const float y = static_cast<float>(GET_Y_LPARAM(lparam));
       const int slot = SlotAt(x, y);

--- a/fushi/windows/runner/hook_toolbar_window.h
+++ b/fushi/windows/runner/hook_toolbar_window.h
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 
+#include <commctrl.h>
 #include <d2d1.h>
 #include <dwrite.h>
 #include <wrl/client.h>
@@ -10,6 +11,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 // BUG-951 — the galgame hook overlay's pass-through escape hatch.
 //
@@ -108,6 +110,39 @@ const wchar_t* SlotGlyph(int slot, const States& states);
 // Whether |slot| draws with the active (highlight) colour under |states|.
 bool SlotActive(int slot, const States& states);
 
+// 槽位悬停提示文案（本地化，由 Dart 在 show 载荷里下发；未下发 / 越界 = 空串
+// = 不显示）。与 kSlotActions 同下标，单一真相：正文内工具条和穿透工具条问的
+// 是同一张表，两处提示不可能各说各话。主线程专用（与整个模块同一约束）。
+void SetSlotTooltips(std::vector<std::wstring> tooltips);
+const std::wstring& SlotTooltip(int slot);
+
+// 手动追踪式 Win32 tooltip（TOOLTIPS_CLASS + TTM_TRACKACTIVATE）。
+//
+// 两个工具条窗都是 WS_EX_NOACTIVATE 的自绘分层窗，永远拿不到激活态，所以用
+// TTS_ALWAYSTIP；又因为按钮矩形每次 Render 都会变（居中随窗宽），不挂
+// TTF_SUBCLASS 的矩形工具，而是由宿主在 WM_MOUSEMOVE 里报「现在悬停在第几
+// 槽 + 该槽屏幕坐标」，本类只负责建窗、换文案、摆位置。
+class SlotTooltipHost {
+ public:
+  SlotTooltipHost() = default;
+  ~SlotTooltipHost();
+
+  SlotTooltipHost(const SlotTooltipHost&) = delete;
+  SlotTooltipHost& operator=(const SlotTooltipHost&) = delete;
+
+  // 在屏幕物理坐标 (|screen_x|, |screen_y|) 为 |slot| 显示提示。slot 未变则
+  // 只跟位（no-op 文案）；slot == -1 或该槽文案为空则隐藏。
+  void Update(HWND owner, int slot, int screen_x, int screen_y);
+  void Hide();
+
+ private:
+  bool EnsureWindow(HWND owner);
+
+  HWND hwnd_ = nullptr;
+  int active_slot_ = -1;
+  TOOLINFOW tool_ = {};
+};
+
 }  // namespace hook_toolbar
 
 class HookToolbarWindow {
@@ -186,6 +221,9 @@ class HookToolbarWindow {
   hook_toolbar::Style style_;
   hook_toolbar::States states_;
   bool has_layout_ = false;
+
+  // 悬停提示（文案来自 hook_toolbar::SlotTooltip 共享表）。
+  hook_toolbar::SlotTooltipHost tooltip_;
 
   Microsoft::WRL::ComPtr<ID2D1Factory> d2d_factory_;
   Microsoft::WRL::ComPtr<IDWriteFactory> dwrite_factory_;


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：2 条提交主题在 `develop` 日志里找不到，`fushi/windows/runner/hook_toolbar_window.cpp` / `.h` 等改动也不在 `develop`。从没开过 PR。

## 内容

Hook 浮窗白卡样式 + 工具条按钮悬停提示（10 条）。未落地约 **+1419 行 / 28 个文件**，含 Windows runner 侧 `hook_toolbar_window` 与 `floating_lyric_window`。

## 注意

首个 commit 里的 `galHookText` 部分已由 PR #951 以另一种形式落地，样式那半没落。合并时注意别与已落地的形式打架。

## 平台边界

galgame hook 相关只做 Windows 端。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
