### PR TITLE
feat(extension): 侧栏查词 UX + 粘贴修复 + Jimaku 字幕搜索（PR #857 合并后追加的提交）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1543 条。点号进各自文件。
+> 共 1545 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1673](bugs/BUG-1673-ext-side-panel-click-lookup-lost.md) | ✅ | ✅ | 侧边栏行内点击查词在迁移原生 Side Panel 时丢失 |
+| [BUG-1672](bugs/BUG-1672-ext-paste-blocked-by-selection-clear.md) | ✅ | ✅ | 开着浏览器扩展时网页粘贴间歇性失效 |
 | [BUG-1671](bugs/BUG-1671-ext-side-panel-subtitle-incomplete.md) | ✅ | ✅ | 浏览器扩展侧边栏获取字幕不全 |
 | [BUG-1670](bugs/BUG-1670-ext-pause-on-lookup-no-resume.md) | ✅ | ✅ | 浏览器扩展查词不暂停视频且关闭弹窗不恢复播放 |
 | [BUG-1669](bugs/BUG-1669-ext-side-panel-lookup-stuck-loading.md) | ✅ | ✅ | 浏览器扩展侧边栏高频查词后「正在查词」永久卡死 |

--- a/docs/bugs/BUG-1672-ext-paste-blocked-by-selection-clear.md
+++ b/docs/bugs/BUG-1672-ext-paste-blocked-by-selection-clear.md
@@ -1,0 +1,13 @@
+## BUG-1672 · 开着浏览器扩展时网页粘贴间歇性失效
+- **报告**：2026-08-15（用户：shishamo 群报「开着插件的时候有可能不会让我粘贴」）
+- **真实性**：✅ 真 bug。排查确认**不是吞按键**（全扩展无 paste/copy/cut 监听，按键表无 V 系绑定，Ctrl+V/Ctrl+Shift+V 均放行）——是**清宿主选区**害的，两条独立路径：
+  1. `tools/browser-extension/content.js` 的 Shift 悬停扫描在 mousemove 时无差别 `fushiClearNativeSelection()`（TODO-1279 引入），对 input/textarea/contenteditable **零设防**。触发面：**Ctrl+Shift+V（粘贴为纯文本）按下期间 Shift 是按住态**，任何一次 mousemove 就清掉编辑器里的选区/插入点；富文本框架（Lexical/ProseMirror/Slate 等）靠 selectionchange 维护内部态，选区被 `removeAllRanges()` 抹掉后粘贴**静默丢弃**。contenteditable 的选区走 `window.getSelection()` 全裸暴露（input/textarea 不走、天然幸免）——正好解释「有可能」的间歇性；
+  2. 查词弹窗开着时点输入框准备粘贴：document 级 mousedown 关窗路径 `fushiRemoveContainer` → `fushiSelection.clearSelection()` → `removeAllRanges()` 无 isCollapsed/可编辑守卫，把编辑器在自己 mousedown 里刚放好的 caret 抹掉 → 焦点在、caret 没了 → Ctrl+V 无效；右键粘贴同理（菜单按「无选区」构建）。
+  3. 附带：扩展强制 DOM 包裹高亮（隔离世界 CSS Highlight 不绘制），查词兜底路径 `highlightSelection` 若落在 contenteditable 会 `extractContents/insertNode` 改写编辑器文本节点，打散其内部模型。
+- **[x] ① 已修复** —（提交哈希：bf6fdce9d）新增 `fushiNodeInEditable`/`fushiSelectionInEditable`（input/textarea/isContentEditable/contenteditable 属性四判据的祖先链走查）：
+  1. `fushiClearNativeSelection` 对可编辑区锚点的选区直接 no-op（普通页面清理行为不回退）；
+  2. `fushiRemoveContainer` 的 `clearSelection` 调用加同守卫；
+  3. DOM 包裹高亮兜底在被查词落在可编辑区时跳过；
+  4. 顺带修 `video-shortcuts.js` 的 isEditable 用 `composedPath()[0]`（Shadow DOM 编辑器被 retarget 误判 → Ctrl+Shift+Z 等被快捷键抢走）。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/native-selection-clear.test.js` 新增：「选区落在 contenteditable 里绝不清」+「普通页面选区仍照常清理（TODO-1279 不回退）」。变异实测：去掉可编辑区守卫用例即红。
+- **备注**：右键菜单/焦点抢占等次要候选未单独处理（主根因已除；复发再按档案里的排查法定位）。镜像由 sync-mirrors 同步。

--- a/docs/bugs/BUG-1673-ext-side-panel-click-lookup-lost.md
+++ b/docs/bugs/BUG-1673-ext-side-panel-click-lookup-lost.md
@@ -1,0 +1,6 @@
+## BUG-1673 · 侧边栏行内点击查词在迁移原生 Side Panel 时丢失
+- **报告**：2026-08-15（用户：shishamo 群报「侧边栏的点击查词好像不见了，只能 shift 查」）
+- **真实性**：✅ 真回归。旧页面内字幕面板（subtitle-panel.js UI 层）的行内文本 click → `window.fushiLookupAtPoint` 是三大契约之一；提交 `4ade5cae5f`（feat: move subtitles to native side panel）把 UI 层削成 headless 数据层时**连调用点一起删了**，且新守卫 `side-panel-performance.test.js` 反把「text 无 click 监听」钉成预期——变更是有意为之但没有替代品，用户只剩 Shift 悬停一条路。`content.js` 的 `fushiLookupAtPoint` 至今是零调用方的遗留死代码（它渲染页面弹窗，Side Panel 也不能直接复用）。
+- **[x] ① 已修复** —（提交哈希：bf6fdce9d）`tools/browser-extension/side-panel.js` 的字幕行文本恢复 click=查词：走 Side Panel 自持的 `lookupAtPointer(pointer, true)`（显式手势分支，绕过在途闸、失败有 toast），带选区守卫（拖选/双击选择文本不触发）+ `stopPropagation`（不冒泡成行 seek）。交互契约：**点文字=查词、点时间戳/行空白=跳转、双击=选择文本、Shift 悬停=扫词**；行 title 文案同步更新。
+- **[x] ② 已加自动化测试** — `side-panel-performance.test.js` 原「text 无 click」断言翻转为专项守卫：钉 text click 监听存在 + isCollapsed 选区守卫 + stopPropagation + `lookupAtPointer(..., true)` 显式手势分支。
+- **备注**：同批一并补的 Side Panel 关闭路径（手动播放反向 dismiss / 面板失焦 / 列表滚动）见 BUG-1670 与 PR 说明。

--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -750,6 +750,40 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           data: r.ok ? await r.json() : null,
           ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
         });
+      } else if (msg.type === 'jimakuSearch') {
+        // Jimaku 查字幕①：Side Panel 搜索框 → server /api/subtitle/jimaku/search（server 持
+        // 用户在 app 设置里填的 Jimaku API key；真人剧 anime=false 补搜也在 server 侧）。
+        const r = await fetch(base + '/api/subtitle/jimaku/search', {
+          method: 'POST',
+          signal: AbortSignal.timeout(20000),
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({
+            query: msg.query || '',
+            ...(Number.isInteger(msg.episode) ? { episode: msg.episode } : {}),
+            ...(typeof msg.anime === 'boolean' ? { anime: msg.anime } : {}),
+          }),
+        });
+        sendResponse({
+          ok: r.ok,
+          status: r.status,
+          data: r.ok ? await r.json() : null,
+          ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
+        });
+      } else if (msg.type === 'jimakuFetch') {
+        // Jimaku 查字幕②：候选 handle → server 下载+自动识别编码+解析，响应与
+        // /api/subtitle/parse 同形（{format,cues}），Side Panel 直接走既有 InstallTrack。
+        const r = await fetch(base + '/api/subtitle/jimaku/fetch', {
+          method: 'POST',
+          signal: AbortSignal.timeout(30000),
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({ handle: msg.handle || '' }),
+        });
+        sendResponse({
+          ok: r.ok,
+          status: r.status,
+          data: r.ok ? await r.json() : null,
+          ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
+        });
       } else if (msg.type === 'mine') {
         // 纯文本挖词（非流媒体页 / 回落）：直接 POST {fields,sentence}，无媒体。
         const r = await fetch(base + '/api/mine', {

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -104,17 +104,40 @@ function fushiApplyPauseOnLookupPrefs(saved) {
 // 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
 // _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
 let fushiPausedForLookup = null;
-// 记「被我们暂停」并挂一次性 play 监听：用户手动点播放（不是我们 resume——我们 resume 前
-// 已先置 null）即视为收回控制权，清掉标记。这样「查词暂停 → 用户播放 → 用户再暂停 → 关窗」
-// 不会把用户自己按下的暂停顶掉；SPA 同元素换 src 继续播的场景同样被覆盖。
-function fushiMarkPausedForLookup(v) {
-  if (fushiPausedForLookup === v) return; // 重复查词同一视频：已挂过监听，别叠加
-  fushiPausedForLookup = v;
+// 「用户手动按下播放」的一次性监听：手动播放 = 收回控制权 + 「我看完了，继续看片」——
+// ①清掉 fushiPausedForLookup（此后关窗/失败路径绝不把用户的暂停顶掉）；②把查词浮层
+// （页面弹窗 + Side Panel 查词面板）一并关掉。我们自己的恢复（fushiResumePausedForLookup）
+// 会先解除武装再 play，不会误触发。
+let fushiPlayDismissTarget = null;
+function fushiArmPlayDismiss(v) {
+  if (!v || fushiPlayDismissTarget === v) return; // 同一视频已挂过监听，别叠加
+  fushiPlayDismissTarget = v;
   try {
     v.addEventListener('play', function () {
+      if (fushiPlayDismissTarget !== v) return; // 已解除武装（我们自己的恢复）
+      fushiPlayDismissTarget = null;
       if (fushiPausedForLookup === v) fushiPausedForLookup = null;
+      fushiDismissLookupOnPlay();
     }, { once: true });
   } catch (_) {}
+}
+// 手动播放 → 关掉两处查词浮层。页面弹窗直接关（fushiRemoveContainer 幂等；其恢复步骤
+// 因标记已清而为 no-op）；Side Panel 是独立扩展页，发一条 runtime 消息让它自关。
+function fushiDismissLookupOnPlay() {
+  try { fushiRemoveContainer(); } catch (_) {}
+  if (fushiExtAlive()) {
+    try {
+      chrome.runtime.sendMessage({ type: 'fushiLookupDismiss', reason: 'play' }, function () {
+        try { void chrome.runtime.lastError; } catch (_) {}
+      });
+    } catch (_) {}
+  }
+}
+// 记「被我们暂停」：恢复真相源 + 顺带武装 play 监听。
+function fushiMarkPausedForLookup(v) {
+  if (fushiPausedForLookup === v) return;
+  fushiPausedForLookup = v;
+  fushiArmPlayDismiss(v);
 }
 // 恢复侧唯一实现（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由查词暂停的
 // 那个视频；用户已手动继续播放的不重复 play（v.paused 守卫）。除关窗汇聚点外，查词失败/
@@ -123,6 +146,7 @@ function fushiResumePausedForLookup() {
   if (!fushiPausedForLookup) return;
   const pausedVideo = fushiPausedForLookup;
   fushiPausedForLookup = null;
+  fushiPlayDismissTarget = null; // 我们自己的恢复不算「用户手动播放」，先解除武装
   try {
     if (pausedVideo.isConnected !== false && pausedVideo.paused) {
       const played = pausedVideo.play();
@@ -1556,14 +1580,46 @@ function fushiClearHighlightOverlay() {
   }
 }
 
+// 当前原生选区是否落在宿主页可编辑区（input/textarea/contenteditable）里。用户在编辑器里
+// 选中/放好 caret 通常是为了输入或粘贴——那不是我们的选区，绝不能清。contenteditable 的选区
+// 走 window.getSelection()（input/textarea 的不走，天然幸免），富文本框架（Lexical/ProseMirror
+// 等）靠 selectionchange 维护内部态，被 removeAllRanges 抹掉后粘贴会静默丢弃。
+function fushiNodeInEditable(node) {
+  try {
+    if (!node) return false;
+    let el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+    while (el) {
+      const tag = el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+      if (el.isContentEditable === true) return true;
+      if (typeof el.getAttribute === 'function') {
+        const ce = el.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true') return true;
+      }
+      el = el.parentElement;
+    }
+  } catch (_) {}
+  return false;
+}
+function fushiSelectionInEditable() {
+  try {
+    const sel = window.getSelection && window.getSelection();
+    return fushiNodeInEditable(sel && sel.anchorNode);
+  } catch (_) { return false; }
+}
+
 // TODO-1279：清掉浏览器原生文本选区（window.getSelection 的蓝色高亮）。只动原生 DOM Selection，
 // 不碰我们自绘的 #fushi-highlight-overlay 覆盖层（独立 <div>，与原生选区无关），也不碰
 // fushiSelection.selection（纯 JS 取词状态，覆盖层就从它的 ranges 只读取几何）。塌缩/空选区时
-// no-op：避免无谓清掉输入框 caret 或没有可见蓝色时反复调用。
+// no-op：避免无谓清掉输入框 caret 或没有可见蓝色时反复调用。落在可编辑区的选区也 no-op：
+// 那是用户为输入/粘贴准备的（Ctrl+Shift+V 的 Shift 会触发本清理路径——用户报「开着插件
+// 有时无法粘贴」的主根因）。
 function fushiClearNativeSelection() {
   try {
     const sel = window.getSelection && window.getSelection();
-    if (sel && sel.rangeCount > 0 && !sel.isCollapsed) sel.removeAllRanges();
+    if (!sel || !(sel.rangeCount > 0) || sel.isCollapsed) return;
+    if (fushiSelectionInEditable()) return;
+    sel.removeAllRanges();
   } catch (_) { /* 某些跨域/detached 上下文 getSelection 可能抛：静默 */ }
 }
 
@@ -1660,8 +1716,12 @@ function fushiRemoveContainer() {
   // 嵌套查词只换弹窗内容、不经此处，天然不会提前恢复——与 app「整栈关空才恢复」同语义。
   fushiResumePausedForLookup();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
+  // 例外：当前原生选区/caret 落在宿主可编辑区时不清——那是用户点进输入框准备输入/粘贴放的
+  // caret（本 mousedown 关窗恰好发生在那一击上），clearSelection 的 removeAllRanges 会把
+  // 富文本编辑器刚放好的插入点抹掉 → 粘贴静默失效（用户报「开着插件有时无法粘贴」）。
   try {
-    if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
+    if (!fushiSelectionInEditable() &&
+        window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
       window.fushiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
@@ -1824,6 +1884,11 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   if (fushiPauseOnLookup && !(fushiPausedForLookup && fushiPausedForLookup.paused)) {
     try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiMarkPausedForLookup(_v); } } catch (_) {}
   }
+  // 即使这次没有可暂停的（视频早已是暂停态，含用户自己暂停的），也武装「手动播放即关浮层」：
+  // 用户按下播放就是「继续看片」，查词浮层不该留着挡画面。
+  if (fushiPauseOnLookup) {
+    try { fushiArmPlayDismiss(fushiPausedForLookup || document.querySelector('video')); } catch (_) {}
+  }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
   // SW 在消息在途时被回收（BUG-1024）：回调永不触发，下面的失败恢复路径也到不了。兜底：
@@ -1962,10 +2027,17 @@ window.fushiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
 window.fushiPrepareLookupFromSidePanel = function (cueWindow) {
   fushiPendingCueWindow = cueWindow && typeof cueWindow === 'object' ? cueWindow : null;
   if (fushiPauseOnLookup) {
-    // Side Panel 自渲染词典、没有「面板关闭」回调到 content script，故此路径只暂停、
-    // 不记 fushiPausedForLookup（否则会被后续无关的页面弹窗关闭误恢复）；恢复由用户手动。
-    try { const video = fushiFindPlayingVideo(); if (video) video.pause(); } catch (_) {}
+    // Side Panel 现在有关闭回调（fushiSubtitleSidePanelLookupClosed → fushiLookupClosedFromSidePanel），
+    // 与页面弹窗同语义：暂停并记录，面板关闭即恢复；手动播放（fushiArmPlayDismiss）即关浮层。
+    try { const video = fushiFindPlayingVideo(); if (video) { video.pause(); fushiMarkPausedForLookup(video); } } catch (_) {}
+    try { fushiArmPlayDismiss(fushiPausedForLookup || document.querySelector('video')); } catch (_) {}
   }
+  return true;
+};
+// Side Panel 查词面板真正关闭时由 subtitle-panel.js 转发到这里：恢复由查词暂停的视频。
+// 「手动播放→dismiss 消息→面板 close→这里」的环路安全：那时标记已被 play 监听清掉，恢复是 no-op。
+window.fushiLookupClosedFromSidePanel = function () {
+  fushiResumePausedForLookup();
   return true;
 };
 window.fushiMineFromSidePanel = function (fields, cueWindow) {
@@ -2350,8 +2422,13 @@ function fushiRender(popupJson, termLen, theme, anchorRect) {
     if (hl.rects.length) {
       fushiDrawHighlightOverlay(hl.rects); // 覆盖层高亮：宿主页 DOM 重绘/事件冲不掉它
       wordRect = hl.bounds;
-    } else if (window.fushiSelection && typeof window.fushiSelection.highlightSelection === 'function') {
+    } else if (window.fushiSelection && typeof window.fushiSelection.highlightSelection === 'function' &&
+        !(window.fushiSelection.selection && window.fushiSelection.selection.ranges &&
+          window.fushiSelection.selection.ranges[0] &&
+          fushiNodeInEditable(window.fushiSelection.selection.ranges[0].startContainer))) {
       // 兜底：selection 结构异常（无 ranges）时退回旧的 bbox 计算，只为拿锚点，不画 DOM 包裹高亮。
+      // 被查词落在宿主可编辑区时跳过——扩展里 highlightSelection 走 DOM 包裹路径
+      // （__fushiCssHighlightsSupported=false），改写编辑器文本节点会打散其内部模型与 caret。
       wordRect = window.fushiSelection.highlightSelection(termLen);
     }
   } catch (_) { wordRect = null; }

--- a/fushi/assets/browser_extension/side-panel.css
+++ b/fushi/assets/browser_extension/side-panel.css
@@ -87,6 +87,46 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   margin-top: 8px;
 }
 
+/* ── Jimaku 查字幕（asb 式云端字幕搜索） ── */
+.jimaku-row {
+  display: grid;
+  grid-template-columns: 1fr 52px 40px;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.jimaku-row input {
+  min-height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+}
+
+.jimaku-results {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
+.jimaku-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 10px;
+  text-align: left;
+}
+
+.jimaku-item-name { font-weight: 600; word-break: break-all; }
+.jimaku-item-meta { color: var(--muted); font-size: 12px; }
+.jimaku-empty { color: var(--muted); font-size: 12px; padding: 4px 2px; }
+
 #offset-value { text-align: center; color: var(--muted); font-variant-numeric: tabular-nums; }
 
 .subtitle-list {
@@ -133,6 +173,11 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
 }
 
 .lookup-pane {
+  /* 拖拽调整大小：浏览器原生右下角把手（Side Panel 是独立文档，无宿主页 CSS 战争）。
+     配套的 userResized 门在 side-panel.js（主题下发不再覆盖用户宽高 + 回写 app 尺寸键）。 */
+  resize: both;
+  min-width: 250px;
+  min-height: 120px;
   position: fixed;
   z-index: 4;
   top: 0;

--- a/fushi/assets/browser_extension/side-panel.html
+++ b/fushi/assets/browser_extension/side-panel.html
@@ -15,6 +15,7 @@
       </div>
       <div class="toolbar" aria-label="字幕工具">
         <button id="load" type="button" title="加载外挂字幕">＋</button>
+        <button id="jimaku" type="button" title="从 Jimaku 搜索字幕">J</button>
         <button id="smaller" type="button" title="缩小字号">A−</button>
         <button id="larger" type="button" title="放大字号">A＋</button>
         <button id="auto-scroll" class="is-on" type="button" title="自动滚动到当前句">AS</button>
@@ -23,6 +24,12 @@
     </div>
     <input id="subtitle-file" type="file" accept=".srt,.ass,.ssa,.vtt" multiple hidden>
     <select id="track" aria-label="字幕轨" hidden></select>
+    <div id="jimaku-row" class="jimaku-row" hidden>
+      <input id="jimaku-query" type="search" placeholder="Jimaku 搜字幕（日文原名命中率最高）" aria-label="Jimaku 搜索词">
+      <input id="jimaku-ep" type="number" min="1" placeholder="集" title="集数（可选）" aria-label="集数">
+      <button id="jimaku-go" type="button" title="搜索">搜</button>
+    </div>
+    <div id="jimaku-results" class="jimaku-results" hidden></div>
     <div id="offset" class="offset-row" hidden>
       <button type="button" data-offset="-500">−0.5</button>
       <button type="button" data-offset="-100">−0.1</button>

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -54,6 +54,10 @@
   // 本地服务与 6 连接上限灌满。0=无在途；带截止时间兜底，任何异常都不会永久闸死。
   var lookupPendingSince = 0;
   var LOOKUP_PENDING_TIMEOUT_MS = 1500;
+  // 用户拖过查词面板尺寸（CSS resize 把手）后置 true：本会话内主题下发/落点重算不再覆盖
+  // 用户宽高；拖拽结果经 popupSize 回写 app（与页面弹窗同一把「拖即解锁」尺寸键）。
+  var lookupUserResized = false;
+  var lookupResizeSnapshot = null;
   // 复杂词的 popupJson 可超过 2 MB，解析后的对象树通常还会膨胀数倍。只按“48 个词”
   // 淘汰会让 Side Panel 很快常驻数百 MB，并在后续查词时触发秒级 GC。双门槛保留常用
   // 小词，同时让超大结果最多只占少量槽位；最新一条即使单独超预算也保留以支持复查。
@@ -135,6 +139,7 @@
   }
 
   function closeLookup() {
+    var wasOpen = !lookupPaneEl.hidden;
     lookupRequestId += 1;
     if (Number.isInteger(window._renderGeneration)) window._renderGeneration += 1;
     window._renderInProgress = false;
@@ -145,6 +150,10 @@
     currentLookupAnchor = null;
     currentLookupPerfContext = null;
     activeScanKey = '';
+    // 面板真关掉时通知视频页：由查词暂停的视频该恢复了（content 侧只恢复「确实是查词
+    // 暂停的」，用户自己暂停的不动）。「手动播放→content 反向 dismiss→这里 close」的
+    // 环路安全：那时暂停标记已被 play 监听清掉，恢复是 no-op。
+    if (wasOpen) sendToTab({ type: 'fushiSubtitleSidePanelLookupClosed' });
   }
 
   function positionLookup(anchor) {
@@ -158,7 +167,9 @@
       lookupPaneEl.style.left = '0px';
       lookupPaneEl.style.top = '0px';
     }
-    lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    if (!lookupUserResized) {
+      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    }
     requestAnimationFrame(function () {
       if (requestId !== lookupRequestId || lookupPaneEl.hidden) return;
       var gap = 4;
@@ -207,10 +218,14 @@
     }
     var wheelSpeed = parseFloat(theme['--fushi-wheel-speed']);
     window.__fushiPopupWheelSpeed = isFinite(wheelSpeed) && wheelSpeed > 0 ? wheelSpeed : 1;
-    lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
+    // 用户拖过尺寸（lookupUserResized）后，本会话内不再让主题下发的宽高盖掉用户的选择；
+    // 拖拽结果经 popupSize 回写 app，下次会话由主题带回来。
+    if (!lookupUserResized) {
+      lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
+      lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
+      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    }
     lookupPaneEl.style.maxWidth = 'calc(100vw - 16px)';
-    lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
-    lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
     lookupPaneEl.style.zoom = theme['--fushi-popup-zoom'] || '1';
   }
 
@@ -624,7 +639,20 @@
       var text = document.createElement('div');
       text.className = 'subtitle-text';
       text.textContent = cue.text;
-      text.title = '单击跳转；按住 Shift 指向文字查词；双击选择文本';
+      text.title = '单击文字查词；点击时间或行空白跳转；双击选择文本；按住 Shift 悬停扫词';
+      text.addEventListener('click', function (event) {
+        // 行内文字单击=查词（asbplayer 同款；8-11 迁原生 Side Panel 时随旧 UI 层一起丢了，
+        // 用户报「点击查词不见了，只能 Shift 查」）。拖选/双击形成的选区在场时不查，
+        // 保住「双击选择文本」。
+        try {
+          var clickSel = window.getSelection && window.getSelection();
+          if (clickSel && !clickSel.isCollapsed) return;
+        } catch (_) {}
+        event.stopPropagation(); // 不冒泡到 row 的 seek：点文字=查词、点行其它区域=跳转
+        lookupAtPointer({
+          x: event.clientX, y: event.clientY, cue: cue, index: index, textEl: text,
+        }, true);
+      });
       function rememberPointer(event) {
         lastPointer = {
           x: event.clientX, y: event.clientY, cue: cue, index: index, textEl: text,
@@ -784,6 +812,126 @@
     fileEl.value = '';
   });
 
+  // ── Jimaku 查字幕（asb 式云端字幕）：搜索框 → server /api/subtitle/jimaku/search（用户在
+  // app 设置里填的 API key；真人剧 anime=false 补搜在 server 侧）→ 点候选下载解析 →
+  // 复用外挂字幕的 InstallTrack 落地（与本地文件同一条轨/偏移/覆盖层链路）。
+  var jimakuRowEl = document.getElementById('jimaku-row');
+  var jimakuQueryEl = document.getElementById('jimaku-query');
+  var jimakuEpEl = document.getElementById('jimaku-ep');
+  var jimakuResultsEl = document.getElementById('jimaku-results');
+  function jimakuErrorText(data, response) {
+    var error = data && data.error;
+    if (error === 'no-api-key') return '请先在 Fushi 设置 → 视频 → 字幕 填写 Jimaku API key';
+    if (error === 'unauthorized') return 'Jimaku API key 无效或无权限';
+    if (error === 'rate-limited') return 'Jimaku 限流，请稍后再试';
+    if (error === 'missing-query') return '请输入搜索词';
+    if (!response || response.ok !== true) return 'Jimaku 搜索失败：请确认 Fushi 已启动';
+    return 'Jimaku 暂不可用，请稍后再试';
+  }
+  async function jimakuInstall(candidate) {
+    toast('正在下载：' + candidate.fileName);
+    var response = await sendRuntime({ type: 'jimakuFetch', handle: candidate.handle });
+    var data = response && response.data;
+    if (!response || response.ok !== true || !data || data.ok !== true ||
+        !Array.isArray(data.cues) || !data.cues.length) {
+      toast(data && data.error === 'unknown-handle'
+        ? '候选已过期，请重新搜索'
+        : (data && data.error === 'unsupported' ? '不支持的字幕格式' : jimakuErrorText(data, response)));
+      return;
+    }
+    var state = await sendToTab({
+      type: 'fushiSubtitleSidePanelInstallTrack',
+      filename: data.filename || candidate.fileName,
+      cues: data.cues,
+    });
+    if (state && state.ok) {
+      stateSignature = metadataSignature(state);
+      applyState(state, true);
+      jimakuResultsEl.hidden = true;
+      jimakuResultsEl.textContent = '';
+      toast('已加载 Jimaku 字幕：' + data.cues.length + ' 句');
+    }
+  }
+  function renderJimakuResults(candidates, truncated) {
+    jimakuResultsEl.textContent = '';
+    if (!candidates.length) {
+      var empty = document.createElement('div');
+      empty.className = 'jimaku-empty';
+      empty.textContent = '无结果。试试日文原名，或填集数缩小范围。';
+      jimakuResultsEl.appendChild(empty);
+      jimakuResultsEl.hidden = false;
+      return;
+    }
+    candidates.forEach(function (candidate) {
+      var row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'jimaku-item';
+      var name = document.createElement('span');
+      name.className = 'jimaku-item-name';
+      name.textContent = candidate.fileName;
+      var meta = document.createElement('span');
+      meta.className = 'jimaku-item-meta';
+      meta.textContent = candidate.entryName +
+        (candidate.language ? ' · ' + candidate.language : '') +
+        (candidate.episode != null ? ' · 第' + candidate.episode + '集' : '');
+      row.appendChild(name);
+      row.appendChild(meta);
+      row.addEventListener('click', function () { jimakuInstall(candidate); });
+      jimakuResultsEl.appendChild(row);
+    });
+    if (truncated) {
+      var more = document.createElement('div');
+      more.className = 'jimaku-empty';
+      more.textContent = '结果过多已截断，填集数可缩小范围。';
+      jimakuResultsEl.appendChild(more);
+    }
+    jimakuResultsEl.hidden = false;
+  }
+  var jimakuSearching = false;
+  async function jimakuSearch() {
+    if (jimakuSearching) return;
+    var query = String(jimakuQueryEl.value || '').trim();
+    if (!query) { toast('请输入搜索词'); return; }
+    var episode = parseInt(jimakuEpEl.value, 10);
+    jimakuSearching = true;
+    toast('正在搜索 Jimaku…');
+    try {
+      var response = await sendRuntime({
+        type: 'jimakuSearch',
+        query: query,
+        ...(Number.isInteger(episode) && episode > 0 ? { episode: episode } : {}),
+      });
+      var data = response && response.data;
+      if (!response || response.ok !== true || !data || data.ok !== true) {
+        toast(jimakuErrorText(data, response));
+        return;
+      }
+      renderJimakuResults(Array.isArray(data.candidates) ? data.candidates : [],
+        data.truncated === true);
+    } finally {
+      jimakuSearching = false;
+    }
+  }
+  document.getElementById('jimaku').addEventListener('click', function () {
+    var show = jimakuRowEl.hidden;
+    jimakuRowEl.hidden = !show;
+    if (!show) { jimakuResultsEl.hidden = true; return; }
+    // 预填当前标签页标题（长显示名命中率低，用户可改成日文原名——placeholder 已提示）。
+    if (!jimakuQueryEl.value && currentTabId != null) {
+      try {
+        chrome.tabs.get(currentTabId, function (tab) {
+          try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+          if (tab && tab.title && !jimakuQueryEl.value) jimakuQueryEl.value = tab.title;
+        });
+      } catch (_) {}
+    }
+    jimakuQueryEl.focus();
+  });
+  document.getElementById('jimaku-go').addEventListener('click', function () { jimakuSearch(); });
+  jimakuQueryEl.addEventListener('keydown', function (event) {
+    if (event.key === 'Enter') jimakuSearch();
+  });
+
   document.getElementById('smaller').addEventListener('click', function () {
     fontStep = Math.max(0, fontStep - 1);
     document.documentElement.style.setProperty('--subtitle-scale', String(FONT_STEPS[fontStep]));
@@ -820,6 +968,46 @@
       closeLookup();
     }
   });
+  // 「popup 不好关」的补齐三路：①content.js 在用户手动播放视频时反向推送 dismiss（页面弹窗
+  // 与本面板一起关）；②焦点离开 Side Panel（点回网页/播放器）即关；③滚动字幕列表（锚点行
+  // 已滚走，浮窗不该原地留着）即关。均幂等，重复触发无副作用。
+  try {
+    chrome.runtime.onMessage.addListener(function (msg) {
+      if (msg && msg.type === 'fushiLookupDismiss') closeLookup();
+    });
+  } catch (_) {}
+  window.addEventListener('blur', function () { closeLookup(); });
+  listEl.addEventListener('wheel', function () { closeLookup(); }, { passive: true });
+  listEl.addEventListener('touchmove', function () { closeLookup(); }, { passive: true });
+  // 查词面板拖拽调整大小（CSS resize 把手在右下角）：pointerdown 落在右下角 20px 内时快照
+  // 尺寸，松手时尺寸真变了才算「用户拖过」——置 lookupUserResized + 回写 app 尺寸键
+  // （app clamp 后按「拖即解锁」持久化，下次查词/会话经主题带回来）。
+  lookupPaneEl.addEventListener('pointerdown', function (event) {
+    try {
+      var rect = lookupPaneEl.getBoundingClientRect();
+      lookupResizeSnapshot =
+        (rect.right - event.clientX <= 20 && rect.bottom - event.clientY <= 20)
+          ? { w: rect.width, h: rect.height }
+          : null;
+    } catch (_) { lookupResizeSnapshot = null; }
+  }, { passive: true });
+  window.addEventListener('pointerup', function () {
+    if (!lookupResizeSnapshot) return;
+    var snap = lookupResizeSnapshot;
+    lookupResizeSnapshot = null;
+    var rect;
+    try { rect = lookupPaneEl.getBoundingClientRect(); } catch (_) { return; }
+    if (Math.abs(rect.width - snap.w) < 3 && Math.abs(rect.height - snap.h) < 3) return;
+    lookupUserResized = true;
+    var zoom = parseFloat(lookupPaneEl.style.zoom) || 1;
+    lookupBaseMaxHeight = Math.round(rect.height / zoom) + 'px';
+    lookupPaneEl.style.maxHeight = '';
+    sendRuntime({
+      type: 'popupSize',
+      maxWidth: Math.round(rect.width / zoom),
+      maxHeight: Math.round(rect.height / zoom),
+    });
+  }, { passive: true });
   window.addEventListener('load', function () {
     // popup.js 在扩展上下文只暴露监听器；与 content.js 的 Shift host 一样，把它
     // 限定挂在常驻 shadow host，避免污染整个 Side Panel 的滚动快速路径。

--- a/fushi/assets/browser_extension/subtitle-panel.js
+++ b/fushi/assets/browser_extension/subtitle-panel.js
@@ -646,6 +646,14 @@
         sendResponse({ ok: handled });
         return false;
       }
+      if (msg.type === 'fushiSubtitleSidePanelLookupClosed') {
+        // Side Panel 查词面板关闭 → 恢复由查词暂停的视频（content.js 只恢复「确实是查词
+        // 暂停的」，用户自己暂停的不动）。
+        var closed = typeof window.fushiLookupClosedFromSidePanel === 'function' &&
+          window.fushiLookupClosedFromSidePanel() === true;
+        sendResponse({ ok: closed });
+        return false;
+      }
       if (msg.type === 'fushiSubtitleSidePanelMine') {
         var mineCue = msg.cue && typeof msg.cue === 'object' ? msg.cue : null;
         var result = typeof window.fushiMineFromSidePanel === 'function'

--- a/fushi/assets/browser_extension/video-shortcuts.js
+++ b/fushi/assets/browser_extension/video-shortcuts.js
@@ -157,6 +157,15 @@
         e.key !== 'ArrowLeft' && e.key !== 'ArrowRight' && e.key !== 'ArrowUp') {
       return;
     }
+    // Shadow DOM 里的编辑器：e.target 被 retarget 成宿主自定义元素，isEditable 会误判 false，
+    // Ctrl+Shift+Z（编辑器重做）等会被快捷键抢走。composedPath()[0] 才是真实目标。
+    var realTarget = e.target;
+    try {
+      if (typeof e.composedPath === 'function') {
+        var path = e.composedPath();
+        if (path && path.length) realTarget = path[0];
+      }
+    } catch (_) {}
     var decision = api.decide(
       {
         key: e.key,
@@ -164,7 +173,7 @@
         ctrl: e.ctrlKey || e.metaKey,
         shift: e.shiftKey,
         alt: e.altKey,
-        editable: isEditable(e.target),
+        editable: isEditable(realTarget),
       },
       {
         enabled: true,

--- a/fushi/lib/src/media/video/jimaku_client.dart
+++ b/fushi/lib/src/media/video/jimaku_client.dart
@@ -377,13 +377,28 @@ class JimakuClient {
         'Accept': 'application/json',
       };
 
+  /// 组 `/entries/search` 的 query 参数。Jimaku 的 `anime` 是**硬相等过滤且服务端默认
+  /// true**：不显式带 `anime=false` 永远搜不到真人剧/日剧条目（jimaku.cc 的 dramas 区）。
+  /// [anime] 为 null 时不带该参数（= 旧行为，只搜番剧），true/false 显式透传。
+  static Map<String, String> buildEntrySearchParams(
+    Map<String, String> base, {
+    bool? anime,
+  }) {
+    if (anime == null) return base;
+    return <String, String>{...base, 'anime': anime ? 'true' : 'false'};
+  }
+
   /// 按 AniList id 搜 Jimaku 条目。
   Future<List<JimakuEntry>> searchByAnilistId(
     int anilistId, {
+    bool? anime,
     bool throwOnError = false,
   }) async {
     return _searchEntries(
-      <String, String>{'anilist_id': '$anilistId'},
+      buildEntrySearchParams(
+        <String, String>{'anilist_id': '$anilistId'},
+        anime: anime,
+      ),
       throwOnError: throwOnError,
     );
   }
@@ -391,11 +406,15 @@ class JimakuClient {
   /// 按文本搜 Jimaku 条目（AniList 匹配不到时的回退）。
   Future<List<JimakuEntry>> searchByQuery(
     String query, {
+    bool? anime,
     bool throwOnError = false,
   }) async {
     if (query.trim().isEmpty) return const <JimakuEntry>[];
     return _searchEntries(
-      <String, String>{'query': query},
+      buildEntrySearchParams(
+        <String, String>{'query': query},
+        anime: anime,
+      ),
       throwOnError: throwOnError,
     );
   }
@@ -408,11 +427,13 @@ class JimakuClient {
   Future<List<JimakuEntry>> searchEntries({
     int? anilistId,
     List<String> queryFallbacks = const <String>[],
+    bool? anime,
     bool throwOnError = false,
   }) async {
     if (anilistId != null) {
       final List<JimakuEntry> byId = await searchByAnilistId(
         anilistId,
+        anime: anime,
         throwOnError: throwOnError,
       );
       if (byId.isNotEmpty) return byId;
@@ -421,6 +442,7 @@ class JimakuClient {
       if (query.trim().isEmpty) continue;
       final List<JimakuEntry> byQuery = await searchByQuery(
         query,
+        anime: anime,
         throwOnError: throwOnError,
       );
       if (byQuery.isNotEmpty) return byQuery;

--- a/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/jimaku_subtitle_provider.dart
@@ -32,6 +32,9 @@ class JimakuVideoSubtitleProvider implements VideoSubtitleProvider {
       final List<JimakuEntry> entries = await _client.searchEntries(
         anilistId: request.media?.anilistId,
         queryFallbacks: fallbacks,
+        // Jimaku 的 anime 过滤是硬相等且服务端默认 true：真人剧必须显式 false 才搜得到，
+        // 由请求方（扩展桥/未来的 UI 开关）决定；null 保持旧行为（只搜番剧）。
+        anime: request.anime,
         throwOnError: true,
       );
       final List<VideoSubtitleCandidate> candidates =

--- a/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
+++ b/fushi/lib/src/media/video/subtitle/video_subtitle_provider.dart
@@ -25,6 +25,7 @@ class VideoSubtitleSearchRequest {
     this.episode,
     this.fingerprint,
     this.page = 1,
+    this.anime,
   })  : alternateTitles = List<String>.unmodifiable(alternateTitles),
         languages = List<String>.unmodifiable(languages),
         assert(page > 0);
@@ -37,6 +38,10 @@ class VideoSubtitleSearchRequest {
   final int? episode;
   final LocalVideoFingerprint? fingerprint;
   final int page;
+
+  /// 内容类型提示（目前只有 Jimaku 消费）：Jimaku 的 `anime` 是硬相等过滤且服务端默认
+  /// true——真人剧/日剧必须显式 false 才搜得到。null = 不带参数（旧行为，只搜番剧）。
+  final bool? anime;
 
   String get effectiveQuery => query?.trim().isNotEmpty == true
       ? query!.trim()

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6070,6 +6070,9 @@ class AppModel with ChangeNotifier {
         _browserExtensionReportedAt = DateTime.now();
         browserExtensionReportedBuild.value = build;
       },
+      // 「Jimaku 查字幕」扩展桥：Side Panel 搜索/下载字幕经 /api/subtitle/jimaku/* 复用
+      // 用户在 app 设置里填的 Jimaku API key；未填时端点回 no-api-key（扩展提示去填）。
+      jimakuApiKeyProvider: () => jimakuApiKey,
       tokenizer: JapaneseLanguage.instance.textToWords,
       readingResolver: (String w) {
         if (!FushiDicts.isInitialized) return '';

--- a/fushi/lib/src/sync/remote_jimaku_subtitle_handlers.dart
+++ b/fushi/lib/src/sync/remote_jimaku_subtitle_handlers.dart
@@ -1,0 +1,198 @@
+import 'dart:typed_data';
+
+import 'package:fushi_audio/fushi_audio.dart' show decodeTextBytes;
+
+import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/video_subtitle_source.dart';
+
+/// 浏览器扩展「Jimaku 查字幕」桥（Side Panel → server → jimaku.cc）的共享 handler 逻辑。
+/// 与 [buildRemoteDictionaryLookupResponse] 同范式：纯逻辑（已解析 body Map → 注入的窄
+/// 依赖 → 响应 Map），不碰 shelf/HTTP，便于单测。
+///
+/// 为什么**不走** VideoSubtitleRegistry：registry.search 只在
+/// `media.discoveryCategory == anime` 时才让 jimaku 参与，而扩展请求只有页面标题、没有
+/// media 引用——走 registry 则 jimaku 永远被过滤掉。扩展桥的目标就是 Jimaku（用户点名），
+/// 直连 [JimakuClient] 语义最诚实；OpenSubtitles 等以后要接再抽通用层。
+///
+/// 下载侧的候选以 [RemoteJimakuCandidate] 形式按 handle 缓存在 server（LRU 上限见
+/// server 侧），`/api/subtitle/jimaku/fetch` 凭 handle 取回——两端点都过鉴权中间件，
+/// handle 无需不可猜。
+
+class RemoteJimakuCandidate {
+  RemoteJimakuCandidate({
+    required this.entryId,
+    required this.entryName,
+    required this.fileName,
+    required this.fileUrl,
+    required this.language,
+    this.fileSize,
+    this.episode,
+  });
+
+  final int entryId;
+  final String entryName;
+  final String fileName;
+  final String fileUrl;
+  final String language;
+  final int? fileSize;
+  final int? episode;
+}
+
+/// 每个 entry 最多取的文件数与响应候选总量上限（防整季包/合集条目把响应撑爆；截断计入
+/// `truncated` 字段，扩展侧可提示「结果过多，请带集数搜索」）。
+const int kJimakuSearchMaxEntries = 5;
+const int kJimakuSearchMaxCandidates = 100;
+
+/// `POST /api/subtitle/jimaku/search` 的响应体。
+/// body：`{query?, anilistId?, episode?, anime?}`——query 与 anilistId 至少给一个；
+/// anime 缺省时先按 Jimaku 默认（只搜番剧）搜，空结果再显式 `anime=false` 补搜真人剧
+/// （Jimaku 的 anime 是硬相等过滤且服务端默认 true，不补搜日剧/真人剧永远 0 结果）。
+Future<Map<String, dynamic>> buildJimakuSearchResponse(
+  Map<String, dynamic> body, {
+  required JimakuClient? Function() clientProvider,
+  required void Function(String handle, RemoteJimakuCandidate candidate)
+      rememberCandidate,
+}) async {
+  final JimakuClient? client = clientProvider();
+  if (client == null) {
+    return <String, dynamic>{'ok': false, 'error': 'no-api-key'};
+  }
+  final String query = body['query']?.toString().trim() ?? '';
+  final Object? rawAnilistId = body['anilistId'];
+  final int? anilistId = rawAnilistId is num ? rawAnilistId.toInt() : null;
+  if (query.isEmpty && anilistId == null) {
+    return <String, dynamic>{'ok': false, 'error': 'missing-query'};
+  }
+  final Object? rawEpisode = body['episode'];
+  final int? episode = rawEpisode is num ? rawEpisode.toInt() : null;
+  final Object? rawAnime = body['anime'];
+  final bool? anime = rawAnime is bool ? rawAnime : null;
+
+  try {
+    List<JimakuEntry> entries = await client.searchEntries(
+      anilistId: anilistId,
+      queryFallbacks: <String>[if (query.isNotEmpty) query],
+      anime: anime,
+      throwOnError: true,
+    );
+    if (entries.isEmpty && anime == null) {
+      entries = await client.searchEntries(
+        anilistId: anilistId,
+        queryFallbacks: <String>[if (query.isNotEmpty) query],
+        anime: false,
+        throwOnError: true,
+      );
+    }
+    final List<Map<String, dynamic>> candidates = <Map<String, dynamic>>[];
+    bool truncated = entries.length > kJimakuSearchMaxEntries;
+    for (final JimakuEntry entry in entries.take(kJimakuSearchMaxEntries)) {
+      final List<JimakuFile> files = await client.listFiles(
+        entry.id,
+        episode: episode,
+        throwOnError: true,
+      );
+      for (final JimakuFile file in files) {
+        if (!file.isTextSubtitle) continue;
+        if (candidates.length >= kJimakuSearchMaxCandidates) {
+          truncated = true;
+          break;
+        }
+        final String handle = 'jimaku:${entry.id}:${file.name}';
+        final String language = detectSubtitleLanguage(file.name) ?? '';
+        rememberCandidate(
+          handle,
+          RemoteJimakuCandidate(
+            entryId: entry.id,
+            entryName: entry.name,
+            fileName: file.name,
+            fileUrl: file.url,
+            language: language,
+            fileSize: file.size,
+            episode: file.episode,
+          ),
+        );
+        candidates.add(<String, dynamic>{
+          'handle': handle,
+          'provider': 'jimaku',
+          'entryId': entry.id,
+          'entryName': entry.name,
+          'fileName': file.name,
+          'language': language,
+          if (file.episode != null) 'episode': file.episode,
+          if (file.size != null) 'fileSize': file.size,
+        });
+      }
+    }
+    return <String, dynamic>{
+      'ok': true,
+      'candidates': candidates,
+      if (truncated) 'truncated': true,
+    };
+  } on JimakuRequestException catch (e) {
+    return <String, dynamic>{
+      'ok': false,
+      'error': switch (e.statusCode) {
+        401 || 403 => 'unauthorized',
+        429 => 'rate-limited',
+        _ => 'unavailable',
+      },
+      if (e.statusCode != null) 'status': e.statusCode,
+    };
+  } on Object {
+    return <String, dynamic>{'ok': false, 'error': 'unavailable'};
+  }
+}
+
+/// `POST /api/subtitle/jimaku/fetch` 的响应体：下载 handle 对应的字幕文件，自动识别编码
+/// （Jimaku 上 Shift-JIS 档不罕见，[decodeTextBytes] 处理），并直接复用
+/// [buildParsedSubtitleResponse] 解析成与 `/api/subtitle/parse` **完全同形**的 cue 载荷——
+/// 扩展侧下游（InstallTrack → applyExternalSubtitle）零改动。
+Future<Map<String, dynamic>> buildJimakuFetchResponse(
+  Map<String, dynamic> body, {
+  required JimakuClient? Function() clientProvider,
+  required RemoteJimakuCandidate? Function(String handle) resolveCandidate,
+}) async {
+  final JimakuClient? client = clientProvider();
+  if (client == null) {
+    return <String, dynamic>{'ok': false, 'error': 'no-api-key'};
+  }
+  final String handle = body['handle']?.toString() ?? '';
+  final RemoteJimakuCandidate? candidate =
+      handle.isEmpty ? null : resolveCandidate(handle);
+  if (candidate == null) {
+    // 缓存过期 / app 重启：扩展侧重搜一次即可恢复。
+    return <String, dynamic>{'ok': false, 'error': 'unknown-handle'};
+  }
+  try {
+    final Uint8List? bytes = await client.downloadFile(
+      candidate.fileUrl,
+      throwOnError: true,
+    );
+    if (bytes == null || bytes.isEmpty) {
+      return <String, dynamic>{'ok': false, 'error': 'download-failed'};
+    }
+    final String content = await decodeTextBytes(bytes);
+    final Map<String, dynamic> parsed = buildParsedSubtitleResponse(
+      filename: candidate.fileName,
+      content: content,
+    );
+    return <String, dynamic>{
+      'ok': parsed['error'] == null,
+      'filename': candidate.fileName,
+      'language': candidate.language,
+      ...parsed,
+    };
+  } on JimakuRequestException catch (e) {
+    return <String, dynamic>{
+      'ok': false,
+      'error': switch (e.statusCode) {
+        401 || 403 => 'unauthorized',
+        429 => 'rate-limited',
+        _ => 'download-failed',
+      },
+      if (e.statusCode != null) 'status': e.statusCode,
+    };
+  } on Object {
+    return <String, dynamic>{'ok': false, 'error': 'download-failed'};
+  }
+}

--- a/fushi/lib/src/sync/yomitan_api_server.dart
+++ b/fushi/lib/src/sync/yomitan_api_server.dart
@@ -8,11 +8,13 @@ import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
+import 'package:fushi/src/media/video/jimaku_client.dart' show JimakuClient;
 import 'package:fushi/src/media/video/video_subtitle_source.dart'
     show buildParsedSubtitleResponse;
 import 'package:fushi/src/media/video/youtube_source_resolver.dart'
     show resolveYoutubeCaptionsForExtension;
 import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
+import 'package:fushi/src/sync/remote_jimaku_subtitle_handlers.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/fushi_sync_server.dart'
     show SyncServerPortInUseException, isAddressInUseError;
@@ -64,6 +66,7 @@ class YomitanApiServer {
     void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     void Function()? onExtensionSeen,
     void Function(String build, String? version)? onExtensionReport,
+    String? Function()? jimakuApiKeyProvider,
     String? apiKey,
     bool allowLan = false,
   })  : _requestedPort = port,
@@ -78,6 +81,7 @@ class YomitanApiServer {
         _onExtensionPopupSize = onExtensionPopupSize,
         _onExtensionSeen = onExtensionSeen,
         _onExtensionReport = onExtensionReport,
+        _jimakuApiKeyProvider = jimakuApiKeyProvider,
         _apiKey = apiKey,
         _allowLan = allowLan;
 
@@ -105,10 +109,40 @@ class YomitanApiServer {
   // （+ manifest version）。app 侧记录后与内置指纹比对，不一致时在扩展管理页给出
   // 更新提示。旧扩展发 '{}'（无 build 字段）时不回调——行为等同现状（向后兼容）。
   final void Function(String build, String? version)? _onExtensionReport;
+  // 「Jimaku 查字幕」扩展桥：从偏好读用户 API key 的供给器。未注入/key 为空时两个
+  // jimaku 端点回 {ok:false, error:'no-api-key'}（扩展提示去 app 设置里填 key）。
+  final String? Function()? _jimakuApiKeyProvider;
   final String? _apiKey;
   final bool _allowLan;
 
   HttpServer? _server;
+
+  // Jimaku client 按 key 缓存复用（每请求新建会泄漏 http.Client）；key 变更时换新关旧。
+  JimakuClient? _jimakuClient;
+  String? _jimakuClientKey;
+  // 搜索候选按 handle 暂存（download 需要 file url 等上下文）；插入序 LRU，上限截断。
+  static const int _kJimakuCandidateCacheLimit = 200;
+  final Map<String, RemoteJimakuCandidate> _jimakuCandidates =
+      <String, RemoteJimakuCandidate>{};
+
+  JimakuClient? _jimakuClientFor() {
+    final String? key = _jimakuApiKeyProvider?.call();
+    if (key == null || key.trim().isEmpty) return null;
+    if (_jimakuClient == null || _jimakuClientKey != key) {
+      _jimakuClient?.close();
+      _jimakuClient = JimakuClient(apiKey: key);
+      _jimakuClientKey = key;
+    }
+    return _jimakuClient;
+  }
+
+  void _rememberJimakuCandidate(String handle, RemoteJimakuCandidate c) {
+    _jimakuCandidates.remove(handle); // 重插到尾部（LRU 触达即续期）
+    _jimakuCandidates[handle] = c;
+    while (_jimakuCandidates.length > _kJimakuCandidateCacheLimit) {
+      _jimakuCandidates.remove(_jimakuCandidates.keys.first);
+    }
+  }
 
   // 单词音频短命 token（与 FushiSyncServer 同款模型）：/api/lookup/audio 存字节、返
   // 免鉴权的 /api/lookup/audio/file?id= URL；命中即续期，5 分钟无访问后 prune。
@@ -140,6 +174,10 @@ class YomitanApiServer {
   Future<void> stop() async {
     await _server?.close(force: true);
     _server = null;
+    _jimakuClient?.close();
+    _jimakuClient = null;
+    _jimakuClientKey = null;
+    _jimakuCandidates.clear();
   }
 
   shelf.Middleware _authMiddleware() {
@@ -264,9 +302,38 @@ class YomitanApiServer {
         return _handleYoutubeCaptions(request);
       case '/api/subtitle/parse':
         return _handleSubtitleParse(request);
+      case '/api/subtitle/jimaku/search':
+        return _handleJimakuSearch(request);
+      case '/api/subtitle/jimaku/fetch':
+        return _handleJimakuFetch(request);
       default:
         return shelf.Response.notFound('Unknown endpoint');
     }
+  }
+
+  /// 「Jimaku 查字幕」扩展桥①搜索：body `{query?, anilistId?, episode?, anime?}`。
+  /// 逻辑在 [buildJimakuSearchResponse]（含真人剧 anime=false 补搜）；候选按 handle
+  /// 暂存供 fetch。
+  Future<shelf.Response> _handleJimakuSearch(shelf.Request request) async {
+    final Map<String, dynamic>? body = await _readJson(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    return _json(await buildJimakuSearchResponse(
+      body,
+      clientProvider: _jimakuClientFor,
+      rememberCandidate: _rememberJimakuCandidate,
+    ));
+  }
+
+  /// 「Jimaku 查字幕」扩展桥②下载+解析：body `{handle}`。响应与 `/api/subtitle/parse`
+  /// 同形（`{format, cues:[...]}` + filename/language），扩展直接走既有 InstallTrack 落地。
+  Future<shelf.Response> _handleJimakuFetch(shelf.Request request) async {
+    final Map<String, dynamic>? body = await _readJson(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    return _json(await buildJimakuFetchResponse(
+      body,
+      clientProvider: _jimakuClientFor,
+      resolveCandidate: (String handle) => _jimakuCandidates[handle],
+    ));
   }
 
   /// BUG-726/自更新：状态端点回带当前内置扩展指纹（extensionBuild），扩展

--- a/fushi/lib/src/sync/yomitan_api_server_manager.dart
+++ b/fushi/lib/src/sync/yomitan_api_server_manager.dart
@@ -18,6 +18,7 @@ class YomitanApiServerManager {
     void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     void Function()? onExtensionSeen,
     void Function(String build, String? version)? onExtensionReport,
+    String? Function()? jimakuApiKeyProvider,
   })  : _lookup = lookupService,
         _mining = miningService,
         _history = historyService,
@@ -28,7 +29,8 @@ class YomitanApiServerManager {
         _extensionBuildProvider = extensionBuildProvider,
         _onExtensionPopupSize = onExtensionPopupSize,
         _onExtensionSeen = onExtensionSeen,
-        _onExtensionReport = onExtensionReport;
+        _onExtensionReport = onExtensionReport,
+        _jimakuApiKeyProvider = jimakuApiKeyProvider;
 
   final FushiRemoteLookupService _lookup;
   final FushiRemoteMiningService? _mining;
@@ -48,6 +50,8 @@ class YomitanApiServerManager {
   // BUG-1079：扩展自报版本回调，透传给 [YomitanApiServer]（app 侧记录浏览器中实际
   // 加载的 build，与内置指纹比对给出更新提示）。
   final void Function(String build, String? version)? _onExtensionReport;
+  // 「Jimaku 查字幕」扩展桥：Jimaku API key 供给器，透传给 [YomitanApiServer]。
+  final String? Function()? _jimakuApiKeyProvider;
 
   YomitanApiServer? _server;
 
@@ -69,6 +73,7 @@ class YomitanApiServerManager {
       onExtensionPopupSize: _onExtensionPopupSize,
       onExtensionSeen: _onExtensionSeen,
       onExtensionReport: _onExtensionReport,
+      jimakuApiKeyProvider: _jimakuApiKeyProvider,
       apiKey: apiKey.isEmpty ? null : apiKey,
       allowLan: true,
     );

--- a/fushi/test/sync/remote_jimaku_subtitle_handlers_test.dart
+++ b/fushi/test/sync/remote_jimaku_subtitle_handlers_test.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/sync/remote_jimaku_subtitle_handlers.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// 「Jimaku 查字幕」扩展桥（/api/subtitle/jimaku/search + /fetch 的共享 handler）契约：
+/// - Jimaku 的 `anime` 是硬相等过滤且服务端默认 true：anime 缺省时空结果必须显式
+///   `anime=false` 补搜（否则 U-Next 主力的真人剧/日剧永远 0 结果）；
+/// - 无 API key 回 no-api-key（扩展提示去 app 设置里填），不是含糊的空结果；
+/// - fetch 响应与 /api/subtitle/parse 同形（format+cues），扩展 InstallTrack 零改动。
+void main() {
+  const String srt = '1\n00:00:01,000 --> 00:00:02,000\nこんにちは\n';
+
+  MockClient jimakuMock({
+    required Map<String, List<Map<String, dynamic>>> entriesByAnimeParam,
+    List<Map<String, dynamic>> files = const <Map<String, dynamic>>[],
+    List<Uri>? seenUris,
+  }) {
+    return MockClient((http.Request request) async {
+      seenUris?.add(request.url);
+      final String path = request.url.path;
+      if (path.endsWith('/entries/search')) {
+        final String animeParam = request.url.queryParameters['anime'] ?? '';
+        return http.Response(
+          jsonEncode(entriesByAnimeParam[animeParam] ?? <Object>[]),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      }
+      if (path.contains('/entries/') && path.endsWith('/files')) {
+        return http.Response(
+          jsonEncode(files),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      }
+      if (path.endsWith('/download.srt')) {
+        return http.Response.bytes(utf8.encode(srt), 200);
+      }
+      return http.Response('not found', 404);
+    });
+  }
+
+  group('JimakuClient.buildEntrySearchParams', () {
+    test('anime 缺省不带参数；true/false 显式透传', () {
+      expect(
+        JimakuClient.buildEntrySearchParams(<String, String>{'query': 'x'}),
+        <String, String>{'query': 'x'},
+      );
+      expect(
+        JimakuClient.buildEntrySearchParams(
+          <String, String>{'query': 'x'},
+          anime: false,
+        ),
+        <String, String>{'query': 'x', 'anime': 'false'},
+      );
+      expect(
+        JimakuClient.buildEntrySearchParams(
+          <String, String>{'anilist_id': '1'},
+          anime: true,
+        ),
+        <String, String>{'anilist_id': '1', 'anime': 'true'},
+      );
+    });
+  });
+
+  group('buildJimakuSearchResponse', () {
+    test('无 API key → no-api-key', () async {
+      final Map<String, dynamic> res = await buildJimakuSearchResponse(
+        <String, dynamic>{'query': 'ドラマ'},
+        clientProvider: () => null,
+        rememberCandidate: (_, __) => fail('不应记录候选'),
+      );
+      expect(res['ok'], isFalse);
+      expect(res['error'], 'no-api-key');
+    });
+
+    test('query 与 anilistId 都缺 → missing-query', () async {
+      final Map<String, dynamic> res = await buildJimakuSearchResponse(
+        <String, dynamic>{},
+        clientProvider: () => JimakuClient(
+            apiKey: 'k', client: jimakuMock(entriesByAnimeParam: {})),
+        rememberCandidate: (_, __) {},
+      );
+      expect(res['error'], 'missing-query');
+    });
+
+    test('anime 缺省时默认搜为空 → 显式 anime=false 补搜命中真人剧', () async {
+      final List<Uri> seen = <Uri>[];
+      final JimakuClient client = JimakuClient(
+        apiKey: 'k',
+        client: jimakuMock(
+          entriesByAnimeParam: <String, List<Map<String, dynamic>>>{
+            // 默认（不带 anime 参数）：空；显式 anime=false：命中日剧条目。
+            '': <Map<String, dynamic>>[],
+            'false': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 7, 'name': '日剧タイトル'},
+            ],
+          },
+          files: <Map<String, dynamic>>[
+            <String, dynamic>{
+              'name': 'ep01.ja.srt',
+              'url': 'https://jimaku.cc/dl/download.srt',
+              'size': 100,
+            },
+          ],
+          seenUris: seen,
+        ),
+      );
+      final Map<String, RemoteJimakuCandidate> remembered =
+          <String, RemoteJimakuCandidate>{};
+      final Map<String, dynamic> res = await buildJimakuSearchResponse(
+        <String, dynamic>{'query': '日剧タイトル'},
+        clientProvider: () => client,
+        rememberCandidate: (String handle, RemoteJimakuCandidate c) =>
+            remembered[handle] = c,
+      );
+      expect(res['ok'], isTrue);
+      final List<dynamic> candidates = res['candidates'] as List<dynamic>;
+      expect(candidates, hasLength(1));
+      final Map<String, dynamic> first =
+          candidates.first as Map<String, dynamic>;
+      expect(first['handle'], 'jimaku:7:ep01.ja.srt');
+      expect(first['entryName'], '日剧タイトル');
+      expect(remembered, contains('jimaku:7:ep01.ja.srt'));
+      // 真的发过一次 anime=false 的补搜。
+      expect(
+        seen.any((Uri u) => u.queryParameters['anime'] == 'false'),
+        isTrue,
+        reason: '缺省空结果必须显式 anime=false 补搜，否则真人剧永远 0 结果',
+      );
+    });
+
+    test('显式 anime=false 直达，不做二次补搜', () async {
+      final List<Uri> seen = <Uri>[];
+      final JimakuClient client = JimakuClient(
+        apiKey: 'k',
+        client: jimakuMock(
+          entriesByAnimeParam: <String, List<Map<String, dynamic>>>{
+            'false': <Map<String, dynamic>>[],
+          },
+          seenUris: seen,
+        ),
+      );
+      final Map<String, dynamic> res = await buildJimakuSearchResponse(
+        <String, dynamic>{'query': 'x', 'anime': false},
+        clientProvider: () => client,
+        rememberCandidate: (_, __) {},
+      );
+      expect(res['ok'], isTrue);
+      expect(res['candidates'], isEmpty);
+      expect(
+        seen.where((Uri u) => u.path.endsWith('/entries/search')).length,
+        1,
+        reason: '调用方已显式指定 anime，空结果不再补搜',
+      );
+    });
+
+    test('401 → unauthorized', () async {
+      final JimakuClient client = JimakuClient(
+        apiKey: 'bad',
+        client: MockClient((_) async => http.Response('denied', 401)),
+      );
+      final Map<String, dynamic> res = await buildJimakuSearchResponse(
+        <String, dynamic>{'query': 'x'},
+        clientProvider: () => client,
+        rememberCandidate: (_, __) {},
+      );
+      expect(res['ok'], isFalse);
+      expect(res['error'], 'unauthorized');
+    });
+  });
+
+  group('buildJimakuFetchResponse', () {
+    RemoteJimakuCandidate candidate() => RemoteJimakuCandidate(
+          entryId: 7,
+          entryName: '日剧タイトル',
+          fileName: 'ep01.ja.srt',
+          fileUrl: 'https://jimaku.cc/dl/download.srt',
+          language: 'ja',
+        );
+
+    test('未知 handle → unknown-handle（缓存过期/app 重启后扩展重搜即可恢复）', () async {
+      final Map<String, dynamic> res = await buildJimakuFetchResponse(
+        <String, dynamic>{'handle': 'jimaku:1:gone.srt'},
+        clientProvider: () => JimakuClient(
+            apiKey: 'k', client: jimakuMock(entriesByAnimeParam: {})),
+        resolveCandidate: (_) => null,
+      );
+      expect(res['ok'], isFalse);
+      expect(res['error'], 'unknown-handle');
+    });
+
+    test('下载 + 解析：响应与 /api/subtitle/parse 同形（format+cues）', () async {
+      final Map<String, dynamic> res = await buildJimakuFetchResponse(
+        <String, dynamic>{'handle': 'jimaku:7:ep01.ja.srt'},
+        clientProvider: () => JimakuClient(
+            apiKey: 'k', client: jimakuMock(entriesByAnimeParam: {})),
+        resolveCandidate: (_) => candidate(),
+      );
+      expect(res['ok'], isTrue);
+      expect(res['filename'], 'ep01.ja.srt');
+      expect(res['language'], 'ja');
+      expect(res['format'], 'srt');
+      final List<dynamic> cues = res['cues'] as List<dynamic>;
+      expect(cues, hasLength(1));
+      final Map<String, dynamic> cue = cues.first as Map<String, dynamic>;
+      expect(cue['text'], 'こんにちは');
+      expect(cue['startMs'], 1000);
+      expect(cue['endMs'], 2000);
+    });
+  });
+}

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -750,6 +750,40 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           data: r.ok ? await r.json() : null,
           ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
         });
+      } else if (msg.type === 'jimakuSearch') {
+        // Jimaku 查字幕①：Side Panel 搜索框 → server /api/subtitle/jimaku/search（server 持
+        // 用户在 app 设置里填的 Jimaku API key；真人剧 anime=false 补搜也在 server 侧）。
+        const r = await fetch(base + '/api/subtitle/jimaku/search', {
+          method: 'POST',
+          signal: AbortSignal.timeout(20000),
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({
+            query: msg.query || '',
+            ...(Number.isInteger(msg.episode) ? { episode: msg.episode } : {}),
+            ...(typeof msg.anime === 'boolean' ? { anime: msg.anime } : {}),
+          }),
+        });
+        sendResponse({
+          ok: r.ok,
+          status: r.status,
+          data: r.ok ? await r.json() : null,
+          ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
+        });
+      } else if (msg.type === 'jimakuFetch') {
+        // Jimaku 查字幕②：候选 handle → server 下载+自动识别编码+解析，响应与
+        // /api/subtitle/parse 同形（{format,cues}），Side Panel 直接走既有 InstallTrack。
+        const r = await fetch(base + '/api/subtitle/jimaku/fetch', {
+          method: 'POST',
+          signal: AbortSignal.timeout(30000),
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({ handle: msg.handle || '' }),
+        });
+        sendResponse({
+          ok: r.ok,
+          status: r.status,
+          data: r.ok ? await r.json() : null,
+          ...(!r.ok ? { connection: await diagnoseConnection(true) } : {}),
+        });
       } else if (msg.type === 'mine') {
         // 纯文本挖词（非流媒体页 / 回落）：直接 POST {fields,sentence}，无媒体。
         const r = await fetch(base + '/api/mine', {

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -104,17 +104,40 @@ function fushiApplyPauseOnLookupPrefs(saved) {
 // 因查词被**我们**暂停的那个 <video>；null=没有。它是恢复侧唯一真相源（对齐 app 的
 // _pausedForLookup 不变式）：用户自己暂停的视频绝不因关弹窗被播起来。
 let fushiPausedForLookup = null;
-// 记「被我们暂停」并挂一次性 play 监听：用户手动点播放（不是我们 resume——我们 resume 前
-// 已先置 null）即视为收回控制权，清掉标记。这样「查词暂停 → 用户播放 → 用户再暂停 → 关窗」
-// 不会把用户自己按下的暂停顶掉；SPA 同元素换 src 继续播的场景同样被覆盖。
-function fushiMarkPausedForLookup(v) {
-  if (fushiPausedForLookup === v) return; // 重复查词同一视频：已挂过监听，别叠加
-  fushiPausedForLookup = v;
+// 「用户手动按下播放」的一次性监听：手动播放 = 收回控制权 + 「我看完了，继续看片」——
+// ①清掉 fushiPausedForLookup（此后关窗/失败路径绝不把用户的暂停顶掉）；②把查词浮层
+// （页面弹窗 + Side Panel 查词面板）一并关掉。我们自己的恢复（fushiResumePausedForLookup）
+// 会先解除武装再 play，不会误触发。
+let fushiPlayDismissTarget = null;
+function fushiArmPlayDismiss(v) {
+  if (!v || fushiPlayDismissTarget === v) return; // 同一视频已挂过监听，别叠加
+  fushiPlayDismissTarget = v;
   try {
     v.addEventListener('play', function () {
+      if (fushiPlayDismissTarget !== v) return; // 已解除武装（我们自己的恢复）
+      fushiPlayDismissTarget = null;
       if (fushiPausedForLookup === v) fushiPausedForLookup = null;
+      fushiDismissLookupOnPlay();
     }, { once: true });
   } catch (_) {}
+}
+// 手动播放 → 关掉两处查词浮层。页面弹窗直接关（fushiRemoveContainer 幂等；其恢复步骤
+// 因标记已清而为 no-op）；Side Panel 是独立扩展页，发一条 runtime 消息让它自关。
+function fushiDismissLookupOnPlay() {
+  try { fushiRemoveContainer(); } catch (_) {}
+  if (fushiExtAlive()) {
+    try {
+      chrome.runtime.sendMessage({ type: 'fushiLookupDismiss', reason: 'play' }, function () {
+        try { void chrome.runtime.lastError; } catch (_) {}
+      });
+    } catch (_) {}
+  }
+}
+// 记「被我们暂停」：恢复真相源 + 顺带武装 play 监听。
+function fushiMarkPausedForLookup(v) {
+  if (fushiPausedForLookup === v) return;
+  fushiPausedForLookup = v;
+  fushiArmPlayDismiss(v);
 }
 // 恢复侧唯一实现（对齐 app 的 shouldResumeAfterLookupDismiss）：只恢复确实由查词暂停的
 // 那个视频；用户已手动继续播放的不重复 play（v.paused 守卫）。除关窗汇聚点外，查词失败/
@@ -123,6 +146,7 @@ function fushiResumePausedForLookup() {
   if (!fushiPausedForLookup) return;
   const pausedVideo = fushiPausedForLookup;
   fushiPausedForLookup = null;
+  fushiPlayDismissTarget = null; // 我们自己的恢复不算「用户手动播放」，先解除武装
   try {
     if (pausedVideo.isConnected !== false && pausedVideo.paused) {
       const played = pausedVideo.play();
@@ -1556,14 +1580,46 @@ function fushiClearHighlightOverlay() {
   }
 }
 
+// 当前原生选区是否落在宿主页可编辑区（input/textarea/contenteditable）里。用户在编辑器里
+// 选中/放好 caret 通常是为了输入或粘贴——那不是我们的选区，绝不能清。contenteditable 的选区
+// 走 window.getSelection()（input/textarea 的不走，天然幸免），富文本框架（Lexical/ProseMirror
+// 等）靠 selectionchange 维护内部态，被 removeAllRanges 抹掉后粘贴会静默丢弃。
+function fushiNodeInEditable(node) {
+  try {
+    if (!node) return false;
+    let el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+    while (el) {
+      const tag = el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+      if (el.isContentEditable === true) return true;
+      if (typeof el.getAttribute === 'function') {
+        const ce = el.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true') return true;
+      }
+      el = el.parentElement;
+    }
+  } catch (_) {}
+  return false;
+}
+function fushiSelectionInEditable() {
+  try {
+    const sel = window.getSelection && window.getSelection();
+    return fushiNodeInEditable(sel && sel.anchorNode);
+  } catch (_) { return false; }
+}
+
 // TODO-1279：清掉浏览器原生文本选区（window.getSelection 的蓝色高亮）。只动原生 DOM Selection，
 // 不碰我们自绘的 #fushi-highlight-overlay 覆盖层（独立 <div>，与原生选区无关），也不碰
 // fushiSelection.selection（纯 JS 取词状态，覆盖层就从它的 ranges 只读取几何）。塌缩/空选区时
-// no-op：避免无谓清掉输入框 caret 或没有可见蓝色时反复调用。
+// no-op：避免无谓清掉输入框 caret 或没有可见蓝色时反复调用。落在可编辑区的选区也 no-op：
+// 那是用户为输入/粘贴准备的（Ctrl+Shift+V 的 Shift 会触发本清理路径——用户报「开着插件
+// 有时无法粘贴」的主根因）。
 function fushiClearNativeSelection() {
   try {
     const sel = window.getSelection && window.getSelection();
-    if (sel && sel.rangeCount > 0 && !sel.isCollapsed) sel.removeAllRanges();
+    if (!sel || !(sel.rangeCount > 0) || sel.isCollapsed) return;
+    if (fushiSelectionInEditable()) return;
+    sel.removeAllRanges();
   } catch (_) { /* 某些跨域/detached 上下文 getSelection 可能抛：静默 */ }
 }
 
@@ -1660,8 +1716,12 @@ function fushiRemoveContainer() {
   // 嵌套查词只换弹窗内容、不经此处，天然不会提前恢复——与 app「整栈关空才恢复」同语义。
   fushiResumePausedForLookup();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。fushiSelection 未加载/无选区时是 no-op。
+  // 例外：当前原生选区/caret 落在宿主可编辑区时不清——那是用户点进输入框准备输入/粘贴放的
+  // caret（本 mousedown 关窗恰好发生在那一击上），clearSelection 的 removeAllRanges 会把
+  // 富文本编辑器刚放好的插入点抹掉 → 粘贴静默失效（用户报「开着插件有时无法粘贴」）。
   try {
-    if (window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
+    if (!fushiSelectionInEditable() &&
+        window.fushiSelection && typeof window.fushiSelection.clearSelection === 'function') {
       window.fushiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
@@ -1824,6 +1884,11 @@ function fushiSendLookup(term, anchorRect, cueWindow) {
   if (fushiPauseOnLookup && !(fushiPausedForLookup && fushiPausedForLookup.paused)) {
     try { const _v = fushiFindPlayingVideo(); if (_v) { _v.pause(); fushiMarkPausedForLookup(_v); } } catch (_) {}
   }
+  // 即使这次没有可暂停的（视频早已是暂停态，含用户自己暂停的），也武装「手动播放即关浮层」：
+  // 用户按下播放就是「继续看片」，查词浮层不该留着挡画面。
+  if (fushiPauseOnLookup) {
+    try { fushiArmPlayDismiss(fushiPausedForLookup || document.querySelector('video')); } catch (_) {}
+  }
   fushiPending = true;
   fushiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
   // SW 在消息在途时被回收（BUG-1024）：回调永不触发，下面的失败恢复路径也到不了。兜底：
@@ -1962,10 +2027,17 @@ window.fushiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
 window.fushiPrepareLookupFromSidePanel = function (cueWindow) {
   fushiPendingCueWindow = cueWindow && typeof cueWindow === 'object' ? cueWindow : null;
   if (fushiPauseOnLookup) {
-    // Side Panel 自渲染词典、没有「面板关闭」回调到 content script，故此路径只暂停、
-    // 不记 fushiPausedForLookup（否则会被后续无关的页面弹窗关闭误恢复）；恢复由用户手动。
-    try { const video = fushiFindPlayingVideo(); if (video) video.pause(); } catch (_) {}
+    // Side Panel 现在有关闭回调（fushiSubtitleSidePanelLookupClosed → fushiLookupClosedFromSidePanel），
+    // 与页面弹窗同语义：暂停并记录，面板关闭即恢复；手动播放（fushiArmPlayDismiss）即关浮层。
+    try { const video = fushiFindPlayingVideo(); if (video) { video.pause(); fushiMarkPausedForLookup(video); } } catch (_) {}
+    try { fushiArmPlayDismiss(fushiPausedForLookup || document.querySelector('video')); } catch (_) {}
   }
+  return true;
+};
+// Side Panel 查词面板真正关闭时由 subtitle-panel.js 转发到这里：恢复由查词暂停的视频。
+// 「手动播放→dismiss 消息→面板 close→这里」的环路安全：那时标记已被 play 监听清掉，恢复是 no-op。
+window.fushiLookupClosedFromSidePanel = function () {
+  fushiResumePausedForLookup();
   return true;
 };
 window.fushiMineFromSidePanel = function (fields, cueWindow) {
@@ -2350,8 +2422,13 @@ function fushiRender(popupJson, termLen, theme, anchorRect) {
     if (hl.rects.length) {
       fushiDrawHighlightOverlay(hl.rects); // 覆盖层高亮：宿主页 DOM 重绘/事件冲不掉它
       wordRect = hl.bounds;
-    } else if (window.fushiSelection && typeof window.fushiSelection.highlightSelection === 'function') {
+    } else if (window.fushiSelection && typeof window.fushiSelection.highlightSelection === 'function' &&
+        !(window.fushiSelection.selection && window.fushiSelection.selection.ranges &&
+          window.fushiSelection.selection.ranges[0] &&
+          fushiNodeInEditable(window.fushiSelection.selection.ranges[0].startContainer))) {
       // 兜底：selection 结构异常（无 ranges）时退回旧的 bbox 计算，只为拿锚点，不画 DOM 包裹高亮。
+      // 被查词落在宿主可编辑区时跳过——扩展里 highlightSelection 走 DOM 包裹路径
+      // （__fushiCssHighlightsSupported=false），改写编辑器文本节点会打散其内部模型与 caret。
       wordRect = window.fushiSelection.highlightSelection(termLen);
     }
   } catch (_) { wordRect = null; }

--- a/tools/browser-extension/native-selection-clear.test.js
+++ b/tools/browser-extension/native-selection-clear.test.js
@@ -13,8 +13,9 @@ const vm = require('node:vm');
 
 const CONTENT = path.join(__dirname, 'content.js');
 
-// 返回带可追踪 getSelection 的 sandbox 加载结果。initialSelectionCollapsed 控制原生选区是否可见。
-function loadContent({ collapsed = false } = {}) {
+// 返回带可追踪 getSelection 的 sandbox 加载结果。collapsed 控制原生选区是否可见；
+// anchorNode 可注入选区锚点（模拟选区落在 contenteditable 等可编辑区）。
+function loadContent({ collapsed = false, anchorNode = null } = {}) {
   const src = fs.readFileSync(CONTENT, 'utf8');
   const docListeners = Object.create(null);
   const winListeners = Object.create(null);
@@ -25,6 +26,7 @@ function loadContent({ collapsed = false } = {}) {
   const nativeSelection = {
     rangeCount: 1,
     isCollapsed: collapsed,
+    anchorNode,
     removeAllRanges() {
       removeAllRangesCalls += 1;
       this.rangeCount = 0;
@@ -118,4 +120,29 @@ test('塌缩选区（仅 caret，无可见蓝色）：不做无谓 removeAllRang
   const ev = { shiftKey: true, buttons: 0, clientX: 300, clientY: 400 };
   for (const fn of docListeners.mousemove) fn(ev);
   assert.strictEqual(getRemoveCalls(), 0, '塌缩选区无可见蓝色，不应调用 removeAllRanges');
+});
+
+test('选区落在 contenteditable 里：绝不清（用户报「开着插件有时无法粘贴」的主根因）', () => {
+  // Ctrl+Shift+V（粘贴为纯文本）按下期间 Shift 在按住态，任何一次 mousemove 都会走清理路径；
+  // 富文本编辑器（Lexical/ProseMirror 等）的选区被 removeAllRanges 抹掉后粘贴静默丢弃。
+  const editor = {
+    nodeType: 1,
+    tagName: 'DIV',
+    getAttribute: (name) => (name === 'contenteditable' ? 'true' : null),
+    parentElement: null,
+  };
+  const textNode = { nodeType: 3, parentElement: editor };
+  const { docListeners, getRemoveCalls } = loadContent({ collapsed: false, anchorNode: textNode });
+  const ev = { shiftKey: true, buttons: 0, clientX: 300, clientY: 400 };
+  for (const fn of docListeners.mousemove) fn(ev);
+  assert.strictEqual(getRemoveCalls(), 0, '可编辑区内的选区是用户为输入/粘贴准备的，绝不能清');
+});
+
+test('普通页面选区（非可编辑区锚点）仍照常清理，TODO-1279 行为不回退', () => {
+  const plain = { nodeType: 1, tagName: 'P', getAttribute: () => null, parentElement: null };
+  const textNode = { nodeType: 3, parentElement: plain };
+  const { docListeners, getRemoveCalls } = loadContent({ collapsed: false, anchorNode: textNode });
+  const ev = { shiftKey: true, buttons: 0, clientX: 300, clientY: 400 };
+  for (const fn of docListeners.mousemove) fn(ev);
+  assert.ok(getRemoveCalls() >= 1, '非可编辑区选区仍应清掉（多余蓝色选区问题不回退）');
 });

--- a/tools/browser-extension/shift-hover.test.js
+++ b/tools/browser-extension/shift-hover.test.js
@@ -235,6 +235,20 @@ test('查词暂停后用户手动播放又手动暂停：关窗不得把用户�
   assert.strictEqual(h.video.paused, true);
 });
 
+test('查词暂停后用户手动播放：页面弹窗关闭并广播 fushiLookupDismiss 给 Side Panel', () => {
+  const h = loadContentAndFireShift();
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.paused, true, '查词先暂停');
+  // 用户手动点播放：关浮层 + 广播 dismiss。
+  h.video.paused = false;
+  h.video.emit('play');
+  const dismiss = h.sent.filter((m) => m && m.type === 'fushiLookupDismiss');
+  assert.strictEqual(dismiss.length, 1, '手动播放必须广播 dismiss（Side Panel 靠它关面板）');
+  // 弹窗已随手动播放关闭：再点外部不得再有任何 play 动作。
+  for (const fn of h.docListeners.mousedown || []) fn({ target: {} });
+  assert.strictEqual(h.video.playCount, 0, '手动播放后扩展不得再碰播放状态');
+});
+
 test('查词失败（无弹窗可关）时立即恢复被查词暂停的视频，暂停不得没有出口', () => {
   const h = loadContentAndFireShift({ response: { ok: false, error: 'ECONNREFUSED' } });
   fireShiftLookup(h.docListeners, 300, 400);

--- a/tools/browser-extension/side-panel-performance.test.js
+++ b/tools/browser-extension/side-panel-performance.test.js
@@ -17,7 +17,7 @@ test('subtitle row click seeks unless this row owns a native text selection', ()
     /row\.addEventListener\('click'[\s\S]*?!selection\.isCollapsed[\s\S]*?row\.contains\(anchorElement\)[\s\S]*?fushiSubtitleSidePanelSeek/,
   );
   assert.match(SIDE_PANEL, /timestamp\.addEventListener\('click'[\s\S]*?event\.stopPropagation\(\)/);
-  assert.doesNotMatch(SIDE_PANEL, /text\.addEventListener\('click'/);
+  // 行内文字 click=查词已恢复（详见下方专项守卫）；seek 只属于时间戳与行空白区域。
 });
 
 test('Shift scans immediately at the last pointer without changing native selection', () => {
@@ -28,6 +28,32 @@ test('Shift scans immediately at the last pointer without changing native select
     /event\.key === 'Shift'[\s\S]*?!event\.repeat[\s\S]*?lookupAtPointer\(lastPointer, true\)/,
   );
   assert.doesNotMatch(SIDE_PANEL, /removeAllRanges|preventDefault\(\)/);
+});
+
+test('subtitle text click looks up the word (restored after native side-panel migration)', () => {
+  // 行内文字单击=查词曾在 4ade5cae5f（迁原生 Side Panel）时随旧 UI 层一起丢失，用户复诉
+  // 「点击查词不见了，只能 Shift 查」。钉三件事：text 有 click 监听、带选区守卫（保住双击
+  // 选择文本）、stopPropagation（不冒泡成 row 的 seek），且走显式手势分支（announceMissing=true）。
+  assert.match(
+    SIDE_PANEL,
+    /text\.addEventListener\('click'[\s\S]*?isCollapsed[\s\S]*?stopPropagation\(\)[\s\S]*?lookupAtPointer\(\{[\s\S]*?\}, true\)/,
+  );
+});
+
+test('lookup pane closes on manual play dismiss / panel blur / list scroll', () => {
+  assert.match(SIDE_PANEL, /msg\.type === 'fushiLookupDismiss'[\s\S]*?closeLookup\(\)/);
+  assert.match(SIDE_PANEL, /window\.addEventListener\('blur', function \(\) \{ closeLookup\(\); \}\)/);
+  assert.match(SIDE_PANEL, /listEl\.addEventListener\('wheel', function \(\) \{ closeLookup\(\); \}, \{ passive: true \}\)/);
+  // 面板真关掉时通知 content 恢复由查词暂停的视频。
+  assert.match(SIDE_PANEL, /wasOpen[\s\S]*?fushiSubtitleSidePanelLookupClosed/);
+});
+
+test('lookup pane is user-resizable and persists via the popupSize channel', () => {
+  const css = fs.readFileSync(path.join(__dirname, 'side-panel.css'), 'utf8');
+  assert.match(css, /\.lookup-pane \{[^}]*resize: both/);
+  assert.match(SIDE_PANEL, /lookupUserResized = true;[\s\S]*?type: 'popupSize'/);
+  // 用户拖过后主题下发不得再覆盖宽高。
+  assert.match(SIDE_PANEL, /if \(!lookupUserResized\) \{[\s\S]*?--fushi-popup-max-width/);
 });
 
 test('side-panel lookup reuses the Shift popup host model and parsed results', () => {

--- a/tools/browser-extension/side-panel.css
+++ b/tools/browser-extension/side-panel.css
@@ -87,6 +87,46 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   margin-top: 8px;
 }
 
+/* ── Jimaku 查字幕（asb 式云端字幕搜索） ── */
+.jimaku-row {
+  display: grid;
+  grid-template-columns: 1fr 52px 40px;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.jimaku-row input {
+  min-height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+}
+
+.jimaku-results {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
+.jimaku-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 10px;
+  text-align: left;
+}
+
+.jimaku-item-name { font-weight: 600; word-break: break-all; }
+.jimaku-item-meta { color: var(--muted); font-size: 12px; }
+.jimaku-empty { color: var(--muted); font-size: 12px; padding: 4px 2px; }
+
 #offset-value { text-align: center; color: var(--muted); font-variant-numeric: tabular-nums; }
 
 .subtitle-list {
@@ -133,6 +173,11 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
 }
 
 .lookup-pane {
+  /* 拖拽调整大小：浏览器原生右下角把手（Side Panel 是独立文档，无宿主页 CSS 战争）。
+     配套的 userResized 门在 side-panel.js（主题下发不再覆盖用户宽高 + 回写 app 尺寸键）。 */
+  resize: both;
+  min-width: 250px;
+  min-height: 120px;
   position: fixed;
   z-index: 4;
   top: 0;

--- a/tools/browser-extension/side-panel.html
+++ b/tools/browser-extension/side-panel.html
@@ -15,6 +15,7 @@
       </div>
       <div class="toolbar" aria-label="字幕工具">
         <button id="load" type="button" title="加载外挂字幕">＋</button>
+        <button id="jimaku" type="button" title="从 Jimaku 搜索字幕">J</button>
         <button id="smaller" type="button" title="缩小字号">A−</button>
         <button id="larger" type="button" title="放大字号">A＋</button>
         <button id="auto-scroll" class="is-on" type="button" title="自动滚动到当前句">AS</button>
@@ -23,6 +24,12 @@
     </div>
     <input id="subtitle-file" type="file" accept=".srt,.ass,.ssa,.vtt" multiple hidden>
     <select id="track" aria-label="字幕轨" hidden></select>
+    <div id="jimaku-row" class="jimaku-row" hidden>
+      <input id="jimaku-query" type="search" placeholder="Jimaku 搜字幕（日文原名命中率最高）" aria-label="Jimaku 搜索词">
+      <input id="jimaku-ep" type="number" min="1" placeholder="集" title="集数（可选）" aria-label="集数">
+      <button id="jimaku-go" type="button" title="搜索">搜</button>
+    </div>
+    <div id="jimaku-results" class="jimaku-results" hidden></div>
     <div id="offset" class="offset-row" hidden>
       <button type="button" data-offset="-500">−0.5</button>
       <button type="button" data-offset="-100">−0.1</button>

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -54,6 +54,10 @@
   // 本地服务与 6 连接上限灌满。0=无在途；带截止时间兜底，任何异常都不会永久闸死。
   var lookupPendingSince = 0;
   var LOOKUP_PENDING_TIMEOUT_MS = 1500;
+  // 用户拖过查词面板尺寸（CSS resize 把手）后置 true：本会话内主题下发/落点重算不再覆盖
+  // 用户宽高；拖拽结果经 popupSize 回写 app（与页面弹窗同一把「拖即解锁」尺寸键）。
+  var lookupUserResized = false;
+  var lookupResizeSnapshot = null;
   // 复杂词的 popupJson 可超过 2 MB，解析后的对象树通常还会膨胀数倍。只按“48 个词”
   // 淘汰会让 Side Panel 很快常驻数百 MB，并在后续查词时触发秒级 GC。双门槛保留常用
   // 小词，同时让超大结果最多只占少量槽位；最新一条即使单独超预算也保留以支持复查。
@@ -135,6 +139,7 @@
   }
 
   function closeLookup() {
+    var wasOpen = !lookupPaneEl.hidden;
     lookupRequestId += 1;
     if (Number.isInteger(window._renderGeneration)) window._renderGeneration += 1;
     window._renderInProgress = false;
@@ -145,6 +150,10 @@
     currentLookupAnchor = null;
     currentLookupPerfContext = null;
     activeScanKey = '';
+    // 面板真关掉时通知视频页：由查词暂停的视频该恢复了（content 侧只恢复「确实是查词
+    // 暂停的」，用户自己暂停的不动）。「手动播放→content 反向 dismiss→这里 close」的
+    // 环路安全：那时暂停标记已被 play 监听清掉，恢复是 no-op。
+    if (wasOpen) sendToTab({ type: 'fushiSubtitleSidePanelLookupClosed' });
   }
 
   function positionLookup(anchor) {
@@ -158,7 +167,9 @@
       lookupPaneEl.style.left = '0px';
       lookupPaneEl.style.top = '0px';
     }
-    lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    if (!lookupUserResized) {
+      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    }
     requestAnimationFrame(function () {
       if (requestId !== lookupRequestId || lookupPaneEl.hidden) return;
       var gap = 4;
@@ -207,10 +218,14 @@
     }
     var wheelSpeed = parseFloat(theme['--fushi-wheel-speed']);
     window.__fushiPopupWheelSpeed = isFinite(wheelSpeed) && wheelSpeed > 0 ? wheelSpeed : 1;
-    lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
+    // 用户拖过尺寸（lookupUserResized）后，本会话内不再让主题下发的宽高盖掉用户的选择；
+    // 拖拽结果经 popupSize 回写 app，下次会话由主题带回来。
+    if (!lookupUserResized) {
+      lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
+      lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
+      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
+    }
     lookupPaneEl.style.maxWidth = 'calc(100vw - 16px)';
-    lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
-    lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
     lookupPaneEl.style.zoom = theme['--fushi-popup-zoom'] || '1';
   }
 
@@ -624,7 +639,20 @@
       var text = document.createElement('div');
       text.className = 'subtitle-text';
       text.textContent = cue.text;
-      text.title = '单击跳转；按住 Shift 指向文字查词；双击选择文本';
+      text.title = '单击文字查词；点击时间或行空白跳转；双击选择文本；按住 Shift 悬停扫词';
+      text.addEventListener('click', function (event) {
+        // 行内文字单击=查词（asbplayer 同款；8-11 迁原生 Side Panel 时随旧 UI 层一起丢了，
+        // 用户报「点击查词不见了，只能 Shift 查」）。拖选/双击形成的选区在场时不查，
+        // 保住「双击选择文本」。
+        try {
+          var clickSel = window.getSelection && window.getSelection();
+          if (clickSel && !clickSel.isCollapsed) return;
+        } catch (_) {}
+        event.stopPropagation(); // 不冒泡到 row 的 seek：点文字=查词、点行其它区域=跳转
+        lookupAtPointer({
+          x: event.clientX, y: event.clientY, cue: cue, index: index, textEl: text,
+        }, true);
+      });
       function rememberPointer(event) {
         lastPointer = {
           x: event.clientX, y: event.clientY, cue: cue, index: index, textEl: text,
@@ -784,6 +812,126 @@
     fileEl.value = '';
   });
 
+  // ── Jimaku 查字幕（asb 式云端字幕）：搜索框 → server /api/subtitle/jimaku/search（用户在
+  // app 设置里填的 API key；真人剧 anime=false 补搜在 server 侧）→ 点候选下载解析 →
+  // 复用外挂字幕的 InstallTrack 落地（与本地文件同一条轨/偏移/覆盖层链路）。
+  var jimakuRowEl = document.getElementById('jimaku-row');
+  var jimakuQueryEl = document.getElementById('jimaku-query');
+  var jimakuEpEl = document.getElementById('jimaku-ep');
+  var jimakuResultsEl = document.getElementById('jimaku-results');
+  function jimakuErrorText(data, response) {
+    var error = data && data.error;
+    if (error === 'no-api-key') return '请先在 Fushi 设置 → 视频 → 字幕 填写 Jimaku API key';
+    if (error === 'unauthorized') return 'Jimaku API key 无效或无权限';
+    if (error === 'rate-limited') return 'Jimaku 限流，请稍后再试';
+    if (error === 'missing-query') return '请输入搜索词';
+    if (!response || response.ok !== true) return 'Jimaku 搜索失败：请确认 Fushi 已启动';
+    return 'Jimaku 暂不可用，请稍后再试';
+  }
+  async function jimakuInstall(candidate) {
+    toast('正在下载：' + candidate.fileName);
+    var response = await sendRuntime({ type: 'jimakuFetch', handle: candidate.handle });
+    var data = response && response.data;
+    if (!response || response.ok !== true || !data || data.ok !== true ||
+        !Array.isArray(data.cues) || !data.cues.length) {
+      toast(data && data.error === 'unknown-handle'
+        ? '候选已过期，请重新搜索'
+        : (data && data.error === 'unsupported' ? '不支持的字幕格式' : jimakuErrorText(data, response)));
+      return;
+    }
+    var state = await sendToTab({
+      type: 'fushiSubtitleSidePanelInstallTrack',
+      filename: data.filename || candidate.fileName,
+      cues: data.cues,
+    });
+    if (state && state.ok) {
+      stateSignature = metadataSignature(state);
+      applyState(state, true);
+      jimakuResultsEl.hidden = true;
+      jimakuResultsEl.textContent = '';
+      toast('已加载 Jimaku 字幕：' + data.cues.length + ' 句');
+    }
+  }
+  function renderJimakuResults(candidates, truncated) {
+    jimakuResultsEl.textContent = '';
+    if (!candidates.length) {
+      var empty = document.createElement('div');
+      empty.className = 'jimaku-empty';
+      empty.textContent = '无结果。试试日文原名，或填集数缩小范围。';
+      jimakuResultsEl.appendChild(empty);
+      jimakuResultsEl.hidden = false;
+      return;
+    }
+    candidates.forEach(function (candidate) {
+      var row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'jimaku-item';
+      var name = document.createElement('span');
+      name.className = 'jimaku-item-name';
+      name.textContent = candidate.fileName;
+      var meta = document.createElement('span');
+      meta.className = 'jimaku-item-meta';
+      meta.textContent = candidate.entryName +
+        (candidate.language ? ' · ' + candidate.language : '') +
+        (candidate.episode != null ? ' · 第' + candidate.episode + '集' : '');
+      row.appendChild(name);
+      row.appendChild(meta);
+      row.addEventListener('click', function () { jimakuInstall(candidate); });
+      jimakuResultsEl.appendChild(row);
+    });
+    if (truncated) {
+      var more = document.createElement('div');
+      more.className = 'jimaku-empty';
+      more.textContent = '结果过多已截断，填集数可缩小范围。';
+      jimakuResultsEl.appendChild(more);
+    }
+    jimakuResultsEl.hidden = false;
+  }
+  var jimakuSearching = false;
+  async function jimakuSearch() {
+    if (jimakuSearching) return;
+    var query = String(jimakuQueryEl.value || '').trim();
+    if (!query) { toast('请输入搜索词'); return; }
+    var episode = parseInt(jimakuEpEl.value, 10);
+    jimakuSearching = true;
+    toast('正在搜索 Jimaku…');
+    try {
+      var response = await sendRuntime({
+        type: 'jimakuSearch',
+        query: query,
+        ...(Number.isInteger(episode) && episode > 0 ? { episode: episode } : {}),
+      });
+      var data = response && response.data;
+      if (!response || response.ok !== true || !data || data.ok !== true) {
+        toast(jimakuErrorText(data, response));
+        return;
+      }
+      renderJimakuResults(Array.isArray(data.candidates) ? data.candidates : [],
+        data.truncated === true);
+    } finally {
+      jimakuSearching = false;
+    }
+  }
+  document.getElementById('jimaku').addEventListener('click', function () {
+    var show = jimakuRowEl.hidden;
+    jimakuRowEl.hidden = !show;
+    if (!show) { jimakuResultsEl.hidden = true; return; }
+    // 预填当前标签页标题（长显示名命中率低，用户可改成日文原名——placeholder 已提示）。
+    if (!jimakuQueryEl.value && currentTabId != null) {
+      try {
+        chrome.tabs.get(currentTabId, function (tab) {
+          try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+          if (tab && tab.title && !jimakuQueryEl.value) jimakuQueryEl.value = tab.title;
+        });
+      } catch (_) {}
+    }
+    jimakuQueryEl.focus();
+  });
+  document.getElementById('jimaku-go').addEventListener('click', function () { jimakuSearch(); });
+  jimakuQueryEl.addEventListener('keydown', function (event) {
+    if (event.key === 'Enter') jimakuSearch();
+  });
+
   document.getElementById('smaller').addEventListener('click', function () {
     fontStep = Math.max(0, fontStep - 1);
     document.documentElement.style.setProperty('--subtitle-scale', String(FONT_STEPS[fontStep]));
@@ -820,6 +968,46 @@
       closeLookup();
     }
   });
+  // 「popup 不好关」的补齐三路：①content.js 在用户手动播放视频时反向推送 dismiss（页面弹窗
+  // 与本面板一起关）；②焦点离开 Side Panel（点回网页/播放器）即关；③滚动字幕列表（锚点行
+  // 已滚走，浮窗不该原地留着）即关。均幂等，重复触发无副作用。
+  try {
+    chrome.runtime.onMessage.addListener(function (msg) {
+      if (msg && msg.type === 'fushiLookupDismiss') closeLookup();
+    });
+  } catch (_) {}
+  window.addEventListener('blur', function () { closeLookup(); });
+  listEl.addEventListener('wheel', function () { closeLookup(); }, { passive: true });
+  listEl.addEventListener('touchmove', function () { closeLookup(); }, { passive: true });
+  // 查词面板拖拽调整大小（CSS resize 把手在右下角）：pointerdown 落在右下角 20px 内时快照
+  // 尺寸，松手时尺寸真变了才算「用户拖过」——置 lookupUserResized + 回写 app 尺寸键
+  // （app clamp 后按「拖即解锁」持久化，下次查词/会话经主题带回来）。
+  lookupPaneEl.addEventListener('pointerdown', function (event) {
+    try {
+      var rect = lookupPaneEl.getBoundingClientRect();
+      lookupResizeSnapshot =
+        (rect.right - event.clientX <= 20 && rect.bottom - event.clientY <= 20)
+          ? { w: rect.width, h: rect.height }
+          : null;
+    } catch (_) { lookupResizeSnapshot = null; }
+  }, { passive: true });
+  window.addEventListener('pointerup', function () {
+    if (!lookupResizeSnapshot) return;
+    var snap = lookupResizeSnapshot;
+    lookupResizeSnapshot = null;
+    var rect;
+    try { rect = lookupPaneEl.getBoundingClientRect(); } catch (_) { return; }
+    if (Math.abs(rect.width - snap.w) < 3 && Math.abs(rect.height - snap.h) < 3) return;
+    lookupUserResized = true;
+    var zoom = parseFloat(lookupPaneEl.style.zoom) || 1;
+    lookupBaseMaxHeight = Math.round(rect.height / zoom) + 'px';
+    lookupPaneEl.style.maxHeight = '';
+    sendRuntime({
+      type: 'popupSize',
+      maxWidth: Math.round(rect.width / zoom),
+      maxHeight: Math.round(rect.height / zoom),
+    });
+  }, { passive: true });
   window.addEventListener('load', function () {
     // popup.js 在扩展上下文只暴露监听器；与 content.js 的 Shift host 一样，把它
     // 限定挂在常驻 shadow host，避免污染整个 Side Panel 的滚动快速路径。

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -646,6 +646,14 @@
         sendResponse({ ok: handled });
         return false;
       }
+      if (msg.type === 'fushiSubtitleSidePanelLookupClosed') {
+        // Side Panel 查词面板关闭 → 恢复由查词暂停的视频（content.js 只恢复「确实是查词
+        // 暂停的」，用户自己暂停的不动）。
+        var closed = typeof window.fushiLookupClosedFromSidePanel === 'function' &&
+          window.fushiLookupClosedFromSidePanel() === true;
+        sendResponse({ ok: closed });
+        return false;
+      }
       if (msg.type === 'fushiSubtitleSidePanelMine') {
         var mineCue = msg.cue && typeof msg.cue === 'object' ? msg.cue : null;
         var result = typeof window.fushiMineFromSidePanel === 'function'

--- a/tools/browser-extension/video-shortcuts.js
+++ b/tools/browser-extension/video-shortcuts.js
@@ -157,6 +157,15 @@
         e.key !== 'ArrowLeft' && e.key !== 'ArrowRight' && e.key !== 'ArrowUp') {
       return;
     }
+    // Shadow DOM 里的编辑器：e.target 被 retarget 成宿主自定义元素，isEditable 会误判 false，
+    // Ctrl+Shift+Z（编辑器重做）等会被快捷键抢走。composedPath()[0] 才是真实目标。
+    var realTarget = e.target;
+    try {
+      if (typeof e.composedPath === 'function') {
+        var path = e.composedPath();
+        if (path && path.length) realTarget = path[0];
+      }
+    } catch (_) {}
     var decision = api.decide(
       {
         key: e.key,
@@ -164,7 +173,7 @@
         ctrl: e.ctrlKey || e.metaKey,
         shift: e.shiftKey,
         alt: e.altKey,
-        editable: isEditable(e.target),
+        editable: isEditable(realTarget),
       },
       {
         enabled: true,


### PR DESCRIPTION
## 这条分支为什么在这里

PR #857 显示 MERGED，但那次合并**之后**又追加了 3 条提交，从此没进过 `develop`。`fushi/lib/src/sync/remote_jimaku_subtitle_handlers.dart` 等 4 个文件在 `develop` 上不存在。

## 内容

扩展侧栏查词 UX 批次 + 粘贴修复 + Jimaku 字幕搜索（BUG-1672 / BUG-1673）。未落地约 **+1352 行 / 23 个文件**。

## 提醒

弹窗/扩展样式是三镜像结构（`fushi/assets/popup/`、`fushi/assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`），合并后请确认三份仍然一致，且 `content.css` 由 `tools/browser-extension/scripts/generate-content-css.mjs` 重新生成。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
