### PR TITLE
fix(focus)!: BUG-1619 主窗不在前台时整棵焦点树不可聚焦（从未开 PR）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1508 条。点号进各自文件。
+> 共 1509 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1619](bugs/BUG-1619-panel-drag-steals-foreground.md) | ✅ | ✅ | 拖剪贴板查词面板顶栏把主窗抢到前台 |
 | [BUG-1608](bugs/BUG-1608-mobile-ankiconnect-ios-missing-and-silent-fallback.md) | ✅ | ✅ | iOS 没接 AnkiConnect（Lapis 区永远隐藏）；移动端清空 API key 后开关静默失效 |
 | [BUG-1607](bugs/BUG-1607-danmaku-exit-relayout.md) | ✅ | ✅ | 弹幕退场时其余弹幕整屏重排 |
 | [BUG-1606](bugs/BUG-1606-gal-ingame-lookup-card-dismissed-by-other-text-layer.md) | ✅ | ✅ | gal 游戏内查词卡片被无关文本层重绘打掉（说话人切换时闪没） |

--- a/docs/bugs/BUG-1619-panel-drag-steals-foreground.md
+++ b/docs/bugs/BUG-1619-panel-drag-steals-foreground.md
@@ -3,7 +3,24 @@
 - **真实性**：✅ 真 bug。根因 `fushi/lib/src/focus/fushi_focus_controller.dart:293` `ensureFocus()`——被动焦点修复在**主窗不在前台**时仍 `requestFocus`，Flutter 引擎把它翻译成 `SetFocus(FlutterView)`，Win32 语义下 `SetFocus(子窗)` 连带激活其顶层窗口，于是主界面盖住用户正在用的游戏 / 浏览器。
 - **[x] ① 根因修复** — commit 见本文件所在分支：`ensureFocus()` 增加**窗口级**前台判据并在被挡下时记账，主窗回到前台由 `_handleFocusChange` 补一次修复；`PageFocusOwnership.reclaim(appResumed)` 与首页 `_reclaimHomeFocusIfOwned` 同判据（进程级 `resumed` 同样会被辅助窗夺焦误触发）；`DesktopForegroundGuard.isMainWindowForeground()` 为新增判据。
 - **[x] ② 已加自动化测试** — `fushi/test/focus/background_focus_repair_test.dart`（3 例：挡下 / 放行 / 补票）+ `fushi/test/focus/resumed_focus_reclaim_guard_test.dart`（6 例，含类名常量与 runner 逐字符一致的源码扫描）。两处判据与补票逻辑均做过变异实测：分别删掉即有对应用例转红。
+- **[x] ③ 根治层（第二轮）** — 逐点判据穷举不完（用户随后报「复制文本也会被拉到前台」，那条链路在全仓 16 处 `requestFocus` 里定位不到），故在 app 根部立结构性不变量：`MainWindowFocusGate` —— 主窗不拥有 OS 焦点时整棵 Flutter 焦点树不可聚焦，任何 `requestFocus` 都是 no-op。配套两级恢复：关门前记录 primaryFocus、开门后精确还给它；还不回去（如 app 在后台启动、路由 ModalScope 在关门期间挂载被挡）则由闸门自己把焦点交进子树。
 - **备注**：真机验收在用户真实数据根上完成（诊断构建 schemaVersion 86 == 库 user_version 86，无迁移）。
+
+### 根治层：为什么是根部不变量而不是逐点判据
+
+三层根因里只有第三层是我们的：① Win32 硬语义 `SetFocus(子窗)` 连带激活顶层窗口；② Flutter 引擎为 IME/键盘无条件对 FlutterView 调 `SetFocus`；③ Fushi 在主窗不在前台时仍发起焦点请求。①② 改不了（除非 fork engine 或 IAT hook `user32!SetFocus`——后者会让 IME 状态错乱且每次引擎升级都可能崩，不采纳）。
+
+第三层落在哪一层实现，决定了它是补丁还是根治：逐点判据要求穷举所有入口，而复制那条至今没定位到；根部不变量让「某处 requestFocus 抢了前台」这个特殊情况**不存在**。
+
+真机 A/B（隔离实例，同一套按键序列）：
+
+| 版本 | 按键到达 Flutter | 开门后 primaryFocus |
+|---|---|---|
+| 闸门启用、无兜底 | ✅ | `View Scope`（退到最外层，页面焦点体系失效） |
+| 闸门禁用（对照） | ✅ | `_ModalScopeState Focus Scope` |
+| **闸门 + 两级恢复** | ✅ | **`FocusNode`（子树内具体节点）** |
+
+门开关序列与焦点恢复实测：`CLOSED`(后台启动) → `OPEN`(激活主窗，兜底交接) → `CLOSED`(切走) → `OPEN`(切回，精确恢复到同一个 FocusNode)。
 
 ### 根因
 

--- a/docs/bugs/BUG-1619-panel-drag-steals-foreground.md
+++ b/docs/bugs/BUG-1619-panel-drag-steals-foreground.md
@@ -1,0 +1,35 @@
+## BUG-1619 · 拖剪贴板查词面板顶栏把主窗抢到前台
+- **报告**：2026-08-14（用户：拖动剪切板弹窗的顶栏的时候，总是会把 fushi 主界面拉到前台）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/focus/fushi_focus_controller.dart:293` `ensureFocus()`——被动焦点修复在**主窗不在前台**时仍 `requestFocus`，Flutter 引擎把它翻译成 `SetFocus(FlutterView)`，Win32 语义下 `SetFocus(子窗)` 连带激活其顶层窗口，于是主界面盖住用户正在用的游戏 / 浏览器。
+- **[x] ① 根因修复** — commit 见本文件所在分支：`ensureFocus()` 增加**窗口级**前台判据并在被挡下时记账，主窗回到前台由 `_handleFocusChange` 补一次修复；`PageFocusOwnership.reclaim(appResumed)` 与首页 `_reclaimHomeFocusIfOwned` 同判据（进程级 `resumed` 同样会被辅助窗夺焦误触发）；`DesktopForegroundGuard.isMainWindowForeground()` 为新增判据。
+- **[x] ② 已加自动化测试** — `fushi/test/focus/background_focus_repair_test.dart`（3 例：挡下 / 放行 / 补票）+ `fushi/test/focus/resumed_focus_reclaim_guard_test.dart`（6 例，含类名常量与 runner 逐字符一致的源码扫描）。两处判据与补票逻辑均做过变异实测：分别删掉即有对应用例转红。
+- **备注**：真机验收在用户真实数据根上完成（诊断构建 schemaVersion 86 == 库 user_version 86，无迁移）。
+
+### 根因
+
+桌面版 Fushi 是**多顶层窗口**进程：主窗之外还有剪贴板查词面板（`FushiGlobalLookupWindow`，`SetActivatable(true)`）、app 外查词覆盖窗、悬浮歌词 / 台词窗。Flutter 的焦点模型只认「一个 view」，Dart 侧任何焦点请求最终都会被引擎翻译成 `SetFocus(FlutterView)`。
+
+完整链路（真机抓到 `win32u!NtUserSetFocus` 调用栈；`SetForegroundWindow` 断点全程未命中，故**不是**显式唤前台）：
+
+```
+拖面板顶栏结束
+  → native WM_EXITSIZEMOVE → windowMoved
+  → ClipboardPanelController 写 clipboard_panel_rect
+  → PreferencesRepository.notifyListeners()
+  → 首页重建 → FushiFocusTarget 重新 register()
+  → FushiFocusController.scheduleRepair() → postFrame → ensureFocus()
+  → requestFocus → 引擎 SetFocus(FlutterView)
+  → Win32：SetFocus(子窗) 连带激活顶层窗口 = 主窗被抬到前台
+```
+
+复现前提（缺一不可，这也是隔离环境长期复现不出来的原因）：主窗**非最小化**、主窗此前被激活过（Dart 焦点落在主窗内）、前台是别的 app。
+
+判据必须是**窗口级**的：真机日志里被挡下的那些 `ensureFocus`，前台窗口是 `FushiGlobalLookupWindow` 且 `mine=true`——沿用既有的进程级判据 `isForegroundOwnedByCurrentProcess()` 会直接放行。
+
+BUG-1455 修的是同一症状的另一条支路（主窗 `WM_ACTIVATE` 里的 `SetFocus(child_content_)`），它拦的是「面板夺焦那一刻」；本 bug 的抢焦点发生在拖动中途与松手后，由引擎主动发起，那条门控结构上拦不住。
+
+### 验证
+
+- 真机（用户真实数据根，Chrome 持有前台）：修复前 `after drag: mainZ=5 rivalZ=7 fg=主窗`（主界面盖住 Chrome）；修复后 `mainZ=7 rivalZ=6 fg=面板`，主窗 Z 序全程不动。
+- 带打点构建实测：拖动结束瞬间 `ensureFocus` 被判据挡下 8 次；主窗切回前台后 `deferred repair -> replayed` + `ensureFocus proceeding`（补票闭环，快捷键不会死）。
+- `flutter test test/focus/` 73 例全绿（既有 70 + 新增 3）；`test/sync/` + `test/pages/` 4948 例全绿；`flutter analyze`（含 test）No issues found。

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:fushi/src/focus/main_window_focus_gate.dart';
 import 'package:macos_ui/macos_ui.dart'
     show MacosTheme, MacosWindow, WindowManipulator;
 import 'package:just_audio_media_kit/just_audio_media_kit.dart';
@@ -151,6 +152,9 @@ void main([List<String> args = const <String>[]]) {
     await recoverLegacyMacosPrefsFromSharedPreferences();
     if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
       await windowManager.ensureInitialized();
+      // BUG-1619：主窗前台真值的唯一来源，必须在 window_manager 初始化之后、
+      // 任何页面挂载之前起来——焦点闸门与焦点控制器都读它。
+      MainWindowForegroundWatcher.instance.start();
       await DesktopWindowPlacement.applyInitialPlacement();
       // Intercept the native window-close signal so we can tear down Bonsoir's
       // mDNS event sources (LAN broadcast + discovery) BEFORE the Flutter engine
@@ -1586,96 +1590,104 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
             // theme so switching themes repaints the system bars. The builder
             // reruns on every theme change, so the AnnotatedRegion re-emits the
             // matching overlay style.
-            return AnnotatedRegion<SystemUiOverlayStyle>(
-              value: fushiSystemOverlayStyle(cs.brightness),
-              child: CupertinoTheme(
-                data:
-                    fushiCupertinoTheme(cs, fontFamily: appModel.appFontFamily),
-                child: LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    final Size viewport = constraints.hasBoundedWidth &&
-                            constraints.hasBoundedHeight
-                        ? constraints.biggest
-                        : MediaQuery.sizeOf(context);
-                    final double uiScale =
-                        appModel.resolveAppUiScaleForViewport(
-                      viewport: viewport,
-                      platform: Theme.of(context).platform,
-                    );
-                    Widget navigation = wrapWithGlobalNavigation(
-                      navigatorKey: appModel.navigatorKey,
-                      focusNavigationEnabled:
-                          appModel.experimentalFocusNavigationEnabled,
-                      registry: appModel.shortcutRegistry,
+            // BUG-1619：整棵 app 焦点树的闸门——主窗不在前台时任何 requestFocus
+            // 都不生效，杜绝「Dart 请求焦点 → 引擎 SetFocus(FlutterView) → Win32
+            // 连带激活主窗」把主界面抢到用户的游戏 / 浏览器前面。见
+            // [MainWindowFocusGate] 的完整推导。
+            return MainWindowFocusGate(
+              child: AnnotatedRegion<SystemUiOverlayStyle>(
+                value: fushiSystemOverlayStyle(cs.brightness),
+                child: CupertinoTheme(
+                  data: fushiCupertinoTheme(cs,
+                      fontFamily: appModel.appFontFamily),
+                  child: LayoutBuilder(
+                    builder:
+                        (BuildContext context, BoxConstraints constraints) {
+                      final Size viewport = constraints.hasBoundedWidth &&
+                              constraints.hasBoundedHeight
+                          ? constraints.biggest
+                          : MediaQuery.sizeOf(context);
+                      final double uiScale =
+                          appModel.resolveAppUiScaleForViewport(
+                        viewport: viewport,
+                        platform: Theme.of(context).platform,
+                      );
+                      Widget navigation = wrapWithGlobalNavigation(
+                        navigatorKey: appModel.navigatorKey,
+                        focusNavigationEnabled:
+                            appModel.experimentalFocusNavigationEnabled,
+                        registry: appModel.shortcutRegistry,
 
-                      // BUG-1349（第二处根因）：焦点导航层（FushiFocusRoot 的
-                      // fallbackNode）必须在全局导航层**之内**。键事件沿焦点树
-                      // 冒泡：fallbackNode 若在 wrapWithGlobalNavigation 之外，
-                      // 零受管目标页把焦点回收到兜底节点后，Esc/全局快捷键根本
-                      // 到不了全局处理器——整个全局键处理静默失效。
-                      child: _wrapFocusNavigation(
-                        enabled: appModel.experimentalFocusNavigationEnabled,
-                        // TODO-354 ①：常驻悬浮字幕查词宿主覆盖在导航之上，让书架/
-                        // 首页开的悬浮字幕（无 reader）点词也能在主窗口弹查词。无
-                        // 挂起请求时整层 IgnorePointer 透传，不抢任何页面的命中测试。
-                        child: Stack(
-                          children: <Widget>[
-                            child!,
-                            const FloatingLyricLookupHost(),
-                          ],
-                        ),
-                      ),
-                    );
-                    if (isMacosPlatform(context)) {
-                      // macOS native shell (Approach B): the MacosWindow + Sidebar
-                      // wrap the WHOLE navigator so every route — home tabs AND
-                      // pushed routes (reader, settings detail, dialogs) — inherits
-                      // a MacosWindowScope and can use native MacosScaffold/ToolBar.
-                      // MacosTheme is derived from the SAME live ColorScheme as the
-                      // rest of the app. The sidebar destinations come from the
-                      // dynamic HomeTab list (video/games toggles) so they
-                      // stay in lock-step with HomePage's rail; selection is shared
-                      // via homeShellTabNotifier. Hide the sidebar while a media
-                      // item (reader/video) is open so reading is full-width; the
-                      // builder reruns when appModel notifies (openMedia/close).
-                      // TODO-1375：sidebar 显隐由 appModel.mediaOpenNotifier 驱动，
-                      // 不再直接读 appModel.isMediaOpen。根因：isMediaOpen 变化不
-                      // notifyListeners，退出阅读器后本 builder 不重跑、sidebar 卡在
-                      // stale null（永久消失→设置 tab 无出口→困死）。改用
-                      // ValueListenableBuilder 监听可靠通知源：退出媒体必重建恢复
-                      // sidebar。navigation（=整个 navigator）作为不变 child 透传，
-                      // 只有 sidebar 参数随 mediaOpen 变，绝不重建 navigator 路由栈。
-                      navigation = MacosTheme(
-                        data: fushiMacosThemeFromColorScheme(cs, cs.brightness),
-                        child: ValueListenableBuilder<bool>(
-                          valueListenable: appModel.mediaOpenNotifier,
-                          builder: (BuildContext context, bool mediaOpen,
-                              Widget? child) {
-                            return MacosWindow(
-                              sidebar: mediaOpen
-                                  ? null
-                                  : buildFushiMacosSidebar(
-                                      activeTabs: homeActiveTabs(
-                                        // 「视频」tab 已毕业为常驻（原
-                                        // experimentalVideoEnabled 恒 true）。games
-                                        // （galgame 库）仅 Windows；macOS 根侧栏此处
-                                        // 恒 false（gamesEnabled 缺省），不显示。
-                                        videoEnabled: true,
-                                        // 浏览器扩展 tab「电脑才有」：此处为 macOS 根
-                                        // 侧栏，macOS 即桌面 → 与底栏/rail 同一门控。
-                                        browserExtensionEnabled:
-                                            DesktopLookupService.isDesktop,
-                                      ),
-                                    ),
-                              child: child!,
-                            );
-                          },
-                          child: navigation,
+                        // BUG-1349（第二处根因）：焦点导航层（FushiFocusRoot 的
+                        // fallbackNode）必须在全局导航层**之内**。键事件沿焦点树
+                        // 冒泡：fallbackNode 若在 wrapWithGlobalNavigation 之外，
+                        // 零受管目标页把焦点回收到兜底节点后，Esc/全局快捷键根本
+                        // 到不了全局处理器——整个全局键处理静默失效。
+                        child: _wrapFocusNavigation(
+                          enabled: appModel.experimentalFocusNavigationEnabled,
+                          // TODO-354 ①：常驻悬浮字幕查词宿主覆盖在导航之上，让书架/
+                          // 首页开的悬浮字幕（无 reader）点词也能在主窗口弹查词。无
+                          // 挂起请求时整层 IgnorePointer 透传，不抢任何页面的命中测试。
+                          child: Stack(
+                            children: <Widget>[
+                              child!,
+                              const FloatingLyricLookupHost(),
+                            ],
+                          ),
                         ),
                       );
-                    }
-                    return FushiAppUiScale(scale: uiScale, child: navigation);
-                  },
+                      if (isMacosPlatform(context)) {
+                        // macOS native shell (Approach B): the MacosWindow + Sidebar
+                        // wrap the WHOLE navigator so every route — home tabs AND
+                        // pushed routes (reader, settings detail, dialogs) — inherits
+                        // a MacosWindowScope and can use native MacosScaffold/ToolBar.
+                        // MacosTheme is derived from the SAME live ColorScheme as the
+                        // rest of the app. The sidebar destinations come from the
+                        // dynamic HomeTab list (video/games toggles) so they
+                        // stay in lock-step with HomePage's rail; selection is shared
+                        // via homeShellTabNotifier. Hide the sidebar while a media
+                        // item (reader/video) is open so reading is full-width; the
+                        // builder reruns when appModel notifies (openMedia/close).
+                        // TODO-1375：sidebar 显隐由 appModel.mediaOpenNotifier 驱动，
+                        // 不再直接读 appModel.isMediaOpen。根因：isMediaOpen 变化不
+                        // notifyListeners，退出阅读器后本 builder 不重跑、sidebar 卡在
+                        // stale null（永久消失→设置 tab 无出口→困死）。改用
+                        // ValueListenableBuilder 监听可靠通知源：退出媒体必重建恢复
+                        // sidebar。navigation（=整个 navigator）作为不变 child 透传，
+                        // 只有 sidebar 参数随 mediaOpen 变，绝不重建 navigator 路由栈。
+                        navigation = MacosTheme(
+                          data:
+                              fushiMacosThemeFromColorScheme(cs, cs.brightness),
+                          child: ValueListenableBuilder<bool>(
+                            valueListenable: appModel.mediaOpenNotifier,
+                            builder: (BuildContext context, bool mediaOpen,
+                                Widget? child) {
+                              return MacosWindow(
+                                sidebar: mediaOpen
+                                    ? null
+                                    : buildFushiMacosSidebar(
+                                        activeTabs: homeActiveTabs(
+                                          // 「视频」tab 已毕业为常驻（原
+                                          // experimentalVideoEnabled 恒 true）。games
+                                          // （galgame 库）仅 Windows；macOS 根侧栏此处
+                                          // 恒 false（gamesEnabled 缺省），不显示。
+                                          videoEnabled: true,
+                                          // 浏览器扩展 tab「电脑才有」：此处为 macOS 根
+                                          // 侧栏，macOS 即桌面 → 与底栏/rail 同一门控。
+                                          browserExtensionEnabled:
+                                              DesktopLookupService.isDesktop,
+                                        ),
+                                      ),
+                                child: child!,
+                              );
+                            },
+                            child: navigation,
+                          ),
+                        );
+                      }
+                      return FushiAppUiScale(scale: uiScale, child: navigation);
+                    },
+                  ),
                 ),
               ),
             );

--- a/fushi/lib/src/focus/fushi_focus_controller.dart
+++ b/fushi/lib/src/focus/fushi_focus_controller.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:fushi/src/focus/focus_geometry.dart';
+import 'package:fushi/src/focus/main_window_focus_gate.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
 import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 
@@ -152,14 +153,32 @@ class FushiFocusController extends ChangeNotifier {
     _rootContext = rootContext;
     if (!_attached) {
       FocusManager.instance.addListener(_handleFocusChange);
+      // BUG-1619：主窗回到前台就补一次修复。焦点闸门在关门期间让出了焦点，
+      // 不补的话用户切回来整页没有焦点、键盘 / 手柄快捷键全不响应。
+      // 与 [_handleFocusChange] 里那条 deferred 补票**并存**是有意的：这条走
+      // window_manager 的窗口事件（可能因 channel 延迟晚到），那条走进程内的
+      // FocusManager 通知（不依赖 channel），两条覆盖不同故障模式。
+      mainWindowForegroundNotifier.addListener(_onMainWindowForegroundChanged);
+      // BUG-1619：主窗回到前台就补一次修复。焦点闸门在关门期间让出了焦点，
+      // 不补的话用户切回来整页没有焦点、键盘 / 手柄快捷键全不响应。
+      // BUG-1619：主窗回到前台就补一次修复。焦点闸门在关门期间让出了焦点，
+      // 不补的话用户切回来整页没有焦点、键盘 / 手柄快捷键全不响应。
       _attached = true;
     }
+    scheduleRepair();
+  }
+
+  void _onMainWindowForegroundChanged() {
+    if (!_attached || !mainWindowForegroundNotifier.value) return;
+    _repairDeferredWhileBackgrounded = false;
     scheduleRepair();
   }
 
   void detach() {
     if (_attached) {
       FocusManager.instance.removeListener(_handleFocusChange);
+      mainWindowForegroundNotifier
+          .removeListener(_onMainWindowForegroundChanged);
       _attached = false;
     }
     _entries.clear();

--- a/fushi/lib/src/focus/fushi_focus_controller.dart
+++ b/fushi/lib/src/focus/fushi_focus_controller.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:fushi/src/focus/focus_geometry.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 
 @immutable
 class FushiFocusId {
@@ -96,6 +97,12 @@ class FushiFocusController extends ChangeNotifier {
   bool _attached = false;
   bool _repairScheduled = false;
   bool _repairMicrotaskScheduled = false;
+
+  /// BUG-1619：有一次被动修复因为「主窗不在前台」被挡下了，欠着。
+  ///
+  /// 主窗真正回到前台时必须补上，否则用户切回来会发现整页没有焦点、键盘 /
+  /// 手柄快捷键全不响应（正是 TODO-900 当初要修的症状）。
+  bool _repairDeferredWhileBackgrounded = false;
 
   BuildContext? get activeContext {
     final FushiFocusTargetEntry? active = _currentEntry();
@@ -291,6 +298,24 @@ class FushiFocusController extends ChangeNotifier {
   }
 
   void ensureFocus() {
+    // BUG-1619：[ensureFocus] 是**被动焦点修复**的汇合点（attach / register /
+    // unregister / scheduleRepair 全落这里），它下面每一条分支都会 requestFocus。
+    //
+    // 桌面版 Fushi 是多顶层窗口进程。主窗不在前台时（用户正在游戏 / 浏览器里，
+    // 剪贴板查词面板浮在上面），Flutter 引擎会把 requestFocus 翻译成
+    // SetFocus(FlutterView)，而 Win32 语义下 SetFocus(子窗) 会**连带激活它的
+    // 顶层窗口** —— 主界面凭空盖住用户正在用的窗口。真机链路：拖面板顶栏结束
+    // → windowMoved → setClipboardPanelRect → PreferencesRepository
+    // .notifyListeners() → 首页重建 → 焦点目标重新 register → scheduleRepair
+    // → 这里 → 主窗被抬到前台。
+    //
+    // 判据只挡**被动修复**：用户显式输入触发的 [move] / [requestById] 不经这里
+    // 的早退（那时主窗必然已经是前台）。被挡下时记账，等主窗真的回到前台再补
+    // 修一次（见 [_handleFocusChange]），否则切回来就没有焦点、快捷键全失效。
+    if (!DesktopForegroundGuard.isMainWindowForeground()) {
+      _repairDeferredWhileBackgrounded = true;
+      return;
+    }
     final FocusNode? primary = FocusManager.instance.primaryFocus;
     if (_isUsablePrimary(primary)) {
       _handleFocusChange();
@@ -648,6 +673,15 @@ class FushiFocusController extends ChangeNotifier {
   }
 
   void _handleFocusChange() {
+    // BUG-1619：主窗回到前台的补票口。FlutterView 重新拿到 OS 焦点会走到这里，
+    // 此时把「后台期间欠下的那次被动修复」补上——这条路径覆盖同进程内从剪贴板
+    // 面板切回主窗（那种切换不产生 AppLifecycleState.resumed，首页那条 resumed
+    // 回收补不到）。
+    if (_repairDeferredWhileBackgrounded &&
+        DesktopForegroundGuard.isMainWindowForeground()) {
+      _repairDeferredWhileBackgrounded = false;
+      scheduleRepair();
+    }
     final FocusNode? primary = FocusManager.instance.primaryFocus;
     for (final FushiFocusTargetEntry entry in _entries.values) {
       if (identical(entry.focusNode, primary)) {

--- a/fushi/lib/src/focus/main_window_focus_gate.dart
+++ b/fushi/lib/src/focus/main_window_focus_gate.dart
@@ -1,0 +1,171 @@
+// BUG-1619 根治层：把「Flutter 焦点树能持有焦点 ⟺ 主窗拥有 OS 焦点」变成一条
+// 结构性不变量，而不是在每个 requestFocus 调用点各写一次判据。
+//
+// 为什么必须在根部立这条不变量（而不是逐点加 if）：
+//
+//   ① Win32 硬语义：SetFocus(子窗) 在其顶层窗口非活动时**连带激活该顶层窗口**。
+//   ② Flutter 引擎：Dart 侧 requestFocus 后，引擎为让键盘 / IME 工作，无条件对
+//      FlutterView 调 SetFocus。
+//   ③ 于是「主窗不在前台时的任意一次 requestFocus」＝把主界面抢到用户正在用的
+//      游戏 / 浏览器前面。
+//
+// ①② 都不在我们手里，能控制的只有 ③。而 ③ 的入口穷举不完——真机上「拖面板顶栏」
+// 走的是 FushiFocusController.ensureFocus，「复制文本」那条至今没能在全仓 16 处
+// requestFocus 里定位到。逐点加判据 = 每发现一个入口补一刀；在根部立不变量 =
+// 这个特殊情况根本不存在。
+//
+// 关门会让出焦点，所以必须配套开门补焦点（[FushiFocusController] 订阅
+// [mainWindowForegroundNotifier]），否则用户切回主窗会发现整页没有焦点、键盘 /
+// 手柄快捷键全不响应（TODO-900 的老症状）。
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// 主窗此刻是否拥有 OS 焦点。**窗口级**真值，不是进程级。
+///
+/// 非桌面 / 非 Windows 恒 true：那些平台没有多顶层窗口结构，不该改变既有语义。
+final ValueNotifier<bool> mainWindowForegroundNotifier =
+    ValueNotifier<bool>(true);
+
+/// 本平台是否需要这条不变量。
+bool get mainWindowFocusGateApplies => Platform.isWindows;
+
+/// 监听主窗自己的 focus / blur（window_manager 底层是主窗 `WM_NCACTIVATE`，
+/// 窗口级信号，不是 `AppLifecycleState.resumed` 那种进程级信号），刷新
+/// [mainWindowForegroundNotifier]。
+///
+/// 与 widget 分开是为了两件事：widget 只读真值（好测），以及非 UI 代码
+/// （焦点控制器）也能订阅同一个真值。
+class MainWindowForegroundWatcher with WindowListener {
+  MainWindowForegroundWatcher._();
+
+  static final MainWindowForegroundWatcher instance =
+      MainWindowForegroundWatcher._();
+
+  bool _started = false;
+
+  void start() {
+    if (_started || !mainWindowFocusGateApplies) return;
+    _started = true;
+    windowManager.addListener(this);
+    sync();
+  }
+
+  @override
+  void onWindowFocus() => sync();
+
+  @override
+  void onWindowBlur() => sync();
+
+  /// 事件只是「该重新看一眼」的触发器，真值一律现问系统：事件走 channel 有延迟，
+  /// 到达时前台可能已经再次变化，照事件方向记账会把门开错。
+  @visibleForTesting
+  void sync() {
+    final bool next = DesktopForegroundGuard.isMainWindowForeground();
+    if (mainWindowForegroundNotifier.value != next) {
+      mainWindowForegroundNotifier.value = next;
+    }
+  }
+}
+
+/// 焦点闸门本体：门关着时整棵子树不可聚焦，任何 requestFocus 都是 no-op。
+///
+/// 关门会让出焦点，所以闸门**自己**负责精确恢复：关门前记下当时的 primaryFocus，
+/// 开门后还给它。不能把恢复外包给 [FushiFocusController]——那条只在「键盘/手柄
+/// 焦点导航」实验开关打开时才有受管目标，而默认是关的（真机 A/B 实测：只靠它
+/// 恢复时，焦点会从路由的 ModalScope 掉到最外层的 View Scope 回不来）。
+class MainWindowFocusGate extends StatefulWidget {
+  const MainWindowFocusGate({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<MainWindowFocusGate> createState() => _MainWindowFocusGateState();
+}
+
+class _MainWindowFocusGateState extends State<MainWindowFocusGate> {
+  bool _open = true;
+
+  /// 闸门自己的节点：兜底恢复时先由它接住焦点，再 [FocusNode.nextFocus] 交给
+  /// 子树里第一个可聚焦控件。
+  final FocusNode _gateNode = FocusNode(
+    debugLabel: 'fushi-main-window-focus-gate',
+    skipTraversal: true,
+  );
+
+  /// 关门前持有焦点的节点，开门后还给它。只在关门那一刻取——关门之后
+  /// primaryFocus 已经被让出，再取就只剩外层 scope 了。
+  FocusNode? _restoreTarget;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!mainWindowFocusGateApplies) return;
+    _open = mainWindowForegroundNotifier.value;
+    mainWindowForegroundNotifier.addListener(_onForegroundChanged);
+  }
+
+  @override
+  void dispose() {
+    if (mainWindowFocusGateApplies) {
+      mainWindowForegroundNotifier.removeListener(_onForegroundChanged);
+    }
+    _gateNode.dispose();
+    super.dispose();
+  }
+
+  void _onForegroundChanged() {
+    final bool next = mainWindowForegroundNotifier.value;
+    if (next == _open) return;
+    if (!next) {
+      _restoreTarget = FocusManager.instance.primaryFocus;
+    }
+    setState(() => _open = next);
+    if (next) {
+      final FocusNode? target = _restoreTarget;
+      _restoreTarget = null;
+      // 等这一帧的 descendantsAreFocusable 生效后再还，否则请求会被仍然关着的
+      // 闸门吃掉。节点可能在后台期间被销毁 / 卸载，所以要重新确认它还在树上。
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !mainWindowForegroundNotifier.value) return;
+        if (target != null &&
+            target.context != null &&
+            target.canRequestFocus) {
+          target.requestFocus();
+          return;
+        }
+        _handOffFocusIntoSubtree();
+      });
+    }
+  }
+
+  /// 兜底：开门后子树里没人持焦时，把焦点交进去。
+  ///
+  /// 必需，而不是锦上添花：app 在**后台启动**（开机自启 / 被别的窗口压着拉起）
+  /// 时，路由的 ModalScope 会在关门期间挂载并被挡下，而 Navigator 只在挂载那一
+  /// 刻请求一次 scope 焦点、之后不会重试——不兜底的话整页焦点体系就永久失效，
+  /// 连点击都救不回来（真机 A/B 实测：primaryFocus 卡在最外层 View Scope）。
+  void _handOffFocusIntoSubtree() {
+    final FocusNode? primary = FocusManager.instance.primaryFocus;
+    if (primary != null && _gateNode.descendants.contains(primary)) return;
+    if (!_gateNode.canRequestFocus) return;
+    _gateNode.requestFocus();
+    _gateNode.nextFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!mainWindowFocusGateApplies) return widget.child;
+    // skipTraversal：这层只是闸门，不能成为方向导航的落点（否则焦点环会框住
+    // 整个窗口，与首页那个整页 key-event sink 同款问题）。
+    return Focus(
+      focusNode: _gateNode,
+      canRequestFocus: _open,
+      descendantsAreFocusable: _open,
+      skipTraversal: true,
+      child: widget.child,
+    );
+  }
+}

--- a/fushi/lib/src/focus/page_focus_ownership.dart
+++ b/fushi/lib/src/focus/page_focus_ownership.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 
 /// 触发「把键盘焦点收回本页正文」的原因。
 ///
@@ -86,6 +87,16 @@ class PageFocusOwnership {
   /// 返回是否真的发起了请求——供测试断言，也让调用点能在被判据否决时走别的
   /// 路径（正常业务代码通常忽略返回值）。
   bool reclaim(FocusReclaimCause cause) {
+    // BUG-1619：[FocusReclaimCause.appResumed] 背后的 `AppLifecycleState.resumed`
+    // 是**进程级**信号。桌面版 Fushi 是多顶层窗口进程，剪贴板查词面板 / app 外
+    // 查词覆盖窗夺得前台时同样会把进程带到前台，而主窗其实还压在用户的游戏 /
+    // 浏览器底下。此时 requestFocus 会被引擎翻译成 SetFocus(FlutterView)，
+    // Win32 语义下连带激活主窗 —— 主界面凭空盖住用户正在用的窗口。
+    // 判据是**窗口级**的：主窗自己在前台才回收（Alt+Tab 真的切回来那次照常）。
+    if (cause == FocusReclaimCause.appResumed &&
+        !DesktopForegroundGuard.isMainWindowForeground()) {
+      return false;
+    }
     if (!_canOwn(cause)) return false;
     node.requestFocus();
     return true;

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -16,6 +16,7 @@ import 'package:macos_ui/macos_ui.dart'
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:fushi_anki/fushi_anki.dart' show AnkiMediaDedupReport;
 import 'package:fushi/src/anki/anki_media_dedup_dialogs.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 import 'package:fushi/src/anki/anki_media_dedup_runner.dart';
 import 'package:fushi/src/anki/anki_view_model.dart'
     show ankiRepositoryProvider;
@@ -613,6 +614,11 @@ class _HomePageState extends BasePageState<HomePage>
   /// （Never break userspace）——对话框关闭时各自的返回点会归还焦点。
   void _reclaimHomeFocusIfOwned() {
     if (!mounted) return;
+    // BUG-1619：进程级 resumed ≠ 主窗回到前台（剪贴板面板 / 查词覆盖窗夺焦
+    // 也会触发它）。主窗不在前台就抢焦点 = 引擎 SetFocus(FlutterView) 连带
+    // 把主界面激活到用户的游戏 / 浏览器之上。判据与共享入口
+    // [PageFocusOwnership.reclaim] 同一条，见那里的完整说明。
+    if (!DesktopForegroundGuard.isMainWindowForeground()) return;
     final ModalRoute<Object?>? owner = ModalRoute.of(context);
     if (owner != null && !owner.isCurrent) return;
     final FushiFocusController? controller =

--- a/fushi/lib/src/sync/desktop_foreground_guard.dart
+++ b/fushi/lib/src/sync/desktop_foreground_guard.dart
@@ -48,7 +48,46 @@ abstract final class DesktopForegroundGuard {
       return false;
     }
   }
+
+  /// **主窗自己**是不是前台窗口——注意与上面两个**进程级**判据的区别。
+  ///
+  /// 桌面版 Fushi 是多顶层窗口进程：主窗之外还有剪贴板查词面板、app 外查词
+  /// 覆盖窗、悬浮歌词 / 台词窗。这些辅助窗取得前台时，进程级判据一律为真，
+  /// 而主窗其实还压在用户的游戏 / 浏览器底下。凡是「主窗该不该抢键盘焦点」
+  /// 这类决策都必须用本判据，用进程级的就会把主界面拽到用户面前
+  /// （BUG-1619：拖剪贴板面板顶栏 → 面板夺焦 → 进程级 resumed →
+  /// 主窗 requestFocus → 引擎 SetFocus(FlutterView) → 连带激活主窗）。
+  ///
+  /// 非 Windows 恒 true：那些平台没有这套多顶层窗口结构，判据不该改变它们
+  /// 既有的 lifecycle 语义。
+  static bool isMainWindowForeground() {
+    final bool? override = debugMainWindowForeground;
+    if (override != null) return override;
+    if (!Platform.isWindows) return true;
+    // `flutter test` 跑在 flutter_tester 里，根本没有 runner 主窗：真实探测必然
+    // 返回 false，会把**所有**被动焦点修复挡死，整批既有焦点测试瞬间转红（实测）。
+    // 这套判据只对「有主窗的桌面 runner」有意义，测试环境一律放行；需要驱动判据的
+    // 用例显式设 [debugMainWindowForeground]（上面的 override 先于此生效）。
+    if (Platform.environment.containsKey('FLUTTER_TEST')) return true;
+    try {
+      return _WindowsForegroundProbe.instance.isMainWindowForeground();
+    } on Object {
+      // 探测失败按「是前台」放行：宁可保留旧的回收行为，也不要把键盘焦点
+      // 永久卡死在无人接管的状态。
+      return true;
+    }
+  }
+
+  @visibleForTesting
+  static bool? debugMainWindowForeground;
 }
+
+/// Flutter runner 主窗的 Win32 窗口类名。
+///
+/// 必须与 `fushi/windows/runner/win32_window.cpp` 注册的类名逐字符一致——
+/// 那是识别「前台窗口是不是主窗」的唯一凭据（辅助窗各有自己的类名）。
+/// 守卫测试 `desktop_foreground_guard_main_window_test.dart` 锁死两边一致。
+const String kFushiMainWindowClassName = 'FLUTTER_RUNNER_WIN32_WINDOW';
 
 final class _WindowsForegroundProbe {
   _WindowsForegroundProbe._()
@@ -58,6 +97,9 @@ final class _WindowsForegroundProbe {
         _getWindowThreadProcessId = DynamicLibrary.open('user32.dll')
             .lookupFunction<_GetWindowThreadProcessIdNative,
                 _GetWindowThreadProcessIdDart>('GetWindowThreadProcessId'),
+        _getClassName = DynamicLibrary.open('user32.dll')
+            .lookupFunction<_GetClassNameNative, _GetClassNameDart>(
+                'GetClassNameW'),
         _getCurrentProcessId = DynamicLibrary.open('kernel32.dll')
             .lookupFunction<_GetCurrentProcessIdNative,
                 _GetCurrentProcessIdDart>('GetCurrentProcessId'),
@@ -75,6 +117,7 @@ final class _WindowsForegroundProbe {
 
   final _GetForegroundWindowDart _getForegroundWindow;
   final _GetWindowThreadProcessIdDart _getWindowThreadProcessId;
+  final _GetClassNameDart _getClassName;
   final _GetCurrentProcessIdDart _getCurrentProcessId;
   final _OpenProcessDart _openProcess;
   final _QueryFullProcessImageNameDart _queryFullProcessImageName;
@@ -98,6 +141,35 @@ final class _WindowsForegroundProbe {
     final String? imagePath = _processImagePath(pid);
     if (imagePath == null) return false;
     return _looksLikeFushiExecutable(imagePath);
+  }
+
+  /// 前台窗口既属于本进程、类名又是主窗类名 → 主窗就是前台窗口。
+  ///
+  /// 两个条件缺一不可：只比进程会把辅助窗（面板 / 覆盖窗 / 浮窗）算成主窗；
+  /// 只比类名会把另一个 Fushi 进程的主窗算成自己的。
+  bool isMainWindowForeground() {
+    final int foregroundHwnd = _getForegroundWindow();
+    if (foregroundHwnd == 0) return false;
+    final Pointer<Uint32> foregroundPid = calloc<Uint32>();
+    try {
+      _getWindowThreadProcessId(foregroundHwnd, foregroundPid);
+      if (foregroundPid.value != _getCurrentProcessId()) return false;
+    } finally {
+      calloc.free(foregroundPid);
+    }
+    return _windowClassName(foregroundHwnd) == kFushiMainWindowClassName;
+  }
+
+  String? _windowClassName(int hwnd) {
+    const int bufferLength = 256;
+    final Pointer<Utf16> buffer = calloc<Uint16>(bufferLength).cast<Utf16>();
+    try {
+      final int written = _getClassName(hwnd, buffer, bufferLength);
+      if (written <= 0) return null;
+      return buffer.toDartString(length: written);
+    } finally {
+      calloc.free(buffer);
+    }
   }
 
   int? _foregroundProcessId() {
@@ -167,6 +239,17 @@ typedef _GetWindowThreadProcessIdNative = Uint32 Function(
 typedef _GetWindowThreadProcessIdDart = int Function(
   int hWnd,
   Pointer<Uint32> processId,
+);
+
+typedef _GetClassNameNative = Int32 Function(
+  IntPtr hWnd,
+  Pointer<Utf16> className,
+  Int32 maxCount,
+);
+typedef _GetClassNameDart = int Function(
+  int hWnd,
+  Pointer<Utf16> className,
+  int maxCount,
 );
 
 typedef _GetCurrentProcessIdNative = Uint32 Function();

--- a/fushi/test/focus/background_focus_repair_test.dart
+++ b/fushi/test/focus/background_focus_repair_test.dart
@@ -1,0 +1,106 @@
+// BUG-1619（根因层）：被动焦点修复在**主窗不在前台**时不得请求焦点。
+//
+// 真机链路（Windows，已抓到 NtUserSetFocus 调用栈实证）：拖剪贴板查词面板顶栏
+// 结束 → windowMoved → setClipboardPanelRect → PreferencesRepository
+// .notifyListeners() → 首页重建 → 焦点目标重新 register → scheduleRepair →
+// ensureFocus() → requestFocus → Flutter 引擎 SetFocus(FlutterView) → Win32
+// 语义下 SetFocus(子窗) 连带激活其顶层窗口 → 主界面盖住用户正在用的游戏 /
+// 浏览器。
+//
+// 判据必须是**窗口级**的：真机日志里被挡下的那些 ensureFocus，前台窗口是
+// FushiGlobalLookupWindow 且**属于本进程**——沿用既有的进程级判据会直接放行。
+//
+// 挡下之后要记账，主窗回到前台再补一次，否则用户切回来整页没有焦点、键盘 /
+// 手柄快捷键全死（TODO-900 当初要修的正是这个症状）。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/focus/fushi_focus_target.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
+
+Widget _app() {
+  return MaterialApp(
+    home: Scaffold(
+      body: FushiFocusRoot(
+        child: Column(
+          children: <Widget>[
+            for (int i = 0; i < 3; i++)
+              FushiFocusTarget(
+                id: FushiFocusId('row-$i'),
+                child: TextButton(onPressed: () {}, child: Text('Row $i')),
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// 用控制器自己的「当前焦点目标」判定，而不是 Focus.of(...)——后者拿到的是
+/// TextButton 内部那个 Focus，不是 FushiFocusTarget 注册的节点。
+bool _anyRowFocused(WidgetTester tester) =>
+    _controller(tester).activeId != null;
+
+FushiFocusController _controller(WidgetTester tester) =>
+    FushiFocusRoot.controllerOf(tester.element(find.text('Row 0')));
+
+/// 制造「没有可用 primary focus」——这正是被动修复真正会 requestFocus 的场景
+/// （[FushiFocusController.ensureFocus] 在已有可用 primary 时只是重算状态）。
+Future<void> _dropFocus(WidgetTester tester) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump();
+}
+
+void main() {
+  tearDown(() {
+    DesktopForegroundGuard.debugMainWindowForeground = null;
+  });
+
+  testWidgets('主窗不在前台时被动修复不抢焦点', (WidgetTester tester) async {
+    DesktopForegroundGuard.debugMainWindowForeground = false;
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await _dropFocus(tester);
+    _controller(tester).ensureFocus();
+    await tester.pumpAndSettle();
+
+    expect(_anyRowFocused(tester), isFalse,
+        reason: '主窗不在前台，被动修复不该请求焦点 —— 真机上这一步等于把主界面'
+            '抢到用户的游戏 / 浏览器前面（BUG-1619）');
+  });
+
+  testWidgets('主窗在前台时被动修复照常落焦点', (WidgetTester tester) async {
+    DesktopForegroundGuard.debugMainWindowForeground = true;
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await _dropFocus(tester);
+    _controller(tester).ensureFocus();
+    await tester.pumpAndSettle();
+
+    expect(_anyRowFocused(tester), isTrue,
+        reason: '主窗自己在前台时被动修复必须照旧 home 焦点，否则键盘 / 手柄'
+            '导航进不去（TODO-900 回归）');
+  });
+
+  testWidgets('后台期间被挡下的修复，在主窗回到前台后补上', (WidgetTester tester) async {
+    DesktopForegroundGuard.debugMainWindowForeground = false;
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await _dropFocus(tester);
+    _controller(tester).ensureFocus();
+    await tester.pumpAndSettle();
+    expect(_anyRowFocused(tester), isFalse);
+
+    // 主窗回到前台：FlutterView 重新拿到 OS 焦点会驱动 FocusManager 通知，
+    // 控制器在那条监听里补上欠下的那次修复。
+    DesktopForegroundGuard.debugMainWindowForeground = true;
+    FocusManager.instance.rootScope.requestFocus(FocusNode());
+    await tester.pumpAndSettle();
+
+    expect(_anyRowFocused(tester), isTrue,
+        reason: '欠下的修复没补上 = 用户切回主窗后整页没有焦点、快捷键全死');
+  });
+}

--- a/fushi/test/focus/main_window_focus_gate_test.dart
+++ b/fushi/test/focus/main_window_focus_gate_test.dart
@@ -1,0 +1,90 @@
+// BUG-1619 根治层守卫：焦点闸门把「能持有焦点 ⟺ 主窗拥有 OS 焦点」变成结构性
+// 不变量。逐点判据穷举不完（复制文本那条真机路径至今没在全仓 16 处 requestFocus
+// 里定位到），所以这条不变量必须由根部保证，且必须配套开门补焦点。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/focus/fushi_focus_target.dart';
+import 'package:fushi/src/focus/main_window_focus_gate.dart';
+
+FushiFocusController controllerOf(WidgetTester tester) =>
+    FushiFocusRoot.controllerOf(tester.element(find.text('Row 0')));
+
+Widget _app(FocusNode probe) {
+  return MaterialApp(
+    home: MainWindowFocusGate(
+      child: Scaffold(
+        body: FushiFocusRoot(
+          child: Column(
+            children: <Widget>[
+              FushiFocusTarget(
+                id: const FushiFocusId('row-0'),
+                child: TextButton(onPressed: () {}, child: const Text('Row 0')),
+              ),
+              Focus(focusNode: probe, child: const Text('probe')),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  tearDown(() => mainWindowForegroundNotifier.value = true);
+
+  testWidgets('门关着：任何 requestFocus 都拿不到焦点', (WidgetTester tester) async {
+    final FocusNode probe = FocusNode(debugLabel: 'probe');
+    addTearDown(probe.dispose);
+    await tester.pumpWidget(_app(probe));
+    await tester.pumpAndSettle();
+
+    mainWindowForegroundNotifier.value = false;
+    await tester.pumpAndSettle();
+
+    probe.requestFocus();
+    await tester.pumpAndSettle();
+    expect(probe.hasFocus, isFalse,
+        reason: '主窗不在前台时请求焦点 = 引擎 SetFocus(FlutterView) = 把主界面'
+            '抢到用户的游戏 / 浏览器前面（BUG-1619）');
+  });
+
+  testWidgets('门开着：焦点照常工作（不改变正常使用）', (WidgetTester tester) async {
+    final FocusNode probe = FocusNode(debugLabel: 'probe');
+    addTearDown(probe.dispose);
+    await tester.pumpWidget(_app(probe));
+    await tester.pumpAndSettle();
+
+    probe.requestFocus();
+    await tester.pumpAndSettle();
+    expect(probe.hasFocus, isTrue);
+  });
+
+  testWidgets('关门会让出既有焦点，开门后由焦点控制器补回内容焦点', (WidgetTester tester) async {
+    final FocusNode probe = FocusNode(debugLabel: 'probe');
+    addTearDown(probe.dispose);
+    await tester.pumpWidget(_app(probe));
+    await tester.pumpAndSettle();
+
+    probe.requestFocus();
+    await tester.pumpAndSettle();
+    expect(probe.hasFocus, isTrue);
+
+    mainWindowForegroundNotifier.value = false;
+    await tester.pumpAndSettle();
+    expect(probe.hasFocus, isFalse, reason: '关门必须让出焦点');
+    expect(controllerOf(tester).primaryFocusIsManagedTarget, isFalse,
+        reason: '关门期间焦点不该落在任何受管目标上');
+
+    mainWindowForegroundNotifier.value = true;
+    await tester.pumpAndSettle();
+
+    final FushiFocusController controller =
+        FushiFocusRoot.controllerOf(tester.element(find.text('Row 0')));
+    // 断言**真实焦点归属**：activeId 只是缓存 id，关门不会清它，拿它断言恒真
+    // （实测：把两条补票路径全删掉这条用例照样绿）。
+    expect(controller.primaryFocusIsManagedTarget, isTrue,
+        reason: '开门后必须补一次焦点修复，否则用户切回主窗整页没有焦点、'
+            '键盘 / 手柄快捷键全不响应（TODO-900 的老症状）');
+  });
+}

--- a/fushi/test/focus/resumed_focus_reclaim_guard_test.dart
+++ b/fushi/test/focus/resumed_focus_reclaim_guard_test.dart
@@ -1,0 +1,103 @@
+// BUG-1619 守卫：`AppLifecycleState.resumed` 是**进程级**信号，桌面多顶层窗口
+// （剪贴板查词面板 / app 外查词覆盖窗 / 悬浮窗）夺焦时同样会触发它。此时若把
+// 键盘焦点收回主窗，Flutter 引擎会对 FlutterView 调 SetFocus，Win32 语义下
+// 连带激活主窗 —— 用户正在玩的游戏 / 正在看的浏览器被主界面盖住。
+//
+// 三层守：
+// ① 判据本身（窗口级，不是进程级）；
+// ② 共享回收入口 PageFocusOwnership 在 appResumed 上真的过了判据；
+// ③ 源码扫描：resumed 分支不得绕过判据裸调 requestFocus（首页走的是自己那条
+//    手写路径，不经 PageFocusOwnership，最容易漏）。
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/page_focus_ownership.dart';
+import 'package:fushi/src/sync/desktop_foreground_guard.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    DesktopForegroundGuard.debugMainWindowForeground = null;
+  });
+
+  group('主窗前台判据', () {
+    test('Dart 侧类名常量与 runner 注册的窗口类名逐字符一致', () {
+      final File source = File('windows/runner/win32_window.cpp');
+      expect(source.existsSync(), isTrue,
+          reason: '守卫要读 ${source.path}，路径变了就更新这里');
+      final String text = source.readAsStringSync();
+      expect(
+        text.contains('L"$kFushiMainWindowClassName"'),
+        isTrue,
+        reason: 'win32_window.cpp 改了主窗类名，'
+            'kFushiMainWindowClassName 必须同步——否则判据永远为假，'
+            '主窗回到前台后再也收不回键盘焦点',
+      );
+    });
+
+    test('测试注入生效（判据可被守卫测试驱动）', () {
+      DesktopForegroundGuard.debugMainWindowForeground = false;
+      expect(DesktopForegroundGuard.isMainWindowForeground(), isFalse);
+      DesktopForegroundGuard.debugMainWindowForeground = true;
+      expect(DesktopForegroundGuard.isMainWindowForeground(), isTrue);
+    });
+  });
+
+  group('PageFocusOwnership.reclaim(appResumed)', () {
+    late FocusNode node;
+
+    setUp(() => node = FocusNode());
+    tearDown(() => node.dispose());
+
+    test('主窗不在前台时不回收（辅助窗夺焦触发的 resumed）', () {
+      DesktopForegroundGuard.debugMainWindowForeground = false;
+      final PageFocusOwnership ownership = PageFocusOwnership(
+        node: node,
+        canOwn: (FocusReclaimCause cause) => true,
+      );
+      expect(ownership.reclaim(FocusReclaimCause.appResumed), isFalse);
+    });
+
+    test('主窗在前台时照常回收（Alt+Tab 真的切回主窗）', () {
+      DesktopForegroundGuard.debugMainWindowForeground = true;
+      final PageFocusOwnership ownership = PageFocusOwnership(
+        node: node,
+        canOwn: (FocusReclaimCause cause) => true,
+      );
+      expect(ownership.reclaim(FocusReclaimCause.appResumed), isTrue);
+    });
+
+    test('判据只管 appResumed，其它 cause 一律不受影响', () {
+      DesktopForegroundGuard.debugMainWindowForeground = false;
+      final PageFocusOwnership ownership = PageFocusOwnership(
+        node: node,
+        canOwn: (FocusReclaimCause cause) => true,
+      );
+      for (final FocusReclaimCause cause in FocusReclaimCause.values) {
+        if (cause == FocusReclaimCause.appResumed) continue;
+        expect(ownership.reclaim(cause), isTrue,
+            reason: '$cause 是页面内部时序，与窗口前台归属无关，不该被这条判据拦下');
+      }
+    });
+  });
+
+  group('源码扫描：resumed 分支不得绕过判据', () {
+    test('首页 resumed 回收路径带主窗前台判据', () {
+      final File source = File('lib/src/pages/implementations/home_page.dart');
+      expect(source.existsSync(), isTrue);
+      final String text = source.readAsStringSync();
+      final int reclaimAt = text.indexOf('void _reclaimHomeFocusIfOwned()');
+      expect(reclaimAt, greaterThan(0), reason: '首页回收方法改名了，同步更新本守卫');
+      final int end = text.indexOf('\n  }', reclaimAt);
+      final String body = text.substring(reclaimAt, end);
+      expect(
+        body.contains('isMainWindowForeground'),
+        isTrue,
+        reason: '首页 resumed 回收必须先确认主窗自己在前台；'
+            '否则剪贴板面板夺焦就会把主界面拽到用户面前（BUG-1619）',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：5 个新增文件在 `develop` 上不存在（含 `fushi/lib/src/focus/main_window_focus_gate.dart` 与 `docs/bugs/BUG-1619-*.md`），2 条提交主题也找不到。从没开过 PR。

## 内容

BUG-1619 根治层：主窗不在前台时整棵焦点树不可聚焦。未落地约 **+723 行 / 9 个文件**。

## ⚠ 破坏性标记

最新提交带 `!`（`fix(focus)!:`），作者自己标了破坏性改动。合并前请确认对既有焦点行为的影响面——本仓有多条焦点所有权相关的历史 bug，参见 `docs/agent/focus-ownership.md`。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
