### PR TITLE
fix(gal): BUG-1691 转区是否生效进会话状态与 UI（从未开 PR）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1532 条。点号进各自文件。
+> 共 1533 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1691](bugs/BUG-1691-gal-japanese-locale-invisible.md) | ✅ | ✅ | 转区静默生效解坏多语言版游戏文字，用户无从发现 |
 | [BUG-1650](bugs/BUG-1650-sync-pulled-progress-stale-until-restart.md) | ✅ | ✅ | 同步拉回更远进度后首页继续与书架不刷新须重启 |
 | [BUG-1649](bugs/BUG-1649-manga-folder-epub-import.md) | ✅ | ✅ | 漫画页选文件夹导入：目录内是 epub 卷时报 Manga image folder has no pages |
 | [BUG-1648](bugs/BUG-1648-embedded-torrent-idle-discovery.md) | ✅ | ✅ | 已完成任务恢复后 DHT 常驻导致网关周期性高延迟 |

--- a/docs/bugs/BUG-1691-gal-japanese-locale-invisible.md
+++ b/docs/bugs/BUG-1691-gal-japanese-locale-invisible.md
@@ -1,0 +1,40 @@
+## BUG-1691 · 转区静默生效解坏多语言版游戏文字，用户无从发现
+- **报告**：2026-08-16（用户：wrds）
+- **真实性**：✅ 真 bug（转区静默生效 + 不可见）。根因 `fushi/lib/src/mining/galgame_japanese_locale.dart:104`（`auto` 判据 = 系统 ACP≠932 且目标 32 位）+ `fushi/lib/src/mining/galgame_audio_source.dart:1279`（结果只喂给 injector，从不向上暴露）。
+- **[x] ① 已修复** — 让「本局是否转区」成为会话事实并显示出来：`EngineHookGalAudioSource.japaneseLocaleApplied` 在算出判据的同一处记账；`GalHookSessionController.launchGame` 写入 `GalHookSessionState.japaneseLocaleApplied` 并记 `launch.japanese_locale_applied` 事件（注入失败降级也照写——游戏进程已经在 CP932 下跑着了）；捕获工作台状态卡窄屏显示短标记、宽屏追加可执行处置（提示去把该游戏的日语区域改成「永不转区」）。提交见下。
+- **[x] ② 已加自动化测试** — `fushi/test/mining/gal_japanese_locale_visibility_test.dart`（8 例）：锁定 `auto` 判据四格（中文系统+32 位⇒转区 / 日文系统⇒不转 / off 兜底 / attach 短路）、转区会话置位并记事件、未转区不置位不记事件、会话停止后复位、`copyWith(clearLaunchExe:)` 复位。**变异实测**：把 `japaneseLocaleApplied: engine.japaneseLocaleApplied` 改成恒 `false` → 2 例转红（exit 1）；反向替换还原后 sha256 与变异前逐字节一致（`87bf5a80…6595`）。
+
+### 现场证据（2026-08-16，TenShiSouZou_R18 / KiriKiri ver1.12 / 本机 ACP=936、游戏 x86）
+
+Fushi 启动该游戏时 injector 命令行实际带着 `--japanese-locale`：
+
+```
+fushi_voice_injector.exe --launch ...\tenshi_sz.exe --hold --wait-ms 30000 --japanese-locale --workdir ... --luna-hook-profile ...
+```
+
+单变量对照（同一条命令，只增删 `--japanese-locale`），差异出现在窗口标题：
+
+| | 窗口标题 | 中文 UI | 切日文 UI |
+|---|---|---|---|
+| 带 `--japanese-locale` | `天使☆騒**器** RE-BOOT!` | 标题栏乱码 | 恢复正常 |
+| 不带 | `天使☆騒**々** RE-BOOT!` | 正常 | 正常 |
+
+「々」被解成「器」= 拿 CP932 解 GBK 字节的典型症状。这是**多国語版**（中/英/日，`plugin/getLangName.dll`），本来就不需要转区，而 `auto` 在中文系统 + 32 位目标上必然给它转区。
+
+### 边界：没有改判据本身
+
+`resolveJapaneseLocale` 的注释已经论证过 `auto` 不可能总判对（exe 位数与文本编码之间没有因果关系），真正兜底的是用户手动选 `off`。本次修的是「兜底够不着」——判错之后用户在任何界面都看不到 Fushi 改了区域，也就无从想到去关它。
+
+收紧判据（例如把 KiriKiri 的 `getLangName.dll` 当作「内建多语言 ⇒ 不转区」的负向信号）**没有做**：手头样本只有 3 个（天使☆騒々 两个版本都有该 DLL；日文原版「屋上の百合霊さん」没有 plugin 目录），不足以排除误伤日文原版的风险。要做需要先补样本。
+
+### 未复现的部分（不要当成本条已覆盖）
+
+同日用户报了一个 KiriKiri 致命错误，**未能复现**，因此没有归因给转区：
+
+```
+{{Script}} load.ks(21)
+{{Exception}} Cannot convert the variable type ((void) to Object)
+{{Trace}} uiloader.tjs(1)[uiloadWithFuncTable] <-- uiload <-- system.tjs <-- conductor.tjs[onTag] <-- timerCallback
+```
+
+用户路径：切界面语言 → 调整左上角文本语言 → 点继续游戏。转区状态下按该路径尝试：语言切换 6 轮、UI 画面遍历 18 次（载入/流程图/鉴赏/系统设定）、切换后 0.3s 内立刻点继续 6 轮、双语（主要=日语 + 字幕=简体中文，已确认生效）路径 6 轮，均未触发。留待带更精确时序/存档状态的复现。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 57732 (3396 per locale)
+/// Strings: 57766 (3398 per locale)
 ///
-/// Built on 2026-08-14 at 15:35 UTC
+/// Built on 2026-08-16 at 12:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4602,6 +4602,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'No subtitle lines found in that file';
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  String get game_session_japanese_locale => 'Japanese locale';
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -12450,6 +12453,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -20365,6 +20373,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -28296,6 +28309,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -36239,6 +36257,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -44110,6 +44133,11 @@ class _StringsId extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -52027,6 +52055,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -59758,6 +59791,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -67496,6 +67534,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -75393,6 +75436,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -83302,6 +83350,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -91197,6 +91250,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -99040,6 +99098,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -106914,6 +106977,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -114773,6 +114841,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 // Path: <root>
@@ -122058,6 +122131,11 @@ class _StringsZhCn extends _StringsEn {
   String get srt_book_reimport_no_cues => '该字幕文件解析不出任何字幕行';
   @override
   String get srt_book_reimport_body_rebuilt => '正文已重建，请重新打开本书';
+  @override
+  String get game_session_japanese_locale => '已转区';
+  @override
+  String get game_session_japanese_locale_hint =>
+      '本局以日文区域 (CP932) 启动。若游戏文字乱码或脚本报错，可把该游戏的日语区域改为「永不转区」。';
 }
 
 // Path: <root>
@@ -129712,6 +129790,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get srt_book_reimport_body_rebuilt =>
       'Book text rebuilt — reopen the book to read it';
+  @override
+  String get game_session_japanese_locale => 'Japanese locale';
+  @override
+  String get game_session_japanese_locale_hint =>
+      'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
 }
 
 /// Flat map(s) containing all translations.
@@ -136691,6 +136774,10 @@ extension on _StringsEn {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -143668,6 +143755,10 @@ extension on _StringsAr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -150667,6 +150758,10 @@ extension on _StringsDe {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -157665,6 +157760,10 @@ extension on _StringsEs {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -164669,6 +164768,10 @@ extension on _StringsFr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -171655,6 +171758,10 @@ extension on _StringsId {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -178655,6 +178762,10 @@ extension on _StringsIt {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -185617,6 +185728,10 @@ extension on _StringsJa {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -192583,6 +192698,10 @@ extension on _StringsKo {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -199577,6 +199696,10 @@ extension on _StringsNl {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -206568,6 +206691,10 @@ extension on _StringsPtBr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -213564,6 +213691,10 @@ extension on _StringsRu {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -220543,6 +220674,10 @@ extension on _StringsTh {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -227531,6 +227666,10 @@ extension on _StringsTr {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -234515,6 +234654,10 @@ extension on _StringsVi {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }
@@ -241441,6 +241584,10 @@ extension on _StringsZhCn {
         return '该字幕文件解析不出任何字幕行';
       case 'srt_book_reimport_body_rebuilt':
         return '正文已重建，请重新打开本书';
+      case 'game_session_japanese_locale':
+        return '已转区';
+      case 'game_session_japanese_locale_hint':
+        return '本局以日文区域 (CP932) 启动。若游戏文字乱码或脚本报错，可把该游戏的日语区域改为「永不转区」。';
       default:
         return null;
     }
@@ -248398,6 +248545,10 @@ extension on _StringsZhHk {
         return 'No subtitle lines found in that file';
       case 'srt_book_reimport_body_rebuilt':
         return 'Book text rebuilt — reopen the book to read it';
+      case 'game_session_japanese_locale':
+        return 'Japanese locale';
+      case 'game_session_japanese_locale_hint':
+        return 'The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game\'s Japanese locale to Never.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "重新导入",
   "srt_book_reimport_subtitle_hint": "替换字幕会用新字幕重建这本书的正文。",
   "srt_book_reimport_no_cues": "该字幕文件解析不出任何字幕行",
-  "srt_book_reimport_body_rebuilt": "正文已重建，请重新打开本书"
+  "srt_book_reimport_body_rebuilt": "正文已重建，请重新打开本书",
+  "game_session_japanese_locale": "已转区",
+  "game_session_japanese_locale_hint": "本局以日文区域 (CP932) 启动。若游戏文字乱码或脚本报错，可把该游戏的日语区域改为「永不转区」。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3394,5 +3394,7 @@
   "srt_book_reimport": "Re-import",
   "srt_book_reimport_subtitle_hint": "Replacing the subtitle rebuilds the book text from the new cues.",
   "srt_book_reimport_no_cues": "No subtitle lines found in that file",
-  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it"
+  "srt_book_reimport_body_rebuilt": "Book text rebuilt — reopen the book to read it",
+  "game_session_japanese_locale": "Japanese locale",
+  "game_session_japanese_locale_hint": "The game was started under a Japanese (CP932) locale. If its text looks garbled or a script error appears, set this game's Japanese locale to Never."
 }

--- a/fushi/lib/src/mining/gal_hook_session_controller.dart
+++ b/fushi/lib/src/mining/gal_hook_session_controller.dart
@@ -411,6 +411,7 @@ class GalHookSessionState {
     this.audioTracks = const <GalAudioTrack>[],
     this.selectedAudioSourcePtr = 0,
     this.excludedAudioSourcePtrs = const <int>{},
+    this.japaneseLocaleApplied = false,
   });
 
   final GalHookSessionPhase phase;
@@ -446,6 +447,16 @@ class GalHookSessionState {
   final int selectedAudioSourcePtr;
   final Set<int> excludedAudioSourcePtrs;
 
+  /// 本局**实际**有没有给游戏套日文区域（CP932）。区别于用户选的档位：`auto` 是现算的，
+  /// 设置页只显示「自动」，用户无从知道这一局到底转没转。
+  ///
+  /// 为什么要让它进状态：`auto` 判据（系统 ACP≠932 且目标 32 位）对多语言版 / 汉化版
+  /// 必然误判为「要转区」，而误转区会把游戏自己的 GBK/UTF-8 字符串按 CP932 解坏。
+  /// [resolveJapaneseLocale] 的注释已经承认 `auto` 不可能总判对、兜底是用户手动选
+  /// [GalJapaneseLocaleMode.off]——但兜底够不着就等于没有。UI 据此显式告诉用户
+  /// 「本局已转区」并给出关掉的入口，这是判错后唯一的自愈路径。
+  final bool japaneseLocaleApplied;
+
   bool get isActive =>
       phase != GalHookSessionPhase.idle && phase != GalHookSessionPhase.error;
   bool get hasText => textSignalReceived;
@@ -480,6 +491,7 @@ class GalHookSessionState {
     List<GalAudioTrack>? audioTracks,
     int? selectedAudioSourcePtr,
     Set<int>? excludedAudioSourcePtrs,
+    bool? japaneseLocaleApplied,
   }) {
     return GalHookSessionState(
       phase: phase ?? this.phase,
@@ -512,6 +524,12 @@ class GalHookSessionState {
           selectedAudioSourcePtr ?? this.selectedAudioSourcePtr,
       excludedAudioSourcePtrs:
           excludedAudioSourcePtrs ?? this.excludedAudioSourcePtrs,
+      // 跟着 launchExe 复位：转区只属于 launch 会话，attach 路径必然没转。会话结束时
+      // stopCapture 会 clearLaunchExe，那一刻这个标记也必须落回 false，否则空闲状态还
+      // 挂着上一局的「已转区」。
+      japaneseLocaleApplied: clearLaunchExe
+          ? false
+          : japaneseLocaleApplied ?? this.japaneseLocaleApplied,
     );
   }
 }
@@ -1292,6 +1310,25 @@ class GalHookSessionController extends ChangeNotifier {
       await engine.stop();
       return const GalHookLaunchResult.failed(
         GalHookLaunchFailureReason.superseded,
+      );
+    }
+    // 转区事实入状态：**注入成功与否都要写**。游戏进程是 injector 按这个档位创建的，
+    // 即使随后注入失败降级到 loopback，游戏也已经在 CP932 下跑着了——而误转区正是
+    // 「文字乱码 / 脚本加载失败」这类症状的常见来源，此时把标记丢掉等于让用户在最需要
+    // 线索的那一刻失去线索。
+    _setState(
+      _state.copyWith(japaneseLocaleApplied: engine.japaneseLocaleApplied),
+    );
+    if (engine.japaneseLocaleApplied) {
+      _record(
+        GalHookEventSeverity.info,
+        'launch',
+        'launch.japanese_locale_applied',
+        'Launched the game with a Japanese (CP932) locale',
+        details: <String, Object?>{
+          'mode': japaneseLocaleMode.name,
+          'exe': executablePath,
+        },
       );
     }
     if (format == null && !engine.textHookReady) {

--- a/fushi/lib/src/mining/galgame_audio_source.dart
+++ b/fushi/lib/src/mining/galgame_audio_source.dart
@@ -1116,6 +1116,20 @@ class EngineHookGalAudioSource implements GalAudioSource {
   /// 最近一次 [start] 失败的结构化诊断；成功后为 [GalHookInjectorFailure.none]。
   GalHookInjectorDiagnostics get lastFailure => _lastFailure;
 
+  bool _japaneseLocaleApplied = false;
+
+  /// 本局**实际**是否给游戏套了日文区域（CP932），而不是用户选了哪个档位。
+  ///
+  /// 两者不是一回事：`auto` 下真正的结果由 [resolveJapaneseLocale] 现算（系统 ACP +
+  /// 目标位数），用户在设置里看到的只是「自动」。而 `auto` 判错的代价是不对称的——
+  /// 多语言版 / 汉化版被误转区时，游戏自己的 GBK/UTF-8 字符串会被按 CP932 解出非法
+  /// 序列，症状从窗口标题乱码到脚本加载失败都有，且**没有一处告诉用户是转区干的**。
+  ///
+  /// [resolveJapaneseLocale] 的注释已经论证过 `auto` 不可能总判对、真正兜底的是用户
+  /// 手动选 [GalJapaneseLocaleMode.off]。可兜底的前提是用户够得着：先得知道本局到底
+  /// 转没转。所以这个事实必须离开本类，一路走到会话状态与诊断里。
+  bool get japaneseLocaleApplied => _japaneseLocaleApplied;
+
   int _launchedPid = 0;
 
   /// launch 模式下 injector 回报的**已创建**游戏 PID（`LAUNCH pid=`）。注入是否成功
@@ -1244,6 +1258,7 @@ class EngineHookGalAudioSource implements GalAudioSource {
     _rawVoiceReady = false;
     _readyFormat = null;
     _launchedPid = 0;
+    _japaneseLocaleApplied = false;
     _diagnosticsBuffer.clear();
     _lastFailure = const GalHookInjectorDiagnostics();
     final String? path = injectorPath;
@@ -1268,6 +1283,9 @@ class EngineHookGalAudioSource implements GalAudioSource {
       is32Bit: launchMode && await exeIs32Bit(exe) == true,
       systemAnsiCodePage: systemAnsiCodePageProbe(),
     );
+    // 在传给 injector 的同一处记账：命令行里的 `--japanese-locale` 与这个字段必须同源，
+    // 否则「诊断说没转区、进程其实转了」这种分叉比不诊断更糟。
+    _japaneseLocaleApplied = japaneseLocale;
     // 1. 拉起 injector 子进程（注入报毒代码只在这个隔离子进程里执行）。
     //    launch 模式：`--launch <exe>` CREATE_SUSPENDED 早注入，从 stdout 解析子进程 PID；
     //    attach 模式：`--pid <PID>` 附着已运行进程。

--- a/fushi/lib/src/pages/implementations/texthooker_page.dart
+++ b/fushi/lib/src/pages/implementations/texthooker_page.dart
@@ -2044,6 +2044,12 @@ class _SessionOverviewCard extends StatelessWidget {
         readiness == GalWorkbenchReadiness.waitingForThread;
     final String audio = galHookAudioBackendLabel(state.audioBackend);
     final String phase = galHookSessionPhaseLabel(state.phase);
+    // 转区标记**窄屏也留着**：它和降级原因同属「不显示就没有第二处能看到」的事实。
+    // `auto` 档在设置页只显示「自动」，真正转没转是启动时按系统 ACP + 目标位数现算的，
+    // 判错时用户看到的只有游戏文字乱码，没有任何线索指向 Hibiki 改了区域。
+    final String localeSuffix = state.japaneseLocaleApplied
+        ? ' · ${t.game_session_japanese_locale}'
+        : '';
     final String? format = state.audioFormat == null
         ? null
         : '${state.audioFormat!.sampleRate} Hz · '
@@ -2081,13 +2087,29 @@ class _SessionOverviewCard extends StatelessWidget {
                   waitingForThread
                       ? '$phase · ${t.game_text_thread_unset}'
                       : compact
-                          ? '$phase · $audio'
+                          ? '$phase · $audio$localeSuffix'
                           : '$phase · $audio'
-                              '${format == null ? '' : ' · $format'}',
+                              '${format == null ? '' : ' · $format'}'
+                              '$localeSuffix',
                   maxLines: compact ? 1 : 2,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
+                // 转区的**可执行处置**：上面那行只说「已转区」，这里说清它可能造成什么、
+                // 以及去哪关。误转区（多语言版 / 汉化版落进 `auto` 的「32 位 ⇒ 日文原版」
+                // 判据）会把游戏自己的 GBK/UTF-8 字符串按 CP932 解坏，症状从窗口标题乱码
+                // 到脚本加载失败都有。[resolveJapaneseLocale] 已经论证过 `auto` 不可能总
+                // 判对、真正兜底的是用户手动选「永不转区」——够得着那个档位的前提就是这
+                // 一行。compact 下省掉：窄屏留短标记即可，长句会把整张卡挤爆。
+                if (state.japaneseLocaleApplied && !compact)
+                  Text(
+                    t.game_session_japanese_locale_hint,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                  ),
                 // 降级原因：优先显示结构化失败的可执行处置（「游戏以管理员身份运行，
                 // 请同样以管理员身份启动 Hibiki」之类）。旧实现把 `engine_attach_failed`
                 // 这种内部代码原样甩给用户，等于什么都没说。没有结构化原因时才退回代码。

--- a/fushi/test/mining/gal_japanese_locale_visibility_test.dart
+++ b/fushi/test/mining/gal_japanese_locale_visibility_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/mining/gal_hook_session_controller.dart';
+import 'package:fushi/src/mining/galgame_audio_encode.dart';
+import 'package:fushi/src/mining/window_capture_channel.dart';
+import 'package:fushi/src/mining/galgame_audio_source.dart';
+import 'package:fushi/src/mining/galgame_japanese_locale.dart';
+import 'package:fushi/src/sync/texthooker_service.dart';
+import 'package:fushi/src/sync/texthooker_ws_client.dart';
+
+/// 转区（日文区域 / CP932）必须是**会话里看得见的事实**，而不是只存在于 injector 命令行。
+///
+/// 背景：`auto` 的判据是「系统 ANSI 代码页 ≠ 932 且目标 exe 是 32 位」。中文系统
+/// （ACP=936）上跑任何 32 位 galgame 都会命中它——包括自带多语言的版本和汉化版，而
+/// 那些游戏的字符串本来就不是 Shift-JIS，套 CP932 反而会解坏（窗口标题乱码、脚本
+/// 加载失败）。[resolveJapaneseLocale] 的注释已经承认 `auto` 不可能总判对、真正兜底
+/// 的是用户手动选 [GalJapaneseLocaleMode.off]；但用户在设置页只看得到「自动」，
+/// 出问题时没有任何线索指向转区。这组测试锁住「本局到底转没转」这条信息的通路。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('resolveJapaneseLocale auto 判据（锁定现状，说明误伤从哪来）', () {
+    test('中文系统 + 32 位目标 => 自动转区（多语言版/汉化版正是落在这一格）', () {
+      expect(
+        resolveJapaneseLocale(
+          mode: GalJapaneseLocaleMode.auto,
+          launchMode: true,
+          is32Bit: true,
+          systemAnsiCodePage: 936,
+        ),
+        isTrue,
+      );
+    });
+
+    test('日文系统 => 不转区（本来就是 932，转了纯属有害无益）', () {
+      expect(
+        resolveJapaneseLocale(
+          mode: GalJapaneseLocaleMode.auto,
+          launchMode: true,
+          is32Bit: true,
+          systemAnsiCodePage: 932,
+        ),
+        isFalse,
+      );
+    });
+
+    test('off 是用户兜底档：任何情况下都不转区', () {
+      expect(
+        resolveJapaneseLocale(
+          mode: GalJapaneseLocaleMode.off,
+          launchMode: true,
+          is32Bit: true,
+          systemAnsiCodePage: 936,
+        ),
+        isFalse,
+      );
+    });
+
+    test('attach 模式必然短路：进程早已存在，改不了它的区域', () {
+      expect(
+        resolveJapaneseLocale(
+          mode: GalJapaneseLocaleMode.on,
+          launchMode: false,
+          is32Bit: true,
+          systemAnsiCodePage: 936,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  test('转区的会话：状态置位并记一条事件', () async {
+    final _LocaleHarness harness = _LocaleHarness(localeApplied: true);
+    final GalHookSessionController controller = harness.build();
+
+    expect(
+      (await controller.launchGame(r'D:\game\tenshi.exe')).launched,
+      isTrue,
+    );
+
+    expect(
+      controller.state.japaneseLocaleApplied,
+      isTrue,
+      reason: '会话状态必须带上本局真的转了区，UI 才有东西可显示',
+    );
+    expect(
+      controller.events.map((GalHookEvent event) => event.code),
+      contains('launch.japanese_locale_applied'),
+      reason: '诊断里也要留痕，事后排障不必去猜 injector 命令行',
+    );
+
+    await harness.dispose(controller);
+  });
+
+  test('未转区的会话：不置位、也不记事件', () async {
+    final _LocaleHarness harness = _LocaleHarness(localeApplied: false);
+    final GalHookSessionController controller = harness.build();
+
+    expect(
+      (await controller.launchGame(r'D:\game\tenshi.exe')).launched,
+      isTrue,
+    );
+
+    expect(controller.state.japaneseLocaleApplied, isFalse);
+    expect(
+      controller.events.map((GalHookEvent event) => event.code),
+      isNot(contains('launch.japanese_locale_applied')),
+      reason: '没转区还报「已转区」会把用户引到错误的排查方向',
+    );
+
+    await harness.dispose(controller);
+  });
+
+  test('会话停止后标记复位，不残留到下一局', () async {
+    final _LocaleHarness harness = _LocaleHarness(localeApplied: true);
+    final GalHookSessionController controller = harness.build();
+
+    await controller.launchGame(r'D:\game\tenshi.exe');
+    expect(controller.state.japaneseLocaleApplied, isTrue);
+
+    await controller.stopCapture();
+
+    expect(
+      controller.state.japaneseLocaleApplied,
+      isFalse,
+      reason: '空闲状态还挂着上一局的「已转区」会让下一局的排查从错误前提开始',
+    );
+
+    await harness.dispose(controller);
+  });
+
+  test('copyWith：clearLaunchExe 复位转区标记（两者同属 launch 会话）', () {
+    const GalHookSessionState applied =
+        GalHookSessionState(japaneseLocaleApplied: true);
+
+    expect(
+        applied.copyWith(clearLaunchExe: true).japaneseLocaleApplied, isFalse);
+    // 不清 launchExe 时保持原值，避免顺手把无关的 copyWith 也复位掉。
+    expect(
+        applied
+            .copyWith(phase: GalHookSessionPhase.running)
+            .japaneseLocaleApplied,
+        isTrue);
+  });
+}
+
+/// 把会话控制器的构造/清理收在一处，避免每个用例重复十几行替身接线。
+class _LocaleHarness {
+  _LocaleHarness({required this.localeApplied});
+
+  final bool localeApplied;
+  final TexthookerService service = TexthookerService.test();
+  final ChangeNotifier endpoints = ChangeNotifier();
+
+  GalHookSessionController build() {
+    final _LocaleEngine engine = _LocaleEngine(localeApplied: localeApplied);
+    return GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => true,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+        GalJapaneseLocaleMode japaneseLocaleMode =
+            kGalDefaultJapaneseLocaleMode,
+      }) =>
+          engine,
+      loopbackSourceFactory: _NoopLoopback.new,
+      windowListLoader: () async => const <ExternalWindowInfo>[],
+      windowPollAttempts: 1,
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+  }
+
+  Future<void> dispose(GalHookSessionController controller) async {
+    await controller.close();
+    endpoints.dispose();
+  }
+}
+
+/// 只回答一个问题的引擎替身：本局转没转区。其余走基类默认，不引入额外行为。
+class _LocaleEngine extends EngineHookGalAudioSource {
+  _LocaleEngine({required this.localeApplied})
+      : super(targetPid: 0, launchExe: 'fake.exe', injectorPath: 'fake.exe');
+
+  final bool localeApplied;
+
+  @override
+  bool get japaneseLocaleApplied => localeApplied;
+
+  @override
+  int? get gamePid => 4242;
+
+  @override
+  bool get textHookReady => true;
+
+  @override
+  Future<PcmFormat?> start() async => const PcmFormat(
+        sampleRate: 44100,
+        channels: 1,
+        bitsPerSample: 16,
+        isFloat: false,
+      );
+
+  @override
+  Future<void> stop() async {}
+}
+
+class _NoopLoopback extends LoopbackGalAudioSource {
+  @override
+  Future<PcmFormat?> start() async => null;
+
+  @override
+  Future<void> stop() async {}
+}


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：`docs/bugs/BUG-1691-*.md` 与 `fushi/test/mining/gal_japanese_locale_visibility_test.dart` 在 `develop` 上不存在，提交主题也找不到。从没开过 PR。

## 内容

BUG-1691：转区不再静默生效——本局是否套 CP932 进会话状态与 UI。未落地约 **+454 行 / 5 个文件**。

## 平台边界

galgame hook 相关只做 Windows 端。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
