### PR TITLE
fix(galgame): BUG-1778 已制卡徽章可被 Anki 真实状态推翻（从未开 PR）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1654 条。点号进各自文件。
+> 共 1655 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1778](bugs/BUG-1778-texthooker-mined-badge-never-revalidated.md) | ✅ | ✅ | galgame 台词列表「已制卡」徽章是单向内存 latch，Anki 删卡后永不复核 |
 | [BUG-1777](bugs/BUG-1777-emphatic-full-collapse-phantom-match.md) | ✅ | ✅ | 查词促音丢失：强调折叠full模式常开产生吞字幻影匹配压过原形 |
 | [BUG-1776](bugs/BUG-1776-subtitle-list-adjacent-chain-dup.md) | ✅ | ✅ | 字幕列表不折叠同文本时间相接的卡拉OK交替事件 |
 | [BUG-1775](bugs/BUG-1775-ass-clip-cue-frame-anchor.md) | ✅ | ✅ | 带clip的ASS事件按容器基线定位与帧空间裁剪几何脱节 |

--- a/docs/bugs/BUG-1778-texthooker-mined-badge-never-revalidated.md
+++ b/docs/bugs/BUG-1778-texthooker-mined-badge-never-revalidated.md
@@ -1,0 +1,59 @@
+## BUG-1778 · galgame 台词列表「已制卡」徽章是单向内存 latch，Anki 删卡后永不复核
+- **报告**：2026-08-23（用户原话：「anki扫描好像不是实时的 我制卡后然后去anki删了，还是显示已制卡。」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/sync/texthooker_service.dart:341`（旧 `final bool mined`）
+  + `:745` 旧 `markLineMined(String id)`。
+  - **定位到底是哪块 UI**：界面上出现「已制卡」这四个字的只有 galgame 捕获工作台台词列表
+    （`fushi/lib/src/pages/implementations/texthooker_page.dart:2738` → `_LineMinedChip` `:2852`，
+    文案 `game_line_mined`；筛选器 `game_filter_mined` `:1872`）。查词弹窗那条车道显示的是
+    ✓ 符号而非文字，且它**本来就是实时的**（BUG-186 已把它改成查词时实时探测 Anki），
+    所以用户说的不是它。收藏夹页的 `collection_mined` 是制卡历史流水，删卡后仍在列属预期。
+  - **根因**：`TexthookerLineEntry.mined` 是个 `bool` 单向 latch，只记录了「制卡这个动作发生过」，
+    **没有记录制出来的是哪张卡**。`markLineMined` 只能 false→true（`:747` 已 mined 直接 return），
+    全仓没有任何一处会把它清回去。数据结构里缺少身份，导致它**结构上无法复核** —— 不是
+    「忘了刷新」，是「就算想刷新也没有可查的凭据」。
+  - 对照：Anki 数据源本身两端都是实时的（AnkiConnect `findNotes` /
+    AnkiDroid `findDuplicateNotes`），查词弹窗每次渲染都实时查（`popup.js:2909`）。
+    这条 galgame 徽章车道是唯一一个从不问 Anki 的「已制卡」显示。
+- **[x] ① 已修复** — 修数据结构，而不是加一个刷新定时器：
+  - `texthooker_service.dart`：`TexthookerLineEntry` 新增 `minedNoteId`（制出的那张 note 的 id
+    = 复核凭据）；`markLineMined(id, {int? noteId})` 记下它，幂等口径改成「已 mined **且** id 没变
+    才跳过」，这样覆写既有卡 / 先前没带回 id 的行也能补登记；新增 `clearMinedForNotes(Set<int>)`
+    把确认已删除的卡对应的行清回未制卡，新增 `minedNoteIds` 供页面批量取证。
+  - `packages/fushi_anki/lib/src/base_anki_repository.dart`：新增 `findDeletedNotes(Set<int>)`，
+    **返回值口径是本次修复的要害**——只返回「后端明确应答、且应答里没有这张 note」的 id；
+    查询失败 / 不可达 / 后端不支持一律**空集**。刻意不用 `bool`/`Map<int,bool>`：`bool` 表达不了
+    「不知道」这个第三态，而把「问不到」误判成「已删除」会在 Anki 没开着时清空满屏徽章，
+    比不复核更糟。基类默认空集 = AnkiDroid / AnkiMobile 保持旧 latch 行为不变。
+  - `ankiconnect_repository.dart`：用一次 `notesInfo` 批量往返实现（常数 1 次，不随 id 数增长）；
+    `notesInfoMany` 对不存在的 note 收到的是空对象项并已跳过，故「id 不在返回 map 里」精确等于
+    「Anki 说这张 note 没了」。不复用 `isDuplicate` 的 30s 不可达冷却窗（BUG-1302）——那个冷却是给
+    渲染路径上逐词条的高频探测省超时的，本方法是切回前台才跑一次的低频复核，借它只会让
+    「Anki 刚重新可达」的那次复核白跑。
+  - `texthooker_page.dart`：State 挂 `WidgetsBindingObserver`，`didChangeAppLifecycleState`
+    收到 `resumed` 时复核（用户原始路径「制卡 → 切去 Anki 删卡 → 切回 Hibiki」回到 app 的那一刻），
+    进页首帧也复核一次（覆盖「卡在别的页面制的」）；`_revalidatingMined` 单次在途守卫防重入。
+  - `gal_hook_mining_coordinator.dart:409`：制卡成功回写时带上 `outcome.noteId ?? updateNoteId`
+    （覆写既有卡时 outcome 不带新 id，退回本次覆写目标 id）。
+  - 未触碰：hook DLL / helper / IPC 契约 / LunaHook / 引擎 adapter / 文本线程选择 / 语音配对；
+    `engine-support.yaml` 原封不动（改 UI 不构成任何引擎状态变化）；查词弹窗 popup.js 制卡状态机
+    未动；`MiningStatistics` / `LookupMiningCounters` 未动（历史计数，删卡不应减，与 BUG-186 同口径）。
+- **[x] ② 已加自动化测试** —
+  - 行为（TexthookerService 层，12 例）：`fushi/test/mining/texthooker_mined_revalidation_test.dart`
+    —— 记 note id / 幂等 / 覆写补登记 / `minedNoteIds` 口径；确认删除→徽章消失、可重新制卡、
+    只在真清掉时通知；**「绝不误清」组是核心不变式**：空集（= 不可达）什么都不清、别的 id 不误伤、
+    没有 note id 的行永不被清。
+  - 契约（Anki 仓库层，7 例）：`packages/fushi_anki/test/find_deleted_notes_test.dart`
+    —— 缺席即已删除、全在则空集、一次批量往返、空输入不打网络、**不可达返回空集**、
+    业务错误同样空集、基类默认降级空集。
+  - **变异实测**（两处，各自逐字节还原并 SHA-256 校验）：
+    ① 把 `clearMinedForNotes` 的清除改成 `continue`（还原成旧 latch）→「徽章消失」组 3 例红；
+    ② 把 `findDeletedNotes` 的 catch 从空集改成 `return noteIds`（把不可达当全删）→「绝不误清」
+    的 2 例红。守卫确认有效。
+- **备注**：
+  - 验证：`flutter test test/mining`（1081 通过）、`fushi_anki` 包全量（430 通过）、
+    `fushi/test/lookup` + `test/anki`（913 通过）、`flutter analyze`（fushi 全量 No issues）、
+    `dart analyze --fatal-infos`（fushi_anki，No issues）。
+  - **未验证项（照 SOP 逐项记账）**：真 Anki 端到端（在本页制卡 → 在 Anki 桌面删掉那张卡 →
+    切回 Hibiki 看徽章消失）需要真 AnkiConnect + 真游戏会话，host 侧测不到，与 BUG-186 的
+    既有免责口径一致。`didChangeAppLifecycleState` 在 Windows 桌面窗口切换时是否稳定发
+    `resumed` 未经真机确认——即便它不发，进页复核与后续制卡回写仍会纠正徽章，只是纠正时机变晚。

--- a/fushi/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/fushi/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -432,8 +432,15 @@ class GalHookMiningCoordinator {
       final MineOutcome outcome = mined.outcome! as MineOutcome;
       // 制卡成功回写行模型：把该行标记为「已制卡」，供捕获工作台列表显示徽章。
       // 幂等（markLineMined 内部去重），覆写既有卡（updateNoteId）成功同样视作已制卡。
+      //
+      // BUG-1778：连同后端回传的 note id 一起记下，这行日后才能向 Anki 复核那张卡
+      // 是否还活着（用户在 Anki 里删了就把徽章清掉）。覆写既有卡时 outcome 不带新 id，
+      // 退回本次覆写的目标 id —— 那正是这行现在对应的那张卡。
       if (outcome.result == MineResult.success) {
-        _textService.markLineMined(entry.id);
+        _textService.markLineMined(
+          entry.id,
+          noteId: outcome.noteId ?? updateNoteId,
+        );
       }
       return GalHookMiningResult(
         outcome: outcome,

--- a/fushi/lib/src/pages/implementations/texthooker_page.dart
+++ b/fushi/lib/src/pages/implementations/texthooker_page.dart
@@ -85,7 +85,7 @@ class TexthookerPage extends ConsumerStatefulWidget {
 }
 
 class _TexthookerPageState extends ConsumerState<TexthookerPage>
-    with DictionaryPageMixin {
+    with DictionaryPageMixin, WidgetsBindingObserver {
   final DictionaryPopupController _popup = DictionaryPopupController(
     lowMemory: false,
     onLookupStackDepthChanged: recordLookupStackDepth,
@@ -94,6 +94,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   final GalHookSessionController _session = GalHookSessionController.instance;
   OverlayEntry? _popupOverlayEntry;
   bool _overlayInert = false;
+
+  /// BUG-1778：「已制卡」徽章向 Anki 复核的单次在途守卫。切回前台可能连发多次
+  /// （resumed 事件 + 首帧），复核本身是一次网络往返，重入只会白打。
+  bool _revalidatingMined = false;
   bool _popupOverlayRebuildScheduled = false;
   String? _activeLineId;
   String? _activeSentence;
@@ -421,6 +425,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     _lastObservedLineId = initialLines.isEmpty ? null : initialLines.last.id;
     TexthookerService.instance.addListener(_onLines);
     _session.addListener(_onSessionChanged);
+    // BUG-1778：监听前台/后台切换，用户去 Anki 删卡再切回来时复核「已制卡」徽章。
+    WidgetsBinding.instance.addObserver(this);
     HardwareKeyboard.instance.addHandler(_handlePopupMineHardwareKey);
     // TODO-1204：接线查词计数（每次查词 +1 → lookup_mining_counters）。
     attachLookupCounter(_popup);
@@ -434,7 +440,49 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         _scroll.jumpTo(_scroll.position.maxScrollExtent);
       }
       _maybeScheduleCaptureSetupDialog();
+      // BUG-1778：进页也复核一次——卡可能是在别的页面制的、随后在 Anki 里被删掉，
+      // 那种路径不经过本页的前台切换事件。
+      unawaited(_revalidateMinedLines());
     });
+  }
+
+  /// BUG-1778：切回前台就复核「已制卡」徽章。用户的原始路径正是「在本页制卡 →
+  /// 切到 Anki 删掉那张卡 → 切回 Hibiki」，`resumed` 就是这条路径回到 app 的那一刻。
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_revalidateMinedLines());
+    }
+  }
+
+  /// BUG-1778：把本会话所有「已制卡且带 note id」的行拿去问 Anki，凡是 Anki 明确
+  /// 应答「这张 note 不存在」的，把对应行的徽章清掉。
+  ///
+  /// 复核的真相源是 Anki 本身，与 [BUG-186] 给查词弹窗 ✓ 定下的口径一致：徽章不是
+  /// 装饰，它表示「Anki 里现在有这张卡」。
+  ///
+  /// **不可达绝不清**：`findDeletedNotes` 在查询失败 / AnkiConnect 不可达时返回空集
+  /// （见其文档），因此 Anki 没开着的时候本方法什么都不做，而不是把满屏徽章清空。
+  Future<void> _revalidateMinedLines() async {
+    if (_revalidatingMined) return;
+    final Set<int> noteIds = TexthookerService.instance.minedNoteIds;
+    if (noteIds.isEmpty) return;
+    if (!mounted || !_appModel.isInitialised) return;
+    _revalidatingMined = true;
+    try {
+      final BaseAnkiRepository repo =
+          _appModel.platformServices.createAnkiRepository();
+      final Set<int> deleted = await repo.findDeletedNotes(noteIds);
+      if (deleted.isEmpty) return;
+      TexthookerService.instance.clearMinedForNotes(deleted);
+    } catch (e, stack) {
+      // 复核是纯装饰性刷新，任何失败都不得冒泡打断捕获工作台。
+      debugPrint('TexthookerPage._revalidateMinedLines: $e');
+      debugPrint('$stack');
+    } finally {
+      _revalidatingMined = false;
+    }
   }
 
   @override
@@ -460,6 +508,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   void dispose() {
     _linePreviewResetTimer?.cancel();
     HardwareKeyboard.instance.removeHandler(_handlePopupMineHardwareKey);
+    WidgetsBinding.instance.removeObserver(this);
     TexthookerService.instance.removeListener(_onLines);
     _session.removeListener(_onSessionChanged);
     final OverlayEntry? popupOverlay = _popupOverlayEntry;
@@ -557,7 +606,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       );
       final String? lineId = _activeLineId;
       if (result.ankiConnect && lineId != null) {
-        TexthookerService.instance.markLineMined(lineId);
+        // BUG-1778：带上 note id，供日后向 Anki 复核这张卡是否还在。
+        TexthookerService.instance.markLineMined(
+          lineId,
+          noteId: result.noteId,
+        );
       }
       return result;
     }

--- a/fushi/lib/src/sync/texthooker_service.dart
+++ b/fushi/lib/src/sync/texthooker_service.dart
@@ -308,6 +308,7 @@ class TexthookerLineEntry {
     this.audioDurationMs,
     this.fallbackReason,
     this.mined = false,
+    this.minedNoteId,
     this.favorited = false,
     this.rubySpans = const <RubySpan>[],
   });
@@ -338,7 +339,18 @@ class TexthookerLineEntry {
 
   /// 本行是否已成功制卡（会话内存态，不落 DB）。制卡成功由
   /// [GalHookMiningCoordinator] / fallback 制卡回写（见 [TexthookerService.markLineMined]）。
+  ///
+  /// BUG-1778：这**不是**单向 latch —— 用户在 Anki 里把那张卡删了之后，
+  /// [TexthookerService.clearMinedForNotes] 会把它清回 false，徽章随之消失。
+  /// 复核凭据是 [minedNoteId]。
   final bool mined;
+
+  /// BUG-1778：本行制出的那张 Anki note 的 id，用于日后复核它是否还活着。
+  ///
+  /// 仅当后端回传了真实 note id（AnkiConnect；galgame 制卡是 Windows 专属车道，
+  /// 因此实际总有 id）时非空。为 null 时 [mined] 退化回旧的单向 latch —— 没有身份
+  /// 就无从复核，此时**保持点亮**而不是清掉（宁可陈旧，不可误清）。
+  final int? minedNoteId;
 
   /// 本行是否已被用户收藏（会话内存态，不落 DB；重启即失）。
   final bool favorited;
@@ -367,9 +379,11 @@ class TexthookerLineEntry {
     int? audioDurationMs,
     String? fallbackReason,
     bool? mined,
+    int? minedNoteId,
     bool? favorited,
     bool clearAudioResourceId = false,
     bool clearFallbackReason = false,
+    bool clearMinedNoteId = false,
   }) {
     return TexthookerLineEntry(
       id: id,
@@ -391,6 +405,7 @@ class TexthookerLineEntry {
       fallbackReason:
           clearFallbackReason ? null : fallbackReason ?? this.fallbackReason,
       mined: mined ?? this.mined,
+      minedNoteId: clearMinedNoteId ? null : minedNoteId ?? this.minedNoteId,
       favorited: favorited ?? this.favorited,
       rubySpans: rubySpans,
     );
@@ -781,15 +796,51 @@ class TexthookerService extends ChangeNotifier {
     return true;
   }
 
-  /// 把 [id] 行标记为已制卡（幂等：已是 mined 直接返回 false 不重复通知）。
-  /// 制卡成功后由挖矿编排回写，供列表显示「已制卡」徽章。
-  bool markLineMined(String id) {
+  /// 把 [id] 行标记为已制卡，[noteId] 是后端回传的 note id（BUG-1778 的复核凭据，
+  /// 无 id 的后端传 null）。制卡成功后由挖矿编排回写，供列表显示「已制卡」徽章。
+  ///
+  /// 幂等口径：已是 mined **且** note id 没变化才跳过；已 mined 的行拿到了新的
+  /// note id（覆写既有卡、或先前那次制卡没带回 id）仍要写进去，否则这行永远复核不了。
+  bool markLineMined(String id, {int? noteId}) {
     final int index = _entries.indexWhere((entry) => entry.id == id);
-    if (index < 0 || _entries[index].mined) return false;
-    _entries[index] = _entries[index].copyWith(mined: true);
+    if (index < 0) return false;
+    final TexthookerLineEntry entry = _entries[index];
+    if (entry.mined && (noteId == null || entry.minedNoteId == noteId)) {
+      return false;
+    }
+    _entries[index] = entry.copyWith(mined: true, minedNoteId: noteId);
     notifyListeners();
     return true;
   }
+
+  /// BUG-1778：把 note 已被删除的行清回「未制卡」。[deletedNoteIds] 必须是
+  /// **确认已从 Anki 删除**的 id 集合（见 `BaseAnkiRepository.findDeletedNotes`
+  /// 的口径：查不到 / 不可达一律给空集，绝不当成已删除）。
+  ///
+  /// 只碰 [TexthookerLineEntry.minedNoteId] 落在集合里的行；没有 note id 的行
+  /// （拿不到 id 的后端）保持原样点亮 —— 没有身份就没有复核依据。
+  /// 返回被清掉的行数；一行都没动时不发通知。
+  int clearMinedForNotes(Set<int> deletedNoteIds) {
+    if (deletedNoteIds.isEmpty) return 0;
+    int cleared = 0;
+    for (int i = 0; i < _entries.length; i++) {
+      final TexthookerLineEntry entry = _entries[i];
+      final int? noteId = entry.minedNoteId;
+      if (!entry.mined || noteId == null) continue;
+      if (!deletedNoteIds.contains(noteId)) continue;
+      _entries[i] = entry.copyWith(mined: false, clearMinedNoteId: true);
+      cleared++;
+    }
+    if (cleared > 0) notifyListeners();
+    return cleared;
+  }
+
+  /// BUG-1778：当前所有「已制卡且带 note id」的行的 note id 集合，供页面拿去
+  /// 向 Anki 批量复核。没有 id 的行不参与（复核不了）。
+  Set<int> get minedNoteIds => _entries
+      .where((TexthookerLineEntry e) => e.mined && e.minedNoteId != null)
+      .map((TexthookerLineEntry e) => e.minedNoteId!)
+      .toSet();
 
   /// 设置 [id] 行的收藏态（会话内存态，不落 DB）。状态无变化时不通知。
   bool setLineFavorite(String id, bool favorited) {

--- a/fushi/test/mining/texthooker_mined_revalidation_test.dart
+++ b/fushi/test/mining/texthooker_mined_revalidation_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/texthooker_service.dart';
+
+// BUG-1778：galgame 捕获工作台台词列表的「已制卡」徽章，此前是**单向内存 latch**
+// （markLineMined 只能 false→true，永不复核 Anki）。用户在 Anki 里把那张卡删掉之后，
+// 徽章仍然亮着——这就是「anki 扫描不是实时的」的真身。
+//
+// 修复把行模型从「制过卡这个事件」改成「制出的那张卡的身份」（minedNoteId），
+// 徽章因此可以被 Anki 的真实状态推翻。这组测试守两件事：
+//   ① 确认被删的卡 → 徽章必须消失；
+//   ② 没被确认删除的一切情形（空集 = Anki 不可达 / 别人的 id / 没有 id 的行）
+//      → 徽章必须**原样保留**。②比①更要害：误清会在 Anki 没开着时清空满屏徽章。
+
+void main() {
+  late TexthookerService service;
+
+  setUp(() => service = TexthookerService.test());
+
+  String appendLine(String text) {
+    final TexthookerLineEntry? entry = service.appendLine(text);
+    expect(entry, isNotNull);
+    return entry!.id;
+  }
+
+  bool minedOf(String id) => service.entryById(id)!.mined;
+
+  group('BUG-1778 制卡回写记下 note id', () {
+    test('markLineMined 记下 note id，徽章点亮', () {
+      final String id = appendLine('こんにちは');
+      expect(service.markLineMined(id, noteId: 1700000000001), isTrue);
+      final TexthookerLineEntry entry = service.entryById(id)!;
+      expect(entry.mined, isTrue);
+      expect(entry.minedNoteId, 1700000000001);
+    });
+
+    test('重复标记同一张卡是幂等的（不重复通知）', () {
+      final String id = appendLine('こんにちは');
+      expect(service.markLineMined(id, noteId: 42), isTrue);
+      expect(service.markLineMined(id, noteId: 42), isFalse);
+    });
+
+    test('已 mined 的行拿到新 note id 仍要写进去（覆写卡后仍可复核）', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+      expect(service.markLineMined(id, noteId: 99), isTrue,
+          reason: '否则这行永远拿着过期 id、复核不到真正那张卡');
+      expect(service.entryById(id)!.minedNoteId, 99);
+    });
+
+    test('minedNoteIds 只收「已制卡且有 id」的行', () {
+      final String withId = appendLine('あ');
+      final String withoutId = appendLine('い');
+      final String notMined = appendLine('う');
+      service.markLineMined(withId, noteId: 7);
+      service.markLineMined(withoutId);
+      expect(service.minedNoteIds, <int>{7});
+      expect(minedOf(withoutId), isTrue, reason: '没有 id 不等于没制卡');
+      expect(minedOf(notMined), isFalse);
+    });
+  });
+
+  group('BUG-1778 卡被删则徽章消失', () {
+    test('确认删除的 note 对应的行清回未制卡', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+
+      expect(service.clearMinedForNotes(<int>{42}), 1);
+
+      final TexthookerLineEntry entry = service.entryById(id)!;
+      expect(entry.mined, isFalse, reason: '徽章必须消失');
+      expect(entry.minedNoteId, isNull, reason: '陈旧 id 一并清掉，不留给下次复核');
+    });
+
+    test('同一张卡被多行引用时全部清掉', () {
+      final String a = appendLine('あ');
+      final String b = appendLine('い');
+      service.markLineMined(a, noteId: 42);
+      service.markLineMined(b, noteId: 42);
+      expect(service.clearMinedForNotes(<int>{42}), 2);
+      expect(minedOf(a), isFalse);
+      expect(minedOf(b), isFalse);
+    });
+
+    test('清掉后可以重新制卡（不是一次性状态）', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+      service.clearMinedForNotes(<int>{42});
+      expect(service.markLineMined(id, noteId: 43), isTrue);
+      expect(minedOf(id), isTrue);
+      expect(service.entryById(id)!.minedNoteId, 43);
+    });
+
+    test('监听者只在真的清掉了东西时被通知', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+      int notifications = 0;
+      service.addListener(() => notifications++);
+
+      expect(service.clearMinedForNotes(<int>{999}), 0);
+      expect(notifications, 0, reason: '一行都没动就不该重绘');
+
+      expect(service.clearMinedForNotes(<int>{42}), 1);
+      expect(notifications, 1);
+    });
+  });
+
+  group('BUG-1778 绝不误清（本组是核心不变式）', () {
+    test('空集什么都不清 —— Anki 不可达时走的正是这条', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+
+      expect(service.clearMinedForNotes(<int>{}), 0);
+
+      expect(minedOf(id), isTrue,
+          reason: 'findDeletedNotes 查询失败时返回空集，'
+              '此时必须一张都不清，否则 Anki 没开着就会清空满屏徽章');
+      expect(service.entryById(id)!.minedNoteId, 42);
+    });
+
+    test('别的 note id 不误伤本行', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id, noteId: 42);
+      expect(service.clearMinedForNotes(<int>{41, 43}), 0);
+      expect(minedOf(id), isTrue);
+    });
+
+    test('没有 note id 的行永不被清（无身份即无复核依据）', () {
+      final String id = appendLine('こんにちは');
+      service.markLineMined(id);
+      expect(minedOf(id), isTrue);
+
+      expect(service.clearMinedForNotes(<int>{42, 99}), 0);
+
+      expect(minedOf(id), isTrue,
+          reason: '拿不到 id 的后端保持旧 latch 行为，宁可陈旧不可误清');
+    });
+
+    test('未制卡的行不受影响', () {
+      final String id = appendLine('こんにちは');
+      expect(service.clearMinedForNotes(<int>{42}), 0);
+      expect(minedOf(id), isFalse);
+    });
+  });
+}

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1137,6 +1137,31 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     }
   }
 
+  // BUG-1778：复核哪些 note 已被用户在 Anki 里删掉。一次 `notesInfo` 批量往返
+  // （常数 1 次，不随 id 数增长），把「应答里没出现」的 id 当作已删除。
+  //
+  // `notesInfoMany` 对不存在的 note 收到的是**空对象项**（没有 noteId 字段），
+  // 在那边已被跳过，所以「id 不在返回 map 里」精确等于「Anki 说这张 note 没了」。
+  //
+  // 传输层/业务层任何失败都返回**空集**（见基类口径）：问不到 ≠ 已删除。这里刻意
+  // **不**复用 isDuplicate 的 30s 不可达冷却窗（BUG-1302）——那个冷却是给渲染路径上
+  // 每词条一发的高频探测省超时的，而本方法是用户切回来才跑一次的低频复核，
+  // 借它的短路只会让「Anki 刚重新可达」的那一次复核白跑。
+  @override
+  Future<Set<int>> findDeletedNotes(Set<int> noteIds) async {
+    if (noteIds.isEmpty) return const <int>{};
+    try {
+      final service = await _getService();
+      final Map<int, Map<String, String>> infos =
+          await service.notesInfoMany(noteIds.toList()..sort());
+      return noteIds.where((int id) => !infos.containsKey(id)).toSet();
+    } catch (e, stack) {
+      debugPrint('AnkiConnectRepository.findDeletedNotes: $e');
+      debugPrint('$stack');
+      return const <int>{};
+    }
+  }
+
   // TODO-1007/1008：在 Anki 桌面端打开浏览器并选中该 note（guiBrowse(nid:<id>)）。
   //
   // 光发 guiBrowse 不够：Anki 若已经在后台开着「浏览」窗口，它内部只是 raise 一个

--- a/packages/fushi_anki/lib/src/base_anki_repository.dart
+++ b/packages/fushi_anki/lib/src/base_anki_repository.dart
@@ -200,6 +200,19 @@ abstract class BaseAnkiRepository {
   /// **默认实现 = 优雅降级**：基类返回 `false`。
   Future<bool> openNoteInAnki(int noteId) async => false;
 
+  /// BUG-1778：复核 [noteIds] 里哪些 note **已经不在 Anki 中了**（用户在 Anki 里删了卡）。
+  ///
+  /// 返回值口径是本方法的全部要害：**只返回「后端明确应答、且应答里没有这张 note」的 id**。
+  /// 查询失败、后端不可达、后端不支持一律返回**空集**，而不是「全都当成已删除」——
+  /// 调用方拿它去清「已制卡」标记，一旦把「问不到」误判成「已删除」，Anki 没开着就会
+  /// 把满屏徽章全部清空，那比不复核更糟。这也是本方法返回**已删除集合**而不是
+  /// `bool` / `Map<int,bool>` 的原因：`bool` 表达不了「不知道」这个第三态，
+  /// 空集天然等于「没有任何一张被确认删除」。
+  ///
+  /// **默认实现 = 优雅降级**：基类恒返回空集（拿不到 note 存在性的后端 —— AnkiDroid
+  /// 只回 bool 查重、AnkiMobile 只有 URL scheme —— 保持既有 latch 行为不变）。
+  Future<Set<int>> findDeletedNotes(Set<int> noteIds) async => const <int>{};
+
   Future<bool> isDuplicate(String expression, String reading);
 
   /// Create [template] as a note type in the backend. Idempotent: returns

--- a/packages/fushi_anki/test/find_deleted_notes_test.dart
+++ b/packages/fushi_anki/test/find_deleted_notes_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+// BUG-1778：「已制卡」标记必须能被 Anki 的真实状态推翻——用户在 Anki 里删掉那张卡
+// 之后，标记要消失。复核入口是 BaseAnkiRepository.findDeletedNotes。
+//
+// 这组测试守的是它**返回值口径**，那才是要害：只报「后端明确应答、且应答里没有这张
+// note」的 id。查询失败 / AnkiConnect 不可达一律空集——把「问不到」当成「已删除」会在
+// Anki 没开着的时候把满屏徽章全部清空，比不复核更糟。
+
+/// 按 id 供应 notesInfo 应答的 service double；[failure] 非空时一律抛出，
+/// 模拟 AnkiConnect 不可达 / 业务错误。
+class _NotesService extends AnkiConnectService {
+  _NotesService({this.present = const <int>{}, this.failure});
+
+  /// Anki 中仍然存在的 note id。
+  final Set<int> present;
+  final Object? failure;
+
+  final List<List<int>> queries = <List<int>>[];
+
+  @override
+  Future<Map<int, Map<String, String>>> notesInfoMany(List<int> noteIds) async {
+    queries.add(List<int>.from(noteIds));
+    final Object? boom = failure;
+    if (boom != null) throw boom;
+    // 真 AnkiConnect 对不存在的 note 回的是**空对象项**，notesInfoMany 那边已把它
+    // 跳过——所以「id 不在返回 map 里」精确等于「Anki 说这张 note 没了」。
+    return <int, Map<String, String>>{
+      for (final int id in noteIds)
+        if (present.contains(id)) id: <String, String>{'Expression': '語'},
+    };
+  }
+}
+
+class _Repo extends AnkiConnectRepository {
+  _Repo({required AnkiConnectService service}) : super(service: service);
+
+  @override
+  Future<AnkiSettings> loadSettings() async => const AnkiSettings(
+        selectedDeckId: 1,
+        selectedNoteTypeId: 2,
+        availableDecks: <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
+        availableNoteTypes: <AnkiNoteType>[
+          AnkiNoteType(
+            id: 2,
+            name: 'Fushi',
+            fields: <String>['Expression', 'Reading'],
+          ),
+        ],
+      );
+}
+
+void main() {
+  group('BUG-1778 findDeletedNotes 只报「确认已删除」', () {
+    test('Anki 应答里缺席的 note 被判为已删除', () async {
+      final service = _NotesService(present: <int>{11, 33});
+      final Set<int> deleted =
+          await _Repo(service: service).findDeletedNotes(<int>{11, 22, 33});
+      expect(deleted, <int>{22},
+          reason: '只有 22 不在应答里，它才是被用户删掉的那张');
+    });
+
+    test('全部都还在时返回空集（一个徽章都不该清）', () async {
+      final service = _NotesService(present: <int>{11, 22});
+      final Set<int> deleted =
+          await _Repo(service: service).findDeletedNotes(<int>{11, 22});
+      expect(deleted, isEmpty);
+    });
+
+    test('一次批量往返查完，不是每个 id 一次', () async {
+      final service = _NotesService(present: <int>{1, 2, 3});
+      await _Repo(service: service).findDeletedNotes(<int>{3, 1, 2});
+      expect(service.queries.length, 1, reason: '常数 1 次往返，不随 id 数增长');
+      expect(service.queries.single, <int>[1, 2, 3], reason: '排序后送出，便于复现');
+    });
+
+    test('空输入不打网络', () async {
+      final service = _NotesService();
+      final Set<int> deleted =
+          await _Repo(service: service).findDeletedNotes(<int>{});
+      expect(deleted, isEmpty);
+      expect(service.queries, isEmpty);
+    });
+
+    // ── 本组的核心不变式 ────────────────────────────────────────────────
+    test('AnkiConnect 不可达时返回空集，绝不把「问不到」当成「已删除」', () async {
+      final service = _NotesService(
+        present: <int>{},
+        failure: const SocketExceptionStub(),
+      );
+      final Set<int> deleted =
+          await _Repo(service: service).findDeletedNotes(<int>{11, 22});
+      expect(deleted, isEmpty,
+          reason: 'Anki 没开着时必须一张都不清，否则满屏徽章会被误清空');
+    });
+
+    test('业务错误（牌组/字段异常）同样返回空集', () async {
+      final service = _NotesService(
+        failure: StateError('AnkiConnect: model not found'),
+      );
+      final Set<int> deleted =
+          await _Repo(service: service).findDeletedNotes(<int>{7});
+      expect(deleted, isEmpty);
+    });
+  });
+
+  group('BUG-1778 基类默认降级', () {
+    test('拿不到 note 存在性的后端恒返回空集（保持旧 latch 行为）', () async {
+      expect(await _DegradedRepo().findDeletedNotes(<int>{1, 2}), isEmpty);
+    });
+  });
+}
+
+/// 只实现抽象成员的最小后端，用来验证基类默认实现（AnkiDroid / AnkiMobile 走这条）。
+class _DegradedRepo extends BaseAnkiRepository {
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      throw UnimplementedError();
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      const MineOutcome(MineResult.error);
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => false;
+
+  @override
+  Future<bool> createDeck(String name) async => false;
+}
+
+/// 独立的传输层异常桩：不引 dart:io，避免测试对平台 socket 类型的耦合。
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+
+  @override
+  String toString() => 'SocketException: Connection refused';
+}


### PR DESCRIPTION
## 这条分支为什么在这里

内容比对确认：3 个新增文件在 `develop` 上不存在（含 `packages/fushi_anki/test/find_deleted_notes_test.dart`），提交主题也找不到。从没开过 PR。这是最近的一条（2026-08-23）。

## 内容

BUG-1778：「已制卡」徽章改为可被 Anki 真实状态推翻，新增 `findDeletedNotes` API。未落地约 **+445 行 / 7 个文件**。

## 提醒

本仓「已制卡」有三条独立路径（浮窗实时 / texthooker 徽章 / 收藏夹历史流水），语义各不相同。合并时确认这次改的是哪一条，别让另两条跟着变。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
