### PR TITLE
refactor(video): 顶栏槽位三段扩为五段，标题可夹在按钮之间（PR #838 合并后追加的提交）

### DIFF
--- a/fushi/lib/src/media/video/video_top_bar_slots.dart
+++ b/fushi/lib/src/media/video/video_top_bar_slots.dart
@@ -2,10 +2,38 @@ import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 
-/// 视频内顶栏的三槽标识（左按钮组 / 标题 / 右按钮组），见 [VideoTopBarSlots]。
-enum VideoTopBarSlotId { left, title, right }
+/// 视频内顶栏的槽标识，见 [VideoTopBarSlots]。
+///
+/// 左右按钮组各拆成 `lead` / `tail` 两段：标题项被用户拖进按钮槽时，它在该槽里的
+/// **索引位置**是有语义的（`VideoControlLayout` 会保序），所以标题要能夹在两段按钮
+/// 之间显示 —— 但它的**宽度**必须最后才分，不能跟按钮抢。
+enum VideoTopBarSlotId { leftLead, leftTail, title, rightLead, rightTail }
 
-/// 视频内顶栏三槽布局：**按钮按需拿宽、标题吃剩余**。
+/// 标题落在顶栏的哪一段（决定它夹在哪两段按钮之间）。
+///
+/// 标题项是单实例（`VideoControlItem.isSingleInstance`），整条顶栏最多一个，所以
+/// 一个枚举就够描述它的位置。
+enum VideoTopBarTitlePlacement {
+  /// 夹在 topLeft 组的 lead / tail 两段之间。
+  left,
+
+  /// 左右两组按钮之间的中段（默认的 topCenter）。
+  center,
+
+  /// 夹在 topRight 组的 lead / tail 两段之间。
+  right,
+}
+
+/// 按钮组要渲染同一个槽里标题**之前**还是**之后**的那段按钮。
+enum VideoTopBarSegment {
+  /// 标题之前的按钮（槽里没有标题时就是整组）。
+  lead,
+
+  /// 标题之后的按钮（槽里没有标题时为空）。
+  tail,
+}
+
+/// 视频内顶栏布局：**按钮按需拿宽、标题吃剩余**。
 ///
 /// 根因（2026-08 修复）：顶栏原来直接是 media_kit fork 的一条 `Row`，左按钮组 / 标题 /
 /// 右按钮组各自挂一个 `Flexible(flex: 1)`。`Flex` 把可用宽按 flex 因子**平分**成三份，
@@ -14,85 +42,134 @@ enum VideoTopBarSlotId { left, title, right }
 /// 按钮挡住、要横滑才点得到」）。标题项被关掉时旧代码还返回 `Spacer()`（= `FlexFit.tight`），
 /// 空白中段照样霸占那 1/3，所以「把名称删掉、中间明明是空的」也救不回按钮。
 ///
-/// 这里换成显式优先级：先满足左槽（返回键等，必达），再满足右槽（功能键），最后把
-/// **真正剩下的**宽度交给标题。按钮永远完整可见；标题窄了靠 `maxLines: 1` + ellipsis
-/// 优雅截断——即「按钮比名称重要」。两侧按钮组自身仍是可横滚的（页面侧用 `shrinkWrap`
-/// ListView 包裹），极窄窗按钮总宽超过整条顶栏时依旧可达、不会被裁没。
+/// 这里换成显式优先级：**四段按钮先按各自内容固有宽足额拿走**，标题最后拿真正剩下的
+/// 那点宽度。按钮永远完整可见；标题窄了靠 `maxLines: 1` + ellipsis 优雅截断——即
+/// 「按钮比名称重要」。按钮段自身仍是可横滚的（页面侧用 `shrinkWrap` ListView 包裹），
+/// 极窄窗按钮总宽超过整条顶栏时依旧可达、不会被裁没。
 ///
-/// 三槽都必须传：不显示的槽传零尺寸占位（如 `SizedBox.shrink()`），它就不占宽。
+/// 五个槽都必须传：不显示的槽传零尺寸占位（如 `SizedBox.shrink()`），它就不占宽。
 class VideoTopBarSlots extends StatelessWidget {
   const VideoTopBarSlots({
-    required this.left,
+    required this.leftLead,
+    required this.leftTail,
     required this.title,
-    required this.right,
+    required this.rightLead,
+    required this.rightTail,
+    this.titlePlacement = VideoTopBarTitlePlacement.center,
     super.key,
   });
 
-  /// 左按钮组（返回键等）：第一优先，按内容固有宽足额分配。
-  final Widget left;
+  /// topLeft 组标题之前的按钮（返回键等）：第一优先。
+  final Widget leftLead;
 
-  /// 标题：最后布局，只吃两侧按钮组用剩的宽。
+  /// topLeft 组标题之后的按钮（标题不在该组时为空占位）。
+  final Widget leftTail;
+
+  /// 标题：最后布局，只吃四段按钮用剩的宽。
   final Widget title;
 
-  /// 右按钮组（功能键）：第二优先，在左槽之后按内容固有宽足额分配。
-  final Widget right;
+  /// topRight 组标题之前的按钮。
+  final Widget rightLead;
+
+  /// topRight 组标题之后的按钮（标题不在该组时为空占位）。
+  final Widget rightTail;
+
+  /// 标题夹在哪两段按钮之间。
+  final VideoTopBarTitlePlacement titlePlacement;
 
   @override
   Widget build(BuildContext context) {
     return CustomMultiChildLayout(
-      delegate: VideoTopBarSlotsDelegate(),
+      delegate: VideoTopBarSlotsDelegate(titlePlacement: titlePlacement),
       children: <Widget>[
-        LayoutId(id: VideoTopBarSlotId.left, child: left),
-        LayoutId(id: VideoTopBarSlotId.right, child: right),
+        LayoutId(id: VideoTopBarSlotId.leftLead, child: leftLead),
+        LayoutId(id: VideoTopBarSlotId.leftTail, child: leftTail),
+        LayoutId(id: VideoTopBarSlotId.rightLead, child: rightLead),
+        LayoutId(id: VideoTopBarSlotId.rightTail, child: rightTail),
         LayoutId(id: VideoTopBarSlotId.title, child: title),
       ],
     );
   }
 }
 
-/// [VideoTopBarSlots] 的排布委托：**布局顺序即优先级**（左按钮 → 右按钮 → 标题吃剩余）。
+/// [VideoTopBarSlots] 的排布委托：**布局顺序即优先级**（四段按钮 → 标题吃剩余）。
 class VideoTopBarSlotsDelegate extends MultiChildLayoutDelegate {
+  VideoTopBarSlotsDelegate({
+    this.titlePlacement = VideoTopBarTitlePlacement.center,
+  });
+
+  final VideoTopBarTitlePlacement titlePlacement;
+
+  /// [positionChild] 要用子尺寸做垂直居中，而 [layoutChild] 每个槽只能调一次，故记账。
+  final Map<VideoTopBarSlotId, Size> _sizes = <VideoTopBarSlotId, Size>{};
+
   @override
   void performLayout(Size size) {
     final double height = size.height;
+    _sizes.clear();
     double consumed = 0;
-    double leftWidth = 0;
-    if (hasChild(VideoTopBarSlotId.left)) {
+
+    /// 按剩余宽布局一个槽；槽自身 shrink-wrap，用多少算多少。
+    double take(VideoTopBarSlotId id) {
+      if (!hasChild(id)) return 0;
       final Size s = layoutChild(
-        VideoTopBarSlotId.left,
-        BoxConstraints.loose(Size(size.width, height)),
-      );
-      leftWidth = s.width;
-      consumed += s.width;
-      positionChild(VideoTopBarSlotId.left, Offset(0, (height - s.height) / 2));
-    }
-    if (hasChild(VideoTopBarSlotId.right)) {
-      final Size s = layoutChild(
-        VideoTopBarSlotId.right,
+        id,
         BoxConstraints.loose(
           Size(math.max(0.0, size.width - consumed), height),
         ),
       );
+      _sizes[id] = s;
       consumed += s.width;
-      positionChild(
-        VideoTopBarSlotId.right,
-        Offset(size.width - s.width, (height - s.height) / 2),
-      );
+      return s.width;
     }
-    if (hasChild(VideoTopBarSlotId.title)) {
-      final Size s = layoutChild(
-        VideoTopBarSlotId.title,
-        BoxConstraints.loose(
-          Size(math.max(0.0, size.width - consumed), height),
-        ),
-      );
-      positionChild(
-        VideoTopBarSlotId.title,
-        Offset(leftWidth, (height - s.height) / 2),
-      );
+
+    // ① 四段按钮先分：它们要多少给多少（上限只有「整条顶栏还剩多少」）。
+    final double leftLead = take(VideoTopBarSlotId.leftLead);
+    final double leftTail = take(VideoTopBarSlotId.leftTail);
+    final double rightLead = take(VideoTopBarSlotId.rightLead);
+    final double rightTail = take(VideoTopBarSlotId.rightTail);
+    // ② 标题最后分，只拿真正剩下的。
+    final double title = take(VideoTopBarSlotId.title);
+
+    /// 槽在顶栏内垂直居中。
+    void place(VideoTopBarSlotId id, double x) {
+      if (!hasChild(id)) return;
+      positionChild(id, Offset(x, (height - _sizeOf(id, height).height) / 2));
     }
+
+    // 左段从左边缘起排；标题若属于左组，就夹在 lead / tail 之间。
+    double x = 0;
+    place(VideoTopBarSlotId.leftLead, x);
+    x += leftLead;
+    if (titlePlacement == VideoTopBarTitlePlacement.left) {
+      place(VideoTopBarSlotId.title, x);
+      x += title;
+    }
+    place(VideoTopBarSlotId.leftTail, x);
+    x += leftTail;
+    // 中段标题紧接左段（文本自身靠左对齐），一直伸到右段左缘。
+    if (titlePlacement == VideoTopBarTitlePlacement.center) {
+      place(VideoTopBarSlotId.title, x);
+    }
+
+    // 右段整体右对齐贴右边缘；标题若属于右组，同样夹在 lead / tail 之间。
+    final double rightTotal = rightLead +
+        rightTail +
+        (titlePlacement == VideoTopBarTitlePlacement.right ? title : 0);
+    double rx = size.width - rightTotal;
+    place(VideoTopBarSlotId.rightLead, rx);
+    rx += rightLead;
+    if (titlePlacement == VideoTopBarTitlePlacement.right) {
+      place(VideoTopBarSlotId.title, rx);
+      rx += title;
+    }
+    place(VideoTopBarSlotId.rightTail, rx);
   }
 
+  Size _sizeOf(VideoTopBarSlotId id, double fallbackHeight) =>
+      _sizes[id] ?? Size(0, fallbackHeight);
+
   @override
-  bool shouldRelayout(VideoTopBarSlotsDelegate oldDelegate) => false;
+  bool shouldRelayout(VideoTopBarSlotsDelegate oldDelegate) =>
+      oldDelegate.titlePlacement != titlePlacement;
 }

--- a/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
@@ -105,18 +105,35 @@ extension _VideoControlsTheme on _VideoFushiPageState {
         // 永远拿不到自己需要的宽。
         Expanded(
           child: VideoTopBarSlots(
-            left: _topBarSlotGroup(
+            leftLead: _topBarSlotGroup(
               VideoControlSlot.topLeft,
               controller,
               layout: layout,
               desktop: true,
+              segment: VideoTopBarSegment.lead,
+            ),
+            leftTail: _topBarSlotGroup(
+              VideoControlSlot.topLeft,
+              controller,
+              layout: layout,
+              desktop: true,
+              segment: VideoTopBarSegment.tail,
             ),
             title: _topBarTitle(),
-            right: _topBarSlotGroup(
+            titlePlacement: _topBarTitlePlacement(),
+            rightLead: _topBarSlotGroup(
               VideoControlSlot.topRight,
               controller,
               layout: layout,
               desktop: true,
+              segment: VideoTopBarSegment.lead,
+            ),
+            rightTail: _topBarSlotGroup(
+              VideoControlSlot.topRight,
+              controller,
+              layout: layout,
+              desktop: true,
+              segment: VideoTopBarSegment.tail,
             ),
           ),
         ),
@@ -278,18 +295,35 @@ extension _VideoControlsTheme on _VideoFushiPageState {
         // 不再让三段各占 fork 顶栏 Row 的 1/3 flex 份额。
         Expanded(
           child: VideoTopBarSlots(
-            left: _topBarSlotGroup(
+            leftLead: _topBarSlotGroup(
               VideoControlSlot.topLeft,
               controller,
               layout: layout,
               desktop: false,
+              segment: VideoTopBarSegment.lead,
+            ),
+            leftTail: _topBarSlotGroup(
+              VideoControlSlot.topLeft,
+              controller,
+              layout: layout,
+              desktop: false,
+              segment: VideoTopBarSegment.tail,
             ),
             title: _topBarTitle(),
-            right: _topBarSlotGroup(
+            titlePlacement: _topBarTitlePlacement(),
+            rightLead: _topBarSlotGroup(
               VideoControlSlot.topRight,
               controller,
               layout: layout,
               desktop: false,
+              segment: VideoTopBarSegment.lead,
+            ),
+            rightTail: _topBarSlotGroup(
+              VideoControlSlot.topRight,
+              controller,
+              layout: layout,
+              desktop: false,
+              segment: VideoTopBarSegment.tail,
             ),
           ),
         ),

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -4997,10 +4997,37 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     ];
   }
 
+  /// 标题项落在顶部哪个槽（用户可把它拖到 topLeft / topCenter / topRight）；没放置
+  /// 或被移除时返回 null。标题是单实例项（[VideoControlItem.isSingleInstance]），
+  /// `VideoControlLayout` 保证它最多出现在一个槽里。
+  VideoControlSlot? _topBarTitleSlot() {
+    for (final VideoControlSlot slot in const <VideoControlSlot>[
+      VideoControlSlot.topLeft,
+      VideoControlSlot.topCenter,
+      VideoControlSlot.topRight,
+    ]) {
+      if (_controlLayout.itemsIn(slot).contains(VideoControlItem.title)) {
+        return slot;
+      }
+    }
+    return null;
+  }
+
+  /// 标题在顶栏里夹在哪两段按钮之间（喂给 [VideoTopBarSlots]）。
+  VideoTopBarTitlePlacement _topBarTitlePlacement() {
+    switch (_topBarTitleSlot()) {
+      case VideoControlSlot.topLeft:
+        return VideoTopBarTitlePlacement.left;
+      case VideoControlSlot.topRight:
+        return VideoTopBarTitlePlacement.right;
+      default:
+        return VideoTopBarTitlePlacement.center;
+    }
+  }
+
   Widget _topBarTitle() {
-    if (!_controlLayout.itemsIn(VideoControlSlot.topCenter).contains(
-          VideoControlItem.title,
-        )) {
+    final VideoControlSlot? slot = _topBarTitleSlot();
+    if (slot == null) {
       // 标题项没配置：交回零宽占位，整条顶栏宽都归两侧按钮组。绝不能返回 Spacer
       // （= Expanded/FlexFit.tight）——那会让「空的中段」硬占一份顶栏宽，用户把标题
       // 关掉后中间明明是空白、右上角按钮却照旧被挤进滚动区裁掉（本轮修复的现象）。
@@ -5009,29 +5036,19 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // TODO-642 → 本轮：标题不再参与 Row 的 flex 分配（旧实现是 Flexible(loose)，与
     // 左右按钮组各占 flex:1 → Flex 把整宽**平分**成三份，loose 用不完的空间又不回流，
     // 所以右侧按钮组无论如何最多只拿 1/3 顶栏宽、多出来的按钮被裁进横滚区）。改由
-    // [_TopBarSlots] 按「按钮按需优先、标题吃剩余」的固定优先级分宽：按钮永远完整可见，
-    // 标题只在剩余宽里显示、靠 maxLines:1 + ellipsis 优雅截断。
+    // [VideoTopBarSlots] 按「按钮按需优先、标题吃剩余」的固定优先级分宽：按钮永远完整
+    // 可见，标题只在剩余宽里显示、靠 maxLines:1 + ellipsis 优雅截断。
+    //
+    // 标题被拖进按钮槽时也走这里（不再有 220 宽的内联块跟同组按钮抢位）：位置由
+    // [_topBarTitlePlacement] 交给顶栏布局还原，对齐跟随所在槽——落在 topRight 就靠
+    // 右贴住它后面那段按钮，其余靠左。
     //
     // 标题走 ValueListenableBuilder（BUG-120）：全屏路由不随页面 setState 重建，
-    // 监听 _titleNotifier 才能在全屏换集后刷新标题。Align 固定标题起点：
-    // topRight 清空时不靠右侧空白占位撑布局，已有按钮未清空时仍保持原有顺序。
+    // 监听 _titleNotifier 才能在全屏换集后刷新标题。
     return _topBarTitleText(
-      alignment: AlignmentDirectional.centerStart,
-    );
-  }
-
-  Widget _topBarInlineTitle(VideoControlSlot slot) {
-    final bool alignEnd = slot == VideoControlSlot.topRight;
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 8 * _videoUiScale),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: 220 * _videoUiScale),
-        child: _topBarTitleText(
-          alignment: alignEnd
-              ? AlignmentDirectional.centerEnd
-              : AlignmentDirectional.centerStart,
-        ),
-      ),
+      alignment: slot == VideoControlSlot.topRight
+          ? AlignmentDirectional.centerEnd
+          : AlignmentDirectional.centerStart,
     );
   }
 
@@ -5264,13 +5281,27 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     VideoPlayerController controller, {
     required VideoControlLayout layout,
     required bool desktop,
+    required VideoTopBarSegment segment,
   }) {
     final List<VideoControlItem> rawItems = layout.itemsIn(slot);
+    // 标题项被拖进按钮槽时，它在槽内的索引位置有语义（`VideoControlLayout` 保序），
+    // 所以按标题把该槽切成 lead / tail 两段按钮，标题本身由顶栏的 title 槽渲染、
+    // **最后**才分宽（[VideoTopBarSlots]）。此前标题是组内一个 220 宽的内联块，会跟
+    // 同组按钮抢横向空间、把按钮挤进横滚区——那正是「名称挡住按钮」的另一半根因。
+    final int titleIndex = rawItems.indexOf(VideoControlItem.title);
+    final List<VideoControlItem> scoped;
+    if (titleIndex < 0) {
+      scoped = segment == VideoTopBarSegment.lead
+          ? rawItems
+          : const <VideoControlItem>[];
+    } else {
+      scoped = segment == VideoTopBarSegment.lead
+          ? rawItems.sublist(0, titleIndex)
+          : rawItems.sublist(titleIndex + 1);
+    }
     final List<VideoControlItem> items = <VideoControlItem>[
-      for (final VideoControlItem item in rawItems)
-        if (item == VideoControlItem.title ||
-            (item.isChipRenderable && _shouldRenderControlItem(item)))
-          item,
+      for (final VideoControlItem item in scoped)
+        if (item.isChipRenderable && _shouldRenderControlItem(item)) item,
     ];
     if (items.isEmpty) return const SizedBox.shrink();
 
@@ -5339,11 +5370,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
                   ? MainAxisAlignment.end
                   : MainAxisAlignment.start,
               children: <Widget>[
-                for (final VideoControlItem item in items)
-                  if (item == VideoControlItem.title)
-                    _topBarInlineTitle(slot)
-                  else
-                    buttonFor(item),
+                for (final VideoControlItem item in items) buttonFor(item),
               ],
             ),
           ],

--- a/fushi/test/pages/video_top_bar_slots_test.dart
+++ b/fushi/test/pages/video_top_bar_slots_test.dart
@@ -2,28 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/video/video_top_bar_slots.dart';
 
-/// 视频内顶栏三槽布局（[VideoTopBarSlots]）的行为守卫。
+/// 视频内顶栏布局（[VideoTopBarSlots]）的行为守卫。
 ///
-/// 原缺陷：顶栏是 media_kit fork 的一条 `Row`，左按钮组 / 标题 / 右按钮组各挂
-/// `Flexible(flex: 1)` → `Flex` 把宽**平分**三份、`loose` 用不完的份额又不回流，
-/// 右上角按钮组最多只拿到 1/3 顶栏宽，多出来的按钮被裁进横滚区；标题项关掉时旧代码
-/// 返回 `Spacer()`，空白中段照旧霸占 1/3（「名称删空了、中间是空的，按钮还是被挡」）。
+/// 原缺陷（两处，同一个「名称挤按钮」病根）：
+/// 1. 顶栏是 media_kit fork 的一条 `Row`，左按钮组 / 标题 / 右按钮组各挂
+///    `Flexible(flex: 1)` → `Flex` 把宽**平分**三份、`loose` 用不完的份额又不回流，
+///    右上角按钮组最多只拿到 1/3 顶栏宽，多出来的按钮被裁进横滚区；标题项关掉时旧代码
+///    返回 `Spacer()`，空白中段照旧霸占 1/3（「名称删空了、中间是空的，按钮还是被挡」）。
+/// 2. 标题被拖进左/右按钮槽时，它是组内一个固定 `maxWidth: 220` 的内联块，跟同组按钮
+///    抢横向空间，把按钮挤进横滚区。
 ///
-/// 现在按优先级分宽：左按钮 → 右按钮 → 标题吃剩余。下面每条都用**真实布局尺寸**断言，
-/// 不是源码扫描。
+/// 现在按优先级分宽：四段按钮（左 lead/tail、右 lead/tail）→ 标题吃剩余。标题仍夹在
+/// 它原来的按钮位置上显示，但**只分剩下的宽**。下面每条都用**真实布局尺寸**断言。
 void main() {
-  const Key leftKey = Key('slot-left');
+  const Key leftLeadKey = Key('slot-left-lead');
+  const Key leftTailKey = Key('slot-left-tail');
   const Key titleKey = Key('slot-title');
-  const Key rightKey = Key('slot-right');
+  const Key rightLeadKey = Key('slot-right-lead');
+  const Key rightTailKey = Key('slot-right-tail');
 
   Future<void> pumpBar(
     WidgetTester tester, {
     required double barWidth,
-    required double leftWidth,
-    required double rightWidth,
+    double leftLead = 0,
+    double leftTail = 0,
+    double rightLead = 0,
+    double rightTail = 0,
     Widget? title,
+    VideoTopBarTitlePlacement placement = VideoTopBarTitlePlacement.center,
     double height = 48,
   }) async {
+    Widget slot(Key key, double width) => width == 0
+        ? SizedBox.shrink(key: key)
+        : SizedBox(key: key, width: width, height: height);
+
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -33,10 +45,13 @@ void main() {
             width: barWidth,
             height: height,
             child: VideoTopBarSlots(
-              left: SizedBox(key: leftKey, width: leftWidth, height: height),
+              leftLead: slot(leftLeadKey, leftLead),
+              leftTail: slot(leftTailKey, leftTail),
               title: title ??
                   SizedBox(key: titleKey, width: barWidth, height: height),
-              right: SizedBox(key: rightKey, width: rightWidth, height: height),
+              titlePlacement: placement,
+              rightLead: slot(rightLeadKey, rightLead),
+              rightTail: slot(rightTailKey, rightTail),
             ),
           ),
         ),
@@ -44,35 +59,35 @@ void main() {
     );
   }
 
-  group('顶栏三槽：按钮按需拿宽、标题吃剩余', () {
+  group('顶栏：按钮按需拿宽、标题吃剩余', () {
     testWidgets('右按钮组能拿到远超 1/3 顶栏宽的自身所需宽度', (WidgetTester tester) async {
       // 600 宽顶栏、右组需要 400（= 2/3）。旧的三等分 Flex 只会给 200。
       await pumpBar(
         tester,
         barWidth: 600,
-        leftWidth: 60,
-        rightWidth: 400,
+        leftLead: 60,
+        rightLead: 400,
       );
 
-      expect(tester.getSize(find.byKey(rightKey)).width, 400,
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 400,
           reason: '右按钮组必须足额拿到自身需要的宽，不被平分成 1/3（200）');
-      expect(tester.getSize(find.byKey(leftKey)).width, 60);
+      expect(tester.getSize(find.byKey(leftLeadKey)).width, 60);
       // 标题只吃剩余：600 - 60 - 400 = 140。
       expect(tester.getSize(find.byKey(titleKey)).width, 140,
           reason: '标题只拿两侧按钮用剩的宽');
     });
 
-    testWidgets('右按钮组贴右边缘、左按钮组贴左边缘、标题接在左组之后', (WidgetTester tester) async {
+    testWidgets('右按钮组贴右边缘、左按钮组贴左边缘、标题接在左段之后', (WidgetTester tester) async {
       await pumpBar(
         tester,
         barWidth: 600,
-        leftWidth: 60,
-        rightWidth: 400,
+        leftLead: 60,
+        rightLead: 400,
       );
 
-      expect(tester.getTopLeft(find.byKey(leftKey)).dx, 0);
+      expect(tester.getTopLeft(find.byKey(leftLeadKey)).dx, 0);
       expect(tester.getTopLeft(find.byKey(titleKey)).dx, 60);
-      expect(tester.getTopRight(find.byKey(rightKey)).dx, 600,
+      expect(tester.getTopRight(find.byKey(rightLeadKey)).dx, 600,
           reason: 'topRight 组必须右对齐到顶栏右边缘');
     });
 
@@ -81,15 +96,15 @@ void main() {
       await pumpBar(
         tester,
         barWidth: 600,
-        leftWidth: 60,
-        rightWidth: 520,
+        leftLead: 60,
+        rightLead: 520,
         title: const SizedBox.shrink(key: titleKey),
       );
 
-      expect(tester.getSize(find.byKey(rightKey)).width, 520,
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 520,
           reason: '标题空了，右按钮组应能吃到 60 之外的全部宽');
       expect(tester.getSize(find.byKey(titleKey)).width, 0);
-      expect(tester.getTopRight(find.byKey(rightKey)).dx, 600);
+      expect(tester.getTopRight(find.byKey(rightLeadKey)).dx, 600);
     });
 
     testWidgets('超长标题不得挤压按钮：按钮先拿够，标题被压成剩余宽', (WidgetTester tester) async {
@@ -97,28 +112,28 @@ void main() {
       await pumpBar(
         tester,
         barWidth: 600,
-        leftWidth: 60,
-        rightWidth: 400,
+        leftLead: 60,
+        rightLead: 400,
         title: const SizedBox(key: titleKey, width: 10000, height: 48),
       );
 
-      expect(tester.getSize(find.byKey(rightKey)).width, 400);
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 400);
       expect(tester.getSize(find.byKey(titleKey)).width, 140,
           reason: '标题被剩余宽钳住（按钮优先于名称）');
       expect(tester.takeException(), isNull, reason: '超长标题不得造成溢出');
     });
 
-    testWidgets('极窄顶栏：左组优先满足，右组吃掉剩下的全部，标题归零且不溢出', (WidgetTester tester) async {
+    testWidgets('极窄顶栏：左段优先满足，右段吃掉剩下的全部，标题归零且不溢出', (WidgetTester tester) async {
       await pumpBar(
         tester,
         barWidth: 300,
-        leftWidth: 60,
-        rightWidth: 400,
+        leftLead: 60,
+        rightLead: 400,
       );
 
-      expect(tester.getSize(find.byKey(leftKey)).width, 60);
-      expect(tester.getSize(find.byKey(rightKey)).width, 240,
-          reason: '右组被钳到剩余的 240（组内自带横滚兜底可达性）');
+      expect(tester.getSize(find.byKey(leftLeadKey)).width, 60);
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 240,
+          reason: '右段被钳到剩余的 240（段内自带横滚兜底可达性）');
       expect(tester.getSize(find.byKey(titleKey)).width, 0);
       expect(tester.takeException(), isNull);
     });
@@ -127,13 +142,91 @@ void main() {
       await pumpBar(
         tester,
         barWidth: 600,
-        leftWidth: 60,
-        rightWidth: 100,
+        leftLead: 60,
+        rightLead: 100,
         title: const SizedBox(key: titleKey, width: 100, height: 20),
         height: 48,
       );
 
       expect(tester.getTopLeft(find.byKey(titleKey)).dy, (48 - 20) / 2);
+    });
+  });
+
+  group('标题被拖进按钮槽：位置保住，但宽度最后才分', () {
+    testWidgets('标题落在 topRight 组中间：两段按钮先拿够，标题吃剩余且夹在中间',
+        (WidgetTester tester) async {
+      // 旧实现里标题是组内 220 宽的内联块，会把同组按钮挤进横滚区。
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftLead: 60,
+        rightLead: 200,
+        rightTail: 100,
+        placement: VideoTopBarTitlePlacement.right,
+        title: const SizedBox(key: titleKey, width: 10000, height: 48),
+      );
+
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 200,
+          reason: '标题前的那段按钮必须足额');
+      expect(tester.getSize(find.byKey(rightTailKey)).width, 100,
+          reason: '标题后的那段按钮必须足额');
+      expect(tester.getSize(find.byKey(titleKey)).width, 240,
+          reason: '标题只拿 600-60-200-100=240，不再是固定 220');
+
+      // 显示顺序仍是 rightLead → title → rightTail，且整段贴右边缘。
+      final double leadRight = tester.getTopRight(find.byKey(rightLeadKey)).dx;
+      final double titleLeft = tester.getTopLeft(find.byKey(titleKey)).dx;
+      final double titleRight = tester.getTopRight(find.byKey(titleKey)).dx;
+      final double tailLeft = tester.getTopLeft(find.byKey(rightTailKey)).dx;
+      expect(titleLeft, leadRight, reason: '标题紧跟它前面那段按钮');
+      expect(tailLeft, titleRight, reason: '标题后面那段按钮紧跟标题');
+      expect(tester.getTopRight(find.byKey(rightTailKey)).dx, 600,
+          reason: '整个右段仍贴右边缘');
+    });
+
+    testWidgets('标题落在 topRight 时按钮永远优先：窄窗下标题归零，按钮一个不少',
+        (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        barWidth: 320,
+        leftLead: 60,
+        rightLead: 160,
+        rightTail: 100,
+        placement: VideoTopBarTitlePlacement.right,
+        title: const SizedBox(key: titleKey, width: 10000, height: 48),
+      );
+
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 160);
+      expect(tester.getSize(find.byKey(rightTailKey)).width, 100);
+      expect(tester.getSize(find.byKey(titleKey)).width, 0,
+          reason: '宽度不够时先饿死标题，绝不裁按钮');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('标题落在 topLeft 组中间：夹在两段按钮之间，从左边缘起排',
+        (WidgetTester tester) async {
+      await pumpBar(
+        tester,
+        barWidth: 600,
+        leftLead: 40,
+        leftTail: 80,
+        rightLead: 120,
+        placement: VideoTopBarTitlePlacement.left,
+        title: const SizedBox(key: titleKey, width: 10000, height: 48),
+      );
+
+      expect(tester.getSize(find.byKey(leftLeadKey)).width, 40);
+      expect(tester.getSize(find.byKey(leftTailKey)).width, 80);
+      expect(tester.getSize(find.byKey(rightLeadKey)).width, 120);
+      expect(tester.getSize(find.byKey(titleKey)).width, 360,
+          reason: '标题吃 600-40-80-120=360');
+
+      expect(tester.getTopLeft(find.byKey(leftLeadKey)).dx, 0);
+      expect(tester.getTopLeft(find.byKey(titleKey)).dx, 40,
+          reason: '标题紧跟 lead 段');
+      expect(tester.getTopLeft(find.byKey(leftTailKey)).dx, 400,
+          reason: 'tail 段紧跟标题');
+      expect(tester.getTopRight(find.byKey(rightLeadKey)).dx, 600);
     });
   });
 }

--- a/fushi/test/pages/video_topbar_guards_test.dart
+++ b/fushi/test/pages/video_topbar_guards_test.dart
@@ -91,10 +91,9 @@ void main() {
       final int titleStart = src.indexOf('Widget _topBarTitle()');
       expect(titleStart, greaterThanOrEqualTo(0),
           reason: '应存在 _topBarTitle() helper');
-      final int titleEnd =
-          src.indexOf('Widget _topBarInlineTitle(', titleStart);
+      final int titleEnd = src.indexOf('Widget _topBarTitleText(', titleStart);
       expect(titleEnd, greaterThan(titleStart),
-          reason: '_topBarTitle() 方法体应正常闭合在 _topBarInlineTitle 之前');
+          reason: '_topBarTitle() 方法体应正常闭合在 _topBarTitleText 之前');
       // 只看代码：方法体注释里必然复述 `Flexible(` / `Spacer()` 这些被禁写法的历史，
       // 带着注释扫会把「解释为什么禁用」误判成「还在用」。掩码走共享原语（块注释/行尾
       // 注释都能盖住，且不移动下标）。
@@ -114,6 +113,21 @@ void main() {
           reason: '桌面与移动顶栏都应经 VideoTopBarSlots 分宽');
       expect(RegExp(r'title:\s*_topBarTitle\(\)').hasMatch(src), isTrue,
           reason: '标题应作为 VideoTopBarSlots 的 title 槽传入');
+      // 标题被拖进左/右按钮槽时也走同一条路径：不能再有「组内固定宽内联标题」这个
+      // 特例——它会跟同组按钮抢横向空间，把按钮挤进横滚区（名称挡按钮的另一半根因）。
+      expect(src.contains('_topBarInlineTitle('), isFalse,
+          reason: '内联标题特例应已删除，标题统一由 VideoTopBarSlots 的 title 槽渲染');
+      expect(containsCodeLine(src, 'maxWidth: 220'), isFalse,
+          reason: '标题不得再有固定宽上限，宽度只能是「按钮分完之后剩下的」');
+      // 按钮组按 lead / tail 两段渲染，标题的槽内位置才能保住。
+      expect(src.contains('segment: VideoTopBarSegment.lead'), isTrue,
+          reason: '顶栏两槽应分别渲染标题之前的按钮段');
+      expect(src.contains('segment: VideoTopBarSegment.tail'), isTrue,
+          reason: '顶栏两槽应分别渲染标题之后的按钮段');
+      expect(
+          RegExp(r'titlePlacement:\s*_topBarTitlePlacement\(\)').hasMatch(src),
+          isTrue,
+          reason: '标题所在槽应驱动它在顶栏里的位置');
       // 标题截断兜底仍在（窄窗让位后靠 ellipsis 优雅收尾）。
       final int textStart = src.indexOf('Widget _topBarTitleText(');
       expect(textStart, greaterThanOrEqualTo(0));


### PR DESCRIPTION
## 这条分支为什么在这里

PR #838 显示 MERGED，但提交 `b1eb8ef428`（2026-08-14）在合并**之后**追加，从此没进过 `develop`。

## 内容

⚠ **提交标题会误导**：标题写的是「删掉 220 硬上限」，但那个根因修复**已经落地**了（`develop` 上 `fushi/lib/src/media/video/video_top_bar_slots.dart` 已无 220 上限）。

本分支真正未落地的是更进一步的**五段重构**：槽位从三段 `{left, title, right}` 扩为五段 `{leftLead, leftTail, title, rightLead, rightTail}`，让标题项被拖进按钮槽时能夹在两段按钮之间显示，同时宽度仍最后分配、不与按钮抢。未落地约 **+369 行 / 5 个文件**。

## 注意路径

文件在 `fushi/lib/src/media/video/`，**不在** `fushi/lib/src/pages/implementations/video_fushi/`。按后者的路径去查会得到「无差异」的假阴结论。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
