### PR TITLE
fix(popup): 词头汉字内联可点替代单字 chip 行，重新落地从未合并的删除 (BUG-1788)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1661 条。点号进各自文件。
+> 共 1662 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1788](bugs/BUG-1788-popup-kanji-chip-row-never-deleted.md) | ✅ | ✅ | 查词弹窗词头下方的单字 chip 行仍在渲染：删除提交从未合并进 develop |
 | [BUG-1787](bugs/BUG-1787-font-library-scope-target-dead-param.md) | ✅ | ✅ | 字体库作用域参数不生效：从游戏入口导入的字体挂到小说正文 |
 | [BUG-1785](bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md) | ✅ | ✅ | TV 整理被无集号特典文件整批卡死 |
 | [BUG-1784](bugs/BUG-1784-download-nyaa-retry-loses-magnet.md) | ✅ | ✅ | 下载重试丢失已选 magnet 致 nyaa notFound |

--- a/docs/bugs/BUG-1788-popup-kanji-chip-row-never-deleted.md
+++ b/docs/bugs/BUG-1788-popup-kanji-chip-row-never-deleted.md
@@ -1,0 +1,19 @@
+## BUG-1788 · 查词弹窗词头下方的单字 chip 行仍在渲染：删除提交从未合并进 develop
+- **报告**：2026-08-23（用户：截图查「理論」，词头下方仍有「理」「論」两个灰方块 chip，「我记得这两个字我删掉了来着」）
+- **真实性**：✅ 真 bug。根因不在代码逻辑，而在**交付链路**：删除工作早已完成但从未落地 develop。
+  - 仍在渲染的实现：`fushi/assets/popup/popup.js:2690`（`createKanjiBreakdown`）+ `:3538` 调用点（插在 `createEntryHeader` 之后、词条正文之前，正是截图里那一排）
+  - 外观：`fushi/assets/popup/popup.css:283` / `:290`（`.kanji-breakdown` / `.kanji-tag`，`min-width:28px; height:28px; 灰底`）
+  - 三份镜像（`fushi/assets/popup/`、`fushi/assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`）**行号完全相同、sha256 全同** —— 不是「删一份漏两份」的漂移，是三份都还是旧的。
+  - 真正的根因：删除提交 **`851d6089ff`**（2026-08-15，`feat(popup): 词头汉字内联可点替代 kanji-breakdown chip 行 + 压缩顶栏与词头间距`）改了 9 个文件、三镜像同步全到位，但 `git merge-base --is-ancestor 851d6089ff develop` = **NO**：它只活在分支 `worktree-popup-inline-kanji-compact-header` 上，`gh pr list --head` 查不到任何 PR —— **从没开过 PR，也从没合并**。于是旧 UI 在 develop 上原封不动继续跑了 8 天。
+- **[x] ① 已修复** — `851d6089ff` cherry-pick 到当前 develop 基底（干净落地零冲突），三件事整体恢复：
+  1. 删除 `createKanjiBreakdown` chip 行；
+  2. 词头里每个汉字自身成为跳转目标（`wrapExpressionInlineKanji` + `.kanji-inline` 淡点线 affordance），包裹 pass 挂在 `postProcessRuby` 尾部，幂等、只切 `.expression` 文本节点，不触碰 ruby-unit/rt 锚定与选区活文本；
+  3. 顶栏贴近词头：无 header 顶栏 40→36（贴住 36×36 的 `_topActionConstraints`，命中区零缩水）、首词条 `padding-top` 8→0。
+
+  落地后复核：三镜像 popup.js / popup.css sha256 各自全同；`content.css` 重跑 `generate-content-css.mjs` 输出**逐字节相同**（不是陈旧生成物）；`wrapExpressionInlineKanji(container)` 确认落在 `postProcessRuby` 函数体末尾（21 个提交的漂移没挪歪插入点）；`_topActionConstraints` 确认仍是 36×36（顶栏 36 的前提成立）。`flutter analyze` 零问题。
+- **[x] ② 已加自动化测试** — `fushi/test/dictionary/popup_inline_kanji_guard_test.dart`（16 个断言，提交 `d797776e60`）
+  - 禁止型：三份 popup.js 不得再有 `createKanjiBreakdown`；三份 popup.css + 两份 content.css 不得再有 `.kanji-tag` / `.kanji-breakdown` 规则。
+  - 要求型：`wrapExpressionInlineKanji` 必须已定义，且调用必须落在 `postProcessRuby` **函数体内**（`methodBody` 锚定，`SourceLexicon.js`）—— 挂到别的函数上会让延迟渲染的尾部词条静默失去可点性，而文件级 `contains` 照样绿。
+  - 全部断言跑在**掩码后**的语料上（`maskCssComments` / `containsIdentifier`）：三份文件的注释里至今写着 `kanji-breakdown` 与 `kanji-tag` 用来说明这段历史，裸 `contains` 会被注释喂成假红。
+  - 变异实测（每次还原后 sha256 逐字节校验）：① `.kanji-inline` → `.kanji-tag`：只有被改的那份镜像红、另两份保持绿（逐镜像精度）；② 调用移出 `postProcessRuby` 但仍留在文件里：文件级断言绿、体内断言红（证明 `methodBody` 锚定在干活）；③ 注释里塞入 `.kanji-tag` / `.kanji-breakdown`：保持绿（掩码生效，无假红）。
+- **备注**：这条的教训不是代码层面的。三镜像彼此一致（都是旧的），定向测试按功能域挑也挑不到一个「本该不存在」的函数 —— 代码层面**没有任何东西**能发现「删除从未落地」。真正的缺口是「改完 → 开 PR → 合并」这条链断在第二步且无人告警。守卫测试补上的是「chip 行已死」这个不变式，但它只在删除**已经落地之后**才能防复活；防不住「下一个删除又停在孤儿分支上」。同批扫描发现的其它未落地分支另行处置。

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -190,6 +190,14 @@
     scroll-margin-bottom: 14px;
 }
 
+/* design-2026-08 讨论区反馈: 顶栏贴近词头——首词条不再叠加自己的 8px 顶距（顶部呼吸空间由
+   Flutter 顶栏 + 振假名 0.55em 预留区承担），词条之间的 8px 节奏不变。
+   :first-child 的语义恰好精确：句子横幅(.global-lookup-sentence)或汉字卡
+   (kanjiSection)在场时首词条不是 first-child，自动保留原间距不贴死。 */
+.entry:first-child {
+    padding-top: 0;
+}
+
 .entry-header {
     display: flex;
     align-items: center;
@@ -257,28 +265,21 @@
     opacity: 0.6;
 }
 
-.kanji-breakdown {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 4px 0 2px;
-}
-
-.kanji-tag {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    height: 28px;
-    padding: 0 6px;
-    border-radius: 4px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 16px;
+/* design-2026-08 讨论区反馈: inline kanji tap targets inside the headword (replace the old
+   kanji-breakdown chip row that duplicated every kanji on its own line). A
+   faint dotted underline is the affordance; text-underline-offset keeps it
+   clear of the glyph without colliding with the next line, and the colour is
+   muted so the headword still reads as one word. The characters stay live,
+   selectable text (BUG-110/123/125/129). */
+.kanji-inline {
     cursor: pointer;
-    -webkit-user-select: none;
+    text-decoration: underline dotted;
+    text-decoration-color: rgba(128, 128, 128, 0.55);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
 }
 
-.kanji-tag:active {
+.kanji-inline:active {
     opacity: 0.6;
 }
 
@@ -1831,11 +1832,15 @@
    白底黑字），比灰阶底更清晰。 */
 :where(#entries-container).eink .expr-tag,
 :where(#entries-container).eink .deinflection-tag,
-:where(#entries-container).eink .kanji-tag,
 :where(#entries-container).eink .glossary-tag,
 :where(#entries-container).eink .pitch-transcription-tag {
     background-color: transparent;
     border: 1px solid currentColor;
+}
+
+/* design-2026-08 讨论区反馈: 半透明灰点线在墨水屏上是抖动灰，压成 currentColor 实点。 */
+:where(#entries-container).eink .kanji-inline {
+    text-decoration-color: currentColor;
 }
 
 :where(#entries-container).eink .frequency-dict-label {

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -235,6 +235,14 @@ body {
     scroll-margin-bottom: 14px;
 }
 
+/* design-2026-08 讨论区反馈: 顶栏贴近词头——首词条不再叠加自己的 8px 顶距（顶部呼吸空间由
+   Flutter 顶栏 + 振假名 0.55em 预留区承担），词条之间的 8px 节奏不变。
+   :first-child 的语义恰好精确：句子横幅(.global-lookup-sentence)或汉字卡
+   (kanjiSection)在场时首词条不是 first-child，自动保留原间距不贴死。 */
+.entry:first-child {
+    padding-top: 0;
+}
+
 .entry-header {
     display: flex;
     align-items: center;
@@ -302,28 +310,21 @@ body {
     opacity: 0.6;
 }
 
-.kanji-breakdown {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 4px 0 2px;
-}
-
-.kanji-tag {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    height: 28px;
-    padding: 0 6px;
-    border-radius: 4px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 16px;
+/* design-2026-08 讨论区反馈: inline kanji tap targets inside the headword (replace the old
+   kanji-breakdown chip row that duplicated every kanji on its own line). A
+   faint dotted underline is the affordance; text-underline-offset keeps it
+   clear of the glyph without colliding with the next line, and the colour is
+   muted so the headword still reads as one word. The characters stay live,
+   selectable text (BUG-110/123/125/129). */
+.kanji-inline {
     cursor: pointer;
-    -webkit-user-select: none;
+    text-decoration: underline dotted;
+    text-decoration-color: rgba(128, 128, 128, 0.55);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
 }
 
-.kanji-tag:active {
+.kanji-inline:active {
     opacity: 0.6;
 }
 
@@ -1941,11 +1942,15 @@ html.eink[data-theme="dark"] {
    白底黑字），比灰阶底更清晰。 */
 html.eink .expr-tag,
 html.eink .deinflection-tag,
-html.eink .kanji-tag,
 html.eink .glossary-tag,
 html.eink .pitch-transcription-tag {
     background-color: transparent;
     border: 1px solid currentColor;
+}
+
+/* design-2026-08 讨论区反馈: 半透明灰点线在墨水屏上是抖动灰，压成 currentColor 实点。 */
+html.eink .kanji-inline {
+    text-decoration-color: currentColor;
 }
 
 html.eink .frequency-dict-label {

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -2687,38 +2687,65 @@ function createFavoriteButton(expression, reading) {
     return button;
 }
 
-function createKanjiBreakdown(expression) {
-    const seen = new Set();
-    const kanjiChars = [];
-    for (const ch of expression) {
-        if (KANJI_PATTERN.test(ch) && !seen.has(ch)) {
-            seen.add(ch);
-            kanjiChars.push(ch);
+// design-2026-08 讨论区反馈: the old kanji-breakdown chip row repeated every kanji of the
+// headword on its own line just to make it clickable. The chips are gone;
+// instead each kanji INSIDE the headword is its own tap target (dotted
+// underline affordance, popup.css .kanji-inline). This is a post-pass over an
+// already-built subtree (called from the tail of postProcessRuby, so every
+// render path that fixes ruby also gets inline kanji): it only splits TEXT
+// nodes under .expression, skipping the reading machinery (rt / rp / .ruby-rt /
+// .ruby-reserve) — the per-base .ruby-unit anchor + em reserve geometry
+// (BUG-722/733/850/1487) is untouched, and each kanji stays a live text node
+// (one span deeper) so ruby lookup selection (BUG-110/123/125/129) keeps
+// working. Idempotent like postProcessRuby itself (BUG-1098): text already
+// inside a .kanji-inline is rejected by the walker filter.
+function wrapExpressionInlineKanji(container) {
+    const roots = container.classList?.contains('expression')
+        ? [container]
+        : container.querySelectorAll('.expression');
+    roots.forEach(root => {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                const p = node.parentElement;
+                if (!node.textContent || !p) return NodeFilter.FILTER_REJECT;
+                if (p.closest('rt, rp, .ruby-rt, .ruby-reserve, .kanji-inline')) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        });
+        const textNodes = [];
+        while (walker.nextNode()) textNodes.push(walker.currentNode);
+        for (const node of textNodes) {
+            const text = node.textContent;
+            let hasKanji = false;
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) { hasKanji = true; break; }
+            }
+            if (!hasKanji) continue;
+            const frag = document.createDocumentFragment();
+            let run = '';
+            const flushRun = () => {
+                if (run) {
+                    frag.appendChild(document.createTextNode(run));
+                    run = '';
+                }
+            };
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) {
+                    flushRun();
+                    const span = document.createElement('span');
+                    span.className = 'kanji-inline';
+                    span.textContent = ch;
+                    frag.appendChild(span);
+                } else {
+                    run += ch;
+                }
+            }
+            flushRun();
+            node.replaceWith(frag);
         }
-    }
-    if (kanjiChars.length === 0) return null;
-
-    const row = el('div', { className: 'kanji-breakdown' });
-    for (const ch of kanjiChars) {
-        const tag = el('span', {
-            className: 'kanji-tag',
-            textContent: ch,
-        });
-        tag.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const rect = tag.getBoundingClientRect();
-            markGlobalLookupExtHit(tag);
-            window.flutter_inappwebview.callHandler('onLinkClick', ch, {
-                x: rect.left,
-                y: rect.top,
-                width: rect.width,
-                height: rect.height
-            });
-        });
-        row.appendChild(tag);
-    }
-    return row;
+    });
 }
 
 function createEntryHeader(entry, idx) {
@@ -2745,9 +2772,19 @@ function createEntryHeader(entry, idx) {
     expressionSpan.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const rect = expressionSpan.getBoundingClientRect();
-        markGlobalLookupExtHit(expressionSpan);
-        window.flutter_inappwebview.callHandler('onLinkClick', expression, {
+        // design-2026-08 讨论区反馈: a click landing on an inline kanji (.kanji-inline, wrapped
+        // by wrapExpressionInlineKanji) looks up THAT character — same
+        // onLinkClick channel + anchor-rect semantics the removed
+        // kanji-breakdown chips used. Anywhere else on the headword keeps the
+        // old whole-expression re-lookup.
+        const kanjiEl = e.target instanceof Element
+            ? e.target.closest('.kanji-inline')
+            : null;
+        const anchorEl = kanjiEl || expressionSpan;
+        const term = kanjiEl ? kanjiEl.textContent : expression;
+        const rect = anchorEl.getBoundingClientRect();
+        markGlobalLookupExtHit(anchorEl);
+        window.flutter_inappwebview.callHandler('onLinkClick', term, {
             x: rect.left,
             y: rect.top,
             width: rect.width,
@@ -3535,11 +3572,6 @@ function buildEntryElement(entry, idx, maximumDictionaryBlocks = Infinity) {
     const entryDiv = el('div', { className: 'entry' });
     entryDiv.appendChild(createEntryHeader(entry, idx));
 
-    const kanjiRow = createKanjiBreakdown(entry.expression);
-    if (kanjiRow) {
-        entryDiv.appendChild(kanjiRow);
-    }
-
     const exprTags = createExpressionTagsSection(entry);
     if (exprTags) {
         entryDiv.appendChild(exprTags);
@@ -3726,6 +3758,11 @@ function postProcessRuby(container) {
             }
         }
     });
+    // design-2026-08 讨论区反馈: inline-kanji tap targets ride the same post-pass so every
+    // render path that ruby-fixes a subtree (first entry, deferred tail
+    // entries, incremental updates) also gets them; both passes are idempotent
+    // so the double walk over entry 0 (BUG-1098) stays harmless.
+    wrapExpressionInlineKanji(container);
 }
 
 function applyCustomCSS() {
@@ -3774,7 +3811,7 @@ function createKanjiCard(kanji) {
     const head = el('div', { className: 'kanji-card-head' });
     const charEl = el('div', { className: 'kanji-card-char', textContent: kanji.character });
     // Tapping the big character re-looks it up (consistent with the term
-    // headword + kanji-breakdown tags), so a kanji card is also a jump-off
+    // headword + inline kanji, design-2026-08 讨论区反馈), so a kanji card is also a jump-off
     // point for a fresh lookup.
     charEl.addEventListener('click', (e) => {
         e.preventDefault();

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -235,6 +235,14 @@ body {
     scroll-margin-bottom: 14px;
 }
 
+/* design-2026-08 讨论区反馈: 顶栏贴近词头——首词条不再叠加自己的 8px 顶距（顶部呼吸空间由
+   Flutter 顶栏 + 振假名 0.55em 预留区承担），词条之间的 8px 节奏不变。
+   :first-child 的语义恰好精确：句子横幅(.global-lookup-sentence)或汉字卡
+   (kanjiSection)在场时首词条不是 first-child，自动保留原间距不贴死。 */
+.entry:first-child {
+    padding-top: 0;
+}
+
 .entry-header {
     display: flex;
     align-items: center;
@@ -302,28 +310,21 @@ body {
     opacity: 0.6;
 }
 
-.kanji-breakdown {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 4px 0 2px;
-}
-
-.kanji-tag {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    height: 28px;
-    padding: 0 6px;
-    border-radius: 4px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 16px;
+/* design-2026-08 讨论区反馈: inline kanji tap targets inside the headword (replace the old
+   kanji-breakdown chip row that duplicated every kanji on its own line). A
+   faint dotted underline is the affordance; text-underline-offset keeps it
+   clear of the glyph without colliding with the next line, and the colour is
+   muted so the headword still reads as one word. The characters stay live,
+   selectable text (BUG-110/123/125/129). */
+.kanji-inline {
     cursor: pointer;
-    -webkit-user-select: none;
+    text-decoration: underline dotted;
+    text-decoration-color: rgba(128, 128, 128, 0.55);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
 }
 
-.kanji-tag:active {
+.kanji-inline:active {
     opacity: 0.6;
 }
 
@@ -1941,11 +1942,15 @@ html.eink[data-theme="dark"] {
    白底黑字），比灰阶底更清晰。 */
 html.eink .expr-tag,
 html.eink .deinflection-tag,
-html.eink .kanji-tag,
 html.eink .glossary-tag,
 html.eink .pitch-transcription-tag {
     background-color: transparent;
     border: 1px solid currentColor;
+}
+
+/* design-2026-08 讨论区反馈: 半透明灰点线在墨水屏上是抖动灰，压成 currentColor 实点。 */
+html.eink .kanji-inline {
+    text-decoration-color: currentColor;
 }
 
 html.eink .frequency-dict-label {

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -2687,38 +2687,65 @@ function createFavoriteButton(expression, reading) {
     return button;
 }
 
-function createKanjiBreakdown(expression) {
-    const seen = new Set();
-    const kanjiChars = [];
-    for (const ch of expression) {
-        if (KANJI_PATTERN.test(ch) && !seen.has(ch)) {
-            seen.add(ch);
-            kanjiChars.push(ch);
+// design-2026-08 讨论区反馈: the old kanji-breakdown chip row repeated every kanji of the
+// headword on its own line just to make it clickable. The chips are gone;
+// instead each kanji INSIDE the headword is its own tap target (dotted
+// underline affordance, popup.css .kanji-inline). This is a post-pass over an
+// already-built subtree (called from the tail of postProcessRuby, so every
+// render path that fixes ruby also gets inline kanji): it only splits TEXT
+// nodes under .expression, skipping the reading machinery (rt / rp / .ruby-rt /
+// .ruby-reserve) — the per-base .ruby-unit anchor + em reserve geometry
+// (BUG-722/733/850/1487) is untouched, and each kanji stays a live text node
+// (one span deeper) so ruby lookup selection (BUG-110/123/125/129) keeps
+// working. Idempotent like postProcessRuby itself (BUG-1098): text already
+// inside a .kanji-inline is rejected by the walker filter.
+function wrapExpressionInlineKanji(container) {
+    const roots = container.classList?.contains('expression')
+        ? [container]
+        : container.querySelectorAll('.expression');
+    roots.forEach(root => {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                const p = node.parentElement;
+                if (!node.textContent || !p) return NodeFilter.FILTER_REJECT;
+                if (p.closest('rt, rp, .ruby-rt, .ruby-reserve, .kanji-inline')) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        });
+        const textNodes = [];
+        while (walker.nextNode()) textNodes.push(walker.currentNode);
+        for (const node of textNodes) {
+            const text = node.textContent;
+            let hasKanji = false;
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) { hasKanji = true; break; }
+            }
+            if (!hasKanji) continue;
+            const frag = document.createDocumentFragment();
+            let run = '';
+            const flushRun = () => {
+                if (run) {
+                    frag.appendChild(document.createTextNode(run));
+                    run = '';
+                }
+            };
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) {
+                    flushRun();
+                    const span = document.createElement('span');
+                    span.className = 'kanji-inline';
+                    span.textContent = ch;
+                    frag.appendChild(span);
+                } else {
+                    run += ch;
+                }
+            }
+            flushRun();
+            node.replaceWith(frag);
         }
-    }
-    if (kanjiChars.length === 0) return null;
-
-    const row = el('div', { className: 'kanji-breakdown' });
-    for (const ch of kanjiChars) {
-        const tag = el('span', {
-            className: 'kanji-tag',
-            textContent: ch,
-        });
-        tag.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const rect = tag.getBoundingClientRect();
-            markGlobalLookupExtHit(tag);
-            window.flutter_inappwebview.callHandler('onLinkClick', ch, {
-                x: rect.left,
-                y: rect.top,
-                width: rect.width,
-                height: rect.height
-            });
-        });
-        row.appendChild(tag);
-    }
-    return row;
+    });
 }
 
 function createEntryHeader(entry, idx) {
@@ -2745,9 +2772,19 @@ function createEntryHeader(entry, idx) {
     expressionSpan.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const rect = expressionSpan.getBoundingClientRect();
-        markGlobalLookupExtHit(expressionSpan);
-        window.flutter_inappwebview.callHandler('onLinkClick', expression, {
+        // design-2026-08 讨论区反馈: a click landing on an inline kanji (.kanji-inline, wrapped
+        // by wrapExpressionInlineKanji) looks up THAT character — same
+        // onLinkClick channel + anchor-rect semantics the removed
+        // kanji-breakdown chips used. Anywhere else on the headword keeps the
+        // old whole-expression re-lookup.
+        const kanjiEl = e.target instanceof Element
+            ? e.target.closest('.kanji-inline')
+            : null;
+        const anchorEl = kanjiEl || expressionSpan;
+        const term = kanjiEl ? kanjiEl.textContent : expression;
+        const rect = anchorEl.getBoundingClientRect();
+        markGlobalLookupExtHit(anchorEl);
+        window.flutter_inappwebview.callHandler('onLinkClick', term, {
             x: rect.left,
             y: rect.top,
             width: rect.width,
@@ -3535,11 +3572,6 @@ function buildEntryElement(entry, idx, maximumDictionaryBlocks = Infinity) {
     const entryDiv = el('div', { className: 'entry' });
     entryDiv.appendChild(createEntryHeader(entry, idx));
 
-    const kanjiRow = createKanjiBreakdown(entry.expression);
-    if (kanjiRow) {
-        entryDiv.appendChild(kanjiRow);
-    }
-
     const exprTags = createExpressionTagsSection(entry);
     if (exprTags) {
         entryDiv.appendChild(exprTags);
@@ -3726,6 +3758,11 @@ function postProcessRuby(container) {
             }
         }
     });
+    // design-2026-08 讨论区反馈: inline-kanji tap targets ride the same post-pass so every
+    // render path that ruby-fixes a subtree (first entry, deferred tail
+    // entries, incremental updates) also gets them; both passes are idempotent
+    // so the double walk over entry 0 (BUG-1098) stays harmless.
+    wrapExpressionInlineKanji(container);
 }
 
 function applyCustomCSS() {
@@ -3774,7 +3811,7 @@ function createKanjiCard(kanji) {
     const head = el('div', { className: 'kanji-card-head' });
     const charEl = el('div', { className: 'kanji-card-char', textContent: kanji.character });
     // Tapping the big character re-looks it up (consistent with the term
-    // headword + kanji-breakdown tags), so a kanji card is also a jump-off
+    // headword + inline kanji, design-2026-08 讨论区反馈), so a kanji card is also a jump-off
     // point for a fresh lookup.
     charEl.addEventListener('click', (e) => {
         e.preventDefault();

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -916,9 +916,11 @@ class DictionaryPopupLayer extends StatelessWidget {
       children: <Widget>[leftCluster, middle, rightCluster],
     );
 
-    // 无 header 的层（app 外覆盖窗/嵌套返回层）保持旧的 40 高度；有 header 时高度由
-    // header 自身（[ReaderChromeScaler] 跟随 UI 缩放）决定。
-    return headerWidget == null ? SizedBox(height: 40, child: bar) : bar;
+    // 无 header 的层（app 外覆盖窗/嵌套返回层）顶栏高度贴住 36×36 的
+    // [_topActionConstraints] 按钮（design-2026-08 讨论区反馈：压缩顶栏与词头间距，命中区零缩水，
+    // 旧值 40 只是给按钮上下各 2px 装饰性余量）；有 header 时高度由 header 自身
+    // （[ReaderChromeScaler] 跟随 UI 缩放）决定。
+    return headerWidget == null ? SizedBox(height: 36, child: bar) : bar;
   }
 
   /// TODO-1353 复诉：弹窗顶栏可见的 A−/A+ 手动字号按钮。点按经

--- a/fushi/test/dictionary/popup_inline_kanji_guard_test.dart
+++ b/fushi/test/dictionary/popup_inline_kanji_guard_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// design-2026-08 讨论区反馈守卫：词头汉字**内联**可点，旧 kanji-breakdown chip 行不得复活。
+///
+/// 为什么需要这条守卫：删除工作本身在 2026-08-15 就做完了（`851d6089ff`，三镜像同步
+/// 全到位），但那个提交**从没开过 PR、从没合并进 develop**，只活在一个孤儿分支上。
+/// 于是「同一个汉字在词头下面再重复一排灰方块才可点」的旧 UI 在 develop 上原封不动
+/// 继续跑了 8 天，直到用户截图报「我记得这两个字我删掉了来着」。
+///
+/// 代码层面没有任何东西能发现这种「删除从未落地」——三份镜像彼此一致（都是旧的），
+/// 定向测试按功能域挑也挑不到一个「本该不存在」的函数。这条守卫就是那个缺失的断言：
+/// 把「chip 行已死、内联可点是唯一形态」钉成三镜像上的结构不变式。
+///
+/// 断言必须跑在**掩码后**的语料上：三份 popup.js / popup.css 的解释性注释里至今仍
+/// 写着 `kanji-breakdown` 与 `kanji-tag`（说明这段历史），裸 `contains` 会被注释喂成
+/// 假红；反过来，若有人删掉实现只留同文注释，不掩码的要求型断言又会假绿。
+///
+/// flutter test cwd 是 hibiki package 根。
+void main() {
+  const String appPopup = 'assets/popup';
+  const String extAssets = 'assets/browser_extension';
+  const String extTools = '../tools/browser-extension';
+
+  /// popup.js / popup.css 的三份镜像（in-app 渲染器 + 两个扩展 vendor 副本）。
+  const List<String> jsMirrors = <String>[
+    '$appPopup/popup.js',
+    '$extAssets/vendor/popup.js',
+    '$extTools/vendor/popup.js',
+  ];
+  const List<String> cssMirrors = <String>[
+    '$appPopup/popup.css',
+    '$extAssets/vendor/popup.css',
+    '$extTools/vendor/popup.css',
+  ];
+
+  /// content.css 是 popup.css 的生成镜像（generate-content-css.mjs），只有扩展侧有。
+  const List<String> generatedCssMirrors = <String>[
+    '$extAssets/vendor/content.css',
+    '$extTools/vendor/content.css',
+  ];
+
+  String read(String p) => File(p).readAsStringSync();
+
+  group('旧 kanji-breakdown chip 行不得复活', () {
+    for (final String path in jsMirrors) {
+      test('[$path] 没有 createKanjiBreakdown 实现', () {
+        final String src = read(path);
+        expect(
+          containsIdentifier(src, 'createKanjiBreakdown'),
+          isFalse,
+          reason:
+              '$path 重新引入了 createKanjiBreakdown——那是把词头每个汉字在下一行'
+              '重复成灰方块 chip 才可点的旧 UI。可点性现在内联在词头里'
+              '（wrapExpressionInlineKanji + .kanji-inline），不要恢复 chip 行。',
+        );
+      });
+    }
+
+    for (final String path in <String>[...cssMirrors, ...generatedCssMirrors]) {
+      test('[$path] 没有 .kanji-tag / .kanji-breakdown 样式', () {
+        final String css = maskCssComments(read(path));
+        for (final String dead in const <String>[
+          '.kanji-tag',
+          '.kanji-breakdown',
+        ]) {
+          expect(
+            css.contains(dead),
+            isFalse,
+            reason:
+                '$path 重新引入了 $dead 样式规则（旧 chip 行的外观）。'
+                '内联形态的样式是 .kanji-inline。',
+          );
+        }
+      });
+    }
+  });
+
+  group('内联可点汉字是唯一形态', () {
+    for (final String path in jsMirrors) {
+      test('[$path] wrapExpressionInlineKanji 已定义且挂在 postProcessRuby 尾部', () {
+        final String src = read(path);
+        expect(
+          containsIdentifier(src, 'wrapExpressionInlineKanji'),
+          isTrue,
+          reason:
+              '$path 丢了 wrapExpressionInlineKanji——词头汉字将不再可点，'
+              '而 chip 行也已删除，等于整个「查单字」入口消失。',
+        );
+
+        // 包裹 pass 必须挂在 postProcessRuby 的**函数体内**：那是每条渲染路径
+        // （首词条 / 延迟尾部词条 / 增量更新）都会流经的唯一 ruby 后处理接缝。
+        // 只断言「文件里出现过这次调用」不够——挂到别的函数上，延迟渲染的词条
+        // 就静默失去可点性，而文件级断言照样绿。
+        final String body = methodBody(
+          src,
+          'function postProcessRuby',
+          lexicon: SourceLexicon.js,
+        );
+        expect(
+          containsIdentifierCall(body, 'wrapExpressionInlineKanji'),
+          isTrue,
+          reason:
+              '$path 的 wrapExpressionInlineKanji 调用不在 postProcessRuby 体内。'
+              '挂在别处会让延迟渲染的词条拿不到内联可点汉字。',
+        );
+      });
+    }
+
+    for (final String path in <String>[...cssMirrors, ...generatedCssMirrors]) {
+      test('[$path] 有 .kanji-inline 的点线 affordance', () {
+        final String css = maskCssComments(read(path));
+        expect(
+          css.contains('.kanji-inline'),
+          isTrue,
+          reason: '$path 丢了 .kanji-inline 规则——内联汉字将没有任何可点提示。',
+        );
+      });
+    }
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -190,6 +190,14 @@
     scroll-margin-bottom: 14px;
 }
 
+/* design-2026-08 讨论区反馈: 顶栏贴近词头——首词条不再叠加自己的 8px 顶距（顶部呼吸空间由
+   Flutter 顶栏 + 振假名 0.55em 预留区承担），词条之间的 8px 节奏不变。
+   :first-child 的语义恰好精确：句子横幅(.global-lookup-sentence)或汉字卡
+   (kanjiSection)在场时首词条不是 first-child，自动保留原间距不贴死。 */
+.entry:first-child {
+    padding-top: 0;
+}
+
 .entry-header {
     display: flex;
     align-items: center;
@@ -257,28 +265,21 @@
     opacity: 0.6;
 }
 
-.kanji-breakdown {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 4px 0 2px;
-}
-
-.kanji-tag {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    height: 28px;
-    padding: 0 6px;
-    border-radius: 4px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 16px;
+/* design-2026-08 讨论区反馈: inline kanji tap targets inside the headword (replace the old
+   kanji-breakdown chip row that duplicated every kanji on its own line). A
+   faint dotted underline is the affordance; text-underline-offset keeps it
+   clear of the glyph without colliding with the next line, and the colour is
+   muted so the headword still reads as one word. The characters stay live,
+   selectable text (BUG-110/123/125/129). */
+.kanji-inline {
     cursor: pointer;
-    -webkit-user-select: none;
+    text-decoration: underline dotted;
+    text-decoration-color: rgba(128, 128, 128, 0.55);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
 }
 
-.kanji-tag:active {
+.kanji-inline:active {
     opacity: 0.6;
 }
 
@@ -1831,11 +1832,15 @@
    白底黑字），比灰阶底更清晰。 */
 :where(#entries-container).eink .expr-tag,
 :where(#entries-container).eink .deinflection-tag,
-:where(#entries-container).eink .kanji-tag,
 :where(#entries-container).eink .glossary-tag,
 :where(#entries-container).eink .pitch-transcription-tag {
     background-color: transparent;
     border: 1px solid currentColor;
+}
+
+/* design-2026-08 讨论区反馈: 半透明灰点线在墨水屏上是抖动灰，压成 currentColor 实点。 */
+:where(#entries-container).eink .kanji-inline {
+    text-decoration-color: currentColor;
 }
 
 :where(#entries-container).eink .frequency-dict-label {

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -235,6 +235,14 @@ body {
     scroll-margin-bottom: 14px;
 }
 
+/* design-2026-08 讨论区反馈: 顶栏贴近词头——首词条不再叠加自己的 8px 顶距（顶部呼吸空间由
+   Flutter 顶栏 + 振假名 0.55em 预留区承担），词条之间的 8px 节奏不变。
+   :first-child 的语义恰好精确：句子横幅(.global-lookup-sentence)或汉字卡
+   (kanjiSection)在场时首词条不是 first-child，自动保留原间距不贴死。 */
+.entry:first-child {
+    padding-top: 0;
+}
+
 .entry-header {
     display: flex;
     align-items: center;
@@ -302,28 +310,21 @@ body {
     opacity: 0.6;
 }
 
-.kanji-breakdown {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 4px 0 2px;
-}
-
-.kanji-tag {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    height: 28px;
-    padding: 0 6px;
-    border-radius: 4px;
-    background: rgba(128, 128, 128, 0.15);
-    font-size: 16px;
+/* design-2026-08 讨论区反馈: inline kanji tap targets inside the headword (replace the old
+   kanji-breakdown chip row that duplicated every kanji on its own line). A
+   faint dotted underline is the affordance; text-underline-offset keeps it
+   clear of the glyph without colliding with the next line, and the colour is
+   muted so the headword still reads as one word. The characters stay live,
+   selectable text (BUG-110/123/125/129). */
+.kanji-inline {
     cursor: pointer;
-    -webkit-user-select: none;
+    text-decoration: underline dotted;
+    text-decoration-color: rgba(128, 128, 128, 0.55);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
 }
 
-.kanji-tag:active {
+.kanji-inline:active {
     opacity: 0.6;
 }
 
@@ -1941,11 +1942,15 @@ html.eink[data-theme="dark"] {
    白底黑字），比灰阶底更清晰。 */
 html.eink .expr-tag,
 html.eink .deinflection-tag,
-html.eink .kanji-tag,
 html.eink .glossary-tag,
 html.eink .pitch-transcription-tag {
     background-color: transparent;
     border: 1px solid currentColor;
+}
+
+/* design-2026-08 讨论区反馈: 半透明灰点线在墨水屏上是抖动灰，压成 currentColor 实点。 */
+html.eink .kanji-inline {
+    text-decoration-color: currentColor;
 }
 
 html.eink .frequency-dict-label {

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2687,38 +2687,65 @@ function createFavoriteButton(expression, reading) {
     return button;
 }
 
-function createKanjiBreakdown(expression) {
-    const seen = new Set();
-    const kanjiChars = [];
-    for (const ch of expression) {
-        if (KANJI_PATTERN.test(ch) && !seen.has(ch)) {
-            seen.add(ch);
-            kanjiChars.push(ch);
+// design-2026-08 讨论区反馈: the old kanji-breakdown chip row repeated every kanji of the
+// headword on its own line just to make it clickable. The chips are gone;
+// instead each kanji INSIDE the headword is its own tap target (dotted
+// underline affordance, popup.css .kanji-inline). This is a post-pass over an
+// already-built subtree (called from the tail of postProcessRuby, so every
+// render path that fixes ruby also gets inline kanji): it only splits TEXT
+// nodes under .expression, skipping the reading machinery (rt / rp / .ruby-rt /
+// .ruby-reserve) — the per-base .ruby-unit anchor + em reserve geometry
+// (BUG-722/733/850/1487) is untouched, and each kanji stays a live text node
+// (one span deeper) so ruby lookup selection (BUG-110/123/125/129) keeps
+// working. Idempotent like postProcessRuby itself (BUG-1098): text already
+// inside a .kanji-inline is rejected by the walker filter.
+function wrapExpressionInlineKanji(container) {
+    const roots = container.classList?.contains('expression')
+        ? [container]
+        : container.querySelectorAll('.expression');
+    roots.forEach(root => {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                const p = node.parentElement;
+                if (!node.textContent || !p) return NodeFilter.FILTER_REJECT;
+                if (p.closest('rt, rp, .ruby-rt, .ruby-reserve, .kanji-inline')) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        });
+        const textNodes = [];
+        while (walker.nextNode()) textNodes.push(walker.currentNode);
+        for (const node of textNodes) {
+            const text = node.textContent;
+            let hasKanji = false;
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) { hasKanji = true; break; }
+            }
+            if (!hasKanji) continue;
+            const frag = document.createDocumentFragment();
+            let run = '';
+            const flushRun = () => {
+                if (run) {
+                    frag.appendChild(document.createTextNode(run));
+                    run = '';
+                }
+            };
+            for (const ch of text) {
+                if (KANJI_PATTERN.test(ch)) {
+                    flushRun();
+                    const span = document.createElement('span');
+                    span.className = 'kanji-inline';
+                    span.textContent = ch;
+                    frag.appendChild(span);
+                } else {
+                    run += ch;
+                }
+            }
+            flushRun();
+            node.replaceWith(frag);
         }
-    }
-    if (kanjiChars.length === 0) return null;
-
-    const row = el('div', { className: 'kanji-breakdown' });
-    for (const ch of kanjiChars) {
-        const tag = el('span', {
-            className: 'kanji-tag',
-            textContent: ch,
-        });
-        tag.addEventListener('click', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const rect = tag.getBoundingClientRect();
-            markGlobalLookupExtHit(tag);
-            window.flutter_inappwebview.callHandler('onLinkClick', ch, {
-                x: rect.left,
-                y: rect.top,
-                width: rect.width,
-                height: rect.height
-            });
-        });
-        row.appendChild(tag);
-    }
-    return row;
+    });
 }
 
 function createEntryHeader(entry, idx) {
@@ -2745,9 +2772,19 @@ function createEntryHeader(entry, idx) {
     expressionSpan.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const rect = expressionSpan.getBoundingClientRect();
-        markGlobalLookupExtHit(expressionSpan);
-        window.flutter_inappwebview.callHandler('onLinkClick', expression, {
+        // design-2026-08 讨论区反馈: a click landing on an inline kanji (.kanji-inline, wrapped
+        // by wrapExpressionInlineKanji) looks up THAT character — same
+        // onLinkClick channel + anchor-rect semantics the removed
+        // kanji-breakdown chips used. Anywhere else on the headword keeps the
+        // old whole-expression re-lookup.
+        const kanjiEl = e.target instanceof Element
+            ? e.target.closest('.kanji-inline')
+            : null;
+        const anchorEl = kanjiEl || expressionSpan;
+        const term = kanjiEl ? kanjiEl.textContent : expression;
+        const rect = anchorEl.getBoundingClientRect();
+        markGlobalLookupExtHit(anchorEl);
+        window.flutter_inappwebview.callHandler('onLinkClick', term, {
             x: rect.left,
             y: rect.top,
             width: rect.width,
@@ -3535,11 +3572,6 @@ function buildEntryElement(entry, idx, maximumDictionaryBlocks = Infinity) {
     const entryDiv = el('div', { className: 'entry' });
     entryDiv.appendChild(createEntryHeader(entry, idx));
 
-    const kanjiRow = createKanjiBreakdown(entry.expression);
-    if (kanjiRow) {
-        entryDiv.appendChild(kanjiRow);
-    }
-
     const exprTags = createExpressionTagsSection(entry);
     if (exprTags) {
         entryDiv.appendChild(exprTags);
@@ -3726,6 +3758,11 @@ function postProcessRuby(container) {
             }
         }
     });
+    // design-2026-08 讨论区反馈: inline-kanji tap targets ride the same post-pass so every
+    // render path that ruby-fixes a subtree (first entry, deferred tail
+    // entries, incremental updates) also gets them; both passes are idempotent
+    // so the double walk over entry 0 (BUG-1098) stays harmless.
+    wrapExpressionInlineKanji(container);
 }
 
 function applyCustomCSS() {
@@ -3774,7 +3811,7 @@ function createKanjiCard(kanji) {
     const head = el('div', { className: 'kanji-card-head' });
     const charEl = el('div', { className: 'kanji-card-char', textContent: kanji.character });
     // Tapping the big character re-looks it up (consistent with the term
-    // headword + kanji-breakdown tags), so a kanji card is also a jump-off
+    // headword + inline kanji, design-2026-08 讨论区反馈), so a kanji card is also a jump-off
     // point for a fresh lookup.
     charEl.addEventListener('click', (e) => {
         e.preventDefault();


### PR DESCRIPTION
## 修的是什么

用户截图报：查词弹窗查「理論」时，词头下方仍渲染出「理」「論」两个可点灰方块 chip，「我记得这两个字我删掉了来着」。

## 根因不在代码，在交付链路

删除工作早在 2026-08-15 就做完了——提交 `851d6089ff` 改了 9 个文件、三镜像同步全到位。但它 `git merge-base --is-ancestor 851d6089ff develop` = **NO**：只活在分支 `worktree-popup-inline-kanji-compact-header` 上，从没开过 PR、从没合并。于是旧 UI 在 `develop` 上原封不动继续跑了 8 天。

不是「删一份漏两份」的镜像漂移——三份 popup.js 的 sha256 完全相同，都是旧的。

## 本 PR 做了什么

1. 把 `851d6089ff` cherry-pick 到当前 `develop` 基底（干净落地，零冲突），三件事整体恢复：
   - 删除 `createKanjiBreakdown` chip 行；
   - 词头里每个汉字自身成为跳转目标（`wrapExpressionInlineKanji` + `.kanji-inline` 淡点线 affordance），包裹 pass 挂在 `postProcessRuby` 尾部，幂等、只切 `.expression` 文本节点，不动 ruby-unit/rt 锚定与选区活文本；
   - 顶栏贴近词头：无 header 顶栏 40 改 36（贴住 36×36 的 `_topActionConstraints`，命中区零缩水）、首词条 `padding-top` 8 改 0。
2. 新增守卫 `fushi/test/dictionary/popup_inline_kanji_guard_test.dart`（16 断言）。
3. 立 BUG-1788 记录根因。

**组合按钮（整词 + 读音）按用户要求保留**：`createExpressionTagsSection` 完好未动，只删了单字 chip 行。

## 验证

- 三镜像 popup.js / popup.css sha256 各自全同；`content.css` 重跑 `generate-content-css.mjs` 输出逐字节相同（不是陈旧生成物）。
- `wrapExpressionInlineKanji(container)` 确认落在 `postProcessRuby` 函数体末尾（21 个提交的漂移没挪歪插入点）。
- `_topActionConstraints` 确认仍是 36×36，顶栏 36 的前提成立。
- `flutter analyze` 零问题。
- 全量测试 20361 个跑完；唯一失败是 `epub_image_list_test.dart` 的 suite 装载 IPC 崩溃（并发伪红），该文件单独复跑 13 个测试全过。

## 守卫做了变异实测

不是「写完就绿」——三轮变异，每次还原后 sha256 逐字节校验：

1. 把一份镜像的 `.kanji-inline` 改回 `.kanji-tag` → 只有那份镜像红，另两份保持绿（逐镜像精度）。
2. 把 `wrapExpressionInlineKanji` 调用移出 `postProcessRuby` 但仍留在文件里 → 文件级断言绿、体内断言红（证明 `methodBody` 锚定在干活，不是摆设）。
3. 往注释里塞 `.kanji-tag` / `.kanji-breakdown` → 保持绿（掩码生效，无假红）。

第 3 条尤其必要：三份文件的注释里至今写着这两个旧名用来说明历史，裸 `contains` 会被注释喂成假红。

https://claude.ai/code/session_01ST4BZQkqXY2rqG9EQrQXWD
