### PR TITLE
fix(reader): 页边距不再点中被 clip 掉的相邻页词 (BUG-1797)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1662 条。点号进各自文件。
+> 共 1663 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1797](bugs/BUG-1797-reader-padding-hit-leak.md) | ✅ | ✅ | 阅读器页边距能点到相邻页的词查词（不可见却可命中） |
 | [BUG-1789](bugs/BUG-1789-pdf-import-whitelists.md) | ✅ | ✅ | PDF 导入白名单三处漏抄：漫画框选不中、拖放不认、文件夹扫描跳过 |
 | [BUG-1787](bugs/BUG-1787-font-library-scope-target-dead-param.md) | ✅ | ✅ | 字体库作用域参数不生效：从游戏入口导入的字体挂到小说正文 |
 | [BUG-1785](bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md) | ✅ | ✅ | TV 整理被无集号特典文件整批卡死 |

--- a/docs/bugs/BUG-1797-reader-padding-hit-leak.md
+++ b/docs/bugs/BUG-1797-reader-padding-hit-leak.md
@@ -1,0 +1,39 @@
+## BUG-1797 · 阅读器页边距能点到相邻页的词查词（不可见却可命中）
+
+- **报告**：2026-08-23（用户：在左右间距或上下间距有的时候可以点击到前一页和后一页的词来查词，但是那块明明没有显示）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/reader/reader_selection_scripts.dart:558`（`getCharacterAtPoint`，修复前）与 `fushi/lib/src/reader/reader_content_styles.dart:900-946`（`padding` + `clip-path` + `html::before` 覆盖条）。
+
+### 根因
+
+分页模式把整章内容排成**一根** multicol，靠移动 `scrollLeft` / `scrollTop` 看每一页。相邻页的列在几何上就**真实地落在 body 的 padding（页边距）带里** —— `body{overflow:hidden}` 只在 border-box 裁，裁不掉 padding 带**内**的东西。`reader_content_styles.dart:918-929` 的注释已经把这点写清楚了，遮住它的是两个**绘制期**机制：
+
+- body 的 `clip-path: inset(...)`（`contentClipCss`，四边各等于 body 实际 padding）
+- `html::before` 那条背景色不透明覆盖条（TODO-1285 的引擎无关兜底）
+
+而查词/选词的命中测试是**布局期**的：`caretPositionFromPoint` 把任意落点 **clamp** 到最近字符（与 BUG-748 同一个 clamp），`getClientRects()` 返回的矩形完全无视 clip-path 和覆盖条。于是「看不见」和「点得到」用了两套互不相干的真相 —— 点页边距就查到了相邻页的词。横排时 turn 轴水平，泄露在左右间距；竖排时 turn 轴垂直，泄露在上下间距，与用户描述逐项对上。「有的时候」= 只有相邻列恰好滚进 padding 带、且落点在那个字形矩形 ±6px 容差内时才命中。
+
+命中链上有三个入口都吃这个 clamp，不止最终确认那一处：
+
+1. `getCharacterAtPoint` 的最终字符确认（`caretPositionFromPoint` 快路）
+2. `getCaretRange` 第一遍「精确包含」逐字符扫描（快路失效时，BUG-765 / TODO-916 的路径）
+3. `getCaretRange` 第二遍「最近字符 + 容差」兜底扫描
+
+只堵第 1 处，页边距接缝上的点会从「查错词」变成「查不到词」（不可见字符赢下最近字符竞争后再被否决，正文内侧边缘出现一条死区），所以三处必须同源。
+
+### 修复
+
+判据从「找得到字符」改成「**这个字符可见吗**」，而不是给页边距加特例分支：
+
+- 新增 `visibleContentBox()`：可见正文盒 = body 的 content box（border-box 内缩 **computed** padding，与 `contentClipCss` 逐项一致）∩ 视口。用 computed 值是为了让引擎去解析 `vh/vw/calc/var`，不在 JS 里重算一遍 CSS，也就不会跟 CSS 那侧漂移。三种布局零特例：分页下 body 是钉在视口帧上的 scroller，content box 恰等于 clip 出的可见区；连续模式 body 随内容滚动，与视口取交后滚出去的那截不会被误判成不可见；VN 模式 body padding 为 0，盒 == 整视口、判据近似恒真。
+- 新增 `charRangeVisible(charRange, box)`：字形矩形与可见正文盒有正面积交集才算可见。跨在 clip 边界上、还露出半个的字符仍算可见（用户确实看得到，点它就该查得到）。拿不到盒时返回 `true` —— 守卫只拦**确证不可见**的字符，不在几何未知时误伤正常查词。
+- 上述三处接入点全部过这一关；`box` 由 `getCharacterAtPoint` 一次算好沿链下传，逐字符兜底扫描才不会跑上千次 `getComputedStyle`（上千次强制 reflow）。
+
+因为查词/选词的所有入口（`selectText` / `beginRangeSelection` / `updateRangeSelection` / `moveSelectionHandle` / `tapHasCharacter`）都走 `getCharacterAtPoint`，一处收口即全覆盖。
+
+- **[x] ① 已修复** — `fushi/lib/src/reader/reader_selection_scripts.dart`（`visibleContentBox` / `charRangeVisible` + 三处接入）
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reader_padding_hit_leak_bug1797_test.dart`：不是源码扫描守卫，而是把生产的 `window.fushiSelection` 对象字面量抽出来在 node 里对着**真的复现 clamp 行为**的 fake DOM 跑 `getCharacterAtPoint`，8 个场景覆盖「页边距点不中相邻页字」「正文照常命中」「跨边界字仍可点」「零 padding 时守卫是 no-op」「caret API 失效时两条兜底扫描同样不泄露」「接缝上退让给本页最近可见字」。三个接入点逐个变异实测均转红（变异 A 的报错正是原 bug 复现：`got {text=隣頁, offset=0}`）。
+
+### 备注
+
+- 同根因的相邻缺陷（**本次未修**）：`fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart:927` 的 `_fushiReaderMouseDragStartAllowed` 末行 `return !_fushiReaderCaretRangeAtPoint(...)` 同样吃 clamp —— 分页模式下页边距按下时 caret 照样 clamp 出一个字符，于是「不在字上才允许拖动翻页」恒为 false，鼠标左键拖动翻页（BUG-368）在页边距起手应该是失效的。改法是让它复用 `fushiSelection.getCharacterAtPoint` 这个同源判据，但需要真机复测鼠标拖动翻页，本轮不做，单独立项。
+- 真机验证缺口：本次只做到 node 行为测试层，未在真机/模拟器上复测原始失败路径（用户已取消真机验证要求）。

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -461,6 +461,66 @@ window.fushiSelection = {
       }
     });
   },
+  // BUG-1797：可见正文盒 = body 的 content box ∩ 视口。
+  //
+  // 分页模式把整章内容当**一根** multicol，靠移动 scrollLeft/scrollTop 看每一页，所以
+  // 相邻页的列在几何上就真实地落在 body 的 padding（页边距）带里。body{overflow:hidden}
+  // 只在 border-box 裁，裁不掉 padding 带**内**的东西；真正遮住它的是 body 的 clip-path
+  // 和 html::before 覆盖条（reader_content_styles.dart 的 contentClipCss / TODO-1285），
+  // 两者都是**绘制期**机制。而命中测试是**布局期**的：caretPositionFromPoint 把落点 clamp
+  // 到最近字符，getClientRects 完全无视 clip-path 与覆盖条 —— 于是「看不见」和「点得到」
+  // 用了两套互不相干的真相，点页边距就查到了相邻页的词（横排在左右间距、竖排在上下间距）。
+  //
+  // 修法不是给页边距加特例分支，而是让两者同源：判据从「找得到字符」变成「这个字符可见吗」。
+  // 盒子取 body 的 content box（border-box 内缩 computed padding，与 contentClipCss 逐项
+  // 一致），computed 值已由引擎把 vh/vw/calc/var 解析成 px，不在 JS 里重算一遍 CSS、也就
+  // 不会跟 CSS 那侧漂移。三种布局零特例：分页下 body 是钉在视口帧上的 scroller，content
+  // box 恰等于 clip 出的可见区；连续模式 body 随内容滚动，与视口取交后滚出去的那截不会被
+  // 误判成不可见；VN 模式 body padding 为 0，盒 == 整视口、判据近似恒真。
+  visibleContentBox: function() {
+    try {
+      var body = document.body;
+      if (!body) return null;
+      var rect = body.getBoundingClientRect();
+      var cs = window.getComputedStyle(body);
+      var px = function(v) { var n = parseFloat(v); return isFinite(n) ? n : 0; };
+      var left = rect.left + px(cs.borderLeftWidth) + px(cs.paddingLeft);
+      var top = rect.top + px(cs.borderTopWidth) + px(cs.paddingTop);
+      var right = rect.right - px(cs.borderRightWidth) - px(cs.paddingRight);
+      var bottom = rect.bottom - px(cs.borderBottomWidth) - px(cs.paddingBottom);
+      var vw = window.innerWidth || (document.documentElement && document.documentElement.clientWidth) || 0;
+      var vh = window.innerHeight || (document.documentElement && document.documentElement.clientHeight) || 0;
+      if (left < 0) left = 0;
+      if (top < 0) top = 0;
+      if (vw > 0 && right > vw) right = vw;
+      if (vh > 0 && bottom > vh) bottom = vh;
+      if (!(right > left) || !(bottom > top)) return null;
+      return { left: left, top: top, right: right, bottom: bottom };
+    } catch (err) {
+      return null;
+    }
+  },
+  // BUG-1797：这个字符真的可见吗（字形矩形与可见正文盒有正面积交集）。命中链上每个候选
+  // 字符都要过这一关，页边距带里被 clip 掉的相邻页字符因此永远成不了查词/选词目标；跨在
+  // 边界上、还露出半个的字符仍算可见（clip 后用户确实看得到，点它就该查得到）。
+  // [box] 由调用方一次算好往下传：逐字符兜底扫描会跑上千次，每次现算 getComputedStyle
+  // 就是上千次强制 reflow。拿不到盒（无 body / 退化几何）一律返回 true —— 这道守卫只负责
+  // 拦下**确证不可见**的字符，绝不在几何未知时把正常查词一起拦掉。
+  charRangeVisible: function(charRange, box) {
+    if (box === undefined) box = this.visibleContentBox();
+    if (!box) return true;
+    var rects = charRange.getClientRects();
+    var list = (rects && rects.length) ? rects : [charRange.getBoundingClientRect()];
+    for (var i = 0; i < list.length; i++) {
+      var r = list[i];
+      if (!r) continue;
+      if (Math.min(r.right, box.right) > Math.max(r.left, box.left) &&
+          Math.min(r.bottom, box.bottom) > Math.max(r.top, box.top)) {
+        return true;
+      }
+    }
+    return false;
+  },
   inCharRange: function(charRange, x, y, pad) {
     // TODO-916 症状④：字符矩形按 [pad]（默认 0 = 旧的精确包含）外扩一圈再判包含，
     // 消除落在字缝/行距/描边外缘的 miss。pad 仅在 getCaretRange 的逐字符兜底里传入小值，
@@ -487,7 +547,10 @@ window.fushiSelection = {
     var dy = cy - y;
     return dx * dx + dy * dy;
   },
-  getCaretRange: function(x, y) {
+  // BUG-1797：[box] 是调用方算好的可见正文盒（见 visibleContentBox），沿命中链往下传，
+  // 逐字符兜底扫描才不会每个字符都现算一次 getComputedStyle。不传时自己算一份。
+  getCaretRange: function(x, y, box) {
+    if (box === undefined) box = this.visibleContentBox();
     // BUG-765 续修：`caretPositionFromPoint` 命中「非文本 / 振假名」节点时**不再早退**，
     // 落到下面的 `elementFromPoint`+最近字符几何兜底。根因：拖选区手柄时手指压在手柄
     // div 上，即便 `moveSelectionHandle` 已把手柄 `pointer-events:none`，部分 Android
@@ -519,7 +582,8 @@ window.fushiSelection = {
       for (var i = 0; i < node.textContent.length; i++) {
         range.setStart(node, i);
         range.setEnd(node, i + 1);
-        if (this.inCharRange(range, x, y)) {
+        // BUG-1797：命中还不够，字符得真的可见 —— 页边距带里的相邻页字符会被这里剔掉。
+        if (this.inCharRange(range, x, y) && this.charRangeVisible(range, box)) {
           range.collapse(true);
           return range;
         }
@@ -540,6 +604,9 @@ window.fushiSelection = {
         if (distSq >= bestDistSq) continue;
         var rect = range.getClientRects()[0] || range.getBoundingClientRect();
         if (!rect) continue;
+        // BUG-1797：不可见字符不得参与「最近字符」竞争 —— 否则页边距带里的相邻页字符
+        // 会以更近的距离抢走本页边缘字符的名额，落点从「查错词」变成「查不到词」。
+        if (!this.charRangeVisible(range, box)) continue;
         var tol = Math.max(6, Math.max(rect.width, rect.height) / 2);
         if (distSq <= tol * tol) {
           bestDistSq = distSq;
@@ -556,7 +623,9 @@ window.fushiSelection = {
     return document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null;
   },
   getCharacterAtPoint: function(x, y) {
-    var range = this.getCaretRange(x, y);
+    // BUG-1797：整条命中链共用同一个可见正文盒，一次 hit-test 只量一次几何。
+    var box = this.visibleContentBox();
+    var range = this.getCaretRange(x, y, box);
     if (!range) return null;
     var node = range.startContainer;
     if (node.nodeType !== Node.TEXT_NODE || this.isFurigana(node)) return null;
@@ -573,7 +642,12 @@ window.fushiSelection = {
         var charRange = document.createRange();
         charRange.setStart(node, offset);
         charRange.setEnd(node, offset + 1);
-        if (this.inCharRange(charRange, x, y, pads[p])) {
+        // BUG-1797：caretPositionFromPoint 的快路把落点 clamp 到最近字符，页边距上的点
+        // 因此照样解析出一个字符；这里的可见性确认是「不可见就不可点」这条不变式在查词/
+        // 选词全部入口（selectText / beginRangeSelection / updateRangeSelection /
+        // moveSelectionHandle / tapHasCharacter）上的唯一收口。
+        if (this.inCharRange(charRange, x, y, pads[p]) &&
+            this.charRangeVisible(charRange, box)) {
           if (this.isScanBoundary(text[offset])) return null;
           return { node: node, offset: offset };
         }

--- a/fushi/test/reader/reader_padding_hit_leak_bug1797_test.dart
+++ b/fushi/test/reader/reader_padding_hit_leak_bug1797_test.dart
@@ -1,0 +1,353 @@
+// BUG-1797：阅读器页边距（横排左右间距 / 竖排上下间距）能点到相邻页的词查词，而那块
+// 明明什么都没显示。
+//
+// 根因：分页模式把整章内容当**一根** multicol，靠移动 scrollLeft/scrollTop 看每一页，
+// 相邻页的列在几何上就落在 body 的 padding 带里；遮住它的 clip-path 与 html::before
+// 覆盖条都是**绘制期**机制，而命中测试是**布局期**的（caretPositionFromPoint 把落点
+// clamp 到最近字符，getClientRects 无视 clip-path）——「看不见」和「点得到」是两套真相。
+//
+// 这个测试不是源码扫描守卫：它把生产的 window.fushiSelection 对象字面量抽出来，在 node
+// 里对着一个**真的复现 clamp 行为**的 fake DOM 跑 getCharacterAtPoint，断言页边距带里
+// 的相邻页字符点不中、而正文内的字符照常命中。删掉 charRangeVisible 的接入点即转红。
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_selection_scripts.dart';
+
+void main() {
+  test(
+      'BUG-1797: getCharacterAtPoint rejects chars clipped into the page-margin '
+      'band and still hits visible body text', () {
+    final Directory temp = Directory.systemTemp.createTempSync(
+      'fushi-bug1797-hit-leak-',
+    );
+    final File payloadFile = File('${temp.path}/payload.json')
+      ..writeAsStringSync(
+        jsonEncode(<String, String>{
+          'selection': ReaderSelectionScripts.source(),
+        }),
+      );
+    late final ProcessResult result;
+    try {
+      result = Process.runSync(
+        'node',
+        <String>['-e', _runner, payloadFile.path],
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+      );
+    } finally {
+      temp.deleteSync(recursive: true);
+    }
+    expect(
+      result.exitCode,
+      0,
+      reason: 'padding hit-leak runner failed:\n'
+          'stdout=${result.stdout}\nstderr=${result.stderr}',
+    );
+    expect(result.stdout.toString().trim(), 'OK');
+  });
+}
+
+const String _runner = r'''
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+
+function assert(value, message) {
+  if (!value) throw new Error(typeof message === 'function' ? message() : message);
+}
+// hits carry live DOM nodes; never JSON.stringify them (circular parentElement).
+function describeHit(hit) {
+  return hit ? ('{text=' + hit.node.textContent + ', offset=' + hit.offset + '}') : 'null';
+}
+
+// ---- minimal DOM that reproduces the two things that matter -----------------
+// 1) per-character client rects (so the visibility test has real geometry)
+// 2) caretPositionFromPoint CLAMPING to the nearest character, exactly like a
+//    real engine -- that clamp is the whole reason a margin tap resolves to a
+//    neighbouring page's word.
+
+function rect(left, top, right, bottom) {
+  return {
+    left: left, top: top, right: right, bottom: bottom,
+    width: right - left, height: bottom - top,
+  };
+}
+
+function makeElement(tag) {
+  const el = {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    parentElement: null,
+    children: [],
+    closest: function (sel) {
+      // Only the queries the production code actually issues matter here.
+      if (sel === 'rt, rp') return null;
+      let node = el;
+      while (node) {
+        if (sel.split(',').some((s) => s.trim().toUpperCase() === node.tagName)) {
+          return node;
+        }
+        node = node.parentElement;
+      }
+      return null;
+    },
+  };
+  return el;
+}
+
+// text node whose i-th character occupies rects[i]
+function makeTextNode(text, rects, parent) {
+  const node = {
+    nodeType: 3,
+    textContent: text,
+    nodeValue: text,
+    parentElement: parent,
+    __rects: rects,
+  };
+  parent.children.push(node);
+  return node;
+}
+
+function distanceSq(r, x, y) {
+  const cx = x < r.left ? r.left : (x > r.right ? r.right : x);
+  const cy = y < r.top ? r.top : (y > r.bottom ? r.bottom : y);
+  return (cx - x) * (cx - x) + (cy - y) * (cy - y);
+}
+
+function buildDom(bodyRect, padding, textNodesSpec) {
+  const body = makeElement('body');
+  const paragraphs = [];
+  const textNodes = [];
+  for (const spec of textNodesSpec) {
+    const p = makeElement('p');
+    p.parentElement = body;
+    body.children.push(p);
+    paragraphs.push(p);
+    textNodes.push(makeTextNode(spec.text, spec.rects, p));
+  }
+  body.getBoundingClientRect = () => bodyRect;
+
+  const doc = {
+    body: body,
+    documentElement: { clientWidth: bodyRect.right, clientHeight: bodyRect.bottom },
+    createRange: function () {
+      const r = {
+        startContainer: null, startOffset: 0, endContainer: null, endOffset: 0,
+        setStart: function (n, o) { r.startContainer = n; r.startOffset = o; },
+        setEnd: function (n, o) { r.endContainer = n; r.endOffset = o; },
+        collapse: function () { r.endContainer = r.startContainer; r.endOffset = r.startOffset; },
+        getClientRects: function () {
+          if (!r.startContainer || r.startContainer !== r.endContainer) return [];
+          return r.startContainer.__rects.slice(r.startOffset, r.endOffset);
+        },
+        getBoundingClientRect: function () {
+          const rects = r.getClientRects();
+          if (!rects.length) return rect(0, 0, 0, 0);
+          return rect(
+            Math.min(...rects.map((q) => q.left)),
+            Math.min(...rects.map((q) => q.top)),
+            Math.max(...rects.map((q) => q.right)),
+            Math.max(...rects.map((q) => q.bottom)),
+          );
+        },
+      };
+      return r;
+    },
+    // The engine behaviour under test: ALWAYS resolve to the nearest character,
+    // even when the point is far outside every glyph (that is the clamp).
+    caretPositionFromPoint: function (x, y) {
+      let best = null;
+      let bestDist = Infinity;
+      for (const node of textNodes) {
+        for (let i = 0; i < node.__rects.length; i++) {
+          const d = distanceSq(node.__rects[i], x, y);
+          if (d < bestDist) { bestDist = d; best = { offsetNode: node, offset: i }; }
+        }
+      }
+      return best;
+    },
+    elementFromPoint: function () { return body; },
+    createTreeWalker: function (root, whatToShow, filter) {
+      const collected = [];
+      (function walk(n) {
+        for (const child of (n.children || [])) {
+          if (child.nodeType === 3) {
+            if (!filter || filter.acceptNode(child) === 1) collected.push(child);
+          } else {
+            walk(child);
+          }
+        }
+      })(root === body ? body : root);
+      let i = -1;
+      return {
+        currentNode: null,
+        nextNode: function () { i++; return i < collected.length ? collected[i] : null; },
+      };
+    },
+  };
+
+  const win = {
+    innerWidth: bodyRect.right,
+    innerHeight: bodyRect.bottom,
+    getComputedStyle: function () {
+      return {
+        paddingLeft: padding.left + 'px',
+        paddingRight: padding.right + 'px',
+        paddingTop: padding.top + 'px',
+        paddingBottom: padding.bottom + 'px',
+        borderLeftWidth: '0px', borderRightWidth: '0px',
+        borderTopWidth: '0px', borderBottomWidth: '0px',
+      };
+    },
+  };
+  return { doc: doc, win: win, textNodes: textNodes };
+}
+
+// ---- load the production object ---------------------------------------------
+function selectionObjectLiteral(source) {
+  const marker = 'window.fushiSelection = {';
+  const start = source.indexOf(marker);
+  assert(start >= 0, 'window.fushiSelection object missing');
+  const brace = source.indexOf('{', start);
+  const end = source.indexOf('\n};', brace);
+  assert(end >= 0, 'window.fushiSelection terminator missing');
+  return source.slice(brace, end + 2);
+}
+
+function loadSelection(dom) {
+  const literal = selectionObjectLiteral(data.selection);
+  const factory = new Function(
+    'window', 'document', 'Node', 'NodeFilter', 'JAPANESE_RANGES',
+    'return (' + literal + ');',
+  );
+  return factory(
+    dom.win,
+    dom.doc,
+    { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    { SHOW_TEXT: 4, FILTER_ACCEPT: 1, FILTER_REJECT: 2 },
+    [[0x3040, 0x309f], [0x30a0, 0x30ff], [0x4e00, 0x9fff]],
+  );
+}
+
+// ---- the scenario ------------------------------------------------------------
+// Horizontal paged layout, 400x800 viewport, 40px left/right page margins and
+// 40px top/bottom. Visible content box is therefore (40,40)-(360,760).
+//   * "本" sits at x 100..120 -> inside the box, a normal word.
+//   * "隣" sits at x 8..28 -> entirely inside the LEFT margin band: this is the
+//     neighbouring page's column, painted over by clip-path / html::before, so
+//     the user sees nothing there.
+const bodyRect = rect(0, 0, 400, 800);
+const padding = { left: 40, right: 40, top: 40, bottom: 40 };
+const dom = buildDom(bodyRect, padding, [
+  { text: '本文', rects: [rect(100, 100, 120, 120), rect(120, 100, 140, 120)] },
+  { text: '隣頁', rects: [rect(8, 100, 28, 120), rect(-12, 100, 8, 120)] },
+]);
+const sel = loadSelection(dom);
+dom.win.fushiSelection = sel;
+
+// Sanity: the fake engine really does clamp a margin tap onto the hidden
+// neighbouring-page character. Without that, this test would prove nothing.
+const clamped = dom.doc.caretPositionFromPoint(18, 110);
+assert(clamped && clamped.offsetNode === dom.textNodes[1] && clamped.offset === 0,
+  'fake engine must clamp the margin tap onto the hidden neighbour char');
+
+// 1) A tap in the left page-margin band must NOT resolve to a word.
+const marginHit = sel.getCharacterAtPoint(18, 110);
+assert(marginHit === null,
+  () => 'tap in the page-margin band must not look up the clipped neighbour page word, got ' +
+  describeHit(marginHit));
+
+// 2) Same for a point that is outside every glyph but still in the margin band
+//    (pure clamp, no glyph anywhere near).
+assert(sel.getCharacterAtPoint(2, 110) === null,
+  'far margin tap must stay blank');
+
+// 3) Real body text still looks up (no regression on the normal path).
+const bodyHit = sel.getCharacterAtPoint(110, 110);
+assert(bodyHit && bodyHit.node === dom.textNodes[0] && bodyHit.offset === 0,
+  () => 'visible body character must still be looked up, got ' + describeHit(bodyHit));
+const bodyHit2 = sel.getCharacterAtPoint(130, 110);
+assert(bodyHit2 && bodyHit2.node === dom.textNodes[0] && bodyHit2.offset === 1,
+  () => 'second visible character must still be looked up, got ' + describeHit(bodyHit2));
+
+// 4) A character straddling the clip edge is still visible -> still clickable.
+const straddle = buildDom(bodyRect, padding, [
+  { text: '半', rects: [rect(30, 100, 50, 120)] },
+]);
+const sel2 = loadSelection(straddle);
+straddle.win.fushiSelection = sel2;
+const straddleHit = sel2.getCharacterAtPoint(45, 110);
+assert(straddleHit && straddleHit.offset === 0,
+  () => 'a glyph straddling the content-box edge stays clickable, got ' + describeHit(straddleHit));
+
+// 5) No body padding (VN layout / unstyled) -> the guard must be a no-op.
+const vn = buildDom(bodyRect, { left: 0, right: 0, top: 0, bottom: 0 }, [
+  { text: '端', rects: [rect(2, 100, 22, 120)] },
+]);
+const sel3 = loadSelection(vn);
+vn.win.fushiSelection = sel3;
+assert(sel3.getCharacterAtPoint(10, 110) !== null,
+  'with zero body padding every on-screen glyph stays clickable');
+
+// 6+7) The caret fast-path is not the only way in: when caretPositionFromPoint
+// returns null (ruby / image / collapsed-box pages -- BUG-765, TODO-916),
+// getCaretRange falls back to elementFromPoint + a per-character scan of the
+// block, first exact-containment then nearest-character-within-tolerance. Both
+// of those scans walk the WHOLE block, neighbouring-page columns included, so
+// both need the same visibility judgement or the margin leak just moves.
+function withoutCaretApi(dom) {
+  dom.doc.caretPositionFromPoint = function () { return null; };
+  const sel = loadSelection(dom);
+  dom.win.fushiSelection = sel;
+  return sel;
+}
+
+// 6) exact-containment pass: the point is literally inside the hidden glyph's
+//    rect, so only the visibility test can reject it.
+const noCaret = buildDom(bodyRect, padding, [
+  { text: '本', rects: [rect(100, 100, 120, 120)] },
+  { text: '隣', rects: [rect(8, 100, 28, 120)] },
+]);
+const sel4 = withoutCaretApi(noCaret);
+assert(sel4.getCharacterAtPoint(18, 110) === null,
+  () => 'exact-containment fallback must not hit a clipped neighbour glyph, got ' +
+  describeHit(sel4.getCharacterAtPoint(18, 110)));
+const sel4Body = sel4.getCharacterAtPoint(110, 110);
+assert(sel4Body && sel4Body.node === noCaret.textNodes[0],
+  () => 'exact-containment fallback must still hit visible text, got ' + describeHit(sel4Body));
+
+// 7) nearest-character pass: the point sits in the margin band just outside the
+//    hidden glyph. Without the visibility filter the hidden glyph wins the
+//    "nearest" contest (it is 4px away) over the visible one (72px away) and the
+//    tap looks up the neighbouring page's word.
+const nearest = buildDom(bodyRect, padding, [
+  { text: '本', rects: [rect(100, 100, 120, 120)] },
+  { text: '隣', rects: [rect(8, 100, 24, 120)] },
+]);
+const sel5 = withoutCaretApi(nearest);
+assert(sel5.getCharacterAtPoint(28, 110) === null,
+  () => 'nearest-character fallback must not adopt a clipped neighbour glyph, got ' +
+  describeHit(sel5.getCharacterAtPoint(28, 110)));
+
+// 8) The visibility judgement must run INSIDE both fallback scans, not only as a
+//    final veto. A tap right on the seam: the point sits inside a hidden
+//    neighbouring-page glyph (16..38, entirely left of the content box at x=40)
+//    and 4px away from the first visible glyph of this page (40..60).
+//    - filtering inside the scans -> the hidden glyph is skipped, the visible one
+//      wins the nearest-character contest, the user looks up THIS page's word.
+//    - filtering only at the end -> the hidden glyph wins (it contains the point),
+//      gets vetoed, and the tap resolves to nothing: the leak turns into a dead
+//      zone along the whole inner edge of the page margin.
+const seam = buildDom(bodyRect, padding, [
+  { text: '端', rects: [rect(40, 100, 60, 120)] },
+  { text: '隣', rects: [rect(16, 100, 38, 120)] },
+]);
+const sel6 = withoutCaretApi(seam);
+const seamHit = sel6.getCharacterAtPoint(36, 110);
+assert(seamHit && seamHit.node === seam.textNodes[0] && seamHit.offset === 0,
+  () => 'a tap on the margin seam must fall back to this page\'s nearest VISIBLE ' +
+  'glyph, not be swallowed by the hidden neighbour, got ' + describeHit(seamHit));
+
+console.log('OK');
+''';


### PR DESCRIPTION
## 用户报告

> 在左右间距或上下间距有的时候可以点击到前一页和后一页的词来查词，但是那块明明没有显示

## 根因

分页模式把整章内容排成**一根** multicol，靠移动 `scrollLeft` / `scrollTop` 看每一页。相邻页的列在几何上就**真实落在 body 的 padding（页边距）带里** —— `body{overflow:hidden}` 只在 border-box 裁，裁不掉 padding 带**内**的东西。`reader_content_styles.dart:918-929` 的注释早就写明了这一点，真正遮住它的是两个**绘制期**机制：

- body 的 `clip-path: inset(...)`（`contentClipCss`，四边各等于 body 实际 padding）
- `html::before` 那条背景色不透明覆盖条（TODO-1285 的引擎无关兜底）

而查词/选词的命中测试是**布局期**的：`caretPositionFromPoint` 把任意落点 **clamp** 到最近字符（与 BUG-748 同一个 clamp），`getClientRects()` 返回的矩形完全无视 clip-path 和覆盖条。于是「看不见」和「点得到」用了两套互不相干的真相。

横排 turn 轴水平 → 泄露在左右间距；竖排 turn 轴垂直 → 泄露在上下间距，与用户描述逐项对上。「有的时候」= 只有相邻列恰好滚进 padding 带、且落点在那个字形矩形 ±6px 容差内才命中。

## 修复

判据从「找得到字符」改成「**这个字符可见吗**」，不加页边距特例分支：

- `visibleContentBox()` — 可见正文盒 = body 的 content box（border-box 内缩 **computed** padding，与 `contentClipCss` 逐项同源）∩ 视口。用 computed 值让引擎去解析 `vh/vw/calc/var`，不在 JS 里重算一遍 CSS，也就不会跟 CSS 那侧漂移。
- `charRangeVisible(charRange, box)` — 字形矩形与可见盒有正面积交集才算可见。跨在 clip 边界上、还露出半个的字符仍算可见。拿不到盒时返回 `true`：守卫只拦**确证不可见**的字符。

接进命中链的**三处**扫描，而不只是最后一道：

1. `getCharacterAtPoint` 的最终字符确认（caret 快路）
2. `getCaretRange` 第一遍「精确包含」逐字符扫描（快路失效时，BUG-765 / TODO-916 的路径）
3. `getCaretRange` 第二遍「最近字符 + 容差」兜底扫描

三处必须同源：只堵第 1 处，页边距接缝上的点会从「查错词」变成「查不到词」（不可见字符赢下最近字符竞争后再被否决，正文内侧边缘出现一条死区）。`box` 由入口一次算好沿链下传，逐字符兜底扫描才不会跑上千次 `getComputedStyle`（上千次强制 reflow）。

查词/选词的所有入口（`selectText` / `beginRangeSelection` / `updateRangeSelection` / `moveSelectionHandle` / `tapHasCharacter`）都走 `getCharacterAtPoint`，一处收口即全覆盖。三种布局零特例：分页下 body 是钉在视口帧上的 scroller，content box 恰等于 clip 出的可见区；连续模式 body 随内容滚动、与视口取交后滚出去的那截不误判；VN 模式 body padding 为 0，盒 == 整视口、判据近似恒真。

## 验证

- **新测试** `fushi/test/reader/reader_padding_hit_leak_bug1797_test.dart` —— **不是源码扫描守卫**：把生产的 `window.fushiSelection` 对象字面量抽出来，在 node 里对着一个**真的复现 clamp 行为**的 fake DOM 跑 `getCharacterAtPoint`。8 个场景：页边距点不中相邻页字 / 正文照常命中 / 跨 clip 边界的字仍可点 / 零 padding 时守卫是 no-op / caret API 失效时两条兜底扫描同样不泄露 / 接缝上退让给本页最近可见字。
- **变异实测**：三个接入点逐个删除均转红（回滚经 sha256 比对确认无残留）。变异 A 的报错正是原 bug 复现 —— `tap in the page-margin band must not look up the clipped neighbour page word, got {text=隣頁, offset=0}`。
- `flutter analyze`（含 test）：`No issues found!`
- 定向测试 `dart run tool/flutter_test_failures.dart --no-pub test/reader test/lookup`：`FLUTTER TEST VERDICT: PASSED - 2053 tests ran, all tests passed`

## 已知缺口

- **未做真机复测**（用户已取消真机验证要求）。本轮只到 node 行为测试层。
- **同根因的相邻缺陷，本次未修**：`reader_fushi/webview.part.dart:927` 的 `_fushiReaderMouseDragStartAllowed` 末行 `return !_fushiReaderCaretRangeAtPoint(...)` 同样吃 clamp —— 分页模式下页边距按下时 caret 照样 clamp 出一个字符，于是「不在字上才允许拖动翻页」恒为 false，鼠标左键拖动翻页（BUG-368）在页边距起手应该是失效的。改法是让它复用 `fushiSelection.getCharacterAtPoint` 这个同源判据，但需要真机复测拖动翻页，已在 BUG-1797 备注里立项。

详见 `docs/bugs/BUG-1797-reader-padding-hit-leak.md`。

https://claude.ai/code/session_01PfbgX5WYM7pCxLo3BS8roo
