### PR TITLE
fix(video): 查词浮层纳入 overlay 门控，修控制条自动显隐窗口期的光标消失与换词打断 (BUG-1798)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1662 条。点号进各自文件。
+> 共 1663 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1798](bugs/BUG-1798-video-lookup-controls-autohide-race.md) | ✅ | ✅ | 查词浮层与控制条自动显隐竞态 |
 | [BUG-1789](bugs/BUG-1789-pdf-import-whitelists.md) | ✅ | ✅ | PDF 导入白名单三处漏抄：漫画框选不中、拖放不认、文件夹扫描跳过 |
 | [BUG-1787](bugs/BUG-1787-font-library-scope-target-dead-param.md) | ✅ | ✅ | 字体库作用域参数不生效：从游戏入口导入的字体挂到小说正文 |
 | [BUG-1785](bugs/BUG-1785-download-organize-tv-preview-blocks-batch.md) | ✅ | ✅ | TV 整理被无集号特典文件整批卡死 |

--- a/docs/bugs/BUG-1798-video-lookup-controls-autohide-race.md
+++ b/docs/bugs/BUG-1798-video-lookup-controls-autohide-race.md
@@ -1,0 +1,26 @@
+## BUG-1798 · 查词浮层与控制条自动显隐竞态
+- **报告**：2026-08-23（用户：在播放控件隐藏的前后几百毫秒内点击查词界面，就可以让查词界面卡住）
+- **真实性**：✅ 真 bug（桌面路径）。沿真实代码路径查实四条独立缺陷，全部集中在「查词浮层不被视为 overlay」这一个建模疏漏上。根因见下。
+
+### 根因（真实代码路径取证）
+
+视频页的查词浮层**不走** `lib/src/lookup/`（那是 Windows 原生 app-外覆盖窗），而是 `DictionaryPageMixin` + **根 Overlay**：`video_fushi_page.dart` 的 `_syncPopupOverlay()` 把 `OverlayEntry(builder: _buildPopupOverlay)` 插进 `Overlay.maybeOf(context, rootOverlay: true)`（用根 Overlay 是因为 media_kit 全屏是推到根 navigator 的独立路由，本页 Stack 会被盖住）。
+
+浮层的 dismiss barrier 是 `Positioned.fill` + `ColoredBox(Colors.transparent)`——`ColoredBox` 的 render object 是 `RenderProxyBoxWithHitTestBehavior(behavior: opaque)`，**命中测试上完全不透明**。判据 `shouldShowLookupDismissBarrier`（`dictionary_popup_layer.dart`）在**开始搜索时**就已为真，即弹窗还没出结果，barrier 就已接管全屏命中。
+
+而 `_hasVideoOverlay`（`video_fushi_page.dart`）此前只列了 5 项（`_videoSidePanel` / `_videoControlPopover` / `_subtitleListVisible` / `_episodeListVisible` / `_videoControlEditMode`），**无一项与查词浮层相关**。由此派生出四条独立缺陷：
+
+1. **Hibiki 侧光标被吃**：`controls_visibility.part.dart` 的 `_applyControlsVisibilityFromMediaKit()` 末尾 `_setCursorHidden(!visible && !_hasVideoOverlay)`。弹窗开着、控制条 2s 自动淡出 → `visible=false` 且 `_hasVideoOverlay=false` → `_buildCursorOverlay()`（`layout.part.dart`）铺一层 `MouseRegion(cursor: none)` 盖满视频区。查词浮层子树除右下角 resize 把手外**不声明任何 cursor**，解析必然下穿到这层 → 鼠标悬在弹窗上时 OS 光标直接消失。
+2. **fork 侧光标被吃（独立第二层）**：`controls_theme.part.dart` 的 `hideMouseOnControlsRemoval` 只排除了两个 push-aside 侧栏，同样漏了查词浮层 → media_kit fork 的控制条 `MouseRegion` 在 `mount=false` 时取 `cursor:none` 分支。**与第 1 条是两层独立的 `none`，只修一层另一层照样把光标吃掉。**
+3. **poke 续命哑火 + 合成事件污染指针记账**：`_pokeControlsVisible()`（`controls_visibility.part.dart`）的全部机理是「派一个合成 `PointerHoverEvent` 命中 media_kit 自己的 `MouseRegion` → 其 `onHover` 重置隐藏 Timer」。barrier 一挂，这条路径 **100% 断掉**（opaque 拦住），派发纯无效；但事件不会凭空消失，它改落进 barrier 的 `Listener(onPointerHover: _onDismissBarrierHover)`。而 `_onDismissBarrierHover` **没有任何合成设备过滤**（同页 `_handleVideoControlsHover` 早就用 `_isSyntheticControlsHover` 滤过，两者不对称纯属遗漏），于是：
+   - `_lastGlobalPointerPos` 被写成**视频区几何中心**（`_videoControlsContext` 是 `Positioned.fill`，其 RenderBox 中心 ≈ 画面正中），BUG-880 的「静止光标 + 按 Shift 立即换词」随即在画面中心反查，用户光标下的词查不到；
+   - 未按 Shift 的分支把 `_barrierHoverLastPos/_barrierHoverLastSentence/_barrierHoverLastGrapheme` 三个去重键清零 → 用户鼠标在**同一个字**上再抖一下就被判成新词，`_lookupAt(replaceStack: true)` **整栈替换**，正在看的弹窗内容被换掉、滚动位置丢失；
+   - 按住 Shift / 开了「悬停即查词」时更直接：合成位置若命中字幕字符即刻换词。
+   - 且 `_handleSubtitleHover` 自己就调 `_pokeControlsVisible()`，构成 hover→poke→hover 自激。
+4. **第二个记账点同样漏过滤**：页面根 `Listener` 的 `onPointerHover` 也无条件写 `_lastGlobalPointerPos`，只滤 barrier 那一处仍会从这里漏进来。
+
+「控件显隐前后几百毫秒」这个窗口的来源：合成设备一旦被 poke 过就永久留在 Flutter `MouseTracker._mouseStates`，`RendererBinding` 每帧按其最后位置（画面正中）重新 hit-test，故 barrier 每次插拔都必然给 media_kit 发一对 exit/enter，控制条随之被动显隐。
+
+- **[x] ① 已修复** — 把「查词浮层占着指针」收敛成单一门控真值 `_lookupOverlayActive`（`ValueNotifier<bool>`，与 `_hasVideoOverlay` 其余五项同构，因为 `_applyControlsVisibilityFromMediaKit` 的输入必须全是可订阅 notifier，否则值变了没人重跑派生），由 `_syncPopupOverlay()`（浮层栈变化的唯一收口）单向写入，判据与 `shouldShowLookupDismissBarrier` 同源（有可见浮层或正在搜索）。四处消费：① 并入 `_hasVideoOverlay`；② 并入 `controls_theme.part.dart` 的 `hideMouseOnControlsRemoval`，并同步加进 `layout.part.dart` `_buildVideoControlsInner` 的 `ListenableBuilder.merge`（防哑火，r5 同款教训）；③ `_pokeControlsVisible()` 增加与其余四个门控同族的早退；④ `_onDismissBarrierHover` 与页面根 `Listener` 两个指针记账点都补上 `_isSyntheticControlsHover(event)` 早退。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_lookup_controls_autohide_guard_test.dart`（5 tests）。四条不变量各一条断言 + 一条剥注释前置自检。断言全部跑在 `maskComments()` 之后：修复的注释里大量出现 `_lookupOverlayActive` / `_isSyntheticControlsHover`，朴素子串匹配会被注释假阳性命中，「删掉真实代码只留注释」也能骗过守卫。**已做变异实测**：7 条变异（逐条删/改真实修复代码）全部被守卫抓红，全部按 sha256 精确还原，还原后复跑仍绿——守卫不是恒绿空壳。
+- **备注**：本轮**未做真机复测**（用户报的是 Windows 桌面路径）。第 1/2 条（光标消失）与第 3/4 条（指针记账污染、换词被打断）的修复都有源码级守卫，但「鼠标悬在弹窗上光标是否真的回来了」属 OS 光标行为，只有 Windows 真机能证；若用户所说的「卡住」实为「点击弹窗无反应 + 鼠标一动刷蓝色选区」，那还有一条**独立**的下游嫌疑没排除：`packages/flutter_inappwebview_windows` 的 `VirtualKeyState` 粘滞位（见 BUG-1419），本轮未触碰。存量 4 个 `.dart` 文件**未跑整文件 `dart format`**：本机 dart 3.44 是 tall style，实测对 HEAD 原版（一行未改）跑 `--set-exit-if-changed` 同样报 `Changed`，整文件 format 会重排存量源码并毁掉源码扫描守卫；改动 hunk 按周边旧风格手写，`flutter analyze` 绿。

--- a/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/controls_theme.part.dart
@@ -67,11 +67,21 @@ extension _VideoControlsTheme on _VideoFushiPageState {
       // r5：选集列表 [_episodeListVisible] 与字幕列表同为 push-aside 侧栏（[_videoWithSubtitlePanel]
       // 的 Row 兄弟列），机理完全相同 → 必须一并排除，否则切到选集列表时视频列 controls MouseRegion
       // 仍走 cursor:none 分支、跨列 none→basic 竞态复现（此前只排除字幕列表 = 选集列表光标照样隐藏）。
-      // ⚠️ 防哑火：本值依赖 [_subtitleListVisible] / [_episodeListVisible]，但构造本 theme 的 builder
-      // （layout.part.dart :_buildVideoControlsInner）必须同时监听这两个 notifier、否则其翻转时 theme
-      // 不重建 = 改了值也白改（见 layout.part.dart 的 ListenableBuilder.merge）。仅桌面 theme，移动端不动。
-      hideMouseOnControlsRemoval:
-          !(_subtitleListVisible.value || _episodeListVisible.value),
+      // BUG-1798：**查词浮层**（[_lookupOverlayActive]）同样必须排除，且这是本条最要紧的一项。
+      // 它与两个 push-aside 侧栏的机理不同但结论相同：浮层是盖在视频列**正上方**的根 Overlay，
+      // 用户此刻全部注意力和指针操作都在弹窗里（点词、点发音、拖 resize 把手、滚正文），而控制条
+      // 照常 2s 自动淡出 → fork 的控制条 MouseRegion（`mount=false` 分支）把整条视频列判成
+      // `cursor:none`，鼠标悬在弹窗上时 OS 光标直接消失（查词浮层子树除右下角 resize 把手外不声明
+      // 任何 cursor，解析必然下穿到这层）。Hibiki 侧 [_buildCursorOverlay] 那层 `none` 已由
+      // [_hasVideoOverlay] 纳入 [_lookupOverlayActive] 修掉，但**两层是独立的**：只修一层，另一层
+      // 照样把光标吃掉，必须同时排除才有效。
+      // ⚠️ 防哑火：本值依赖 [_subtitleListVisible] / [_episodeListVisible] / [_lookupOverlayActive]，
+      // 但构造本 theme 的 builder（layout.part.dart :_buildVideoControlsInner）必须同时监听这三个
+      // notifier、否则其翻转时 theme 不重建 = 改了值也白改（见 layout.part.dart 的
+      // ListenableBuilder.merge）。仅桌面 theme，移动端不动。
+      hideMouseOnControlsRemoval: !(_subtitleListVisible.value ||
+          _episodeListVisible.value ||
+          _lookupOverlayActive.value),
       // 单击画面 = 播放/暂停（media_kit 桌面默认 false，故此前点画面毫无反应，
       // BUG-130）。字幕字符点击在更上层 [VideoSubtitleOverlay] 的 opaque GestureDetector
       // 独立处理、不会冒泡到这里，故启用后点字幕仍是查词、点空白区才暂停，不冲突。

--- a/fushi/lib/src/pages/implementations/video_fushi/controls_visibility.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/controls_visibility.part.dart
@@ -34,6 +34,16 @@ extension _VideoControlsVisibility on _VideoFushiPageState {
     if (_videoSidePanel.value != null) return;
     if (_subtitleListVisible.value) return;
     if (_videoControlEditMode.value) return;
+    // BUG-1798：查词浮层开着时同样早退，与上面四个门控同族（「控制条本被遮住/压制，续命只会
+    // 打架」）。浮层的 dismiss barrier 是全屏 **opaque** 命中层（`ColoredBox` 的 render object
+    // 命中行为为 opaque），它一挂上，合成 hover 就再也到不了 media_kit 自己的 MouseRegion——
+    // 本方法赖以工作的那条「命中 fork 的 onHover → 重置隐藏 Timer」路径 100% 断掉，派发是**纯
+    // 无效**的。而事件并不会凭空消失：它改落进 barrier 的 [_onDismissBarrierHover]，污染指针
+    // 记账与换词去重键（那侧已按设备滤掉，此处再从源头掐断，两道都不是补丁——前者是「合成事件
+    // 不参与指针记账」的不变量，后者是「明知到不了目标就不派发」）。
+    // 顺带消除一个自激环：[_handleSubtitleHover] 收到字幕 hover 就调本方法，而合成 hover 又会
+    // 被 barrier 收走再触发换词逻辑。
+    if (_lookupOverlayActive.value) return;
     if (!_isDesktopVideoControls) {
       // 移动端：底部按钮栏按下时经此续命 media_kit 隐藏 Timer（fork 只在整屏 tap / seek 时
       // 重置，按按钮不重置 → 手指还在按控制条却隐藏 = 误触）。移动无 hover 语义，故不派合成

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -233,6 +233,10 @@ extension _VideoLayout on _VideoFushiPageState {
           _controlLayoutNotifier,
           _subtitleListVisible,
           _episodeListVisible,
+          // BUG-1798：查词浮层也进 theme 的 `hideMouseOnControlsRemoval` 判据
+          // （controls_theme.part.dart），同 r5 的教训——不并进来就是「值改了、theme 不重建」，
+          // 弹窗一开控制条 theme 仍是上一轮的 true，光标照样被 fork 那层 cursor:none 吃掉。
+          _lookupOverlayActive,
           // 自定义「快捷键」按钮绑定：改绑后按钮的图标 / tooltip / 执行体全变，且
           // 「从未绑定变成已绑定」还决定它显不显示（见 `_shouldRenderControlItem`）。
           // 不并进来就是「设置里改了、播放器上纹丝不动」。

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1869,6 +1869,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _subtitleListVisible.addListener(_applyControlsVisibilityFromMediaKit);
     _episodeListVisible.addListener(_applyControlsVisibilityFromMediaKit);
     _videoControlEditMode.addListener(_applyControlsVisibilityFromMediaKit);
+    // BUG-1798：查词浮层也是 [_hasVideoOverlay] 的输入，与上面六个门控同等订阅——否则弹窗
+    // 打开 / 关闭时光标策略不重跑，鼠标悬在弹窗上仍被上一轮的 `cursor: none` 吃掉。
+    _lookupOverlayActive.addListener(_applyControlsVisibilityFromMediaKit);
     // TODO-611：侧栏面板锁定不持久化。面板一关闭就把锁复位为 false，下次重开默认未锁
     // ——锁生命周期绑定可见性，关闭路径无需逐个复位。
     WidgetsBinding.instance.addObserver(this);
@@ -3693,6 +3696,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     _subtitleListVisible.removeListener(_applyControlsVisibilityFromMediaKit);
     _episodeListVisible.removeListener(_applyControlsVisibilityFromMediaKit);
     _videoControlEditMode.removeListener(_applyControlsVisibilityFromMediaKit);
+    // BUG-1798：与上面六个门控同批摘监听（顺序同理——回调读多个 notifier，先摘再 dispose）。
+    _lookupOverlayActive.removeListener(_applyControlsVisibilityFromMediaKit);
+    _lookupOverlayActive.dispose();
     _subtitleListVisible.dispose();
     _episodeListVisible.dispose();
     _videoSidePanel.dispose();
@@ -3810,12 +3816,35 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 字幕跳转列表 [_subtitleListVisible]，TODO-329）。有 overlay 时光标不该被沉浸 /
   /// 自动隐藏定时吃掉（用户要在 overlay 上操作）；纯沉浸锁（无 overlay）静止超时仍隐藏
   /// 画面光标（BUG-258）。
+  ///
+  /// BUG-1798：**查词浮层栈**（根 Overlay 的 [_popupOverlayEntry]）此前漏在集外。它是本页
+  /// 最需要光标的覆盖层——用户要在弹窗里点词、点发音、拖 resize 把手、滚正文——但查词期间
+  /// 控制条照常 2s 自动淡出，`visible=false && !_hasVideoOverlay` 于是把 [_cursorHidden]
+  /// 置真，[_buildCursorOverlay] 铺一层 `cursor: none` 盖满视频区。查词浮层子树除右下角
+  /// resize 把手外不声明任何 cursor（`dictionary_popup_layer.dart` 唯一一处 MouseRegion），
+  /// cursor 解析下穿到该层 → **鼠标悬在弹窗上时 OS 光标直接消失**。media_kit fork 侧的
+  /// `hideMouseOnControlsRemoval`（`controls_theme.part.dart`）同样只排除了字幕列表 / 选集
+  /// 列表，对查词弹窗也是漏项，两层 `none` 叠加。搜索中（[DictionaryPopupController.isSearchingUi]）
+  /// 与已出结果同等对待：dismiss barrier 在搜索期就已挂上（见 [shouldShowLookupDismissBarrier]），
+  /// 那一刻起指针语义就归浮层，光标不能消失。
   bool get _hasVideoOverlay =>
       _videoSidePanel.value != null ||
       _videoControlPopover.value != null ||
       _subtitleListVisible.value ||
       _episodeListVisible.value ||
-      _videoControlEditMode.value;
+      _videoControlEditMode.value ||
+      _lookupOverlayActive.value;
+
+  /// 「查词浮层此刻占着指针」的门控真值（BUG-1798）。
+  ///
+  /// 与 [_hasVideoOverlay] 其余五项一样是 [ValueNotifier]——[_applyControlsVisibilityFromMediaKit]
+  /// 的输入必须全是可订阅的 notifier，否则值变了没有任何东西触发重跑派生（光标策略会停在
+  /// 上一次的结论上）。真值由 [_syncPopupOverlay] 单向推入（那里是浮层栈变化的唯一收口），
+  /// getter 一律读这里，不再各处直接读 [_popup]，避免两个真相源漂移。
+  ///
+  /// 判据与 [shouldShowLookupDismissBarrier] 同源：**有可见浮层或正在搜索**即为真。barrier
+  /// 在搜索期就已挂上并接管全屏命中，那一刻起光标就该归浮层管。
+  final ValueNotifier<bool> _lookupOverlayActive = ValueNotifier<bool>(false);
 
   /// 手柄重设计 P3：可用 D-pad 逐行浏览的三类面板任一打开（字幕列表 / 剧集轨 /
   /// 侧栏）。与 [_hasVideoOverlay] 刻意不同集：控件 popover 与控制条编辑模式不是
@@ -4039,6 +4068,21 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 命中同一字符（同句同 grapheme）短路去重，避免同词反复 `replaceStack` 闪烁 / 刷 FFI。
   /// 换词经 [_handleSubtitleLookupTap] → [_lookupAt]（`replaceStack: true` 复用热槽无缝替换）。
   void _onDismissBarrierHover(PointerHoverEvent event) {
+    // BUG-1798：先滤掉[_pokeControlsVisible]派发的**合成** hover。它不是用户的鼠标：位置恒为
+    // [_videoControlsContext]（整个视频区）的几何中心，设备是固定的 [_syntheticHoverDevice]。
+    // 浮层一开，全屏 opaque 的 dismiss barrier 就接管了命中测试，合成 hover 再也到不了
+    // media_kit 自己的 MouseRegion（poke 本该续命控制条，此时已必然哑火），却**全量落进本
+    // 回调**被当成真实鼠标消费，三处污染：
+    // ① `_lastGlobalPointerPos` 被写成画面正中 → BUG-880 的「静止光标 + 按 Shift 立即换词」
+    //    改在画面中心反查，用户光标下的词查不到；
+    // ② 未按 Shift 时下面那条分支把 `_barrierHoverLastPos/Sentence/Grapheme` 三个去重键清零
+    //    → 用户鼠标在**同一个字**上再抖一下就被判成新词，`_lookupAt(replaceStack: true)` 整栈
+    //    替换，正在看的弹窗内容被换掉、滚动位置丢失；
+    // ③ 按住 Shift / 开了「悬停即查词」时更直接：合成位置若命中字幕字符就立即换词。
+    // 且 [_handleSubtitleHover] 自己就调 [_pokeControlsVisible]，构成 hover→poke→hover 自激。
+    // 同页 [_handleVideoControlsHover] 早就用同一判据滤过合成事件（controls_visibility.part.dart），
+    // 本路径与它不对称纯属遗漏——这里补齐，语义即「合成事件不代表用户指针，不参与任何指针记账」。
+    if (_isSyntheticControlsHover(event)) return;
     // BUG-880：浮层打开时 barrier 盖住一切、页面根 Listener 收不到 hover，故在此持续更新
     // 最后指针位置，让「静止光标 + 按 Shift」在浮层已开时也能立即换词（在 Shift 门控之前，
     // 未按 Shift 也照常记录）。
@@ -4288,6 +4332,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 路由，本页 `Stack` 会被全屏路由盖住；根 Overlay 浮在所有路由之上，窗口/全屏统一。
   void _syncPopupOverlay() {
     if (!mounted) return;
+    // BUG-1798：把浮层栈的「占着指针」真值推给门控 notifier。这里是栈 push/pop/搜索态变化的
+    // 唯一收口（[DictionaryPageMixin] 各路径都 setState → 重 build → post-frame 调本方法），
+    // 故也是唯一写入点。[ValueNotifier] 自带同值去重，每帧调用不会产生多余通知；值真变时其
+    // 监听（[_applyControlsVisibilityFromMediaKit]）重跑光标策略，弹窗一开光标即恢复可见。
+    _lookupOverlayActive.value = _hasVisiblePopup || _popup.isSearchingUi;
     if (_popup.entries.isEmpty) {
       final OverlayEntry? entry = _popupOverlayEntry;
       if (entry != null) {
@@ -5026,10 +5075,15 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         // BUG-880：页面根持续记录全局指针位置（不消费、不影响下层控制条 / 查词手势），供
         // Shift 按下时反查。浮层打开后 barrier 盖住这里收不到 hover，由 [_onDismissBarrierHover]
         // 接力更新同一字段。
+        // BUG-1798：与那个接力点用同一条判据滤掉合成 hover——[_pokeControlsVisible] 的合成事件
+        // 位置恒为视频区几何中心，写进来就是把「用户光标在哪」记成画面正中，Shift 反查随即查错
+        // 位置。合成事件不代表用户指针，两个记账点必须同时滤，只滤一个仍会从另一个漏进来。
         child: Listener(
           behavior: HitTestBehavior.translucent,
-          onPointerHover: (PointerHoverEvent event) =>
-              _lastGlobalPointerPos = event.position,
+          onPointerHover: (PointerHoverEvent event) {
+            if (_isSyntheticControlsHover(event)) return;
+            _lastGlobalPointerPos = event.position;
+          },
           child: child,
         ),
       ),

--- a/fushi/test/pages/video_lookup_controls_autohide_guard_test.dart
+++ b/fushi/test/pages/video_lookup_controls_autohide_guard_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1798 守卫：查词浮层与视频控制条自动显隐之间的四条不变量。
+///
+/// 背景（真实代码路径）：视频页的查词浮层挂在**根 Overlay**（`_syncPopupOverlay`），其
+/// dismiss barrier 是全屏 **opaque** 命中层。浮层一开，① `_pokeControlsVisible` 派发的
+/// 合成 hover 再也到不了 media_kit 自己的 `MouseRegion`（续命哑火），却会落进 barrier 的
+/// `_onDismissBarrierHover` 被当成真实鼠标消费，污染指针记账与换词去重键；② 控制条照常
+/// 2s 自动淡出，而查词浮层此前不在 `_hasVideoOverlay` 里，Hibiki 侧 `_buildCursorOverlay`
+/// 与 fork 侧 `hideMouseOnControlsRemoval` **两层独立的** `cursor: none` 同时生效，鼠标悬
+/// 在弹窗上时 OS 光标消失。
+///
+/// 这些不变量全部落在私有 `State` 成员与 media_kit fork 的 theme 上，widget 测试要真起
+/// 播放器 + 平台视图才能触达，故取**源码扫描**这一最强可落地层。
+///
+/// ⚠️ 本文件的每条断言都在 [maskComments] 之后执行。修复的注释里大量出现
+/// `_lookupOverlayActive` / `_isSyntheticControlsHover` 字样，若直接对原始源码做子串匹配，
+/// 删掉真实代码、只留注释也会绿 —— 那正是本仓反复踩过的假绿。
+void main() {
+  const String pageRelPath =
+      'lib/src/pages/implementations/video_fushi_page.dart';
+  const String visibilityRelPath =
+      'lib/src/pages/implementations/video_fushi/controls_visibility.part.dart';
+  const String themeRelPath =
+      'lib/src/pages/implementations/video_fushi/controls_theme.part.dart';
+  const String layoutRelPath =
+      'lib/src/pages/implementations/video_fushi/layout.part.dart';
+
+  /// 读源码并**剥掉注释/字符串**，返回只含真实代码的等长掩码串。
+  String code(String relPath) {
+    final File file = File(relPath);
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason:
+          '守卫目标文件不存在：$relPath（文件被移动/改名时本守卫必须同步更新，'
+          '而不是被静默跳过）',
+    );
+    return maskComments(file.readAsStringSync());
+  }
+
+  test('剥注释前置自检：注释里的符号不算数，真实代码必须留下', () {
+    // 这条是本守卫自身的反例保护：如果 maskComments 哪天把真实代码也吃掉，
+    // 下面四条断言会集体假绿（永远匹配不到 = 永远不报警）。
+    expect(
+      maskComments('/// 见 [_lookupOverlayActive] 的文档\n'),
+      isNot(contains('_lookupOverlayActive')),
+      reason: '文档注释里的符号必须被剥掉，否则「只留注释」也能骗过守卫',
+    );
+    expect(
+      maskComments('if (_lookupOverlayActive.value) return; // 早退'),
+      contains('_lookupOverlayActive.value'),
+      reason: '真实代码必须保留，否则守卫恒不命中 = 恒假绿',
+    );
+  });
+
+  test('BUG-1798 ①：_pokeControlsVisible 在查词浮层开着时早退', () {
+    final String src = code(visibilityRelPath);
+    final int pokeStart = src.indexOf('void _pokeControlsVisible()');
+    expect(
+      pokeStart,
+      greaterThanOrEqualTo(0),
+      reason: '_pokeControlsVisible 已改名/删除，守卫需同步更新',
+    );
+    // 只截到方法体内合成事件构造之前那段（早退门控区），避免匹配到后文无关代码。
+    final int dispatchAt = src.indexOf('_pendingPokeHover', pokeStart);
+    expect(dispatchAt, greaterThan(pokeStart));
+    final String gateRegion = src.substring(pokeStart, dispatchAt);
+
+    expect(
+      RegExp(
+        r'if\s*\(\s*_lookupOverlayActive\.value\s*\)\s*return\s*;',
+      ).hasMatch(gateRegion),
+      isTrue,
+      reason:
+          '浮层开着时 barrier 已接管全屏命中，合成 hover 必然到不了 media_kit 的 '
+          'MouseRegion（续命纯无效），却会落进 _onDismissBarrierHover 污染指针记账。'
+          '必须与其余四个门控同族地早退。',
+    );
+  });
+
+  test('BUG-1798 ②：两个指针位置记账点都滤掉合成 hover', () {
+    final String src = code(pageRelPath);
+    // `_lastGlobalPointerPos` 是「用户光标在哪」的唯一真值，供 Shift 反查使用。
+    // 合成 hover 的位置恒为视频区几何中心，写进来就是把它记成画面正中。
+    final Iterable<Match> writes = RegExp(
+      r'_lastGlobalPointerPos\s*=\s*event\.position',
+    ).allMatches(src);
+    expect(
+      writes.length,
+      2,
+      reason:
+          '记账点数量变了（当前 ${writes.length} 处）。新增/删除记账点时必须同步'
+          '本守卫——每一个写入点都要有合成事件过滤，只滤一个仍会从另一个漏进来。',
+    );
+
+    for (final Match m in writes) {
+      // 往前回看一小段，要求同一作用域内先有合成设备早退。
+      final int from = m.start - 400 < 0 ? 0 : m.start - 400;
+      final String before = src.substring(from, m.start);
+      expect(
+        before.contains('_isSyntheticControlsHover(event)'),
+        isTrue,
+        reason:
+            '偏移 ${m.start} 处的 _lastGlobalPointerPos 写入没有被 '
+            '_isSyntheticControlsHover 保护：合成 hover 会把用户光标位置记成画面正中，'
+            'Shift 反查随即查错位置。',
+      );
+    }
+  });
+
+  test('BUG-1798 ③：_hasVideoOverlay 把查词浮层算作 overlay', () {
+    final String src = code(pageRelPath);
+    final int start = src.indexOf('bool get _hasVideoOverlay');
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: '_hasVideoOverlay 已改名/删除，守卫需同步更新',
+    );
+    final int end = src.indexOf(';', start);
+    expect(end, greaterThan(start));
+    final String body = src.substring(start, end);
+
+    expect(
+      body.contains('_lookupOverlayActive.value'),
+      isTrue,
+      reason:
+          '查词浮层是本页最需要光标的覆盖层（点词/点发音/拖把手/滚正文），'
+          '不在 _hasVideoOverlay 里就会在控制条自动淡出时被 _setCursorHidden(true) '
+          '连同弹窗一起把 OS 光标吃掉。',
+    );
+
+    // 门控真值必须是可订阅的 notifier 且被真正订阅，否则值变了没人重跑派生。
+    expect(
+      src.contains(
+        '_lookupOverlayActive.addListener(_applyControlsVisibilityFromMediaKit)',
+      ),
+      isTrue,
+      reason:
+          '_applyControlsVisibilityFromMediaKit 的输入必须全部被订阅，'
+          '否则弹窗开/关时光标策略停在上一次的结论上（改了也白改）。',
+    );
+    expect(
+      src.contains(
+        '_lookupOverlayActive.removeListener(_applyControlsVisibilityFromMediaKit)',
+      ),
+      isTrue,
+      reason: 'dispose 必须与 initState 对称摘监听，否则回调在已释放的 notifier 上触发。',
+    );
+    // 单一写入点：栈变化的唯一收口负责推真值。
+    expect(
+      RegExp(r'_lookupOverlayActive\.value\s*=').hasMatch(src),
+      isTrue,
+      reason: '必须有唯一写入点把 _popup 的真值推进门控 notifier，否则它恒为 false。',
+    );
+  });
+
+  test('BUG-1798 ④：fork 侧 hideMouseOnControlsRemoval 也排除查词浮层，且不哑火', () {
+    final String themeSrc = code(themeRelPath);
+    final int start = themeSrc.indexOf('hideMouseOnControlsRemoval:');
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: 'hideMouseOnControlsRemoval 赋值已消失，守卫需同步更新',
+    );
+    final int end = themeSrc.indexOf(',', themeSrc.indexOf(')', start));
+    final String expr = themeSrc.substring(start, end < start ? start : end);
+
+    expect(
+      expr.contains('_lookupOverlayActive.value'),
+      isTrue,
+      reason:
+          'Hibiki 侧 _buildCursorOverlay 与 fork 侧 hideMouseOnControlsRemoval 是'
+          '**两层独立的** cursor:none，只修一层，另一层照样把光标吃掉。',
+    );
+
+    // 防哑火：theme 由 layout 的 ListenableBuilder.merge 构造，判据里的 notifier
+    // 必须全在 merge 列表内，否则翻转时 theme 不重建 = 改了值也白改（r5 教训）。
+    final String layoutSrc = code(layoutRelPath);
+    final int mergeAt = layoutSrc.indexOf('Listenable.merge');
+    expect(mergeAt, greaterThanOrEqualTo(0));
+    final int mergeEnd = layoutSrc.indexOf('],', mergeAt);
+    expect(mergeEnd, greaterThan(mergeAt));
+    expect(
+      layoutSrc.substring(mergeAt, mergeEnd).contains('_lookupOverlayActive'),
+      isTrue,
+      reason:
+          '_lookupOverlayActive 进了 theme 判据却没进 merge 列表 = 哑火：'
+          '弹窗一开 theme 仍是上一轮的 true，光标照样被 fork 那层 cursor:none 吃掉。',
+    );
+  });
+}

--- a/fushi/test/pages/video_mouse_autohide_guard_test.dart
+++ b/fushi/test/pages/video_mouse_autohide_guard_test.dart
@@ -19,14 +19,23 @@ void main() {
     // 选集列表打开时不隐藏视频列光标（从源头消除跨列 none→basic 竞态），其余时间仍
     // 隐藏（默认 = true，保 BUG-106）。故守卫从字面 `: true` 收紧为「绑这两个列表
     // notifier 的否定表达式」，既钉住 BUG-106 默认隐藏语义，又钉住 BUG-391 的列表豁免。
+    // BUG-1798：豁免项从两项变三项（查词浮层 [_lookupOverlayActive] 加入）。本守卫改为
+    // **锁语义不锁字面**——断言「是 `!( ... )` 否定表达式」+「两个列表 notifier 都在里面」，
+    // 不再要求豁免项恰好是那两个、也不再要求它们的排列顺序。否则每加一个正当豁免项都要
+    // 改一次守卫，而守卫真正要守的是「默认隐藏 + 这两个列表必须豁免」这两条语义。
     final String src = readVideoFushiSource();
-    expect(
-      RegExp(r'hideMouseOnControlsRemoval:\s*'
-              r'!\(_subtitleListVisible\.value \|\| _episodeListVisible\.value\)')
-          .hasMatch(src),
-      isTrue,
-      reason: '桌面控制条隐藏时默认一并隐藏光标（BUG-106），仅 push-aside 列表开时豁免（BUG-391）',
+    final RegExp negatedExpr = RegExp(
+      r'hideMouseOnControlsRemoval:\s*!\(([\s\S]*?)\),',
     );
+    final RegExpMatch? m = negatedExpr.firstMatch(src);
+    expect(m, isNotNull,
+        reason: '桌面控制条隐藏时默认一并隐藏光标（BUG-106），'
+            '取值必须是 `!( 豁免条件 )` 形式，仅在豁免条件成立时才不隐藏');
+    final String exemptions = m!.group(1)!.replaceAll(RegExp(r'\s+'), '');
+    expect(exemptions.contains('_subtitleListVisible.value'), isTrue,
+        reason: 'BUG-391：字幕列表 push-aside 侧栏开启时必须豁免');
+    expect(exemptions.contains('_episodeListVisible.value'), isTrue,
+        reason: 'BUG-391 r5：选集列表与字幕列表机理相同，必须一并豁免');
     // 反向钉死：不得退回字面 `: true`（那会让 push-aside 列表开时仍隐藏光标，回归 BUG-391）。
     expect(src.contains('hideMouseOnControlsRemoval: true'), isFalse,
         reason: 'BUG-391：列表开时必须豁免，不能用字面 true');

--- a/fushi/test/pages/video_subtitle_list_cursor_reveal_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_list_cursor_reveal_guard_test.dart
@@ -185,14 +185,19 @@ void main() {
           reason: '管 1·2a：hideMouseOnControlsRemoval 不得是裸 true（列表开时必须翻 false）');
       // r5：选集列表 [_episodeListVisible] 与字幕列表同为 push-aside 侧栏，机理相同 → 必须
       // 一并排除（去掉首尾空白后匹配，容忍 dart format 折行）。只排字幕列表会让选集列表光标照样隐藏。
-      final String normalized =
-          src.replaceAll(RegExp(r'\s+'), '').replaceAll(',', '');
-      expect(
-          normalized.contains(
-              'hideMouseOnControlsRemoval:!(_subtitleListVisible.value||_episodeListVisible.value)'),
-          isTrue,
-          reason:
-              'r5·管 1·2a：hideMouseOnControlsRemoval 须同时排除字幕列表与选集列表可见（!(_subtitleListVisible.value || _episodeListVisible.value)）');
+      // BUG-1798：查词浮层 [_lookupOverlayActive] 成为第三个豁免项。断言改为**锁语义**——
+      // 只要求取值是 `!( 豁免条件 )` 且两个列表 notifier 都在豁免条件里，不再把豁免项的
+      // 个数与顺序写死（本条守卫要守的是「列表开时必须豁免」，不是「有且只有两项」）。
+      final RegExp negatedExpr =
+          RegExp(r'hideMouseOnControlsRemoval:\s*!\(([\s\S]*?)\),');
+      final RegExpMatch? m = negatedExpr.firstMatch(src);
+      expect(m, isNotNull,
+          reason: '管 1·2a：hideMouseOnControlsRemoval 必须是 `!( 豁免条件 )` 形式');
+      final String exemptions = m!.group(1)!.replaceAll(RegExp(r'\s+'), '');
+      expect(exemptions.contains('_subtitleListVisible.value'), isTrue,
+          reason: 'r5·管 1·2a：字幕列表可见时必须豁免（否则列表开时光标照样被隐藏）');
+      expect(exemptions.contains('_episodeListVisible.value'), isTrue,
+          reason: 'r5·管 1·2a：选集列表可见时必须豁免（只排字幕列表会让选集列表光标照样隐藏）');
     });
 
     test(

--- a/fushi/test/pages/video_subtitle_list_zoom_lookup_wiring_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_list_zoom_lookup_wiring_guard_test.dart
@@ -70,9 +70,14 @@ void main() {
 
   group('BUG-880 Shift 静止光标查词（keydown 反查最后指针位置）', () {
     test('页面根持续记录全局指针位置', () {
+      // BUG-1798：这个回调从箭头函数改成了块体（先按 [_isSyntheticControlsHover] 滤掉
+      // [_pokeControlsVisible] 派发的合成 hover，再记账——合成事件的位置恒为视频区几何
+      // 中心，写进来会把「用户光标在哪」记成画面正中，Shift 反查随即查错位置）。故正则
+      // 同时容纳箭头体与块体：本条守卫要守的是「页面根确实记录了指针位置」，回调写成哪
+      // 种形式不是它的约束对象。
       expect(
-        RegExp(r'onPointerHover:\s*\(PointerHoverEvent event\) =>\s*'
-                r'_lastGlobalPointerPos = event\.position')
+        RegExp(r'onPointerHover:\s*\(PointerHoverEvent event\)\s*(?:=>|\{)'
+                r'[\s\S]{0,400}?_lastGlobalPointerPos = event\.position')
             .hasMatch(src),
         isTrue,
         reason: 'Shift 按下时要用最后指针位置反查，必须先在页面根记录它',


### PR DESCRIPTION
## 用户报告

> 在播放控件隐藏的前后几百毫秒内点击查词界面，就可以让查词界面卡住。

## 根因

视频页查词浮层挂在**根 Overlay**（`_syncPopupOverlay`，因为 media_kit 全屏是推到根 navigator 的独立路由），其 dismiss barrier 是 `Positioned.fill` + `ColoredBox` —— 后者的 render object 命中行为是 **opaque**，且判据 `shouldShowLookupDismissBarrier` 在**开始搜索时**就已为真。

但 `_hasVideoOverlay` 的 5 个组成项（侧栏 / 控件 popover / 字幕列表 / 选集列表 / 编辑态）**无一与查词浮层相关**。这一个建模疏漏派生出四条独立缺陷：

| # | 缺陷 |
|---|---|
| 1 | 控制条 2s 淡出 → `_setCursorHidden(true)` → `_buildCursorOverlay` 铺 `cursor:none` 盖满视频区；浮层子树除 resize 把手外不声明 cursor，解析必然下穿 → **鼠标悬在弹窗上时 OS 光标消失** |
| 2 | media_kit fork 的 `hideMouseOnControlsRemoval` 同样漏了浮层 → 控制条 `mount=false` 时取 `cursor:none` 分支。**与 ① 是两层独立的 none，只修一层另一层照样吃掉光标** |
| 3 | `_pokeControlsVisible` 派发的合成 hover 被 barrier 拦住，续命路径 **100% 断掉**（纯无效派发）；但事件不消失，改落进 `_onDismissBarrierHover`，而那里**没有合成设备过滤**（同页 `_handleVideoControlsHover` 早就有，两者不对称纯属遗漏）→ `_lastGlobalPointerPos` 被写成**视频区几何中心**（Shift 反查查错位置）、换词去重键被清零（同一个字再抖一下就被判成新词，`replaceStack` **整栈替换**，正在看的弹窗被换掉、滚动位置丢失） |
| 4 | 页面根 `Listener` 是第二个未过滤的指针记账点，只滤 barrier 仍会从这里漏进来 |

「控件显隐前后几百毫秒」这个窗口的来源：合成设备一旦被 poke 过就永久留在 `MouseTracker._mouseStates`，`RendererBinding` 每帧按其最后位置重新 hit-test，故 barrier 每次插拔都必然给 media_kit 发一对 exit/enter。

## 修法

把「查词浮层占着指针」收敛成**单一门控真值** `_lookupOverlayActive`（`ValueNotifier<bool>`，与 `_hasVideoOverlay` 其余五项同构 —— `_applyControlsVisibilityFromMediaKit` 的输入必须全是可订阅 notifier，否则值变了没人重跑派生），由 `_syncPopupOverlay()`（浮层栈变化的唯一收口）**单向写入**，判据与 `shouldShowLookupDismissBarrier` 同源。

四处消费 + 一处防哑火：并入 `_hasVideoOverlay`；并入 fork 的 `hideMouseOnControlsRemoval` 并同步加进 `_buildVideoControlsInner` 的 `ListenableBuilder.merge`（r5 同款教训 —— 不并进来就是「值改了、theme 不重建」）；`_pokeControlsVisible` 增加与其余四个门控同族的早退；两个指针记账点补 `_isSyntheticControlsHover` 早退。

## 测试

新增 `fushi/test/pages/video_lookup_controls_autohide_guard_test.dart`（5 tests）。**断言全部跑在 `maskComments()` 之后** —— 修复的注释里大量出现 `_lookupOverlayActive` / `_isSyntheticControlsHover`，朴素子串匹配会被注释假阳性命中。

- **新守卫变异实测**：7 条变异全部被抓红，全部按 sha256 精确还原，还原后复跑仍绿。
- **三条既有守卫**因把我改动的那几行**字面形状**写死而转红，改为**锁语义**，并**变异确认其原本的负向能力未被放松掉**。

## 验证

- `flutter analyze` 全量绿（含 test 目录）
- 定向 `test/media/video/` + `test/pages/` + `test/focus/` + `test/lookup/`：**6472 tests 全绿**

## 未做

- **未做 Windows 真机复测**：光标是否真的回到弹窗上属 OS 光标行为，只有真机能证。
- 若「卡住」实为「点击弹窗无反应 + 鼠标一动刷蓝色选区」，还有一条**独立的下游嫌疑**没排除：`flutter_inappwebview_windows` 的 `VirtualKeyState` 粘滞位（BUG-1419 同族），本轮未触碰。
- 存量 4 个 `.dart` 文件未跑整文件 `dart format`：本机 dart 3.44 是 tall style，实测对 HEAD 原版（一行未改）跑 `--set-exit-if-changed` 同样报 `Changed`，整文件 format 会毁掉源码扫描守卫。

https://claude.ai/code/session_015F6dgm2XLMg48GKRfKhdyx
