### PR TITLE
feat(download): 内置引擎排第一位；「后端未配置」直接弹配置引导

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 63784 (3752 per locale)
+/// Strings: 63886 (3758 per locale)
 ///
-/// Built on 2026-08-23 at 16:17 UTC
+/// Built on 2026-08-24 at 03:12 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5095,6 +5095,16 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Install failed: ${message}';
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  String get download_backend_setup_title => 'Set up download backend';
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  String get download_backend_setup_start => 'Set up now';
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -13793,6 +13803,22 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -22556,6 +22582,22 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -31335,6 +31377,22 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -40126,6 +40184,22 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -48847,6 +48921,22 @@ class _StringsId extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -57612,6 +57702,22 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -66194,6 +66300,22 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -74784,6 +74906,22 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -83529,6 +83667,22 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -92286,6 +92440,22 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -101030,6 +101200,22 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -109722,6 +109908,22 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -118445,6 +118647,22 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -127154,6 +127372,22 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 // Path: <root>
@@ -135209,6 +135443,19 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
+  @override
+  String get download_backend_setup_title => '配置下载后端';
+  @override
+  String get download_backend_setup_intro => '选择由哪个引擎执行下载任务，之后可随时在下载设置里更改。';
+  @override
+  String get download_backend_embedded_hint => '推荐。下载在 Fushi 内部完成，无需另外安装软件。';
+  @override
+  String get download_backend_qb_hint => '连接到你已经在运行的 qBittorrent WebUI。';
+  @override
+  String get download_backend_setup_start => '开始配置';
+  @override
+  String get download_backend_embedded_unavailable =>
+      '本次安装缺少内置引擎运行库。请重装完整安装包，或改用外接 qBittorrent。';
 }
 
 // Path: <root>
@@ -143716,6 +143963,22 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get download_backend_setup_title => 'Set up download backend';
+  @override
+  String get download_backend_setup_intro =>
+      'Pick which engine runs your downloads. You can change this any time in download settings.';
+  @override
+  String get download_backend_embedded_hint =>
+      'Recommended. Downloads run inside Fushi - nothing else to install.';
+  @override
+  String get download_backend_qb_hint =>
+      'Connect Fushi to a qBittorrent WebUI you already run.';
+  @override
+  String get download_backend_setup_start => 'Set up now';
+  @override
+  String get download_backend_embedded_unavailable =>
+      'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
 }
 
 /// Flat map(s) containing all translations.
@@ -151410,6 +151673,18 @@ extension on _StringsEn {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -159102,6 +159377,18 @@ extension on _StringsAr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -166816,6 +167103,18 @@ extension on _StringsDe {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -174529,6 +174828,18 @@ extension on _StringsEs {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -182248,6 +182559,18 @@ extension on _StringsFr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -189949,6 +190272,18 @@ extension on _StringsId {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -197664,6 +197999,18 @@ extension on _StringsIt {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -205341,6 +205688,18 @@ extension on _StringsJa {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -213022,6 +213381,18 @@ extension on _StringsKo {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -220731,6 +221102,18 @@ extension on _StringsNl {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -228437,6 +228820,18 @@ extension on _StringsPtBr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -236148,6 +236543,18 @@ extension on _StringsRu {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -243842,6 +244249,18 @@ extension on _StringsTh {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -251545,6 +251964,18 @@ extension on _StringsTr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -259244,6 +259675,18 @@ extension on _StringsVi {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }
@@ -266886,6 +267329,18 @@ extension on _StringsZhCn {
         return ({required Object message}) => '安装失败：${message}';
       case 'game_hook_reason_capability_probe_failed':
         return '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
+      case 'download_backend_setup_title':
+        return '配置下载后端';
+      case 'download_backend_setup_intro':
+        return '选择由哪个引擎执行下载任务，之后可随时在下载设置里更改。';
+      case 'download_backend_embedded_hint':
+        return '推荐。下载在 Fushi 内部完成，无需另外安装软件。';
+      case 'download_backend_qb_hint':
+        return '连接到你已经在运行的 qBittorrent WebUI。';
+      case 'download_backend_setup_start':
+        return '开始配置';
+      case 'download_backend_embedded_unavailable':
+        return '本次安装缺少内置引擎运行库。请重装完整安装包，或改用外接 qBittorrent。';
       default:
         return null;
     }
@@ -274558,6 +275013,18 @@ extension on _StringsZhHk {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'download_backend_setup_title':
+        return 'Set up download backend';
+      case 'download_backend_setup_intro':
+        return 'Pick which engine runs your downloads. You can change this any time in download settings.';
+      case 'download_backend_embedded_hint':
+        return 'Recommended. Downloads run inside Fushi - nothing else to install.';
+      case 'download_backend_qb_hint':
+        return 'Connect Fushi to a qBittorrent WebUI you already run.';
+      case 'download_backend_setup_start':
+        return 'Set up now';
+      case 'download_backend_embedded_unavailable':
+        return 'The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "已装好 AnkiConnect：启动或重启 Anki，然后点「测试连接」。",
   "onboarding_anki_addon_no_anki": "没找到 Anki 数据目录：请先安装 Anki 并打开一次，再回来重试。",
   "onboarding_anki_addon_failed": "安装失败：$message",
-  "game_hook_reason_capability_probe_failed": "捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。"
+  "game_hook_reason_capability_probe_failed": "捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。",
+  "download_backend_setup_title": "配置下载后端",
+  "download_backend_setup_intro": "选择由哪个引擎执行下载任务，之后可随时在下载设置里更改。",
+  "download_backend_embedded_hint": "推荐。下载在 Fushi 内部完成，无需另外安装软件。",
+  "download_backend_qb_hint": "连接到你已经在运行的 qBittorrent WebUI。",
+  "download_backend_setup_start": "开始配置",
+  "download_backend_embedded_unavailable": "本次安装缺少内置引擎运行库。请重装完整安装包，或改用外接 qBittorrent。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3750,5 +3750,11 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "download_backend_setup_title": "Set up download backend",
+  "download_backend_setup_intro": "Pick which engine runs your downloads. You can change this any time in download settings.",
+  "download_backend_embedded_hint": "Recommended. Downloads run inside Fushi - nothing else to install.",
+  "download_backend_qb_hint": "Connect Fushi to a qBittorrent WebUI you already run.",
+  "download_backend_setup_start": "Set up now",
+  "download_backend_embedded_unavailable": "The built-in engine runtime is missing from this install. Reinstall the complete package, or use external qBittorrent instead."
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -4488,6 +4488,10 @@ class AppModel with ChangeNotifier {
     ));
   }
 
+  /// 本平台是否具备内置 libtorrent 引擎。UI（后端选择器 / 配置引导）与运行时
+  /// 后端解析共用同一判据，别再各处手抄一份 `Platform.isXxx` 串。
+  bool get supportsEmbeddedTorrent => _supportsEmbeddedTorrent();
+
   /// 内置 libtorrent 支持的平台：桌面 + Android（`libfushi_torrent_ffi.so`
   /// 经 jniLibs 随包）。iOS 不支持：从不构建也从不打包内置引擎产物。
   bool _supportsEmbeddedTorrent() =>

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -21,6 +21,7 @@ import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
 import 'package:fushi/src/pages/implementations/jimaku_entry_picker.dart';
 import 'package:fushi/src/pages/implementations/download_actions.dart';
+import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
 import 'package:fushi/src/pages/implementations/downloads_page.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
@@ -1131,6 +1132,25 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
 
   // ---------------------------------------------------------------- 渲染
 
+  /// 「开始配置」：直接弹后端配置引导（只问「谁来下载」+ 所选后端的必填项），
+  /// 配完当场重算就绪状态。用户不再被丢进整页下载设置自己找字段。
+  Future<void> _openBackendSetup() async {
+    final bool done = await promptDownloadBackendSetup(
+      context: context,
+      appModel: ref.read(appProvider),
+    );
+    if (done && mounted) setState(() {});
+  }
+
+  /// 后端没就绪时的统一出口：**先弹引导**再决定要不要继续，而不是甩一句
+  /// 「请先配置下载后端」把动作丢掉。返回 true = 现在可以继续原动作。
+  Future<bool> _ensureBackendReady() async {
+    if (torrentBackendReady(ref.read(appProvider))) return true;
+    await _openBackendSetup();
+    if (!mounted) return false;
+    return torrentBackendReady(ref.read(appProvider));
+  }
+
   /// 「去设置」：embedded 由下载页回调切页内设置面板；独立对话框（视频页入口）
   /// push 下载页并直落设置面板——两个入口都能一键走到配置，不再让新用户死路。
   void _openBackendSettings() {
@@ -1176,6 +1196,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
             ),
           ),
           const SizedBox(width: 8),
+          // 主动作是引导（配完就能下）；「去设置」留给要调限速/上传/做种的用户。
+          TextButton(
+            onPressed: _openBackendSetup,
+            child: Text(t.download_backend_setup_start),
+          ),
           TextButton(
             onPressed: _openBackendSettings,
             child: Text(t.download_open_settings),
@@ -2235,11 +2260,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// torrent-missing 超时从头算）。addTorrent 报失败但种子已在后端列表
   /// （入库失败类重试的常态——重复添加被后端拒绝）也算在下，交回轮询重走完成流程。
   Future<void> _retryPlan(AnimeDownloadPlan plan) async {
+    if (!await _ensureBackendReady()) return;
     final AppModel appModel = ref.read(appProvider);
-    if (!torrentBackendReady(appModel)) {
-      _snack(t.download_backend_not_configured);
-      return;
-    }
     final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
     if (store == null) {
       _snack(t.anime_download_store_unavailable);
@@ -2313,11 +2335,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     AnimeDownloadPlan plan, {
     required bool pause,
   }) async {
+    if (!await _ensureBackendReady()) return;
     final AppModel appModel = ref.read(appProvider);
-    if (!torrentBackendReady(appModel)) {
-      _snack(t.download_backend_not_configured);
-      return;
-    }
     final TorrentBackend backend = appModel.createTorrentBackend(
       effectiveTorrentConfig(appModel.qbConnectionConfig),
     );

--- a/fushi/lib/src/pages/implementations/download_backend_setup_dialog.dart
+++ b/fushi/lib/src/pages/implementations/download_backend_setup_dialog.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/torrent/anime_download_config.dart';
+import 'package:fushi/src/media/torrent/qb_torrent_backend.dart';
+import 'package:fushi/src/media/torrent/torrent_backend.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/utils.dart';
+
+/// 下载后端配置引导。
+///
+/// 「请先配置下载后端」以前只是一句话 + 一个「去设置」按钮：用户被丢进整页
+/// 下载设置（后端、限速、上传、做种、内存、连接数、代理……几十个字段），要自己
+/// 认出哪几个是**现在**必须填的。本对话框把这段路收成一步——只问「谁来下载」，
+/// 只显示所选后端**必填**的那几个字段，配完当场就能用。
+///
+/// 内置引擎排在第一位：它是 [QbConnectionConfig.backendAuto] 在有引擎的平台上的
+/// 解析结果，也是唯一不需要用户另外装软件的选项。外接 qBittorrent 排第二。
+///
+/// 纯 UI + AppModel 写入；不做导航，调用方拿返回值决定要不要重算前置条件。
+class DownloadBackendSetupDialog extends StatefulWidget {
+  const DownloadBackendSetupDialog({
+    required this.appModel,
+    super.key,
+    this.embeddedSupportedOverride,
+  });
+
+  final AppModel appModel;
+
+  /// 仅测试注入：覆盖「本平台是否有内置引擎」的判据（同
+  /// `TorrentSettingsSection.embeddedSupportedOverride`）。null = 问 AppModel。
+  final bool? embeddedSupportedOverride;
+
+  @override
+  State<DownloadBackendSetupDialog> createState() =>
+      _DownloadBackendSetupDialogState();
+}
+
+class _DownloadBackendSetupDialogState
+    extends State<DownloadBackendSetupDialog> {
+  late final QbConnectionConfig _initial =
+      effectiveTorrentConfig(widget.appModel.qbConnectionConfig);
+
+  late final bool _embeddedSupported = widget.embeddedSupportedOverride ??
+      widget.appModel.supportsEmbeddedTorrent;
+
+  /// 当前选中的后端。初值走 [QbConnectionConfig.resolveBackend]，所以
+  /// 「从没配过」（backend = auto）在有内置引擎的平台上开屏即停在内置引擎，
+  /// 用户直接点「完成」就配好了。
+  late String _backend =
+      _initial.resolveBackend(embeddedSupported: _embeddedSupported);
+
+  late final TextEditingController _urlCtrl =
+      TextEditingController(text: _initial.baseUrl);
+  late final TextEditingController _userCtrl =
+      TextEditingController(text: _initial.username);
+  late final TextEditingController _passCtrl =
+      TextEditingController(text: _initial.password);
+
+  bool _probing = false;
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    super.dispose();
+  }
+
+  bool get _isEmbedded => _backend == QbConnectionConfig.backendEmbedded;
+
+  /// 当前选择是否已经可用：内置引擎要宿主真就绪（缺 DLL 的包配了也下不了），
+  /// 外接 qb 至少要有地址。判据与 `torrentBackendReady` 同源。
+  bool get _canFinish {
+    if (_saving) return false;
+    if (_isEmbedded) return widget.appModel.isEmbeddedTorrentReady;
+    return _urlCtrl.text.trim().isNotEmpty;
+  }
+
+  QbConnectionConfig _composed() => _initial.copyWith(
+        backend: _backend,
+        baseUrl: _urlCtrl.text.trim(),
+        username: _userCtrl.text.trim(),
+        password: _passCtrl.text,
+      );
+
+  /// 测试连接：用**对话框里当前填的值**建后端，而不是已保存的配置——否则用户
+  /// 填完还没保存就点测试，测的是上一份配置，结果与所见不符。
+  Future<void> _probeConnection() async {
+    if (_probing) return;
+    setState(() => _probing = true);
+    final TorrentBackend backend =
+        widget.appModel.createTorrentBackend(_composed());
+    String? version;
+    String? failure;
+    try {
+      version = await backend.probeConnection();
+    } finally {
+      if (version == null && backend is QbTorrentBackend) {
+        failure = backend.lastProbeFailure;
+      }
+      backend.close();
+    }
+    if (!mounted) return;
+    setState(() => _probing = false);
+    final String message;
+    if (version != null) {
+      message = t.download_test_connection_ok(version: version);
+    } else if (failure != null && failure.isNotEmpty) {
+      message = t.download_test_connection_failed_reason(message: failure);
+    } else {
+      message = t.download_test_connection_failed;
+    }
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _finish() async {
+    if (_saving) return;
+    setState(() => _saving = true);
+    await widget.appModel.setQbConnectionConfig(_composed());
+    // 后端刚变，管线 runtime 要跟着重建：上一次启动因为没有可用后端而失败时
+    // service 会留 null，不重建的话配完仍然是「后端未配置」。
+    await widget.appModel.reloadVideoDownloadPipelineRuntime();
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  Widget _field({
+    required TextEditingController controller,
+    required String label,
+    String? hint,
+    bool obscure = false,
+    TextInputType? keyboard,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: TextField(
+        controller: controller,
+        obscureText: obscure,
+        keyboardType: keyboard,
+        decoration: InputDecoration(
+          labelText: label,
+          hintText: hint,
+          isDense: true,
+          border: const OutlineInputBorder(),
+        ),
+        onChanged: (String _) => setState(() {}),
+      ),
+    );
+  }
+
+  Widget _note(ThemeData theme, String text, {bool warning = false}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Text(
+        text,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: warning
+              ? theme.colorScheme.error
+              : theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final String saveRoot = widget.appModel.downloadSaveRoot;
+    // 走设计系统的对话框壳，**不能**用 AlertDialog：后者把内容裹进
+    // IntrinsicWidth，而后端选择器 [FushiSegmentedStrip] 内部是 LayoutBuilder
+    // （不支持被问固有尺寸），两者相遇当场 assert。
+    return FushiDialogFrame(
+      maxWidth: 460,
+      maxHeightFactor: 0.82,
+      scrollable: false,
+      child: FushiModalSheetFrame(
+        title: t.download_backend_setup_title,
+        leadingIcon: Icons.download_outlined,
+        scrollable: true,
+        bodyPadding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            _note(theme, t.download_backend_setup_intro),
+            if (_embeddedSupported)
+              FushiSegmentedStrip<String>(
+                segments: <ButtonSegment<String>>[
+                  ButtonSegment<String>(
+                    value: QbConnectionConfig.backendEmbedded,
+                    label: Text(t.video_setting_torrent_backend_embedded),
+                  ),
+                  ButtonSegment<String>(
+                    value: QbConnectionConfig.backendQbittorrent,
+                    label: Text(t.video_setting_torrent_backend_qb),
+                  ),
+                ],
+                selected: _backend,
+                onChanged: (String value) => setState(() => _backend = value),
+              )
+            else
+              _note(theme, t.download_backend_unsupported_note),
+            const SizedBox(height: 12),
+            if (_isEmbedded) ...<Widget>[
+              _note(theme, t.download_backend_embedded_hint),
+              if (!widget.appModel.isEmbeddedTorrentReady)
+                _note(theme, t.download_backend_embedded_unavailable,
+                    warning: true)
+              else if (saveRoot.isNotEmpty) ...<Widget>[
+                Text(
+                  t.download_save_root_title,
+                  style: theme.textTheme.labelMedium,
+                ),
+                const SizedBox(height: 2),
+                _note(theme, saveRoot),
+              ],
+            ] else ...<Widget>[
+              _note(theme, t.download_backend_qb_hint),
+              _field(
+                controller: _urlCtrl,
+                label: t.video_setting_qb_url,
+                hint: t.video_setting_qb_url_hint,
+                keyboard: TextInputType.url,
+              ),
+              _field(controller: _userCtrl, label: t.video_setting_qb_username),
+              _field(
+                controller: _passCtrl,
+                label: t.video_setting_qb_password,
+                obscure: true,
+              ),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton.icon(
+                  onPressed: _probing || _urlCtrl.text.trim().isEmpty
+                      ? null
+                      : _probeConnection,
+                  icon: _probing
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.network_check, size: 18),
+                  label: Text(t.download_test_connection),
+                ),
+              ),
+            ],
+          ],
+        ),
+        footer: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: <Widget>[
+            TextButton(
+              onPressed:
+                  _saving ? null : () => Navigator.of(context).pop(false),
+              child: Text(t.dialog_cancel),
+            ),
+            SizedBox(width: tokens.spacing.gap),
+            FilledButton(
+              onPressed: _canFinish ? _finish : null,
+              child: Text(t.dialog_done),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 「下载后端未配置」的统一出口：**直接弹配置引导**，而不是把用户支去设置页
+/// 自己找字段。返回 true = 用户配完了（调用方据此重算前置条件 / 重试原动作）。
+Future<bool> promptDownloadBackendSetup({
+  required BuildContext context,
+  required AppModel appModel,
+}) async {
+  final bool? done = await showAppDialog<bool>(
+    context: context,
+    builder: (BuildContext _) => DownloadBackendSetupDialog(appModel: appModel),
+  );
+  return done ?? false;
+}

--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/media/video/download/video_resource_registry.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/anime_download_dialog.dart';
 import 'package:fushi/src/pages/implementations/manual_download_task_dialog.dart';
+import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
 import 'package:fushi/src/pages/implementations/downloads_resource_gap.dart';
 import 'package:fushi/src/pages/implementations/media_sources_dialog.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
@@ -122,7 +123,20 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     });
   }
 
-  Widget _buildResourceTab(BuildContext tabContext) {
+  /// 「后端没配好」空态的动作：就地弹配置引导，配完重算前置条件——与
+  /// [_addVideoSource] 同一姿态，不把用户支去设置 tab 再走回来。
+  Future<void> _openBackendSetup() async {
+    final bool done = await promptDownloadBackendSetup(
+      context: context,
+      appModel: ref.read(appProvider),
+    );
+    if (!mounted || !done) return;
+    setState(() {
+      _resourceDependencies = _loadResourceDependencies();
+    });
+  }
+
+  Widget _buildResourceTab() {
     return FutureBuilder<_DownloadsResourceState>(
       future: _resourceDependencies,
       builder: (
@@ -144,13 +158,14 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                 label: t.download_add_video_source,
                 onPressed: _addVideoSource,
               ),
+            // 空态动作直接开配置引导（同 [_addVideoSource] 的就地补齐姿态）：
+            // 「后端没配」缺的就是那三两个字段，不该把用户支到整页设置里找。
             DownloadsResourceNoBackend(detail: final String? detail) =>
               _buildResourceGate(
                 message: detail ?? t.download_backend_not_configured,
-                icon: Icons.settings_outlined,
-                label: t.download_open_settings,
-                onPressed: () =>
-                    DefaultTabController.of(tabContext).animateTo(3),
+                icon: Icons.download_outlined,
+                label: t.download_backend_setup_start,
+                onPressed: _openBackendSetup,
               ),
           };
         }
@@ -310,7 +325,7 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                   Expanded(
                     child: TabBarView(
                       children: <Widget>[
-                        _buildResourceTab(tabContext),
+                        _buildResourceTab(),
                         // 任务 tab：漫画目录卷下载队列（有任务才占位）+ torrent 任务，
                         // 统一下载中心的同屏任务视图。
                         //

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -16,6 +16,7 @@ import 'package:macos_ui/macos_ui.dart'
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:fushi_anki/fushi_anki.dart' show AnkiMediaDedupReport;
 import 'package:fushi/src/anki/anki_media_dedup_dialogs.dart';
+import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
 import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 import 'package:fushi/src/anki/anki_media_dedup_runner.dart';
 import 'package:fushi/src/anki/anki_view_model.dart'
@@ -1311,6 +1312,14 @@ class _HomePageState extends BasePageState<HomePage>
     );
   }
 
+  /// 后端没配好时的统一出口：**直接弹配置引导**，而不是甩一句「请先配置下载
+  /// 后端」让用户自己去翻设置。配完再点一次原入口即可继续。
+  Future<void> _promptDownloadBackendSetup(BuildContext context) =>
+      promptDownloadBackendSetup(
+        context: context,
+        appModel: appModelNoUpdate,
+      );
+
   Future<void> _openVideoDiscoveryResourceSearch(
     BuildContext context,
     VideoDiscoveryItem item,
@@ -1320,7 +1329,7 @@ class _HomePageState extends BasePageState<HomePage>
     final VideoDownloadPipelineService? pipeline =
         appModelNoUpdate.videoDownloadPipelineService;
     if (registry == null || pipeline == null) {
-      _showVideoDiscoveryMessage(context, t.download_backend_not_configured);
+      unawaited(_promptDownloadBackendSetup(context));
       return;
     }
     final List<MediaSourceRow> sources =
@@ -1340,7 +1349,7 @@ class _HomePageState extends BasePageState<HomePage>
       return;
     } on Object {
       if (context.mounted) {
-        _showVideoDiscoveryMessage(context, t.download_backend_not_configured);
+        unawaited(_promptDownloadBackendSetup(context));
       }
       return;
     }
@@ -1389,7 +1398,7 @@ class _HomePageState extends BasePageState<HomePage>
     if (registry == null ||
         appModelNoUpdate.videoDownloadPipelineService == null ||
         appModelNoUpdate.videoDownloadSubscriptionService == null) {
-      _showVideoDiscoveryMessage(context, t.download_backend_not_configured);
+      unawaited(_promptDownloadBackendSetup(context));
       return;
     }
     final List<MediaSourceRow> sources =
@@ -1409,7 +1418,7 @@ class _HomePageState extends BasePageState<HomePage>
       return;
     } on Object {
       if (context.mounted) {
-        _showVideoDiscoveryMessage(context, t.download_backend_not_configured);
+        unawaited(_promptDownloadBackendSetup(context));
       }
       return;
     }

--- a/fushi/lib/src/pages/implementations/manual_download_task_dialog.dart
+++ b/fushi/lib/src/pages/implementations/manual_download_task_dialog.dart
@@ -14,8 +14,37 @@ import 'package:fushi/src/media/video/download/video_download_pipeline_service.d
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart'
     show VideoMetadataMediaKind;
 import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi_core/fushi_core.dart' show MediaSourceRow;
+
+/// 「管线 + 后端身份」的一次性解析结果。两者要么都有（可以开表单），要么就是
+/// 后端没配好——把它们收成一个值，调用方的重试路径才不用把三个变量各自搬一遍。
+class _ManualDownloadBackend {
+  const _ManualDownloadBackend({this.pipeline, this.identity, this.error});
+
+  final VideoDownloadPipelineService? pipeline;
+  final VideoDownloadBackendIdentity? identity;
+
+  /// 身份解析抛出的原因（后端配了但连不上时透传给用户）。
+  final Object? error;
+
+  bool get usable => pipeline != null && identity != null;
+}
+
+Future<_ManualDownloadBackend> _resolveBackend(AppModel appModel) async {
+  final VideoDownloadPipelineService? pipeline =
+      appModel.videoDownloadPipelineService;
+  if (pipeline == null) return const _ManualDownloadBackend();
+  try {
+    return _ManualDownloadBackend(
+      pipeline: pipeline,
+      identity: await appModel.currentVideoDownloadBackendIdentity(),
+    );
+  } on Object catch (error) {
+    return _ManualDownloadBackend(pipeline: pipeline, error: error);
+  }
+}
 
 /// 手动添加下载任务的唯一入口（下载页页头「添加任务」）。
 ///
@@ -25,25 +54,31 @@ Future<void> showManualDownloadTaskDialog({
   required BuildContext context,
   required AppModel appModel,
 }) async {
-  final VideoDownloadPipelineService? pipeline =
-      appModel.videoDownloadPipelineService;
-  if (pipeline == null) {
-    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-      SnackBar(content: Text(t.download_backend_not_configured)),
+  _ManualDownloadBackend resolved = await _resolveBackend(appModel);
+  if (!resolved.usable) {
+    if (!context.mounted) return;
+    // 后端没配好：**直接弹引导**，配完当场重试一次，而不是甩一句提示把用户
+    // 想做的事丢掉。用户取消引导 = 明确放弃，不再补提示。
+    final bool configured = await promptDownloadBackendSetup(
+      context: context,
+      appModel: appModel,
     );
-    return;
-  }
-  final VideoDownloadBackendIdentity identity;
-  try {
-    identity = await appModel.currentVideoDownloadBackendIdentity();
-  } on Object catch (error) {
-    if (context.mounted) {
+    if (!configured || !context.mounted) return;
+    resolved = await _resolveBackend(appModel);
+    if (!context.mounted) return;
+    if (!resolved.usable) {
       ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-        SnackBar(content: Text('$error')),
+        SnackBar(
+          content: Text(
+            resolved.error?.toString() ?? t.download_backend_not_configured,
+          ),
+        ),
       );
+      return;
     }
-    return;
   }
+  final VideoDownloadPipelineService pipeline = resolved.pipeline!;
+  final VideoDownloadBackendIdentity identity = resolved.identity!;
   final List<MediaSourceRow> sources =
       await appModel.getManagedVideoDownloadSources();
   if (!context.mounted) return;

--- a/fushi/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/fushi/lib/src/pages/implementations/torrent_settings_section.dart
@@ -398,14 +398,16 @@ class _TorrentSettingsSectionState
         // 比没有选项更糟。改为一行说明交代本平台只有外接 qb。
         if (_supportsEmbedded) ...<Widget>[
           FushiSegmentedStrip<String>(
+            // 内置引擎排在第一段：它才是本平台的默认（`backendAuto` 解析结果），
+            // 也是开箱即用的那一个。qb 需要用户另装并配好 WebUI 才能用，排第二。
             segments: <ButtonSegment<String>>[
-              ButtonSegment<String>(
-                value: QbConnectionConfig.backendQbittorrent,
-                label: Text(t.video_setting_torrent_backend_qb),
-              ),
               ButtonSegment<String>(
                 value: QbConnectionConfig.backendEmbedded,
                 label: Text(t.video_setting_torrent_backend_embedded),
+              ),
+              ButtonSegment<String>(
+                value: QbConnectionConfig.backendQbittorrent,
+                label: Text(t.video_setting_torrent_backend_qb),
               ),
             ],
             selected: backend,

--- a/fushi/test/pages/download_backend_setup_dialog_test.dart
+++ b/fushi/test/pages/download_backend_setup_dialog_test.dart
@@ -1,0 +1,246 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/media/torrent/anime_download_config.dart';
+import 'package:fushi/src/media/torrent/download_network_proxy.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
+import 'package:fushi/src/pages/implementations/torrent_settings_section.dart';
+import 'package:fushi/utils.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 下载后端的**呈现顺序**与**配置引导**。
+///
+/// 断言的是真实渲染：段的先后用两个标签的实际横坐标比，不是「字符串存在」——
+/// 把两段调换回去，本文件必须红。
+class _TestAppModel extends AppModel {
+  _TestAppModel({
+    required QbConnectionConfig config,
+    this.embeddedReady = true,
+  })  : _config = config,
+        super(testPlatformServices());
+
+  QbConnectionConfig _config;
+  final bool embeddedReady;
+  final String saveRoot = r'D:\downloads';
+
+  /// 引导点「完成」时写进来的配置（断言真的落到了 AppModel）。
+  QbConnectionConfig? saved;
+  int pipelineReloads = 0;
+
+  @override
+  Locale get appLocale => const Locale('en', 'US');
+
+  @override
+  PackageInfo get packageInfo => PackageInfo(
+        appName: 'Hibiki',
+        packageName: 'jp.hibiki.test',
+        version: '1.0.0',
+        buildNumber: '1',
+      );
+
+  @override
+  QbConnectionConfig? get qbConnectionConfig => _config;
+
+  @override
+  Future<void> setQbConnectionConfig(QbConnectionConfig? config) async {
+    saved = config;
+    if (config != null) _config = config;
+  }
+
+  @override
+  Future<void> reloadVideoDownloadPipelineRuntime() async => pipelineReloads++;
+
+  @override
+  bool get supportsEmbeddedTorrent => true;
+
+  @override
+  bool get isEmbeddedTorrentReady => embeddedReady;
+
+  @override
+  String get downloadSaveRoot => saveRoot;
+
+  @override
+  DownloadNetworkProxyConfig get downloadNetworkProxyConfig =>
+      const DownloadNetworkProxyConfig();
+}
+
+Widget _harness(
+  _TestAppModel appModel,
+  Widget child, {
+  bool scrollable = true,
+}) {
+  final FushiDatabase db = FushiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+  final ThemeNotifier themeNotifier = ThemeNotifier(db, () => const TextTheme())
+    ..loadFromPrefsSnapshot(<String, String>{
+      'design_system': PrefCodec.encode('material'),
+      'app_theme_key': PrefCodec.encode('system-theme'),
+      'brightness_mode': PrefCodec.encode('system'),
+      'custom_theme_seed': PrefCodec.encode(0xFF1F4959),
+    });
+  appModel.themeNotifier = themeNotifier;
+  addTearDown(() async {
+    themeNotifier.dispose();
+    await db.close();
+  });
+
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+    child: MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        platform: TargetPlatform.android,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF386A58)),
+        extensions: <ThemeExtension<dynamic>>[
+          FushiDesignSystemTheme(themeNotifier.designSystemTheme),
+        ],
+      ),
+      // 对话框走 Center：AlertDialog 自带 IntrinsicWidth，套进滚动视图会去问
+      // FushiSegmentedStrip 的 LayoutBuilder 要固有高度而炸掉（生产路径是
+      // showAppDialog，本来就不在滚动视图里）。
+      home: Scaffold(
+        body: SizedBox(
+          width: 900,
+          child: scrollable
+              ? SingleChildScrollView(child: child)
+              : Center(child: child),
+        ),
+      ),
+    ),
+  );
+}
+
+/// 两个后端标签的实际横坐标：内置引擎必须在外接 qb 左边。
+void _expectEmbeddedRendersFirst(WidgetTester tester) {
+  final Finder embedded =
+      find.text(t.video_setting_torrent_backend_embedded).last;
+  final Finder qb = find.text(t.video_setting_torrent_backend_qb).last;
+  expect(embedded, findsOneWidget);
+  expect(qb, findsOneWidget);
+  expect(
+    tester.getTopLeft(embedded).dx,
+    lessThan(tester.getTopLeft(qb).dx),
+    reason: '内置引擎是开箱即用的默认后端，必须排在外接 qBittorrent 前面',
+  );
+}
+
+void main() {
+  testWidgets('下载设置：内置引擎段排在外接 qBittorrent 之前', (WidgetTester tester) async {
+    final _TestAppModel appModel =
+        _TestAppModel(config: const QbConnectionConfig());
+    await tester.pumpWidget(_harness(
+      appModel,
+      const TorrentSettingsSection(embeddedSupportedOverride: true),
+    ));
+    await tester.pump();
+    _expectEmbeddedRendersFirst(tester);
+  });
+
+  testWidgets('引导：段序同上，且开屏即停在内置引擎', (WidgetTester tester) async {
+    final _TestAppModel appModel =
+        _TestAppModel(config: const QbConnectionConfig());
+    await tester.pumpWidget(_harness(
+      appModel,
+      DownloadBackendSetupDialog(
+        appModel: appModel,
+        embeddedSupportedOverride: true,
+      ),
+      scrollable: false,
+    ));
+    await tester.pump();
+
+    _expectEmbeddedRendersFirst(tester);
+    // 内置分支渲染的是「下载目录」，不是 qb 地址输入框：证明选中的是内置引擎，
+    // 而不是只把标签画在了第一位。
+    expect(find.text(appModel.saveRoot), findsOneWidget);
+    expect(find.text(t.video_setting_qb_url), findsNothing);
+  });
+
+  testWidgets('引导：内置引擎一步落库，无需填任何字段', (WidgetTester tester) async {
+    final _TestAppModel appModel =
+        _TestAppModel(config: const QbConnectionConfig());
+    await tester.pumpWidget(_harness(
+      appModel,
+      DownloadBackendSetupDialog(
+        appModel: appModel,
+        embeddedSupportedOverride: true,
+      ),
+      scrollable: false,
+    ));
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, t.dialog_done));
+    await tester.pumpAndSettle();
+
+    expect(appModel.saved?.backend, QbConnectionConfig.backendEmbedded);
+    expect(appModel.pipelineReloads, 1,
+        reason: '后端刚配好，管线 runtime 必须重建，否则仍报「后端未配置」');
+  });
+
+  testWidgets('引导：内置引擎运行库缺失时不让「完成」，并说清原因',
+      (WidgetTester tester) async {
+    final _TestAppModel appModel = _TestAppModel(
+      config: const QbConnectionConfig(),
+      embeddedReady: false,
+    );
+    await tester.pumpWidget(_harness(
+      appModel,
+      DownloadBackendSetupDialog(
+        appModel: appModel,
+        embeddedSupportedOverride: true,
+      ),
+      scrollable: false,
+    ));
+    await tester.pump();
+
+    expect(find.text(t.download_backend_embedded_unavailable), findsOneWidget);
+    final FilledButton done = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, t.dialog_done),
+    );
+    expect(done.onPressed, isNull,
+        reason: '缺 DLL 的包配了也下不了，不能让用户以为配好了');
+  });
+
+  testWidgets('引导：切到外接 qb 后地址是必填项', (WidgetTester tester) async {
+    final _TestAppModel appModel =
+        _TestAppModel(config: const QbConnectionConfig());
+    await tester.pumpWidget(_harness(
+      appModel,
+      DownloadBackendSetupDialog(
+        appModel: appModel,
+        embeddedSupportedOverride: true,
+      ),
+      scrollable: false,
+    ));
+    await tester.pump();
+
+    await tester.tap(find.text(t.video_setting_torrent_backend_qb).last);
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_setting_qb_url), findsOneWidget);
+    FilledButton done() => tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, t.dialog_done),
+        );
+    expect(done().onPressed, isNull, reason: '地址空着的 qb 后端连不上');
+
+    await tester.enterText(
+      find.byType(TextField).first,
+      'http://127.0.0.1:8080',
+    );
+    await tester.pump();
+    expect(done().onPressed, isNotNull);
+
+    await tester.tap(find.widgetWithText(FilledButton, t.dialog_done));
+    await tester.pumpAndSettle();
+    expect(appModel.saved?.backend, QbConnectionConfig.backendQbittorrent);
+    expect(appModel.saved?.baseUrl, 'http://127.0.0.1:8080');
+  });
+}


### PR DESCRIPTION
## 改了什么

1. **后端二选一的段序调成「内置引擎 → 外接 qBittorrent」**（设置页 + 新引导同一段序）。内置引擎才是 `backendAuto` 在有引擎平台上的解析结果，也是唯一开箱即用的选项；qb 需要用户另装并配好 WebUI，排第二。

2. **「请先配置下载后端」不再是死路**。原来是一句话 + 一个「去设置」，把用户丢进整页下载设置（后端/限速/上传/做种/内存/连接数/代理几十个字段）自己认哪几个是现在必须填的。新增 `DownloadBackendSetupDialog` 把这段路收成一步：只问「谁来下载」，只显示所选后端的必填项——内置引擎零字段直接完成，qb 三字段 + 测试连接。完成时写 `QbConnectionConfig` 并重建下载管线 runtime（上次启动因无可用后端而失败时 service 会留 null，不重建就会「配完仍报未配置」）。

## 接入点

- 下载页「资源」空态（原来跳设置 tab）
- 番剧下载对话框的未配置横幅（「开始配置」为主动作，「去设置」保留）+ 重试计划 / 暂停恢复
- 手动添加任务（配完当场重试一次原动作，不把用户想做的事丢掉）
- 首页发现的资源搜索与订阅入口（原来只弹一句提示）

## 实现注意

- 对话框走 `FushiDialogFrame` + `FushiModalSheetFrame` 而不是 `AlertDialog`：后者把内容裹进 `IntrinsicWidth`，与 `FushiSegmentedStrip` 内部的 `LayoutBuilder` 相遇当场 assert（这是实测撞出来的，不是风格选择）。
- `AppModel` 暴露 `supportsEmbeddedTorrent`，避免第三处手抄 `Platform.isXxx`。
- 新增 6 个 i18n key，走 `i18n_sync` + `dart run slang` + `dart format --language-version=3.6`；`strings.g.dart` 只动 469 行（没触发整文件重排）。

## 验证

- `flutter analyze`（含 test）零问题
- 新测试 `test/pages/download_backend_setup_dialog_test.dart` 5 条全绿；段序按**实际横坐标**断言，不是「字符串存在」
- 变异实测三处，都能让对应断言变红：设置页段序换回去、引导段序换回去、去掉管线重建
- 相邻定向：`torrent_settings_*` / `downloads_resource_gap` / `anime_download_dialog_*` / `test/media/torrent` / `test/i18n` 共 247 条全绿
- 目录枚举型守卫：`md3_design_system_static_test` / `md3_dialog_chrome_merged_static_test` 全绿
- 未做真机验证

https://claude.ai/code/session_01KLMMKXUhM12aEwAu9Shozc
