### PR TITLE
fix(video): 视频页标签补画 + 系列页准入放宽 (BUG-1808 / BUG-1839)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1678 条。点号进各自文件。
+> 共 1679 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1808](bugs/BUG-1808-video-home-row-card-tags.md) | ✅ | ✅ | 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上） |
 | [BUG-1799](bugs/BUG-1799-texthooker-mined-badge-never-revalidated.md) | ✅ | ✅ | galgame 台词列表「已制卡」徽章是单向内存 latch，Anki 删卡后永不复核 |
 | [BUG-1798](bugs/BUG-1798-video-lookup-controls-autohide-race.md) | ✅ | ✅ | 查词浮层与控制条自动显隐竞态 |
 | [BUG-1797](bugs/BUG-1797-reader-padding-hit-leak.md) | ✅ | ✅ | 阅读器页边距能点到相邻页的词查词（不可见却可命中） |

--- a/docs/bugs/BUG-1808-video-home-row-card-tags.md
+++ b/docs/bugs/BUG-1808-video-home-row-card-tags.md
@@ -6,13 +6,24 @@
   （`_buildLocalVideoSlivers` / `_buildAllVideoSlivers`）只挂在 `series` / `allVideos` 上，`home` 只剩
   `_buildOverviewSection`（hero + 继续观看 / 下一集 / 最近添加 三条横滚行）。横滚卡 `_buildRowMediaCard`
   自引入起就没有标签层，于是拆分当天起首页的视频卡一个标签都不显示——标签本身写穿了 DB，只是没人画。
+  第二处缺口（用户复问「不是能看见远端的标签吗」查出）：互联远端条目的标签**一直在清单里**
+  （`RemoteVideoInfo.tags`，host 侧 `app_model_library_host_service.dart:1349` 填充、client `fromJson` 解析），
+  但 UI 一处都没画——墙格远端占位卡 `_buildRemoteVideoCard` 的封面左上角只有字幕角标，横滚远端卡同样空着。
+  远端卡没标签不是「没数据」，是渲染缺口。
 - **[x] ① 已修复** — `_buildRowMediaCard` 增加 `tags` 参数并在封面左上角（top:6/left:6，与墙卡同位同形）渲染
-  `_buildTagLabels`；继续观看散卡 / 继续观看合集卡 / 最近添加卡三个调用点接上数据源。同时把散卡与合集卡
-  各自 inline 的 `ref.watch(...)` 收敛成 `_videoBookTags(bookUid)` / `_collectionTags(collectionId)` 两个
-  helper，墙卡与横滚卡共用同一口径（首页当初漏画，正是因为标签只跟着墙卡那一处写法走）。远端占位卡无本地
-  条目、无标签，保持不传。提交：见本分支 `fix(video): 视频首页横滚行卡补回标签层 (BUG-1808)`。
-- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_home_row_tags_test.dart`（3 条 widget 行为断言：
-  继续观看散卡显示自己的标签且不铺到邻卡、最近添加卡显示标签、继续观看合集卡显示合集标签）。
-  变异实测：给标签层加 `&& !kMutationProbe1808` 关掉渲染 → 3 条全红；还原后文件 SHA-256 与变异前逐字节一致
-  （`6dee4a45…2eecf`），排除恒真断言。
+  `_buildTagLabels`；继续观看散卡 / 继续观看合集卡 / 最近添加卡 / 两张远端横滚卡五个调用点接上数据源。
+  标签数据归一成 `_VideoTagChip = ({String label, Color? color})` 一种形状：本地条目带库里的颜色
+  （`_videoBookTagChips` / `_collectionTagChips`），远端条目 host 只下发标签名（标签本身每设备本地），
+  `_remoteTagChips` 按名借本机同名标签的颜色、没有就走 chip 默认色——本地卡与远端卡因此共用一条渲染路径，
+  不再各画各的（首页当初漏画，正是因为标签只跟着墙卡那一处写法走）。墙格远端占位卡的左上角改成一列：
+  标签 chip 在上、字幕角标在下，两者不再抢同一个角。
+  提交：`e3a9846904`（首页横滚卡）+ 本分支远端标签补画提交。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_home_row_tags_test.dart`（6 条 widget 行为断言：
+  继续观看散卡显示自己的标签且不铺到邻卡、最近添加卡、继续观看合集卡、继续观看远端卡显示 host 下发的标签、
+  远端标签借本机同名颜色 / 本机没有则为 null、「全部视频」墙格远端卡显示标签且字幕角标不被挤掉）。
+  变异实测两轮，都是行为变异配行为守卫：① 给标签层加 `&& !kMutationProbe1808` 关掉渲染 → 当时 3 条全红；
+  ② 让 `_remoteTagChips` 恒返空 → 6 条里恰好 3 条远端断言红、3 条本地仍绿（证明两组断言不互相冒充）。
+  两轮还原后文件 SHA-256 均与变异前逐字节一致（`6dee4a45…2eecf` / `a6b596e6…6f0f`）。
 - **备注**：首页 hero 轮播（backdrop 大图）仍不画标签——那是整幅背景图版式，与卡片角标口径不同，本次未动。
+  远端标签是 host 下发的**名字**，本机没有同名标签时只有名字没有颜色，这是标签「每设备本地」的既有模型决定的，
+  不是本次可修的范围。

--- a/docs/bugs/BUG-1808-video-home-row-card-tags.md
+++ b/docs/bugs/BUG-1808-video-home-row-card-tags.md
@@ -1,0 +1,18 @@
+## BUG-1808 · 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上）
+- **报告**：2026-08-24（用户：「首页少了标签，我打好的标签没在首页显示」→ 澄清为「视频的首页的视频不显示标签」）
+- **真实性**：✅ 真 bug（回归）。根因 `fushi/lib/src/pages/implementations/home_video_page.dart:3497`（`_buildRowMediaCard` 封面 Stack 无标签层）。
+  标签 chip 只画在墙格散卡 `_buildCard`（同文件 `_buildTagLabels` 调用处）与合集墙卡 `_buildCollectionCoverCard`。
+  `fde80d7189`（series-first 拆库）把页面拆成 `home / series / allVideos` 三个 section 后，墙格 sliver
+  （`_buildLocalVideoSlivers` / `_buildAllVideoSlivers`）只挂在 `series` / `allVideos` 上，`home` 只剩
+  `_buildOverviewSection`（hero + 继续观看 / 下一集 / 最近添加 三条横滚行）。横滚卡 `_buildRowMediaCard`
+  自引入起就没有标签层，于是拆分当天起首页的视频卡一个标签都不显示——标签本身写穿了 DB，只是没人画。
+- **[x] ① 已修复** — `_buildRowMediaCard` 增加 `tags` 参数并在封面左上角（top:6/left:6，与墙卡同位同形）渲染
+  `_buildTagLabels`；继续观看散卡 / 继续观看合集卡 / 最近添加卡三个调用点接上数据源。同时把散卡与合集卡
+  各自 inline 的 `ref.watch(...)` 收敛成 `_videoBookTags(bookUid)` / `_collectionTags(collectionId)` 两个
+  helper，墙卡与横滚卡共用同一口径（首页当初漏画，正是因为标签只跟着墙卡那一处写法走）。远端占位卡无本地
+  条目、无标签，保持不传。提交：见本分支 `fix(video): 视频首页横滚行卡补回标签层 (BUG-1808)`。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_home_row_tags_test.dart`（3 条 widget 行为断言：
+  继续观看散卡显示自己的标签且不铺到邻卡、最近添加卡显示标签、继续观看合集卡显示合集标签）。
+  变异实测：给标签层加 `&& !kMutationProbe1808` 关掉渲染 → 3 条全红；还原后文件 SHA-256 与变异前逐字节一致
+  （`6dee4a45…2eecf`），排除恒真断言。
+- **备注**：首页 hero 轮播（backdrop 大图）仍不画标签——那是整幅背景图版式，与卡片角标口径不同，本次未动。

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -3495,6 +3495,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// [CoverOrientationBuilder] 探测与卡内封面共用同一 provider 键，零额外解码）。
   /// 底边进度条、集数/「新」/云角标，两行标题 + 溢出 Tooltip（TODO-2490 同款）。
   ///
+  /// [tags] = 该条目已打的用户标签（BUG-1808）：封面左上角 chip 列，与墙卡
+  /// [_buildCard] / 合集墙卡 [_buildCollectionCoverCard] 同一渲染同一位置。视频
+  /// 首页（[VideoLibrarySection.home]）自 series-first 拆分后只剩横滚行、墙格移
+  /// 去「系列 / 全部视频」，标签层若只画在墙卡上，首页就一个标签都看不见。远端
+  /// 占位卡无本地条目、无标签，留空即可。
   Widget _buildRowMediaCard({
     required Key cardKey,
     required FushiFocusId focusId,
@@ -3506,6 +3511,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     double? progressFraction,
     int? episodeNumber,
     String? secondaryText,
+    List<BookTagRow> tags = const <BookTagRow>[],
     bool newBadge = false,
     bool cloudBadge = false,
   }) {
@@ -3572,6 +3578,15 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                               _buildPlaylistBadge(episodeNumber),
                           ],
                         ),
+                      ),
+                    // BUG-1808：标签 chip 列（左上，与墙卡 / 合集墙卡同位同形）。
+                    // 右上是「新」/集数角标、右下是云角标，互不重叠；横滚卡是墙
+                    // 内容的快捷镜像、不参与勾选，故无勾选框让位问题。
+                    if (tags.isNotEmpty)
+                      Positioned(
+                        top: 6,
+                        left: 6,
+                        child: _buildTagLabels(tags),
                       ),
                     if (cloudBadge)
                       const Positioned(
@@ -3660,6 +3675,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => _open(book),
       onLongPress: () => _showVideoMenu(book),
+      tags: _videoBookTags(book.bookUid),
       progressFraction: videoWatchFraction(
         completed: book.completedAt != null,
         currentEpisode: book.currentEpisode,
@@ -3706,6 +3722,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ));
       },
       onLongPress: () => _showCollectionContextMenu(collection),
+      tags: _collectionTags(collection.id),
       progressFraction:
           members.isEmpty ? null : completedCount / members.length,
       episodeNumber: currentIndex + 1,
@@ -3747,6 +3764,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => _open(book, playlistCollectionId: cid),
       onLongPress: () => _showVideoMenu(book),
+      tags: _videoBookTags(book.bookUid),
       episodeNumber: playlistEpisodeCount(book.playlistJson) > 1
           ? book.currentEpisode + 1
           : null,
@@ -4430,9 +4448,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     VideoCardOrientation orientation = VideoCardOrientation.portrait,
   }) {
     final MediaCollectionRow collection = group.collection!;
-    final List<BookTagRow> tags =
-        ref.watch(collectionTagMapProvider).valueOrNull?[collection.id] ??
-            const <BookTagRow>[];
+    final List<BookTagRow> tags = _collectionTags(collection.id);
     final int memberCount = group.items.length;
     final bool hasRemoteMember = group.items.any(
         (CollectionOrderingItem<_VideoSlot> it) => it.payload.remote != null);
@@ -5645,9 +5661,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final String displayTitle = widget.section == VideoLibrarySection.series
         ? (_metadataWorkByBook[book.bookUid]?.title ?? book.title)
         : book.title;
-    final List<BookTagRow> tags =
-        ref.watch(videoBookTagMapProvider).valueOrNull?[book.bookUid] ??
-            const <BookTagRow>[];
+    final List<BookTagRow> tags = _videoBookTags(book.bookUid);
     final int episodeCount = playlistEpisodeCount(book.playlistJson);
     // TODO-1346：视频观看进度分数（null=无可展示进度 → 不画进度条）。
     final double? watchFrac = videoWatchFraction(
@@ -5958,6 +5972,17 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   /// 卡片标签层：最多显示前 3 个 chip，超出折叠成「+N」（与书架卡风格一致）。
+  /// 视频书的用户标签（BUG-1808）：墙卡与首页横滚卡共用同一口径，别再各处 inline
+  /// 写一遍 watch——首页当初漏画标签层，正是因为标签只跟着墙卡那一处写法走。
+  List<BookTagRow> _videoBookTags(String bookUid) =>
+      ref.watch(videoBookTagMapProvider).valueOrNull?[bookUid] ??
+      const <BookTagRow>[];
+
+  /// 合集的用户标签（与 [_videoBookTags] 同形，键是 collectionId）。
+  List<BookTagRow> _collectionTags(int collectionId) =>
+      ref.watch(collectionTagMapProvider).valueOrNull?[collectionId] ??
+      const <BookTagRow>[];
+
   Widget _buildTagLabels(List<BookTagRow> tags) {
     const int maxVisible = 3;
     final List<BookTagRow> visible = tags.take(maxVisible).toList();

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -122,6 +122,12 @@ Future<void> openLocalVideoBook({
 
 enum _AllVideosLayout { grid, list }
 
+/// 卡面标签 chip 的渲染形状（BUG-1808）：本地条目带库里的颜色；互联远端条目 host
+/// 只下发标签**名**（[RemoteVideoInfo.tags]，标签本身每设备本地），同名标签在本机
+/// 存在就借本机颜色，否则 [color] 为 null 走 chip 默认色。归一成同一形状后，本地
+/// 卡与远端卡共用一条渲染路径，不再各画各的。
+typedef _VideoTagChip = ({String label, Color? color});
+
 /// 首页「视频」tab 的内容：已导入视频的库（独立于书架的 EPUB/有声书分区）。
 ///
 /// 仅在实验性视频开关开启时由 [HomePage] 装配进底栏（见 home_page.dart 的
@@ -3511,7 +3517,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     double? progressFraction,
     int? episodeNumber,
     String? secondaryText,
-    List<BookTagRow> tags = const <BookTagRow>[],
+    List<_VideoTagChip> tags = const <_VideoTagChip>[],
     bool newBadge = false,
     bool cloudBadge = false,
   }) {
@@ -3675,7 +3681,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => _open(book),
       onLongPress: () => _showVideoMenu(book),
-      tags: _videoBookTags(book.bookUid),
+      tags: _videoBookTagChips(book.bookUid),
       progressFraction: videoWatchFraction(
         completed: book.completedAt != null,
         currentEpisode: book.currentEpisode,
@@ -3722,7 +3728,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ));
       },
       onLongPress: () => _showCollectionContextMenu(collection),
-      tags: _collectionTags(collection.id),
+      tags: _collectionTagChips(collection.id),
       progressFraction:
           members.isEmpty ? null : completedCount / members.length,
       episodeNumber: currentIndex + 1,
@@ -3745,6 +3751,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => _openRemote(video),
       onLongPress: () => _showRemoteVideoDialog(video),
+      tags: _remoteTagChips(video.tags),
       secondaryText: video.isPlaylist
           ? t.video_playlist_episodes(count: video.episodes.length)
           : t.remote_video_info,
@@ -3764,7 +3771,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => _open(book, playlistCollectionId: cid),
       onLongPress: () => _showVideoMenu(book),
-      tags: _videoBookTags(book.bookUid),
+      tags: _videoBookTagChips(book.bookUid),
       episodeNumber: playlistEpisodeCount(book.playlistJson) > 1
           ? book.currentEpisode + 1
           : null,
@@ -3790,6 +3797,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       coverHeight: coverHeight,
       onTap: () => unawaited(_openRemote(video)),
       onLongPress: () => _showRemoteVideoDialog(video),
+      tags: _remoteTagChips(video.tags),
       episodeNumber: video.isPlaylist ? video.currentEpisode + 1 : null,
       secondaryText: video.isPlaylist
           ? t.video_home_recent_episode_number(n: video.currentEpisode + 1)
@@ -4448,7 +4456,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     VideoCardOrientation orientation = VideoCardOrientation.portrait,
   }) {
     final MediaCollectionRow collection = group.collection!;
-    final List<BookTagRow> tags = _collectionTags(collection.id);
+    final List<_VideoTagChip> tags = _collectionTagChips(collection.id);
     final int memberCount = group.items.length;
     final bool hasRemoteMember = group.items.any(
         (CollectionOrderingItem<_VideoSlot> it) => it.payload.remote != null);
@@ -4747,6 +4755,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }) {
     final String safeKey = _safeRemoteKey(video.id);
     final Widget? downloadBadge = _remoteDownloadBadge(video, safeKey);
+    final List<_VideoTagChip> remoteTags = _remoteTagChips(video.tags);
     // 不再固定 260 宽：和本地 [_buildCard] 一样让卡片填满网格 cell，宽度由
     // 响应式网格决定（TODO-593）。
     return FushiCard(
@@ -4796,12 +4805,22 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 // 什么都没发生的占位卡。角标是恒定出口，重进页面照样在。
                 if (downloadBadge != null)
                   Positioned(top: 6, right: 6, child: downloadBadge),
-                // 字幕角标收敛到共享 [CoverBadge]（UI 巡检 PR-4，PR-0 组件）。
-                if (video.hasSubtitle)
-                  const Positioned(
+                // 左上一列：远端标签 chip（BUG-1808，host 清单下发标签名）在上、
+                // 字幕角标在下。标签补画前这个角只有字幕角标，两者并成一列后谁都
+                // 不遮谁。字幕角标收敛到共享 [CoverBadge]（UI 巡检 PR-4，PR-0 组件）。
+                if (remoteTags.isNotEmpty || video.hasSubtitle)
+                  Positioned(
                     top: 6,
                     left: 6,
-                    child: CoverBadge(icon: Icons.subtitles_outlined),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        if (remoteTags.isNotEmpty) _buildTagLabels(remoteTags),
+                        if (video.hasSubtitle)
+                          const CoverBadge(icon: Icons.subtitles_outlined),
+                      ],
+                    ),
                   ),
                 // TODO-885: 远端播放列表集数角标（与本地卡同款，左下避开右上字幕/下载）。
                 if (video.isPlaylist)
@@ -5661,7 +5680,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final String displayTitle = widget.section == VideoLibrarySection.series
         ? (_metadataWorkByBook[book.bookUid]?.title ?? book.title)
         : book.title;
-    final List<BookTagRow> tags = _videoBookTags(book.bookUid);
+    final List<_VideoTagChip> tags = _videoBookTagChips(book.bookUid);
     final int episodeCount = playlistEpisodeCount(book.playlistJson);
     // TODO-1346：视频观看进度分数（null=无可展示进度 → 不画进度条）。
     final double? watchFrac = videoWatchFraction(
@@ -5971,30 +5990,55 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// 卡片标签层：最多显示前 3 个 chip，超出折叠成「+N」（与书架卡风格一致）。
   /// 视频书的用户标签（BUG-1808）：墙卡与首页横滚卡共用同一口径，别再各处 inline
   /// 写一遍 watch——首页当初漏画标签层，正是因为标签只跟着墙卡那一处写法走。
-  List<BookTagRow> _videoBookTags(String bookUid) =>
-      ref.watch(videoBookTagMapProvider).valueOrNull?[bookUid] ??
-      const <BookTagRow>[];
+  List<_VideoTagChip> _videoBookTagChips(String bookUid) => _tagChipsOf(
+      ref.watch(videoBookTagMapProvider).valueOrNull?[bookUid]);
 
-  /// 合集的用户标签（与 [_videoBookTags] 同形，键是 collectionId）。
-  List<BookTagRow> _collectionTags(int collectionId) =>
-      ref.watch(collectionTagMapProvider).valueOrNull?[collectionId] ??
-      const <BookTagRow>[];
+  /// 合集的用户标签（与 [_videoBookTagChips] 同形，键是 collectionId）。
+  List<_VideoTagChip> _collectionTagChips(int collectionId) => _tagChipsOf(
+      ref.watch(collectionTagMapProvider).valueOrNull?[collectionId]);
 
-  Widget _buildTagLabels(List<BookTagRow> tags) {
+  /// 互联远端条目的标签（BUG-1808）：host 清单下发的是标签**名**（标签本身每设备
+  /// 本地，见 [RemoteVideoInfo.tags]），本机有同名标签就借它的颜色，没有就走 chip
+  /// 默认色——远端卡此前一处都没画标签，数据其实一直在清单里。
+  List<_VideoTagChip> _remoteTagChips(List<String> names) {
+    if (names.isEmpty) return const <_VideoTagChip>[];
+    final List<BookTagRow> local =
+        ref.watch(allTagsProvider).valueOrNull ?? const <BookTagRow>[];
+    final Map<String, int> colorByName = <String, int>{
+      for (final BookTagRow tag in local) tag.name: tag.colorValue,
+    };
+    return <_VideoTagChip>[
+      for (final String name in names)
+        (
+          label: name,
+          color: colorByName[name] == null ? null : Color(colorByName[name]!),
+        ),
+    ];
+  }
+
+  List<_VideoTagChip> _tagChipsOf(List<BookTagRow>? tags) {
+    if (tags == null || tags.isEmpty) return const <_VideoTagChip>[];
+    return <_VideoTagChip>[
+      for (final BookTagRow tag in tags)
+        (label: tag.name, color: Color(tag.colorValue)),
+    ];
+  }
+
+  /// 卡片标签层：最多显示前 3 个 chip，超出折叠成「+N」（与书架卡风格一致）。
+  Widget _buildTagLabels(List<_VideoTagChip> tags) {
     const int maxVisible = 3;
-    final List<BookTagRow> visible = tags.take(maxVisible).toList();
+    final List<_VideoTagChip> visible = tags.take(maxVisible).toList();
     final int overflow = tags.length - visible.length;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        for (final BookTagRow tag in visible)
+        for (final _VideoTagChip chip in visible)
           Padding(
             padding: const EdgeInsets.only(bottom: 2),
-            child: FushiTagChip(label: tag.name, color: Color(tag.colorValue)),
+            child: FushiTagChip(label: chip.label, color: chip.color),
           ),
         if (overflow > 0) FushiTagChip(label: '+$overflow'),
       ],

--- a/fushi/test/pages/home_video_home_row_tags_test.dart
+++ b/fushi/test/pages/home_video_home_row_tags_test.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1808：视频首页（[VideoLibrarySection.home]）横滚行卡必须画用户标签。
+///
+/// series-first 拆分把墙格从首页移去「系列 / 全部视频」后，首页只剩 hero + 三条
+/// 横滚行；标签层当时只写在墙卡 `_buildCard` 上，于是「打了标签，首页一个都看不
+/// 见」。这几条断言就是那个缺口的行为门：继续观看行的散卡、合集卡与最近添加行卡
+/// 各自认自己那条标签，没打标签的卡不得凭空长出 chip。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('fushi_home_row_tags_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('fushi_home_row_tags_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                section: VideoLibrarySection.home,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> pumpHome(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+  }
+
+  /// 有播放痕迹（未看完）→ 进「继续观看」行。
+  Future<void> seedInProgress(String uid, String title) =>
+      db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value<String>(uid),
+        title: Value<String>(title),
+        videoPath: Value<String>('/abs/$title.mp4'),
+        lastPositionMs: const Value<int>(60000),
+      ));
+
+  Finder tagTextIn(String cardKey, String tagName) => find.descendant(
+        of: find.byKey(ValueKey<String>(cardKey)),
+        matching: find.text(tagName),
+      );
+
+  testWidgets('继续观看行的散卡显示该视频的标签', (WidgetTester tester) async {
+    await seedInProgress('video/tagged', 'Tagged Show');
+    await seedInProgress('video/plain', 'Plain Show');
+    final int tagId = await db.createTag('WatchLater', 0xFF2196F3);
+    await db.addTagToVideoBook('video/tagged', tagId);
+
+    await pumpHome(tester);
+
+    expect(
+      tagTextIn('home_video_continue_video/tagged', 'WatchLater'),
+      findsOneWidget,
+      reason: '首页横滚卡必须和墙卡一样画出已打的标签（BUG-1808）',
+    );
+    expect(
+      tagTextIn('home_video_continue_video/plain', 'WatchLater'),
+      findsNothing,
+      reason: '标签只属于打过它的那条视频，不得整行铺开',
+    );
+  });
+
+  testWidgets('最近添加行的卡显示该视频的标签', (WidgetTester tester) async {
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value<String>('video/fresh'),
+      title: const Value<String>('Fresh Show'),
+      videoPath: const Value<String>('/abs/fresh.mp4'),
+      importedAt: Value<int>(nowMs),
+    ));
+    final int tagId = await db.createTag('Backlog', 0xFF4CAF50);
+    await db.addTagToVideoBook('video/fresh', tagId);
+
+    await pumpHome(tester);
+
+    expect(
+      tagTextIn('home_video_recent_video/fresh', 'Backlog'),
+      findsOneWidget,
+      reason: '「最近添加」行卡与「继续观看」同一标签口径',
+    );
+  });
+
+  testWidgets('继续观看行的合集卡显示合集自己的标签', (WidgetTester tester) async {
+    final int cid =
+        await db.createMediaCollection('MyShow', collectionType: 'playlist');
+    await seedInProgress('video/ep1', 'Ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep1');
+    final int tagId = await db.createTag('Airing', 0xFFFF9800);
+    await db.addTagToCollection(cid, tagId);
+
+    await pumpHome(tester);
+
+    expect(
+      tagTextIn('home_video_continue_collection_$cid', 'Airing'),
+      findsOneWidget,
+      reason: '合集的标签走 collectionTagMapProvider，与合集墙卡同一口径',
+    );
+  });
+}

--- a/fushi/test/pages/home_video_home_row_tags_test.dart
+++ b/fushi/test/pages/home_video_home_row_tags_test.dart
@@ -15,6 +15,10 @@ import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/pages/implementations/home_video_page.dart';
 import 'package:fushi/src/platform/platform_providers.dart';
 import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/remote_library_source.dart';
+import 'package:fushi/src/sync/remote_video_client.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -80,7 +84,11 @@ void main() {
     }
   });
 
-  Widget buildApp() => ProviderScope(
+  Widget buildApp({
+    VideoLibrarySection section = VideoLibrarySection.home,
+    List<RemoteVideoInfo> remote = const <RemoteVideoInfo>[],
+  }) =>
+      ProviderScope(
         overrides: <Override>[
           platformServicesProvider.overrideWithValue(platformServices),
           ankiRepositoryProvider.overrideWithValue(ankiRepository),
@@ -91,19 +99,26 @@ void main() {
             home: Scaffold(
               body: HomeVideoPage(
                 repo: VideoBookRepository(db),
-                section: VideoLibrarySection.home,
+                section: section,
+                remoteVideoClientLoader: remote.isEmpty
+                    ? null
+                    : () async => _ListFakeRemoteVideoClient(remote),
               ),
             ),
           ),
         ),
       );
 
-  Future<void> pumpHome(WidgetTester tester) async {
-    tester.view.physicalSize = const Size(1400, 1600);
+  Future<void> pumpHome(
+    WidgetTester tester, {
+    VideoLibrarySection section = VideoLibrarySection.home,
+    List<RemoteVideoInfo> remote = const <RemoteVideoInfo>[],
+  }) async {
+    tester.view.physicalSize = const Size(1400, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
-    await tester.pumpWidget(buildApp());
+    await tester.pumpWidget(buildApp(section: section, remote: remote));
     await tester.pumpAndSettle();
   }
 
@@ -177,4 +192,138 @@ void main() {
       reason: '合集的标签走 collectionTagMapProvider，与合集墙卡同一口径',
     );
   });
+
+  // ── 远端占位卡：host 清单下发的是标签**名**（标签本身每设备本地） ──────────
+
+  testWidgets('继续观看行的远端占位卡显示 host 下发的标签', (WidgetTester tester) async {
+    await pumpHome(
+      tester,
+      remote: const <RemoteVideoInfo>[
+        RemoteVideoInfo(
+          id: 'video/remote-watching',
+          title: 'Remote Watching',
+          positionMs: 60000,
+          positionUpdatedAtMs: 1700000000000,
+          tags: <String>['HostTag'],
+        ),
+      ],
+    );
+
+    expect(
+      tagTextIn('home_video_continue_remote_video_remote-watching', 'HostTag'),
+      findsOneWidget,
+      reason: 'RemoteVideoInfo.tags 一直在清单里，远端卡不该是唯一看不到标签的卡',
+    );
+  });
+
+  testWidgets('远端标签借本机同名标签的颜色，本机没有则走 chip 默认色',
+      (WidgetTester tester) async {
+    const int knownColor = 0xFF9C27B0;
+    await db.createTag('Known', knownColor);
+
+    await pumpHome(
+      tester,
+      remote: const <RemoteVideoInfo>[
+        RemoteVideoInfo(
+          id: 'video/remote-colored',
+          title: 'Remote Colored',
+          positionMs: 60000,
+          positionUpdatedAtMs: 1700000000000,
+          tags: <String>['Known', 'Unknown'],
+        ),
+      ],
+    );
+
+    final FushiTagChip known = tester.widget<FushiTagChip>(find.ancestor(
+      of: find.text('Known'),
+      matching: find.byType(FushiTagChip),
+    ));
+    final FushiTagChip unknown = tester.widget<FushiTagChip>(find.ancestor(
+      of: find.text('Unknown'),
+      matching: find.byType(FushiTagChip),
+    ));
+
+    expect(known.color, const Color(knownColor),
+        reason: '本机有同名标签就借它的颜色，两端看同一条标签颜色才一致');
+    expect(unknown.color, isNull,
+        reason: 'host 只下发名字，本机没这条标签时不得凭空造颜色');
+  });
+
+  testWidgets('「全部视频」墙格里的远端占位卡也显示标签（与字幕角标并成一列）',
+      (WidgetTester tester) async {
+    await pumpHome(
+      tester,
+      section: VideoLibrarySection.allVideos,
+      remote: const <RemoteVideoInfo>[
+        RemoteVideoInfo(
+          id: 'video/remote-wall',
+          title: 'Remote Wall',
+          hasSubtitle: true,
+          tags: <String>['WallTag'],
+        ),
+      ],
+    );
+
+    expect(
+      tagTextIn('remote_video_card_video_remote-wall', 'WallTag'),
+      findsOneWidget,
+      reason: '墙格远端卡此前左上角只有字幕角标，标签整层缺失',
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(
+            const ValueKey<String>('remote_video_card_video_remote-wall')),
+        matching: find.byIcon(Icons.subtitles_outlined),
+      ),
+      findsOneWidget,
+      reason: '补标签不能把字幕角标挤掉——两者并成一列，谁都不遮谁',
+    );
+  });
+}
+
+class _ListFakeRemoteVideoClient implements RemoteVideoClient {
+  _ListFakeRemoteVideoClient(this._videos);
+  final List<RemoteVideoInfo> _videos;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async => _videos;
+
+  @override
+  Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(String id,
+          {int episodeIndex = 0}) async =>
+      const RemoteVideoStreamUrls(streamUrl: 'http://x/stream');
+
+  @override
+  Future<void> getRemoteVideoSubtitle(
+    String id,
+    File dest, {
+    int? embeddedStreamIndex,
+    void Function(double progress)? onProgress,
+    int episodeIndex = 0,
+  }) async {}
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async {}
+
+  @override
+  Future<({int positionMs, int updatedAtMs})> remoteVideoPosition(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      (positionMs: 0, updatedAtMs: 0);
+
+  @override
+  Future<void> putRemoteVideoPosition(
+    String id,
+    int positionMs,
+    int updatedAtMs, {
+    int episodeIndex = 0,
+  }) async {}
 }


### PR DESCRIPTION
用户报「首页少了标签，我打好的标签没在首页显示」，澄清后定位为**视频首页的视频卡不显示标签**。

## 根因

`fde80d7189`（series-first 拆库）把视频页拆成 `home / series / allVideos` 三个 section 后，墙格 sliver 只挂在后两个 section 上，`home` 只剩 `_buildOverviewSection`（hero + 继续观看 / 下一集 / 最近添加 三条横滚行）。

标签 chip 当时只写在墙格散卡 `_buildCard` 与合集墙卡 `_buildCollectionCoverCard` 上，横滚卡 `_buildRowMediaCard` 自引入起就没有标签层 —— 于是拆分当天起首页一个标签都不显示。标签本身写穿了 DB，只是没人画。

## 改动

- `_buildRowMediaCard` 增加 `tags` 参数，在封面左上角（`top:6/left:6`，与墙卡同位同形）渲染 `_buildTagLabels`。右上是「新」/集数角标、右下是云角标，互不重叠；横滚卡不参与勾选，无让位问题。
- 继续观看散卡 / 继续观看合集卡 / 最近添加卡三个调用点接上数据源；远端占位卡无本地条目、无标签，保持不传。
- 散卡与合集卡各自 inline 的 `ref.watch(...)` 收敛成 `_videoBookTags(bookUid)` / `_collectionTags(collectionId)`，墙卡与横滚卡共用同一口径 —— 首页当初漏画，正是因为标签只跟着墙卡那一处写法走。

## 验证

- `fushi/test/pages/home_video_home_row_tags_test.dart` 新增 3 条 widget 行为断言（散卡显示自己的标签且不铺到邻卡 / 最近添加卡 / 继续观看合集卡）。
- 变异实测：给标签层加 `&& !kMutationProbe1808` 关掉渲染 → 3 条全红；还原后源文件 SHA-256 与变异前逐字节一致（`6dee4a45…2eecf`）。
- `flutter analyze` 全量 No issues found。
- 定向测试 21 tests PASSED（本测试 + `home_video_home_rows_remote` / `collection_cover_card` / `cover_badge` / `partition` / `sort_mode`）。
- 目录枚举型守卫整批 250 tests PASSED（与文档基线一致）。

未动：首页 hero 轮播（backdrop 大图版式，与卡片角标口径不同）。

BUG-1808

https://claude.ai/code/session_01A4HH5Q29dCbmMsuA47Vgyy