### PR TITLE
fix(ui): 库页顶栏分区导航改走 MD3 tabs；视频页发现归位到本地库之后

### DIFF
--- a/fushi/lib/src/pages/implementations/downloads_page.dart
+++ b/fushi/lib/src/pages/implementations/downloads_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:fushi/src/focus/fushi_focus_controller.dart';
-
 import 'package:fushi/src/media/manga/online/mokuro_moe_tasks_section.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
 import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
@@ -210,65 +208,46 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     );
   }
 
-  /// 统一门头：分段条（资源 / 任务 / 订阅 / 设置）作页头主位 + 页头动作，与其余
-  /// 顶层库页同构。分段条选中态跟随 [TabController]（横滑切页后高亮同步），点段
-  /// 走 animateTo；独立 push 进来（无 home 壳）时在 leading 位保留返回按钮——
-  /// 旧 AppBar 的自动返回键由这里承接。
+  /// 统一门头：分区导航（资源 / 任务 / 订阅 / 设置）作页头主位 + 页头动作，与其余
+  /// 顶层库页同构；独立 push 进来（无 home 壳）时在 leading 位保留返回按钮——旧
+  /// AppBar 的自动返回键由这里承接。
+  ///
+  /// 走 [LibrarySectionTabs.controlled]：本页的 [TabController] 同时驱动 [TabBarView]，
+  /// 交给导航组件共用那一个即可。此前这里是「分段条镜像 controller」——外面套
+  /// [AnimatedBuilder] 读 index、点段回调 animateTo，两处都只是把 controller 的状态
+  /// 抄一遍；抄出来的指示器在横滑 TabBarView 时只能在越过一半时跳一下，共用同一个
+  /// controller 才跟手连续滑动。
   Widget _buildHeader(BuildContext tabContext) {
-    final TabController tabController = DefaultTabController.of(tabContext);
     final bool canPop = Navigator.of(context).canPop();
-    return AnimatedBuilder(
-      animation: tabController,
-      builder: (BuildContext context, _) {
-        final int index = tabController.index;
-        void select(int value) {
-          if (value != tabController.index) tabController.animateTo(value);
-        }
-
-        return FushiPageHeader.customTitle(
-          leading: canPop
-              ? FushiIconButton(
-                  icon: Icons.arrow_back,
-                  tooltip: t.back,
-                  onTap: () => Navigator.of(context).maybePop(),
-                )
-              : null,
-          title: FushiAdjustableSegmented<int>(
-            values: const <int>[0, 1, 2, 3],
-            selected: index,
-            onChanged: select,
-            focusIdPrefix: 'downloads-tab',
-            focusId: const FushiFocusId('downloads-tab-sections'),
-            child: FushiSegmentedStrip<int>(
-              segments: <ButtonSegment<int>>[
-                ButtonSegment<int>(
-                  value: 0,
-                  label: Text(t.download_resources_tab),
-                ),
-                ButtonSegment<int>(value: 1, label: Text(t.download_tasks_tab)),
-                ButtonSegment<int>(
-                  value: 2,
-                  label: Text(t.download_subscriptions_tab),
-                ),
-                ButtonSegment<int>(value: 3, label: Text(t.settings)),
-              ],
-              selected: index,
-              onChanged: select,
-            ),
-          ),
-          // 页头动作只留「添加任务」（2026-08-21 用户点名）：旧「放送日历」
-          // 「在线目录」入口都不是下载动作，前者迁往发现页（独立改造），后者
-          // 在漫画库页「浏览」视图仍然可达。
-          actions: <Widget>[
-            FushiIconButton(
-              icon: Icons.add,
-              tooltip: t.download_task_add,
-              label: t.download_task_add,
-              onTap: _openManualTaskDialog,
-            ),
-          ],
-        );
-      },
+    return FushiPageHeader.customTitle(
+      leading: canPop
+          ? FushiIconButton(
+              icon: Icons.arrow_back,
+              tooltip: t.back,
+              onTap: () => Navigator.of(context).maybePop(),
+            )
+          : null,
+      title: LibrarySectionTabs<int>.controlled(
+        tabs: <LibrarySectionTab<int>>[
+          LibrarySectionTab<int>(value: 0, label: t.download_resources_tab),
+          LibrarySectionTab<int>(value: 1, label: t.download_tasks_tab),
+          LibrarySectionTab<int>(value: 2, label: t.download_subscriptions_tab),
+          LibrarySectionTab<int>(value: 3, label: t.settings),
+        ],
+        controller: DefaultTabController.of(tabContext),
+        focusIdPrefix: 'downloads-tab',
+      ),
+      // 页头动作只留「添加任务」（2026-08-21 用户点名）：旧「放送日历」
+      // 「在线目录」入口都不是下载动作，前者迁往发现页（独立改造），后者
+      // 在漫画库页「浏览」视图仍然可达。
+      actions: <Widget>[
+        FushiIconButton(
+          icon: Icons.add,
+          tooltip: t.download_task_add,
+          label: t.download_task_add,
+          onTap: _openManualTaskDialog,
+        ),
+      ],
     );
   }
 

--- a/fushi/lib/src/pages/implementations/video_library_shell.dart
+++ b/fushi/lib/src/pages/implementations/video_library_shell.dart
@@ -130,11 +130,6 @@ class _VideoLibraryShellState extends State<VideoLibraryShell> {
           value: VideoLibrarySection.home,
           label: t.nav_home,
         ),
-        // 与书 / 漫画 / 游戏的发现视图同 key（同概念一词,原 video_discovery_tab 已删）。
-        LibrarySectionTab<VideoLibrarySection>(
-          value: VideoLibrarySection.discover,
-          label: t.library_view_browse,
-        ),
         LibrarySectionTab<VideoLibrarySection>(
           value: VideoLibrarySection.series,
           label: t.series,
@@ -142,6 +137,14 @@ class _VideoLibraryShellState extends State<VideoLibraryShell> {
         LibrarySectionTab<VideoLibrarySection>(
           value: VideoLibrarySection.allVideos,
           label: t.video_library_all_videos,
+        ),
+        // 与书 / 漫画 / 游戏的发现视图同 key（同概念一词,原 video_discovery_tab 已删），
+        // **也同位**：本地库的各视图排完才是在线发现，最后才是管理类分区。此前发现夹在
+        // 首页与系列 / 全部视频之间，一排里「自己的库 → 推荐 → 自己的库」来回跳，是四个
+        // 模块里唯一的例外（2026-08-24 用户反馈）。
+        LibrarySectionTab<VideoLibrarySection>(
+          value: VideoLibrarySection.discover,
+          label: t.library_view_browse,
         ),
         LibrarySectionTab<VideoLibrarySection>(
           value: VideoLibrarySection.sources,

--- a/fushi/lib/src/utils/components/library_section_tabs.dart
+++ b/fushi/lib/src/utils/components/library_section_tabs.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
-import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/utils/components/settings_shared.dart';
 
@@ -152,23 +151,14 @@ class _FushiSectionTabBarState<T extends Object>
 
   @override
   Widget build(BuildContext context) {
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final double fontSize = tokens.type.controlLabel.fontSize ?? 14.0;
-    final double textScale = MediaQuery.textScalerOf(context).scale(1);
     // 自然宽是纯 build 期可算量（只依赖文案 / 字号 / 缩放）：页头用它判定「左边摆得
-    // 下吗」，据此决定是否把动作收进 ⋯ 菜单。tab 各自取宽，故是逐段求和而不是
-    // 「段数 × 最宽段」——后者是等宽分段条的算法，用在这里会高估近一倍。
-    double naturalWidth = 0.0;
-    for (final LibrarySectionTab<T> tab in widget.tabs) {
-      naturalWidth += estimateLabelAdvanceWidth(
-            label: tab.label,
-            fontSize: fontSize,
-            textScaleFactor: textScale,
-          ) +
-          _kSectionTabHorizontalPadding * 2;
-    }
+    // 下吗」，据此决定是否把动作收进 ⋯ 菜单。
     FushiHeaderCrampScope.maybeOf(context)?.reportTitleNaturalWidth(
-      naturalWidth,
+      estimateSectionTabBarWidth(
+        context,
+        <String>[for (final LibrarySectionTab<T> tab in widget.tabs) tab.label],
+        horizontalPaddingPerTab: _kSectionTabHorizontalPadding,
+      ),
     );
 
     _scheduleProjection();

--- a/fushi/lib/src/utils/components/library_section_tabs.dart
+++ b/fushi/lib/src/utils/components/library_section_tabs.dart
@@ -128,12 +128,24 @@ class _FushiSectionTabBarState<T extends Object>
     super.dispose();
   }
 
-  /// 把 controller 拉回 [widget.selected] 的投影。同值直接返回，不会自激。
+  bool _projectionScheduled = false;
+
+  /// 把 controller 拉回 [widget.selected] 的投影。
+  ///
+  /// 判据只看 `_controller.index`——切换动画进行中它已经是**目标**下标，此时无需干预，
+  /// 让动画自己走完；若还去 `animateTo` 同一个下标，只会把动画反复推倒重来。
+  ///
+  /// build 与 onTap 各调一次，缺一不可：宿主接受本次切换时走 build（父 rebuild），
+  /// 宿主**拒绝**时父可能根本不 rebuild（游戏页「设置」段可由宿主改成打开别的页面），
+  /// 那一路只剩 onTap 这次校正把指示器拉回真正生效的分区。一帧内去重。
   void _scheduleProjection() {
+    if (_projectionScheduled) return;
+    _projectionScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((Duration _) {
+      _projectionScheduled = false;
       if (!mounted) return;
       final int index = _selectedIndex;
-      if (_controller.index == index && !_controller.indexIsChanging) return;
+      if (_controller.index == index) return;
       _controller.animateTo(index);
     });
   }
@@ -170,7 +182,12 @@ class _FushiSectionTabBarState<T extends Object>
       // MD3 的 tab 分隔线会横贯整条 TabBar，而这里 TabBar 只占页头标题槽、右边还有
       // 动作区——画出来是条半截线，故去掉；页头自身的留白已经分隔了内容。
       dividerHeight: 0,
-      onTap: (int index) => widget.onChanged(widget.tabs[index].value),
+      onTap: (int index) {
+        widget.onChanged(widget.tabs[index].value);
+        // TabBar 已把指示器移过去了；宿主若不接受这次切换（不改 selected、也不
+        // rebuild），得靠这次校正把它拉回来。
+        _scheduleProjection();
+      },
       tabs: <Widget>[
         for (final LibrarySectionTab<T> tab in widget.tabs)
           Tab(text: tab.label),

--- a/fushi/lib/src/utils/components/library_section_tabs.dart
+++ b/fushi/lib/src/utils/components/library_section_tabs.dart
@@ -40,34 +40,95 @@ class LibrarySectionTab<T> {
 /// * 页头协作——经 [FushiHeaderCrampScope] 上报自然宽，页头据此决定窄屏是否把动作
 ///   收进 ⋯ 菜单。
 class LibrarySectionTabs<T extends Object> extends StatelessWidget {
+  /// 组件自持选中态：宿主只给「当前是哪个」和「点了哪个」，内部 [TabController]
+  /// 是 [selected] 的投影。四个库页壳（书架 / 漫画 / 视频 / 游戏）用这个形态——
+  /// 它们的子视图是 [Offstage] 保活的独立页面，页内没有 [TabBarView]。
   const LibrarySectionTabs({
     required this.tabs,
-    required this.selected,
-    required this.onChanged,
+    required T this.selected,
+    required ValueChanged<T> this.onChanged,
     required this.focusIdPrefix,
     super.key,
-  });
+  }) : controller = null;
+
+  /// 宿主已持有 [TabController]（页内还有 [TabBarView] 由它驱动）：直接共用那一个，
+  /// **不**再镜像出第二份选中态。
+  ///
+  /// 差别不只是少一个对象：镜像形态下横滑 [TabBarView] 时，宿主 index 只在越过一半
+  /// 时跳变，镜像出的指示器只能跟着 `animateTo` 一跳；共用同一个 controller 时指示器
+  /// 跟手连续滑动，那才是 MD3 tabs 与 [TabBarView] 配对时的正常行为。
+  ///
+  /// 值域即下标：`tabs[i].value` 必须与 controller 的第 i 个 tab 对应。
+  const LibrarySectionTabs.controlled({
+    required this.tabs,
+    required TabController this.controller,
+    required this.focusIdPrefix,
+    super.key,
+  })  : selected = null,
+        onChanged = null;
 
   final List<LibrarySectionTab<T>> tabs;
-  final T selected;
-  final ValueChanged<T> onChanged;
+
+  /// 仅自持形态；[LibrarySectionTabs.controlled] 下为 null（真相在 [controller]）。
+  final T? selected;
+  final ValueChanged<T>? onChanged;
+
+  /// 仅 [LibrarySectionTabs.controlled] 形态；自持形态下为 null。
+  final TabController? controller;
 
   /// focusId 前缀（如 `game-library-tab`），焦点停靠点 id 为 `<prefix>-sections`。
   final String focusIdPrefix;
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _focusShell({
+    required T selectedValue,
+    required ValueChanged<T> onSelect,
+    required Widget child,
+  }) {
     return FushiAdjustableSegmented<T>(
       values: <T>[for (final LibrarySectionTab<T> tab in tabs) tab.value],
-      selected: selected,
-      onChanged: onChanged,
+      selected: selectedValue,
+      onChanged: onSelect,
       focusIdPrefix: focusIdPrefix,
       focusId: FushiFocusId('$focusIdPrefix-sections'),
-      child: FushiSectionTabBar<T>(
-        tabs: tabs,
-        selected: selected,
-        onChanged: onChanged,
-      ),
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TabController? host = controller;
+    if (host == null) {
+      final T selectedValue = selected as T;
+      final ValueChanged<T> onSelect = onChanged!;
+      return _focusShell(
+        selectedValue: selectedValue,
+        onSelect: onSelect,
+        child: FushiSectionTabBar<T>(
+          tabs: tabs,
+          selected: selectedValue,
+          onChanged: onSelect,
+        ),
+      );
+    }
+    // 焦点外壳要的是「当前值 + 怎么切」，从宿主 controller 就地派生；监听它才能让
+    // 横滑 / 外部 animateTo 之后方向键的起点跟着走。
+    return AnimatedBuilder(
+      animation: host,
+      builder: (BuildContext context, Widget? child) {
+        final int index = host.index.clamp(0, tabs.length - 1);
+        return _focusShell(
+          selectedValue: tabs[index].value,
+          onSelect: (T value) {
+            final int target =
+                tabs.indexWhere((LibrarySectionTab<T> tab) => tab.value == value);
+            if (target >= 0 && target != host.index) host.animateTo(target);
+          },
+          child: FushiSectionTabBar<T>.controlled(
+            tabs: tabs,
+            controller: host,
+          ),
+        );
+      },
     );
   }
 }
@@ -79,16 +140,27 @@ class LibrarySectionTabs<T extends Object> extends StatelessWidget {
 /// 情形——游戏页的「设置」段可由宿主改成打开别的页面而不改分区值，此时 [TabBar] 自己
 /// 已经把指示器移过去了，若不校正，指示器会停在一个并未生效的分区上。
 class FushiSectionTabBar<T extends Object> extends StatefulWidget {
+  /// 自持形态：内部 controller 是 [selected] 的投影。
   const FushiSectionTabBar({
     required this.tabs,
-    required this.selected,
-    required this.onChanged,
+    required T this.selected,
+    required ValueChanged<T> this.onChanged,
     super.key,
-  });
+  }) : controller = null;
+
+  /// 宿主持有形态：直接用宿主的 controller（页内 [TabBarView] 也由它驱动），不投影、
+  /// 不接管点击、不负责它的生命周期。
+  const FushiSectionTabBar.controlled({
+    required this.tabs,
+    required TabController this.controller,
+    super.key,
+  })  : selected = null,
+        onChanged = null;
 
   final List<LibrarySectionTab<T>> tabs;
-  final T selected;
-  final ValueChanged<T> onChanged;
+  final T? selected;
+  final ValueChanged<T>? onChanged;
+  final TabController? controller;
 
   @override
   State<FushiSectionTabBar<T>> createState() => _FushiSectionTabBarState<T>();
@@ -96,7 +168,10 @@ class FushiSectionTabBar<T extends Object> extends StatefulWidget {
 
 class _FushiSectionTabBarState<T extends Object>
     extends State<FushiSectionTabBar<T>> with TickerProviderStateMixin {
-  late TabController _controller = _createController();
+  /// 自持形态下由本 State 创建并负责 dispose；宿主持有形态下恒为 null。
+  TabController? _owned;
+
+  TabController get _controller => widget.controller ?? _owned!;
 
   int get _selectedIndex {
     final int index = widget.tabs
@@ -111,19 +186,35 @@ class _FushiSectionTabBarState<T extends Object>
       );
 
   @override
+  void initState() {
+    super.initState();
+    if (widget.controller == null) _owned = _createController();
+  }
+
+  @override
   void didUpdateWidget(covariant FushiSectionTabBar<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.controller != null) {
+      // 换成宿主持有：自持时期的 controller 不再是任何东西的真相，就地释放。
+      _owned?.dispose();
+      _owned = null;
+      return;
+    }
+    if (_owned == null) {
+      _owned = _createController();
+      return;
+    }
     // 段数变了（模块按能力增删分区）才需要换 controller；选中值的变化由每帧末尾的
     // 投影校正统一承接，不在这里分叉。
     if (widget.tabs.length != oldWidget.tabs.length) {
-      _controller.dispose();
-      _controller = _createController();
+      _owned!.dispose();
+      _owned = _createController();
     }
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _owned?.dispose();
     super.dispose();
   }
 
@@ -161,7 +252,9 @@ class _FushiSectionTabBarState<T extends Object>
       ),
     );
 
-    _scheduleProjection();
+    // 宿主持有 controller 时它本身就是真相，没有第二份要对齐的东西。
+    final bool hostControlled = widget.controller != null;
+    if (!hostControlled) _scheduleProjection();
 
     return TabBar(
       controller: _controller,
@@ -172,12 +265,16 @@ class _FushiSectionTabBarState<T extends Object>
       // MD3 的 tab 分隔线会横贯整条 TabBar，而这里 TabBar 只占页头标题槽、右边还有
       // 动作区——画出来是条半截线，故去掉；页头自身的留白已经分隔了内容。
       dividerHeight: 0,
-      onTap: (int index) {
-        widget.onChanged(widget.tabs[index].value);
-        // TabBar 已把指示器移过去了；宿主若不接受这次切换（不改 selected、也不
-        // rebuild），得靠这次校正把它拉回来。
-        _scheduleProjection();
-      },
+      // 宿主持有形态不接管点击：TabBar 自己 animateTo 那一个 controller，页内的
+      // TabBarView 跟着走，中间不该再插一手。
+      onTap: hostControlled
+          ? null
+          : (int index) {
+              widget.onChanged!(widget.tabs[index].value);
+              // TabBar 已把指示器移过去了；宿主若不接受这次切换（不改 selected、
+              // 也不 rebuild），得靠这次校正把它拉回来。
+              _scheduleProjection();
+            },
       tabs: <Widget>[
         for (final LibrarySectionTab<T> tab in widget.tabs)
           Tab(text: tab.label),

--- a/fushi/lib/src/utils/components/library_section_tabs.dart
+++ b/fushi/lib/src/utils/components/library_section_tabs.dart
@@ -1,19 +1,15 @@
 import 'package:flutter/material.dart';
 
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/utils/components/settings_shared.dart';
 
-/// 库页顶栏分段导航的统一每段最小宽（逻辑像素）。
+/// MD3 tab 的左右内边距（逻辑像素，单侧）。
 ///
-/// TODO-2937：书架 / 漫画 / 视频 / 游戏四个模块的顶栏分段各自按本页最长文案取
-/// 宽，段数与字数不同导致四页的分段块宽窄不一、观感割裂。统一下限后，常规中文
-/// 文案（≤5 字）在四页渲染成等宽块；更长文案（其他语言）仍按该条最长段等宽放
-/// 大，放不下时先退自然宽、再退横向滚动（见 [FushiSegmentedStrip.minSegmentWidth]），
-/// 手机窄屏行为不变。
-/// 取值 = 5 个 CJK 字的估宽（5 × 14）+ 每段 chrome（28）。定值时最长中文顶栏
-/// 文案是 5 字「捕获工作台」；该页签后改短为 3 字「工作台」（TODO-2937 拍板），
-/// 保留 5 字下限维持改名前的四页等宽观感，并为 ≤5 字的中文文案留余量。
-const double kLibrarySectionTabMinSegmentWidth = 98.0;
+/// 与 framework 的 `_kTabLabelPadding`（`EdgeInsets.symmetric(horizontal: 16)`）
+/// 同值：自然宽估算必须与真实布局同口径，否则页头的「摆不摆得下」会判错。
+const double _kSectionTabHorizontalPadding = 16.0;
 
 /// [LibrarySectionTabs] 的一段：值 + 用户可读标签。
 class LibrarySectionTab<T> {
@@ -23,14 +19,27 @@ class LibrarySectionTab<T> {
   final String label;
 }
 
-/// 库页（书架 / 漫画 / 视频 / 游戏）顶栏共用的分段导航。
+/// 库页（书架 / 漫画 / 视频 / 游戏）顶栏共用的分区导航，形态是 MD3 primary tabs。
 ///
-/// 收敛点（TODO-2937）：此前 [MediaLibraryShell]、`VideoLibraryShell`、
-/// `GameSectionTabs` 三处各自拼一遍「[FushiAdjustableSegmented] +
-/// [FushiSegmentedStrip]」，样式细节（每段宽度、focusId 约定）随调用点漂移。
-/// 本组件把这对组合与顶栏统一样式收成唯一实现：
-/// - 单个焦点停靠点，focusId 恒为 `<focusIdPrefix>-sections`，左右方向键原地切段；
-/// - 每段宽度下限 [kLibrarySectionTabMinSegmentWidth]，四个模块顶栏观感一致。
+/// 为什么是 tabs 而不是分段按钮（2026-08-24 改）：这排控件切的是**六个互相独立的
+/// 目的地**（发现 / 来源 / 设置各自是独立页面、独立 State），是页面级导航。MD3 对
+/// 分段按钮的规定是「affects section-level views and should not be considered a
+/// replacement for navigational tabs」——用错控件带来两个可见后果，用户都报过：
+/// * 分段按钮是**等宽**控件，六段按最长文案取宽后远超页头标题槽，手机上必然溢出，
+///   尾段被切成半个胶囊（看着像渲染 bug，而不是「右边还有」）；
+/// * 为了让它当导航用，此前堆了统一最小段宽、自然宽估算、两侧渐隐、选中段自动滚入、
+///   桌面鼠标拖滚一整套补丁（TODO-2937 / BUG-1719 / BUG-1184）——全是 tabs 自带的。
+///
+/// 换成 [TabBar] 后：滚动是它的正常形态而非降级；tab 按各自文案取宽（中文顶栏文案
+/// 下比等宽分段窄约三分之一，多数窗口直接不再需要滚）；四个模块共用同一实现、同一
+/// 指示器与内边距，观感一致由「同一个控件」保证，不再依赖估算出来的等宽下限。
+///
+/// 保持不变的两件事：
+/// * 焦点契约——外层仍是 [FushiAdjustableSegmented]，整排是**单个**焦点停靠点
+///   （focusId 恒为 `<focusIdPrefix>-sections`），左右方向键 / D-pad 原地切段，
+///   内部 tab 由该外壳的 [ExcludeFocus] 移出遍历，鼠标点击不受影响；
+/// * 页头协作——经 [FushiHeaderCrampScope] 上报自然宽，页头据此决定窄屏是否把动作
+///   收进 ⋯ 菜单。
 class LibrarySectionTabs<T extends Object> extends StatelessWidget {
   const LibrarySectionTabs({
     required this.tabs,
@@ -55,15 +64,117 @@ class LibrarySectionTabs<T extends Object> extends StatelessWidget {
       onChanged: onChanged,
       focusIdPrefix: focusIdPrefix,
       focusId: FushiFocusId('$focusIdPrefix-sections'),
-      child: FushiSegmentedStrip<T>(
-        segments: <ButtonSegment<T>>[
-          for (final LibrarySectionTab<T> tab in tabs)
-            ButtonSegment<T>(value: tab.value, label: Text(tab.label)),
-        ],
+      child: FushiSectionTabBar<T>(
+        tabs: tabs,
         selected: selected,
         onChanged: onChanged,
-        minSegmentWidth: kLibrarySectionTabMinSegmentWidth,
       ),
+    );
+  }
+}
+
+/// [LibrarySectionTabs] 的呈现层：受控的 MD3 [TabBar]。
+///
+/// 「受控」指 [TabController] 只是 [selected] 的投影，不是第二份真相：每帧结束都把
+/// controller 拉回 [selected] 对应的下标。这条不变式覆盖了宿主**拒绝**本次切换的
+/// 情形——游戏页的「设置」段可由宿主改成打开别的页面而不改分区值，此时 [TabBar] 自己
+/// 已经把指示器移过去了，若不校正，指示器会停在一个并未生效的分区上。
+class FushiSectionTabBar<T extends Object> extends StatefulWidget {
+  const FushiSectionTabBar({
+    required this.tabs,
+    required this.selected,
+    required this.onChanged,
+    super.key,
+  });
+
+  final List<LibrarySectionTab<T>> tabs;
+  final T selected;
+  final ValueChanged<T> onChanged;
+
+  @override
+  State<FushiSectionTabBar<T>> createState() => _FushiSectionTabBarState<T>();
+}
+
+class _FushiSectionTabBarState<T extends Object>
+    extends State<FushiSectionTabBar<T>> with TickerProviderStateMixin {
+  late TabController _controller = _createController();
+
+  int get _selectedIndex {
+    final int index = widget.tabs
+        .indexWhere((LibrarySectionTab<T> tab) => tab.value == widget.selected);
+    return index < 0 ? 0 : index;
+  }
+
+  TabController _createController() => TabController(
+        length: widget.tabs.length,
+        initialIndex: _selectedIndex,
+        vsync: this,
+      );
+
+  @override
+  void didUpdateWidget(covariant FushiSectionTabBar<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 段数变了（模块按能力增删分区）才需要换 controller；选中值的变化由每帧末尾的
+    // 投影校正统一承接，不在这里分叉。
+    if (widget.tabs.length != oldWidget.tabs.length) {
+      _controller.dispose();
+      _controller = _createController();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// 把 controller 拉回 [widget.selected] 的投影。同值直接返回，不会自激。
+  void _scheduleProjection() {
+    WidgetsBinding.instance.addPostFrameCallback((Duration _) {
+      if (!mounted) return;
+      final int index = _selectedIndex;
+      if (_controller.index == index && !_controller.indexIsChanging) return;
+      _controller.animateTo(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final double fontSize = tokens.type.controlLabel.fontSize ?? 14.0;
+    final double textScale = MediaQuery.textScalerOf(context).scale(1);
+    // 自然宽是纯 build 期可算量（只依赖文案 / 字号 / 缩放）：页头用它判定「左边摆得
+    // 下吗」，据此决定是否把动作收进 ⋯ 菜单。tab 各自取宽，故是逐段求和而不是
+    // 「段数 × 最宽段」——后者是等宽分段条的算法，用在这里会高估近一倍。
+    double naturalWidth = 0.0;
+    for (final LibrarySectionTab<T> tab in widget.tabs) {
+      naturalWidth += estimateLabelAdvanceWidth(
+            label: tab.label,
+            fontSize: fontSize,
+            textScaleFactor: textScale,
+          ) +
+          _kSectionTabHorizontalPadding * 2;
+    }
+    FushiHeaderCrampScope.maybeOf(context)?.reportTitleNaturalWidth(
+      naturalWidth,
+    );
+
+    _scheduleProjection();
+
+    return TabBar(
+      controller: _controller,
+      isScrollable: true,
+      // 可滚动 TabBar 默认留 52px 起始缩进（[TabAlignment.startOffset]）；顶栏里
+      // 首段必须与页头标题左缘对齐，故贴左。
+      tabAlignment: TabAlignment.start,
+      // MD3 的 tab 分隔线会横贯整条 TabBar，而这里 TabBar 只占页头标题槽、右边还有
+      // 动作区——画出来是条半截线，故去掉；页头自身的留白已经分隔了内容。
+      dividerHeight: 0,
+      onTap: (int index) => widget.onChanged(widget.tabs[index].value),
+      tabs: <Widget>[
+        for (final LibrarySectionTab<T> tab in widget.tabs)
+          Tab(text: tab.label),
+      ],
     );
   }
 }

--- a/fushi/lib/src/utils/components/settings_shared.dart
+++ b/fushi/lib/src/utils/components/settings_shared.dart
@@ -877,6 +877,34 @@ double _segmentLabelContentWidth(String label, double scaledFont) =>
       textScaleFactor: 1.0,
     );
 
+/// 估算一排 MD3 tab（库页顶栏 [LibrarySectionTabs]）按各自文案取宽时的自然总宽
+/// （逻辑像素）。[horizontalPaddingPerTab] 是单侧 label 内边距。
+///
+/// 逐段求和，不是「段数 × 最宽段」——后者是等宽分段条 [estimateSegmentedStripWidth]
+/// 的算法，tab 各自取宽，用错会高估近一倍。
+///
+/// 字号 / 文字缩放在这里就地取自 tokens 与 [MediaQuery]，调用点不再重复那三行样板，
+/// 也不必自己碰 `fontSize`——顶栏字号是共享组件层的决策，页面侧不该重开。
+double estimateSectionTabBarWidth(
+  BuildContext context,
+  List<String> labels, {
+  required double horizontalPaddingPerTab,
+}) {
+  final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+  final double fontSize = tokens.type.controlLabel.fontSize ?? 14.0;
+  final double textScaleFactor = MediaQuery.textScalerOf(context).scale(1);
+  double total = 0.0;
+  for (final String label in labels) {
+    total += estimateLabelAdvanceWidth(
+          label: label,
+          fontSize: fontSize,
+          textScaleFactor: textScaleFactor,
+        ) +
+        horizontalPaddingPerTab * 2;
+  }
+  return total;
+}
+
 /// 一段标签文案的估算横向进距（逻辑像素），CJK / 全角按 1em、其余按 0.62em。
 ///
 /// Build 期可算（只依赖文案 / 字号 / 文字缩放，不依赖布局），供两类顶栏控件共用：

--- a/fushi/lib/src/utils/components/settings_shared.dart
+++ b/fushi/lib/src/utils/components/settings_shared.dart
@@ -870,7 +870,25 @@ const double _kSegmentNarrowGlyphWidthFactor = 0.62;
 
 /// Estimated advance width of [label] (logical pixels) at [scaledFont],
 /// classifying each rune as wide (CJK/fullwidth, >= U+1100) or narrow.
-double _segmentLabelContentWidth(String label, double scaledFont) {
+double _segmentLabelContentWidth(String label, double scaledFont) =>
+    estimateLabelAdvanceWidth(
+      label: label,
+      fontSize: scaledFont,
+      textScaleFactor: 1.0,
+    );
+
+/// 一段标签文案的估算横向进距（逻辑像素），CJK / 全角按 1em、其余按 0.62em。
+///
+/// Build 期可算（只依赖文案 / 字号 / 文字缩放，不依赖布局），供两类顶栏控件共用：
+/// [segmentedStripCellWidth]（分段条的等宽单元格）与库页顶栏 [LibrarySectionTabs]
+/// 的 tab 自然宽。两者的换行 / 滚动兜底判据必须出自同一张字宽表，否则同一批文案
+/// 在两个控件上会得出不同的「摆得下吗」结论。
+double estimateLabelAdvanceWidth({
+  required String label,
+  required double fontSize,
+  required double textScaleFactor,
+}) {
+  final double scaledFont = fontSize * textScaleFactor;
   double width = 0.0;
   for (final int rune in label.runes) {
     width += scaledFont *
@@ -1147,12 +1165,15 @@ class FushiSegmentedStrip<T extends Object> extends StatelessWidget {
   final AlignmentGeometry alignment;
 
   /// Uniform per-segment width floor (logical pixels), applied only while the
-  /// widened strip still fits its host. Library-page top bars pass
-  /// [kLibrarySectionTabMinSegmentWidth] so all four modules' section tabs read
-  /// as the same control regardless of per-page label lengths (TODO-2937);
-  /// when the floor does not fit, the strip falls back to its natural width,
-  /// then to horizontal scrolling -- the floor never forces a scroll that the
-  /// natural width would avoid.
+  /// widened strip still fits its host. Callers that host several strips in one
+  /// view pass a shared floor so they read as the same control regardless of
+  /// per-strip label lengths; when the floor does not fit, the strip falls back
+  /// to its natural width, then to horizontal scrolling -- the floor never
+  /// forces a scroll that the natural width would avoid.
+  ///
+  /// 库页顶栏曾是本参数最大的消费者（TODO-2937 的统一段宽），2026-08-24 起顶栏改走
+  /// MD3 tabs（[LibrarySectionTabs]），四页观感一致由「同一个控件」保证，不再需要
+  /// 估算出来的等宽下限。
   final double? minSegmentWidth;
 
   @override

--- a/fushi/test/media/drag_drop/drop_surface_gate_widget_test.dart
+++ b/fushi/test/media/drag_drop/drop_surface_gate_widget_test.dart
@@ -195,8 +195,8 @@ void main() {
 
       dropped.clear();
       tester
-          .widget<FushiSegmentedStrip<MediaLibraryViewKind>>(
-            find.byType(FushiSegmentedStrip<MediaLibraryViewKind>),
+          .widget<FushiSectionTabBar<MediaLibraryViewKind>>(
+            find.byType(FushiSectionTabBar<MediaLibraryViewKind>),
           )
           .onChanged(MediaLibraryViewKind.discover);
       await tester.pumpAndSettle();
@@ -264,8 +264,8 @@ void main() {
 
       dropped.clear();
       tester
-          .widget<FushiSegmentedStrip<VideoLibrarySection>>(
-            find.byType(FushiSegmentedStrip<VideoLibrarySection>),
+          .widget<FushiSectionTabBar<VideoLibrarySection>>(
+            find.byType(FushiSectionTabBar<VideoLibrarySection>),
           )
           .onChanged(VideoLibrarySection.discover);
       await tester.pumpAndSettle();

--- a/fushi/test/media/drag_drop/drop_surface_gate_widget_test.dart
+++ b/fushi/test/media/drag_drop/drop_surface_gate_widget_test.dart
@@ -198,7 +198,7 @@ void main() {
           .widget<FushiSectionTabBar<MediaLibraryViewKind>>(
             find.byType(FushiSectionTabBar<MediaLibraryViewKind>),
           )
-          .onChanged(MediaLibraryViewKind.discover);
+          .onChanged!(MediaLibraryViewKind.discover);
       await tester.pumpAndSettle();
 
       await _performOsDrop(tester);
@@ -267,7 +267,7 @@ void main() {
           .widget<FushiSectionTabBar<VideoLibrarySection>>(
             find.byType(FushiSectionTabBar<VideoLibrarySection>),
           )
-          .onChanged(VideoLibrarySection.discover);
+          .onChanged!(VideoLibrarySection.discover);
       await tester.pumpAndSettle();
 
       await _performOsDrop(tester);

--- a/fushi/test/pages/downloads_header_unified_guard_test.dart
+++ b/fushi/test/pages/downloads_header_unified_guard_test.dart
@@ -6,13 +6,18 @@ import '../helpers/source_guard.dart';
 
 /// 门头统一守卫（2026-08-13 用户定案）：下载页此前是全 app 唯一还在用
 /// `AppBar + 居中 TabBar` 门头的顶层 tab，与书 / 漫画 / 视频 / 游戏库页的
-/// `FushiPageHeader.customTitle`（左对齐分段条 + FushiIconButton 动作）不一致。
+/// `FushiPageHeader.customTitle`（左对齐分区导航 + FushiIconButton 动作）不一致。
 /// 本守卫钉死统一后的形态不被回退。
+///
+/// 2026-08-24：库页顶栏改走 MD3 tabs（[LibrarySectionTabs]），本页跟着换，钉死的
+/// 「同范式」随之从分段条变成该共享组件。本页有 [TabBarView]，用
+/// `LibrarySectionTabs.controlled` 与之共用同一个 [TabController]——不是回退到旧
+/// 形态：旧形态是 **AppBar 内嵌居中 TabBar**，下面第四条仍然钉着它。
 ///
 /// 注释与三引号语料先经 [maskCommentsAndScriptLines] 掩掉：源文件的说明注释里
 /// 会提到旧 AppBar 与新范式的名字，裸 contains 会两个方向都误判。
 void main() {
-  test('下载页门头走 FushiPageHeader.customTitle 分段条范式，不再用 AppBar', () {
+  test('下载页门头走 FushiPageHeader.customTitle + 共享分区导航，不再用 AppBar', () {
     final File f = File('lib/src/pages/implementations/downloads_page.dart');
     expect(f.existsSync(), isTrue,
         reason: '找不到 downloads_page.dart（路径变了要同步本守卫）');
@@ -20,8 +25,12 @@ void main() {
 
     expect(code, contains('FushiPageHeader.customTitle'),
         reason: '下载页门头必须与其余顶层库页同范式（分段条作页头主位）');
-    expect(code, contains('FushiSegmentedStrip<int>'),
-        reason: '子页导航必须是统一的分段条组件（可滚不裁字契约由它承接）');
+    expect(code, contains('LibrarySectionTabs<int>.controlled'),
+        reason: '子页导航必须走库页共享的 LibrarySectionTabs；本页有 TabBarView，'
+            '须用 controlled 形态与它共用同一个 TabController（镜像出第二份选中态会让'
+            '横滑时指示器只能跳、不跟手）');
+    expect(code, isNot(contains('FushiSegmentedStrip<')),
+        reason: 'MD3：分段按钮是 section 级单选控件，不得替代导航 tabs');
     expect(code, isNot(contains('appBar: AppBar(')),
         reason: '不得回退到独有的 AppBar 门头（与其它库页不一致）');
     expect(code, isNot(contains('bottom: TabBar(')),

--- a/fushi/test/pages/game_topbar_geometry_bug1719_test.dart
+++ b/fushi/test/pages/game_topbar_geometry_bug1719_test.dart
@@ -21,8 +21,13 @@ import '../helpers/test_platform_services.dart';
 /// 最长标签更窄，「捕获工作台」折成两行，分段条比兄弟页签高 8px——顶栏肉眼可见地
 /// 下沉/跳动。（该页签其后已改短为「工作台」，TODO-2937 拍板；测试断言当前标签。）
 ///
+/// 2026-08-24 起顶栏改走 MD3 tabs（[LibrarySectionTabs] / [FushiSectionTabBar]）：
+/// 等宽布局连同上面那个估算一起退出顶栏，tab 各自按文案取宽，本 bug 的成因在结构上
+/// 消失。两条不变式**原样保留**——它们守的是「切页签时顶栏不许动、标签不许折行」这个
+/// 用户可见结果，与用什么控件实现无关，换控件后同样必须成立。
+///
 /// 守卫两条不变式（zh-CN，多档窗宽）：
-/// 1. 六个子区的分段条 top 与 height 完全一致（切页签顶栏纹丝不动）；
+/// 1. 六个子区的分区导航 top 与 height 完全一致（切页签顶栏纹丝不动）；
 /// 2. 「工作台」（monitor 页签）标签永远单行（任何分支都不允许把段挤到折行）。
 Widget _stubDashboard(BuildContext _, VoidCallback __) => const SizedBox();
 
@@ -62,9 +67,9 @@ void main() {
     await tester.pump();
     final Finder f = find.descendant(
       of: find.byKey(sectionKey),
-      matching: find.byType(SegmentedButton<GameSection>),
+      matching: find.byType(FushiSectionTabBar<GameSection>),
     );
-    expect(f, findsOneWidget, reason: '子区 $section 应有分段条');
+    expect(f, findsOneWidget, reason: '子区 $section 应有分区导航');
     // 「工作台」在该子区的分段条里必须单行（高度 = 一行行高）。折行是
     // BUG-1719 的直接症状：段被钳到比最长标签窄。
     final Finder label = find.descendant(

--- a/fushi/test/pages/library_section_tabs_uniform_test.dart
+++ b/fushi/test/pages/library_section_tabs_uniform_test.dart
@@ -4,18 +4,29 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/utils.dart';
 
-/// TODO-2937：书架 / 漫画 / 视频 / 游戏四个模块的顶栏分段因每页段数与文案长度
-/// 不同而宽窄不一。四页顶栏统一走 [LibrarySectionTabs]（唯一实现），每段宽度
-/// 下限 [kLibrarySectionTabMinSegmentWidth]——常规中文文案（≤5 字）下四页的分段
-/// 块渲染成同一宽度。
+/// 书架 / 漫画 / 视频 / 游戏四个模块的顶栏分区导航统一走 [LibrarySectionTabs]
+/// （唯一实现），形态是 MD3 primary tabs。
+///
+/// 历史（TODO-2937）：顶栏曾是 [SegmentedButton]，那是个**等宽**控件——每段被撑到
+/// 最长段的宽度，于是四页因段数与文案长度不同而宽窄不一，靠一个统一最小段宽
+/// (`kLibrarySectionTabMinSegmentWidth`) 硬垫成同宽。2026-08-24 改走 tabs 后这条
+/// 补丁连同它守的不变式一起作废：tab 各自按文案取宽，四页观感一致由「同一个控件、
+/// 同一套内边距与指示器」保证，不再需要估算出来的下限。
+///
+/// 本文件因此守两件**换控件之后**才成立、且直接对应用户报障的事：
+/// * 同一段文案在任何顶栏配置、任何窗口宽度下渲染同宽（旧等宽方案做不到：一段的
+///   宽度被同排最长段绑架，窄屏还会整体退化）；
+/// * 四页都不许绕过共享组件自己拼一排导航。
 void main() {
   setUp(() => LocaleSettings.setLocaleRaw('zh-CN'));
   tearDown(() => LocaleSettings.setLocaleRaw('en'));
 
-  Future<double> cellWidthOf(
+  Future<void> pumpTabs(
     WidgetTester tester,
-    List<String> labels,
-  ) async {
+    List<String> labels, {
+    required double width,
+  }) async {
+    await tester.binding.setSurfaceSize(Size(width, 900));
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -34,40 +45,85 @@ void main() {
         ),
       ),
     );
-    await tester.pump();
-    final Rect strip = tester.getRect(find.byType(SegmentedButton<int>));
-    return strip.width / labels.length;
+    await tester.pumpAndSettle();
   }
 
-  testWidgets('中文短文案下四模块顶栏分段块等宽（统一最小段宽）', (WidgetTester tester) async {
-    await tester.binding.setSurfaceSize(const Size(1600, 900));
+  /// 相邻两段的中心距 = 两段各自占用横向空间的一半之和，是「这一格多宽」的可测代理。
+  ///
+  /// 不能直接量 [Tab] 的 rect：等宽布局下 [Tab] 自身仍是文案自然宽，被撑开的是它
+  /// 外层由 TabBar 布局的格子——量 [Tab] 会得到一个**恒真**的断言（本文件早先的写法
+  /// 正是这样，变异实测时等宽变异一次都没被抓到）。
+  double centerGap(WidgetTester tester, String left, String right) =>
+      tester.getRect(find.widgetWithText(Tab, right)).center.dx -
+      tester.getRect(find.widgetWithText(Tab, left)).center.dx;
+
+  const List<String> videoTabs = <String>[
+    '首页',
+    '系列',
+    '全部视频',
+    '发现',
+    '来源',
+    '设置',
+  ];
+
+  testWidgets('段宽由各自文案决定，不被同排最长段绑架', (WidgetTester tester) async {
     addTearDown(() => tester.binding.setSurfaceSize(null));
+    await pumpTabs(tester, videoTabs, width: 1600);
 
-    // 书架/漫画形态：4 段、全 2 字文案。
-    final double shortCells = await cellWidthOf(
-      tester,
-      <String>['书架', '发现', '导入', '设置'],
-    );
-    // 游戏形态：6 段、最长 3 字（「游戏库」/「工作台」——捕获工作台页签
-    // 已改短为「工作台」，TODO-2937 拍板）。
-    final double gameCells = await cellWidthOf(
-      tester,
-      <String>['首页', '游戏库', '发现', '工作台', '导入', '设置'],
-    );
+    // 「系列」(2 字) → 「全部视频」(4 字) 的中心距，必须明显大于两个 2 字段之间的
+    // 中心距。等宽控件下每格同宽、两个距离相等——那正是旧顶栏把 6 段撑到装不下、
+    // 尾段被切掉的成因。
+    final double shortToShort = centerGap(tester, '首页', '系列');
+    final double shortToLong = centerGap(tester, '系列', '全部视频');
 
     expect(
-      shortCells,
-      moreOrLessEquals(kLibrarySectionTabMinSegmentWidth, epsilon: 0.5),
-      reason: '短文案页的分段块应被统一最小段宽垫到同宽',
-    );
-    expect(
-      gameCells,
-      moreOrLessEquals(shortCells, epsilon: 0.5),
-      reason: '游戏页与书架页的分段块宽度应一致（中文 ≤5 字文案）',
+      shortToLong,
+      greaterThan(shortToShort + 8.0),
+      reason: '4 字段应比 2 字段占更多横向空间；两者相等即说明退回了等宽布局',
     );
   });
 
-  test('四模块顶栏分段收敛到 LibrarySectionTabs（不许各写一份分段条）', () {
+  testWidgets('窄屏靠滚动容纳，段几何不变（不压窄、不裁字）', (WidgetTester tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await pumpTabs(tester, videoTabs, width: 1600);
+    final double wide = centerGap(tester, '系列', '全部视频');
+
+    // 手机竖屏宽：整排放不下。旧等宽方案在这一档把每格压到「可用宽 / 段数」并裁字
+    // （用户看到的「全部视」被切成半个胶囊）；tabs 保持各段几何、整排横向滚动。
+    await pumpTabs(tester, videoTabs, width: 402);
+    final double narrow = centerGap(tester, '系列', '全部视频');
+
+    expect(
+      narrow,
+      moreOrLessEquals(wide, epsilon: 0.5),
+      reason: '窄屏不得改变单段几何——放不下要滚动，不是把每段压窄',
+    );
+  });
+
+  testWidgets('顶栏形态是 MD3 tabs，不是分段按钮', (WidgetTester tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await pumpTabs(
+      tester,
+      <String>['首页', '系列', '全部视频', '发现', '来源', '设置'],
+      width: 1600,
+    );
+
+    final TabBar bar = tester.widget<TabBar>(find.byType(TabBar));
+    expect(bar.isScrollable, isTrue, reason: '段数可变，滚动是正常形态而非降级');
+    expect(
+      bar.tabAlignment,
+      TabAlignment.start,
+      reason: '首段必须与页头标题左缘对齐（默认 startOffset 会留 52px 缩进）',
+    );
+    expect(
+      find.byType(SegmentedButton<int>),
+      findsNothing,
+      reason: 'MD3：分段按钮是 section 级单选控件，不得替代导航 tabs',
+    );
+  });
+
+  test('四模块顶栏分区导航收敛到 LibrarySectionTabs（不许各写一份）', () {
     const Map<String, String> topBarSources = <String, String>{
       '书架/漫画': 'lib/src/pages/implementations/media_library_shell.dart',
       '视频': 'lib/src/pages/implementations/video_library_shell.dart',
@@ -80,12 +136,18 @@ void main() {
         isTrue,
         reason: '${entry.key} 顶栏（${entry.value}）应使用共享的 LibrarySectionTabs',
       );
-      expect(
-        src.contains('FushiSegmentedStrip<'),
-        isFalse,
-        reason: '${entry.key} 顶栏（${entry.value}）不应绕过共享组件手拼分段条'
-            '（统一段宽/焦点约定会漂移，TODO-2937）',
-      );
+      for (final String bypass in <String>[
+        'FushiSegmentedStrip<',
+        'SegmentedButton<',
+        'TabBar(',
+      ]) {
+        expect(
+          src.contains(bypass),
+          isFalse,
+          reason: '${entry.key} 顶栏（${entry.value}）不应绕过共享组件手拼一排导航'
+              '（发现的 `$bypass`：焦点约定与几何会随调用点漂移）',
+        );
+      }
     }
   });
 }

--- a/fushi/test/pages/library_section_tabs_uniform_test.dart
+++ b/fushi/test/pages/library_section_tabs_uniform_test.dart
@@ -123,6 +123,46 @@ void main() {
     );
   });
 
+  testWidgets('宿主拒绝切换时指示器不许停在未生效的分区上', (WidgetTester tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(1600, 900));
+
+    // 宿主收下点击但**不改** selected——真实存在的分支：游戏页的「设置」段可由宿主
+    // 改成打开别的页面而不切分区。TabBar 自己已经把指示器移过去了，若没有「controller
+    // 只是 selected 的投影」这条校正，指示器会停在一个并未生效的分区上。
+    final List<int> taps = <int>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: LibrarySectionTabs<int>(
+              tabs: <LibrarySectionTab<int>>[
+                for (int i = 0; i < videoTabs.length; i++)
+                  LibrarySectionTab<int>(value: i, label: videoTabs[i]),
+              ],
+              selected: 0,
+              onChanged: taps.add,
+              focusIdPrefix: 'reject-test',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(Tab, '全部视频'));
+    await tester.pumpAndSettle();
+
+    expect(taps, <int>[2], reason: '点击必须照常上报给宿主');
+    expect(
+      tester.widget<TabBar>(find.byType(TabBar)).controller!.index,
+      0,
+      reason: '宿主没改 selected，指示器必须被拉回——controller 是 selected 的投影，'
+          '不是第二份真相',
+    );
+  });
+
   test('四模块顶栏分区导航收敛到 LibrarySectionTabs（不许各写一份）', () {
     const Map<String, String> topBarSources = <String, String>{
       '书架/漫画': 'lib/src/pages/implementations/media_library_shell.dart',

--- a/fushi/test/pages/library_section_tabs_uniform_test.dart
+++ b/fushi/test/pages/library_section_tabs_uniform_test.dart
@@ -163,11 +163,63 @@ void main() {
     );
   });
 
-  test('四模块顶栏分区导航收敛到 LibrarySectionTabs（不许各写一份）', () {
+  testWidgets('controlled 形态共用宿主 TabController，不镜像出第二份选中态',
+      (WidgetTester tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(1600, 900));
+
+    // 宿主（下载页）自己持有 controller 驱动 TabBarView。导航组件必须共用**那一个**：
+    // 镜像出第二个 controller 时，横滑 TabBarView 的连续进度传不到指示器上，指示器
+    // 只能在宿主 index 越过一半跳变时跟着跳一下。
+    final TabController host = TabController(length: 4, vsync: const TestVSync());
+    addTearDown(host.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: LibrarySectionTabs<int>.controlled(
+              tabs: const <LibrarySectionTab<int>>[
+                LibrarySectionTab<int>(value: 0, label: '资源'),
+                LibrarySectionTab<int>(value: 1, label: '任务'),
+                LibrarySectionTab<int>(value: 2, label: '订阅'),
+                LibrarySectionTab<int>(value: 3, label: '设置'),
+              ],
+              controller: host,
+              focusIdPrefix: 'controlled-test',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      identical(tester.widget<TabBar>(find.byType(TabBar)).controller, host),
+      isTrue,
+      reason: 'TabBar 必须挂在宿主那一个 controller 上，不得自建第二个',
+    );
+
+    // 点击必须直接落到宿主 controller（页内 TabBarView 靠它换页）。
+    await tester.tap(find.widgetWithText(Tab, '订阅'));
+    await tester.pumpAndSettle();
+    expect(host.index, 2, reason: '点段必须真的驱动宿主 controller');
+
+    // 反向：宿主自己换页（横滑 / 外部 animateTo）时指示器跟着走。
+    host.animateTo(0);
+    await tester.pumpAndSettle();
+    expect(tester.widget<TabBar>(find.byType(TabBar)).controller!.index, 0);
+  });
+
+  test('顶层页分区导航收敛到 LibrarySectionTabs（不许各写一份）', () {
     const Map<String, String> topBarSources = <String, String>{
       '书架/漫画': 'lib/src/pages/implementations/media_library_shell.dart',
       '视频': 'lib/src/pages/implementations/video_library_shell.dart',
       '游戏': 'lib/src/pages/implementations/game_shared.dart',
+      // 下载页也是顶层 tab、也切四个独立目的地，同属这条收敛（它页内还有
+      // TabBarView，走 controlled 形态共用同一个 TabController）。
+      '下载': 'lib/src/pages/implementations/downloads_page.dart',
     };
     for (final MapEntry<String, String> entry in topBarSources.entries) {
       final String src = File(entry.value).readAsStringSync();

--- a/fushi/test/pages/media_library_shell_test.dart
+++ b/fushi/test/pages/media_library_shell_test.dart
@@ -95,7 +95,7 @@ void main() {
     final FushiSectionTabBar<MediaLibraryViewKind> strip = tester.widget(
       find.byType(FushiSectionTabBar<MediaLibraryViewKind>),
     );
-    strip.onChanged(kind);
+    strip.onChanged!(kind);
     await tester.pumpAndSettle();
   }
 

--- a/fushi/test/pages/media_library_shell_test.dart
+++ b/fushi/test/pages/media_library_shell_test.dart
@@ -92,14 +92,14 @@ void main() {
     WidgetTester tester,
     MediaLibraryViewKind kind,
   ) async {
-    final FushiSegmentedStrip<MediaLibraryViewKind> strip = tester.widget(
-      find.byType(FushiSegmentedStrip<MediaLibraryViewKind>),
+    final FushiSectionTabBar<MediaLibraryViewKind> strip = tester.widget(
+      find.byType(FushiSectionTabBar<MediaLibraryViewKind>),
     );
     strip.onChanged(kind);
     await tester.pumpAndSettle();
   }
 
-  testWidgets('分段条包在 FushiAdjustableSegmented 里（裸 SegmentedButton 即转红）',
+  testWidgets('分区导航包在 FushiAdjustableSegmented 里（裸 TabBar 即转红）',
       (WidgetTester tester) async {
     await tester.pumpWidget(harness(<MediaLibraryViewSpec>[
       spec(0, MediaLibraryViewKind.library, '书架'),
@@ -110,14 +110,14 @@ void main() {
     expect(
       find.byType(FushiAdjustableSegmented<MediaLibraryViewKind>),
       findsOneWidget,
-      reason: '方向焦点控制器只遍历已注册 target；裸 SegmentedButton 会被整个跳过，'
+      reason: '方向焦点控制器只遍历已注册 target；裸 TabBar 会被整个跳过，'
           '手柄/键盘用户切不了视图',
     );
-    // 且它必须真的包着本壳的分段条（不是树里别处碰巧有一个）。
+    // 且它必须真的包着本壳的分区导航（不是树里别处碰巧有一个）。
     expect(
       find.descendant(
         of: find.byType(FushiAdjustableSegmented<MediaLibraryViewKind>),
-        matching: find.byType(FushiSegmentedStrip<MediaLibraryViewKind>),
+        matching: find.byType(FushiSectionTabBar<MediaLibraryViewKind>),
       ),
       findsOneWidget,
     );

--- a/fushi/test/pages/module_top_settings_tabs_guard_test.dart
+++ b/fushi/test/pages/module_top_settings_tabs_guard_test.dart
@@ -11,14 +11,14 @@ bool _containsCode(String source, String needle) =>
 
 /// 下载页的「设置」顶部段。
 ///
-/// PR#820 把下载页门头从 `AppBar + TabBar` 换成与库页同构的
-/// `FushiPageHeader.customTitle` + `FushiSegmentedStrip`，承载形态从
-/// `Tab(text: …)` 变成 `ButtonSegment(value: …, label: Text(…))`。守卫要守的
-/// **行为**没变（设置是常驻的第四个顶部段，不是临时齿轮模式），锚点跟着搬到
-/// 新形态即可——别因为形态换了就把断言删掉。
+/// 承载形态换过三次：`Tab(text: …)` → PR#820 与库页同构的
+/// `ButtonSegment(value: …, label: Text(…))` → 2026-08-24 库页顶栏改走 MD3 tabs 后的
+/// `LibrarySectionTab(value: …, label: …)`。守卫要守的**行为**三次都没变（设置是常驻的
+/// 第四个顶部段，不是临时齿轮模式），锚点跟着搬到新形态即可——别因为形态换了就把断言
+/// 删掉。
 bool _hasSettingsSegment(String source) => RegExp(
-      r'\bButtonSegment<int>\s*\(\s*value:\s*3\s*,\s*'
-      r'label:\s*Text\s*\(\s*t\.settings\s*\)\s*\)',
+      r'\bLibrarySectionTab<int>\s*\(\s*value:\s*3\s*,\s*'
+      r'label:\s*t\.settings\s*\)',
     ).hasMatch(_code(source));
 
 bool _hasFullWidthTorrentSettings(String source) => RegExp(
@@ -33,7 +33,7 @@ void main() {
 // kind: MediaLibraryViewKind.settings
 /* value: GameSection.settings
 value: VideoLibrarySection.settings
-ButtonSegment<int>(value: 3, label: Text(t.settings))
+LibrarySectionTab<int>(value: 3, label: t.settings)
 TorrentSettingsSection(constrainWidth: false)
 */
 ''';
@@ -62,7 +62,7 @@ const String decoy = '''
 kind: MediaLibraryViewKind.settings
 value: GameSection.settings
 value: VideoLibrarySection.settings
-ButtonSegment<int>(value: 3, label: Text(t.settings))
+LibrarySectionTab<int>(value: 3, label: t.settings)
 TorrentSettingsSection(constrainWidth: false)
 ''';
 """;
@@ -123,10 +123,10 @@ TorrentSettingsSection(constrainWidth: false)
 
     final String downloadsCode = _code(downloads);
     final int subscriptions = downloadsCode.indexOf(
-      'Text(t.download_subscriptions_tab)',
+      'label: t.download_subscriptions_tab',
     );
     final Match? settings = RegExp(
-      r'label:\s*Text\s*\(\s*t\.settings\s*\)',
+      r'label:\s*t\.settings\b',
     ).firstMatch(downloadsCode);
     expect(subscriptions, greaterThanOrEqualTo(0));
     expect(settings, isNotNull);

--- a/fushi/test/pages/video_discovery_production_wiring_guard_test.dart
+++ b/fushi/test/pages/video_discovery_production_wiring_guard_test.dart
@@ -50,10 +50,11 @@ void main() {
       'lib/src/pages/implementations/downloads_page.dart',
     ).readAsStringSync();
 
-    // PR#820 起下载页门头是 FushiSegmentedStrip（与库页同构），首段承载形态
-    // 由 `Tab(text: …)` 变为 `ButtonSegment(value: 0, label: Text(…))`；本条守的
-    // 行为不变：第一段必须是「资源」，不是第二个 discovery 页。
-    expect(source, contains('label: Text(t.download_resources_tab)'));
+    // 首段的**承载形态**换过三次：`Tab(text: …)` → PR#820 与库页同构的
+    // `ButtonSegment(value: 0, label: Text(…))` → 2026-08-24 库页改走 MD3 tabs 后的
+    // `LibrarySectionTab(value: 0, label: …)`。本条守的**行为**三次都没变：第一段
+    // 必须是「资源」，不是第二个 discovery 页。
+    expect(source, contains('value: 0, label: t.download_resources_tab'));
     expect(source, contains('VideoResourceSearchSurface('));
     expect(source, contains('VideoDownloadJobsPanel.database('));
     expect(source, contains('VideoDownloadSubscriptionsPanel()'));

--- a/fushi/test/pages/video_library_shell_test.dart
+++ b/fushi/test/pages/video_library_shell_test.dart
@@ -135,7 +135,7 @@ void main() {
     final FushiSectionTabBar<VideoLibrarySection> strip = tester.widget(
       find.byType(FushiSectionTabBar<VideoLibrarySection>),
     );
-    strip.onChanged(section);
+    strip.onChanged!(section);
     await tester.pumpAndSettle();
   }
 

--- a/fushi/test/pages/video_library_shell_test.dart
+++ b/fushi/test/pages/video_library_shell_test.dart
@@ -132,27 +132,33 @@ void main() {
     WidgetTester tester,
     VideoLibrarySection section,
   ) async {
-    final FushiSegmentedStrip<VideoLibrarySection> strip = tester.widget(
-      find.byType(FushiSegmentedStrip<VideoLibrarySection>),
+    final FushiSectionTabBar<VideoLibrarySection> strip = tester.widget(
+      find.byType(FushiSectionTabBar<VideoLibrarySection>),
     );
     strip.onChanged(section);
     await tester.pumpAndSettle();
   }
 
-  testWidgets('页签顺序固定为首页、发现、系列、全部视频、来源、设置', (WidgetTester tester) async {
+  // 本地库的各视图（首页 / 系列 / 全部视频）排完才是在线发现，最后才是管理类分区
+  // ——与书 / 漫画 / 游戏同位。发现曾夹在首页与系列之间，一排里「自己的库 → 推荐 →
+  // 自己的库」来回跳（2026-08-24 用户反馈），是四个模块里唯一的例外。
+  testWidgets('页签顺序固定为首页、系列、全部视频、发现、来源、设置',
+      (WidgetTester tester) async {
     await tester.pumpWidget(harness());
     await tester.pump();
 
-    final FushiSegmentedStrip<VideoLibrarySection> strip = tester.widget(
-      find.byType(FushiSegmentedStrip<VideoLibrarySection>),
+    final FushiSectionTabBar<VideoLibrarySection> strip = tester.widget(
+      find.byType(FushiSectionTabBar<VideoLibrarySection>),
     );
     expect(
-      strip.segments.map((segment) => segment.value).toList(),
+      strip.tabs
+          .map((LibrarySectionTab<VideoLibrarySection> tab) => tab.value)
+          .toList(),
       <VideoLibrarySection>[
         VideoLibrarySection.home,
-        VideoLibrarySection.discover,
         VideoLibrarySection.series,
         VideoLibrarySection.allVideos,
+        VideoLibrarySection.discover,
         VideoLibrarySection.sources,
         VideoLibrarySection.settings,
       ],


### PR DESCRIPTION
﻿## 起因

用户报视频页左上角的分段选择器「太丑」，并指出信息架构反直觉：「第一页是自己看的，第二页又变成推荐的了，第三页又变成自己看的」，建议把「发现」移到「系列、全部视频」后面。

## 两个问题都是真的

**顺序**：视频页是四个模块里唯一的例外。

| 模块 | 顺序 |
|---|---|
| 书架 | 书架 → **发现** → 导入 → 设置 |
| 漫画 | 书架 → **发现** → 导入 → 设置 |
| 游戏 | 仪表盘 → 游戏库 → **发现** → 工作台 → 导入 → 设置 |
| 视频（改前） | 首页 → **发现** → 系列 → 全部视频 → 来源 → 设置 |

**观感**：顶栏用 `SegmentedButton` 承载页面级导航（六个独立目的地：发现/来源/设置各自是独立页面、独立 State）。MD3 明确规定分段按钮 *"affects section-level views and should not be considered a replacement for navigational tabs"*。用错控件带来两个可见后果：

- 分段按钮是**等宽**控件，六段按最长文案取宽后远超页头标题槽，手机上必然溢出，尾段被切成半个胶囊（看着像渲染 bug，而不是「右边还有」）；
- 为了让它当导航用，此前堆了统一最小段宽、自然宽估算、两侧渐隐、选中段自动滚入、桌面鼠标拖滚一整套补丁（TODO-2937 / BUG-1719 / BUG-1184）——全是 tabs 自带的。

## 改动

- `LibrarySectionTabs` 内部由 `FushiSegmentedStrip` 换成受控 `TabBar`，四个模块顶栏同时生效；删掉 `kLibrarySectionTabMinSegmentWidth` 这个估算出来的等宽下限。
- `TabController` 只是 `selected` 的投影，build 与 onTap 各校正一次——覆盖宿主**拒绝**本次切换的情形（游戏页「设置」段可由宿主改成打开别的页面而不切分区）。
- 焦点契约不变：外层仍是 `FushiAdjustableSegmented`，整排是单个焦点停靠点，左右方向键 / D-pad 原地切段，内部 tab 由该外壳的 `ExcludeFocus` 移出遍历。
- 页头协作不变：仍经 `FushiHeaderCrampScope` 上报自然宽，改为逐段求和；估宽收进共享组件层的 `estimateSectionTabBarWidth`，调用点不再碰 `fontSize`。
- 视频页 `discover` 移到 `allVideos` 之后。

## 实测几何（中文，视频页 6 段）

| 量 | 改前（等宽） | 改后（tabs） |
|---|---|---|
| 顶栏自然总宽 | 588.0px（6 × 98） | **389.4px** |
| 手机档标题槽 ~274px 内完整可见段数 | 2.8 段（第 3 段起被切） | **4 / 6**（首页・系列・全部视频・发现） |

顺序改完后，首屏可见的正好是三个本地视图 + 发现；来源/设置滚出去。

## 验证

- `flutter analyze` 全量（含 test）零问题。
- 定向 **309 tests passed**（视频/漫画/游戏/书架页 + 顶栏几何 + 拖放门 + 页头收纳 + 窄屏溢出）。
- 目录枚举型守卫整批 **250 tests passed**（与 fast-workflow.md 基线 N 一致）。该批抓到过一处真问题：`fontSize:` 落在页面组件里，已按守卫意图把估宽移回共享组件层，未走 allowlist。
- BUG-1719 顶栏几何守卫的两条不变式原样保留（切页签顶栏不许动、标签不许折行），只换控件定位，在新控件下仍绿。
- 守卫变异实测：等宽变异（`isScrollable:false` + `TabAlignment.fill`）→ 三条转红；拿掉 onTap 校正 → 投影守卫转红。初版按 `Tab` 的 rect 量宽是**恒真空断言**，等宽变异一次都没抓到，已改量相邻段中心距。

## 未覆盖

没有真机截图：连着的是用户本人手机，不往上装 worktree 构建（会碰生产库）。观感证据是上面的量化几何 + widget 测试，不是视觉比对。

https://claude.ai/code/session_01HqeyobcnN4TjxHDA7fZm9m


---

## 补充（应用户「其他的页呢，没一块改吗」）

先澄清范围：**控件是四个模块一起换的** —— `LibrarySectionTabs` 是唯一实现，书架/漫画/游戏/视频顶栏同时生效。只有**顺序**是视频页独有的问题（其余三页本来就是「自有内容 → 发现 → 管理」）。

然后扫了全仓 24 处分段控件，判导航还是 section 级选项：

| 结论 | 处数 | 例子 |
|---|---|---|
| ❌ 页面级导航（该用 tabs） | **1** | 下载页门头 |
| ✅ 合法 section 级选项 | 23 | 代理模式/画质档位/OCR 引擎/图表区间/字幕筛选/协议选择/同视图换呈现（Mihon 热门·最新、快捷键列表·手柄图示）等 |

### 下载页：同根因，而且方向本来是反的

它切「资源 / 任务 / 订阅 / 设置」四个独立目的地，是导航。而且它**本来就是 TabBar** —— 2026-08-13 为「统一门头」被换成分段按钮；页内的 `DefaultTabController` + `TabBarView` 一直都在，分段条只是把 controller 的状态抄了一遍（外面套 `AnimatedBuilder` 读 index、点段回调 `animateTo`）。抄出来的指示器在横滑 `TabBarView` 时只能在宿主 index 越过一半时跳一下，不跟手。

- `LibrarySectionTabs` 加 `.controlled` 形态：宿主已持有 `TabController` 时**共用那一个**，不投影、不接管点击、不管它的生命周期。四个库页壳继续用自持形态（子视图是 Offstage 保活的独立页面，页内没有 TabBarView）。
- 下载页改用它，镜像层整个删掉，门头代码净减约 40 行；`focusId` 仍是 `downloads-tab-sections`，焦点契约零变化。
- 「统一门头」这个原始目标反而更彻底：下载页与四个库页现在是同一个组件、同一套几何。

### 守卫

四条源码扫描守卫的锚点写死了当时的承载形态，全部按「行为不变、锚点跟着搬」处理，**没有删断言**。其中 `module_top_settings_tabs_guard` 的注释/字符串**注入自校验语料一并换** —— 不换的话新正则匹配不到旧语料，那两条会退化成恒真断言。

新增守卫「controlled 形态共用宿主 TabController，不镜像出第二份选中态」，变异实测（把 controlled 退化成镜像）转红。

### 验证（累计）

- `flutter analyze` 全量零问题。
- 定向 **393 tests passed**（74 个文件）。
- 目录枚举型守卫整批 **250 tests passed**。
- 四次变异实测全部转红：等宽变异（3 条）、拿掉 onTap 校正（1 条）、controlled 退化成镜像（1 条）。
