### PR TITLE
ci(release): 正式版资产镜像到 R2，供 fushi.moe/releases 分发

### DIFF
--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -1,9 +1,9 @@
 name: Mirror release assets to R2
 
-# 把正式发布的安装包镜像一份到 Cloudflare R2，给 dl.fushi.moe 当主下载源。
+# 把正式发布的安装包镜像一份到 Cloudflare R2，给 fushi.moe/releases 当主下载源。
 #
 # 为什么值得做：R2 出网免费，走 CF 的路由对多数地区比 GitHub Releases 稳；
-# 更重要的是它给下载链路提供了第二份存储——GitHub 挂掉时，dl.fushi.moe
+# 更重要的是它给下载链路提供了第二份存储——GitHub 挂掉时，fushi.moe/releases
 # 仍能从 R2 里的 manifest.json + 资产把包发出去。
 #
 # 这个 workflow 刻意独立于 release.yml：只在 release 发布完成之后被动触发，
@@ -103,13 +103,14 @@ jobs:
 
       - name: Setup Node
         if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
       - name: Install wrangler
         if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
-        run: npm install --no-save wrangler@^4.125.0
+        # 只需要 Wrangler CLI；锁死版本并禁用依赖生命周期脚本，避免 CI 执行供应链侧代码。
+        run: npm install --ignore-scripts --no-save --package-lock=false wrangler@4.125.0
 
       - name: Upload assets to R2
         if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
@@ -132,7 +133,7 @@ jobs:
               continue
             fi
             echo "上传 $name ($((size / 1024 / 1024))MB)"
-            npx wrangler r2 object put "$BUCKET/releases/$TAG/$name" --file "$f" --remote
+            ./node_modules/.bin/wrangler r2 object put "$BUCKET/releases/$TAG/$name" --file "$f" --remote
           done
 
           # manifest.json 是「GitHub 挂了下载还活着」的那一环：
@@ -153,7 +154,7 @@ jobs:
             fs.writeFileSync("manifest.json", JSON.stringify(m, null, 2));
             console.log("清单收录 " + m.assets.length + " 个资产，跳过 " + skipped.size + " 个");
           '
-          npx wrangler r2 object put "$BUCKET/manifest.json" --file manifest.json --content-type application/json --remote
+          ./node_modules/.bin/wrangler r2 object put "$BUCKET/manifest.json" --file manifest.json --content-type application/json --remote
 
       - name: Prune old mirrored releases
         if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
@@ -166,7 +167,7 @@ jobs:
 
           # R2 的 list 不在 wrangler CLI 里，所以自己维护一份「镜像了哪些 tag、
           # 每个 tag 有哪些文件」的台账，删除时才知道该删什么。
-          if npx wrangler r2 object get "$BUCKET/mirrored.json" --file mirrored.json --remote 2>/dev/null; then
+          if ./node_modules/.bin/wrangler r2 object get "$BUCKET/mirrored.json" --file mirrored.json --remote 2>/dev/null; then
             echo "读到已有台账"
           else
             echo '{"releases":[]}' > mirrored.json
@@ -197,21 +198,25 @@ jobs:
             while IFS= read -r key; do
               [ -z "$key" ] && continue
               echo "删除 $key"
-              npx wrangler r2 object delete "$BUCKET/$key" --remote || echo "::warning::删除 $key 失败，跳过"
+              ./node_modules/.bin/wrangler r2 object delete "$BUCKET/$key" --remote || echo "::warning::删除 $key 失败，跳过"
             done < to-delete.txt
           fi
 
           # 台账最后写：中途失败时宁可下次重复删一遍（删不存在的对象是无害的），
           # 也不要台账已更新而对象还在，那会变成永远没人认领的存量。
-          npx wrangler r2 object put "$BUCKET/mirrored.json" --file mirrored.json --content-type application/json --remote
+          ./node_modules/.bin/wrangler r2 object put "$BUCKET/mirrored.json" --file mirrored.json --content-type application/json --remote
 
       - name: Summary
         if: always() && steps.guard.outputs.ready == 'true'
+        env:
+          TARGET_TAG: ${{ steps.target.outputs.tag }}
+          TARGET_SKIPPED: ${{ steps.target.outputs.skip }}
+          ASSET_COUNT: ${{ steps.download.outputs.count }}
         run: |
           {
             echo "### R2 镜像"
             echo ""
-            echo "- tag: \`${{ steps.target.outputs.tag }}\`"
-            echo "- 是否跳过: \`${{ steps.target.outputs.skip }}\`"
-            echo "- 资产数: \`${{ steps.download.outputs.count || '0' }}\`"
+            printf -- '- tag: `%s`\n' "${TARGET_TAG:-}"
+            printf -- '- 是否跳过: `%s`\n' "${TARGET_SKIPPED:-}"
+            printf -- '- 资产数: `%s`\n' "${ASSET_COUNT:-0}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -1,0 +1,217 @@
+name: Mirror release assets to R2
+
+# 把正式发布的安装包镜像一份到 Cloudflare R2，给 dl.fushi.moe 当主下载源。
+#
+# 为什么值得做：R2 出网免费，走 CF 的路由对多数地区比 GitHub Releases 稳；
+# 更重要的是它给下载链路提供了第二份存储——GitHub 挂掉时，dl.fushi.moe
+# 仍能从 R2 里的 manifest.json + 资产把包发出去。
+#
+# 这个 workflow 刻意独立于 release.yml：只在 release 发布完成之后被动触发，
+# 不改任何现有发布路径、不参与发布通道判定。它失败也不影响发布本身，
+# 只是少一层下载冗余。
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: '要镜像的 release tag（留空 = 最新正式版）'
+        required: false
+      force_prerelease:
+        description: '允许镜像预发布版本（默认只镜像正式版）'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: mirror-releases
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # 保留最近几个版本。每个正式版约 1.3GB，R2 免费额度 10GB。
+  KEEP_RELEASES: '2'
+  # wrangler r2 object put 是单次上传，超过这个大小会失败。
+  # 与其让整个 job 红掉，不如跳过该文件并明确报出来——下载会自动回退 GitHub。
+  MAX_ASSET_MB: '300'
+  BUCKET: fushi-releases
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check Cloudflare credentials
+        id: guard
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_TOKEN" ] || [ -z "$CF_ACCOUNT" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::未配置 CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID，跳过 R2 镜像。下载会全部走 GitHub Releases，功能不缺，只是少一层冗余。"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve target release
+        id: target
+        if: steps.guard.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          FORCE_PRERELEASE: ${{ github.event.inputs.force_prerelease }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${INPUT_TAG:-}" ]; then
+            TAG="$INPUT_TAG"
+          elif [ -n "${EVENT_TAG:-}" ]; then
+            TAG="$EVENT_TAG"
+          else
+            TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)"
+          fi
+
+          PRERELEASE="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease -q .isPrerelease)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          # 调试/测试通道每次 push 都会出包，镜像它们会迅速吃光 R2 免费额度，
+          # 而下载页指向的 latest 本来就是最新正式版。默认只镜像正式版。
+          if [ "$PRERELEASE" = "true" ] && [ "${FORCE_PRERELEASE:-false}" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$TAG 是预发布版本，按策略不镜像（需要时用 workflow_dispatch 勾 force_prerelease）。"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download release assets
+        id: download
+        if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets --clobber
+          ls -la assets
+          echo "count=$(ls -1 assets | wc -l)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install wrangler
+        if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
+        run: npm install --no-save wrangler@^4.125.0
+
+      - name: Upload assets to R2
+        if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          MAX_BYTES=$(( MAX_ASSET_MB * 1024 * 1024 ))
+          SKIPPED=""
+
+          for f in assets/*; do
+            name="$(basename "$f")"
+            size="$(stat -c %s "$f")"
+            if [ "$size" -gt "$MAX_BYTES" ]; then
+              echo "::warning::$name 有 $((size / 1024 / 1024))MB，超过单次上传上限 ${MAX_ASSET_MB}MB，跳过镜像（该平台的下载会回退 GitHub）"
+              SKIPPED="$SKIPPED $name"
+              continue
+            fi
+            echo "上传 $name ($((size / 1024 / 1024))MB)"
+            npx wrangler r2 object put "$BUCKET/releases/$TAG/$name" --file "$f" --remote
+          done
+
+          # manifest.json 是「GitHub 挂了下载还活着」的那一环：
+          # Worker 拿不到 GitHub API 时，就靠它知道最新版本有哪些文件。
+          # 跳过的大文件不能写进去——写了会让 Worker 以为镜像里有，白绕一圈才回退。
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,publishedAt,assets \
+            -q '{tag: .tagName, publishedAt: .publishedAt, assets: [.assets[] | {name: .name, size: .size, url: .url}]}' \
+            > manifest-full.json
+
+          export SKIPPED
+          node -e '
+            const fs = require("fs");
+            const m = JSON.parse(fs.readFileSync("manifest-full.json", "utf8"));
+            const skipped = new Set((process.env.SKIPPED || "").trim().split(/\s+/).filter(Boolean));
+            m.assets = m.assets.filter((a) => !skipped.has(a.name));
+            m.mirroredAt = new Date().toISOString();
+            fs.writeFileSync("manifest.json", JSON.stringify(m, null, 2));
+            console.log("清单收录 " + m.assets.length + " 个资产，跳过 " + skipped.size + " 个");
+          '
+          npx wrangler r2 object put "$BUCKET/manifest.json" --file manifest.json --content-type application/json --remote
+
+      - name: Prune old mirrored releases
+        if: steps.guard.outputs.ready == 'true' && steps.target.outputs.skip == 'false'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # R2 的 list 不在 wrangler CLI 里，所以自己维护一份「镜像了哪些 tag、
+          # 每个 tag 有哪些文件」的台账，删除时才知道该删什么。
+          if npx wrangler r2 object get "$BUCKET/mirrored.json" --file mirrored.json --remote 2>/dev/null; then
+            echo "读到已有台账"
+          else
+            echo '{"releases":[]}' > mirrored.json
+          fi
+
+          node -e '
+            const fs = require("fs");
+            const led = JSON.parse(fs.readFileSync("mirrored.json", "utf8"));
+            const manifest = JSON.parse(fs.readFileSync("manifest.json", "utf8"));
+            const tag = process.env.TAG;
+            const keep = Number(process.env.KEEP_RELEASES || "2");
+
+            led.releases = (led.releases || []).filter((r) => r.tag !== tag);
+            led.releases.push({ tag, files: manifest.assets.map((a) => a.name) });
+
+            const drop = led.releases.slice(0, Math.max(0, led.releases.length - keep));
+            led.releases = led.releases.slice(-keep);
+
+            fs.writeFileSync("mirrored.json", JSON.stringify(led, null, 2));
+            fs.writeFileSync(
+              "to-delete.txt",
+              drop.flatMap((r) => r.files.map((f) => "releases/" + r.tag + "/" + f)).join("\n"),
+            );
+            console.log("保留 " + led.releases.length + " 个版本，待删 " + drop.length + " 个旧版本");
+          '
+
+          if [ -s to-delete.txt ]; then
+            while IFS= read -r key; do
+              [ -z "$key" ] && continue
+              echo "删除 $key"
+              npx wrangler r2 object delete "$BUCKET/$key" --remote || echo "::warning::删除 $key 失败，跳过"
+            done < to-delete.txt
+          fi
+
+          # 台账最后写：中途失败时宁可下次重复删一遍（删不存在的对象是无害的），
+          # 也不要台账已更新而对象还在，那会变成永远没人认领的存量。
+          npx wrangler r2 object put "$BUCKET/mirrored.json" --file mirrored.json --content-type application/json --remote
+
+      - name: Summary
+        if: always() && steps.guard.outputs.ready == 'true'
+        run: |
+          {
+            echo "### R2 镜像"
+            echo ""
+            echo "- tag: \`${{ steps.target.outputs.tag }}\`"
+            echo "- 是否跳过: \`${{ steps.target.outputs.skip }}\`"
+            echo "- 资产数: \`${{ steps.download.outputs.count || '0' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
配合官网 hajisensai/fushi.moe#1：把正式 Release 资产镜像到 R2，供 `fushi.moe/releases/*` 分发；R2 不可用时官网 Worker 仍会回退 GitHub Releases。下载使用主域路径，不新增 `dl.*` 别名。

## 范围

只新增 `.github/workflows/mirror-releases.yml`，由 `release published` 被动触发；不修改现有发布 workflow，不参与发布通道判定，镜像失败不影响 Release 本身。缺 Cloudflare 密钥时跳过并留 notice。

## 策略

- 默认只镜像正式版；`workflow_dispatch` 可显式允许预发布。
- 单文件超过 300MB 时跳过并 warning，对应下载自动回退 GitHub。
- R2 同时保存 `manifest.json`，让 GitHub API 不可达时仍能解析最新资产。
- `mirrored.json` 维护最近两个版本的对象台账，旧对象清理后才写回台账。
- Wrangler 锁定 `4.125.0`、禁用 npm 生命周期脚本并直接调用本地 CLI；`actions/setup-node` 锁定完整提交 SHA。
- Step Summary 只通过环境变量读取输出，避免把表达式值直接插入 shell。

## 验证边界

YAML 解析、7 个 `run` 块的 `bash -n`、`git diff --check` 已通过。未使用真实 Cloudflare 密钥/R2 桶做上传验收；首次启用前必须先创建 `fushi-releases` 桶并手动运行一次 workflow 验证对象、清单和清理台账。