### PR TITLE
chore(security): 根 .gitignore 拦截任意层级的签名凭据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,10 @@ third_party/media_kit_video/macos/Headers/
 
 # Magpie 精简包的组包产物（tools/build_magpie_slim.ps1 生成，随主包发行不入库）
 /dist/
+
+# Android 签名凭据：任何层级都不得入库。
+# fushi/android/.gitignore 里的同名规则只作用于它自己那一层，改名前遗留的
+# hibiki/android/ 下就躺着正式 keystore 和明文口令，此前在 git status 里是裸的，
+# 离泄漏只差一次 git add -A。keystore 泄漏不可撤销：任何人都能签发覆盖安装的伪造更新。
+**/key.properties
+**/*.jks


### PR DESCRIPTION
## 问题

`fushi/android/.gitignore` 里的 `key.properties` / `**/*.jks` 规则**只作用于它自己那一层**，根 `.gitignore` 对二者**零规则**。

改名前遗留的 `hibiki/android/`（工作区内未追踪目录）下躺着：

- `fushi-release.jks` —— 正式签名 keystore（`key.properties` 的 `storeFile` 指向它）
- `hibiki-release.jks`
- `key.properties` —— 含 store/key 明文口令

它们此前在 `git status` 里是裸的 `??`，离入库只差一次 `git add -A`。本仓明令禁止 `add -A`，但那是纪律，不是机械护栏。

## 没有泄漏

三个文件**从未被追踪**，`git log --all -- "*key.properties"` 全分支零记录。所以**不需要轮换签名密钥**。本 PR 只是补上缺失的护栏。

## 验证

隔离临时仓库（只放本 PR 的 `.gitignore`）实测：

| 检查 | 结果 |
|---|---|
| `hibiki/android/{key.properties,fushi-release.jks,hibiki-release.jks}` | 全部命中 `.gitignore:158/159` |
| `fushi/android/key.properties`（另一层级） | 命中 |
| 反向对照 `hibiki/android/normal-file.txt` | **未**被忽略（规则不过宽） |
| `git add -A` 后索引内凭据数 | **0** |
| develop 上已追踪的 `*.jks` / `key.properties` | 无 —— 本规则不改变任何现状 |

纯 `.gitignore` 改动，不涉及代码/构建，未跑 Flutter 测试。

## 遗留（本 PR 不处理）

上游继承历史里的 `android/app/key/key.jks`（提交 `cb92796577` / `4660ddcde1`）加了又删，HEAD/develop 上没有但 clone 可取回。清理需改写历史，属破坏性操作，待决策。

https://claude.ai/code/session_018kebQ12s34FK5Ymb2zVAAY