### PR TITLE
fix(manga): BUG-1830 mokuro 页图根改为解析，卷子目录布局不再必失败

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1688 条。点号进各自文件。
+> 共 1689 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1830](bugs/BUG-1830-mokuro-volume-subdir.md) | ✅ | ✅ | mokuro 卷子目录布局导入必失败（img_path 裸文件名） |
 | [BUG-1826](bugs/BUG-1826-mihon-loading-gate-blocks-store-edit.md) | 🚧 | 🚧 | 漫画扩展页 loading 一位两义：初始化联网刷新期间连添加/编辑仓库都点不动 |
 | [BUG-1808](bugs/BUG-1808-video-home-row-card-tags.md) | ✅ | ✅ | 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上） |
 | [BUG-1807](bugs/BUG-1807-url-keyboard-missing-across-app.md) | ✅ | ✅ | 全仓 10 处 URL/host 输入框漏声明 keyboardType，与 BUG-1804 同族 |

--- a/docs/bugs/BUG-1830-mokuro-volume-subdir.md
+++ b/docs/bugs/BUG-1830-mokuro-volume-subdir.md
@@ -22,7 +22,7 @@
   - 失败 toast 走默认 `Toast.LENGTH_SHORT`（桌面 2000ms，含两端 200ms 淡入淡出，
     实际可读约 1.6s），一条带路径的长错误读不完就消失。
 
-- **[x] ① 已修复** — 提交哈希见下方「备注」补记。根因修复，不是加参数绕过：
+- **[x] ① 已修复** — `07c30508d9`。根因修复，不是加参数绕过：
   1. 新增**唯一**页图根解析原语 `resolveMokuroPageRoot` / `mokuroPageRootCandidates` /
      `joinMokuroPageRoot`（`fushi/lib/src/media/manga/mokuro_payload.dart`）。零 IO：
      存在性探针由调用方注入，本地传文件系统 stat、远端传相对路径查找表，于是

--- a/docs/bugs/BUG-1830-mokuro-volume-subdir.md
+++ b/docs/bugs/BUG-1830-mokuro-volume-subdir.md
@@ -1,0 +1,61 @@
+## BUG-1830 · mokuro 卷子目录布局导入必失败（img_path 裸文件名）
+- **报告**：2026-08-24（用户：wrds）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/manga/manga_importer.dart:226`（修复前）
+  `final Directory srcDir = mokuroFile.parent;` —— 页图根被**硬编码**成「`.mokuro` 同级」，
+  但 mokuro 的 `img_path` 有两种并存惯例：
+  - 惯例 A：`img_path` 自带卷名/`images/` 前缀（如已入库的「あつまれ！ふしぎ研究部」）→ 同级解析恰好命中；
+  - 惯例 B：**卷子目录布局**，`img_path` 是裸文件名（`DLRAW.TO_00001.jpeg`），页图躺在与
+    `.mokuro` 同名的子目录里 → 解析成 `<父目录>/DLRAW.TO_00001.jpeg`，文件不存在，
+    `planMangaDestRels` 抛 `Missing manga page image`，整卷导入必失败。
+
+  同一个错误假设**在三处各写了一遍**，所以远端来源库扫描（`source_library_scanner.dart`
+  的 `_importMangaRemote` 按 `page.url` 直接查远端相对路径表）对惯例 B 同样必失败——
+  这是同源分身，不是另一个 bug。
+
+  更糟的是准入判定 `mangaImportCanImport` 会往下探**一层子目录**找图片，把惯例 B 判为
+  「可导入」：**门放行、执行必失败**。门与执行是两套判据，这才是「一位两义」的来源。
+
+  可观测性同时有两个洞，导致事后无从定位：
+  - 批量导入把逐卷异常收进 `MangaBatchImportReport` 后**只 `debugPrint`**，
+    `ImportFlowMixin.runImport` 那道 `ErrorLogService` 落盘永远拿不到真正的原因 →
+    错误日志页 / `error_log.txt` 里翻不到；
+  - 失败 toast 走默认 `Toast.LENGTH_SHORT`（桌面 2000ms，含两端 200ms 淡入淡出，
+    实际可读约 1.6s），一条带路径的长错误读不完就消失。
+
+- **[x] ① 已修复** — 提交哈希见下方「备注」补记。根因修复，不是加参数绕过：
+  1. 新增**唯一**页图根解析原语 `resolveMokuroPageRoot` / `mokuroPageRootCandidates` /
+     `joinMokuroPageRoot`（`fushi/lib/src/media/manga/mokuro_payload.dart`）。零 IO：
+     存在性探针由调用方注入，本地传文件系统 stat、远端传相对路径查找表，于是
+     **本地导入器与远端扫描镜像共用同一份判据**，不再各写一遍。
+     候选**只有**两个（就地 / `<卷名>/`），卷名取自 `.mokuro` 文件名本身（与卷 1:1），
+     不扫「任意子目录」——否则同批次里 `001.jpg` 这类无卷前缀的页名会误绑到别卷。
+  2. `importFromMokuroPath` 改为**解析**页图根；顺手删掉它原先那道
+     `mangaImportCanImport` 前置判据——那是真校验的一个更弱的重复副本，
+     正是「门放行 / 执行失败」两义的产地。真校验 = 解析根 + 逐页存在性。
+  3. `mangaImportCanImport` 契约写清：它是**载体分类**（廉价、宽松），不是导入成功的
+     保证；真校验在导入器内。门保持宽松是有意分工，不是遗漏。
+  4. `_importMangaRemote` 用同一原语解析远端页图根，并**连根一起原样镜像**到临时目录，
+     使镜像布局与远端逐段同构、本地导入器再解析一次即命中。
+  5. 两种惯例都不成立时，错误文案**逐条列出搜过的目录**
+     （`Missing manga page image: X (searched: <同级>, <同级>/<卷名>)`），
+     候选与文案共用 `mokuroPageRootCandidates`，日后加惯例不会只改一处让文案说谎。
+  6. 逐卷失败原因落盘挪到**吞掉异常的那一层**（`_importOneVolume` 的 catch，
+     source=`MangaBatchImport.volume`），而不是某一个对话框——报告有多个消费方。
+  7. 导入失败 toast 提到 `Toast.LENGTH_LONG`（`ImportFlowMixin.runImport`）。
+
+- **[x] ② 已加自动化测试** — 全部做过变异实测（去掉修复 → 变红；还原后 sha256 逐字节比对一致）：
+  - `fushi/test/media/manga/manga_importer_test.dart`（4 条新增）
+    - 卷子目录布局（裸 `img_path`）从 `<卷名>/` 解析页图并成功导入（含页图**字节**比对）
+    - 准入判定放行的卷子目录布局，执行也必须真能导入（门与执行不再两义 —— 就是这个 bug 的成对复现）
+    - 卷子目录只绑自己那一卷，不会误取同批另一卷的同名页图（钉死候选集不许扩成「任意子目录」）
+    - 两种布局都不成立时，错误文案指名道姓列出搜过的目录
+  - `fushi/test/media/source_library/source_library_scanner_network_test.dart`（1 条新增）
+    - 远端漫画：卷子目录布局也能镜像并导入（变异下复现 `Missing manga page image: DLRAW.TO_00001.jpeg (searched: /remote/manga)`）
+  - `fushi/test/media/manga/manga_folder_batch_test.dart`（2 条新增）
+    - 坏卷的真实原因写进 `ErrorLogService`（含卷名），而不是只 `debugPrint`
+    - 全成功时不往错误日志塞噪声
+
+- **备注**：`importFromMangaJson`（内部 `manga.json` 格式）不在此列——它只有一种惯例，
+  且页图根由调用方通过 `imageRootPath` 显式传入，没有「必须猜」的问题，刻意不动。
+  用户报告里「snackbar 只活约 1.1 秒 + `error_log.txt` 不落盘」两条已分别由第 6、7 项处理；
+  真机端到端复测未做（本轮为自动化测试覆盖，缺口如实记在此）。

--- a/fushi/lib/src/media/import/import_flow_mixin.dart
+++ b/fushi/lib/src/media/import/import_flow_mixin.dart
@@ -44,7 +44,8 @@ mixin ImportFlowMixin<T extends StatefulWidget> on State<T> {
   ///    [action] 自己做**（各对话框 pop 语义不同：book 回 bool、video 回 bookUid）；
   /// 3. 失败被捕获（绝不逃逸 zone）：[ErrorLogService] 以 [logTag] 为源落日志 +
   ///    `debugPrint`（[debugMessage] 可定制，默认 `'$logTag failed: $e'`）+ toast
-  ///    `t.srt_import_error: $e`——**不 pop**，对话框留在原地供用户改参重试；
+  ///    `t.srt_import_error: $e`（LENGTH_LONG——错误文案带着唯一的可诊断原因，
+  ///    SHORT 的 2s 读不完）——**不 pop**，对话框留在原地供用户改参重试；
   /// 4. finally `setState(() => importing = false)` 复位（mounted 门控）。
   ///
   /// [isCancelled] / [onCancelled]：用户主动取消类异常（如同名书弹窗选「否」）
@@ -71,6 +72,11 @@ mixin ImportFlowMixin<T extends StatefulWidget> on State<T> {
           FushiToast.show(
             msg: '${t.srt_import_error}: $e',
             severity: ToastSeverity.error,
+            // 失败 toast 必须走 LONG：这条文案带着**唯一**的可诊断原因（哪一页缺、
+            // 搜过哪些目录）。默认 SHORT 在桌面只有 2000ms（含两端 200ms 淡入淡出，
+            // 实际可读约 1.6s），一条带路径的长错误根本读不完就没了，用户只能靠
+            // 逐帧截图去抓——那不是提示，是障碍。
+            toastLength: Toast.LENGTH_LONG,
           );
         }
       }

--- a/fushi/lib/src/media/manga/import/manga_folder_batch.dart
+++ b/fushi/lib/src/media/manga/import/manga_folder_batch.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/media/manga/import/manga_pdf_importer.dart';
 import 'package:fushi/src/media/manga/manga_importer.dart';
 import 'package:fushi/src/ocr/manga_ocr_folder_job.dart'
     show enumerateMangaPages, naturalCompare;
+import 'package:fushi/src/utils/misc/error_log_service.dart';
 
 /// 一个目录里「每个文件一卷」的整卷载体文件，按文件名自然序。
 ///
@@ -183,7 +184,17 @@ Future<MangaBatchVolumeResult> _importOneVolume({
       path: volumePath,
       status: MangaBatchVolumeStatus.duplicate,
     );
-  } catch (error) {
+  } catch (error, stack) {
+    // 逐卷失败原因必须在**吞掉它的这一层**落盘。批量路径把每卷异常收进报告、只给
+    // 调用方一句「成功 N / 失败 M」的汇总，于是 ImportFlowMixin.runImport 那道
+    // ErrorLogService 永远拿不到真正的原因——用户事后翻错误日志是空的（用户报的
+    // 「error_log.txt 里翻不到」就是这个洞）。放这里而不是放某一个对话框里，是因为
+    // 报告有多个消费方，落日志不该跟着 UI 走。
+    ErrorLogService.instance.log(
+      'MangaBatchImport.volume',
+      '${p.basename(volumePath)}: $error',
+      stack,
+    );
     return MangaBatchVolumeResult(
       path: volumePath,
       status: MangaBatchVolumeStatus.failed,

--- a/fushi/lib/src/media/manga/manga_importer.dart
+++ b/fushi/lib/src/media/manga/manga_importer.dart
@@ -23,10 +23,17 @@ import 'package:fushi/src/utils/misc/fushi_time_format.dart';
 /// 手写漂移，bmp 漫画 OCR 静默缺页），守卫测试钉死两关口径一致。
 const Set<String> kMangaImageExtensions = kImageExtensionsBase;
 
-/// 是否可作为 mokuro 漫画导入：[paths] 中至少有一个 `.mokuro` 文件，且其同级目录里有图片
-/// 来源。图片来源识别一层深，覆盖 mokuro 的两种惯例布局：
-/// - `<卷名>.mokuro` 配 `<卷名>/`（或 `images/`）子目录，图片在该子目录内；
-/// - 图片直接平铺在 `.mokuro` 同级目录。
+/// **载体分类**判据：[paths] 中至少有一个 `.mokuro` 文件，且其同级目录（含一层子目录）
+/// 里有图片来源——即「这看起来是一卷 mokuro 漫画」，用于对话框即时禁用按钮 / 拖入分流。
+///
+/// **不是导入必定成功的保证**，也不该被当成保证使用：页图能不能对上取决于 `.mokuro` 里
+/// 的 `img_path` 惯例（见 [resolveMokuroPageRoot]），而那要读并解析可能几 MB 的 JSON，
+/// 不能塞进一个每帧都可能被调的同步判据里。真正的校验在 [MangaImporter.importFromMokuroPath]
+/// 内：解析页图根 + 逐页校验，失败时给出指名道姓的可诊断错误。
+///
+/// BUG-1830 之前这里与导入器是**两套**判据（这里探一层子目录、导入器硬编码同级），
+/// 于是卷子目录布局「门放行、执行必失败」。现在导入器认识两种惯例，门与执行不再打架；
+/// 门保持宽松且**廉价**，是有意的分工，不是遗漏。
 ///
 /// 纯判定（仅同步文件系统探测，无平台通道、无 async），便于单测与对话框即时禁用按钮。
 bool mangaImportCanImport(List<String> paths) {
@@ -206,11 +213,10 @@ class MangaImporter {
     void Function(int done, int total)? onProgress,
     int? sourceId,
   }) async {
-    if (!mangaImportCanImport(<String>[mokuroPath])) {
-      throw const MangaImportException('Not a valid Mokuro manga folder');
-    }
-
     final File mokuroFile = File(mokuroPath);
+    if (!mokuroFile.existsSync()) {
+      throw MangaImportException('Mokuro file not found: $mokuroPath');
+    }
     final String jsonStr = await mokuroFile.readAsString();
     final MokuroPayload payload = parseMokuro(jsonStr);
     if (payload.images.isEmpty) {
@@ -223,7 +229,31 @@ class MangaImporter {
     final Map<String, Object?> root =
         rawRoot is Map ? rawRoot.cast<String, Object?>() : <String, Object?>{};
 
-    final Directory srcDir = mokuroFile.parent;
+    // 页图根**解析**出来，不硬编码成 `.mokuro` 同级（BUG-1830 的根因）：mokuro 的
+    // `img_path` 有两种并存惯例，卷子目录布局下裸文件名相对同级解析必然落空。判据与
+    // 远端扫描镜像、下游逐页校验共用 [resolveMokuroPageRoot] 一份实现。
+    final Directory mokuroDir = mokuroFile.parent;
+    final String volumeName = p.basenameWithoutExtension(mokuroPath);
+    final List<String>? pageRoot = resolveMokuroPageRoot(
+      payload: payload,
+      volumeName: volumeName,
+      pageExists: (String rel) => _sourceFile(mokuroDir.path, rel).existsSync(),
+    );
+    if (pageRoot == null) {
+      // 两种惯例都不成立：把搜过的目录逐条报出来。这条文案是用户唯一能拿到的线索，
+      // 只说「缺图」而不说「在哪找的」正是当初排查要靠逐帧截图的原因。
+      final String searched = mokuroPageRootCandidates(volumeName: volumeName)
+          .map((List<String> candidate) =>
+              p.joinAll(<String>[mokuroDir.path, ...candidate]))
+          .join(', ');
+      throw MangaImportException(
+        'Missing manga page image: ${payload.images.first.url} '
+        '(searched: $searched)',
+      );
+    }
+    final Directory srcDir = pageRoot.isEmpty
+        ? mokuroDir
+        : Directory(p.joinAll(<String>[mokuroDir.path, ...pageRoot]));
 
     // 标题 → 冲突解析 → bookKey（= 净化标题即主键，与 EpubImporter/PdfImporter 同口径）。
     final String proposedTitle = (title != null && title.trim().isNotEmpty)

--- a/fushi/lib/src/media/manga/mokuro_payload.dart
+++ b/fushi/lib/src/media/manga/mokuro_payload.dart
@@ -153,6 +153,61 @@ String normalizeMangaUrl(String raw) {
   return forward.startsWith('/') ? forward.substring(1) : forward;
 }
 
+/// 页图根解析的**唯一口径**：mokuro 的 `img_path` 有两种并存惯例，页图到底躺在
+/// 哪个目录下是必须**解析**出来的事实，不是「`.mokuro` 同级」这种可以硬编码的常量。
+///
+/// - 惯例 A（`img_path` 自带卷名前缀，如 `vol1/p001.jpg`）：根 = `.mokuro` 同级目录，
+///   即返回空前缀。
+/// - 惯例 B（卷子目录布局，`img_path` 是裸文件名如 `DLRAW.TO_00001.jpeg`，图躺在与
+///   `.mokuro` 同名的子目录里）：根 = `<卷名>/`，即返回 `[卷名]`。
+///
+/// 候选**只有**这两个，且卷名取自 `.mokuro` 文件名本身（与卷 1:1），所以绝不会误绑到
+/// 同一批量目录里另一卷的同名页图（`001.jpg` 这类不带卷前缀的页名尤其危险）。BUG-1830
+/// 之前三处消费方（本地导入器 / 准入判定 / 远端扫描镜像）各自硬编码惯例 A，惯例 B 的
+/// 卷必然报 `Missing manga page image`。
+///
+/// [pageExists] 是注入的存在性探针（本地传文件系统 stat，远端传相对路径查找表），
+/// 因此本函数零 IO、零平台依赖，三处消费方共用同一份判据而不是各写一遍。
+///
+/// 返回值：命中的根前缀段（`const <String>[]` = 就地）。两种惯例下**首页**都找不到时
+/// 返回 null——调用方据此报出「两种布局都试过了」的可诊断错误，而不是继续按错误假设
+/// 走到下游报一个误导性的缺图。首页命中但后续页缺图时**仍返回该候选**，让下游逐页
+/// 校验给出精确的缺页文件名（那是真·坏卷，不是布局判错）。
+List<String>? resolveMokuroPageRoot({
+  required MokuroPayload payload,
+  required String volumeName,
+  required bool Function(String relPath) pageExists,
+}) {
+  if (payload.images.isEmpty) return null;
+  final List<List<String>> candidates =
+      mokuroPageRootCandidates(volumeName: volumeName);
+  final String firstUrl = payload.images.first.url;
+  List<String>? firstPageHit;
+  for (final List<String> candidate in candidates) {
+    if (!pageExists(joinMokuroPageRoot(candidate, firstUrl))) continue;
+    firstPageHit ??= candidate;
+    final bool all = payload.images.every(
+      (MokuroImage page) => pageExists(joinMokuroPageRoot(candidate, page.url)),
+    );
+    if (all) return candidate;
+  }
+  return firstPageHit;
+}
+
+/// [resolveMokuroPageRoot] 试的候选根，按优先级排列。**公开**是为了让报错文案能
+/// 逐条列出「都搜过哪里」——判据与文案共用同一份候选，日后加惯例时不会只改一处而
+/// 让错误信息说谎（诊断信息漂移正是这个 bug 当初难查的原因之一）。
+List<List<String>> mokuroPageRootCandidates({required String volumeName}) =>
+    <List<String>>[
+      const <String>[],
+      if (volumeName.trim().isNotEmpty) <String>[volumeName],
+    ];
+
+/// 把 [root]（[resolveMokuroPageRoot] 的返回值）与页 `url` 拼成相对根目录的正斜杠
+/// 路径。空根原样返回 `url`，让惯例 A 的路径与解析前逐字节一致。
+String joinMokuroPageRoot(List<String> root, String url) =>
+    root.isEmpty ? url : '${root.join('/')}/$url';
+
 /// Parse a modern mokuro (v0.2+) `.mokuro` JSON document into a
 /// [MokuroPayload]. Tolerant of missing fields: `font_size` defaults to 0,
 /// `vertical` defaults to false, `lines` defaults to empty, and `zIndex`

--- a/fushi/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
+++ b/fushi/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
@@ -4,8 +4,9 @@
 ///
 /// 布局契约：CBZ 顶层是一个 `<卷名>/` 目录（内放页图），`.mokuro` 的 `img_path`
 /// 与之一致（`<卷名>/001.jpg`）。解包目录 T 下得到 `T/<卷名>/*.jpg`，`.mokuro`
-/// 落 `T/<卷名>.mokuro`——正好满足 [mangaImportCanImport] 的「同级一层子目录有图」
-/// 判定，零转换直通现有导入链。
+/// 落 `T/<卷名>.mokuro`——即 mokuro 的惯例 A（`img_path` 自带卷名前缀，相对
+/// `.mokuro` 同级解析），[resolveMokuroPageRoot] 的首个候选就命中，零转换直通
+/// 现有导入链。
 ///
 /// 下载范式照 `manga_ocr_model_downloader.dart`（Range 续传 / 416 / 非 206 处理），
 /// 但 CBZ 无预知长度：完整性校验放宽为「zip 中央目录可解析」，不做 expectedBytes
@@ -192,8 +193,8 @@ class MokuroMoeVolumeDownloader {
         ),
       );
 
-      // 4. `.mokuro` 放到解包目录同级（`T/<卷名>.mokuro` 配 `T/<卷名>/` 图片目录，
-      // 满足 mangaImportCanImport 的同级判定；img_path 相对 T 解析）。
+      // 4. `.mokuro` 放到解包目录同级（`T/<卷名>.mokuro` 配 `T/<卷名>/` 图片目录；
+      // img_path 自带 `<卷名>/` 前缀，故页图根解析成「就地」，相对 T 解析）。
       _checkCancelled();
       final File placedMokuro =
           File(p.join(extractDir.path, '$volumeName.mokuro'));

--- a/fushi/lib/src/media/source_library/source_library_scanner.dart
+++ b/fushi/lib/src/media/source_library/source_library_scanner.dart
@@ -48,7 +48,13 @@ import 'package:fushi/src/media/manga/manga_importer.dart';
 import 'package:fushi/src/media/manga/manga_storage.dart'
     show MangaImportException;
 import 'package:fushi/src/media/manga/mokuro_payload.dart'
-    show MokuroImage, MokuroPayload, parseMokuro;
+    show
+        MokuroImage,
+        MokuroPayload,
+        joinMokuroPageRoot,
+        mokuroPageRootCandidates,
+        parseMokuro,
+        resolveMokuroPageRoot;
 import 'package:fushi/src/media/source_library/source_file_system.dart';
 import 'package:fushi/src/pdf/pdf_importer.dart';
 import 'package:fushi/src/media/source_library/source_library_credential_store.dart';
@@ -763,12 +769,34 @@ class SourceLibraryScanner {
         remoteByRel[segs.join('/')] = e.path;
       }
 
+      // 页图根与本地导入同一口径（[resolveMokuroPageRoot]）：远端同样有「img_path
+      // 自带卷名前缀」和「卷子目录布局裸文件名」两种惯例，这里若仍硬编码同级，
+      // 卷子目录布局的远端卷在查表阶段就报缺图（BUG-1830 的远端同源分身）。
+      final String remoteVolumeName = p.basenameWithoutExtension(mokuroName);
+      final List<String>? pageRoot = resolveMokuroPageRoot(
+        payload: payload,
+        volumeName: remoteVolumeName,
+        pageExists: remoteByRel.containsKey,
+      );
+      if (pageRoot == null) {
+        final String searched =
+            mokuroPageRootCandidates(volumeName: remoteVolumeName)
+                .map((List<String> candidate) => candidate.isEmpty
+                    ? parentDir
+                    : '$prefix${candidate.join('/')}')
+                .join(', ');
+        throw MangaImportException(
+          'Missing manga page image: ${payload.images.first.url} '
+          '(searched: $searched)',
+        );
+      }
+
       final Directory tmp =
           Directory.systemTemp.createTempSync('m1c_scan_manga_');
       try {
-        // 逐页镜像（保留相对子目录布局——导入器按 payload.url 相对 `.mokuro`
-        // 同级解析）。`..` 段直接拒绝：临时镜像在书目录 sanitize 之前落盘，
-        // 不能靠后面那道防穿越。
+        // 逐页镜像，**连页图根一起原样保留**（`<根>/<url>`）：本地导入器对着镜像
+        // 目录再解析一次根，两边同一口径，于是镜像布局与远端逐段同构。`..` 段直接
+        // 拒绝：临时镜像在书目录 sanitize 之前落盘，不能靠后面那道防穿越。
         for (final MokuroImage page in payload.images) {
           final List<String> segs = page.url
               .split(RegExp(r'[\\/]+'))
@@ -777,12 +805,17 @@ class SourceLibraryScanner {
           if (segs.isEmpty || segs.contains('..')) {
             throw MangaImportException('Invalid manga page path: ${page.url}');
           }
-          final String? remotePath = remoteByRel[segs.join('/')];
+          final String rel = joinMokuroPageRoot(pageRoot, segs.join('/'));
+          final String? remotePath = remoteByRel[rel];
           if (remotePath == null) {
-            throw MangaImportException('Missing manga page image: ${page.url}');
+            throw MangaImportException('Missing manga page image: $rel');
           }
-          final Directory destDir = Directory(p.joinAll(
-              <String>[tmp.path, ...segs.sublist(0, segs.length - 1)]));
+          final List<String> destSegs = <String>[
+            ...pageRoot,
+            ...segs.sublist(0, segs.length - 1),
+          ];
+          final Directory destDir =
+              Directory(p.joinAll(<String>[tmp.path, ...destSegs]));
           destDir.createSync(recursive: true);
           await fs.copyToLocal(remotePath, destDir.path);
         }

--- a/fushi/test/media/manga/manga_folder_batch_test.dart
+++ b/fushi/test/media/manga/manga_folder_batch_test.dart
@@ -16,6 +16,7 @@ import 'package:fushi/src/epub/epub_storage.dart';
 import 'package:fushi/src/media/import/import_carrier.dart';
 import 'package:fushi/src/media/manga/import/manga_folder_batch.dart';
 import 'package:fushi/src/media/manga/manga_module.dart';
+import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:image/image.dart' as img;
 import 'package:path/path.dart' as p;
@@ -192,6 +193,69 @@ void main() {
 
       expect(progress.first, (0, 2));
       expect(progress.last, (2, 2));
+    });
+  });
+
+  group('逐卷失败必须落进错误日志', () {
+    // 批量路径把每卷异常收进报告、只给调用方一句「成功 N / 失败 M」的汇总，于是
+    // ImportFlowMixin.runImport 那道 ErrorLogService 永远拿不到真正的原因，用户
+    // 事后翻错误日志页是空的。落盘因此必须在**吞掉异常的这一层**。
+    test('坏卷的真实原因写进 ErrorLogService，而不是只 debugPrint', () async {
+      final int before = ErrorLogService.instance.entries.length;
+
+      // 一卷好的 + 一卷坏的：坏卷是页图在任何布局下都找不到的 .mokuro——正是用户
+      // 撞上的那种失败，只不过这里让它发生在批量路径里。
+      _writeCbz(root, 'good.cbz');
+      File(p.join(root.path, 'broken.mokuro'))
+          .writeAsStringSync(jsonEncode(<String, Object?>{
+        'version': '0.2.0',
+        'title': 'Broken',
+        'pages': <Object?>[
+          <String, Object?>{
+            'img_width': 800,
+            'img_height': 1200,
+            'img_path': 'nowhere.jpg',
+            'blocks': <Object?>[],
+          },
+        ],
+      }));
+
+      final MangaBatchImportReport report =
+          await importMangaBatchFolder(db: db, path: root.path);
+
+      expect(report.failedCount, 1, reason: '坏卷必须计入失败');
+      final List<ErrorLogEntry> added =
+          ErrorLogService.instance.entries.skip(before).toList();
+      expect(
+        added.where((ErrorLogEntry e) => e.source == 'MangaBatchImport.volume'),
+        isNotEmpty,
+        reason: '坏卷的原因必须以 MangaBatchImport.volume 落进错误日志',
+      );
+      expect(
+        added
+            .where((ErrorLogEntry e) => e.source == 'MangaBatchImport.volume')
+            .map((ErrorLogEntry e) => e.error)
+            .join('\n'),
+        contains('broken.mokuro'),
+        reason: '日志必须指名道姓说是哪一卷，否则 20 卷里的失败无从定位',
+      );
+    });
+
+    test('全成功时不往错误日志塞噪声', () async {
+      final int before = ErrorLogService.instance.entries.length;
+      _writeCbz(root, 'ok1.cbz');
+      _writeCbz(root, 'ok2.cbz');
+
+      final MangaBatchImportReport report =
+          await importMangaBatchFolder(db: db, path: root.path);
+
+      expect(report.failedCount, 0);
+      expect(
+        ErrorLogService.instance.entries
+            .skip(before)
+            .where((ErrorLogEntry e) => e.source == 'MangaBatchImport.volume'),
+        isEmpty,
+      );
     });
   });
 }

--- a/fushi/test/media/manga/manga_importer_test.dart
+++ b/fushi/test/media/manga/manga_importer_test.dart
@@ -52,6 +52,48 @@ String _writeValidSample(
   return mokuroPath;
 }
 
+/// 写出一份**卷子目录布局**（mokuro 惯例 B / BUG-1830 复现体）样本：`img_path` 是裸
+/// 文件名，页图躺在与 `.mokuro` 同名的子目录里。返回 `.mokuro` 路径。
+///
+/// 与 [_writeValidSample]（惯例 A：`img_path` 自带 `images/` 前缀，图与 `.mokuro` 同级）
+/// 的差别**只有布局**，页数、字段、字节写法刻意保持一致——两个 helper 的产物必须都能
+/// 导入，任何一个失败都说明页图根解析退回了单一惯例的硬编码。
+String _writeVolumeSubdirSample(
+  String srcDir, {
+  required String title,
+  String volume = 'DLRAW_VOL01',
+  String pagePrefix = 'DLRAW.TO_',
+}) {
+  Directory(srcDir).createSync(recursive: true);
+  final Directory pages = Directory(p.join(srcDir, volume))
+    ..createSync(recursive: true);
+  File(p.join(pages.path, '${pagePrefix}00001.jpeg'))
+      .writeAsBytesSync(<int>[11, 12, 13]);
+  File(p.join(pages.path, '${pagePrefix}00002.jpeg'))
+      .writeAsBytesSync(<int>[14, 15, 16]);
+  final Map<String, Object?> payload = <String, Object?>{
+    'version': '0.2.0',
+    'title': title,
+    'pages': <Object?>[
+      <String, Object?>{
+        'img_width': 1200,
+        'img_height': 1700,
+        'img_path': '${pagePrefix}00001.jpeg',
+        'blocks': <Object?>[],
+      },
+      <String, Object?>{
+        'img_width': 1200,
+        'img_height': 1700,
+        'img_path': '${pagePrefix}00002.jpeg',
+        'blocks': <Object?>[],
+      },
+    ],
+  };
+  final String mokuroPath = p.join(srcDir, '$volume.mokuro');
+  File(mokuroPath).writeAsStringSync(jsonEncode(payload));
+  return mokuroPath;
+}
+
 Map<String, Object?> _readMangaJson(String extractDir) => jsonDecode(
       File(p.join(extractDir, MangaStorage.kMangaJsonFileName))
           .readAsStringSync(),
@@ -443,5 +485,133 @@ void main() {
     );
     // 取消后不落第二本。
     expect((await db.getAllEpubBooks()).length, 1);
+  });
+
+  // ── BUG-1830：mokuro 的两种 img_path 惯例必须都能导入 ────────────────────
+  // 之前页图根被硬编码成「`.mokuro` 同级」，卷子目录布局（裸 img_path）解析成
+  // `<父目录>/<裸文件名>`，必然 `Missing manga page image`；而准入判定会往下探一层
+  // 子目录、把这种布局判为「可导入」——门放行、执行必失败。
+
+  test('卷子目录布局（裸 img_path）从 <卷名>/ 解析页图并成功导入', () async {
+    final String mokuro = _writeVolumeSubdirSample(
+      p.join(srcRoot.path, 'dlraw'),
+      title: 'DLRAW Vol.1',
+    );
+
+    final String bookKey =
+        await MangaImporter.importFromMokuroPath(db: db, mokuroPath: mokuro);
+
+    final EpubBookRow row = (await db.getEpubBook(bookKey))!;
+    expect(row.format, 'manga');
+    expect(row.chapterCount, 2);
+    // 裸 img_path → destRel 只加 `images/` 前缀，不再带卷名一层。
+    expect(row.coverPath, 'images/DLRAW.TO_00001.jpeg');
+    final File cover =
+        File(p.join(row.extractDir, 'images', 'DLRAW.TO_00001.jpeg'));
+    expect(cover.existsSync(), isTrue);
+    // 字节来自卷子目录里的真页图（不是同名空壳/别处文件）。
+    expect(cover.readAsBytesSync(), <int>[11, 12, 13]);
+    expect(
+      File(p.join(row.extractDir, 'images', 'DLRAW.TO_00002.jpeg'))
+          .readAsBytesSync(),
+      <int>[14, 15, 16],
+    );
+    final Map<String, Object?> json = _readMangaJson(row.extractDir);
+    expect(
+      (json['pages']! as List<Object?>)
+          .map((Object? page) => (page! as Map)['url'])
+          .toList(),
+      <String>['images/DLRAW.TO_00001.jpeg', 'images/DLRAW.TO_00002.jpeg'],
+    );
+  });
+
+  test('准入判定放行的卷子目录布局，执行也必须真能导入（门与执行不再两义）',
+      () async {
+    final String mokuro = _writeVolumeSubdirSample(
+      p.join(srcRoot.path, 'gate'),
+      title: 'Gate Vol.1',
+    );
+
+    // 门：探到一层子目录里有页图 → 放行（这一步一直是 true，从来不是 bug 所在）。
+    expect(mangaImportCanImport(<String>[mokuro]), isTrue);
+    // 执行：以前在这里抛 Missing manga page image，现在必须落库。
+    final String bookKey =
+        await MangaImporter.importFromMokuroPath(db: db, mokuroPath: mokuro);
+    expect((await db.getEpubBook(bookKey))!.format, 'manga');
+  });
+
+  test('卷子目录只绑自己那一卷，不会误取同批另一卷的同名页图', () async {
+    // 一个批量目录里两卷共存，页名都叫 001.jpg（不带卷前缀的常见命名）。
+    final Directory batch = Directory(p.join(srcRoot.path, 'batch'))
+      ..createSync(recursive: true);
+    for (final (String vol, List<int> bytes) in <(String, List<int>)>[
+      ('A', <int>[1, 1, 1]),
+      ('B', <int>[2, 2, 2]),
+    ]) {
+      Directory(p.join(batch.path, vol)).createSync(recursive: true);
+      File(p.join(batch.path, vol, '001.jpg')).writeAsBytesSync(bytes);
+      File(p.join(batch.path, '$vol.mokuro'))
+          .writeAsStringSync(jsonEncode(<String, Object?>{
+        'version': '0.2.0',
+        'title': 'Series $vol',
+        'pages': <Object?>[
+          <String, Object?>{
+            'img_width': 800,
+            'img_height': 1200,
+            'img_path': '001.jpg',
+            'blocks': <Object?>[],
+          },
+        ],
+      }));
+    }
+
+    final String bookKey = await MangaImporter.importFromMokuroPath(
+      db: db,
+      mokuroPath: p.join(batch.path, 'A.mokuro'),
+    );
+
+    final EpubBookRow row = (await db.getEpubBook(bookKey))!;
+    expect(
+      File(p.join(row.extractDir, 'images', '001.jpg')).readAsBytesSync(),
+      <int>[1, 1, 1],
+      reason: '候选根只有「就地」与「<卷名>/」两个，绝不能扫到 B/ 去',
+    );
+  });
+
+  test('两种布局都不成立时，错误文案指名道姓列出搜过的目录', () async {
+    final Directory srcDir = Directory(p.join(srcRoot.path, 'nowhere'))
+      ..createSync(recursive: true);
+    // 同级有一张不相干的图 → 准入判定仍放行，逼真复现「门放行」的前提。
+    File(p.join(srcDir.path, 'cover.jpg')).writeAsBytesSync(<int>[9]);
+    final String mokuro = p.join(srcDir.path, 'Vol9.mokuro');
+    File(mokuro).writeAsStringSync(jsonEncode(<String, Object?>{
+      'version': '0.2.0',
+      'title': 'Vol9',
+      'pages': <Object?>[
+        <String, Object?>{
+          'img_width': 800,
+          'img_height': 1200,
+          'img_path': 'p001.jpg',
+          'blocks': <Object?>[],
+        },
+      ],
+    }));
+
+    expect(mangaImportCanImport(<String>[mokuro]), isTrue);
+    await expectLater(
+      MangaImporter.importFromMokuroPath(db: db, mokuroPath: mokuro),
+      throwsA(
+        isA<MangaImportException>().having(
+          (MangaImportException e) => e.message,
+          'message',
+          allOf(
+            contains('p001.jpg'),
+            contains(srcDir.path),
+            contains(p.join(srcDir.path, 'Vol9')),
+          ),
+        ),
+      ),
+    );
+    expect(await db.getAllEpubBooks(), isEmpty);
   });
 }

--- a/fushi/test/media/source_library/source_library_scanner_network_test.dart
+++ b/fushi/test/media/source_library/source_library_scanner_network_test.dart
@@ -605,5 +605,73 @@ void main() {
       expect(books.single.title, 'OddNames');
       expect(fs.copyToLocalCalls, 3, reason: '三张页图都要镜像成功');
     });
+
+    testWidgets('远端漫画：卷子目录布局（img_path 是裸文件名）也能镜像并导入',
+        (WidgetTester tester) async {
+      final FushiDatabase db = _memDb();
+      addTearDown(db.close);
+
+      // BUG-1830 的远端同源分身：mokuro 的另一种惯例是 img_path 只写裸文件名，
+      // 页图躺在与 `.mokuro` 同名的子目录里。镜像阶段此前硬按「相对 .mokuro 同级」
+      // 查表（键 `DLRAW.TO_00001.jpeg`），而远端真实相对路径是
+      // `Vol1/DLRAW.TO_00001.jpeg`，于是整卷在查表阶段就 Missing manga page image。
+      final String pageA = p.join(tmp.path, 'bare_a.jpg');
+      final String pageB = p.join(tmp.path, 'bare_b.jpg');
+      File(pageA).writeAsBytesSync(<int>[7, 7]);
+      File(pageB).writeAsBytesSync(<int>[8, 8]);
+      final String mokuroLocal = p.join(tmp.path, 'Vol1.mokuro');
+      File(mokuroLocal).writeAsStringSync(jsonEncode(<String, Object?>{
+        'version': '0.2.0',
+        'title': 'BareVolume',
+        'pages': <Object?>[
+          for (final String rel in <String>[
+            'DLRAW.TO_00001.jpeg',
+            'DLRAW.TO_00002.jpeg',
+          ])
+            <String, Object?>{
+              'img_width': 800,
+              'img_height': 1200,
+              'img_path': rel,
+              'blocks': <Object?>[],
+            },
+        ],
+      }));
+
+      final _FakeVirtualNetworkFs fs = _FakeVirtualNetworkFs(<String, String>{
+        '/remote/manga/Vol1.mokuro': mokuroLocal,
+        '/remote/manga/Vol1/DLRAW.TO_00001.jpeg': pageA,
+        '/remote/manga/Vol1/DLRAW.TO_00002.jpeg': pageB,
+      });
+
+      final int sid = await db.insertMediaSource(MediaSourcesCompanion.insert(
+        label: 'Bare Manga',
+        mediaKind: 'manga',
+        rootPath: '/remote/manga',
+        transport: const Value('sftp'),
+        createdAt: 1000,
+      ));
+      final SourceLibraryRow source = (await db.getMediaSourceById(sid))!;
+
+      await tester.runAsync(() async {
+        await SourceLibraryScanner(db).scan(source, fs: fs);
+      });
+
+      final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
+      expect(after.lastScanError, isNull,
+          reason: '硬编码同级会在这里留下 Missing manga page image；'
+              '实际值=${after.lastScanError}');
+      final List<EpubBookRow> books = await db.getAllEpubBooks();
+      expect(books, hasLength(1));
+      expect(books.single.title, 'BareVolume');
+      expect(books.single.format, 'manga');
+      expect(fs.copyToLocalCalls, 2, reason: '两张页图都要镜像成功');
+      // 落库产物与本地导入同构：裸 img_path → destRel 只加 images/ 前缀。
+      expect(books.single.coverPath, 'images/DLRAW.TO_00001.jpeg');
+      expect(
+        File(p.join(books.single.extractDir, 'images', 'DLRAW.TO_00001.jpeg'))
+            .readAsBytesSync(),
+        <int>[7, 7],
+      );
+    });
   });
 }


### PR DESCRIPTION
## 根因

`fushi/lib/src/media/manga/manga_importer.dart:226`（修复前）把页图根**硬编码**成 `.mokuro` 同级：

```dart
final Directory srcDir = mokuroFile.parent;
```

但 mokuro 的 `img_path` 有两种并存惯例：

- **惯例 A**：`img_path` 自带卷名 / `images/` 前缀 → 同级解析恰好命中（已入库的「あつまれ！ふしぎ研究部」就是这种）；
- **惯例 B（卷子目录布局）**：`img_path` 是裸文件名（`DLRAW.TO_00001.jpeg`），页图躺在与 `.mokuro` 同名的子目录里 → 解析成 `<父目录>/DLRAW.TO_00001.jpeg`，不存在，整卷 `Missing manga page image`。

同一个错误假设**在三处各写了一遍**（本地导入器 / 准入判定 / 远端来源库扫描镜像），所以远端惯例 B 的卷同样必失败——同源分身，不是另一个 bug。

而准入判定 `mangaImportCanImport` 会往下探**一层子目录**找图片，把惯例 B 判为「可导入」：**门放行、执行必失败**。门与执行是两套判据，这才是「一位两义」的产地。

可观测性另有两个洞，导致事后无从定位：批量导入把逐卷异常收进报告后**只 `debugPrint`**（`runImport` 的 `ErrorLogService` 落盘永远拿不到真原因，`error_log.txt` 里翻不到）；失败 toast 走默认 `LENGTH_SHORT`（桌面 2000ms 含两端 200ms 淡入淡出，带路径的长错误读不完就没了）。

## 改法

不是加参数、不是加特例分支——把「页图根」从假设收成**必须解析出来的事实**，并收敛成唯一原语：

1. 新增 `resolveMokuroPageRoot` / `mokuroPageRootCandidates` / `joinMokuroPageRoot`（`mokuro_payload.dart`）。**零 IO**：存在性探针由调用方注入（本地传文件系统 stat、远端传相对路径查找表），于是本地与远端共用同一份判据。
2. 候选**只有两个**（就地 / `<卷名>/`），卷名取自 `.mokuro` 文件名本身（与卷 1:1）。刻意不扫「任意子目录」——同批次里 `001.jpg` 这类无卷前缀页名会误绑到别卷。
3. `importFromMokuroPath` 改为解析页图根，并**删掉**它原先那道 `mangaImportCanImport` 前置判据：那是真校验的一个更弱的重复副本。真校验 = 解析根 + 逐页存在性。
4. `mangaImportCanImport` 契约写清：**载体分类**（廉价、宽松），不是导入成功的保证。门保持宽松是有意分工。
5. `_importMangaRemote` 同一口径解析远端根，并**连根一起原样镜像**到临时目录，使镜像布局与远端逐段同构。
6. 两种惯例都不成立时，错误文案**逐条列出搜过的目录**；候选与文案共用同一实现，日后加惯例不会只改一处让文案说谎。
7. 逐卷失败原因落盘挪到**吞掉异常的那一层**（`_importOneVolume` 的 catch，source=`MangaBatchImport.volume`）——报告有多个消费方，落日志不该跟着 UI 走。
8. 导入失败 toast 提到 `Toast.LENGTH_LONG`。

## 验证

- `flutter analyze`（全量，含 test）：`No issues found!`
- 定向：`test/media/manga` + `test/media/source_library` + `test/media/import` → **689 passed**
- 新增 7 条用例（导入器 4 / 远端扫描 1 / 批量落盘 2），**全部做过变异实测**：去掉修复即变红（远端那条复现出 `Missing manga page image: DLRAW.TO_00001.jpeg (searched: /remote/manga)`），还原后 sha256 逐字节一致。
- 未做真机端到端复测（本轮为自动化测试覆盖），缺口已记在 `docs/bugs/BUG-1830-mokuro-volume-subdir.md`。
- 未跑 `dart format`：本机 Dart 3.12 是 tall style，整文件格式化会重排存量代码（实测 `mokuro_payload.dart` 34 行改动里多数不是本次改动）。新代码手写匹配周边风格，analyze 干净。

https://claude.ai/code/session_013Nj2xXx8VPxF6YgC3xMjXD
