### PR TITLE
feat(download): 让推荐包的 GitHub + CF 双源真正并拉

### DIFF
--- a/fushi/lib/src/utils/misc/segmented_downloader.dart
+++ b/fushi/lib/src/utils/misc/segmented_downloader.dart
@@ -218,7 +218,12 @@ class SegmentedDownloader {
     StackTrace? lastStack;
     for (int attempt = 0; attempt < maxAttemptsPerPart; attempt++) {
       _throwIfCancelled();
-      final DownloadSource source = part.sources[attempt % part.sources.length];
+      // 源轮换把**分片序号**也算进去：只按 attempt 取模的话，第一轮所有并发分片
+      // 全打 sources[0]，第二个源只有失败重试才用得上——那是故障转移，不是双源并拉。
+      // 加上 part.index 后，片 0→源 0、片 1→源 1……天然摊到所有来源；而 attempt+1
+      // 仍然换到下一个源，重试换源的性质原样保留。
+      final DownloadSource source =
+          part.sources[(part.index + attempt) % part.sources.length];
       try {
         await _fetchPartFrom(part, source);
         return;

--- a/fushi/test/utils/segmented_downloader_test.dart
+++ b/fushi/test/utils/segmented_downloader_test.dart
@@ -314,6 +314,35 @@ void main() {
       );
     });
 
+    test('多源时首轮就摊到所有来源，而不是全压首选源', () async {
+      // 「GitHub 放切片、CF 放整包」要真的并拉，前提是并发的各片**首轮**就分散到
+      // 不同来源。只按 attempt 取模会让首轮全部打 sources[0]，第二个源沦为纯故障
+      // 转移——带宽只吃一家、另一家永远闲着。这条断言钉死那个退化。
+      final Uint8List body = _payload(400);
+      final _FakeHost host = _FakeHost()
+        ..resources['https://cf/pack.zip'] = body
+        ..resources['https://gh/pack.zip'] = body;
+      final DownloadPlan plan = DownloadPlan.ranged(
+        urls: const <String>['https://cf/pack.zip', 'https://gh/pack.zip'],
+        totalBytes: body.length,
+        partSize: 100,
+      );
+
+      final File out = await build(plan, host).download();
+
+      expect(out.readAsBytesSync(), body);
+      int hits(String url) => host.requests
+          .where((MapEntry<String, String?> e) => e.key == url)
+          .length;
+      // 两个源都活着，4 片应当各取一次、零重试；否则下面的分布断言就失去意义。
+      expect(host.requests.length, 4, reason: '不该出现失败重试');
+      expect(hits('https://cf/pack.zip'), 2);
+      expect(
+        hits('https://gh/pack.zip'),
+        2,
+        reason: '第二个来源必须真的分到片，而不是只在故障时才顶上',
+      );
+    });
     test('切片来源忽略 Range（回 200）时按整片重写，结果仍正确', () async {
       // 物理切片：URL 指向的就是这一片，200 回的整个 body 正好是本片内容。
       final Uint8List body = _payload(240);


### PR DESCRIPTION
推荐包（约 9.5 GB）的下载器**本来就支持多来源**——清单的 `mirrors` / `part_base_urls`，`recommended_pack.dart` 注释里明写「GitHub 放切片、CF 放整包」可以互为镜像。但两处让它落不了地，本 PR 各修一处。

## 1. 分片选源退化成故障转移（`segmented_downloader.dart`）

```dart
part.sources[attempt % part.sources.length]   // 只看重试次数
```

首轮所有并发分片全打 `sources[0]`，第二个源只有某片失败重试才用得上——带宽只吃一家，另一家全程闲着。

修法一行，不加调度器、不加状态、不加配置：

```dart
part.sources[(part.index + attempt) % part.sources.length]
```

首轮片 0→源 0、片 1→源 1 天然摊开；`attempt+1` 仍然换到**下一个**源，重试换源的性质原样保留。

**变异实测**（还原成旧写法）：

| | 第一个源 | 第二个源 |
|---|---|---|
| 旧写法（4 片 2 源） | **4 次** | **0 次** |
| 本 PR | 2 次 | 2 次 |

新用例当场红（`Expected: <2> Actual: <4>`），其余全绿。

既有用例不受影响：「镜像 404 时自动轮换」是 2 片 2 源，片 0 仍先打 dead（断言的正是这条）；「退避」用例只有 1 个源，`% 1` 恒 0。

## 2. 工具示例把人往坑里带（`make_download_manifest.dart`）

用法示例原本是 `--part-base-url https://github.com/hajisensai/Fushi/releases/download/pack-…`。照着做会出事：主仓库的 `mirror-releases.yml` 挂在 `release: published` 上且**没有 tag 过滤**，只跳过预发布。在那里发布包 release 会：

1. 把整包（约 9.5 GB）拉进 runner
2. 每个分片都超过 `MAX_ASSET_MB=300` 被跳过上传
3. 仍然**无条件**把一份资产列表为空的 `manifest.json` 覆盖写进 R2
4. 按 `KEEP_RELEASES` 轮转，删掉上一版 app 的镜像文件

净结果：**`fushi.moe/releases` 下载当场失效**。

改文档不够，这种只能靠机械护栏——参数校验直接拒绝指向 `hajisensai/Fushi` release 的地址（owner/repo 大小写不敏感，对齐 GitHub URL 语义），示例改指独立仓库 `fushi-pack`，分片大小示例 1GiB → 256MiB（**分片即重试粒度**，1.5 GB 一片失败一次白扔太多）。

新增 `parseArgsForTest` 让测试走**真实**参数解析路径：只测纯函数的话，把校验里那两行调用删掉，纯函数用例照样全绿、守卫沦为摆设。变异实测（删掉调用点）：4 条纯函数用例仍绿，钉调用点那条当场红。

## 验证

- 4 个测试文件共 **59 项全过**，退出码 0
- `flutter analyze` **No issues found**
- 两处变异实测均按预期红，按唯一锚点复原后逐字节核对

**刻意不跑 `dart format`**：本机 3.44 的 tall style 会把存量文件整体重排（实测污染 211 行），与并发分支徒增冲突面。

## 仍需人工

包分片要传到 `hajisensai/fushi-pack` 的 release，清单传到 `dl.wrds.xyz`——工具跑完即可，本 PR 不含这一步。

https://claude.ai/code/session_018kebQ12s34FK5Ymb2zVAAY