### PR TITLE
fix(update): launcher 消失后自更新永久卡死（BUG-1831）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1688 条。点号进各自文件。
+> 共 1689 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1831](bugs/BUG-1831-win-update-launcher-vanished.md) | ✅ | ✅ | 改名让路后新 launcher 被回滚删除，安装目录再无 launcher，自更新永久卡死 |
 | [BUG-1826](bugs/BUG-1826-mihon-loading-gate-blocks-store-edit.md) | 🚧 | 🚧 | 漫画扩展页 loading 一位两义：初始化联网刷新期间连添加/编辑仓库都点不动 |
 | [BUG-1808](bugs/BUG-1808-video-home-row-card-tags.md) | ✅ | ✅ | 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上） |
 | [BUG-1807](bugs/BUG-1807-url-keyboard-missing-across-app.md) | ✅ | ✅ | 全仓 10 处 URL/host 输入框漏声明 keyboardType，与 BUG-1804 同族 |

--- a/docs/bugs/BUG-1831-win-update-launcher-vanished.md
+++ b/docs/bugs/BUG-1831-win-update-launcher-vanished.md
@@ -1,0 +1,79 @@
+## BUG-1831 · 改名让路后新 launcher 被回滚删除，安装目录再无 launcher，自更新永久卡死
+- **报告**：2026-08-24（用户：「自动更新修复生效没有，你看看」+ 截图「下载失败: UpdateInstallerException: update launcher not found: D:\APP\Hibiki\fushi_update_launcher.exe」）
+- **真实性**：✅ 真 bug —— BUG-1786 修复自身带出的第四层缺陷，现场证据齐全（安装目录清单 + 应用日志 + updates 目录）
+
+### 用户现场
+
+用户问的是「BUG-1786 那个自动更新修复生效没有」。答案是**没有，而且这台机器已经卡进一个比
+BUG-1786 更死的状态：应用内更新连安装器都起不来了**。
+
+| 证据 | 值 |
+|---|---|
+| `D:\APP\Hibiki\data\app.so`（全部 Dart 代码） | **2026-08-19 05:12** |
+| `D:\APP\Hibiki\fushi.exe` | 2026-08-23 18:56 |
+| `D:\APP\Hibiki\fushi_update_launcher.exe` | **不存在** |
+| `D:\APP\Hibiki\fushi_update_launcher.old.exe` | 存在（2026-08-19 05:18） |
+| `%APPDATA%\Fushi\Fushi\updates\` | 8-18 ~ 8-24 共 13 个 `.meta.json`，**一条 `.install.log` 都没有**，历次 setup.exe 全被回收 |
+
+即 BUG-1786 记录的半更新态（新 exe + 8-19 的 Dart 代码）原样还在——那一版修复**从没装进这台
+机器**，所以用户点更新走的仍是旧逻辑、旧判据。应用日志（2026-08-24 19:35，连续三次）：
+
+```
+WindowsInstaller.handoffPrepared  target=2.2.1-debug.12215, installer=...\fushi-2.2.1-debug.12215-windows-setup.exe
+WindowsInstaller.launchFailed     UpdateInstallerException: update launcher not found: D:\APP\Hibiki\fushi_update_launcher.exe
+  #0 WindowsInstaller.runAndExit (platform_updater.dart:718)
+```
+
+包下载完好（249 MB 落盘），**安装器一次都没起来**——所以 updates 目录里连一条 Inno 日志都不会
+产生，任何基于日志的诊断都拿不到材料。
+
+### 根因
+
+`fushi_update_launcher.old.exe` 这个名字全仓库**只有一处**能产生：`fushi.iss` 的
+`MakeWayForRunningLauncher`（BUG-1786 修复第 3 条「改名让路」）。所以链条是：
+
+1. 某次应用内更新跑了**带 BUG-1786 修复的新包**，Inno 探测到 launcher 被自己占用 →
+   改名成 `.old` 让路（这一步按设计工作了）；
+2. 那次安装在后面某个文件上**仍然回滚了**。关键在于：**改名之后
+   `fushi_update_launcher.exe` 这个路径是空的，Inno 往里写的是一个「新建」文件，而 Inno 的回滚
+   会删除本次新建的文件**——只有被覆盖的已存在文件才像 BUG-1786 ② 说的那样原样保留。
+   于是原件（已改名成 `.old`）+ 新件（被回滚删掉）双失，`{app}` 下**再也没有 launcher**；
+3. 此后每一次应用内更新都在 `runAndExit`（`fushi/lib/src/utils/misc/platform_updater.dart:718`）
+   撞 `update launcher not found` 并直接抛出，安装器一次都起不来。
+
+BUG-1786 备注里写的「存量用户下一次应用内更新即自愈」那条通道，被修复自己切断了：它假定
+安装目录里**总有**一个 `fushi_update_launcher.exe` 可用，而「改名让路」恰恰把这个文件从
+「必然存在」变成了「可以永久消失」。用户只剩手动跑安装包一条路，且不做就永远收不到任何更新。
+
+`MakeWayForRunningLauncher` 还会**主动毁掉**唯一的恢复材料：它开头无条件
+`if FileExists(Stale) then DeleteFile(Stale)`，然后才 `if not FileExists(Launcher) then Exit`。
+即在「原件已消失、只剩残留」这个状态下先把残留删了再退出——把「还能自愈」变成「彻底没救」。
+
+### 修复
+
+1. **`platform_updater.dart`**：新增 `resolveWindowsUpdateLauncherSource()`——按序解析一份
+   **实际存在**的 launcher 映像：原件 → `fushi_update_launcher.old.exe` → 带序号的退让名
+   （前缀 + `.exe` 扫描，不硬编码名字清单）。`runAndExit` 用它做 stage 源与 executable，
+   两者皆无才抛 not found。`.old` 与原件是同一份映像，拿它把这次安装跑完，Inno 就会把新
+   launcher 装回原位——**这台机器下次点更新即自愈**，不需要手动装包。
+   回退时打一条 `WindowsInstaller.staleLauncher` 日志，不让自愈变成静默行为。
+2. **`fushi.iss`**：`MakeWayForRunningLauncher` 补上恢复语义与顺序不变式——
+   原件不在而残留在 ⇒ `RenameFile(Stale, Launcher)` **改回去**再退出（本次安装随后正常覆盖它）；
+   删残留只在「原件在位且未被占用」的分支里做。另外让路目标删不掉时（残留可能正是拉起本
+   安装器的那个进程，即自愈路径）退让到带序号的名字，不因一个删不掉的残留放弃整次安装。
+
+- **[x] ① 已修复** — `fushi/lib/src/utils/misc/platform_updater.dart`（`resolveWindowsUpdateLauncherSource` + `runAndExit` 改用它）、`fushi/windows/installer/fushi.iss`（`MakeWayForRunningLauncher` 恢复分支 + 顺序 + 序号退让）
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/update_launcher_vanished_test.dart`（6 条：解析优先级四态 + 前缀误命中负例 + 走真实 `runAndExit` 黑盒断言「只剩 `.old` 时拉起的是 `.old`」，直接钉住用户现场的磁盘状态）
+  + `fushi/test/build/windows_installer_launcher_lock_guard_test.dart` 追加 1 条（钉住 iss 的恢复分支与「先判原件在不在、再谈删残留」的顺序）
+
+### 备注
+
+- **仅 Windows 受影响**：这条链路是 Inno + `fushi_update_launcher.exe` 专有。
+- 用户机器当前仍是半更新态（新 exe + 8-19 的 app.so）。装上本修复之前它发不出任何更新，
+  需**手动跑一次完整安装包**（已下载好的 `fushi-2.2.1-debug.12215-windows-setup.exe` 即可）恢复
+  一致；装上之后 `.old` 兜底与 iss 恢复分支同时到位，这个状态不会再出现。
+- **未做（明确记一句）**：本轮没有真机复跑「只剩 `.old` → 点更新 → 装完整」这条端到端路径
+  （需要一台处于该状态的机器 + 一个含本修复的正式包）。Dart 侧行为由走真实 `runAndExit` 的
+  黑盒测试覆盖，iss 侧只有源码守卫，恢复分支本身**未经 ISCC 运行期实测**。
+- BUG-1786 ② 里「已经复制成功的文件原样保留」这句话只对**被覆盖**的文件成立；对改名让路后
+  变成「新建」的文件，回滚会删掉。这个区别正是本 bug 的全部内容，后续再动让路逻辑时须记住。

--- a/fushi/lib/src/utils/misc/platform_updater.dart
+++ b/fushi/lib/src/utils/misc/platform_updater.dart
@@ -489,6 +489,12 @@ List<String> windowsInstallerArgs(
 
 const String kWindowsUpdateLauncherExecutable = 'fushi_update_launcher.exe';
 
+/// 「改名让路」在安装目录里留下的 launcher 残留名（`fushi.iss` 的
+/// `MakeWayForRunningLauncher`）。它和 [kWindowsUpdateLauncherExecutable] 是**同一份
+/// 可执行映像**，只是换了个文件名，照样能拉起 Inno。
+const String kWindowsUpdateLauncherStaleExecutable =
+    'fushi_update_launcher.old.exe';
+
 String windowsUpdateLauncherPath({String? currentExecutablePath}) {
   final String executablePath =
       currentExecutablePath ?? Platform.resolvedExecutable;
@@ -496,6 +502,72 @@ String windowsUpdateLauncherPath({String? currentExecutablePath}) {
   if (sep < 0) return kWindowsUpdateLauncherExecutable;
   return '${executablePath.substring(0, sep)}'
       '${Platform.pathSeparator}$kWindowsUpdateLauncherExecutable';
+}
+
+/// 解析一个**实际存在**的 launcher 可执行文件：先要原件，原件不在就用「改名让路」
+/// 留下的 `.old` 残留。两个都没有返回 null（调用方据此抛 not found）。
+///
+/// 根因（BUG-1831）：BUG-1786 的「改名让路」把 launcher 从「必然存在的文件」变成了
+/// **可以永久消失的文件**。改名之后 `fushi_update_launcher.exe` 这个路径是空的，Inno
+/// 往里写的是一个**新建**文件——而 Inno 的回滚会删除本次新建的文件（只有被覆盖的文件
+/// 才原样保留）。于是任何一次「改名让路后仍然回滚」的安装都留下：原件已改名成 `.old`、
+/// 新件被回滚删掉 ⇒ 安装目录里**再也没有** launcher。
+///
+/// 此后每一次应用内更新都在 `runAndExit` 抛 `update launcher not found`，安装器一次都
+/// 起不来（连 Inno 日志都不会产生），BUG-1786 备注里「下一次应用内更新即自愈」的通道
+/// 被自己切断，用户只剩手动跑安装包一条路。现场：`{app}` 下只有
+/// `fushi_update_launcher.old.exe`，`data\app.so` 停在四天前。
+///
+/// `.old` 与原件是同一份映像，拿它当 stage 源即可自愈：这次更新照常跑完，Inno 会把
+/// 新 launcher 装回原位。
+/// 让路残留名的公共前缀。让路目标一旦删不掉就退让到带序号的名字
+/// （`fushi_update_launcher.old1.exe`…），所以这里按**前缀**认而不是逐个名字硬编码
+/// ——两侧靠一份命名约定对齐，不靠一张必须同步维护的名字清单。
+const String kWindowsUpdateLauncherStalePrefix = 'fushi_update_launcher.old';
+
+String? resolveWindowsUpdateLauncherSource({
+  required String installedLauncherPath,
+  bool Function(String path)? exists,
+  List<String> Function(String dirPath)? listDirectory,
+}) {
+  final bool Function(String path) probe =
+      exists ?? (String path) => File(path).existsSync();
+  if (probe(installedLauncherPath)) return installedLauncherPath;
+
+  final int sep = _lastPathSeparatorIndex(installedLauncherPath);
+  if (sep < 0) return null;
+  final String dirPath = installedLauncherPath.substring(0, sep);
+  String joined(String name) => '$dirPath${Platform.pathSeparator}$name';
+
+  // 常态残留名优先，命中就不必列目录。
+  final String stalePath = joined(kWindowsUpdateLauncherStaleExecutable);
+  if (probe(stalePath)) return stalePath;
+
+  // 带序号的退让名（`.old1.exe`…）。名字不固定，只能扫。
+  final List<String> Function(String dirPath) list = listDirectory ??
+      (String path) {
+        try {
+          return Directory(path)
+              .listSync(followLinks: false)
+              .whereType<File>()
+              .map((File f) => f.path.substring(
+                  _lastPathSeparatorIndex(f.path) + 1))
+              .toList();
+        } catch (_) {
+          return const <String>[];
+        }
+      };
+  final List<String> candidates = list(dirPath)
+      .where((String name) =>
+          name.toLowerCase().startsWith(kWindowsUpdateLauncherStalePrefix) &&
+          name.toLowerCase().endsWith('.exe'))
+      .toList()
+    ..sort();
+  for (final String name in candidates) {
+    final String path = joined(name);
+    if (probe(path)) return path;
+  }
+  return null;
 }
 
 List<String> windowsUpdateLauncherArgs({
@@ -764,10 +836,25 @@ class WindowsInstaller {
       // BUG-1786：从安装目录**外**的副本运行 launcher。留在安装目录里运行等于自己占着
       // 自己的文件，Inno 复制到它必然 code 5 → /SUPPRESSMSGBOXES 默认 Abort → 整包回滚，
       // data\app.so（全部 Dart 代码）永远装不上。副本失败则退化成旧行为，不阻断更新。
+      // BUG-1831：原件可能已被「改名让路 + 本次安装回滚」的组合抹掉，安装目录里只剩
+      // `fushi_update_launcher.old.exe`。它是同一份映像，拿它接着走即可自愈；不接受
+      // 它就等于让这台机器永远发不出更新（安装器一次都起不来，连日志都不会有）。
+      final String launcherSourcePath = resolveWindowsUpdateLauncherSource(
+            installedLauncherPath: installedLauncherPath,
+          ) ??
+          installedLauncherPath;
+      if (useDelayedLauncher && launcherSourcePath != installedLauncherPath) {
+        ErrorLogService.instance.log(
+          'WindowsInstaller.staleLauncher',
+          'Update launcher missing at $installedLauncherPath; falling back to '
+              'the rename-out-of-the-way leftover at $launcherSourcePath '
+              '(same image). This install will put the real one back.',
+        );
+      }
       final String? stagedLauncherPath =
           useDelayedLauncher && Platform.isWindows
               ? await stageWindowsUpdateLauncher(
-                  launcherPath: installedLauncherPath,
+                  launcherPath: launcherSourcePath,
                   stageRoot: handoffMarkerFile.parent,
                 )
               : null;
@@ -783,7 +870,7 @@ class WindowsInstaller {
         );
       }
       final String executable = useDelayedLauncher
-          ? (stagedLauncherPath ?? installedLauncherPath)
+          ? (stagedLauncherPath ?? launcherSourcePath)
           : installerPath;
       final List<String> launchArgs = useDelayedLauncher
           ? windowsUpdateLauncherArgs(

--- a/fushi/test/build/windows_installer_launcher_lock_guard_test.dart
+++ b/fushi/test/build/windows_installer_launcher_lock_guard_test.dart
@@ -37,13 +37,60 @@ void main() {
     );
     // 改名而不是删除：Windows 允许给运行中的 exe 改名，但删不掉；而且**不能**杀它
     // ——BUG-1708 把「安装失败后把 app 拉回来」交给了它。
+    // 过程体取到下一个 procedure/function 为止，**不用固定字符窗口**：BUG-1831 补进来
+    // 的注释一度把真正的让路语句挤出了 900 字符窗口，守卫于是改为被别处的 RenameFile
+    // 蒙混通过——一条守卫因为无关的注释增删而悄悄失去覆盖，比没有守卫更坏。
     final int makeWayAt = iss.indexOf('procedure MakeWayForRunningLauncher(');
-    final String body = iss.substring(makeWayAt, makeWayAt + 900);
-    expect(body, contains('RenameFile('), reason: '让路手段必须是改名');
+    final int makeWayEnd = iss.indexOf('function PrepareToInstall(', makeWayAt);
+    expect(makeWayEnd, greaterThan(makeWayAt));
+    final String body = iss.substring(makeWayAt, makeWayEnd);
+    // 断言字面量（勿改）: 'RenameFile(Launcher, Stale)'
+    // 方向要钉死：Launcher → Stale 才是让路，反过来是 BUG-1831 的恢复分支，
+    // 两者都必须在，任一缺失都是一条独立的复发路径。
+    expect(
+      body,
+      contains('RenameFile(Launcher, Stale)'),
+      reason: '让路手段必须是改名（把占用中的原件改走），不能是删除、也不能是杀进程',
+    );
     expect(
       body,
       contains('FileLockedForWrite('),
       reason: '只在真的被占用时才改名，别给正常路径平添残留文件',
+    );
+  });
+
+  test('BUG-1831：launcher 已消失、只剩残留时，把残留改回去而不是删掉', () {
+    final String iss = readInstallerScript();
+    final int makeWayAt = iss.indexOf('procedure MakeWayForRunningLauncher(');
+    expect(makeWayAt, greaterThan(0));
+    final int endAt = iss.indexOf('function PrepareToInstall(', makeWayAt);
+    expect(endAt, greaterThan(makeWayAt));
+    final String body = iss.substring(makeWayAt, endAt);
+
+    // 断言字面量（勿改）: 'RenameFile(Stale, Launcher)'
+    //
+    // 「改名让路」把 launcher 从「必然存在的文件」变成了「可以永久消失的文件」：改名后
+    // 目标路径是空的，Inno 往里写的是**新建**文件，而回滚会删除本次新建的文件（只有被
+    // 覆盖的文件才原样保留）。让路成功但本次安装仍然回滚 ⇒ 原件已改名 + 新件被删 ⇒
+    // 安装目录里再没有 launcher，旧版 app 只认这一个路径，从此每次更新都止步
+    // not found，安装器一次都起不来。残留是同一份映像，必须改回去。
+    expect(
+      body,
+      contains('RenameFile(Stale, Launcher)'),
+      reason: 'launcher 缺失时必须用残留把它恢复回去，否则这台机器永远发不出更新',
+    );
+
+    // 顺序不变式：先判「原件在不在」，再谈删残留。反过来（现状之前就是如此）会在
+    // 最需要残留的那一刻把它删掉，把「还能自愈」变成「永久卡死」。
+    final int missingCheckAt = body.indexOf('if not FileExists(Launcher) then');
+    final int firstDeleteAt = body.indexOf('DeleteFile(Stale)');
+    expect(missingCheckAt, greaterThan(0));
+    expect(firstDeleteAt, greaterThan(0));
+    expect(
+      missingCheckAt,
+      lessThan(firstDeleteAt),
+      reason: '删残留必须发生在「原件在位」这个分支里；'
+          '无条件先删会毁掉唯一的恢复材料',
     );
   });
 

--- a/fushi/test/utils/misc/update_launcher_vanished_test.dart
+++ b/fushi/test/utils/misc/update_launcher_vanished_test.dart
@@ -1,0 +1,166 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/platform_updater.dart';
+
+/// BUG-1831：安装目录里的 `fushi_update_launcher.exe` **消失**之后，应用内更新永久卡死。
+///
+/// 现场（用户机器，2026-08-24）：`{app}` 下只有 `fushi_update_launcher.old.exe`，
+/// 原件不见了；`data\app.so` 停在 8-19（比 BUG-1786 的修复还早），三次更新全部止步于
+/// `update launcher not found`，`updates\` 里一条 Inno 日志都没有——安装器一次都没起来。
+///
+/// 成因是 BUG-1786「改名让路」的后半段：改名之后 `fushi_update_launcher.exe` 这个路径
+/// 是空的，Inno 往里写的是**新建**文件，而 Inno 的回滚会删除本次新建的文件（只有被
+/// 覆盖的文件才原样保留）。于是「让路成功但本次安装仍然回滚」= 原件已改名 + 新件被删
+/// ⇒ 安装目录里再没有 launcher，BUG-1786 备注里「下一次应用内更新即自愈」的通道被
+/// 自己切断。
+///
+/// 不变式：只要磁盘上还有**任何一份** launcher 映像（`.old` 残留也算），更新就必须发得出去。
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('fushi-launcher-vanished');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  String join(String name) => '${tempDir.path}${Platform.pathSeparator}$name';
+
+  group('resolveWindowsUpdateLauncherSource', () {
+    test('原件在位时用原件（不因为存在残留就改用残留）', () async {
+      await File(
+        join(kWindowsUpdateLauncherExecutable),
+      ).writeAsString('MZ-new');
+      await File(
+        join(kWindowsUpdateLauncherStaleExecutable),
+      ).writeAsString('MZ-old');
+
+      expect(
+        resolveWindowsUpdateLauncherSource(
+          installedLauncherPath: join(kWindowsUpdateLauncherExecutable),
+        ),
+        join(kWindowsUpdateLauncherExecutable),
+      );
+    });
+
+    test('原件消失、只剩 .old 残留时用残留 —— 正是用户现场，卡死与自愈的分界', () async {
+      await File(
+        join(kWindowsUpdateLauncherStaleExecutable),
+      ).writeAsString('MZ-old');
+
+      expect(
+        resolveWindowsUpdateLauncherSource(
+          installedLauncherPath: join(kWindowsUpdateLauncherExecutable),
+        ),
+        join(kWindowsUpdateLauncherStaleExecutable),
+        reason: '.old 与原件是同一份映像；不认它就等于这台机器永远发不出更新',
+      );
+    });
+
+    test('残留退让到带序号的名字时照样认（两侧靠命名约定对齐，不靠硬编码清单）', () async {
+      await File(
+        join('fushi_update_launcher.old3.exe'),
+      ).writeAsString('MZ-old3');
+
+      expect(
+        resolveWindowsUpdateLauncherSource(
+          installedLauncherPath: join(kWindowsUpdateLauncherExecutable),
+        ),
+        join('fushi_update_launcher.old3.exe'),
+      );
+    });
+
+    test('一份映像都没有时返回 null（调用方照旧抛 not found，不静默假装成功）', () {
+      expect(
+        resolveWindowsUpdateLauncherSource(
+          installedLauncherPath: join(kWindowsUpdateLauncherExecutable),
+        ),
+        isNull,
+      );
+    });
+
+    test('同名前缀的无关文件不会被误当成 launcher', () async {
+      await File(
+        join('fushi_update_launcher.old.exe.bak'),
+      ).writeAsString('not-an-exe');
+      await File(join('fushi_update_launcher_notes.txt')).writeAsString('nope');
+
+      expect(
+        resolveWindowsUpdateLauncherSource(
+          installedLauncherPath: join(kWindowsUpdateLauncherExecutable),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('WindowsInstaller.runAndExit', () {
+    test('只剩 .old 残留时照样把更新发出去，拉起的是残留而不是不存在的原件', () async {
+      // 安装目录：exe 在、launcher 只剩 .old（用户现场的磁盘状态）。
+      final Directory installDir = Directory(
+        '${tempDir.path}${Platform.pathSeparator}app',
+      );
+      await installDir.create(recursive: true);
+      String inApp(String name) =>
+          '${installDir.path}${Platform.pathSeparator}$name';
+      await File(inApp('fushi.exe')).writeAsString('MZ-app');
+      await File(
+        inApp(kWindowsUpdateLauncherStaleExecutable),
+      ).writeAsString('MZ-old-launcher');
+
+      final Directory updatesDir = Directory(
+        '${tempDir.path}${Platform.pathSeparator}updates',
+      );
+      await updatesDir.create(recursive: true);
+      final File installer = File(
+        '${updatesDir.path}${Platform.pathSeparator}setup.exe',
+      );
+      // MZ 头：runAndExit 会先校验下载的确实是个 Windows 可执行文件。
+      await installer.writeAsBytes(<int>[0x4D, 0x5A, 0x90, 0x00]);
+      final File marker = File(
+        '${updatesDir.path}${Platform.pathSeparator}handoff.json',
+      );
+
+      String? launched;
+      var exitCalls = 0;
+      await WindowsInstaller.runAndExit(
+        installer.path,
+        targetVersion: '2.2.1-debug.12215',
+        handoffMarkerFile: marker,
+        currentExecutablePath: inApp('fushi.exe'),
+        collectDiagnostics: () async => const WindowsInstallerDiagnostics(),
+        startProcess: (String executable, List<String> args) async {
+          launched = executable;
+          return const WindowsInstallerStartedProcess(pid: 1234);
+        },
+        exitProcess: (int code) => exitCalls++,
+      );
+
+      // 按**内容**判定源，而不是按路径：Windows 上还会把它 stage 成安装目录外的副本
+      // （BUG-1786），路径因此不固定，但那份字节必须来自 `.old` 残留。
+      expect(launched, isNotNull);
+      final String launchedPath = launched!;
+      expect(
+        File(launchedPath).existsSync(),
+        isTrue,
+        reason: '拉起的必须是磁盘上真实存在的映像，而不是一个不存在的路径',
+      );
+      expect(
+        await File(launchedPath).readAsString(),
+        'MZ-old-launcher',
+        reason:
+            '原件不在磁盘上，拿它当 executable 只会得到 not found；'
+            '残留是同一份映像，必须接着用它把这次安装跑完',
+      );
+      expect(
+        launchedPath,
+        isNot(inApp(kWindowsUpdateLauncherExecutable)),
+        reason: '绝不能回退到那个已经消失的原件路径',
+      );
+      expect(exitCalls, 1, reason: 'launcher 起来之后当前实例必须让出文件锁');
+    });
+  });
+}

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -349,17 +349,45 @@ procedure MakeWayForRunningLauncher(const AppDir: String);
 var
   Launcher: String;
   Stale: String;
+  Attempt: Integer;
 begin
   Launcher := AddBackslash(AppDir) + 'fushi_update_launcher.exe';
   Stale := AddBackslash(AppDir) + 'fushi_update_launcher.old.exe';
-  { 上一轮改名留下的残留：那个进程早已退出，这次能删就删干净，不让它无限堆积。 }
-  if FileExists(Stale) then
-    DeleteFile(Stale);
+  { BUG-1831：launcher 不在位、只剩残留 —— 上一轮让路之后那次安装**仍然回滚了**。
+    改名之后 Launcher 这个路径是空的，Inno 往里写的是一个**新建**文件，而回滚会删除
+    本次新建的文件（只有被覆盖的文件才原样保留）⇒ 原件已改名、新件被删，安装目录里
+    再没有 launcher。此时必须把残留**改回去**：它是同一份映像，旧版 app 又只认
+    fushi_update_launcher.exe 这一个路径。先删掉它等于把「还能自愈」变成「这台机器
+    永远发不出更新」（安装器一次都起不来，连 Inno 日志都不会产生）。
+    改回去之后本次安装照常覆盖它，一次装完即回到正常态。 }
   if not FileExists(Launcher) then
+  begin
+    if FileExists(Stale) then
+      RenameFile(Stale, Launcher);
     Exit;
-  { 没被占用就什么都不做——不给正常路径平添一次改名和一个残留文件。 }
+  end;
+  { 没被占用就什么都不做——不给正常路径平添一次改名和一个残留文件。
+    顺手清掉上一轮的残留：原件在位说明它早已完成使命，不让它无限堆积。 }
   if not FileLockedForWrite(Launcher) then
+  begin
+    if FileExists(Stale) then
+      DeleteFile(Stale);
     Exit;
+  end;
+  { 让路目标必须先空出来，否则 RenameFile 直接失败、等于没让路。残留可能正是
+    **拉起本安装器的那个进程**（BUG-1831 的自愈路径上 app 就是从 .old 起的 launcher），
+    删不掉就换个序号名——绝不因为一个删不掉的残留放弃整次安装。 }
+  Attempt := 0;
+  while FileExists(Stale) do
+  begin
+    if DeleteFile(Stale) then
+      Break;
+    Attempt := Attempt + 1;
+    if Attempt > 8 then
+      Exit;
+    Stale := AddBackslash(AppDir) + 'fushi_update_launcher.old' +
+      IntToStr(Attempt) + '.exe';
+  end;
   RenameFile(Launcher, Stale);
 end;
 


### PR DESCRIPTION
## 现场

用户报「自动更新修复生效没有」。答案：BUG-1786 的修复**从没装进那台机器**，而且它已经卡进一个更死的状态——应用内更新连安装器都起不来。

| 证据 | 值 |
|---|---|
| `D:\APP\Hibiki\data\app.so` | 2026-08-19 05:12（半更新态原样还在） |
| `fushi_update_launcher.exe` | **不存在** |
| `fushi_update_launcher.old.exe` | 存在 |
| `%APPDATA%\Fushi\Fushi\updates\` | 13 个 `.meta.json`，**一条 `.install.log` 都没有** |

应用日志：包下载完好（249 MB），随即 `UpdateInstallerException: update launcher not found` —— 安装器一次都没起来，所以连 Inno 日志都不会产生。

## 根因

`.old.exe` 全仓库只有 `fushi.iss` 的 `MakeWayForRunningLauncher`（BUG-1786 修复第 3 条「改名让路」）能产生。

改名之后 `fushi_update_launcher.exe` 这个路径是空的，**Inno 往里写的是「新建」文件，而 Inno 的回滚会删除本次新建的文件**——只有被覆盖的已存在文件才像 BUG-1786 ② 说的那样原样保留。于是「让路成功但本次安装仍然回滚」= 原件已改名 + 新件被删 ⇒ 安装目录里再没有 launcher，旧版 app 只认这一个路径，从此每次更新都止步 not found。

BUG-1786 备注里「存量用户下一次应用内更新即自愈」的通道，被修复自己切断了。`MakeWayForRunningLauncher` 还会主动毁掉恢复材料：它开头无条件 `DeleteFile(Stale)`，然后才判原件在不在。

## 修复

1. `platform_updater.dart`：新增 `resolveWindowsUpdateLauncherSource()`，按序解析一份**实际存在**的 launcher 映像（原件 → `.old` → 带序号退让名，按前缀扫描而非硬编码清单）；两者皆无才抛 not found。`.old` 是同一份映像，拿它跑完这次安装，Inno 就会把新 launcher 装回原位 —— **卡住的机器下次点更新即自愈**。
2. `fushi.iss`：`MakeWayForRunningLauncher` 补恢复语义（原件不在而残留在则改回去），删残留只在「原件在位且未被占用」的分支做；让路目标删不掉时退让到带序号的名字。
3. 守卫收紧：BUG-1786 那条守卫用固定 900 字符窗口取过程体，被本次注释稀释后已经守不到真正的让路语句（变异实测时暴露），改为取到下一个 function 为止并钉死 `RenameFile` 的方向。

## 验证

- `flutter analyze`（含 test）：No issues found
- 定向 `test/utils/misc/` + `test/build/`：**421 绿**
- 变异实测四处，各自精确红：Dart 用回固定路径 → 红 1（端到端）；iss 恢复分支退化成删除 → 红 2；iss 把删残留提前 → 红 1（顺序断言）；Dart 解析只认原件 → 红 3。两文件还原后 sha256 与变异前逐字节一致。
- **未做**：iss 恢复分支未经 ISCC 运行期实测，也没有真机复跑「只剩 `.old` → 点更新 → 装完整」端到端（需要一台处于该状态的机器 + 含本修复的正式包）。Dart 侧由走真实 `runAndExit` 的黑盒测试覆盖。

https://claude.ai/code/session_014dxBSVHPANH7MyvkvZjGqJ
