### PR TITLE
fix(video): YouTube 兜底 client 链补入 android（BUG-1832）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1689 条。点号进各自文件。
+> 共 1690 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1832](bugs/BUG-1832-youtube-client-fallback-missing-android.md) | ✅ | ✅ | YouTube 部分视频打不开：兜底 client 链缺 android |
 | [BUG-1831](bugs/BUG-1831-win-update-launcher-vanished.md) | ✅ | ✅ | 改名让路后新 launcher 被回滚删除，安装目录再无 launcher，自更新永久卡死 |
 | [BUG-1826](bugs/BUG-1826-mihon-loading-gate-blocks-store-edit.md) | 🚧 | 🚧 | 漫画扩展页 loading 一位两义：初始化联网刷新期间连添加/编辑仓库都点不动 |
 | [BUG-1808](bugs/BUG-1808-video-home-row-card-tags.md) | ✅ | ✅ | 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上） |

--- a/docs/bugs/BUG-1832-youtube-client-fallback-missing-android.md
+++ b/docs/bugs/BUG-1832-youtube-client-fallback-missing-android.md
@@ -1,0 +1,93 @@
+## BUG-1832 · YouTube 部分视频打不开：兜底 client 链缺 android
+- **报告**：2026-08-24（用户：`https://www.youtube.com/watch?v=D8uACXBAqkE` 观看不了）
+- **真实性**：✅ 真 bug（已按原始 URL 复现）。根因 `fushi/lib/src/media/video/youtube_source_resolver.dart:383`（旧 `kYoutubeManifestClientFallback = [androidVr, ios, tv]`）；字幕侧同根因在同文件 `_fetchCaptionTracks`（旧代码硬编码 `yt.YoutubeApiClient.androidVr`）。
+- **[x] ① 已修复** — 兜底链补入 `yt.YoutubeApiClient.android`（顺序 `androidVr → android → ios → tv`）；`_fetchCaptionTracks` 改为按同一条链逐个试、首个非空即用；外层总超时改为由链长派生。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/youtube_client_fallback_test.dart`（9 条断言，含两轮变异实测）。
+- **备注**：见下。
+
+### 复现
+
+`resolveYoutubeSource('https://www.youtube.com/watch?v=D8uACXBAqkE')` 抛：
+
+```
+StateError: youtube manifest failed for all clients (...): VideoUnplayableException: Video 'D8uACXBAqkE' is unplayable.
+```
+
+即 `_getManifestWithClientFallback` 走完全链仍拿不到流 → 播放页拿不到 `streamUrl` → **视频根本打不开**。
+
+### 根因
+
+逐 client 实测（youtube_explode_dart 2.5.3，目标视频 vs 对照视频 `dQw4w9WgXcQ`）：
+
+| client | D8uACXBAqkE | dQw4w9WgXcQ（对照） |
+|---|---|---|
+| androidVr | ❌ `VideoUnplayableException` (1.6s) | ✅ muxed 1 / vo 22 / ao 4 |
+| ios | ❌ 首流 HEAD 403（itag 313，16.2s） | ✅ vo 22 / ao 5 |
+| tv | ❌ `VideoUnplayableException` (9.7s) | ❌ `VideoUnplayableException` |
+| **android** | ✅ **muxed 1 / vo 23 / ao 6**（3.0s） | ✅ muxed 1 / vo 23 / ao 6 |
+
+链里恰好只缺唯一能出流的那个 client。**不是**地区限制、年龄门或视频本身不可用——同一时刻 `android` 一次就出全部 30 条流。
+
+`android` 当年被排除的理由（源码注释「默认 android/ios client 签发的直链实测被 403」）在当前版本**已不成立**。实测 `android` 签发的三条流用 `kYoutubeStreamReplayUserAgent`（= youtube_explode 铸流所用的同一完整 Chrome UA）发 Range 请求：
+
+| 流 | 结果 |
+|---|---|
+| itag 137（1080p avc1）video-only | `206`，65534 字节 |
+| itag 251（opus）audio-only | `206`，65534 字节 |
+| itag 18（muxed 360p） | `206`，65534 字节 |
+
+与 androidVr 基线逐条一致。当年 403 的根因是**回放 UA 与铸流 UA 不一致**（TODO-1365 / BUG-678 已修），不是 client 本身。
+
+### 同根因的第二处：字幕静默消失
+
+`_fetchCaptionTracks` 硬编码 `androidVr` 取 player response。该视频 androidVr 的 `closedCaptionTrack` **恒为 0 条**，旧代码把它当成「这个视频没字幕」：
+
+| client | D8uACXBAqkE 字幕轨 | dQw4w9WgXcQ |
+|---|---|---|
+| androidVr | **0** | 6 |
+| android | **7**（my, zh-TW, en, **ja**, **ja**, ko, vi） | 6 |
+| ios | **7**（同上） | 6 |
+| tv | 0 | 0 |
+
+即修完取流后视频能播，但日语字幕（这个 app 的核心功能）仍是空的。
+
+### 顺带修正的既有缺陷：超时预算靠注释人肉维护
+
+旧代码把「每 client 上限 × 链长 ≤ 外层总超时」写在注释里（「13s × 3 = 39s 不超外层 40s」）。这个不变式：
+
+- 加第 4 个 client 时必然失配；
+- 且 `resolveYoutubeVideoVariants` 的 20s 默认值**当时就已经容不下 3 × 13s = 39s**——画质菜单在首选 client 慢时必然整体超时。
+
+改为从链长**派生**（`kYoutubeResolveTimeout = kYoutubePerClientManifestTimeout × 链长 + 3s`），两个入口共用同一预算，增删 client 时自动跟随。
+
+### 修复
+
+`fushi/lib/src/media/video/youtube_source_resolver.dart`：
+
+1. `kYoutubeManifestClientFallback` → `[androidVr, android, ios, tv]`。`android` 排在 `ios` 之前：实测 `android` 成功 ~3s，而 `ios` 取流失败要等满首流 HEAD 403 探测（16s）。
+2. 新增 `kYoutubePerClientManifestTimeout`（13s）与派生的 `kYoutubeResolveTimeout`；`resolveYoutubeSource` / `resolveYoutubeVideoVariants` 的 `timeout` 参数改为 `Duration?`，null 取派生值。
+3. `_fetchCaptionTracks` 改为经新的注入式纯编排 `fetchFirstNonEmptyByClient` 按同一条链逐个试、首个非空即用并短路；单 client 的一次取轨拆到 `_fetchCaptionTracksWithClient`，保持原有的 best-effort（失败返回空表，绝不冒泡阻断播放）。
+4. 清掉文件头与 `resolveYoutubeSource` doc 里已被实测推翻的「android/ios 直链必 403」「唯一可取字幕的是 ANDROID_VR」两处陈述。
+
+### 验证
+
+修复后跑真实网络路径（`resolveYoutubeSource` + `resolveYoutubeVideoVariants`）：
+
+| 视频 | 取流 | 画质档 | 字幕 cue |
+|---|---|---|---|
+| D8uACXBAqkE（原始失败） | ✅ 15.8s，分离流（非 muxed 回退） | 8 档 | **332**（修前 0） |
+| dQw4w9WgXcQ（对照，防回归） | ✅ 4.8s | 8 档 | 60（与修前一致） |
+
+自动化测试 `fushi/test/media/video/youtube_client_fallback_test.dart` 9 条全绿，并做了两轮变异实测：
+
+- 变异「把 `android` 从链里删掉」→ 2 条断言变红；
+- 变异「去掉短路、跑完全链再返回首个非空」→ 2 条断言变红（结果值仍正确，只有调用序列断言抓到）。
+
+两轮变异后均以 sha256 逐字节校验还原源文件。
+
+`flutter analyze` 全绿（无 issue）。
+
+### 未覆盖
+
+- 未做真机 / 集成测试复测播放画面：本次验证停在解析层（流 URL 可 206 拉取、画质档与字幕 cue 数量），未在真实播放页跑到出画面。
+- 测试不含网络断言（CI 无外网，且 YouTube 各 client 的行为本就会漂），锁的是链构成、超时不变式与逐 client 编排行为这三件本地可判定的事实。

--- a/fushi/lib/src/media/video/youtube_source_resolver.dart
+++ b/fushi/lib/src/media/video/youtube_source_resolver.dart
@@ -10,15 +10,17 @@ import 'package:youtube_explode_dart/youtube_explode_dart.dart' as yt;
 // TODO-1000 根因：YouTube 已对 web 端 timedtext（字幕）URL 加 proof-of-origin
 // 门槛，公开 API（closedCaptions.getManifest → web 观看页派生的 URL）实测**所有格式
 // 都返回空体**，`.get()` 解析空 XML 抛 XmlParserException，进而**炸掉整个
-// resolveYoutubeSource → 视频根本打不开（黑屏/报错）**。唯一仍可直取的是 ANDROID_VR
-// innertube player response 内嵌的字幕 URL（移动端豁免该门槛）。公开 API 不暴露按
-// client 取 player response 的入口，故此处必须触达内部符号；一旦 youtube_explode 升级
-// 改了这些符号，守卫测试 test/media/video/youtube_resolver_impl_symbols_test.dart 会
-// 大声失败。依赖锁定在 youtube_explode_dart 2.5.x。
-// TODO-1307（A2）：androidVr getPlayerResponse **无需先取 WatchPage** 即返回全部
-// closedCaptionTrack（含 ja）——实测 dQw4w9WgXcQ 不带 watchPage 396ms 拿到 6 轨、带
-// watchPage 1674ms 拿到同 6 轨，WatchPage 是纯多余往返，故 [_resolveYoutubeCaptions]
-// 只做一次 getPlayerResponse，不再 import/使用 WatchPage。
+// resolveYoutubeSource → 视频根本打不开（黑屏/报错）**。仍可直取的是**移动端 innertube
+// player response**内嵌的字幕 URL（移动端豁免该门槛）——具体走哪个 client 见
+// [_fetchCaptionTracks]：BUG-1832 后按 kYoutubeManifestClientFallback 逐个试，不再钉死
+// ANDROID_VR（它对部分视频返回 0 轨）。公开 API 不暴露按 client 取 player response 的入口，
+// 故此处必须触达内部符号；一旦 youtube_explode 升级改了这些符号，守卫测试
+// test/media/video/youtube_resolver_impl_symbols_test.dart 会大声失败。依赖锁定在
+// youtube_explode_dart 2.5.x。
+// TODO-1307（A2）：getPlayerResponse **无需先取 WatchPage** 即返回全部 closedCaptionTrack
+// （含 ja）——实测 dQw4w9WgXcQ 不带 watchPage 396ms 拿到 6 轨、带 watchPage 1674ms 拿到同
+// 6 轨，WatchPage 是纯多余往返，故 [_fetchCaptionTracks] 只做 getPlayerResponse，
+// 不再 import/使用 WatchPage。
 // ignore: implementation_imports
 import 'package:youtube_explode_dart/src/videos/video_controller.dart'
     show VideoController;
@@ -377,15 +379,47 @@ Future<Map<String, dynamic>> resolveYoutubeCaptionsForExtension(
 }
 
 /// A1 多 client 兜底顺序（TODO-1307，借鉴 yt-dlp 多 client 抽流）：**androidVr 首选**——它
-/// 签发的直链无需签名解密、libmpv/ffmpeg 用普通浏览器 UA 即可拉取（默认 android/ios 直链
-/// 实测被 403）；仅 androidVr 取流失败/空流时才回落 ios、tv（覆盖部分地区限制/年龄门视频）。
+/// 签发的直链无需签名解密、libmpv/ffmpeg 用普通浏览器 UA 即可拉取；仅 androidVr 取流失败/
+/// 空流时才逐个回落 [android]、[ios]、[tv]（覆盖部分地区限制/年龄门视频）。
 /// [ios] 是 `static final` 非 const，故整表用 `final` 而非 `const`。
+///
+/// BUG-1832：**[android] 必须在链里**。存在一类视频（实测 `D8uACXBAqkE`，播客类长视频）
+/// 对 androidVr / tv 返回 `VideoUnplayableException`、对 ios 返回的 4K 直链首流 HEAD 即 403，
+/// 三个 client 全挂 → [_getManifestWithClientFallback] 抛 StateError → **视频根本打不开**。
+/// 同一视频用 [android] 一次即拿到 muxed 1 + video-only 23 + audio-only 6 条流。
+///
+/// 旧注释「默认 android/ios 直链实测被 403」在当前 youtube_explode 2.5.3 下**已不成立**：
+/// 实测 [android] 签发的 itag137(1080p avc1) / itag251(opus) / itag18(muxed) 三条流，用
+/// [kYoutubeStreamReplayUserAgent]（= youtube_explode 铸流所用的同一完整 Chrome UA）发
+/// Range 请求全部返回 206 + 真实字节，与 androidVr 基线逐条一致。当年 403 的根因是回放 UA
+/// 与铸流 UA 不一致（TODO-1365/BUG-678 已修），不是 client 本身。
+///
+/// 排在 [ios] 之前：实测 [android] 成功 ~3s，而 [ios] 在取流失败时要等满首流 HEAD 403 探测
+/// （实测 16s）——把更可靠且更快的 client 提前，缩短兜底链的实际等待。
 final List<yt.YoutubeApiClient> kYoutubeManifestClientFallback =
     <yt.YoutubeApiClient>[
   yt.YoutubeApiClient.androidVr,
+  yt.YoutubeApiClient.android,
   yt.YoutubeApiClient.ios,
   yt.YoutubeApiClient.tv,
 ];
+
+/// 单个 manifest client 的取流超时上限（[_getManifestWithClientFallback] 默认值）。
+///
+/// googlevideo/innertube 偶发 tarpit（限流时连接不完成），没有单 client 上限时首选 client
+/// 一挂就要等满外层总超时才轮到兜底 client。实测正常取流 1.6~4.5s，13s 留 ~3x 余量。
+const Duration kYoutubePerClientManifestTimeout = Duration(seconds: 13);
+
+/// YouTube 解析的**外层总超时**，由兜底链长度派生：每 client 上限 × 链长 + 3s 余量。
+///
+/// BUG-1832：旧代码把这个关系写在注释里（「取值需保证三 client 累计 13s × 3 = 39s 不超外层
+/// 40s 兜底」），靠人肉维护——加第 4 个 client 时必然失配，而
+/// [resolveYoutubeVideoVariants] 的 20s 默认值**当时就已经容不下 3 × 13s = 39s**（画质菜单
+/// 在首选 client 慢时必然整体超时）。改成从链长派生后，增删 client 时总预算自动跟随，
+/// 这个不变式不再可能悄悄破掉。
+final Duration kYoutubeResolveTimeout =
+    kYoutubePerClientManifestTimeout * kYoutubeManifestClientFallback.length +
+        const Duration(seconds: 3);
 
 /// TODO-1365（BUG-678）：YouTube 分离流的**回放 User-Agent 必须与 youtube_explode 铸造 +
 /// 校验该流所用的 UA 完全一致**。[yt.YoutubeApiClient.androidVr] 的 innertube context 不带
@@ -419,17 +453,19 @@ Map<String, String> youtubeStreamReplayHeaders() =>
 /// = 该 client 失败），androidVr 成功即零回归返回，只有它失败才试下一个。全部失败抛最后异常。
 ///
 /// 提速（用户报「YouTube 加载巨慢」）：每个 client 的 getManifest 加 [perClientTimeout]
-/// 上限。googlevideo/innertube 偶发 tarpit（限流时连接不完成），旧代码只有外层 40s 总超时
-/// 兜底——首选 androidVr 一旦 tarpit，要等满 40s 才轮到 ios/tv，用户干等到近乎放弃。加
+/// 上限。googlevideo/innertube 偶发 tarpit（限流时连接不完成），没有单 client 上限时首选
+/// androidVr 一旦 tarpit，要等满外层总超时才轮到后面的 client，用户干等到近乎放弃。加
 /// 每 client 超时后，某 client 挂住 [perClientTimeout] 即判失败、立刻试下一个兜底 client，
-/// 常见「androidVr 慢」场景从「等 40s」降到「等 ~perClientTimeout 就换」。取值需保证
-/// 三 client 累计（[perClientTimeout] × 3）不超外层 40s 兜底（13s × 3 = 39s）。超时按普通
+/// 常见「androidVr 慢」场景从「等满总超时」降到「等 ~perClientTimeout 就换」。超时按普通
 /// client 失败处理（记异常、试下一个），与 403/无流同路径。
+///
+/// 「每 client 上限累计不超外层总超时」的不变式现在由 [kYoutubeResolveTimeout] 从链长
+/// **派生**保证（BUG-1832），不再靠注释人肉维护。
 Future<yt.StreamManifest> _getManifestWithClientFallback(
   yt.YoutubeExplode client,
   yt.VideoId videoId,
   List<yt.YoutubeApiClient> ytClients, {
-  Duration perClientTimeout = const Duration(seconds: 13),
+  Duration perClientTimeout = kYoutubePerClientManifestTimeout,
 }) async {
   Object? lastError;
   for (final yt.YoutubeApiClient api in ytClients) {
@@ -458,8 +494,9 @@ Future<yt.StreamManifest> _getManifestWithClientFallback(
 
 /// IO：用 youtube_explode 解析可播放流 URL + 日文字幕（无则空）+ 标题。
 ///
-/// 流用 **ANDROID_VR** client 取：它签发的直链无需签名解密、且 libmpv/ffmpeg 用普通
-/// 浏览器 UA 即可拉取（默认 android/ios client 签发的直链实测被 403），取**最高清
+/// 流优先用 **ANDROID_VR** client 取：它签发的直链无需签名解密、且 libmpv/ffmpeg 用普通
+/// 浏览器 UA 即可拉取；它对该视频不可用时按 [kYoutubeManifestClientFallback] 逐个回落
+/// （android → ios → tv，BUG-1832），取**最高清
 /// video-only + 最高码率 audio-only** 分离流（可达 4K），播放时视频流经 libmpv、音频流经
 /// `AudioTrack.uri` 外挂；制卡时 GIF/帧从视频流、音频段从音频流各自 ffmpeg 裁。仅当该视频
 /// 无分离流才回落 muxed（≤360p，YouTube 侧限制）。字幕见 [_resolveBestCaptionCues]。
@@ -468,8 +505,9 @@ Future<YoutubeResolvedSource> resolveYoutubeSource(
   String preferSubtitleLang = 'ja',
   // 慢网下每个 youtube_explode 请求可达 7~9s。TODO-1307 后播放页走「快解析 gate」
   // （withCaptions=false）：只 getManifest 取流即起播、跳过 videos.get（title 用 book.title）
-  // 与字幕（后置异步解析灌 1302 字幕轨），解析从 >25s 降到 ~getManifest。40s 仅作 tarpit 兜底。
-  Duration timeout = const Duration(seconds: 40),
+  // 与字幕（后置异步解析灌 1302 字幕轨），解析从 >25s 降到 ~getManifest。这里仅作 tarpit
+  // 兜底：null = [kYoutubeResolveTimeout]（由兜底链长度派生，BUG-1832）。
+  Duration? timeout,
   // 制卡 / 快解析 gate 只需流 URL，不需字幕 cue → 传 false 跳过 videos.get + 昂贵的字幕解析，
   // 解析降到 ~getManifest。仅遗留「一次性同步取字幕」的调用方用默认 true。
   bool withCaptions = true,
@@ -492,7 +530,7 @@ Future<YoutubeResolvedSource> resolveYoutubeSource(
       withCaptions,
       ytClients ?? kYoutubeManifestClientFallback,
       playbackTargetHeight,
-    ).timeout(timeout);
+    ).timeout(timeout ?? kYoutubeResolveTimeout);
   } finally {
     client.close();
   }
@@ -720,7 +758,9 @@ List<T> dedupeVideoStreamsByHeight<T>(
 /// [resolveYoutubeSource]（androidVr→ios→tv、每 client 有超时）。
 Future<YoutubeVariantSet> resolveYoutubeVideoVariants(
   String url, {
-  Duration timeout = const Duration(seconds: 20),
+  // BUG-1832：旧默认 20s **容不下**兜底链（3 × 13s = 39s 就已超），首选 client 一慢画质
+  // 菜单必整体超时。null = [kYoutubeResolveTimeout]（由链长派生，与取流路径同一预算）。
+  Duration? timeout,
   List<yt.YoutubeApiClient>? ytClients,
   // 用户显式画质目标（与 [resolveYoutubeSource] 同义）：非 null 时「自动」档下标
   // 对齐 ≤目标 的最高档，与初始播放选择一致。
@@ -734,7 +774,7 @@ Future<YoutubeVariantSet> resolveYoutubeVideoVariants(
       url,
       ytClients ?? kYoutubeManifestClientFallback,
       playbackTargetHeight,
-    ).timeout(timeout);
+    ).timeout(timeout ?? kYoutubeResolveTimeout);
   } finally {
     client.close();
   }
@@ -1058,17 +1098,57 @@ Future<List<AudioCue>> resolveYoutubeCaptionCues(
   }
 }
 
-/// IO：从 ANDROID_VR innertube player response 取字幕轨元数据表（公开 API 的 web 字幕 URL 已
-/// 失效，见文件头注释）。best-effort：整体失败返回空表；**单轨字段缺失（vssId/name null）跳过
-/// 该轨、不连坐整表**（防一条坏轨令字幕轨选择器全空 = 回归）。
+/// IO：从 innertube player response 取字幕轨元数据表（公开 API 的 web 字幕 URL 已失效，见
+/// 文件头注释）。best-effort：整体失败返回空表；**单轨字段缺失（vssId/name null）跳过该轨、
+/// 不连坐整表**（防一条坏轨令字幕轨选择器全空 = 回归）。
 ///
-/// TODO-1307（A2）：只做**一次** getPlayerResponse（androidVr），不再先取 WatchPage——实测
-/// androidVr 不带 watchPage 即返回全部字幕轨（含 ja）且省一次往返（见文件头）。
-Future<List<YoutubeCaptionTrack>> _fetchCaptionTracks(yt.VideoId id) async {
+/// TODO-1307（A2）：只做 getPlayerResponse，不再先取 WatchPage——实测不带 watchPage 即返回
+/// 全部字幕轨（含 ja）且省一次往返（见文件头）。
+///
+/// BUG-1832：**按 [kYoutubeManifestClientFallback] 逐个 client 试，首个拿到非空轨表的即用**，
+/// 不再硬编码 androidVr。根因与取流侧同一个：单一 client 对某些视频不返回数据。实测
+/// `D8uACXBAqkE` 的 androidVr player response `closedCaptionTrack` **恒为 0 条**（该视频对
+/// androidVr 本就 unplayable），而 [yt.YoutubeApiClient.android] / [yt.YoutubeApiClient.ios]
+/// 都返回完整 7 条（含 2 条 ja）——旧代码把它当成「这个视频没字幕」，日语学习的核心功能静默
+/// 消失。tv client 实测对任何视频都返回 0 轨（它排在链尾，恒空不影响判据）。
+///
+/// 判据是「非空即返回」：真没字幕的视频会走完全链（4 次往返、实测各 ~0.5s），但字幕是
+/// TODO-1302 的**后置异步**解析，不在起播关键路径上，这点代价换回「有字幕的视频不再被误判
+/// 成没有」。
+Future<List<YoutubeCaptionTrack>> _fetchCaptionTracks(yt.VideoId id) =>
+    fetchFirstNonEmptyByClient<YoutubeCaptionTrack>(
+      kYoutubeManifestClientFallback,
+      (yt.YoutubeApiClient api) => _fetchCaptionTracksWithClient(id, api),
+    );
+
+/// 纯编排（IO 全部由 [fetch] 注入）：按 [clients] 顺序逐个调 [fetch]，**首个返回非空列表**
+/// 的结果即用并**立刻停止**（不再调用后续 client）；全部为空返回空表。
+///
+/// BUG-1832 的通用形状：YouTube 的每个 innertube client 对**同一个视频**给出的数据并不一致
+/// （实测 `D8uACXBAqkE` 的字幕轨表 androidVr=0 条、android=7 条），钉死单一 client 就会把
+/// 「这个 client 没数据」误读成「这个视频没数据」。抽成注入式纯编排是为了能真单测「空→试下
+/// 一个、非空→短路」这两条行为，而不是靠扫源码字符串。
+Future<List<T>> fetchFirstNonEmptyByClient<T>(
+  List<yt.YoutubeApiClient> clients,
+  Future<List<T>> Function(yt.YoutubeApiClient client) fetch,
+) async {
+  for (final yt.YoutubeApiClient api in clients) {
+    final List<T> got = await fetch(api);
+    if (got.isNotEmpty) return got;
+  }
+  return <T>[];
+}
+
+/// IO：用**单个** [api] client 取一次字幕轨表（[_fetchCaptionTracks] 的每步）。
+/// best-effort：该 client 失败/无轨返回空表，由调用方决定是否试下一个。
+Future<List<YoutubeCaptionTrack>> _fetchCaptionTracksWithClient(
+  yt.VideoId id,
+  yt.YoutubeApiClient api,
+) async {
   final yt.YoutubeHttpClient http = _createYoutubeHttpClient();
   try {
-    final PlayerResponse response = await VideoController(http)
-        .getPlayerResponse(id, yt.YoutubeApiClient.androidVr);
+    final PlayerResponse response =
+        await VideoController(http).getPlayerResponse(id, api);
     final List<YoutubeCaptionTrack> out = <YoutubeCaptionTrack>[];
     for (final ClosedCaptionTrack t in response.closedCaptionTrack) {
       try {

--- a/fushi/test/media/video/youtube_client_fallback_test.dart
+++ b/fushi/test/media/video/youtube_client_fallback_test.dart
@@ -1,0 +1,108 @@
+// BUG-1832 守卫：YouTube 多 client 兜底链的构成、超时预算不变式，以及「逐 client 取首个
+// 非空」的短路行为。
+//
+// 原始失败：`https://www.youtube.com/watch?v=D8uACXBAqkE` 打不开。根因是兜底链
+// `[androidVr, ios, tv]` 里没有 `android`——该视频对 androidVr/tv 是 unplayable、对 ios 的
+// 首流 HEAD 是 403，三个 client 全挂即抛 StateError；而 `android` 一次就能出流。同一根因在
+// 字幕侧的表现是 `_fetchCaptionTracks` 钉死 androidVr（该视频 androidVr 返回 0 条字幕轨，
+// android/ios 返回 7 条含 2 条 ja），日语字幕静默消失。
+//
+// 这里不做网络断言（CI 无外网，且 YouTube 的 client 行为本就会漂），只锁住三件**本地可判定**
+// 且一旦回退就会重现该 bug 的事实。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart' as yt;
+
+import 'package:fushi/src/media/video/youtube_source_resolver.dart';
+
+/// 取 client 的 innertube clientName（兜底链的可读身份，用于断言链的构成与顺序）。
+String _clientName(yt.YoutubeApiClient client) =>
+    (client.payload['context']['client']
+        as Map<String, dynamic>)['clientName'] as String;
+
+void main() {
+  group('BUG-1832 兜底链构成', () {
+    test('链里必须含 ANDROID，且顺序为 androidVr → android → ios → tv', () {
+      // ANDROID 缺席正是原始 bug：只有它能给 D8uACXBAqkE 出流。
+      expect(
+        kYoutubeManifestClientFallback.map(_clientName).toList(),
+        <String>['ANDROID_VR', 'ANDROID', 'IOS', 'TVHTML5'],
+      );
+    });
+
+    test('链内无重复 client（重复 = 白白多等一轮超时）', () {
+      final List<String> names =
+          kYoutubeManifestClientFallback.map(_clientName).toList();
+      expect(names.toSet().length, names.length);
+    });
+  });
+
+  group('BUG-1832 超时预算不变式', () {
+    test('外层总超时 ≥ 每 client 上限 × 链长（增删 client 时自动跟随）', () {
+      // 旧代码把这个关系写在注释里靠人肉维护，加第 4 个 client 时必然失配。
+      final Duration needed = kYoutubePerClientManifestTimeout *
+          kYoutubeManifestClientFallback.length;
+      expect(
+        kYoutubeResolveTimeout,
+        greaterThanOrEqualTo(needed),
+        reason: '总预算 ${kYoutubeResolveTimeout.inSeconds}s 容不下 '
+            '${kYoutubeManifestClientFallback.length} 个 client × '
+            '${kYoutubePerClientManifestTimeout.inSeconds}s',
+      );
+    });
+
+    test('每 client 上限为正（0 会让每个 client 立即超时 = 永远解析失败）', () {
+      expect(kYoutubePerClientManifestTimeout, greaterThan(Duration.zero));
+    });
+  });
+
+  group('BUG-1832 fetchFirstNonEmptyByClient', () {
+    test('首个 client 返回空时继续试下一个', () async {
+      final List<String> called = <String>[];
+      final List<int> got = await fetchFirstNonEmptyByClient<int>(
+        kYoutubeManifestClientFallback,
+        (yt.YoutubeApiClient c) async {
+          called.add(_clientName(c));
+          // 只有第二个（ANDROID）有数据——正是 D8uACXBAqkE 的实测形状。
+          return _clientName(c) == 'ANDROID' ? <int>[1, 2, 3] : <int>[];
+        },
+      );
+      expect(got, <int>[1, 2, 3]);
+      expect(called, <String>['ANDROID_VR', 'ANDROID']);
+    });
+
+    test('拿到非空即短路，不再调用后续 client', () async {
+      final List<String> called = <String>[];
+      final List<int> got = await fetchFirstNonEmptyByClient<int>(
+        kYoutubeManifestClientFallback,
+        (yt.YoutubeApiClient c) async {
+          called.add(_clientName(c));
+          return <int>[7];
+        },
+      );
+      expect(got, <int>[7]);
+      expect(called, <String>['ANDROID_VR'],
+          reason: '首个非空后仍调用后续 client = 每次解析都多打 3 次无谓请求');
+    });
+
+    test('全部 client 都空时返回空表（不抛，字幕是 best-effort）', () async {
+      int calls = 0;
+      final List<int> got = await fetchFirstNonEmptyByClient<int>(
+        kYoutubeManifestClientFallback,
+        (yt.YoutubeApiClient _) async {
+          calls++;
+          return <int>[];
+        },
+      );
+      expect(got, isEmpty);
+      expect(calls, kYoutubeManifestClientFallback.length);
+    });
+
+    test('空 client 列表返回空表（不抛）', () async {
+      final List<int> got = await fetchFirstNonEmptyByClient<int>(
+        const <yt.YoutubeApiClient>[],
+        (yt.YoutubeApiClient _) async => <int>[1],
+      );
+      expect(got, isEmpty);
+    });
+  });
+}

--- a/fushi/test/media/video/youtube_fast_load_guard_test.dart
+++ b/fushi/test/media/video/youtube_fast_load_guard_test.dart
@@ -134,9 +134,9 @@ void main() {
         reason: 'connecting 阶段必须在 buildStreamVideoLaunch（慢网可数秒）之前置起');
   });
 
-  test('A2：字幕解析只做一次 getPlayerResponse（不再取多余 WatchPage）', () {
-    // 不再 import watch_page.dart、不再调用 WatchPage.get（androidVr getPlayerResponse 无需
-    // WatchPage 即返回全部字幕轨，实测省 ~1.3s 往返）。注意断言真实用法而非注释里的词。
+  test('A2：字幕解析只做 getPlayerResponse（不再取多余 WatchPage）', () {
+    // 不再 import watch_page.dart、不再调用 WatchPage.get（getPlayerResponse 无需 WatchPage
+    // 即返回全部字幕轨，实测省 ~1.3s 往返）。注意断言真实用法而非注释里的词。
     expect(
       resolverSrc.contains('watch_page.dart'),
       isFalse,
@@ -147,11 +147,19 @@ void main() {
       isFalse,
       reason: 'A2：字幕解析不得再取 WatchPage',
     );
+    // BUG-1832：client 不再钉死 androidVr（它对部分视频返回 0 条字幕轨），改为按
+    // kYoutubeManifestClientFallback 逐个试；这里锁的仍是「每个 client 只做一次
+    // getPlayerResponse、不再补 WatchPage 往返」。
     expect(
-      resolverSrc
-          .contains('.getPlayerResponse(id, yt.YoutubeApiClient.androidVr)'),
+      resolverSrc.contains('.getPlayerResponse(id, api)'),
       isTrue,
-      reason: 'A2：字幕只做一次 androidVr getPlayerResponse',
+      reason: 'A2：单 client 取轨只做一次 getPlayerResponse',
+    );
+    // 单行锚点：跨行匹配在 CRLF 检出下会恒不成立，令守卫静默空转。
+    expect(
+      resolverSrc.contains('fetchFirstNonEmptyByClient<YoutubeCaptionTrack>('),
+      isTrue,
+      reason: 'BUG-1832：字幕取轨必须走整条兜底链，不得钉死单一 client',
     );
   });
 }

--- a/fushi/test/media/video/youtube_source_resolver_test.dart
+++ b/fushi/test/media/video/youtube_source_resolver_test.dart
@@ -169,10 +169,13 @@ void main() {
     });
   });
 
-  // TODO-1307 A1：多 client 兜底顺序——androidVr 首选（零回归），失败才回落 ios、tv。
+  // TODO-1307 A1：多 client 兜底顺序——androidVr 首选（零回归），失败才逐个回落。
+  // BUG-1832：链里补入 android（实测存在只有它能出流的视频，如 D8uACXBAqkE），并排在
+  // ios 之前（android 成功 ~3s，ios 取流失败要等满首流 HEAD 403 探测 ~16s）。
   group('A1 多 client 兜底顺序 (TODO-1307)', () {
-    test('kYoutubeManifestClientFallback = androidVr -> ios -> tv', () {
-      expect(kYoutubeManifestClientFallback.length, 3);
+    test('kYoutubeManifestClientFallback = androidVr -> android -> ios -> tv',
+        () {
+      expect(kYoutubeManifestClientFallback.length, 4);
       expect(
         identical(
             kYoutubeManifestClientFallback[0], yt.YoutubeApiClient.androidVr),
@@ -180,11 +183,17 @@ void main() {
         reason: 'androidVr 必须首选（其直链无需签名解密、libmpv 普通 UA 可拉取）',
       );
       expect(
-        identical(kYoutubeManifestClientFallback[1], yt.YoutubeApiClient.ios),
+        identical(
+            kYoutubeManifestClientFallback[1], yt.YoutubeApiClient.android),
+        isTrue,
+        reason: 'BUG-1832：android 缺席会让只有它能出流的视频彻底打不开',
+      );
+      expect(
+        identical(kYoutubeManifestClientFallback[2], yt.YoutubeApiClient.ios),
         isTrue,
       );
       expect(
-        identical(kYoutubeManifestClientFallback[2], yt.YoutubeApiClient.tv),
+        identical(kYoutubeManifestClientFallback[3], yt.YoutubeApiClient.tv),
         isTrue,
       );
     });


### PR DESCRIPTION
用户报 `https://www.youtube.com/watch?v=D8uACXBAqkE` 观看不了。已复现为 `resolveYoutubeSource` 抛 `StateError: youtube manifest failed for all clients`。

## 根因

`kYoutubeManifestClientFallback = [androidVr, ios, tv]` 里没有 `android`，而该视频恰好只有 `android` 能出流：

| client | D8uACXBAqkE | dQw4w9WgXcQ（对照） |
|---|---|---|
| androidVr | ❌ `VideoUnplayableException` (1.6s) | ✅ muxed 1 / vo 22 / ao 4 |
| ios | ❌ 首流 HEAD 403（itag 313，16.2s） | ✅ vo 22 / ao 5 |
| tv | ❌ `VideoUnplayableException` (9.7s) | ❌ `VideoUnplayableException` |
| **android** | ✅ **muxed 1 / vo 23 / ao 6**（3.0s） | ✅ muxed 1 / vo 23 / ao 6 |

不是地区限制或年龄门——同一时刻 `android` 一次就出全部 30 条流。

`android` 当年被排除的理由（注释「默认 android/ios client 签发的直链实测被 403」）在 youtube_explode 2.5.3 下**已不成立**。实测 `android` 签发的三条流用 `kYoutubeStreamReplayUserAgent`（= youtube_explode 铸流所用的同一完整 Chrome UA）发 Range 请求：

| 流 | 结果 |
|---|---|
| itag 137（1080p avc1）video-only | `206`，65534 字节 |
| itag 251（opus）audio-only | `206`，65534 字节 |
| itag 18（muxed 360p） | `206`，65534 字节 |

与 androidVr 基线逐条一致。当年 403 的根因是回放 UA 与铸流 UA 不一致（TODO-1365 / BUG-678 已修），不是 client 本身。

## 同根因第二处：日语字幕静默消失

`_fetchCaptionTracks` 硬编码 `androidVr` 取 player response。该视频 androidVr 的 `closedCaptionTrack` **恒为 0 条**，旧代码把它当成「这个视频没字幕」：

| client | D8uACXBAqkE 字幕轨 | dQw4w9WgXcQ |
|---|---|---|
| androidVr | **0** | 6 |
| android | **7**（my, zh-TW, en, **ja**, **ja**, ko, vi） | 6 |
| ios | **7** | 6 |
| tv | 0 | 0 |

只修取流的话，视频能播但日语字幕仍为空。

## 顺带修正的既有缺陷

旧代码把「每 client 上限 × 链长 ≤ 外层总超时」写在注释里靠人肉维护。这个不变式此前**已经破了**：`resolveYoutubeVideoVariants` 的 20s 默认值容不下 3 × 13s = 39s，画质菜单在首选 client 慢时必然整体超时。改为从链长派生（`kYoutubeResolveTimeout`），增删 client 时自动跟随。

## 改动

- 链改为 `androidVr → android → ios → tv`（`android` 排 `ios` 前：成功 ~3s，而 `ios` 取流失败要等满首流 HEAD 403 探测 ~16s）
- 新增 `kYoutubePerClientManifestTimeout` 与派生的 `kYoutubeResolveTimeout`；两个入口的 `timeout` 参数改为 `Duration?`，null 取派生值
- `_fetchCaptionTracks` 经新的注入式纯编排 `fetchFirstNonEmptyByClient` 走整条链、首个非空即用并短路；单 client 取轨拆到 `_fetchCaptionTracksWithClient`，保持 best-effort（失败返回空表，绝不阻断播放）
- 清掉文件头与 doc 里两处被实测推翻的陈述

## 验证

真实网络路径（`resolveYoutubeSource` + `resolveYoutubeVideoVariants`）：

| 视频 | 取流 | 画质档 | 字幕 cue |
|---|---|---|---|
| D8uACXBAqkE（原始失败） | ✅ 15.8s，分离流 | 8 档 | **332**（修前 0） |
| dQw4w9WgXcQ（对照） | ✅ 4.8s | 8 档 | 60（无回归） |

- 新守卫 `fushi/test/media/video/youtube_client_fallback_test.dart` 9 条；既有 `youtube_source_resolver_test` / `youtube_fast_load_guard_test` 更新到新契约
- 三轮变异实测全部被抓住（删 android / 去短路 / 字幕钉回 androidVr），每轮以 sha256 逐字节校验还原
- 定向 `test/media/video` + `test/mining` **3816 tests 全绿**；rebase 后 `test/media/video` **2712 全绿**
- 目录枚举型守卫整批 **251 全绿**
- 本地全量 **20523 tests**，唯一 2 个 error 是 `video_source_work_planner_test.dart` 的**装载失败**（`Cannot close sink while adding stream` / `Connection closed before test suite loaded`）——并发伪红形态②，单独重跑 4 tests 全绿，且与本改动无关
- `flutter analyze` 无 issue

## 未覆盖

- 未做真机 / 集成测试复测播放画面：验证停在解析层（流 URL 可 206 拉取、画质档与字幕 cue 数量），未在真实播放页跑到出画面
- 测试不含网络断言（CI 无外网，且 YouTube 各 client 行为本就会漂），锁的是链构成、超时不变式与逐 client 编排行为这三件本地可判定的事实

https://claude.ai/code/session_01KafFVamB9iM4ivUfZR4ArW
