### PR TITLE
fix(anki): 按 AnkiConnect 端口认 Anki 进程，修新 launcher 下跳转不到前台 (BUG-1837)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1690 条。点号进各自文件。
+> 共 1692 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1838](bugs/BUG-1838-ankiconnect-installer-launcher-not-found.md) | 🚧 | 🚧 | AnkiConnect 一键代装误报 Anki 没运行：新版 launcher 下找不到入口 exe |
+| [BUG-1837](bugs/BUG-1837-anki-open-foreground-pid-launcher.md) | ✅ | ✅ | 制卡后在 Anki 中打开仍不到前台：新版 Anki launcher 下进程识别失效 |
 | [BUG-1836](bugs/BUG-1836-manual-install-rescue-reports-failure.md) | 🚧 | 🚧 | 手动跑安装包救援成功后仍必报更新失败（Inno 日志判据拿不到证据） |
 | [BUG-1831](bugs/BUG-1831-win-update-launcher-vanished.md) | ✅ | ✅ | 改名让路后新 launcher 被回滚删除，安装目录再无 launcher，自更新永久卡死 |
 | [BUG-1826](bugs/BUG-1826-mihon-loading-gate-blocks-store-edit.md) | 🚧 | 🚧 | 漫画扩展页 loading 一位两义：初始化联网刷新期间连添加/编辑仓库都点不动 |

--- a/docs/bugs/BUG-1837-anki-open-foreground-pid-launcher.md
+++ b/docs/bugs/BUG-1837-anki-open-foreground-pid-launcher.md
@@ -1,0 +1,41 @@
+## BUG-1837 · 制卡后在 Anki 中打开仍不到前台：新版 Anki launcher 下进程识别失效
+- **报告**：2026-08-24（用户：制卡后点跳转，有时候 Anki 不会拉到前台，电脑上）
+- **真实性**：✅ 真 bug — 根因 `packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart:_isAnkiProcess`
+  （认 Anki 的唯一判据是「窗口所属进程的 exe 叫 `anki.exe`」）
+
+  BUG-1641 已经修过一次同一现象（让渡前台权限 + 兜底 raise），但那套修复**只有在认得出 Anki 进程时才成立**。
+  本机取证（Windows 11，用户日常环境）：
+
+  | 进程 | exe | 顶层窗口 | 监听 8765 |
+  |---|---|---|---|
+  | pid 79788 | `D:\APP\Anki\anki.exe` | **0 个** | 否 |
+  | pid 13324 | `...\AnkiProgramFiles\python\cpython-3.13.5\pythonw.exe`（`-c "import aqt; aqt.run()"`） | 「账户 1 - Anki」+「浏览（已选取 1 张卡片）」 | **是** |
+
+  即：新版 Anki 的 `anki.exe` 只是个 launcher，一个窗口都没有；真正跑 aqt、持有全部窗口、
+  监听 AnkiConnect 端口的是 venv 里的 `pythonw.exe`。于是 `findAnkiProcessId()` 恒为 null →
+  `grantForegroundToAnki()` 直接返回 → `raiseAnkiWindow(null)` 立即 return → **BUG-1641 的整套修复全程空转**，
+  症状精确回到修复前：Anki 的「浏览」窗口没开时新建窗口能弹出来（看着正常），已在后台开着时走复用路径
+  被 Windows 前台锁定降级成闪任务栏。用户口中的「有时候」就是这两半。
+
+  真机实测坐实（`grantForegroundToAnki` 走真实 FFI）：旧判据 `findRunningAnkiExecutable()` → `null`，
+  新判据 → `pid=13324`。
+- **[x] ① 已修复** — 换数据源，而不是给 `pythonw.exe` 加特例：认 Anki 的首选判据改成
+  **「谁在监听我们正在对话的这个 AnkiConnect 端口」**（`GetExtendedTcpTable` +
+  `TCP_TABLE_OWNER_PID_LISTENER`，IPv4 表优先、IPv6 兜底），那必然就是要授权和要拉前台的那个进程，
+  与 exe 叫什么、装在哪、是不是 venv 全无关系。
+  - `anki_desktop_foreground.dart`：backend 新增 `findProcessListeningOnPort(int port)` +
+    `_WindowsAnkiForeground` 的 iphlpapi 实现；`grantForegroundToAnki({required int ankiConnectPort})`
+    经 `resolveAnkiProcessId` 端口优先、进程名兜底（旧版单进程 Anki 在读不到监听表的环境下仍认得出）。
+  - `ankiconnect_repository.dart`：`openNoteInAnki` 传 `service.port`（不是硬编码 8765——用户可以改端口）。
+  - fail-soft 口径不变：两个判据都空 / 非 Windows / FFI 不可用一律退回「什么都不做」。
+- **[x] ② 已加自动化测试** — `fushi/test/anki/anki_desktop_foreground_test.dart` 新增 group「认 Anki 进程（BUG-1837）」3 例
+  （共 12 例通过）：进程名判据落空时仍按端口找到 Anki 且让渡/兜底都打在该 pid 上、端口取自 `service.port` 而非硬编码、
+  监听表读不到时退回进程名判据。已做变异实测：把 `resolveAnkiProcessId` 改回只用 `findAnkiProcessId()` → 6 处红；
+  把 `service.port` 换成硬编码 `8765` → 1 处红（正是端口透传那条）。
+- **备注**：同根因第二受害点**未在本轮修**——`findRunningAnkiExecutable()`（AnkiConnect 一键代装，
+  `ankiconnect_installer.dart:99`）用的还是同一个「有窗口 + exe 叫 anki.exe」判据，在新 launcher 下同样恒为 null，
+  会把「Anki 明明开着」误报成 `ankiNotRunning`（本机实测 `legacyExe=null` 已坐实）。
+  它不能照抄端口判据：installer 要的是能 `launch(exe, <file>.ankiaddon)` 的**入口 exe**，而端口判据给出的是
+  `pythonw.exe`，拿它启动是错的。正确修法应是「遍历全部进程（不要求有窗口）找 launcher `anki.exe`」，
+  但**前提是先验证新 launcher 会把 `.ankiaddon` 参数转发给运行中的实例**——没有这个证据不能盲改，
+  否则可能起第二个实例。已另立 BUG-1838。

--- a/docs/bugs/BUG-1838-ankiconnect-installer-launcher-not-found.md
+++ b/docs/bugs/BUG-1838-ankiconnect-installer-launcher-not-found.md
@@ -1,0 +1,26 @@
+## BUG-1838 · AnkiConnect 一键代装误报 Anki 没运行：新版 launcher 下找不到入口 exe
+- **报告**：2026-08-24（查 BUG-1837 时顺带发现，非用户报告）
+- **真实性**：✅ 真 bug（本机实测坐实，尚未修） — 根因
+  `packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart:findRunningAnkiExecutable`
+  → `ankiconnect_installer.dart:99`
+
+  与 [BUG-1837](BUG-1837-anki-open-foreground-pid-launcher.md) 同根因：判据是「**有可见顶层窗口**且 exe 叫 `anki.exe`」。
+  新版 Anki 的 `anki.exe` 只是 launcher，**一个窗口都没有**；持有全部窗口的是 venv 里的 `pythonw.exe`。
+  两个条件互斥，判据必然落空 → `findRunningAnkiExecutable()` 恒 null → `install()` 在 Anki 明明开着时
+  直接返回 `AnkiAddonInstallStatus.ankiNotRunning`，一键代装整条路在这类环境下不可用。
+
+  本机实测（Anki 正在运行，主窗 + 浏览窗都在）：`findRunningAnkiExecutable()` → `null`。
+- **[ ] ① 未修复** — 不能照抄 BUG-1837 的端口判据：installer 要的是能
+  `launch(exe, <file>.ankiaddon)` 的**入口 exe**，而端口判据给出的是 `pythonw.exe`，拿它启动是错的
+  （它会把 `.ankiaddon` 当 python 脚本）。
+
+  方向：把进程枚举与「有没有窗口」解耦——遍历全部进程（`EnumProcesses` / Toolhelp32）找 `anki.exe`，
+  launcher 常驻，能被找到（本机 pid 79788 = `D:\APP\Anki\anki.exe`）。
+
+  **前置证据（必须先取，否则不许动手）**：新版 anki-launcher 是否会把命令行里的 `.ankiaddon`
+  透传给已运行的 aqt 实例（Anki 的 single-instance 转发）。若不透传，改完只会起第二个实例或弹更新窗，
+  比现在的「明确报错」更糟。
+- **[ ] ② 未加自动化测试** — 修复时与 ① 同批补：至少钉「属主进程没有窗口时仍能找到 launcher」。
+- **备注**：与 BUG-1837 共用 `AnkiDesktopForegroundBackend`，但语义必须分开——
+  **前台目标进程**（要授权 + raise 的，= 跑 aqt 的那个）和**入口 exe**（要拿去 launch 的，= launcher）
+  在旧架构下重合、在新 launcher 架构下分裂，把两者混成一个函数正是这两条 bug 的共同源头。

--- a/fushi/test/anki/anki_desktop_foreground_test.dart
+++ b/fushi/test/anki/anki_desktop_foreground_test.dart
@@ -54,6 +54,7 @@ void main() {
 
     expect(ok, isTrue);
     expect(events, <String>[
+      'listen:8765',
       'find',
       'allow:4321',
       'http:guiBrowse',
@@ -77,7 +78,14 @@ void main() {
     await repo.openNoteInAnki(305);
 
     expect(
-        events, <String>['find', 'allow:4321', 'http:guiBrowse', 'foreground?'],
+        events,
+        <String>[
+          'listen:8765',
+          'find',
+          'allow:4321',
+          'http:guiBrowse',
+          'foreground?'
+        ],
         reason: 'Anki 自己已经上来了，再 SetForegroundWindow 只会抢焦点');
   });
 
@@ -116,7 +124,7 @@ void main() {
     final bool ok = await repo.openNoteInAnki(305);
 
     expect(ok, isTrue);
-    expect(events, <String>['find', 'http:guiBrowse']);
+    expect(events, <String>['listen:8765', 'find', 'http:guiBrowse']);
   });
 
   test('窗口一次没拉上来时重试，且总次数有上限', () async {
@@ -144,6 +152,71 @@ void main() {
     );
 
     expect(await repo.openNoteInAnki(305), isTrue);
+  });
+
+  /// BUG-1837：认 Anki 进程的判据。用户装的 `anki.exe` 在新 launcher 架构下只是个
+  /// 启动器——**一个窗口都没有**，真正跑 aqt、持有全部窗口、监听 AnkiConnect 端口的
+  /// 是 venv 里的 `pythonw.exe`。所以「窗口所属进程的 exe 叫 anki.exe」必然落空，
+  /// 整套让渡 + 兜底空转，症状精确回到 BUG-1641 修复前（浏览窗已开着时只闪任务栏）。
+  group('认 Anki 进程（BUG-1837）', () {
+    test('进程名判据落空时，仍按「谁在监听 AnkiConnect 端口」找到 Anki', () async {
+      final List<String> events = <String>[];
+      AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+        events: events,
+        // 新 launcher 架构：没有任何窗口的属主进程叫 anki.exe。
+        ankiPid: null,
+        listenerPid: 13324,
+        foregroundPidSequence: <int?>[null, 13324],
+      );
+      final AnkiConnectRepository repo = AnkiConnectRepository(
+        service: AnkiConnectService(client: clientRecording(events)),
+      );
+
+      final bool ok = await repo.openNoteInAnki(305);
+
+      expect(ok, isTrue);
+      expect(events, <String>[
+        'listen:8765',
+        'allow:13324',
+        'http:guiBrowse',
+        'foreground?',
+        'raise:13324',
+        'foreground?',
+      ], reason: '端口判据命中就够了，不必再问进程名；让渡与兜底都必须打在 13324 上');
+    });
+
+    test('端口判据用的是这个 service 的真实端口，不是硬编码 8765', () async {
+      final List<String> events = <String>[];
+      AnkiDesktopForeground.debugBackend = _FakeForegroundBackend(
+        events: events,
+        ankiPid: null,
+        listenerPid: 777,
+        foregroundPidSequence: <int?>[777],
+      );
+      final AnkiConnectRepository repo = AnkiConnectRepository(
+        service: AnkiConnectService(
+          client: clientRecording(events),
+          port: 8790,
+        ),
+      );
+
+      await repo.openNoteInAnki(305);
+
+      expect(events.first, 'listen:8790');
+    });
+
+    test('监听表读不到时退回进程名判据（旧版单进程 Anki 仍能被认出）', () {
+      final List<String> events = <String>[];
+      final _FakeForegroundBackend backend = _FakeForegroundBackend(
+        events: events,
+        ankiPid: 4321,
+        listenerPid: null,
+        foregroundPidSequence: <int?>[null],
+      );
+
+      expect(AnkiDesktopForeground.resolveAnkiProcessId(backend, 8765), 4321);
+      expect(events, <String>['listen:8765', 'find']);
+    });
   });
 
   /// 代装 AnkiConnect 要拿 `anki.exe` 的路径。刻意只认**正在运行的进程**报出来
@@ -196,6 +269,7 @@ class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
     required List<int?> foregroundPidSequence,
     this.raiseSucceeds = true,
     this.ankiExecutablePath,
+    this.listenerPid,
   }) : _foregroundPidSequence = foregroundPidSequence;
 
   final List<String> events;
@@ -203,9 +277,18 @@ class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
   final bool raiseSucceeds;
   final String? ankiExecutablePath;
 
+  /// 监听 AnkiConnect 端口的进程；null = 监听表读不到（退回进程名判据）。
+  final int? listenerPid;
+
   /// 依次返回的「当前前台进程」；用完后保持最后一个值。
   final List<int?> _foregroundPidSequence;
   int _foregroundReads = 0;
+
+  @override
+  int? findProcessListeningOnPort(int port) {
+    events.add('listen:$port');
+    return listenerPid;
+  }
 
   @override
   int? findAnkiProcessId() {
@@ -243,6 +326,10 @@ class _FakeForegroundBackend implements AnkiDesktopForegroundBackend {
 }
 
 class _ThrowingForegroundBackend implements AnkiDesktopForegroundBackend {
+  @override
+  int? findProcessListeningOnPort(int port) =>
+      throw StateError('iphlpapi unavailable');
+
   @override
   int? findAnkiProcessId() => throw StateError('user32 unavailable');
 

--- a/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/anki_desktop_foreground.dart
@@ -25,6 +25,17 @@ import 'package:flutter/foundation.dart';
 ///
 /// 全程 fail-soft：找不到 Anki 窗口、非 Windows、FFI 加载失败都退回「什么都不做」，
 /// 与修复前的行为一致，绝不让制卡链路因此报错。
+///
+/// BUG-1837：上面这套只有在**认得出 Anki 进程**时才成立，而「窗口所属进程的 exe
+/// 叫 anki.exe」这个判据在 Anki 的新 launcher 架构下必错——用户装的 `anki.exe`
+/// 只是个启动器，一个窗口都没有；真正跑 aqt、持有全部窗口、监听 AnkiConnect 端口
+/// 的是 venv 里的 `pythonw.exe`。判据落空 → pid 为 null → 让渡与兜底整套空转，
+/// 症状精确回到修复前（「浏览」窗口已开着时只闪任务栏）。
+///
+/// 所以认 Anki 的首选判据换成**「谁在监听我正在对话的这个 AnkiConnect 端口」**
+/// （[AnkiDesktopForegroundBackend.findProcessListeningOnPort]）：那必然就是要授权
+/// 和要拉前台的那个进程，与 exe 叫什么、装在哪、是不是 venv 全无关系。进程名判据
+/// 降级为兜底（端口表读不到时才用）。
 abstract final class AnkiDesktopForeground {
   /// 单测替身：注入后完全取代真实 Win32 后端（含平台判断）。
   @visibleForTesting
@@ -72,18 +83,35 @@ abstract final class AnkiDesktopForeground {
 
   /// 把前台权限让渡给本机 Anki 进程，返回它的 pid（找不到/不适用时 null）。
   ///
+  /// [ankiConnectPort] 是调用方**正在对话的那个** AnkiConnect 的端口——认 Anki
+  /// 的首选判据（BUG-1837），进程名只作兜底。
+  ///
   /// 返回值交给 [raiseAnkiWindow]，避免在这里存跨调用的可变全局状态。
-  static int? grantForegroundToAnki() {
+  static int? grantForegroundToAnki({required int ankiConnectPort}) {
     final AnkiDesktopForegroundBackend? backend = _backend;
     if (backend == null) return null;
     try {
-      final int? pid = backend.findAnkiProcessId();
+      final int? pid = resolveAnkiProcessId(backend, ankiConnectPort);
       if (pid == null) return null;
       backend.allowSetForegroundWindow(pid);
       return pid;
     } on Object {
       return null;
     }
+  }
+
+  /// 认 Anki 进程：先问「谁在监听 AnkiConnect 端口」（精确：那就是我们这条 HTTP
+  /// 请求的收件人），端口表读不到时才退回「窗口 + exe 名叫 anki.exe」。
+  ///
+  /// 兜底之所以保留：端口表在极少数环境读不到（权限/异常 IPv6-only 绑定），而旧版
+  /// 单进程 Anki 在那种环境下仍能被进程名认出来。两个判据都空才算找不到。
+  @visibleForTesting
+  static int? resolveAnkiProcessId(
+    AnkiDesktopForegroundBackend backend,
+    int ankiConnectPort,
+  ) {
+    return backend.findProcessListeningOnPort(ankiConnectPort) ??
+        backend.findAnkiProcessId();
   }
 
   /// 兜底把 [ankiPid] 的顶层窗口拉到前台；前台已经归它时立即返回。
@@ -111,7 +139,13 @@ abstract final class AnkiDesktopForeground {
 /// [AnkiDesktopForeground] 依赖的平台原语，抽出来是为了让编排逻辑可单测（真实实现
 /// 全是 Win32 调用，测试环境里跑不了）。
 abstract interface class AnkiDesktopForegroundBackend {
+  /// 本机监听 TCP [port] 的进程 id；没有人监听 / 读不到监听表时返回 null。
+  int? findProcessListeningOnPort(int port);
+
   /// 本机正在运行的 Anki 桌面端进程 id；没找到返回 null。
+  ///
+  /// 判据是「有可见顶层窗口且 exe 叫 anki.exe」，在新 launcher 架构下会落空
+  /// （BUG-1837），只作 [AnkiDesktopForeground.resolveAnkiProcessId] 的兜底。
   int? findAnkiProcessId();
 
   /// `AllowSetForegroundWindow`：把本进程的前台权限让渡给 [pid]。
@@ -163,10 +197,14 @@ final class _WindowsAnkiForeground implements AnkiDesktopForegroundBackend {
             _QueryFullProcessImageNameDart>('QueryFullProcessImageNameW'),
         _closeHandle =
             _kernel32.lookupFunction<_CloseHandleNative, _CloseHandleDart>(
-                'CloseHandle');
+                'CloseHandle'),
+        _getExtendedTcpTable = _iphlpapi.lookupFunction<
+            _GetExtendedTcpTableNative,
+            _GetExtendedTcpTableDart>('GetExtendedTcpTable');
 
   static final DynamicLibrary _user32 = DynamicLibrary.open('user32.dll');
   static final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+  static final DynamicLibrary _iphlpapi = DynamicLibrary.open('iphlpapi.dll');
 
   static final _WindowsAnkiForeground instance = _WindowsAnkiForeground._();
 
@@ -183,14 +221,83 @@ final class _WindowsAnkiForeground implements AnkiDesktopForegroundBackend {
   final _OpenProcessDart _openProcess;
   final _QueryFullProcessImageNameDart _queryFullProcessImageName;
   final _CloseHandleDart _closeHandle;
+  final _GetExtendedTcpTableDart _getExtendedTcpTable;
 
   static const int _gwHwndNext = 2;
   static const int _swRestore = 9;
   static const int _processQueryLimitedInformation = 0x1000;
   static const int _imagePathBufferLength = 32768;
 
+  static const int _afInet = 2;
+  static const int _afInet6 = 23;
+
+  /// `TCP_TABLE_OWNER_PID_LISTENER`：只要 LISTEN 状态的行，正好是我们要的。
+  static const int _tcpTableOwnerPidListener = 3;
+  static const int _noError = 0;
+  static const int _errorInsufficientBuffer = 122;
+
+  /// `MIB_TCPROW_OWNER_PID` = 6 个 DWORD（state / localAddr / localPort /
+  /// remoteAddr / remotePort / owningPid）。
+  static const int _tcpRowWords = 6;
+  static const int _tcpRowPortWord = 2;
+  static const int _tcpRowPidWord = 5;
+
+  /// `MIB_TCP6ROW_OWNER_PID` = 56 字节：localAddr[16] / localScopeId /
+  /// localPort / remoteAddr[16] / remoteScopeId / remotePort / state /
+  /// owningPid，全部 4 字节对齐，按 DWORD 数就是 14。
+  static const int _tcp6RowWords = 14;
+  static const int _tcp6RowPortWord = 5;
+  static const int _tcp6RowPidWord = 13;
+
   /// 顶层窗口链的遍历上限；纯粹是防御异常的 Z 序环，正常桌面远达不到。
   static const int _enumerationGuard = 4096;
+
+  /// 谁在监听 [port]：IPv4 监听表优先，空了再看 IPv6（AnkiConnect 默认绑
+  /// `0.0.0.0`，但用户可以把它配成 `::`）。
+  @override
+  int? findProcessListeningOnPort(int port) {
+    return _pidListeningOnPort(port, _afInet) ??
+        _pidListeningOnPort(port, _afInet6);
+  }
+
+  int? _pidListeningOnPort(int port, int family) {
+    final int rowWords = family == _afInet6 ? _tcp6RowWords : _tcpRowWords;
+    final int portWord =
+        family == _afInet6 ? _tcp6RowPortWord : _tcpRowPortWord;
+    final int pidWord = family == _afInet6 ? _tcp6RowPidWord : _tcpRowPidWord;
+    final Pointer<Uint32> size = calloc<Uint32>();
+    Pointer<Uint8> table = nullptr;
+    try {
+      // 第一趟只问尺寸：监听表大小随系统连接数变化，不能拍脑袋定长。
+      final int probe = _getExtendedTcpTable(
+          nullptr, size, 0, family, _tcpTableOwnerPidListener, 0);
+      if (probe != _errorInsufficientBuffer && probe != _noError) return null;
+      if (size.value == 0) return null;
+      table = calloc<Uint8>(size.value);
+      final int rc = _getExtendedTcpTable(
+          table.cast(), size, 0, family, _tcpTableOwnerPidListener, 0);
+      if (rc != _noError) return null;
+      final Pointer<Uint32> words = table.cast<Uint32>();
+      final int rows = words[0];
+      // 表头是 dwNumEntries 一个 DWORD，行从第 1 个 DWORD 起。
+      final int capacity = (size.value ~/ 4 - 1) ~/ rowWords;
+      final int count = rows < capacity ? rows : capacity;
+      for (int i = 0; i < count; i++) {
+        final int base = 1 + i * rowWords;
+        if (_portFromNetworkOrder(words[base + portWord]) != port) continue;
+        final int pid = words[base + pidWord];
+        if (pid != 0) return pid;
+      }
+      return null;
+    } finally {
+      if (table != nullptr) calloc.free(table);
+      calloc.free(size);
+    }
+  }
+
+  /// `dwLocalPort` 的低 16 位是**网络字节序**，高 16 位是没定义的填充。
+  static int _portFromNetworkOrder(int raw) =>
+      ((raw & 0xFF) << 8) | ((raw >> 8) & 0xFF);
 
   @override
   int? findAnkiProcessId() {
@@ -352,3 +459,20 @@ typedef _QueryFullProcessImageNameDart = int Function(
 
 typedef _CloseHandleNative = Int32 Function(IntPtr handle);
 typedef _CloseHandleDart = int Function(int handle);
+
+typedef _GetExtendedTcpTableNative = Uint32 Function(
+  Pointer<Void> tcpTable,
+  Pointer<Uint32> size,
+  Int32 order,
+  Uint32 family,
+  Uint32 tableClass,
+  Uint32 reserved,
+);
+typedef _GetExtendedTcpTableDart = int Function(
+  Pointer<Void> tcpTable,
+  Pointer<Uint32> size,
+  int order,
+  int family,
+  int tableClass,
+  int reserved,
+);

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1171,12 +1171,17 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   //
   // 只对本机 Anki 生效：host 非 loopback 时说的是另一台机器上的 AnkiConnect，
   // 去激活本机窗口毫无意义。
+  //
+  // BUG-1837：认 Anki 进程要用 **service.port**（谁在监听我们正在对话的这个
+  // AnkiConnect），而不是「exe 叫 anki.exe」——新版 Anki 的 anki.exe 只是启动器，
+  // 真正持有窗口的是 venv 里的 pythonw.exe，按名字找必然落空、整套让渡空转。
   @override
   Future<bool> openNoteInAnki(int noteId) async {
     try {
       final service = await _getService();
       final int? ankiPid = ankiConnectHostIsLoopback(service.host)
-          ? AnkiDesktopForeground.grantForegroundToAnki()
+          ? AnkiDesktopForeground.grantForegroundToAnki(
+              ankiConnectPort: service.port)
           : null;
       await service.guiBrowse(noteId);
       await AnkiDesktopForeground.raiseAnkiWindow(ankiPid);


### PR DESCRIPTION
﻿## 现象

用户报：电脑上制完卡点跳转，**有时候** Anki 不会拉到前台。

## 根因（不是玄学的「有时候」）

BUG-1641 已经修过一次同一现象（发 `guiBrowse` 前 `AllowSetForegroundWindow` 让渡前台权限、发完兜底 raise），
但那套修复**只有在认得出 Anki 进程时才成立**，而判据是「窗口所属进程的 exe 叫 `anki.exe`」。

本机取证（用户日常环境，Windows 11）：

| 进程 | exe | 顶层窗口 | 监听 8765 |
|---|---|---|---|
| pid 79788 | `D:\APP\Anki\anki.exe` | **0 个** | 否 |
| pid 13324 | `...\AnkiProgramFiles\python\cpython-3.13.5\pythonw.exe`（`-c "import aqt; aqt.run()"`） | 「账户 1 - Anki」+「浏览（已选取 1 张卡片）」 | **是** |

新版 Anki 的 `anki.exe` 只是个 launcher，一个窗口都没有；真正跑 aqt、持有全部窗口、监听 AnkiConnect
端口的是 venv 里的 `pythonw.exe`。于是 `findAnkiProcessId()` 恒为 null → 让渡与兜底整套空转，症状精确
回到 BUG-1641 修复前：Anki「浏览」窗口没开时新建窗口能弹出来（看着正常），已在后台开着时走复用路径被
Windows 前台锁定降级成闪任务栏。用户口中的「有时候」就是这两半。

## 修法

不给 `pythonw.exe` 加特例，而是换数据源：认 Anki 的首选判据改成**「谁在监听我们正在对话的这个
AnkiConnect 端口」**（`GetExtendedTcpTable` + `TCP_TABLE_OWNER_PID_LISTENER`，IPv4 表优先、IPv6 兜底）
——那必然就是要授权和要拉前台的那个进程，与 exe 叫什么、装在哪、是不是 venv 全无关系。进程名判据降级
为兜底（旧版单进程 Anki 在读不到监听表的环境下仍认得出）。端口取自 `service.port`，不硬编码 8765。

fail-soft 口径不变：两个判据都空 / 非 Windows / FFI 不可用一律退回「什么都不做」。

## 验证

- **真机实测**（`grantForegroundToAnki` 走真实 FFI，跑在本机进程表上）：旧判据 `null`，新判据 `pid=13324`
  —— 正是持有 Anki 窗口的那个进程。
- 测试新增 group「认 Anki 进程（BUG-1837）」3 例，`fushi/test/anki/anki_desktop_foreground_test.dart` 共 12 例通过。
- **变异实测**：`resolveAnkiProcessId` 改回只用 `findAnkiProcessId()` → 6 处红；`service.port` 换成硬编码
  `8765` → 1 处红（正是端口透传那条）。
- `flutter analyze`（fushi + fushi_anki）零问题；`fushi/test/anki` 284 例、`packages/fushi_anki` 430 例全绿。

## 未在本轮修（已立案 BUG-1838）

同根因第二受害点：AnkiConnect 一键代装（`ankiconnect_installer.dart:99`）用的还是同一个判据，在新 launcher
下同样恒为 null，会把「Anki 明明开着」误报成 `ankiNotRunning`（本机实测坐实）。它**不能**照抄端口判据——
installer 要的是能 `launch(exe, <file>.ankiaddon)` 的入口 exe，端口判据给出的是 `pythonw.exe`，拿它启动是错的。
正确修法是「遍历全部进程找 launcher `anki.exe`」，但前提得先验证新 launcher 会把 `.ankiaddon` 转发给运行中的
实例，没有这个证据不盲改。

https://claude.ai/code/session_01QfhUQoxzDRLBD6zGN5QW61
