### PR TITLE
fix(update): 更新是否落地改由「运行中代码版本」判定（BUG-1836）

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -367,6 +367,7 @@ jobs:
           flutter build windows --release -v
           --build-name "${{ steps.channel.outputs.build_version_name }}"
           --build-number "${{ steps.channel.outputs.release_sequence }}"
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
       # 失败时把 CMake 自己的日志捞出来：-v 打的是 flutter 侧，CMake 配置期的
       # 报错只在这两个文件里。artifact 而不是 echo，避免再被日志截断吃掉。
       - name: Upload Windows build logs on failure
@@ -885,6 +886,7 @@ jobs:
           flutter build macos --release
           --build-name "${{ steps.channel.outputs.build_version_name }}"
           --build-number "${{ steps.channel.outputs.release_sequence }}"
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
       - name: Bundle and sign pinned Mihon desktop runtimes
         shell: bash
         run: |
@@ -1391,6 +1393,7 @@ jobs:
           flutter build ios --release --no-codesign
           --build-name "${{ steps.channel.outputs.build_version_name }}"
           --build-number "${{ steps.channel.outputs.release_sequence }}"
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
       - name: Prepare unsigned iOS IPA release asset
         working-directory: fushi
         shell: bash
@@ -1588,6 +1591,7 @@ jobs:
           --export-options-plist "$RUNNER_TEMP/ExportOptions.plist"
           --build-name "${{ steps.channel.outputs.build_version_name }}"
           --build-number "${{ steps.channel.outputs.release_sequence }}"
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
       - name: Upload to TestFlight
         if: steps.signing.outputs.testflight == 'true'
         working-directory: fushi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,7 +449,8 @@ jobs:
         set -euo pipefail
         flutter --verbose build apk --debug \
           --build-name "${{ steps.channel.outputs.build_version_name }}" \
-          --build-number "${{ steps.channel.outputs.android_build_number }}"
+          --build-number "${{ steps.channel.outputs.android_build_number }}" \
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
 
     - name: Prepare debug APK release asset
       if: steps.channel.outputs.build_debug_apk == 'true'
@@ -479,7 +480,8 @@ jobs:
         set -euo pipefail
         flutter --verbose build apk --release --target-platform android-arm64 \
           --build-name "${{ steps.channel.outputs.build_version_name }}" \
-          --build-number "${{ steps.channel.outputs.android_build_number }}"
+          --build-number "${{ steps.channel.outputs.android_build_number }}" \
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
 
     - name: Prepare release-signed debug-channel APK asset
       if: steps.channel.outputs.build_debug_channel_apk == 'true'
@@ -509,7 +511,8 @@ jobs:
         set -euo pipefail
         flutter --verbose build apk --split-per-abi --release \
           --build-name "${{ steps.channel.outputs.build_version_name }}" \
-          --build-number "${{ steps.channel.outputs.android_build_number }}"
+          --build-number "${{ steps.channel.outputs.android_build_number }}" \
+          --dart-define="FUSHI_BUILD_VERSION=${{ steps.channel.outputs.build_version_name }}"
 
     - name: Collect Android post-build diagnostics
       if: ${{ always() && (steps.channel.outputs.build_debug_apk == 'true' || steps.channel.outputs.build_debug_channel_apk == 'true' || steps.channel.outputs.build_split_release_apk == 'true') }}

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1836](bugs/BUG-1836-manual-install-rescue-reports-failure.md) | 🚧 | 🚧 | 手动跑安装包救援成功后仍必报更新失败（Inno 日志判据拿不到证据） |
+| [BUG-1836](bugs/BUG-1836-manual-install-rescue-reports-failure.md) | ✅ | ✅ | 手动跑安装包救援成功后仍必报更新失败（Inno 日志判据拿不到证据） |
 | [BUG-1831](bugs/BUG-1831-win-update-launcher-vanished.md) | ✅ | ✅ | 改名让路后新 launcher 被回滚删除，安装目录再无 launcher，自更新永久卡死 |
 | [BUG-1826](bugs/BUG-1826-mihon-loading-gate-blocks-store-edit.md) | 🚧 | 🚧 | 漫画扩展页 loading 一位两义：初始化联网刷新期间连添加/编辑仓库都点不动 |
 | [BUG-1808](bugs/BUG-1808-video-home-row-card-tags.md) | ✅ | ✅ | 视频首页横滚行卡不显示标签（拆 section 后首页只剩横滚卡，标签层只画在墙格卡上） |

--- a/docs/bugs/BUG-1786-win-update-launcher-self-lock.md
+++ b/docs/bugs/BUG-1786-win-update-launcher-self-lock.md
@@ -171,6 +171,7 @@ Dart 代码。（正式版通道下这条判据尚有意义：target 无预发�
   **再下一次**更新才走新路径（那之后安装目录里的 launcher 根本不再被持有，连改名都不需要）。
 - 用户机器当前处于半更新态（新 exe + 8-19 的 app.so），需**手动跑一次完整安装包**恢复一致；
   在装上带本修复的版本之前，再点应用内更新仍会重蹈覆辙。
-- 未做（明确记一句）：Dart 侧没有独立于 exe 版本资源的「运行中代码版本」常量，所以
-  「exe 与 app.so 不同步」目前只能靠 Inno 日志间接发现，无法自检。要根治得在构建期把版本注入
-  Dart（`--dart-define`）并让关于页/握手同时比对两个来源，属独立改动，本轮未做。
+- ~~未做~~ **已补做**（2026-08-24，见 [BUG-1836](BUG-1836-manual-install-rescue-reports-failure.md)）：
+  构建期 `--dart-define=FUSHI_BUILD_VERSION` 已注入 Dart（`fushi/lib/src/utils/misc/build_version.dart`），
+  握手判据改吃这条与产物同体的证据，关于页在两个来源基版本不一致时并排显示 exe 版本
+  ——「exe 与 app.so 不同步」从此可自检，不再只能靠 Inno 日志间接发现。

--- a/docs/bugs/BUG-1836-manual-install-rescue-reports-failure.md
+++ b/docs/bugs/BUG-1836-manual-install-rescue-reports-failure.md
@@ -28,25 +28,62 @@ BUG-1786 那条规矩在**应用内更新**语境下是对的（日志缺失 = �
 影响有界：失败分支**不重试、不重新下载**，且 `lastPromptedFailureFingerprint` 去重让它只弹
 一次，之后静默。所以是**误导**，不是功能损坏。
 
-### 可行修法（未实施）
+### 修复
 
-判据缺的是「运行中的这份代码到底是不是 target」这条正面证据，有两条路：
+判据缺的是「运行中的这份代码到底是不是 target」这条正面证据。此前两个证据源**都不是被
+替换的产物本身**：Inno 日志是安装器的旁证，exe 版本资源和 `app.so` 是两个文件。
 
-1. **构建期把版本注入 Dart**（`--dart-define`），让 app 能报出自己这份 `app.so` 的
-   `-debug.N`，reconcile 直接比 `运行中代码版本 == targetVersion` ⇒ 无论谁装的都判成功。
-   这正是 BUG-1786 备注最后一段列为「未做」的那条，做了能同时根治「exe 与 app.so 不同步
-   无法自检」。
-2. **拿 `unins000.dat` 的 mtime 当安装时刻**：它由 Inno 运行期重写，是真实安装时刻（现场
-   21:11），而 `[Files]` 装出来的 exe/so 带的是**源文件时间戳**（09:2x，构建时刻），不能用。
-   若 `unins000.dat` 的 mtime 晚于 marker 的 `installerLaunchFailedAt` / `startedAt`，说明
-   marker 写下之后确实发生过一次完整安装。比 ① 轻，但依赖 Inno 实现细节，属兜底而非首选。
+新增第三个证据源 `kFushiBuildVersionDefine`（`fushi/lib/src/utils/misc/build_version.dart`）：
+构建期 `--dart-define=FUSHI_BUILD_VERSION=<build-name>` 注入，编译进 AOT 快照，**与被替换的
+产物同体**——`app.so` 没被换掉它就报旧值，谁也伪造不了。
 
-- **[ ] ① 未修复** — 需先定版本注入方案（与 BUG-1786 的「未做」项同源，建议合并处理）
-- **[ ] ② 未加自动化测试** —
+判据收敛成一张三源证据表 `isWindowsUpdateInstalled`（`update_handoff.dart`）：
+
+| Inno 日志 | 代码版本证据 | 结果 |
+|---|---|---|
+| aborted | 任意 | 失败（回滚保留被覆盖的文件，整包仍可能是半更新态） |
+| unknown | 达标 | **成功** ← 本条 bug |
+| 任意 | 达标 | 成功 |
+| 任意 | 未达标 | 失败（日志说成功也不能给旧代码背书） |
+| succeeded | 不可比 | 看 exe 版本（旧判据） |
+| unknown | 不可比 | 失败（旧判据） |
+
+「代码版本证据」刻意**不是 bool**：版本号之间并不总是可比。`2.2.1-debug.12215` 和
+`2.2.1-beta.30` 谁新，SemVer 只会按字符串把 `debug` 排在 `beta` 之后，那是巧合不是事实；
+同理 SemVer 规定「正式版 > 同号预发布版」，于是 `2.2.1` 恒 > `2.2.1-debug.12215`——BUG-1786
+抱怨的「判据恒为真」正是这条。所以基版本相同时只有**通道标签一致**才比序号，否则标
+`inconclusive` 退回日志判据。少了这一层，一次失败的跨通道安装会被硬判成成功。
+
+代码版本未知时（本次改动之前发布的历史版本、本地 `flutter run`）逐行退化成 BUG-1786 的旧
+判据，**行为逐字不变**——所以这条修复对存量用户零风险，但也**要装上带注入的新包之后才生效**。
+
+顺带修掉两处同源缺陷：
+
+- **幂等键**（`lastPromptedAppVersion`）改用代码版本。Windows 上 exe 版本资源在同 base 的两个
+  debug 构建上完全相同（`2.2.1` == `2.2.1`），marker 因 AV 占用删不掉时会把**下一次**更新的
+  提示一并吞掉。
+- **关于页与日志上传**改报真实构建版本；两者基版本不一致时关于页并排显示 `≠ exe <ver>`
+  ——「新 exe + 旧 app.so」的半更新态第一次变得可自查（这正是 BUG-1786 备注里列的「未做」项）。
+
+守卫 `fushi/test/build/build_version_define_guard_test.dart` 按 `- name:` 切步骤（**不用固定行
+窗口**——BUG-1831 踩过一次：新增注释把被断言的语句顶出窗口，守卫悄悄失效），钉死 7 处
+`--build-name` 每处都配同值的 `--dart-define`，漏一处 CI 红。
+
+- **[x] ① 已修复** — commit `83b6df61e8`
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/update_install_evidence_test.dart`（三源
+  判定表 8 例 + reconcile 端到端 3 例）、`fushi/test/build/build_version_define_guard_test.dart`
+  （构建期注入配对守卫）、`fushi/test/settings/app_version_display_format_test.dart`（关于页
+  展示 4 例）。四个变异（漏注入一处 / 两侧 define 名字对不上 / 判据忽略代码版本 / 回滚不再
+  一票否决）实测各自精确变红。
 
 ### 备注
 
-- **仅 Windows**：Inno 日志判据是 Windows 专有。
+- **仅 Windows**：Inno 日志判据是 Windows 专有。macOS 的 `Info.plist` 用
+  `$(FLUTTER_BUILD_NAME)`，**完整保留** `-debug.N`，版本判据本来就有效，未改动。
+- **更新检查**不受后缀丢失影响：`currentReleaseSequence()` 早已用 `buildNumber` 反解 seq
+  绕过（BUG-457 / BUG-846），本轮未动那条链。
+- **生效节奏**：注入在构建期，所以只有装上带本修复的包之后，下一次更新的判据才吃到代码
+  版本；在那之前逐行退化成旧判据（行为不变）。
 - 与 [BUG-1831](BUG-1831-win-update-launcher-vanished.md) 相邻但不同因：1831 是 launcher 消失
   导致**安装器起不来**，本条是安装器**跑成功了却判不出来**。
 - 严重性低（一次性误报、不触发重试），但它命中的正是「用户刚照着指引把机器修好」的时刻，

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -7,6 +7,7 @@ import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/sync/sync_http.dart';
+import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/utils/misc/crash_dump_locator.dart';
 import 'package:fushi/src/utils/misc/platform_updater.dart';
 import 'package:fushi/utils.dart';
@@ -550,7 +551,10 @@ Widget _buildRuntimeAppVersionRow(SettingsContext settingsContext) {
   final packageInfo = settingsContext.appModel.packageInfo;
   return AdaptiveSettingsRow(
     title: t.app_version,
-    subtitle: formatAppVersionDisplay(packageInfo),
+    subtitle: formatAppVersionDisplay(
+      packageInfo,
+      runningCodeVersion: fushiRunningCodeVersion,
+    ),
     icon: Icons.info_outline,
     showIcon: true,
   );
@@ -560,6 +564,31 @@ Widget _buildRuntimeAppVersionRow(SettingsContext settingsContext) {
 /// buildNumber 是 Android versionCode（如 `1000561300`），两者语义不同：
 /// 绝不能用 semver 的 `+` build-metadata 把 versionCode 拼进 versionName，
 /// 否则会渲染出畸形的 `0.11.1-debug.5613+1000561300`。用括号并列展示。
+///
+/// [runningCodeVersion] 是编译进 `app.so` 的构建版本（见 `build_version.dart`）。
+/// 有它就用它当版本名——Windows 的 exe 版本资源丢掉了 `-debug.N` 整段后缀，
+/// 只显示 `2.2.1` 时用户根本看不出自己跑在哪个构建上，BUG-1786 现场就是这么被
+/// 蒙了好几天。两者**基版本**不一致时并排显示 exe 那个值：这正是「新 exe + 旧
+/// app.so」半更新态的可见症状，关于页是用户唯一能自查它的地方。
 @visibleForTesting
-String formatAppVersionDisplay(PackageInfo packageInfo) =>
-    '${packageInfo.version} (${packageInfo.buildNumber})';
+String formatAppVersionDisplay(
+  PackageInfo packageInfo, {
+  String? runningCodeVersion,
+}) {
+  final String executableVersion = packageInfo.version;
+  final String shown = runningCodeVersion ?? executableVersion;
+  final String display = '$shown (${packageInfo.buildNumber})';
+  if (runningCodeVersion == null) return display;
+  if (_baseVersionOf(runningCodeVersion) ==
+      _baseVersionOf(executableVersion)) {
+    return display;
+  }
+  return '$display ≠ exe $executableVersion';
+}
+
+/// 取语义版本的基版本段（`2.2.1-debug.12215+abc` → `2.2.1`）。
+///
+/// 只比基版本，不比后缀：exe 版本资源在 Windows 上**必然**丢后缀，拿后缀去比
+/// 会让每个 debug 构建都显示成不一致，警告立刻退化成噪音。
+String _baseVersionOf(String version) =>
+    version.trim().split('+').first.split('-').first;

--- a/fushi/lib/src/utils/misc/build_version.dart
+++ b/fushi/lib/src/utils/misc/build_version.dart
@@ -1,0 +1,48 @@
+/// 「运行中的这份 Dart 代码来自哪一次构建」——编译期常量，随 AOT 快照
+/// （Windows 上就是 `data\app.so`）一起落地。
+///
+/// 为什么需要它（BUG-1786 / BUG-1831 / BUG-1836 的共同根因）：
+///
+/// 更新是否真的落地，此前只有两个证据源，两个都会说谎：
+///
+/// 1. **exe 版本资源**（`PackageInfo.fromPlatform()`）。Windows 上它读的是
+///    `fushi.exe` 的 VERSIONINFO，只有语义版本 `2.2.1`，**预发布后缀
+///    `-debug.12215` 整段丢失**。更要命的是它和 Dart 代码是两个文件：Inno 的
+///    回滚保留「被覆盖」的文件、只删「新建」的文件，于是「新 exe + 旧 app.so」
+///    的半更新态里，版本资源报的是新版本，跑的却是旧代码。BUG-1786 现场连着
+///    几天报「更新成功」就是这么来的。
+/// 2. **Inno 安装日志**。它只在 app 自己发起更新、经 `/LOG=` 传路径时才存在；
+///    用户手动双击安装包救援时 Inno 一个字都不写，判据拿不到证据只能判失败
+///    （BUG-1836）。
+///
+/// 这个常量是第三个证据源，也是唯一一个**和被替换的产物同体**的：它就编译在
+/// `app.so` 里，`app.so` 没被换掉它就报旧值，谁也伪造不了。所以
+/// 「运行中代码版本 >= 目标版本」是**运行中的代码确实被换成了目标版本**的直接
+/// 证据，与谁拉起的安装器、有没有日志都无关。
+///
+/// 注入方式：构建期 `--dart-define=FUSHI_BUILD_VERSION=<build-name>`，与
+/// `flutter build --build-name` 同值、同一处传（守卫测试
+/// `test/build/build_version_define_guard_test.dart` 钉死这条配对，漏一处 CI 红）。
+library;
+
+/// 构建期注入的完整 build-name，例如 `2.2.1-debug.12215`。
+///
+/// 没注入时（本地 `flutter run`、`flutter test`、以及**这次改动之前**发布的所有
+/// 历史版本）为空串。空串必须当「未知」处理，绝不能当版本号参与比较。
+const String kFushiBuildVersionDefine =
+    String.fromEnvironment('FUSHI_BUILD_VERSION');
+
+/// 运行中这份 Dart 代码的版本；未注入时返回 `null`（未知，不是 `0.0.0`）。
+///
+/// 调用方必须把 `null` 当「拿不到这条证据」并退回旧判据，而不是当成「版本不符」。
+String? get fushiRunningCodeVersion =>
+    normalizeFushiBuildVersion(kFushiBuildVersionDefine);
+
+/// 纯函数版本，供测试注入任意 define 值。
+///
+/// 只做两件事：去掉首尾空白、把空串折叠成 `null`。**不做**版本号合法性校验——
+/// 校验的活归比较函数，这里多一层规则只会制造「合法但被判 null」的特殊情况。
+String? normalizeFushiBuildVersion(String rawDefine) {
+  final String trimmed = rawDefine.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/fushi/lib/src/utils/misc/log_uploader.dart
+++ b/fushi/lib/src/utils/misc/log_uploader.dart
@@ -7,6 +7,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/utils/misc/log_upload_config.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 
@@ -113,7 +114,10 @@ Future<({String appVersion, String platform, String device})>
   String appVersion = 'unknown';
   try {
     final PackageInfo info = await PackageInfo.fromPlatform();
-    appVersion = '${info.version}+${info.buildNumber}';
+    // 优先报运行中这份 Dart 代码的版本：Windows 的 exe 版本资源丢 `-debug.N`，
+    // 服务端看到的全是 `2.2.1+12215`，分不出通道，也认不出「新 exe + 旧 app.so」。
+    final String version = fushiRunningCodeVersion ?? info.version;
+    appVersion = '$version+${info.buildNumber}';
   } catch (_) {}
   return (
     appVersion: appVersion,

--- a/fushi/lib/src/utils/misc/update_handoff.dart
+++ b/fushi/lib/src/utils/misc/update_handoff.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fushi/src/utils/misc/build_version.dart';
+
 enum WindowsUpdateHandoffStatus {
   installed,
   incomplete,
@@ -645,9 +647,12 @@ abstract final class WindowsUpdateHandoff {
     );
   }
 
+  /// [runningCodeVersionDefine] 默认就是编译进本份 `app.so` 的常量，生产路径无需
+  /// 传参；测试用它注入任意「运行中代码版本」。空串 = 未注入 = 该证据不可用。
   static Future<WindowsUpdateHandoffResult?> reconcile({
     required File markerFile,
     required String currentVersion,
+    String runningCodeVersionDefine = kFushiBuildVersionDefine,
     DateTime? now,
   }) async {
     final WindowsUpdateHandoffRecord? record = await read(markerFile);
@@ -661,22 +666,35 @@ abstract final class WindowsUpdateHandoff {
     // 安装中途 Abort 回滚要报成功，安装器压根没跑起来同样报成功。用户现场因此连着几天
     // 收到「更新成功」，跑的却始终是旧 Dart 代码。
     //
-    // 现在以 Inno 日志的收尾结论为主判据：只有日志明确写了「Installation process
-    // succeeded」才可能是成功；aborted（回滚）与 unknown（日志缺失 = 安装没跑起来）
-    // 一律走失败分支，让用户看见诊断而不是一句成功。版本判据保留为 AND 条件——它在
-    // 正式版通道仍能识别「exe 根本没被换掉」这种失败。
+    // BUG-1836 根因修复：判据升级为三源证据表（见 [isWindowsUpdateInstalled]）。
+    // 旧判据只有「Inno 日志 + exe 版本资源」两源，两源都不是**被替换的产物本身**：
+    // 日志只在 app 自己拉起安装器时才存在（手动救援装成功也判失败），版本资源和
+    // Dart 代码是两个文件（半更新态里它报新版本、跑的是旧代码）。现在加入编译进
+    // `app.so` 的 [kFushiBuildVersionDefine]，它与被替换的产物同体，是唯一伪造
+    // 不了的证据。没有它的历史版本/本地构建行为与旧判据完全一致。
+    final String? runningCodeVersion =
+        normalizeFushiBuildVersion(runningCodeVersionDefine);
+    // 「这条提示是不是已经弹过」的幂等键。优先用代码版本：Windows 上 exe 版本资源
+    // 丢后缀，同一 base 的两个 debug 构建拿到的 `currentVersion` 完全相同
+    // （`2.2.1` == `2.2.1`），marker 若因 AV 占用删不掉就会把**下一次**更新的提示
+    // 一并吞掉。代码版本带 `-debug.N`，粒度精确到构建。
+    final String promptedVersionKey = runningCodeVersion ?? currentVersion;
     final WindowsInnoInstallVerdict verdict = windowsInnoLogVerdict(
       await _readInnoLogContents(record.innoLogPath),
     );
-    if (verdict == WindowsInnoInstallVerdict.succeeded &&
-        _isVersionAtLeast(currentVersion, record.targetVersion)) {
+    if (isWindowsUpdateInstalled(
+      verdict: verdict,
+      targetVersion: record.targetVersion,
+      executableVersion: currentVersion,
+      runningCodeVersion: runningCodeVersion,
+    )) {
       // Idempotency guard mirroring the failure branch below: if we already
       // surfaced the success dialog for this app version, stay silent. Relying
       // solely on deleting the marker is fragile — the delete can fail on real
       // machines (antivirus/indexer locks, permission errors in the updates
       // dir) and is swallowed by the catch, leaving the marker in place so the
       // success dialog pops on every startup (TODO-1035 / BUG-483).
-      if (record.lastPromptedAppVersion == currentVersion) {
+      if (record.lastPromptedAppVersion == promptedVersionKey) {
         // Best-effort cleanup is still worth retrying in case the lock cleared.
         try {
           if (await markerFile.exists()) await markerFile.delete();
@@ -688,7 +706,7 @@ abstract final class WindowsUpdateHandoff {
       // Persist the prompted version *before* attempting deletion so that even
       // if the delete fails, the next startup is silenced by the guard above.
       final WindowsUpdateHandoffRecord prompted = record.copyWith(
-        lastPromptedAppVersion: currentVersion,
+        lastPromptedAppVersion: promptedVersionKey,
         lastPromptedAt: now ?? DateTime.now(),
       );
       try {
@@ -709,13 +727,13 @@ abstract final class WindowsUpdateHandoff {
 
     final WindowsUpdateHandoffRecord enriched =
         await _enrichFailureDiagnostics(record);
-    if (enriched.lastPromptedAppVersion == currentVersion &&
+    if (enriched.lastPromptedAppVersion == promptedVersionKey &&
         enriched.lastPromptedFailureFingerprint ==
             enriched.failureFingerprint) {
       return null;
     }
     final WindowsUpdateHandoffRecord prompted = enriched.copyWith(
-      lastPromptedAppVersion: currentVersion,
+      lastPromptedAppVersion: promptedVersionKey,
       lastPromptedFailureFingerprint: enriched.failureFingerprint,
       lastPromptedAt: now ?? DateTime.now(),
     );
@@ -1046,6 +1064,48 @@ List<Map<String, dynamic>> _listOfMaps(Object? raw) {
         ),
       )
       .toList(growable: false);
+}
+
+/// 「这次 Windows 更新到底装上了没有」的唯一判据，纯函数。
+///
+/// 三个证据源，按可信度排（BUG-1786 / BUG-1831 / BUG-1836 三条现场换来的顺序）：
+///
+/// - [runningCodeVersion]：编译进 `app.so` 的构建版本。**唯一与被替换的产物同体**
+///   的证据——`app.so` 没被换掉它就报旧值。见 `build_version.dart`。
+/// - [verdict]：Inno 日志的收尾结论。只有 app 自己经 `/LOG=` 拉起安装器时才有；
+///   缺失（`unknown`）**不等于**失败，只等于「这条证据不可用」。
+/// - [executableVersion]：exe 版本资源（`PackageInfo`）。Windows 上丢预发布后缀，
+///   且与 `app.so` 是两个文件，只能识别「exe 根本没被换掉」这一种失败。
+///
+/// 判定表（`runningCodeVersion == null` 时逐行退化成 BUG-1786 的旧行为）：
+///
+/// | verdict   | 代码版本 >= 目标 | 结果 |
+/// |-----------|------------------|------|
+/// | aborted   | 任意             | 失败 |
+/// | succeeded | 是 / 未知且 exe 版本达标 | 成功 |
+/// | succeeded | 否               | 失败 |
+/// | unknown   | 是               | 成功 |
+/// | unknown   | 否 / 未知        | 失败 |
+bool isWindowsUpdateInstalled({
+  required WindowsInnoInstallVerdict verdict,
+  required String targetVersion,
+  required String executableVersion,
+  required String? runningCodeVersion,
+}) {
+  // 回滚是「整包不一致」的正面证据，优先级高于任何版本比较：Inno 的回滚**保留**
+  // 被覆盖的文件、只删本次新建的文件，所以回滚之后 `app.so` 完全可能已经是新版
+  // （BUG-1786 现场就是「新 exe + 新 app.so + 旧插件 dll」这类半更新态）。此时
+  // 代码版本达标也不能判成功——装到一半的包必须让用户看见诊断。
+  if (verdict == WindowsInnoInstallVerdict.aborted) return false;
+
+  if (runningCodeVersion != null) {
+    return _isVersionAtLeast(runningCodeVersion, targetVersion);
+  }
+
+  // 拿不到代码版本（本次改动之前发布的历史版本、本地 `flutter run`）：退回旧判据，
+  // 行为逐字不变——日志明确成功 AND exe 版本达标。
+  return verdict == WindowsInnoInstallVerdict.succeeded &&
+      _isVersionAtLeast(executableVersion, targetVersion);
 }
 
 bool _isVersionAtLeast(String current, String target) {

--- a/fushi/lib/src/utils/misc/update_handoff.dart
+++ b/fushi/lib/src/utils/misc/update_handoff.dart
@@ -1079,13 +1079,13 @@ List<Map<String, dynamic>> _listOfMaps(Object? raw) {
 ///
 /// 判定表（`runningCodeVersion == null` 时逐行退化成 BUG-1786 的旧行为）：
 ///
-/// | verdict   | 代码版本 >= 目标 | 结果 |
-/// |-----------|------------------|------|
-/// | aborted   | 任意             | 失败 |
-/// | succeeded | 是 / 未知且 exe 版本达标 | 成功 |
-/// | succeeded | 否               | 失败 |
-/// | unknown   | 是               | 成功 |
-/// | unknown   | 否 / 未知        | 失败 |
+/// | verdict   | 代码版本证据 | 结果 |
+/// |-----------|--------------|------|
+/// | aborted   | 任意         | 失败 |
+/// | 任意      | 达标         | 成功 |
+/// | 任意      | 未达标       | 失败 |
+/// | succeeded | 不可比       | 看 exe 版本（旧判据） |
+/// | unknown   | 不可比       | 失败（旧判据） |
 bool isWindowsUpdateInstalled({
   required WindowsInnoInstallVerdict verdict,
   required String targetVersion,
@@ -1098,14 +1098,82 @@ bool isWindowsUpdateInstalled({
   // 代码版本达标也不能判成功——装到一半的包必须让用户看见诊断。
   if (verdict == WindowsInnoInstallVerdict.aborted) return false;
 
-  if (runningCodeVersion != null) {
-    return _isVersionAtLeast(runningCodeVersion, targetVersion);
+  switch (classifyRunningCodeVersion(
+    runningCodeVersion: runningCodeVersion,
+    targetVersion: targetVersion,
+  )) {
+    case RunningCodeVersionEvidence.atLeastTarget:
+      return true;
+    case RunningCodeVersionEvidence.belowTarget:
+      return false;
+    case RunningCodeVersionEvidence.inconclusive:
+      // 拿不到（历史版本 / 本地构建）或不可比（跨通道）：退回旧判据，行为逐字
+      // 不变——日志明确成功 AND exe 版本达标。
+      return verdict == WindowsInnoInstallVerdict.succeeded &&
+          _isVersionAtLeast(executableVersion, targetVersion);
+  }
+}
+
+/// 「运行中代码版本」这条证据的三种结论。
+///
+/// 刻意**不是** bool：版本号之间并不总是可比。`2.2.1-debug.12215` 和
+/// `2.2.1-beta.30` 谁新谁旧，SemVer 只会按字符串把 `debug` 排在 `beta` 后面，那是
+/// 巧合不是事实；同理 SemVer 规定「正式版 > 同号预发布版」，于是 `2.2.1` 恒 >
+/// `2.2.1-debug.12215`——BUG-1786 抱怨的「判据恒为真」正是这条。把这类情况诚实地
+/// 标成 [inconclusive] 退回日志判据，比硬编出一个大小关系安全得多。
+enum RunningCodeVersionEvidence {
+  /// 运行中的代码确实是目标版本或更新的构建。
+  atLeastTarget,
+
+  /// 运行中的代码明确比目标旧——更新没落地。
+  belowTarget,
+
+  /// 拿不到（未注入）或两者不可比（跨通道）。这条证据不可用，不代表失败。
+  inconclusive,
+}
+
+/// 判定 [runningCodeVersion] 相对 [targetVersion] 的证据结论。
+///
+/// 基版本不同的一律可比（`2.3.0` 比 `2.2.1-debug.x` 新是事实，与通道无关）；
+/// 基版本相同时才看预发布段，且**只有通道标签相同**（都是 `debug.` / 都是
+/// `beta.` / 都是正式版）才比序号，否则不可比。
+RunningCodeVersionEvidence classifyRunningCodeVersion({
+  required String? runningCodeVersion,
+  required String targetVersion,
+}) {
+  if (runningCodeVersion == null) {
+    return RunningCodeVersionEvidence.inconclusive;
+  }
+  final String running =
+      _stripBuildMetadata(_stripLeadingV(runningCodeVersion.trim()));
+  final String target =
+      _stripBuildMetadata(_stripLeadingV(targetVersion.trim()));
+
+  final int base = _compareBase(_basePart(running), _basePart(target));
+  if (base != 0) {
+    return base > 0
+        ? RunningCodeVersionEvidence.atLeastTarget
+        : RunningCodeVersionEvidence.belowTarget;
   }
 
-  // 拿不到代码版本（本次改动之前发布的历史版本、本地 `flutter run`）：退回旧判据，
-  // 行为逐字不变——日志明确成功 AND exe 版本达标。
-  return verdict == WindowsInnoInstallVerdict.succeeded &&
-      _isVersionAtLeast(executableVersion, targetVersion);
+  final String? runningPre = _prereleasePart(running);
+  final String? targetPre = _prereleasePart(target);
+  if (runningPre == null && targetPre == null) {
+    return RunningCodeVersionEvidence.atLeastTarget;
+  }
+  if (_channelLabelOf(runningPre) != _channelLabelOf(targetPre)) {
+    return RunningCodeVersionEvidence.inconclusive;
+  }
+  return _comparePrerelease(runningPre!, targetPre!) >= 0
+      ? RunningCodeVersionEvidence.atLeastTarget
+      : RunningCodeVersionEvidence.belowTarget;
+}
+
+/// 预发布段的通道标签（`debug.12215` → `debug`）；正式版为 `null`。
+String? _channelLabelOf(String? prerelease) {
+  if (prerelease == null) return null;
+  final String label = prerelease.split('.').first;
+  return label.isEmpty ? null : label;
 }
 
 bool _isVersionAtLeast(String current, String target) {

--- a/fushi/test/build/build_version_define_guard_test.dart
+++ b/fushi/test/build/build_version_define_guard_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1836 守卫：**每一条**发布构建都必须把 build-name 同时注入 Dart。
+///
+/// `--build-name` 只写进原生版本资源。Windows 的 VERSIONINFO 只能存 4 段数字 +
+/// 一个由 Flutter 生成的字符串，`-debug.12215` 这段后缀在那里**必然丢失**，而且它
+/// 和 `app.so` 是两个文件——「新 exe + 旧 app.so」的半更新态里它照样报新版本。
+/// 所以「运行中的代码是哪个构建」这条证据只能靠
+/// `--dart-define=FUSHI_BUILD_VERSION`（编译进 AOT 快照，与产物同体）。
+///
+/// 漏在任何一条构建上，那个平台/通道的包就退回「只能靠 Inno 日志判断装没装上」的
+/// 老状态：手动装包救援必报失败（BUG-1836），半更新态无法自检（BUG-1786）。
+void main() {
+  const String defineName = 'FUSHI_BUILD_VERSION';
+
+  Directory workflowsDir() {
+    // 测试 cwd 是 `fushi/`。
+    final Directory dir = Directory('../.github/workflows');
+    expect(
+      dir.existsSync(),
+      isTrue,
+      reason: 'expected workflows at ${dir.absolute.path}',
+    );
+    return dir;
+  }
+
+  /// 按 `- name:` 切成步骤：构建命令绝不会跨两个步骤，用它当边界比固定行窗口
+  /// 可靠（固定窗口会被新增注释顶出范围，守卫悄悄失效 —— BUG-1831 踩过一次）。
+  List<String> splitSteps(String yaml) {
+    final List<String> steps = <String>[];
+    final StringBuffer current = StringBuffer();
+    for (final String line in const LineSplitter().convert(yaml)) {
+      if (RegExp(r'^\s*-\s+name:').hasMatch(line)) {
+        if (current.isNotEmpty) steps.add(current.toString());
+        current.clear();
+      }
+      current.writeln(line);
+    }
+    if (current.isNotEmpty) steps.add(current.toString());
+    return steps;
+  }
+
+  test('每处 --build-name 都配了同值的 --dart-define=$defineName', () {
+    int checked = 0;
+    for (final File file in workflowsDir().listSync().whereType<File>().where(
+      (File f) => f.path.endsWith('.yml'),
+    )) {
+      for (final String step in splitSteps(file.readAsStringSync())) {
+        final Iterable<RegExpMatch> buildNames = RegExp(
+          r'--build-name\s+"([^"]*)"',
+        ).allMatches(step);
+        for (final RegExpMatch match in buildNames) {
+          final String value = match.group(1)!;
+          checked++;
+          expect(
+            step,
+            contains('--dart-define="$defineName=$value"'),
+            reason:
+                '${file.path} 里有一处 --build-name "$value" 没同时注入 Dart；'
+                '该平台的包将无法自报运行中代码的版本',
+          );
+        }
+      }
+    }
+    expect(
+      checked,
+      greaterThanOrEqualTo(7),
+      reason:
+          '发布构建点少于预期（Windows / macOS / iOS / IPA / 三条 APK）——'
+          '要么有构建被删了，要么 --build-name 换了写法让这条守卫扫空',
+    );
+  });
+
+  test('Dart 侧确实读这个 define（两侧名字必须同时改）', () {
+    final File source = File('lib/src/utils/misc/build_version.dart');
+    expect(source.existsSync(), isTrue);
+    // 断言字面量（勿改）: 'FUSHI_BUILD_VERSION'
+    //
+    // 先抹掉所有空白再匹配：`dart format` 的 tall style 会把这行折成三行，
+    // 单行字面量断言会**恒不匹配**而不是报错——守卫悄悄失效比没有守卫更糟。
+    expect(
+      source.readAsStringSync().replaceAll(RegExp(r'\s+'), ''),
+      contains("String.fromEnvironment('$defineName')"),
+      reason: '构建期注入的名字和 Dart 侧读的名字对不上，注入就是白注入',
+    );
+  });
+}

--- a/fushi/test/settings/app_version_display_format_test.dart
+++ b/fushi/test/settings/app_version_display_format_test.dart
@@ -40,6 +40,60 @@ void main() {
     });
   });
 
+  /// BUG-1836 / BUG-1786：Windows 的 exe 版本资源丢 `-debug.N`，关于页只显示
+  /// `2.2.1`，用户看不出自己跑在哪个构建上；「新 exe + 旧 app.so」的半更新态更是
+  /// 完全不可见。有了编译进 `app.so` 的构建版本，这两件事都能在关于页直接看出来。
+  group('运行中代码版本优先展示', () {
+    PackageInfo windowsInfo() => PackageInfo(
+          appName: 'Fushi',
+          packageName: 'app.hibiki.reader',
+          // Windows 上 package_info 读 exe VERSIONINFO，必然只有基版本。
+          version: '2.2.1',
+          buildNumber: '12215',
+        );
+
+    test('注入了代码版本就显示带后缀的真值', () {
+      expect(
+        formatAppVersionDisplay(
+          windowsInfo(),
+          runningCodeVersion: '2.2.1-debug.12215',
+        ),
+        '2.2.1-debug.12215 (12215)',
+      );
+    });
+
+    test('没注入时退回 exe 版本资源，形状不变', () {
+      expect(formatAppVersionDisplay(windowsInfo()), '2.2.1 (12215)');
+    });
+
+    test('基版本不一致时并排显示 exe 版本（半更新态的可见症状）', () {
+      final PackageInfo info = PackageInfo(
+        appName: 'Fushi',
+        packageName: 'app.hibiki.reader',
+        version: '2.3.0',
+        buildNumber: '12300',
+      );
+
+      expect(
+        formatAppVersionDisplay(
+          info,
+          runningCodeVersion: '2.2.1-debug.12215',
+        ),
+        '2.2.1-debug.12215 (12300) ≠ exe 2.3.0',
+      );
+    });
+
+    test('只有后缀不同不算不一致（否则每个 debug 构建都会报警）', () {
+      expect(
+        formatAppVersionDisplay(
+          windowsInfo(),
+          runningCodeVersion: '2.2.1-debug.12215',
+        ),
+        isNot(contains('≠')),
+      );
+    });
+  });
+
   group('source guard', () {
     test(
         'settings_schema_system.dart no longer concatenates version+buildNumber',

--- a/fushi/test/utils/misc/update_install_evidence_test.dart
+++ b/fushi/test/utils/misc/update_install_evidence_test.dart
@@ -122,6 +122,94 @@ void main() {
     });
   });
 
+  group('代码版本并不总是可比', () {
+    test('跨通道不可比 ⇒ 退回日志判据，不能硬判成功', () {
+      // 用户从 debug 通道切到 beta，target 是 `2.2.1-beta.30`，安装失败且没留日志，
+      // 跑的仍是 `2.2.1-debug.12215`。SemVer 会把 `debug` 排在 `beta` 之后，于是
+      // 「代码版本 >= 目标」为真——纯属字符串巧合。硬信它就是把失败报成成功。
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: '2.2.1-debug.12215',
+          targetVersion: '2.2.1-beta.30',
+        ),
+        RunningCodeVersionEvidence.inconclusive,
+      );
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.unknown,
+          targetVersion: '2.2.1-beta.30',
+          executableVersion: exeVersion,
+          runningCodeVersion: '2.2.1-debug.12215',
+        ),
+        isFalse,
+      );
+    });
+
+    test('正式版 vs 同号预发布版不可比（BUG-1786 抱怨的「恒为真」）', () {
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: '2.2.1',
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.inconclusive,
+      );
+    });
+
+    test('基版本不同一律可比，与通道无关', () {
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: '2.3.0',
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.atLeastTarget,
+      );
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: '2.1.9-beta.4',
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.belowTarget,
+      );
+    });
+
+    test('同通道按序号比，前导 v 与 +metadata 不影响', () {
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: 'v$target+abc1234',
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.atLeastTarget,
+      );
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: oldCode,
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.belowTarget,
+      );
+    });
+
+    test('两边都是正式版且同号 ⇒ 达标', () {
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: '2.2.1',
+          targetVersion: '2.2.1',
+        ),
+        RunningCodeVersionEvidence.atLeastTarget,
+      );
+    });
+
+    test('未注入 ⇒ 不可比（不是「未达标」）', () {
+      expect(
+        classifyRunningCodeVersion(
+          runningCodeVersion: null,
+          targetVersion: target,
+        ),
+        RunningCodeVersionEvidence.inconclusive,
+      );
+    });
+  });
+
   group('normalizeFushiBuildVersion', () {
     test('未注入（空串 / 空白）折叠成 null，绝不当版本号参与比较', () {
       expect(normalizeFushiBuildVersion(''), isNull);

--- a/fushi/test/utils/misc/update_install_evidence_test.dart
+++ b/fushi/test/utils/misc/update_install_evidence_test.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/misc/build_version.dart';
+import 'package:fushi/src/utils/misc/update_handoff.dart';
+
+/// BUG-1836 根因修复：「这次更新到底装上了没有」的三源证据表。
+///
+/// 现场（2026-08-24）：用户照 BUG-1786 / BUG-1831 的指引**手动双击**装完
+/// `fushi-2.2.1-debug.12215-windows-setup.exe`，磁盘证据显示整包换新成功，重启后
+/// app 仍弹「更新失败」。原因是判据只认 Inno 日志，而手动装包时 Inno 一个字都不写。
+///
+/// 新证据源 [kFushiBuildVersionDefine] 编译在 `app.so` 里，与被替换的产物同体：
+/// `app.so` 没被换掉它就报旧值。有它就不需要日志背书。
+void main() {
+  const String target = '2.2.1-debug.12215';
+  const String oldCode = '2.2.1-debug.12067';
+  // Windows 的 exe 版本资源恒为基版本（丢 `-debug.N`），现场取到的就是这个值。
+  const String exeVersion = '2.2.1';
+
+  group('三源证据判定表', () {
+    test('无日志 + 代码版本已是目标 ⇒ 成功（手动装包救援，BUG-1836）', () {
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.unknown,
+          targetVersion: target,
+          executableVersion: exeVersion,
+          runningCodeVersion: target,
+        ),
+        isTrue,
+      );
+    });
+
+    test('无日志 + 代码版本仍是旧的 ⇒ 失败（安装器根本没跑起来）', () {
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.unknown,
+          targetVersion: target,
+          executableVersion: exeVersion,
+          runningCodeVersion: oldCode,
+        ),
+        isFalse,
+      );
+    });
+
+    test('回滚 + 代码版本已是目标 ⇒ 仍判失败（整包半更新态）', () {
+      // Inno 的回滚**保留**被覆盖的文件、只删本次新建的文件，所以回滚之后
+      // `app.so` 完全可能已经是新版，而别的文件还是旧的。此时代码版本达标也不能
+      // 判成功——这正是 BUG-1786 现场「新 exe + 旧插件 dll」的形状。
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.aborted,
+          targetVersion: target,
+          executableVersion: exeVersion,
+          runningCodeVersion: target,
+        ),
+        isFalse,
+      );
+    });
+
+    test('日志说成功 + 代码版本仍是旧的 ⇒ 判失败（日志不能给旧代码背书）', () {
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.succeeded,
+          targetVersion: target,
+          executableVersion: exeVersion,
+          runningCodeVersion: oldCode,
+        ),
+        isFalse,
+      );
+    });
+
+    test('代码版本比目标还新 ⇒ 成功（用户手动装了更新的包）', () {
+      expect(
+        isWindowsUpdateInstalled(
+          verdict: WindowsInnoInstallVerdict.unknown,
+          targetVersion: target,
+          executableVersion: exeVersion,
+          runningCodeVersion: '2.2.1-debug.12216',
+        ),
+        isTrue,
+      );
+    });
+
+    group('拿不到代码版本时逐行退化成 BUG-1786 的旧判据', () {
+      test('日志成功 + exe 版本达标 ⇒ 成功', () {
+        expect(
+          isWindowsUpdateInstalled(
+            verdict: WindowsInnoInstallVerdict.succeeded,
+            targetVersion: target,
+            executableVersion: exeVersion,
+            runningCodeVersion: null,
+          ),
+          isTrue,
+        );
+      });
+
+      test('无日志 ⇒ 失败（旧行为，不因新判据放宽）', () {
+        expect(
+          isWindowsUpdateInstalled(
+            verdict: WindowsInnoInstallVerdict.unknown,
+            targetVersion: target,
+            executableVersion: exeVersion,
+            runningCodeVersion: null,
+          ),
+          isFalse,
+        );
+      });
+
+      test('日志回滚 ⇒ 失败（旧行为）', () {
+        expect(
+          isWindowsUpdateInstalled(
+            verdict: WindowsInnoInstallVerdict.aborted,
+            targetVersion: target,
+            executableVersion: exeVersion,
+            runningCodeVersion: null,
+          ),
+          isFalse,
+        );
+      });
+    });
+  });
+
+  group('normalizeFushiBuildVersion', () {
+    test('未注入（空串 / 空白）折叠成 null，绝不当版本号参与比较', () {
+      expect(normalizeFushiBuildVersion(''), isNull);
+      expect(normalizeFushiBuildVersion('   '), isNull);
+    });
+
+    test('注入值去空白后原样保留', () {
+      expect(normalizeFushiBuildVersion('  $target\n'), target);
+    });
+  });
+
+  group('reconcile 端到端', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fushi-install-evidence');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    File markerWithoutInnoLog() {
+      final File marker = WindowsUpdateHandoff.markerFile(tempDir);
+      marker.writeAsStringSync(
+        jsonEncode(<String, dynamic>{
+          'targetVersion': target,
+          'installerPath': '${tempDir.path}${Platform.pathSeparator}setup.exe',
+          // 手动双击安装包时 Inno 不写日志：这个路径**故意**指向不存在的文件。
+          'innoLogPath':
+              '${tempDir.path}${Platform.pathSeparator}never-written.log',
+          'startedAt': DateTime.now().toUtc().toIso8601String(),
+          'installerLaunchSucceeded': false,
+          'launchError': 'UpdateInstallerException: update launcher not found',
+        }),
+      );
+      return marker;
+    }
+
+    test('手动装包救援成功后判 installed，而不是再报一次失败', () async {
+      final File marker = markerWithoutInnoLog();
+
+      final WindowsUpdateHandoffResult? result =
+          await WindowsUpdateHandoff.reconcile(
+            markerFile: marker,
+            currentVersion: exeVersion,
+            runningCodeVersionDefine: target,
+          );
+
+      expect(result, isNotNull);
+      expect(
+        result!.status,
+        WindowsUpdateHandoffStatus.installed,
+        reason: '现场：磁盘上整包已换新，判据却因为拿不到 Inno 日志报了失败',
+      );
+      expect(
+        result.record.lastPromptedAppVersion,
+        target,
+        reason:
+            '幂等键要用带 -debug.N 的代码版本，exe 版本资源的 `2.2.1` '
+            '在同 base 的两个构建之间无法区分',
+      );
+    });
+
+    test('同样没有日志、但跑的还是旧代码 ⇒ 仍报失败', () async {
+      final File marker = markerWithoutInnoLog();
+
+      final WindowsUpdateHandoffResult? result =
+          await WindowsUpdateHandoff.reconcile(
+            markerFile: marker,
+            currentVersion: exeVersion,
+            runningCodeVersionDefine: oldCode,
+          );
+
+      expect(result, isNotNull);
+      expect(result!.status, WindowsUpdateHandoffStatus.launchFailed);
+    });
+
+    test('未注入代码版本时，无日志仍报失败（历史版本行为不变）', () async {
+      final File marker = markerWithoutInnoLog();
+
+      final WindowsUpdateHandoffResult? result =
+          await WindowsUpdateHandoff.reconcile(
+            markerFile: marker,
+            currentVersion: exeVersion,
+            runningCodeVersionDefine: '',
+          );
+
+      expect(result, isNotNull);
+      expect(result!.status, WindowsUpdateHandoffStatus.launchFailed);
+    });
+  });
+}


### PR DESCRIPTION
## 问题

判「这次更新装上了没有」此前只有两个证据源，**两个都不是被替换的产物本身**：

1. **Inno 安装日志** —— 只在 app 自己经 `/LOG=` 拉起安装器时存在。用户按 BUG-1786 / BUG-1831 的指引**手动双击**安装包救援时 Inno 一个字都不写，判据拿不到证据只能判失败。于是「照着指引把机器修好」这一刻必然收到一句「更新失败」（BUG-1836 现场）。这是本条 bug 的**真根因**。
2. **exe 版本资源**（`PackageInfo`）—— 它和 `app.so` 是**两个文件**：Inno 的回滚保留被覆盖的文件、只删本次新建的文件，「新 exe + 旧 app.so」的半更新态照样落地，版本资源却报新版本（BUG-1786 现场连着几天报「更新成功」）。

### 前提纠正（审查查出来的，已实测坐实）

本 PR 最初把「Windows exe 版本资源丢 `-debug.N`」当前提——**那是错的**，它抄自 BUG-1786 的代码注释：

- 实测 `D:\APP\Hibiki\fushi.exe` 的 **ProductVersion = `2.2.1-debug.12215+12215`**。VERSIONINFO 丢后缀的只是 `FILEVERSION` 那四段**数字**字段（`ProductVersionRaw = 2.2.1.12215`），字符串字段保留完整 build-name，而 `package_info_plus` 读的正是字符串字段。
- 旁证：用户机器 `update-handoff.json` 的 `lastPromptedAppVersion` = `2.2.1-debug.12215`，那个值就是运行期的 `packageInfo.version`。

**真正丢后缀的是 beta 通道的 `--build-name` 本身**：`release-desktop.yml` 原先只给 debug tag 把 `BUILD_VERSION_NAME` 覆盖成 tag 派生值（`6c2cedc972`，2026-06-13，为 debug 写的最小改动，commit message 一个字没提 beta，之后被逐字复制进 macOS / iOS 三个 job）。beta 包因此在所有来源里一律自称裸 `2.2.1` ⇒ 第三源证据在 beta 上退化成常量 ⇒ BUG-1786 的「判据恒为真」与本条的「救援判失败」在 beta 通道原封不动地活着。

## 修复

### 1. 新证据源：编译进 `app.so` 的构建版本

`kFushiBuildVersionDefine`（`fushi/lib/src/utils/misc/build_version.dart`）由构建期 `--dart-define=FUSHI_BUILD_VERSION` 注入，编译进 AOT 快照，**与被替换的产物同体**——`app.so` 没被换掉它就报旧值。

判据收敛成三源证据表 `isWindowsUpdateInstalled`：

| Inno 日志 | 代码版本证据 | 结果 |
|---|---|---|
| aborted | 任意 | 失败（回滚保留被覆盖的文件，整包仍可能半更新） |
| 任意 | 达标 | 成功（手动装包救援因此判成功） |
| 任意 | 未达标 | 失败（日志说成功也不能给旧代码背书） |
| succeeded | 不可比 | 看 exe 版本（旧判据） |
| unknown | 不可比 | 失败（旧判据） |

代码版本证据**刻意不是 bool**：版本号之间并不总是可比。SemVer 按字符串把 `debug` 排在 `beta` 之后，硬信它会把一次失败的跨通道安装报成成功；「正式版 > 同号预发布版」同理。基版本相同时只有**通道标签一致**才比序号，否则 `inconclusive` 退回日志判据。

**向后兼容**：代码版本未知时（历史版本、本地 `flutter run`）逐行退化成 BUG-1786 的旧判据，行为逐字不变。

### 2. 版本名对所有版本 tag 派生（beta 不再自称裸 `2.2.1`）

与 `release.yml`（Android）对齐——那边一直如此。仍保留正则守门：`release` 事件的 tag 未经格式校验，无条件 `${TAG#v}` 会让 `--build-name` 拿到 `debug-rolling` 这类非版本串直接构建失败。

**唯一例外 iOS**：Apple 只接受「至多三段非负整数」的 `CFBundleShortVersionString`（`ios/Runner/Info.plist` = `$(FLUTTER_BUILD_NAME)`），`2.2.1-beta.30` 会在 `altool --validate-app` 直接被拒。iOS 传剥掉预发布段的 `apple_build_version_name`，而 `--dart-define=FUSHI_BUILD_VERSION` 仍注入完整版本名——注入值因此**刻意与 `--build-name` 解耦**。

已核对不受影响：客户端选包只按后缀 + `-debug.` 子串判断、不解析文件名里的版本（`platform_updater.dart` 的 `_windowsAssetMatchesChannel`）；rolling prune 的 seq 解析只在 debug 通道跑；镜像不做文件名匹配且默认跳过 prerelease；`check_release_policy.ps1`、`update_settings_android_only_guard`、`release_workflow_diagnostics` 等既有守卫全绿。

### 3. 顺带修掉的同源缺陷

- **幂等键**改用代码版本：它来自 `app.so`，`currentVersion` 来自 exe 版本资源，半更新态下两者指向不同构建，而这个键要回答的正是「跑着的这份代码有没有被提示过」。
- **关于页 / 日志上传**改报真实构建版本；两者**逐字**不一致时关于页并排显示 `≠ exe <ver>`。比对必须逐字：半更新态的形状恰恰是 `2.2.1-debug.12216` 的 exe 配 `2.2.1-debug.12215` 的 app.so，基版本相同、只差序号一位，只比基版本等于对唯一需要它的输入闭眼。
- **判据的空断言崩溃路径**：`_channelLabelOf` 对空标签返回 null，会让 `2.2.1-.1` 与「无预发布段」判成同通道，随后抛 TypeError。marker 是磁盘 JSON，而 reconcile 跑在启动路径上。
- **`PackageInfo` 抛异常时日志上传不再报 unknown**——编译期常量那时照样可用。

## 守卫

`fushi/test/build/build_version_define_guard_test.dart` 三条：每处 `--build-name` 必须注入完整版本名；tag 派生不得再被 debug-only 正则挡住；iOS 两处构建必须用 `apple_build_version_name`（防止别人「顺手统一」把 TestFlight 弄红）。

按 YAML 列表项切步骤而**不用固定行窗口**（BUG-1831 踩过：新增注释把被断言的语句顶出窗口，守卫悄悄失效），引号感知取值（`"${{ ... }}"` 里有空格，`\S+` 会截断成半截串恒不匹配），并跳过注释行与报错文案——散文里提到 `--build-name` / `flutter build ipa` 是常事。

## 验证

- `flutter analyze` No issues found
- 全量 `dart run tool/flutter_test_failures.dart --no-pub` → **PASSED - 20556 tests ran**（基线 20526）
- `tool/check_release_policy.ps1` → passed
- **9 个变异各自精确变红、还原后工作区干净**：漏注入一处 / 两侧 define 名字对不上 / 判据忽略代码版本 / 回滚不再一票否决 / 跨通道照比大小 / tag 派生退回 debug-only / iOS 顺手统一成完整版本名 / 关于页退回只比基版本 / 去掉「一侧无预发布段不可比」
- 两个 workflow YAML 折叠后命令解析正确（`yaml.safe_load` 复核）

## 生效节奏

注入在构建期，所以**装上带本修复的包之后，下一次更新的判据才吃到代码版本**；在那之前逐行退化成旧判据。

## 已知残留（不在本 PR）

半更新态下「是否有更新可用」这条链仍只看 exe 版本 + buildNumber（`home_page.dart` / `update_checker_release.dart`），两者都报新值 ⇒ 客户端认为自己已是最新 ⇒ 不再提示更新，用户困在旧代码里。新证据源能解这一环，但那是另一条代码路径，单独处理。

https://claude.ai/code/session_014dxBSVHPANH7MyvkvZjGqJ
