### PR TITLE
feat(tool): 清单生成器拒绝把包分片挂到主 app 仓库的 release

### DIFF
--- a/fushi/test/tools/make_download_manifest_release_host_guard_test.dart
+++ b/fushi/test/tools/make_download_manifest_release_host_guard_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/make_download_manifest.dart';
+
+void main() {
+  group('包分片来源守卫', () {
+    test('主 app 仓库的 release 地址被判为危险', () {
+      final String? reason = hazardousReleaseHost(
+        'https://github.com/hajisensai/Fushi/releases/download/pack-1/x.000',
+      );
+      expect(reason, isNotNull);
+      expect(reason, contains('mirror-releases.yml'));
+    });
+
+    test('大小写不同也拦得住——GitHub 的 owner/repo 在 URL 里不区分大小写', () {
+      expect(
+        hazardousReleaseHost(
+          'https://github.com/HajiSensai/fushi/releases/download/pack-1/x.000',
+        ),
+        isNotNull,
+      );
+    });
+
+    test('独立仓库 fushi-pack 放行', () {
+      expect(
+        hazardousReleaseHost(
+          'https://github.com/hajisensai/fushi-pack/releases/download/pack-1',
+        ),
+        isNull,
+      );
+    });
+
+    test('非 github 主机放行', () {
+      expect(hazardousReleaseHost('https://dl.wrds.xyz/parts/pack-1'), isNull);
+    });
+
+    test('真实参数解析路径会拒绝该地址 —— 钉住调用点，不只是纯函数', () {
+      // 只测纯函数的话，把 _Args.parse 里的调用整行删掉，上面四条照样全绿。
+      // 这条走真实校验入口，让「守卫函数还在但没人调用」当场红。
+      // 参数刻意在 parse 阶段就触发：不会去读 --input 指的文件。
+      expect(
+        () => parseArgsForTest(<String>[
+          '--input', 'not-read.zip',
+          '--whole-url', 'https://dl.wrds.xyz/pack.zip',
+          '--part-base-url',
+          'https://github.com/hajisensai/Fushi/releases/download/pack-1',
+        ]),
+        throwsA(isA<FormatException>().having(
+          (FormatException e) => e.message,
+          'message',
+          contains('mirror-releases.yml'),
+        )),
+      );
+    });
+
+    test('换成 fushi-pack 后同一组参数不再被拒', () {
+      expect(
+        () => parseArgsForTest(<String>[
+          '--input', 'not-read.zip',
+          '--whole-url', 'https://dl.wrds.xyz/pack.zip',
+          '--part-base-url',
+          'https://github.com/hajisensai/fushi-pack/releases/download/pack-1',
+          '--out-dir', 'out',
+        ]),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/fushi/tool/make_download_manifest.dart
+++ b/fushi/tool/make_download_manifest.dart
@@ -14,9 +14,9 @@
 //     --mode range --version 2026-08-14
 //
 //   dart run tool/make_download_manifest.dart \
-//     --input ...zip --mode slice --part-size 1GiB --out-dir D:\packs\slices \
+//     --input ...zip --mode slice --part-size 256MiB --out-dir D:\packs\slices \
 //     --whole-url https://dl.wrds.xyz/....zip \
-//     --part-base-url https://github.com/hajisensai/Fushi/releases/download/pack-2026-08-14 \
+//     --part-base-url https://github.com/hajisensai/fushi-pack/releases/download/pack-2026-08-14 \
 //     --mirror https://mirror2.example/....zip
 //
 // 切片文件名固定为 `<包名>.NNN`（三位十进制，从 000 起），与清单里的 `name` 对应。
@@ -167,6 +167,38 @@ class _DigestSink implements Sink<Digest> {
   void close() {}
 }
 
+/// 包分片**不能**放主 app 仓库（hajisensai/Fushi）的 release。
+///
+/// 那个仓库的 `.github/workflows/mirror-releases.yml` 挂在 `release: published`
+/// 上且**没有 tag 过滤**，只跳过预发布。一旦在那里发布包 release，它会：
+/// ① 把整包（约 9.5 GB）拉进 runner；② 每个分片都超过 MAX_ASSET_MB=300 被跳过上传；
+/// ③ 仍然**无条件**把一份资产列表为空的 manifest.json 覆盖写进 R2；
+/// ④ 按 KEEP_RELEASES 轮转，删掉上一版 app 的镜像文件。
+/// 净结果是 fushi.moe/releases 下载当场失效。
+///
+/// 所以这里直接拒绝，而不是写进文档指望人记得——包分片放独立仓库 fushi-pack。
+/// 将来若给那个 workflow 加了 tag 过滤，改这一个函数即可。
+/// 测试入口：驱动**真实**的参数解析路径。
+///
+/// 只测 [hazardousReleaseHost] 纯函数的话，把 `_Args.parse` 里那两行调用删掉，
+/// 纯函数的用例照样全绿——守卫就成了摆设。测试经由这里走真实校验，
+/// 调用点一旦消失当场红。
+void parseArgsForTest(List<String> argv) => _Args.parse(argv);
+
+String? hazardousReleaseHost(String url) {
+  final Uri? parsed = Uri.tryParse(url);
+  if (parsed == null) return null;
+  if (parsed.host.toLowerCase() != 'github.com') return null;
+  final List<String> seg = parsed.pathSegments;
+  if (seg.length < 2) return null;
+  if (seg[0].toLowerCase() != 'hajisensai') return null;
+  if (seg[1].toLowerCase() != 'fushi') return null;
+  return '拒绝：$url 指向主 app 仓库的 release。'
+      '在那里发布包会触发 mirror-releases.yml，用空资产清单覆盖 R2 的 '
+      'manifest.json 并轮转删除上一版镜像，fushi.moe/releases 会当场失效。'
+      '请改用独立仓库，例如 https://github.com/hajisensai/fushi-pack/releases/download/<tag>。';
+}
+
 class _Args {
   _Args({
     required this.input,
@@ -225,6 +257,8 @@ class _Args {
       if (!url.startsWith('https://')) {
         throw FormatException('镜像/切片地址必须是 https：$url');
       }
+      final String? hazard = hazardousReleaseHost(url);
+      if (hazard != null) throw FormatException(hazard);
     }
 
     final String mode = single['--mode'] ?? 'slice';


### PR DESCRIPTION
承接已合并的 #984（分片按片号轮换来源）。那条让双源**能**并拉，这条防止双源被**配错**。

## 问题：工具的用法示例把人往坑里带

`fushi/tool/make_download_manifest.dart` 的示例原本写着：

```
--part-base-url https://github.com/hajisensai/Fushi/releases/download/pack-2026-08-14
```

照着做会出事。主仓库的 `.github/workflows/mirror-releases.yml` 挂在 `release: published` 上且**没有 tag 过滤**，只跳过预发布。在那里发布包 release 会：

1. 把整包（约 9.5 GB）拉进 runner
2. 每个分片都超过 `MAX_ASSET_MB=300` 被跳过上传
3. 仍然**无条件**把一份资产列表为空的 `manifest.json` 覆盖写进 R2
4. 按 `KEEP_RELEASES` 轮转，删掉上一版 app 的镜像文件

净结果：**`fushi.moe/releases` 下载当场失效**。

（另一条也查过：`release-desktop.yml` 的剪枝按文件名形状圈定 `*-windows-setup.exe|*-macos.zip|*-ios.ipa`，**不会**误删包分片，不构成问题。）

## 修法：机械护栏，不是文档提醒

参数校验里直接拒绝指向 `hajisensai/Fushi` release 的地址，owner/repo 大小写不敏感（对齐 GitHub URL 语义）。将来若给那个 workflow 加了 tag 过滤，改这一个函数即可。

同时把示例改指独立仓库 `fushi-pack`，分片大小示例 `1GiB` → `256MiB`：**分片就是重试粒度**，切片模式下每个分片是一个 `DownloadPart`，失败会整片重下，1.5 GB 一片在抖动网络上代价太大；256MiB 约 38 片，既远低于 GitHub 单资产 2 GB 硬限，也够摊到两个源。

## 为什么加 `parseArgsForTest`

只测纯函数 `hazardousReleaseHost` 的话，把校验里那两行调用删掉，纯函数用例照样全绿——守卫沦为摆设。这个入口让测试走**真实**参数解析路径。

**变异实测**（删掉 `_Args.parse` 里的调用点）：4 条纯函数用例仍绿，钉调用点那条当场红。按唯一锚点复原后复验通过。

## 验证

- 3 个测试文件 **44 项全过**，退出码 0（已 rebase 到含 #984 的 develop）
- `flutter analyze` **No issues found**

## 仍需人工

包分片传到 `hajisensai/fushi-pack` 的 release、清单传到 `dl.wrds.xyz`。工具跑完即可，本 PR 不含这一步。

https://claude.ai/code/session_018kebQ12s34FK5Ymb2zVAAY