### PR TITLE
feat(installer): Windows 全新安装可选数据存储位置

### DIFF
--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -88,6 +88,15 @@ gh release view v<version> --repo hajisensai/Fushi --json assets \
 - Windows 老用户**不需要**桥包：他们按 `-windows-setup.exe` 后缀直接拿
   `fushi-<version>-windows-setup.exe`，Inno `AppId` 未变 → 原地升级，数据由
   `legacy_support_dir_migration.dart` 自动搬迁。所以别给桥分支发桌面产物。
+- Windows 安装器的「数据存储位置」页（`fushi/windows/installer/fushi.iss`）**只在全新
+  安装出现**（无卸载键且 `%APPDATA%\Fushi\Fushi` 不存在）；用户的选择写进
+  `{app}\data_root.bootstrap`，app 首启在 `AppPaths.resolve()` 之前由
+  `lib/src/storage/installer_data_root_bootstrap.dart` 一次性消费成 `data_root` 偏好
+  后删除。升级 / 保留数据重装 / 静默自更新都不弹这页、不写这个文件；安装器是一次性
+  写者，数据根的唯一真相源仍是 app 的 `data_root` 偏好（要搬走走设置里的迁移）。
+  改 iss 后本机可用 `ISCC.exe /DAppVersion=0.0.0 /DSourceDir=<任意含一个文件的目录>
+  /DOutputDir=<临时目录> fushi.iss` 验编译，但**别运行**产物——同 AppId 会覆盖本机真实
+  安装的卸载键。契约守卫：`test/build/windows_installer_data_root_page_guard_test.dart`。
 
 ### 快速发版（跳测试）
 

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -28,6 +28,7 @@ import 'package:fushi/src/models/dictionary_download_controller.dart';
 import 'package:fushi/src/storage/app_paths.dart';
 import 'package:fushi/src/storage/books_directory.dart';
 import 'package:fushi/src/storage/export_directory.dart';
+import 'package:fushi/src/storage/installer_data_root_bootstrap.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/src/utils/misc/lookup_input_limits.dart';
 import 'package:fushi/src/media/drag_drop/desktop_drop_reinitializer.dart';
@@ -2195,6 +2196,9 @@ class AppModel with ChangeNotifier {
   /// the application. [AppModel] is initialised in the main function before
   /// [runApp] is executed.
   Future<void> _prepareRuntimeDirectories() async {
+    // Windows 安装向导里选的「数据存储位置」经一次性引导文件送达，必须在 resolve
+    // 读 data_root pref 之前消费（全新安装才生效，见该函数契约）。
+    await consumeInstallerDataRootBootstrap();
     // TODO-935 E0：三个数据根经唯一入口 [AppPaths] 解析（内部已honor测试分支
     // [fushiTestDirectory]，故行为与旧的 test/production 双分支逐字节等价）。
     _appPaths = await AppPaths.resolve();

--- a/fushi/lib/src/storage/app_paths.dart
+++ b/fushi/lib/src/storage/app_paths.dart
@@ -335,7 +335,7 @@ class AppPaths {
       _legacyFlatDocumentsRoot = stored == documentsLayoutFlat;
       return;
     }
-    final bool flat = await _existingInstallHasDatabase();
+    final bool flat = await existingInstallHasDatabase();
     _legacyFlatDocumentsRoot = flat;
     // 固化锚点（best-effort）。写失败只意味着下次启动再探一次，不改变本次结果——而下次
     // 探测的判据（主库文件是否存在）此时只会更成立，不会翻转成新布局。
@@ -391,7 +391,7 @@ class AppPaths {
   /// 兼看旧文件名 [legacyHibikiDatabaseFileName]：老安装在第一次开库前主库还叫
   /// `hibiki.db`（开库时 fushi_core 才做一次性改名），这里若只认新名会把老安装
   /// 误判成全新安装。
-  static Future<bool> _existingInstallHasDatabase() async {
+  static Future<bool> existingInstallHasDatabase() async {
     try {
       final Directory support = await _resolveSupportRoot();
       Future<bool> dbExists(String fileName) =>

--- a/fushi/lib/src/storage/app_paths.dart
+++ b/fushi/lib/src/storage/app_paths.dart
@@ -347,6 +347,12 @@ class AppPaths {
     }
   }
 
+  /// 供 [resolve] 之前就需要「默认位置」定义的调用方（安装器数据根引导）提前定下容器名，
+  /// 保证它算出的 [defaultLocationDocumentsRoot] 与紧随其后的 [resolve] 是同一个；
+  /// [resolve] 内再调时已判定、直接沿用。
+  static Future<void> ensureDocumentsContainerDecided() async =>
+      _ensureDocumentsContainerDecided(await _prefsOrNull());
+
   /// Fushi 改名（Phase 3）：判定 + 固化 nested 容器名。锚点已有直接用；没有则
   /// 探测一次：老容器 `<Documents>/Hibiki/data` 存在而新容器不存在 → 存量安装，
   /// 锚 `Hibiki`（目录与 DB 内绝对路径都不动）；否则锚 `Fushi`（新装）。

--- a/fushi/lib/src/storage/installer_data_root_bootstrap.dart
+++ b/fushi/lib/src/storage/installer_data_root_bootstrap.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -13,8 +14,12 @@ import 'package:fushi/src/storage/data_root_migrator.dart'
 /// 文件里（`windows/installer/fushi.iss` 的 `ssPostInstall` 写；文件名两侧由
 /// `test/build/windows_installer_data_root_page_guard_test.dart` 守住一致）。
 ///
-/// 内容：UTF-8（安装器写 BOM）、单行绝对目录路径。
+/// 内容：UTF-8（安装器写 BOM，Dart 的 utf8 解码器自动剥掉）、单行绝对目录路径。
 const String installerDataRootBootstrapFileName = 'data_root.bootstrap';
+
+/// 用户挑的目录可能在网络盘 / 移动盘上：所有触碰它的 IO 都封顶，与 [AppPaths] 的
+/// `_probeDataRootExists` 同一纪律（启动最早期，绝不让一个掉线的盘挂住主 isolate）。
+const Duration _pickedRootIoTimeout = Duration(seconds: 2);
 
 /// 生产：引导文件恒在 exe 同目录（`{app}` = 安装目录，安装器就写在那里，app 用
 /// [Platform.resolvedExecutable] 定位，不猜安装位置）。非 Windows 没有这个安装器 → null。
@@ -27,6 +32,11 @@ File? _productionBootstrapFile() {
     ),
   );
 }
+
+/// 进行中的消费。`AppModel.initialise` 的 Retry 可能在上一轮还没跑完（IO 超时被
+/// `_guardInitIo` 抛出但底层 future 仍在）时再次进入；两轮各读一次文件、各写一次 pref
+/// 就是两个数据根写者。同一进程内只允许一次消费在飞，后来者等它。
+Future<void>? _inFlight;
 
 /// 首启前消费安装包写下的数据根引导文件，把用户在安装向导里选的目录变成
 /// [AppPaths.dataRootPrefKey]。必须在 [AppPaths.resolve] **之前**调用（数据根解析读的
@@ -41,19 +51,38 @@ File? _productionBootstrapFile() {
 ///    （[AppPaths.existingInstallHasDatabase]）→ 忽略。卸载后保留数据再重装、用户在向导里
 ///    另选了目录时，绝不能让旧书库从新根下「消失」；用户要搬走走设置里的迁移（连 DB 内
 ///    绝对路径一起 rebase）。
-///  - 路径须为绝对路径，且不能是安装目录或其祖先（与 `validateDataRootTarget` 的
-///    `containsExecutable` 同一条规则：自动更新/回滚会整体处理安装目录，数据不能压在下面）。
+///  - 路径须为绝对路径，且与安装目录**不得相同或互相包含**（比设置页的
+///    `containsExecutable` 更严：数据落在 `{app}` 之下会被卸载 / 自更新回滚一起处理）。
+///  - 目标下已派生出非空的 `documents` / `support` 子树 → 拒绝（同设置页
+///    `targetNotEmpty`）：把用户自己的 `D:\Downloads\documents` 当成 Fushi 私有树，
+///    之后的整树迁移会连用户文件一起搬走 / 删掉。
 ///  - 归一化与设置页迁移共用 [resolveDataRootMigrationTarget]：用户选中默认位置
 ///    （`<Documents>\Fushi` 或 `<Documents>\Fushi\data`）= 与全新安装同形 → **不写** pref，
 ///    DB 留在平台固定落点，而不是派生成 `<Documents>\Fushi\{documents,support}` 第三种布局。
-///  - 目录建不出来 → 不写 pref，退回默认根并打日志（此时没有任何数据，不构成数据丢失；
-///    用户可在设置里再选）。
+///    归一化前先让 [AppPaths.ensureDocumentsContainerDecided] 定下容器名，与紧随其后的
+///    `resolve()` 用同一个「默认位置」。
+///  - 目录建不出来 / pref 写失败 → 不采纳，退回默认根并打日志（此时没有任何数据，不构成
+///    数据丢失；用户可在设置里再选）。
 ///
 /// [bootstrapFile] / [executablePath] 仅供测试注入；生产走 exe 同目录与
 /// [Platform.resolvedExecutable]。
 Future<void> consumeInstallerDataRootBootstrap({
   File? bootstrapFile,
   String? executablePath,
+}) {
+  final Future<void>? running = _inFlight;
+  if (running != null) return running;
+  final Future<void> run = _consumeOnce(
+    bootstrapFile: bootstrapFile,
+    executablePath: executablePath,
+  ).whenComplete(() => _inFlight = null);
+  _inFlight = run;
+  return run;
+}
+
+Future<void> _consumeOnce({
+  required File? bootstrapFile,
+  required String? executablePath,
 }) async {
   final File? file = bootstrapFile ?? _productionBootstrapFile();
   if (file == null || !await file.exists()) return;
@@ -84,12 +113,9 @@ Future<void> consumeInstallerDataRootBootstrap({
   }
 }
 
-/// 剥 BOM、取第一个非空行、去首尾空白；没有有效行返回 null。
+/// 取第一个非空行、去首尾空白；没有有效行返回 null。
 String? _readPickedPath(String raw) {
-  // U+FEFF：Inno 的 SaveStringsToUTF8File 会写 BOM。
-  final String bom = String.fromCharCode(0xFEFF);
-  final String text = raw.startsWith(bom) ? raw.substring(bom.length) : raw;
-  for (final String line in text.split(RegExp(r'\r?\n'))) {
+  for (final String line in raw.split(RegExp(r'\r?\n'))) {
     final String trimmed = line.trim();
     if (trimmed.isNotEmpty) return trimmed;
   }
@@ -115,11 +141,15 @@ Future<void> _applyPickedDataRoot({
     return;
   }
   final String canonPicked = p.canonicalize(picked);
-  if (p.isWithin(canonPicked, p.canonicalize(executablePath))) {
-    debugPrint('InstallerDataRootBootstrap: 路径包含安装目录，忽略: $picked');
+  final String canonExeDir = p.canonicalize(p.dirname(executablePath));
+  if (p.equals(canonPicked, canonExeDir) ||
+      p.isWithin(canonPicked, canonExeDir) ||
+      p.isWithin(canonExeDir, canonPicked)) {
+    debugPrint('InstallerDataRootBootstrap: 与安装目录相同或互相包含，忽略: $picked');
     return;
   }
 
+  await AppPaths.ensureDocumentsContainerDecided();
   final Directory defaultDocs = await AppPaths.defaultLocationDocumentsRoot();
   final Directory platformSupport = await getApplicationSupportDirectory();
   final DataRootMigrationTarget target = resolveDataRootMigrationTarget(
@@ -131,16 +161,40 @@ Future<void> _applyPickedDataRoot({
     debugPrint('InstallerDataRootBootstrap: 选中默认位置，按全新安装布局');
     return;
   }
+  if (await _hasFiles(target.documentsRoot) ||
+      await _hasFiles(target.supportRoot)) {
+    debugPrint(
+      'InstallerDataRootBootstrap: 目标下已有非空 documents/support 子树，忽略: $picked',
+    );
+    return;
+  }
 
   final String dataRoot = target.dataRootPrefValue!;
   try {
-    await Directory(dataRoot).create(recursive: true);
+    await Directory(
+      dataRoot,
+    ).create(recursive: true).timeout(_pickedRootIoTimeout);
   } catch (e) {
     debugPrint('InstallerDataRootBootstrap: 建目录失败，退回默认根: $dataRoot: $e');
     return;
   }
-  await prefs.setString(AppPaths.dataRootPrefKey, dataRoot);
+  // shared_preferences_windows 写盘失败是返回 false 而非抛错；设置页的提交同样看这个
+  // 布尔值（data_root.part.dart）。
+  if (!await prefs.setString(AppPaths.dataRootPrefKey, dataRoot)) {
+    debugPrint('InstallerDataRootBootstrap: 写 data_root 失败，退回默认根: $dataRoot');
+    return;
+  }
   debugPrint('InstallerDataRootBootstrap: 采纳安装器数据根: $dataRoot');
+}
+
+/// 目录存在且至少有一个条目。探测超时 / 抛错按「有内容」处理（保守：拿不准就不接管）。
+Future<bool> _hasFiles(Directory dir) async {
+  try {
+    if (!await dir.exists().timeout(_pickedRootIoTimeout)) return false;
+    return !await dir.list().isEmpty.timeout(_pickedRootIoTimeout);
+  } catch (_) {
+    return true;
+  }
 }
 
 Future<void> _deleteQuietly(File file) async {

--- a/fushi/lib/src/storage/installer_data_root_bootstrap.dart
+++ b/fushi/lib/src/storage/installer_data_root_bootstrap.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fushi/src/storage/app_paths.dart';
+import 'package:fushi/src/storage/data_root_migrator.dart'
+    show DataRootMigrationTarget, resolveDataRootMigrationTarget;
+
+/// Windows 安装包在「数据存储位置」页收到的用户选择，落到 exe 同目录的这个一次性引导
+/// 文件里（`windows/installer/fushi.iss` 的 `ssPostInstall` 写；文件名两侧由
+/// `test/build/windows_installer_data_root_page_guard_test.dart` 守住一致）。
+///
+/// 内容：UTF-8（安装器写 BOM）、单行绝对目录路径。
+const String installerDataRootBootstrapFileName = 'data_root.bootstrap';
+
+/// 生产：引导文件恒在 exe 同目录（`{app}` = 安装目录，安装器就写在那里，app 用
+/// [Platform.resolvedExecutable] 定位，不猜安装位置）。非 Windows 没有这个安装器 → null。
+File? _productionBootstrapFile() {
+  if (!Platform.isWindows) return null;
+  return File(
+    p.join(
+      p.dirname(Platform.resolvedExecutable),
+      installerDataRootBootstrapFileName,
+    ),
+  );
+}
+
+/// 首启前消费安装包写下的数据根引导文件，把用户在安装向导里选的目录变成
+/// [AppPaths.dataRootPrefKey]。必须在 [AppPaths.resolve] **之前**调用（数据根解析读的
+/// 就是这个 pref），即 `AppModel._prepareRuntimeDirectories` 的第一步。
+///
+/// 契约（安装器是**一次性**写者，之后唯一真相源仍是 pref）：
+///  - 文件不存在 → 无事。
+///  - 文件一旦被读到，无论采纳与否都删除——绝不让安装器留下的路径在之后的启动里反复
+///    生效（那会变成 pref 之外的第二个数据根写者）。唯一例外是 prefs 通道本身不可用：
+///    没法写 pref 就没法消费，留到下次启动。
+///  - **只对全新安装生效**：已有 `data_root` pref，或平台 support 根下已有主库
+///    （[AppPaths.existingInstallHasDatabase]）→ 忽略。卸载后保留数据再重装、用户在向导里
+///    另选了目录时，绝不能让旧书库从新根下「消失」；用户要搬走走设置里的迁移（连 DB 内
+///    绝对路径一起 rebase）。
+///  - 路径须为绝对路径，且不能是安装目录或其祖先（与 `validateDataRootTarget` 的
+///    `containsExecutable` 同一条规则：自动更新/回滚会整体处理安装目录，数据不能压在下面）。
+///  - 归一化与设置页迁移共用 [resolveDataRootMigrationTarget]：用户选中默认位置
+///    （`<Documents>\Fushi` 或 `<Documents>\Fushi\data`）= 与全新安装同形 → **不写** pref，
+///    DB 留在平台固定落点，而不是派生成 `<Documents>\Fushi\{documents,support}` 第三种布局。
+///  - 目录建不出来 → 不写 pref，退回默认根并打日志（此时没有任何数据，不构成数据丢失；
+///    用户可在设置里再选）。
+///
+/// [bootstrapFile] / [executablePath] 仅供测试注入；生产走 exe 同目录与
+/// [Platform.resolvedExecutable]。
+Future<void> consumeInstallerDataRootBootstrap({
+  File? bootstrapFile,
+  String? executablePath,
+}) async {
+  final File? file = bootstrapFile ?? _productionBootstrapFile();
+  if (file == null || !await file.exists()) return;
+
+  final SharedPreferences prefs;
+  try {
+    prefs = await SharedPreferences.getInstance();
+  } catch (e) {
+    debugPrint('InstallerDataRootBootstrap: prefs 不可用，本次不消费: $e');
+    return;
+  }
+
+  try {
+    final String? picked = _readPickedPath(await file.readAsString());
+    if (picked == null) {
+      debugPrint('InstallerDataRootBootstrap: 引导文件为空，忽略');
+      return;
+    }
+    await _applyPickedDataRoot(
+      picked: picked,
+      prefs: prefs,
+      executablePath: executablePath ?? Platform.resolvedExecutable,
+    );
+  } catch (e, stack) {
+    debugPrint('InstallerDataRootBootstrap: 消费失败，退回默认根: $e\n$stack');
+  } finally {
+    await _deleteQuietly(file);
+  }
+}
+
+/// 剥 BOM、取第一个非空行、去首尾空白；没有有效行返回 null。
+String? _readPickedPath(String raw) {
+  // U+FEFF：Inno 的 SaveStringsToUTF8File 会写 BOM。
+  final String bom = String.fromCharCode(0xFEFF);
+  final String text = raw.startsWith(bom) ? raw.substring(bom.length) : raw;
+  for (final String line in text.split(RegExp(r'\r?\n'))) {
+    final String trimmed = line.trim();
+    if (trimmed.isNotEmpty) return trimmed;
+  }
+  return null;
+}
+
+Future<void> _applyPickedDataRoot({
+  required String picked,
+  required SharedPreferences prefs,
+  required String executablePath,
+}) async {
+  final String? existing = prefs.getString(AppPaths.dataRootPrefKey);
+  if (existing != null && existing.trim().isNotEmpty) {
+    debugPrint('InstallerDataRootBootstrap: 已有 data_root 配置，忽略安装器选择');
+    return;
+  }
+  if (await AppPaths.existingInstallHasDatabase()) {
+    debugPrint('InstallerDataRootBootstrap: 本机已有数据库，忽略安装器选择（要搬走请走设置）');
+    return;
+  }
+  if (!p.isAbsolute(picked)) {
+    debugPrint('InstallerDataRootBootstrap: 非绝对路径，忽略: $picked');
+    return;
+  }
+  final String canonPicked = p.canonicalize(picked);
+  if (p.isWithin(canonPicked, p.canonicalize(executablePath))) {
+    debugPrint('InstallerDataRootBootstrap: 路径包含安装目录，忽略: $picked');
+    return;
+  }
+
+  final Directory defaultDocs = await AppPaths.defaultLocationDocumentsRoot();
+  final Directory platformSupport = await getApplicationSupportDirectory();
+  final DataRootMigrationTarget target = resolveDataRootMigrationTarget(
+    pickedRoot: picked,
+    defaultDocumentsRoot: defaultDocs.path,
+    platformSupportRoot: platformSupport.path,
+  );
+  if (target.isDefaultLocation) {
+    debugPrint('InstallerDataRootBootstrap: 选中默认位置，按全新安装布局');
+    return;
+  }
+
+  final String dataRoot = target.dataRootPrefValue!;
+  try {
+    await Directory(dataRoot).create(recursive: true);
+  } catch (e) {
+    debugPrint('InstallerDataRootBootstrap: 建目录失败，退回默认根: $dataRoot: $e');
+    return;
+  }
+  await prefs.setString(AppPaths.dataRootPrefKey, dataRoot);
+  debugPrint('InstallerDataRootBootstrap: 采纳安装器数据根: $dataRoot');
+}
+
+Future<void> _deleteQuietly(File file) async {
+  try {
+    await file.delete();
+  } catch (e) {
+    // 删不掉（安装目录只读等）：pref 已定 / DB 已建，下次启动的门控会再次忽略它，
+    // 不会重复生效。
+    debugPrint('InstallerDataRootBootstrap: 删除引导文件失败: $e');
+  }
+}

--- a/fushi/test/build/windows_installer_data_root_page_guard_test.dart
+++ b/fushi/test/build/windows_installer_data_root_page_guard_test.dart
@@ -4,16 +4,21 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fushi/src/storage/installer_data_root_bootstrap.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 源码守卫：Windows 安装器「数据存储位置」页与 app 首启消费之间的契约。
 ///
 /// 两侧靠一个文件名 + 一个位置（`{app}\data_root.bootstrap`）握手，任何一侧改了另一侧
 /// 就静默失效（安装器写了没人读 / app 等一个永远不会出现的文件）——所以把握手点钉死：
 ///  - iss 里的常量与 Dart 常量同值；
-///  - 页面只在全新安装出现（`ShouldSkipPage` 走 `IsFreshInstall`），升级/重装不得再问；
-///  - `IsFreshInstall` 查的卸载键 GUID 必须等于 `[Setup] AppId`；
-///  - 下一步校验：可写预检 + 与安装目录不重合/不嵌套；
+///  - 页面只在全新安装、非静默时出现（`ShouldSkipPage` 走 `WizardSilent` + `IsFreshInstall`）；
+///  - `IsFreshInstall` 的卸载键从 `[Setup] AppId` 派生（手抄会漏掉 `{{`→`{` 转义，
+///    真值尾部是 `}}`），并兼看新旧两个平台 support 根；
+///  - 下一步校验：可写预检 + 与安装目录不重合/不嵌套 + 目标下无既有 documents/support；
 ///  - `ssPostInstall` 写文件、`[UninstallDelete]` 收尾；
 ///  - app 侧在 `AppPaths.resolve()` **之前**消费。
+///
+/// `[Code]` 段按 `//` 注释掩码后再断言（[maskComments]），把断言字面量写进注释骗不过。
 void main() {
   String readInstallerScript() {
     final File file = File('windows/installer/fushi.iss');
@@ -23,6 +28,28 @@ void main() {
       reason: 'expected Inno Setup script at ${file.absolute.path}',
     );
     return file.readAsStringSync();
+  }
+
+  /// `[Code]` 段（`//` 注释已掩码）。Pascal 的 `{ }` 块注释里没有本文件断言的
+  /// 任何代码字面量（它们都含 `(`/`:=`/引号），不另掩。
+  String readCode() {
+    final String iss = readInstallerScript();
+    final int start = iss.indexOf('[Code]');
+    expect(
+      start,
+      greaterThan(0),
+      reason: 'fushi.iss must have a [Code] section',
+    );
+    return maskComments(iss.substring(start));
+  }
+
+  String block(String code, String head) {
+    final RegExpMatch? match = RegExp(
+      '${RegExp.escape(head)}[\\s\\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(code);
+    expect(match, isNotNull, reason: 'expected "$head" in [Code]');
+    return match!.group(0)!;
   }
 
   test('bootstrap file name matches between installer and app', () {
@@ -38,7 +65,9 @@ void main() {
     expect(constant!.group(1), installerDataRootBootstrapFileName);
 
     expect(
-      iss.contains(r"ExpandConstant('{app}\' + DataRootBootstrapFileName)"),
+      readCode().contains(
+        r"ExpandConstant('{app}\' + DataRootBootstrapFileName)",
+      ),
       isTrue,
       reason:
           'bootstrap must be written next to the exe ({app}); the app '
@@ -60,85 +89,99 @@ void main() {
     );
   });
 
-  test('data root page exists and is only offered on a fresh install', () {
-    final String iss = readInstallerScript();
+  test('data root page exists and is only offered on a fresh, non-silent '
+      'install', () {
+    final String code = readCode();
     expect(
-      iss.contains('CreateInputDirPage(wpSelectDir'),
+      code.contains('CreateInputDirPage(wpSelectDir'),
       isTrue,
       reason: 'the data root page must follow the install dir page',
     );
 
-    final RegExpMatch? skip = RegExp(
-      r'function ShouldSkipPage\(PageID: Integer\): Boolean;[\s\S]*?^end;',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(skip, isNotNull, reason: 'ShouldSkipPage must exist');
-    final String skipBody = skip!.group(0)!;
-    expect(skipBody.contains('DataRootPage.ID'), isTrue);
+    final String skip = block(
+      code,
+      'function ShouldSkipPage(PageID: Integer): Boolean;',
+    );
+    expect(skip.contains('DataRootPage.ID'), isTrue);
     expect(
-      skipBody.contains('DataRootPageOffered := IsFreshInstall()'),
+      skip.contains(
+        'DataRootPageOffered := (not WizardSilent()) and IsFreshInstall()',
+      ),
       isTrue,
       reason:
-          'the page is gated by IsFreshInstall and the decision is '
-          'remembered for ssPostInstall (the uninstall key exists by then)',
+          'silent installs must skip the page (Inno aborts the whole '
+          'install when a ClickThrough NextButtonClick returns False) and the '
+          'decision must be remembered for ssPostInstall (the uninstall key '
+          'exists by then)',
     );
   });
 
-  test('IsFreshInstall checks the real uninstall key and the support root', () {
-    final String iss = readInstallerScript();
-    final RegExpMatch? appId = RegExp(
-      r'^AppId=\{\{([0-9A-Fa-f-]+)\}\}?',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(appId, isNotNull, reason: '[Setup] AppId must be a GUID');
-    final String guid = appId!.group(1)!;
-
-    final RegExpMatch? key = RegExp(
-      r"FushiUninstallKey\s*=\s*'([^']+)'",
-    ).firstMatch(iss);
-    expect(key, isNotNull);
+  test('uninstall key derives from [Setup] AppId and both support roots are '
+      'probed', () {
+    final String code = readCode();
+    final String key = block(code, 'function FushiUninstallKey(): String;');
     expect(
-      key!.group(1),
-      r'Software\Microsoft\Windows\CurrentVersion\Uninstall\{'
-      '$guid}_is1',
-      reason:
-          'uninstall key GUID must equal [Setup] AppId (Pascal literals '
-          'cannot expand it, so it is copied by hand)',
-    );
-
-    final RegExpMatch? fresh = RegExp(
-      r'function IsFreshInstall\(\): Boolean;[\s\S]*?^end;',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(fresh, isNotNull);
-    final String body = fresh!.group(0)!;
-    expect(body.contains('RegKeyExists(HKCU, FushiUninstallKey)'), isTrue);
-    expect(
-      body.contains(r'{userappdata}\Fushi\Fushi'),
+      key.contains(
+        r"ExpandConstant('{#SetupSetting("
+        '"AppId"'
+        r")}')",
+      ),
       isTrue,
       reason:
-          'must also detect a kept-data reinstall via the platform '
-          'support root (%APPDATA%\\<CompanyName>\\<ProductName>)',
+          'AppId must come from [Setup] via ISPP + ExpandConstant ({{ → {); '
+          'a hand-copied GUID misses the trailing "}}" of the real AppId and '
+          'RegKeyExists never matches',
+    );
+    expect(key.contains(r"'_is1'"), isTrue);
+    expect(
+      RegExp(r'Uninstall\\\{[0-9A-Fa-f-]{36}').hasMatch(code),
+      isFalse,
+      reason: 'no hand-copied GUID anywhere in [Code]',
+    );
+
+    final String fresh = block(code, 'function IsFreshInstall(): Boolean;');
+    expect(fresh.contains('RegKeyExists(HKCU, FushiUninstallKey())'), isTrue);
+    expect(
+      fresh.contains(r'{userappdata}\Fushi\Fushi'),
+      isTrue,
+      reason:
+          'must detect a kept-data reinstall via the platform support root '
+          '(%APPDATA%\\<CompanyName>\\<ProductName>)',
+    );
+    expect(
+      fresh.contains(r'{userappdata}\Hibiki\Hibiki'),
+      isTrue,
+      reason:
+          'legacy support root is migrated by migrateLegacySupportDir on '
+          'first launch and then counts as an existing install — the wizard '
+          'must not ask a question the app will discard',
     );
   });
 
   test('NextButtonClick validates the data root page', () {
-    final String iss = readInstallerScript();
-    final RegExpMatch? next = RegExp(
-      r'function NextButtonClick\(CurPageID: Integer\): Boolean;[\s\S]*?^end;',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(next, isNotNull);
-    final String body = next!.group(0)!;
-    final int dataRootBranch = body.indexOf('CurPageID = DataRootPage.ID');
+    final String next = block(
+      readCode(),
+      'function NextButtonClick(CurPageID: Integer): Boolean;',
+    );
+    final int dataRootBranch = next.indexOf('CurPageID = DataRootPage.ID');
     expect(dataRootBranch, greaterThan(0));
-    final String branch = body.substring(dataRootBranch);
+    final String branch = next.substring(dataRootBranch);
     expect(
       branch.contains('IsSameOrAncestorDir(DataRoot, WizardDirValue)'),
       isTrue,
     );
     expect(
       branch.contains('IsSameOrAncestorDir(WizardDirValue, DataRoot)'),
+      isTrue,
+    );
+    expect(
+      branch.contains("DirExists(AddBackslash(DataRoot) + 'documents')"),
+      isTrue,
+      reason:
+          'pre-existing documents/ subtree must be rejected (targetNotEmpty)',
+    );
+    expect(
+      branch.contains("DirExists(AddBackslash(DataRoot) + 'support')"),
       isTrue,
     );
     expect(
@@ -149,32 +192,26 @@ void main() {
   });
 
   test('ssPostInstall writes the bootstrap only when the page was offered', () {
-    final String iss = readInstallerScript();
-    final RegExpMatch? write = RegExp(
-      r'procedure WriteDataRootBootstrap\(\);[\s\S]*?^end;',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(write, isNotNull);
-    final String body = write!.group(0)!;
-    expect(body.contains('if not DataRootPageOffered then'), isTrue);
+    final String code = readCode();
+    final String write = block(code, 'procedure WriteDataRootBootstrap();');
+    expect(write.contains('if not DataRootPageOffered then'), isTrue);
     expect(
-      body.contains('SaveStringsToUTF8File('),
+      write.contains('SaveStringsToUTF8File('),
       isTrue,
       reason: 'paths may contain non-ASCII; SaveStringToFile writes ANSI',
     );
 
-    final RegExpMatch? step = RegExp(
-      r'procedure CurStepChanged\(CurStep: TSetupStep\);[\s\S]*?^end;',
-      multiLine: true,
-    ).firstMatch(iss);
-    expect(step, isNotNull);
-    expect(step!.group(0)!.contains('WriteDataRootBootstrap();'), isTrue);
+    final String step = block(
+      code,
+      'procedure CurStepChanged(CurStep: TSetupStep);',
+    );
+    expect(step.contains('WriteDataRootBootstrap();'), isTrue);
   });
 
   test('app consumes the bootstrap before AppPaths.resolve()', () {
-    final String appModel = File(
-      'lib/src/models/app_model.dart',
-    ).readAsStringSync();
+    final String appModel = maskComments(
+      File('lib/src/models/app_model.dart').readAsStringSync(),
+    );
     final int consume = appModel.indexOf(
       'await consumeInstallerDataRootBootstrap();',
     );

--- a/fushi/test/build/windows_installer_data_root_page_guard_test.dart
+++ b/fushi/test/build/windows_installer_data_root_page_guard_test.dart
@@ -1,0 +1,191 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/storage/installer_data_root_bootstrap.dart';
+
+/// 源码守卫：Windows 安装器「数据存储位置」页与 app 首启消费之间的契约。
+///
+/// 两侧靠一个文件名 + 一个位置（`{app}\data_root.bootstrap`）握手，任何一侧改了另一侧
+/// 就静默失效（安装器写了没人读 / app 等一个永远不会出现的文件）——所以把握手点钉死：
+///  - iss 里的常量与 Dart 常量同值；
+///  - 页面只在全新安装出现（`ShouldSkipPage` 走 `IsFreshInstall`），升级/重装不得再问；
+///  - `IsFreshInstall` 查的卸载键 GUID 必须等于 `[Setup] AppId`；
+///  - 下一步校验：可写预检 + 与安装目录不重合/不嵌套；
+///  - `ssPostInstall` 写文件、`[UninstallDelete]` 收尾；
+///  - app 侧在 `AppPaths.resolve()` **之前**消费。
+void main() {
+  String readInstallerScript() {
+    final File file = File('windows/installer/fushi.iss');
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: 'expected Inno Setup script at ${file.absolute.path}',
+    );
+    return file.readAsStringSync();
+  }
+
+  test('bootstrap file name matches between installer and app', () {
+    final String iss = readInstallerScript();
+    final RegExpMatch? constant = RegExp(
+      r"DataRootBootstrapFileName\s*=\s*'([^']+)'",
+    ).firstMatch(iss);
+    expect(
+      constant,
+      isNotNull,
+      reason: 'fushi.iss must declare DataRootBootstrapFileName',
+    );
+    expect(constant!.group(1), installerDataRootBootstrapFileName);
+
+    expect(
+      iss.contains(r"ExpandConstant('{app}\' + DataRootBootstrapFileName)"),
+      isTrue,
+      reason:
+          'bootstrap must be written next to the exe ({app}); the app '
+          'locates it via Platform.resolvedExecutable',
+    );
+    final RegExpMatch? uninstallDelete = RegExp(
+      r'^\[UninstallDelete\]([\s\S]*?)^\[',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(uninstallDelete, isNotNull, reason: '[UninstallDelete] section');
+    expect(
+      uninstallDelete!
+          .group(1)!
+          .contains(
+            'Type: files; Name: "{app}\\$installerDataRootBootstrapFileName"',
+          ),
+      isTrue,
+      reason: '[UninstallDelete] must remove the bootstrap file',
+    );
+  });
+
+  test('data root page exists and is only offered on a fresh install', () {
+    final String iss = readInstallerScript();
+    expect(
+      iss.contains('CreateInputDirPage(wpSelectDir'),
+      isTrue,
+      reason: 'the data root page must follow the install dir page',
+    );
+
+    final RegExpMatch? skip = RegExp(
+      r'function ShouldSkipPage\(PageID: Integer\): Boolean;[\s\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(skip, isNotNull, reason: 'ShouldSkipPage must exist');
+    final String skipBody = skip!.group(0)!;
+    expect(skipBody.contains('DataRootPage.ID'), isTrue);
+    expect(
+      skipBody.contains('DataRootPageOffered := IsFreshInstall()'),
+      isTrue,
+      reason:
+          'the page is gated by IsFreshInstall and the decision is '
+          'remembered for ssPostInstall (the uninstall key exists by then)',
+    );
+  });
+
+  test('IsFreshInstall checks the real uninstall key and the support root', () {
+    final String iss = readInstallerScript();
+    final RegExpMatch? appId = RegExp(
+      r'^AppId=\{\{([0-9A-Fa-f-]+)\}\}?',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(appId, isNotNull, reason: '[Setup] AppId must be a GUID');
+    final String guid = appId!.group(1)!;
+
+    final RegExpMatch? key = RegExp(
+      r"FushiUninstallKey\s*=\s*'([^']+)'",
+    ).firstMatch(iss);
+    expect(key, isNotNull);
+    expect(
+      key!.group(1),
+      r'Software\Microsoft\Windows\CurrentVersion\Uninstall\{'
+      '$guid}_is1',
+      reason:
+          'uninstall key GUID must equal [Setup] AppId (Pascal literals '
+          'cannot expand it, so it is copied by hand)',
+    );
+
+    final RegExpMatch? fresh = RegExp(
+      r'function IsFreshInstall\(\): Boolean;[\s\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(fresh, isNotNull);
+    final String body = fresh!.group(0)!;
+    expect(body.contains('RegKeyExists(HKCU, FushiUninstallKey)'), isTrue);
+    expect(
+      body.contains(r'{userappdata}\Fushi\Fushi'),
+      isTrue,
+      reason:
+          'must also detect a kept-data reinstall via the platform '
+          'support root (%APPDATA%\\<CompanyName>\\<ProductName>)',
+    );
+  });
+
+  test('NextButtonClick validates the data root page', () {
+    final String iss = readInstallerScript();
+    final RegExpMatch? next = RegExp(
+      r'function NextButtonClick\(CurPageID: Integer\): Boolean;[\s\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(next, isNotNull);
+    final String body = next!.group(0)!;
+    final int dataRootBranch = body.indexOf('CurPageID = DataRootPage.ID');
+    expect(dataRootBranch, greaterThan(0));
+    final String branch = body.substring(dataRootBranch);
+    expect(
+      branch.contains('IsSameOrAncestorDir(DataRoot, WizardDirValue)'),
+      isTrue,
+    );
+    expect(
+      branch.contains('IsSameOrAncestorDir(WizardDirValue, DataRoot)'),
+      isTrue,
+    );
+    expect(
+      branch.contains('InstallDirWritable(DataRoot)'),
+      isTrue,
+      reason: 'same writability preflight as the install dir (BUG-1483)',
+    );
+  });
+
+  test('ssPostInstall writes the bootstrap only when the page was offered', () {
+    final String iss = readInstallerScript();
+    final RegExpMatch? write = RegExp(
+      r'procedure WriteDataRootBootstrap\(\);[\s\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(write, isNotNull);
+    final String body = write!.group(0)!;
+    expect(body.contains('if not DataRootPageOffered then'), isTrue);
+    expect(
+      body.contains('SaveStringsToUTF8File('),
+      isTrue,
+      reason: 'paths may contain non-ASCII; SaveStringToFile writes ANSI',
+    );
+
+    final RegExpMatch? step = RegExp(
+      r'procedure CurStepChanged\(CurStep: TSetupStep\);[\s\S]*?^end;',
+      multiLine: true,
+    ).firstMatch(iss);
+    expect(step, isNotNull);
+    expect(step!.group(0)!.contains('WriteDataRootBootstrap();'), isTrue);
+  });
+
+  test('app consumes the bootstrap before AppPaths.resolve()', () {
+    final String appModel = File(
+      'lib/src/models/app_model.dart',
+    ).readAsStringSync();
+    final int consume = appModel.indexOf(
+      'await consumeInstallerDataRootBootstrap();',
+    );
+    final int resolve = appModel.indexOf(
+      '_appPaths = await AppPaths.resolve();',
+    );
+    expect(consume, greaterThan(0));
+    expect(
+      resolve,
+      greaterThan(consume),
+      reason: 'resolve() reads the data_root pref the bootstrap writes',
+    );
+  });
+}

--- a/fushi/test/storage/installer_data_root_bootstrap_test.dart
+++ b/fushi/test/storage/installer_data_root_bootstrap_test.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fushi/src/storage/app_paths.dart';
+import 'package:fushi/src/storage/installer_data_root_bootstrap.dart';
+
+/// Windows 安装向导「数据存储位置」页 → `{app}\data_root.bootstrap` → 首启消费成
+/// `data_root` 偏好。这里断言消费函数的契约（一次性、只对全新安装生效、路径校验、
+/// 默认位置归一化），安装器侧的写入由 `test/build/windows_installer_data_root_page_guard_test.dart`
+/// 源码守卫。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+  late Directory platformDocuments;
+  late Directory platformSupport;
+  late Directory appDir;
+  late File bootstrap;
+  late String exePath;
+
+  String defaultUmbrella() => p.join(platformDocuments.path, 'Fushi');
+
+  Future<void> writeBootstrap(String content) =>
+      bootstrap.writeAsString(content, flush: true);
+
+  Future<String?> storedDataRoot() async =>
+      (await SharedPreferences.getInstance()).getString(
+        AppPaths.dataRootPrefKey,
+      );
+
+  Future<void> consume() => consumeInstallerDataRootBootstrap(
+    bootstrapFile: bootstrap,
+    executablePath: exePath,
+  );
+
+  setUp(() {
+    AppPaths.debugResetDocumentsLayoutCache();
+    AppPaths.debugDataRootReader = null;
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+
+    tmp = Directory.systemTemp.createTempSync('fushi_installer_bootstrap_');
+    platformDocuments = Directory(p.join(tmp.path, 'Documents'))
+      ..createSync(recursive: true);
+    platformSupport = Directory(p.join(tmp.path, 'AppData', 'Fushi', 'Fushi'))
+      ..createSync(recursive: true);
+    appDir = Directory(p.join(tmp.path, 'LocalAppData', 'Fushi'))
+      ..createSync(recursive: true);
+    exePath = p.join(appDir.path, 'fushi.exe');
+    bootstrap = File(p.join(appDir.path, installerDataRootBootstrapFileName));
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall call) async {
+            switch (call.method) {
+              case 'getApplicationDocumentsDirectory':
+                return platformDocuments.path;
+              case 'getApplicationSupportDirectory':
+                return platformSupport.path;
+              case 'getTemporaryDirectory':
+                return p.join(tmp.path, 'systemp');
+            }
+            return null;
+          },
+        );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    AppPaths.debugResetDocumentsLayoutCache();
+    tmp.deleteSync(recursive: true);
+  });
+
+  test('no bootstrap file → no-op', () async {
+    await consume();
+    expect(await storedDataRoot(), isNull);
+  });
+
+  test(
+    'fresh install + custom dir → data_root written, dir created, file consumed',
+    () async {
+      final String picked = p.join(tmp.path, 'D_drive', 'FushiData');
+      await writeBootstrap(picked);
+
+      await consume();
+
+      expect(await storedDataRoot(), picked);
+      expect(Directory(picked).existsSync(), isTrue);
+      expect(bootstrap.existsSync(), isFalse, reason: '引导文件是一次性的，读完必删');
+    },
+  );
+
+  test('BOM + CRLF + surrounding whitespace are stripped', () async {
+    final String picked = p.join(tmp.path, 'Data');
+    final String bom = String.fromCharCode(0xFEFF);
+    await writeBootstrap('$bom  $picked  \r\n');
+
+    await consume();
+
+    expect(await storedDataRoot(), picked);
+  });
+
+  test(
+    'picking the default umbrella (<Documents>\\Fushi) writes no pref',
+    () async {
+      await writeBootstrap(defaultUmbrella());
+
+      await consume();
+
+      expect(
+        await storedDataRoot(),
+        isNull,
+        reason: '默认位置 = 与全新安装同形，不得派生成 <Documents>/Fushi/{documents,support}',
+      );
+      expect(bootstrap.existsSync(), isFalse);
+    },
+  );
+
+  test(
+    'picking the default documents root (<Documents>\\Fushi\\data) writes no pref',
+    () async {
+      await writeBootstrap(p.join(defaultUmbrella(), 'data'));
+
+      await consume();
+
+      expect(await storedDataRoot(), isNull);
+    },
+  );
+
+  test('existing data_root pref wins; file still consumed', () async {
+    final String existing = p.join(tmp.path, 'Existing');
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      AppPaths.dataRootPrefKey: existing,
+    });
+    await writeBootstrap(p.join(tmp.path, 'FromInstaller'));
+
+    await consume();
+
+    expect(await storedDataRoot(), existing);
+    expect(bootstrap.existsSync(), isFalse);
+  });
+
+  test(
+    'existing database at platform support root → installer choice ignored',
+    () async {
+      File(
+        p.join(platformSupport.path, 'fushi.db'),
+      ).writeAsStringSync('presence is all that matters');
+      await writeBootstrap(p.join(tmp.path, 'FromInstaller'));
+
+      await consume();
+
+      expect(
+        await storedDataRoot(),
+        isNull,
+        reason: '卸载保留数据后重装：旧库必须继续被看见，绝不切到空根',
+      );
+      expect(bootstrap.existsSync(), isFalse);
+    },
+  );
+
+  test('legacy hibiki.db also counts as an existing install', () async {
+    File(p.join(platformSupport.path, 'hibiki.db')).writeAsStringSync('x');
+    await writeBootstrap(p.join(tmp.path, 'FromInstaller'));
+
+    await consume();
+
+    expect(await storedDataRoot(), isNull);
+  });
+
+  test('path that contains the install dir is rejected', () async {
+    await writeBootstrap(p.dirname(appDir.path));
+
+    await consume();
+
+    expect(await storedDataRoot(), isNull);
+    expect(bootstrap.existsSync(), isFalse);
+  });
+
+  test('install dir itself is rejected', () async {
+    await writeBootstrap(appDir.path);
+
+    await consume();
+
+    expect(await storedDataRoot(), isNull);
+  });
+
+  test('relative path is rejected', () async {
+    await writeBootstrap(p.join('relative', 'FushiData'));
+
+    await consume();
+
+    expect(await storedDataRoot(), isNull);
+    expect(bootstrap.existsSync(), isFalse);
+  });
+
+  test('blank file is ignored and consumed', () async {
+    await writeBootstrap('  \r\n\r\n');
+
+    await consume();
+
+    expect(await storedDataRoot(), isNull);
+    expect(bootstrap.existsSync(), isFalse);
+  });
+
+  test(
+    'adopted root is what AppPaths.resolve derives documents/support from',
+    () async {
+      final String picked = p.join(tmp.path, 'Adopted');
+      await writeBootstrap(picked);
+      await consume();
+
+      final AppPaths paths = await AppPaths.resolve();
+
+      expect(paths.documentsRoot.path, p.join(picked, 'documents'));
+      expect(paths.supportRoot.path, p.join(picked, 'support'));
+    },
+  );
+}

--- a/fushi/test/storage/installer_data_root_bootstrap_test.dart
+++ b/fushi/test/storage/installer_data_root_bootstrap_test.dart
@@ -193,6 +193,78 @@ void main() {
     expect(await storedDataRoot(), isNull);
   });
 
+  test('subdirectory of the install dir is rejected', () async {
+    await writeBootstrap(p.join(appDir.path, 'data'));
+
+    await consume();
+
+    expect(
+      await storedDataRoot(),
+      isNull,
+      reason: 'data under {app} is taken along by uninstall / update rollback',
+    );
+  });
+
+  test(
+    'target with a pre-existing non-empty documents/ subtree is rejected',
+    () async {
+      final String picked = p.join(tmp.path, 'Downloads');
+      File(p.join(picked, 'documents', 'thesis.docx'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('mine');
+      await writeBootstrap(picked);
+
+      await consume();
+
+      expect(
+        await storedDataRoot(),
+        isNull,
+        reason:
+            'the user\'s own documents/ must never become a Fushi-owned tree',
+      );
+      expect(bootstrap.existsSync(), isFalse);
+    },
+  );
+
+  test(
+    'target with a pre-existing non-empty support/ subtree is rejected',
+    () async {
+      final String picked = p.join(tmp.path, 'OldRoot');
+      File(p.join(picked, 'support', 'fushi.db'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('old');
+      await writeBootstrap(picked);
+
+      await consume();
+
+      expect(await storedDataRoot(), isNull);
+    },
+  );
+
+  test('target with empty documents/ and support/ dirs is accepted', () async {
+    final String picked = p.join(tmp.path, 'Empty');
+    Directory(p.join(picked, 'documents')).createSync(recursive: true);
+    Directory(p.join(picked, 'support')).createSync(recursive: true);
+    await writeBootstrap(picked);
+
+    await consume();
+
+    expect(await storedDataRoot(), picked);
+  });
+
+  test('concurrent callers share one consumption', () async {
+    final String picked = p.join(tmp.path, 'Once');
+    await writeBootstrap(picked);
+
+    final Future<void> first = consume();
+    final Future<void> second = consume();
+    expect(identical(first, second), isTrue);
+    await Future.wait(<Future<void>>[first, second]);
+
+    expect(await storedDataRoot(), picked);
+    expect(bootstrap.existsSync(), isFalse);
+  });
+
   test('relative path is rejected', () async {
     await writeBootstrap(p.join('relative', 'FushiData'));
 

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -461,10 +461,6 @@ end;
 // 塞一个进去只会让既有书库「消失」；要搬走走设置里的迁移（连 DB 内绝对路径一起 rebase）。
 const
   DataRootBootstrapFileName = 'data_root.bootstrap';
-  { [Setup] AppId 去掉 ISPP 转义后的真值 + Inno 卸载键固定后缀。PrivilegesRequired=lowest
-    → 卸载键在 HKCU。Pascal 字符串字面量不做常量展开，只能照抄；与 [Setup] AppId 的
-    一致性由 test/build/windows_installer_data_root_page_guard_test.dart 守住。 }
-  FushiUninstallKey = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{8F2C1A3E-7B4D-4E9A-9C21-0A1B2C3D4E5F}_is1';
 
 var
   DataRootPage: TInputDirWizardPage;
@@ -472,13 +468,27 @@ var
     已经写好，届时再调 IsFreshInstall 恒为 False，所以必须在页面阶段落下这个标记。 }
   DataRootPageOffered: Boolean;
 
-{ 全新安装 = 卸载键不存在（没装过 / 已卸载）且 app 的平台固定落点
-  %APPDATA%\Fushi\Fushi（path_provider 取 exe 版本资源 CompanyName\ProductName）不存在。
-  后者兜住「卸载但保留了数据」的重装：那种机器上 app 首启会认出旧库，安装器不该再问。 }
+{ Inno 卸载键：HKCU（PrivilegesRequired=lowest）\...\Uninstall\<AppId>_is1。AppId 直接
+  经 ISPP 从 Setup 段取，再让 ExpandConstant 做双左括号 → 单左括号的转义——Setup 段里
+  写的是双括号包着的 GUID，真值是「单左括号 + GUID + 双右括号」（尾部两个右括号是 Inno
+  的既定行为，不是笔误）。手抄 GUID 会漏掉这一层，键永远匹配不上。
+  注意：本注释任何一行都不能以「[」开头——Inno 段解析先于 Code 段，会当成段标签。 }
+function FushiUninstallKey(): String;
+begin
+  Result := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\'
+    + ExpandConstant('{#SetupSetting("AppId")}') + '_is1';
+end;
+
+{ 全新安装 = 卸载键不存在（没装过 / 已卸载）且 app 的平台固定落点不存在——
+  %APPDATA%\Fushi\Fushi（path_provider 取 exe 版本资源 CompanyName\ProductName），
+  兼看改名前的 %APPDATA%\Hibiki\Hibiki（app 首启 migrateLegacySupportDir 会把它搬成新名，
+  随后认出旧库、丢弃安装器的选择）。这两条兜住「卸载但保留了数据」的重装：那种机器上
+  app 首启会认出旧库，安装器不该再问。 }
 function IsFreshInstall(): Boolean;
 begin
-  Result := (not RegKeyExists(HKCU, FushiUninstallKey))
-    and (not DirExists(ExpandConstant('{userappdata}\Fushi\Fushi')));
+  Result := (not RegKeyExists(HKCU, FushiUninstallKey()))
+    and (not DirExists(ExpandConstant('{userappdata}\Fushi\Fushi')))
+    and (not DirExists(ExpandConstant('{userappdata}\Hibiki\Hibiki')));
 end;
 
 { A 等于 B、或是 B 的祖先目录（大小写不敏感、按整段路径前缀比较：尾部补反斜杠后
@@ -507,7 +517,10 @@ begin
   Result := False;
   if (DataRootPage <> nil) and (PageID = DataRootPage.ID) then
   begin
-    DataRootPageOffered := IsFreshInstall();
+    { 静默安装（/SILENT、/VERYSILENT：无人值守部署、app 内自更新）没人回答这页，
+      Inno 仍会逐页 ClickThrough——NextButtonClick 返回 False 会整个安装中止。
+      静默 = 不问、不写引导文件，app 按默认根走，与改动前逐字节一致。 }
+    DataRootPageOffered := (not WizardSilent()) and IsFreshInstall();
     Result := not DataRootPageOffered;
   end;
 end;
@@ -661,7 +674,7 @@ begin
     DataRoot := RemoveBackslashUnlessRoot(Trim(DataRootPage.Values[0]));
     { 数据目录与安装目录不得相同或互相包含：自动更新 / 安装回滚会整体处理安装目录，
       数据压在下面会被一起清；反过来安装目录落在数据根里则迁移会拒绝（含运行中 exe）。
-      与 app 侧 validateDataRootTarget 的 containsExecutable 是同一条规则。 }
+      app 侧 installer_data_root_bootstrap.dart 首启再做一次同样的双向判定。 }
     if IsSameOrAncestorDir(DataRoot, WizardDirValue)
       or IsSameOrAncestorDir(WizardDirValue, DataRoot) then
     begin
@@ -670,6 +683,19 @@ begin
         + '数据目录：' + DataRoot + #13#10#13#10
         + '请另选一个独立的目录（推荐默认 '
         + ExpandConstant('{userdocs}\Fushi') + '）。',
+        mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+    { app 会在所选目录下派生 documents\ 与 support\ 两棵私有子树并整树接管；用户自己的
+      目录里已经有同名子目录（典型：把 D:\Downloads 选成数据根）就不能选——否则之后的
+      数据根迁移会把用户文件当 Fushi 数据整树搬走 / 删掉。app 首启同样拒绝（targetNotEmpty），
+      这里提前拦，别让用户装完才发现选择被丢弃。 }
+    if DirExists(AddBackslash(DataRoot) + 'documents')
+      or DirExists(AddBackslash(DataRoot) + 'support') then
+    begin
+      MsgBox('所选目录下已经存在 documents 或 support 子目录：' + #13#10 + DataRoot + #13#10#13#10
+        + 'Fushi 会在数据目录下创建并接管这两个子目录，请选一个空目录或新建一个目录。',
         mbError, MB_OK);
       Result := False;
       Exit;

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -129,6 +129,11 @@ Root: HKCU; Subkey: "Software\Classes\.webm\OpenWithProgids"; ValueType: none; V
 Root: HKCU; Subkey: "Software\Classes\.mov\OpenWithProgids"; ValueType: none; ValueName: "Hibiki.Video"; Flags: deletevalue
 Root: HKCU; Subkey: "Software\Classes\.ts\OpenWithProgids"; ValueType: none; ValueName: "Hibiki.Video"; Flags: deletevalue
 
+[UninstallDelete]
+; 数据存储位置引导文件（见 [Code] WriteDataRootBootstrap）。app 首启即消费并删除；
+; 装完从没启动过就卸载时由这里收尾，别在安装目录留一个孤儿文件。
+Type: files; Name: "{app}\data_root.bootstrap"
+
 [Run]
 Filename: "{app}\fushi.exe"; Description: "启动 Fushi"; Flags: nowait postinstall
 
@@ -444,6 +449,87 @@ begin
   Result := not FileExists(ExpandConstant('{userdesktop}\Fushi.lnk'));
 end;
 
+// ── 数据存储位置（全新安装向导页）──────────────────────────────────────────
+// 安装目录 ({app}) 与数据目录是两回事：书库/漫画/视频封面字幕/词典/数据库全落数据根，
+// 体积可能远大于程序本身。旧行为是 app 首启无条件用默认根（<Documents>\Fushi\data +
+// %APPDATA%\Fushi\Fushi），用户只能装完再去「设置 → 数据存储位置」整树迁移 + 重启。
+// 这里在全新安装时多问一页；用户的选择经 {app}\data_root.bootstrap 一次性交给 app
+// （lib/src/storage/installer_data_root_bootstrap.dart 首启消费后删除、之后唯一真相源
+// 仍是 app 自己的 data_root 偏好）。安装器只是一次性写者，不是第二个配置来源。
+//
+// 只对全新安装显示：升级/重装时 app 已经有自己的数据根（默认或自定义），从安装器再
+// 塞一个进去只会让既有书库「消失」；要搬走走设置里的迁移（连 DB 内绝对路径一起 rebase）。
+const
+  DataRootBootstrapFileName = 'data_root.bootstrap';
+  { [Setup] AppId 去掉 ISPP 转义后的真值 + Inno 卸载键固定后缀。PrivilegesRequired=lowest
+    → 卸载键在 HKCU。Pascal 字符串字面量不做常量展开，只能照抄；与 [Setup] AppId 的
+    一致性由 test/build/windows_installer_data_root_page_guard_test.dart 守住。 }
+  FushiUninstallKey = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{8F2C1A3E-7B4D-4E9A-9C21-0A1B2C3D4E5F}_is1';
+
+var
+  DataRootPage: TInputDirWizardPage;
+  { ShouldSkipPage 里判定并记住「本次真的向用户展示了数据目录页」。ssPostInstall 时卸载键
+    已经写好，届时再调 IsFreshInstall 恒为 False，所以必须在页面阶段落下这个标记。 }
+  DataRootPageOffered: Boolean;
+
+{ 全新安装 = 卸载键不存在（没装过 / 已卸载）且 app 的平台固定落点
+  %APPDATA%\Fushi\Fushi（path_provider 取 exe 版本资源 CompanyName\ProductName）不存在。
+  后者兜住「卸载但保留了数据」的重装：那种机器上 app 首启会认出旧库，安装器不该再问。 }
+function IsFreshInstall(): Boolean;
+begin
+  Result := (not RegKeyExists(HKCU, FushiUninstallKey))
+    and (not DirExists(ExpandConstant('{userappdata}\Fushi\Fushi')));
+end;
+
+{ A 等于 B、或是 B 的祖先目录（大小写不敏感、按整段路径前缀比较：尾部补反斜杠后
+  'C:\Fushi\' 不会误配 'C:\FushiData\'）。 }
+function IsSameOrAncestorDir(const A, B: String): Boolean;
+begin
+  Result := Pos(Lowercase(AddBackslash(A)), Lowercase(AddBackslash(B))) = 1;
+end;
+
+procedure InitializeWizard();
+begin
+  DataRootPageOffered := False;
+  DataRootPage := CreateInputDirPage(wpSelectDir,
+    '选择数据存储位置',
+    '导入的书籍、漫画、视频封面与字幕、词典和数据库存放在哪里？',
+    '这些数据可能远大于程序本身，建议选一个空间充足的位置。' + #13#10 +
+    '之后可以在「设置 → 数据存储位置」里迁移。' + #13#10#13#10 +
+    '点击「下一步」继续。',
+    False, 'Fushi');
+  DataRootPage.Add('');
+  DataRootPage.Values[0] := ExpandConstant('{userdocs}\Fushi');
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  if (DataRootPage <> nil) and (PageID = DataRootPage.ID) then
+  begin
+    DataRootPageOffered := IsFreshInstall();
+    Result := not DataRootPageOffered;
+  end;
+end;
+
+{ ssPostInstall：把用户选的数据目录交给 app。默认值也照写——「选的是不是默认位置」由
+  app 按它自己的默认根定义归一化，安装器不复制这条规则。 }
+procedure WriteDataRootBootstrap();
+var
+  Lines: TArrayOfString;
+  Target: String;
+begin
+  if not DataRootPageOffered then
+    Exit;
+  Target := RemoveBackslashUnlessRoot(Trim(DataRootPage.Values[0]));
+  if Target = '' then
+    Exit;
+  SetArrayLength(Lines, 1);
+  Lines[0] := Target;
+  if not SaveStringsToUTF8File(ExpandConstant('{app}\' + DataRootBootstrapFileName), Lines, False) then
+    Log('WriteDataRootBootstrap: 写入失败，app 将使用默认数据位置');
+end;
+
 // Fushi 改名的旧名残留清理，全部放在 ssPostInstall（新文件已全部落地之后），
 // 不放 [InstallDelete]：后者在复制前执行，且 Inno 不会在安装失败/取消时回滚删除，
 // 于是任何一次中途失败的升级都会把「还剩个能跑的旧版」变成「一个可执行文件都没有」。
@@ -456,6 +542,8 @@ procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep <> ssPostInstall then
     Exit;
+
+  WriteDataRootBootstrap();
 
   // 旧名可执行文件：Inno 只覆盖同名文件，改了名的旧 exe 不清就会与 fushi.exe
   // 并存，旧快捷方式还能把上一版拉起来。
@@ -551,6 +639,8 @@ begin
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  DataRoot: String;
 begin
   Result := True;
   if CurPageID = wpSelectDir then
@@ -562,6 +652,33 @@ begin
         + ExpandConstant('{localappdata}\Fushi') + '）。' + #13#10#13#10
         + '不建议装进需要管理员权限的目录：即使以管理员身份重装到该目录，'
         + '应用日常以普通权限运行，之后每次自动更新都需要再次提权。',
+        mbError, MB_OK);
+      Result := False;
+    end;
+  end
+  else if (DataRootPage <> nil) and (CurPageID = DataRootPage.ID) then
+  begin
+    DataRoot := RemoveBackslashUnlessRoot(Trim(DataRootPage.Values[0]));
+    { 数据目录与安装目录不得相同或互相包含：自动更新 / 安装回滚会整体处理安装目录，
+      数据压在下面会被一起清；反过来安装目录落在数据根里则迁移会拒绝（含运行中 exe）。
+      与 app 侧 validateDataRootTarget 的 containsExecutable 是同一条规则。 }
+    if IsSameOrAncestorDir(DataRoot, WizardDirValue)
+      or IsSameOrAncestorDir(WizardDirValue, DataRoot) then
+    begin
+      MsgBox('数据存储位置不能与安装目录相同或互相包含：' + #13#10
+        + '安装目录：' + WizardDirValue + #13#10
+        + '数据目录：' + DataRoot + #13#10#13#10
+        + '请另选一个独立的目录（推荐默认 '
+        + ExpandConstant('{userdocs}\Fushi') + '）。',
+        mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+    if not InstallDirWritable(DataRoot) then
+    begin
+      MsgBox('当前权限无法写入所选数据目录：' + #13#10 + DataRoot + #13#10#13#10
+        + '请改选用户可写的目录（推荐默认 '
+        + ExpandConstant('{userdocs}\Fushi') + '）。',
         mbError, MB_OK);
       Result := False;
     end;


### PR DESCRIPTION
## 做了什么

- `fushi.iss`：安装目录页之后新增「数据存储位置」页（默认 `{userdocs}\Fushi`），**只在全新安装、非静默时出现**（卸载键不存在 且 `%APPDATA%\Fushi\Fushi`、`%APPDATA%\Hibiki\Hibiki` 都不存在，且 `not WizardSilent()`）。卸载键经 ISPP `SetupSetting("AppId")` + `ExpandConstant` 派生（真值尾部是 `}}`，手抄会永远匹配不上）。下一步校验：与安装目录不相同/不互相包含、目标下没有既有 `documents`/`support` 子目录、可写预检（复用 BUG-1483）。`ssPostInstall` 把路径写进 `{app}\data_root.bootstrap`（UTF-8）；`[UninstallDelete]` 收尾。
- 新增 `lib/src/storage/installer_data_root_bootstrap.dart`：`AppModel._prepareRuntimeDirectories` 在 `AppPaths.resolve()` 之前一次性消费该文件 → 写 `data_root` 偏好。读完必删；已有 `data_root` 偏好 / 平台 support 根已有 DB / 相对路径 / 与安装目录相同或互相包含 / 目标下已有非空 `documents`·`support` 子树 → 忽略；归一化复用 `resolveDataRootMigrationTarget`（先 `ensureDocumentsContainerDecided` 与 `resolve()` 对齐容器名），选中默认位置 = 不写偏好、与全新安装同形。触碰所选目录的 IO 全部 2s 封顶；同进程并发消费去重（init Retry 重入）；`setString` 返回 false 视为未采纳。
- `AppPaths`：`existingInstallHasDatabase` / `ensureDocumentsContainerDecided` 公开给消费端复用。
- `docs/agent/build.md` 补安装器数据根页说明。

## 验证

- `flutter analyze` 全量 0 issue（含 test）。
- 新测试 24 条：`test/storage/installer_data_root_bootstrap_test.dart`（18 用例，含 `AppPaths.resolve()` 派生断言、并发去重、非空子树拒绝）+ `test/build/windows_installer_data_root_page_guard_test.dart`（6 条源码守卫，`//` 注释掩码；变异实测两次：改 iss 文件名 / 去掉 `WizardSilent` 均红）。
- `test/storage` + `test/build` 全目录 510 条全绿；目录枚举型守卫 36 文件 251 条全绿。
- `ISCC.exe` 本机对 dummy SourceDir 编译通过（`[Code]` 段 Pascal 编译成功）。**未**在真机跑安装向导（本机已有真实 Fushi 安装，同 AppId 的 dummy 安装包会覆盖其卸载键，故未运行产物）。
- `/code-review medium` 8 条发现已全部处理（见第二个 commit）。

## 缺口

- 真机全新安装 E2E（向导页展示 → 引导文件 → app 首启落到所选目录）未做，需要一台干净机器或干净用户账户。

https://claude.ai/code/session_01RxfGTh5PqWHgbzuh2vmuky
