### PR TITLE
feat(home): 功能模块开关补「下载」「查词」tab 显隐

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 64345 (3785 per locale)
+/// Strings: 64396 (3788 per locale)
 ///
-/// Built on 2026-08-24 at 09:09 UTC
+/// Built on 2026-08-24 at 18:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5147,6 +5147,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'This device has no built-in text recognition available';
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  String get module_downloads_label => 'Downloads';
+  String get module_lookup_label => 'Lookup';
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -13912,6 +13916,13 @@ class _StringsAr extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -22882,6 +22893,13 @@ class _StringsDe extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -31895,6 +31913,13 @@ class _StringsEs extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -40937,6 +40962,13 @@ class _StringsFr extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -49812,6 +49844,13 @@ class _StringsId extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -58760,6 +58799,13 @@ class _StringsIt extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -67161,6 +67207,13 @@ class _StringsJa extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -75578,6 +75631,13 @@ class _StringsKo extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -84485,6 +84545,13 @@ class _StringsNl extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -93448,6 +93515,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -102385,6 +102459,13 @@ class _StringsRu extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -111143,6 +111224,13 @@ class _StringsTh extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -120005,6 +120093,13 @@ class _StringsTr extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -128848,6 +128943,13 @@ class _StringsVi extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 // Path: <root>
@@ -136980,6 +137082,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       '在线章节的页面不在本地，只能用 Google Lens 识别——页面图片会上传给 Google。';
+  @override
+  String get module_downloads_label => '下载';
+  @override
+  String get module_lookup_label => '查词';
+  @override
+  String get module_tool_toggle_hint => '在底栏/侧栏显示该页；关闭即隐藏';
 }
 
 // Path: <root>
@@ -145127,6 +145235,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_tap_ocr_online_lens_only =>
       'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+  @override
+  String get module_downloads_label => 'Downloads';
+  @override
+  String get module_lookup_label => 'Lookup';
+  @override
+  String get module_tool_toggle_hint =>
+      'Show this tab in the navigation bar; turn off to hide it';
 }
 
 /// Flat map(s) containing all translations.
@@ -152891,6 +153006,12 @@ extension on _StringsEn {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -160652,6 +160773,12 @@ extension on _StringsAr {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -168453,6 +168580,12 @@ extension on _StringsDe {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -176246,6 +176379,12 @@ extension on _StringsEs {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -184047,6 +184186,12 @@ extension on _StringsFr {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -191822,6 +191967,12 @@ extension on _StringsId {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -199617,6 +199768,12 @@ extension on _StringsIt {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -207348,6 +207505,12 @@ extension on _StringsJa {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -215081,6 +215244,12 @@ extension on _StringsKo {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -222869,6 +223038,12 @@ extension on _StringsNl {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -230653,6 +230828,12 @@ extension on _StringsPtBr {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -238444,6 +238625,12 @@ extension on _StringsRu {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -246209,6 +246396,12 @@ extension on _StringsTh {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -253989,6 +254182,12 @@ extension on _StringsTr {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -261763,6 +261962,12 @@ extension on _StringsVi {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }
@@ -269475,6 +269680,12 @@ extension on _StringsZhCn {
         return '此设备没有可用的系统文字识别';
       case 'manga_tap_ocr_online_lens_only':
         return '在线章节的页面不在本地，只能用 Google Lens 识别——页面图片会上传给 Google。';
+      case 'module_downloads_label':
+        return '下载';
+      case 'module_lookup_label':
+        return '查词';
+      case 'module_tool_toggle_hint':
+        return '在底栏/侧栏显示该页；关闭即隐藏';
       default:
         return null;
     }
@@ -277188,6 +277399,12 @@ extension on _StringsZhHk {
         return 'This device has no built-in text recognition available';
       case 'manga_tap_ocr_online_lens_only':
         return 'Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.';
+      case 'module_downloads_label':
+        return 'Downloads';
+      case 'module_lookup_label':
+        return 'Lookup';
+      case 'module_tool_toggle_hint':
+        return 'Show this tab in the navigation bar; turn off to hide it';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "设备自带",
   "manga_ocr_engine_system_desc": "用设备自带的文字识别。不用下载、完全离线、不上传任何内容；但对竖排气泡和手写体明显不如本地模型。",
   "manga_ocr_engine_system_unavailable": "此设备没有可用的系统文字识别",
-  "manga_tap_ocr_online_lens_only": "在线章节的页面不在本地，只能用 Google Lens 识别——页面图片会上传给 Google。"
+  "manga_tap_ocr_online_lens_only": "在线章节的页面不在本地，只能用 Google Lens 识别——页面图片会上传给 Google。",
+  "module_downloads_label": "下载",
+  "module_lookup_label": "查词",
+  "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3783,5 +3783,8 @@
   "manga_ocr_engine_system": "Device OCR",
   "manga_ocr_engine_system_desc": "Uses the text recognition built into your device. No download, fully offline, nothing uploaded — but noticeably weaker on vertical speech bubbles and handwriting than the local model.",
   "manga_ocr_engine_system_unavailable": "This device has no built-in text recognition available",
-  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google."
+  "manga_tap_ocr_online_lens_only": "Online chapters are not stored locally, so only Google Lens can read them — the page image is uploaded to Google.",
+  "module_downloads_label": "Downloads",
+  "module_lookup_label": "Lookup",
+  "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it"
 }

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1790,6 +1790,10 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                                               appModel.moduleVideoEnabled,
                                           mangaEnabled:
                                               appModel.moduleMangaEnabled,
+                                          downloadsEnabled:
+                                              appModel.moduleDownloadsEnabled,
+                                          dictionariesEnabled: appModel
+                                              .moduleDictionariesEnabled,
                                           // 浏览器扩展 tab「电脑才有」：此处为 macOS 根
                                           // 侧栏，macOS 即桌面 → 与底栏/rail 同一门控。
                                           browserExtensionEnabled:

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -5907,6 +5907,12 @@ class AppModel with ChangeNotifier {
   bool get moduleGamesEnabled => prefsRepo.moduleGamesEnabled;
   Future<void> setModuleGamesEnabled(bool value) =>
       prefsRepo.setModuleGamesEnabled(value);
+  bool get moduleDownloadsEnabled => prefsRepo.moduleDownloadsEnabled;
+  Future<void> setModuleDownloadsEnabled(bool value) =>
+      prefsRepo.setModuleDownloadsEnabled(value);
+  bool get moduleDictionariesEnabled => prefsRepo.moduleDictionariesEnabled;
+  Future<void> setModuleDictionariesEnabled(bool value) =>
+      prefsRepo.setModuleDictionariesEnabled(value);
 
   /// 是否已展示过「上传/做种」首用提示（下载对话框首次推送时弹一次性提醒）。
   bool get torrentUploadIntroShown => prefsRepo.torrentUploadIntroShown;

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -804,10 +804,11 @@ class PreferencesRepository extends ChangeNotifier {
     await setPref('first_time_setup', false);
   }
 
-  /// 「功能模块」显隐：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 是否出现在
-  /// 底栏/侧栏。默认全开（与旧版行为一致）；新手引导的功能选择与 设置 → 系统 →
-  /// 功能模块 写同一真值。games（Windows）与浏览器扩展（桌面）在读取端还叠加
-  /// 平台门控，这里只存用户意愿。首页/下载/词典/设置恒在，不提供开关。
+  /// 「功能模块」显隐：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 加 下载/查词
+  /// 两个工具 tab 是否出现在底栏/侧栏。默认全开（与旧版行为一致）；新手引导的功能
+  /// 选择与 设置 → 系统 → 功能模块 写同一真值（引导只勾库页，不勾下载/查词）。
+  /// games（Windows）与浏览器扩展（桌面）在读取端还叠加平台门控，这里只存用户意愿。
+  /// 首页/设置恒在，是全部隐藏后的安全回退面，不提供开关。
   bool get moduleBooksEnabled =>
       getPref('module_books_enabled', defaultValue: true) as bool;
 
@@ -845,6 +846,22 @@ class PreferencesRepository extends ChangeNotifier {
 
   Future<void> setModuleGamesEnabled(bool value) async {
     await setPref('module_games_enabled', value);
+    notifyListeners();
+  }
+
+  bool get moduleDownloadsEnabled =>
+      getPref('module_downloads_enabled', defaultValue: true) as bool;
+
+  Future<void> setModuleDownloadsEnabled(bool value) async {
+    await setPref('module_downloads_enabled', value);
+    notifyListeners();
+  }
+
+  bool get moduleDictionariesEnabled =>
+      getPref('module_dictionaries_enabled', defaultValue: true) as bool;
+
+  Future<void> setModuleDictionariesEnabled(bool value) async {
+    await setPref('module_dictionaries_enabled', value);
     notifyListeners();
   }
 

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -117,21 +117,24 @@ List<HomeTab> homeActiveTabs({
   bool booksEnabled = true,
   bool mangaEnabled = true,
   bool gamesEnabled = false,
+  bool downloadsEnabled = true,
+  bool dictionariesEnabled = true,
   bool browserExtensionEnabled = false,
 }) =>
     <HomeTab>[
       HomeTab.home,
-      // 小说/漫画/视频/游戏/浏览器扩展五个库页 tab 可按「功能模块」偏好隐藏
-      // （新手引导的功能选择与 设置 → 系统 → 功能模块 写同一真值）；首页/下载/
-      // 词典/设置恒在，是隐藏后的安全回退面。
+      // 小说/漫画/视频/游戏/浏览器扩展五个库页 tab 与 下载/查词 两个工具 tab 都可
+      // 按「功能模块」偏好隐藏（设置 → 系统 → 功能模块；新手引导的功能选择只写
+      // 库页那几项）；首页/设置恒在，是全部隐藏后的安全回退面。
       if (booksEnabled) HomeTab.books,
       if (mangaEnabled) HomeTab.manga,
       if (videoEnabled) HomeTab.video,
       if (gamesEnabled) HomeTab.games,
-      // 下载 tab 恒在（统一下载中心）：除番剧 torrent 外还承载通用磁力（书）与
-      // 漫画「在线目录」卷下载队列，不再随视频开关隐藏；位置在视频/游戏之后。
-      HomeTab.downloads,
-      HomeTab.dictionaries,
+      // 下载 tab（统一下载中心）：除番剧 torrent 外还承载通用磁力（书）与漫画
+      // 「在线目录」卷下载队列，所以不随视频开关联动，只听自己的模块开关；位置在
+      // 视频/游戏之后。
+      if (downloadsEnabled) HomeTab.downloads,
+      if (dictionariesEnabled) HomeTab.dictionaries,
       // 浏览器扩展管理（安装引导 + 连接检测 + 版本）独立成页，仅桌面出现（手机浏览器
       // 不支持加载未解压扩展，故按平台而非实验开关门控），位置紧邻设置之前。
       if (browserExtensionEnabled) HomeTab.browserExtension,
@@ -773,6 +776,8 @@ class _HomePageState extends BasePageState<HomePage>
         videoEnabled: appModel.moduleVideoEnabled,
         mangaEnabled: appModel.moduleMangaEnabled,
         gamesEnabled: Platform.isWindows && appModel.moduleGamesEnabled,
+        downloadsEnabled: appModel.moduleDownloadsEnabled,
+        dictionariesEnabled: appModel.moduleDictionariesEnabled,
         browserExtensionEnabled: DesktopLookupService.isDesktop &&
             appModel.moduleBrowserExtensionEnabled,
       );
@@ -785,9 +790,17 @@ class _HomePageState extends BasePageState<HomePage>
     return tabs.contains(_currentTab) ? _currentTab : HomeTab.home;
   }
 
+  /// 设置页返回箭头的目标：来源 tab 若在设置里刚被「功能模块」关掉，回落首页。
+  HomeTab get _previousVisibleTab =>
+      _activeTabs().contains(_previousTab) ? _previousTab : HomeTab.home;
+
   /// 统一切换顶层 tab：进入「设置」前记录来源 tab，供设置全屏返回箭头切回。
-  /// 所有切 tab 入口（侧栏 / 底栏 / 快捷键）都走这里，保证 _previousTab 一致。
+  /// 所有切 tab 入口（侧栏 / 底栏 / 快捷键 / 程序化跳转）都走这里，保证
+  /// _previousTab 一致。目标 tab 已被「功能模块」隐藏时直接忽略：隐藏即该页
+  /// 不可达，快捷键 / 「查看下载」/ 桌面查词请求都不该把用户莫名其妙甩到首页
+  /// （旧行为：`_currentTab` 设成隐藏 tab 后由 [_visibleTab] 兜底成首页）。
   void _selectTab(HomeTab tab) {
+    if (!_activeTabs().contains(tab)) return;
     // A same-route home-tab switch (IndexedStack, no route push/pop) still
     // changes the visible screen, so reset any focus ring lit on the old tab so
     // it is not carried onto the new one (BUG-398). Route-based navigation is
@@ -1007,7 +1020,7 @@ class _HomePageState extends BasePageState<HomePage>
           leading: showSettingsBack
               ? MacosBackButton(
                   fillColor: Colors.transparent,
-                  onPressed: () => _selectTab(_previousTab),
+                  onPressed: () => _selectTab(_previousVisibleTab),
                 )
               : null,
           automaticallyImplyLeading: false,
@@ -2205,7 +2218,7 @@ class _HomePageState extends BasePageState<HomePage>
   Widget _buildSettingsTabContent({required bool showBackButton}) {
     return HomeSettingsTabContent(
       showBackButton: showBackButton,
-      onReturnToPreviousTab: () => _selectTab(_previousTab),
+      onReturnToPreviousTab: () => _selectTab(_previousVisibleTab),
     );
   }
 }

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -145,9 +145,10 @@ SettingsDestination buildSystemDestination() {
           ),
         ],
       ),
-      // 「功能模块」：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 的显隐开关
-      // （与新手引导的功能选择写同一真值）。首页/下载/词典/设置恒在，不提供开关；
-      // games 仅 Windows、扩展仅桌面显示（读取端还叠加平台门控）。
+      // 「功能模块」：小说/漫画/视频/游戏/浏览器扩展五个库页 tab 加 下载/查词 两个
+      // 工具 tab 的显隐开关（库页那几项与新手引导的功能选择写同一真值）。首页/设置
+      // 恒在，不提供开关；games 仅 Windows、扩展仅桌面显示（读取端还叠加平台门控）。
+      // 顺序与底栏一致：库页 → 下载 → 查词 → 扩展。
       SettingsSection(
         title: t.settings_section_modules,
         items: <SettingsItem>[
@@ -197,6 +198,31 @@ SettingsDestination buildSystemDestination() {
                 settingsContext.appModel.moduleGamesEnabled,
             onChanged: (SettingsContext settingsContext, bool value) async {
               await settingsContext.appModel.setModuleGamesEnabled(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'system.module_downloads',
+            title: t.module_downloads_label,
+            subtitle: t.module_tool_toggle_hint,
+            icon: Icons.download_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.moduleDownloadsEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setModuleDownloadsEnabled(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'system.module_lookup',
+            title: t.module_lookup_label,
+            subtitle: t.module_tool_toggle_hint,
+            icon: Icons.search_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.moduleDictionariesEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setModuleDictionariesEnabled(value);
               settingsContext.refresh();
             },
           ),

--- a/fushi/test/models/preferences_repository_test.dart
+++ b/fushi/test/models/preferences_repository_test.dart
@@ -63,16 +63,22 @@ void main() {
       expect(repo.moduleVideoEnabled, true);
       expect(repo.moduleGamesEnabled, true);
       expect(repo.moduleBrowserExtensionEnabled, true);
+      expect(repo.moduleDownloadsEnabled, true);
+      expect(repo.moduleDictionariesEnabled, true);
       await repo.setModuleBooksEnabled(false);
       await repo.setModuleMangaEnabled(false);
       await repo.setModuleVideoEnabled(false);
       await repo.setModuleGamesEnabled(false);
       await repo.setModuleBrowserExtensionEnabled(false);
+      await repo.setModuleDownloadsEnabled(false);
+      await repo.setModuleDictionariesEnabled(false);
       expect(repo.moduleBooksEnabled, false);
       expect(repo.moduleMangaEnabled, false);
       expect(repo.moduleVideoEnabled, false);
       expect(repo.moduleGamesEnabled, false);
       expect(repo.moduleBrowserExtensionEnabled, false);
+      expect(repo.moduleDownloadsEnabled, false);
+      expect(repo.moduleDictionariesEnabled, false);
     });
 
     test('currentHomeTabIndex defaults to 0', () {

--- a/fushi/test/pages/home_page_tabs_test.dart
+++ b/fushi/test/pages/home_page_tabs_test.dart
@@ -179,6 +179,45 @@ void main() {
       );
     });
 
+    test('downloadsEnabled=false 只隐藏下载 tab，词典仍紧随最后一个媒体库页', () {
+      final List<HomeTab> tabs = homeActiveTabs(
+        videoEnabled: true,
+        gamesEnabled: true,
+        downloadsEnabled: false,
+      );
+      expect(tabs, isNot(contains(HomeTab.downloads)));
+      expect(
+          tabs.indexOf(HomeTab.dictionaries), tabs.indexOf(HomeTab.games) + 1);
+      expect(tabs, contains(HomeTab.settings));
+    });
+
+    test('dictionariesEnabled=false 只隐藏查词 tab，下载仍在', () {
+      final List<HomeTab> tabs = homeActiveTabs(
+        videoEnabled: true,
+        browserExtensionEnabled: true,
+        dictionariesEnabled: false,
+      );
+      expect(tabs, isNot(contains(HomeTab.dictionaries)));
+      expect(tabs, contains(HomeTab.downloads));
+      expect(
+        tabs.indexOf(HomeTab.browserExtension),
+        tabs.indexOf(HomeTab.downloads) + 1,
+      );
+    });
+
+    test('七个模块全关时只剩首页/设置（安全回退面）', () {
+      final List<HomeTab> tabs = homeActiveTabs(
+        videoEnabled: false,
+        booksEnabled: false,
+        mangaEnabled: false,
+        gamesEnabled: false,
+        downloadsEnabled: false,
+        dictionariesEnabled: false,
+        browserExtensionEnabled: false,
+      );
+      expect(tabs, <HomeTab>[HomeTab.home, HomeTab.settings]);
+    });
+
     test('隐藏 tab 后越界视觉索引回退到恒在的 home（不再是可隐藏的书架）', () {
       final List<HomeTab> tabs = homeActiveTabs(
         videoEnabled: false,

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -35,14 +35,16 @@ import '../helpers/test_platform_services.dart';
 /// 让覆盖测试不对「别处已覆盖」的项裸喊 UNVERIFIED/FAIL，且强制每个 changed
 /// 但未 effect-verified 的设置都必须有去处（no silent caps）。
 const Map<String, String> kCoveredElsewhere = <String, String>{
-  // 「功能模块」三开关（新手引导 PR）。写 prefsRepo（changed=true），生效点是
-  // HomePage/macOS 侧栏的可见 tab 列表——harness 里没有挂 HomePage 外壳，探不到
-  // 底栏。行为由 homeActiveTabs 纯函数用例咬住：mangaEnabled/videoEnabled/
-  // gamesEnabled=false 各自隐藏对应 tab、书架/词典/设置/下载恒在。
+  // 「功能模块」七开关（五库页 + 下载/查词两个工具 tab）。写 prefsRepo
+  // （changed=true），生效点是 HomePage/macOS 侧栏的可见 tab 列表——harness 里没有
+  // 挂 HomePage 外壳，探不到底栏。行为由 homeActiveTabs 纯函数用例咬住：各开关
+  // =false 各自隐藏对应 tab、首页/设置恒在。
   'system/Novels': 'test/pages/home_page_tabs_test.dart',
   'system/Manga': 'test/pages/home_page_tabs_test.dart',
   'system/Video': 'test/pages/home_page_tabs_test.dart',
   'system/Galgame': 'test/pages/home_page_tabs_test.dart',
+  'system/Downloads': 'test/pages/home_page_tabs_test.dart',
+  'system/Lookup': 'test/pages/home_page_tabs_test.dart',
   'system/Browser extension': 'test/pages/home_page_tabs_test.dart',
   // 漫画观看偏好五项。写 prefsRepo（changed=true），生效点全部在**漫画阅读器的
   // WebView 文档**里——这些值被注入成 CSS 过渡声明 / JS 常量（ZOOM_SENS、


### PR DESCRIPTION
## 改了什么

用户诉求：「下载和查词 底栏/侧栏也支持关闭或隐藏」。

此前 设置 → 系统 → 功能模块 只能关小说/漫画/视频/游戏/浏览器扩展五个库页 tab，`homeActiveTabs` 里下载与查词写死恒在。本 PR 照既有模式补两个开关：

- `PreferencesRepository` / `AppModel`：`module_downloads_enabled` / `module_dictionaries_enabled`，默认 **true**（升级用户底栏不变，Never break userspace）。
- `homeActiveTabs` 加 `downloadsEnabled` / `dictionariesEnabled`；`HomePage._activeTabs`（rail/底栏）与 `main.dart` macOS 根侧栏传同一真值。首页/设置仍恒在，是全部关掉后的兜底面。
- `_selectTab` 对已隐藏 tab 的显式跳转（快捷键 `homeTabDict` / `homeFocusSearch`、下载入队后「查看下载」、桌面浮窗查词 `homeDictionaryTabRequest`）**改为忽略**。旧行为是把 `_currentTab` 设成隐藏 tab、再由 `_visibleTab` 兜底成首页——用户按个快捷键被甩到首页很怪。设置页返回箭头的目标若在设置里刚被关掉，回落首页（`_previousVisibleTab`）。
- 设置「功能模块」分区加「下载」「查词」两个开关，顺序与底栏一致（库页 → 下载 → 查词 → 扩展）。i18n 经 `i18n_sync --add` 新增 `module_downloads_label` / `module_lookup_label` / `module_tool_toggle_hint`（工具 tab 用独立 hint，不再沿用「库页」措辞）。
- 新手引导的功能勾选**不加**下载/查词（它只勾库页；引导只写有勾选项的偏好，不影响这两个键）。

## 边界

- 查词 tab 隐藏后，桌面悬浮字幕条点词这类「显式打开查词 tab」请求会被忽略，待查词留在 `DesktopLookupService.pendingText` 里直到用户重新打开该 tab。这是「隐藏 = 该页不可达」的自然结果，与隐藏书架后的行为同型；弹窗查词不受影响。
- 「启动时打开查词」开关在查词 tab 隐藏时无效（`_visibleTab` 兜底到首页），未额外加联动。

## 验证

- `flutter analyze` 全量（含 test）：No issues found。
- 定向：`test/pages/home_page_tabs_test.dart`（新增 3 条隐藏组合用例）、`test/models/preferences_repository_test.dart`、`home_tab_{games,video,browser_extension}_test`、`test/macos/macos_shell_static_test.dart`、`test/settings`（覆盖守卫已登记 `system/Downloads` / `system/Lookup`）、`test/i18n`：541 过 0 红。
- `test/tools` 守卫批：359 过；`update_manifest_publish_race_test.dart` 9 红为 PowerShell 环境无 `bash` 的已知伪红（每条用例 `Process.start('bash')`），与本改动无关。
- 未真机验证底栏实际显隐（纯 tab 列表纯函数 + 偏好写穿，行为与既有五个开关同路径）。

https://claude.ai/code/session_01XYPzabq6vqxdxeCbkordWM
