### PR TITLE
docs: 删掉 16 份用户手册里已失效的推荐包下载链接

### DIFF
--- a/docs/user-guide.ar.md
+++ b/docs/user-guide.ar.md
@@ -40,7 +40,7 @@ https://github.com/hajisensai/Fushi/releases/latest
 
 ### 1. استيراد القواميس المُوصى بها (قواميس الكلمات + النبر الصوتي + التكرار) والصوت المحلي (قاعدتا بيانات صوتية لليابانية والإنجليزية) (يُوصى به بشدة للمبتدئين!!! · اختياري)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [التنزيل عبر Cloudflare (‏9.5 غيغابايت)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 داخل التطبيق: الإعدادات -> المزامنة والنسخ الاحتياطي -> اضغط على **استيراد نسخة احتياطية**.
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -40,7 +40,7 @@ Die APKs, deren Namen mit `bridge-` beginnen, sind Migrationsbrücken für **Nut
 
 ### 1. Empfohlene Wörterbücher (Wort- + Tonhöhenakzent- + Häufigkeitswörterbücher) und lokales Audio (japanische und englische Audiodatenbanken) importieren (Sehr empfehlenswert für Einsteiger!!! · optional)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare-Download (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 In der App: Einstellungen -> Synchronisierung & Sicherung -> tippe auf **Sicherung importieren**.
 

--- a/docs/user-guide.es.md
+++ b/docs/user-guide.es.md
@@ -40,7 +40,7 @@ Los APK cuyo nombre empieza por `bridge-` son puentes de migración para los **u
 
 ### 1. Importar los diccionarios recomendados (diccionarios de palabras + acento tonal + frecuencia) y el audio local (bases de datos de audio en japonés e inglés) (Muy recomendado para principiantes!!! · opcional)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Descarga desde Cloudflare (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 En la aplicación: Ajustes -> Sincronización y copia de seguridad -> toca **Importar copia de seguridad**.
 

--- a/docs/user-guide.fr.md
+++ b/docs/user-guide.fr.md
@@ -40,7 +40,7 @@ Les APK dont le nom commence par `bridge-` sont des passerelles de migration des
 
 ### 1. Importer les dictionnaires recommandés (dictionnaires de mots + accent de hauteur + fréquence) et l'audio local (bases de données audio japonaise et anglaise) (Fortement recommandé pour les débutants!!! · facultatif)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Téléchargement Cloudflare (9,5 Go)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 Dans l'application : Paramètres -> Synchronisation et sauvegarde -> appuyez sur **Importer une sauvegarde**.
 

--- a/docs/user-guide.id.md
+++ b/docs/user-guide.id.md
@@ -40,7 +40,7 @@ APK yang namanya diawali `bridge-` adalah jembatan migrasi untuk **pengguna Hibi
 
 ### 1. Mengimpor kamus yang direkomendasikan (kamus kata + aksen nada + frekuensi) dan audio lokal (basis data audio bahasa Jepang dan Inggris) (Sangat direkomendasikan untuk pemula!!! · opsional)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Unduhan Cloudflare (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 Di dalam aplikasi: Pengaturan -> Sinkronisasi & Cadangan -> ketuk **Impor Cadangan**.
 

--- a/docs/user-guide.it.md
+++ b/docs/user-guide.it.md
@@ -40,7 +40,7 @@ Gli APK il cui nome inizia con `bridge-` sono ponti di migrazione per gli **uten
 
 ### 1. Importare i dizionari consigliati (dizionari di parole + accento tonale + frequenza) e l'audio locale (database audio giapponese e inglese) (Altamente consigliato per i principianti!!! · facoltativo)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Download da Cloudflare (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 Nell'app: Impostazioni -> Sincronizzazione e backup -> tocca **Importa backup**.
 

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -40,7 +40,7 @@ https://github.com/hajisensai/Fushi/releases/latest
 
 ### 1. 推奨辞書（語彙＋アクセント＋頻度辞書）とローカル音声（日本語・英語の音声データベース）をインポートする（初心者に強くおすすめ！！！・任意）
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare からダウンロード（9.5 GB）](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 アプリ内で：設定 -> 同期とバックアップ -> **バックアップをインポート** をタップします。
 

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -40,7 +40,7 @@ https://github.com/hajisensai/Fushi/releases/latest
 
 ### 1. 추천 사전(단어 + 고저 악센트 + 빈도 사전)과 로컬 오디오(일본어 및 영어 오디오 데이터베이스) 가져오기(초보자에게 강력 추천!!! · 선택 사항)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare 다운로드(9.5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 앱에서: 설정 -> 동기화 및 백업 -> **백업 가져오기**를 탭합니다.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,7 +44,7 @@ The APKs whose names start with `bridge-` are migration bridges for **legacy Hib
 
 ### 1. Import recommended dictionaries (word + pitch-accent + frequency dictionaries) and local audio (Japanese and English audio databases) (Highly recommended for beginners!!! · optional)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare download (9.5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 In the app: Settings -> Sync & Backup -> tap **Import Backup**.
 

--- a/docs/user-guide.nl.md
+++ b/docs/user-guide.nl.md
@@ -40,7 +40,7 @@ De APK's waarvan de naam met `bridge-` begint, zijn migratiebruggen voor **oude 
 
 ### 1. Aanbevolen woordenboeken (woord- + toonhoogteaccent- + frequentiewoordenboeken) en lokale audio (Japanse en Engelse audiodatabases) importeren (Sterk aanbevolen voor beginners!!! · optioneel)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare-download (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 In de app: Instellingen -> Synchronisatie en back-up -> tik op **Back-up importeren**.
 

--- a/docs/user-guide.pt-BR.md
+++ b/docs/user-guide.pt-BR.md
@@ -40,7 +40,7 @@ Os APKs cujos nomes começam com `bridge-` são pontes de migração para **usu�
 
 ### 1. Importar os dicionários recomendados (dicionários de palavras + acento tonal + frequência) e o áudio local (bancos de dados de áudio em japonês e inglês) (Altamente recomendado para iniciantes!!! · opcional)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Download pelo Cloudflare (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 No aplicativo: Configurações -> Sincronização e backup -> toque em **Importar backup**.
 

--- a/docs/user-guide.ru.md
+++ b/docs/user-guide.ru.md
@@ -40,7 +40,7 @@ APK, имена которых начинаются с `bridge-`, — это п�
 
 ### 1. Импорт рекомендуемых словарей (словари слов + тонального ударения + частотности) и локального аудио (базы данных японского и английского аудио) (Настоятельно рекомендуется новичкам!!! · необязательно)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Загрузка через Cloudflare (9,5 ГБ)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 В приложении: Настройки -> Синхронизация и резервное копирование -> нажмите **Импортировать резервную копию**.
 

--- a/docs/user-guide.th.md
+++ b/docs/user-guide.th.md
@@ -40,7 +40,7 @@ https://github.com/hajisensai/Fushi/releases/latest
 
 ### 1. นำเข้าพจนานุกรมที่แนะนำ (พจนานุกรมคำศัพท์ + ระดับเสียงสูงต่ำ + ความถี่) และไฟล์เสียงในเครื่อง (ฐานข้อมูลเสียงภาษาญี่ปุ่นและภาษาอังกฤษ) (แนะนำอย่างยิ่งสำหรับมือใหม่!!! · ไม่บังคับ)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [ดาวน์โหลดผ่าน Cloudflare (9.5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 ในแอป: การตั้งค่า -> ซิงค์และสำรองข้อมูล -> แตะ **นำเข้าข้อมูลสำรอง**
 

--- a/docs/user-guide.tr.md
+++ b/docs/user-guide.tr.md
@@ -40,7 +40,7 @@ Adı `bridge-` ile başlayan APK'ler **eski Hibiki kullanıcıları** için geç
 
 ### 1. Önerilen sözlükleri (kelime + vurgu + sıklık sözlükleri) ve yerel sesi (Japonca ve İngilizce ses veritabanları) içe aktarma (Yeni başlayanlara şiddetle önerilir!!! · isteğe bağlı)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare üzerinden indirme (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 Uygulamada: Ayarlar -> Eşitleme ve Yedekleme -> **Yedeği İçe Aktar** öğesine dokunun.
 

--- a/docs/user-guide.vi.md
+++ b/docs/user-guide.vi.md
@@ -40,7 +40,7 @@ Các tệp APK có tên bắt đầu bằng `bridge-` là cầu nối chuyển �
 
 ### 1. Nhập các từ điển được đề xuất (từ điển từ vựng + trọng âm cao độ + tần suất) và âm thanh cục bộ (cơ sở dữ liệu âm thanh tiếng Nhật và tiếng Anh) (Rất khuyến khích cho người mới!!! · tùy chọn)
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Tải xuống qua Cloudflare (9,5 GB)](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 Trong ứng dụng: Cài đặt -> Đồng bộ & Sao lưu -> nhấn **Nhập bản sao lưu**.
 

--- a/docs/user-guide.zh-Hant.md
+++ b/docs/user-guide.zh-Hant.md
@@ -40,7 +40,7 @@ https://github.com/hajisensai/Fushi/releases/latest
 
 ### 1. 匯入推薦詞典（包含詞語＋聲調＋詞頻詞典）及本機音訊（包含日語及英語音訊資料庫）（極其推薦新手使用此方法！！！可選）
 
-[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing) · [Cloudflare 下載（9.5 GB）](https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip)
+[Google Drive](https://drive.google.com/file/d/1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp/view?usp=sharing)
 
 在 App 中：設定 -> 同步與備份 -> 點擊 **匯入備份**。
 


### PR DESCRIPTION
## 实测

`dl.wrds.xyz` **整站 404**——连根路径都是，服务器是 Cloudflare：

| URL | 经代理 | 直连 |
|---|---|---|
| `/fushi-recommended-2026-08-14.fushi.zip` | 404 | — |
| `/fushi-recommended-manifest.json` | 404 | 404 |
| `/`（根） | 404 | 404 |

所以 16 份用户手册里那条「Cloudflare 下载（9.5 GB）」全是死链，用户点了就是 404。

## 改法

只删这一段，**保留同一行的 Google Drive 链接**——那是目前唯一还活着的整包源（实测 206、支持 Range、`Content-Range` 报 10,220,484,385 字节 ≈ 9.52 GiB）。

不新增任何文案，所以不需要给 16 种语言补翻译；改动是纯删除、语言无关。

## app 内下载不受影响

它走清单，而清单已改由官网 + GitHub 承载（#993 已合并）。这条 PR 只修手册里的手动下载入口。

## 仍待处理（不在本 PR）

`recommended_pack.dart` 里的整包回退直链还指着这个死域名。等 `hajisensai/fushi-pack` 的首个 release 建好后一并处理——那时才知道该把它指向哪里。

https://claude.ai/code/session_018kebQ12s34FK5Ymb2zVAAY