### PR TITLE
fix(onboarding): 整包回退直链改指还活着的主机，落盘名不再带日期

### DIFF
--- a/fushi/lib/src/onboarding/recommended_pack.dart
+++ b/fushi/lib/src/onboarding/recommended_pack.dart
@@ -16,30 +16,30 @@ import 'package:path/path.dart' as p;
 /// GitHub 两个主机上，拿到清单就走分片并发 + 双源。这条只在两个主机都拉不到
 /// 清单时兜底。
 ///
-/// **为什么它还在这个域名上**：整包约 9.5 GB，官网和 GitHub 都放不下——
+/// **为什么是 Google Drive**：原来的私有分发域名已**整站 404**（实测连根路径
+/// 都是），指着它等于保证失败一次。整包约 9.5 GB，官网和 GitHub 都放不下——
 /// GitHub Release 单资产上限 2 GB（所以包才要切片），R2 免费额度共 10 GB
-/// 且要留给 app 的发布镜像。搬走它需要另找一个能存 9.5 GB 单文件的主机；
-/// 在那之前别把它改成 fushi.moe 下的路径，那只会得到 404。
-/// 另一条独立的整包线路是 Google Drive（[kRecommendedPackGoogleDriveDirectUrl]），
-/// UI 里可手动切换。
-const String kRecommendedPackCloudflareUrl =
-    'https://dl.wrds.xyz/fushi-recommended-2026-08-14.fushi.zip';
+/// 且要留给 app 的发布镜像。Drive 是目前唯一还活着的整包源（实测 206、支持
+/// Range），所以这条只能是它。别把它改成 fushi.moe 下的路径，那只会得到 404。
+const String kRecommendedPackWholeFileUrl = kRecommendedPackGoogleDriveDirectUrl;
 const String kRecommendedPackGoogleDriveFileId =
     '1W0Civ-b9NAyCu6LpXYMcNI_wZJWB9xjp';
 const String kRecommendedPackGoogleDriveUrl =
     'https://drive.google.com/file/d/$kRecommendedPackGoogleDriveFileId/view?usp=sharing';
 
 /// Google Drive 应用内直下地址（`confirm=t` 跳过大文件病毒扫描确认页）。
-/// 与 [kRecommendedPackCloudflareUrl] 指向同一份包；URL 尾段不含文件名，
+/// 整包回退直链 [kRecommendedPackWholeFileUrl] 就是它；URL 尾段不含文件名，
 /// 下载器须显式传 [RecommendedPackDownloader.fileName]。
 const String kRecommendedPackGoogleDriveDirectUrl =
     'https://drive.usercontent.google.com/download'
     '?id=$kRecommendedPackGoogleDriveFileId&export=download&confirm=t';
 
-/// 从内置回退直链推导的包文件名（Google 线路等无文件名 URL 复用它落盘，
-/// 两条线路指向同一份包，半截文件因此天然可跨线路续传）。
-final String kRecommendedPackFileName =
-    Uri.parse(kRecommendedPackCloudflareUrl).pathSegments.last;
+/// 落盘用的包文件名。**刻意不带版本/日期**：换包不需要改这里，各条线路也共用
+/// 同一个名字，半截文件因此天然可跨线路续传。
+///
+/// 版本隔离不靠文件名——续传进度绑的是清单的 version + sha256 + 总长
+/// （见 `segmented_downloader.dart`），对不上会整份作废重来。
+const String kRecommendedPackFileName = 'fushi-recommended.fushi.zip';
 
 /// 推荐包**稳定清单**地址：换包时上传新 zip + 更新这份 json 即可，app 零发版。
 /// 格式（字段见 [RecommendedPackManifest]）：
@@ -309,7 +309,7 @@ Future<RecommendedPackManifest?> fetchRecommendedPackManifest() async {
 class RecommendedPackDownloader {
   RecommendedPackDownloader({
     required Directory packDir,
-    this.url = kRecommendedPackCloudflareUrl,
+    this.url = kRecommendedPackWholeFileUrl,
     this.sha256Hex,
     this.manifest,
     this.concurrency = SegmentedDownloader.kDefaultDownloadConcurrency,

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -104,7 +104,7 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
   String get _packBrowserUrl {
     switch (_packRoute) {
       case _PackRoute.cloudflare:
-        return _manifestDownloader?.url ?? kRecommendedPackCloudflareUrl;
+        return _manifestDownloader?.url ?? kRecommendedPackWholeFileUrl;
       case _PackRoute.googleDrive:
         return kRecommendedPackGoogleDriveUrl;
     }

--- a/fushi/test/onboarding/recommended_pack_manifest_test.dart
+++ b/fushi/test/onboarding/recommended_pack_manifest_test.dart
@@ -274,6 +274,19 @@ void main() {
       expect(hosts, contains('github.com'));
     });
 
+    test('整包回退直链必须是活着的主机，且落盘名不带版本', () {
+      // 旧的私有分发域名已整站 404，指着它等于保证失败一次；这条钉住别再回潮。
+      expect(kRecommendedPackWholeFileUrl, isNot(contains('dl.wrds.xyz')));
+      expect(kRecommendedPackWholeFileUrl, startsWith('https://'));
+      // 整包回退只能落在还存得下 9.5 GB 单文件的主机上。
+      expect(kRecommendedPackWholeFileUrl, contains('drive.usercontent.google.com'));
+      expect(kRecommendedPackWholeFileUrl, contains('confirm=t'),
+          reason: '少了 confirm=t 会拿到病毒扫描确认页而不是文件');
+      // 换包不该再改文件名——版本隔离由清单的 version + sha256 负责。
+      expect(kRecommendedPackFileName, isNot(matches(RegExp(r'\d{4}-\d{2}-\d{2}'))));
+      expect(kRecommendedPackFileName, endsWith('.fushi.zip'));
+    });
+
     test('候选一律 https', () {
       for (final String u in kRecommendedPackManifestUrls) {
         expect(u, startsWith('https://'), reason: u);


### PR DESCRIPTION
## 问题

实测 `dl.wrds.xyz` **整站 404**（连根路径都是，服务器 Cloudflare）。而：

- `kRecommendedPackCloudflareUrl` 指着它 → 清单拉不到时**保证再失败一次**
- `kRecommendedPackFileName` 是从这个 URL 尾段推导的 → 落盘名捎带着 `2026-08-14`，换包就得改常量

## 改法

| 旧 | 新 |
|---|---|
| `kRecommendedPackCloudflareUrl` = 死域名 | `kRecommendedPackWholeFileUrl` = Google Drive 直下 |
| `kRecommendedPackFileName` 从 URL 推导 | 固定名 `fushi-recommended.fushi.zip` |

**为什么只能是 Drive**：整包约 9.5 GB，GitHub Release 单资产上限 2 GB（所以包才要切片）、R2 免费额度共 10 GB 且要留给 app 的发布镜像——两边都放不下。Drive 是目前唯一还活着的整包源（实测 206、支持 Range、`Content-Range` 报 10,220,484,385 字节）。常量也顺带改名，因为它已经不是 Cloudflare 了。

**为什么改文件名是安全的**：版本隔离本来就不靠文件名——续传进度绑的是清单的 `version` + `sha256` + 总长，对不上会整份作废重来（`segmented_downloader.dart:528`）。

## 守卫

新增一条钉住四件事：回退直链不得再出现那个死域名、必须 https、**必须带 `confirm=t`**（少了会拿到 Drive 的病毒扫描确认页而不是文件）、落盘名不得再含日期。

## 验证

- 21 项测试全过，退出码 0
- `flutter analyze` **No issues found**

## 上下文

配套 #993（清单改由官网 + GitHub 承载）与 #998（清掉 16 份手册里的死链）。正常路径根本走不到这条回退：拿到清单就走分片并发 + 多源。

https://claude.ai/code/session_018kebQ12s34FK5Ymb2zVAAY