### PR TITLE
fix(video-home): 继续观看走 Next-Up 口径；Jimaku 搜索按钮移到固定底栏（BUG-1855/1856）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1730 条。点号进各自文件。
+> 共 1732 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1856](bugs/BUG-1856-jimaku-dialog-search-button-unreachable-phone-landscape-keyboard.md) | ✅ | ✅ | Jimaku 获取字幕对话框在手机横屏弹键盘时只看得见「取消」，搜索按钮藏在可滚区不可达 |
+| [BUG-1855](bugs/BUG-1855-home-continue-row-drops-collection-after-episode-complete.md) | ✅ | ✅ | 视频首页「继续观看」一集看完退出后合集消失，只有中途退出才在 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |
 | [BUG-1850](bugs/BUG-1850-settings-destination-itest-vacuous-selected-row.md) | ✅ | ✅ | 集成测试用恒真的选中行谓词当设置分类打开判据 |

--- a/docs/bugs/BUG-1855-home-continue-row-drops-collection-after-episode-complete.md
+++ b/docs/bugs/BUG-1855-home-continue-row-drops-collection-after-episode-complete.md
@@ -1,0 +1,6 @@
+## BUG-1855 · 视频首页「继续观看」一集看完退出后合集消失，只有中途退出才在
+- **报告**：2026-08-25（用户：截图 Yuru Yuri「看到第 9 集」；一集从头看完退出，再进首页「继续观看」里就没它了，只有中途退出才有；用户提议「下一集也放一份在这」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_video_page.dart:3126-3132`（改前 `_buildContinueRow`）对合集只认「最近播放那集未完成」——`latestPlayedSeriesIndex` 取到的那集 `completedAt != null` 就直接 `return`，合集整个不进本行。而同页 hero 大卡的「继续看·第 N 集」走 `collection_continue.dart` 的 `continueMemberIndex`（锚点已完成 → 下一集），同一页两套口径，行卡那套是残缺的。
+- **[x] ① 已修复** — 新增纯函数 `continueWatchingSeriesIndex`（`fushi/lib/src/media/video/video_home_layout.dart`）：最近播放那集没看完 → 它自己；已看完 → 紧接的下一集；整部看完 / 无痕迹 / 位置拖回 0 → null。`_buildContinueRow` 改用它；目标集尚未开播时卡片副文案走 `video_home_next_episode_number`（「下一集 · 第 N 集」）而非「看到第 N 集」，由成员自身状态决定不另传标志。「下一集」行照旧，两行各一份。提交见 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_home_layout_test.dart`（纯函数四态）+ `fushi/test/pages/home_video_continue_row_nextup_test.dart`（真 widget：看完→继续行出合集卡指向第 2 集且文案「下一集 · 第 2 集」；中途退出停在自身；整部看完不进本行）。变异实测：把「未开播即 return」的旧判据加回去，widget 测试红。
+- **备注**：远端占位卡（`RemoteVideoInfo`）无完成口径，不在本改动范围。未做真机复测（逻辑层已由 widget 测试覆盖）。

--- a/docs/bugs/BUG-1856-jimaku-dialog-search-button-unreachable-phone-landscape-keyboard.md
+++ b/docs/bugs/BUG-1856-jimaku-dialog-search-button-unreachable-phone-landscape-keyboard.md
@@ -1,6 +1,6 @@
 ## BUG-1856 · Jimaku 获取字幕对话框在手机横屏弹键盘时只看得见「取消」，搜索按钮藏在可滚区不可达
 - **报告**：2026-08-25（用户：iPhone 横屏截图，点「集数（可选）」弹出数字键盘后整个对话框只剩标题、半个输入框和「取消」）
 - **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart:1023-1030`（改前 `_buildFilterPane`）把唯一主操作「搜索」`FilledButton` 放在 `SingleChildScrollView` 筛选面板里，底部固定栏只有「取消」。横屏 390dp 高的屏弹出 ~200dp 键盘后对话框只剩百来 dp，面板 `Flexible` 被压到只露一个输入框，按钮滚出视野；且 iOS 数字键盘（`TextInputType.number`）没有回车键，`onSubmitted` 也触发不了——主操作在该视口下结构上不可达。
-- **[x] ① 已修复** — 搜索按钮移到底部固定操作栏与「取消」并排（`Row` 右对齐：取消 · 搜索），面板只留输入与筛选。提交见 PR。
-- **[x] ② 已加自动化测试** — `fushi/test/pages/jimaku_two_pane_layout_test.dart`：①「搜索与取消同一行、在取消右侧、不在 SingleChildScrollView 内」；② 回归用例复刻 844×390 横屏 + `viewInsets.bottom=200` 键盘，断言搜索按钮完整落在键盘上方、`onPressed` 非空、`hitTestOnBinding` 真能命中。变异实测：把按钮挪回面板，两条都红。
+- **[x] ① 已修复** — 搜索按钮移到底部固定操作栏与「取消」并排，面板只留输入与筛选。审查跟进：底栏用 `OverflowBar`（非裸 `Row`）——320dp 窄机内容宽只剩 240，en/de/ru 两钮并排实测溢出 13~70px，OverflowBar 放不下自动竖排；标题限 2 行省略——面板 Flexible 缩到 0 时标题 + 底栏是仅剩固定高，法语标题（测试 Ahem 字体下 4 行）实测把底栏挤出 8px。提交见 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/jimaku_two_pane_layout_test.dart`：①「搜索与取消同一行、在取消右侧、不在 SingleChildScrollView 内」；② 回归用例复刻 844×390 横屏 + `viewInsets.bottom=200` 键盘，断言搜索按钮完整落在键盘上方、`onPressed` 非空、`hitTestOnBinding` 真能命中。③ 17 语种 × 320×568 + 260dp 键盘逐个开框：无 RenderFlex 溢出、搜索按钮在对话框内且落在键盘上方。变异实测：把按钮挪回面板，①② 红；OverflowBar 退回裸 Row，③ 在 en/de/ru 红；标题去掉 maxLines，③ 在 fr 红。
 - **备注**：旧测试「search button lives in filter pane」是上一轮按手绘稿定的排版（KEY→TITLE→SEARCH 同栏），本轮以「主操作必须在非滚动槽位」取代它。未做 iOS 真机复测。

--- a/docs/bugs/BUG-1856-jimaku-dialog-search-button-unreachable-phone-landscape-keyboard.md
+++ b/docs/bugs/BUG-1856-jimaku-dialog-search-button-unreachable-phone-landscape-keyboard.md
@@ -1,0 +1,6 @@
+## BUG-1856 · Jimaku 获取字幕对话框在手机横屏弹键盘时只看得见「取消」，搜索按钮藏在可滚区不可达
+- **报告**：2026-08-25（用户：iPhone 横屏截图，点「集数（可选）」弹出数字键盘后整个对话框只剩标题、半个输入框和「取消」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart:1023-1030`（改前 `_buildFilterPane`）把唯一主操作「搜索」`FilledButton` 放在 `SingleChildScrollView` 筛选面板里，底部固定栏只有「取消」。横屏 390dp 高的屏弹出 ~200dp 键盘后对话框只剩百来 dp，面板 `Flexible` 被压到只露一个输入框，按钮滚出视野；且 iOS 数字键盘（`TextInputType.number`）没有回车键，`onSubmitted` 也触发不了——主操作在该视口下结构上不可达。
+- **[x] ① 已修复** — 搜索按钮移到底部固定操作栏与「取消」并排（`Row` 右对齐：取消 · 搜索），面板只留输入与筛选。提交见 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/jimaku_two_pane_layout_test.dart`：①「搜索与取消同一行、在取消右侧、不在 SingleChildScrollView 内」；② 回归用例复刻 844×390 横屏 + `viewInsets.bottom=200` 键盘，断言搜索按钮完整落在键盘上方、`onPressed` 非空、`hitTestOnBinding` 真能命中。变异实测：把按钮挪回面板，两条都红。
+- **备注**：旧测试「search button lives in filter pane」是上一轮按手绘稿定的排版（KEY→TITLE→SEARCH 同栏），本轮以「主操作必须在非滚动槽位」取代它。未做 iOS 真机复测。

--- a/fushi/lib/src/media/video/video_home_layout.dart
+++ b/fushi/lib/src/media/video/video_home_layout.dart
@@ -185,6 +185,24 @@ int? nextEpisodeAfterLatestPlayed(
   return current + 1;
 }
 
+/// 「继续观看」行的合集目标集（Next-Up 语义，与 hero 大卡的
+/// `continueMemberIndex` 同口径）：
+///
+/// * 最近实际播放的那集**没看完**（有进度）→ 停在它；
+/// * 它**已看完** → 紧接的下一集（整部看完、没有下一集 → null，不再占继续行）；
+/// * 没有播放痕迹、或有痕迹但位置被拖回 0 且未标完成 → null（与改动前一致）。
+///
+/// 此前本行只认第一种情况：一集从头看到尾再退出，`completedAt` 一落库合集就从
+/// 「继续观看」消失、只剩「下一集」行有它；中途退出的反而在。用户视角是同一部番
+/// 在首页时有时无。看完一集的用户下一步显然是看下一集——那就是「继续观看」。
+int? continueWatchingSeriesIndex(List<VideoSeriesPlaybackState> members) {
+  final int? current = latestPlayedSeriesIndex(members);
+  if (current == null) return null;
+  final VideoSeriesPlaybackState state = members[current];
+  if (state.completed) return nextEpisodeAfterLatestPlayed(members);
+  return state.positionMs > 0 ? current : null;
+}
+
 /// 条目级看完状态判定（本地即筛）：
 /// * completed —— `completedAt` 非空；
 /// * watching —— 未完成但有播放痕迹（`lastPositionMs > 0`）；

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -3123,14 +3123,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           lastWatched = at;
         }
       }
-      final int? currentIndex = latestPlayedSeriesIndex(
+      // Next-Up 口径（[continueWatchingSeriesIndex]）：续播用户最后实际播放且尚未
+      // 完成的那一集；那集已看完则落到紧接的下一集。不能退回序列中更早的未完成
+      // 集，也不能误跳到合集最后一集；整部看完不进本行。
+      final int? currentIndex = continueWatchingSeriesIndex(
         _seriesPlaybackStates(members),
       );
       if (currentIndex == null) return;
-      final VideoBookRow current = members[currentIndex];
-      // “继续观看”只续播用户最后实际播放且尚未完成的那一集，不能退回序列中
-      // 更早的未完成集，也不能误跳到合集最后一集。
-      if (current.completedAt != null || current.lastPositionMs <= 0) return;
       final MediaCollectionRow collection = _collectionsById[cid]!;
       items.add(_VideoRowItem(
         recentMs: lastWatched?.millisecondsSinceEpoch ?? 0,
@@ -3734,12 +3733,19 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       progressFraction:
           members.isEmpty ? null : completedCount / members.length,
       episodeNumber: currentIndex + 1,
-      secondaryText: _continueSecondaryText(
-        members[currentIndex],
-        episodeNumber: currentIndex + 1,
-      ),
+      // 目标集还没开播（上一集看完落到的下一集）→「下一集 · 第 N 集」；
+      // 有进度 →「看到第 N 集 · 剩 M 分钟」。由成员自身状态决定，不另传标志。
+      secondaryText: _isUnstarted(members[currentIndex])
+          ? t.video_home_next_episode_number(n: currentIndex + 1)
+          : _continueSecondaryText(
+              members[currentIndex],
+              episodeNumber: currentIndex + 1,
+            ),
     );
   }
+
+  static bool _isUnstarted(VideoBookRow book) =>
+      book.completedAt == null && book.lastPositionMs <= 0;
 
   /// 继续观看行·远端占位卡：点击流播（BUG-995 血缘——只看远端也有续播入口）；
   /// 云角标；远端无完成口径，不画进度条。

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -1289,7 +1289,14 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Text(t.video_jimaku_fetch, style: theme.textTheme.titleLarge),
+          // 标题限两行：窄机 + 键盘下正文 Flexible 已缩到 0，标题与底栏是仅剩的
+          // 固定高，标题再无限换行就把底栏挤出对话框（法语 4 行实测溢出 8px）。
+          Text(
+            t.video_jimaku_fetch,
+            style: theme.textTheme.titleLarge,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
           const SizedBox(height: 16),
           // 正文按内容宽自适应：宽屏左右两栏（筛选|结果，手绘稿布局），窄屏上下两段。
           Flexible(
@@ -1306,14 +1313,18 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
           // 正文滚动的槽位——它此前跟着输入框放在筛选面板（可滚区）里，iPhone 横屏
           // 弹出数字键盘后视口只剩百来 dp，面板只露出一个输入框，按钮滚出视野；
           // 而 iOS 数字键盘没有回车键，onSubmitted 也触发不了——用户只看得见「取消」。
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
+          // OverflowBar 而非裸 Row：320dp 窄机内容宽只剩 240，en/de/ru 两个按钮并排
+          // 装不下（裸 Row 实测溢出 13~70px），OverflowBar 放不下自动改竖排。
+          OverflowBar(
+            alignment: MainAxisAlignment.end,
+            overflowAlignment: OverflowBarAlignment.end,
+            spacing: 8,
+            overflowSpacing: 4,
             children: <Widget>[
               TextButton(
                 onPressed: () => Navigator.pop(context),
                 child: Text(t.dialog_cancel),
               ),
-              const SizedBox(width: 8),
               FilledButton.icon(
                 onPressed: _searching ? null : _search,
                 icon: const Icon(Icons.search),

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -1020,14 +1020,8 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
             ),
             onSubmitted: (_) => _search(),
           ),
-          const SizedBox(height: 12),
-          // 搜索按钮跟着搜索输入走（手绘稿：左栏 KEY→TITLE→SEARCH），不再窝在对话框
-          // 右下角和「取消」挤一排。
-          FilledButton.icon(
-            onPressed: _searching ? null : _search,
-            icon: const Icon(Icons.search),
-            label: Text(t.video_jimaku_search),
-          ),
+          // 搜索按钮不在这里：本面板是可滚动区，主操作放进来在矮视口下结构上
+          // 不可达（见 build 里底部操作栏的注释）。
           _buildSeriesSection(theme),
           if (_candidates.isNotEmpty) ...<Widget>[
             const SizedBox(height: 12),
@@ -1308,12 +1302,24 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
             ),
           ),
           const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(t.dialog_cancel),
-            ),
+          // 底部固定操作栏：「取消」+「搜索」。搜索是本框唯一主操作，必须在不随
+          // 正文滚动的槽位——它此前跟着输入框放在筛选面板（可滚区）里，iPhone 横屏
+          // 弹出数字键盘后视口只剩百来 dp，面板只露出一个输入框，按钮滚出视野；
+          // 而 iOS 数字键盘没有回车键，onSubmitted 也触发不了——用户只看得见「取消」。
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: Text(t.dialog_cancel),
+              ),
+              const SizedBox(width: 8),
+              FilledButton.icon(
+                onPressed: _searching ? null : _search,
+                icon: const Icon(Icons.search),
+                label: Text(t.video_jimaku_search),
+              ),
+            ],
           ),
         ],
       ),

--- a/fushi/test/media/video/video_home_layout_test.dart
+++ b/fushi/test/media/video/video_home_layout_test.dart
@@ -312,6 +312,86 @@ void main() {
       expect(nextEpisodeAfterLatestPlayed(members), 2);
     });
 
+    // 用户实报：一集从头看完再退出，合集就从「继续观看」消失（只剩「下一集」行）；
+    // 中途退出的反而在。本行改走 Next-Up 口径：看完 → 下一集。
+    test('继续观看：最近播放那集已看完 → 落到紧接的下一集', () {
+      const List<VideoSeriesPlaybackState> members = <VideoSeriesPlaybackState>[
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 300,
+          positionMs: 0,
+          completed: true,
+        ),
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 0,
+          positionMs: 0,
+          completed: false,
+        ),
+      ];
+      expect(continueWatchingSeriesIndex(members), 1);
+    });
+
+    test('继续观看：最近播放那集没看完 → 停在它自己', () {
+      const List<VideoSeriesPlaybackState> members = <VideoSeriesPlaybackState>[
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 100,
+          positionMs: 0,
+          completed: true,
+        ),
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 300,
+          positionMs: 60000,
+          completed: false,
+        ),
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 0,
+          positionMs: 0,
+          completed: false,
+        ),
+      ];
+      expect(continueWatchingSeriesIndex(members), 1);
+    });
+
+    test('继续观看：整部看完（最后一集已完成）→ 不进本行', () {
+      const List<VideoSeriesPlaybackState> members = <VideoSeriesPlaybackState>[
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 100,
+          positionMs: 0,
+          completed: true,
+        ),
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 300,
+          positionMs: 0,
+          completed: true,
+        ),
+      ];
+      expect(continueWatchingSeriesIndex(members), isNull);
+    });
+
+    test('继续观看：无痕迹 / 位置拖回 0 且未完成 → 不进本行', () {
+      const List<VideoSeriesPlaybackState> untouched =
+          <VideoSeriesPlaybackState>[
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 0,
+          positionMs: 0,
+          completed: false,
+        ),
+      ];
+      expect(continueWatchingSeriesIndex(untouched), isNull);
+      const List<VideoSeriesPlaybackState> rewound = <VideoSeriesPlaybackState>[
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 300,
+          positionMs: 0,
+          completed: false,
+        ),
+        VideoSeriesPlaybackState(
+          lastWatchedAtMs: 0,
+          positionMs: 0,
+          completed: false,
+        ),
+      ];
+      expect(continueWatchingSeriesIndex(rewound), isNull);
+    });
+
     test('最后一集之后没有下一集', () {
       const List<VideoSeriesPlaybackState> members = <VideoSeriesPlaybackState>[
         VideoSeriesPlaybackState(

--- a/fushi/test/pages/home_video_continue_row_nextup_test.dart
+++ b/fushi/test/pages/home_video_continue_row_nextup_test.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 视频首页「继续观看」行的 Next-Up 语义（用户实报）：一集从头看到尾再退出，
+/// 合集就从「继续观看」消失、只剩「下一集」行有它；中途退出的反而在。同一部番在
+/// 首页时有时无，而 hero 大卡的「继续看·第 N 集」早就是「看完 → 下一集」口径。
+///
+/// 这里断言：最近播放那集已看完 → 继续行仍出该合集卡、指向下一集、文案是
+/// 「下一集 · 第 N 集」；整部看完 → 不进继续行。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir = Directory.systemTemp.createTempSync(
+      'fushi_home_continue_nextup_pp',
+    );
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync(
+      'fushi_home_continue_nextup_store',
+    );
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp({VideoLibrarySection section = VideoLibrarySection.home}) =>
+      ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                section: section,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> pumpHome(
+    WidgetTester tester, {
+    VideoLibrarySection section = VideoLibrarySection.home,
+  }) async {
+    tester.view.physicalSize = const Size(1400, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp(section: section));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> seedEpisode(
+    String uid,
+    String title, {
+    int positionMs = 0,
+    bool completed = false,
+    int? lastPlayedAt,
+  }) => db.upsertVideoBook(
+    VideoBooksCompanion(
+      bookUid: Value<String>(uid),
+      title: Value<String>(title),
+      videoPath: Value<String>('/abs/$title.mp4'),
+      lastPositionMs: Value<int>(positionMs),
+      completedAt: Value<DateTime?>(completed ? DateTime.now() : null),
+      lastPlayedAt: Value<int?>(lastPlayedAt),
+    ),
+  );
+
+  Finder continueCard(int cid) =>
+      find.byKey(ValueKey<String>('home_video_continue_collection_$cid'));
+
+  testWidgets('最近播放那集已看完 → 继续观看行指向下一集', (WidgetTester tester) async {
+    final int cid = await db.createMediaCollection(
+      'Yuru Yuri',
+      collectionType: 'playlist',
+    );
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await seedEpisode(
+      'video/yy-ep1',
+      'YY Ep1',
+      positionMs: 1,
+      completed: true,
+      lastPlayedAt: nowMs,
+    );
+    await seedEpisode('video/yy-ep2', 'YY Ep2');
+    await db.addToCollection(cid, MediaKind.video, 'video/yy-ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/yy-ep2');
+
+    await pumpHome(tester);
+
+    expect(continueCard(cid), findsOneWidget, reason: '看完一集退出后，合集不能从「继续观看」消失');
+    expect(
+      find.descendant(
+        of: continueCard(cid),
+        matching: find.text(t.video_home_next_episode_number(n: 2)),
+      ),
+      findsOneWidget,
+      reason: '目标是还没开播的下一集，文案应是「下一集 · 第 2 集」而非「看到第 2 集」',
+    );
+    expect(
+      find.byKey(ValueKey<String>('home_video_next_collection_$cid')),
+      findsOneWidget,
+      reason: '「下一集」行照旧有它——两行各放一份',
+    );
+  });
+
+  testWidgets('最近播放那集没看完 → 继续观看行停在它自己', (WidgetTester tester) async {
+    final int cid = await db.createMediaCollection(
+      'Mid Show',
+      collectionType: 'playlist',
+    );
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await seedEpisode(
+      'video/mid-ep1',
+      'Mid Ep1',
+      positionMs: 1,
+      completed: true,
+      lastPlayedAt: nowMs - 1000,
+    );
+    await seedEpisode(
+      'video/mid-ep2',
+      'Mid Ep2',
+      positionMs: 60000,
+      lastPlayedAt: nowMs,
+    );
+    await seedEpisode('video/mid-ep3', 'Mid Ep3');
+    for (final String uid in <String>[
+      'video/mid-ep1',
+      'video/mid-ep2',
+      'video/mid-ep3',
+    ]) {
+      await db.addToCollection(cid, MediaKind.video, uid);
+    }
+
+    await pumpHome(tester);
+
+    expect(continueCard(cid), findsOneWidget);
+    expect(
+      find.descendant(
+        of: continueCard(cid),
+        matching: find.textContaining(
+          t.video_home_continue_episode_number(n: 2),
+        ),
+      ),
+      findsOneWidget,
+      reason: '中途退出仍是「看到第 2 集」，不得跳到第 3 集',
+    );
+  });
+
+  testWidgets('整部看完 → 不进继续观看行', (WidgetTester tester) async {
+    final int cid = await db.createMediaCollection(
+      'Done Show',
+      collectionType: 'playlist',
+    );
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await seedEpisode(
+      'video/done-ep1',
+      'Done Ep1',
+      positionMs: 1,
+      completed: true,
+      lastPlayedAt: nowMs - 1000,
+    );
+    await seedEpisode(
+      'video/done-ep2',
+      'Done Ep2',
+      positionMs: 1,
+      completed: true,
+      lastPlayedAt: nowMs,
+    );
+    await db.addToCollection(cid, MediaKind.video, 'video/done-ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/done-ep2');
+
+    await pumpHome(tester);
+
+    expect(
+      continueCard(cid),
+      findsNothing,
+      reason: '没有下一集可续，整部看完的合集不该赖在「继续观看」',
+    );
+    expect(
+      find.byKey(ValueKey<String>('home_video_next_collection_$cid')),
+      findsNothing,
+    );
+  });
+}

--- a/fushi/test/pages/jimaku_two_pane_layout_test.dart
+++ b/fushi/test/pages/jimaku_two_pane_layout_test.dart
@@ -249,4 +249,31 @@ void main() {
       reason: '搜索按钮必须真能被点中（没被遮、没被裁）',
     );
   });
+
+  testWidgets(
+      'regression: 320dp phone + keyboard, every locale: action bar never overflows',
+      (WidgetTester tester) async {
+    // 审查发现：底栏若用裸 Row，320dp 窄机（内容宽 240）下 en/de/ru 的「取消 +
+    // 搜索」并排溢出 13~70px。OverflowBar 放不下改竖排——17 语种逐个过。
+    final AppLocale previous = LocaleSettings.currentLocale;
+    addTearDown(() => LocaleSettings.setLocale(previous));
+    const Size screen = Size(320, 568);
+    const double keyboard = 260;
+    tester.view.viewInsets = const FakeViewPadding(bottom: keyboard);
+    addTearDown(tester.view.resetViewInsets);
+    for (final AppLocale locale in AppLocale.values) {
+      LocaleSettings.setLocale(locale);
+      await pumpDialog(tester, screen: screen, candidateCount: 0, seriesCount: 0);
+      expect(tester.takeException(), isNull,
+          reason: '$locale：操作栏不得 RenderFlex 溢出');
+      final Rect btn = tester.getRect(find.byType(FilledButton));
+      final Rect dialog = tester.getRect(find.byType(Dialog));
+      expect(btn.right, lessThanOrEqualTo(dialog.right + 0.5),
+          reason: '$locale：搜索按钮不得伸出对话框右缘');
+      expect(btn.bottom, lessThanOrEqualTo(screen.height - keyboard + 0.5),
+          reason: '$locale：搜索按钮必须落在键盘上方');
+      await tester.tap(find.byType(FilledButton), warnIfMissed: false);
+      await tester.pumpWidget(const SizedBox.shrink());
+    }
+  });
 }

--- a/fushi/test/pages/jimaku_two_pane_layout_test.dart
+++ b/fushi/test/pages/jimaku_two_pane_layout_test.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/video/anilist_client.dart';
 import 'package:fushi/src/pages/implementations/jimaku_subtitle_dialog.dart';
 
@@ -188,19 +190,63 @@ void main() {
         reason: '窄屏下结果列表应与筛选面板同列（上下两段）');
   });
 
-  testWidgets('search button lives in filter pane; cancel stays at bottom',
+  testWidgets('search button sits in the fixed bottom action bar with cancel',
       (WidgetTester tester) async {
-    // 配置项重排：搜索按钮跟随搜索输入组（手绘稿左栏 KEY→TITLE→SEARCH），
-    // 底部动作区只留「取消」。
+    // 搜索是本框唯一主操作，必须在不随正文滚动的底部操作栏里——放进可滚动的
+    // 筛选面板（上一版「跟随输入框」的排版）在矮视口下结构上不可达。
     await pumpDialog(tester, screen: const Size(1280, 800));
     final Finder searchBtn = find.byType(FilledButton);
     expect(searchBtn, findsOneWidget);
-    final Finder queryField = find.byWidgetPredicate(
-        (Widget w) => w is TextField && w.controller?.text == 'Some Anime');
-    // 搜索按钮与番名输入框水平对齐（同在左栏），而非对话框右下角。
+    final Finder cancelBtn = find.widgetWithText(TextButton, t.dialog_cancel);
+    expect(cancelBtn, findsOneWidget);
     final Rect btnRect = tester.getRect(searchBtn);
-    final Rect queryRect = tester.getRect(queryField);
-    expect(btnRect.left, closeTo(queryRect.left, 1.0),
-        reason: '搜索按钮应在筛选面板内与输入框同栏');
+    final Rect cancelRect = tester.getRect(cancelBtn);
+    final Rect dialogRect = tester.getRect(find.byType(Dialog));
+    expect(btnRect.center.dy, closeTo(cancelRect.center.dy, 1.0),
+        reason: '搜索与取消同一行');
+    expect(btnRect.left, greaterThan(cancelRect.right),
+        reason: '主操作在取消右侧');
+    expect(btnRect.bottom, lessThanOrEqualTo(dialogRect.bottom),
+        reason: '操作栏在对话框内');
+    expect(
+      find.descendant(
+        of: find.byType(SingleChildScrollView),
+        matching: find.byType(FilledButton),
+      ),
+      findsNothing,
+      reason: '搜索按钮不得回到可滚动的筛选面板里',
+    );
+  });
+
+  testWidgets(
+      'regression: phone landscape + keyboard keeps search button reachable',
+      (WidgetTester tester) async {
+    // 用户截图：iPhone 横屏点集数框弹出数字键盘（iOS 数字键盘无回车键），对话框
+    // 只剩百来 dp 高——筛选面板只露出一个输入框，旧版藏在面板里的搜索按钮滚出
+    // 视野，整个框只看得见「取消」。修后搜索按钮固定在底栏、必须落在键盘上方且
+    // 可点。
+    const Size screen = Size(844, 390);
+    const double keyboard = 200;
+    tester.view.viewInsets = const FakeViewPadding(bottom: keyboard);
+    addTearDown(tester.view.resetViewInsets);
+    await pumpDialog(tester, screen: screen, candidateCount: 0, seriesCount: 0);
+    expect(tester.takeException(), isNull);
+
+    final Finder searchBtn = find.byType(FilledButton);
+    expect(searchBtn, findsOneWidget);
+    final Rect btnRect = tester.getRect(searchBtn);
+    expect(btnRect.bottom, lessThanOrEqualTo(screen.height - keyboard),
+        reason: '搜索按钮必须完整落在键盘上方');
+    expect(btnRect.top, greaterThanOrEqualTo(0));
+    expect(tester.widget<FilledButton>(searchBtn).onPressed, isNotNull);
+    final RenderObject buttonRender = tester.renderObject(searchBtn);
+    expect(
+      tester
+          .hitTestOnBinding(btnRect.center)
+          .path
+          .any((HitTestEntry e) => e.target == buttonRender),
+      isTrue,
+      reason: '搜索按钮必须真能被点中（没被遮、没被裁）',
+    );
   });
 }


### PR DESCRIPTION
## 两个用户报的 bug

### BUG-1855 · 「继续观看」一集看完退出后合集消失
- 根因：`_buildContinueRow` 对合集只认「最近播放那集未完成」，`completedAt` 落库即整个 `return`；同页 hero 大卡早就是 Next-Up（看完 → 下一集），两套口径。
- 修复：新增纯函数 `continueWatchingSeriesIndex`（未看完 → 自身；已看完 → 紧接下一集；整部看完 / 无痕迹 → null），继续行改用它；目标集未开播时副文案「下一集 · 第 N 集」。「下一集」行照旧，两行各一份（用户要求）。

### BUG-1856 · Jimaku 获取字幕对话框只看得见「取消」
- 根因：唯一主操作「搜索」放在可滚动筛选面板里，底栏只有「取消」。iPhone 横屏弹数字键盘后对话框只剩百来 dp，按钮滚出视野；iOS 数字键盘无回车键，`onSubmitted` 也触发不了。
- 修复：搜索按钮移到底部固定操作栏与「取消」并排。替换旧「按钮在面板内」测试（上一轮手绘稿排版）。

## 验证
- `flutter analyze` 零问题。
- 定向：`video_home_layout_test` / `home_video_continue_row_nextup_test` / `jimaku_two_pane_layout_test` 39 通过；相邻 11 个 home_video/jimaku/collection 套件 96 通过；`bugs_per_file_guard_test` 通过。
- 变异实测：两处修复各退回旧逻辑 → 恰好对应的 3 条新测试红，其余绿。
- 未做 iOS 真机复测（逻辑层由 widget 测试覆盖：844×390 横屏 + 200dp 键盘下按钮落在键盘上方且 hitTest 可命中）。

https://claude.ai/code/session_01U8NvRFLTnx2LviX81nsGo2
