### PR TITLE
fix(gal-hook): 查词浮窗穿透态滚轮照滚、滚动条可拖 thumb（BUG-1859/1860，叠在 #1003 上）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1733 条。点号进各自文件。
+> 共 1735 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1860](bugs/BUG-1860-gal-overlay-scrollbar-not-draggable.md) | ✅ | ✅ | gal 查词浮窗滚动条只是指示条：按住拖 thumb 变成拖窗 |
+| [BUG-1859](bugs/BUG-1859-gal-overlay-passthrough-wheel-gate.md) | ✅ | ✅ | gal 查词浮窗穿透态滚轮不滚：ScrollBy 的 pass_through_ 门是 WS_EX_TRANSPARENT 时代遗物 |
 | [BUG-1857](bugs/BUG-1857-gal-overlay-resize-card-does-not-follow-drag.md) | ✅ | ✅ | 查词浮窗拖右下角调大小时卡片不跟手，松手才跳到位 |
 | [BUG-1854](bugs/BUG-1854-gal-mining-capture-includes-title-bar.md) | ✅ | ✅ | 制卡截图把游戏窗口标题栏截进去了，应裁到客户区 |
 | [BUG-1853](bugs/BUG-1853-gal-passthrough-glyph-holes-fall-through.md) | ✅ | ✅ | 穿透态点到文字笔画镂空处直接透给游戏，碰撞箱应为行矩形 |

--- a/docs/bugs/BUG-1859-gal-overlay-passthrough-wheel-gate.md
+++ b/docs/bugs/BUG-1859-gal-overlay-passthrough-wheel-gate.md
@@ -1,0 +1,9 @@
+## BUG-1859 · gal 查词浮窗穿透态滚轮不滚：ScrollBy 的 pass_through_ 门是 WS_EX_TRANSPARENT 时代遗物
+- **报告**：2026-08-25（用户：截图圈出 hook 台词浮窗右侧滚动条，「在穿透模式下没法滚轮」）
+- **真实性**：✅ 真 bug。根因 `fushi/windows/runner/floating_lyric_window.cpp` `ScrollBy()`（改前 `if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) return false;`）。
+  - 这条 `pass_through_` 判据是 BUG-951 时代写的：那时穿透态正文窗带 `WS_EX_TRANSPARENT`，系统不投任何鼠标消息，判据只兜「置位到应用 ex-style 之间那一瞬」。
+  - BUG-1480 把穿透态改成**逐像素 alpha 命中**（`ApplyPassThroughExStyle` 明确不再设 `WS_EX_TRANSPARENT`，`Render` 把背景压成真 alpha 0）：OS 在合成阶段分流——落在字形（BUG-1853 后是整个行盒）上的鼠标事件归浮窗，落在 alpha-0 背景上的归游戏。于是穿透态下滚轮**能**投到 `WM_MOUSEWHEEL`，却被 `ScrollBy` 的旧门拦下、落到 `DefWindowProc`；这窗没有父窗，事件既不滚文本也到不了游戏，就是「没法滚轮」。
+  - 同一份判定在点击上早就放开了（穿透态点字查词），滚轮还留着门 = 两条路径对「穿透态鼠标归谁」的回答不一致。
+- **[x] ① 已修复** — `ScrollBy` 去掉 `pass_through_` 门，只剩「hook 模式 + 真有溢出」；写偏移收成唯一入口 `SetScrollOffset()`（滚轮与 BUG-1860 拖 thumb 共用）；`WM_MOUSEWHEEL` 注释改写为「穿透态不是例外，与 BUG-1480 同一份判定」。提交见 PR（叠在 PR #1003 之上）。
+- **[x] ② 已加自动化测试** — `fushi/test/build/gal_overlay_scroll_guard_test.dart` ⑤ 改断新前置条件、新增 ⑧：`ScrollBy` / `SetScrollOffset` 源码不含 `pass_through_`，`WM_MOUSEWHEEL` 不准自己加穿透态分支。
+- **备注**：C++ 分层窗无法在 Dart 测试里执行，测试层是源码守卫；真机复验清单：穿透态开、文本溢出、鼠标停在文字上滚轮→文本滚动，停在背景上滚轮→游戏收到。本轮未真机复验。

--- a/docs/bugs/BUG-1860-gal-overlay-scrollbar-not-draggable.md
+++ b/docs/bugs/BUG-1860-gal-overlay-scrollbar-not-draggable.md
@@ -1,0 +1,15 @@
+## BUG-1860 · gal 查词浮窗滚动条只是指示条：按住拖 thumb 变成拖窗
+- **报告**：2026-08-25（用户：截图圈出右侧滚动条，「按住的话，变拖拽窗口了」）
+- **真实性**：✅ 真 bug。根因 `fushi/windows/runner/floating_lyric_window.cpp`：
+  - BUG-1095 第二阶段只把滚动条画成「指示条」（`Render` 内联算几何、画轨道 + thumb），没有任何命中逻辑；`WM_LBUTTONDOWN` 只认工具条按钮（`ControlActionAt`），其余全按「正文按压」处理（`pressed_ = true`），`WM_MOUSEMOVE` 走过 `kDragThresholdDip` 即提升为拖窗。用户看到滚动条、按住去拖，得到的是窗口跟着走。锁定态下则是「按了没反应」——两种都不是滚动。
+  - 与穿透态（BUG-1859）无关：非穿透态同样拖窗；穿透态还多一层——命中带里没画到的像素是 alpha 0，按下直接透给游戏推台词。
+  - 4dp 视觉细条本身也抓不住（Fitts），必须有比它宽的命中带。
+- **[x] ① 已修复** —
+  - 几何收成唯一真相 `ComputeScrollBar()`（`ScrollBarGeometry`：轨道 / thumb / 命中带 `kScrollBarHitWidthDip`=14dp），`Render` 绘制、`ScrollBarContains()` 命中、`BeginScrollThumbDrag()` 起拖三处同源，画哪按哪。
+  - `WM_LBUTTONDOWN`：工具条按钮之后、正文按压之前判滚动条；命中即 `BeginScrollThumbDrag`（按在 thumb 外先把 thumb 中心搬到指针下，再起拖——「按 thumb」与「按轨道」是同一手势，没有第二套「翻页」行为），`SetCapture` 出窗继续跟；**不看 `locked_`**（锁的是位置不是滚动）。
+  - `WM_MOUSEMOVE`：`scroll_thumb_dragging_` 分支在拖窗分支之前，按「轨道可走距离 ↔ 可滚行程」等比换算写 `SetScrollOffset`，并 return 掉不让 Shift-悬停查词在滚动条上乱出词。
+  - 手势终结统一走 `CancelPointerGesture()`（`WM_LBUTTONUP` / `WM_CAPTURECHANGED` / `Hide` / `SetLocked` 一个不漏，BUG-1471 同款纪律）；`WM_MOUSELEAVE` 拖 thumb 期间不熄 hover 高亮。
+  - 穿透态：`Render` 给命中带整块铺 `kHookTextMinCatchAlpha` 的不可见 catch fill（与 BUG-1853 行盒同一技法），「看得见的滚动条」与「按得到的滚动条」是同一块像素。
+  - 提交见 PR（叠在 PR #1003 之上）。
+- **[x] ② 已加自动化测试** — `fushi/test/build/gal_overlay_scroll_guard_test.dart` ⑥ 改断几何同源、新增 ⑨：状态与终结者、`WM_LBUTTONDOWN` 判定次序与不依赖 `locked_`、`WM_MOUSEMOVE` 分支次序与等比换算、capture、命中带常量、穿透态 catch fill。
+- **备注**：C++ 分层窗无法在 Dart 测试里执行，测试层是源码守卫；真机复验清单：①非穿透态按 thumb 拖→文本滚、窗不动；②按轨道空白→thumb 跳到指针下再跟手；③锁定态同样能拖；④穿透态按 thumb 旁 5px 内→仍是滚动、不推台词；⑤拖出窗外继续跟、松手后 hover 查词正常。本轮未真机复验。

--- a/fushi/test/build/gal_overlay_scroll_guard_test.dart
+++ b/fushi/test/build/gal_overlay_scroll_guard_test.dart
@@ -8,9 +8,12 @@
 //   ② 绘制原点随偏移上移（滚动的实现方式），裁剪框不动；
 //   ③ 命中测试在视口判边界、在布局取坐标（滚动后点字不错行）；
 //   ④ 新台词回到顶部；
-//   ⑤ 接管条件（hook 模式 / 非穿透 / 有溢出）集中在 ScrollBy，滚到头不吞事件；
-//   ⑥ 滚动条画在文本区右侧留白里，且只在 hook 模式真溢出时画；
-//   ⑦ 不滚动时逐像素不变（歌词条 / 剪贴板文本窗完全不受影响）。
+//   ⑤ 接管条件（hook 模式 / 有溢出）集中在 ScrollBy，滚到头不吞事件；
+//   ⑥ 滚动条几何唯一真相 ComputeScrollBar：画在文本区右侧留白里，只在 hook 模式
+//      真溢出时存在，Render 与命中同源；
+//   ⑦ 不滚动时逐像素不变（歌词条 / 剪贴板文本窗完全不受影响）；
+//   ⑧ BUG-1859：穿透态滚轮照滚——ScrollBy / WM_MOUSEWHEEL 不按 pass_through_ 拦；
+//   ⑨ BUG-1860：滚动条是控件——按 thumb 拖动内容不拖窗，穿透态命中带铺 catch fill。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -108,11 +111,9 @@ void main() {
 
   test('⑤ 接管条件集中在 ScrollBy，滚到头不吞事件', () {
     expect(
-      src.contains(
-          'if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) {'),
+      src.contains('if (!hook_text_mode_ || scroll_max_px_ <= 0.0f) {'),
       isTrue,
-      reason: '三个前置条件必须写在一处：hook 模式 / 非穿透 / 真有溢出。'
-          '穿透 = 鼠标整个属于游戏，顶部恢复带也不例外',
+      reason: '两个前置条件必须写在一处：hook 模式 / 真有溢出',
     );
     expect(src.contains('case WM_MOUSEWHEEL:'), isTrue, reason: '滚轮是最低交互要求');
     expect(
@@ -122,12 +123,18 @@ void main() {
     );
     // 到顶 / 到底时 ScrollBy 返回 false，滚轮落回 DefWindowProc，
     // 窗口不做吃掉滚轮的黑洞。
-    final int i = src.indexOf('bool FloatingLyricWindow::ScrollBy(');
-    expect(i, greaterThan(0));
-    final String scrollBy = src.substring(
-        i, src.indexOf('void FloatingLyricWindow::SetLocked(', i));
+    final String scrollBy =
+        _functionSource(src, 'bool FloatingLyricWindow::ScrollBy(');
     expect(
-      scrollBy.contains('if (next == scroll_offset_px_) {'),
+      scrollBy
+          .contains('return SetScrollOffset(scroll_offset_px_ + delta_px);'),
+      isTrue,
+      reason: 'ScrollBy 只做前置判断，写偏移走唯一入口 SetScrollOffset',
+    );
+    final String setOffset =
+        _functionSource(src, 'bool FloatingLyricWindow::SetScrollOffset(');
+    expect(
+      setOffset.contains('if (next == scroll_offset_px_) {'),
       isTrue,
       reason: '偏移没变就不能返回 true，否则窗口会变成吃掉滚轮的黑洞',
     );
@@ -144,22 +151,136 @@ void main() {
   test('⑥ 滚动条画在右侧留白，且只在 hook 模式真溢出时出现', () {
     expect(src.contains('kScrollBarWidthDip'), isTrue);
     expect(src.contains('kScrollBarMinThumbDip'), isTrue);
+    final String geometry = _functionSource(src,
+        'FloatingLyricWindow::ScrollBarGeometry FloatingLyricWindow::ComputeScrollBar()');
     expect(
-      src.contains('if (hook_text_mode_ && scroll_max_px_ > 0.0f) {'),
+      geometry
+          .contains('g.visible = hook_text_mode_ && scroll_max_px_ > 0.0f;'),
       isTrue,
-      reason: '没有溢出就一个像素都不画（不滚动时逐像素不变）',
+      reason: '没有溢出就一个像素都不画、一次命中都不算（不滚动时逐像素不变）',
     );
     expect(
-      src.contains('static_cast<float>(width) - pad * 0.5f - bar_w * 0.5f;'),
+      geometry.contains('g.bar_x = width - pad * 0.5f - g.bar_w * 0.5f;'),
       isTrue,
       reason: '轨道必须落在 text_rect_ 右侧的留白里：压到文字就要缩窄换行宽度，'
           '而换行宽度会反过来改行程，形成回环',
     );
     expect(
-      src.contains('text_rect_.height - ScaleForDpi(kResizeGripDip)'),
+      geometry.contains('text_rect_.height - ScaleForDpi(kResizeGripDip)'),
       isTrue,
       reason: '轨道底端要让开右下角 resize grip，两个可拖拽的东西不叠在一起',
     );
+    // Render 只准问 ComputeScrollBar，不准自己再算一遍几何。
+    final String render =
+        _functionSource(src, 'void FloatingLyricWindow::Render()');
+    expect(render.contains('const ScrollBarGeometry sb = ComputeScrollBar();'),
+        isTrue,
+        reason: '绘制几何必须与命中几何同源');
+    final int sb =
+        render.indexOf('const ScrollBarGeometry sb = ComputeScrollBar();');
+    final String bar =
+        render.substring(sb, render.indexOf('if (text_only_) {', sb));
+    expect(bar.contains('if (sb.visible) {'), isTrue);
+    expect(bar.contains('kResizeGripDip'), isFalse,
+        reason: 'Render 的滚动条段不该再有第二份几何');
+    expect(bar.contains('kScrollBarMinThumbDip'), isFalse,
+        reason: 'Render 的滚动条段不该再有第二份几何');
+  });
+
+  test('⑧ 穿透态滚轮照滚：ScrollBy 没有 pass_through_ 门（BUG-1859）', () {
+    // BUG-1480 之后穿透态靠逐像素 alpha 分流：滚轮能投到正文窗就说明它落在
+    // 文字上，与「穿透态点字查词」是同一份判定。ScrollBy 再拿 pass_through_ 拦
+    // 一道，事件只会被 DefWindowProc 吞掉（无父窗、到不了游戏），穿透态永远滚
+    // 不动。
+    // 注释里可以（也应该）解释为什么没有这道门，所以只看剥掉 // 注释后的代码。
+    final String scrollBy = _stripLineComments(
+        _functionSource(src, 'bool FloatingLyricWindow::ScrollBy('));
+    expect(scrollBy.contains('pass_through_'), isFalse,
+        reason: 'ScrollBy 不准按穿透态拦滚轮');
+    final String setOffset = _stripLineComments(
+        _functionSource(src, 'bool FloatingLyricWindow::SetScrollOffset('));
+    expect(setOffset.contains('pass_through_'), isFalse);
+    final int w = src.indexOf('case WM_MOUSEWHEEL:');
+    final String wheelCase =
+        _stripLineComments(src.substring(w, src.indexOf('case WM_SIZE:', w)));
+    expect(wheelCase.contains('if (ScrollBy(step)) {'), isTrue,
+        reason: '滚轮唯一的接管判定是 ScrollBy 的返回值');
+    expect(wheelCase.contains('pass_through_'), isFalse,
+        reason: 'WM_MOUSEWHEEL 也不准自己加穿透态分支');
+  });
+
+  test('⑨ 滚动条是控件不是正文：按 thumb 拖动内容，不拖窗（BUG-1860）', () {
+    // 状态 + 唯一终结者：拖 thumb 与拖窗 / 查词按压是同一笔互斥事务。
+    expect(hdr.contains('bool scroll_thumb_dragging_ = false;'), isTrue);
+    expect(hdr.contains('bool ScrollBarContains(float x, float y) const;'),
+        isTrue);
+    expect(hdr.contains('bool BeginScrollThumbDrag(float y);'), isTrue);
+    final String cancel = _functionSource(
+        src, 'void FloatingLyricWindow::CancelPointerGesture()');
+    expect(cancel.contains('scroll_thumb_dragging_ = false;'), isTrue,
+        reason: 'WM_CAPTURECHANGED / Hide / SetLocked 都经 CancelPointerGesture '
+            '终结手势，拖 thumb 漏掉就会像 BUG-1471 那样卡死');
+
+    // WM_LBUTTONDOWN：滚动条命中要在「正文按压」之前判，且不依赖 locked_
+    //（锁的是位置，不是滚动）。
+    final int down = src.indexOf('case WM_LBUTTONDOWN: {');
+    final int capture = src.indexOf('case WM_CAPTURECHANGED:', down);
+    expect(down, greaterThan(0));
+    final String downCase = src.substring(down, capture);
+    final int scrollHit = downCase
+        .indexOf('if (ScrollBarContains(x, y) && BeginScrollThumbDrag(y)) {');
+    final int bodyPress = downCase.indexOf('pressed_ = true;');
+    expect(scrollHit, greaterThan(0), reason: '按在滚动条上必须走 thumb 手势');
+    expect(bodyPress, greaterThan(scrollHit),
+        reason: '滚动条判定必须在正文按压（pressed_ = true）之前，否则松手前'
+            '移动几个像素就被提升成拖窗');
+    expect(
+      downCase.substring(0, scrollHit).contains('locked_'),
+      isFalse,
+      reason: '锁定只锁位置，锁定态滚动条照样能拖',
+    );
+
+    // WM_MOUSEMOVE：拖 thumb 分支在拖窗分支之前，按轨道↔行程等比换算，且 return
+    // 掉不让 Shift-悬停查词在滚动条上乱出词。
+    final int move = src.indexOf('case WM_MOUSEMOVE: {');
+    final String moveCase =
+        src.substring(move, src.indexOf('case WM_TIMER:', move));
+    final int thumb = moveCase.indexOf('if (scroll_thumb_dragging_) {');
+    final int windowDrag = moveCase.indexOf('if (dragging_) {');
+    expect(thumb, greaterThan(0));
+    expect(windowDrag, greaterThan(thumb), reason: '拖 thumb 分支必须先于拖窗分支');
+    expect(
+      moveCase.contains('(y - scroll_drag_origin_y_) * scroll_drag_px_per_px_'),
+      isTrue,
+      reason: '指针位移 ↔ 内容偏移必须按轨道行程等比换算',
+    );
+
+    // 几何同源：命中带 / 绘制 / 拖动全部问 ComputeScrollBar。
+    final String contains =
+        _functionSource(src, 'bool FloatingLyricWindow::ScrollBarContains(');
+    expect(contains.contains('ComputeScrollBar()'), isTrue);
+    final String begin =
+        _functionSource(src, 'bool FloatingLyricWindow::BeginScrollThumbDrag(');
+    expect(begin.contains('ComputeScrollBar()'), isTrue);
+    expect(begin.contains('SetCapture(hwnd_);'), isTrue,
+        reason: '拖 thumb 出窗也要继续跟，必须 capture');
+    expect(src.contains('kScrollBarHitWidthDip'), isTrue,
+        reason: '4dp 视觉细条抓不住，命中带要比它宽');
+
+    // 穿透态：命中带要铺 catch fill，否则 alpha-0 像素把按下透给游戏。
+    final String render =
+        _functionSource(src, 'void FloatingLyricWindow::Render()');
+    final int sb =
+        render.indexOf('const ScrollBarGeometry sb = ComputeScrollBar();');
+    final String bar =
+        render.substring(sb, render.indexOf('if (text_only_) {', sb));
+    expect(bar.contains('if (pass_through_) {'), isTrue);
+    expect(
+      bar.contains('D2D1::RectF(sb.hit_left, sb.track_top, sb.hit_right,'),
+      isTrue,
+      reason: '穿透态命中带必须整块铺 kHookTextMinCatchAlpha 的 catch fill',
+    );
+    expect(bar.contains('kHookTextMinCatchAlpha << 24'), isTrue);
   });
 
   test('⑦ 歌词条 / 剪贴板文本窗不受滚动影响', () {
@@ -178,4 +299,19 @@ void main() {
         src.contains('strip_height_dip_ / kBaseStripHeightForFontDip'), isTrue,
         reason: '有声书歌词条「拖高放大」是既有行为，不得连坐');
   });
+}
+
+/// 剥掉 `//` 行注释（只剩代码），让守卫不被注释里出现的标识符假阳性命中。
+String _stripLineComments(String code) =>
+    code.replaceAll(RegExp(r'//[^\n]*'), '');
+
+/// 截出 C++ 函数源码：从 [signature] 起到第一个顶格 `}` 行止（本文件里的成员
+/// 函数都是顶格闭合，内部作用域缩进两格）。
+String _functionSource(String src, String signature) {
+  final int start = src.indexOf(signature);
+  expect(start, greaterThanOrEqualTo(0), reason: '找不到函数签名：$signature');
+  final Match? close = RegExp(r'\r?\n}\r?\n').firstMatch(src.substring(start));
+  return close == null
+      ? src.substring(start)
+      : src.substring(start, start + close.end);
 }

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -138,6 +138,10 @@ constexpr uint32_t kHookTextMinCatchAlpha = 5;  // ~2%, invisible but hittable
 constexpr float kScrollBarWidthDip = 4.0f;
 constexpr float kScrollBarMinThumbDip = 16.0f;
 constexpr float kScrollWheelStepDip = 40.0f;
+// 滚动条的**命中带**比画出来的 4dp 细条宽：4dp 是指示用的视觉宽度，按 Fitts
+// 定律根本抓不住。命中带以细条为中心对称展开，只管鼠标按下 / 拖 thumb，
+// 不影响绘制，也不影响文本换行宽度。
+constexpr float kScrollBarHitWidthDip = 14.0f;
 
 // ARGB (0xAARRGGBB) -> D2D1_COLOR_F (straight alpha).
 D2D1_COLOR_F ColorFromArgb(uint32_t argb) {
@@ -455,6 +459,9 @@ void FloatingLyricWindow::CancelPointerGesture() {
   pressed_ = false;
   dragging_ = false;
   press_was_text_ = false;
+  // 拖 thumb 与拖窗 / 查词按压是互斥的同一笔事务：终结者也走同一个出口
+  //（WM_LBUTTONUP / WM_CAPTURECHANGED / Hide / SetLocked 一个都不会漏）。
+  scroll_thumb_dragging_ = false;
   if (hwnd_ != nullptr && GetCapture() == hwnd_) {
     ReleaseCapture();
   }
@@ -631,22 +638,105 @@ void FloatingLyricWindow::SetHoverAutoLookup(bool enabled) {
 }
 
 bool FloatingLyricWindow::ScrollBy(float delta_px) {
-  // 三个前置条件写在一处，调用方（WM_MOUSEWHEEL）不必再抄一遍：
+  // 两个前置条件写在一处，调用方（WM_MOUSEWHEEL）不必再抄一遍：
   //  * 只有 hook 台词能滚——歌词条 / 剪贴板文本窗保持历史行为，一字不改；
-  //  * 穿透模式下鼠标整个属于游戏，滚轮不归我们（BUG-951 之后正文窗直接带
-  //    WS_EX_TRANSPARENT，系统压根不往这儿投鼠标消息；这条判据留着是为了
-  //    「先置位、还没走到应用 ex-style」那一瞬也不例外）；
   //  * 没有溢出就没有行程，返回 false 让事件继续往下传。
-  if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) {
+  //
+  // BUG-1859：这里**没有** pass_through_ 判据。它是 BUG-951 时代的遗物——那时穿透
+  // 态正文窗带 WS_EX_TRANSPARENT，系统不投任何鼠标消息，这条判据只是兜「置位到
+  // 应用 ex-style 之间那一瞬」。BUG-1480 之后穿透态改成逐像素 alpha 命中：OS 已经
+  // 在合成阶段把鼠标分好了——落在文字（BUG-1853 后是整个行盒）上的归我们，落在
+  // alpha-0 背景上的归游戏。一个滚轮事件既然能到这里，就说明它落在了文字上，和
+  // 「点字查词」是同一份判定；再用 pass_through_ 拦一道，等于把 OS 判给我们的事件
+  // 吞进 DefWindowProc（这窗没有父窗，事件到不了游戏），穿透态就永远滚不动。
+  if (!hook_text_mode_ || scroll_max_px_ <= 0.0f) {
     return false;
   }
-  const float next =
-      std::clamp(scroll_offset_px_ + delta_px, 0.0f, scroll_max_px_);
+  return SetScrollOffset(scroll_offset_px_ + delta_px);
+}
+
+bool FloatingLyricWindow::SetScrollOffset(float offset_px) {
+  const float next = std::clamp(offset_px, 0.0f, scroll_max_px_);
   if (next == scroll_offset_px_) {
     return false;  // 已经顶到头 / 到底：不吞事件。
   }
   scroll_offset_px_ = next;
   RequestRender();
+  return true;
+}
+
+FloatingLyricWindow::ScrollBarGeometry FloatingLyricWindow::ComputeScrollBar()
+    const {
+  // BUG-1095 (第二阶段) / BUG-1860 — 滚动条几何的唯一真相。Render 画它、
+  // ScrollBarContains 判命中、WM_MOUSEMOVE 拖 thumb 三处都问这里，所以「画在哪」
+  // 和「按哪算按到」物理上不可能不一致。
+  //
+  // 只在 hook 模式且真有溢出时存在；其余情况 visible=false，一个像素都不画、
+  // 一次命中都不算（不滚动时逐像素不变、歌词条 / 剪贴板文本窗完全不受影响）。
+  //
+  // 轨道画在文本区**右侧的留白**里：text_rect_ 只占 [pad, width - pad]，所以这条
+  // 指示条压不到任何一个字，也就不必为它缩窄换行宽度——缩窄宽度会反过来改变
+  // metrics.height，从而改变可滚行程，形成回环。轨道底端让开右下角 resize grip，
+  // 免得两个可拖拽的东西叠在同一块像素上。
+  ScrollBarGeometry g;
+  g.visible = hook_text_mode_ && scroll_max_px_ > 0.0f;
+  if (!g.visible) {
+    return g;
+  }
+  // text_rect_ 由 Render 按 [pad, width - pad] 铺出来，反推 pad 与 width 就不必
+  // 再抄一遍 padding 的换算（ScrollBarContains 在 Render 之外被调用，没有局部
+  // 变量可用）。
+  const float pad = text_rect_.left;
+  const float width = text_rect_.left + text_rect_.width + pad;
+  g.bar_w = ScaleForDpi(kScrollBarWidthDip);
+  g.bar_x = width - pad * 0.5f - g.bar_w * 0.5f;
+  g.track_top = text_rect_.top;
+  g.track_bottom = std::max(
+      g.track_top + g.bar_w,
+      text_rect_.top + text_rect_.height - ScaleForDpi(kResizeGripDip));
+  const float track_h = g.track_bottom - g.track_top;
+  const float content_h = text_rect_.height + scroll_max_px_;
+  const float min_thumb = std::min(track_h, ScaleForDpi(kScrollBarMinThumbDip));
+  g.thumb_h = std::clamp(
+      track_h * (text_rect_.height / std::max(1.0f, content_h)), min_thumb,
+      track_h);
+  g.thumb_y =
+      g.track_top + (track_h - g.thumb_h) * (scroll_offset_px_ / scroll_max_px_);
+  const float hit_half =
+      std::max(g.bar_w, ScaleForDpi(kScrollBarHitWidthDip)) * 0.5f;
+  const float bar_center = g.bar_x + g.bar_w * 0.5f;
+  g.hit_left = bar_center - hit_half;
+  g.hit_right = std::min(width, bar_center + hit_half);
+  return g;
+}
+
+bool FloatingLyricWindow::ScrollBarContains(float x, float y) const {
+  const ScrollBarGeometry g = ComputeScrollBar();
+  return g.visible && x >= g.hit_left && x <= g.hit_right && y >= g.track_top &&
+         y <= g.track_bottom;
+}
+
+bool FloatingLyricWindow::BeginScrollThumbDrag(float y) {
+  const ScrollBarGeometry g = ComputeScrollBar();
+  if (!g.visible) {
+    return false;
+  }
+  const float travel = (g.track_bottom - g.track_top) - g.thumb_h;
+  if (travel <= 0.0f) {
+    return false;  // thumb 撑满轨道：没有可拖的行程。
+  }
+  // 按在 thumb 外（轨道上）：先把 thumb 中心搬到指针下，再从这里起拖。这样
+  // 「按 thumb 拖」和「按轨道拖」是同一个手势——thumb 永远跟着指针走，不需要
+  // 「轨道点击翻页」这种第二套行为。
+  if (y < g.thumb_y || y > g.thumb_y + g.thumb_h) {
+    SetScrollOffset((y - g.track_top - g.thumb_h * 0.5f) / travel *
+                    scroll_max_px_);
+  }
+  scroll_thumb_dragging_ = true;
+  scroll_drag_origin_y_ = y;
+  scroll_drag_start_offset_ = scroll_offset_px_;
+  scroll_drag_px_per_px_ = scroll_max_px_ / travel;
+  SetCapture(hwnd_);
   return true;
 }
 
@@ -924,6 +1014,15 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // 鼠标进了窗口才开轮询表：静止光标上按下 Shift 也要能出词（BUG-880 在视频页
       // 的同款坑）。离开窗口时 WM_MOUSELEAVE 停表。
       StartHoverLookupPolling();
+      // BUG-1860：拖滚动条 thumb。行程按「轨道可走距离 ↔ 可滚行程」等比换算，
+      // 指针离窗（有 capture，坐标照样送来）也继续跟。这里 return 掉，既不进
+      // 拖窗分支，也不让 Shift-悬停查词在滚动条上乱出词。
+      if (scroll_thumb_dragging_) {
+        const float y = static_cast<float>(GET_Y_LPARAM(lparam));
+        SetScrollOffset(scroll_drag_start_offset_ +
+                        (y - scroll_drag_origin_y_) * scroll_drag_px_per_px_);
+        return 0;
+      }
       if (dragging_) {
         POINT cursor;
         GetCursorPos(&cursor);
@@ -1013,7 +1112,7 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       StopHoverLookupPolling();
       ResetHoverLookupAnchor();
       slot_tooltip_.Hide();
-      if (hovered_ && !dragging_) {
+      if (hovered_ && !dragging_ && !scroll_thumb_dragging_) {
         hovered_ = false;
         RequestRender();
       }
@@ -1032,7 +1131,14 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
         return 0;
       }
 
-      // 2. Otherwise this is a pending press over the body of the strip. We do
+      // 2. BUG-1860: the scroll bar is a control, not body. A press on it starts
+      // a thumb drag (locked or not — lock is a POSITION lock, the text must
+      // still scroll) and never becomes a move-the-window drag.
+      if (ScrollBarContains(x, y) && BeginScrollThumbDrag(y)) {
+        return 0;
+      }
+
+      // 3. Otherwise this is a pending press over the body of the strip. We do
       // NOT decide lookup-vs-drag yet: a still press is a lookup on button-up,
       // a moving press is promoted to a drag in WM_MOUSEMOVE.
       POINT cursor;
@@ -1106,11 +1212,11 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
     case WM_MOUSEWHEEL: {
       // BUG-1095 (第二阶段) — 滚轮翻台词。交互契约写在这里，别处不再重复：
       //
-      //  * **接管条件**全在 ScrollBy 里（hook 模式 + 非穿透 + 真有溢出）。不满足
+      //  * **接管条件**全在 ScrollBy 里（hook 模式 + 真有溢出）。不满足
       //    就落回 DefWindowProc，歌词条 / 剪贴板文本窗的行为一字不改。
-      //  * **穿透模式**下正文窗带 WS_EX_TRANSPARENT，系统不投递任何鼠标消息，
-      //    滚轮压根到不了这里（BUG-951）；工具条独立窗自己不吃滚轮。穿透就是
-      //    「鼠标整个属于游戏」，不留半个例外。
+      //  * **穿透模式**不是例外（BUG-1859）：穿透态靠逐像素 alpha 分流，滚轮
+      //    落在文字行盒上才会投到这里，落在背景上 OS 直接给游戏。到了这里就
+      //    照滚——与「穿透态点字查词」（BUG-1480）是同一份判定。
       //  * **和工具条不打架**：那八个按钮只吃 WM_LBUTTONDOWN，从不吃滚轮。所以
       //    滚轮的命中区可以是整个窗口，不需要「避开按钮」这种特例分支——鼠标停
       //    在按钮上滚也照样翻文本，这正是用户预期。
@@ -1636,43 +1742,46 @@ void FloatingLyricWindow::Render() {
       // buttons are unaffected).
       render_target_->PopAxisAlignedClip();
 
-      // BUG-1095 (第二阶段) — 滚动指示条。没有它用户根本不知道「下面还有」，
-      // 也看不出自己滚到了哪里。画在 text_rect_ 右侧的留白里（见
-      // kScrollBarWidthDip 的注释），所以不遮字、不改换行宽度；只在 hook 模式
-      // 且真有溢出时才出现，其余情况一个像素都不画。
-      if (hook_text_mode_ && scroll_max_px_ > 0.0f) {
-        const float bar_w = ScaleForDpi(kScrollBarWidthDip);
-        const float bar_x =
-            static_cast<float>(width) - pad * 0.5f - bar_w * 0.5f;
-        const float track_top = text_rect_.top;
-        const float track_bottom = std::max(
-            track_top + bar_w,
-            text_rect_.top + text_rect_.height - ScaleForDpi(kResizeGripDip));
-        const float track_h = track_bottom - track_top;
-        const float content_h = text_rect_.height + scroll_max_px_;
-        const float min_thumb =
-            std::min(track_h, ScaleForDpi(kScrollBarMinThumbDip));
-        const float thumb_h = std::clamp(
-            track_h * (text_rect_.height / std::max(1.0f, content_h)),
-            min_thumb, track_h);
-        const float thumb_y =
-            track_top +
-            (track_h - thumb_h) * (scroll_offset_px_ / scroll_max_px_);
+      // BUG-1095 (第二阶段) — 滚动条。没有它用户根本不知道「下面还有」，也看
+      // 不出自己滚到了哪里。几何全部来自 ComputeScrollBar()（画在 text_rect_ 右侧
+      // 留白里、不遮字、不改换行宽度、只在 hook 模式真溢出时出现），命中测试问
+      // 的是同一份几何（BUG-1860），画哪按哪。
+      const ScrollBarGeometry sb = ComputeScrollBar();
+      if (sb.visible) {
+        // 穿透态整窗背景是真 alpha 0：命中带里没画到的像素会把按下直接透给游戏，
+        // 用户按 thumb 旁边 2px 就推了台词。给命中带铺一层与 BUG-1853 行盒同款
+        // 的不可见 catch fill，让「看得见的滚动条」和「按得到的滚动条」是同一块。
+        if (pass_through_) {
+          Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> catch_brush;
+          render_target_->CreateSolidColorBrush(
+              ColorFromArgb((kHookTextMinCatchAlpha << 24) |
+                            (style_.bg_color & 0x00FFFFFF)),
+              catch_brush.GetAddressOf());
+          if (catch_brush != nullptr) {
+            render_target_->FillRectangle(
+                D2D1::RectF(sb.hit_left, sb.track_top, sb.hit_right,
+                            sb.track_bottom),
+                catch_brush.Get());
+          }
+        }
         Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> bar;
         render_target_->CreateSolidColorBrush(
             ColorFromArgb(style_.button_text_color), bar.GetAddressOf());
         if (bar != nullptr) {
-          bar->SetOpacity(hovered_ ? 0.12f : 0.05f);
+          const bool lit = hovered_ || scroll_thumb_dragging_;
+          bar->SetOpacity(lit ? 0.12f : 0.05f);
           render_target_->FillRoundedRectangle(
-              D2D1::RoundedRect(
-                  D2D1::RectF(bar_x, track_top, bar_x + bar_w, track_bottom),
-                  bar_w / 2.0f, bar_w / 2.0f),
+              D2D1::RoundedRect(D2D1::RectF(sb.bar_x, sb.track_top,
+                                            sb.bar_x + sb.bar_w,
+                                            sb.track_bottom),
+                                sb.bar_w / 2.0f, sb.bar_w / 2.0f),
               bar.Get());
-          bar->SetOpacity(hovered_ ? 0.75f : 0.35f);
+          bar->SetOpacity(lit ? 0.75f : 0.35f);
           render_target_->FillRoundedRectangle(
-              D2D1::RoundedRect(
-                  D2D1::RectF(bar_x, thumb_y, bar_x + bar_w, thumb_y + thumb_h),
-                  bar_w / 2.0f, bar_w / 2.0f),
+              D2D1::RoundedRect(D2D1::RectF(sb.bar_x, sb.thumb_y,
+                                            sb.bar_x + sb.bar_w,
+                                            sb.thumb_y + sb.thumb_h),
+                                sb.bar_w / 2.0f, sb.bar_w / 2.0f),
               bar.Get());
         }
       }

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -350,6 +350,29 @@ class FloatingLyricWindow {
   // 非 hook 模式、穿透模式、没有溢出时恒为 no-op，歌词条与剪贴板文本
   // 窗逐像素不变。
   bool ScrollBy(float delta_px);
+  // 把滚动偏移写成 |offset_px|（夹到 [0, scroll_max_px_]）；变了就重绘并返回
+  // true。ScrollBy（滚轮）与拖 thumb（BUG-1860）共用的唯一写入口。
+  bool SetScrollOffset(float offset_px);
+
+  // BUG-1860 — 滚动条几何（客户区物理 px），绘制 / 命中 / 拖 thumb 的唯一真相。
+  // visible=false 时其余字段无意义。
+  struct ScrollBarGeometry {
+    bool visible = false;
+    float bar_x = 0.0f;  // 画出来的细条左沿
+    float bar_w = 0.0f;
+    float track_top = 0.0f;
+    float track_bottom = 0.0f;
+    float thumb_y = 0.0f;
+    float thumb_h = 0.0f;
+    float hit_left = 0.0f;  // 命中带（比细条宽，见 kScrollBarHitWidthDip）
+    float hit_right = 0.0f;
+  };
+  ScrollBarGeometry ComputeScrollBar() const;
+  // 客户区点是否落在滚动条命中带里（hook 模式且真有溢出时才可能为 true）。
+  bool ScrollBarContains(float x, float y) const;
+  // 从客户区 y 开始拖 thumb：按在 thumb 外先把 thumb 中心搬到指针下。返回 false
+  // = 没有可拖行程（thumb 撑满轨道），调用方按普通按压处理。
+  bool BeginScrollThumbDrag(float y);
 
   // Minimum visible margin (in 96-DPI logical px) that must always stay inside
   // the target monitor's work area, so the strip can never be dragged or
@@ -446,6 +469,12 @@ class FloatingLyricWindow {
   // 把偏移留在旧行程外。
   float scroll_offset_px_ = 0.0f;
   float scroll_max_px_ = 0.0f;
+  // BUG-1860 — 拖滚动条 thumb 的手势状态。与 pressed_ / dragging_ 互斥，同样由
+  // CancelPointerGesture 统一终结。
+  bool scroll_thumb_dragging_ = false;
+  float scroll_drag_origin_y_ = 0.0f;      // 按下时的客户区 y
+  float scroll_drag_start_offset_ = 0.0f;  // 按下时的 scroll_offset_px_
+  float scroll_drag_px_per_px_ = 0.0f;     // 指针走 1px ↔ 内容滚多少 px
 
   // Press / drag / resize state for moving and sizing the strip.
   //


### PR DESCRIPTION
> **堆叠在 PR #1003 之上**（base = `worktree-gal-overlay-resize-passthrough-capture`）。#1003 合入 develop 后请把本 PR 的 base 改回 `develop`；届时 diff 只剩本 PR 的一个 commit。

## 用户报告

穿透模式下 hook 台词浮窗右侧的滚动条：① 滚轮滚不动；② 按住滚动条拖，变成拖窗口。

## 根因

- **BUG-1859（滚轮）**：`ScrollBy()` 有一道 `pass_through_` 门。它是 BUG-951 时代的遗物——当时穿透态正文窗带 `WS_EX_TRANSPARENT`，系统不投鼠标消息。BUG-1480 把穿透态改成**逐像素 alpha 命中**后，落在文字（BUG-1853 后是整个行盒）上的滚轮本来就投到正文窗，却被这道门拦下落进 `DefWindowProc`（无父窗，到不了游戏），于是穿透态永远滚不动。同一份「穿透态鼠标归谁」的判定在点击上早就放开了（穿透态点字查词），滚轮还留着门，两条路径答案不一致。
- **BUG-1860（拖窗）**：滚动条只是 BUG-1095 画出来的**指示条**，没有任何命中逻辑；`WM_LBUTTONDOWN` 只认工具条按钮，其余按下全走「正文按压」→ 移动几像素即提升为拖窗。与穿透态无关，非穿透态同样拖窗；穿透态还多一层：命中带里没画到的像素是 alpha 0，按下直接透给游戏推台词。4dp 视觉细条也根本抓不住。

## 修复

- `ScrollBy` 去掉 `pass_through_` 门；写偏移收成唯一入口 `SetScrollOffset()`。
- 滚动条几何收成唯一真相 `ComputeScrollBar()`（`ScrollBarGeometry`：轨道 / thumb / 14dp 命中带）：`Render` 绘制、`ScrollBarContains()` 命中、`BeginScrollThumbDrag()` 起拖三处同源，画哪按哪。
- `WM_LBUTTONDOWN`：工具条按钮之后、正文按压之前判滚动条；按在 thumb 外先把 thumb 中心搬到指针下再起拖（「按 thumb」「按轨道」是同一手势，没有第二套翻页行为）；`SetCapture` 出窗继续跟；**不看 `locked_`**（锁的是位置不是滚动）。
- `WM_MOUSEMOVE`：`scroll_thumb_dragging_` 分支在拖窗分支之前，按「轨道可走距离 ↔ 可滚行程」等比换算，并 return 掉不让 Shift-悬停查词在滚动条上乱出词。
- 手势终结统一走 `CancelPointerGesture()`（BUG-1471 同款纪律）；`WM_MOUSELEAVE` 拖 thumb 期间不熄 hover 高亮。
- 穿透态：`Render` 给命中带整块铺 `kHookTextMinCatchAlpha` 的不可见 catch fill（与 BUG-1853 行盒同一技法）。

## 验证

- `flutter build windows --debug`（worktree 全新构建）：`√ Built build\windows\x64\runner\Debug\fushi.exe`，退出码 0，`floating_lyric_window.cpp` 零 warning。
- `flutter analyze`（含 test）：No issues found。
- 守卫 `fushi/test/build/gal_overlay_scroll_guard_test.dart`：⑤⑥ 改断新契约，新增 ⑧（BUG-1859）⑨（BUG-1860），9/9 绿；连同其它 9 个引用该 cpp 的守卫共 61 条绿。
- **变异实测** 4 条（重新加 `pass_through_` 门 / 去掉 `WM_LBUTTONDOWN` 滚动条判定 / 去掉穿透态 catch fill / 去掉 `WM_MOUSEMOVE` 拖 thumb 分支）→ 守卫全部变红，文件 hash 还原一致。
- **未真机复验**（本轮无真机）。复验清单在两个 BUG 文件「备注」里：穿透态文字上滚轮 / 背景上滚轮给游戏；非穿透 & 锁定态按 thumb 拖、按轨道空白跳 thumb、穿透态按 thumb 旁 5px 不推台词、拖出窗外继续跟。

Bug 文件：`docs/bugs/BUG-1859-gal-overlay-passthrough-wheel-gate.md`、`docs/bugs/BUG-1860-gal-overlay-scrollbar-not-draggable.md`（① ② 已勾）。

https://claude.ai/code/session_01HHCyNhCD8HJzRU7zUVL5xa
