### PR TITLE
feat(shelf): 书卡菜单加「打开文件位置」（漫画卷直接选中 manga.json）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 64617 (3801 per locale)
+/// Strings: 64651 (3803 per locale)
 ///
-/// Built on 2026-08-24 at 21:26 UTC
+/// Built on 2026-08-25 at 07:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5171,6 +5171,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Show this tab in the navigation bar; turn off to hide it';
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  String get book_file_location_open => 'Open file location';
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -13977,6 +13980,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -22986,6 +22994,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -32038,6 +32051,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -41119,6 +41137,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -50034,6 +50057,11 @@ class _StringsId extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -59021,6 +59049,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -67465,6 +67498,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -75925,6 +75963,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -84872,6 +84915,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -93875,6 +93923,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -102851,6 +102904,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -111650,6 +111708,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -120551,6 +120614,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -129434,6 +129502,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 // Path: <root>
@@ -137602,6 +137675,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       '「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。';
+  @override
+  String get book_file_location_open => '打开文件位置';
+  @override
+  String get book_file_location_failed => '无法打开这本书的文件位置。';
 }
 
 // Path: <root>
@@ -145787,6 +145864,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+  @override
+  String get book_file_location_open => 'Open file location';
+  @override
+  String get book_file_location_failed =>
+      'Could not open this book\'s file location.';
 }
 
 /// Flat map(s) containing all translations.
@@ -153584,6 +153666,10 @@ extension on _StringsEn {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -161378,6 +161464,10 @@ extension on _StringsAr {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -169212,6 +169302,10 @@ extension on _StringsDe {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -177038,6 +177132,10 @@ extension on _StringsEs {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -184872,6 +184970,10 @@ extension on _StringsFr {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -192680,6 +192782,10 @@ extension on _StringsId {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -200508,6 +200614,10 @@ extension on _StringsIt {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -208272,6 +208382,10 @@ extension on _StringsJa {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -216038,6 +216152,10 @@ extension on _StringsKo {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -223859,6 +223977,10 @@ extension on _StringsNl {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -231676,6 +231798,10 @@ extension on _StringsPtBr {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -239500,6 +239626,10 @@ extension on _StringsRu {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -247298,6 +247428,10 @@ extension on _StringsTh {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -255111,6 +255245,10 @@ extension on _StringsTr {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -262918,6 +263056,10 @@ extension on _StringsVi {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }
@@ -270663,6 +270805,10 @@ extension on _StringsZhCn {
         return '在底栏/侧栏显示该页；关闭即隐藏';
       case 'module_downloads_hidden_hint':
         return '「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。';
+      case 'book_file_location_open':
+        return '打开文件位置';
+      case 'book_file_location_failed':
+        return '无法打开这本书的文件位置。';
       default:
         return null;
     }
@@ -278409,6 +278555,10 @@ extension on _StringsZhHk {
         return 'Show this tab in the navigation bar; turn off to hide it';
       case 'module_downloads_hidden_hint':
         return 'The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.';
+      case 'book_file_location_open':
+        return 'Open file location';
+      case 'book_file_location_failed':
+        return 'Could not open this book\'s file location.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "Restored the text layer from before the re-scan",
   "manga_rescan_undo_failed": "Could not restore the previous text layer",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "已还原重新识别前的文字层",
   "manga_rescan_undo_failed": "还原上一版文字层失败",
   "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏",
-  "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。"
+  "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。",
+  "book_file_location_open": "打开文件位置",
+  "book_file_location_failed": "无法打开这本书的文件位置。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3799,5 +3799,7 @@
   "manga_rescan_undone": "已還原重新識別前的文字層",
   "manga_rescan_undo_failed": "還原上一版文字層失敗",
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
-  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions."
+  "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
+  "book_file_location_open": "Open file location",
+  "book_file_location_failed": "Could not open this book's file location."
 }

--- a/fushi/lib/src/epub/book_file_location.dart
+++ b/fushi/lib/src/epub/book_file_location.dart
@@ -1,0 +1,31 @@
+import 'package:fushi_core/fushi_core.dart' show EpubBookRow;
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
+
+/// 书在磁盘上的主文件绝对路径。
+///
+/// EPUB / PDF / 漫画是同一张 `EpubBooks` 表上的三种书身份，路径列的语义完全一致：
+/// [EpubBookRow.extractDir] 是书目录绝对路径，[EpubBookRow.epubPath] 是目录内的主文件
+/// （EPUB 的 `.epub`、PDF 的 `kPdfFileName`、漫画的 `manga.json`）。因此这里不按
+/// `format` 分叉——三种书取路径是同一件事。
+///
+/// 少数历史行 / 数据根迁移过的行把 `epubPath` 写成绝对路径。不必为此加分支：
+/// [p.join] 的契约就是后段为绝对路径时丢弃前段，两种形态自然收敛到同一条语句。
+String bookMainFilePath(EpubBookRow row) =>
+    p.join(row.extractDir, row.epubPath);
+
+/// 在系统文件管理器里定位这本书：优先选中主文件本身（漫画即直接选中 `manga.json`，
+/// 用户要手改 mokuro 数据时省掉一层目录），主文件不在了再退回打开书目录。
+///
+/// [reveal] 只为测试注入。返回 false = 两个目标都打不开（移动端无契约、书目录已被
+/// 删除、或文件管理器启动失败），调用方必须提示而不是静默。
+Future<bool> revealBookLocation(
+  EpubBookRow row, {
+  Future<bool> Function(String path) reveal = revealInFileManager,
+}) async {
+  final String mainFile = bookMainFilePath(row);
+  if (await reveal(mainFile)) return true;
+  if (mainFile == row.extractDir) return false;
+  return reveal(row.extractDir);
+}

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -11,6 +11,7 @@ import 'package:transparent_image/transparent_image.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/pages.dart';
 import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi/src/epub/book_file_location.dart';
 import 'package:fushi/src/epub/epub_importer.dart';
 import 'package:fushi/src/media/audiobook/audiobook_import_dialog.dart';
 import 'package:fushi/src/media/audiobook/srt_book_reimport_dialog.dart';
@@ -65,6 +66,7 @@ import 'package:fushi/src/media/selection/selection_gestures.dart';
 import 'package:fushi/src/media/collections/collection_shelf_row.dart';
 import 'package:fushi/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:fushi/src/pages/implementations/series_shelf_card.dart';
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
 import 'package:fushi/src/utils/misc/shelf_ordering.dart';
 import 'package:fushi/src/profile/profile_repository.dart';
 import 'package:fushi/src/profile/profile_view_model.dart';
@@ -2188,6 +2190,15 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
         icon: Icons.headphones_outlined,
         onPressed: () => _openAudiobookImport(item, bookKey),
       ),
+      // 桌面才有文件管理器契约（[currentRevealHost] 在移动端返回 null）——整条隐藏，
+      // 而不是画一个点了没反应的按钮。漫画卷要手改 mokuro 数据时，这一条直接把书目录
+      // 里的 manga.json 选中，省掉「书在哪个 bookKey 目录」这层猜。
+      if (currentRevealHost() != null)
+        DialogListAction(
+          label: t.book_file_location_open,
+          icon: Icons.folder_open_outlined,
+          onPressed: () => _openBookFileLocation(bookKey),
+        ),
       DialogListAction(
         label: _completedBookKeys.contains(bookKey)
             ? t.book_mark_uncompleted_action
@@ -2461,6 +2472,22 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 不必为了画一行菜单再去读一次库。
   bool _isMangaItem(MediaItem item) =>
       item.mediaSourceIdentifier == MangaFushiSource.kUniqueKey;
+
+  /// 在系统文件管理器里定位这本书的磁盘文件（EPUB / PDF / 漫画同一条路径）。
+  ///
+  /// 与 [_convertBookFormat] 同款：读行 + 探磁盘都放在**点击后**，塞进菜单 build 会让
+  /// 书架每次重绘都吃一遍 IO。定位不到（书目录已被外部删除、文件管理器起不来）时给
+  /// 一句提示，不静默——静默的「打开文件位置」和坏掉的按钮无法区分。
+  Future<void> _openBookFileLocation(String bookKey) async {
+    Navigator.pop(context);
+    final EpubBookRow? row = await appModel.database.getEpubBook(bookKey);
+    final bool revealed = row != null && await revealBookLocation(row);
+    if (revealed || !mounted) return;
+    FushiToast.show(
+      msg: t.book_file_location_failed,
+      severity: ToastSeverity.error,
+    );
+  }
 
   /// 单卡「书 ↔ 漫画」转化：重建目标格式的磁盘产物，再把 `EpubBooks` 行指过去。
   ///

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,12 +9,12 @@ import 'package:fushi_core/fushi_core.dart'
         VideoDownloadJobLifecycle,
         VideoDownloadJobRow,
         VideoDownloadJobStage;
-import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/src/media/torrent/torrent_backend.dart';
 import 'package:fushi/src/media/torrent/torrent_task_display.dart';
 import 'package:fushi/src/media/video/download/video_download_error_presentation.dart';
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
 import 'package:fushi/utils.dart';
 
 typedef VideoDownloadJobAction = Future<void> Function(
@@ -152,7 +151,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
     this.onSetPriority,
     this.locationLoader,
     this.onDelete,
-    this.pathRevealer = revealVideoDownloadPath,
+    this.pathRevealer = revealInFileManager,
     this.metricsLoader,
     this.selectedSizeLoader,
     this.lifecycleLabel,
@@ -169,7 +168,7 @@ class VideoDownloadJobsPanel extends StatefulWidget {
     VideoDownloadJobPriorityAction? onSetPriority,
     VideoDownloadJobLocationLoader? locationLoader,
     VideoDownloadJobDeleteAction? onDelete,
-    VideoDownloadPathRevealer pathRevealer = revealVideoDownloadPath,
+    VideoDownloadPathRevealer pathRevealer = revealInFileManager,
     VideoDownloadJobMetricsLoader? metricsLoader,
     VideoDownloadJobSelectedSizeLoader? selectedSizeLoader,
     String Function(String lifecycle)? lifecycleLabel,
@@ -490,7 +489,7 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
         // Mobile has no file-manager reveal contract; the action would
         // always fail, so it is not offered there.
         onOpenLocation: widget.locationLoader == null ||
-                currentVideoDownloadRevealHost() == null
+                currentRevealHost() == null
             ? null
             : () => _openLocation(job),
         onDelete: widget.onDelete == null ? null : () => _confirmDelete(job),
@@ -1098,119 +1097,6 @@ class _VideoDownloadJobCard extends StatelessWidget {
         VideoDownloadJobLifecycle.cancelled => Icons.block,
         _ => Icons.downloading_outlined,
       };
-}
-
-/// Desktop hosts that have a file manager to reveal a task path in.
-enum VideoDownloadRevealHost { windows, macos, linux }
-
-/// The reveal host of the running platform, or null on mobile where no file
-/// manager contract exists and the surface must not offer the action at all.
-VideoDownloadRevealHost? currentVideoDownloadRevealHost() {
-  if (Platform.isWindows) return VideoDownloadRevealHost.windows;
-  if (Platform.isMacOS) return VideoDownloadRevealHost.macos;
-  if (Platform.isLinux) return VideoDownloadRevealHost.linux;
-  return null;
-}
-
-/// A resolved file-manager invocation plus whether its exit code means
-/// anything. See [videoDownloadRevealCommand].
-class VideoDownloadRevealCommand {
-  const VideoDownloadRevealCommand({
-    required this.executable,
-    required this.arguments,
-    required this.exitCodeIsMeaningful,
-  });
-
-  final String executable;
-  final List<String> arguments;
-
-  /// False when the process reports a status that is unrelated to success, so
-  /// spawning it at all is the only signal available.
-  final bool exitCodeIsMeaningful;
-}
-
-/// Builds the file-manager invocation for [host].
-///
-/// Windows specifics, measured on Windows 11 by launching each form and
-/// reading back the opened window through `Shell.Application`:
-/// * `explorer.exe` exits with 1 on every form, including the ones that open
-///   and select correctly, so its exit code carries no success signal.
-/// * `/select,` and the path must stay two separate argv entries. Dart quotes
-///   any argument containing a space, so joining them into `/select,<path>`
-///   yields the command line `explorer "/select,C:\dir\file.mkv"`, which
-///   explorer answers by opening Documents instead - 3/3 runs, with and
-///   without spaces in the path. The split form selected the file in every
-///   run.
-VideoDownloadRevealCommand videoDownloadRevealCommand({
-  required VideoDownloadRevealHost host,
-  required String path,
-  required bool isDirectory,
-}) {
-  switch (host) {
-    case VideoDownloadRevealHost.windows:
-      final String windowsPath = p.normalize(path).replaceAll('/', r'\');
-      return VideoDownloadRevealCommand(
-        executable: 'explorer',
-        arguments: isDirectory
-            ? <String>[windowsPath]
-            : <String>['/select,', windowsPath],
-        exitCodeIsMeaningful: false,
-      );
-    case VideoDownloadRevealHost.macos:
-      return VideoDownloadRevealCommand(
-        executable: 'open',
-        arguments: isDirectory ? <String>[path] : <String>['-R', path],
-        exitCodeIsMeaningful: true,
-      );
-    case VideoDownloadRevealHost.linux:
-      return VideoDownloadRevealCommand(
-        executable: 'xdg-open',
-        arguments: <String>[isDirectory ? path : p.dirname(path)],
-        exitCodeIsMeaningful: true,
-      );
-  }
-}
-
-/// Opens a task path in the platform file manager. Files are selected when the
-/// platform supports it; directories are opened directly.
-Future<bool> revealVideoDownloadPath(String path) => revealVideoDownloadPathOn(
-      path,
-      host: currentVideoDownloadRevealHost(),
-      typeOf: (String value) =>
-          FileSystemEntity.type(value, followLinks: false),
-      run: Process.run,
-    );
-
-/// Injectable core of [revealVideoDownloadPath] so the per-host argv shape and
-/// the exit-code policy stay testable without a real file manager.
-@visibleForTesting
-Future<bool> revealVideoDownloadPathOn(
-  String path, {
-  required VideoDownloadRevealHost? host,
-  required Future<FileSystemEntityType> Function(String path) typeOf,
-  required Future<ProcessResult> Function(
-    String executable,
-    List<String> arguments,
-  ) run,
-}) async {
-  if (host == null) return false;
-  final FileSystemEntityType type = await typeOf(path);
-  if (type == FileSystemEntityType.notFound) return false;
-  final VideoDownloadRevealCommand command = videoDownloadRevealCommand(
-    host: host,
-    path: path,
-    isDirectory: type == FileSystemEntityType.directory,
-  );
-  try {
-    final ProcessResult result = await run(
-      command.executable,
-      command.arguments,
-    );
-    if (!command.exitCodeIsMeaningful) return true;
-    return result.exitCode == 0;
-  } on Object {
-    return false;
-  }
 }
 
 class _TaskMetrics extends StatelessWidget {

--- a/fushi/lib/src/utils/misc/reveal_in_file_manager.dart
+++ b/fushi/lib/src/utils/misc/reveal_in_file_manager.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:path/path.dart' as p;
+
+/// 在系统文件管理器里定位一条本地路径的唯一原语（三桌面端）。
+///
+/// 归属：这套 argv 形状原本长在视频下载面板里（`videoDownloadReveal*`），但它和视频
+/// 下载没有任何关系——是纯粹的「路径 → 文件管理器」平台边界。书架的「打开文件位置」
+/// 需要同一行为，与其复制第二份 explorer 调用（仓库里已经因此踩过 BUG-920 那种正/反
+/// 斜杠坑），不如把原语搬到中立位置、两个调用方共用。
+///
+/// 契约：能选中就选中文件本身、否则打开其所在目录；移动端**没有**文件管理器契约，
+/// [currentRevealHost] 返回 null，调用方据此整条隐藏入口，而不是画一个点了没反应的
+/// 按钮。
+enum RevealHost { windows, macos, linux }
+
+/// 当前平台的文件管理器宿主；移动端返回 null（无契约，入口必须隐藏）。
+RevealHost? currentRevealHost() {
+  if (Platform.isWindows) return RevealHost.windows;
+  if (Platform.isMacOS) return RevealHost.macos;
+  if (Platform.isLinux) return RevealHost.linux;
+  return null;
+}
+
+/// 一条已解析的文件管理器调用，外加「它的退出码是否有意义」。见 [revealCommand]。
+class RevealCommand {
+  /// 用可执行文件 [executable]、参数 [arguments] 和退出码语义
+  /// [exitCodeIsMeaningful] 构造。
+  const RevealCommand({
+    required this.executable,
+    required this.arguments,
+    required this.exitCodeIsMeaningful,
+  });
+
+  /// 要启动的可执行文件（`explorer` / `open` / `xdg-open`）。
+  final String executable;
+
+  /// 传给它的 argv；顺序与拆分方式本身就是契约的一部分，见 [revealCommand]。
+  final List<String> arguments;
+
+  /// false = 该进程报的状态与成功无关，能把它启动起来就是唯一可得的信号。
+  final bool exitCodeIsMeaningful;
+}
+
+/// 为 [host] 构造文件管理器调用。
+///
+/// Windows specifics, measured on Windows 11 by launching each form and
+/// reading back the opened window through `Shell.Application`:
+/// * `explorer.exe` exits with 1 on every form, including the ones that open
+///   and select correctly, so its exit code carries no success signal.
+/// * `/select,` and the path must stay two separate argv entries. Dart quotes
+///   any argument containing a space, so joining them into `/select,<path>`
+///   yields the command line `explorer "/select,C:\dir\file.mkv"`, which
+///   explorer answers by opening Documents instead - 3/3 runs, with and
+///   without spaces in the path. The split form selected the file in every
+///   run.
+RevealCommand revealCommand({
+  required RevealHost host,
+  required String path,
+  required bool isDirectory,
+}) {
+  switch (host) {
+    case RevealHost.windows:
+      final String windowsPath = p.normalize(path).replaceAll('/', r'\');
+      return RevealCommand(
+        executable: 'explorer',
+        arguments: isDirectory
+            ? <String>[windowsPath]
+            : <String>['/select,', windowsPath],
+        exitCodeIsMeaningful: false,
+      );
+    case RevealHost.macos:
+      return RevealCommand(
+        executable: 'open',
+        arguments: isDirectory ? <String>[path] : <String>['-R', path],
+        exitCodeIsMeaningful: true,
+      );
+    case RevealHost.linux:
+      return RevealCommand(
+        executable: 'xdg-open',
+        arguments: <String>[isDirectory ? path : p.dirname(path)],
+        exitCodeIsMeaningful: true,
+      );
+  }
+}
+
+/// 在系统文件管理器里打开 [path]：支持选中的平台选中文件本身，目录则直接打开。
+///
+/// 返回 false = 平台无文件管理器契约、路径已不存在，或启动失败——调用方据此提示，
+/// 不要吞掉。
+Future<bool> revealInFileManager(String path) => revealInFileManagerOn(
+      path,
+      host: currentRevealHost(),
+      typeOf: (String value) =>
+          FileSystemEntity.type(value, followLinks: false),
+      run: Process.run,
+    );
+
+/// [revealInFileManager] 的可注入内核：让 per-host 的 argv 形状与退出码策略脱离真实
+/// 文件管理器可测。
+@visibleForTesting
+Future<bool> revealInFileManagerOn(
+  String path, {
+  required RevealHost? host,
+  required Future<FileSystemEntityType> Function(String path) typeOf,
+  required Future<ProcessResult> Function(
+    String executable,
+    List<String> arguments,
+  ) run,
+}) async {
+  if (host == null) return false;
+  final FileSystemEntityType type = await typeOf(path);
+  if (type == FileSystemEntityType.notFound) return false;
+  final RevealCommand command = revealCommand(
+    host: host,
+    path: path,
+    isDirectory: type == FileSystemEntityType.directory,
+  );
+  try {
+    final ProcessResult result = await run(
+      command.executable,
+      command.arguments,
+    );
+    if (!command.exitCodeIsMeaningful) return true;
+    return result.exitCode == 0;
+  } on Object {
+    return false;
+  }
+}

--- a/fushi/test/epub/book_file_location_test.dart
+++ b/fushi/test/epub/book_file_location_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/epub/book_file_location.dart';
+
+/// 书架「打开文件位置」的路径决策。
+///
+/// 这里守的是两件容易悄悄坏掉的事：
+/// * EPUB / PDF / 漫画三种书身份取磁盘路径**是同一件事**（同一张表、同样两列），
+///   一旦有人给某一种加 `format` 分支，本文件的三条同构断言会同时变得可疑。
+/// * `epubPath` 存量里有「书目录内文件名」和「绝对路径」两种形态。无条件 join 会
+///   把后者拼成一条谁都打不开的字符串；这条退化路径没有 UI 报错，只会表现成
+///   「点了打开文件位置，资源管理器开在别处」。
+Future<FushiDatabase> _openDb() async {
+  final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+Future<EpubBookRow> _seedBook({
+  required String bookKey,
+  required String epubPath,
+  required String extractDir,
+  required String format,
+}) async {
+  final FushiDatabase db = await _openDb();
+  await db.insertEpubBook(
+    EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: bookKey,
+      epubPath: epubPath,
+      extractDir: extractDir,
+      chapterCount: 1,
+      chaptersJson: '[]',
+      importedAt: 1700000000000,
+      format: Value<String>(format),
+    ),
+  );
+  return (await db.getEpubBook(bookKey))!;
+}
+
+void main() {
+  group('bookMainFilePath', () {
+    test('漫画卷指向书目录里的 manga.json', () async {
+      final EpubBookRow row = await _seedBook(
+        bookKey: 'Volume 01',
+        epubPath: 'manga.json',
+        extractDir: '/books/Volume 01',
+        format: 'manga',
+      );
+
+      final String path = bookMainFilePath(row);
+
+      expect(p.basename(path), 'manga.json',
+          reason: '用户手改 mokuro 数据要的就是这个文件被选中');
+      expect(p.equals(p.dirname(path), '/books/Volume 01'), isTrue);
+    });
+
+    test('EPUB 与 PDF 走同一条语句，不按 format 分叉', () async {
+      final EpubBookRow epub = await _seedBook(
+        bookKey: 'Novel',
+        epubPath: 'novel.epub',
+        extractDir: '/books/Novel',
+        format: 'epub',
+      );
+      final EpubBookRow pdf = await _seedBook(
+        bookKey: 'Paper',
+        epubPath: 'book.pdf',
+        extractDir: '/books/Paper',
+        format: 'pdf',
+      );
+
+      expect(p.equals(bookMainFilePath(epub), '/books/Novel/novel.epub'),
+          isTrue);
+      expect(p.equals(bookMainFilePath(pdf), '/books/Paper/book.pdf'), isTrue);
+    });
+
+    // `/…` 开头在 windows 与 posix 两种 path context 下都算 rooted，故这条断言在
+    // 本机 Windows 与 CI Linux 上是同一个判据。
+    test('绝对 epubPath 原样返回，不被拼到书目录后面', () async {
+      final EpubBookRow row = await _seedBook(
+        bookKey: 'External',
+        epubPath: '/elsewhere/original.epub',
+        extractDir: '/books/External',
+        format: 'epub',
+      );
+
+      expect(p.equals(bookMainFilePath(row), '/elsewhere/original.epub'),
+          isTrue);
+    });
+  });
+
+  group('revealBookLocation', () {
+    Future<EpubBookRow> mangaRow() => _seedBook(
+          bookKey: 'Volume 02',
+          epubPath: 'manga.json',
+          extractDir: '/books/Volume 02',
+          format: 'manga',
+        );
+
+    test('主文件在就只定位主文件，不退回目录', () async {
+      final EpubBookRow row = await mangaRow();
+      final List<String> targets = <String>[];
+
+      final bool revealed = await revealBookLocation(
+        row,
+        reveal: (String path) async {
+          targets.add(path);
+          return true;
+        },
+      );
+
+      expect(revealed, isTrue);
+      expect(targets, hasLength(1));
+      expect(p.basename(targets.single), 'manga.json');
+    });
+
+    test('主文件没了退回打开书目录', () async {
+      final EpubBookRow row = await mangaRow();
+      final List<String> targets = <String>[];
+
+      final bool revealed = await revealBookLocation(
+        row,
+        reveal: (String path) async {
+          targets.add(path);
+          return p.basename(path) != 'manga.json';
+        },
+      );
+
+      expect(revealed, isTrue);
+      expect(targets, hasLength(2));
+      expect(p.equals(targets.last, '/books/Volume 02'), isTrue);
+    });
+
+    test('两个目标都打不开时报失败，调用方必须提示', () async {
+      final EpubBookRow row = await mangaRow();
+
+      expect(
+        await revealBookLocation(row, reveal: (String _) async => false),
+        isFalse,
+      );
+    });
+
+    test('主文件路径退化成书目录本身时不重复调用', () async {
+      final EpubBookRow row = await _seedBook(
+        bookKey: 'Degenerate',
+        epubPath: '',
+        extractDir: '/books/Degenerate',
+        format: 'epub',
+      );
+      int calls = 0;
+
+      final bool revealed = await revealBookLocation(
+        row,
+        reveal: (String _) async {
+          calls++;
+          return false;
+        },
+      );
+
+      expect(revealed, isFalse);
+      expect(calls, 1);
+    });
+  });
+}

--- a/fushi/test/pages/reader_shelf_open_file_location_guard_test.dart
+++ b/fushi/test/pages/reader_shelf_open_file_location_guard_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 书架书卡「打开文件位置」的接线守卫。
+///
+/// 这条动作只在有文件管理器契约的桌面端成立。门控一旦被删，移动端会多出一个点了
+/// 必然失败的菜单项——它不会让任何测试变红，只会让用户点了以为坏了，所以判据放在
+/// 源码层：门控表达式必须**紧挨着**这条动作本身，而不是文件里某处出现过。
+void main() {
+  final String source =
+      File('lib/src/pages/implementations/reader_fushi_history_page.dart')
+          .readAsStringSync();
+
+  test('「打开文件位置」被 currentRevealHost 门控', () {
+    // \s 覆盖 \r\n，故本判据在 CRLF 与 LF 两种 checkout 下同样成立。
+    expect(
+      RegExp(r'currentRevealHost\(\)\s*!=\s*null\s*\)\s*DialogListAction\('
+              r'\s*label:\s*t\.book_file_location_open')
+          .hasMatch(source),
+      isTrue,
+      reason: '门控必须直接包住这条动作，移动端不得出现点了必失败的菜单项',
+    );
+  });
+
+  test('定位走共享的书路径原语，不在页面里另拼一份路径', () {
+    expect(source, contains('revealBookLocation('));
+    // 页面里自己 join extractDir/epubPath = 又一份会和 [bookMainFilePath] 漂移的
+    // 路径逻辑；三种书身份取路径只允许有一处实现。
+    expect(source.contains('.extractDir, '), isFalse,
+        reason: '书主文件路径只能由 bookMainFilePath 决定');
+  });
+}

--- a/fushi/test/pages/video_download_jobs_panel_test.dart
+++ b/fushi/test/pages/video_download_jobs_panel_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -94,107 +93,6 @@ Future<void> _pumpPanel(
 }
 
 void main() {
-  group('reveal command', () {
-    test('windows keeps /select, and the path as separate arguments', () {
-      final VideoDownloadRevealCommand command = videoDownloadRevealCommand(
-        host: VideoDownloadRevealHost.windows,
-        path: r'D:\media\Show S01E01.mkv',
-        isDirectory: false,
-      );
-
-      expect(command.executable, 'explorer');
-      // Measured on Windows 11: joining these into one argument makes Dart
-      // quote it ("/select,D:\media\Show S01E01.mkv") and explorer answers by
-      // opening Documents. Split, it selects the file every time.
-      expect(
-          command.arguments, <String>['/select,', r'D:\media\Show S01E01.mkv']);
-    });
-
-    test('windows explorer exit codes carry no success signal', () {
-      expect(
-        videoDownloadRevealCommand(
-          host: VideoDownloadRevealHost.windows,
-          path: r'D:\media\Show S01E01.mkv',
-          isDirectory: false,
-        ).exitCodeIsMeaningful,
-        isFalse,
-      );
-      expect(
-        videoDownloadRevealCommand(
-          host: VideoDownloadRevealHost.macos,
-          path: '/media/Show S01E01.mkv',
-          isDirectory: false,
-        ).exitCodeIsMeaningful,
-        isTrue,
-      );
-    });
-
-    test('windows reveal succeeds although explorer.exe exits with 1',
-        () async {
-      String? executable;
-      List<String>? arguments;
-      final bool revealed = await revealVideoDownloadPathOn(
-        r'D:\media\Show S01E01.mkv',
-        host: VideoDownloadRevealHost.windows,
-        typeOf: (String _) async => FileSystemEntityType.file,
-        run: (String value, List<String> args) async {
-          executable = value;
-          arguments = args;
-          // explorer.exe returns 1 even when it opened and selected the file.
-          return ProcessResult(0, 1, '', '');
-        },
-      );
-
-      expect(revealed, isTrue);
-      expect(executable, 'explorer');
-      expect(arguments, <String>['/select,', r'D:\media\Show S01E01.mkv']);
-    });
-
-    test('a failing exit code still fails where it means something', () async {
-      expect(
-        await revealVideoDownloadPathOn(
-          '/media/Show S01E01.mkv',
-          host: VideoDownloadRevealHost.macos,
-          typeOf: (String _) async => FileSystemEntityType.file,
-          run: (String _, List<String> __) async => ProcessResult(0, 1, '', ''),
-        ),
-        isFalse,
-      );
-    });
-
-    test('a host without a file manager never spawns anything', () async {
-      bool spawned = false;
-      final bool revealed = await revealVideoDownloadPathOn(
-        '/storage/emulated/0/Show S01E01.mkv',
-        host: null,
-        typeOf: (String _) async => FileSystemEntityType.file,
-        run: (String _, List<String> __) async {
-          spawned = true;
-          return ProcessResult(0, 0, '', '');
-        },
-      );
-
-      expect(revealed, isFalse);
-      expect(spawned, isFalse);
-    });
-
-    test('a missing path never spawns anything', () async {
-      bool spawned = false;
-      final bool revealed = await revealVideoDownloadPathOn(
-        r'D:\media\gone.mkv',
-        host: VideoDownloadRevealHost.windows,
-        typeOf: (String _) async => FileSystemEntityType.notFound,
-        run: (String _, List<String> __) async {
-          spawned = true;
-          return ProcessResult(0, 0, '', '');
-        },
-      );
-
-      expect(revealed, isFalse);
-      expect(spawned, isFalse);
-    });
-  });
-
   setUp(() => LocaleSettings.setLocale(AppLocale.en));
 
   test('classifyVideoDownloadError maps common pipeline diagnostics', () {

--- a/fushi/test/utils/reveal_in_file_manager_test.dart
+++ b/fushi/test/utils/reveal_in_file_manager_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
+
+/// 文件管理器 reveal 原语的 per-host argv 形状与退出码策略。
+///
+/// 这些用例原本挂在视频下载面板的测试里；原语搬到 `utils/misc` 后随之搬家——书架
+/// 「打开文件位置」与下载面板现在共用同一份实现，argv 形状只有这一处需要守住。
+void main() {
+  group('reveal command', () {
+    test('windows keeps /select, and the path as separate arguments', () {
+      final RevealCommand command = revealCommand(
+        host: RevealHost.windows,
+        path: r'D:\media\Show S01E01.mkv',
+        isDirectory: false,
+      );
+
+      expect(command.executable, 'explorer');
+      // Measured on Windows 11: joining these into one argument makes Dart
+      // quote it ("/select,D:\media\Show S01E01.mkv") and explorer answers by
+      // opening Documents. Split, it selects the file every time.
+      expect(
+          command.arguments, <String>['/select,', r'D:\media\Show S01E01.mkv']);
+    });
+
+    test('windows explorer exit codes carry no success signal', () {
+      expect(
+        revealCommand(
+          host: RevealHost.windows,
+          path: r'D:\media\Show S01E01.mkv',
+          isDirectory: false,
+        ).exitCodeIsMeaningful,
+        isFalse,
+      );
+      expect(
+        revealCommand(
+          host: RevealHost.macos,
+          path: '/media/Show S01E01.mkv',
+          isDirectory: false,
+        ).exitCodeIsMeaningful,
+        isTrue,
+      );
+    });
+
+    test('windows reveal succeeds although explorer.exe exits with 1',
+        () async {
+      String? executable;
+      List<String>? arguments;
+      final bool revealed = await revealInFileManagerOn(
+        r'D:\media\Show S01E01.mkv',
+        host: RevealHost.windows,
+        typeOf: (String _) async => FileSystemEntityType.file,
+        run: (String value, List<String> args) async {
+          executable = value;
+          arguments = args;
+          // explorer.exe returns 1 even when it opened and selected the file.
+          return ProcessResult(0, 1, '', '');
+        },
+      );
+
+      expect(revealed, isTrue);
+      expect(executable, 'explorer');
+      expect(arguments, <String>['/select,', r'D:\media\Show S01E01.mkv']);
+    });
+
+    test('a failing exit code still fails where it means something', () async {
+      expect(
+        await revealInFileManagerOn(
+          '/media/Show S01E01.mkv',
+          host: RevealHost.macos,
+          typeOf: (String _) async => FileSystemEntityType.file,
+          run: (String _, List<String> __) async => ProcessResult(0, 1, '', ''),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a host without a file manager never spawns anything', () async {
+      bool spawned = false;
+      final bool revealed = await revealInFileManagerOn(
+        '/storage/emulated/0/Show S01E01.mkv',
+        host: null,
+        typeOf: (String _) async => FileSystemEntityType.file,
+        run: (String _, List<String> __) async {
+          spawned = true;
+          return ProcessResult(0, 0, '', '');
+        },
+      );
+
+      expect(revealed, isFalse);
+      expect(spawned, isFalse);
+    });
+
+    test('a missing path never spawns anything', () async {
+      bool spawned = false;
+      final bool revealed = await revealInFileManagerOn(
+        r'D:\media\gone.mkv',
+        host: RevealHost.windows,
+        typeOf: (String _) async => FileSystemEntityType.notFound,
+        run: (String _, List<String> __) async {
+          spawned = true;
+          return ProcessResult(0, 0, '', '');
+        },
+      );
+
+      expect(revealed, isFalse);
+      expect(spawned, isFalse);
+    });
+  });
+
+}


### PR DESCRIPTION
## 起因

用户要求：能在硬盘上打开已下载漫画卷的文件位置——他手改过 mokuro 数据，下次再改时不想先猜「这卷落在哪个 bookKey 目录」。

## 改了什么

**书架书卡长按/右键菜单新增「打开文件位置」。** EPUB / PDF / 漫画是同一张 `EpubBooks` 表的三种书身份，漫画库的书架就是同一个页面，所以一处接线三种书一起生效。

行为：优先在系统文件管理器里**选中书目录内的主文件**（漫画卷即 `manga.json`，正是要手改的那个），主文件已被外部删除时退回打开书目录，两者都打不开给一句 toast 而不是静默——静默的「打开文件位置」和坏掉的按钮无法区分。

动作只在有文件管理器契约的桌面端出现（`currentRevealHost()` 移动端返回 null），移动端整条隐藏，而不是画一个点了必失败的按钮。

**顺带把 reveal 原语收成共享实现。** 三平台调用（Windows `explorer /select,`、macOS `open -R`、Linux `xdg-open`）原本长在 `video_download_jobs_panel.dart` 里、名字带 `VideoDownload`，但它和视频下载没有关系——是纯粹的「路径 → 文件管理器」平台边界，其中「`/select,` 与路径必须是两个 argv」是实测踩出来的契约。与其为书架复制第二份 explorer 调用（仓库已经因此有过 BUG-920 的正反斜杠坑），把它搬到 `utils/misc/reveal_in_file_manager.dart`，两个调用方共用，面板侧净删 122 行。

**书主文件路径单点决定**（`epub/book_file_location.dart`）：`extractDir` + `epubPath` 两列语义在三种书身份下完全一致，故不按 `format` 分叉；`epubPath` 存量里的绝对路径形态靠 `p.join` 自身契约收敛，不加分支。

## 测试

- `test/epub/book_file_location_test.dart`：路径决策（三身份同构、绝对路径不被拼歪）与 reveal 退回顺序，用内存库造真行。
- `test/utils/reveal_in_file_manager_test.dart`：per-host argv 形状与退出码策略（随原语从面板测试搬家）。
- `test/pages/reader_shelf_open_file_location_guard_test.dart`：书架接线守卫，**已做变异实测**——删掉桌面门控即红，还原后源文件 sha256 与变异前一致。
- 本地全量 20796 条通过。唯一失败是并发下 `flutter_tester` IPC 崩溃导致的 suite 装载失败（`video_cover_extractor_test`，与本 PR 无关），单独重跑 7 条全绿。
- `flutter analyze`（含 test 目录）零问题。

## 未做

真机点击验证没做——本 PR 的行为判据全部落在可自动化的层（路径决策 + argv 形状 + 接线门控），资源管理器窗口本身没有可断言的产物。

https://claude.ai/code/session_01HH2BrZn4VfDr5ULTF6LSEt
