### PR TITLE
fix(video): Esc/返回键先逐级关前台浮层再退出（BUG-1862）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1730 条。点号进各自文件。
+> 共 1731 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1862](bugs/BUG-1862-video-esc-skips-overlay-dismiss.md) | ✅ | ✅ | 视频页 Esc/返回键在侧栏等前台浮层打开时直接退出页面，未逐级关闭 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |
 | [BUG-1850](bugs/BUG-1850-settings-destination-itest-vacuous-selected-row.md) | ✅ | ✅ | 集成测试用恒真的选中行谓词当设置分类打开判据 |

--- a/docs/bugs/BUG-1862-video-esc-skips-overlay-dismiss.md
+++ b/docs/bugs/BUG-1862-video-esc-skips-overlay-dismiss.md
@@ -1,0 +1,28 @@
+## BUG-1862 · 视频页 Esc/返回键在侧栏等前台浮层打开时直接退出页面，未逐级关闭
+- **报告**：2026-08-25（用户：截图为视频页右侧「视频设置」抽屉打开在字幕 tab，诉求「esc 应该先关闭侧栏等前台弹窗再退出」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/video_fushi_page.dart:4456`（旧 `_handleBackOrExit`：只关词典浮层，其余一律直接 pop 路由）+ `fushi/lib/src/pages/implementations/video_fushi/layout.part.dart:469`（侧栏 overlay 挂在 media_kit controls 的**兄弟**位置，不在其快捷键表作用域内）。
+
+  **两条互相独立的缺陷叠在一起：**
+
+  ① **层级表被抄成两份，其中一份只有一层。** 逐级退出（编辑态 → 字幕跳转列表 → 剧集列表 → 侧栏 → 沉浸锁 → 退全屏 → 退页）只写在 `escape:` 快捷键回调里；`_handleBackOrExit`（`PopScope` / Android 系统返回键 / 手柄 B 的落点）只关词典浮层，之后直接 `nav.pop()`。方法头注释写着「[PopScope] 与 Escape 快捷键共用，保证两条退出路径行为一致」——**这句话是假的**。
+
+  ② **快捷键表够不着自家 overlay。** 视频页的整表快捷键经 media_kit 的 `MaterialDesktopVideoControlsThemeData.keyboardShortcuts` 安装，那层 `CallbackShortcuts` 只包住 media_kit **自己的 controls 子树**（`third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart:651`）。而设置 / 速度 / 章节侧栏、side rail、控制按钮 popover、布局编辑层都是 `_buildVideoControls` 那个 `Stack` 里与 controls **平级的兄弟节点**；侧栏一打开，`PanelFocusScope` 就把键盘焦点领进侧栏子树。
+
+  **合起来就是用户看到的现象**：焦点在侧栏 → Esc 的冒泡路径不经过 media_kit 那张表 → 一路走到全局 `_handleGlobalBack`（`shortcuts/global_navigation.dart:222`）→ `nav.maybePop()` → 视频页 `PopScope(canPop: false)` → `_handleBackOrExit()` → 没有词典浮层 → **pop 掉整个视频页，侧栏还开着**。Android 系统返回键、手柄 B 走同一条 `PopScope` 路径，无论焦点在哪都复现同样症状。
+
+- **[x] ① 已修复** — 分两步做根因修复，不加特例分支：
+  1. **层级顺序收敛成单点真相源**：新增纯函数 `topVideoForegroundLayer`（`fushi/lib/src/media/video/video_foreground_layers.dart`）+ 枚举 `VideoForegroundLayer`（声明顺序即视觉层序）；页面 `_dismissTopForegroundLayer()` 只做「读状态 → 查表 → 执行关闭动作 → 返回是否关掉了一层」。`_handleBackOrExit` 与 `escape:` 回调都先问它，注释里承诺的「两条路径一致」这才成真，Android 返回键 / 手柄 B 一并修好。
+  2. **补上快捷键表够不着的那半**：`_wrapVideoControlsBackKey`（`layout.part.dart`）包在 controls builder 最外层——它是那些 overlay 的共同祖先，且窗口与全屏复用同一 builder，两种场景一并覆盖。只在**真的关掉了一层**时消费按键，否则返回 `KeyEventResult.ignored` 原样放行，不改写退全屏 / 退页语义、不吞其它按键；不夺焦、不进 Tab 遍历；文本框持焦时关闭物理键回退（与 `_handleGlobalBack` 同款判据，避免 IME 打字误触，TODO-847）。
+
+  提交：见本分支 `worktree-video-esc-dismiss-overlays`。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/media/video/video_foreground_layers_test.dart`（6 条）：层序规则本身。含「六层全开反复按返回，按视觉层序一层层剥到底、不重复不跳过」与「两两比对：更靠前的枚举值就是更前台的层」。
+  - `fushi/test/media/video/video_escape_dismiss_guard_test.dart`（6 条）：接线守卫。锁住「`_handleBackOrExit` 先问层级表再 pop」「escape 回调不许再抄一份 if 链」「controls builder 外层包着兜底层」「兜底层只在真关掉一层时消费按键」。源码读取统一 CRLF 归一化，避免换行风格一变整套守卫静默空转。
+  - 变异实测 6 轮全部被抓到（含一轮**先没抓到**：兜底层「无条件返回 handled」——那会把 Esc 整个吞掉、视频页再也退不出去；据此把断言从「出现过 ignored」加强成「消费与否必须由层级表返回值门控 + 不许出现裸 `return KeyEventResult.handled;`」）。
+  - 四条既有守卫（`video_player_keyboard_static_test.dart` / `video_immersive_lock_guard_test.dart` / `video_subtitle_jump_list_guard_test.dart` / `dictionary_child_popup_close_guard_test.dart`）原本锚在「escape 回调体里必须有某个 if 分支」这种实现位置上，层级表搬家后失配。已改成锚定新的单点层级表，断言的行为一条没减（编辑态 / 沉浸锁 / 字幕列表比侧栏更前台 / back 仍逐层退回而非清整栈）。
+
+- **备注**：
+  - **验证**：`flutter analyze` 全量（含 test 目录）零问题；`flutter test test/media/video/ test/focus/ test/shortcuts/ test/pages/` 共 **6444 条全绿**（9 skipped）。
+  - **未覆盖的缺口（真机）**：本轮只有静态与纯函数层验证，没有在真机 / 离屏跑「开侧栏 → 按 Esc → 侧栏关、页面还在」的端到端复现。窗口模式那条链路（全局 back → `PopScope` → 层级表）逻辑上闭合；全屏模式下焦点在侧栏时 Esc 由新加的 controls 兜底层接住，也未真机复测。
+  - **相邻行为的有意取舍**：全屏分支（`isFullscreen → _exitVideoFullscreen`）**没有**并进 `_handleBackOrExit`。它同时被顶栏返回按钮、加载中 / 加载失败页的返回按钮调用，点「返回」箭头的语义是明确退出这个页面，不该变成「先退全屏」；而 `PopScope` 路径在全屏时根本轮不到（全屏是推到根 navigator 的独立路由，框架先 pop 它）。故全屏那一级仍留在 `escape:` 回调里。

--- a/fushi/lib/src/media/video/video_foreground_layers.dart
+++ b/fushi/lib/src/media/video/video_foreground_layers.dart
@@ -1,0 +1,57 @@
+/// 视频页「逐级退出」的层级判据（BUG-1862）。
+///
+/// 视频页同时可能开着好几层前台 chrome：词典浮层、控制布局编辑态、字幕跳转列表、
+/// 剧集列表、设置 / 速度 / 章节侧栏、沉浸锁。按「返回上一级」（默认 Esc / 手柄 B /
+/// Android 系统返回键）时必须**从最前台往后台一层一层关**，全关完了才轮到退全屏、
+/// 退出视频页。
+///
+/// 判据独立成纯函数的动机：这条顺序此前被抄成两份——Escape 快捷键回调里一份、
+/// [PopScope] 的退出汇聚点里一份（而且后者只写了词典浮层一层），两份必然漂。漂的
+/// 后果就是 BUG-1862：设置侧栏打开时焦点被 `PanelFocusScope` 领进侧栏，Esc 绕过
+/// media_kit controls 子树里的快捷键表冒泡到全局 back，落进只认词典浮层的那份，
+/// 于是整页被 pop 掉、侧栏还开着。顺序收进本文件后，页面只剩「读状态 → 查表 →
+/// 执行动作」，规则本身可以直接断言。
+library;
+
+/// 视频页可被「返回上一级」逐级关闭的前台层，**声明顺序即视觉层序**（越靠前越前台，
+/// 越先被关）。
+enum VideoForegroundLayer {
+  /// 词典查词浮层。挂在根 Overlay 上，全屏路由之上，永远是最前台的一层。
+  dictionaryPopup,
+
+  /// 控制按钮布局编辑态（拖拽摆放播放器按钮）。
+  controlEdit,
+
+  /// push-aside 字幕跳转列表（TODO-314）。
+  subtitleList,
+
+  /// push-aside 剧集列表（TODO-638）。
+  episodeList,
+
+  /// 设置 / 速度 / 章节 / 画质 / 弹幕匹配侧栏（同一个 side panel 槽位，互斥）。
+  sidePanel,
+
+  /// 沉浸 / 锁定模式（TODO-101）。是最外层沉浸态，故排在所有面板之后。
+  immersiveLock,
+}
+
+/// 当前最前台的可关层；一层都没开返回 `null`（调用方这才可以退全屏 / 退出视频页）。
+///
+/// [hasVisibleDictionaryPopup] 必须是「有 **VISIBLE** 浮层」而不是「浮层栈非空」：
+/// 常驻隐藏的热槽（BUG-094）让栈长期非空，拿栈长度当判据会永久吞掉退出。
+VideoForegroundLayer? topVideoForegroundLayer({
+  required bool hasVisibleDictionaryPopup,
+  required bool controlEditActive,
+  required bool subtitleListVisible,
+  required bool episodeListVisible,
+  required bool sidePanelOpen,
+  required bool immersiveLocked,
+}) {
+  if (hasVisibleDictionaryPopup) return VideoForegroundLayer.dictionaryPopup;
+  if (controlEditActive) return VideoForegroundLayer.controlEdit;
+  if (subtitleListVisible) return VideoForegroundLayer.subtitleList;
+  if (episodeListVisible) return VideoForegroundLayer.episodeList;
+  if (sidePanelOpen) return VideoForegroundLayer.sidePanel;
+  if (immersiveLocked) return VideoForegroundLayer.immersiveLock;
+  return null;
+}

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -156,7 +156,49 @@ extension _VideoLayout on _VideoFushiPageState {
     // isFullscreen 判定不会被窗口侧重建覆写。
     return VideoControlsFocusGate(
       fullscreenRouteActive: _videoFullscreenActive,
-      child: _buildVideoControlsInner(state, controller),
+      child: _wrapVideoControlsBackKey(
+        _buildVideoControlsInner(state, controller),
+      ),
+    );
+  }
+
+  /// BUG-1862：把「返回上一级」键的兜底装在 controls builder 的**最外层**，覆盖那些
+  /// 挂在 media_kit controls 旁边、却不在它快捷键表作用域里的自建 overlay。
+  ///
+  /// media_kit 的整表快捷键（[_videoKeyboardShortcuts]）由它自己的 [CallbackShortcuts]
+  /// 承载，而那层只包住 media_kit 的 controls 子树；本页的设置 / 速度 / 章节侧栏、side
+  /// rail、控制按钮 popover、布局编辑层都是本 builder 里 [Stack] 的**兄弟节点**。侧栏
+  /// 打开时 `PanelFocusScope` 会把键盘焦点领进侧栏，于是 Esc 的冒泡路径根本不经过那张
+  /// 表，一路走到全局 back 把整页 pop 掉——用户看到「侧栏开着按 Esc，页面退了、侧栏还
+  /// 在」。本层是这些 overlay 的共同祖先，且窗口与全屏复用同一 controls builder，两种
+  /// 场景一并覆盖。
+  ///
+  /// 只在 [_dismissTopForegroundLayer] **真的关掉了一层**时消费按键；没有前台层可关时
+  /// 返回 [KeyEventResult.ignored] 原样放行，退全屏 / 退页仍走既有路径——不新增第二条
+  /// 退出语义，也不吞任何其它按键。文本框持焦时关闭物理键回退（与 `_handleGlobalBack`
+  /// 同款判据，避免 IME 打字误触，TODO-847）。
+  Widget _wrapVideoControlsBackKey(Widget child) {
+    return Focus(
+      // 纯观察层：不夺焦、不进 Tab 遍历，只在键盘事件冒泡路上看一眼。
+      canRequestFocus: false,
+      skipTraversal: true,
+      onKeyEvent: (FocusNode _, KeyEvent event) {
+        if (event is! KeyDownEvent) return KeyEventResult.ignored;
+        final PhysicalKeyboardKey? imeFallbackPhysicalKey =
+            focusedEditableText() == null ? event.physicalKey : null;
+        final ShortcutAction? action =
+            appModel.shortcutRegistry.resolveKeyboard(
+          event.logicalKey,
+          modifiers: activeModifierKeys(),
+          scope: ShortcutScope.universal,
+          physicalKey: imeFallbackPhysicalKey,
+        );
+        if (action != ShortcutAction.globalBack) return KeyEventResult.ignored;
+        return _dismissTopForegroundLayer()
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
+      },
+      child: child,
     );
   }
 

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -98,11 +98,13 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
         focusedEditableText,
         tryDictionaryPopupGamepadButton;
 import 'package:fushi/src/shortcuts/input_binding.dart'
-    show GamepadButton, InputBinding;
+    show GamepadButton, InputBinding, activeModifierKeys;
 import 'package:fushi/src/shortcuts/reader_caret_router.dart'
     show CaretAction, ReaderCaretRouter;
 import 'package:fushi/src/shortcuts/shortcut_action.dart'
     show ShortcutAction, ShortcutScope;
+import 'package:fushi/src/media/video/video_foreground_layers.dart'
+    show VideoForegroundLayer, topVideoForegroundLayer;
 import 'package:fushi/src/media/video/video_shader_manager.dart';
 import 'package:fushi/src/media/video/video_shader_tier.dart';
 import 'package:fushi/src/media/video/video_chapter_panel.dart';
@@ -4449,18 +4451,60 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   ) =>
       _onUpdateEntryImpl(noteId, fields);
 
-  /// 退出/返回汇聚点：浮层栈有可见层先关栈（一层层退），否则 await 落库后真正
-  /// pop 路由。[PopScope] 与 Escape 快捷键共用，保证两条退出路径行为一致。
+  /// 退出/返回汇聚点：前台浮层还开着就先关一层（逐级退出），一层都没开才 await
+  /// 落库后真正 pop 路由。[PopScope] 与 Escape 快捷键共用同一份层级表
+  /// [_dismissTopForegroundLayer]，保证两条退出路径行为一致。
   ///
-  /// 只有 VISIBLE 浮层拦截 back；常驻隐藏的热槽（BUG-094）让栈非空但不得吞掉退出。
+  /// BUG-1862：此前本方法只关词典浮层，逐级退出的其余五层（控制布局编辑态 / 字幕跳转
+  /// 列表 / 剧集列表 / 设置侧栏 / 沉浸锁）只写在 Escape 快捷键回调里，于是两条路径根本
+  /// 不一致。而那份快捷键表装在 media_kit controls 子树内的 [CallbackShortcuts] 上
+  /// （media_kit `material_desktop.dart`），本页自建的 overlay（[_buildVideoSidePanelOverlay]
+  /// 等）在 controls builder 的 Stack 里是它的**兄弟**、不是后代——侧栏一打开就把键盘
+  /// 焦点领进自己（`PanelFocusScope`），Esc 便绕过整张表冒泡到全局 back →
+  /// `Navigator.maybePop` → 本页 [PopScope] → 本方法 → 直接 pop 整页。用户看到的就是
+  /// 「设置侧栏开着按 Esc，视频页退了、侧栏没关」。Android 系统返回键与手柄 B 走同一条
+  /// [PopScope] 路径，症状相同。层级判定收敛到 [_dismissTopForegroundLayer] 单点后，
+  /// 键盘 / 系统返回 / 手柄三条输入通道共用同一份语义，不再各写一份。
   Future<void> _handleBackOrExit() async {
-    if (_hasVisiblePopup) {
-      _popNestedPopupAt(_topVisiblePopupIndex);
-      return;
-    }
+    if (_dismissTopForegroundLayer()) return;
     final NavigatorState nav = Navigator.of(context);
     await _controller?.flushPosition();
     if (mounted) nav.pop();
+  }
+
+  /// 逐级退出的**唯一**层级表（BUG-1862）：从最前台到最后台关掉一层并返回 true；一层
+  /// 都没开返回 false，调用方这才可以真正退全屏 / 退页。
+  ///
+  /// 顺序判据本身在纯函数 [topVideoForegroundLayer]（`video_foreground_layers.dart`）里，
+  /// 可直接单测；本方法只负责「读页面状态 → 查表 → 执行对应关闭动作」，不再自带顺序。
+  /// push-aside 字幕列表（TODO-314）、剧集列表（TODO-638）与侧栏是三条独立可见性，
+  /// 分别关闭。
+  bool _dismissTopForegroundLayer() {
+    final VideoForegroundLayer? layer = topVideoForegroundLayer(
+      hasVisibleDictionaryPopup: _hasVisiblePopup,
+      controlEditActive: _videoControlEditMode.value,
+      subtitleListVisible: _subtitleListVisible.value,
+      episodeListVisible: _episodeListVisible.value,
+      sidePanelOpen: _videoSidePanel.value != null,
+      immersiveLocked: _immersiveLocked.value,
+    );
+    switch (layer) {
+      case null:
+        return false;
+      case VideoForegroundLayer.dictionaryPopup:
+        _popNestedPopupAt(_topVisiblePopupIndex);
+      case VideoForegroundLayer.controlEdit:
+        _hideVideoControlEditOverlay(revealControls: false);
+      case VideoForegroundLayer.subtitleList:
+        _toggleSubtitleJumpList();
+      case VideoForegroundLayer.episodeList:
+        _closeEpisodeList();
+      case VideoForegroundLayer.sidePanel:
+        _hideVideoSidePanel();
+      case VideoForegroundLayer.immersiveLock:
+        _toggleImmersiveLock();
+    }
+    return true;
   }
 
   /// 桌面键盘快捷键，整表覆盖 media_kit 默认（[MaterialDesktopVideoControlsThemeData.
@@ -4732,30 +4776,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       // 沉浸查词门控在 _enterSubtitleCaret 内按 _immersiveAllowsLookup 判）。
       enterCaret: () => _handleEnterCaretAction(controller),
       escape: () {
-        if (_videoControlEditMode.value) {
-          _hideVideoControlEditOverlay(revealControls: false);
-          return;
-        }
-        // 字幕跳转列表开着时，Esc 先关它（不退页 / 不退全屏）——逐级退出，符合直觉。
-        // 锁定 / 沉浸模式开着时，Esc 先解锁（最外层沉浸态，逐级退出，TODO-101）。
-        // push-aside 字幕列表（TODO-314）与浮层是两条独立可见性，分别关闭。
-        if (_subtitleListVisible.value) {
-          _toggleSubtitleJumpList();
-          return;
-        }
-        // TODO-638：剧集列表 push-aside 侧栏开着时，Esc 先关它（逐级退出）。
-        if (_episodeListVisible.value) {
-          _closeEpisodeList();
-          return;
-        }
-        if (_videoSidePanel.value != null) {
-          _hideVideoSidePanel();
-          return;
-        }
-        if (_immersiveLocked.value) {
-          _toggleImmersiveLock();
-          return;
-        }
+        // 逐级退出：字幕跳转列表 / 剧集列表 / 侧栏 / 沉浸锁等前台层开着时先关一层，
+        // 不退页也不退全屏。层级表是 [_dismissTopForegroundLayer] 单点（BUG-1862 起与
+        // [PopScope]、系统返回键、手柄 B 共用同一份），这里只保留「没有前台层可关」之后
+        // 的两级：全屏 → 退全屏；窗口 → 退页。
+        if (_dismissTopForegroundLayer()) return;
         final BuildContext? ctx = _videoControlsContext;
         if (ctx != null && ctx.mounted && isFullscreen(ctx)) {
           unawaited(_exitVideoFullscreen(ctx));

--- a/fushi/test/media/video/video_escape_dismiss_guard_test.dart
+++ b/fushi/test/media/video/video_escape_dismiss_guard_test.dart
@@ -1,0 +1,129 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1862 源码守卫：视频页的「返回上一级」必须先逐级关前台浮层，再退全屏 / 退页，
+/// 且三条输入通道（键盘 Escape / [PopScope] 系统返回键 / 手柄 B）共用同一个层级表。
+///
+/// 纯函数层序由 `video_foreground_layers_test.dart` 断言；本文件守的是**接线**：
+///   ① 退出汇聚点 `_handleBackOrExit` 必须先问 `_dismissTopForegroundLayer`——它是
+///      [PopScope] / 系统返回键 / 手柄 B 的落点，漏了就等于 BUG-1862 原样复发；
+///   ② Escape 快捷键回调也走同一个单点，不许再抄一份 if 链回来；
+///   ③ controls builder 外面必须包着 `_wrapVideoControlsBackKey`——媒体页把侧栏等
+///      overlay 挂在 media_kit controls 的**兄弟**位置，那层快捷键表够不着它们。
+void main() {
+  final File page = File(
+    'lib/src/pages/implementations/video_fushi_page.dart',
+  );
+  final File layout = File(
+    'lib/src/pages/implementations/video_fushi/layout.part.dart',
+  );
+
+  /// 统一按 LF 读源码：换行风格一变（CRLF checkout）就让所有子串断言恒不匹配、
+  /// 整套守卫静默空转，比没有守卫更糟。
+  String read(File f) => f.readAsStringSync().replaceAll('\r\n', '\n');
+
+  test('视频页与 layout part 都在（守卫不能因为文件改名而静默空转）', () {
+    expect(page.existsSync(), isTrue, reason: '${page.path} 不存在');
+    expect(layout.existsSync(), isTrue, reason: '${layout.path} 不存在');
+  });
+
+  test('退出汇聚点 _handleBackOrExit 第一件事是逐级关前台层', () {
+    final String src = read(page);
+    final int at = src.indexOf('Future<void> _handleBackOrExit() async {');
+    expect(at, greaterThan(0), reason: '找不到 _handleBackOrExit 定义');
+    final String body = src.substring(at, at + 400);
+    expect(
+      body.contains('if (_dismissTopForegroundLayer()) return;'),
+      isTrue,
+      reason: '_handleBackOrExit 必须先问 _dismissTopForegroundLayer 再 pop 路由，'
+          '否则侧栏 / 字幕列表开着时按系统返回键会直接退掉整页（BUG-1862）',
+    );
+    // pop 路由必须排在关层之后。
+    final int dismissAt = body.indexOf('_dismissTopForegroundLayer()');
+    final int popAt = body.indexOf('nav.pop()');
+    expect(popAt, greaterThan(dismissAt), reason: '真正 pop 路由必须排在逐级关层之后');
+  });
+
+  test('Escape 快捷键回调复用同一个层级表，不另抄一份 if 链', () {
+    final String src = read(page);
+    final int at = src.indexOf('      escape: () {');
+    expect(at, greaterThan(0), reason: '找不到 escape 快捷键回调');
+    final String body = src.substring(at, at + 900);
+    expect(
+      body.contains('if (_dismissTopForegroundLayer()) return;'),
+      isTrue,
+      reason: 'escape 回调必须走 _dismissTopForegroundLayer 单点',
+    );
+    for (final String forbidden in <String>[
+      '_hideVideoSidePanel();',
+      '_closeEpisodeList();',
+      '_toggleSubtitleJumpList();',
+    ]) {
+      expect(
+        body.contains(forbidden),
+        isFalse,
+        reason: 'escape 回调里又出现了 $forbidden —— 层级顺序被抄成第二份，'
+            '它必然与 _dismissTopForegroundLayer 漂开（BUG-1862 的根因形态）',
+      );
+    }
+  });
+
+  test('层级表只有一处：关闭动作不在页面里散落第二份', () {
+    final String src = read(page);
+    // 每个关闭动作在整份主体里只应被层级表调用一次（定义处的调用）。
+    // 其它入口（按钮 / 互斥逻辑）走各自的 part 文件，不在本文件里。
+    expect(
+      '_hideVideoSidePanel();'.allMatches(src).length,
+      1,
+      reason: '_hideVideoSidePanel 在 video_fushi_page.dart 里出现了不止一次，'
+          '逐级退出的层级表可能又被抄了一份',
+    );
+  });
+
+  test('controls builder 外层包着 back 键兜底层', () {
+    final String src = read(layout);
+    final int at = src.indexOf('return VideoControlsFocusGate(');
+    expect(at, greaterThan(0), reason: '找不到 VideoControlsFocusGate 挂载点');
+    final String body = src.substring(at, at + 300);
+    expect(
+      body.contains('_wrapVideoControlsBackKey('),
+      isTrue,
+      reason: 'controls builder 必须包 _wrapVideoControlsBackKey：侧栏 / rail / '
+          'popover 是 media_kit controls 的兄弟节点，焦点进了侧栏后 Esc 根本不经过 '
+          'media_kit 的 keyboardShortcuts（BUG-1862）',
+    );
+    expect(
+      body.contains('_buildVideoControlsInner('),
+      isTrue,
+      reason: '兜底层必须真的包住 controls 内容',
+    );
+  });
+
+  test('back 键兜底层只在真关掉了一层时消费按键', () {
+    final String src = read(layout);
+    final int at = src.indexOf('Widget _wrapVideoControlsBackKey(');
+    expect(at, greaterThan(0), reason: '找不到 _wrapVideoControlsBackKey 定义');
+    final String body = src.substring(at, at + 1600);
+    expect(body.contains('canRequestFocus: false'), isTrue, reason: '兜底层不得夺焦');
+    expect(body.contains('skipTraversal: true'), isTrue,
+        reason: '兜底层不得进 Tab 遍历');
+    expect(
+      body.contains('return _dismissTopForegroundLayer()'),
+      isTrue,
+      reason: '消费与否必须由 _dismissTopForegroundLayer() 的**返回值**决定；'
+          '把它调完就丢、无条件返回 handled，会把 Esc 整个吞掉——视频页再也退不出去',
+    );
+    expect(
+      body.contains('return KeyEventResult.handled;'),
+      isFalse,
+      reason: '兜底层里出现了无条件 handled：没有前台层可关时必须放行，'
+          '否则退全屏 / 退页语义被这层改写',
+    );
+    expect(
+      body.contains('KeyEventResult.ignored'),
+      isTrue,
+      reason: '没有前台层可关时必须放行，不能改写退全屏 / 退页语义',
+    );
+  });
+}

--- a/fushi/test/media/video/video_foreground_layers_test.dart
+++ b/fushi/test/media/video/video_foreground_layers_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_foreground_layers.dart';
+
+/// BUG-1862：视频页「返回上一级」的逐级退出层序。
+///
+/// 这条顺序此前被抄成两份（Escape 快捷键回调一份、[PopScope] 退出汇聚点一份，而且
+/// 后者只认词典浮层），漂出来的后果就是「设置侧栏开着按 Esc，视频页退了、侧栏还在」。
+/// 收成纯函数后在这里直接断言规则本身。
+void main() {
+  /// 一次「按下返回上一级」：读当前状态、拿到该关的层。
+  VideoForegroundLayer? top(Set<VideoForegroundLayer> open) =>
+      topVideoForegroundLayer(
+        hasVisibleDictionaryPopup:
+            open.contains(VideoForegroundLayer.dictionaryPopup),
+        controlEditActive: open.contains(VideoForegroundLayer.controlEdit),
+        subtitleListVisible: open.contains(VideoForegroundLayer.subtitleList),
+        episodeListVisible: open.contains(VideoForegroundLayer.episodeList),
+        sidePanelOpen: open.contains(VideoForegroundLayer.sidePanel),
+        immersiveLocked: open.contains(VideoForegroundLayer.immersiveLock),
+      );
+
+  test('没有任何前台层时返回 null（调用方这才可以退全屏 / 退出视频页）', () {
+    expect(top(<VideoForegroundLayer>{}), isNull);
+  });
+
+  test('单独打开任意一层，按返回就关掉那一层', () {
+    for (final VideoForegroundLayer layer in VideoForegroundLayer.values) {
+      expect(
+        top(<VideoForegroundLayer>{layer}),
+        layer,
+        reason: '只开着 $layer 时应该关它，而不是退页',
+      );
+    }
+  });
+
+  test('设置侧栏开着时返回的是侧栏，绝不越过它去退页（BUG-1862 原始症状）', () {
+    expect(
+      top(<VideoForegroundLayer>{VideoForegroundLayer.sidePanel}),
+      VideoForegroundLayer.sidePanel,
+    );
+    // 侧栏 + 沉浸锁同时开：先关更前台的侧栏。
+    expect(
+      top(<VideoForegroundLayer>{
+        VideoForegroundLayer.sidePanel,
+        VideoForegroundLayer.immersiveLock,
+      }),
+      VideoForegroundLayer.sidePanel,
+    );
+  });
+
+  test('词典浮层永远最前台，压过其它任何一层', () {
+    for (final VideoForegroundLayer other in VideoForegroundLayer.values) {
+      expect(
+        top(<VideoForegroundLayer>{
+          VideoForegroundLayer.dictionaryPopup,
+          other,
+        }),
+        VideoForegroundLayer.dictionaryPopup,
+      );
+    }
+  });
+
+  test('六层全开时反复按返回：按视觉层序一层层剥到底，不重复也不跳过', () {
+    final Set<VideoForegroundLayer> open = VideoForegroundLayer.values.toSet();
+    final List<VideoForegroundLayer> dismissed = <VideoForegroundLayer>[];
+    for (int i = 0; i < VideoForegroundLayer.values.length; i++) {
+      final VideoForegroundLayer? layer = top(open);
+      expect(layer, isNotNull, reason: '还有 ${open.length} 层开着就不该放行退出');
+      dismissed.add(layer!);
+      open.remove(layer);
+    }
+    expect(dismissed, VideoForegroundLayer.values);
+    // 全部关完才轮到退全屏 / 退页。
+    expect(top(open), isNull);
+  });
+
+  test('层序表本身：更靠前的枚举值就是更前台的层', () {
+    // 两两比对：任意两层同时开着时，返回的必是枚举里更靠前的那个。
+    const List<VideoForegroundLayer> values = VideoForegroundLayer.values;
+    for (int i = 0; i < values.length; i++) {
+      for (int j = i + 1; j < values.length; j++) {
+        expect(
+          top(<VideoForegroundLayer>{values[i], values[j]}),
+          values[i],
+          reason: '${values[i]} 应该比 ${values[j]} 更前台',
+        );
+      }
+    }
+  });
+}

--- a/fushi/test/media/video/video_player_keyboard_static_test.dart
+++ b/fushi/test/media/video/video_player_keyboard_static_test.dart
@@ -77,22 +77,39 @@ void main() {
 
     test('Escape cancels video control edit mode before video exit handling',
         () {
+      // BUG-1862：逐级退出的层级表搬进 `_dismissTopForegroundLayer`（页面私有）+
+      // `topVideoForegroundLayer`（纯函数）单点后，escape 回调只剩「先关一层，关不动
+      // 才退全屏 / 退页」。断言的行为没变：编辑态必须在任何退出动作之前被吃掉，只是
+      // 门从 escape 回调里挪到了那张共用层级表上（[PopScope] / 手柄 B 因此也照吃）。
       final String escapeBody = region(page, 'escape: () {', '},\n      ),');
-      final int editGate = escapeBody.indexOf('_videoControlEditMode.value');
-      final int cancelEdit = escapeBody.indexOf(
-        '_hideVideoControlEditOverlay(revealControls: false)',
-      );
+      final int dismissGate =
+          escapeBody.indexOf('_dismissTopForegroundLayer()');
       final int fullscreenExit = escapeBody.indexOf('_exitVideoFullscreen(');
       final int backExit = escapeBody.indexOf('_handleBackOrExit()');
 
+      expect(dismissGate, greaterThanOrEqualTo(0),
+          reason: 'Escape must first try to dismiss the top foreground layer');
+      expect(fullscreenExit, greaterThan(dismissGate),
+          reason: 'fullscreen exit must only run after the dismiss gate');
+      expect(backExit, greaterThan(dismissGate),
+          reason: 'page exit must only run after the dismiss gate');
+
+      // 编辑态确实还在那张层级表里，且关闭动作排在判定之后。
+      final String dismissBody = region(
+        page,
+        'bool _dismissTopForegroundLayer() {',
+        '\n  }\n',
+      );
+      final int editGate = dismissBody.indexOf(
+        'controlEditActive: _videoControlEditMode.value',
+      );
+      final int cancelEdit = dismissBody.indexOf(
+        '_hideVideoControlEditOverlay(revealControls: false)',
+      );
       expect(editGate, greaterThanOrEqualTo(0),
-          reason: 'Escape must first test on-video control edit mode');
+          reason: 'the shared layer table must still read control edit mode');
       expect(cancelEdit, greaterThan(editGate),
           reason: 'editing Escape should cancel the draft overlay');
-      expect(fullscreenExit, greaterThan(cancelEdit),
-          reason: 'fullscreen exit must only run after edit cancel gate');
-      expect(backExit, greaterThan(cancelEdit),
-          reason: 'page exit must only run after edit cancel gate');
     });
 
     test('exit confluence: PopScope and Escape share _handleBackOrExit', () {

--- a/fushi/test/pages/dictionary_child_popup_close_guard_test.dart
+++ b/fushi/test/pages/dictionary_child_popup_close_guard_test.dart
@@ -168,13 +168,23 @@ void main() {
     expect(
         barrierBody, contains('VideoFushiPage.shouldSwitchWordOnBarrierTap('),
         reason: '字幕反查门控保持不变');
-    // 红线：back/Esc 逐层退回（_handleBackOrExit）保持不变，仍逐层关一层。
+    // 红线：back/Esc 逐层退回保持不变，仍逐层关一层。BUG-1862 把逐级退出的层级表
+    // 从 _handleBackOrExit 体内搬进共用单点 _dismissTopForegroundLayer（词典浮层是
+    // 其中最前台的一层），退回语义不变——仍是 _popNestedPopupAt(_topVisiblePopupIndex)
+    // 的「关一层」，不是 barrier 的清整栈。
     expect(video, contains('Future<void> _handleBackOrExit()'),
         reason: 'back/Esc 退出汇聚点仍在');
     final int backStart = video.indexOf('Future<void> _handleBackOrExit()');
     final String backBody = video.substring(backStart, backStart + 220);
-    expect(backBody, contains('_popNestedPopupAt(_topVisiblePopupIndex);'),
+    expect(backBody, contains('_dismissTopForegroundLayer()'),
+        reason: 'back/Esc 必须先走共用层级表逐级关层');
+    final int tableStart = video.indexOf('bool _dismissTopForegroundLayer() {');
+    expect(tableStart, greaterThanOrEqualTo(0), reason: '缺共用层级表');
+    final String tableBody = video.substring(tableStart, tableStart + 900);
+    expect(tableBody, contains('_popNestedPopupAt(_topVisiblePopupIndex);'),
         reason: 'back/Esc 仍逐层退回（不受 TODO-834 barrier 改动影响）');
+    expect(tableBody, isNot(contains('_popNestedPopupAt(0);')),
+        reason: 'back/Esc 绝不清整栈（那是 barrier 的语义）');
   });
 
   test('mixin onTapOutside closes descendants of the tapped layer', () {

--- a/fushi/test/pages/video_immersive_lock_guard_test.dart
+++ b/fushi/test/pages/video_immersive_lock_guard_test.dart
@@ -277,14 +277,27 @@ void main() {
   });
 
   test('Esc 优先解锁（最外层沉浸态，排在退全屏 / 退页之前）', () {
+    // BUG-1862：逐级退出的层级表收进 `_dismissTopForegroundLayer` 单点（键盘 Esc /
+    // [PopScope] 系统返回键 / 手柄 B 共用），escape 回调只剩「先关一层，关不动才退全屏
+    // / 退页」。断言的行为没变：锁定态必须在任何退出动作之前被吃掉。
     final int escIdx = src.indexOf('escape: () {');
     expect(escIdx, greaterThanOrEqualTo(0), reason: '缺 escape 回调');
-    final int unlockIdx = src.indexOf('_immersiveLocked.value', escIdx);
+    final int dismissIdx = src.indexOf('_dismissTopForegroundLayer()', escIdx);
     final int fullscreenExitIdx =
         src.indexOf('_exitVideoFullscreen(ctx)', escIdx);
     final int exitIdx = src.indexOf('_handleBackOrExit()', escIdx);
-    expect(unlockIdx, greaterThanOrEqualTo(0), reason: 'Esc 未在锁定态先解锁');
-    expect(unlockIdx, lessThan(fullscreenExitIdx), reason: 'Esc 解锁必须排在退全屏之前');
-    expect(unlockIdx, lessThan(exitIdx), reason: 'Esc 解锁必须排在退页之前（逐级退出）');
+    expect(dismissIdx, greaterThanOrEqualTo(0), reason: 'Esc 未先逐级关前台层');
+    expect(dismissIdx, lessThan(fullscreenExitIdx),
+        reason: 'Esc 关前台层必须排在退全屏之前');
+    expect(dismissIdx, lessThan(exitIdx), reason: 'Esc 关前台层必须排在退页之前（逐级退出）');
+
+    // 解锁确实还在那张共用层级表里。
+    final int tableIdx = src.indexOf('bool _dismissTopForegroundLayer() {');
+    expect(tableIdx, greaterThanOrEqualTo(0), reason: '缺共用层级表');
+    final int lockGate =
+        src.indexOf('immersiveLocked: _immersiveLocked.value', tableIdx);
+    final int unlockIdx = src.indexOf('_toggleImmersiveLock();', tableIdx);
+    expect(lockGate, greaterThanOrEqualTo(0), reason: '层级表未读锁定态');
+    expect(unlockIdx, greaterThan(lockGate), reason: '层级表未在锁定态解锁');
   });
 }

--- a/fushi/test/pages/video_subtitle_jump_list_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_jump_list_guard_test.dart
@@ -84,23 +84,31 @@ void main() {
   });
 
   test('Esc 优先关 push-aside 字幕列表 / 浮层，再退页或退全屏（TODO-314）', () {
+    // BUG-1862：层序判定收进纯函数 `topVideoForegroundLayer`，执行收进
+    // `_dismissTopForegroundLayer`，键盘 Esc / [PopScope] 系统返回键 / 手柄 B 共用同一
+    // 份（此前 [PopScope] 那条只关词典浮层，侧栏开着按 Esc 会直接退掉整页）。这里断言
+    // 的行为没变：字幕列表比侧栏更前台，两者都排在退页之前。
     final int escIdx = src.indexOf('escape: () {');
     expect(escIdx, greaterThanOrEqualTo(0), reason: '缺 escape 回调');
-    // push-aside 字幕列表分支先判 _subtitleListVisible → 关列表。
-    final int listGate =
-        src.indexOf('if (_subtitleListVisible.value) {', escIdx);
-    final int listCloseIdx = src.indexOf('_toggleSubtitleJumpList();', escIdx);
-    // 浮层分支判 _videoSidePanel → _hideVideoSidePanel。
-    final int panelGate =
-        src.indexOf('if (_videoSidePanel.value != null) {', escIdx);
-    final int closeIdx = src.indexOf('_hideVideoSidePanel();', escIdx);
+    final int dismissIdx = src.indexOf('_dismissTopForegroundLayer()', escIdx);
     final int exitIdx = src.indexOf('_handleBackOrExit()', escIdx);
-    expect(listGate, greaterThanOrEqualTo(0),
-        reason: 'Esc 未先判 push-aside 字幕列表');
-    expect(listCloseIdx, greaterThan(listGate), reason: 'Esc 字幕列表分支未关列表');
-    expect(panelGate, greaterThan(listGate), reason: 'Esc 浮层分支应在字幕列表之后');
-    expect(closeIdx, greaterThan(panelGate), reason: 'Esc 浮层分支未关浮层');
-    expect(closeIdx, lessThan(exitIdx), reason: 'Esc 关侧栏必须排在退页之前');
+    expect(dismissIdx, greaterThanOrEqualTo(0), reason: 'Esc 未先逐级关前台层');
+    expect(dismissIdx, lessThan(exitIdx), reason: 'Esc 关前台层必须排在退页之前');
+
+    final int tableIdx = src.indexOf('bool _dismissTopForegroundLayer() {');
+    expect(tableIdx, greaterThanOrEqualTo(0), reason: '缺共用层级表');
+    // 层级表读的是两条独立可见性：push-aside 字幕列表 与 side panel。
+    final int listGate = src.indexOf(
+        'subtitleListVisible: _subtitleListVisible.value', tableIdx);
+    final int panelGate =
+        src.indexOf('sidePanelOpen: _videoSidePanel.value != null', tableIdx);
+    final int listCloseIdx =
+        src.indexOf('_toggleSubtitleJumpList();', tableIdx);
+    final int closeIdx = src.indexOf('_hideVideoSidePanel();', tableIdx);
+    expect(listGate, greaterThanOrEqualTo(0), reason: '层级表未读 push-aside 字幕列表');
+    expect(panelGate, greaterThan(listGate), reason: '字幕列表比侧栏更前台，读取顺序应保持一致');
+    expect(listCloseIdx, greaterThanOrEqualTo(0), reason: '层级表未关字幕列表');
+    expect(closeIdx, greaterThan(listCloseIdx), reason: '层级表未按层序关侧栏');
   });
 
   test('一体式字幕侧栏只剩「全部 / 收藏」两档，无制卡勾选框', () {


### PR DESCRIPTION
用户报：视频设置侧栏开着时按 Esc，视频页直接退了、侧栏还在。

## 根因（两条独立缺陷叠在一起）

**① 逐级退出的层级表被抄成两份，其中一份只有一层。**
完整阶梯（编辑态 → 字幕跳转列表 → 剧集列表 → 侧栏 → 沉浸锁 → 退全屏 → 退页）只写在 `escape:` 快捷键回调里；`_handleBackOrExit` —— `PopScope` / Android 系统返回键 / 手柄 B 的落点 —— 只关词典浮层就直接 `nav.pop()`。它头上那句「[PopScope] 与 Escape 快捷键共用，保证两条退出路径行为一致」是假的。

**② 快捷键表够不着自家 overlay。**
视频页的整表快捷键经 media_kit 的 `keyboardShortcuts` 安装，那层 `CallbackShortcuts` 只包住 media_kit **自己的 controls 子树**（`third_party/media_kit_video/.../material_desktop.dart:651`）。而设置 / 速度 / 章节侧栏、side rail、控制按钮 popover、布局编辑层都是 `_buildVideoControls` 那个 `Stack` 里与 controls **平级的兄弟节点**；侧栏一打开，`PanelFocusScope` 就把键盘焦点领进侧栏子树。

**合起来**：焦点在侧栏 → Esc 绕过整张表冒泡到全局 back → `maybePop` → `PopScope` → ① 的那一层 → pop 掉整页，侧栏还开着。Android 系统返回键与手柄 B 走同一条 `PopScope` 路径，无论焦点在哪都复现。

## 修复

1. **层级顺序收敛成单点真相源**：新增纯函数 `topVideoForegroundLayer` + 枚举 `VideoForegroundLayer`（声明顺序即视觉层序），页面 `_dismissTopForegroundLayer()` 只做「读状态 → 查表 → 执行关闭动作 → 返回是否关掉了一层」。`_handleBackOrExit` 与 `escape:` 都先问它 —— 键盘 / 系统返回 / 手柄三条通道这才真的共用同一份语义。
2. **补上快捷键表够不着的那半**：`_wrapVideoControlsBackKey` 包在 controls builder 最外层，作那些 overlay 的共同祖先（窗口与全屏复用同一 builder，两种场景一并覆盖）。只在**真的关掉了一层**时消费按键，否则 `KeyEventResult.ignored` 原样放行，不改写退全屏 / 退页语义、不吞其它按键；不夺焦、不进 Tab 遍历；文本框持焦时关闭物理键回退（同 `_handleGlobalBack` 判据，避免 IME 打字误触）。

全屏那一级**有意**留在 `escape:` 回调里：`_handleBackOrExit` 还被顶栏返回按钮、加载中 / 失败页返回按钮调用，点返回箭头的语义是退出页面而非先退全屏；且 `PopScope` 在全屏时轮不到（全屏是推到根 navigator 的独立路由，框架先 pop 它）。

## 测试

- `video_foreground_layers_test.dart`（6 条）：层序规则本身。含「六层全开反复按返回，按视觉层序一层层剥到底、不重复不跳过」与两两层序比对。
- `video_escape_dismiss_guard_test.dart`（6 条）：接线守卫。源码读取做 CRLF 归一化，避免换行风格一变整套守卫静默空转。
- **变异实测 6 轮全部被抓到**。其中「兜底层无条件返回 handled」一轮**最初没抓到**（那会把 Esc 整个吞掉、视频页再也退不出去），据此把断言从「出现过 ignored」加强成「消费与否必须由层级表返回值门控 + 不许出现裸 `return KeyEventResult.handled;`」。
- 四条既有守卫原本锚在「escape 回调体里必须有某个 if 分支」这种实现位置上，层级表搬家后失配；已改成锚定新的单点层级表，断言的行为一条没减。

## 验证

- `flutter analyze` 全量（含 test 目录）零问题。
- `flutter test test/media/video/ test/focus/ test/shortcuts/ test/pages/` 共 **6444 条全绿**（9 skipped）。
- **缺口**：未做真机 / 离屏端到端复现（开侧栏 → 按 Esc → 侧栏关、页面还在）。窗口模式那条链路逻辑上闭合；全屏下焦点在侧栏时由新加的 controls 兜底层接住，也未真机复测。

docs/bugs/BUG-1862-video-esc-skips-overlay-dismiss.md

https://claude.ai/code/session_01U4kHLhuxxyBcejRwyCX1qw
