### PR TITLE
fix(video): 获取的字幕进不了字幕轨列表（BUG-1861）+ 从后台切回静止区域变灰（BUG-1863）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1731 条。点号进各自文件。
+> 共 1732 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1863](bugs/BUG-1863-video-resume-gray-static-areas.md) | ✅ | ✅ | 从后台切回视频静止区域变成灰色 |
 | [BUG-1861](bugs/BUG-1861-video-subtitle-imported-not-listed.md) | ✅ | ✅ | 获取的字幕能应用上却不出现在字幕轨列表里 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1730 条。点号进各自文件。
+> 共 1731 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1861](bugs/BUG-1861-video-subtitle-imported-not-listed.md) | ✅ | ✅ | 获取的字幕能应用上却不出现在字幕轨列表里 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |
 | [BUG-1850](bugs/BUG-1850-settings-destination-itest-vacuous-selected-row.md) | ✅ | ✅ | 集成测试用恒真的选中行谓词当设置分类打开判据 |

--- a/docs/bugs/BUG-1861-video-subtitle-imported-not-listed.md
+++ b/docs/bugs/BUG-1861-video-subtitle-imported-not-listed.md
@@ -1,0 +1,21 @@
+## BUG-1861 · 获取的字幕能应用上却不出现在字幕轨列表里
+- **报告**：2026-08-25（用户：「获取的字幕，能被应用上，但不会出现在列表里」+ 手机端「视频设置 → 字幕轨」截图：列表里只有「获取字幕（Jimaku）」「导入字幕文件…」「关闭字幕」「副字幕」四行固定项，一条可选字幕源都没有）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart` 的 `_registerImportedSubtitleSource`（修复前：`if (_isRemote) return;` + `if (videoPath == null || _subtitleMenuSourcesPath != videoPath) return;`）与同文件 `_buildSubtitleTrackRows` 的远端分支。
+
+  BUG-1329 已经把「下载/导入完当场并入字幕轨列表」接上了，但那条并入路径把**「新档要不要进列表」挂在了「枚举缓存对当前视频是否有效」这个与它无关的前置条件上**，于是四种情况下新档被**静默丢弃**：
+
+  1. **枚举在途**。字幕轨枚举（`_ensureSubtitleMenuSourcesLoaded` → `listAllSubtitleSources`，对整个容器跑 `ffmpeg -i`，超时预算按文件体积放大）由「进入字幕分类」事件驱动，是异步的。用户一进「字幕」分类就点「获取字幕（Jimaku）」——搜索 + 下载要几秒，而大容器探测同样要几秒到数十秒。下载回来时缓存 key 还没写 → 登记静默 return；随后枚举完成，用 `_rebuild` **整体覆盖** `_subtitleMenuSources`，而它带上「当前持久化字幕」用的是**枚举启动时抓的 `_currentSubtitleSource` 快照**（`_subtitleSourcesForMenu` 的入参在 `await` 之前读），刚下载的档案也进不了 `includeCurrentPersistedSubtitleForMenu`。两头都漏。
+  2. **枚举失败**。`enumerated == null`（ffmpeg 缺失 / 超时 / 路径不可枚举）时按设计不写缓存 key（留给下次重试），此后**每一次**登记都静默 return。
+  3. **换集后没再进过字幕分类**。缓存 key 还是上一集的路径。
+  4. **远端模式整个跳过**（`if (_isRemote) return;`）。而远端字幕轨行只覆盖三类：YouTube 轨（`_youtubeCaptionTracks`）、host sidecar（`_remoteSubtitlePath`）、host 内封轨（`_remoteEmbeddedSubtitleTracks`）。远端 Jimaku 下载走 `_applyRemoteSubtitle` 只改内存里的 `_currentSubtitleSource`，**列表里根本没有一行能承载本机下载的档案** —— 字幕在画面上生效了，列表里既看不到它、也切不回它（只有退出重进后，`_loadRemoteEpisode` 的持久化重放把它挂到 `_remoteSubtitlePath` 上，才会以「host 字幕」行出现）。
+
+  用户截图那一屏在两种表面下都成立：生肉视频（正因为没字幕才要去 Jimaku 取）枚举结果恒空，列表本来就只有固定项；下载完之后它**仍然**是空的。
+
+- **[x] ① 已修复** — 把「枚举结果」与「本会话落盘的档案」拆成两份独立真相，渲染时合并：
+  - 新增 `_importedSubtitleSources`（视频页字段，换视频源 / 远端换集时清空），`_registerImportedSubtitleSource` **去掉全部前置门**（不看 `_isRemote`、不看 `_currentVideoPath`、不看缓存 key），只按 `isImportedExternalSubtitlePath` 收外挂档案路径、按 `sameExternalSubtitlePathForMenu` 去重。「这个档案就在盘上、刚被应用」是不依赖枚举的既成事实。
+  - 新纯函数 `mergeImportedSubtitleSourcesForMenu`（`video_subtitle_source.dart`）在渲染时合并两份列表，导入档排最前。写进独立列表而不是枚举缓存，后到的枚举结果整体覆盖缓存时也冲不掉它。
+  - 主字幕轨行与副字幕轨行（BUG-900 起共用同一份可用列表）都改读合并后的 `_menuSubtitleSources`。
+  - 远端分支新增「本机导入档」行（点击走 `_applyRemoteSubtitle`），与 host sidecar 行按路径去重；远端 Jimaku 下载 / 远端手动导入两条落盘路径都补上登记。
+  提交：见本分支 `fix(video): ...` commit。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_subtitle_imported_list_guard_test.dart`：`mergeImportedSubtitleSourcesForMenu` / `sameSubtitleFilePath` 的行为单测（含「枚举结果为空时导入档仍可见」这一用户报的那一屏），加调用点静态守卫（登记函数体内不得再出现三个前置门符号中的任何一个；两处渲染都读合并列表且不得再裸遍历枚举结果；远端分支有导入档行；远端两条落盘路径都登记；两条换源路径都清空）。已做变异实测：加回 `if (_isRemote) return;` → 「登记新档没有任何前置门」当场红；主字幕行退回 `_subtitleMenuSources` → 「本地字幕轨行与副字幕行都读合并后的列表」当场红；还原后源文件 sha256 回到基线。同批修正 BUG-1329 守卫里那条已被本次修复取代的断言（它锁的正是被删掉的缓存 key 门）。
+- **备注**：media_kit 跑不了 headless、ffmpeg 枚举也不能在单测里真跑，字幕轨行的渲染进不了 widget 测试，故列表行契约只能锁到调用点/源码层；**未做真机复测**（未在手机上重跑一遍 Jimaku 下载 → 看列表出现新行）。

--- a/docs/bugs/BUG-1863-video-resume-gray-static-areas.md
+++ b/docs/bugs/BUG-1863-video-resume-gray-static-areas.md
@@ -1,0 +1,48 @@
+## BUG-1863 · 从后台切回视频静止区域变成灰色
+- **报告**：2026-08-25（用户：「从后台切回来的时候有时候静止的地方会变成灰色」+ 手机端截图：两个角色（运动区域）画得完整，天空 / 房屋 / 地面这些静止背景整片 `#808080`，角色边缘还挂着几块没被覆盖掉的彩色残片）
+- **真实性**：✅ 真 bug，机制可从截图直接读出；**触发条件未在真机上复现**（报修时本机 adb 里那台手机 `offline`，见备注）。
+
+  截图里那个灰是 `#808080`，正是 libavcodec 在**参考帧缺失**时给帧填的中性灰
+  （`1 << (bit_depth - 1)`，error concealment 的 gray init）；运动区域完整则说明 P 帧的残差
+  被正常解出来并叠上去了。两件事合起来只有一个含义：**解码器在播放中途被重建过，却没有
+  回到关键帧就继续喂包**，DPB 里没有可参考的前帧，于是「这一帧没被残差碰到的地方」全是
+  concealment 的灰。画面要等到下一个 IDR 才自愈——GOP 长的片源就是好几秒。
+
+  中途重建的来源是 Android 平台事实：MediaCodec 是有限的系统资源，前台应用优先，app 在
+  不可见期间持有的硬解实例会被回收（尤其期间开了相机 / 别的播放器）。Fushi 移动端走
+  `hwdec=auto-copy` → `mediacodec-copy`（`video_mpv_config.dart` 的
+  `resolvePlatformHwdec`），且真后台期间**不暂停解码**（`didChangeAppLifecycleState` 的
+  `paused` 分支只落库 + 停观看计时），所以后台期间一直在用那个随时会被收走的解码器。
+
+  media_kit 并非没管这件事：`third_party/media_kit_video/lib/src/video_controller/
+  android_video_controller/real.dart` 的 `widListener` 在 `--wid` 变更后重设 `vo`，**尾部就是
+  `await player.seek(currentPosition)`** —— 与本次修复同一手法。但它的触发条件是
+  **surface 真的被重建**（Flutter `SurfaceProducer` 的 `onSurfaceCleanup` /
+  `onSurfaceAvailable` → `wid` 这个 `ValueNotifier` 值变化）。而「surface 有没有被重建」与
+  「解码器有没有被系统回收」是两件独立的事：短暂切走、或系统没有释放 surface 时 `wid` 不变，
+  `ValueNotifier` 压根不通知，那条刷新路径整个不触发。**这就是「有时候才灰」的缺口。**
+
+- **[x] ① 已修复（`implemented_unverified`）** — 视频页记下「真的进过后台」
+  （`_enteredRealBackground`，`paused` / `hidden` 置真，`inactive` 不置——通知栏下拉一瞥期间
+  app 仍持有解码器），回前台时经纯判据
+  `VideoPlayerController.shouldRefreshDecodeOnResume`（移动端 + 有解码出画的视频轨 + 时长
+  已知可 seek）决定是否调 `refreshDecodeAfterResume()`：seek 到**当前位置**本身。mpv 的 seek
+  会 flush 解码器并从目标之前的关键帧重新解码，DPB 被重新填满，concealment 的灰块被真实
+  像素取代。走 `Player.seek` 而不是 `seekMs`——播放位置根本没变，不该清主动跳转快照、不该
+  作废「只播这一句就停」、不该触发字幕权威重算。标记在任何早退之前无条件清掉，不会攒到
+  下一次 resume 变成「某次切窗后莫名 seek 一下」。直播 / 时长未知流不刷新（那一 seek 可能
+  把播放头甩走，宁可留着灰屏也不打断直播）；桌面不做（窗口失焦不会让系统回收解码器）。
+  提交：见本分支 `fix(video): ...` commit。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_resume_decode_refresh_guard_test.dart`：
+  `shouldRefreshDecodeOnResume` 五种输入组合的行为单测 + 调用点静态守卫（标记只在
+  paused/hidden 置、resumed 分支真调刷新、标记在第一个 return 之前就清、刷新不走 `seekMs`
+  且确实 seek 到当前位置、判据不在页面里被重写一遍）。已做变异实测：把置标记挪进
+  `inactive` 分支 → 「只有 paused / hidden 置标记」当场红；把清除挪到早退之后 →
+  「标记无条件清除」当场红；还原后源文件 sha256 回到基线。
+- **备注**：**真机未复测**。报修当时本机 adb 里唯一那台设备（CPH2747，无线调试）是
+  `offline`，`adb reconnect` 拉不回来，没法在真机上跑「播放 → 切后台 → 抢占解码器 → 切回」
+  这条原始失败路径，也就无法给出「修复后不再灰」的像素证据。系统回收 MediaCodec 这件事
+  在单测里造不出来，media_kit 也跑不了 headless，所以自动化只能锁到判据与调用点。
+  按上面的机制分析，本修复覆盖的是「参考帧缺失」这一**类**成因（解码器中途重建、
+  surface 重建时 seek 被吞、硬解中途回落软解都在内），不是只针对某一条触发路径；但**在
+  真机上复现并复测之前，只能标 `implemented_unverified`，不能宣称已修好**。

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/media/video/video_playback_source.dart';
 import 'package:fushi/src/media/video/video_shader_manager.dart';
 import 'package:fushi/src/media/video/video_subtitle_source.dart';
+import 'package:fushi/src/utils/misc/platform_utils.dart';
 import 'package:fushi_audio/fushi_audio.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -645,6 +646,56 @@ class VideoPlayerController extends ChangeNotifier
   @visibleForTesting
   static bool framePresent(int? width, int? height) =>
       width != null && width > 0 && height != null && height > 0;
+
+  /// BUG-1863：**纯判据**——从真后台回到前台后，是否需要强制重建一次视频解码链。
+  ///
+  /// 症状是移动端切回来后画面「静止的地方变成灰色、运动的地方正常」。那个灰是
+  /// `#808080`（`1 << (bit_depth - 1)`），正是 libavcodec 在**参考帧缺失**时 error
+  /// concealment 填进帧里的中性灰；运动区域正常说明 P 帧残差解得好好的。合起来只有一个
+  /// 含义：解码器在播放中途被重建过，却**没有回到关键帧**就继续喂包，DPB 里没有可参考的
+  /// 前帧。移动端在 app 不可见期间被系统回收硬件解码器（MediaCodec 是有限资源，前台
+  /// 应用优先）就会产生这个中途重建，而画面要等到下一个 IDR 才自愈——GOP 长的片源可能
+  /// 是好几秒。
+  ///
+  /// media_kit 只在 **surface 真的被重建**时刷新（`android_video_controller` 的
+  /// `widListener` 尾部就是 `player.seek(currentPosition)`，与这里同一手法）。但 surface
+  /// 是否重建由 Flutter 的 `SurfaceProducer` 生命周期决定，与「解码器有没有被系统回收」
+  /// 是两件独立的事：短暂切走 / 系统没释放 surface 时 `wid` 不变，`ValueNotifier` 压根
+  /// 不通知，那条刷新路径整个不触发——正是「有时候才灰」的来源。
+  ///
+  /// 判据只认三件事，全部可测：
+  ///  - [enteredRealBackground]：真进过后台（`paused` / `hidden`）。`inactive`（通知栏
+  ///    下拉 / 多任务一瞥）不算——那期间 app 仍持有解码器。
+  ///  - [hasVideo]：当前有解码出画的视频轨（纯音频 / 未起播时刷新毫无意义）。
+  ///  - [seekable]：时长已知且为正。直播 / 未知时长流上这次 seek 可能把播放头甩走，
+  ///    宁可留着灰屏也不打断直播。
+  ///
+  /// [isMobile] 默认取 [isMobilePlatform]，注入仅为单测。桌面不做：窗口失焦不会让系统
+  /// 回收解码器，白白 seek 只会给用户一次无谓的卡顿。
+  static bool shouldRefreshDecodeOnResume({
+    required bool enteredRealBackground,
+    required bool hasVideo,
+    required bool seekable,
+    bool? isMobile,
+  }) {
+    if (!(isMobile ?? isMobilePlatform)) return false;
+    return enteredRealBackground && hasVideo && seekable;
+  }
+
+  /// BUG-1863：强制重建视频解码链——seek 到**当前位置**。
+  ///
+  /// mpv 的 seek 会 flush 解码器并从目标位置之前的关键帧重新解码，因而 DPB 被重新填满、
+  /// error concealment 的灰块被真实像素取代。这是 media_kit 自己在 surface 重建后用的
+  /// 同一手法（`android_video_controller` 的 `widListener`），不是新发明的偏方。
+  ///
+  /// 走 [Player.seek] 而不是 [seekMs]：这不是「用户改变了播放位置」，不该清主动跳转
+  /// 快照、不该作废「只播这一句就停」、也不该触发字幕权威重算——位置根本没变。
+  /// 未 [load]（无 player）时 no-op 安全。
+  Future<void> refreshDecodeAfterResume() async {
+    final Player? player = _player;
+    if (player == null) return;
+    await player.seek(player.state.position);
+  }
 
   /// libmpv 当前是否处于缓冲态（`core-idle` / `paused-for-cache`）。media_kit 的
   /// 缓冲圈据同一 `player.state.buffering` 渲染，此处读同一真值让页面的首开就绪判据

--- a/fushi/lib/src/media/video/video_subtitle_source.dart
+++ b/fushi/lib/src/media/video/video_subtitle_source.dart
@@ -890,8 +890,48 @@ bool sameExternalSubtitlePathForMenu(
   String currentSubtitleSource,
 ) {
   if (source.isEmbedded || source.externalPath == null) return false;
-  return _subtitleMenuPathKey(source.externalPath!) ==
-      _subtitleMenuPathKey(currentSubtitleSource);
+  return sameSubtitleFilePath(source.externalPath!, currentSubtitleSource);
+}
+
+/// **纯函数**：两个字幕文件路径是否指向同一个档案（大小写 / 分隔符 / `..` 归一）。
+/// [sameExternalSubtitlePathForMenu] 的裸路径版，供尚未包成 [SubtitleSource] 的登记 /
+/// 去重路径复用同一判据（BUG-1861）。
+bool sameSubtitleFilePath(String a, String b) =>
+    _subtitleMenuPathKey(a) == _subtitleMenuPathKey(b);
+
+/// **纯函数**：把「本次播放会话里落盘并应用过的外挂字幕档」[imported] 并进字幕轨菜单
+/// 的枚举结果 [enumerated]，返回最终要渲染的列表（导入档排在前，与
+/// [includeCurrentPersistedSubtitleForMenu] 的「当前导入排最前」约定一致）。
+///
+/// BUG-1861：这一层存在的理由是**枚举结果与「用户刚拿到的字幕档」是两件独立的事实**。
+/// [listAllSubtitleSources] 按设计只看内封轨 + 视频同目录 sidecar；Jimaku 下载 / 手动
+/// 导入的档案住在 `<dataRoot>/documents/video_subtitles/`，它永远枚举不到。而枚举本身
+/// 会失败（ffprobe 不可用 / 超时）、会在途（大容器探测数秒到数十秒）、也会因换集而让
+/// 缓存 key 失配。BUG-1329 把「并入新档」挂在「枚举缓存有效」这个前置条件上，于是上述
+/// 三种情况下新档被**静默丢弃** —— 用户看到「字幕明明应用上了、列表里却没有它」。
+///
+/// 两份列表在渲染时合并（而不是把新档写进枚举缓存）：枚举缓存保持「纯枚举结果」语义，
+/// 后到的枚举结果整体覆盖它时也不会把导入档冲掉。按路径去重（[sameSubtitleFilePath]），
+/// 导入档若同时是视频同目录 sidecar（已在 [enumerated] 里）则不重复列出。
+List<SubtitleSource> mergeImportedSubtitleSourcesForMenu(
+  List<SubtitleSource> enumerated,
+  List<SubtitleSource> imported,
+) {
+  if (imported.isEmpty) return enumerated;
+  final List<SubtitleSource> extras = <SubtitleSource>[];
+  for (final SubtitleSource source in imported) {
+    final String? path = source.externalPath;
+    if (path == null) continue;
+    final bool listed =
+        enumerated.any((SubtitleSource s) =>
+                sameExternalSubtitlePathForMenu(s, path)) ||
+            extras.any((SubtitleSource s) =>
+                sameExternalSubtitlePathForMenu(s, path));
+    if (listed) continue;
+    extras.add(source);
+  }
+  if (extras.isEmpty) return enumerated;
+  return <SubtitleSource>[...extras, ...enumerated];
 }
 
 SubtitleSource? firstTextEmbeddedSubtitleSource(

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -224,8 +224,36 @@ extension _VideoSubtitle on _VideoFushiPageState {
                     )
                 : null,
           ),
+      // BUG-1861：远端模式下本机落盘的字幕档（Jimaku 下载 / 手动导入）也要有自己的行。
+      // 远端字幕轨行原本只覆盖 YouTube 轨 / host sidecar / host 内封轨三类，本机档案
+      // 经 [_applyRemoteSubtitle] 应用后只改 `_currentSubtitleSource`，列表里没有任何
+      // 行能承载它——「字幕明明应用上了、列表里却没有它」。与 host sidecar 行按路径去重
+      // （重进时的持久化重放会把同一档案挂到 `_remoteSubtitlePath` 上，见 [_loadRemoteEpisode]）。
+      if (_isRemote)
+        for (final SubtitleSource source in _importedSubtitleSources)
+          if (hostSub == null ||
+              !sameExternalSubtitlePathForMenu(source, hostSub))
+            ListTile(
+              leading: const Icon(Icons.subtitles),
+              title: Text(source.label),
+              selected: subtitleSourceMatchesPersistedForMenu(
+                source,
+                _currentSubtitleSource,
+              ),
+              selectedColor: cs.primary,
+              enabled: !_subtitleLoadingShown,
+              onTap: _subtitleLoadingShown
+                  ? null
+                  : () => unawaited(
+                        _applyRemoteSubtitle(
+                          controller,
+                          source.externalPath!,
+                          label: source.label,
+                        ),
+                      ),
+            ),
       if (!_isRemote)
-        for (final SubtitleSource source in _subtitleMenuSources)
+        for (final SubtitleSource source in _menuSubtitleSources)
           ListTile(
             leading: Icon(
               source.isGraphicEmbedded
@@ -370,10 +398,10 @@ extension _VideoSubtitle on _VideoFushiPageState {
             : () => unawaited(_selectSecondarySubtitleOff(controller)),
       ),
       const Divider(height: 1),
-      // BUG-900：遍历完整 [_subtitleMenuSources]（与主字幕轨行同一份可用列表），外挂
-      // 字幕文件也能选为副字幕。图标与主字幕轨行一致：图形轨 image / 内嵌 movie /
-      // 外挂 subtitles。
-      for (final SubtitleSource source in _subtitleMenuSources)
+      // BUG-900：遍历完整可用列表（与主字幕轨行同一份，BUG-1861 起含本会话导入 /
+      // 下载的档案），外挂字幕文件也能选为副字幕。图标与主字幕轨行一致：图形轨
+      // image / 内嵌 movie / 外挂 subtitles。
+      for (final SubtitleSource source in _menuSubtitleSources)
         ListTile(
           leading: Icon(
             source.isGraphicEmbedded
@@ -494,15 +522,31 @@ extension _VideoSubtitle on _VideoFushiPageState {
   ///     带来的唯一新信息，就是我们手里这个已知路径的外挂文件。
   ///
   /// 新档是本 app 刚写下的外挂文件，路径与标签都在手里，没有任何需要向 ffmpeg 求证的
-  /// 东西：直接插到列表首位（与 [includeCurrentPersistedSubtitleForMenu] 的「当前导入排
-  /// 最前」约定一致），内嵌轨枚举缓存保持有效、不重探。尚未为当前视频枚举过（缓存 key
-  /// 不匹配）时什么都不做——首次枚举本就会经 [includeCurrentPersistedSubtitleForMenu]
-  /// 把它带上。远端视频没有本地枚举列表（走 host / YouTube 轨），直接跳过。
+  /// 东西：直接记进 [_importedSubtitleSources]，渲染时经
+  /// [mergeImportedSubtitleSourcesForMenu] 排到列表首位（与
+  /// [includeCurrentPersistedSubtitleForMenu] 的「当前导入排最前」约定一致），内嵌轨枚举
+  /// 缓存保持有效、不重探。
+  ///
+  /// BUG-1861：**登记不再有任何前置条件**。BUG-1329 的实现把新档直接写进
+  /// `_subtitleMenuSources`，因而必须先确认「枚举缓存对当前视频有效」
+  /// （`_subtitleMenuSourcesPath == videoPath`），否则就丢弃；并且远端模式整个跳过。
+  /// 这三种情况下用户都会看到「字幕应用上了、列表里却没有它」：
+  ///  1. **枚举尚在途**：用户一进「字幕」分类就点获取字幕，而大容器的 `ffmpeg -i` 探测要
+  ///     数秒到数十秒。缓存 key 此刻还没写，新档被丢；等枚举回来又用**它启动时抓的**
+  ///     `_currentSubtitleSource` 快照整体覆盖列表，新档也进不了
+  ///     [includeCurrentPersistedSubtitleForMenu]。
+  ///  2. **枚举失败**：ffmpeg 缺失 / 超时 / 路径不可枚举（网络流）时 `enumerated == null`，
+  ///     缓存 key 永远不写，此后每次登记都静默 return。
+  ///  3. **换集后未再进字幕分类**：缓存 key 还是上一集的路径。
+  /// 而「这个档案就在盘上、刚刚被应用」是**不依赖枚举的既成事实**，不该被枚举缓存的
+  /// 有效性 gate 掉。现在两份列表各自独立、渲染时合并（见
+  /// [mergeImportedSubtitleSourcesForMenu]）。
+  ///
+  /// 只收**外挂字幕档案路径**（[isImportedExternalSubtitlePath]：非 `embedded:<n>`、扩展名
+  /// 受支持）；远端内封轨抽取出来的临时档由 `embedded:<n>` 源指针自己的行承载，不进这里。
   void _registerImportedSubtitleSource(String path) {
-    if (_isRemote) return;
-    final String? videoPath = _currentVideoPath;
-    if (videoPath == null || _subtitleMenuSourcesPath != videoPath) return;
-    final bool alreadyListed = _subtitleMenuSources.any(
+    if (!isImportedExternalSubtitlePath(path)) return;
+    final bool alreadyListed = _importedSubtitleSources.any(
       (SubtitleSource source) => sameExternalSubtitlePathForMenu(source, path),
     );
     if (alreadyListed) return;
@@ -511,9 +555,20 @@ extension _VideoSubtitle on _VideoFushiPageState {
       label: p.basename(path),
     );
     _rebuild(() {
-      _subtitleMenuSources = <SubtitleSource>[added, ..._subtitleMenuSources];
+      _importedSubtitleSources = <SubtitleSource>[
+        added,
+        ..._importedSubtitleSources,
+      ];
     });
   }
+
+  /// 字幕轨 / 副字幕轨行共用的**最终可选列表**：枚举结果（内封轨 + 视频同目录 sidecar）
+  /// 与本会话导入 / 下载的档案合并（BUG-1861）。本地视频专用；远端各类轨各自成行。
+  List<SubtitleSource> get _menuSubtitleSources =>
+      mergeImportedSubtitleSourcesForMenu(
+        _subtitleMenuSources,
+        _importedSubtitleSources,
+      );
 
   /// **纯映射**：把 [SubtitleCueLoadFailure] 翻成给用户看的一句话。
   ///
@@ -783,6 +838,10 @@ extension _VideoSubtitle on _VideoFushiPageState {
     if (_isRemote) {
       // 远端：内存应用，不写本地 DB（_applyRemoteSubtitle 自带 cue 为空时的失败提示
       // + 成功 OSD），不叠加额外提示。
+      // BUG-1861：先登记再应用——远端字幕轨列表原本没有承载本机档案的行，下完只改了
+      // `_currentSubtitleSource`，用户看到字幕生效却在列表里找不到它（也就切不回来）。
+      // 与本地分支一样**不**按应用成功门控：文件已经在盘上了，坏档也该列出来。
+      _registerImportedSubtitleSource(downloaded);
       await _applyRemoteSubtitle(controller, downloaded);
       return;
     }
@@ -850,6 +909,8 @@ extension _VideoSubtitle on _VideoFushiPageState {
     } catch (_) {
       // 保留原始 pick 路径应用；本次可播，只是可能不持久。
     }
+    // BUG-1861：与远端 Jimaku 下载同理，导入的档案要在字幕轨列表里有自己的行。
+    _registerImportedSubtitleSource(applyPath);
     await _applyRemoteSubtitle(controller, applyPath);
   }
 

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1167,6 +1167,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   List<SubtitleSource> _subtitleMenuSources = const <SubtitleSource>[];
   bool _subtitleMenuLoading = false;
 
+  /// BUG-1863：本页在前台期间是否真的进过后台（`paused` / `hidden`，**不含**
+  /// `inactive`）。回前台时据它决定要不要重建视频解码链，见
+  /// [_refreshDecodeAfterResumeIfNeeded]。
+  bool _enteredRealBackground = false;
+
   /// BUG-939：`_subtitleMenuSources` 已成功枚举时对应的本地视频路径。字幕轨枚举
   /// （ffprobe 探测内嵌轨 + 同目录外挂）按此 key 记忆：同一视频重开「字幕」分类直接
   /// 用缓存渲染，不再每次重跑 ffprobe 显加载条、也不再把已枚举出的字幕轨先清空重来
@@ -1932,9 +1937,17 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         unawaited(_flushPersistedVideoSpeed());
         unawaited(_flushPersistedVideoVolume());
         _watchTracker?.stop();
+        // BUG-1863：记下「真的进过后台」。移动端在 app 不可见期间可能被系统回收硬件
+        // 解码器，回来后解码从非关键帧继续、参考帧缺失 → 静止区域被 libavcodec 的
+        // error concealment 填成中性灰。`inactive` 不置这个标记（那期间 app 仍持有
+        // 解码器，白白刷新只是给用户一次无谓卡顿）。
+        _enteredRealBackground = true;
       case AppLifecycleState.resumed:
         // 回前台：重启观看计时器（start() 重置 _tickStart=now，下一窗从此刻起算）。
         _watchTracker?.start();
+        // BUG-1863：从真后台回来先把视频解码链重建一次（详见
+        // [VideoPlayerController.shouldRefreshDecodeOnResume] 的判据与机制说明）。
+        _refreshDecodeAfterResumeIfNeeded();
         // TODO-158/BUG-219: 回前台重申沉浸隐藏系统栏（移动端）。后台 / 通知栏下拉 /
         // 多任务切回后 Android 会把系统栏恢复显示，immersiveSticky 只在进入时设一次
         // 不会自动复申 → 这里主动重设，保证「一直隐藏」。桌面 no-op。
@@ -1946,6 +1959,27 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       case AppLifecycleState.detached:
         break;
     }
+  }
+
+  /// BUG-1863：从真后台回前台后按需重建视频解码链（消除「静止的地方变成灰色」）。
+  ///
+  /// 标记**无条件**清掉，判据不成立只是这一轮不刷新，不能让它攒到下一次 resume 才放
+  /// （那会变成「某次切窗后莫名 seek 一下」）。刷新本身 fire-and-forget：它只是把播放
+  /// 头 seek 回原地，失败（player 已释放 / 流不可 seek）也没有需要回滚的状态。
+  void _refreshDecodeAfterResumeIfNeeded() {
+    final bool wasBackgrounded = _enteredRealBackground;
+    _enteredRealBackground = false;
+    final VideoPlayerController? controller = _controller;
+    if (controller == null) return;
+    final int? durationMs = controller.durationMs;
+    if (!VideoPlayerController.shouldRefreshDecodeOnResume(
+      enteredRealBackground: wasBackgrounded,
+      hasVideo: controller.hasFirstFrame,
+      seekable: durationMs != null && durationMs > 0,
+    )) {
+      return;
+    }
+    unawaited(controller.refreshDecodeAfterResume());
   }
 
   /// 进程退出统一 flush（TODO-086/BUG-191）。把当前播放位置写穿（[flushPosition]

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1173,8 +1173,19 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// （用户报「字幕轨每次都要加载、明明没可加载的地方；之前有的字幕还会消失要等」）。
   /// null=尚未为当前视频枚举 / 已失效（换视频）→ 下次打开重新枚举。BUG-1329：导入或
   /// 下载新字幕档**不**作废这个 key（那会换来一整趟无谓的容器重探 + 长时间加载条），
-  /// 新档由 `_registerImportedSubtitleSource` 就地并入 `_subtitleMenuSources`。
+  /// 新档由 `_registerImportedSubtitleSource` 记进 `_importedSubtitleSources`，渲染时
+  /// 与本枚举结果合并（BUG-1861，不再写进本缓存）。
   String? _subtitleMenuSourcesPath;
+
+  /// BUG-1861：本次播放会话里**落盘并应用过**的外挂字幕档（Jimaku 下载 / 手动导入）。
+  ///
+  /// 与 `_subtitleMenuSources`（纯枚举结果：内封轨 + 视频同目录 sidecar）是两份独立
+  /// 真相，渲染时由 `mergeImportedSubtitleSourcesForMenu` 合并。独立存放的理由见该函数
+  /// 注释：枚举可能失败 / 在途 / 因换集失配，而「这个档案就在盘上、刚被应用」是不依赖
+  /// 枚举的既成事实，不能被枚举缓存的有效性 gate 掉（那正是用户报的「字幕应用上了但
+  /// 列表里没有」）。远端模式同样维护它——远端字幕轨行只覆盖 host sidecar / YouTube 轨 /
+  /// host 内封轨，本机下载的档案此前在远端根本没有对应行。换视频源时清空。
+  List<SubtitleSource> _importedSubtitleSources = const <SubtitleSource>[];
 
   /// 当前视频是否有内封章节（TODO-424）：控制条章节入口按钮的显隐门控。章节列表是
   /// [VideoPlayerController.refreshChapters] open 后**异步**填充的，故缓存这个布尔并由
@@ -2292,6 +2303,10 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // TODO-1307：新一集起播重置「用户已关字幕」标记（字幕后置自动应用的门控，见
     // [_resolveDeferredYoutubeCaptions]）。
     _remoteSubtitleUserDismissed = false;
+    // BUG-1861：本会话导入 / 下载的字幕档按视频源作用域，远端换集一并清空（上一集下的
+    // 档案不该继续挂在新集的字幕轨列表里）。本地换源在 [_applyLoad] 的
+    // `clipExportSourceChanged` 分支清（远端 `_currentVideoPath` 恒 null，走不到那里）。
+    _importedSubtitleSources = const <SubtitleSource>[];
     // YouTube 画质档是 per-video 懒解析：新一集起播先复位（下次点开画质菜单再懒解析）。
     _youtubeVariants = const <YoutubeVideoVariant>[];
     _selectedYoutubeVariantIndex = -1;
@@ -3227,6 +3242,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         _subtitleMenuSources = const <SubtitleSource>[];
         _subtitleMenuLoading = false;
         _subtitleMenuSourcesPath = null;
+        // BUG-1861：导入档登记同样按视频源作用域，换源一并清空（换集后上一集下载的
+        // 档案不该继续挂在新集的字幕轨列表里）。
+        _importedSubtitleSources = const <SubtitleSource>[];
       }
       // externalSubtitlePath 即持久化值：外挂路径 / `embedded:<n>` / `off:`（显式关闭
       // 哨兵，TODO-818）都按原样写进 _currentSubtitleSource 供菜单高亮。内嵌自动加载

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.2.1+1227
+version: 2.2.1+1228
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/media/video/video_secondary_subtitle_same_list_guard_test.dart
+++ b/fushi/test/media/video/video_secondary_subtitle_same_list_guard_test.dart
@@ -31,16 +31,18 @@ void main() {
     return src.substring(start, next < 0 ? src.length : next);
   }
 
-  test('副字幕行遍历完整 _subtitleMenuSources（不得过滤成 isEmbedded）', () {
+  test('副字幕行遍历完整可用列表（不得过滤成 isEmbedded）', () {
     final String src = source.readAsStringSync();
     final String body =
         methodBody(src, 'List<Widget> _buildSecondarySubtitleRows(');
 
+    // BUG-1861 起「同一份可用列表」是 `_menuSubtitleSources`（枚举结果 ∪ 本会话导入 /
+    // 下载的档案），不再是裸 `_subtitleMenuSources`（只有枚举结果）。BUG-900 的不变量
+    // 没变——副字幕要与主字幕轨行读同一份——只是那份列表的名字换了。
     expect(
-      body.contains(
-          'for (final SubtitleSource source in _subtitleMenuSources)'),
+      body.contains('for (final SubtitleSource source in _menuSubtitleSources)'),
       isTrue,
-      reason: '副字幕行必须遍历完整 _subtitleMenuSources（与主字幕同一份可用列表）',
+      reason: '副字幕行必须遍历完整 _menuSubtitleSources（与主字幕同一份可用列表）',
     );
     expect(
       body.contains('.where((SubtitleSource s) => s.isEmbedded)'),

--- a/fushi/test/pages/video_resume_decode_refresh_guard_test.dart
+++ b/fushi/test/pages/video_resume_decode_refresh_guard_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+
+import '../helpers/source_guard.dart';
+import 'video_fushi_page_source_corpus.dart';
+
+/// 解码链刷新原语所在文件（不在视频页 part 语料里，守卫单独读它）。
+const String kVideoPlayerControllerPath =
+    'lib/src/media/video/video_player_controller.dart';
+
+/// BUG-1863：移动端从后台切回来，画面「静止的地方变成灰色、运动的地方正常」。
+///
+/// 那个灰是 `#808080`（`1 << (bit_depth - 1)`），libavcodec 在**参考帧缺失**时 error
+/// concealment 就填这个值；运动区域正常说明 P 帧残差解得好好的。合起来只有一个含义：
+/// 解码器在播放中途被重建过，却没有回到关键帧就继续喂包。移动端在不可见期间被系统
+/// 回收硬件解码器（MediaCodec 是有限资源）会造成这个中途重建，画面要等下一个 IDR 才
+/// 自愈。media_kit 只在 surface 真被重建时刷新（`widListener` 尾部的
+/// `player.seek(currentPosition)`），而 surface 是否重建与解码器是否被回收是两件独立的
+/// 事——这就是「有时候才灰」的缺口。
+///
+/// media_kit 跑不了 headless、系统回收解码器也没法在单测里制造，所以这里测纯判据 +
+/// 锁调用点契约。**真机未复测**（报修时手机 adb 离线），见 BUG-1863 的备注。
+void main() {
+  group('shouldRefreshDecodeOnResume', () {
+    test('移动端真进过后台 + 有画面 + 可 seek → 刷新', () {
+      expect(
+        VideoPlayerController.shouldRefreshDecodeOnResume(
+          enteredRealBackground: true,
+          hasVideo: true,
+          seekable: true,
+          isMobile: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('inactive 一瞥（没真进后台）不刷新', () {
+      // 通知栏下拉 / 多任务一瞥期间 app 仍持有解码器，刷新只是无谓卡顿。
+      expect(
+        VideoPlayerController.shouldRefreshDecodeOnResume(
+          enteredRealBackground: false,
+          hasVideo: true,
+          seekable: true,
+          isMobile: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('纯音频 / 首帧未出画不刷新', () {
+      expect(
+        VideoPlayerController.shouldRefreshDecodeOnResume(
+          enteredRealBackground: true,
+          hasVideo: false,
+          seekable: true,
+          isMobile: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('不可 seek（直播 / 时长未知）不刷新', () {
+      // 直播流上这一 seek 可能把播放头甩走，宁可留着灰屏也不打断直播。
+      expect(
+        VideoPlayerController.shouldRefreshDecodeOnResume(
+          enteredRealBackground: true,
+          hasVideo: true,
+          seekable: false,
+          isMobile: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('桌面一律不刷新', () {
+      // 窗口失焦不会让系统回收解码器；桌面切窗后 seek 只会给用户无谓卡顿。
+      expect(
+        VideoPlayerController.shouldRefreshDecodeOnResume(
+          enteredRealBackground: true,
+          hasVideo: true,
+          seekable: true,
+          isMobile: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('BUG-1863 调用点契约', () {
+    final String src = readVideoFushiSource();
+    final String code = maskCommentsAndScriptLines(src);
+
+    String region(String startSig, String endSig) {
+      final int start = src.indexOf(startSig);
+      expect(start, greaterThanOrEqualTo(0), reason: 'missing $startSig');
+      final int end = src.indexOf(endSig, start + startSig.length);
+      expect(end, greaterThan(start), reason: 'missing $endSig after $startSig');
+      return code.substring(start, end);
+    }
+
+    test('只有 paused / hidden 置「真进过后台」标记，inactive 不置', () {
+      final String body = region(
+        'void didChangeAppLifecycleState(AppLifecycleState state) {',
+        'Future<void> _flushAllForProcessExit() async {',
+      );
+      final int inactive = body.indexOf('case AppLifecycleState.inactive:');
+      final int paused = body.indexOf('case AppLifecycleState.paused:');
+      final int resumed = body.indexOf('case AppLifecycleState.resumed:');
+      expect(inactive, greaterThanOrEqualTo(0));
+      expect(paused, greaterThan(inactive));
+      expect(resumed, greaterThan(paused));
+      // 标记只能出现在 paused/hidden 这一段里：落进 inactive 段就等于「通知栏下拉一下
+      // 也要 seek」，落在 resumed 段之后就永远不会被置真。
+      expect(body.substring(inactive, paused).contains('_enteredRealBackground'),
+          isFalse,
+          reason: 'inactive 期间 app 仍持有解码器，不该记「进过后台」（BUG-1863）');
+      expect(
+          body.substring(paused, resumed).contains('_enteredRealBackground = true'),
+          isTrue,
+          reason: '真后台（paused / hidden）必须记下标记，否则回前台无从判断（BUG-1863）');
+    });
+
+    test('resumed 分支调用解码链刷新', () {
+      final String body = region(
+        'case AppLifecycleState.resumed:',
+        'case AppLifecycleState.detached:',
+      );
+      expect(body.contains('_refreshDecodeAfterResumeIfNeeded()'), isTrue,
+          reason: '回前台必须走一次刷新判断（BUG-1863）');
+    });
+
+    test('标记无条件清除，不会攒到下一次 resume', () {
+      final String body = region(
+        'void _refreshDecodeAfterResumeIfNeeded() {',
+        'Future<void> _flushAllForProcessExit() async {',
+      );
+      final int read = body.indexOf('final bool wasBackgrounded =');
+      final int clear = body.indexOf('_enteredRealBackground = false');
+      expect(read, greaterThanOrEqualTo(0), reason: '必须先取快照再清');
+      expect(clear, greaterThan(read));
+      // 清除必须在任何 return 之前：若被塞进「判据成立」分支里，某次不满足条件的 resume
+      // 会把标记留到下一次 resume，变成「某次切窗后莫名 seek 一下」。
+      final int firstReturn = body.indexOf('return');
+      expect(firstReturn, greaterThan(clear),
+          reason: '标记要在第一个 return 之前就清掉（BUG-1863）');
+      expect(body.contains('controller.refreshDecodeAfterResume()'), isTrue,
+          reason: '判据成立时必须真调刷新');
+    });
+
+    test('刷新不走用户 seek 链路', () {
+      // seekMs 是「用户改变了播放位置」：会清主动跳转快照、作废「只播这一句就停」、
+      // 触发字幕权威重算。解码链刷新的播放位置根本没变，套那套副作用是错的。
+      // 断言落在 controller 文件（不在视频页语料里），同样先掩注释再切。
+      final String controllerSrc =
+          File(kVideoPlayerControllerPath).readAsStringSync();
+      final String controllerCode =
+          maskCommentsAndScriptLines(controllerSrc.replaceAll('\r\n', '\n'));
+      const String sig = 'Future<void> refreshDecodeAfterResume() async {';
+      final int start = controllerCode.indexOf(sig);
+      expect(start, greaterThanOrEqualTo(0), reason: 'missing $sig');
+      final int end = controllerCode.indexOf('bool get isBuffering', start);
+      expect(end, greaterThan(start), reason: 'missing isBuffering after $sig');
+      final String body = controllerCode.substring(start, end);
+      expect(body.contains('seekMs('), isFalse,
+          reason: '刷新只是把播放头 seek 回原地，不该带用户 seek 的副作用（BUG-1863）');
+      expect(body.contains('player.seek(player.state.position)'), isTrue,
+          reason: '刷新必须 seek 到当前位置本身（BUG-1863）');
+    });
+
+    test('刷新判据不在页面里被重新实现一遍', () {
+      expect(code.contains('VideoPlayerController.shouldRefreshDecodeOnResume('),
+          isTrue,
+          reason: '判据是 controller 上的纯函数（可单测），页面不得另写一份（BUG-1863）');
+    });
+  });
+}

--- a/fushi/test/pages/video_subtitle_imported_list_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_imported_list_guard_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_subtitle_source.dart';
+
+import '../helpers/source_guard.dart';
+import 'video_fushi_page_source_corpus.dart';
+
+/// BUG-1861：「获取的字幕能被应用上，但不会出现在列表里」。
+///
+/// BUG-1329 已经把「下载完当场并入列表」接上了，但那条并入路径带着一个前置门
+/// （`_subtitleMenuSourcesPath != videoPath` → 直接 return，且 `_isRemote` 整个跳过）。
+/// 于是三种情况下新档仍被静默丢弃：枚举在途（大容器 ffprobe 要数秒到数十秒）、枚举
+/// 失败（缓存 key 永远不写）、换集后没再进过字幕分类。远端模式更彻底——字幕轨行只覆盖
+/// YouTube 轨 / host sidecar / host 内封轨，本机下载的档案根本没有能承载它的行。
+///
+/// 修法是把两件事拆成两份独立真相：`_subtitleMenuSources` 只装枚举结果，
+/// `_importedSubtitleSources` 装本会话落盘的档案，渲染时由
+/// [mergeImportedSubtitleSourcesForMenu] 合并。下面一半是纯函数行为测试，一半是调用点
+/// 静态守卫（media_kit 跑不了 headless，字幕轨行渲染进不了 widget 测试）。
+void main() {
+  group('mergeImportedSubtitleSourcesForMenu', () {
+    SubtitleSource ext(String path) =>
+        SubtitleSource.external(externalPath: path, label: path);
+
+    test('导入档排在枚举结果之前', () {
+      final List<SubtitleSource> merged = mergeImportedSubtitleSourcesForMenu(
+        <SubtitleSource>[
+          const SubtitleSource.embedded(streamIndex: 0, label: '内封 0'),
+          ext('/videos/ep01.ja.srt'),
+        ],
+        <SubtitleSource>[ext('/docs/video_subtitles/jimaku.srt')],
+      );
+      expect(merged.length, 3);
+      expect(merged.first.externalPath, '/docs/video_subtitles/jimaku.srt');
+    });
+
+    test('枚举结果为空（无内封轨 / 无 sidecar）时导入档仍然可见', () {
+      // 这是用户报的那一屏：生肉视频枚举恒空，列表里就该只有刚下载的那一条。
+      final List<SubtitleSource> merged = mergeImportedSubtitleSourcesForMenu(
+        const <SubtitleSource>[],
+        <SubtitleSource>[ext('/docs/video_subtitles/jimaku.srt')],
+      );
+      expect(merged.length, 1);
+      expect(merged.single.externalPath, '/docs/video_subtitles/jimaku.srt');
+    });
+
+    test('同一路径不重复列出（导入档同时是视频同目录 sidecar）', () {
+      final List<SubtitleSource> merged = mergeImportedSubtitleSourcesForMenu(
+        <SubtitleSource>[ext('/videos/ep01.srt')],
+        <SubtitleSource>[ext('/videos/./ep01.srt')],
+      );
+      expect(merged.length, 1);
+    });
+
+    test('导入档之间也按路径去重', () {
+      final List<SubtitleSource> merged = mergeImportedSubtitleSourcesForMenu(
+        const <SubtitleSource>[],
+        <SubtitleSource>[
+          ext('/docs/video_subtitles/a.srt'),
+          ext('/docs/video_subtitles/./a.srt'),
+        ],
+      );
+      expect(merged.length, 1);
+    });
+
+    test('无导入档时原样返回枚举结果（不复制、不重排）', () {
+      final List<SubtitleSource> enumerated = <SubtitleSource>[
+        const SubtitleSource.embedded(streamIndex: 0, label: '内封 0'),
+      ];
+      expect(
+        identical(
+          mergeImportedSubtitleSourcesForMenu(
+            enumerated,
+            const <SubtitleSource>[],
+          ),
+          enumerated,
+        ),
+        isTrue,
+      );
+    });
+
+    test('内封源（无 externalPath）混进导入列表时被忽略而不是崩', () {
+      final List<SubtitleSource> merged = mergeImportedSubtitleSourcesForMenu(
+        const <SubtitleSource>[],
+        <SubtitleSource>[
+          const SubtitleSource.embedded(streamIndex: 1, label: '内封 1'),
+        ],
+      );
+      expect(merged, isEmpty);
+    });
+  });
+
+  group('sameSubtitleFilePath', () {
+    test('归一化 `..` 与冗余分隔符后视为同一档案', () {
+      expect(
+        sameSubtitleFilePath('/a/b/../b/x.srt', '/a/b/x.srt'),
+        isTrue,
+      );
+    });
+
+    test('不同档案不误判', () {
+      expect(sameSubtitleFilePath('/a/x.srt', '/a/y.srt'), isFalse);
+    });
+  });
+
+  group('BUG-1861 调用点契约', () {
+    final String src = readVideoFushiSource();
+    final String code = maskCommentsAndScriptLines(src);
+
+    String region(String startSig, String endSig) {
+      final int start = src.indexOf(startSig);
+      expect(start, greaterThanOrEqualTo(0), reason: 'missing $startSig');
+      final int end = src.indexOf(endSig, start + startSig.length);
+      expect(end, greaterThan(start), reason: 'missing $endSig after $startSig');
+      return code.substring(start, end);
+    }
+
+    test('登记新档没有任何前置门', () {
+      final String body = region(
+        'void _registerImportedSubtitleSource(String path) {',
+        '/// 字幕轨 / 副字幕轨行共用',
+      );
+      // 「这个档案就在盘上、刚被应用」不依赖枚举是否跑过、跑成没跑成，也不分本地/远端。
+      // 任一符号回到这里都意味着又给登记加回了一个会静默丢档的前置条件（BUG-1861）。
+      for (final String gate in <String>[
+        '_subtitleMenuSourcesPath',
+        '_currentVideoPath',
+        '_isRemote',
+      ]) {
+        expect(body.contains(gate), isFalse,
+            reason: '$gate 不得成为登记的前置条件：枚举在途 / 枚举失败 / 换集失配 / 远端'
+                '四种情况下它都会把用户刚下载的字幕静默丢掉（BUG-1861）');
+      }
+      expect(body.contains('_importedSubtitleSources = <SubtitleSource>['),
+          isTrue,
+          reason: '新档写进独立的导入档列表，而不是枚举缓存——后到的枚举结果会整体覆盖'
+              '枚举缓存，写那里等于让新档随时可能被冲掉（BUG-1861）');
+    });
+
+    test('本地字幕轨行与副字幕行都读合并后的列表', () {
+      // 裸 `_subtitleMenuSources` 只有枚举结果，导入档不在里面。两处渲染都必须走
+      // `_menuSubtitleSources`（= 枚举 ∪ 导入），否则下载的字幕在对应那一栏里消失。
+      expect(
+        'for (final SubtitleSource source in _menuSubtitleSources)'
+            .allMatches(code)
+            .length,
+        2,
+        reason: '主字幕轨行 + 副字幕轨行两处都要读合并列表（BUG-1861 / BUG-900）',
+      );
+      expect(
+        code.contains('for (final SubtitleSource source in _subtitleMenuSources)'),
+        isFalse,
+        reason: '渲染不得再直接遍历纯枚举结果，那样导入档永远不显示（BUG-1861）',
+      );
+    });
+
+    test('远端字幕轨列表给本机导入档留了行', () {
+      expect(
+        code.contains(
+            'for (final SubtitleSource source in _importedSubtitleSources)'),
+        isTrue,
+        reason: '远端行原本只有 YouTube 轨 / host sidecar / host 内封轨，本机下载的档案'
+            '没有任何行能承载它——应用上了却在列表里找不到（BUG-1861）',
+      );
+    });
+
+    test('远端下载 / 导入两条落盘路径都登记', () {
+      final String jimaku = region(
+        'Future<void> _openJimakuDialog(VideoPlayerController controller) async {',
+        'Future<void> _pickAndImportSubtitle(',
+      );
+      final int remoteBranch = jimaku.indexOf('await _applyRemoteSubtitle(');
+      expect(remoteBranch, greaterThanOrEqualTo(0),
+          reason: 'missing remote branch');
+      expect(
+        jimaku
+            .substring(0, remoteBranch)
+            .contains('_registerImportedSubtitleSource(downloaded)'),
+        isTrue,
+        reason: '远端 Jimaku 下载也要登记（BUG-1861）',
+      );
+      final String remoteImport = region(
+        'Future<void> _pickAndImportRemoteSubtitle(',
+        'Future<void> _applyRemoteSubtitle(',
+      );
+      expect(
+        remoteImport.contains('_registerImportedSubtitleSource(applyPath)'),
+        isTrue,
+        reason: '远端手动导入也要登记（BUG-1861）',
+      );
+    });
+
+    test('换视频源时导入档一并清空（本地换源 + 远端换集两条路径）', () {
+      expect(
+        '_importedSubtitleSources = const <SubtitleSource>[]'
+            .allMatches(code)
+            .length,
+        greaterThanOrEqualTo(2),
+        reason: '本地 _applyLoad 换源分支与远端 _loadRemoteEpisode 都要清，否则上一集'
+            '下载的档案会挂在新集的字幕轨列表上（BUG-1861）',
+      );
+      final String remote = region(
+        '_remoteSubtitleUserDismissed = false;',
+        'final int initialPositionMs =',
+      );
+      expect(
+        remote.contains('_importedSubtitleSources = const <SubtitleSource>[]'),
+        isTrue,
+        reason: '远端换集必须清导入档（远端 _currentVideoPath 恒 null，走不到本地换源'
+            '分支的那次清空）',
+      );
+    });
+  });
+}

--- a/fushi/test/pages/video_subtitle_menu_refresh_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_menu_refresh_guard_test.dart
@@ -70,10 +70,8 @@ void main() {
   test('BUG-1329: 并入不重探容器、不重置枚举缓存 key', () {
     final String body = region(
       'void _registerImportedSubtitleSource(String path) {',
-      '/// 选中某副字幕源',
+      '/// 字幕轨 / 副字幕轨行共用',
     );
-    expect(body.contains('_subtitleMenuSourcesPath != videoPath'), isTrue,
-        reason: '尚未为当前视频枚举过时不该硬塞（首次枚举本就会带上它）');
     expect(body.contains('sameExternalSubtitlePathForMenu('), isTrue,
         reason: '已在列表里的同一路径不能再插一条重复行');
     expect(body.contains('_subtitleMenuSourcesPath = null'), isFalse,


### PR DESCRIPTION
用户两条反馈：①「获取的字幕，能被应用上，但不会出现在列表里」（附「视频设置 → 字幕轨」截图，列表里只有四行固定项）；②「从后台切回来的时候有时候静止的地方会变成灰色」（附截图：角色完整、背景整片灰）。

## BUG-1861 · 获取/导入的字幕不进字幕轨列表

BUG-1329 把「下载完当场并入列表」挂在了**跟它无关**的前置条件上——`_subtitleMenuSourcesPath != videoPath` 就 return、`_isRemote` 整个跳过。四种情况下新档被静默丢弃：

1. **枚举在途**：字幕轨枚举是「进入字幕分类」事件驱动的异步 `ffmpeg -i`，大容器要数秒到数十秒。用户一进分类就点「获取字幕」，下载回来时缓存 key 还没写 → 丢；随后枚举完成又**整体覆盖**列表，而它带「当前持久化字幕」用的是 `await` 之前抓的 `_currentSubtitleSource` 快照，新档也进不了 `includeCurrentPersistedSubtitleForMenu`。两头都漏。
2. **枚举失败**：`enumerated == null` 时按设计不写缓存 key，此后每次登记都静默 return。
3. **换集后没再进过字幕分类**：缓存 key 还是上一集的路径。
4. **远端模式**：远端字幕轨行只有 YouTube 轨 / host sidecar / host 内封轨三类，本机下载的档案**没有任何行能承载它** —— 字幕生效了，列表里既看不到也切不回去。

修法是把两件事拆成两份独立真相、渲染时合并：

- `_importedSubtitleSources` 独立存放本会话落盘的档案，`_registerImportedSubtitleSource` **去掉全部前置门**（只按扩展名收 + 按路径去重）。「这个档案就在盘上、刚被应用」是不依赖枚举的既成事实。
- 新纯函数 `mergeImportedSubtitleSourcesForMenu` 在渲染时合并，导入档排最前。写独立列表而非枚举缓存，后到的枚举结果整体覆盖时冲不掉它。
- 主字幕轨行与副字幕轨行（BUG-900 起共用同一份列表）都改读合并后的 `_menuSubtitleSources`。
- 远端分支新增「本机导入档」行（走 `_applyRemoteSubtitle`），与 host sidecar 行按路径去重；远端 Jimaku 下载 / 远端手动导入两条落盘路径补上登记；两条换源路径清空登记表。

## BUG-1863 · 从后台切回来静止区域变灰（`implemented_unverified`）

截图那片灰是 `#808080`，正是 libavcodec 在**参考帧缺失**时填的中性灰（`1 << (bit_depth-1)`，error concealment）；运动区域完整说明 P 帧残差解得好好的。合起来只有一个含义：**解码器在播放中途被重建过，却没有回到关键帧就继续喂包**，DPB 里没有可参考的前帧，要等下一个 IDR 才自愈。

Android 侧：MediaCodec 是有限资源、前台优先，app 不可见期间持有的硬解实例会被回收；而视频页真后台并不暂停解码。

media_kit 并非没管——`android_video_controller` 的 `widListener` 在 `--wid` 变更后重设 `vo`，尾部就是 `player.seek(currentPosition)`，与本修复同一手法。但它的触发条件是 **surface 真被重建**（`SurfaceProducer` → `wid` 这个 `ValueNotifier` 值变化）。**surface 重不重建，与解码器被不被回收，是两件独立的事**：surface 没变时 ValueNotifier 压根不通知，那条刷新路径整个不触发——这就是「**有时候**才灰」。

修法：视频页记「真的进过后台」（`paused`/`hidden` 置真，`inactive` 不置——那期间仍持有解码器），回前台经纯判据 `shouldRefreshDecodeOnResume`（移动端 + 有解码出画的视频轨 + 时长已知可 seek）决定是否 seek 到当前位置本身。走 `Player.seek` 而非 `seekMs`：位置根本没变，不该清主动跳转快照 / 作废「只播这一句就停」/ 触发字幕权威重算。标记在任何早退之前无条件清掉。直播不刷新（那一 seek 会甩走播放头），桌面不做。

## 测试

新增两份守卫（均已**变异实测**，还原后源文件 sha256 回基线）：

- `video_subtitle_imported_list_guard_test.dart`：合并/路径比较纯函数行为（含「枚举结果为空时导入档仍可见」= 用户报的那一屏）+ 调用点契约（登记不得再出现三个前置门符号；两处渲染都读合并列表；远端分支有导入档行；远端两条落盘路径都登记；两条换源路径都清空）。
- `video_resume_decode_refresh_guard_test.dart`：判据五种输入组合 + 调用点契约（标记只在 paused/hidden 置、resumed 真调刷新、标记在第一个 return 前就清、刷新不走 `seekMs`、判据不在页面里重写）。

同批修正两条被本次改名波及的既有守卫（BUG-1329 那条锁的正是被删掉的缓存 key 门；BUG-900 那条锁的列表变量名换成了 `_menuSubtitleSources`，契约不变）。

跑过：全量 `flutter analyze`（含 test）绿；`test/pages` 3084 绿；`test/media` 5297（2 个 error 事件全部来自同一 suite 的并发装载竞态，单跑 14 全绿）；目录枚举型守卫整批 252 绿；读到本次改动文件的其余 29 个测试 258 绿。覆盖面按「谁读了被 `indexOf` 锚点当语料的文件」精确枚举，共 236 份，已全部覆盖。

## 缺口（如实说明）

**BUG-1863 未做真机复测**：报修时本机唯一那台设备（CPH2747，无线调试）adb `offline`，拉不回来，跑不了「播放 → 切后台 → 抢占解码器 → 切回」这条原始失败路径，也就给不出「修复后不再灰」的像素证据。系统回收 MediaCodec 在单测里造不出来，media_kit 也跑不了 headless，自动化只能锁到判据与调用点。故按 SOP 标 `implemented_unverified`，未宣称已修好。

BUG-1861 同样未真机复测（列表行渲染进不了 widget 测试），但它是可从代码路径钉死的逻辑缺陷，契约已由守卫锁住。
