### PR TITLE
fix(download): 特典目录先分类再解集号 + 公共索引器重解析不再联网 (BUG-1865, BUG-1866)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1731 条。点号进各自文件。
+> 共 1733 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1866](bugs/BUG-1866-resolve-public-indexer-needs-network.md) | ✅ | ✅ | 公共索引器重解析非要联网重搜，搜不中就把活资源误报 notFound |
+| [BUG-1865](bugs/BUG-1865-organizer-numbered-extras.md) | ✅ | ✅ | 剧集整理把带编号的特典当正片，与真正片撞号整批失败 |
 | [BUG-1858](bugs/BUG-1858-settings-form-field-width.md) | ✅ | ✅ | 设置页输入框宽度三套并存：下载设置 480 / 在线服务 560 / 其余撑满 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |

--- a/docs/bugs/BUG-1865-organizer-numbered-extras.md
+++ b/docs/bugs/BUG-1865-organizer-numbered-extras.md
@@ -1,0 +1,33 @@
+## BUG-1865 · 剧集整理把带编号的特典当正片，与真正片撞号整批失败
+- **报告**：2026-08-25（用户：Windows 2.2.1-debug.12346）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/download/video_download_organizer.dart:129`（修复前）——`plan()` 对每个视频文件**只按 basename 解析集号**，完全不看它在种子里躺在哪个目录。发布组把特典收进 `EXTRA/` `SPs/` `Previews/` 时，那些文件名同样以 `- 05` / `[SP05]` 结尾，于是「特典」和「正片」抢同一个 `Season NN/<标题> - SNNENN.mkv`。
+
+  用户原始报错（生产库 `video_download_jobs.job_id=f46faffa…`，`last_error`）：
+  ```
+  organization target collision: 響け！ユーフォニアム３ (2024)/Season 03/響け！ユーフォニアム３ (2024) - S03E05.mkv
+  ```
+  种子 `[Moozzi2] Hibike! Euphonium S3 … - TV + SP`（69 文件 / 61 视频）里，解析成第 5 集的有 **7 个**，真正片只占其中一个：
+  ```
+  EXTRA/…[SP05] Making Video Collection - 05 .mkv
+  EXTRA/…[SP08] Extra Episode - 05 .mkv
+  EXTRA/…[SP06] Unused Movie in Main Story Collection - 05 .mkv
+  EXTRA/…[SP07] Web Yokoku - 05 .mkv
+  EXTRA/…[SP00] Menu - 05 [ Ver.01 ] .mkv
+  EXTRA/…[SP00] Menu - 05 [ Ver.02 ] .mkv
+  …[Moozzi2] Hibike! Euphonium S3 - 05 .mkv          ← 唯一的正片
+  ```
+  EXTRA 文件的 backend index 是 7–54、正片是 55–67，**先到先得**，赢下 S03E05 的根本不是正片。
+
+  BUG-1785 只补了「**解不出**集号的进 Extras」，带编号的特典照样冒充正片。撞号只是响的那一半：**不响的那一半是 Menu/PV 被静默改名成正片入库**，那个更贵。
+
+  同类第二例：`job_id=0250057d…`（`[VCB-Studio] Hibike! Euphonium 2`），`Previews/` `SPs/` 下 `[SP01]`–`[SP07]` / `[Menu01]`–`[Menu07]` / `[WEB Preview02]`–`[13]` 与根目录正片 `[01]`–`[13]` 同形。
+
+- **[x] ① 已修复** — `d8e89d7eb4`：把「先解析集号、撞了再说」翻成**先按目录判正片/特典、再解析集号**。新增 `_isInExtraDirectory()` + `_extraDirectoryNames` 词表（`extra/extras/sp/sps/previews/menu/nc/ncop/nced/pv/cm/scan/bdscan/…`），**只查目录段、不查文件名段**——正片文件名天然带 `S3` `BD` `FLACx3`，同一张表扫文件名迟早误伤真番剧标题（`Extra Olympia Kyklos`）。词表没收录的目录名只会退回旧口径（按集号判），不会把正片错判成特典。撞号检查保留给**真**重复（同集 v1/v2），并把消息改成点名两个源文件，否则用户无从判断该删哪个。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/video_download_organizer_test.dart`：
+  - `numbered specials in an EXTRA directory never claim episode targets (BUG-1865)` — 语料是用户原始种子的真实文件名。
+  - `numbered specials in SPs/Previews directories stay out of Season (BUG-1865)` — VCB 布局（编号写在方括号里）。
+  - `a Season subdirectory is not mistaken for an extras directory` — 反向守卫：`Season 1/` 不在词表，必须继续走集号解析，否则整季种子会被整批扫进 Extras（比撞号更糟）。
+  - `a genuine duplicate still fails, and names both source files` — 真冲突仍显式失败。
+
+  变异实测：删掉 `!_isInExtraDirectory(…)` 判定 → 前两条同时红，且报出的正是用户那条 `S03E05` 冲突；把冲突消息改回只有目标名 → 第四条红。两次还原均以 sha256 校验。
+- **备注**：存量卡住的任务（`f46faffa` / `0250057d`）修复后需要用户在下载页手动重试一次；`needsAttention` 会在重试时清掉 `last_error`。词表是增量的——遇到新发布组的特典目录名（不在表里）会退回旧口径，此时症状仍是撞号或错命名，补词表即可。

--- a/docs/bugs/BUG-1866-resolve-public-indexer-needs-network.md
+++ b/docs/bugs/BUG-1866-resolve-public-indexer-needs-network.md
@@ -1,0 +1,25 @@
+## BUG-1866 · 公共索引器重解析非要联网重搜，搜不中就把活资源误报 notFound
+- **报告**：2026-08-25（用户：Windows 2.2.1-debug.12346）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/download/video_download_pipeline_service.dart:1481`（修复前）——`_resolvePayload()` 在任务行没落磁链时，**先**拿 `job.resourceTitle`（完整发布名）回索引器全文重搜找回候选，搜不中才落到 BUG-1784 的离线兜底。
+
+  用户原始报错：
+  ```
+  ExternalProviderFailure(provider=nyaa:nyaa.si, operation=resolve, kind=notFound): selected resource is no longer available
+  ```
+  抛点 `fushi/lib/src/media/video/download/video_resource_registry.dart:116`。
+
+  nyaa 对 `[Airota&VCB-Studio] Gekijouban Hibike! Euphonium Chikai no Finale / 劇場版 響け! ユーフォニアム ~誓いのフィナーレ~ 10-bit 1080p HEVC BDRip [MOVIE]` 这种整串**必然**搜不中；更糟的是 `preferredNyaaSearchQueries()` 会把这串当 romanized 候选、**挤掉**媒体自己的罗马字别名。于是每次重启/重试都要先把一个还活着的资源报成 notFound，再被兜底捞回来。
+
+  取证：生产库 `video_download_jobs.job_id=89656a4f…` 现存的 `magnet_uri` 里空格是 `+`、`&` 是 `%26`，即 `Uri.encodeQueryComponent` 的产物——只有兜底函数这么拼（`NyaaTorrent.magnet` 用 `Uri.encodeComponent`，空格是 `%20`）。说明这条路径在真机上反复走。
+
+  私有 Torznab 没有兜底，同样情况会直接失败到底。
+
+- **[x] ① 已修复** — `d8e89d7eb4`：公共索引器（nyaa/apibay/knaben）的 payload 就是「info hash + 该索引器固定 tracker 集」拼出来的磁链，是**任务行已有数据的纯函数**，压根不需要网络。把它从「重搜失败后的兜底」提到**联网之前**，这条误报就没有产生的余地了。`_recoverPublicMagnetPayload` 随之改名 `_publicIndexerMagnetPayload`（它不再是「恢复」，而是主路径）。
+
+  等价性：nyaa provider 的 `resolve()` 返回 `NyaaTorrent.magnet` = 同一 hash + `kNyaaTrackers`；apibay/knaben 走 `buildPublicVideoIndexMagnet()` = 同一 hash + `kPublicVideoIndexTrackers`。离线拼出来的与联网重搜拿到的只差 `dn` 显示名的编码，BT 语义相同。只认 40 位 v1 hash：BT v2 的 64 位 hash 要走 `urn:btmh:`，拿它拼 `btih` 只会得到一个谁也认不出的磁链，宁可退回重搜。真正必须重搜的只剩私有 Torznab（`.torrent` 走临时凭据 URL，不落库），其失败语义原样保留。
+
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/download/video_download_pipeline_service_test.dart`：
+  `public indexer job resolves offline without touching the network (BUG-1866)` — 存量任务行没磁链 + 索引器**彻底不可达**（`failSearch` 直接抛），断言任务照样进 `download`、`last_error` 为空，且 `searchCalls == 0` / `resolveCalls == 0`（一次网络都不打）。
+
+  变异实测：删掉离线优先块 → 本条与 BUG-1784 的存量行用例同时红。还原以 sha256 校验。
+- **备注**：`_resolvePayload` 给 Torznab 重搜时仍把完整发布名当 query 传（会挤掉 media 别名），本次未动——Torznab 是精确索引，发布名通常能中，且没有已知故障样本。真出现 Torznab 找不回，改的应该是 query 选择而不是再加一层兜底。

--- a/fushi/lib/src/media/video/download/video_download_organizer.dart
+++ b/fushi/lib/src/media/video/download/video_download_organizer.dart
@@ -108,7 +108,7 @@ class VideoDownloadOrganizer {
                 .first
             : null;
     final String? sharedRoot = _sharedRootSegment(videoFiles);
-    final Set<String> targetKeys = <String>{};
+    final Map<String, String> claimedTargets = <String, String>{};
     final List<VideoOrganizationFilePlan> planned =
         <VideoOrganizationFilePlan>[];
     var recognizedEpisodes = 0;
@@ -120,7 +120,14 @@ class VideoDownloadOrganizer {
       // 剧集与电影共用同一条 Extras 规则：认得出集号的进 Season 目录，其余
       // 一律镜像进 Extras（预告/特典/菜单等，BUG-1785），下游 `kind: 'extra'`
       // 已是既有概念。电影额外把最大文件抬成正片。
-      if (request.kind == VideoOrganizationKind.episodic) {
+      //
+      // 集号只对**正片**有意义（BUG-1865）：发布组把特典收进 `EXTRA/` `SPs/`
+      // `Previews/` 时，那些文件名同样以 `- 05` / `[SP05]` 结尾，硬解析会让
+      // 「Making Video Collection - 05」和真正的第 5 集抢同一个目标名。所以
+      // 先按目录判正片/特典、再解析集号；顺序反过来就只能靠撞号事后发现，
+      // 而**没撞上的那些会被静默改名成正片**——后者才是更贵的一半。
+      if (request.kind == VideoOrganizationKind.episodic &&
+          !_isInExtraDirectory(file.name, sharedRoot: sharedRoot)) {
         final VideoNameInfo parsed =
             parseVideoFilename(_segments(file.name).last);
         episodeNumber = parsed.episode;
@@ -151,9 +158,16 @@ class VideoDownloadOrganizer {
       }
       final String targetKey =
           Platform.isWindows ? relative.toLowerCase() : relative;
-      if (!targetKeys.add(targetKey)) {
-        throw FormatException('organization target collision: $relative');
+      // 冲突消息必须点名**两个**源文件：只报目标名的话，用户看到
+      // 「S03E05 撞了」根本不知道是哪两个文件在抢，也就无从判断该删哪个。
+      final String? claimedBy = claimedTargets[targetKey];
+      if (claimedBy != null) {
+        throw FormatException(
+          'organization target collision: $relative '
+          '(claimed by "$claimedBy", also matched by "${file.name}")',
+        );
       }
+      claimedTargets[targetKey] = file.name;
       final String finalPath = p.normalize(p.joinAll(<String>[
         request.sourceRoot,
         ...relative.split('/'),
@@ -168,11 +182,17 @@ class VideoDownloadOrganizer {
       ));
     }
     // 一集都认不出说明种子与「剧集」判定不符（比如误标 kind），全 Extras 的
-    // 静默入库只会把问题藏起来，仍然显式失败。
+    // 静默入库只会把问题藏起来，仍然显式失败。报的样本取**正片候选**里的第一个
+    // ——报特典目录里的文件只会把人往「特典没识别」的错方向带。
     if (request.kind == VideoOrganizationKind.episodic &&
         recognizedEpisodes == 0) {
+      final TorrentFileEntry sample = videoFiles.firstWhere(
+        (TorrentFileEntry file) =>
+            !_isInExtraDirectory(file.name, sharedRoot: sharedRoot),
+        orElse: () => videoFiles.first,
+      );
       throw FormatException(
-        'unable to determine episode number: ${videoFiles.first.name}',
+        'unable to determine episode number: ${sample.name}',
       );
     }
     return VideoOrganizationPlan(remoteSourceRoot: remoteRoot, files: planned);
@@ -289,6 +309,66 @@ class VideoDownloadOrganizer {
     }
     return root;
   }
+
+  /// 发布组显式划为「非正片」的目录名（归一化后比较，见 [_normalizedSegment]）。
+  ///
+  /// 只用来判**目录段**，绝不拿去扫文件名：正片文件名天然带 `S3` `BD Rip`
+  /// `FLACx3` 这类词，同一张表扫文件名迟早误伤真番剧标题（`Extra Olympia
+  /// Kyklos`、`Special A`）。目录是发布组自己划的边界，语义确定得多；表里没有
+  /// 的目录名只会退回旧口径（按集号判），不会把正片错判成特典。
+  static const Set<String> _extraDirectoryNames = <String>{
+    'bdscan',
+    'bdscans',
+    'bonus',
+    'cd',
+    'cds',
+    'cm',
+    'extra',
+    'extras',
+    'interview',
+    'interviews',
+    'making',
+    'menu',
+    'menus',
+    'misc',
+    'nc',
+    'nced',
+    'ncop',
+    'other',
+    'others',
+    'preview',
+    'previews',
+    'pv',
+    'scan',
+    'scans',
+    'sp',
+    'special',
+    'specials',
+    'sps',
+    'trailer',
+    'trailers',
+    'webpreview',
+    'webpreviews',
+  };
+
+  /// 该文件是否躺在发布组标记的特典目录里（共享根与文件名段都不参与判定）。
+  static bool _isInExtraDirectory(String name, {String? sharedRoot}) {
+    final List<String> segments = _segments(name);
+    final List<String> inner = sharedRoot != null && segments.length > 1
+        ? segments.sublist(1)
+        : segments;
+    for (final String segment in inner.take(inner.length - 1)) {
+      if (_extraDirectoryNames.contains(_normalizedSegment(segment))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// 目录名归一化：转小写并去掉所有非字母数字，`SPs` → `sps`、`[SP]` → `sp`、
+  /// `Web Previews` → `webpreviews`、`BD Scans` → `bdscans`。
+  static String _normalizedSegment(String value) =>
+      value.toLowerCase().replaceAll(RegExp('[^a-z0-9]'), '');
 
   /// Extras 目标段：镜像种子内目录结构（剥共享根），路径天然唯一，不同子目录
   /// 里的同名特典不会互相顶掉。每段过 [_safeSegment]，末段扩展名统一小写。

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -1477,29 +1477,32 @@ class VideoDownloadPipelineService {
     if (job.resourceProvider == kManualVideoDownloadResourceProvider) {
       return _resolveManualMetainfoPayload(job);
     }
-    final TorrentAddPayload payload;
-    try {
-      payload = await resourceRegistry.resolveSelection(
-        selection: VideoResourceSelection(
-          providerId: job.resourceProvider,
-          remoteId: job.selectedResourceId,
-          title: job.resourceTitle ?? job.title,
-        ),
-        request: VideoResourceSearchRequest(
-          media: _mediaReference(job),
-          query: job.resourceTitle ?? job.title,
-          season: job.season,
-        ),
-      );
-    } on Object {
-      // 重搜找不回（条目下架/发布名分词搜不中/索引器故障）不代表资源没了：
-      // 公共索引器（nyaa/apibay/knaben）的磁链本就是 info hash + 固定
-      // tracker 现场拼出来的，任务行里的 hash 就够重建（BUG-1784 存量行）。
-      final TorrentMagnetPayload? recovered = _recoverPublicMagnetPayload(job);
-      if (recovered == null) rethrow;
-      await _persistResolvedMagnet(job, recovered.magnetUri);
-      return recovered;
+    // 公共索引器（nyaa/apibay/knaben）的 payload 就是「info hash + 该索引器的
+    // 固定 tracker 集」拼出来的磁链——那是任务行里**已有数据的纯函数**，压根
+    // 不需要网络（BUG-1866）。此前它只是重搜失败后的兜底，正常路径先拿完整
+    // 发布名回索引器全文搜：nyaa 对
+    // `[Airota&VCB-Studio] Gekijouban … BDRip [MOVIE]` 这种串必然搜不中，于是
+    // 每次重启/重试都要先把一个还活着的资源误报成 notFound、再被兜底捞回来。
+    // 把纯函数摆到联网之前，这条误报就没有产生的余地了；产出与联网重搜等价
+    // （同一 hash、同一 tracker 集，只有 `dn` 显示名的编码可能不同）。
+    // 真正必须重搜的只剩私有 Torznab：它的 .torrent 走临时凭据 URL，不落库。
+    final TorrentMagnetPayload? offline = _publicIndexerMagnetPayload(job);
+    if (offline != null) {
+      await _persistResolvedMagnet(job, offline.magnetUri);
+      return offline;
     }
+    final TorrentAddPayload payload = await resourceRegistry.resolveSelection(
+      selection: VideoResourceSelection(
+        providerId: job.resourceProvider,
+        remoteId: job.selectedResourceId,
+        title: job.resourceTitle ?? job.title,
+      ),
+      request: VideoResourceSearchRequest(
+        media: _mediaReference(job),
+        query: job.resourceTitle ?? job.title,
+        season: job.season,
+      ),
+    );
     // 重搜成功解析出的磁链写回任务行：下次重启/重试不再吃索引器可用性。
     if (payload is TorrentMagnetPayload) {
       await _persistResolvedMagnet(job, payload.magnetUri);
@@ -1507,13 +1510,15 @@ class VideoDownloadPipelineService {
     return payload;
   }
 
-  /// 公共索引器任务的离线磁链重建：`magnet:?xt=urn:btih:<hash>` + 该索引器
-  /// 的固定 tracker 集。私有 Torznab（DHT 关闭、需 .torrent 凭据）返回 null，
-  /// 保持原失败语义。
-  TorrentMagnetPayload? _recoverPublicMagnetPayload(VideoDownloadJobRow job) {
+  /// 公共索引器任务的离线磁链：`magnet:?xt=urn:btih:<hash>` + 该索引器的固定
+  /// tracker 集。私有 Torznab（DHT 关闭、需 .torrent 凭据）返回 null，由调用方
+  /// 回索引器重搜，保持原失败语义。
+  ///
+  /// 只认 40 位 v1 hash：BT v2 的 64 位 hash 要走 `urn:btmh:`，拿它拼 `btih`
+  /// 只会得到一个谁也认不出的磁链，宁可退回重搜。
+  TorrentMagnetPayload? _publicIndexerMagnetPayload(VideoDownloadJobRow job) {
     final String provider = job.resourceProvider;
-    bool isProvider(String id) =>
-        provider == id || provider.startsWith('$id:');
+    bool isProvider(String id) => provider == id || provider.startsWith('$id:');
     final List<String>? trackers = isProvider('nyaa')
         ? kNyaaTrackers
         : isProvider(kApibayResourceProviderId) ||

--- a/fushi/test/media/video/download/video_download_organizer_test.dart
+++ b/fushi/test/media/video/download/video_download_organizer_test.dart
@@ -210,6 +210,273 @@ void main() {
     );
   });
 
+  test(
+      'numbered specials in an EXTRA directory never claim episode targets '
+      '(BUG-1865)', () async {
+    final Directory root = await Directory.systemTemp.createTemp(
+      'fushi-organizer-numbered-extras-',
+    );
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+    // 用户原始种子（Moozzi2 Hibike! Euphonium S3 - TV + SP）的真实文件名：
+    // EXTRA 里有 6 个以 `- 05` 结尾的特典，硬按文件名解集号时它们与真正的第 5
+    // 集抢同一个 `Season 03/… - S03E05.mkv`，整批整理直接失败。
+    const String releaseRoot =
+        '[Moozzi2] Hibike! Euphonium S3 [ x265-10Bit Ver. ] - TV + SP';
+    const String suffix = '(BD 1920x1080 x265-10Bit Flac).mkv';
+    final VideoOrganizationPlan plan = const VideoDownloadOrganizer().plan(
+      VideoOrganizationRequest(
+        torrentId: 'hash',
+        title: '響け！ユーフォニアム３',
+        year: 2024,
+        kind: VideoOrganizationKind.episodic,
+        defaultSeasonNumber: 3,
+        sourceRoot: root.path,
+        pathMapping: VideoDownloadPathMapping(
+          remoteRoot: '/library',
+          localRoot: root.path,
+        ),
+      ),
+      <TorrentFileEntry>[
+        const TorrentFileEntry(
+          name: '$releaseRoot/EXTRA/[Moozzi2] Hibike! Euphonium S3 '
+              '[SP05] Making Video Collection - 05 $suffix',
+          size: 30,
+          progress: 1,
+          index: 11,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/EXTRA/[Moozzi2] Hibike! Euphonium S3 '
+              '[SP08] Extra Episode - 05 $suffix',
+          size: 31,
+          progress: 1,
+          index: 16,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/EXTRA/[Moozzi2] Hibike! Euphonium S3 '
+              '[SP00] Menu - 05 [ Ver.01 ] $suffix',
+          size: 32,
+          progress: 1,
+          index: 26,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/EXTRA/[Moozzi2] Hibike! Euphonium S3 '
+              '[SP01] NCOP $suffix',
+          size: 33,
+          progress: 1,
+          index: 13,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/[Moozzi2] Hibike! Euphonium S3 - 05 '
+              '(BD 1920x1080 x265-10Bit FLACx3).mkv',
+          size: 900,
+          progress: 1,
+          index: 64,
+        ),
+      ],
+    );
+
+    final Map<int, VideoOrganizationFilePlan> byIndex =
+        <int, VideoOrganizationFilePlan>{
+      for (final VideoOrganizationFilePlan file in plan.files)
+        file.backendFileIndex: file,
+    };
+    // 唯一的正片拿到 Season 目标，且拿到的是它自己的集号。
+    expect(
+      byIndex[64]!.targetRelativePath,
+      '響け！ユーフォニアム３ (2024)/Season 03/'
+      '響け！ユーフォニアム３ (2024) - S03E05.mkv',
+    );
+    expect(byIndex[64]!.episodeNumber, 5);
+    // 特典一律镜像进 Extras/EXTRA/，且**不带集号**——带了就意味着它还在参与
+    // 集号命名空间，撞号只是迟早的事。
+    for (final int index in <int>[11, 16, 26, 13]) {
+      expect(
+        byIndex[index]!.targetRelativePath,
+        startsWith('響け！ユーフォニアム３ (2024)/Extras/EXTRA/'),
+        reason: 'index $index 应进 Extras',
+      );
+      expect(byIndex[index]!.episodeNumber, isNull, reason: 'index $index');
+    }
+    // Season 目录下有且只有正片一个文件。
+    expect(
+      plan.files
+          .where(
+            (VideoOrganizationFilePlan file) =>
+                file.targetRelativePath.contains('/Season '),
+          )
+          .map((VideoOrganizationFilePlan file) => file.backendFileIndex),
+      <int>[64],
+    );
+  });
+
+  test(
+      'numbered specials in SPs/Previews directories stay out of Season '
+      '(BUG-1865)', () async {
+    final Directory root = await Directory.systemTemp.createTemp(
+      'fushi-organizer-vcb-extras-',
+    );
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+    // 第二个真实种子（VCB-Studio Hibike! Euphonium 2）：编号写在方括号里
+    // （`[SP05]` `[Menu05]` `[WEB Preview05]`），与正片 `[05]` 同形。
+    const String releaseRoot = '[VCB-Studio] Hibike! Euphonium 2 [Ma10p_1080p]';
+    final VideoOrganizationPlan plan = const VideoDownloadOrganizer().plan(
+      VideoOrganizationRequest(
+        torrentId: 'hash',
+        title: '響け！ユーフォニアム 2',
+        year: 2016,
+        kind: VideoOrganizationKind.episodic,
+        defaultSeasonNumber: 2,
+        sourceRoot: root.path,
+        pathMapping: VideoDownloadPathMapping(
+          remoteRoot: '/library',
+          localRoot: root.path,
+        ),
+      ),
+      <TorrentFileEntry>[
+        const TorrentFileEntry(
+          name: '$releaseRoot/'
+              '[VCB-Studio] Hibike! Euphonium 2 [05][Ma10p_1080p][x265_flac_2aac].mkv',
+          size: 900,
+          progress: 1,
+          index: 0,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot\\SPs\\'
+              '[VCB-Studio] Hibike! Euphonium 2 [SP05][Ma10p_1080p][x265_flac].mkv',
+          size: 40,
+          progress: 1,
+          index: 1,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/SPs/'
+              '[VCB-Studio] Hibike! Euphonium 2 [Menu05][Ma10p_1080p][x265_flac].mkv',
+          size: 41,
+          progress: 1,
+          index: 2,
+        ),
+        const TorrentFileEntry(
+          name: '$releaseRoot/Previews/'
+              '[VCB-Studio] Hibike! Euphonium 2 [WEB Preview05][Ma10p_1080p][x265_flac].mkv',
+          size: 42,
+          progress: 1,
+          index: 3,
+        ),
+      ],
+    );
+
+    final Map<int, VideoOrganizationFilePlan> byIndex =
+        <int, VideoOrganizationFilePlan>{
+      for (final VideoOrganizationFilePlan file in plan.files)
+        file.backendFileIndex: file,
+    };
+    expect(
+      byIndex[0]!.targetRelativePath,
+      '響け！ユーフォニアム 2 (2016)/Season 02/'
+      '響け！ユーフォニアム 2 (2016) - S02E05.mkv',
+    );
+    expect(
+      byIndex[1]!.targetRelativePath,
+      startsWith('響け！ユーフォニアム 2 (2016)/Extras/SPs/'),
+    );
+    expect(
+      byIndex[2]!.targetRelativePath,
+      startsWith('響け！ユーフォニアム 2 (2016)/Extras/SPs/'),
+    );
+    expect(
+      byIndex[3]!.targetRelativePath,
+      startsWith('響け！ユーフォニアム 2 (2016)/Extras/Previews/'),
+    );
+  });
+
+  test('a Season subdirectory is not mistaken for an extras directory', () {
+    // 特典判定只认词表里的目录名。`Season 1/` 这类真·正片目录不在表里，必须
+    // 继续走集号解析——否则整季种子会被整批扫进 Extras，比撞号还糟。
+    final VideoOrganizationPlan plan = const VideoDownloadOrganizer().plan(
+      VideoOrganizationRequest(
+        torrentId: 'hash',
+        title: 'Show',
+        kind: VideoOrganizationKind.episodic,
+        sourceRoot: _localRoot,
+        pathMapping: VideoDownloadPathMapping(
+          remoteRoot: '/library',
+          localRoot: _localRoot,
+        ),
+      ),
+      <TorrentFileEntry>[
+        const TorrentFileEntry(
+          name: 'Show Complete/Season 1/Show - 01.mkv',
+          size: 100,
+          progress: 1,
+          index: 0,
+        ),
+        const TorrentFileEntry(
+          name: 'Show Complete/Extras/Show NCOP.mkv',
+          size: 10,
+          progress: 1,
+          index: 1,
+        ),
+      ],
+    );
+
+    expect(
+      plan.files.first.targetRelativePath,
+      'Show/Season 01/Show - S01E01.mkv',
+    );
+    expect(plan.files.first.episodeNumber, 1);
+    expect(
+      plan.files.last.targetRelativePath,
+      'Show/Extras/Extras/Show NCOP.mkv',
+    );
+  });
+
+  test('a genuine duplicate still fails, and names both source files', () {
+    // 撞号检查保留给**真**冲突（同一集两个文件）。修 BUG-1865 是把假冲突消掉，
+    // 不是把冲突检查拆掉；消息必须点名两个源文件，否则用户无从判断删哪个。
+    expect(
+      () => const VideoDownloadOrganizer().plan(
+        VideoOrganizationRequest(
+          torrentId: 'hash',
+          title: 'Show',
+          kind: VideoOrganizationKind.episodic,
+          sourceRoot: _localRoot,
+          pathMapping: VideoDownloadPathMapping(
+            remoteRoot: '/library',
+            localRoot: _localRoot,
+          ),
+        ),
+        <TorrentFileEntry>[
+          const TorrentFileEntry(
+            name: 'Show/Show - 01 [v1].mkv',
+            size: 100,
+            progress: 1,
+            index: 0,
+          ),
+          const TorrentFileEntry(
+            name: 'Show/Show - 01 [v2].mkv',
+            size: 110,
+            progress: 1,
+            index: 1,
+          ),
+        ],
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (FormatException error) => error.message,
+          'message',
+          allOf(
+            contains('organization target collision'),
+            contains('Show - 01 [v1].mkv'),
+            contains('Show - 01 [v2].mkv'),
+          ),
+        ),
+      ),
+    );
+  });
+
   test('unparseable episodic filename blocks before backend mutation',
       () async {
     final Directory root = await Directory.systemTemp.createTemp(

--- a/fushi/test/media/video/download/video_download_pipeline_service_test.dart
+++ b/fushi/test/media/video/download/video_download_pipeline_service_test.dart
@@ -174,7 +174,8 @@ void main() {
     expect(backend.addCalls, 1);
   });
 
-  test('legacy job without magnet recovers offline from its info hash '
+  test(
+      'legacy job without magnet recovers offline from its info hash '
       'when re-search misses (BUG-1784)', () async {
     final _FakeTorrentBackend backend = _FakeTorrentBackend(
       snapshots: <TorrentSnapshot>[_downloadingSnapshot(progress: 0.25)],
@@ -183,7 +184,8 @@ void main() {
       backend: backend,
     );
     addTearDown(environment.close);
-    // 存量任务行形态：入队时没落磁链，且条目已从索引器搜不回。
+    // 存量任务行形态：入队时没落磁链。索引器就算会搜空也不影响结果——BUG-1866
+    // 起离线磁链是主路径，这条设置只是让「重搜找不回」这个历史前提留在用例里。
     environment.provider.returnEmptySearch = true;
 
     final String jobId = await environment.service.enqueue(
@@ -198,6 +200,39 @@ void main() {
     // 离线重建的磁链（info hash + 该索引器固定 tracker）落回任务行。
     expect(downloading.magnetUri, startsWith('magnet:?xt=urn:btih:'));
     expect(downloading.magnetUri, contains(_torrentHash));
+    expect(environment.provider.resolveCalls, 0);
+    expect(backend.addCalls, 1);
+  });
+
+  test(
+      'public indexer job resolves offline without touching the network '
+      '(BUG-1866)', () async {
+    final _FakeTorrentBackend backend = _FakeTorrentBackend(
+      snapshots: <TorrentSnapshot>[_downloadingSnapshot(progress: 0.25)],
+    );
+    final _PipelineEnvironment environment = await _PipelineEnvironment.create(
+      backend: backend,
+    );
+    addTearDown(environment.close);
+    // 原始失败路径：存量任务行没磁链，索引器又不可达。旧口径先联网重搜、抛了
+    // 才兜底，那一次失败会把一个**还活着**的资源标成
+    // `ExternalProviderFailure(kind=notFound)` 推到用户面前。
+    environment.provider.failSearch = true;
+
+    final String jobId = await environment.service.enqueue(
+      environment.enqueueRequest(),
+    );
+    final VideoDownloadJobRow downloading = await _waitForJob(
+      environment.database,
+      jobId,
+      (VideoDownloadJobRow row) => row.stage == VideoDownloadJobStage.download,
+    );
+
+    expect(downloading.magnetUri, contains(_torrentHash));
+    expect(downloading.lastError, isNull);
+    // 关键不变式：公共索引器的 payload 是任务行数据的纯函数，一次网络都不打。
+    // 这条断言塌成 `searchCalls >= 0` 就等于把 BUG-1866 放回来了。
+    expect(environment.provider.searchCalls, 0);
     expect(environment.provider.resolveCalls, 0);
     expect(backend.addCalls, 1);
   });
@@ -1970,6 +2005,9 @@ class _FakeResourceProvider implements VideoResourceProvider {
   /// true = 重搜找不回已选条目（条目下架/发布名搜不中），search 返回空成功。
   bool returnEmptySearch = false;
 
+  /// true = 索引器彻底不可达（网络故障/限流/下线），search 直接抛。
+  bool failSearch = false;
+
   @override
   String get id => 'nyaa';
 
@@ -1987,6 +2025,14 @@ class _FakeResourceProvider implements VideoResourceProvider {
     VideoResourceSearchRequest request,
   ) async {
     searchCalls += 1;
+    if (failSearch) {
+      throw const ExternalProviderFailure(
+        providerId: 'nyaa',
+        operation: 'search',
+        kind: ExternalProviderFailureKind.unavailable,
+        message: 'indexer is unreachable',
+      );
+    }
     return ProviderBatchResult<VideoResourceCandidate>.success(
       returnEmptySearch
           ? const <VideoResourceCandidate>[]


### PR DESCRIPTION
用户 2026-08-25 在 Windows `2.2.1-debug.12346` 上报的两条下载任务报错，都做了根因修复。

## BUG-1865 · 带编号的特典冒充正片，与真正片撞号整批失败

```
organization target collision: 響け！ユーフォニアム３ (2024)/Season 03/響け！ユーフォニアム３ (2024) - S03E05.mkv
```

`plan()` 对每个视频文件**只按 basename 解集号**，不看它在种子里躺在哪个目录。发布组把特典收进 `EXTRA/` `SPs/` `Previews/` 时，那些文件名同样以 `- 05` / `[SP05]` 结尾。用户那个种子（`[Moozzi2] Hibike! Euphonium S3 … - TV + SP`，61 个视频）里解析成第 5 集的有 **7 个**，真正片只占其中一个，而 EXTRA 的 backend index 更靠前、先到先得。

BUG-1785 只补了「**解不出**集号的进 Extras」。撞号只是响的那一半——**不响的那一半是 Menu/PV 被静默改名成正片入库**。

改成**先按目录判正片/特典、再解析集号**：新增 `_isInExtraDirectory()` + `_extraDirectoryNames` 词表，**只查目录段、不查文件名段**（正片文件名天然带 `S3` `BD` `FLACx3`，同一张表扫文件名迟早误伤真番剧标题如 `Extra Olympia Kyklos`）。词表没收录的目录名退回旧口径，不会把正片错判成特典。撞号检查保留给**真**重复（同集 v1/v2），消息改成点名两个源文件。

## BUG-1866 · 公共索引器重解析非要联网，搜不中就把活资源误报 notFound

```
ExternalProviderFailure(provider=nyaa:nyaa.si, operation=resolve, kind=notFound): selected resource is no longer available
```

`_resolvePayload()` 在任务行没落磁链时**先**拿完整发布名回索引器重搜。nyaa 对 `[Airota&VCB-Studio] Gekijouban … BDRip [MOVIE]` 必然搜不中（且这串会挤掉 media 自己的罗马字别名），于是每次重启/重试都要先把一个还活着的资源报成 notFound、再被 BUG-1784 的离线兜底捞回来。

公共索引器的 payload 本就是「info hash + 固定 tracker 集」的**纯函数**，不需要网络。把它提到联网之前，这条误报就没有产生的余地。产出与联网重搜等价（同 hash、同 tracker 集，只差 `dn` 编码）。只认 40 位 v1 hash；私有 Torznab 仍走重搜，失败语义不变。

## 验证

- `flutter analyze` 全绿（No issues found）
- 全量 `dart run tool/flutter_test_failures.dart --no-pub` → `FLUTTER TEST VERDICT: PASSED - 20798 tests ran`
- **变异实测三条全部有效**：去掉特典目录判定 → 两条 BUG-1865 测试红且报出用户原始那条 `S03E05` 冲突；冲突消息去掉源文件名 → 重复检测测试红；删掉离线优先块 → BUG-1866 与 BUG-1784 同时红。还原均以 sha256 校验。
- **真实语料回归**（生产库导出的完整文件清单，非样本）：Moozzi2 S3 从 61 个视频认出 13 集正片、集号 1–13 完整无重复、48 个进 Extras；VCB Hibike 2 从 51 个视频认出 13 集、38 个进 Extras。正片全部来自根目录，无特典混入、无漏集。

## 存量任务

用户那两个卡在 `needsAttention/organize` 的任务（`f46faffa` / `0250057d`）需要在下载页手动重试一次，重试会清掉 `last_error`。

https://claude.ai/code/session_017tfH7YAXYRxGux3hLCHVDo
