### PR TITLE
fix(video): 封面回填不再把 best-effort 失败刷进用户错误日志（BUG-1867）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1731 条。点号进各自文件。
+> 共 1732 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1867](bugs/BUG-1867-cover-backfill-hollow-m2ts.md) | ✅ | ✅ | 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg |
 | [BUG-1858](bugs/BUG-1858-settings-form-field-width.md) | ✅ | ✅ | 设置页输入框宽度三套并存：下载设置 480 / 在线服务 560 / 其余撑满 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |

--- a/docs/bugs/BUG-1867-cover-backfill-hollow-m2ts.md
+++ b/docs/bugs/BUG-1867-cover-backfill-hollow-m2ts.md
@@ -1,8 +1,8 @@
 ## BUG-1867 · 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg
 - **报告**：2026-08-25（用户：错误日志页连刷 `extractVideoFrameViaFfmpeg ffmpeg exit -1094995529 … Error opening input files: Invalid data found when processing input`）
 - **真实性**：✅ 真 bug（本机生产库实测复现，三类失败全部拿到 ffmpeg 原始 stderr 与逐条耗时）
-- **[x] ① 已修复** — `1cd7ad0` 见下「修复」
-- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_cover_source_filter_test.dart`（新增 9 例，4 个变异实测全部抓住）
+- **[x] ① 已修复** — `501ccabefd` 见下「修复」
+- **[x] ② 已加自动化测试** — `501ccabefd` · `fushi/test/media/video/video_cover_source_filter_test.dart`（新增 9 例，4 个变异实测全部抓住）
 - **备注**：调查中另量到一个**独立**的性能问题（C/OK 类抽帧 18–75s/条），未在本轮修，见文末「相邻发现」。
 
 ### 复现与证据（本机生产库 `D:\APP\HIBIKI_date\support\fushi.db`，随包 `D:\APP\Hibiki\ffmpeg.exe` n7.1.5）

--- a/docs/bugs/BUG-1867-cover-backfill-hollow-m2ts.md
+++ b/docs/bugs/BUG-1867-cover-backfill-hollow-m2ts.md
@@ -1,0 +1,89 @@
+## BUG-1867 · 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg
+- **报告**：2026-08-25（用户：错误日志页连刷 `extractVideoFrameViaFfmpeg ffmpeg exit -1094995529 … Error opening input files: Invalid data found when processing input`）
+- **真实性**：✅ 真 bug（本机生产库实测复现，三类失败全部拿到 ffmpeg 原始 stderr 与逐条耗时）
+- **[x] ① 已修复** — `1cd7ad0` 见下「修复」
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_cover_source_filter_test.dart`（新增 9 例，4 个变异实测全部抓住）
+- **备注**：调查中另量到一个**独立**的性能问题（C/OK 类抽帧 18–75s/条），未在本轮修，见文末「相邻发现」。
+
+### 复现与证据（本机生产库 `D:\APP\HIBIKI_date\support\fushi.db`，随包 `D:\APP\Hibiki\ffmpeg.exe` n7.1.5）
+
+`_maybeBackfillCovers`（`fushi/lib/src/pages/implementations/home_video_page.dart:805`）扫全库 858 行，
+筛出 **34 条**「无封面 + 本地文件存在」的候选，全部是 BDMV `.m2ts`。逐条按生产参数
+（`buildFfmpegFrameArgs`：`-ss 10.000 -i <path> -an -frames:v 1 -update 1 out.jpg`）实跑并计时：
+
+| 类 | ffmpeg 末行 | 实际是什么 | 条数 | ffmpeg 合计 | 单条均值 |
+|---|---|---|---|---|---|
+| A | `Error opening input files: Invalid data found when processing input` | torrent **预分配但未下载完成**的空洞文件（头 64KB 全 `0x00`，无 TS sync），共 70.3GB | 12 | 0.3s | 0.02s |
+| B | `Output file does not contain any stream` | BDMV 的**纯音频短 m2ts**（菜单/音轨，0.3–3.3MB），容器里没有视频流 | 16 | 1.2s | 0.07s |
+| C | `Nothing was written…` / `Conversion failed!` | 有视频流，`-ss 10` 处取不到帧 | 2 | 36.6s | 18.31s |
+| — | 成功 | 真出封面 | 4 | 301.3s | 75.33s |
+
+A 类逐字命中用户日志。判据交叉验证：实跑分类为 A 的 12 条，`head[0:65536] == b"\x00"*65536` **全部**为 True；
+B/C/OK 的 22 条**全部**为 False（零假阳性零假阴性）。对照样本 `Vol1\STREAM\00010.m2ts`（完整，192 字节步长
+10922/10922 命中 `0x47`）抽帧成功；`Vol1\STREAM\00014.m2ts`（空洞，0/10922）报 A。
+
+### 根因
+
+1. **best-effort 的回填失败被当成 app 错误上报**（= 用户看到的刷屏）。
+   `extractVideoFrameViaFfmpeg`（`fushi/lib/src/utils/misc/desktop_audio_clipper.dart:745`）非零退出一律走
+   `_reportFfmpegFailure` → `ErrorLogService.log`（**用户可见错误日志页**）。
+   而同一条产线上游的 `extractEmbeddedVideoCoverViaFfmpeg`
+   （`fushi/lib/src/media/video/video_cover_extractor.dart:94`）对非零退出的判定是
+   「这容器没有内嵌封面 = 预期内的正常结果」，**不上报**。同一个「这文件给不出封面」的事实，
+   两步给了两种严重性。回填这条后台 best-effort 路径上，A/B/C 三类全是预期内的正常结果：
+   书架显示占位图本身就是用户可见的反馈，错误日志页是留给「app 出错了」的。
+
+2. **候选判据只问「路径存在」，不问「内容是否已落盘」**。
+   `isLocalFrameExtractableVideoSource`（`video_cover_extractor.dart:149`）只排除空路径 / `http(s)` / 播放列表清单；
+   `_maybeBackfillCovers` 再补一道 `File(path).existsSync()`。torrent 预分配的空洞文件两道都过——它有正确的
+   扩展名、正确的字节数（8GB）、路径存在，只是**内容还不在盘上**。
+
+   ⚠ 诚实计量：这一条**不是性能问题**。实测 ffmpeg 在头部就 probe 失败，0.02s/条，12 条合计 0.3s。
+   修它买的是三件事：① 不为必然失败的抽帧去排 `VideoCoverMutationGate` 的队（同期的删除、手选封面、
+   刮削要等在后面）；② 把「还没下完」与「这文件坏了」分成两个可诊断的原因，而不是混成同一个
+   `extract-failed`；③ 判定不依赖 ffmpeg 的具体行为（换 demuxer 白名单或版本都不影响判据正确性）。
+
+放大器：`CoverBackfillLedger`（`fushi/lib/src/media/video/cover_backfill_ledger.dart`）是**会话级内存单例**，
+文件头注释写「不落库持久化 … 每次冷启动最多为每个坏条目付一次探测成本」。该取舍在本库上的实际代价是：
+每次冷启动进视频页 = 重烧 34 次 ffmpeg（**合计 339s**）+ 刷 30 条用户可见错误日志。
+
+### 修复
+
+- ① 回填路径的抽帧失败降级为诊断日志：`extractVideoFrameViaFfmpeg` / `extractVideoCover` 加
+  `diagnosticOnly`（复用既有机制 `desktop_audio_clipper.dart:373`），`_maybeBackfillCovers` 传 `true`。
+  与 `extractEmbeddedVideoCoverViaFfmpeg` 的既有判据对齐。**`ProcessException`（ffmpeg 根本起不来）
+  仍进错误日志**——那是真错误，不受本开关影响；用户主动触发的导入/换封面路径保持默认 `false`。
+- ② 新增 `isHollowMediaHeaderBytes` / `hasHollowMediaHeader`（`video_cover_extractor.dart`）。
+  两处接线：抽取器层 `_extractVideoCoverUnlocked` 早退（与 BUG-1564 的清单拒收同层收口，所有调用方
+  一并免疫）+ page 层 `_maybeBackfillCovers` 在**进闸门之前**判掉并记账 `reason: 'hollow-header'`。
+  判据安全性：每种被支持的容器头部都有魔数（TS `0x47` / MP4 `ftyp` / MKV `1A45DFA3` / RIFF / FLV），
+  合法媒体文件头部不可能全零，无误伤面。读失败（权限/掉盘/竞态删除）返回 true = 按「此刻不可用」跳过。
+- ledger 持久化**不做**：失败重烧的时间大头不在 A 类（见上表），持久化解决不了它，反而要付 schema
+  迁移 + 陈旧账本的代价。保持 BUG-1564 的原取舍。
+
+### 测试
+
+`fushi/test/media/video/video_cover_source_filter_test.dart` 新增 9 例：纯函数判据（空/全零/尾字节非零/
+四种真容器魔数）、真文件 IO（空洞预分配 / 192 字节步长的真 m2ts 布局 / 内容只在探测窗之后 / 短于探测窗 /
+零长 / 不存在）、抽取器层拒收（无 path_provider mock、无 ffmpeg，靠早退才不炸 MissingPluginException）、
+两条视频页接线守卫（空洞判据必须在闸门之前 + 回填必须 `diagnosticOnly: true`）。
+
+变异实测（二进制读写、唯一锚点、sha256 校验回滚，4/4 全部抓住）：
+真删除 page 层判据整块 → 顺序守卫红；删 `diagnosticOnly: true` → 分级守卫红；
+删抽取器层拒收 → 行为测试红（MissingPluginException）；判据恒返 false → 4 条真文件用例红。
+
+相邻定向：`cover_backfill_ledger_test` / `video_cover_extractor_test` / `playlist_cover_test` /
+`video_import_cover_gate_guard_test` / `media_cover_write_guard_test` / `ffmpeg_tls_pin_args_test` /
+`ffmpeg_backend_test` / `home_video_cover_badge_test` / `continue_cover_portrait_guard_test` /
+`home_video_collection_cover_card_test` / `audiobook_clip_export_logging_guard_test` /
+`audio_stream_map_tolerant_guard_test` / `ffmpeg_min_network_h264_guard_test` /
+`youtube_stream_replay_ua_test` 全绿。
+
+### 相邻发现（**未修**，独立问题，需要单独立项）
+
+上表右两列是本轮调查的副产品：真正的时间大头不是失败，是**成功与 C 类的抽帧本身**——
+`-ss 10` 对 BDMV 的 m2ts 要 **18s（C）到 75s（成功）** 一条。34 条候选跑满一轮 = **339s**。
+后果是：`_maybeBackfillCovers` 每次冷启动都要在后台烧近 6 分钟 ffmpeg，而 `if (!mounted) return;`
+让用户切走页面就中断——本机那 4 条「能成功」的至今 `cover_path` 仍为空，说明它们从来没轮到过。
+方向（待验证）：BDMV 的 m2ts 没有全局索引，输入定位在其上退化；可考虑先 ffprobe 拿时长/关键帧，
+或对无索引容器改用更小的 seek 点。本 bug 不扩大范围去改抽帧策略。

--- a/fushi/lib/src/media/video/video_cover_extractor.dart
+++ b/fushi/lib/src/media/video/video_cover_extractor.dart
@@ -154,6 +154,59 @@ bool isLocalFrameExtractableVideoSource(String videoPath) {
   return true;
 }
 
+/// 封面回填候选判据默认探测的头部字节数（[hasHollowMediaHeader]）。
+const int kHollowMediaHeaderProbeBytes = 64 * 1024;
+
+/// 纯函数：[head]（文件**头部**若干字节）是否说明「内容尚未落盘」——空，或全为 `0x00`。
+///
+/// BUG-1867：判据的正当性在于**每种被支持的容器头部都有魔数**——MPEG-TS 的 `0x47`
+/// sync 字节（`.m2ts` 是 192 字节步长、前 4 字节 TP_extra_header）、MP4/MOV 的 `ftyp`、
+/// Matroska 的 `1A 45 DF A3`、AVI/WAV 的 `RIFF`、FLV 的 `FLV`。合法媒体文件的头部
+/// **不可能**全零，所以「全零 = 还不是媒体」没有误伤面。
+bool isHollowMediaHeaderBytes(List<int> head) {
+  if (head.isEmpty) return true;
+  for (final int byte in head) {
+    if (byte != 0) return false;
+  }
+  return true;
+}
+
+/// [path] 的头 [probeBytes] 字节是否「尚未落盘」（见 [isHollowMediaHeaderBytes]）。
+///
+/// BUG-1867 根因②：torrent **预分配但未下载完成**的文件在文件系统层与真视频完全
+/// 一致——正确的扩展名、正确的字节数（甚至 8GB）、路径存在，`existsSync()` 与
+/// [isLocalFrameExtractableVideoSource] 两道判据都放行，只有**内容**还是空洞。喂给
+/// ffmpeg 的结果恒是 `Error opening input files: Invalid data found when processing
+/// input`。
+///
+/// 这条判据买的**不是**时间：ffmpeg 在头部就 probe 失败，实测 0.02s/条（本机 12 条
+/// 空洞 BDMV 合计 0.3s），一次 64KB 读只把它压到 1.3ms。买的是三件事——
+/// ① 不为一个必然失败的抽帧去排 `VideoCoverMutationGate` 的队（同期的删除、手选封面、
+/// 刮削要等在后面）；② 把「还没下完」与「这文件坏了」分成两个可诊断的原因，而不是
+/// 混成同一个 `extract-failed`；③ 判定不依赖 ffmpeg 的具体行为（构建裁掉某个 demuxer
+/// 或换版本都不影响这条判据的正确性）。
+///
+/// 读失败（权限 / 盘掉线 / 竞态删除）返回 `true`：读不出头部的文件此刻同样抽不出帧，
+/// 与其让 ffmpeg 再失败一次，不如按「暂不可用」跳过——文件恢复后 mtime/size 变化会
+/// 让 `CoverBackfillLedger` 自动放行重试。
+bool hasHollowMediaHeader(String path,
+    {int probeBytes = kHollowMediaHeaderProbeBytes}) {
+  RandomAccessFile? handle;
+  try {
+    handle = File(path).openSync();
+    final int length = handle.lengthSync();
+    if (length <= 0) return true;
+    final int wanted = length < probeBytes ? length : probeBytes;
+    return isHollowMediaHeaderBytes(handle.readSync(wanted));
+  } catch (_) {
+    return true;
+  } finally {
+    try {
+      handle?.closeSync();
+    } catch (_) {}
+  }
+}
+
 /// 由 [bookUid] 生成视频封面文件名（无目录），把路径分隔符与 `:` 等非法字符
 /// 归一成 `_`，避免 `video/playlist/...` 这类带 `/` `:` 的 bookUid 当文件名非法
 /// （尤其 Windows）。纯函数，便于单测。
@@ -241,6 +294,9 @@ Future<String?> extractVideoCover({
   double atSeconds = 10.0,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给抽帧 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
+  // BUG-1867：best-effort 后台产线（书架封面回填）把抽帧失败降级成诊断日志，见
+  // [extractVideoFrameViaFfmpeg]。用户主动触发的导入/换封面路径保持默认 false。
+  bool diagnosticOnly = false,
 }) {
   final VideoScrapeOperationLease? lease =
       VideoScrapeOperationGate.tryEnterOperation();
@@ -250,6 +306,7 @@ Future<String?> extractVideoCover({
     bookUid: bookUid,
     atSeconds: atSeconds,
     tlsPinSha256: tlsPinSha256,
+    diagnosticOnly: diagnosticOnly,
   ).whenComplete(lease.release);
 }
 
@@ -258,6 +315,7 @@ Future<String?> _extractVideoCoverUnlocked({
   required String bookUid,
   required double atSeconds,
   required String? tlsPinSha256,
+  required bool diagnosticOnly,
 }) async {
   // BUG-1564：**本地**播放列表清单（.m3u8/.m3u）是文本列表不是媒体流，两条 ffmpeg
   // 路（内嵌封面 / 抽帧）对它都必然失败（`Invalid data found`）——在抽取器层直接
@@ -267,6 +325,11 @@ Future<String?> _extractVideoCoverUnlocked({
   final bool isRemoteInput =
       videoPath.startsWith('http://') || videoPath.startsWith('https://');
   if (!isRemoteInput && isPlaylistManifestPath(videoPath)) return null;
+  // BUG-1867：**本地**文件的内容尚未落盘（头部全零 —— torrent 预分配的空洞文件）时，
+  // 两条 ffmpeg 路对它同样必然失败（`Invalid data found`）。与上面的清单拒收同层收口：
+  // 所有调用方（回填 / 导入 / 拆集 / host 服务）一并免疫，给出确定性的 null 而不是靠
+  // ffmpeg 的行为兜底。远端输入不做本判据（读不到本地字节，且 ffmpeg 能直接吃流）。
+  if (!isRemoteInput && hasHollowMediaHeader(videoPath)) return null;
   // TODO-1236：经 AppPaths 解析封面目录（跟随桌面自定义数据根 →
   // `<dataRoot>/documents/video_covers`；默认根仍是平台 Documents），与 TODO-1226
   // 迁移白名单 `video_covers` 一致，避免自定义数据根下新封面落回平台 Documents。
@@ -284,6 +347,7 @@ Future<String?> _extractVideoCoverUnlocked({
     outputPath: outputPath,
     atSeconds: atSeconds,
     tlsPinSha256: tlsPinSha256,
+    diagnosticOnly: diagnosticOnly,
   );
 }
 

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -28,7 +28,7 @@ import 'package:fushi/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:fushi/src/media/media_cover_service.dart';
 import 'package:fushi/src/media/video/cover_backfill_ledger.dart';
 import 'package:fushi/src/media/video/video_cover_extractor.dart'
-    show isLocalFrameExtractableVideoSource;
+    show hasHollowMediaHeader, isLocalFrameExtractableVideoSource;
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_subtitle_attach.dart';
@@ -801,6 +801,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         if (!CoverBackfillLedger.instance.shouldAttempt(path)) {
           continue; // 此前失败且文件未变：不再白烧 ffmpeg。
         }
+        if (hasHollowMediaHeader(path)) {
+          // BUG-1867：路径在、字节数对（torrent 预分配的 8GB 也「在」），但内容还没
+          // 落盘——头部全零，喂进去恒是 `Invalid data found`。判据与上面的 existsSync
+          // 同层、同理由：不为一个必然失败的抽帧去占进程级封面写锁，让同期的删除、
+          // 手选封面、刮削等在后面。记账用独立原因 `hollow-header`（区别于「文件坏了」
+          // 的 extract-failed），下载有进展（mtime/size 变）后账本自动放行重试。
+          CoverBackfillLedger.instance
+              .recordFailure(path, reason: 'hollow-header');
+          continue;
+        }
         bool admitted = false;
         final String? extracted = await VideoCoverMutationGate.runExclusive(
           () async {
@@ -824,6 +834,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             final String? result = await extractVideoCover(
               videoPath: path,
               bookUid: row.bookUid,
+              // BUG-1867：回填是 best-effort 后台产线，「这文件给不出帧」（无视频流的
+              // BDMV 音轨 m2ts、seek 落在空洞区）是预期内的正常结果，不该刷用户可见
+              // 错误日志页——书架显示占位图本身就是反馈。证据仍进诊断日志。
+              diagnosticOnly: true,
             );
             if (result == null) return null;
             await widget.repo.updateCover(row.bookUid, result);

--- a/fushi/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/fushi/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -716,6 +716,12 @@ Future<String?> extractVideoFrameViaFfmpeg({
   FfmpegFailureReporter? onFailure,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
+  // BUG-1867：调用方是 best-effort 后台产线（书架封面回填）——「这文件给不出帧」是
+  // 预期内的正常结果（无视频流的 BDMV 音轨 m2ts、seek 落在空洞区…），与上游
+  // [extractEmbeddedVideoCoverViaFfmpeg] 把「容器没有内嵌封面」判为正常同层，不该
+  // 进用户可见错误日志页。ffmpeg **根本起不来**（ProcessException）仍是真错误，
+  // 不受本开关影响。
+  bool diagnosticOnly = false,
 }) async {
   if (!_isRemoteFfmpegInput(inputPath) && !File(inputPath).existsSync()) {
     return null;
@@ -742,7 +748,8 @@ Future<String?> extractVideoFrameViaFfmpeg({
         output.deleteSync();
       } catch (_) {}
     }
-    _reportFfmpegFailure('extractVideoFrameViaFfmpeg', result, onFailure);
+    _reportFfmpegFailure('extractVideoFrameViaFfmpeg', result, onFailure,
+        diagnosticOnly: diagnosticOnly);
     return null;
   } on ProcessException catch (e, stack) {
     _reportFfmpegProcessException(

--- a/fushi/test/media/video/video_cover_source_filter_test.dart
+++ b/fushi/test/media/video/video_cover_source_filter_test.dart
@@ -93,6 +93,127 @@ void main() {
     });
   });
 
+  group('isHollowMediaHeaderBytes（BUG-1867 内容已落盘判据 · 纯函数）', () {
+    test('空 / 全零 -> true', () {
+      expect(isHollowMediaHeaderBytes(const <int>[]), isTrue);
+      expect(isHollowMediaHeaderBytes(List<int>.filled(65536, 0)), isTrue);
+    });
+
+    test('任一非零字节 -> false（含只有最后一字节非零）', () {
+      final List<int> tailOnly = List<int>.filled(65536, 0);
+      tailOnly[65535] = 0x47;
+      expect(isHollowMediaHeaderBytes(tailOnly), isFalse);
+      // 真容器魔数：MPEG-TS sync / MP4 ftyp / Matroska EBML / RIFF。
+      expect(
+        isHollowMediaHeaderBytes(const <int>[0x47, 0x40, 0x00, 0x10]),
+        isFalse,
+      );
+      expect(
+        isHollowMediaHeaderBytes(
+          const <int>[0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70],
+        ),
+        isFalse,
+      );
+      expect(
+        isHollowMediaHeaderBytes(const <int>[0x1A, 0x45, 0xDF, 0xA3]),
+        isFalse,
+      );
+      expect(isHollowMediaHeaderBytes('RIFF'.codeUnits), isFalse);
+    });
+  });
+
+  group('hasHollowMediaHeader（BUG-1867 · 真文件）', () {
+    late Directory tmp;
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('fushi_hollow_');
+    });
+    tearDown(() {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    File write(String name, List<int> bytes) {
+      final File f = File('${tmp.path}${Platform.pathSeparator}$name');
+      f.writeAsBytesSync(bytes);
+      return f;
+    }
+
+    test('torrent 预分配的空洞文件（探测窗全零）-> true', () {
+      final File hollow = write(
+        'preallocated.m2ts',
+        List<int>.filled(kHollowMediaHeaderProbeBytes * 2, 0),
+      );
+      expect(hasHollowMediaHeader(hollow.path), isTrue);
+    });
+
+    test('已下载完成的 m2ts（192 字节步长的 TS sync）-> false', () {
+      // 真 .m2ts 布局：4 字节 TP_extra_header + 0x47 sync + 187 字节负载。
+      final List<int> bytes = <int>[];
+      while (bytes.length < kHollowMediaHeaderProbeBytes * 2) {
+        bytes.addAll(<int>[0x26, 0xF0, 0x4B, 0xE8, 0x47]);
+        bytes.addAll(List<int>.filled(187, 0xFF));
+      }
+      final File complete = write('downloaded.m2ts', bytes);
+      expect(hasHollowMediaHeader(complete.path), isFalse);
+    });
+
+    test('内容只在探测窗之后才出现 -> 仍判 true（ffmpeg 此刻同样打不开）', () {
+      final List<int> bytes =
+          List<int>.filled(kHollowMediaHeaderProbeBytes * 3, 0);
+      bytes[kHollowMediaHeaderProbeBytes + 4] = 0x47;
+      final File partial = write('midfile.m2ts', bytes);
+      expect(hasHollowMediaHeader(partial.path), isTrue);
+    });
+
+    test('短于探测窗的小文件按实际长度判定（不因读不满而误判）', () {
+      expect(
+        hasHollowMediaHeader(write('tiny_ok.ts', <int>[0x47, 1, 2]).path),
+        isFalse,
+      );
+      expect(
+        hasHollowMediaHeader(write('tiny_hollow.ts', <int>[0, 0, 0]).path),
+        isTrue,
+      );
+    });
+
+    test('零长文件 / 不存在的路径 -> true（此刻同样抽不出帧）', () {
+      expect(
+        hasHollowMediaHeader(write('empty.mkv', const <int>[]).path),
+        isTrue,
+      );
+      expect(
+        hasHollowMediaHeader('${tmp.path}${Platform.pathSeparator}nope.mkv'),
+        isTrue,
+      );
+    });
+  });
+
+  group('extractVideoCover 抽取器层拒收空洞文件（BUG-1867）', () {
+    test('头部全零的本地文件直接返回 null，不烧 ffmpeg 子进程', () async {
+      // 与上面的清单拒收同一手法：早退发生在 AppPaths / ffmpeg 之前。若有人删掉抽取器
+      // 层的空洞拒收，这里会因 path_provider 的 MissingPluginException 立即红。
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('fushi_cover_hollow_');
+      addTearDown(() {
+        try {
+          tmp.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final File hollow =
+          File('${tmp.path}${Platform.pathSeparator}00014.m2ts');
+      hollow.writeAsBytesSync(
+        List<int>.filled(kHollowMediaHeaderProbeBytes * 2, 0),
+      );
+
+      final String? cover = await extractVideoCover(
+        videoPath: hollow.path,
+        bookUid: 'video/local/bdmv-00014',
+      );
+      expect(cover, isNull);
+    });
+  });
+
   group('视频页回填接线守卫（源码扫描）', () {
     late String source;
     setUpAll(() {
@@ -128,6 +249,27 @@ void main() {
       expect(gate, greaterThanOrEqualTo(0));
       expect(freshBook, greaterThan(gate));
       expect(currentCover, greaterThan(freshBook));
+    });
+
+    test('_maybeBackfillCovers：空洞判据必须在封面写锁闸门之前（BUG-1867）', () {
+      final String body = methodBody('_maybeBackfillCovers');
+      final int hollow = body.indexOf('hasHollowMediaHeader(path)');
+      final int gate = body.indexOf('VideoCoverMutationGate.runExclusive');
+      expect(hollow, greaterThanOrEqualTo(0),
+          reason: '回填必须在进 ffmpeg 前判「内容是否已落盘」');
+      expect(gate, greaterThan(hollow),
+          reason: '判据在闸门之后 = 一个必然失败的抽帧仍会独占进程级封面写锁');
+      // 判掉的路径要记账，否则同一会话每轮 listAll 都重读一次头部。
+      expect(body, contains("reason: 'hollow-header'"));
+    });
+
+    test('_maybeBackfillCovers：回填抽帧失败只进诊断日志（BUG-1867）', () {
+      final String body = methodBody('_maybeBackfillCovers');
+      final int call = body.indexOf('extractVideoCover(');
+      expect(call, greaterThanOrEqualTo(0));
+      final int flag = body.indexOf('diagnosticOnly: true', call);
+      expect(flag, greaterThan(call),
+          reason: 'best-effort 回填的「给不出帧」不是 app 错误，不该刷用户可见错误日志页');
     });
 
     test('_pullToRefresh：显式刷新是唯一清账入口', () {


### PR DESCRIPTION
用户错误日志页连刷 `extractVideoFrameViaFfmpeg … Error opening input files: Invalid data found when processing input`。

## 复现（本机生产库 858 行 / 34 条回填候选，逐条实跑 + 计时）

| 类 | ffmpeg 末行 | 实际是什么 | 条数 | ffmpeg 合计 | 单条均值 |
|---|---|---|---|---|---|
| A | `Error opening input files: Invalid data found` | torrent **预分配但未下载完成**的空洞文件（头 64KB 全零，共 70.3GB） | 12 | 0.3s | 0.02s |
| B | `Output file does not contain any stream` | BDMV 的纯音频短 m2ts，容器里没有视频流 | 16 | 1.2s | 0.07s |
| C | `Conversion failed!` | 有视频流，`-ss 10` 处取不到帧 | 2 | 36.6s | 18.31s |
| — | 成功 | 真出封面 | 4 | 301.3s | 75.33s |

A 类逐字命中用户日志。判据交叉验证：A 类 12 条 `head[0:65536]` 全零**全部**为 True，B/C/OK 的 22 条**全部**为 False。

## 根因

1. **同一事实两种严重性**。同一条产线上游的 `extractEmbeddedVideoCoverViaFfmpeg` 把非零退出判为「没有内嵌封面 = 正常」不上报，而 `extractVideoFrameViaFfmpeg` 一律进用户可见错误日志页。回填是 best-effort 后台产线，书架显示占位图本身就是反馈。
2. **候选判据只问「路径存在」，不问「内容是否已落盘」**。预分配空洞文件有正确的扩展名、正确的字节数（8GB）、存在的路径，`existsSync()` 与 `isLocalFrameExtractableVideoSource` 两道都放行。

## 修复

- ① `extractVideoFrameViaFfmpeg` / `extractVideoCover` 加 `diagnosticOnly`（复用既有机制），`_maybeBackfillCovers` 传 `true`。**`ProcessException`（ffmpeg 起不来）仍进错误日志**；用户主动触发的导入/换封面路径保持默认 `false`。
- ② 新增 `isHollowMediaHeaderBytes` / `hasHollowMediaHeader`。抽取器层早退（与 BUG-1564 的清单拒收同层收口，所有调用方一并免疫）+ page 层在**进封面写锁闸门之前**判掉并记 `reason: 'hollow-header'`。无误伤面：每种被支持的容器头部都有魔数（TS `0x47` / MP4 `ftyp` / MKV `1A45DFA3` / RIFF / FLV）。
- **诚实计量**：② 买的不是时间（ffmpeg 在头部就 probe 失败，0.02s/条）。买的是不占写锁排队、原因可诊断、判定不依赖 ffmpeg 行为。
- ledger 持久化**不做**：时间大头不在 A 类，持久化解决不了，还要付 schema 迁移 + 陈旧账本的代价。

## 测试

`video_cover_source_filter_test.dart` 新增 9 例（纯函数判据含四种真容器魔数 / 真文件 IO 六种边界 / 抽取器层拒收 / 两条视频页接线守卫）。

变异实测 4/4 全部抓住（二进制读写、唯一锚点、sha256 校验回滚）：真删除 page 层判据整块 → 顺序守卫红；删 `diagnosticOnly: true` → 分级守卫红；删抽取器层拒收 → 行为测试红；判据恒返 false → 4 条真文件用例红。

相邻定向 14 个测试文件全绿；全量 `flutter analyze` 绿。

## 相邻发现（**未修**，需单独立项）

上表右两列是副产品：真正的时间大头是**成功路径本身**——`-ss 10` 对 BDMV m2ts 要 18s（C）到 75s（成功）一条，一轮回填 339s。`if (!mounted) return;` 让用户切走页面就中断，本机那 4 条「能成功」的至今 `cover_path` 仍为空，说明从来没轮到过。这是「封面始终补不上」的真正原因，本 PR 不扩大范围去改抽帧策略。

https://claude.ai/code/session_019kN8KookNb5P4ucFTMpQfY
