### PR TITLE
perf(lookup): 查词弹窗慢（尤其嵌套）—— 每次查词重传 33.7MB 内联字体的四条根因

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1731 条。点号进各自文件。
+> 共 1732 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1868](bugs/BUG-1868-lookup-popup-slow.md) | ✅ | ✅ | 查词弹窗慢，尤其嵌套查词 |
 | [BUG-1858](bugs/BUG-1858-settings-form-field-width.md) | ✅ | ✅ | 设置页输入框宽度三套并存：下载设置 480 / 在线服务 560 / 其余撑满 |
 | [BUG-1852](bugs/BUG-1852-manga-region-rescan-lookup-action-removed.md) | 🚧 | 🚧 | 框选区域重识别移除了旧「框选查词」直通词典的入口 |
 | [BUG-1851](bugs/BUG-1851-manga-region-rescan-auto-engine-mix.md) | 🚧 | 🚧 | auto 引擎偏好下区域重识别可能与整卷用不同引擎，页内混引擎且 ocr 元数据仍写旧引擎 |

--- a/docs/bugs/BUG-1868-lookup-popup-slow.md
+++ b/docs/bugs/BUG-1868-lookup-popup-slow.md
@@ -5,11 +5,12 @@
   调 `buildStackRenderScript` 时**完全没传** `knownStaticRevisions` /
   `emittedStaticRevisions`（当时是可选形参），于是 BUG-1833 那套静态段去重对剪贴板
   面板整条路径失效。
-- **[x] ① 已修复** — `1532f2331d`（四条根因）+ `8408b83dde`（字体改走 URL，⚠ 见备注）
+- **[x] ① 已修复** — `1532f2331d`（四条根因）+ `8408b83dde`（字体改走 URL，已端到端验证 `392c2a22ff`）
 - **[x] ② 已加自动化测试** — `fushi/test/lookup/popup_static_revision_dedup_guard_test.dart`（新）、
   `fushi/test/utils/misc/popup_dict_css_memo_test.{js,dart}`（新）、
   `fushi/test/reader/dictionary_font_css_test.dart`（增 URL 模式 4 例）、
-  `fushi/test/pages/popup_settings_injection_memo_test.dart`（改用真账本走 cold→commit→hot）
+  `fushi/test/pages/popup_settings_injection_memo_test.dart`（改用真账本走 cold→commit→hot）、
+  `fushi/integration_test/dict_popup_font_url_itest.dart`（新，Windows 真 WebView2 端到端 + 负向对照）
 - **备注**：
 
 ### 量级（用户真实配置）
@@ -65,21 +66,32 @@ revision 已缓存，`dropDescriptorStaticSource` 直接丢掉。**整整 33.7 M
    三元组 memo；外层用 css 串本身分桶，内容变了自然落新桶，无需失效钩子。三份
    dict-media.js（app + 扩展两镜像）同步移植。
 
-### ⚠ 未验证部分（`8408b83dde`）
+### in-app 字体走 URL（`8408b83dde`）—— 已端到端验证（Windows）
 
-in-app 弹窗字体改走 URL（`https://fushi.local/dictfonts/<enc>`）是唯一能根治嵌套那条
-路的办法：嵌套每层都是新 WebView（新 realm，静态段必须重发），去重救不了，只能让被
-重发的东西本身从 33.7 MB 降到 KB 级；URL 还能跨 WebView 共享 HTTP 缓存，`data:` 永远
-共享不了。
+嵌套那条路去重救不了：每层都是新 WebView（新 realm，静态段必须重发）。唯一的根治是
+让被重发的东西本身从 33.7 MB 降到 KB 级——字体改走
+`https://fushi.local/dictfonts/<enc>`，字节由弹窗 WebView 的 `shouldInterceptRequest`
+按需供，且**跨 WebView 共享 HTTP 缓存**（`data:` 每次都是全新资源，永远共享不了）。
 
-已有代码级证据（Windows fork `web_resource_response.cpp:59-66` 确实把 headers 逐条
-`AppendHeader` 进 WebView2），但**没有端到端证据**。风险方向是「字体静默不生效」，比慢
-更糟：Android 的 `file://` 与 Windows `initialData` 的 opaque origin 都是跨源，成败取决
-于 ACAO 头是否被插件如实传给浏览器。阅读器那条同机制路径是**同源**的，其生产表现不能
-直接推断这里。**合入前必须在真机打开查词弹窗确认词典字体仍生效。**
+Windows 离屏实测（`392c2a22ff`，`tool/run_windows_itest.ps1`，隔离 app data + 隔离
+WebView2 profile，**不启动 app、不碰生产库**）：
 
-平台边界：iOS / macOS 只有 `WKURLSchemeHandler`，其 `URLResponse` 带不了任何 header，
-字体会被 CORS 拒，故这两个平台继续内联——不是偷懒，是能力边界。
+```
+[cors]   fetch:200 | bytes:3936 | load:ok | check:true | faces:ItestFont=loaded
+[nocors] fetch-threw:TypeError: Failed to fetch | check:false | faces:ItestFont=error
+```
+
+负向对照（同样字节、同样 200，唯独抽掉 `Access-Control-Allow-Origin`）确实失败，
+证明该环境真在检查 CORS，正向那条绿不是恒真。
+
+覆盖边界：只实测了 **Windows**。Android 走同一套 `shouldInterceptRequest` +
+`WebResourceResponse` headers 机制（阅读器 `fushi.local/fonts/` 已在生产用它），但
+**未实测**。iOS / macOS 只有 `WKURLSchemeHandler`，其 `URLResponse` 带不了任何 header，
+字体会被 CORS 拒 → 这两个平台继续内联，不受影响（能力边界，非偷懒）。
+
+验证过程中修掉两个**测试自身**的坑（已写进测试文件注释）：`evaluateJavascript` 不会
+await Promise（头两轮的「失败」全是假的）；`Directory.systemTemp` 在 Windows 给反斜杠，
+手拼 `/` 造出混合分隔符会被白名单挡下。
 
 ### 尚未处理（收益递减，另开）
 

--- a/docs/bugs/BUG-1868-lookup-popup-slow.md
+++ b/docs/bugs/BUG-1868-lookup-popup-slow.md
@@ -100,4 +100,12 @@ await Promise（头两轮的「失败」全是假的）；`Directory.systemTemp`
   「bound is deliberate — a dictionary frame owns popup.js, observers and **decoded
   fonts**」——字体改走 URL 后这条理由变弱，池可以再评估。
 - `FushiDicts.instance.lookup` 同步跑在主 isolate（`app_model.dart:5051`），无 compute。
+  **已调查，不建议顺手改**：引擎自己的源码（`native/fushidicts/fushidicts_src/` +
+  `fushidicts_ffi.cpp`）里**没有任何 mutex / std::thread / pthread**（全仓命中的并发原语
+  都在 vendored 的 glaze 里），即它是无内部同步的单线程设计——多个 isolate 拿同一个
+  handle 并发查询会直接踩共享状态。已有先例 `FushiDicts.importDictionary`
+  （`fushidicts.dart:527`）之所以能 `Isolate.run`，是因为它是 **static、不需要 handle**，
+  在新 isolate 里自建 bindings；`lookup` 需要主 isolate 建的 handle，情况完全不同。
+  唯一安全的形态是**单个专用查词 isolate 串行化**，但那要把引擎 handle 的所有权整体
+  迁过去（牵动 AppModel 初始化与所有同步调用点），是独立的架构改动，应单独立项。
 - `popup.js` masonry 在 forEach 里写 6 个样式再读 `offsetHeight`，每张卡片一次强制同步布局。

--- a/docs/bugs/BUG-1868-lookup-popup-slow.md
+++ b/docs/bugs/BUG-1868-lookup-popup-slow.md
@@ -1,0 +1,91 @@
+## BUG-1868 · 查词弹窗慢，尤其嵌套查词
+- **报告**：2026-08-25（用户：）
+- **真实性**：✅ 真 bug。不是「渲染慢」，是**每次查词都重传一遍本可只传一次的巨量负载**。
+  根因有四处，最大一处是 `fushi/lib/src/lookup/clipboard_panel_controller.dart:477`
+  调 `buildStackRenderScript` 时**完全没传** `knownStaticRevisions` /
+  `emittedStaticRevisions`（当时是可选形参），于是 BUG-1833 那套静态段去重对剪贴板
+  面板整条路径失效。
+- **[x] ① 已修复** — `1532f2331d`（四条根因）+ `8408b83dde`（字体改走 URL，⚠ 见备注）
+- **[x] ② 已加自动化测试** — `fushi/test/lookup/popup_static_revision_dedup_guard_test.dart`（新）、
+  `fushi/test/utils/misc/popup_dict_css_memo_test.{js,dart}`（新）、
+  `fushi/test/reader/dictionary_font_css_test.dart`（增 URL 模式 4 例）、
+  `fushi/test/pages/popup_settings_injection_memo_test.dart`（改用真账本走 cold→commit→hot）
+- **备注**：
+
+### 量级（用户真实配置）
+
+词典字体绑了两个（读自生产库 `src:reader_fushi:font_targets` 的 `dict_fonts` 目标）：
+
+| 字体 | 文件 | base64 内联后 |
+|---|---|---|
+| Klee One | 8.32 MB | 11.09 MB |
+| Noto Sans SC | 16.95 MB | 22.60 MB |
+| | | **合计 ≈ 33.7 MB** |
+
+这两个字体以 `data:` URL 内联在**静态设置段**里（`popup_settings_injection.dart` 的
+`$fontStyleJs`）。静态段本该「只发一次」，但去重是各调用方自己拼的、三处三种做法、
+两处漏了：
+
+| 路径 | 去重 | 后果 |
+|---|---|---|
+| 桌面全局查词窗 / gal 浮窗 | ✅ per-host revision + `staticSettingsRequired` 回补 | 正常 |
+| **app 内弹窗**（阅读器/视频/首页） | ❌ `_lastSentStaticRevision` 是 **per-WebView 实例字段**（`dictionary_popup_webview.dart:416`） | 第一层走热槽复用不重发；**每嵌套一层就新建 WebView → 字段为 null → 重发 33.7 MB** |
+| **剪贴板面板** | ❌ 调用点完全没传去重形参 | 每次查词（含嵌套）都重发 33.7 MB |
+
+中间那行就是用户说的「**特别是嵌套查词开始**」。
+
+讽刺的是 host 侧（`global_lookup_host.js:2246` 起）**早就写好了正确答案**——把字体
+data URL 重写成同源 Blob object URL 跨 iframe 共享。它收到重发的 33.7 MB 后发现
+revision 已缓存，`dropDescriptorStaticSource` 直接丢掉。**整整 33.7 MB 是白传的。**
+
+旁证：`%TEMP%\hibiki_glookup.log` 里「渲染下发 → 首个按钮探测」稳定 750~1180 ms，
+`entries=1` 与 `entries=84` 几乎同耗时——与词条数无关，是固定体积开销，不是渲染计算量。
+
+### 四条根因与修法
+
+1. **静态段去重对面板完全失效**（最大头）。根因是「去重状态由每个调用方自己维护、
+   且可以不传」。修法不是给面板补参数，而是把这个特殊情况消灭掉：新增
+   `PopupStaticRevisionCache` 收口账本，形参改**必填**，待确认版本从返回值
+   `pendingRevisions` 带出——漏传即编译错误。面板同时接上 host 的
+   `staticSettingsRequired` 回补通道：**去重与回补是一对**，只做前者会让宿主丢缓存后
+   永远等不到静态段（无主题/无字体/无词典样式），比不去重更糟。
+
+2. **每条日志一次最多 512 KB 整文件回读**。`ErrorLogService._trimLogFileToMaxBytes`
+   每次 append 后都 `readAsBytes()` 整个文件才比长度，而日志长期贴着上限运行。改为先
+   `stat length()`，超限才读回来裁。
+
+3. **渲染热路径上的无条件 debug console.log**。`[RICHTEXT_HTML]` 每行释义一条、
+   `[IMG_CREATE]` 每张词典图一条，每条都是跨进程 console 消息，在 in-app 表面还会经
+   `onConsoleMessage` 落进 ErrorLogService（叠加第 2 条）。不删日志，改
+   `window.__fushiPopupDebug` 门控，默认关。门控包住**整条语句**——参数里的
+   substring/拼接在传参前就求值了，只挡输出等于没挡住开销。
+
+4. **`constructDictCss` 无 memo**，被「N 词条 × M 词典」重复调用，每次对同一本词典
+   那份（Yomitan 动辄几十 KB 的）CSS 重做逐字符扫描。加 `(css, dictName, scopePrefix)`
+   三元组 memo；外层用 css 串本身分桶，内容变了自然落新桶，无需失效钩子。三份
+   dict-media.js（app + 扩展两镜像）同步移植。
+
+### ⚠ 未验证部分（`8408b83dde`）
+
+in-app 弹窗字体改走 URL（`https://fushi.local/dictfonts/<enc>`）是唯一能根治嵌套那条
+路的办法：嵌套每层都是新 WebView（新 realm，静态段必须重发），去重救不了，只能让被
+重发的东西本身从 33.7 MB 降到 KB 级；URL 还能跨 WebView 共享 HTTP 缓存，`data:` 永远
+共享不了。
+
+已有代码级证据（Windows fork `web_resource_response.cpp:59-66` 确实把 headers 逐条
+`AppendHeader` 进 WebView2），但**没有端到端证据**。风险方向是「字体静默不生效」，比慢
+更糟：Android 的 `file://` 与 Windows `initialData` 的 opaque origin 都是跨源，成败取决
+于 ACAO 头是否被插件如实传给浏览器。阅读器那条同机制路径是**同源**的，其生产表现不能
+直接推断这里。**合入前必须在真机打开查词弹窗确认词典字体仍生效。**
+
+平台边界：iOS / macOS 只有 `WKURLSchemeHandler`，其 `URLResponse` 带不了任何 header，
+字体会被 CORS 拒，故这两个平台继续内联——不是偷懒，是能力边界。
+
+### 尚未处理（收益递减，另开）
+
+- 嵌套时各帧 `entriesJs` 仍全栈重传（静态段修好后它就是下一个大头）。
+- `global_lookup_host.js:109` standby 池只有 1，连点第二层掉回冷 iframe 创建。注释说
+  「bound is deliberate — a dictionary frame owns popup.js, observers and **decoded
+  fonts**」——字体改走 URL 后这条理由变弱，池可以再评估。
+- `FushiDicts.instance.lookup` 同步跑在主 isolate（`app_model.dart:5051`），无 compute。
+- `popup.js` masonry 在 forEach 里写 6 个样式再读 `offsetHeight`，每张卡片一次强制同步布局。

--- a/fushi/assets/browser_extension/vendor/dict-media.js
+++ b/fushi/assets/browser_extension/vendor/dict-media.js
@@ -54,7 +54,36 @@ function rewriteDictLinks(html, dictName) {
     });
 }
 
+/* 词典 CSS 作用域化的结果**只由** (css, dictName, scopePrefix) 决定——纯函数，
+   同输入必同输出。但它的调用点是 createGlossarySection，即「每个词条的每个词典块」
+   各调一次：N 条词条 × M 本词典就是 N×M 次把同一本词典那份（Yomitan 词典动辄几十 KB
+   的）CSS 重新做一遍逐字符扫描（下面的 while 循环对空白字符是一个字符 push 一次数组）。
+   查一次词就白烧几十上百遍完全相同的解析。
+   这里按三元组做 memo：外层用 css 串本身分桶（内容变了自然落到新桶，无需失效钩子，
+   也就不存在「换词典集后拿到旧作用域 CSS」的风险），内层用 dictName+scopePrefix。
+   递归分支走未缓存的实现，避免把每个 at-block 的子串都塞进缓存。 */
+const __dictCssCache = new Map();
+const __dictCssCacheMaxBuckets = 64;
+
 function constructDictCss(css, dictName, scopePrefix) {
+    if (!css) return '';
+    let byScope = __dictCssCache.get(css);
+    if (byScope === undefined) {
+        // 词典集切换/重新导入会带来新的 css 串；给桶数封顶，别让缓存无界增长。
+        if (__dictCssCache.size >= __dictCssCacheMaxBuckets) __dictCssCache.clear();
+        byScope = new Map();
+        __dictCssCache.set(css, byScope);
+    }
+    const key = JSON.stringify([dictName || '', scopePrefix || '']);
+    let out = byScope.get(key);
+    if (out === undefined) {
+        out = constructDictCssUncached(css, dictName, scopePrefix);
+        byScope.set(key, out);
+    }
+    return out;
+}
+
+function constructDictCssUncached(css, dictName, scopePrefix) {
     if (!css) return '';
     const prefix = scopePrefix || `[data-dictionary="${dictName}"]`;
     const parts = [];
@@ -113,7 +142,7 @@ function constructDictCss(css, dictName, scopePrefix) {
             parts.push(selectorPart, ' {');
             if (isConditionalGroup) {
                 // Recurse so inner style rules get the prefix; the prelude stays raw.
-                parts.push(constructDictCss(atBlockContent, dictName, scopePrefix));
+                parts.push(constructDictCssUncached(atBlockContent, dictName, scopePrefix));
             } else {
                 // @font-face / @keyframes / @page: body is declarations or
                 // keyframe selectors — emit verbatim, never prefixed.
@@ -166,7 +195,7 @@ function constructDictCss(css, dictName, scopePrefix) {
                 }
             }
             parts.push(properties);
-            if (nestedRules) parts.push(constructDictCss(nestedRules, dictName, scopePrefix));
+            if (nestedRules) parts.push(constructDictCssUncached(nestedRules, dictName, scopePrefix));
         } else {
             parts.push(blockContent);
         }

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -3,6 +3,18 @@
    lookup / overlay append / selection / height read through these helpers so they
    resolve inside the shadow (fall back to document before the shadow exists). */
 function __fushiRootNode(){ return window.__fushiRoot || document; }
+/* 渲染热路径上的诊断日志门控（默认关）。
+   每条 console.log 都是一次跨进程消息：宿主 in-app 表面在 onConsoleMessage 里
+   debugPrint 之，并把带调试前缀的那几类**写进 ErrorLogService**（落盘 + 通知监听
+   者）。而 [RICHTEXT_HTML] 是**每行释义**打一条、[IMG_CREATE] 是**每张词典图**打
+   一条——一次多词条查词就是成百上千条，全部压在 UI isolate 与落盘串行链上，直接
+   偷走下一次（含嵌套）查词的时间。
+   这里不删日志（排障时它们有价值），改为默认关闭：需要取证时在弹窗 WebView 控制台
+   里 `window.__fushiPopupDebug = true` 即可实时打开，无需重新构建。错误路径
+   （[IMG_ERROR] 之类）不受门控，照常无条件输出。
+   门控一律写成 `if (window.__fushiPopupDebug)` 包住**整条语句**，而不是包一个
+   打日志的 helper：参数里的 substring / 字符串拼接 / toFixed 在传给 helper 之前
+   就已经求值了，只挡输出等于没挡住热路径上的那部分开销。 */
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
@@ -1368,7 +1380,9 @@ function createDefinitionImage(data, dictionary, exporting = false) {
     
     if (typeof border === 'string') { imageContainer.style.border = border; }
     if (typeof borderRadius === 'string') { imageContainer.style.borderRadius = borderRadius; }
-    console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    if (window.__fushiPopupDebug) {
+        console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    }
     if (useEmUnits) {
         imageContainer.style.width = `${usedWidth}em`;
     } else if (!hasDimensions && isSvg) {
@@ -2039,7 +2053,7 @@ function appendRichTextLine(parent, line) {
         });
         html = tmp2.innerHTML;
     }
-    if (hasHtml) {
+    if (hasHtml && window.__fushiPopupDebug) {
         console.log('[RICHTEXT_HTML] input=' + line.substring(0, 150) + ' | sanitized=' + html.substring(0, 150));
     }
     const frag = document.createElement('span');
@@ -4538,7 +4552,7 @@ window.renderPopup = function() {
         }
         applyCustomCSS();
         window._renderedGlossaryCounts = [];
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 0, { kanjiOnly: true });
         return;
@@ -4580,7 +4594,7 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = entries.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex;
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 1, { firstVisible: true });
         return;
@@ -4591,7 +4605,7 @@ window.renderPopup = function() {
     // counts/domIndex 在途值只作占位，最终值由 finishRemainingEntries 写齐。
     window._renderedGlossaryCounts = [entries[0].glossaries.length];
     window._entryDomIndex = [entryDomIndex[0]];
-    console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length);
+    if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length); }
     _firePopupRendered(true);
     _emitPopupRenderPerf('first-entry-dom', t0, entries.length);
 
@@ -4610,8 +4624,10 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = completed.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex.slice(0, completedCount);
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
-            'ms entries=' + completedCount + '/' + entries.length);
+        if (window.__fushiPopupDebug) {
+            console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
+                'ms entries=' + completedCount + '/' + entries.length);
+        }
         _firePopupRendered();
         _emitPopupRenderPerf(terminalPhase, t0, completedCount, {
             expectedEntryCount: entries.length,

--- a/fushi/assets/popup/dict-media.js
+++ b/fushi/assets/popup/dict-media.js
@@ -24,7 +24,36 @@ function rewriteDictLinks(html, dictName) {
     });
 }
 
+/* 词典 CSS 作用域化的结果**只由** (css, dictName, scopePrefix) 决定——纯函数，
+   同输入必同输出。但它的调用点是 createGlossarySection，即「每个词条的每个词典块」
+   各调一次：N 条词条 × M 本词典就是 N×M 次把同一本词典那份（Yomitan 词典动辄几十 KB
+   的）CSS 重新做一遍逐字符扫描（下面的 while 循环对空白字符是一个字符 push 一次数组）。
+   查一次词就白烧几十上百遍完全相同的解析。
+   这里按三元组做 memo：外层用 css 串本身分桶（内容变了自然落到新桶，无需失效钩子，
+   也就不存在「换词典集后拿到旧作用域 CSS」的风险），内层用 dictName+scopePrefix。
+   递归分支走未缓存的实现，避免把每个 at-block 的子串都塞进缓存。 */
+const __dictCssCache = new Map();
+const __dictCssCacheMaxBuckets = 64;
+
 function constructDictCss(css, dictName, scopePrefix) {
+    if (!css) return '';
+    let byScope = __dictCssCache.get(css);
+    if (byScope === undefined) {
+        // 词典集切换/重新导入会带来新的 css 串；给桶数封顶，别让缓存无界增长。
+        if (__dictCssCache.size >= __dictCssCacheMaxBuckets) __dictCssCache.clear();
+        byScope = new Map();
+        __dictCssCache.set(css, byScope);
+    }
+    const key = JSON.stringify([dictName || '', scopePrefix || '']);
+    let out = byScope.get(key);
+    if (out === undefined) {
+        out = constructDictCssUncached(css, dictName, scopePrefix);
+        byScope.set(key, out);
+    }
+    return out;
+}
+
+function constructDictCssUncached(css, dictName, scopePrefix) {
     if (!css) return '';
     const prefix = scopePrefix || `[data-dictionary="${dictName}"]`;
     const parts = [];
@@ -83,7 +112,7 @@ function constructDictCss(css, dictName, scopePrefix) {
             parts.push(selectorPart, ' {');
             if (isConditionalGroup) {
                 // Recurse so inner style rules get the prefix; the prelude stays raw.
-                parts.push(constructDictCss(atBlockContent, dictName, scopePrefix));
+                parts.push(constructDictCssUncached(atBlockContent, dictName, scopePrefix));
             } else {
                 // @font-face / @keyframes / @page: body is declarations or
                 // keyframe selectors — emit verbatim, never prefixed.
@@ -136,7 +165,7 @@ function constructDictCss(css, dictName, scopePrefix) {
                 }
             }
             parts.push(properties);
-            if (nestedRules) parts.push(constructDictCss(nestedRules, dictName, scopePrefix));
+            if (nestedRules) parts.push(constructDictCssUncached(nestedRules, dictName, scopePrefix));
         } else {
             parts.push(blockContent);
         }

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -3,6 +3,18 @@
    lookup / overlay append / selection / height read through these helpers so they
    resolve inside the shadow (fall back to document before the shadow exists). */
 function __fushiRootNode(){ return window.__fushiRoot || document; }
+/* 渲染热路径上的诊断日志门控（默认关）。
+   每条 console.log 都是一次跨进程消息：宿主 in-app 表面在 onConsoleMessage 里
+   debugPrint 之，并把带调试前缀的那几类**写进 ErrorLogService**（落盘 + 通知监听
+   者）。而 [RICHTEXT_HTML] 是**每行释义**打一条、[IMG_CREATE] 是**每张词典图**打
+   一条——一次多词条查词就是成百上千条，全部压在 UI isolate 与落盘串行链上，直接
+   偷走下一次（含嵌套）查词的时间。
+   这里不删日志（排障时它们有价值），改为默认关闭：需要取证时在弹窗 WebView 控制台
+   里 `window.__fushiPopupDebug = true` 即可实时打开，无需重新构建。错误路径
+   （[IMG_ERROR] 之类）不受门控，照常无条件输出。
+   门控一律写成 `if (window.__fushiPopupDebug)` 包住**整条语句**，而不是包一个
+   打日志的 helper：参数里的 substring / 字符串拼接 / toFixed 在传给 helper 之前
+   就已经求值了，只挡输出等于没挡住热路径上的那部分开销。 */
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
@@ -1368,7 +1380,9 @@ function createDefinitionImage(data, dictionary, exporting = false) {
     
     if (typeof border === 'string') { imageContainer.style.border = border; }
     if (typeof borderRadius === 'string') { imageContainer.style.borderRadius = borderRadius; }
-    console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    if (window.__fushiPopupDebug) {
+        console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    }
     if (useEmUnits) {
         imageContainer.style.width = `${usedWidth}em`;
     } else if (!hasDimensions && isSvg) {
@@ -2039,7 +2053,7 @@ function appendRichTextLine(parent, line) {
         });
         html = tmp2.innerHTML;
     }
-    if (hasHtml) {
+    if (hasHtml && window.__fushiPopupDebug) {
         console.log('[RICHTEXT_HTML] input=' + line.substring(0, 150) + ' | sanitized=' + html.substring(0, 150));
     }
     const frag = document.createElement('span');
@@ -4538,7 +4552,7 @@ window.renderPopup = function() {
         }
         applyCustomCSS();
         window._renderedGlossaryCounts = [];
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 0, { kanjiOnly: true });
         return;
@@ -4580,7 +4594,7 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = entries.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex;
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 1, { firstVisible: true });
         return;
@@ -4591,7 +4605,7 @@ window.renderPopup = function() {
     // counts/domIndex 在途值只作占位，最终值由 finishRemainingEntries 写齐。
     window._renderedGlossaryCounts = [entries[0].glossaries.length];
     window._entryDomIndex = [entryDomIndex[0]];
-    console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length);
+    if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length); }
     _firePopupRendered(true);
     _emitPopupRenderPerf('first-entry-dom', t0, entries.length);
 
@@ -4610,8 +4624,10 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = completed.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex.slice(0, completedCount);
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
-            'ms entries=' + completedCount + '/' + entries.length);
+        if (window.__fushiPopupDebug) {
+            console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
+                'ms entries=' + completedCount + '/' + entries.length);
+        }
         _firePopupRendered();
         _emitPopupRenderPerf(terminalPhase, t0, completedCount, {
             expectedEntryCount: entries.length,

--- a/fushi/integration_test/dict_popup_font_url_itest.dart
+++ b/fushi/integration_test/dict_popup_font_url_itest.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_webview_media.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-1868 端到端验证：查词弹窗的导入字体改走 URL 之后，**在真 WebView2 里真的能
+/// 加载**。
+///
+/// 为什么必须端到端验：这条改动把字体从「一定能显示的 `data:` 内联」换成了「依赖
+/// 宿主资源拦截器的 URL」。失败方向不是变慢，而是**字体静默不生效**——比原来的慢
+/// 更糟。而失败与否取决于一串只有真浏览器才能回答的问题：
+///   ① `https://fushi.local/...` 会不会真的进 `shouldInterceptRequest`（而不是被
+///      当成外网请求走 DNS）；
+///   ② 插件把 `WebResourceResponse.headers` 传给 WebView2 之后，浏览器认不认；
+///   ③ 弹窗文档是 `initialData` 的 **opaque origin**，与 `fushi.local` 跨源，而字体
+///      是**强制 CORS 模式**的子资源——没有 `Access-Control-Allow-Origin` 就会被静默
+///      拒绝。
+/// 单测和静态分析一个都答不了，代码级证据（fork 里确有 AppendHeader）也只覆盖 ②。
+///
+/// 本测试**不启动 app**（不碰生产数据库），只挂一个 InAppWebView，用与生产同一个
+/// `dictionaryFontWebResourceResponse` 供字节，素材是仓库自带的真 ttf。
+///
+/// 两个用例是一对，第二个是**负向对照**：去掉 ACAO 之后必须失败。没有它，第一个
+/// 用例可能只是「在某个不检查 CORS 的实现上恒真」，那就成了自我欺骗的绿。
+///
+/// 跑法（仓库 fushi/ 下，离屏、不抢焦点、隔离 WebView2 profile）：
+///   .\tool\run_windows_itest.ps1 integration_test\dict_popup_font_url_itest.dart
+String _jsString(String value) => jsonEncode(value);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory fontDir;
+  late File fontFile;
+
+  setUp(() async {
+    // 素材用仓库自带的真 ttf：必须是浏览器**真能解析**的字体，否则
+    // document.fonts.check 即便 CORS 通过也会是 false，测不出所以然。
+    final ByteData bytes =
+        await rootBundle.load('assets/fonts/MaterialSymbolsRounded.ttf');
+    fontDir = await Directory.systemTemp.createTemp('fushi_font_url_itest');
+    // 用 p.join 而不是手拼 '/'：systemTemp 在 Windows 给的是反斜杠路径，手拼会造出
+    // 混合分隔符（`...\temp\xxx/ItestFont.ttf`），而白名单两侧都按 p.canonicalize
+    // 比对——第一次跑这个测试就是栽在这里，请求被白名单挡下，压根没走到 CORS。
+    fontFile = File(p.join(fontDir.path, 'ItestFont.ttf'));
+    await fontFile.writeAsBytes(bytes.buffer.asUint8List());
+  });
+
+  tearDown(() async {
+    if (fontDir.existsSync()) {
+      await fontDir.delete(recursive: true);
+    }
+  });
+
+  /// 挂一个 WebView，文档用 initialData（与生产的 Windows 弹窗一样是 opaque
+  /// origin），页面里声明一个引用 [kDictionaryFontUrlPrefix] 的 @font-face，
+  /// 然后真去 load 它。返回 `document.fonts.check` 的结果。
+  Future<({String probe, List<String> intercepted, bool served})>
+      loadFontThroughInterceptor(
+    WidgetTester tester, {
+    required bool sendCorsHeader,
+  }) async {
+    final Completer<InAppWebViewController> ready =
+        Completer<InAppWebViewController>();
+    final String fontUrl = dictionaryFontUrl(fontFile.path);
+    final List<String> intercepted = <String>[];
+    bool served = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InAppWebView(
+            initialData: InAppWebViewInitialData(
+              data: '<!DOCTYPE html><html><head><meta charset="utf-8">'
+                  '<style>'
+                  '@font-face { font-family: "ItestFont"; '
+                  'src: url("$fontUrl") format("truetype"); }'
+                  '</style></head>'
+                  '<body><span id="probe" '
+                  'style="font-family:\'ItestFont\'">e</span></body></html>',
+            ),
+            initialSettings: InAppWebViewSettings(
+              useShouldInterceptRequest: true,
+              resourceCustomSchemes: dictionaryMediaCustomSchemes,
+            ),
+            shouldInterceptRequest: (controller, request) async {
+              intercepted.add(request.url.toString());
+              final WebResourceResponse? real =
+                  await dictionaryFontWebResourceResponse(
+                request.url,
+                allowedRoots: <String>[fontDir.path],
+                // 白名单必须与拦截器内部同一套归一化（p.canonicalize），
+                // 否则分隔符/大小写差异会让合法字体被自己的白名单挡下。
+                whitelistedPaths: <String>{p.canonicalize(fontFile.path)},
+              );
+              if (real == null) return null;
+              served = real.statusCode == 200;
+              if (sendCorsHeader) return real;
+              // 负向对照：同样的字节、同样的 200，唯独抽掉 CORS 头。
+              return WebResourceResponse(
+                contentType: real.contentType,
+                statusCode: real.statusCode,
+                reasonPhrase: real.reasonPhrase,
+                data: real.data,
+              );
+            },
+            onLoadStop: (controller, url) {
+              if (!ready.isCompleted) ready.complete(controller);
+            },
+          ),
+        ),
+      ),
+    );
+
+    // WebView2 冷启动 + 导航；给足时间，别用固定 sleep 赌。
+    final InAppWebViewController controller = await ready.future.timeout(
+      const Duration(seconds: 60),
+    );
+    for (int i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+    }
+
+    // evaluateJavascript **不会 await Promise**：直接 return 一个 async IIFE
+    // 只会拿到序列化后的 Promise（表现为 `{}`）。这个坑让本测试头两轮跑出的
+    // 「失败」全是假的——探针压根没取到值，与 CORS / 拦截器无关。
+    // 所以改成两步：先把结果写进 window.__fushiFontProbe，再轮询读那个同步值。
+    await controller.evaluateJavascript(
+      source: '''
+        window.__fushiFontProbe = 'pending';
+        (async () => {
+          var out = [];
+          try {
+            var r = await fetch(${_jsString(fontUrl)});
+            out.push('fetch:' + r.status);
+            var b = await r.arrayBuffer();
+            out.push('bytes:' + b.byteLength);
+          } catch (e) {
+            out.push('fetch-threw:' + e);
+          }
+          try {
+            await document.fonts.load('16px "ItestFont"');
+            out.push('load:ok');
+          } catch (e) {
+            out.push('load-threw:' + e);
+          }
+          out.push('check:' + document.fonts.check('16px "ItestFont"'));
+          out.push('status:' + document.fonts.status);
+          var faces = [];
+          document.fonts.forEach(function(f) {
+            faces.push(f.family + '=' + f.status);
+          });
+          out.push('faces:' + faces.join(','));
+          window.__fushiFontProbe = out.join(' | ');
+        })();
+      ''',
+    );
+
+    String probe = 'pending';
+    for (int i = 0; i < 60; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      final Object? v = await controller.evaluateJavascript(
+        source: 'window.__fushiFontProbe',
+      );
+      probe = '$v';
+      if (probe != 'pending' && probe.isNotEmpty) break;
+    }
+
+    return (
+      probe: probe,
+      intercepted: intercepted,
+      served: served,
+    );
+  }
+
+  testWidgets(
+    'BUG-1868: 跨源 + ACAO 时，经拦截器的 URL 字体真的加载成功',
+    (WidgetTester tester) async {
+      final r = await loadFontThroughInterceptor(tester, sendCorsHeader: true);
+      // ignore: avoid_print
+      print('[BUG-1868][cors] probe=${r.probe}');
+      // ignore: avoid_print
+      print('[BUG-1868][cors] served=${r.served} '
+          'intercepted=${r.intercepted}');
+      expect(
+        r.probe,
+        contains('check:true'),
+        reason: '字体没能经 https://fushi.local/dictfonts/ 加载。这条路一旦不通，'
+            '用户的词典字体会静默失效——比原来的慢更糟，不得合入。'
+            '探针：${r.probe}；拦截到的请求：${r.intercepted}',
+      );
+    },
+  );
+
+  testWidgets(
+    'BUG-1868 负向对照：抽掉 ACAO 后必须失败（证明上面那条不是恒真）',
+    (WidgetTester tester) async {
+      final r = await loadFontThroughInterceptor(tester, sendCorsHeader: false);
+      // ignore: avoid_print
+      print('[BUG-1868][nocors] probe=${r.probe}');
+      expect(
+        r.probe,
+        isNot(contains('check:true')),
+        reason: '没有 Access-Control-Allow-Origin 也能加载，说明这个环境根本没在'
+            '检查 CORS——那么正向用例的绿就不能证明生产环境也会通过，本测试失去意义。'
+            '探针：${r.probe}',
+      );
+    },
+  );
+}

--- a/fushi/lib/src/lookup/clipboard_panel_controller.dart
+++ b/fushi/lib/src/lookup/clipboard_panel_controller.dart
@@ -76,6 +76,20 @@ class ClipboardPanelController {
   static const OverlayWindowChannel _channel =
       OverlayWindowChannel(FushiChannels.clipboardPanel);
 
+  /// 本面板在静态段账本里的宿主标识。面板窗是**独立的 WebView2 realm**（native 给
+  /// 它单独的 user-data leaf），与桌面瞬态窗 / galCard 各算一个物理宿主，账本不能混。
+  static const String _kPanelHostKey = 'clipboardPanel';
+
+  /// 面板宿主已装载的静态设置版本（BUG-1833 的去重账本）。
+  ///
+  /// 这条路径此前**完全没有参与去重**：[buildStackRenderScript] 的对应形参当时是
+  /// 可选的，面板一个都没传，于是每次查词——包括每次在面板里点词的嵌套查词——都把
+  /// 完整静态段重新序列化、过平台通道、在 WebView2 里解析一遍，然后被 host.js 按
+  /// revision 认出是已缓存版本、当场丢弃。用户导入两个 CJK 词典字体（base64 内联
+  /// 后合计几十 MB）时，这就是每查一个词白传几十 MB。
+  final PopupStaticRevisionCache _hostStaticRevisions =
+      PopupStaticRevisionCache();
+
   /// BUG-1210 — 查词后自动朗读。此前**只有瞬态覆盖窗接了线**，本面板整条路径没有
   /// 任何朗读调用：同一个全局开关 `autoReadOnLookup` 在那个表面生效、在这里完全
   /// 无效，用户表现为「面板查词不读，必须手动点 ♪」。实现与覆盖窗共用同一份
@@ -474,7 +488,7 @@ class ClipboardPanelController {
             leadingUnits: model.lookupLeadingStripUnits(rootQuery),
             bestLength: rootResult.bestLength,
           );
-    final String script = buildStackRenderScript(
+    final StackRenderScript stackRender = buildStackRenderScript(
       context: ctx,
       appModel: model,
       payloads: payloads,
@@ -488,6 +502,10 @@ class ClipboardPanelController {
       cardBgAlpha: 1.0,
       sentenceHitStart: hit.length > 0 ? hit.start : -1,
       sentenceHitLength: hit.length,
+      // 面板是独立的 WebView2 realm（flutter_window.cpp 给它单独的 user-data
+      // leaf），所以它有自己的静态段账本，不与桌面瞬态窗 / galCard 共用。
+      staticRevisions: _hostStaticRevisions,
+      hostKey: _kPanelHostKey,
     );
     // pin 视觉态并进同一渲染脚本：native pending_json_ 是单槽缓存，冷启动时
     // 独立脚本会互相覆盖；同一 ExecuteScript 保证 pin 图标与卡片同帧就位。
@@ -507,13 +525,33 @@ class ClipboardPanelController {
         ? '\nwindow.__globalLookupHost && '
             'window.__globalLookupHost.scrollRootToTop();'
         : '';
-    await _channel
-        .render('$script\n$pinVisualJs\n$blockCaptureVisualJs$scrollResetJs');
+    await _channel.render(
+      '${stackRender.script}\n$pinVisualJs\n$blockCaptureVisualJs$scrollResetJs',
+    );
+    // 与瞬态窗同一纪律：平台侧收下完整脚本之后才记账。发送失败/被作废时版本必须
+    // 保持「未装载」，让下一次渲染重新带上自足的静态段。
+    _hostStaticRevisions.commit(_kPanelHostKey, stackRender.pendingRevisions);
   }
 
   void _onJsMessage(Map<String, Object?> message) {
     final Object? handler = message['handler'];
     final AppModel? model = _appModel;
+    // host.js 自报某个静态设置版本在它那儿没了（整块 WebView 恢复、iframe realm 重
+    // 建等）。**去重与这条回补通道是一对，缺一不可**：只做去重不接回补，宿主一旦
+    // 丢掉缓存就再也等不到静态段，卡片会永远停在没主题/没字体/没词典样式的状态。
+    // 这里把该版本从账本划掉并重渲，下一次渲染就会重新带上自足的静态段。
+    if (handler == 'staticSettingsRequired') {
+      final Object? args = message['args'];
+      final Object? first = (args is List && args.isNotEmpty) ? args.first : null;
+      final int? revision = first is num
+          ? first.toInt()
+          : (first is String ? int.tryParse(first) : null);
+      if (revision != null) {
+        _hostStaticRevisions.invalidate(_kPanelHostKey, revision);
+        unawaited(_rerender());
+      }
+      return;
+    }
     // 九根 DEFERRED 桥走共享权威 handler，经本 channel 的 resolveBridge 回传
     // （与瞬态覆盖窗同一实现，spec 红线：绝不复制）。
     if (maybeHandleOverlayDeferredBridge(

--- a/fushi/lib/src/lookup/clipboard_panel_controller.dart
+++ b/fushi/lib/src/lookup/clipboard_panel_controller.dart
@@ -19,6 +19,7 @@ import 'package:fushi/src/lookup/global_lookup_controller.dart'
     show
         GlobalLookupController,
         GlobalLookupMediaRequest,
+        parseStaticSettingsRequired,
         resolveGlobalLookupMedia;
 import 'package:fushi/src/lookup/overlay_auto_read.dart';
 import 'package:fushi/src/lookup/clipboard_history_payload.dart';
@@ -541,11 +542,9 @@ class ClipboardPanelController {
     // 丢掉缓存就再也等不到静态段，卡片会永远停在没主题/没字体/没词典样式的状态。
     // 这里把该版本从账本划掉并重渲，下一次渲染就会重新带上自足的静态段。
     if (handler == 'staticSettingsRequired') {
-      final Object? args = message['args'];
-      final Object? first = (args is List && args.isNotEmpty) ? args.first : null;
-      final int? revision = first is num
-          ? first.toInt()
-          : (first is String ? int.tryParse(first) : null);
+      // 与瞬态窗共用同一份载荷解析：同一条协议消息被两边各解析一份，等协议再加
+      // 参数时必然漂移（正是本轮修的那个 bug 的形状——同一件事分散在多处各做各的）。
+      final int? revision = parseStaticSettingsRequired(message).revision;
       if (revision != null) {
         _hostStaticRevisions.invalidate(_kPanelHostKey, revision);
         unawaited(_rerender());

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -1209,17 +1209,14 @@ class GlobalLookupController {
       glog('js: handler=$handler args=${message['args']}');
     }
     if (handler == 'staticSettingsRequired') {
-      final int? revision = _firstIntArg(message);
+      final ({int? revision, int? hostGeometryEpoch}) req =
+          parseStaticSettingsRequired(message);
+      final int? revision = req.revision;
       if (revision != null) {
         final GlobalLookupRoute route = GlobalLookupChannel.currentRoute;
         final String hostKey = route.target.isEmpty ? 'desktop' : route.target;
         _hostStaticRevisions.invalidate(hostKey, revision);
-        final Object? requestArgs = message['args'];
-        final int? hostGeometryCounter =
-            requestArgs is List && requestArgs.length > 1
-            ? parseGlobalLookupGeometryEpoch(requestArgs[1])
-            : null;
-        if (hostGeometryCounter == 0) {
+        if (req.hostGeometryEpoch == 0) {
           // A whole-WebView recovery restarts the host counter. Its first bbox
           // can equal the retired document's epoch and bounds, so clear Dart's
           // de-dup only for this fresh-realm signal. Ordinary child cache misses
@@ -2247,6 +2244,36 @@ class GlobalLookupController {
 /// Parses one non-negative renderer geometry epoch from a MethodChannel value.
 /// Integral doubles are accepted because native JSON bridges may materialise a
 /// JavaScript integer as either an int or a double.
+/// host.js `staticSettingsRequired` 的载荷解析（`args = [revision, geometryEpoch]`）。
+///
+/// 抽出来共享是因为它有**两个**消费方（桌面/galCard 的 GlobalLookupController 与剪贴板
+/// 面板），而两边原先各写了一份 num/String 兼容解析。同一条协议消息被解析成两份，等
+/// 协议再加一个参数时必然漂移——这正是本轮修的那个 bug 的形状（同一件事分散在多处各做
+/// 各的，漏掉一处就静默失效）。
+///
+/// [revision] 为 null 表示载荷不合法，调用方应整条忽略。
+/// [hostGeometryEpoch] 仅桌面路径消费（面板模式下 host.js 短路了 measureAndReport）。
+({int? revision, int? hostGeometryEpoch}) parseStaticSettingsRequired(
+  Map<String, Object?> message,
+) {
+  final Object? args = message['args'];
+  if (args is! List || args.isEmpty) {
+    return (revision: null, hostGeometryEpoch: null);
+  }
+  int? asInt(Object? v) {
+    if (v is num) return v.toInt();
+    if (v is String) return int.tryParse(v);
+    return null;
+  }
+
+  return (
+    revision: asInt(args.first),
+    hostGeometryEpoch: args.length > 1
+        ? parseGlobalLookupGeometryEpoch(args[1])
+        : null,
+  );
+}
+
 int? parseGlobalLookupGeometryEpoch(Object? value) {
   if (value is int) {
     return value >= 0 ? value : null;

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -1897,6 +1897,14 @@ class GlobalLookupController {
     // Commit only after the platform call accepted the complete script. A
     // thrown/invalidated send must leave the revision unknown so the next render
     // remains self-contained.
+    //
+    // 🔴 光 await 是**不够**的：[OverlayWindowChannel._invoke] 在路由失效时直接
+    // `return Future.value()` 把整条调用丢掉（挡住旧 zone 里排队的 Future 复活
+    // 老窗口），await 它正常完成，看不出脚本压根没送出去。若就此记账，宿主会被
+    // 标成「已装载」而它其实什么都没收到——下一次渲染不再下发静态段，卡片停在
+    // 没主题/没字体/没词典样式的状态，正是这套去重最怕的那个方向。
+    // 所以记账前再确认一次路由：宁可漏记（下次重发，只多一次带宽），不可误记。
+    if (!_isCurrentRoute) return;
     _hostStaticRevisions.commit(hostKey, stackRender.pendingRevisions);
   }
 

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -110,7 +110,8 @@ class GlobalLookupController {
   // font can make this payload ~13 MB, so only revisions not yet acknowledged
   // by the current host ride the render call. The host can demand a resend after
   // a whole-WebView recovery via `staticSettingsRequired`.
-  final Map<String, Set<int>> _hostStaticRevisions = <String, Set<int>>{};
+  final PopupStaticRevisionCache _hostStaticRevisions =
+      PopupStaticRevisionCache();
   int _desktopLookupEpoch = 0;
   // Last physical size pushed to the overlay; used to converge the page's
   // resize -> re-measure loop (see _onJsMessage 'overlaySize'). Reset per
@@ -1212,7 +1213,7 @@ class GlobalLookupController {
       if (revision != null) {
         final GlobalLookupRoute route = GlobalLookupChannel.currentRoute;
         final String hostKey = route.target.isEmpty ? 'desktop' : route.target;
-        _hostStaticRevisions[hostKey]?.remove(revision);
+        _hostStaticRevisions.invalidate(hostKey, revision);
         final Object? requestArgs = message['args'];
         final int? hostGeometryCounter =
             requestArgs is List && requestArgs.length > 1
@@ -1860,12 +1861,7 @@ class GlobalLookupController {
     final double screenH = pickScreenDim(_screenWorkH, _layoutBoundsH, cardH);
     final GlobalLookupRoute route = GlobalLookupChannel.currentRoute;
     final String hostKey = route.target.isEmpty ? 'desktop' : route.target;
-    final Set<int> knownStaticRevisions = _hostStaticRevisions.putIfAbsent(
-      hostKey,
-      () => <int>{},
-    );
-    final Set<int> emittedStaticRevisions = <int>{};
-    final String stackScript = buildStackRenderScript(
+    final StackRenderScript stackRender = buildStackRenderScript(
       context: ctx,
       appModel: model,
       payloads: payloads,
@@ -1887,21 +1883,21 @@ class GlobalLookupController {
       // preserving the desktop global-lookup cascade.
       fitNestedHeightToAnchorSide: route.source == 'galCard',
       clipboardHistoryAvailable: _allowClipboardHistory,
-      knownStaticRevisions: knownStaticRevisions,
-      emittedStaticRevisions: emittedStaticRevisions,
+      staticRevisions: _hostStaticRevisions,
+      hostKey: hostKey,
     );
     // Cold-create and process-recovery paths cache exactly one complete script
     // until NavigationCompleted.  Keep beginLookup + renderStack indivisible so
     // last-wins caching cannot discard the immutable route epoch while retaining
     // the pixels.  Subsequent nested/visual-only renders omit the prelude.
     final String script = beginRoute == null
-        ? stackScript
-        : '${buildBeginLookupScript(kGlobalLookupRootFrameId, source: beginRoute.source, routeEpoch: beginRoute.routeEpoch, lookupEpoch: beginRoute.lookupEpoch)}$stackScript';
+        ? stackRender.script
+        : '${buildBeginLookupScript(kGlobalLookupRootFrameId, source: beginRoute.source, routeEpoch: beginRoute.routeEpoch, lookupEpoch: beginRoute.lookupEpoch)}${stackRender.script}';
     await GlobalLookupChannel.render(script);
     // Commit only after the platform call accepted the complete script. A
     // thrown/invalidated send must leave the revision unknown so the next render
     // remains self-contained.
-    knownStaticRevisions.addAll(emittedStaticRevisions);
+    _hostStaticRevisions.commit(hostKey, stackRender.pendingRevisions);
   }
 
   /// TODO-867 P3c C2 — parses the onLinkClick anchor arg ({x,y,width,height} in

--- a/fushi/lib/src/lookup/global_lookup_render.dart
+++ b/fushi/lib/src/lookup/global_lookup_render.dart
@@ -239,8 +239,15 @@ const double kGlobalLookupLayoutBoundsHeightFactor = 2.0;
 class PopupStaticRevisionCache {
   final Map<String, Set<int>> _byHost = <String, Set<int>>{};
 
-  /// [hostKey] 宿主当前已确认装载的版本集合（可直接读，不要外部改写）。
-  Set<int> knownFor(String hostKey) =>
+  /// [hostKey] 宿主当前已确认装载的版本集合的**可变副本**。
+  ///
+  /// 刻意不返回内部集合本身。这个类存在的全部动机就是「别让漏做去重在结构上成为
+  /// 可能」，那么把「请不要改写我返回的 Set」这条纪律寄托在一句注释上就是自相矛盾
+  /// ——渲染器拿到它之后本来就要往里加本次发出的版本，一不小心加到内部集合上，
+  /// 就等于在平台调用还没发生时先记了账。
+  Set<int> snapshotFor(String hostKey) => <int>{..._known(hostKey)};
+
+  Set<int> _known(String hostKey) =>
       _byHost.putIfAbsent(hostKey, () => <int>{});
 
   /// 把本次渲染真正发出去的版本记为「已装载」。
@@ -249,7 +256,7 @@ class PopupStaticRevisionCache {
   /// 渲染以为宿主已经有这个版本而不再下发，卡片就永远拿不到主题/字体/样式。
   void commit(String hostKey, Set<int> emitted) {
     if (emitted.isEmpty) return;
-    knownFor(hostKey).addAll(emitted);
+    _known(hostKey).addAll(emitted);
   }
 
   /// 宿主自报某个版本没了（整块 WebView 恢复、iframe realm 重建等，见 host.js 的
@@ -409,7 +416,9 @@ StackRenderScript buildStackRenderScript({
   required PopupStaticRevisionCache staticRevisions,
   required String hostKey,
 }) {
-  final Set<int> knownStaticRevisions = staticRevisions.knownFor(hostKey);
+  // 本次渲染开始时宿主已装载的版本（副本）；下面每发出一个新版本就往里加，
+  // 同一次调用内的后续帧据此不再重复携带同一份静态段。
+  final Set<int> availableStaticRevisions = staticRevisions.snapshotFor(hostKey);
   final Set<int> emittedStaticRevisions = <int>{};
   // TODO-867 P3c F2 — the host shell (.global-lookup-frame-shell) is built in the
   // TOP-LEVEL host document, which carries no data-theme of its own (the theme
@@ -433,7 +442,6 @@ StackRenderScript buildStackRenderScript({
     cardH: maxHeight,
   );
   final List<Map<String, Object?>> popups = <Map<String, Object?>>[];
-  final Set<int> availableStaticRevisions = <int>{...knownStaticRevisions};
   for (int i = 0; i < payloads.length; i++) {
     final GlobalLookupFramePayload p = payloads[i];
     final bool isPanelRoot = layoutMode == 'panel' && p.frame.parentIndex < 0;

--- a/fushi/lib/src/lookup/global_lookup_render.dart
+++ b/fushi/lib/src/lookup/global_lookup_render.dart
@@ -222,6 +222,48 @@ const double kGlobalLookupCascadeStep = 28.0;
 const double kGlobalLookupLayoutBoundsWidthFactor = 2.4;
 const double kGlobalLookupLayoutBoundsHeightFactor = 2.0;
 
+/// 每个**物理宿主**（一个独立的 WebView2 realm：桌面瞬态窗 / galCard 浮窗 /
+/// 剪贴板面板各算一个）已经装载好的静态设置版本号集合。
+///
+/// BUG-1833 起，静态设置段（主题变量 + 词典字体 + 词典样式 + 自定义 CSS + 各种
+/// window.* 开关）按 [PopupStaticSettingsJs.revision] 去重：宿主已经装过的版本不再
+/// 随渲染负载重发。这件事非做不可——用户导入的词典字体是 `data:` URL 内联的，两个
+/// CJK 字体就能让这一段到几十 MB；每次查词重发一遍，等于每次查词都往平台通道里灌
+/// 几十 MB、在 WebView2 里解析一遍，然后被宿主按 revision 认出是旧相识、原样丢弃。
+///
+/// 这个类存在的理由是「让漏做去重在结构上不可能」：去重状态曾经由每个调用方自己
+/// 拿 `Map<String, Set<int>>` 拼，而 [buildStackRenderScript] 的对应形参是**可选**
+/// 的——于是剪贴板面板那条路径压根没传，整套去重对它完全失效，每次查词（包括每次
+/// 在面板里点词的嵌套查词）都重发全量静态段。现在形参必填、待确认版本从返回值带
+/// 出，少传一个就是编译错误。
+class PopupStaticRevisionCache {
+  final Map<String, Set<int>> _byHost = <String, Set<int>>{};
+
+  /// [hostKey] 宿主当前已确认装载的版本集合（可直接读，不要外部改写）。
+  Set<int> knownFor(String hostKey) =>
+      _byHost.putIfAbsent(hostKey, () => <int>{});
+
+  /// 把本次渲染真正发出去的版本记为「已装载」。
+  ///
+  /// **必须等平台侧 render 调用成功之后再调**：脚本没送到宿主就先记账，会让后续
+  /// 渲染以为宿主已经有这个版本而不再下发，卡片就永远拿不到主题/字体/样式。
+  void commit(String hostKey, Set<int> emitted) {
+    if (emitted.isEmpty) return;
+    knownFor(hostKey).addAll(emitted);
+  }
+
+  /// 宿主自报某个版本没了（整块 WebView 恢复、iframe realm 重建等，见 host.js 的
+  /// `staticSettingsRequired`），把它从已装载集合里划掉，下一次渲染重新带上。
+  void invalidate(String hostKey, int revision) {
+    _byHost[hostKey]?.remove(revision);
+  }
+}
+
+/// [buildStackRenderScript] 的产物：要执行的脚本，以及**本次真正带上了静态段**的
+/// 版本号集合。调用方在平台 render 成功后把后者交给
+/// [PopupStaticRevisionCache.commit]。
+typedef StackRenderScript = ({String script, Set<int> pendingRevisions});
+
 /// TODO-1095 — the STABLE root frame id reused across hotkey lookups. Before
 /// this, every hotkey lookup minted a fresh `frame-N` id, so the host tore the
 /// root popup.html iframe down (removeMissing) and rebuilt it (createRecord ->
@@ -319,7 +361,7 @@ String buildPlayWordAudioScript(String frameId, String url, int token) {
 /// [screenWidth]/[screenHeight] and [maxWidth]/[maxHeight] are CSS / logical px
 /// (NOT physical — see global_lookup_layout coordinate rule): the dpr boundary
 /// is the C++ window geometry, never this layout math.
-String buildStackRenderScript({
+StackRenderScript buildStackRenderScript({
   required BuildContext context,
   required AppModel appModel,
   required List<GlobalLookupFramePayload> payloads,
@@ -354,14 +396,21 @@ String buildStackRenderScript({
   int sentenceHitStart = -1,
   int sentenceHitLength = 0,
   // BUG-1833 — static settings revisions already acknowledged by this physical
-  // host. The stable root iframe survives lookup-to-lookup, so a
-  // 9.6 MB custom font must not become a ~13 MB data-URL platform message on
-  // every Shift lookup. Unknown/new frames still receive a self-contained
-  // static payload. [emittedStaticRevisions] lets the caller commit the cache
-  // only after the native render call succeeds.
-  Set<int> knownStaticRevisions = const <int>{},
-  Set<int>? emittedStaticRevisions,
+  // host. The stable root iframe survives lookup-to-lookup, so a custom font
+  // (two CJK faces already run to tens of MB once base64-inlined) must not ride
+  // the platform message on every lookup. Unknown/new frames still receive a
+  // self-contained static payload.
+  //
+  // 这两个参数**必填**，而且是同一件事的两半：从哪个宿主的账本上查（[hostKey]），
+  // 查到的账本是谁（[staticRevisions]）。曾经它们是带默认值的可选参数，剪贴板面板
+  // 那条调用路径就那么静默地一个都没传，去重对它完全失效——每次查词重发几十 MB。
+  // 必填之后，少传就是编译错误。本次真正发出去的版本从返回值的 pendingRevisions
+  // 带出，调用方在 render 成功后 commit。
+  required PopupStaticRevisionCache staticRevisions,
+  required String hostKey,
 }) {
+  final Set<int> knownStaticRevisions = staticRevisions.knownFor(hostKey);
+  final Set<int> emittedStaticRevisions = <int>{};
   // TODO-867 P3c F2 — the host shell (.global-lookup-frame-shell) is built in the
   // TOP-LEVEL host document, which carries no data-theme of its own (the theme
   // vars live INSIDE each iframe). So the shell's dark/light border variant can't
@@ -425,7 +474,7 @@ String buildStackRenderScript({
     if (!availableStaticRevisions.contains(settings.staticRevision)) {
       map['staticHeadJs'] = settings.staticHeadJs;
       map['staticTailJs'] = settings.staticTailJs;
-      emittedStaticRevisions?.add(settings.staticRevision);
+      emittedStaticRevisions.add(settings.staticRevision);
       availableStaticRevisions.add(settings.staticRevision);
     }
     popups.add(map);
@@ -452,8 +501,12 @@ String buildStackRenderScript({
     };
   }
   final String payloadJson = jsonEncode(payloadObj);
-  return 'window.__globalLookupHost && '
-      'window.__globalLookupHost.renderStack($payloadJson);';
+  return (
+    script:
+        'window.__globalLookupHost && '
+        'window.__globalLookupHost.renderStack($payloadJson);',
+    pendingRevisions: emittedStaticRevisions,
+  );
 }
 
 /// Resolves ONE frame's shell rect (CSS px) for the host payload. With a real

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -12,7 +12,9 @@ import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_input_bridge.dart';
 import 'package:fushi/src/pages/implementations/dictionary_webview_media.dart';
+import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi/src/pages/implementations/popup_settings_injection.dart';
+import 'package:path/path.dart' as p;
 import 'package:fushi/src/platform/selection_external_actions.dart';
 import 'package:fushi/src/reader/popup_swipe_close_script.dart';
 import 'package:fushi/src/reader/reader_caret_scripts.dart';
@@ -414,6 +416,30 @@ class DictionaryPopupWebViewState
   /// 串做全串比较，现在只存 int（builder 侧按输入 memo，同内容 ⇒ 同 revision）。
   /// 页面重载（onLoadStop）时置 null 强制重发（新页面无状态）。
   int? _lastSentStaticRevision;
+
+  /// 字体 URL 拦截器的目录白名单：只有导入字体落盘的那一个目录。
+  ///
+  /// 与注入侧 [_dictionaryFontStyleJsMemo] 用的白名单同源——两边不一致的话，会出现
+  /// 「CSS 里引了某个字体，拦截器却拒绝供给」的哑失败（字体静默不生效）。
+  List<String> _dictionaryFontAllowedRoots() {
+    final appModel = ref.read(appProvider);
+    return <String>[p.join(appModel.appDirectory.path, 'custom_fonts')];
+  }
+
+  /// 字体 URL 拦截器的**条目**白名单：当前真正配置在词典字体里的那几个文件。
+  ///
+  /// 光有目录白名单不够。目录里可能躺着历史导入的一堆字体文件，而注入的 CSS 是可被
+  /// 内容影响的；只放行「此刻确实配置了的路径」，把可读集合收敛到最小。
+  Set<String> _configuredDictionaryFontPaths() {
+    final List<Map<String, dynamic>> fonts =
+        ReaderFushiSource.readerSettings?.dictionaryFonts ??
+            const <Map<String, dynamic>>[];
+    return fonts
+        .map((Map<String, dynamic> e) => e['path'] as String?)
+        .whereType<String>()
+        .map(p.canonicalize)
+        .toSet();
+  }
 
   /// BUG-717 ③：最近一次已注入的 in-app 固定块（`__fushiResetPopupScroll` 钩子 +
   /// 句子上下文 i18n 文案 + `sentenceContextPreviewEnabled`）的键。该块只随静态段
@@ -1058,6 +1084,10 @@ JSON.stringify((function(){
     final PopupStaticSettingsJs staticSettings = buildPopupStaticSettingsJs(
       appModel: appModel,
       theme: Theme.of(context),
+      // 导入字体以 URL 引用下发，字节由本 WebView 的 shouldInterceptRequest 供
+      // （见 dictionaryFontWebResourceResponse）。仅在宿主真有能带 CORS 头的拦截器
+      // 时启用——否则字体会被静默拒绝，那比慢更糟。见 kInAppPopupFontUrlSupported。
+      fontUrlBuilder: kInAppPopupFontUrlSupported ? dictionaryFontUrl : null,
       options: PopupSettingsOptions(
         // TODO-1065：app 外 / 悬浮字幕独立查词窗令 <html> 透明消除泛白（见字段 doc）。
         mobileExternal: widget.transparentDocumentBackground,
@@ -1568,6 +1598,15 @@ JSON.stringify((function(){
         disableContextMenu: isWindowsPlatform,
       ),
       shouldInterceptRequest: (controller, request) async {
+        // 字体先于词典媒体判：两者 URL 形状不重叠，字体分支不命中时返回 null，
+        // 原有的 image:// / dictmedia:// 路径逐字不变。
+        final WebResourceResponse? font =
+            await dictionaryFontWebResourceResponse(
+          request.url,
+          allowedRoots: _dictionaryFontAllowedRoots(),
+          whitelistedPaths: _configuredDictionaryFontPaths(),
+        );
+        if (font != null) return font;
         return dictionaryMediaWebResourceResponse(request.url);
       },
       onWebViewCreated: (controller) {

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -419,11 +419,33 @@ class DictionaryPopupWebViewState
 
   /// 字体 URL 拦截器的目录白名单：只有导入字体落盘的那一个目录。
   ///
-  /// 与注入侧 [_dictionaryFontStyleJsMemo] 用的白名单同源——两边不一致的话，会出现
+  /// 与注入侧 [buildPopupStaticSettingsJs] 用的白名单同源——两边不一致的话，会出现
   /// 「CSS 里引了某个字体，拦截器却拒绝供给」的哑失败（字体静默不生效）。
-  List<String> _dictionaryFontAllowedRoots() {
-    final appModel = ref.read(appProvider);
-    return <String>[p.join(appModel.appDirectory.path, 'custom_fonts')];
+  ///
+  /// 惰性解析并缓存，三个约束一起满足：
+  ///   * **不每次请求都读**：`useShouldInterceptRequest` 让本 WebView 的每一条子资源
+  ///     请求都进拦截器闭包，在那里 `ref.read` + 拼路径是白付的重复开销；
+  ///   * **dispose 之后不碰 `ref`**：资源请求回调由平台侧驱动，完全可能在 widget 已
+  ///     dispose、WebView 尚未销毁完的窗口里到达，那时 `ref.read` 会抛 StateError，
+  ///     而且是在 async 回调里抛 → 未捕获异常。故先看 `mounted`；
+  ///   * **AppModel 未初始化时不炸**：`appDirectory` 是 late 字段，widget 测试里的裸
+  ///     AppModel 读它会抛 LateInitializationError。拿不到就返回 null，让字体分支
+  ///     整个短路——真实 app 里等到 appDirectory 就绪自然会拿到，而那之前也不可能有
+  ///     字体 URL 请求（URL 是注入侧产的，注入侧同样要 appDirectory）。
+  List<String>? _dictionaryFontRootsCache;
+
+  List<String>? _resolveDictionaryFontRoots() {
+    final List<String>? cached = _dictionaryFontRootsCache;
+    if (cached != null) return cached;
+    if (!mounted) return null;
+    try {
+      final String appDir = ref.read(appProvider).appDirectory.path;
+      return _dictionaryFontRootsCache = <String>[
+        p.join(appDir, 'custom_fonts'),
+      ];
+    } catch (_) {
+      return null;
+    }
   }
 
   /// 字体 URL 拦截器的**条目**白名单：当前真正配置在词典字体里的那几个文件。
@@ -1598,15 +1620,22 @@ JSON.stringify((function(){
         disableContextMenu: isWindowsPlatform,
       ),
       shouldInterceptRequest: (controller, request) async {
-        // 字体先于词典媒体判：两者 URL 形状不重叠，字体分支不命中时返回 null，
-        // 原有的 image:// / dictmedia:// 路径逐字不变。
-        final WebResourceResponse? font =
-            await dictionaryFontWebResourceResponse(
-          request.url,
-          allowedRoots: _dictionaryFontAllowedRoots(),
-          whitelistedPaths: _configuredDictionaryFontPaths(),
-        );
-        if (font != null) return font;
+        // 前缀判定必须在**最前面**：`useShouldInterceptRequest: true` 让本闭包接住
+        // 这个 WebView 的**每一条**子资源请求（popup.html / popup.css / popup.js /
+        // 每张词典图 / 每条发音）。把两个白名单当实参写在调用处，它们会在前缀判定
+        // 之前就被求值——而 _configuredDictionaryFontPaths() 内部要把 font_catalog
+        // 和 font_targets 两串 JSON 全量 decode 一遍。那等于在一个「消除重复开销」
+        // 的改动里新引入一条同形状的重复开销（与本轮 popup.js 门控踩的是同一个坑：
+        // 参数在传参之前就求值了，只挡输出挡不住开销）。
+        if (isDictionaryFontUrl(request.url)) {
+          final List<String>? roots = _resolveDictionaryFontRoots();
+          if (roots == null) return null;
+          return dictionaryFontWebResourceResponse(
+            request.url,
+            allowedRoots: roots,
+            whitelistedPaths: _configuredDictionaryFontPaths(),
+          );
+        }
         return dictionaryMediaWebResourceResponse(request.url);
       },
       onWebViewCreated: (controller) {

--- a/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
@@ -52,8 +52,33 @@ bool get kInAppPopupFontUrlSupported =>
     defaultTargetPlatform == TargetPlatform.windows;
 
 /// 把通过白名单校验的绝对字体路径编成 [kDictionaryFontUrlPrefix] 下的 URL。
-String dictionaryFontUrl(String safePath) =>
-    '$kDictionaryFontUrlPrefix${Uri.encodeComponent(safePath)}';
+///
+/// URL 末尾带 `?v=<mtimeUs>-<size>` 内容版本戳。**不是装饰**：内联路径的缓存键本来
+/// 就是 `(path, mtime, size)`（见 DictionaryFontCss 的 _dataUrlCache，注释写明「文件
+/// 被原地覆盖时 mtime/size 变化自动失效」）。换成 URL 之后，如果 URL 只含路径，用户
+/// 用同名文件覆盖导入的字体后产出的 URL 一字不变，而响应带着 `max-age`——浏览器可能
+/// 在缓存期内继续用旧字节。那是相对内联模式的**行为倒退**。版本戳让覆盖后的 URL 天然
+/// 变成一条新资源。stat 失败时退化成不带版本（仍可用，只是失去自动失效）。
+String dictionaryFontUrl(String safePath) {
+  String version = '';
+  try {
+    final FileStat stat = FileStat.statSync(safePath);
+    if (stat.type != FileSystemEntityType.notFound) {
+      version = '?v=${stat.modified.microsecondsSinceEpoch}-${stat.size}';
+    }
+  } catch (_) {
+    // 拿不到版本不影响可用性，只是少了自动失效。
+  }
+  return '$kDictionaryFontUrlPrefix${Uri.encodeComponent(safePath)}$version';
+}
+
+/// 这条 URL 是否是字体请求。
+///
+/// 拦截器闭包必须先用它做**廉价前缀判定**，再去构造白名单实参——`shouldInterceptRequest`
+/// 接住的是 WebView 的每一条子资源请求，把白名单当实参写在调用处会让它们在前缀判定
+/// 之前就被求值（其中一个要全量 decode 两串 JSON）。
+bool isDictionaryFontUrl(Uri url) =>
+    url.toString().startsWith(kDictionaryFontUrlPrefix);
 
 /// 服务 [kDictionaryFontUrlPrefix] 下的字体请求；不是字体 URL 时返回 null（交回
 /// 其它拦截分支）。
@@ -74,7 +99,11 @@ Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
 }) async {
   final String full = url.toString();
   if (!full.startsWith(kDictionaryFontUrlPrefix)) return null;
-  final String raw = full.substring(kDictionaryFontUrlPrefix.length);
+  String raw = full.substring(kDictionaryFontUrlPrefix.length);
+  // 剥掉 `?v=<mtime>-<size>` 内容版本戳：它只为让覆盖字体后的 URL 成为新资源，
+  // 不参与路径解析。
+  final int q = raw.indexOf('?');
+  if (q >= 0) raw = raw.substring(0, q);
   if (raw.isEmpty) return null;
 
   String requested;

--- a/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
@@ -109,8 +109,8 @@ Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
   String requested;
   try {
     requested = Uri.decodeComponent(raw);
-  } catch (e, stack) {
-    _logDictionaryMediaSkip('font url undecodable: $raw ($e)', stack);
+  } catch (e) {
+    _logFontDenial('font url undecodable: $raw ($e)');
     return _fontDenied();
   }
 
@@ -119,23 +119,23 @@ Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
     allowedRoots: allowedRoots,
   );
   if (safePath == null) {
-    _logDictionaryMediaSkip('font outside allowed directory: $requested');
+    _logFontDenial('font outside allowed directory: $requested');
     return _fontDenied();
   }
   if (!whitelistedPaths.contains(p.canonicalize(safePath))) {
-    _logDictionaryMediaSkip('font not in configured list: $requested');
+    _logFontDenial('font not in configured list: $requested');
     return _fontDenied();
   }
 
   try {
     final File file = File(safePath);
     if (!file.existsSync()) {
-      _logDictionaryMediaSkip('font not found: $safePath');
+      _logFontDenial('font not found: $safePath');
       return _fontDenied();
     }
     final Uint8List data = await file.readAsBytes();
     if (!isValidFontData(data)) {
-      _logDictionaryMediaSkip('font corrupted: $safePath (${data.length} B)');
+      _logFontDenial('font corrupted: $safePath (${data.length} B)');
       return _fontDenied();
     }
     return WebResourceResponse(
@@ -148,8 +148,8 @@ Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
       },
       data: data,
     );
-  } catch (e, stack) {
-    _logDictionaryMediaSkip('font read failed: $safePath ($e)', stack);
+  } catch (e) {
+    _logFontDenial('font read failed: $safePath ($e)');
     return _fontDenied();
   }
 }
@@ -158,6 +158,22 @@ Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
 ///
 /// 返回 null 会让请求**穿透**到真实网络（`fushi.local` 不存在，最终是一次 DNS 失败
 /// 的等待），而不是干脆地失败；给个明确的 403 让浏览器立刻回退到字体链的下一位。
+/// 同一条路径的拒绝只记一次日志。
+///
+/// 字体静默失配正是本次改动最大的风险方向，而**每个新建的嵌套 WebView 都会重新请求
+/// 一遍字体**：不去重的话，一次失配就会沿着刚优化过的那条落盘链刷出成串日志（还会
+/// 顶掉 512 KB 窗口里真正有价值的记录）。集合有上限，防止被构造出来的路径撑爆。
+final Set<String> _loggedFontDenials = <String>{};
+
+void _logFontDenial(String reason) {
+  if (_loggedFontDenials.length > 64) _loggedFontDenials.clear();
+  if (!_loggedFontDenials.add(reason)) return;
+  debugPrint('[DictionaryFont] $reason');
+  // 用独立 tag：这不是词典媒体缓存的问题，混进 DictionaryMedia.cache 会把排查引向
+  // 错误的子系统。
+  ErrorLogService.instance.log('DictionaryFont.denied', reason);
+}
+
 WebResourceResponse _fontDenied() => WebResourceResponse(
       contentType: 'text/plain',
       statusCode: 403,

--- a/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_webview_media.dart
@@ -4,6 +4,11 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:fushi/src/dictionary/dictionary_media_types.dart';
+import 'package:fushi/src/epub/epub_book.dart' show fallbackMimeType;
+import 'package:fushi/src/media/sources/reader_fushi_source.dart';
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart'
+    show isValidFontData;
+import 'package:path/path.dart' as p;
 import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
@@ -12,6 +17,124 @@ const List<String> dictionaryMediaCustomSchemes = <String>[
   'image',
   'dictmedia',
 ];
+
+/// in-app 查词弹窗给导入词典字体用的虚拟 URL 前缀。
+///
+/// 为什么字体不能再走 `data:` 内联：内联把字体塞进了「每次渲染都要重新注入的那段
+/// 脚本」。两个 CJK 字体（8.3 MB + 17 MB）base64 之后是三十多 MB，而 in-app 弹窗
+/// **每嵌套一层就新建一个 WebView**（新 JS realm，window.* 全空，静态段必须重发）
+/// ——于是「在弹窗里点词」每点一次就重新序列化、跨平台通道、重新解析这三十多 MB。
+/// 这正是用户报的「查词弹窗慢的逆天，特别是嵌套查词开始」。
+///
+/// 换成 URL 之后，字节由下面的拦截器按需供，而且**跨 WebView 共享 HTTP 缓存**
+/// （`data:` URL 每次都是一个全新资源，永远共享不了）。
+///
+/// host 沿用阅读器那套 `fushi.local`（与阅读器 WebView 各自拦截，互不干扰），
+/// 路径段是 URI 编码后的绝对路径。
+const String kDictionaryFontUrlPrefix = 'https://fushi.local/dictfonts/';
+
+/// in-app 查词弹窗能不能用 URL 投递字体，取决于该平台有没有**能带 CORS 头**的资源
+/// 拦截器。字体是强制 CORS 模式的子资源，而弹窗文档与 `fushi.local` 从来不同源
+/// （Android 是 `file://`，Windows 是 `initialData` 的 opaque origin），拿不到
+/// `Access-Control-Allow-Origin` 就会被静默拒绝——表现为「字体没生效」，比慢更糟。
+///
+///   - Android：`useShouldInterceptRequest: true` 让所有请求进 Dart，
+///     `WebResourceResponse` 支持 headers。✅（阅读器的 `fushi.local/fonts/` 已在
+///     生产用同一套机制跑了很久）
+///   - Windows：fork 的 `WebResourceRequested` 对 file/http/https 恒触发，并把
+///     `shouldInterceptRequest` 的响应连同 headers 灌回去。✅
+///   - iOS / macOS：**没有** `shouldInterceptRequest`，只有 `WKURLSchemeHandler`，
+///     而它构造的 `URLResponse` 带不了任何 header。❌ 这两个平台继续内联 `data:`
+///     URL——不是偷懒，是平台能力边界；要绕开只能把 popup 文档本身改成从自定义
+///     scheme 加载以取得同源，那是另一个量级的改动。
+bool get kInAppPopupFontUrlSupported =>
+    defaultTargetPlatform == TargetPlatform.android ||
+    defaultTargetPlatform == TargetPlatform.windows;
+
+/// 把通过白名单校验的绝对字体路径编成 [kDictionaryFontUrlPrefix] 下的 URL。
+String dictionaryFontUrl(String safePath) =>
+    '$kDictionaryFontUrlPrefix${Uri.encodeComponent(safePath)}';
+
+/// 服务 [kDictionaryFontUrlPrefix] 下的字体请求；不是字体 URL 时返回 null（交回
+/// 其它拦截分支）。
+///
+/// 三道校验照抄阅读器 `/fonts/` 那条已在生产跑了很久的路径，一道都不少：
+///   ① 路径必须落在 [allowedRoots]（`safeCustomFontPath` 做规范化 + 前缀比对，
+///      挡 `..` 逃逸）；
+///   ② 路径必须在**当前配置的字体白名单**里——光有目录白名单不够，
+///      那样任何能影响注入 CSS 的人都能读走该目录下的任意文件；
+///   ③ 字节必须通过字体魔数校验，避免把任意文件当字体吐出去。
+/// 另外必须带 `Access-Control-Allow-Origin`：字体是强制 CORS 模式的子资源，而弹窗
+/// 文档在 Android 是 `file://`、在 Windows 是 opaque origin，都与 `fushi.local`
+/// 不同源，没有这个头字体会被静默拒绝（表现为「字体没生效」而不是报错）。
+Future<WebResourceResponse?> dictionaryFontWebResourceResponse(
+  Uri url, {
+  required Iterable<String> allowedRoots,
+  required Set<String> whitelistedPaths,
+}) async {
+  final String full = url.toString();
+  if (!full.startsWith(kDictionaryFontUrlPrefix)) return null;
+  final String raw = full.substring(kDictionaryFontUrlPrefix.length);
+  if (raw.isEmpty) return null;
+
+  String requested;
+  try {
+    requested = Uri.decodeComponent(raw);
+  } catch (e, stack) {
+    _logDictionaryMediaSkip('font url undecodable: $raw ($e)', stack);
+    return _fontDenied();
+  }
+
+  final String? safePath = ReaderFushiSource.safeCustomFontPath(
+    requested,
+    allowedRoots: allowedRoots,
+  );
+  if (safePath == null) {
+    _logDictionaryMediaSkip('font outside allowed directory: $requested');
+    return _fontDenied();
+  }
+  if (!whitelistedPaths.contains(p.canonicalize(safePath))) {
+    _logDictionaryMediaSkip('font not in configured list: $requested');
+    return _fontDenied();
+  }
+
+  try {
+    final File file = File(safePath);
+    if (!file.existsSync()) {
+      _logDictionaryMediaSkip('font not found: $safePath');
+      return _fontDenied();
+    }
+    final Uint8List data = await file.readAsBytes();
+    if (!isValidFontData(data)) {
+      _logDictionaryMediaSkip('font corrupted: $safePath (${data.length} B)');
+      return _fontDenied();
+    }
+    return WebResourceResponse(
+      contentType: fallbackMimeType(safePath),
+      statusCode: 200,
+      reasonPhrase: 'OK',
+      headers: const <String, String>{
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'max-age=3600',
+      },
+      data: data,
+    );
+  } catch (e, stack) {
+    _logDictionaryMediaSkip('font read failed: $safePath ($e)', stack);
+    return _fontDenied();
+  }
+}
+
+/// 拒绝一条字体请求：回 403 空体而不是 null。
+///
+/// 返回 null 会让请求**穿透**到真实网络（`fushi.local` 不存在，最终是一次 DNS 失败
+/// 的等待），而不是干脆地失败；给个明确的 403 让浏览器立刻回退到字体链的下一位。
+WebResourceResponse _fontDenied() => WebResourceResponse(
+      contentType: 'text/plain',
+      statusCode: 403,
+      reasonPhrase: 'Forbidden',
+      data: Uint8List(0),
+    );
 
 /// 制卡前把 JS 负载里的词典媒体（gaiji 外字等）字节落盘到 Anki 媒体缓存目录，
 /// 供 [BaseAnkiRepository] 的 storeMediaFile 读取嵌进卡片。

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -144,14 +144,41 @@ String dictionaryFontStyleJs(AppModel appModel) =>
 /// 停启用 / 文件原地覆盖 / 导入换路径 / 目录变化都会换键重建；命中时返回同一
 /// 实例，零拷贝。瞬时读盘失败（[DictionaryFontCss.inlineFailureCount] 变化）的
 /// 降级产物不进 memo，下次查词自然重试。
-String? _fontStyleJsMemoKey;
-String _fontStyleJsMemoValue = '';
-Object _fontStyleJsMemoToken = Object();
+/// 一个字体投递模式的 memo 槽。
+///
+/// **必须按模式分槽**，不能共用一个：两种模式的产物完全不同（一个内嵌 base64
+/// 字节、一个只有 URL），而两个消费者（in-app 弹窗走 URL、app 外裸 WebView2 仍走
+/// 内联）在同一个进程里交替调用。共用单槽会让每次交替都 miss 并重建，而内联模式
+/// 的一次重建正是几十 MB 的 base64 编码——那比不缓存还糟。
+class _FontStyleMemoSlot {
+  String? key;
+  String value = '';
+  Object token = Object();
+}
+
+final _FontStyleMemoSlot _fontStyleMemoInline = _FontStyleMemoSlot();
+final _FontStyleMemoSlot _fontStyleMemoUrl = _FontStyleMemoSlot();
 final Object _noSettingsFontStyleToken = Object();
 
+/// 测试用：清空两个字体 memo 槽，避免用例之间互相污染。
+@visibleForTesting
+void debugResetDictionaryFontStyleMemo() {
+  _fontStyleMemoInline
+    ..key = null
+    ..value = ''
+    ..token = Object();
+  _fontStyleMemoUrl
+    ..key = null
+    ..value = ''
+    ..token = Object();
+}
+
 ({String cacheKey, Object cacheToken, String js}) _dictionaryFontStyleJsMemo(
-  AppModel appModel,
-) {
+  AppModel appModel, {
+  String Function(String safePath)? fontUrlBuilder,
+}) {
+  final _FontStyleMemoSlot slot =
+      fontUrlBuilder == null ? _fontStyleMemoInline : _fontStyleMemoUrl;
   // BUG: `ReaderFushiSource.readerSettings` is only populated while a book /
   // reader is open. In the app-external clipboard-lookup flow (VN / game, no
   // book), it is null, so the user's configured dictionary font was never
@@ -214,16 +241,16 @@ final Object _noSettingsFontStyleToken = Object();
       .join('|');
   final String cacheKey =
       '${DictionaryFontCss.fontListFingerprint(fonts, allowedDirectories: allowedDirectories)}|$languageFingerprint|$defaultContentLanguage|$lookupLanguage|${defaultTargetPlatform.name}';
-  if (cacheKey == _fontStyleJsMemoKey) {
-    return (
-      cacheKey: cacheKey,
-      cacheToken: _fontStyleJsMemoToken,
-      js: _fontStyleJsMemoValue,
-    );
+  if (cacheKey == slot.key) {
+    return (cacheKey: cacheKey, cacheToken: slot.token, js: slot.value);
   }
   final int inlineFailuresBefore = DictionaryFontCss.inlineFailureCount;
   final ({String fontFamily, String fontFaces, List<String> families}) css =
-      DictionaryFontCss.build(fonts, allowedDirectories: allowedDirectories);
+      DictionaryFontCss.build(
+        fonts,
+        allowedDirectories: allowedDirectories,
+        fontUrlBuilder: fontUrlBuilder,
+      );
   String js = '';
   // 语言分流 CSS 现在**总是**产出（哪怕用户没配任何词典字体）——popup.css 的
   // 内建链只写了 macOS 的 Hiragino，Windows/Android/Linux 上一个存在的 CJK 家族
@@ -260,10 +287,11 @@ final Object _noSettingsFontStyleToken = Object();
       })();''';
   }
   if (DictionaryFontCss.inlineFailureCount == inlineFailuresBefore) {
-    _fontStyleJsMemoKey = cacheKey;
-    _fontStyleJsMemoValue = js;
-    _fontStyleJsMemoToken = Object();
-    return (cacheKey: cacheKey, cacheToken: _fontStyleJsMemoToken, js: js);
+    slot
+      ..key = cacheKey
+      ..value = js
+      ..token = Object();
+    return (cacheKey: cacheKey, cacheToken: slot.token, js: js);
   }
   // Do not let the outer static-settings memo pin a transient degraded result.
   // A unique token forces the next lookup to retry even though the stable font
@@ -613,9 +641,7 @@ int _staticSettingsRevision = 0;
 /// 互相污染。revision 计数不重置（单调性是契约）。
 @visibleForTesting
 void debugResetPopupSettingsInjectionCaches() {
-  _fontStyleJsMemoKey = null;
-  _fontStyleJsMemoValue = '';
-  _fontStyleJsMemoToken = Object();
+  debugResetDictionaryFontStyleMemo();
   _staticSettingsMemo.clear();
 }
 
@@ -623,10 +649,25 @@ void debugResetPopupSettingsInjectionCaches() {
 /// CSS）：只随主题、设置、词典集变化，不随查词变化。in-app 路径按产物
 /// [PopupStaticSettingsJs.revision] 去重，变了才随下一次推送重发（BUG-717 ③：
 /// 原先命中后仍有 4~5 遍 MB 级串拷贝/转义/比较，现在命中路径零 MB 级操作）。
+/// [fontUrlBuilder] 非空时，导入字体以 URL 引用写进 `@font-face`，由宿主 WebView
+/// 的资源拦截器按需供字节；为空则内联成 `data:` URL（历史行为）。
+///
+/// 谁传谁不传，取决于**宿主有没有能带 CORS 头的资源拦截器**：
+///   - in-app 弹窗（Android / Windows）：有 `shouldInterceptRequest`，传。字体是强制
+///     CORS 模式的子资源，拦截器回 `Access-Control-Allow-Origin` 才拿得到。
+///   - in-app 弹窗（iOS / macOS）：只有 WKURLSchemeHandler，它构造的 URLResponse
+///     带不了任何 header，字体会被 CORS 拒；只能继续内联。
+///   - app 外裸 WebView2（全局查词窗 / 剪贴板面板）：字节走 native 侧另一条通道，
+///     暂仍内联（见 global_lookup_render 的调用点）。
+///
+/// 之所以是「调用方传」而不是在这里判平台：这个函数不知道自己产出的脚本要注入进
+/// 哪个宿主，而同一个平台上两类宿主的答案不同（Windows 的 in-app 能拦、裸 WebView2
+/// 这条路还没接）。让宿主自己声明能力，比在这里猜宿主身份可靠。
 PopupStaticSettingsJs buildPopupStaticSettingsJs({
   required AppModel appModel,
   required ThemeData theme,
   required PopupSettingsOptions options,
+  String Function(String safePath)? fontUrlBuilder,
 }) {
   final String themeVarsJs = _themeVariablesJs(
     appModel: appModel,
@@ -635,7 +676,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     mobileExternal: options.mobileExternal,
   );
   final ({String cacheKey, Object cacheToken, String js}) fontStyle =
-      _dictionaryFontStyleJsMemo(appModel);
+      _dictionaryFontStyleJsMemo(appModel, fontUrlBuilder: fontUrlBuilder);
   final String wheelBindingsJson = popupEntryWheelBindingsJson(
     appModel.shortcutRegistry,
     theme.platform,

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -131,8 +131,16 @@ String _themeVariablesJs({
 /// `data:` URL `@font-face` for imported files). Returns an empty string when no
 /// dictionary font is configured. Shared so the app-outside window applies the
 /// SAME font the in-app popup does.
-String dictionaryFontStyleJs(AppModel appModel) =>
-    _dictionaryFontStyleJsMemo(appModel).js;
+/// [fontUrlBuilder] 语义同 [buildPopupStaticSettingsJs]：非空则字体以 URL 引用产出，
+/// 为空则内联 `data:` URL。
+///
+/// **必须转发**而不是写死内联：这是个公开函数，写死的话任何将来的调用方都会静默拿到
+/// 几十 MB 的内联版本，而它自己完全看不出为什么慢。
+String dictionaryFontStyleJs(
+  AppModel appModel, {
+  String Function(String safePath)? fontUrlBuilder,
+}) =>
+    _dictionaryFontStyleJsMemo(appModel, fontUrlBuilder: fontUrlBuilder).js;
 
 /// BUG-717 ③：[dictionaryFontStyleJs] 最终产物的进程内 memo。
 ///

--- a/fushi/lib/src/reader/dictionary_font_css.dart
+++ b/fushi/lib/src/reader/dictionary_font_css.dart
@@ -201,13 +201,23 @@ class DictionaryFontCss {
       final FileStat stat = FileStat.statSync(path);
       if (stat.type == FileSystemEntityType.notFound) return false;
       final int length = stat.size;
-      return length > 0 && length <= maxBytes;
+      if (length <= 0 || length > maxBytes) return false;
+      // 只 stat 是**不够**的：内联路径会真的 readAsBytesSync，于是「文件在、大小
+      // 合法、但读不出来」（权限、被独占、路径其实是目录）在那边会抛 → 计入
+      // _inlineFailureCount → 跳过该条且本次产物不进 memo。URL 路径若只 stat 就
+      // 放行，同一份字体列表在两种模式下会选出**不同**的字体集合（正是本函数
+      // 声称要避免的事），而且更糟：那条坏字体的产物会被 memo 永久缓存，拦截器
+      // 每次请求都 403 并写一条错误日志。
+      // 这里开一下再关，代价是一次 open/close，不读任何内容。
+      final RandomAccessFile handle = File(path).openSync();
+      handle.closeSync();
+      return true;
     } catch (e, stack) {
-      // 与内联路径同样计入瞬时失败：上层 memo 用「build 前后计数未变」判定本次
-      // 产物没有瞬时降级、可安全缓存。stat 失败却不计数，会把一次「字体临时读不到」
-      // 的残缺产物永久缓存下来。
+      // 与内联路径同一套失败记账：上层 memo 用「build 前后计数未变」判定本次产物
+      // 没有瞬时降级、可安全缓存。失败却不计数，会把一次「字体临时读不到」的残缺
+      // 产物永久缓存下来。
       _inlineFailureCount++;
-      ErrorLogService.instance.log('DictionaryFontCss.stat', e, stack);
+      ErrorLogService.instance.log('DictionaryFontCss.probe', e, stack);
       return false;
     }
   }

--- a/fushi/lib/src/reader/dictionary_font_css.dart
+++ b/fushi/lib/src/reader/dictionary_font_css.dart
@@ -40,10 +40,24 @@ class DictionaryFontCss {
   /// whitelist model as the reader's font serving). Reads happen synchronously;
   /// any unreadable / oversized / unknown-extension file is skipped, degrading
   /// to the remaining usable fonts (and ultimately the popup.css default).
+  /// [fontUrlBuilder] 非空时**不读文件、不做 base64**，直接把它对通过白名单校验的
+  /// 绝对路径产出的 URL 写进 `@font-face src`，由宿主 WebView 的资源拦截器按需供字节。
+  ///
+  /// 为什么要有这条路：内联 `data:` URL 的代价不是「多几个字节」，而是它把字体塞进了
+  /// **每次渲染都要重新注入的那段脚本**里。两个 CJK 字体（8.3 MB + 17 MB）base64 之后
+  /// 是三十多 MB；而 in-app 弹窗每嵌套一层就新建一个 WebView（新 JS realm，window.*
+  /// 全空，静态段必须重发），于是「在弹窗里点词」每点一次就重新序列化、跨平台通道、
+  /// 重新解析这三十多 MB。换成 URL 后这段脚本降到 KB 级，字体由浏览器按 URL 取并
+  /// **跨 WebView 共享 HTTP 缓存**——data: URL 每次都是一个全新资源，永远共享不了。
+  ///
+  /// 留成可选参数而不是直接切换：iOS / macOS 的 in-app 弹窗**不能**走这条路（它们只有
+  /// WKURLSchemeHandler，构造的 URLResponse 带不了任何 header，而字体是强制 CORS 模式
+  /// 的子资源，拿不到 `Access-Control-Allow-Origin` 就会被拒），那两个平台继续内联。
   static ({String fontFamily, String fontFaces, List<String> families}) build(
     Iterable<Map<String, dynamic>> fonts, {
     Iterable<String> allowedDirectories = const <String>[],
     int maxFileBytes = defaultMaxFileBytes,
+    String Function(String safePath)? fontUrlBuilder,
   }) {
     final Iterable<Map<String, dynamic>> enabled = fonts.where(
       (Map<String, dynamic> e) => e['enabled'] as bool? ?? true,
@@ -81,18 +95,22 @@ class DictionaryFontCss {
       );
       if (safePath == null) continue;
 
-      final String? dataUrl = _inlineFontDataUrl(
-        safePath,
-        type.mime,
-        maxFileBytes,
-      );
-      if (dataUrl == null) continue;
+      final String? src;
+      if (fontUrlBuilder != null) {
+        // URL 模式：只确认文件还在（一次 stat，不碰内容），字节由宿主拦截器按需供。
+        // 文件消失时跳过这条，与内联模式「不可读就降级掉这一条」的语义一致。
+        if (!_fontFileUsable(safePath, maxFileBytes)) continue;
+        src = fontUrlBuilder(safePath);
+      } else {
+        src = _inlineFontDataUrl(safePath, type.mime, maxFileBytes);
+      }
+      if (src == null) continue;
 
       families.add(cssName);
       rawFamilies.add(bareName);
       faces.add(
         '@font-face { font-family: $cssName; '
-        'src: url("$dataUrl") format("${type.format}"); '
+        'src: url("$src") format("${type.format}"); '
         'font-display: swap; }',
       );
     }
@@ -172,6 +190,27 @@ class DictionaryFontCss {
   /// 戳、启动自愈迁移）天然换键，无需接任何设置变更通知。
   static final Map<String, ({int mtimeUs, int size, String dataUrl})>
   _dataUrlCache = <String, ({int mtimeUs, int size, String dataUrl})>{};
+
+  /// URL 模式下对字体文件的可用性判据：与 [_inlineFontDataUrl] **同一套门槛**
+  /// （存在、非空、不超 [maxBytes]），但只 stat、不读内容、不编码。
+  ///
+  /// 保持门槛一致是有意的：同一份字体列表在内联模式与 URL 模式下必须产出同一组
+  /// `@font-face`，否则「换个平台字体就多一条/少一条」会变成极难查的显示差异。
+  static bool _fontFileUsable(String path, int maxBytes) {
+    try {
+      final FileStat stat = FileStat.statSync(path);
+      if (stat.type == FileSystemEntityType.notFound) return false;
+      final int length = stat.size;
+      return length > 0 && length <= maxBytes;
+    } catch (e, stack) {
+      // 与内联路径同样计入瞬时失败：上层 memo 用「build 前后计数未变」判定本次
+      // 产物没有瞬时降级、可安全缓存。stat 失败却不计数，会把一次「字体临时读不到」
+      // 的残缺产物永久缓存下来。
+      _inlineFailureCount++;
+      ErrorLogService.instance.log('DictionaryFontCss.stat', e, stack);
+      return false;
+    }
+  }
 
   static String? _inlineFontDataUrl(String path, String mime, int maxBytes) {
     try {

--- a/fushi/lib/src/utils/misc/error_log_service.dart
+++ b/fushi/lib/src/utils/misc/error_log_service.dart
@@ -182,9 +182,18 @@ class ErrorLogService extends ChangeNotifier with FrameSafeNotifier {
     return '$header$tail$footer';
   }
 
+  /// 裁剪判据只查文件**长度**（stat，O(1)），超限了才把内容读回来裁。
+  ///
+  /// 原实现每次 append 后都 `readAsBytes()` 整个文件再比长度——在未超限的常态下，
+  /// 读回来的字节除了被 `bytes.length` 量一下之外原样丢弃。日志文件长期贴着
+  /// [_maxFileBytes] 上限运行，于是**每条日志**都要付一次最多 512 KB 的读盘 +
+  /// 解码。任何高频日志源（渲染期每行释义一条的 popup console 桥就是一个）都会
+  /// 把这条放大成成百上千次整文件回读，压在同一条串行落盘链上，拖住其后的所有
+  /// UI 工作。`length()` 拿的是文件元数据，不触碰内容，超限分支的行为逐字不变。
   Future<void> _trimLogFileToMaxBytes() async {
     final File? file = _logFile;
     if (file == null || !await file.exists()) return;
+    if (await file.length() <= _maxFileBytes) return;
     final List<int> bytes = await file.readAsBytes();
     if (bytes.length <= _maxFileBytes) return;
     await file.writeAsString(_trimLogBytes(bytes));
@@ -193,6 +202,7 @@ class ErrorLogService extends ChangeNotifier with FrameSafeNotifier {
   void _trimLogFileToMaxBytesSync() {
     final File? file = _logFile;
     if (file == null || !file.existsSync()) return;
+    if (file.lengthSync() <= _maxFileBytes) return;
     final List<int> bytes = file.readAsBytesSync();
     if (bytes.length <= _maxFileBytes) return;
     file.writeAsStringSync(_trimLogBytes(bytes), flush: true);

--- a/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
@@ -405,7 +405,10 @@ void main() {
         reason: 'modern global lookup diffs a small revision, not an MB font',
       );
       expect(hostJs.contains('staticSettingsByRevision'), isTrue);
-      expect(render.contains('knownStaticRevisions'), isTrue);
+      // 钉的不变量是「渲染前先问宿主账本已经装过哪些静态段版本」。锚点从旧的局部
+      // 变量名 knownStaticRevisions 换成账本接口本身：账本现在是必填参数
+      // （PopupStaticRevisionCache），比一个可以随手改名的局部变量更贴近不变量。
+      expect(render.contains('staticRevisions.snapshotFor(hostKey)'), isTrue);
       expect(render.contains("map['entriesJs']"), isTrue);
       expect(
         render.contains("map['staticHeadJs']"),

--- a/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
@@ -64,7 +64,12 @@ void main() {
       () {
         final String render = read('lib/src/lookup/global_lookup_render.dart');
         // buildStackRenderScript must end by calling the host renderStack entry.
-        final int at = render.indexOf('String buildStackRenderScript(');
+        // 返回类型是 StackRenderScript（脚本 + 本次真正下发的静态段版本号，供调用方
+        // 在平台 render 成功后记账去重），不再是裸 String。这里钉的不变量与返回类型
+        // 无关：栈渲染器必须驱动 host 的 renderStack diff。
+        final int at = render.indexOf(
+          'StackRenderScript buildStackRenderScript(',
+        );
         expect(
           at,
           greaterThan(-1),

--- a/fushi/test/lookup/popup_static_revision_dedup_guard_test.dart
+++ b/fushi/test/lookup/popup_static_revision_dedup_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 查词弹窗静态设置段的**去重完整性**守卫。
 ///
 /// 背景：`buildStackRenderScript` 产出的渲染负载里，静态段（主题变量 + 词典字体 +
@@ -31,10 +33,12 @@ void main() {
     final List<File> callers = <File>[];
     for (final FileSystemEntity entity in libDir.listSync(recursive: true)) {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
-      final String src = _codeOnly(entity.readAsStringSync());
-      if (!src.contains('buildStackRenderScript(')) continue;
+      final String src = entity.readAsStringSync();
+      if (!containsCodeLine(src, 'buildStackRenderScript(')) continue;
       // 跳过定义处本身（它声明返回类型，调用点不会）。
-      if (src.contains('StackRenderScript buildStackRenderScript(')) continue;
+      if (containsCodeLine(src, 'StackRenderScript buildStackRenderScript(')) {
+        continue;
+      }
       callers.add(entity);
     }
 
@@ -47,19 +51,19 @@ void main() {
     );
 
     for (final File caller in callers) {
-      final String src = _codeOnly(caller.readAsStringSync());
+      final String src = caller.readAsStringSync();
       final String path = caller.path;
       expect(
-        src,
-        contains('.commit('),
+        containsCodeLine(src, '.commit('),
+        isTrue,
         reason:
             '$path 调用了 buildStackRenderScript 却没有 commit 已发出的版本。'
             '不记账 = 下一次渲染仍认为宿主没装过 = 每次查词都重发几十 MB 静态段。'
             'commit 必须在平台 render 调用成功之后进行。',
       );
       expect(
-        src,
-        contains("== 'staticSettingsRequired'"),
+        containsCodeLine(src, "== 'staticSettingsRequired'"),
+        isTrue,
         reason:
             '$path 参与了静态段去重，却没有处理 host 的 staticSettingsRequired '
             '回补请求。去重与回补是一对：宿主整块 WebView 恢复 / realm 重建后会丢掉'
@@ -72,52 +76,34 @@ void main() {
   test('the render builder exposes no optional dedup escape hatch', () {
     final File render = File('lib/src/lookup/global_lookup_render.dart');
     expect(render.existsSync(), isTrue);
-    final String src = _codeOnly(render.readAsStringSync());
+    final String src = render.readAsStringSync();
 
     expect(
-      src,
-      contains('required PopupStaticRevisionCache staticRevisions'),
+      containsCodeLine(src, 'required PopupStaticRevisionCache staticRevisions'),
+      isTrue,
       reason:
           '宿主账本必须是必填参数——一旦退回可选（带默认值），'
           '新调用方就能像剪贴板面板当初那样静默地完全不去重',
     );
     expect(
-      src,
-      contains('required String hostKey'),
+      containsCodeLine(src, 'required String hostKey'),
+      isTrue,
       reason:
           'hostKey 必须必填：不同 WebView2 realm 的账本不能混，'
           '混了会让 A 宿主的已装载记录挡住 B 宿主的首次下发',
     );
     // 旧的两个可选形参不得复活。
     expect(
-      src,
-      isNot(contains('Set<int> knownStaticRevisions = const <int>{}')),
+      containsCodeLine(src, 'Set<int> knownStaticRevisions = const <int>{}'),
+      isFalse,
       reason: '带默认值的 knownStaticRevisions 形参正是事故根源，不得复活',
     );
     expect(
-      src,
-      isNot(contains('Set<int>? emittedStaticRevisions')),
+      containsCodeLine(src, 'Set<int>? emittedStaticRevisions'),
+      isFalse,
       reason:
           '可空的 emittedStaticRevisions 出参正是事故根源，不得复活；'
           '待确认版本应从返回值的 pendingRevisions 带出',
     );
   });
-}
-
-/// 剥掉 `//` 行注释与 `/* */` 块注释，只留下真正的代码。
-///
-/// 这一步不是洁癖：本仓的注释密度很高，而这条守卫要找的恰恰是
-/// `staticSettingsRequired` / `commit` 这类**会被大段中文注释反复提及**的词。不剥
-/// 注释直接 `contains`，守卫会被自己的说明文字喂饱、对真实代码的缺失视而不见——
-/// 即「输出可信但结论错」的经典形状。实测：把面板的回补分支改名注入变异后，不剥
-/// 注释的版本照样全绿，剥注释的版本才抓得住。
-String _codeOnly(String source) {
-  final String withoutBlocks = source.replaceAll(
-    RegExp(r'/\*.*?\*/', dotAll: true),
-    '',
-  );
-  return withoutBlocks
-      .split('\n')
-      .where((String line) => !line.trimLeft().startsWith('//'))
-      .join('\n');
 }

--- a/fushi/test/lookup/popup_static_revision_dedup_guard_test.dart
+++ b/fushi/test/lookup/popup_static_revision_dedup_guard_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 查词弹窗静态设置段的**去重完整性**守卫。
+///
+/// 背景：`buildStackRenderScript` 产出的渲染负载里，静态段（主题变量 + 词典字体 +
+/// 词典样式 + 自定义 CSS + 各种 window.* 开关）是大头。用户导入的词典字体走 `data:`
+/// URL 内联，两个 CJK 字体 base64 之后就是几十 MB。所以静态段按
+/// `PopupStaticSettingsJs.revision` 去重：宿主已装过的版本不再随渲染负载重发。
+///
+/// 这条守卫钉的是一个**真实发生过**的事故形状：去重曾经是「可选参数 + 各调用方自己
+/// 拿 Map 拼」，于是剪贴板面板那条路径一个参数都没传，整套去重对它完全失效——每次
+/// 查词（包括每次在面板里点词的嵌套查词）都把几十 MB 静态段重新序列化、过平台通道、
+/// 在 WebView2 里解析，然后被 host.js 按 revision 认出是旧相识、当场丢弃。纯浪费。
+///
+/// 形参现在是必填的，「漏传」由编译器兜住。这条测试兜的是编译器管不到的另外两半：
+///   ① **忘记 commit**——渲染发出去了却不记账，等于每次都重发，静默退回事故状态；
+///   ② **只做去重、不接回补**——host.js 在整块 WebView 恢复 / iframe realm 重建后会
+///      发 `staticSettingsRequired` 要求重发某个版本。只去重不接这条通道，宿主一旦
+///      丢掉缓存就再也等不到静态段，卡片会永远停在没主题、没字体、没词典样式的状态。
+///      这两件事必须成对出现，缺一不可。
+///
+/// 采用目录枚举（`listSync(recursive: true)`）而不是硬编码文件清单：将来任何新增的
+/// 渲染调用方都会自动落进扫描面，不会像定向清单那样漏掉。
+void main() {
+  test('every buildStackRenderScript caller commits and honours resend', () {
+    final Directory libDir = Directory('lib');
+    expect(libDir.existsSync(), isTrue, reason: '必须在 fushi/ 下跑（工作目录应含 lib/）');
+
+    final List<File> callers = <File>[];
+    for (final FileSystemEntity entity in libDir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final String src = _codeOnly(entity.readAsStringSync());
+      if (!src.contains('buildStackRenderScript(')) continue;
+      // 跳过定义处本身（它声明返回类型，调用点不会）。
+      if (src.contains('StackRenderScript buildStackRenderScript(')) continue;
+      callers.add(entity);
+    }
+
+    expect(
+      callers,
+      isNotEmpty,
+      reason:
+          '扫不到任何调用方 = 守卫在空转（函数被改名了？）——'
+          '此时必须回来按行为重新推导扫描面，而不是让它静默通过',
+    );
+
+    for (final File caller in callers) {
+      final String src = _codeOnly(caller.readAsStringSync());
+      final String path = caller.path;
+      expect(
+        src,
+        contains('.commit('),
+        reason:
+            '$path 调用了 buildStackRenderScript 却没有 commit 已发出的版本。'
+            '不记账 = 下一次渲染仍认为宿主没装过 = 每次查词都重发几十 MB 静态段。'
+            'commit 必须在平台 render 调用成功之后进行。',
+      );
+      expect(
+        src,
+        contains("== 'staticSettingsRequired'"),
+        reason:
+            '$path 参与了静态段去重，却没有处理 host 的 staticSettingsRequired '
+            '回补请求。去重与回补是一对：宿主整块 WebView 恢复 / realm 重建后会丢掉'
+            '缓存，只去重不回补会让这个表面永远等不到静态段（无主题/无字体/无词典'
+            '样式），比不去重更糟。',
+      );
+    }
+  });
+
+  test('the render builder exposes no optional dedup escape hatch', () {
+    final File render = File('lib/src/lookup/global_lookup_render.dart');
+    expect(render.existsSync(), isTrue);
+    final String src = _codeOnly(render.readAsStringSync());
+
+    expect(
+      src,
+      contains('required PopupStaticRevisionCache staticRevisions'),
+      reason:
+          '宿主账本必须是必填参数——一旦退回可选（带默认值），'
+          '新调用方就能像剪贴板面板当初那样静默地完全不去重',
+    );
+    expect(
+      src,
+      contains('required String hostKey'),
+      reason:
+          'hostKey 必须必填：不同 WebView2 realm 的账本不能混，'
+          '混了会让 A 宿主的已装载记录挡住 B 宿主的首次下发',
+    );
+    // 旧的两个可选形参不得复活。
+    expect(
+      src,
+      isNot(contains('Set<int> knownStaticRevisions = const <int>{}')),
+      reason: '带默认值的 knownStaticRevisions 形参正是事故根源，不得复活',
+    );
+    expect(
+      src,
+      isNot(contains('Set<int>? emittedStaticRevisions')),
+      reason:
+          '可空的 emittedStaticRevisions 出参正是事故根源，不得复活；'
+          '待确认版本应从返回值的 pendingRevisions 带出',
+    );
+  });
+}
+
+/// 剥掉 `//` 行注释与 `/* */` 块注释，只留下真正的代码。
+///
+/// 这一步不是洁癖：本仓的注释密度很高，而这条守卫要找的恰恰是
+/// `staticSettingsRequired` / `commit` 这类**会被大段中文注释反复提及**的词。不剥
+/// 注释直接 `contains`，守卫会被自己的说明文字喂饱、对真实代码的缺失视而不见——
+/// 即「输出可信但结论错」的经典形状。实测：把面板的回补分支改名注入变异后，不剥
+/// 注释的版本照样全绿，剥注释的版本才抓得住。
+String _codeOnly(String source) {
+  final String withoutBlocks = source.replaceAll(
+    RegExp(r'/\*.*?\*/', dotAll: true),
+    '',
+  );
+  return withoutBlocks
+      .split('\n')
+      .where((String line) => !line.trimLeft().startsWith('//'))
+      .join('\n');
+}

--- a/fushi/test/pages/dictionary_font_interceptor_test.dart
+++ b/fushi/test/pages/dictionary_font_interceptor_test.dart
@@ -1,0 +1,159 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_webview_media.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-1868：`dictionaryFontWebResourceResponse` 是本次唯一一段**直接把磁盘字节吐给
+/// WebView** 的代码。它的三道校验和 403/null 的分流原本全靠人眼，这里补上回归保护。
+///
+/// 三道校验缺一不可，各自挡的东西不同：
+///   ① 目录白名单（`safeCustomFontPath` 先 canonicalize 再 isWithin）——挡 `..` 逃逸；
+///   ② **当前配置条目**白名单——只有目录白名单的话，任何能影响注入 CSS 的人都能读走
+///      该目录下的任意文件（那目录里常年躺着历次导入的字体）；
+///   ③ 字体魔数——避免把任意文件当字体吐出去。
+///
+/// 另外钉两条容易在重构里被当成冗余抹掉的设计决策：
+///   * 非本前缀的 URL 必须返回 **null**（这是「不影响 image:// / dictmedia:// 原有
+///     分支」的唯一保证）；
+///   * 拒绝时返回 **403 而不是 null**——null 会让请求穿透到真实网络，`fushi.local`
+///     并不存在，于是变成一次 DNS 失败的干等，而不是干脆地失败让字体链回退。
+void main() {
+  late Directory allowed;
+  late Directory outside;
+  late File goodFont;
+
+  /// 一个最小但合法的 TrueType 头（`00 01 00 00`），足够通过魔数校验。
+  Uint8List ttfBytes() => Uint8List.fromList(<int>[
+        0x00, 0x01, 0x00, 0x00, // sfnt version
+        0x00, 0x01, // numTables
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ]);
+
+  setUp(() async {
+    allowed = await Directory.systemTemp.createTemp('fushi_font_allow');
+    outside = await Directory.systemTemp.createTemp('fushi_font_outside');
+    goodFont = File(p.join(allowed.path, 'Good.ttf'));
+    await goodFont.writeAsBytes(ttfBytes());
+  });
+
+  tearDown(() async {
+    for (final Directory d in <Directory>[allowed, outside]) {
+      if (d.existsSync()) await d.delete(recursive: true);
+    }
+  });
+
+  Future<WebResourceResponse?> serve(
+    String url, {
+    Set<String>? whitelist,
+  }) =>
+      dictionaryFontWebResourceResponse(
+        Uri.parse(url),
+        allowedRoots: <String>[allowed.path],
+        whitelistedPaths:
+            whitelist ?? <String>{p.canonicalize(goodFont.path)},
+      );
+
+  test('非字体 URL 返回 null（原有 image:// / dictmedia:// 分支不受影响）', () async {
+    expect(await serve('image://?dictionary=X&path=a.png'), isNull);
+    expect(await serve('dictmedia://styles.css?dictionary=X'), isNull);
+    expect(await serve('https://fushi.local/fonts/whatever'), isNull,
+        reason: '阅读器自己的 /fonts/ 前缀不归本拦截器管');
+    expect(await serve('https://example.com/x.ttf'), isNull);
+  });
+
+  test('白名单内 + 魔数合法 → 200，带 CORS 头与字节', () async {
+    final WebResourceResponse? r = await serve(dictionaryFontUrl(goodFont.path));
+    expect(r, isNotNull);
+    expect(r!.statusCode, 200);
+    expect(r.data, isNotNull);
+    expect(r.data!.length, ttfBytes().length);
+    expect(
+      r.headers?['Access-Control-Allow-Origin'],
+      '*',
+      reason: '字体是强制 CORS 模式的子资源，弹窗文档与 fushi.local 从不同源，'
+          '少了这个头字体会被静默拒绝（表现为「字体没生效」而不是报错）',
+    );
+  });
+
+  test('URL 带内容版本戳，且版本戳不影响路径解析', () async {
+    final String url = dictionaryFontUrl(goodFont.path);
+    expect(url, contains('?v='),
+        reason: '没有版本戳的话，用户用同名文件覆盖字体后 URL 一字不变，'
+            '带着 max-age 的缓存可能继续供旧字节——相对内联模式的行为倒退');
+    final WebResourceResponse? r = await serve(url);
+    expect(r?.statusCode, 200);
+
+    // 覆盖文件（改大小）后版本戳必须变，否则自动失效无从谈起。
+    await goodFont.writeAsBytes(Uint8List.fromList(<int>[
+      ...ttfBytes(),
+      ...List<int>.filled(32, 0),
+    ]));
+    expect(dictionaryFontUrl(goodFont.path), isNot(url));
+  });
+
+  test('目录白名单之外 → 403（不是 null，也不是 200）', () async {
+    final File out = File(p.join(outside.path, 'Outside.ttf'));
+    await out.writeAsBytes(ttfBytes());
+    final WebResourceResponse? r = await serve(
+      dictionaryFontUrl(out.path),
+      whitelist: <String>{p.canonicalize(out.path)},
+    );
+    expect(r, isNotNull, reason: '必须是明确的拒绝，不能返回 null 让请求穿透到网络');
+    expect(r!.statusCode, 403);
+  });
+
+  test('路径逃逸（..）→ 403', () async {
+    final String escaped =
+        p.join(allowed.path, '..', p.basename(outside.path), 'Escaped.ttf');
+    final File out = File(p.join(outside.path, 'Escaped.ttf'));
+    await out.writeAsBytes(ttfBytes());
+    final WebResourceResponse? r = await serve(
+      dictionaryFontUrl(escaped),
+      whitelist: <String>{p.canonicalize(escaped)},
+    );
+    expect(r?.statusCode, 403);
+  });
+
+  test('在目录白名单内、但不在当前配置条目里 → 403', () async {
+    final File stray = File(p.join(allowed.path, 'Stray.ttf'));
+    await stray.writeAsBytes(ttfBytes());
+    final WebResourceResponse? r = await serve(
+      dictionaryFontUrl(stray.path),
+      // 配置里只有 Good.ttf
+      whitelist: <String>{p.canonicalize(goodFont.path)},
+    );
+    expect(r?.statusCode, 403,
+        reason: '目录白名单不够：那个目录里常年躺着历次导入的字体，'
+            '只放行此刻确实配置了的路径才能把可读集合收敛到最小');
+  });
+
+  test('魔数不合法 → 403（不把任意文件当字体吐出去）', () async {
+    final File fake = File(p.join(allowed.path, 'Fake.ttf'));
+    await fake.writeAsBytes(Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8]));
+    final WebResourceResponse? r = await serve(
+      dictionaryFontUrl(fake.path),
+      whitelist: <String>{p.canonicalize(fake.path)},
+    );
+    expect(r?.statusCode, 403);
+  });
+
+  test('文件不存在 → 403', () async {
+    final String missing = p.join(allowed.path, 'Missing.ttf');
+    final WebResourceResponse? r = await serve(
+      '$kDictionaryFontUrlPrefix${Uri.encodeComponent(missing)}',
+      whitelist: <String>{p.canonicalize(missing)},
+    );
+    expect(r?.statusCode, 403);
+  });
+
+  test('isDictionaryFontUrl 只认本前缀（拦截器靠它做廉价前缀判定）', () {
+    expect(isDictionaryFontUrl(Uri.parse(dictionaryFontUrl(goodFont.path))),
+        isTrue);
+    expect(isDictionaryFontUrl(Uri.parse('image://?dictionary=X')), isFalse);
+    expect(isDictionaryFontUrl(Uri.parse('https://fushi.local/fonts/x')),
+        isFalse);
+  });
+}

--- a/fushi/test/pages/popup_settings_injection_memo_test.dart
+++ b/fushi/test/pages/popup_settings_injection_memo_test.dart
@@ -173,9 +173,12 @@ void main() {
             ),
           ],
         );
-        final Set<int> emitted = <int>{};
-        late String cold;
-        late String hot;
+        // 用真正的宿主账本走一遍「首次渲染 → 平台收下 → 再次渲染」，而不是手工传
+        // 两个裸 Set：账本是唯一入口，这样这条测试也顺带钉住 commit 的时机语义。
+        final PopupStaticRevisionCache revisions = PopupStaticRevisionCache();
+        const String hostKey = 'test-host';
+        late StackRenderScript cold;
+        late StackRenderScript hot;
         bool built = false;
         await tester.pumpWidget(
           MaterialApp(
@@ -203,8 +206,11 @@ void main() {
                     screenHeight: 1080,
                     maxWidth: 480,
                     maxHeight: 600,
-                    emittedStaticRevisions: emitted,
+                    staticRevisions: revisions,
+                    hostKey: hostKey,
                   );
+                  // 模拟平台侧 render 调用成功——只有此时才允许记账。
+                  revisions.commit(hostKey, cold.pendingRevisions);
                   hot = buildStackRenderScript(
                     context: context,
                     appModel: appModel,
@@ -213,7 +219,8 @@ void main() {
                     screenHeight: 1080,
                     maxWidth: 480,
                     maxHeight: 600,
-                    knownStaticRevisions: emitted,
+                    staticRevisions: revisions,
+                    hostKey: hostKey,
                   );
                 }
                 return const SizedBox.shrink();
@@ -222,18 +229,23 @@ void main() {
           ),
         );
 
-        expect(emitted, hasLength(1));
-        expect(cold, contains('"staticHeadJs"'));
-        expect(cold, contains('"staticTailJs"'));
+        expect(cold.pendingRevisions, hasLength(1));
+        expect(cold.script, contains('"staticHeadJs"'));
+        expect(cold.script, contains('"staticTailJs"'));
         expect(
-          hot,
+          hot.script,
           isNot(contains('"staticHeadJs"')),
           reason: '连续 Shift 查词不得再次跨 MethodChannel 发送 MB 级字体',
         );
-        expect(hot, isNot(contains('"staticTailJs"')));
-        expect(hot, contains('"staticRevision"'));
-        expect(hot, contains('"entriesJs"'));
-        expect(hot, contains('"renderJs"'));
+        expect(hot.script, isNot(contains('"staticTailJs"')));
+        expect(
+          hot.pendingRevisions,
+          isEmpty,
+          reason: '第二次渲染没有新发出任何静态段，账本不该再收到待确认版本',
+        );
+        expect(hot.script, contains('"staticRevision"'));
+        expect(hot.script, contains('"entriesJs"'));
+        expect(hot.script, contains('"renderJs"'));
       },
     );
   });

--- a/fushi/test/reader/dictionary_font_css_test.dart
+++ b/fushi/test/reader/dictionary_font_css_test.dart
@@ -47,6 +47,123 @@ void main() {
     expect(result.fontFamily, '"Good"');
   });
 
+  group('fontUrlBuilder（URL 模式：让静态段不再扛着字体走）', () {
+    // 为什么需要它：内联 data: URL 把字体塞进了「每次渲染都要重新注入的那段脚本」。
+    // 两个 CJK 字体 base64 后三十多 MB，而 in-app 弹窗每嵌套一层就新建 WebView
+    // （新 realm，静态段必须重发）——于是在弹窗里每点一次词就重传三十多 MB。
+    // URL 模式把脚本降到 KB 级，字节由宿主拦截器按需供、并跨 WebView 共享 HTTP 缓存。
+
+    test('产出 URL 而非 data:，且完全不含 base64 字节', () async {
+      final Directory dir = await Directory.systemTemp.createTemp(
+        'hibiki_dictfont_url',
+      );
+      addTearDown(() async {
+        if (dir.existsSync()) await dir.delete(recursive: true);
+      });
+      final File fontFile = File('${dir.path}/MyFont.ttf');
+      await fontFile.writeAsBytes(<int>[0x00, 0x01, 0x02, 0x03]);
+
+      final result = DictionaryFontCss.build(
+        <Map<String, dynamic>>[_e('MyFont', path: fontFile.path)],
+        allowedDirectories: <String>[dir.path],
+        fontUrlBuilder: (String safePath) =>
+            'https://fushi.local/dictfonts/${Uri.encodeComponent(safePath)}',
+      );
+
+      expect(result.fontFamily, '"MyFont"');
+      expect(result.fontFaces, contains('@font-face'));
+      expect(result.fontFaces, contains('https://fushi.local/dictfonts/'));
+      expect(result.fontFaces, contains('format("truetype")'));
+      // 关键：一个 base64 字节都不许出现，否则这条路就白走了。
+      expect(result.fontFaces, isNot(contains('base64')));
+      expect(result.fontFaces, isNot(contains('AAECAw==')));
+    });
+
+    test('与内联模式产出同一组 families（门槛必须一致）', () async {
+      final Directory dir = await Directory.systemTemp.createTemp(
+        'hibiki_dictfont_parity',
+      );
+      addTearDown(() async {
+        if (dir.existsSync()) await dir.delete(recursive: true);
+      });
+      final File ok = File('${dir.path}/Good.ttf');
+      await ok.writeAsBytes(<int>[1, 2, 3, 4]);
+      final List<Map<String, dynamic>> fonts = <Map<String, dynamic>>[
+        _e('SystemOne'),
+        _e('Good', path: ok.path),
+        _e('Missing', path: '${dir.path}/nope.ttf'),
+        _e('BadExt', path: '${dir.path}/x.bin'),
+      ];
+
+      final inlined = DictionaryFontCss.build(
+        fonts,
+        allowedDirectories: <String>[dir.path],
+      );
+      final urled = DictionaryFontCss.build(
+        fonts,
+        allowedDirectories: <String>[dir.path],
+        fontUrlBuilder: (String safePath) => 'https://x/$safePath',
+      );
+
+      expect(urled.fontFamily, inlined.fontFamily,
+          reason: '同一份字体列表在两种模式下必须选出同一组字体，'
+              '否则换平台就会多一条/少一条，变成极难查的显示差异');
+      expect(urled.families, inlined.families);
+    });
+
+    test('文件不存在 / 超上限时同样跳过（只 stat，不读内容）', () async {
+      final Directory dir = await Directory.systemTemp.createTemp(
+        'hibiki_dictfont_skip',
+      );
+      addTearDown(() async {
+        if (dir.existsSync()) await dir.delete(recursive: true);
+      });
+      final File big = File('${dir.path}/Big.ttf');
+      await big.writeAsBytes(List<int>.filled(64, 7));
+
+      final missing = DictionaryFontCss.build(
+        <Map<String, dynamic>>[_e('Missing', path: '${dir.path}/nope.ttf')],
+        allowedDirectories: <String>[dir.path],
+        fontUrlBuilder: (String safePath) => 'https://x/$safePath',
+      );
+      expect(missing.fontFaces, isEmpty);
+      expect(missing.fontFamily, isEmpty);
+
+      final tooBig = DictionaryFontCss.build(
+        <Map<String, dynamic>>[_e('Big', path: big.path)],
+        allowedDirectories: <String>[dir.path],
+        maxFileBytes: 8,
+        fontUrlBuilder: (String safePath) => 'https://x/$safePath',
+      );
+      expect(tooBig.fontFaces, isEmpty,
+          reason: 'URL 模式也必须尊重 maxFileBytes，门槛与内联模式一致');
+    });
+
+    test('白名单之外的路径不得产出 URL（越权读盘的入口不能因换模式而放开）',
+        () async {
+      final Directory allowed = await Directory.systemTemp.createTemp(
+        'hibiki_dictfont_allow',
+      );
+      final Directory other = await Directory.systemTemp.createTemp(
+        'hibiki_dictfont_other',
+      );
+      addTearDown(() async {
+        if (allowed.existsSync()) await allowed.delete(recursive: true);
+        if (other.existsSync()) await other.delete(recursive: true);
+      });
+      final File outside = File('${other.path}/Outside.ttf');
+      await outside.writeAsBytes(<int>[9, 9, 9, 9]);
+
+      final result = DictionaryFontCss.build(
+        <Map<String, dynamic>>[_e('Outside', path: outside.path)],
+        allowedDirectories: <String>[allowed.path],
+        fontUrlBuilder: (String safePath) => 'https://x/$safePath',
+      );
+      expect(result.fontFaces, isEmpty);
+      expect(result.fontFamily, isEmpty);
+    });
+  });
+
   test(
     'imported file inside the allowed dir → base64 data: @font-face',
     () async {

--- a/fushi/test/utils/misc/popup_dict_css_atrule_scope_test.dart
+++ b/fushi/test/utils/misc/popup_dict_css_atrule_scope_test.dart
@@ -78,8 +78,14 @@ void main() {
       greaterThan(atBranch),
       reason: 'at-rule branch must split conditional groups from the rest',
     );
+    // 递归走的是 constructDictCssUncached：外层 constructDictCss 现在是带 memo 的
+    // 入口（同一本词典的 CSS 会被每条词条的每个词典块重复请求，见
+    // popup_dict_css_memo_test.js），递归分支刻意绕开缓存，免得把每个 at-block 的
+    // 子串都塞进缓存。这里钉的不变量没变：条件组 at-rule 必须**递归**，内部规则才
+    // 会被加上作用域前缀。
     final int recurse = js.indexOf(
-        'constructDictCss(atBlockContent, dictName, scopePrefix)', atBranch);
+        'constructDictCssUncached(atBlockContent, dictName, scopePrefix)',
+        atBranch);
     expect(
       recurse,
       greaterThan(atBranch),

--- a/fushi/test/utils/misc/popup_dict_css_memo_test.dart
+++ b/fushi/test/utils/misc/popup_dict_css_memo_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 查词弹窗性能：`assets/popup/dict-media.js` 的 `constructDictCss` 现在是**带 memo
+/// 的入口**，真正的扫描实现是 `constructDictCssUncached`。
+///
+/// 为什么要 memo：它的调用点是 `createGlossarySection`，即「每条词条的每个词典块」
+/// 各调一次。N 条词条 × M 本词典 = N×M 次对同一本词典那份（Yomitan 词典动辄几十 KB
+/// 的）CSS 做完全相同的逐字符扫描（实现里对空白字符是一个字符 push 一次数组）。查一
+/// 次词就白烧几十上百遍相同的解析，全部压在首屏渲染路径上。
+///
+/// memo 的正确性风险只有一个方向——**串味**：把 A 词典的作用域化结果发给 B 词典，或
+/// 者词典集换了以后还发旧内容。缓存 key 必须覆盖 `(css, dictName, scopePrefix)` 三
+/// 元组的全部三项，缺一项就会串。
+///
+/// 两层守护（与 popup_dict_css_atrule_scope_test.dart 同款）：
+/// ① 行为级——用 Node 真执行 memo 入口与未 memo 实现，断言两者对同一输入逐字节相同、
+///    交叉输入不串味、缓存桶被撑爆 clear() 之后结果依旧正确。无 node 时 skip。
+/// ② 源码级——静态扫描 dict-media.js，保证 memo 结构与「key 含 scopePrefix」在位
+///    （CI 无 node 也守住这条最容易被"顺手简化"掉的不变量）。
+void main() {
+  test(
+    'constructDictCss memo never cross-contaminates (executes via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+          'node not found on PATH; skipping JS behavior execution',
+        );
+        return;
+      }
+
+      final File jsTest = File('test/utils/misc/popup_dict_css_memo_test.js');
+      expect(
+        jsTest.existsSync(),
+        isTrue,
+        reason: 'behavior harness ${jsTest.path} must exist',
+      );
+
+      final ProcessResult result = await Process.run(nodeExe, <String>[
+        jsTest.path,
+      ], workingDirectory: Directory.current.path);
+
+      expect(
+        result.exitCode,
+        0,
+        reason:
+            'dict CSS memo JS behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(
+        result.stdout.toString(),
+        contains('all assertions passed'),
+        reason: 'behavior harness must reach its success marker',
+      );
+    },
+  );
+
+  test('dict-media.js keeps the memo split and a full cache key', () {
+    final String js = File('assets/popup/dict-media.js').readAsStringSync();
+
+    expect(
+      js,
+      contains('function constructDictCssUncached('),
+      reason:
+          'the un-memoised implementation must stay separately callable, '
+          'otherwise the recursion would populate the cache with at-block '
+          'substrings',
+    );
+    expect(
+      js,
+      contains('function constructDictCss('),
+      reason:
+          'the memoised entry point must keep the original name so every '
+          'existing call site is cached without being touched',
+    );
+
+    // 缓存 key 必须同时含 dictName 与 scopePrefix。只用 dictName 会让
+    // `.yomitan-glossary [data-dictionary="X"]` 作用域的结果覆盖裸作用域的结果
+    // （反之亦然）——即同一本词典在弹窗与词条内联两种上下文之间串味。
+    final int keyLine = js.indexOf('const key =');
+    expect(
+      keyLine,
+      greaterThanOrEqualTo(0),
+      reason: 'memo entry must build a cache key',
+    );
+    final int keyLineEnd = js.indexOf('\n', keyLine);
+    final String keyExpr = js.substring(keyLine, keyLineEnd);
+    expect(
+      keyExpr,
+      contains('dictName'),
+      reason: 'cache key must include dictName',
+    );
+    expect(
+      keyExpr,
+      contains('scopePrefix'),
+      reason:
+          'cache key must include scopePrefix — dropping it makes the '
+          'scoped and bare variants of the same dictionary collide',
+    );
+
+    // 外层按 css 串本身分桶：内容变了自然落到新桶，所以不需要（也不存在）失效钩子。
+    expect(
+      js,
+      contains('__dictCssCache.get(css)'),
+      reason:
+          'the outer cache must be keyed by the css string itself so a '
+          'changed dictionary stylesheet cannot return a stale scoping',
+    );
+    // 桶数必须封顶，否则换词典集/反复导入会让缓存无界增长。
+    expect(
+      js,
+      contains('__dictCssCache.clear()'),
+      reason: 'the cache must be bounded',
+    );
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates = Platform.isWindows
+      ? <String>['node.exe', 'node']
+      : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) {
+        return name;
+      }
+    } on ProcessException {
+      // Not found; try next candidate.
+    }
+  }
+  return null;
+}

--- a/fushi/test/utils/misc/popup_dict_css_memo_test.js
+++ b/fushi/test/utils/misc/popup_dict_css_memo_test.js
@@ -1,0 +1,148 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// 查词弹窗性能：`constructDictCss` 的调用点是 createGlossarySection，即「每条词条的
+// 每个词典块」各调一次。N 条词条 × M 本词典 = N×M 次对同一本词典那份（Yomitan 词典
+// 动辄几十 KB 的）CSS 做完全相同的逐字符扫描。于是给它加了 memo。
+//
+// memo 的正确性风险只有一个方向：**串味**——把 A 词典的作用域化结果发给 B 词典，或者
+// 词典集换了以后还发旧内容。本 harness 就钉这件事：
+//   ① 缓存版与未缓存版对同一输入必须逐字节相同（memo 不得改变语义）；
+//   ② 同一份 css、不同 dictName / scopePrefix 必须各得其所（内层 key 完整）；
+//   ③ 不同 css 内容必须各得其所（外层按 css 串分桶）；
+//   ④ 桶数超上限触发 clear() 之后，结果仍然正确（缓存只是加速，不是真相源）。
+// 无 node 时由 .dart 侧 skip；源码级守卫见 popup_dict_css_atrule_scope_test.dart。
+
+// 三份 dict-media.js：app 弹窗用的那份，以及浏览器扩展的两个镜像（扩展那份是**有意
+// 分叉**的——它多一条把 `image://` 改写到同步服务器 HTTP 端点的分支——但
+// constructDictCss 本体逐字相同，同样被「每条词条 × 每本词典」重复调用，所以 memo
+// 必须三份都在。逐份跑同一套断言，任何一份漏了移植都会在这里红。
+const DICT_MEDIA_PATHS = [
+  path.resolve(__dirname, '../../../assets/popup/dict-media.js'),
+  path.resolve(__dirname, '../../../assets/browser_extension/vendor/dict-media.js'),
+  path.resolve(__dirname, '../../../../tools/browser-extension/vendor/dict-media.js'),
+];
+
+function load(dictMediaPath) {
+  const context = { console, window: {} };
+  context.globalThis = context;
+  vm.runInNewContext(fs.readFileSync(dictMediaPath, 'utf8'), context, {
+    filename: dictMediaPath,
+  });
+  return context;
+}
+
+for (const dictMediaPath of DICT_MEDIA_PATHS) {
+  assert.ok(fs.existsSync(dictMediaPath), `missing mirror: ${dictMediaPath}`);
+  runSuite(load(dictMediaPath), dictMediaPath);
+}
+
+console.log('all assertions passed');
+
+function runSuite(ctx, where) {
+assert.strictEqual(
+  typeof ctx.constructDictCss, 'function',
+  `constructDictCss must be defined (${where})`);
+assert.strictEqual(
+  typeof ctx.constructDictCssUncached, 'function',
+  `constructDictCssUncached (the un-memoised implementation) must be defined (${where})`);
+
+// 覆盖到 scoper 的各条分支：普通选择器、逗号选择器列表、条件组 at-rule（内部递归）、
+// 非条件组 at-rule（整块透传）、语句型 at-rule、嵌套规则、注释。
+const SAMPLES = [
+  '',
+  '.gloss { color: red; }',
+  '.a, .b > .c { margin: 0; padding: 1px }',
+  '@media (max-width: 500px) { .img { width: 50%; } }',
+  '@font-face { font-family: X; src: url(a.ttf); }',
+  '@keyframes spin { from { transform: rotate(0) } to { transform: rotate(360deg) } }',
+  '@import url("x.css"); .after-import { color: blue; }',
+  '/* leading comment */ .commented { color: green; }',
+  '.outer { color: red; .nested { color: blue; } }',
+  '@supports (display: grid) { .g, .h { display: grid; } }',
+];
+
+const DICTS = ['明鏡国語辞典', 'JMdict', 'a b', ''];
+const SCOPES = [undefined, '.yomitan-glossary [data-dictionary="X"]', 'a', 'a b'];
+
+// ① 等价性：memo 版必须与未 memo 版逐字节相同，且重复调用稳定。
+for (const css of SAMPLES) {
+  for (const dict of DICTS) {
+    for (const scope of SCOPES) {
+      const expected = ctx.constructDictCssUncached(css, dict, scope);
+      const first = ctx.constructDictCss(css, dict, scope);
+      const second = ctx.constructDictCss(css, dict, scope);
+      assert.strictEqual(
+        first, expected,
+        `memo 首次调用与未 memo 实现不一致: css=${JSON.stringify(css)} dict=${JSON.stringify(dict)} scope=${JSON.stringify(scope)}`);
+      assert.strictEqual(
+        second, expected,
+        `memo 命中后与未 memo 实现不一致: css=${JSON.stringify(css)} dict=${JSON.stringify(dict)} scope=${JSON.stringify(scope)}`);
+    }
+  }
+}
+
+// ② 同一份 css、不同 dictName 不得串味（先热身建缓存，再交叉比对）。
+{
+  const css = '.x { color: red; }';
+  const a = ctx.constructDictCss(css, 'DictA');
+  const b = ctx.constructDictCss(css, 'DictB');
+  assert.notStrictEqual(a, b, '不同 dictName 必须产出不同作用域前缀');
+  assert.ok(a.includes('[data-dictionary="DictA"]'), 'DictA 前缀缺失');
+  assert.ok(b.includes('[data-dictionary="DictB"]'), 'DictB 前缀缺失');
+  assert.strictEqual(
+    ctx.constructDictCss(css, 'DictA'), a, 'DictA 二次取值被 DictB 覆盖了');
+}
+
+// ②b 同一份 css、同一 dictName、不同 scopePrefix 不得串味。
+{
+  const css = '.y { color: red; }';
+  const bare = ctx.constructDictCss(css, 'D');
+  const scoped = ctx.constructDictCss(css, 'D', '.wrap [data-dictionary="D"]');
+  assert.notStrictEqual(bare, scoped, '不同 scopePrefix 必须产出不同结果');
+  assert.ok(scoped.includes('.wrap [data-dictionary="D"] .y'), 'scopePrefix 未生效');
+  assert.strictEqual(ctx.constructDictCss(css, 'D'), bare, 'scopePrefix 变体污染了无前缀取值');
+}
+
+// ②c key 拼接不得因分隔符产生碰撞：(dict='a b', scope='') 与 (dict='a', scope='b')
+// 在朴素的 `dict + ' ' + scope` 方案下会撞成同一个 key。
+{
+  const css = '.z { color: red; }';
+  const first = ctx.constructDictCss(css, 'a b', '');
+  const second = ctx.constructDictCss(css, 'a', 'b');
+  assert.strictEqual(
+    first, ctx.constructDictCssUncached(css, 'a b', ''), 'key 碰撞: (a b, "") 被覆盖');
+  assert.strictEqual(
+    second, ctx.constructDictCssUncached(css, 'a', 'b'), 'key 碰撞: (a, b) 取到了别人的值');
+  assert.notStrictEqual(first, second, '两组不同输入不应产出相同结果');
+}
+
+// ③ 不同 css 内容各自分桶：同 dictName 下换 css 必须重新作用域化。
+{
+  const one = ctx.constructDictCss('.p { color: red; }', 'Same');
+  const two = ctx.constructDictCss('.q { color: blue; }', 'Same');
+  assert.ok(one.includes('.p'), '第一份 css 结果异常');
+  assert.ok(two.includes('.q'), '换 css 后仍拿到旧桶的结果');
+  assert.ok(!two.includes('.p'), '换 css 后结果里混入了旧 css');
+}
+
+// ④ 撑爆桶上限触发 clear() 之后仍然正确（缓存只是加速，不是真相源）。
+{
+  const dict = 'Overflow';
+  const probeCss = '.probe { color: red; }';
+  const before = ctx.constructDictCss(probeCss, dict);
+  // 上限是 64 个桶；灌 200 份互不相同的 css 必定跨过 clear()。
+  for (let i = 0; i < 200; i++) {
+    ctx.constructDictCss(`.gen${i} { color: red; }`, dict);
+  }
+  const after = ctx.constructDictCss(probeCss, dict);
+  assert.strictEqual(
+    after, before, 'clear() 之后重算的结果与首次不一致');
+  assert.strictEqual(
+    after, ctx.constructDictCssUncached(probeCss, dict),
+    'clear() 之后的结果与未 memo 实现不一致');
+}
+
+}

--- a/tools/browser-extension/vendor/dict-media.js
+++ b/tools/browser-extension/vendor/dict-media.js
@@ -54,7 +54,36 @@ function rewriteDictLinks(html, dictName) {
     });
 }
 
+/* 词典 CSS 作用域化的结果**只由** (css, dictName, scopePrefix) 决定——纯函数，
+   同输入必同输出。但它的调用点是 createGlossarySection，即「每个词条的每个词典块」
+   各调一次：N 条词条 × M 本词典就是 N×M 次把同一本词典那份（Yomitan 词典动辄几十 KB
+   的）CSS 重新做一遍逐字符扫描（下面的 while 循环对空白字符是一个字符 push 一次数组）。
+   查一次词就白烧几十上百遍完全相同的解析。
+   这里按三元组做 memo：外层用 css 串本身分桶（内容变了自然落到新桶，无需失效钩子，
+   也就不存在「换词典集后拿到旧作用域 CSS」的风险），内层用 dictName+scopePrefix。
+   递归分支走未缓存的实现，避免把每个 at-block 的子串都塞进缓存。 */
+const __dictCssCache = new Map();
+const __dictCssCacheMaxBuckets = 64;
+
 function constructDictCss(css, dictName, scopePrefix) {
+    if (!css) return '';
+    let byScope = __dictCssCache.get(css);
+    if (byScope === undefined) {
+        // 词典集切换/重新导入会带来新的 css 串；给桶数封顶，别让缓存无界增长。
+        if (__dictCssCache.size >= __dictCssCacheMaxBuckets) __dictCssCache.clear();
+        byScope = new Map();
+        __dictCssCache.set(css, byScope);
+    }
+    const key = JSON.stringify([dictName || '', scopePrefix || '']);
+    let out = byScope.get(key);
+    if (out === undefined) {
+        out = constructDictCssUncached(css, dictName, scopePrefix);
+        byScope.set(key, out);
+    }
+    return out;
+}
+
+function constructDictCssUncached(css, dictName, scopePrefix) {
     if (!css) return '';
     const prefix = scopePrefix || `[data-dictionary="${dictName}"]`;
     const parts = [];
@@ -113,7 +142,7 @@ function constructDictCss(css, dictName, scopePrefix) {
             parts.push(selectorPart, ' {');
             if (isConditionalGroup) {
                 // Recurse so inner style rules get the prefix; the prelude stays raw.
-                parts.push(constructDictCss(atBlockContent, dictName, scopePrefix));
+                parts.push(constructDictCssUncached(atBlockContent, dictName, scopePrefix));
             } else {
                 // @font-face / @keyframes / @page: body is declarations or
                 // keyframe selectors — emit verbatim, never prefixed.
@@ -166,7 +195,7 @@ function constructDictCss(css, dictName, scopePrefix) {
                 }
             }
             parts.push(properties);
-            if (nestedRules) parts.push(constructDictCss(nestedRules, dictName, scopePrefix));
+            if (nestedRules) parts.push(constructDictCssUncached(nestedRules, dictName, scopePrefix));
         } else {
             parts.push(blockContent);
         }

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3,6 +3,18 @@
    lookup / overlay append / selection / height read through these helpers so they
    resolve inside the shadow (fall back to document before the shadow exists). */
 function __fushiRootNode(){ return window.__fushiRoot || document; }
+/* 渲染热路径上的诊断日志门控（默认关）。
+   每条 console.log 都是一次跨进程消息：宿主 in-app 表面在 onConsoleMessage 里
+   debugPrint 之，并把带调试前缀的那几类**写进 ErrorLogService**（落盘 + 通知监听
+   者）。而 [RICHTEXT_HTML] 是**每行释义**打一条、[IMG_CREATE] 是**每张词典图**打
+   一条——一次多词条查词就是成百上千条，全部压在 UI isolate 与落盘串行链上，直接
+   偷走下一次（含嵌套）查词的时间。
+   这里不删日志（排障时它们有价值），改为默认关闭：需要取证时在弹窗 WebView 控制台
+   里 `window.__fushiPopupDebug = true` 即可实时打开，无需重新构建。错误路径
+   （[IMG_ERROR] 之类）不受门控，照常无条件输出。
+   门控一律写成 `if (window.__fushiPopupDebug)` 包住**整条语句**，而不是包一个
+   打日志的 helper：参数里的 substring / 字符串拼接 / toFixed 在传给 helper 之前
+   就已经求值了，只挡输出等于没挡住热路径上的那部分开销。 */
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
@@ -1368,7 +1380,9 @@ function createDefinitionImage(data, dictionary, exporting = false) {
     
     if (typeof border === 'string') { imageContainer.style.border = border; }
     if (typeof borderRadius === 'string') { imageContainer.style.borderRadius = borderRadius; }
-    console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    if (window.__fushiPopupDebug) {
+        console.log('[IMG_CREATE]', path, 'dims=' + hasDimensions, 'svg=' + isSvg, usedWidth + 'x' + (usedWidth * invAspectRatio) + (useEmUnits ? 'em' : 'px'));
+    }
     if (useEmUnits) {
         imageContainer.style.width = `${usedWidth}em`;
     } else if (!hasDimensions && isSvg) {
@@ -2039,7 +2053,7 @@ function appendRichTextLine(parent, line) {
         });
         html = tmp2.innerHTML;
     }
-    if (hasHtml) {
+    if (hasHtml && window.__fushiPopupDebug) {
         console.log('[RICHTEXT_HTML] input=' + line.substring(0, 150) + ' | sanitized=' + html.substring(0, 150));
     }
     const frag = document.createElement('span');
@@ -4538,7 +4552,7 @@ window.renderPopup = function() {
         }
         applyCustomCSS();
         window._renderedGlossaryCounts = [];
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=0 kanji=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 0, { kanjiOnly: true });
         return;
@@ -4580,7 +4594,7 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = entries.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex;
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1');
+        if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) + 'ms entries=1'); }
         _firePopupRendered();
         _emitPopupRenderPerf('complete', t0, 1, { firstVisible: true });
         return;
@@ -4591,7 +4605,7 @@ window.renderPopup = function() {
     // counts/domIndex 在途值只作占位，最终值由 finishRemainingEntries 写齐。
     window._renderedGlossaryCounts = [entries[0].glossaries.length];
     window._entryDomIndex = [entryDomIndex[0]];
-    console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length);
+    if (window.__fushiPopupDebug) { console.log('[popup-perf] renderPopup first-entry: ' + (performance.now() - t0).toFixed(1) + 'ms entries=' + entries.length); }
     _firePopupRendered(true);
     _emitPopupRenderPerf('first-entry-dom', t0, entries.length);
 
@@ -4610,8 +4624,10 @@ window.renderPopup = function() {
         window._renderedGlossaryCounts = completed.map(
             e => (e && Array.isArray(e.glossaries)) ? e.glossaries.length : 0);
         window._entryDomIndex = entryDomIndex.slice(0, completedCount);
-        console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
-            'ms entries=' + completedCount + '/' + entries.length);
+        if (window.__fushiPopupDebug) {
+            console.log('[popup-perf] renderPopup: ' + (performance.now() - t0).toFixed(1) +
+                'ms entries=' + completedCount + '/' + entries.length);
+        }
         _firePopupRendered();
         _emitPopupRenderPerf(terminalPhase, t0, completedCount, {
             expectedEntryCount: entries.length,


### PR DESCRIPTION
﻿用户报「查词弹窗慢的逆天，特别是嵌套查词开始」。**不是渲染慢，是每次查词都重传一遍本可只传一次的巨量负载。** 档案：`docs/bugs/BUG-1868-lookup-popup-slow.md`

## 量级（用户真实配置，读自生产库 `src:reader_fushi:font_targets`）

词典字体绑了 Klee One(8.3MB) + Noto Sans SC(17MB)，**base64 内联后合计 33.7MB**，内联在「每次渲染都要重新注入」的静态设置段里。

三条查词路径的去重状态：

| 路径 | 去重 | 后果 |
|---|---|---|
| 桌面全局查词窗 / gal 浮窗 | ✅ 本来就有 | 正常 |
| **app 内弹窗** | ❌ `_lastSentStaticRevision` 是 **per-WebView 实例字段** | 第一层走热槽不重发；**每嵌套一层新建 WebView → 重发 33.7MB** ← 用户说的「特别是嵌套查词开始」 |
| **剪贴板面板** | ❌ 调用点两个去重形参**一个都没传**（当时是可选的） | 每次查词都重发 |

host.js 早就写好了正确答案（把 data URL 转同源 Blob 跨 iframe 共享），它收到重发后按 revision 认出是旧相识直接丢弃——**33.7MB 是纯白传**。

旁证：`hibiki_glookup.log` 里「渲染下发 → 首个按钮探测」稳定 750~1180ms，`entries=1` 与 `entries=84` 几乎同耗时——与词条数无关，是固定体积开销。

## 修了什么

1. **静态段去重的根因是「状态由每个调用方自己拼、且可以不传」**。不是给面板补参数，而是消灭这个特殊情况：新增 `PopupStaticRevisionCache` 收口账本，形参改**必填**，待确认版本从返回值带出——漏传即编译错误。面板同时接上 host 的 `staticSettingsRequired` 回补通道：**去重与回补是一对**，只做前者会让宿主丢缓存后永远等不到静态段，比不去重更糟。
2. **字体改走 URL**（`https://fushi.local/dictfonts/<enc>?v=<mtime>-<size>`）。嵌套那条路去重救不了（新 realm 必须重发），唯一根治是让被重发的东西本身降到 KB 级；URL 还能跨 WebView 共享 HTTP 缓存，`data:` 永远共享不了。
3. **ErrorLogService 每条日志一次最多 512KB 整文件回读** → 改 `stat length()`，超限才读回。
4. **渲染热路径上的无条件 debug console.log**（每行释义一条、每张图一条）→ `window.__fushiPopupDebug` 门控，默认关（不删日志，保留取证）。
5. **`constructDictCss` 无 memo**，被 N词条×M词典 重复字符级扫描 → 三元组 memo，三份 dict-media.js 同步。

## 验证

- `FLUTTER TEST VERDICT: PASSED - 20810 tests ran`（仓库唯一会把「零测试」判为失败的入口）
- `flutter analyze` 全量干净
- **字体走 URL 有端到端证据**（Windows 离屏 itest，不启动 app、不碰生产库）：
  - 正向 `fetch:200 | load:ok | check:true | faces=loaded`
  - **负向对照**（同字节同 200，只抽掉 ACAO）`fetch-threw | faces=error` → 证明环境真在查 CORS，正向绿不是恒真
- 三处守卫做过变异实测，均精确抓获后按 sha256 还原

## 覆盖边界（请注意）

- 字体走 URL **只实测了 Windows**。Android 走同一套 `shouldInterceptRequest` + headers 机制（阅读器 `fushi.local/fonts/` 已在生产用它），但**未实测**。
- iOS / macOS 只有 `WKURLSchemeHandler`，其 `URLResponse` 带不了任何 header，而字体是强制 CORS 子资源 → 这两个平台**继续内联**，不受影响（能力边界，非偷懒）。

## 未做（档案里有理由）

- 嵌套时 `entriesJs` 仍全栈重传（静态段修好后它是下一个大头）。要做需配套一条 host 侧 entries 重发通道，否则 host 回收 record 时会白卡——正是本 PR 面板那条踩过的坑，不能只做一半。
- standby 池=1：字体走 URL 后它「frame owns decoded fonts」的理由变弱，但**没有测量依据**，改它属调参非根治。
- 查词 FFI 移出主 isolate：**已调查判定不做**。引擎源码零 mutex/thread，多 isolate 共用 handle 不安全；`importDictionary` 能 `Isolate.run` 是因为它 static 且不需要 handle，不能据此类推。

🤖 本 PR 由 Claude Code 生成，含一轮独立代码审查及其修正（审查揪出「commit 会给根本没发出去的版本记账」，那让上一版的核心主张只成立一半）。

https://claude.ai/code/session_01MS6sxCQdDYZxBSXBiXMxY1
