### PR TITLE
fix(ci): checkout R2 planner before execution

### DIFF
--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
       - name: Check Cloudflare credentials
         id: guard
         env:

--- a/fushi/test/build/r2_mirror_budget_guard_test.dart
+++ b/fushi/test/build/r2_mirror_budget_guard_test.dart
@@ -9,6 +9,10 @@ void main() {
     ).readAsStringSync();
 
     expect(workflow, contains("MAX_BUCKET_BYTES: '8000000000'"));
+    expect(
+      workflow,
+      contains('actions/checkout@11d5960a326750d5838078e36cf38b85af677262'),
+    );
     expect(workflow, contains('node --test tool/r2_mirror_plan.test.mjs'));
     expect(workflow, contains("if: steps.capacity.outputs.allowed == 'true'"));
     expect(workflow, contains('Roll back partial upload on failure'));


### PR DESCRIPTION
Mirror planning failed safely before upload because the job had no checkout, so tool/r2_mirror_plan.test.mjs was absent. Add pinned checkout and a static guard. Planner tests remain 4/4.