### PR TITLE
fix(storage): 迁移进度 623/620 + 存储页数据库快照残留聚成可删条目（BUG-1869/1870）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1745 条。点号进各自文件。
+> 共 1747 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1870](bugs/BUG-1870-storage-usage-db-snapshots-unlabeled-undeletable.md) | ✅ | ✅ | 存储页「数据库与内部数据」把几十个数据库快照残留按原始文件名逐条列出且无法删除 |
+| [BUG-1869](bugs/BUG-1869-data-root-migration-progress-exceeds-total.md) | ✅ | ✅ | 数据迁移进度「已复制 623 / 620」超过总数：选择性搬移的顶层单文件只加分子不加分母 |
 | [BUG-1867](bugs/BUG-1867-cover-backfill-hollow-m2ts.md) | ✅ | ✅ | 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg |
 | [BUG-1866](bugs/BUG-1866-resolve-public-indexer-needs-network.md) | ✅ | ✅ | 公共索引器重解析非要联网重搜，搜不中就把活资源误报 notFound |
 | [BUG-1865](bugs/BUG-1865-organizer-numbered-extras.md) | ✅ | ✅ | 剧集整理把带编号的特典当正片，与真正片撞号整批失败 |

--- a/docs/bugs/BUG-1869-data-root-migration-progress-exceeds-total.md
+++ b/docs/bugs/BUG-1869-data-root-migration-progress-exceeds-total.md
@@ -9,7 +9,7 @@
   文件 → 分子恰好多 3（623 / 620）；`local_audio_*.db` 等顶层大件同理。
 - **[x] ① 已修复** — 顶层单文件分支先 `progress.addToTotal(1)` 再复制；同时把「copy + 字节数
   校验」抽成 `_copyFileVerified(src, dst, label)`，整树路径与顶层单文件共用一份校验口径
-  （提交 `<hash>`）。
+  （提交 `50a8610e62`）。
 - **[x] ② 已加自动化测试** — `fushi/test/storage/data_root_migrator_test.dart`
   `BUG-1869：跨盘 copy 进度分子永不越过分母，收尾时 copied == total`：用 `seedDb`（support 顶层
   有 fushi.db + 侧车 + local_audio_1.db）+ 旧 support 顶层再放一个 `shared_preferences.json`

--- a/docs/bugs/BUG-1869-data-root-migration-progress-exceeds-total.md
+++ b/docs/bugs/BUG-1869-data-root-migration-progress-exceeds-total.md
@@ -1,0 +1,21 @@
+## BUG-1869 · 数据迁移进度「已复制 623 / 620」超过总数：选择性搬移的顶层单文件只加分子不加分母
+- **报告**：2026-08-25（用户截图「正在迁移数据 … 正在复制文件：623 / 620」）
+- **真实性**：✅ 真 bug。跨盘复制进度由 `_CopyProgress` 累加：分母只在
+  `_copyTreeVerified` 里 `addToTotal(await _countFilesAsync(src))` 按**子树**计入
+  （`fushi/lib/src/storage/data_root_migrator.dart` 原 `_copyTreeVerified`），而 support 根走
+  `_moveTreeSelective`（prefs 排除项 → `isSelective`）时，顶层**单文件**分支
+  （原 `data_root_migrator.dart:535-545`）直接 `entity.copy` + `progress.fileCopied()`，从没把这
+  个文件计进分母。用户 support 根顶层正是 `fushi.db` / `fushi.db-wal` / `fushi.db-shm` 三个
+  文件 → 分子恰好多 3（623 / 620）；`local_audio_*.db` 等顶层大件同理。
+- **[x] ① 已修复** — 顶层单文件分支先 `progress.addToTotal(1)` 再复制；同时把「copy + 字节数
+  校验」抽成 `_copyFileVerified(src, dst, label)`，整树路径与顶层单文件共用一份校验口径
+  （提交 `<hash>`）。
+- **[x] ② 已加自动化测试** — `fushi/test/storage/data_root_migrator_test.dart`
+  `BUG-1869：跨盘 copy 进度分子永不越过分母，收尾时 copied == total`：用 `seedDb`（support 顶层
+  有 fushi.db + 侧车 + local_audio_1.db）+ 旧 support 顶层再放一个 `shared_preferences.json`
+  逼出**选择性搬移**（没有它排除集为空、plan 走整树 copy，根本到不了出 bug 的分支——第一版
+  测试就是这样在变异下假绿的）+ `debugForceCopyFallback` 强制跨盘 copy，断言每次回报
+  `copied <= total`、末次 `copied == total`、且 `total == 搬移前旧根会被搬的真实文件数`。
+  变异实测：注掉 `progress.addToTotal(1)` 该用例单独变红（`进度 6 / 5 分子越过分母`，与用户
+  截图同形），按唯一锚点还原后 sha256 与改动前一致。
+- **备注**：同盘 rename 路径不触碰进度对象（回调不会被调用），不受影响。

--- a/docs/bugs/BUG-1870-storage-usage-db-snapshots-unlabeled-undeletable.md
+++ b/docs/bugs/BUG-1870-storage-usage-db-snapshots-unlabeled-undeletable.md
@@ -19,7 +19,7 @@
     可删性从「按类目」改为「按条目」，视图里 `category == books ? … : …` 的特判随之消失；
   - `_scanDatabase` 把全部快照残留聚成**一条** `databaseSnapshots` 条目（标题
     「数据库备份快照（N 个文件）」，字节数=各文件之和，`paths`=清单），活库与其它 support
-    子项仍只读单列；删除经 `settings_schema_storage.dart` 接 fushi_core 原语（提交 `<hash>`）。
+    子项仍只读单列；删除经 `settings_schema_storage.dart` 接 fushi_core 原语（提交 `50a8610e62`）。
 - **[x] ② 已加自动化测试** —
   - `packages/fushi_core/test/database_snapshot_files_test.dart`：口径正/反例（现行 corrupt-bak、
     pre-restore、历史 bak.v16 / WIPED / before-v20 命中；新旧活库与三种侧车、`local_audio_*.db`、

--- a/docs/bugs/BUG-1870-storage-usage-db-snapshots-unlabeled-undeletable.md
+++ b/docs/bugs/BUG-1870-storage-usage-db-snapshots-unlabeled-undeletable.md
@@ -1,0 +1,35 @@
+## BUG-1870 · 存储页「数据库与内部数据」把几十个数据库快照残留按原始文件名逐条列出且无法删除
+- **报告**：2026-08-25（用户：「存储里面好多磁盘占用名字没正常显示，并且没办法删除」）
+- **真实性**：✅ 真 bug。用户机器 support 根（`D:\APP\HIBIKI_date\support`）实测有 ~80 个
+  `hibiki.db.bak.v16.<stamp>` / `hibiki.db-wal.bak.v20.*` / `hibiki.db.WIPED-*` /
+  `hibiki.db.corrupt-*` 之类的旧迁移快照（当前代码只产 `fushi.db.corrupt-bak-<stamp>[-wal|-shm]`，
+  见 `packages/fushi_core/lib/src/database/database.dart` `_rebuildSidecar`），存储页
+  `StorageUsageService._scanDatabase`（`fushi/lib/src/storage/storage_usage_service.dart`）把
+  support 根**每个直接子项一条**按 `support/<原始文件名>` 铺出来（前 20 条 + 「其余 N 项」），
+  在用户眼里就是一堆看不懂的名字；而 `StorageUsageView._buildEntryRows`
+  （`fushi/lib/src/pages/implementations/storage_usage_view.dart`）的可删性按**类目**判定
+  （`id == books || id == dictionaries`），数据库类目整体只读——用户无法清掉这些没人引用的
+  副本。书籍/词典条目不受影响（22 本书标题全非空，已按 DB 复核）。
+- **[x] ① 已修复** —
+  - fushi_core 新增主库快照的**唯一识别口径** `isDatabaseSnapshotFileName`（以主库名
+    `fushi.db` / 旧名 `hibiki.db` 开头、但不是本体及 `-wal`/`-shm`/`-journal` 侧车）+
+    `listDatabaseSnapshotFiles` / `deleteDatabaseSnapshotFiles(supportRoot)`，与产快照的代码同源，
+    活库/侧车结构上删不到；
+  - `StorageEntryUsage` 加 `kind`（`book` / `dictionary` / `databaseSnapshots` / `readOnly`），
+    可删性从「按类目」改为「按条目」，视图里 `category == books ? … : …` 的特判随之消失；
+  - `_scanDatabase` 把全部快照残留聚成**一条** `databaseSnapshots` 条目（标题
+    「数据库备份快照（N 个文件）」，字节数=各文件之和，`paths`=清单），活库与其它 support
+    子项仍只读单列；删除经 `settings_schema_storage.dart` 接 fushi_core 原语（提交 `<hash>`）。
+- **[x] ② 已加自动化测试** —
+  - `packages/fushi_core/test/database_snapshot_files_test.dart`：口径正/反例（现行 corrupt-bak、
+    pre-restore、历史 bak.v16 / WIPED / before-v20 命中；新旧活库与三种侧车、`local_audio_*.db`、
+    prefs、图标不命中）、只列直接子层、删除只动快照且活库逐字节不变、幂等、根不存在不抛；
+  - `fushi/test/storage/storage_usage_service_test.dart` `BUG-1870：database 明细把主库快照残留聚成
+    一条可删条目…`：聚合条目 id/bytes/paths、其余条目全只读且一个不多不少、类目总量不重不漏；
+    另一条断言无残留时不出现空聚合条目；
+  - `fushi/test/pages/storage_usage_view_test.dart` `BUG-1870：数据库快照残留聚成一条带文件数的
+    可删条目…`：真 widget 行为——原始文件名不再出现、翻译标题带文件数、整个类目只有它有删除按钮、
+    确认框文案、确认后走注入原语真删文件、活库不动、重扫后聚合条目消失。
+- **备注**：`support/local_audio_*.db`（用户机器上 6.2 GB + 1.2 GB 的本地发音库副本）仍是只读
+  条目——它们被 `local_audio_dbs` 偏好引用，删除必须走发音库自己的管理入口，不在本条范围。
+  其它类目（封面/缩略图/字幕副本等）的只读设计保持不变（有 DB 引用或墓碑护栏）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 64651 (3803 per locale)
+/// Strings: 64685 (3805 per locale)
 ///
-/// Built on 2026-08-25 at 07:05 UTC
+/// Built on 2026-08-25 at 13:50 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5174,6 +5174,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_file_location_open => 'Open file location';
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -13985,6 +13989,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -22999,6 +23009,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -32056,6 +32072,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -41142,6 +41164,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -50062,6 +50090,12 @@ class _StringsId extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -59054,6 +59088,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -67503,6 +67543,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -75968,6 +76014,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -84920,6 +84972,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -93928,6 +93986,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -102909,6 +102973,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -111713,6 +111783,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -120619,6 +120695,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -129507,6 +129589,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 // Path: <root>
@@ -137679,6 +137767,12 @@ class _StringsZhCn extends _StringsEn {
   String get book_file_location_open => '打开文件位置';
   @override
   String get book_file_location_failed => '无法打开这本书的文件位置。';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      '数据库备份快照（${n} 个文件）';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      '将删除全部数据库备份快照残留（corrupt-bak / pre-restore / 旧版本迁移副本）。正在使用的数据库及其 -wal/-shm 侧车不受影响。';
 }
 
 // Path: <root>
@@ -145869,6 +145963,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String storage_entry_database_snapshots_label({required Object n}) =>
+      'Database backup snapshots (${n} files)';
+  @override
+  String get storage_entry_delete_database_snapshots_confirm_body =>
+      'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
 }
 
 /// Flat map(s) containing all translations.
@@ -153670,6 +153770,11 @@ extension on _StringsEn {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -161468,6 +161573,11 @@ extension on _StringsAr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -169306,6 +169416,11 @@ extension on _StringsDe {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -177136,6 +177251,11 @@ extension on _StringsEs {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -184974,6 +185094,11 @@ extension on _StringsFr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -192786,6 +192911,11 @@ extension on _StringsId {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -200618,6 +200748,11 @@ extension on _StringsIt {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -208386,6 +208521,11 @@ extension on _StringsJa {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -216156,6 +216296,11 @@ extension on _StringsKo {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -223981,6 +224126,11 @@ extension on _StringsNl {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -231802,6 +231952,11 @@ extension on _StringsPtBr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -239630,6 +239785,11 @@ extension on _StringsRu {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -247432,6 +247592,11 @@ extension on _StringsTh {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -255249,6 +255414,11 @@ extension on _StringsTr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -263060,6 +263230,11 @@ extension on _StringsVi {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }
@@ -270809,6 +270984,10 @@ extension on _StringsZhCn {
         return '打开文件位置';
       case 'book_file_location_failed':
         return '无法打开这本书的文件位置。';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) => '数据库备份快照（${n} 个文件）';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return '将删除全部数据库备份快照残留（corrupt-bak / pre-restore / 旧版本迁移副本）。正在使用的数据库及其 -wal/-shm 侧车不受影响。';
       default:
         return null;
     }
@@ -278559,6 +278738,11 @@ extension on _StringsZhHk {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'storage_entry_database_snapshots_label':
+        return ({required Object n}) =>
+            'Database backup snapshots (${n} files)';
+      case 'storage_entry_delete_database_snapshots_confirm_body':
+        return 'This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏",
   "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。",
   "book_file_location_open": "打开文件位置",
-  "book_file_location_failed": "无法打开这本书的文件位置。"
+  "book_file_location_failed": "无法打开这本书的文件位置。",
+  "storage_entry_database_snapshots_label": "数据库备份快照（$n 个文件）",
+  "storage_entry_delete_database_snapshots_confirm_body": "将删除全部数据库备份快照残留（corrupt-bak / pre-restore / 旧版本迁移副本）。正在使用的数据库及其 -wal/-shm 侧车不受影响。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3801,5 +3801,7 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "storage_entry_database_snapshots_label": "Database backup snapshots ($n files)",
+  "storage_entry_delete_database_snapshots_confirm_body": "This removes all leftover database backup snapshots (corrupt-bak / pre-restore / legacy migration copies). The live database and its -wal/-shm sidecars are not touched."
 }

--- a/fushi/lib/src/pages/implementations/storage_usage_view.dart
+++ b/fushi/lib/src/pages/implementations/storage_usage_view.dart
@@ -30,6 +30,7 @@ class StorageUsageView extends ConsumerStatefulWidget {
     required this.dictionaryNamesProvider,
     required this.deleteBook,
     required this.deleteDictionary,
+    required this.deleteDatabaseSnapshots,
     this.anime4kBytesProvider = anime4kInstalledBytes,
     this.anime4kDelete = deleteAnime4kShaderFiles,
     super.key,
@@ -51,6 +52,11 @@ class StorageUsageView extends ConsumerStatefulWidget {
   /// 返回 null = 成功，非 null = 失败原因——`deleteDictionary` 内部 catch-all
   /// 不上抛，接线方必须以「删除后该名是否仍在」为准回报，不能拿无异常当成功。
   final Future<String?> Function(String name) deleteDictionary;
+
+  /// 删除 support 根下全部主库快照残留（BUG-1870；真实现 fushi_core
+  /// `deleteDatabaseSnapshotFiles(supportRoot)`，识别口径与扫描侧同源：
+  /// 展示什么就删什么，活库与侧车结构上删不到）。返回已删路径。
+  final Future<List<String>> Function() deleteDatabaseSnapshots;
 
   /// Anime4K 已下载字节数 / 删除（默认真实现；测试注临时目录版）。
   final Future<int> Function() anime4kBytesProvider;
@@ -173,23 +179,33 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     return ok == true && mounted;
   }
 
-  Future<void> _deleteEntry(
-    StorageCategoryId category,
-    StorageEntryUsage entry,
-  ) async {
+  /// 条目显示名：快照聚合条目按文件数翻译，其余用服务层给的 label。
+  String _entryTitle(StorageEntryUsage entry) =>
+      entry.kind == StorageEntryKind.databaseSnapshots
+          ? t.storage_entry_database_snapshots_label(n: entry.paths.length)
+          : entry.label;
+
+  Future<void> _deleteEntry(StorageEntryUsage entry) async {
     if (_busyEntryId != null) return;
-    final String body = category == StorageCategoryId.books
-        ? t.storage_entry_delete_book_confirm_body
-        : t.storage_entry_delete_dictionary_confirm_body;
-    if (!await _confirmDelete(entry.label, body)) return;
+    final String body = switch (entry.kind) {
+      StorageEntryKind.book => t.storage_entry_delete_book_confirm_body,
+      StorageEntryKind.dictionary =>
+        t.storage_entry_delete_dictionary_confirm_body,
+      StorageEntryKind.databaseSnapshots =>
+        t.storage_entry_delete_database_snapshots_confirm_body,
+      StorageEntryKind.readOnly => throw StateError('read-only entry'),
+    };
+    if (!await _confirmDelete(_entryTitle(entry), body)) return;
     setState(() => _busyEntryId = entry.id);
     String? failure;
     try {
-      if (category == StorageCategoryId.books) {
-        failure = await widget.deleteBook(entry.id);
-      } else {
-        failure = await widget.deleteDictionary(entry.id);
-      }
+      failure = switch (entry.kind) {
+        StorageEntryKind.book => await widget.deleteBook(entry.id),
+        StorageEntryKind.dictionary => await widget.deleteDictionary(entry.id),
+        StorageEntryKind.databaseSnapshots =>
+          await widget.deleteDatabaseSnapshots().then((List<String> _) => null),
+        StorageEntryKind.readOnly => throw StateError('read-only entry'),
+      };
     } catch (e) {
       failure = '$e';
     } finally {
@@ -385,19 +401,14 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
                 })
             : null,
       ),
-      if (expandable && expanded) ..._buildEntryRows(id, usage),
+      if (expandable && expanded) ..._buildEntryRows(usage),
     ];
   }
 
-  List<Widget> _buildEntryRows(
-    StorageCategoryId id,
-    StorageCategoryUsage usage,
-  ) {
-    // 只有书籍/词典明细接得上既有删除原语（`deleteBook` / `deleteDictionary`）；
-    // 其余类目的明细是磁盘子项，删它就是裸 `Directory.delete`——会绕过墓碑/
-    // 引用护栏，也可能删掉主库文件，故一律只读展示。
-    final bool deletable =
-        id == StorageCategoryId.books || id == StorageCategoryId.dictionaries;
+  List<Widget> _buildEntryRows(StorageCategoryUsage usage) {
+    // 可删性由**条目 kind** 决定（书/词典/数据库快照残留各接自己的删除原语）；
+    // readOnly 条目是磁盘子项，删它就是裸 `Directory.delete`——会绕过墓碑/引用
+    // 护栏，也可能删掉主库文件，故只读展示。
     final List<StorageEntryUsage> visible =
         usage.entries.take(kMaxVisibleEntries).toList(growable: false);
     final List<StorageEntryUsage> rest =
@@ -407,11 +418,11 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     return <Widget>[
       for (final StorageEntryUsage entry in visible)
         FushiListItem(
-          title: Text(entry.label),
+          title: Text(_entryTitle(entry)),
           subtitle: Text(formatStorageBytes(entry.bytes)),
           padding: const EdgeInsetsDirectional.only(start: 32, end: 8),
           density: FushiListDensity.compact,
-          trailing: !deletable
+          trailing: entry.kind == StorageEntryKind.readOnly
               ? null
               : (_busyEntryId == entry.id
                   ? const SizedBox(
@@ -424,7 +435,7 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
                       icon: const Icon(Icons.delete_outline, size: 18),
                       onPressed: _busyEntryId != null
                           ? null
-                          : () => _deleteEntry(id, entry),
+                          : () => _deleteEntry(entry),
                     )),
         ),
       if (rest.isNotEmpty)

--- a/fushi/lib/src/settings/settings_schema_storage.dart
+++ b/fushi/lib/src/settings/settings_schema_storage.dart
@@ -8,6 +8,7 @@ import 'package:fushi/src/pages/implementations/tag_filter_sheet.dart'
     show bookTagMapProvider, srtBookTagMapProvider;
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/storage/app_paths.dart';
 import 'package:fushi/src/storage/storage_usage_service.dart';
 import 'package:fushi/src/sync/sync_settings_schema.dart'
     show buildDataStorageLocationSection;
@@ -80,6 +81,9 @@ SettingsDestination buildStorageDestination() {
         }
         return result.deleted ? null : result.failureReason;
       },
+      // BUG-1870：主库快照残留的删除原语在 fushi_core（与扫描侧识别口径同源）。
+      deleteDatabaseSnapshots: () async =>
+          deleteDatabaseSnapshotFiles(await AppPaths.supportRootDirectory()),
       deleteDictionary: (String name) async {
         // AppModel.deleteDictionary 内部 catch-all 不上抛（自弹失败 toast），
         // 「无异常」不等于成功——以「删除后该名是否仍在词典表」为准回报

--- a/fushi/lib/src/storage/data_root_migrator.dart
+++ b/fushi/lib/src/storage/data_root_migrator.dart
@@ -532,14 +532,10 @@ class DataRootMigrator {
         plan.deferredCopy = true;
         deferredSourceDeletions.add(entity);
       } else if (entity is File) {
-        await File(target).parent.create(recursive: true);
-        await entity.copy(target);
-        final int srcLen = await entity.length();
-        final int dstLen = await File(target).length();
-        if (srcLen != dstLen) {
-          throw DataRootMigrationException(
-              '跨盘复制校验失败：$name 字节数不一致（$srcLen != $dstLen）');
-        }
+        // BUG-1869：顶层单文件也是一个进度单元——先计入分母再复制，否则分子会越过分母
+        //（support 根顶层的 fushi.db / -wal / -shm 各多算一次 → 「623 / 620」）。
+        progress.addToTotal(1);
+        await _copyFileVerified(entity, File(target), name);
         progress.fileCopied();
         plan.deferredCopy = true;
         deferredSourceDeletions.add(entity);
@@ -603,16 +599,26 @@ class DataRootMigrator {
       if (entity is Directory) {
         await Directory(target).create(recursive: true);
       } else if (entity is File) {
-        await Directory(p.dirname(target)).create(recursive: true);
-        await entity.copy(target);
-        final int srcLen = await entity.length();
-        final int dstLen = await File(target).length();
-        if (srcLen != dstLen) {
-          throw DataRootMigrationException(
-              '跨盘复制校验失败：$rel 字节数不一致（$srcLen != $dstLen）');
-        }
+        await _copyFileVerified(entity, File(target), rel);
         progress?.fileCopied();
       }
+    }
+  }
+
+  /// 跨盘复制的最小单元：单文件 copy + 字节数校验。[label] 只进错误信息（相对路径
+  /// 或顶层名）。整树路径与选择性搬移的顶层单文件共用，两边校验口径不可能漂移。
+  static Future<void> _copyFileVerified(
+    File src,
+    File dst,
+    String label,
+  ) async {
+    await dst.parent.create(recursive: true);
+    await src.copy(dst.path);
+    final int srcLen = await src.length();
+    final int dstLen = await dst.length();
+    if (srcLen != dstLen) {
+      throw DataRootMigrationException(
+          '跨盘复制校验失败：$label 字节数不一致（$srcLen != $dstLen）');
     }
   }
 

--- a/fushi/lib/src/storage/storage_usage_service.dart
+++ b/fushi/lib/src/storage/storage_usage_service.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:fushi_core/fushi_core.dart' show fnv1a32Hex;
+import 'package:fushi_core/fushi_core.dart'
+    show fnv1a32Hex, fushiDatabaseFileName, isDatabaseSnapshotFileName;
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/storage/app_paths.dart';
@@ -15,9 +16,11 @@ import 'package:fushi/src/storage/export_directory.dart'
 ///
 /// 只读扫描：本文件**不做任何删除**。删除一律走各域既有的删除路径
 /// （书籍 `ReaderFushiSource.deleteBook`、词典 `AppModel.deleteDictionary`、
+/// 主库快照残留 fushi_core `deleteDatabaseSnapshotFiles`、
 /// OCR 模型 `MangaOcrService.deleteModels`、Anime4K `deleteAnime4kShaderFiles`），
 /// 由 UI 层接线——存储页新写裸 `Directory.delete` 会绕过墓碑/引用护栏
-/// （见 `video_storage.dart` 头注释的共享资产误删坑）。
+/// （见 `video_storage.dart` 头注释的共享资产误删坑）。每条明细带
+/// [StorageEntryKind] 说明它接哪条原语（或只读）。
 ///
 /// 类目清单是 [AppPaths.fushiOwnedDocumentsEntries] 的**全覆盖分组**：documents
 /// 根下白名单顶层目录每一个都归属且只归属一个类目（守卫见
@@ -68,6 +71,23 @@ enum StorageCategoryId {
   ocrModels,
 }
 
+/// 明细条目的种类 = 它接哪条删除原语。可删性属于**条目**而不是类目：同一个
+/// 「数据库与内部数据」类目里，活库是只读的，快照残留却可删（BUG-1870）。
+enum StorageEntryKind {
+  /// 一本书（`id` = bookKey；删除走 `ReaderFushiSource.deleteBook`）。
+  book,
+
+  /// 一部词典（`id` = 词典名；删除走 `AppModel.deleteDictionary`）。
+  dictionary,
+
+  /// support 根下全部主库快照残留聚成的**一条**（`paths` = 文件清单；删除走
+  /// fushi_core `deleteDatabaseSnapshotFiles`，识别口径同源）。
+  databaseSnapshots,
+
+  /// 类目根下的磁盘子项，只读展示（删它就是裸 `Directory.delete`，绕过墓碑/引用护栏）。
+  readOnly,
+}
+
 /// 一个类目内的单条可展开条目（一本书 / 一部词典 / 类目根下的一个子项）。
 class StorageEntryUsage {
   const StorageEntryUsage({
@@ -75,13 +95,17 @@ class StorageEntryUsage {
     required this.label,
     required this.bytes,
     required this.paths,
+    required this.kind,
   });
 
   /// 域内主键（书 = bookKey，词典 = 词典名，通用子项 = 绝对路径）。
   final String id;
 
-  /// 显示名（书名 / 词典名 / `<顶层目录>/<子项名>`）。
+  /// 显示名（书名 / 词典名 / `<顶层目录>/<子项名>`）。[StorageEntryKind.databaseSnapshots]
+  /// 的显示名由 UI 按 `paths.length` 翻译，此处只是无 i18n 的兜底。
   final String label;
+
+  final StorageEntryKind kind;
 
   /// 该条目占用字节数（多个目录求和）。
   final int bytes;
@@ -259,6 +283,7 @@ List<Map<String, Object>> _childEntriesSync(final List<String> roots) {
         'label': '${p.basename(root)}/${p.basename(child.path)}',
         'path': child.path,
         'bytes': directorySizeSync(child.path),
+        'isFile': child is File,
       });
     }
   }
@@ -358,6 +383,7 @@ class StorageUsageService {
           label: books[i].title,
           bytes: sizes[i + 1],
           paths: perBookPaths[i],
+          kind: StorageEntryKind.book,
         ),
     ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
         b.bytes.compareTo(a.bytes));
@@ -394,6 +420,7 @@ class StorageUsageService {
           label: dictionaryNames[i],
           bytes: sizes[i + 1],
           paths: <String>[perDictPaths[i]],
+          kind: StorageEntryKind.dictionary,
         ),
     ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
         b.bytes.compareTo(a.bytes));
@@ -404,42 +431,86 @@ class StorageUsageService {
     );
   }
 
+  /// 快照聚合条目的域内主键（UI 用它做忙碌态/去重）。
+  static const String kDatabaseSnapshotsEntryId = 'database-snapshots';
+
   Future<StorageCategoryUsage> _scanDatabase(final Directory support) async {
     // support 根的直接子项，减去 OCR 模型子目录（后者单列一类）。明细里因此
     // 能看到主库 `fushi.db`、本地发音库副本 `local_audio_*.db` 等具体大件。
-    return _scanGeneric(
-      StorageCategoryId.database,
-      <String>[support.path],
-      excludePaths: <String>{p.join(support.path, kOcrModelsSupportChild)},
+    //
+    // BUG-1870：主库快照残留（`fushi.db.corrupt-bak-*`、旧 `hibiki.db.bak.v16.*` 等，
+    // 用户机器上实测几十个）不再逐个按原始文件名铺开，而是聚成**一条**可删条目——
+    // 识别口径直接用 fushi_core 的 [isDatabaseSnapshotFileName]，与删除原语同源。
+    final List<Map<String, Object>> raw =
+        await _run(() => _childEntriesSync(<String>[support.path]));
+    final List<Map<String, Object>> snapshots = <Map<String, Object>>[
+      for (final Map<String, Object> e in raw)
+        if (e['isFile'] as bool &&
+            isDatabaseSnapshotFileName(p.basename(e['path'] as String)))
+          e,
+    ];
+    final List<String> snapshotPaths = <String>[
+      for (final Map<String, Object> e in snapshots) e['path'] as String,
+    ];
+    final List<StorageEntryUsage> entries = <StorageEntryUsage>[
+      ..._readOnlyEntries(raw, excludePaths: <String>{
+        p.join(support.path, kOcrModelsSupportChild),
+        ...snapshotPaths,
+      }),
+      if (snapshots.isNotEmpty)
+        StorageEntryUsage(
+          id: kDatabaseSnapshotsEntryId,
+          label: '${p.basename(support.path)}/$fushiDatabaseFileName.*',
+          bytes: snapshots.fold<int>(
+              0, (int sum, Map<String, Object> e) => sum + (e['bytes'] as int)),
+          paths: snapshotPaths,
+          kind: StorageEntryKind.databaseSnapshots,
+        ),
+    ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
+        b.bytes.compareTo(a.bytes));
+    return StorageCategoryUsage(
+      id: StorageCategoryId.database,
+      bytes: _sumBytes(entries),
+      entries: entries,
     );
   }
 
   /// 通用类目扫描：类目根下每个直接子项一条明细，类目总量 = 明细求和。
-  /// [excludePaths] 里的子项既不计入明细也不计入总量（被别的类目单列时用）。
   Future<StorageCategoryUsage> _scanGeneric(
     final StorageCategoryId id,
-    final List<String> roots, {
-    final Set<String> excludePaths = const <String>{},
-  }) async {
+    final List<String> roots,
+  ) async {
     final List<Map<String, Object>> raw =
         await _run(() => _childEntriesSync(roots));
-    final List<StorageEntryUsage> entries = <StorageEntryUsage>[
+    final List<StorageEntryUsage> entries = _readOnlyEntries(raw)
+      ..sort((StorageEntryUsage a, StorageEntryUsage b) =>
+          b.bytes.compareTo(a.bytes));
+    return StorageCategoryUsage(
+        id: id, bytes: _sumBytes(entries), entries: entries);
+  }
+
+  /// isolate 回传的原始子项 → 只读明细。[excludePaths] 里的子项既不计入明细也不
+  /// 计入总量（被别的类目单列、或已聚合进别的条目时用）。
+  static List<StorageEntryUsage> _readOnlyEntries(
+    final List<Map<String, Object>> raw, {
+    final Set<String> excludePaths = const <String>{},
+  }) {
+    return <StorageEntryUsage>[
       for (final Map<String, Object> e in raw)
         if (!excludePaths.contains(e['path'] as String))
           StorageEntryUsage(
-            // 通用明细没有域内主键，用绝对路径当身份（UI 只拿它做展开/去重，
-            // 不接删除原语——通用条目一律只读展示）。
+            // 通用明细没有域内主键，用绝对路径当身份（UI 只拿它做展开/去重）。
             id: e['path'] as String,
             label: e['label'] as String,
             bytes: e['bytes'] as int,
             paths: <String>[e['path'] as String],
+            kind: StorageEntryKind.readOnly,
           ),
-    ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
-        b.bytes.compareTo(a.bytes));
-    final int bytes =
-        entries.fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes);
-    return StorageCategoryUsage(id: id, bytes: bytes, entries: entries);
+    ];
   }
+
+  static int _sumBytes(final List<StorageEntryUsage> entries) =>
+      entries.fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes);
 
   /// 随包组件占用（桌面端安装目录内、随安装包携带；**只展示不可删**——
   /// 更新 = 安装器整体重写安装目录，删掉的必然回来）。移动端返回空。

--- a/fushi/test/pages/storage_usage_view_test.dart
+++ b/fushi/test/pages/storage_usage_view_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart' show deleteDatabaseSnapshotFiles;
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/pages/implementations/storage_usage_view.dart';
@@ -55,6 +56,7 @@ void main() {
     required StorageUsageService service,
     Future<List<StorageBookRef>> Function()? books,
     Future<String?> Function(String bookKey)? deleteBook,
+    Future<List<String>> Function()? deleteDatabaseSnapshots,
     Future<int> Function()? anime4kBytes,
     Future<List<String>> Function()? anime4kDelete,
   }) {
@@ -64,6 +66,8 @@ void main() {
       dictionaryNamesProvider: () async => const <String>[],
       deleteBook: deleteBook ?? (String _) async => null,
       deleteDictionary: (String _) async => null,
+      deleteDatabaseSnapshots:
+          deleteDatabaseSnapshots ?? () async => const <String>[],
       anime4kBytesProvider: anime4kBytes ?? () async => 0,
       anime4kDelete: anime4kDelete ?? () async => const <String>[],
     );
@@ -142,6 +146,70 @@ void main() {
 
     expect(deleted, <String>['keyA']);
     // 重扫必须自然结束（进度圈消失）——转不停就是 _scanning 永挂的产品 bug。
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('BUG-1870：数据库快照残留聚成一条带文件数的可删条目，确认后走注入原语并重扫',
+      (WidgetTester tester) async {
+    writeFile(p.join(support.path, 'fushi.db'), 1000);
+    writeFile(p.join(support.path, 'fushi.db.corrupt-bak-1'), 7);
+    writeFile(p.join(support.path, 'hibiki.db.bak.v16.1780592923530'), 3);
+    writeFile(p.join(support.path, 'hibiki.db-wal.bak.v20.1'), 1);
+    int deleteCalls = 0;
+
+    await tester.pumpWidget(wrap(view(
+      service: service(),
+      deleteDatabaseSnapshots: () async {
+        deleteCalls++;
+        return deleteDatabaseSnapshotFiles(support);
+      },
+    )));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text(t.storage_category_database));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.storage_category_database));
+    await tester.pumpAndSettle();
+
+    // 原始文件名不再逐条铺开，取而代之的是一条带文件数的翻译标题。
+    final String title = t.storage_entry_database_snapshots_label(n: 3);
+    expect(find.text(title), findsOneWidget);
+    expect(find.text('support/fushi.db.corrupt-bak-1'), findsNothing);
+    expect(find.text('support/hibiki.db.bak.v16.1780592923530'), findsNothing);
+    // 活库仍只读单列。
+    expect(find.text('support/fushi.db'), findsOneWidget);
+    // 整个类目里只有快照条目有删除按钮。
+    expect(find.byTooltip(t.dialog_delete), findsOneWidget);
+
+    // 数据库类目在页面底部，展开后的条目行在滚动视口外：先滚进来再点，
+    // 否则 tap 落空、确认框不弹（widget 在树上但不在屏上）。
+    await tester.ensureVisible(find.byTooltip(t.dialog_delete));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip(t.dialog_delete));
+    await tester.pumpAndSettle();
+    expect(find.text(t.storage_entry_delete_confirm_title(name: title)),
+        findsOneWidget);
+    expect(find.text(t.storage_entry_delete_database_snapshots_confirm_body),
+        findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, t.dialog_delete));
+    for (int i = 0; i < 20; i++) {
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 20)));
+      await tester.pump();
+      if (deleteCalls > 0 &&
+          find.byType(CircularProgressIndicator).evaluate().isEmpty) {
+        break;
+      }
+    }
+
+    expect(deleteCalls, 1);
+    // 真删了快照、活库一字节没动。
+    expect(File(p.join(support.path, 'fushi.db.corrupt-bak-1')).existsSync(),
+        isFalse);
+    expect(File(p.join(support.path, 'fushi.db')).lengthSync(), 1000);
+    // 重扫后聚合条目消失（已无快照），活库条目仍在。
+    expect(find.text(title), findsNothing);
+    expect(find.text('support/fushi.db'), findsOneWidget);
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
 

--- a/fushi/test/storage/data_root_migrator_test.dart
+++ b/fushi/test/storage/data_root_migrator_test.dart
@@ -1007,6 +1007,53 @@ void main() {
       }
     });
 
+    test('BUG-1869：跨盘 copy 进度分子永不越过分母，收尾时 copied == total', () async {
+      // 用户截图「正在复制文件：623 / 620」：support 根走**选择性**搬移（`_MovePlan.isSelective`：
+      // 顶层有 prefs 要留原地 / 目标 support 非空需合并 / documents 白名单），其顶层单文件
+      // （fushi.db / -wal / -shm、local_audio_*.db）跨盘复制时只 fileCopied() 加分子、从没进过
+      // 分母。seedDb 在 support 顶层放了 fushi.db（+ WAL 侧车）和 local_audio_1.db；再往旧
+      // support 顶层放一个 shared_preferences.json（默认根迁移的真实形态）逼出选择性路径——
+      // 没有它排除集为空，plan 走整树 copy，根本到不了出 bug 的分支。
+      await seedDb();
+      final String newDataRoot = p.join(tmp.path, 'progress_bound');
+      // 分母应等于搬移前旧根里**会被搬**的真实文件数：prefs 留原地，不计。
+      int countFiles(Directory d) => d
+          .listSync(recursive: true, followLinks: false)
+          .whereType<File>()
+          .length;
+      final int sourceFiles = countFiles(oldDocs) + countFiles(oldSupport);
+      File(p.join(oldSupport.path, 'shared_preferences.json'))
+          .writeAsStringSync('{}');
+      final List<({int copied, int total})> reports =
+          <({int copied, int total})>[];
+      DataRootMigrator.debugForceCopyFallback = true;
+      try {
+        await const DataRootMigrator().migrate(DataRootMigrationRequest(
+          oldDocumentsRoot: oldDocs,
+          oldSupportRoot: oldSupport,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
+          documentsTopLevelIncludeNames: null,
+          closeResources: () async {},
+          commitLocation: (DataRootMigrationTarget t) async {},
+          onProgress: (int copied, int total) =>
+              reports.add((copied: copied, total: total)),
+        ));
+      } finally {
+        DataRootMigrator.debugForceCopyFallback = false;
+      }
+      expect(reports, isNotEmpty);
+      for (final ({int copied, int total}) r in reports) {
+        expect(r.copied, lessThanOrEqualTo(r.total),
+            reason: '进度 ${r.copied} / ${r.total} 分子越过分母');
+      }
+      final ({int copied, int total}) last = reports.last;
+      expect(last.total, greaterThan(0));
+      expect(last.copied, equals(last.total));
+      // 分母就是旧根真实文件数：support 顶层的 fushi.db（含侧车）与 local_audio_1.db
+      // 与 documents 子树一样被计入，不多不少。
+      expect(last.total, equals(sourceFiles));
+    });
+
     test('跨盘 copy 成功路径：提交成功后才删源，新根齐全 + DB rebase + 旧根清空', () async {
       await seedDb();
       final String newDataRoot = p.join(tmp.path, 'defer_ok');

--- a/fushi/test/storage/storage_usage_service_test.dart
+++ b/fushi/test/storage/storage_usage_service_test.dart
@@ -238,6 +238,76 @@ void main() {
       expect(ocr.bytes, 300);
     });
 
+    test('BUG-1870：database 明细把主库快照残留聚成一条可删条目，活库/侧车仍只读单列', () async {
+      // 用户机器实测：support 根下几十个 hibiki.db.bak.v16.* / fushi.db.corrupt-bak-*
+      // 逐条按原始文件名铺开、没有删除按钮。修复后它们聚成一条 databaseSnapshots。
+      writeFile(p.join(support.path, 'fushi.db'), 1000);
+      writeFile(p.join(support.path, 'fushi.db-wal'), 100);
+      writeFile(p.join(support.path, 'fushi.db-shm'), 10);
+      writeFile(p.join(support.path, 'fushi.db.corrupt-bak-1'), 7);
+      writeFile(p.join(support.path, 'fushi.db.corrupt-bak-1-wal'), 5);
+      writeFile(p.join(support.path, 'hibiki.db.bak.v16.1780592923530'), 3);
+      writeFile(p.join(support.path, 'hibiki.db-wal.bak.v20.1'), 1);
+      writeFile(p.join(support.path, 'local_audio_1.db'), 20);
+      // 同名子目录不是文件，不进快照集合（按只读目录单列）。
+      writeFile(p.join(support.path, 'fushi.db.corrupt-bak-dir', 'x'), 2);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: const <StorageBookRef>[],
+        dictionaryNames: const <String>[],
+      ).toList();
+      final StorageCategoryUsage db = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.database);
+
+      final StorageEntryUsage snapshots = db.entries.singleWhere(
+          (StorageEntryUsage e) =>
+              e.kind == StorageEntryKind.databaseSnapshots);
+      expect(snapshots.id, StorageUsageService.kDatabaseSnapshotsEntryId);
+      expect(snapshots.bytes, 7 + 5 + 3 + 1);
+      expect(
+        snapshots.paths.map(p.basename).toSet(),
+        <String>{
+          'fushi.db.corrupt-bak-1',
+          'fushi.db.corrupt-bak-1-wal',
+          'hibiki.db.bak.v16.1780592923530',
+          'hibiki.db-wal.bak.v20.1',
+        },
+      );
+      // 其余条目全是只读，且活库 + 侧车 + 无关文件 + 同名目录一个不少、一个不多。
+      final List<StorageEntryUsage> readOnly = db.entries
+          .where((StorageEntryUsage e) => e.kind == StorageEntryKind.readOnly)
+          .toList();
+      expect(
+        readOnly.map((StorageEntryUsage e) => e.label).toSet(),
+        <String>{
+          'support/fushi.db',
+          'support/fushi.db-wal',
+          'support/fushi.db-shm',
+          'support/local_audio_1.db',
+          'support/fushi.db.corrupt-bak-dir',
+        },
+      );
+      // 类目总量 = 全部明细之和（快照没有被算两次、也没有丢）。
+      expect(db.bytes, 1000 + 100 + 10 + 7 + 5 + 3 + 1 + 20 + 2);
+      expect(db.entries.length, readOnly.length + 1);
+    });
+
+    test('无快照残留时 database 明细不出现空的聚合条目', () async {
+      writeFile(p.join(support.path, 'fushi.db'), 1000);
+      writeFile(p.join(support.path, 'fushi.db-wal'), 100);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: const <StorageBookRef>[],
+        dictionaryNames: const <String>[],
+      ).toList();
+      final StorageCategoryUsage db = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.database);
+      expect(
+        db.entries.map((StorageEntryUsage e) => e.kind).toSet(),
+        <StorageEntryKind>{StorageEntryKind.readOnly},
+      );
+    });
+
     test('每个类目恰好产出一次结果', () async {
       final List<StorageCategoryUsage> all = await service().scanCategories(
         books: const <StorageBookRef>[],

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -297,6 +297,54 @@ const String fushiDatabaseFileName = 'fushi.db';
 /// app 层「本机是否已有安装」的判据也要兼看它（旧安装升级后第一次开库前旧名还在）。
 const String legacyHibikiDatabaseFileName = 'hibiki.db';
 
+/// 主库**快照残留**的唯一识别口径（BUG-1870；存储页「数据库备份快照」条目与
+/// [deleteDatabaseSnapshotFiles] 共用，展示什么就删什么）。
+///
+/// 规则只有一条：文件名以主库名（[fushiDatabaseFileName] 或旧名
+/// [legacyHibikiDatabaseFileName]）开头，但**不是**主库本体及其 `-wal` / `-shm` /
+/// `-journal` 侧车。覆盖 [_rebuildSidecar] 产的 `fushi.db.corrupt-bak-<stamp>[-wal|-shm]`、
+/// backup_service 的 `fushi.db.pre-restore.bak`，以及历史迁移留下的
+/// `hibiki.db.bak.v16.<stamp>` / `hibiki.db-wal.bak.*` 之类。它们都只是整文件副本，
+/// 没有任何表、偏好或引用指向它们，删掉不影响活库；活库与侧车被显式排除，永远不会
+/// 落进这个集合（旧名 `hibiki.db` 尚未被 [_migrateLegacyDatabaseFileName] 改名时同样受保护）。
+bool isDatabaseSnapshotFileName(final String name) {
+  for (final String db in <String>[
+    fushiDatabaseFileName,
+    legacyHibikiDatabaseFileName,
+  ]) {
+    if (!name.startsWith(db)) continue;
+    final String rest = name.substring(db.length);
+    return rest.isNotEmpty &&
+        rest != '-wal' &&
+        rest != '-shm' &&
+        rest != '-journal';
+  }
+  return false;
+}
+
+/// [supportRoot] **直接**子层里的主库快照残留文件（同步、不递归、不追 symlink；
+/// 存储页在扫描 isolate 里调用）。
+List<File> listDatabaseSnapshotFiles(final Directory supportRoot) {
+  if (!supportRoot.existsSync()) return const <File>[];
+  return <File>[
+    for (final FileSystemEntity e in supportRoot.listSync(followLinks: false))
+      if (e is File && isDatabaseSnapshotFileName(p.basename(e.path))) e,
+  ];
+}
+
+/// 删除 [supportRoot] 下全部主库快照残留，返回已删路径。识别口径与
+/// [listDatabaseSnapshotFiles] 同源，故活库/侧车结构上不可能被删到。
+/// 单个文件删不掉（被占用等）照实抛——调用方按失败提示用户，不吞。
+Future<List<String>> deleteDatabaseSnapshotFiles(
+    final Directory supportRoot) async {
+  final List<String> deleted = <String>[];
+  for (final File f in listDatabaseSnapshotFiles(supportRoot)) {
+    await f.delete();
+    deleted.add(f.path);
+  }
+  return deleted;
+}
+
 /// Fushi 终局清算 W1：`hibiki.db` → `fushi.db` 一次性文件改名，必须发生在任何
 /// SQLite 连接打开之前（WAL 库的 `-wal`/`-shm` 与主文件名绑定，开着连接改名等于
 /// 撕裂 sidecar）。改名顺序刻意是 **sidecar 先、主文件最后**：判据只看两个主文件

--- a/packages/fushi_core/test/database_snapshot_files_test.dart
+++ b/packages/fushi_core/test/database_snapshot_files_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-1870：主库快照残留的识别口径 + 删除原语。
+///
+/// 口径只有一条：文件名以主库名（`fushi.db` / 旧名 `hibiki.db`）开头，但不是主库本体
+/// 及其 `-wal` / `-shm` / `-journal` 侧车。活库结构上永远不在集合里——这是删除原语
+/// 能安全暴露给存储页的前提。
+void main() {
+  group('isDatabaseSnapshotFileName', () {
+    test('活库本体与侧车（新旧两个名字）都不是快照', () {
+      for (final String db in <String>['fushi.db', 'hibiki.db']) {
+        expect(isDatabaseSnapshotFileName(db), isFalse, reason: db);
+        for (final String sidecar in <String>['-wal', '-shm', '-journal']) {
+          expect(
+            isDatabaseSnapshotFileName('$db$sidecar'),
+            isFalse,
+            reason: '$db$sidecar',
+          );
+        }
+      }
+    });
+
+    test('现行与历史各种快照/备份命名都命中', () {
+      const List<String> snapshots = <String>[
+        // _rebuildSidecar 现行产物（主文件 + 两个侧车副本）。
+        'fushi.db.corrupt-bak-1780735422',
+        'fushi.db.corrupt-bak-1780735422-wal',
+        'fushi.db.corrupt-bak-1780735422-shm',
+        // backup_service 的覆盖导入前快照。
+        'fushi.db.pre-restore.bak',
+        // 历史迁移残留（用户机器实测）。
+        'hibiki.db.bak.v16.1780592923530',
+        'hibiki.db-wal.bak.v20.1780723449590',
+        'hibiki.db-shm.bak.v23.1780839460016',
+        'hibiki.db.WIPED-before-restore',
+        'hibiki.db.before-v20-realtest-wal',
+        'hibiki.db.v19-discarded-keep',
+      ];
+      for (final String name in snapshots) {
+        expect(isDatabaseSnapshotFileName(name), isTrue, reason: name);
+      }
+    });
+
+    test('与主库无关的文件不是快照', () {
+      for (final String name in <String>[
+        'local_audio_1782831652275.db',
+        'youtube_stream_cache.json',
+        'shared_preferences.json',
+        'window_icon_default.png',
+      ]) {
+        expect(isDatabaseSnapshotFileName(name), isFalse, reason: name);
+      }
+    });
+  });
+
+  group('listDatabaseSnapshotFiles / deleteDatabaseSnapshotFiles', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('fushi_db_snapshots_');
+    });
+    tearDown(() async {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {
+        /* Windows 句柄延迟释放 */
+      }
+    });
+
+    File put(String name, [String content = 'x']) =>
+        File(p.join(tmp.path, name))..writeAsStringSync(content);
+
+    test('只列直接子层的快照文件：活库/侧车/无关文件/子目录/子目录里的同名都不进', () {
+      final File live = put('fushi.db');
+      final File wal = put('fushi.db-wal');
+      final File shm = put('fushi.db-shm');
+      final File other = put('local_audio_1.db');
+      final File snap1 = put('fushi.db.corrupt-bak-1');
+      final File snap2 = put('hibiki.db.bak.v16.2');
+      Directory(p.join(tmp.path, 'fushi.db.corrupt-bak-dir')).createSync();
+      Directory(p.join(tmp.path, 'backups')).createSync();
+      put(p.join('backups', 'fushi.db.corrupt-bak-nested'));
+
+      final Set<String> listed = listDatabaseSnapshotFiles(
+        tmp,
+      ).map((File f) => p.basename(f.path)).toSet();
+      expect(listed, <String>{p.basename(snap1.path), p.basename(snap2.path)});
+      for (final File keep in <File>[live, wal, shm, other]) {
+        expect(listed, isNot(contains(p.basename(keep.path))));
+      }
+    });
+
+    test('删除只动快照，活库与侧车逐字节不变，返回已删路径', () async {
+      final File live = put('fushi.db', 'LIVE');
+      final File wal = put('fushi.db-wal', 'WAL');
+      final File snap1 = put('fushi.db.corrupt-bak-1');
+      final File snap2 = put('hibiki.db-wal.bak.v20.3');
+
+      final List<String> deleted = await deleteDatabaseSnapshotFiles(tmp);
+      expect(deleted.toSet(), <String>{snap1.path, snap2.path});
+      expect(snap1.existsSync(), isFalse);
+      expect(snap2.existsSync(), isFalse);
+      expect(live.readAsStringSync(), 'LIVE');
+      expect(wal.readAsStringSync(), 'WAL');
+      // 幂等：再删一次无事发生。
+      expect(await deleteDatabaseSnapshotFiles(tmp), isEmpty);
+    });
+
+    test('support 根不存在 → 空集，不抛', () async {
+      final Directory missing = Directory(p.join(tmp.path, 'nope'));
+      expect(listDatabaseSnapshotFiles(missing), isEmpty);
+      expect(await deleteDatabaseSnapshotFiles(missing), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告
- 截图：数据迁移对话框「正在复制文件：623 / 620」——已复制数超过总数。
- 「存储里面好多磁盘占用名字没正常显示，并且没办法删除」。

## BUG-1869 迁移进度分子越过分母
support 根走**选择性搬移**（prefs 留原地 / 目标非空合并 / documents 白名单）时，顶层**单文件**跨盘复制只 `fileCopied()` 加分子、从未进过分母（`_moveTreeSelective` 文件分支）。修复：先 `addToTotal(1)` 再复制；把 copy + 字节校验抽成 `_copyFileVerified` 与整树路径共用。

## BUG-1870 存储页数据库快照残留
用户机器 support 根实测 ~80 个 `hibiki.db.bak.v16.*` / `fushi.db.corrupt-bak-*` 旧快照，存储页「数据库与内部数据」按原始文件名逐条铺开、且整个类目按**类目**判只读，用户删不掉。修复：
- `fushi_core`：快照识别唯一口径 `isDatabaseSnapshotFileName`（以主库名开头但不是本体及 `-wal/-shm/-journal` 侧车）+ `listDatabaseSnapshotFiles` / `deleteDatabaseSnapshotFiles`，与产快照的 `_rebuildSidecar` 同源；
- `StorageEntryUsage.kind`：可删性从「按类目」改为「按条目」，视图里 `category == books ? … : …` 特判消失；
- 快照残留聚成一条「数据库备份快照（N 个文件）」可删条目；活库/侧车/`local_audio_*.db` 等仍只读单列；
- i18n +2 key（17 语言，`strings.g.dart` +186/−2 纯插入）。

## 验证
- `flutter analyze`（fushi 含 test）No issues；`dart analyze --fatal-infos` fushi_core 改动文件干净。
- 定向：`data_root_migrator_test`（含新用例，**变异注掉 `addToTotal(1)` → 「进度 6 / 5」红**）、`storage_usage_service_test`、`storage_usage_view_test`（7/7）、`test/i18n`；fushi_core `database_snapshot_files_test` 6/6（**变异去掉 `-wal` 排除 → 3 例红**）。
- 目录枚举型守卫整批：`FLUTTER TEST VERDICT: PASSED - 252 tests ran`。
- 未做：真机复看设置→存储页（用户机器上目前 app 正在运行、未驱动其 UI）；widget 行为测试覆盖了展示/删除全链路。

https://claude.ai/code/session_01E6kEbbWM4sxBm8hNztkL6M
