### PR TITLE
fix(discovery): 发现页三处空态/加载态引导 + 下载设置副标题撞词（BUG-1871~1874）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1745 条。点号进各自文件。
+> 共 1749 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1874](bugs/BUG-1874-settings-downloads-open-page-subtitle-duplicate.md) | ✅ | ✅ | 「下载」设置分类里的下载页入口副标题也叫「下载设置」 |
+| [BUG-1873](bugs/BUG-1873-manga-discovery-loading-rows-bare-lines.md) | ✅ | ✅ | 漫画发现页来源热门行加载态是一排无标签的裸横线 |
+| [BUG-1872](bugs/BUG-1872-video-discovery-no-managed-source-snackbar.md) | ✅ | ✅ | 视频发现搜索资源/订阅在缺受管视频来源时只弹「暂无来源」snackbar |
+| [BUG-1871](bugs/BUG-1871-manga-global-search-empty-state-no-import-cta.md) | ✅ | ✅ | 漫画全源搜索空态文案指向不存在的「扩展」且无导入引导按钮 |
 | [BUG-1867](bugs/BUG-1867-cover-backfill-hollow-m2ts.md) | ✅ | ✅ | 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg |
 | [BUG-1866](bugs/BUG-1866-resolve-public-indexer-needs-network.md) | ✅ | ✅ | 公共索引器重解析非要联网重搜，搜不中就把活资源误报 notFound |
 | [BUG-1865](bugs/BUG-1865-organizer-numbered-extras.md) | ✅ | ✅ | 剧集整理把带编号的特典当正片，与真正片撞号整批失败 |

--- a/docs/bugs/BUG-1871-manga-global-search-empty-state-no-import-cta.md
+++ b/docs/bugs/BUG-1871-manga-global-search-empty-state-no-import-cta.md
@@ -1,0 +1,6 @@
+## BUG-1871 · 漫画全源搜索空态文案指向不存在的「扩展」且无导入引导按钮
+- **报告**：2026-08-25（用户：截图——「搜索全部来源」页正文只有一句「没有已启用的漫画来源，请先安装并启用扩展。」，「这里提示不对，而且应该有按钮引导去导入」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/media/manga/manga_global_search_page.dart:175`（修前）`_buildBody` 在 `_sources().isEmpty` 时只渲染一段 `Text(t.manga_global_search_no_sources)`：文案叫用户去「安装并启用扩展」，可漫画库的三视图是「书架 / 发现 / 导入」（`manga_library_page.dart:56` `library_view_import`），根本没有叫「扩展」的入口；而且整页没有任何可点的东西，用户只能按返回自己翻。壳早就为这类空态准备了 `MediaLibraryShellScope.select(MediaLibraryViewKind.sources)`（`media_library_shell.dart:54`），本页没接。
+- **[x] ① 已修复** — `c953b9494d`：`MangaGlobalSearchPage` 新增 `onOpenSources` 回调；空态文案改为「还没有已启用的漫画来源，去「导入」添加一个。」并渲染「去导入」按钮（`manga_global_search_open_sources`），点击**先 pop 本页再调回调**（切视图发生在本页下面的壳里，顺序反了用户什么都看不到）。`MangaDiscoveryPage._submitSearch` 经 `MediaLibraryShellScope.maybeOf` 接回调；不在壳里（被独立 push）时为 null，只显示文案不显示按钮。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/manga_global_search_page_test.dart`：「no sources: empty state names the Import tab and its button pops then opens it」断言文案包含 `library_view_import`、按钮存在、点击后回调计数 1 且搜索页已 pop；「no sources without a shell to switch」断言无回调时无按钮。变异实测：去掉 `Navigator.pop()` → 红。
+- **备注**：i18n 用 `--remove` + `--add` 重写同名 key（不是改名），其余 16 语回落英文待译。

--- a/docs/bugs/BUG-1872-video-discovery-no-managed-source-snackbar.md
+++ b/docs/bugs/BUG-1872-video-discovery-no-managed-source-snackbar.md
@@ -1,0 +1,6 @@
+## BUG-1872 · 视频发现搜索资源/订阅在缺受管视频来源时只弹「暂无来源」snackbar
+- **报告**：2026-08-25（用户：截图——视频发现详情页点「搜索资源」，底部只弹「暂无来源」；「这里的暂无来源不对，看上去只是没配置下载后端。应该给弹窗配置」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_page.dart:1432` / `:1504`（修前）`_openVideoDiscoveryResourceSearch` / `_openVideoDiscoverySubscription`：`registry`/`pipeline` 非空（后端**已就绪**）后 `getManagedVideoDownloadSources()` 为空 → `_showVideoDiscoveryMessage(t.media_source_no_sources)`。真正缺的是「下载完成后落地用的本地视频文件夹」（`app_model.dart:3938` 过滤 `transport == 'local'` 且目录存在），snackbar 既不说缺什么也没处点，用户自然猜成「没配下载后端」。下载页早在 BUG-1706 把这一环拆成 `DownloadsResourceNoManagedSource` → 就地开 `MediaSourcesDialog(mediaKind: 'video')`（`downloads_page.dart:110`），首页发现路径漏改。
+- **[x] ① 已修复** — `c953b9494d`：新增 `fushi/lib/src/pages/implementations/managed_video_source_prompt.dart`（`promptManagedVideoSourceSetup` + `ManagedVideoSourcePromptDialog`，与 `promptDownloadBackendSetup` 同姿态：一句说清缺的是落地用的视频文件夹 + 「添加视频来源」按钮就地开 `MediaSourcesDialog`）；`home_page.dart` 两条流程统一走 `_managedVideoDownloadSourcesOrPrompt`，用户加完来源后重读清单继续原动作，取消 = 明确放弃。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/managed_video_source_prompt_test.dart`：确认 → 来源对话框开一次、返回 true、不再出现「暂无来源」；取消 → 不开对话框、返回 false。
+- **备注**：`VideoDownloadBackendUnavailable`（后端配了但连不上，如内置引擎缺运行时）仍按原样透传后端自己的原因，不改成配置引导——用户已经配过了。

--- a/docs/bugs/BUG-1873-manga-discovery-loading-rows-bare-lines.md
+++ b/docs/bugs/BUG-1873-manga-discovery-loading-rows-bare-lines.md
@@ -1,0 +1,6 @@
+## BUG-1873 · 漫画发现页来源热门行加载态是一排无标签的裸横线
+- **报告**：2026-08-25（用户：截图——漫画「发现」页顶部一个转圈，下面二十多条等距的深色横线铺满整页；「漫画的发现加载太抽象了」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/media/manga/discovery/manga_discovery_page.dart:574`（修前）`MangaDiscoverySourceRow.build` 在 `_items == null` 时只渲染 `LinearProgressIndicator(minHeight: 2)`：每个已启用 Mihon 源一条（`mihonDiscoverySourceFeeds` 按 `enabledMangaOnlineSources` 逐源建行），启用二十几个源就是二十几条没有任何标签的 2px 横线，看不出那是什么、也看不出在等谁；加载完成后行头才出现，布局跳动。全局搜索页同场景早已是「源名行头 + 16px 行内转圈」（`manga_global_search_page.dart:238` `_statusTrailing`）。
+- **[x] ① 已修复** — `c953b9494d`：加载中就渲染带源名的行头（`manga_discovery_source_popular(source:)`）+ 行内 16px `CircularProgressIndicator`，与全局搜索页同形；`items == null` 不渲染卡片条，`items.isEmpty`/失败仍整行收起。加载完成标题原位不动，卡片条在其下长出。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/discovery/manga_discovery_page_test.dart`：「来源热门行加载中显示带源名的行头，而不是一条裸横线」用 `Completer` 钉住 pending 态，断言行头文案 + 行内转圈存在、`LinearProgressIndicator` 不存在；完成后卡片出现、转圈消失。变异实测：`items == null` 时收起整行 → 红。
+- **备注**：二十几个源同时 `getPopular` 的请求量本条不动（是行首次挂载即加载的既有设计）；只修可读性。

--- a/docs/bugs/BUG-1874-settings-downloads-open-page-subtitle-duplicate.md
+++ b/docs/bugs/BUG-1874-settings-downloads-open-page-subtitle-duplicate.md
@@ -1,0 +1,6 @@
+## BUG-1874 · 「下载」设置分类里的下载页入口副标题也叫「下载设置」
+- **报告**：2026-08-25（用户：「下载设置里面怎么还有一个下载设置」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/settings/settings_schema_downloads.dart:36-38`（修前）：destination 的 `summary: t.download_settings`（「下载设置」），其第一条 `SettingsNavigationItem('downloads.open_page')` 的 `subtitle` 也是 `t.download_settings`——同一个词出现两层，而这条导航项打开的其实是**下载页**（`DownloadsPage`：任务 / 资源 / 订阅），不是任何设置。
+- **[x] ① 已修复** — `c953b9494d`：副标题改为新 key `settings_downloads_open_page_hint`（「打开下载页（任务 / 资源 / 订阅）」）。
+- **[x] ② 已加自动化测试** — `fushi/test/settings/settings_downloads_open_page_subtitle_guard_test.dart`：源码守卫，`downloads.open_page` 项的 subtitle 必须是 `settings_downloads_open_page_hint` 且不得回到 `download_settings`。变异实测：改回 `t.download_settings` → 红。
+- **备注**：

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 64651 (3803 per locale)
+/// Strings: 64685 (3805 per locale)
 ///
-/// Built on 2026-08-25 at 07:05 UTC
+/// Built on 2026-08-25 at 14:38 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4561,8 +4561,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_global_search_hint => 'Search every enabled source';
   String get manga_global_search_prompt =>
       'Type a title to search every enabled manga source at once.';
-  String get manga_global_search_no_sources =>
-      'No enabled manga sources. Install and enable an extension first.';
   String get anki_connect_addon_install => 'Install AnkiConnect';
   String get anki_connect_addon_install_hint =>
       'Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.';
@@ -5174,6 +5172,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_file_location_open => 'Open file location';
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  String get manga_global_search_open_sources => 'Go to Import';
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -12943,9 +12946,6 @@ class _StringsAr extends _StringsEn {
   String get manga_global_search_prompt =>
       'اكتب عنواناً للبحث في جميع مصادر المانغا المُفعّلة دفعة واحدة.';
   @override
-  String get manga_global_search_no_sources =>
-      'لا توجد مصادر مانغا مُفعّلة. ثبّت وفعّل إضافة أولاً.';
-  @override
   String get anki_connect_addon_install => 'تثبيت AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -13985,6 +13985,14 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -21936,9 +21944,6 @@ class _StringsDe extends _StringsEn {
   String get manga_global_search_prompt =>
       'Geben Sie einen Titel ein, um alle aktivierten Manga-Quellen gleichzeitig zu durchsuchen.';
   @override
-  String get manga_global_search_no_sources =>
-      'Keine aktivierten Manga-Quellen. Installieren und aktivieren Sie zuerst eine Erweiterung.';
-  @override
   String get anki_connect_addon_install => 'AnkiConnect installieren';
   @override
   String get anki_connect_addon_install_hint =>
@@ -22999,6 +23004,14 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -30984,9 +30997,6 @@ class _StringsEs extends _StringsEn {
   String get manga_global_search_prompt =>
       'Escriba un título para buscar en todas las fuentes de manga activas a la vez.';
   @override
-  String get manga_global_search_no_sources =>
-      'Sin fuentes de manga activas. Instale y active una extensión primero.';
-  @override
   String get anki_connect_addon_install => 'Instalar AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -32056,6 +32066,14 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -40068,9 +40086,6 @@ class _StringsFr extends _StringsEn {
   String get manga_global_search_prompt =>
       'Tapez un titre pour rechercher dans toutes les sources de manga activées à la fois.';
   @override
-  String get manga_global_search_no_sources =>
-      'Aucune source de manga activée. Installez et activez d\'abord une extension.';
-  @override
   String get anki_connect_addon_install => 'Installer AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -41142,6 +41157,14 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -49012,9 +49035,6 @@ class _StringsId extends _StringsEn {
   String get manga_global_search_prompt =>
       'Ketik judul untuk mencari setiap sumber manga yang aktif sekaligus.';
   @override
-  String get manga_global_search_no_sources =>
-      'Tidak ada sumber manga yang aktif. Instal dan aktifkan ekstensi terlebih dahulu.';
-  @override
   String get anki_connect_addon_install => 'Instal AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -50062,6 +50082,14 @@ class _StringsId extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -57994,9 +58022,6 @@ class _StringsIt extends _StringsEn {
   String get manga_global_search_prompt =>
       'Digita un titolo per cercare in ogni fonte manga abilitata contemporaneamente.';
   @override
-  String get manga_global_search_no_sources =>
-      'Nessuna fonte manga abilitata. Installa e abilita prima un\'estensione.';
-  @override
   String get anki_connect_addon_install => 'Installa AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -59054,6 +59079,14 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -66511,9 +66544,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get manga_global_search_prompt => 'タイトルを入力して、すべての有効なマンガソースを一括検索します。';
   @override
-  String get manga_global_search_no_sources =>
-      '有効なマンガソースがありません。まず拡張機能をインストールして有効にしてください。';
-  @override
   String get anki_connect_addon_install => 'AnkiConnectをインストール';
   @override
   String get anki_connect_addon_install_hint =>
@@ -67503,6 +67533,14 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -74972,9 +75010,6 @@ class _StringsKo extends _StringsEn {
   String get manga_global_search_prompt =>
       '제목을 입력하면 활성화된 모든 만화 소스를 한 번에 검색합니다.';
   @override
-  String get manga_global_search_no_sources =>
-      '활성화된 만화 소스가 없습니다. 먼저 확장을 설치하고 활성화하세요.';
-  @override
   String get anki_connect_addon_install => 'AnkiConnect 설치';
   @override
   String get anki_connect_addon_install_hint =>
@@ -75968,6 +76003,14 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -83865,9 +83908,6 @@ class _StringsNl extends _StringsEn {
   String get manga_global_search_prompt =>
       'Typ een titel om elke ingeschakelde mangabron tegelijk te doorzoeken.';
   @override
-  String get manga_global_search_no_sources =>
-      'Geen ingeschakelde mangabronnen. Installeer en schakel eerst een extensie in.';
-  @override
   String get anki_connect_addon_install => 'AnkiConnect installeren';
   @override
   String get anki_connect_addon_install_hint =>
@@ -84920,6 +84960,14 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -92860,9 +92908,6 @@ class _StringsPtBr extends _StringsEn {
   String get manga_global_search_prompt =>
       'Digite um título para buscar em todas as fontes de mangá ativadas de uma vez.';
   @override
-  String get manga_global_search_no_sources =>
-      'Nenhuma fonte de mangá ativada. Instale e ative uma extensão primeiro.';
-  @override
   String get anki_connect_addon_install => 'Instalar AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -93928,6 +93973,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -101843,9 +101896,6 @@ class _StringsRu extends _StringsEn {
   String get manga_global_search_prompt =>
       'Введите название для поиска по всем включённым источникам манги одновременно.';
   @override
-  String get manga_global_search_no_sources =>
-      'Нет включённых источников манги. Сначала установите и включите расширение.';
-  @override
   String get anki_connect_addon_install => 'Установить AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -102909,6 +102959,14 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -110667,9 +110725,6 @@ class _StringsTh extends _StringsEn {
   String get manga_global_search_prompt =>
       'พิมพ์ชื่อเรื่องเพื่อค้นหาทุกแหล่งมังงะที่เปิดใช้งานพร้อมกัน';
   @override
-  String get manga_global_search_no_sources =>
-      'ไม่มีแหล่งมังงะที่เปิดใช้งาน ติดตั้งและเปิดใช้งานส่วนขยายก่อน';
-  @override
   String get anki_connect_addon_install => 'ติดตั้ง AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -111713,6 +111768,14 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -119566,9 +119629,6 @@ class _StringsTr extends _StringsEn {
   String get manga_global_search_prompt =>
       'Etkin tüm manga kaynaklarında aynı anda aramak için bir başlık yazın.';
   @override
-  String get manga_global_search_no_sources =>
-      'Etkin manga kaynağı yok. Önce bir eklenti yükleyip etkinleştirin.';
-  @override
   String get anki_connect_addon_install => 'AnkiConnect\'i yükle';
   @override
   String get anki_connect_addon_install_hint =>
@@ -120619,6 +120679,14 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -128450,9 +128518,6 @@ class _StringsVi extends _StringsEn {
   String get manga_global_search_prompt =>
       'Nhập tựa đề để tìm kiếm tất cả nguồn truyện tranh đã bật cùng lúc.';
   @override
-  String get manga_global_search_no_sources =>
-      'Không có nguồn truyện tranh nào được bật. Cài đặt và bật một tiện ích mở rộng trước.';
-  @override
   String get anki_connect_addon_install => 'Cài đặt AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -129507,6 +129572,14 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 // Path: <root>
@@ -136738,8 +136811,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get manga_global_search_prompt => '输入书名，一次搜索所有已启用的漫画来源。';
   @override
-  String get manga_global_search_no_sources => '没有已启用的漫画来源，请先安装并启用扩展。';
-  @override
   String get anki_connect_addon_install => '安装 AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -137679,6 +137750,12 @@ class _StringsZhCn extends _StringsEn {
   String get book_file_location_open => '打开文件位置';
   @override
   String get book_file_location_failed => '无法打开这本书的文件位置。';
+  @override
+  String get manga_global_search_no_sources => '还没有已启用的漫画来源，去「导入」添加一个。';
+  @override
+  String get manga_global_search_open_sources => '去导入';
+  @override
+  String get settings_downloads_open_page_hint => '打开下载页（任务 / 资源 / 订阅）';
 }
 
 // Path: <root>
@@ -144917,8 +144994,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_global_search_prompt => '輸入書名，一次搜索所有已啟用的漫畫來源。';
   @override
-  String get manga_global_search_no_sources => '沒有已啟用的漫畫來源，請先安裝並啟用擴展。';
-  @override
   String get anki_connect_addon_install => '安裝 AnkiConnect';
   @override
   String get anki_connect_addon_install_hint =>
@@ -145869,6 +145944,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get manga_global_search_no_sources =>
+      'No enabled manga sources yet. Add one in the Import tab.';
+  @override
+  String get manga_global_search_open_sources => 'Go to Import';
+  @override
+  String get settings_downloads_open_page_hint =>
+      'Open the Downloads page (tasks, resources, subscriptions)';
 }
 
 /// Flat map(s) containing all translations.
@@ -152793,8 +152876,6 @@ extension on _StringsEn {
         return 'Search every enabled source';
       case 'manga_global_search_prompt':
         return 'Type a title to search every enabled manga source at once.';
-      case 'manga_global_search_no_sources':
-        return 'No enabled manga sources. Install and enable an extension first.';
       case 'anki_connect_addon_install':
         return 'Install AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -153670,6 +153751,12 @@ extension on _StringsEn {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -160590,8 +160677,6 @@ extension on _StringsAr {
         return 'بحث في كل مصدر مُفعّل';
       case 'manga_global_search_prompt':
         return 'اكتب عنواناً للبحث في جميع مصادر المانغا المُفعّلة دفعة واحدة.';
-      case 'manga_global_search_no_sources':
-        return 'لا توجد مصادر مانغا مُفعّلة. ثبّت وفعّل إضافة أولاً.';
       case 'anki_connect_addon_install':
         return 'تثبيت AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -161468,6 +161553,12 @@ extension on _StringsAr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -168424,8 +168515,6 @@ extension on _StringsDe {
         return 'Jede aktivierte Quelle durchsuchen';
       case 'manga_global_search_prompt':
         return 'Geben Sie einen Titel ein, um alle aktivierten Manga-Quellen gleichzeitig zu durchsuchen.';
-      case 'manga_global_search_no_sources':
-        return 'Keine aktivierten Manga-Quellen. Installieren und aktivieren Sie zuerst eine Erweiterung.';
       case 'anki_connect_addon_install':
         return 'AnkiConnect installieren';
       case 'anki_connect_addon_install_hint':
@@ -169306,6 +169395,12 @@ extension on _StringsDe {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -176256,8 +176351,6 @@ extension on _StringsEs {
         return 'Buscar en todas las fuentes activas';
       case 'manga_global_search_prompt':
         return 'Escriba un título para buscar en todas las fuentes de manga activas a la vez.';
-      case 'manga_global_search_no_sources':
-        return 'Sin fuentes de manga activas. Instale y active una extensión primero.';
       case 'anki_connect_addon_install':
         return 'Instalar AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -177136,6 +177229,12 @@ extension on _StringsEs {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -184094,8 +184193,6 @@ extension on _StringsFr {
         return 'Rechercher dans chaque source activée';
       case 'manga_global_search_prompt':
         return 'Tapez un titre pour rechercher dans toutes les sources de manga activées à la fois.';
-      case 'manga_global_search_no_sources':
-        return 'Aucune source de manga activée. Installez et activez d\'abord une extension.';
       case 'anki_connect_addon_install':
         return 'Installer AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -184974,6 +185071,12 @@ extension on _StringsFr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -191909,8 +192012,6 @@ extension on _StringsId {
         return 'Cari setiap sumber yang aktif';
       case 'manga_global_search_prompt':
         return 'Ketik judul untuk mencari setiap sumber manga yang aktif sekaligus.';
-      case 'manga_global_search_no_sources':
-        return 'Tidak ada sumber manga yang aktif. Instal dan aktifkan ekstensi terlebih dahulu.';
       case 'anki_connect_addon_install':
         return 'Instal AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -192786,6 +192887,12 @@ extension on _StringsId {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -199739,8 +199846,6 @@ extension on _StringsIt {
         return 'Cerca in ogni fonte abilitata';
       case 'manga_global_search_prompt':
         return 'Digita un titolo per cercare in ogni fonte manga abilitata contemporaneamente.';
-      case 'manga_global_search_no_sources':
-        return 'Nessuna fonte manga abilitata. Installa e abilita prima un\'estensione.';
       case 'anki_connect_addon_install':
         return 'Installa AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -200618,6 +200723,12 @@ extension on _StringsIt {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -207510,8 +207621,6 @@ extension on _StringsJa {
         return 'すべてのソースを検索';
       case 'manga_global_search_prompt':
         return 'タイトルを入力して、すべての有効なマンガソースを一括検索します。';
-      case 'manga_global_search_no_sources':
-        return '有効なマンガソースがありません。まず拡張機能をインストールして有効にしてください。';
       case 'anki_connect_addon_install':
         return 'AnkiConnectをインストール';
       case 'anki_connect_addon_install_hint':
@@ -208386,6 +208495,12 @@ extension on _StringsJa {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -215280,8 +215395,6 @@ extension on _StringsKo {
         return '활성화된 모든 소스 검색';
       case 'manga_global_search_prompt':
         return '제목을 입력하면 활성화된 모든 만화 소스를 한 번에 검색합니다.';
-      case 'manga_global_search_no_sources':
-        return '활성화된 만화 소스가 없습니다. 먼저 확장을 설치하고 활성화하세요.';
       case 'anki_connect_addon_install':
         return 'AnkiConnect 설치';
       case 'anki_connect_addon_install_hint':
@@ -216156,6 +216269,12 @@ extension on _StringsKo {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -223102,8 +223221,6 @@ extension on _StringsNl {
         return 'Doorzoek elke ingeschakelde bron';
       case 'manga_global_search_prompt':
         return 'Typ een titel om elke ingeschakelde mangabron tegelijk te doorzoeken.';
-      case 'manga_global_search_no_sources':
-        return 'Geen ingeschakelde mangabronnen. Installeer en schakel eerst een extensie in.';
       case 'anki_connect_addon_install':
         return 'AnkiConnect installeren';
       case 'anki_connect_addon_install_hint':
@@ -223981,6 +224098,12 @@ extension on _StringsNl {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -230923,8 +231046,6 @@ extension on _StringsPtBr {
         return 'Buscar em todas as fontes ativadas';
       case 'manga_global_search_prompt':
         return 'Digite um título para buscar em todas as fontes de mangá ativadas de uma vez.';
-      case 'manga_global_search_no_sources':
-        return 'Nenhuma fonte de mangá ativada. Instale e ative uma extensão primeiro.';
       case 'anki_connect_addon_install':
         return 'Instalar AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -231802,6 +231923,12 @@ extension on _StringsPtBr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -238751,8 +238878,6 @@ extension on _StringsRu {
         return 'Поиск по всем включённым источникам';
       case 'manga_global_search_prompt':
         return 'Введите название для поиска по всем включённым источникам манги одновременно.';
-      case 'manga_global_search_no_sources':
-        return 'Нет включённых источников манги. Сначала установите и включите расширение.';
       case 'anki_connect_addon_install':
         return 'Установить AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -239630,6 +239755,12 @@ extension on _StringsRu {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -246555,8 +246686,6 @@ extension on _StringsTh {
         return 'ค้นหาทุกแหล่งที่เปิดใช้งาน';
       case 'manga_global_search_prompt':
         return 'พิมพ์ชื่อเรื่องเพื่อค้นหาทุกแหล่งมังงะที่เปิดใช้งานพร้อมกัน';
-      case 'manga_global_search_no_sources':
-        return 'ไม่มีแหล่งมังงะที่เปิดใช้งาน ติดตั้งและเปิดใช้งานส่วนขยายก่อน';
       case 'anki_connect_addon_install':
         return 'ติดตั้ง AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -247432,6 +247561,12 @@ extension on _StringsTh {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -254371,8 +254506,6 @@ extension on _StringsTr {
         return 'Etkin tüm kaynaklarda ara';
       case 'manga_global_search_prompt':
         return 'Etkin tüm manga kaynaklarında aynı anda aramak için bir başlık yazın.';
-      case 'manga_global_search_no_sources':
-        return 'Etkin manga kaynağı yok. Önce bir eklenti yükleyip etkinleştirin.';
       case 'anki_connect_addon_install':
         return 'AnkiConnect\'i yükle';
       case 'anki_connect_addon_install_hint':
@@ -255249,6 +255382,12 @@ extension on _StringsTr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -262182,8 +262321,6 @@ extension on _StringsVi {
         return 'Tìm kiếm mọi nguồn đã bật';
       case 'manga_global_search_prompt':
         return 'Nhập tựa đề để tìm kiếm tất cả nguồn truyện tranh đã bật cùng lúc.';
-      case 'manga_global_search_no_sources':
-        return 'Không có nguồn truyện tranh nào được bật. Cài đặt và bật một tiện ích mở rộng trước.';
       case 'anki_connect_addon_install':
         return 'Cài đặt AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -263060,6 +263197,12 @@ extension on _StringsVi {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }
@@ -269933,8 +270076,6 @@ extension on _StringsZhCn {
         return '搜索所有已启用来源';
       case 'manga_global_search_prompt':
         return '输入书名，一次搜索所有已启用的漫画来源。';
-      case 'manga_global_search_no_sources':
-        return '没有已启用的漫画来源，请先安装并启用扩展。';
       case 'anki_connect_addon_install':
         return '安装 AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -270809,6 +270950,12 @@ extension on _StringsZhCn {
         return '打开文件位置';
       case 'book_file_location_failed':
         return '无法打开这本书的文件位置。';
+      case 'manga_global_search_no_sources':
+        return '还没有已启用的漫画来源，去「导入」添加一个。';
+      case 'manga_global_search_open_sources':
+        return '去导入';
+      case 'settings_downloads_open_page_hint':
+        return '打开下载页（任务 / 资源 / 订阅）';
       default:
         return null;
     }
@@ -277683,8 +277830,6 @@ extension on _StringsZhHk {
         return '搜索所有已啟用來源';
       case 'manga_global_search_prompt':
         return '輸入書名，一次搜索所有已啟用的漫畫來源。';
-      case 'manga_global_search_no_sources':
-        return '沒有已啟用的漫畫來源，請先安裝並啟用擴展。';
       case 'anki_connect_addon_install':
         return '安裝 AnkiConnect';
       case 'anki_connect_addon_install_hint':
@@ -278559,6 +278704,12 @@ extension on _StringsZhHk {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'manga_global_search_no_sources':
+        return 'No enabled manga sources yet. Add one in the Import tab.';
+      case 'manga_global_search_open_sources':
+        return 'Go to Import';
+      case 'settings_downloads_open_page_hint':
+        return 'Open the Downloads page (tasks, resources, subscriptions)';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Search all sources",
   "manga_global_search_hint": "Search every enabled source",
   "manga_global_search_prompt": "Type a title to search every enabled manga source at once.",
-  "manga_global_search_no_sources": "No enabled manga sources. Install and enable an extension first.",
   "anki_connect_addon_install": "Install AnkiConnect",
   "anki_connect_addon_install_hint": "Downloads AnkiConnect from AnkiWeb and hands it to the running Anki. Anki will ask you to confirm, then advise a restart.",
   "anki_connect_addon_handed": "Handed AnkiConnect to Anki. Confirm the prompt in Anki, then restart Anki as it advises.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "بحث في جميع المصادر",
   "manga_global_search_hint": "بحث في كل مصدر مُفعّل",
   "manga_global_search_prompt": "اكتب عنواناً للبحث في جميع مصادر المانغا المُفعّلة دفعة واحدة.",
-  "manga_global_search_no_sources": "لا توجد مصادر مانغا مُفعّلة. ثبّت وفعّل إضافة أولاً.",
   "anki_connect_addon_install": "تثبيت AnkiConnect",
   "anki_connect_addon_install_hint": "يحمّل AnkiConnect من AnkiWeb ويسلّمه إلى Anki قيد التشغيل. سيطلب منك Anki التأكيد، ثم ينصح بإعادة التشغيل.",
   "anki_connect_addon_handed": "تم تسليم AnkiConnect إلى Anki. أكّد الطلب في Anki، ثم أعد تشغيل Anki كما ينصح.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Alle Quellen durchsuchen",
   "manga_global_search_hint": "Jede aktivierte Quelle durchsuchen",
   "manga_global_search_prompt": "Geben Sie einen Titel ein, um alle aktivierten Manga-Quellen gleichzeitig zu durchsuchen.",
-  "manga_global_search_no_sources": "Keine aktivierten Manga-Quellen. Installieren und aktivieren Sie zuerst eine Erweiterung.",
   "anki_connect_addon_install": "AnkiConnect installieren",
   "anki_connect_addon_install_hint": "Lädt AnkiConnect von AnkiWeb herunter und übergibt es dem laufenden Anki. Anki wird Sie zur Bestätigung auffordern und dann einen Neustart empfehlen.",
   "anki_connect_addon_handed": "AnkiConnect an Anki übergeben. Bestätigen Sie die Aufforderung in Anki und starten Sie Anki wie empfohlen neu.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Buscar en todas las fuentes",
   "manga_global_search_hint": "Buscar en todas las fuentes activas",
   "manga_global_search_prompt": "Escriba un título para buscar en todas las fuentes de manga activas a la vez.",
-  "manga_global_search_no_sources": "Sin fuentes de manga activas. Instale y active una extensión primero.",
   "anki_connect_addon_install": "Instalar AnkiConnect",
   "anki_connect_addon_install_hint": "Descarga AnkiConnect de AnkiWeb y lo entrega a Anki en ejecución. Anki le pedirá que confirme, luego aconsejará reiniciar.",
   "anki_connect_addon_handed": "AnkiConnect entregado a Anki. Confirme el diálogo en Anki, luego reinicie Anki como aconseja.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Rechercher dans toutes les sources",
   "manga_global_search_hint": "Rechercher dans chaque source activée",
   "manga_global_search_prompt": "Tapez un titre pour rechercher dans toutes les sources de manga activées à la fois.",
-  "manga_global_search_no_sources": "Aucune source de manga activée. Installez et activez d'abord une extension.",
   "anki_connect_addon_install": "Installer AnkiConnect",
   "anki_connect_addon_install_hint": "Télécharge AnkiConnect depuis AnkiWeb et le transmet à l'Anki en cours d'exécution. Anki vous demandera de confirmer, puis recommandera un redémarrage.",
   "anki_connect_addon_handed": "AnkiConnect transmis à Anki. Confirmez l'invite dans Anki, puis redémarrez Anki comme indiqué.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Cari semua sumber",
   "manga_global_search_hint": "Cari setiap sumber yang aktif",
   "manga_global_search_prompt": "Ketik judul untuk mencari setiap sumber manga yang aktif sekaligus.",
-  "manga_global_search_no_sources": "Tidak ada sumber manga yang aktif. Instal dan aktifkan ekstensi terlebih dahulu.",
   "anki_connect_addon_install": "Instal AnkiConnect",
   "anki_connect_addon_install_hint": "Mengunduh AnkiConnect dari AnkiWeb dan menyerahkannya ke Anki yang sedang berjalan. Anki akan meminta Anda untuk mengonfirmasi, lalu menyarankan restart.",
   "anki_connect_addon_handed": "AnkiConnect diserahkan ke Anki. Konfirmasi dialog di Anki, lalu restart Anki sesuai saran.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Cerca in tutte le fonti",
   "manga_global_search_hint": "Cerca in ogni fonte abilitata",
   "manga_global_search_prompt": "Digita un titolo per cercare in ogni fonte manga abilitata contemporaneamente.",
-  "manga_global_search_no_sources": "Nessuna fonte manga abilitata. Installa e abilita prima un'estensione.",
   "anki_connect_addon_install": "Installa AnkiConnect",
   "anki_connect_addon_install_hint": "Scarica AnkiConnect da AnkiWeb e lo passa ad Anki in esecuzione. Anki chiederà conferma, poi consiglierà un riavvio.",
   "anki_connect_addon_handed": "AnkiConnect passato ad Anki. Conferma il prompt in Anki, poi riavvia Anki come consigliato.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "グローバル検索",
   "manga_global_search_hint": "すべてのソースを検索",
   "manga_global_search_prompt": "タイトルを入力して、すべての有効なマンガソースを一括検索します。",
-  "manga_global_search_no_sources": "有効なマンガソースがありません。まず拡張機能をインストールして有効にしてください。",
   "anki_connect_addon_install": "AnkiConnectをインストール",
   "anki_connect_addon_install_hint": "AnkiWebからAnkiConnectをダウンロードし、実行中のAnkiに渡します。Ankiが確認を求め、再起動を促します。",
   "anki_connect_addon_handed": "AnkiConnectをAnkiに渡しました。Ankiのプロンプトを確認し、指示通りにAnkiを再起動してください。",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "모든 소스 검색",
   "manga_global_search_hint": "활성화된 모든 소스 검색",
   "manga_global_search_prompt": "제목을 입력하면 활성화된 모든 만화 소스를 한 번에 검색합니다.",
-  "manga_global_search_no_sources": "활성화된 만화 소스가 없습니다. 먼저 확장을 설치하고 활성화하세요.",
   "anki_connect_addon_install": "AnkiConnect 설치",
   "anki_connect_addon_install_hint": "AnkiWeb에서 AnkiConnect를 다운로드하여 실행 중인 Anki에 전달합니다. Anki에서 확인을 요청한 후 재시작을 안내합니다.",
   "anki_connect_addon_handed": "AnkiConnect를 Anki에 전달했습니다. Anki의 프롬프트를 확인한 후 안내에 따라 Anki를 재시작하세요.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Alle bronnen doorzoeken",
   "manga_global_search_hint": "Doorzoek elke ingeschakelde bron",
   "manga_global_search_prompt": "Typ een titel om elke ingeschakelde mangabron tegelijk te doorzoeken.",
-  "manga_global_search_no_sources": "Geen ingeschakelde mangabronnen. Installeer en schakel eerst een extensie in.",
   "anki_connect_addon_install": "AnkiConnect installeren",
   "anki_connect_addon_install_hint": "Downloadt AnkiConnect van AnkiWeb en overhandigt het aan de draaiende Anki. Anki zal je vragen om te bevestigen en dan een herstart adviseren.",
   "anki_connect_addon_handed": "AnkiConnect aan Anki overhandigd. Bevestig het verzoek in Anki en herstart Anki dan zoals geadviseerd.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Buscar em todas as fontes",
   "manga_global_search_hint": "Buscar em todas as fontes ativadas",
   "manga_global_search_prompt": "Digite um título para buscar em todas as fontes de mangá ativadas de uma vez.",
-  "manga_global_search_no_sources": "Nenhuma fonte de mangá ativada. Instale e ative uma extensão primeiro.",
   "anki_connect_addon_install": "Instalar AnkiConnect",
   "anki_connect_addon_install_hint": "Baixa o AnkiConnect do AnkiWeb e entrega ao Anki em execução. O Anki pedirá confirmação e recomendará reiniciar.",
   "anki_connect_addon_handed": "AnkiConnect entregue ao Anki. Confirme o prompt no Anki e reinicie conforme recomendado.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Поиск по всем источникам",
   "manga_global_search_hint": "Поиск по всем включённым источникам",
   "manga_global_search_prompt": "Введите название для поиска по всем включённым источникам манги одновременно.",
-  "manga_global_search_no_sources": "Нет включённых источников манги. Сначала установите и включите расширение.",
   "anki_connect_addon_install": "Установить AnkiConnect",
   "anki_connect_addon_install_hint": "Загружает AnkiConnect из AnkiWeb и передаёт в запущенный Anki. Anki попросит подтвердить, а затем предложит перезапуск.",
   "anki_connect_addon_handed": "AnkiConnect передан в Anki. Подтвердите запрос в Anki, затем перезапустите Anki.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "ค้นหาทุกแหล่ง",
   "manga_global_search_hint": "ค้นหาทุกแหล่งที่เปิดใช้งาน",
   "manga_global_search_prompt": "พิมพ์ชื่อเรื่องเพื่อค้นหาทุกแหล่งมังงะที่เปิดใช้งานพร้อมกัน",
-  "manga_global_search_no_sources": "ไม่มีแหล่งมังงะที่เปิดใช้งาน ติดตั้งและเปิดใช้งานส่วนขยายก่อน",
   "anki_connect_addon_install": "ติดตั้ง AnkiConnect",
   "anki_connect_addon_install_hint": "ดาวน์โหลด AnkiConnect จาก AnkiWeb และส่งให้ Anki ที่กำลังทำงาน Anki จะขอให้คุณยืนยัน จากนั้นแนะนำให้รีสตาร์ท",
   "anki_connect_addon_handed": "ส่ง AnkiConnect ให้ Anki แล้ว ยืนยันข้อความใน Anki แล้วรีสตาร์ท Anki ตามที่แนะนำ",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Tüm kaynaklarda ara",
   "manga_global_search_hint": "Etkin tüm kaynaklarda ara",
   "manga_global_search_prompt": "Etkin tüm manga kaynaklarında aynı anda aramak için bir başlık yazın.",
-  "manga_global_search_no_sources": "Etkin manga kaynağı yok. Önce bir eklenti yükleyip etkinleştirin.",
   "anki_connect_addon_install": "AnkiConnect'i yükle",
   "anki_connect_addon_install_hint": "AnkiConnect'i AnkiWeb'den indirir ve çalışan Anki'ye iletir. Anki onaylamanızı isteyecek, ardından yeniden başlatmanızı tavsiye edecektir.",
   "anki_connect_addon_handed": "AnkiConnect Anki'ye iletildi. Anki'deki istemi onaylayın, ardından Anki'yi tavsiye ettiği gibi yeniden başlatın.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "Tìm kiếm tất cả nguồn",
   "manga_global_search_hint": "Tìm kiếm mọi nguồn đã bật",
   "manga_global_search_prompt": "Nhập tựa đề để tìm kiếm tất cả nguồn truyện tranh đã bật cùng lúc.",
-  "manga_global_search_no_sources": "Không có nguồn truyện tranh nào được bật. Cài đặt và bật một tiện ích mở rộng trước.",
   "anki_connect_addon_install": "Cài đặt AnkiConnect",
   "anki_connect_addon_install_hint": "Tải AnkiConnect từ AnkiWeb và chuyển cho Anki đang chạy. Anki sẽ yêu cầu bạn xác nhận, sau đó khuyên khởi động lại.",
   "anki_connect_addon_handed": "Đã chuyển AnkiConnect cho Anki. Xác nhận lời nhắc trong Anki, rồi khởi động lại Anki theo hướng dẫn.",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "搜索全部来源",
   "manga_global_search_hint": "搜索所有已启用来源",
   "manga_global_search_prompt": "输入书名，一次搜索所有已启用的漫画来源。",
-  "manga_global_search_no_sources": "没有已启用的漫画来源，请先安装并启用扩展。",
   "anki_connect_addon_install": "安装 AnkiConnect",
   "anki_connect_addon_install_hint": "从 AnkiWeb 下载 AnkiConnect 并交给正在运行的 Anki。Anki 会弹窗请你确认，之后按它的提示重启。",
   "anki_connect_addon_handed": "已把 AnkiConnect 交给 Anki。请在 Anki 弹出的确认框中同意，然后按 Anki 的提示重启。",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏",
   "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。",
   "book_file_location_open": "打开文件位置",
-  "book_file_location_failed": "无法打开这本书的文件位置。"
+  "book_file_location_failed": "无法打开这本书的文件位置。",
+  "manga_global_search_no_sources": "还没有已启用的漫画来源，去「导入」添加一个。",
+  "manga_global_search_open_sources": "去导入",
+  "settings_downloads_open_page_hint": "打开下载页（任务 / 资源 / 订阅）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3368,7 +3368,6 @@
   "manga_global_search_title": "搜索全部來源",
   "manga_global_search_hint": "搜索所有已啟用來源",
   "manga_global_search_prompt": "輸入書名，一次搜索所有已啟用的漫畫來源。",
-  "manga_global_search_no_sources": "沒有已啟用的漫畫來源，請先安裝並啟用擴展。",
   "anki_connect_addon_install": "安裝 AnkiConnect",
   "anki_connect_addon_install_hint": "從 AnkiWeb 下載 AnkiConnect 並交給正在運行的 Anki。Anki 會彈窗請你確認，之後按它的提示重啟。",
   "anki_connect_addon_handed": "已把 AnkiConnect 交給 Anki。請在 Anki 彈出的確認框中同意，然後按 Anki 的提示重啟。",
@@ -3801,5 +3800,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "manga_global_search_no_sources": "No enabled manga sources yet. Add one in the Import tab.",
+  "manga_global_search_open_sources": "Go to Import",
+  "settings_downloads_open_page_hint": "Open the Downloads page (tasks, resources, subscriptions)"
 }

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_page.dart
@@ -22,6 +22,7 @@ import 'package:fushi/src/media/manga/online/mokuro_moe_catalog_view.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_source_row.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/discovery_header.dart';
+import 'package:fushi/src/pages/implementations/media_library_shell.dart';
 import 'package:fushi/utils.dart';
 
 /// 漫画库「发现」视图：**漫画唯一的发现入口**。
@@ -277,6 +278,11 @@ class _MangaDiscoveryPageState extends ConsumerState<MangaDiscoveryPage> {
       return;
     }
     final MangaSourceCatalog scope = catalog.filterById(selected);
+    // 一个源都没有时搜索页的空态要能把用户带去「导入」视图装来源：切视图走库页
+    // 壳的 [MediaLibraryShellScope]（本页在壳里、搜索页 pop 回来就是它）。不在壳
+    // 里（本页被独立 push）时拿到 null，搜索页只给文案不给按钮。
+    final MediaLibraryShellScope? shell =
+        MediaLibraryShellScope.maybeOf(context);
     Navigator.of(context).push(
       adaptivePageRoute<void>(
         context: context,
@@ -285,6 +291,9 @@ class _MangaDiscoveryPageState extends ConsumerState<MangaDiscoveryPage> {
           mihonSources: scope.mihonSources,
           aidokuPackages: scope.aidokuPackages,
           initialQuery: query,
+          onOpenSources: shell == null
+              ? null
+              : () => shell.select(MediaLibraryViewKind.sources),
         ),
       ),
     );
@@ -530,7 +539,12 @@ class _MangaDiscoveryPageState extends ConsumerState<MangaDiscoveryPage> {
 }
 
 /// 一条「来源热门」横滑行：首次挂载才加载（发现视图本身已惰性构建，行不会
-/// 因页面存在就打请求风暴）；加载中显示细进度条，空/失败整行收起。
+/// 因页面存在就打请求风暴）；空/失败整行收起。
+///
+/// 加载中渲染的是**带源名的行头 + 行内小转圈**，与全局搜索页每段的加载态同形。
+/// 此前是一条 2px 的裸 `LinearProgressIndicator`：启用二十几个源时页面就是二十
+/// 几条没有任何标签的横线，用户看不出那是什么、也看不出在等谁。行头有了名字，
+/// 加载完成时标题原位不动、卡片条在它下面长出来，没有布局跳动。
 class MangaDiscoverySourceRow extends StatefulWidget {
   const MangaDiscoverySourceRow({required this.feed, super.key});
 
@@ -568,13 +582,7 @@ class _MangaDiscoverySourceRowState extends State<MangaDiscoverySourceRow> {
   Widget build(BuildContext context) {
     if (_failed) return const SizedBox.shrink();
     final List<MangaDiscoverySourceItem>? items = _items;
-    if (items == null) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: LinearProgressIndicator(minHeight: 2),
-      );
-    }
-    if (items.isEmpty) return const SizedBox.shrink();
+    if (items != null && items.isEmpty) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Column(
@@ -582,24 +590,40 @@ class _MangaDiscoverySourceRowState extends State<MangaDiscoverySourceRow> {
         children: <Widget>[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Text(
-              t.manga_discovery_source_popular(source: widget.feed.name),
-              style: Theme.of(context).textTheme.titleMedium,
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    t.manga_discovery_source_popular(source: widget.feed.name),
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (items == null)
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+              ],
             ),
           ),
-          const SizedBox(height: 8),
-          SizedBox(
-            height: 214,
-            child: HorizontalDragScrollable(
-              child: ListView.builder(
-                scrollDirection: Axis.horizontal,
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                itemCount: items.length,
-                itemBuilder: (BuildContext context, int index) =>
-                    _buildCard(items[index]),
+          if (items != null) ...<Widget>[
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 214,
+              child: HorizontalDragScrollable(
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: items.length,
+                  itemBuilder: (BuildContext context, int index) =>
+                      _buildCard(items[index]),
+                ),
               ),
             ),
-          ),
+          ],
         ],
       ),
     );

--- a/fushi/lib/src/media/manga/manga_global_search_page.dart
+++ b/fushi/lib/src/media/manga/manga_global_search_page.dart
@@ -30,10 +30,16 @@ class MangaGlobalSearchPage extends StatefulWidget {
     super.key,
     this.aidokuRuntime,
     this.initialQuery,
+    this.onOpenSources,
   });
 
   /// Mihon 宿主。不支持的平台传 `null`（此时 [mihonSources] 必为空）。
   final MihonManager? mihonManager;
+
+  /// 一个源都没有时空态按钮的去处：本页先 pop 自己，再调它把用户带到漫画库的
+  /// 「导入」视图（来源都在那里装 / 启用）。为 null 时只显示文案不显示按钮——
+  /// 调用方不在库页壳里、没有「导入」视图可切。
+  final VoidCallback? onOpenSources;
 
   /// 已启用、且扩展也启用的 Mihon 在线源。
   final List<MangaOnlineSourceRow> mihonSources;
@@ -171,14 +177,39 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
     );
   }
 
+  /// 空态按钮：先把本页弹掉，再切库页壳到「导入」——顺序不能反，切视图发生在
+  /// 本页下面的壳里，本页留着用户什么都看不到。
+  void _openSources() {
+    final VoidCallback? onOpenSources = widget.onOpenSources;
+    if (onOpenSources == null) return;
+    Navigator.of(context).pop();
+    onOpenSources();
+  }
+
   Widget _buildBody() {
     if (_sources().isEmpty) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(
-            t.manga_global_search_no_sources,
-            textAlign: TextAlign.center,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                t.manga_global_search_no_sources,
+                textAlign: TextAlign.center,
+              ),
+              if (widget.onOpenSources != null) ...<Widget>[
+                const SizedBox(height: 16),
+                FilledButton.tonalIcon(
+                  key: const ValueKey<String>(
+                    'manga_global_search_open_sources',
+                  ),
+                  onPressed: _openSources,
+                  icon: const Icon(Icons.extension_outlined),
+                  label: Text(t.manga_global_search_open_sources),
+                ),
+              ],
+            ],
           ),
         ),
       );

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -18,6 +18,7 @@ import 'package:fushi_anki/fushi_anki.dart' show AnkiMediaDedupReport;
 import 'package:fushi/src/anki/anki_media_dedup_dialogs.dart';
 import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
+import 'package:fushi/src/pages/implementations/managed_video_source_prompt.dart';
 import 'package:fushi/src/sync/desktop_foreground_guard.dart';
 import 'package:fushi/src/anki/anki_media_dedup_runner.dart';
 import 'package:fushi/src/anki/anki_view_model.dart'
@@ -1413,6 +1414,22 @@ class _HomePageState extends BasePageState<HomePage>
         appModel: appModelNoUpdate,
       );
 
+  /// 受管视频来源清单；为空时**弹「添加视频来源」引导**，用户加完再读一次。
+  ///
+  /// 此前这一环被折叠成一条「暂无来源」snackbar：后端配得好好的，用户看到的却
+  /// 是一句既不说缺什么、也没处点的提示（下载页在 BUG-1706 已拆开，这里漏改）。
+  /// 返回空表 = 用户取消或加完仍为空，调用方直接返回。
+  Future<List<MediaSourceRow>> _managedVideoDownloadSourcesOrPrompt(
+    BuildContext context,
+  ) async {
+    final List<MediaSourceRow> sources =
+        await appModelNoUpdate.getManagedVideoDownloadSources();
+    if (sources.isNotEmpty || !context.mounted) return sources;
+    final bool added = await promptManagedVideoSourceSetup(context: context);
+    if (!added) return const <MediaSourceRow>[];
+    return appModelNoUpdate.getManagedVideoDownloadSources();
+  }
+
   Future<void> _openVideoDiscoveryResourceSearch(
     BuildContext context,
     VideoDiscoveryItem item,
@@ -1426,12 +1443,8 @@ class _HomePageState extends BasePageState<HomePage>
       return;
     }
     final List<MediaSourceRow> sources =
-        await appModelNoUpdate.getManagedVideoDownloadSources();
-    if (!context.mounted) return;
-    if (sources.isEmpty) {
-      _showVideoDiscoveryMessage(context, t.media_source_no_sources);
-      return;
-    }
+        await _managedVideoDownloadSourcesOrPrompt(context);
+    if (!context.mounted || sources.isEmpty) return;
     final VideoDownloadBackendIdentity identity;
     try {
       identity = await appModelNoUpdate.currentVideoDownloadBackendIdentity();
@@ -1498,12 +1511,8 @@ class _HomePageState extends BasePageState<HomePage>
       return;
     }
     final List<MediaSourceRow> sources =
-        await appModelNoUpdate.getManagedVideoDownloadSources();
-    if (!context.mounted) return;
-    if (sources.isEmpty) {
-      _showVideoDiscoveryMessage(context, t.media_source_no_sources);
-      return;
-    }
+        await _managedVideoDownloadSourcesOrPrompt(context);
+    if (!context.mounted || sources.isEmpty) return;
     final VideoDownloadBackendIdentity identity;
     try {
       identity = await appModelNoUpdate.currentVideoDownloadBackendIdentity();

--- a/fushi/lib/src/pages/implementations/managed_video_source_prompt.dart
+++ b/fushi/lib/src/pages/implementations/managed_video_source_prompt.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/pages/implementations/media_sources_dialog.dart';
+import 'package:fushi/utils.dart';
+
+/// 「后端没问题、只是还没有受管视频来源」的统一出口（发现页 / 详情页版）。
+///
+/// 与 `promptDownloadBackendSetup` 同一姿态：说清缺的是**下载完成后落地用的本地
+/// 视频文件夹**，并就地开来源管理对话框补上，而不是甩一句「暂无来源」snackbar
+/// 让用户自己猜缺什么、去哪补（下载页早已按 BUG-1706 把这一环拆开，首页发现路径
+/// 此前漏改）。
+///
+/// 返回 true = 用户走完了「添加视频来源」对话框；调用方据此重新读取来源清单并
+/// 重试原动作。用户取消 = 明确放弃，不再补提示。
+///
+/// [openSourcesDialog] 只给测试注入：默认开 [MediaSourcesDialog]（视频域），它要
+/// 真 AppModel。
+Future<bool> promptManagedVideoSourceSetup({
+  required BuildContext context,
+  Future<void> Function(BuildContext context) openSourcesDialog =
+      _openVideoSourcesDialog,
+}) async {
+  final bool? add = await showAppDialog<bool>(
+    context: context,
+    builder: (BuildContext ctx) => ManagedVideoSourcePromptDialog(
+      onCancel: () => Navigator.pop(ctx, false),
+      onAdd: () => Navigator.pop(ctx, true),
+    ),
+  );
+  if (add != true || !context.mounted) return false;
+  await openSourcesDialog(context);
+  return true;
+}
+
+Future<void> _openVideoSourcesDialog(BuildContext context) =>
+    showAppDialog<void>(
+      context: context,
+      builder: (BuildContext _) => const MediaSourcesDialog(mediaKind: 'video'),
+    );
+
+/// 「还没有受管视频来源」引导：一句说清缺什么 + 一个直接补上它的按钮。
+class ManagedVideoSourcePromptDialog extends StatelessWidget {
+  const ManagedVideoSourcePromptDialog({
+    required this.onCancel,
+    required this.onAdd,
+    super.key,
+  });
+
+  final VoidCallback onCancel;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    return FushiDialogFrame(
+      maxWidth: 380,
+      padding: EdgeInsets.all(tokens.spacing.card + 4),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            t.download_add_video_source,
+            style: textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.gap + 4),
+          Text(
+            t.download_no_managed_video_source,
+            style: textTheme.bodyMedium?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.card + tokens.spacing.gap),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              adaptiveDialogAction(
+                context: context,
+                onPressed: onCancel,
+                child: Text(t.dialog_cancel),
+              ),
+              SizedBox(width: tokens.spacing.gap),
+              KeyedSubtree(
+                key: const ValueKey<String>('managed_video_source_prompt_add'),
+                child: adaptiveDialogAction(
+                  context: context,
+                  isDefaultAction: true,
+                  onPressed: onAdd,
+                  child: Text(t.download_add_video_source),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/settings/settings_schema_downloads.dart
+++ b/fushi/lib/src/settings/settings_schema_downloads.dart
@@ -32,10 +32,13 @@ SettingsDestination buildDownloadsDestination() {
     sections: <SettingsSection>[
       SettingsSection(
         items: <SettingsItem>[
+          // 副标题说清它打开的是下载**页**（任务 / 资源 / 订阅）。此前写的是
+          // `download_settings`（「下载设置」），与本 destination 的 summary 同一个
+          // 词——用户看到的就是「下载设置里面还有一个下载设置」。
           SettingsNavigationItem(
             id: 'downloads.open_page',
             title: t.nav_downloads,
-            subtitle: t.download_settings,
+            subtitle: t.settings_downloads_open_page_hint,
             icon: Icons.download_outlined,
             showIcon: true,
             onTap: (SettingsContext settingsContext) async {

--- a/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
+++ b/fushi/test/media/manga/discovery/manga_discovery_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -153,6 +155,62 @@ void main() {
     await tester.tap(find.text('源里的热门作品'));
     await tester.pump();
     expect(opened, 1, reason: '点卡片走 feed 的 open 动作（生产适配为直进源详情页）');
+  });
+
+  // 加载中的来源行此前是一条 2px 裸进度条：二十几个源就是二十几条无标签横线。
+  // 现在加载中就渲染带源名的行头 + 行内小转圈，加载完卡片条在行头下面长出来。
+  testWidgets('来源热门行加载中显示带源名的行头，而不是一条裸横线', (WidgetTester tester) async {
+    final Completer<List<MangaDiscoverySourceItem>> pending =
+        Completer<List<MangaDiscoverySourceItem>>();
+    final _FakeProvider provider = _FakeProvider(<Object>[
+      const MangaDiscoverySnapshot(
+        feeds: <MangaDiscoveryFeed, List<MangaDiscoveryEntry>>{},
+      ),
+    ]);
+    await tester.pumpWidget(wrap(MangaDiscoveryPage(
+      provider: provider,
+      sourceFeedsOverride: <MangaDiscoverySourceFeed>[
+        MangaDiscoverySourceFeed(
+          id: 'slow',
+          name: '慢源',
+          language: 'ja',
+          loadPopular: () => pending.future,
+        ),
+      ],
+    )));
+    await tester.pump();
+    await tester.pump();
+
+    final Finder header =
+        find.text(t.manga_discovery_source_popular(source: '慢源'));
+    expect(header, findsOneWidget, reason: '加载中就要能看出在等哪个源');
+    expect(
+      find.descendant(
+        of: find.byType(MangaDiscoverySourceRow),
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+
+    pending.complete(<MangaDiscoverySourceItem>[
+      MangaDiscoverySourceItem(
+        title: '慢源的热门作品',
+        buildCover: (BuildContext context) =>
+            const ColoredBox(color: Color(0xFF808080)),
+        open: (BuildContext context) {},
+      ),
+    ]);
+    await tester.pumpAndSettle();
+    expect(header, findsOneWidget);
+    expect(find.text('慢源的热门作品'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(MangaDiscoverySourceRow),
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
   });
 
   // BUG-1710：合并前「发现」没有搜索框也没有来源筛选，来源清单在另一个同名

--- a/fushi/test/media/manga/manga_global_search_page_test.dart
+++ b/fushi/test/media/manga/manga_global_search_page_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
 
 import 'package:fushi/src/media/manga/aidoku/aidoku_package_store.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_runtime.dart';
 import 'package:fushi/src/media/manga/manga_global_search_page.dart';
 
 void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
   AidokuInstalledPackage package(String id, String name) =>
       AidokuInstalledPackage(
         id: id,
@@ -59,6 +62,77 @@ void main() {
     expect(
       find.textContaining('Cloudflare'),
       findsOneWidget,
+    );
+  });
+
+  // 空态此前只有一句「请先安装并启用扩展」：漫画库里根本没有叫「扩展」的 tab
+  // （来源都在「导入」视图装），而且没有任何可点的东西。现在文案指向「导入」，
+  // 并给一个按钮：先 pop 本页、再让调用方切壳视图（顺序不能反）。
+  testWidgets(
+      'no sources: empty state names the Import tab and its button pops then opens it',
+      (WidgetTester tester) async {
+    int opened = 0;
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: TextButton(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => MangaGlobalSearchPage(
+                      mihonManager: null,
+                      mihonSources: const <Never>[],
+                      aidokuPackages: const <AidokuInstalledPackage>[],
+                      onOpenSources: () => opened++,
+                    ),
+                  ),
+                ),
+                child: const Text('shell'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('shell'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_global_search_no_sources), findsOneWidget);
+    expect(
+      t.manga_global_search_no_sources,
+      contains(t.library_view_import),
+      reason: '空态文案必须点名用户真能找到的那个 tab（「导入」），不是「扩展」',
+    );
+    final Finder button =
+        find.byKey(const ValueKey<String>('manga_global_search_open_sources'));
+    expect(button, findsOneWidget);
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(opened, 1);
+    expect(find.byType(MangaGlobalSearchPage), findsNothing,
+        reason: '按钮先把搜索页弹掉，用户回到壳里才看得见切过去的「导入」视图');
+  });
+
+  testWidgets('no sources without a shell to switch: text only, no button',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: MangaGlobalSearchPage(
+            mihonManager: null,
+            mihonSources: const <Never>[],
+            aidokuPackages: const <AidokuInstalledPackage>[],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text(t.manga_global_search_no_sources), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('manga_global_search_open_sources')),
+      findsNothing,
     );
   });
 }

--- a/fushi/test/pages/managed_video_source_prompt_test.dart
+++ b/fushi/test/pages/managed_video_source_prompt_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+
+import 'package:fushi/src/pages/implementations/managed_video_source_prompt.dart';
+
+/// 视频发现 / 详情页「搜索资源」「订阅」在**后端已就绪、只是没有受管视频来源**时
+/// 的出口：此前是一条「暂无来源」snackbar（既不说缺什么，也没处点）；现在弹
+/// 引导说清缺的是落地用的本地视频文件夹，并就地开来源管理对话框补上。
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  Future<bool?> pump(
+    WidgetTester tester, {
+    required Future<void> Function(BuildContext context) openSourcesDialog,
+  }) async {
+    bool? result;
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: TextButton(
+                onPressed: () async {
+                  result = await promptManagedVideoSourceSetup(
+                    context: context,
+                    openSourcesDialog: openSourcesDialog,
+                  );
+                },
+                child: const Text('go'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    return result;
+  }
+
+  testWidgets('说清缺的是落地用的视频文件夹；「添加视频来源」开来源对话框并返回 true',
+      (WidgetTester tester) async {
+    int opened = 0;
+    await pump(tester, openSourcesDialog: (BuildContext _) async => opened++);
+
+    expect(find.text(t.download_no_managed_video_source), findsOneWidget);
+    expect(find.text('暂无来源'), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('managed_video_source_prompt_add')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(opened, 1, reason: '确认后就地开来源管理对话框，不把用户支去别处');
+    expect(find.text(t.download_no_managed_video_source), findsNothing);
+  });
+
+  testWidgets('取消 = 明确放弃：不开来源对话框、返回 false', (WidgetTester tester) async {
+    int opened = 0;
+    await pump(tester, openSourcesDialog: (BuildContext _) async => opened++);
+    await tester.tap(find.text(t.dialog_cancel));
+    await tester.pumpAndSettle();
+    expect(opened, 0);
+    expect(find.text(t.download_no_managed_video_source), findsNothing);
+  });
+}

--- a/fushi/test/settings/settings_downloads_open_page_subtitle_guard_test.dart
+++ b/fushi/test/settings/settings_downloads_open_page_subtitle_guard_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 「下载」设置分类里那条直达下载页的导航项，副标题此前写的是
+/// `download_settings`（「下载设置」）——与本分类的 summary 同一个词，用户看到的
+/// 就是「下载设置里面还有一个下载设置」。它打开的是下载**页**（任务 / 资源 /
+/// 订阅），副标题必须说这个。用源码断言（零 harness 依赖）。
+void main() {
+  test('downloads.open_page subtitle names the page, not "download settings"',
+      () {
+    final String src = File('lib/src/settings/settings_schema_downloads.dart')
+        .readAsStringSync()
+        .replaceAll('\r\n', '\n');
+    final int itemStart = src.indexOf("id: 'downloads.open_page'");
+    expect(itemStart, isNonNegative);
+    final int itemEnd = src.indexOf('onTap:', itemStart);
+    expect(itemEnd, greaterThan(itemStart));
+    final String item = src.substring(itemStart, itemEnd);
+    expect(item, contains('subtitle: t.settings_downloads_open_page_hint'));
+    expect(item, isNot(contains('t.download_settings')));
+  });
+}


### PR DESCRIPTION
## 用户报告（2026-08-25 四张截图/一句话）

| BUG | 现象 | 根因 | 修复 |
|---|---|---|---|
| BUG-1871 | 漫画「搜索全部来源」空态说「请先安装并启用扩展」，没按钮 | `manga_global_search_page.dart` 空态只有一段 Text；漫画库根本没有叫「扩展」的 tab（是「导入」） | 文案指向「导入」+「去导入」按钮：先 pop 本页再经 `MediaLibraryShellScope.select(sources)` 切壳视图 |
| BUG-1872 | 视频发现详情「搜索资源」只弹「暂无来源」snackbar | `home_page.dart` 两条流程把「后端就绪但缺受管视频来源」折叠成一句 snackbar（下载页 BUG-1706 已拆开，首页漏改） | 新 `promptManagedVideoSourceSetup`：说清缺的是落地用的本地视频文件夹 + 就地开 `MediaSourcesDialog(video)`，加完自动重试原动作 |
| BUG-1873 | 漫画发现页加载态是二十几条无标签横线 | 每个已启用源一条 2px 裸 `LinearProgressIndicator` | 带源名的行头 + 行内 16px 转圈（与全局搜索页同形），加载完卡片条在行头下长出、无布局跳动 |
| BUG-1874 | 「下载设置里面还有一个下载设置」 | `settings_schema_downloads.dart` 直达下载页的导航项 subtitle 用了 `download_settings`，与 destination summary 撞词 | 新 key `settings_downloads_open_page_hint`「打开下载页（任务 / 资源 / 订阅）」 |

## i18n
- `manga_global_search_no_sources` 重写（`--remove` + `--add`，其余 16 语回落英文待译）
- 新增 `manga_global_search_open_sources` / `settings_downloads_open_page_hint`
- `strings.g.dart` 用 `--language-version=3.6` 格式化，diff 只含目标 key

## 验证
- `flutter analyze --no-pub`（含 test）No issues
- 定向：4 个改动测试文件 + `video_discovery_acquisition_dialogs_test` + `settings_destination_order_guard_test` + `test/i18n` → 48 passed
- 目录枚举型守卫整批：`FLUTTER TEST VERDICT: PASSED - 252 tests ran`
- 三条新守卫变异实测各自变红后 sha1 原样还原
- 未做真机复测（本轮无真机；四处都是纯 widget 层改动，widget 测试覆盖原始失败路径）

https://claude.ai/code/session_01AAK1unvHax28Std4ghrYyu
