### PR TITLE
feat(video): 字幕轨外挂档案长按 / 右键「删除字幕文件」

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 64651 (3803 per locale)
+/// Strings: 64719 (3807 per locale)
 ///
-/// Built on 2026-08-25 at 07:05 UTC
+/// Built on 2026-08-25 at 15:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5174,6 +5174,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_file_location_open => 'Open file location';
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  String get video_subtitle_delete => 'Delete subtitle file';
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -13985,6 +13992,17 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -22999,6 +23017,17 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -32056,6 +32085,17 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -41142,6 +41182,17 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -50062,6 +50113,17 @@ class _StringsId extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -59054,6 +59116,17 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -67503,6 +67576,17 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -75968,6 +76052,17 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -84920,6 +85015,17 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -93928,6 +94034,17 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -102909,6 +103026,17 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -111713,6 +111841,17 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -120619,6 +120758,17 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -129507,6 +129657,17 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 // Path: <root>
@@ -137679,6 +137840,16 @@ class _StringsZhCn extends _StringsEn {
   String get book_file_location_open => '打开文件位置';
   @override
   String get book_file_location_failed => '无法打开这本书的文件位置。';
+  @override
+  String get video_subtitle_delete => '删除字幕文件';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      '确定从磁盘删除这个字幕文件？此操作不可撤销。\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) => '已删除字幕文件：${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      '删除字幕文件失败：${label}';
 }
 
 // Path: <root>
@@ -145869,6 +146040,17 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get video_subtitle_delete => 'Delete subtitle file';
+  @override
+  String video_subtitle_delete_confirm({required Object path}) =>
+      'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+  @override
+  String video_subtitle_deleted({required Object label}) =>
+      'Subtitle file deleted: ${label}';
+  @override
+  String video_subtitle_delete_failed({required Object label}) =>
+      'Failed to delete subtitle file: ${label}';
 }
 
 /// Flat map(s) containing all translations.
@@ -153670,6 +153852,16 @@ extension on _StringsEn {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -161468,6 +161660,16 @@ extension on _StringsAr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -169306,6 +169508,16 @@ extension on _StringsDe {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -177136,6 +177348,16 @@ extension on _StringsEs {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -184974,6 +185196,16 @@ extension on _StringsFr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -192786,6 +193018,16 @@ extension on _StringsId {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -200618,6 +200860,16 @@ extension on _StringsIt {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -208386,6 +208638,16 @@ extension on _StringsJa {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -216156,6 +216418,16 @@ extension on _StringsKo {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -223981,6 +224253,16 @@ extension on _StringsNl {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -231802,6 +232084,16 @@ extension on _StringsPtBr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -239630,6 +239922,16 @@ extension on _StringsRu {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -247432,6 +247734,16 @@ extension on _StringsTh {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -255249,6 +255561,16 @@ extension on _StringsTr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -263060,6 +263382,16 @@ extension on _StringsVi {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }
@@ -270809,6 +271141,14 @@ extension on _StringsZhCn {
         return '打开文件位置';
       case 'book_file_location_failed':
         return '无法打开这本书的文件位置。';
+      case 'video_subtitle_delete':
+        return '删除字幕文件';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) => '确定从磁盘删除这个字幕文件？此操作不可撤销。\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => '已删除字幕文件：${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) => '删除字幕文件失败：${label}';
       default:
         return null;
     }
@@ -278559,6 +278899,16 @@ extension on _StringsZhHk {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'video_subtitle_delete':
+        return 'Delete subtitle file';
+      case 'video_subtitle_delete_confirm':
+        return ({required Object path}) =>
+            'Delete this subtitle file from disk? This can\'t be undone.\n${path}';
+      case 'video_subtitle_deleted':
+        return ({required Object label}) => 'Subtitle file deleted: ${label}';
+      case 'video_subtitle_delete_failed':
+        return ({required Object label}) =>
+            'Failed to delete subtitle file: ${label}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏",
   "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。",
   "book_file_location_open": "打开文件位置",
-  "book_file_location_failed": "无法打开这本书的文件位置。"
+  "book_file_location_failed": "无法打开这本书的文件位置。",
+  "video_subtitle_delete": "删除字幕文件",
+  "video_subtitle_delete_confirm": "确定从磁盘删除这个字幕文件？此操作不可撤销。\\n$path",
+  "video_subtitle_deleted": "已删除字幕文件：$label",
+  "video_subtitle_delete_failed": "删除字幕文件失败：$label"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3801,5 +3801,9 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "video_subtitle_delete": "Delete subtitle file",
+  "video_subtitle_delete_confirm": "Delete this subtitle file from disk? This can't be undone.\\n$path",
+  "video_subtitle_deleted": "Subtitle file deleted: $label",
+  "video_subtitle_delete_failed": "Failed to delete subtitle file: $label"
 }

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -500,7 +500,9 @@ extension _VideoSubtitle on _VideoFushiPageState {
   /// 坐标，而 [showMenu] 的 [RelativeRect] 落在根 Navigator 的 Overlay 坐标系，界面
   /// 大小≠100% 时要经 `Overlay.globalToLocal` 换算才不偏移（BUG-781 同族）。
   /// 字幕抽取进行中（[_subtitleLoadingShown]）不弹：与行本身 `enabled: false` 一致，
-  /// 避免删掉正在抽取 / 解析的那个档案。
+  /// 避免删掉正在抽取 / 解析的那个档案。菜单是压在本页之上的覆盖层、会夺焦，按
+  /// docs/agent/focus-ownership.md 用 [PageFocusOwnership.guardOverlay] 包 `await`
+  /// 点，任何退出路径（选中 / 点外部 / Esc）都归还焦点。
   Future<void> _showSubtitleFileMenu(
     BuildContext context,
     VideoPlayerController controller,
@@ -513,80 +515,78 @@ extension _VideoSubtitle on _VideoFushiPageState {
     if (overlay is! RenderBox) return;
     final Offset anchor = overlay.globalToLocal(globalPosition);
     final ColorScheme scheme = Theme.of(context).colorScheme;
-    final bool? delete = await showMenu<bool>(
-      context: context,
-      position: RelativeRect.fromRect(
-        Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
-        Offset.zero & overlay.size,
-      ),
-      items: <PopupMenuEntry<bool>>[
-        PopupMenuItem<bool>(
-          value: true,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Icon(Icons.delete_outline, size: 20, color: scheme.error),
-              const SizedBox(width: 12),
-              Text(
-                t.video_subtitle_delete,
-                style: TextStyle(color: scheme.error),
-              ),
-            ],
-          ),
+    final bool? delete = await _focusOwnership.guardOverlay(
+      () => showMenu<bool>(
+        context: context,
+        position: RelativeRect.fromRect(
+          Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
+          Offset.zero & overlay.size,
         ),
-      ],
+        items: <PopupMenuEntry<bool>>[
+          FushiPopupMenuItem<bool>(
+            value: true,
+            label: t.video_subtitle_delete,
+            icon: Icons.delete_outline,
+            color: scheme.error,
+          ),
+        ],
+      ),
     );
     if (delete != true || !mounted) return;
     await _deleteSubtitleFile(controller, source);
   }
 
   /// 删除一个外挂字幕档案（[SubtitleSource.external]）：二次确认（显示完整路径）→
-  /// 删磁盘文件 → 若它正是当前主 / 副字幕则走**既有**关闭路径 → 从两份列表移除。
+  /// 删磁盘文件 → 若它正是当前主字幕则把选择清回「无偏好」、当前副字幕则走既有
+  /// 关闭路径 → 从两份列表移除。
   ///
-  /// 为什么必须先关字幕再删列表项：单视频模式下 [_selectSubtitleSource] 把解析出的
+  /// 为什么必须先清字幕再删列表项：单视频模式下 [_selectSubtitleSource] 把解析出的
   /// cue 与源指针一起落库（BUG-081），只删文件不清库，重开视频时 `loadCues` 仍命中
-  /// 旧 cue、把已删字幕原样显示回来；副字幕 / 远端同理各有自己的持久化指针。复用
-  /// [_selectSubtitleOff] / [_selectSecondarySubtitleOff]（远端 [_clearRemoteSubtitle]
-  /// / [_clearRemoteSecondarySubtitle]）而不另写一套清理，保证与用户手点「关闭」
-  /// 的落库形状完全一致。判「是否当前源」用 [sameExternalSubtitlePathForMenu]
-  /// （大小写 / 分隔符归一），与列表高亮同一判据。
+  /// 旧 cue、把已删字幕原样显示回来；副字幕 / 远端同理各有自己的持久化指针。
+  ///
+  /// 主字幕**不**复用 [_selectSubtitleOff] / [_clearRemoteSubtitle]：它们落的是
+  /// `off:` 显式关闭哨兵（TODO-818），下次起播会短路 sidecar 探测 / 内嵌轨自动抽取
+  /// / host 默认字幕。「删掉一个下错的字幕档」≠「我不要字幕」——用户删掉错误的
+  /// Jimaku 档后，下次重开理应像从没选过一样自动挑同目录 sidecar / 内嵌轨。故走
+  /// [_forgetDeletedSubtitleSelection] 清回 `null`（无偏好）。副字幕没有自动选择，
+  /// `null` 与 `off:` 恢复行为相同，直接复用 [_selectSecondarySubtitleOff] /
+  /// [_clearRemoteSecondarySubtitle]。判「是否当前源」用
+  /// [sameExternalSubtitlePathForMenu]（大小写 / 分隔符归一），与列表高亮同一判据。
   ///
   /// 列表项从 [_subtitleMenuSources]（枚举结果）与 [_importedSubtitleSources]
   /// （本会话登记）两份都移除：渲染走 [mergeImportedSubtitleSourcesForMenu] 合并，
   /// 只删一份另一份还会把它合回来。不重跑 ffmpeg 枚举——删的是本地档案，容器内封
   /// 轨的缓存仍然有效。
+  ///
+  /// 先删文件再清字幕不会自锁：外挂字幕只解析进内存 cue，libmpv 侧收到的是
+  /// `SubtitleTrack.no()`，app 自身不持有该文件句柄。
   Future<void> _deleteSubtitleFile(
     VideoPlayerController controller,
     SubtitleSource source,
   ) async {
     final String? path = source.externalPath;
     if (path == null) return;
-    final bool confirmed = await showAppDialog<bool>(
-          context: context,
-          builder: (BuildContext ctx) => AlertDialog(
-            title: Text(t.video_subtitle_delete),
-            content: Text(t.video_subtitle_delete_confirm(path: path)),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, false),
-                child: Text(t.dialog_cancel),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, true),
-                child: Text(t.dialog_delete),
-              ),
-            ],
-          ),
-        ) ??
-        false;
-    if (!mounted) return;
-    // 菜单 + 对话框都是模态、会夺焦；无论删不删，关闭后把焦点还给视频（BUG-131 同族）。
-    _focusOwnership.reclaimAfterFrame(FocusReclaimCause.overlayClosed);
-    if (!confirmed) return;
+    // 全 app 统一的「确认销毁」对话框（FushiDestructiveConfirmDialog）；pop null =
+    // 取消。对话框是覆盖层、会夺焦，guardOverlay 在任何退出路径归还焦点。
+    final FushiDestructiveConfirmResult? confirmed =
+        await _focusOwnership.guardOverlay(
+      () => showAppDialog<FushiDestructiveConfirmResult>(
+        context: context,
+        builder: (BuildContext _) => FushiDestructiveConfirmDialog(
+          title: t.video_subtitle_delete,
+          message: t.video_subtitle_delete_confirm(path: path),
+        ),
+      ),
+    );
+    if (confirmed == null || !mounted) return;
     try {
       final File file = File(path);
       if (await file.exists()) await file.delete();
-    } catch (_) {
+    } catch (e) {
+      // 占用 / 只读 / 权限各不相同，用户报「删除失败」时要能从日志判型。
+      debugPrint(
+        '[video-playback] delete external subtitle failed path=$path: $e',
+      );
       if (!mounted) return;
       _showOsd(
         t.video_subtitle_delete_failed(label: source.label),
@@ -597,9 +597,7 @@ extension _VideoSubtitle on _VideoFushiPageState {
     if (!mounted) return;
     final String? primary = _currentSubtitleSource;
     if (primary != null && sameExternalSubtitlePathForMenu(source, primary)) {
-      await (_isRemote
-          ? _clearRemoteSubtitle(controller)
-          : _selectSubtitleOff(controller));
+      await _forgetDeletedSubtitleSelection(controller);
     }
     if (!mounted) return;
     final String? secondary = _currentSecondarySubtitleSource;
@@ -618,6 +616,34 @@ extension _VideoSubtitle on _VideoFushiPageState {
           _importedSubtitleSources.where(notDeleted).toList();
     });
     _showOsd(t.video_subtitle_deleted(label: source.label));
+  }
+
+  /// 当前主字幕档案已被删除：清空 overlay cue，并把持久化指针清回 `null`（无偏好）。
+  ///
+  /// 与 [_selectSubtitleOff] / [_clearRemoteSubtitle] 的唯一差别是落 `null` 而非
+  /// `off:` 哨兵（TODO-818 三态：非空=具体源 / `off:`=显式关闭 / `null`=无偏好→
+  /// 下次起播自动选默认），也**不**置 [_remoteSubtitleUserDismissed]——用户没有表达
+  /// 「不要字幕」。落库形状与各自的关闭路径逐项对齐：单视频 cue + 指针原子写
+  /// （BUG-081）、播放列表只写指针、远端经 [AppModel.setRemoteSubtitleSource]。
+  Future<void> _forgetDeletedSubtitleSelection(
+    VideoPlayerController controller,
+  ) async {
+    controller.setCues(const <AudioCue>[]);
+    await controller.selectSubtitleTrack(SubtitleTrack.no());
+    if (_isRemote) {
+      final (String uid, int ep) = _remotePositionKeyForIndex(_currentEpisode);
+      unawaited(appModel.setRemoteSubtitleSource(uid, ep, null));
+    } else if (_episodes.isEmpty) {
+      await widget.repo.saveSubtitleSelection(
+        bookUid: widget.bookUid,
+        subtitleSource: null,
+        cues: const <AudioCue>[],
+      );
+    } else {
+      await widget.repo.updateSubtitleSource(widget.bookUid, null);
+    }
+    if (!mounted) return;
+    _rebuild(() => _currentSubtitleSource = null);
   }
 
   /// 弹「字幕源」菜单：枚举当前视频的全部字幕源（内嵌轨 + 同目录外挂文件）+

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -233,9 +233,46 @@ extension _VideoSubtitle on _VideoFushiPageState {
         for (final SubtitleSource source in _importedSubtitleSources)
           if (hostSub == null ||
               !sameExternalSubtitlePathForMenu(source, hostSub))
+            _withSubtitleFileMenu(
+              context,
+              controller,
+              source,
+              ListTile(
+                leading: const Icon(Icons.subtitles),
+                title: Text(source.label),
+                selected: subtitleSourceMatchesPersistedForMenu(
+                  source,
+                  _currentSubtitleSource,
+                ),
+                selectedColor: cs.primary,
+                enabled: !_subtitleLoadingShown,
+                onTap: _subtitleLoadingShown
+                    ? null
+                    : () => unawaited(
+                          _applyRemoteSubtitle(
+                            controller,
+                            source.externalPath!,
+                            label: source.label,
+                          ),
+                        ),
+              ),
+            ),
+      if (!_isRemote)
+        for (final SubtitleSource source in _menuSubtitleSources)
+          _withSubtitleFileMenu(
+            context,
+            controller,
+            source,
             ListTile(
-              leading: const Icon(Icons.subtitles),
+              leading: Icon(
+                source.isGraphicEmbedded
+                    ? Icons.image_outlined
+                    : (source.isEmbedded ? Icons.movie : Icons.subtitles),
+              ),
               title: Text(source.label),
+              subtitle: source.isGraphicEmbedded
+                  ? Text(t.video_subtitle_graphic_hint)
+                  : null,
               selected: subtitleSourceMatchesPersistedForMenu(
                 source,
                 _currentSubtitleSource,
@@ -244,35 +281,8 @@ extension _VideoSubtitle on _VideoFushiPageState {
               enabled: !_subtitleLoadingShown,
               onTap: _subtitleLoadingShown
                   ? null
-                  : () => unawaited(
-                        _applyRemoteSubtitle(
-                          controller,
-                          source.externalPath!,
-                          label: source.label,
-                        ),
-                      ),
+                  : () => unawaited(_selectSubtitleSource(controller, source)),
             ),
-      if (!_isRemote)
-        for (final SubtitleSource source in _menuSubtitleSources)
-          ListTile(
-            leading: Icon(
-              source.isGraphicEmbedded
-                  ? Icons.image_outlined
-                  : (source.isEmbedded ? Icons.movie : Icons.subtitles),
-            ),
-            title: Text(source.label),
-            subtitle: source.isGraphicEmbedded
-                ? Text(t.video_subtitle_graphic_hint)
-                : null,
-            selected: subtitleSourceMatchesPersistedForMenu(
-              source,
-              _currentSubtitleSource,
-            ),
-            selectedColor: cs.primary,
-            enabled: !_subtitleLoadingShown,
-            onTap: _subtitleLoadingShown
-                ? null
-                : () => unawaited(_selectSubtitleSource(controller, source)),
           ),
       // TODO-857 / TODO-1312 视频双字幕：副字幕入口。副字幕走 Flutter overlay 副层
       // cue 流（可逐字符查词）。TODO-2837：远端也支持（host sidecar / host 内嵌轨
@@ -388,24 +398,29 @@ extension _VideoSubtitle on _VideoFushiPageState {
         for (final SubtitleSource source in _importedSubtitleSources)
           if (hostSub == null ||
               !sameExternalSubtitlePathForMenu(source, hostSub))
-            ListTile(
-              leading: const Icon(Icons.subtitles),
-              title: Text(source.label),
-              selected: subtitleSourceMatchesPersistedForMenu(
-                source,
-                _currentSecondarySubtitleSource,
-              ),
-              selectedColor: cs.primary,
-              enabled: !_subtitleLoadingShown,
-              onTap: _subtitleLoadingShown
-                  ? null
-                  : () => unawaited(
-                        _applyRemoteSecondarySubtitle(
-                          controller,
-                          source.externalPath!,
-                          label: source.label,
+            _withSubtitleFileMenu(
+              context,
+              controller,
+              source,
+              ListTile(
+                leading: const Icon(Icons.subtitles),
+                title: Text(source.label),
+                selected: subtitleSourceMatchesPersistedForMenu(
+                  source,
+                  _currentSecondarySubtitleSource,
+                ),
+                selectedColor: cs.primary,
+                enabled: !_subtitleLoadingShown,
+                onTap: _subtitleLoadingShown
+                    ? null
+                    : () => unawaited(
+                          _applyRemoteSecondarySubtitle(
+                            controller,
+                            source.externalPath!,
+                            label: source.label,
+                          ),
                         ),
-                      ),
+              ),
             ),
       ];
     }
@@ -428,22 +443,181 @@ extension _VideoSubtitle on _VideoFushiPageState {
       // 下载的档案），外挂字幕文件也能选为副字幕。图标与主字幕轨行一致：图形轨
       // image / 内嵌 movie / 外挂 subtitles。
       for (final SubtitleSource source in _menuSubtitleSources)
-        ListTile(
-          leading: Icon(
-            source.isGraphicEmbedded
-                ? Icons.image_outlined
-                : (source.isEmbedded ? Icons.movie : Icons.subtitles),
+        _withSubtitleFileMenu(
+          context,
+          controller,
+          source,
+          ListTile(
+            leading: Icon(
+              source.isGraphicEmbedded
+                  ? Icons.image_outlined
+                  : (source.isEmbedded ? Icons.movie : Icons.subtitles),
+            ),
+            title: Text(source.label),
+            selected: source.matchesPersisted(_currentSecondarySubtitleSource),
+            selectedColor: cs.primary,
+            enabled: !_subtitleLoadingShown,
+            onTap: _subtitleLoadingShown
+                ? null
+                : () => unawaited(
+                      _selectSecondarySubtitleSource(controller, source),
+                    ),
           ),
-          title: Text(source.label),
-          selected: source.matchesPersisted(_currentSecondarySubtitleSource),
-          selectedColor: cs.primary,
-          enabled: !_subtitleLoadingShown,
-          onTap: _subtitleLoadingShown
-              ? null
-              : () =>
-                  unawaited(_selectSecondarySubtitleSource(controller, source)),
         ),
     ];
+  }
+
+  /// 外挂字幕行的长按 / 右键上下文菜单包装（主字幕轨行与副字幕轨行共用）。
+  ///
+  /// 只有磁盘上真有档案的外挂源（[SubtitleSource.external]：视频同目录 sidecar /
+  /// 导入副本 / Jimaku 下载）才挂手势；内嵌轨（`embedded:<n>`）没有任何可删除的
+  /// 东西，原样返回——「不给菜单」比「给一个禁用的删除项」少一个特殊状态。
+  /// 桌面右键 [GestureDetector.onSecondaryTapDown]、触屏长按
+  /// [GestureDetector.onLongPressStart] 都落到 [_showSubtitleFileMenu]；
+  /// [ListTile.onTap] 的单击选轨路径不动。
+  Widget _withSubtitleFileMenu(
+    BuildContext context,
+    VideoPlayerController controller,
+    SubtitleSource source,
+    Widget row,
+  ) {
+    if (source.isEmbedded) return row;
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onLongPressStart: (LongPressStartDetails d) => unawaited(
+        _showSubtitleFileMenu(context, controller, source, d.globalPosition),
+      ),
+      onSecondaryTapDown: (TapDownDetails d) => unawaited(
+        _showSubtitleFileMenu(context, controller, source, d.globalPosition),
+      ),
+      child: row,
+    );
+  }
+
+  /// 在 [globalPosition] 处弹外挂字幕档案的上下文菜单：目前只有「删除字幕文件」
+  /// 一项（[_deleteSubtitleFile]）。照仓库既有长按 / 右键菜单范式
+  /// （tag_management_page `_showTagMenu`）：[globalPosition] 是手势报的真实视口
+  /// 坐标，而 [showMenu] 的 [RelativeRect] 落在根 Navigator 的 Overlay 坐标系，界面
+  /// 大小≠100% 时要经 `Overlay.globalToLocal` 换算才不偏移（BUG-781 同族）。
+  /// 字幕抽取进行中（[_subtitleLoadingShown]）不弹：与行本身 `enabled: false` 一致，
+  /// 避免删掉正在抽取 / 解析的那个档案。
+  Future<void> _showSubtitleFileMenu(
+    BuildContext context,
+    VideoPlayerController controller,
+    SubtitleSource source,
+    Offset globalPosition,
+  ) async {
+    if (_subtitleLoadingShown) return;
+    final RenderObject? overlay =
+        Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) return;
+    final Offset anchor = overlay.globalToLocal(globalPosition);
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    final bool? delete = await showMenu<bool>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<bool>>[
+        PopupMenuItem<bool>(
+          value: true,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.delete_outline, size: 20, color: scheme.error),
+              const SizedBox(width: 12),
+              Text(
+                t.video_subtitle_delete,
+                style: TextStyle(color: scheme.error),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    if (delete != true || !mounted) return;
+    await _deleteSubtitleFile(controller, source);
+  }
+
+  /// 删除一个外挂字幕档案（[SubtitleSource.external]）：二次确认（显示完整路径）→
+  /// 删磁盘文件 → 若它正是当前主 / 副字幕则走**既有**关闭路径 → 从两份列表移除。
+  ///
+  /// 为什么必须先关字幕再删列表项：单视频模式下 [_selectSubtitleSource] 把解析出的
+  /// cue 与源指针一起落库（BUG-081），只删文件不清库，重开视频时 `loadCues` 仍命中
+  /// 旧 cue、把已删字幕原样显示回来；副字幕 / 远端同理各有自己的持久化指针。复用
+  /// [_selectSubtitleOff] / [_selectSecondarySubtitleOff]（远端 [_clearRemoteSubtitle]
+  /// / [_clearRemoteSecondarySubtitle]）而不另写一套清理，保证与用户手点「关闭」
+  /// 的落库形状完全一致。判「是否当前源」用 [sameExternalSubtitlePathForMenu]
+  /// （大小写 / 分隔符归一），与列表高亮同一判据。
+  ///
+  /// 列表项从 [_subtitleMenuSources]（枚举结果）与 [_importedSubtitleSources]
+  /// （本会话登记）两份都移除：渲染走 [mergeImportedSubtitleSourcesForMenu] 合并，
+  /// 只删一份另一份还会把它合回来。不重跑 ffmpeg 枚举——删的是本地档案，容器内封
+  /// 轨的缓存仍然有效。
+  Future<void> _deleteSubtitleFile(
+    VideoPlayerController controller,
+    SubtitleSource source,
+  ) async {
+    final String? path = source.externalPath;
+    if (path == null) return;
+    final bool confirmed = await showAppDialog<bool>(
+          context: context,
+          builder: (BuildContext ctx) => AlertDialog(
+            title: Text(t.video_subtitle_delete),
+            content: Text(t.video_subtitle_delete_confirm(path: path)),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: Text(t.dialog_cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: Text(t.dialog_delete),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!mounted) return;
+    // 菜单 + 对话框都是模态、会夺焦；无论删不删，关闭后把焦点还给视频（BUG-131 同族）。
+    _focusOwnership.reclaimAfterFrame(FocusReclaimCause.overlayClosed);
+    if (!confirmed) return;
+    try {
+      final File file = File(path);
+      if (await file.exists()) await file.delete();
+    } catch (_) {
+      if (!mounted) return;
+      _showOsd(
+        t.video_subtitle_delete_failed(label: source.label),
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    if (!mounted) return;
+    final String? primary = _currentSubtitleSource;
+    if (primary != null && sameExternalSubtitlePathForMenu(source, primary)) {
+      await (_isRemote
+          ? _clearRemoteSubtitle(controller)
+          : _selectSubtitleOff(controller));
+    }
+    if (!mounted) return;
+    final String? secondary = _currentSecondarySubtitleSource;
+    if (secondary != null &&
+        sameExternalSubtitlePathForMenu(source, secondary)) {
+      await (_isRemote
+          ? _clearRemoteSecondarySubtitle(controller)
+          : _selectSecondarySubtitleOff(controller));
+    }
+    if (!mounted) return;
+    bool notDeleted(SubtitleSource s) =>
+        !sameExternalSubtitlePathForMenu(s, path);
+    _rebuild(() {
+      _subtitleMenuSources = _subtitleMenuSources.where(notDeleted).toList();
+      _importedSubtitleSources =
+          _importedSubtitleSources.where(notDeleted).toList();
+    });
+    _showOsd(t.video_subtitle_deleted(label: source.label));
   }
 
   /// 弹「字幕源」菜单：枚举当前视频的全部字幕源（内嵌轨 + 同目录外挂文件）+

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -165,7 +165,9 @@ import 'package:fushi/src/utils/misc/show_app_dialog.dart';
 import 'package:fushi/src/utils/overlay_entry_lifecycle.dart';
 import 'package:fushi/src/utils/components/fading_chrome_gate.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+import 'package:fushi/src/utils/components/fushi_destructive_confirm_dialog.dart';
 import 'package:fushi/src/utils/components/fushi_icon_button.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
 
 part 'video_fushi/danmaku.part.dart';
 part 'video_fushi/clip_export.part.dart';

--- a/fushi/test/pages/video_subtitle_delete_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_delete_guard_test.dart
@@ -10,9 +10,12 @@ import 'video_fushi_page_source_corpus.dart';
 ///  - 四处外挂字幕行（主 / 副 × 本地 / 远端导入）都经 `_withSubtitleFileMenu` 包装；
 ///  - 包装只给外挂源挂手势，内嵌轨原样返回（没有可删的东西、不给菜单）；
 ///  - 长按与右键都落到同一个菜单；菜单坐标经 Overlay.globalToLocal 换算（BUG-781）；
-///  - 删除前二次确认并显示路径；删文件后先走**既有**关闭路径清掉当前主 / 副字幕
-///    的 cue 与持久化指针（否则 BUG-081 落库的 cue 会把已删字幕显示回来），再从
-///    枚举 / 登记两份列表都移除（渲染是两份合并，只删一份会合回来）。
+///  - 删除前经共享 FushiDestructiveConfirmDialog 二次确认并显示路径；菜单与对话框
+///    都经 guardOverlay 归还焦点；
+///  - 删文件后先清掉当前主 / 副字幕的 cue 与持久化指针（否则 BUG-081 落库的 cue 会
+///    把已删字幕显示回来）：主字幕清回 `null` 无偏好（不是 `off:` 显式关闭——删错档
+///    ≠ 不要字幕，下次起播仍要自动选 sidecar / 内嵌轨），副字幕复用既有关闭路径；
+///    再从枚举 / 登记两份列表都移除（渲染是两份合并，只删一份会合回来）。
 void main() {
   final String src = readVideoFushiSource();
 
@@ -70,7 +73,9 @@ void main() {
         reason: '长按与右键必须落到同一个菜单、传手势自己报的视口坐标');
   });
 
-  test('菜单：抽取进行中不弹；坐标经 Overlay.globalToLocal 换算；只有删除一项', () {
+  test(
+      '菜单：抽取进行中不弹；坐标经 Overlay.globalToLocal 换算；'
+      '唯一一项是共享 FushiPopupMenuItem；showMenu 经 guardOverlay 归还焦点', () {
     final String menu = region(
       'Future<void> _showSubtitleFileMenu(',
       'Future<void> _deleteSubtitleFile(',
@@ -83,21 +88,38 @@ void main() {
         reason: '菜单锚点要落在根 Navigator Overlay 坐标系');
     expect(menu.contains('overlay.globalToLocal(globalPosition)'), isTrue,
         reason: '界面大小≠100% 时视口坐标直接喂 showMenu 会偏移（BUG-781 同族）');
-    expect(menu.contains('t.video_subtitle_delete,'), isTrue);
+    expect(count(menu, 'FushiPopupMenuItem<bool>('), 1,
+        reason: '菜单只有「删除字幕文件」一项，且用仓库收口的 FushiPopupMenuItem，'
+            '不手搓 PopupMenuItem(Row(Icon, Text))');
+    // 带左边界：`FushiPopupMenuItem<bool>(` 本身含子串 `PopupMenuItem<bool>(`，
+    // 裸 contains 会假阳性红。
+    expect(
+        RegExp(r'(?<![A-Za-z])PopupMenuItem<bool>\(').hasMatch(menu), isFalse,
+        reason: '裸 PopupMenuItem 是 md3 收口前的旧形态');
+    expect(menu.contains('label: t.video_subtitle_delete,'), isTrue);
+    expect(
+        RegExp(r'_focusOwnership\.guardOverlay\(\s*\(\) => showMenu<bool>\(')
+            .hasMatch(menu),
+        isTrue,
+        reason: '菜单是覆盖层、会夺焦；按 docs/agent/focus-ownership.md 用 '
+            'guardOverlay 包 await 点，任何退出路径都归还焦点');
     expect(
         menu.contains('await _deleteSubtitleFile(controller, source);'), isTrue,
         reason: '选中删除项后必须进入带二次确认的删除路径');
   });
 
-  test('删除：先确认（带路径）再删文件，再关当前主 / 副字幕，最后从两份列表移除', () {
+  test(
+      '删除：先确认（共享销毁确认框、带路径）再删文件，再清当前主 / 副字幕，'
+      '最后从两份列表移除', () {
     final String del = region(
       'Future<void> _deleteSubtitleFile(',
-      '\n  /// 弹「字幕源」菜单',
+      'Future<void> _forgetDeletedSubtitleSelection(',
     );
     final int confirm =
         del.indexOf('t.video_subtitle_delete_confirm(path: path)');
     final int deleteFile = del.indexOf('await file.delete()');
-    final int offPrimary = del.indexOf('_selectSubtitleOff(controller)');
+    final int forgetPrimary =
+        del.indexOf('await _forgetDeletedSubtitleSelection(controller);');
     final int offSecondary =
         del.indexOf('_selectSecondarySubtitleOff(controller)');
     final int removeEnumerated = del.indexOf(
@@ -106,32 +128,64 @@ void main() {
         del.indexOf('_importedSubtitleSources.where(notDeleted)');
     expect(confirm, greaterThanOrEqualTo(0),
         reason: '删磁盘文件是不可逆操作，必须二次确认并把完整路径给用户看');
+    expect(del.contains('FushiDestructiveConfirmDialog('), isTrue,
+        reason: '确认框用全 app 统一的 FushiDestructiveConfirmDialog，'
+            '不再手搓裸 AlertDialog + TextButton');
+    expect(del.contains('AlertDialog('), isFalse);
+    expect(
+        RegExp(r'_focusOwnership\.guardOverlay\(\s*\(\) => showAppDialog<FushiDestructiveConfirmResult>\(')
+            .hasMatch(del),
+        isTrue,
+        reason: '对话框是覆盖层、会夺焦；guardOverlay 在任何退出路径归还焦点');
     expect(deleteFile, greaterThan(confirm), reason: '确认在删文件之前');
     // 光有对话框不够：结果必须真的门住删除（变异实测「去掉这行守卫仍绿」补的）。
-    final int gate = del.indexOf('if (!confirmed) return;');
+    final int gate = del.indexOf('if (confirmed == null || !mounted) return;');
     expect(gate, greaterThan(confirm), reason: '确认结果要在对话框返回之后判');
     expect(gate, lessThan(deleteFile), reason: '用户取消时不得走到 file.delete()');
-    expect(offPrimary, greaterThan(deleteFile),
-        reason: '删掉的是当前主字幕时要走既有关闭路径清 cue + 落哨兵（BUG-081：'
+    expect(del.contains("'[video-playback] delete external subtitle failed"),
+        isTrue,
+        reason: '删除失败要留日志，占用 / 只读 / 权限才能从日志判型');
+    expect(forgetPrimary, greaterThan(deleteFile),
+        reason: '删掉的是当前主字幕时要清 cue + 清持久化指针（BUG-081：'
             '单视频落库的 cue 不清，重开会把已删字幕显示回来）');
+    expect(del.contains('_selectSubtitleOff(controller)'), isFalse,
+        reason: '主字幕不能落 off: 显式关闭哨兵——「删了个下错的字幕」≠「我不要字幕」，'
+            'off: 会短路下次起播的 sidecar / 内嵌轨自动选择（TODO-818）');
+    expect(del.contains('_clearRemoteSubtitle(controller)'), isFalse,
+        reason: '远端同理，_clearRemoteSubtitle 也落 off: 并置 userDismissed');
     expect(offSecondary, greaterThan(deleteFile),
-        reason: '副字幕同理，走既有 _selectSecondarySubtitleOff');
-    expect(del.contains('_clearRemoteSubtitle(controller)'), isTrue,
-        reason: '远端模式主字幕的关闭路径是 _clearRemoteSubtitle');
+        reason: '副字幕没有自动选择，null 与 off: 恢复行为相同，'
+            '直接复用既有 _selectSecondarySubtitleOff');
     expect(del.contains('_clearRemoteSecondarySubtitle(controller)'), isTrue,
         reason: '远端模式副字幕的关闭路径是 _clearRemoteSecondarySubtitle');
     expect(removeEnumerated, greaterThan(offSecondary),
-        reason: '列表移除在关闭之后（关闭路径读的是当前源指针，不依赖列表）');
+        reason: '列表移除在清字幕之后（清理路径读的是当前源指针，不依赖列表）');
     expect(removeImported, greaterThan(removeEnumerated),
         reason: '渲染是 mergeImportedSubtitleSourcesForMenu 两份合并，'
             '只从枚举列表删、登记列表还会把它合回来');
     expect(del.contains('sameExternalSubtitlePathForMenu(source, primary)'),
         isTrue,
         reason: '判「是否当前源」用与列表高亮同一份路径归一判据');
+  });
+
+  test('清当前主字幕：落 null（无偏好）而非 off: 哨兵，三种落库形状齐全', () {
+    final String forget = region(
+      'Future<void> _forgetDeletedSubtitleSelection(',
+      '\n  /// 弹「字幕源」菜单',
+    );
+    expect(forget.contains('controller.setCues(const <AudioCue>[]);'), isTrue,
+        reason: '内存态 overlay cue 要清空');
+    expect(forget.contains('setRemoteSubtitleSource(uid, ep, null)'), isTrue,
+        reason: '远端：清回 null，下次起播恢复 host 默认字幕');
+    expect(forget.contains('_remoteSubtitleUserDismissed'), isFalse,
+        reason: '用户没有表达「不要字幕」，不得置 userDismissed');
+    expect(forget.contains('subtitleSource: null,'), isTrue,
+        reason: '单视频：cue + 指针原子写（BUG-081），指针为 null');
     expect(
-        del.contains(
-            '_focusOwnership.reclaimAfterFrame(FocusReclaimCause.overlayClosed)'),
-        isTrue,
-        reason: '菜单 + 对话框都是模态、会夺焦；关闭后要把焦点还给视频（BUG-131 同族）');
+        forget.contains('updateSubtitleSource(widget.bookUid, null)'), isTrue,
+        reason: '播放列表：只写指针，为 null');
+    expect(forget.contains('offSentinel'), isFalse,
+        reason: 'off: 会短路下次起播的自动选择（TODO-818）');
+    expect(forget.contains('_currentSubtitleSource = null'), isTrue);
   });
 }

--- a/fushi/test/pages/video_subtitle_delete_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_delete_guard_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'video_fushi_page_source_corpus.dart';
+
+/// 视频「字幕」分类里外挂字幕行的长按 / 右键「删除字幕文件」入口的源码守卫。
+///
+/// 行为住在 `_VideoFushiPageState` 的 part（`subtitle.part.dart`）里，字幕轨行由
+/// State 的十几个私有字段驱动，脱离整个视频页（media_kit 播放器）无法实例化，
+/// 所以按本仓惯例锁调用点不变量：
+///  - 四处外挂字幕行（主 / 副 × 本地 / 远端导入）都经 `_withSubtitleFileMenu` 包装；
+///  - 包装只给外挂源挂手势，内嵌轨原样返回（没有可删的东西、不给菜单）；
+///  - 长按与右键都落到同一个菜单；菜单坐标经 Overlay.globalToLocal 换算（BUG-781）；
+///  - 删除前二次确认并显示路径；删文件后先走**既有**关闭路径清掉当前主 / 副字幕
+///    的 cue 与持久化指针（否则 BUG-081 落库的 cue 会把已删字幕显示回来），再从
+///    枚举 / 登记两份列表都移除（渲染是两份合并，只删一份会合回来）。
+void main() {
+  final String src = readVideoFushiSource();
+
+  String region(String startSig, String endSig) {
+    final int start = src.indexOf(startSig);
+    expect(start, greaterThanOrEqualTo(0), reason: 'missing $startSig');
+    final int end = src.indexOf(endSig, start + startSig.length);
+    expect(end, greaterThan(start), reason: 'missing $endSig after $startSig');
+    return src.substring(start, end);
+  }
+
+  int count(String haystack, String needle) =>
+      needle.allMatches(haystack).length;
+
+  test('主字幕轨行：本地列表 + 远端导入档案两处外挂行都挂上下文菜单', () {
+    final String rows = region(
+      'Widget _buildSubtitleTrackRows(',
+      'List<Widget> _buildSecondarySubtitleRows(',
+    );
+    expect(count(rows, '_withSubtitleFileMenu('), 2,
+        reason: '主字幕轨里有两处会出现外挂档案的行：远端 `_importedSubtitleSources` '
+            '与本地 `_menuSubtitleSources`，两处都要能长按 / 右键删除');
+    // 两处各自的行体紧跟在包装之后（包装的是那一行，不是别的 widget）。
+    expect(
+        RegExp(r'_withSubtitleFileMenu\(\s*context,\s*controller,\s*source,\s*ListTile\(')
+            .allMatches(rows)
+            .length,
+        2,
+        reason: '包装对象必须是该源自己的 ListTile 行');
+  });
+
+  test('副字幕轨行：远端导入档案 + 本地列表两处外挂行都挂上下文菜单', () {
+    final String rows = region(
+      'List<Widget> _buildSecondarySubtitleRows(',
+      'Widget _withSubtitleFileMenu(',
+    );
+    expect(count(rows, '_withSubtitleFileMenu('), 2,
+        reason: '副字幕轨与主字幕轨同一份可用列表（BUG-900 / BUG-1861），'
+            '删除入口要对称');
+  });
+
+  test('包装器：只给外挂源挂手势，内嵌轨原样返回；长按与右键落同一菜单', () {
+    final String wrap = region(
+      'Widget _withSubtitleFileMenu(',
+      'Future<void> _showSubtitleFileMenu(',
+    );
+    expect(wrap.contains('if (source.isEmbedded) return row;'), isTrue,
+        reason: '内嵌轨没有磁盘档案可删，不该出现「删除字幕文件」菜单');
+    expect(wrap.contains('onLongPressStart:'), isTrue, reason: '触屏靠长按');
+    expect(wrap.contains('onSecondaryTapDown:'), isTrue, reason: '桌面靠右键');
+    expect(
+        count(wrap,
+            '_showSubtitleFileMenu(context, controller, source, d.globalPosition)'),
+        2,
+        reason: '长按与右键必须落到同一个菜单、传手势自己报的视口坐标');
+  });
+
+  test('菜单：抽取进行中不弹；坐标经 Overlay.globalToLocal 换算；只有删除一项', () {
+    final String menu = region(
+      'Future<void> _showSubtitleFileMenu(',
+      'Future<void> _deleteSubtitleFile(',
+    );
+    expect(menu.contains('if (_subtitleLoadingShown) return;'), isTrue,
+        reason: '行本身在抽取期间是 enabled: false，菜单要一致，'
+            '否则能删掉正在抽取 / 解析的那个档案');
+    expect(
+        menu.contains('Overlay.of(context).context.findRenderObject()'), isTrue,
+        reason: '菜单锚点要落在根 Navigator Overlay 坐标系');
+    expect(menu.contains('overlay.globalToLocal(globalPosition)'), isTrue,
+        reason: '界面大小≠100% 时视口坐标直接喂 showMenu 会偏移（BUG-781 同族）');
+    expect(menu.contains('t.video_subtitle_delete,'), isTrue);
+    expect(
+        menu.contains('await _deleteSubtitleFile(controller, source);'), isTrue,
+        reason: '选中删除项后必须进入带二次确认的删除路径');
+  });
+
+  test('删除：先确认（带路径）再删文件，再关当前主 / 副字幕，最后从两份列表移除', () {
+    final String del = region(
+      'Future<void> _deleteSubtitleFile(',
+      '\n  /// 弹「字幕源」菜单',
+    );
+    final int confirm =
+        del.indexOf('t.video_subtitle_delete_confirm(path: path)');
+    final int deleteFile = del.indexOf('await file.delete()');
+    final int offPrimary = del.indexOf('_selectSubtitleOff(controller)');
+    final int offSecondary =
+        del.indexOf('_selectSecondarySubtitleOff(controller)');
+    final int removeEnumerated = del.indexOf(
+        '_subtitleMenuSources = _subtitleMenuSources.where(notDeleted)');
+    final int removeImported =
+        del.indexOf('_importedSubtitleSources.where(notDeleted)');
+    expect(confirm, greaterThanOrEqualTo(0),
+        reason: '删磁盘文件是不可逆操作，必须二次确认并把完整路径给用户看');
+    expect(deleteFile, greaterThan(confirm), reason: '确认在删文件之前');
+    // 光有对话框不够：结果必须真的门住删除（变异实测「去掉这行守卫仍绿」补的）。
+    final int gate = del.indexOf('if (!confirmed) return;');
+    expect(gate, greaterThan(confirm), reason: '确认结果要在对话框返回之后判');
+    expect(gate, lessThan(deleteFile), reason: '用户取消时不得走到 file.delete()');
+    expect(offPrimary, greaterThan(deleteFile),
+        reason: '删掉的是当前主字幕时要走既有关闭路径清 cue + 落哨兵（BUG-081：'
+            '单视频落库的 cue 不清，重开会把已删字幕显示回来）');
+    expect(offSecondary, greaterThan(deleteFile),
+        reason: '副字幕同理，走既有 _selectSecondarySubtitleOff');
+    expect(del.contains('_clearRemoteSubtitle(controller)'), isTrue,
+        reason: '远端模式主字幕的关闭路径是 _clearRemoteSubtitle');
+    expect(del.contains('_clearRemoteSecondarySubtitle(controller)'), isTrue,
+        reason: '远端模式副字幕的关闭路径是 _clearRemoteSecondarySubtitle');
+    expect(removeEnumerated, greaterThan(offSecondary),
+        reason: '列表移除在关闭之后（关闭路径读的是当前源指针，不依赖列表）');
+    expect(removeImported, greaterThan(removeEnumerated),
+        reason: '渲染是 mergeImportedSubtitleSourcesForMenu 两份合并，'
+            '只从枚举列表删、登记列表还会把它合回来');
+    expect(del.contains('sameExternalSubtitlePathForMenu(source, primary)'),
+        isTrue,
+        reason: '判「是否当前源」用与列表高亮同一份路径归一判据');
+    expect(
+        del.contains(
+            '_focusOwnership.reclaimAfterFrame(FocusReclaimCause.overlayClosed)'),
+        isTrue,
+        reason: '菜单 + 对话框都是模态、会夺焦；关闭后要把焦点还给视频（BUG-131 同族）');
+  });
+}


### PR DESCRIPTION
## 改了什么

视频页「字幕」分类里的外挂字幕行（视频同目录 sidecar / 导入副本 / Jimaku 下载）此前只能加不能删。现在：

- 主字幕轨行 + 副字幕展开区（本地列表 + 远端导入两处，共四处）的**外挂**行包一层 `GestureDetector`：触屏**长按** / 桌面**右键** → 弹「删除字幕文件」菜单。
- 选删除 → 带完整路径的二次确认 → 删磁盘文件 → 若它正是当前主 / 副字幕，复用既有 `_selectSubtitleOff` / `_selectSecondarySubtitleOff`（远端 `_clearRemote*`）清 cue + 落哨兵（BUG-081：单视频落库的 cue 不清会把已删字幕显示回来）→ 从枚举 / 登记两份列表都移除（渲染是 `mergeImportedSubtitleSourcesForMenu` 两份合并，只删一份会合回来）。
- 内嵌轨（`embedded:<n>`）没有可删的东西，**不给菜单**（比「给一个禁用项」少一个状态）。
- 菜单坐标经 `Overlay.globalToLocal` 换算（BUG-781 同族）；菜单 / 对话框关闭后 `reclaimAfterFrame(overlayClosed)` 归还焦点（BUG-131 同族）；字幕抽取进行中不弹菜单（与行 `enabled: false` 一致）。

## i18n

`i18n_sync --add` 新增 4 个 key（17 语言）：`video_subtitle_delete` / `video_subtitle_delete_confirm` / `video_subtitle_deleted` / `video_subtitle_delete_failed`。`strings.g.dart` 走 slang 裸输出 → `dart format --language-version=3.6`，纯插入。

## 验证

- `flutter analyze`：0 issues。
- 新守卫 `test/pages/video_subtitle_delete_guard_test.dart`（5 条）+ 相邻 `video_subtitle_fixes_guard` / `video_remote_subtitle_menu_guard` / 语料契约 / md3 / `test/i18n`：112 条全绿。
- 守卫变异实测 6/6 抓住（内嵌也挂菜单 / 登记列表不删 / 枚举列表不删 / 右键脱钩 / 跳过确认 / 不归还焦点），其中「跳过确认」首轮漏了、补了 `if (!confirmed) return;` 位置断言后抓住。
- 缺口：未在真机 / 离屏 Windows app 上手点右键菜单（本轮无真机驱动），行为由源码守卫锁定。

https://claude.ai/code/session_01WcLhAa9Nz3BRYAUd1LxBBr
