### PR TITLE
fix(popup): 查词弹窗底色回到主题 scheme.surface，撤掉抄过头的纯白/纯黑 (BUG-1878)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1745 条。点号进各自文件。
+> 共 1746 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1878](bugs/BUG-1878-lookup-popup-surface-forced-pure-white-black.md) | ✅ | ✅ | 查词弹窗底色被钉成纯白/纯黑，不跟随 MD3 主题 |
 | [BUG-1867](bugs/BUG-1867-cover-backfill-hollow-m2ts.md) | ✅ | ✅ | 封面回填把 best-effort 失败刷进用户错误日志，且对未落盘文件仍走 ffmpeg |
 | [BUG-1866](bugs/BUG-1866-resolve-public-indexer-needs-network.md) | ✅ | ✅ | 公共索引器重解析非要联网重搜，搜不中就把活资源误报 notFound |
 | [BUG-1865](bugs/BUG-1865-organizer-numbered-extras.md) | ✅ | ✅ | 剧集整理把带编号的特典当正片，与真正片撞号整批失败 |

--- a/docs/bugs/BUG-1878-lookup-popup-surface-forced-pure-white-black.md
+++ b/docs/bugs/BUG-1878-lookup-popup-surface-forced-pure-white-black.md
@@ -1,0 +1,25 @@
+## BUG-1878 · 查词弹窗底色被钉成纯白/纯黑，不跟随 MD3 主题
+- **报告**：2026-08-26（用户：查词弹窗的背景颜色不对，之前抄的时候抄过头了）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/popup_theme_css.dart:38` 的
+  `popupCardSurface()` —— 2026-08-23 的「弹窗窗体观感对齐 Niratan」提交
+  `9ba9baea20` 把弹窗卡面从 `overrideDictionaryColor ?? scheme.surface`
+  改成了硬编码纯白 `0xFFFFFFFF` / 纯黑 `0xFF000000`（照抄 Niratan
+  `DictionaryPopupMaterial.GetOpaqueSurfaceColor`）。那是 Niratan 自己的色彩
+  体系；Fushi 全应用走 MD3 种子色，实测种子 `#386A58` 的深色 `scheme.surface`
+  是 `rgb(15, 21, 18)`，弹窗改纯黑后与它贴着的阅读器 / 视频页 / 设置页底色
+  割裂。同提交的其余观感项（伴随投影窗、系统灰描边、悬停浮现滚动条）与底色
+  无关，保留不动 —— 抄过头的只有这一条。
+  影响四个注入点（都经该 helper）：`app_model.dart:2938`（浏览器扩展 theme
+  下发）、`popup_settings_injection.dart:88`、`dictionary_popup_webview.dart:997`
+  （主题变量重注）与 `:1418`（热槽初始 HTML）。
+- **[x] ① 已修复** — `popupCardSurface` 回到 `override ?? scheme.surface`，
+  用户手动指定的词典底色优先级不变；四个调用点的过时注释同步改正。单一真源
+  helper 保留（BUG-688/736 的手抄漂移教训），只改取值。
+- **[x] ② 已加自动化测试** — `fushi/test/dictionary/popup_card_surface_follows_theme_test.dart`：
+  真行为测试（直接调 helper + `buildPopupThemeCssVars`），不是源码扫描。含一条
+  前置断言钉住「种子主题的 surface 确实是 tinted」，防止 fromSeed 恰好给纯白
+  时整个文件假绿。**变异实测**：把纯白/纯黑写回 helper → 3 条测试红
+  （`rgb(0, 0, 0)` vs 期望 `rgb(15, 21, 18)`）；还原后 sha256 与变异前一致。
+- **备注**：popup.css 里 `html[data-theme]` 块的 `--background-color: #fff/#000`
+  是**宿主不注入时的兜底**（只有 Android 原生弹窗走到），在这次「抄 Niratan」
+  之前就存在，不属于本 bug，未改动。

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2932,8 +2932,8 @@ class AppModel with ChangeNotifier {
   Map<String, String> browserExtensionThemeColors() {
     final ColorScheme s = themeNotifier.buildColorScheme(
         themeNotifier.isDarkMode ? Brightness.dark : Brightness.light);
-    // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑（popupCardSurface），
-    // 不再用 tinted scheme.surface；override 优先级不变。
+    // 卡面底色跟随主题 scheme.surface（popupCardSurface 单一真源），
+    // override 优先级不变。
     final Color bgColor =
         popupCardSurface(scheme: s, override: _overrideDictionaryColor);
     // BUG-736：核心色/圆角/列数变量的取值统一来自 buildPopupThemeCssVars——与 in-app

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -993,7 +993,7 @@ JSON.stringify((function(){
     // popup CSS 在属性缺席时回退 1（经典单列不受影响）。
     final Map<String, String> vars = buildPopupThemeCssVars(
       scheme: scheme,
-      // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑，override 优先级不变。
+      // 卡面底色跟随主题 scheme.surface，override 优先级不变。
       backgroundColor: popupCardSurface(
           scheme: scheme, override: appModel.overrideDictionaryColor),
       surfaceContainerHigh: scheme.surfaceContainerHigh,
@@ -1413,8 +1413,8 @@ JSON.stringify((function(){
     );
     final t = Translations.of(context);
     final appModel = ref.read(appProvider);
-    // Niratan 对齐（2026-08-23）：初始 HTML 底色与主题注入器同源纯白/纯黑，
-    // 避免「先 tinted 后纯色」的一帧闪变。
+    // 初始 HTML 底色与主题注入器同源（popupCardSurface），
+    // 避免两路底色不一致造成的一帧闪变。
     final Color bgColor = popupCardSurface(
         scheme: Theme.of(context).colorScheme,
         override: appModel.overrideDictionaryColor);

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -84,7 +84,7 @@ String _themeVariablesJs({
   final ColorScheme scheme = theme.colorScheme;
   final Map<String, String> vars = buildPopupThemeCssVars(
     scheme: scheme,
-    // Niratan 对齐（2026-08-23）：默认卡面纯白/纯黑，override 优先级不变。
+    // 卡面底色跟随主题 scheme.surface，override 优先级不变。
     backgroundColor: popupCardSurface(
       scheme: scheme,
       override: appModel.overrideDictionaryColor,

--- a/fushi/lib/src/utils/popup_theme_css.dart
+++ b/fushi/lib/src/utils/popup_theme_css.dart
@@ -28,18 +28,20 @@ String cssRgbTriplet(Color c) => '${(c.r * 255.0).round().clamp(0, 255)}, '
 /// [c] 的 `rgba(r, g, b, 0.35)` 串——查到词高亮色（primary @0.35 alpha）的固定配方。
 String cssRgba035(Color c) => 'rgba(${cssRgbTriplet(c)}, 0.35)';
 
-/// Niratan 对齐（2026-08-23）：弹窗卡面默认**纯白/纯黑**，不再用 MD3 tinted
-/// `scheme.surface`。Niratan 的弹窗表面就是 #FFF/#000
-/// （DictionaryPopupMaterial.GetOpaqueSurfaceColor），MD3 种子色染出的
-/// surface（浅色偏米/偏绿、深色偏灰）正是「我们的弹窗观感发闷」的来源之一。
+/// 弹窗卡面色：跟随当前主题的 MD3 `scheme.surface`。
+///
+/// 2026-08-23 的「对齐 Niratan」曾把这里钉成纯白 #FFF / 纯黑 #000
+/// （Niratan DictionaryPopupMaterial.GetOpaqueSurfaceColor 的取值），但那是
+/// Niratan 自己的色彩体系；Fushi 全应用走 MD3 种子色，弹窗突然变纯
+/// 白/纯黑会与它贴着的阅读器、视频页、设置页底色割裂（用户反馈：
+/// 背景色不对，抜的时候抜过头了）。因此只保留那批改动里的窗体观感
+/// （伴随投影窗 / 系统灰描边 / 悬停浮现滚动条），底色回到主题真值。
+///
 /// 用户手动指定的词典底色 [override]（overrideDictionaryColor）优先级不变；
 /// 四个消费方（AppModel 扩展 theme map、两个 in-app 注入器、热槽 WebView
 /// 初始 HTML）统一走本 helper，防再漂移（BUG-688/736 同型教训）。
 Color popupCardSurface({required ColorScheme scheme, Color? override}) =>
-    override ??
-    (scheme.brightness == Brightness.dark
-        ? const Color(0xFF000000)
-        : const Color(0xFFFFFFFF));
+    override ?? scheme.surface;
 
 /// 三个弹窗表面共用的核心主题变量（变量名 → CSS 值，保序）。
 ///

--- a/fushi/test/dictionary/popup_card_surface_follows_theme_test.dart
+++ b/fushi/test/dictionary/popup_card_surface_follows_theme_test.dart
@@ -1,0 +1,55 @@
+// BUG-1878：查词弹窗底色必须跟随当前主题的 MD3 `scheme.surface`。
+//
+// 2026-08-23 的「对齐 Niratan」把 popupCardSurface 钉成了纯白 #FFFFFF /
+// 纯黑 #000000（Niratan 自己的色彩体系），于是弹窗与它贴着的阅读器、视频页、
+// 设置页底色割裂——用户反馈「背景颜色不对，之前抄的时候抄过头了」。
+//
+// 这是真行为测试（直接调 helper），不是源码扫描：纯白/纯黑一旦被写回来，
+// tinted seed 主题下的断言立刻红。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/popup_theme_css.dart';
+
+void main() {
+  // MD3 种子色主题：surface 带色调，天然不等于纯白/纯黑。
+  final ColorScheme light = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF386A58), brightness: Brightness.light);
+  final ColorScheme dark = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF386A58), brightness: Brightness.dark);
+
+  test('前置：种子主题的 surface 确实是 tinted（否则本文件的断言无意义）', () {
+    // 没有这一条，「不等于纯白」可能只是因为 fromSeed 恰好也给了纯白 —— 那样
+    // 下面的测试即使 helper 写死纯白也照样绿（假绿）。
+    expect(light.surface, isNot(const Color(0xFFFFFFFF)),
+        reason: 'MD3 浅色 surface 应带种子色调');
+    expect(dark.surface, isNot(const Color(0xFF000000)),
+        reason: 'MD3 深色 surface 应带种子色调');
+  });
+
+  test('浅色主题：卡面取 scheme.surface，不是纯白', () {
+    expect(popupCardSurface(scheme: light), light.surface);
+  });
+
+  test('深色主题：卡面取 scheme.surface，不是纯黑', () {
+    expect(popupCardSurface(scheme: dark), dark.surface);
+  });
+
+  test('用户指定的词典底色 override 仍然优先于主题 surface', () {
+    const Color override = Color(0xFF112233);
+    expect(popupCardSurface(scheme: light, override: override), override);
+    expect(popupCardSurface(scheme: dark, override: override), override);
+  });
+
+  test('注入 CSS 的 --background-color / --fushi-card-bg-rgb 跟着走主题色', () {
+    final Map<String, String> vars = buildPopupThemeCssVars(
+      scheme: dark,
+      backgroundColor: popupCardSurface(scheme: dark),
+      surfaceContainerHigh: dark.surfaceContainerHigh,
+      dictionaryColumns: 1,
+    );
+    expect(vars['--background-color'], cssRgb(dark.surface));
+    expect(vars['--fushi-card-bg-rgb'], cssRgbTriplet(dark.surface));
+    expect(vars['--background-color'], isNot('rgb(0, 0, 0)'),
+        reason: '弹窗底色不得回到 Niratan 的纯黑');
+  });
+}


### PR DESCRIPTION
用户报告：查词弹窗的背景颜色不对，之前抄的时候抄过头了。

## 根因

`fushi/lib/src/utils/popup_theme_css.dart` 的 `popupCardSurface()`。2026-08-23 的
「弹窗窗体观感对齐 Niratan」(9ba9baea20) 把弹窗卡面从 `override ?? scheme.surface`
改成硬编码纯白 `#FFFFFF` / 纯黑 `#000000`，照抄的是 Niratan
`DictionaryPopupMaterial.GetOpaqueSurfaceColor`。

那是 Niratan 自己的色彩体系。Fushi 全应用走 MD3 种子色 —— 实测种子 `#386A58` 的深色
`scheme.surface` 是 `rgb(15, 21, 18)`，弹窗改纯黑后与它贴着的阅读器 / 视频页 / 设置页
底色割裂。

影响四个注入点（都经该 helper）：扩展 theme 下发、两个 in-app 注入器、热槽初始 HTML。

## 修复

- `popupCardSurface` 回到 `override ?? scheme.surface`；用户手动指定的词典底色 override
  优先级不变。单一真源 helper 保留（BUG-688/736 手抄漂移教训），只改取值。
- 四个调用点的过时注释同步改正。
- 同提交的其余观感项（伴随投影窗、系统灰描边、悬停浮现滚动条）与底色无关，**保留不动**
  —— 抄过头的只有这一条。
- `popup.css` 里 `html[data-theme]` 的 `#fff/#000` 是宿主不注入时的兜底（仅 Android
  原生弹窗走到），早于本次抄袭存在，未动。

未改 popup.css / popup.js，因此无三镜像同步负担。

## 验证

- 新增 `fushi/test/dictionary/popup_card_surface_follows_theme_test.dart`：真行为测试
  （直调 helper + `buildPopupThemeCssVars`），含防假绿的前置断言（钉住种子主题的 surface
  确实是 tinted）。
- **变异实测**：把纯白/纯黑写回 helper → 3 条测试红（`rgb(0, 0, 0)` vs 期望
  `rgb(15, 21, 18)`）；还原后 sha256 与变异前一致。
- `flutter analyze`（含 test）：No issues found。
- 定向 45 项全绿；36 条目录枚举型守卫 252 项全绿；弹窗爆炸半径（`test/dictionary/` +
  `test/lookup/` + 三镜像 parity 守卫等）1065 项全绿。

BUG-1878。

> 说明：本机网络对 GitHub 极不稳定（多次 TLS 握手失败），无法可靠 fetch develop，
> 因此未在本地合并，改由本 PR 走远端 CI。BUG 号的跨分支复核（`dart run tool/bug.dart
> check`）也因同样原因未完成，合并前需补。

https://claude.ai/code/session_01VgfoGTHAHcR6o9RJuwfyt6