### PR TITLE
ci(manifest): update-manifest 资产带 size 与 sha256

### DIFF
--- a/tool/merge_update_manifest.py
+++ b/tool/merge_update_manifest.py
@@ -149,13 +149,33 @@ def _stamp(
     version: str,
 ) -> dict[str, Any]:
     """Normalize an asset to the persisted shape with provenance stamped on."""
-    return {
+    out = {
         "name": asset["name"],
         "browser_download_url": asset["browser_download_url"],
         "releaseSequence": seq,
         "tag": tag,
         "version": version,
     }
+    return _with_integrity(out, asset)
+
+
+def _with_integrity(out: dict[str, Any], asset: dict[str, Any]) -> dict[str, Any]:
+    """Copy the optional integrity fields (size / sha256) when they are well-formed.
+
+    publish_update_manifest.sh computes both from the artifact on disk so the
+    website downloader can verify a chunked download; older manifests (and
+    assets retained from them) simply carry neither. Garbage is dropped rather
+    than persisted: a malformed sha256 would make every client-side check fail.
+    """
+    size = asset.get("size")
+    if isinstance(size, int) and not isinstance(size, bool) and size >= 0:
+        out["size"] = size
+    sha = asset.get("sha256")
+    if isinstance(sha, str):
+        sha = sha.strip().lower()
+        if len(sha) == 64 and all(c in "0123456789abcdef" for c in sha):
+            out["sha256"] = sha
+    return out
 
 
 def merge_manifest(
@@ -247,13 +267,16 @@ def merge_manifest(
             else existing_version
         )
         normalized_existing.append(
-            {
-                "name": a["name"],
-                "browser_download_url": a["browser_download_url"],
-                "releaseSequence": seq,
-                "tag": atag,
-                "version": aver,
-            }
+            _with_integrity(
+                {
+                    "name": a["name"],
+                    "browser_download_url": a["browser_download_url"],
+                    "releaseSequence": seq,
+                    "tag": atag,
+                    "version": aver,
+                },
+                a,
+            )
         )
 
     # Group per platform, keeping the highest-sequence asset SET per platform.

--- a/tool/merge_update_manifest_test.py
+++ b/tool/merge_update_manifest_test.py
@@ -311,9 +311,81 @@ def test_mirror_never_creates_a_manifest():
     check(out == {}, "mirror is a no-op when there is no manifest to augment")
 
 
+# ── integrity fields (size / sha256) ────────────────────────────────────────
+#
+# publish_update_manifest.sh computes both from the artifact on disk so the
+# website's chunked downloader can verify the reassembled file. They must
+# survive normalization (incoming AND retained-from-existing), and malformed
+# values must be dropped rather than persisted.
+
+
+def _by_name(manifest, name):
+    return next(a for a in manifest["assets"] if a["name"] == name)
+
+
+def test_integrity_fields_survive_incoming():
+    tag, version, assets, name = _android(10200)
+    assets[0]["size"] = 123456789
+    assets[0]["sha256"] = "AB" * 32
+    m = merge_manifest(
+        {},
+        tag=tag,
+        channel="debug",
+        version=version,
+        prerelease=True,
+        notes="",
+        release_sequence=10200,
+        new_assets=assets,
+    )
+    a = _by_name(json.loads(json.dumps(m)), name)
+    check(a.get("size") == 123456789, "incoming size persisted")
+    check(a.get("sha256") == "ab" * 32, "incoming sha256 persisted, lower-cased")
+
+
+def test_integrity_fields_survive_retained_asset():
+    tag, version, assets, exe = _desktop(10182)
+    assets[0]["size"] = 42
+    assets[0]["sha256"] = "cd" * 32
+    m = merge_manifest(
+        {},
+        tag=tag,
+        channel="debug",
+        version=version,
+        prerelease=True,
+        notes="",
+        release_sequence=10182,
+        new_assets=assets,
+    )
+    m2, apk = _publish(json.loads(json.dumps(m)), _android, 10192, live={exe, apk} if False else None)
+    a = _by_name(m2, exe)
+    check(a.get("size") == 42 and a.get("sha256") == "cd" * 32, "retained desktop asset keeps size/sha256")
+    check("sha256" not in _by_name(m2, apk), "asset published without sha256 carries none (no invented value)")
+
+
+def test_integrity_fields_malformed_dropped():
+    tag, version, assets, name = _android(10300)
+    assets[0]["size"] = "big"
+    assets[0]["sha256"] = "not-a-hash"
+    m = merge_manifest(
+        {},
+        tag=tag,
+        channel="debug",
+        version=version,
+        prerelease=True,
+        notes="",
+        release_sequence=10300,
+        new_assets=assets,
+    )
+    a = _by_name(json.loads(json.dumps(m)), name)
+    check("size" not in a and "sha256" not in a, "malformed size/sha256 are dropped, not persisted")
+
+
 def main():
     for fn in [
         test_first_publish,
+        test_integrity_fields_survive_incoming,
+        test_integrity_fields_survive_retained_asset,
+        test_integrity_fields_malformed_dropped,
         test_cross_platform_union_newer_tag,
         test_monotonic_guard_old_platform_late,
         test_same_platform_downgrade_rejected,

--- a/tool/publish_update_manifest.sh
+++ b/tool/publish_update_manifest.sh
@@ -122,13 +122,35 @@ if [ "${#ASSET_FILES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# size + sha256 come from the artifact on disk (the same bytes that were just
+# uploaded), not from the GitHub API: the website's chunked downloader verifies
+# the reassembled file against sha256, and the R2 mirror can cross-check it.
 PLATFORM_ASSETS_JSON="$(
-  REPO="$REPO" DOWNLOAD_TAG="$DOWNLOAD_TAG" python3 - "${ASSET_FILES[@]}" <<'PY'
-import json, os, sys
+  REPO="$REPO" DOWNLOAD_TAG="$DOWNLOAD_TAG" ARTIFACTS_DIR="$ARTIFACTS_DIR" python3 - "${ASSET_FILES[@]}" <<'PY'
+import hashlib, json, os, sys
 repo = os.environ["REPO"]
 tag = os.environ["DOWNLOAD_TAG"]
+artifacts = os.environ["ARTIFACTS_DIR"]
 base = f"https://github.com/{repo}/releases/download/{tag}"
-out = [{"name": name, "browser_download_url": f"{base}/{name}"} for name in sys.argv[1:]]
+
+
+def digest(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+out = []
+for name in sys.argv[1:]:
+    path = os.path.join(artifacts, name)
+    out.append({
+        "name": name,
+        "browser_download_url": f"{base}/{name}",
+        "size": os.path.getsize(path),
+        "sha256": digest(path),
+    })
 print(json.dumps(out))
 PY
 )"


### PR DESCRIPTION
publish_update_manifest.sh 对刚上传的产物在磁盘上算 SHA-256 与大小写进资产项；merge_update_manifest.py 规整资产时把这两个可选字段带过去（incoming 与留存资产都保留，畸形值丢弃不落盘）。官网 fushi.moe 的浏览器分片下载器据此校验拼好的文件；老清单没有字段时客户端标「未校验」。客户端 buildReleaseFromManifest 只读 name + url，不受影响。

验证：python tool/merge_update_manifest_test.py 新增 3 条全绿（去掉 _with_integrity 即红）；publish 脚本对本地裸仓库端到端跑通，size/sha256 与 hashlib 逐字一致。

https://claude.ai/code/session_01J8M6X1ADvGVgRaEpUCA4ea