### PR TITLE
feat(delete): 删除确认框加「同时删除本地文件」，联动清理下载任务

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -5174,6 +5174,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_file_location_open => 'Open file location';
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  String get delete_local_files => 'Also delete local files';
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -13985,6 +13990,14 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -22999,6 +23012,14 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -32056,6 +32077,14 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -41142,6 +41171,14 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -50062,6 +50099,14 @@ class _StringsId extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -59054,6 +59099,14 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -67503,6 +67556,14 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -75968,6 +76029,14 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -84920,6 +84989,14 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -93928,6 +94005,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -102909,6 +102994,14 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -111713,6 +111806,14 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -120619,6 +120720,14 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -129507,6 +129616,14 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 // Path: <root>
@@ -137679,6 +137796,12 @@ class _StringsZhCn extends _StringsEn {
   String get book_file_location_open => '打开文件位置';
   @override
   String get book_file_location_failed => '无法打开这本书的文件位置。';
+  @override
+  String get delete_local_files => '同时删除本地文件';
+  @override
+  String get delete_local_files_desc => '原始文件将从本设备删除，无法恢复';
+  @override
+  String get delete_local_files_video_desc => '视频文件将从本设备删除，对应的下载任务一并清除，无法恢复';
 }
 
 // Path: <root>
@@ -145869,6 +145992,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_file_location_failed =>
       'Could not open this book\'s file location.';
+  @override
+  String get delete_local_files => 'Also delete local files';
+  @override
+  String get delete_local_files_desc =>
+      'The original files are removed from this device. This cannot be undone.';
+  @override
+  String get delete_local_files_video_desc =>
+      'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
 }
 
 /// Flat map(s) containing all translations.
@@ -153670,6 +153801,12 @@ extension on _StringsEn {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -161468,6 +161605,12 @@ extension on _StringsAr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -169306,6 +169449,12 @@ extension on _StringsDe {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -177136,6 +177285,12 @@ extension on _StringsEs {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -184974,6 +185129,12 @@ extension on _StringsFr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -192786,6 +192947,12 @@ extension on _StringsId {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -200618,6 +200785,12 @@ extension on _StringsIt {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -208386,6 +208559,12 @@ extension on _StringsJa {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -216156,6 +216335,12 @@ extension on _StringsKo {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -223981,6 +224166,12 @@ extension on _StringsNl {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -231802,6 +231993,12 @@ extension on _StringsPtBr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -239630,6 +239827,12 @@ extension on _StringsRu {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -247432,6 +247635,12 @@ extension on _StringsTh {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -255249,6 +255458,12 @@ extension on _StringsTr {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -263060,6 +263275,12 @@ extension on _StringsVi {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }
@@ -270809,6 +271030,12 @@ extension on _StringsZhCn {
         return '打开文件位置';
       case 'book_file_location_failed':
         return '无法打开这本书的文件位置。';
+      case 'delete_local_files':
+        return '同时删除本地文件';
+      case 'delete_local_files_desc':
+        return '原始文件将从本设备删除，无法恢复';
+      case 'delete_local_files_video_desc':
+        return '视频文件将从本设备删除，对应的下载任务一并清除，无法恢复';
       default:
         return null;
     }
@@ -278559,6 +278786,12 @@ extension on _StringsZhHk {
         return 'Open file location';
       case 'book_file_location_failed':
         return 'Could not open this book\'s file location.';
+      case 'delete_local_files':
+        return 'Also delete local files';
+      case 'delete_local_files_desc':
+        return 'The original files are removed from this device. This cannot be undone.';
+      case 'delete_local_files_video_desc':
+        return 'The video file is removed from this device and its download task is cleared too. This cannot be undone.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "在底栏/侧栏显示该页；关闭即隐藏",
   "module_downloads_hidden_hint": "「下载」页已在 设置 → 系统 → 功能模块 中隐藏；重新打开它才能管理订阅。",
   "book_file_location_open": "打开文件位置",
-  "book_file_location_failed": "无法打开这本书的文件位置。"
+  "book_file_location_failed": "无法打开这本书的文件位置。",
+  "delete_local_files": "同时删除本地文件",
+  "delete_local_files_desc": "原始文件将从本设备删除，无法恢复",
+  "delete_local_files_video_desc": "视频文件将从本设备删除，对应的下载任务一并清除，无法恢复"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3801,5 +3801,8 @@
   "module_tool_toggle_hint": "Show this tab in the navigation bar; turn off to hide it",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → System → Feature modules; turn it back on to manage subscriptions.",
   "book_file_location_open": "Open file location",
-  "book_file_location_failed": "Could not open this book's file location."
+  "book_file_location_failed": "Could not open this book's file location.",
+  "delete_local_files": "Also delete local files",
+  "delete_local_files_desc": "The original files are removed from this device. This cannot be undone.",
+  "delete_local_files_video_desc": "The video file is removed from this device and its download task is cleared too. This cannot be undone."
 }

--- a/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
@@ -1001,7 +1001,7 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
     final NavigatorState outerNavigator =
         Navigator.of(context, rootNavigator: true);
 
-    final DeleteScope? scope = await showDeleteScopeConfirm(
+    final DeleteDecision? decision = await showDeleteScopeConfirm(
       context,
       title: t.dialog_delete,
       message: t.audiobook_delete_confirm,
@@ -1009,14 +1009,20 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
         target: DeletionDisclosureTarget.attachedAudiobook,
       ),
       db: widget.repo.database,
+      // 登记了原始音频（显式列表或 audioRoot）才有原件可删。
+      offerLocalFiles: hasAudiobookSourceFiles(
+        audioPaths: ab.audioPaths,
+        audioRoot: ab.audioRoot,
+      ),
     );
-    debugPrint('AudiobookImportDialog: scope=$scope');
-    if (scope == null) return;
+    debugPrint('AudiobookImportDialog: decision=$decision');
+    if (decision == null) return;
 
     try {
       await widget.repo.deleteAudiobook(
         widget.bookKey,
-        propagateDeletion: scope == DeleteScope.syncEverywhere,
+        propagateDeletion: decision.scope == DeleteScope.syncEverywhere,
+        deleteLocalFiles: decision.deleteLocalFiles,
       );
       debugPrint('AudiobookImportDialog: deleteAudiobook done');
     } catch (e, st) {

--- a/fushi/lib/src/media/audiobook/audiobook_session_launcher.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_session_launcher.dart
@@ -190,31 +190,13 @@ class AudiobookSessionLauncher {
     return null;
   }
 
+  /// 原件解析的单一真相在 fushi_audio 的 [resolveAudiobookSourceFiles]：删除
+  /// 确认框「同时删除本地文件」删的就是这里装载的同一批文件。
   Future<List<File>> _resolveAudioFiles({
     required List<String>? audioPaths,
     required String? audioRoot,
-  }) async {
-    if (audioPaths != null && audioPaths.isNotEmpty) {
-      final List<File> files = <File>[];
-      for (final String path in audioPaths) {
-        final File f = File(path);
-        if (await f.exists()) files.add(f);
-      }
-      return files;
-    }
-    if (audioRoot != null) {
-      final Directory dir = Directory(audioRoot);
-      if (!await dir.exists()) return <File>[];
-      final List<FileSystemEntity> entries = await dir.list().toList();
-      final List<File> files = entries
-          .whereType<File>()
-          .where((File f) => AudiobookStorage.isAudioFile(f.path))
-          .toList()
-        ..sort((File a, File b) => compareAudioFilePath(a.path, b.path));
-      return files;
-    }
-    return <File>[];
-  }
+  }) =>
+      resolveAudiobookSourceFiles(audioPaths: audioPaths, audioRoot: audioRoot);
 
   Audiobook _audiobookFromRow(AudiobookRow row) {
     final Audiobook ab = Audiobook()

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -860,13 +860,22 @@ class ReaderFushiSource extends ReaderMediaSource {
   /// 本机不传播（消费远端删除标记时也走此值——删本地、绝不再回写墓碑造成循环）。备份防
   /// 复活墓碑（[FushiDatabase.deleteEpubBook] 的 tombstone:true）与 scope 无关，永远记
   /// （用户在本机删的东西，导入自己的旧备份不该复活）。
+  /// [deleteLocalFiles]（默认 false，对应删除弹窗「同时删除本地文件」）：true 时连
+  /// 这本书附带的有声书 / 配对字幕书登记的**原始音频文件**一起删。书本体（EPUB /
+  /// PDF / 漫画）导入即拷贝进 app 目录、原件路径根本没入库，没有可删的原件——
+  /// 这就是 [hasLocalSourceFiles] 只看音频列的原因。
   Future<DeleteBookResult> deleteBook({
     required FushiDatabase db,
     required String bookKey,
     AppModel? appModel,
     DeleteScope scope = DeleteScope.keepLocalOnly,
+    bool deleteLocalFiles = false,
   }) async {
     try {
+      // 原件位置在 audiobooks / srt_books 行上，deleteEpubBook 的事务会把它们
+      // 级联删掉，必须先快照。
+      final Audiobook? audiobookBefore =
+          deleteLocalFiles ? await AudiobookRepository(db).findByBookKey(bookKey) : null;
       // HBK-AUDIT-041: db.deleteEpubBook removes every associated DB row
       // (readerPositions, bookmarks, srtBooks, audioCues, audiobooks for the
       // same bookKey) inside one transaction. Previously deleteBook ALSO
@@ -931,6 +940,22 @@ class ReaderFushiSource extends ReaderMediaSource {
         if (bookRow != null) {
           await EpubStorage.deleteBookDir(bookRow.extractDir);
         }
+        // 用户明确勾选后才删原始音频；两条记录可能指向同一批文件，第二次解析
+        // 到的已不存在自然跳过。
+        if (deleteLocalFiles) {
+          if (audiobookBefore != null) {
+            await deleteAudiobookSourceFiles(
+              audioPaths: audiobookBefore.audioPaths,
+              audioRoot: audiobookBefore.audioRoot,
+            );
+          }
+          if (srt != null) {
+            await deleteAudiobookSourceFiles(
+              audioPaths: srt.audioPaths,
+              audioRoot: srt.audioRoot,
+            );
+          }
+        }
 
         // HBK-AUDIT-040: these books are created with canDelete:false, so the
         // generic AppModel.deleteMediaItem cleanup (clearOverrideValues) never
@@ -986,6 +1011,26 @@ class ReaderFushiSource extends ReaderMediaSource {
       debugPrint('[ReaderFushiSource] deleteBook failed: $e');
       return DeleteBookResult.failure(e.toString());
     }
+  }
+
+  /// 这本书（按 [bookKey]）有没有本机可删的原始文件——删除确认框据此决定摆不摆
+  /// 「同时删除本地文件」勾选框。只看附带有声书 / 配对字幕书登记的原始音频
+  /// （见 [deleteBook] 的说明）。
+  Future<bool> hasLocalSourceFiles({
+    required FushiDatabase db,
+    required String bookKey,
+  }) async {
+    if (bookKey.isEmpty) return false;
+    final Audiobook? ab = await AudiobookRepository(db).findByBookKey(bookKey);
+    if (ab != null &&
+        hasAudiobookSourceFiles(
+            audioPaths: ab.audioPaths, audioRoot: ab.audioRoot)) {
+      return true;
+    }
+    final SrtBook? srt = await SrtBookRepository(db).findByBookKey(bookKey);
+    return srt != null &&
+        hasAudiobookSourceFiles(
+            audioPaths: srt.audioPaths, audioRoot: srt.audioRoot);
   }
 
   // ── Settings (same keys as ReaderTtuSource for seamless migration) ──

--- a/fushi/lib/src/media/torrent/anime_download_service.dart
+++ b/fushi/lib/src/media/torrent/anime_download_service.dart
@@ -499,12 +499,26 @@ class AnimeDownloadService {
 
   /// 删除计划并在后端支持时真实取消种子。与 importNow/tick 共用 per-plan
   /// 串行边界，避免「删除后旧 tick 晚回又 save 把计划复活」。
-  Future<bool> deletePlan(String planId, {bool deleteFiles = false}) =>
+  ///
+  /// [deleteFiles]：连后端已下载的数据一起删（`removeTorrent(deleteFiles: true)`）。
+  /// 计划本身不记录落盘路径，包内视频的绝对路径只有种子还在后端时才反查得到，
+  /// 所以在摘种子**之前**先 `listFiles` 解析出来，删完经 [onFilesDeleted] 回给
+  /// 调用方（用来清掉已入库的视频行——旧计划入库后库行与文件之间同样只有路径
+  /// 这一条纽带）。种子已不在后端时无从反查，回调不触发。
+  Future<bool> deletePlan(
+    String planId, {
+    bool deleteFiles = false,
+    Future<void> Function(List<String> videoAbsolutePaths)? onFilesDeleted,
+  }) =>
       _runPlanSerial<bool>(planId, () async {
         final QbConnectionConfig? config = _configProvider();
+        List<String> deletedVideos = const <String>[];
         if (config != null && config.isConfigured) {
           final TorrentBackend backend = _backendFactory(config);
           try {
+            if (deleteFiles && onFilesDeleted != null) {
+              deletedVideos = await _resolvePlanVideoPaths(backend, planId);
+            }
             if (backend is TorrentRemovalBackend) {
               await backend.removeTorrent(planId, deleteFiles: deleteFiles);
             }
@@ -513,10 +527,46 @@ class AnimeDownloadService {
           }
         }
         await store.delete(planId);
+        if (deletedVideos.isNotEmpty && onFilesDeleted != null) {
+          await onFilesDeleted(deletedVideos);
+        }
         return !(await store.loadAll()).any(
           (AnimeDownloadPlan plan) => plan.id == planId,
         );
       });
+
+  /// 种子仍在后端时反查这个计划包内视频文件的绝对路径；查不到（种子已摘 / 后端
+  /// 离线 / 元数据未解析）返回空表，绝不抛——它只服务 best-effort 的库行清理。
+  Future<List<String>> _resolvePlanVideoPaths(
+    TorrentBackend backend,
+    String planId,
+  ) async {
+    try {
+      AnimeDownloadPlan? plan;
+      for (final AnimeDownloadPlan candidate in await store.loadAll()) {
+        if (candidate.id == planId) {
+          plan = candidate;
+          break;
+        }
+      }
+      if (plan == null) return const <String>[];
+      final QbConnectionConfig? config = _configProvider();
+      final List<TorrentSnapshot> torrents = await backend.listTorrents(
+        category: config == null || config.category.isEmpty
+            ? null
+            : config.category,
+      );
+      for (final TorrentSnapshot info in torrents) {
+        if (info.hash.toLowerCase() != planId.toLowerCase()) continue;
+        final List<TorrentFileEntry> files = await backend.listFiles(info.hash);
+        final (List<String> videos, _) = _classifyContent(plan, info, files);
+        return videos;
+      }
+    } catch (_) {
+      // 反查失败只影响库行清理，不阻塞删除本身。
+    }
+    return const <String>[];
+  }
 
   Future<T> _runPlanSerial<T>(
     String planId,

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -534,6 +534,12 @@ Future<void> reconcileVideoDownloadJobsAfterLocalDelete({
               updatedAt: Value<int>(now),
             ),
           );
+          // 种子还在后端（做种 / 还在下别的集）时，文件已从磁盘消失，必须把它在
+          // 后端标 skip：否则 libtorrent / qB 一做校验就撞「文件缺失」把整个种子
+          // 停掉，别的集也跟着断。
+          if (pipeline != null && file.backendFileIndex != null) {
+            await pipeline.skipBackendFile(job, file.backendFileIndex!);
+          }
         }
       }
     } on Object catch (error, stack) {
@@ -1220,6 +1226,31 @@ class VideoDownloadPipelineService {
 
   /// Removes a durable task and, when requested, only the files that this task
   /// explicitly recorded. Directories are never recursively removed here.
+  /// 把 [job] 在后端的第 [fileIndex] 个文件标为不下载（[TorrentFilePriority.skip]）。
+  /// 库侧删掉某一集的本地文件后调用：种子仍在后端时，缺失的文件若还是 normal
+  /// 优先级，下一次校验就会让整个种子报错停掉。best-effort：后端离线 / 不支持
+  /// 文件优先级 / 种子已不在，都静默返回 false。
+  Future<bool> skipBackendFile(VideoDownloadJobRow job, int fileIndex) async {
+    final String torrentId =
+        (job.backendTaskId ?? job.torrentHash ?? '').trim();
+    if (torrentId.isEmpty) return false;
+    try {
+      final VideoDownloadBackendBinding? binding = await backendResolver(job);
+      _validateBackendBinding(job, binding);
+      final TorrentBackend backend = binding!.backend;
+      if (backend is! TorrentDetailBackend || !backend.detailAvailable) {
+        return false;
+      }
+      return await backend.setFilePriority(
+        torrentId,
+        fileIndex,
+        TorrentFilePriority.skip,
+      );
+    } on Object {
+      return false;
+    }
+  }
+
   Future<void> deleteJob(String jobId, {required bool deleteFiles}) async {
     VideoDownloadJobRow? job = await database.getVideoDownloadJob(jobId);
     if (job == null) return;

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -463,6 +463,89 @@ Future<void> deletePersistedVideoDownloadJob({
   }
 }
 
+/// 库侧删视频且用户勾了「同时删除本地文件」后，把已从磁盘消失的 [deletedPaths]
+/// 对账回下载任务——这是 [deletePersistedVideoDownloadJob]（任务侧删 → 联动删库行）
+/// 的反方向。任务与库行之间没有 id 级外键，唯一纽带是
+/// `VideoDownloadJobFiles.finalAbsolutePath`，按 [normalizeVideoPath] 归一后比对。
+///
+/// 命中的任务分两档：
+/// - **视频文件全没了**（任务已终态，且除本次删掉的之外没有任何 kind=video 文件
+///   仍在磁盘上）→ 整个任务删除：有 [pipeline] 走 [VideoDownloadPipelineService.deleteJob]
+///   （先从后端摘种子并删数据，再删任务行与残余字幕/附件）；没有 pipeline 走
+///   [deletePersistedVideoDownloadJob] 的 db-only 路径。
+/// - **只删了部分集**或任务还在跑 → 任务保留，只把命中的文件行标 `skipped`，任务
+///   页不再把它当已入库文件展示；后端种子不动（还在下的集不能被打断）。
+///
+/// 全程 best-effort：任务对账失败只记 ErrorLog，视频与文件早已删掉，不回滚。
+Future<void> reconcileVideoDownloadJobsAfterLocalDelete({
+  required FushiDatabase database,
+  required Set<String> deletedPaths,
+  VideoDownloadPipelineService? pipeline,
+}) async {
+  if (deletedPaths.isEmpty) return;
+  final Set<String> deletedNormalized = <String>{
+    for (final String path in deletedPaths) normalizeVideoPath(path),
+  };
+  for (final VideoDownloadJobRow job in await database.getVideoDownloadJobs()) {
+    final List<VideoDownloadJobFileRow> files =
+        await database.getVideoDownloadJobFiles(job.jobId);
+    final List<VideoDownloadJobFileRow> hit = <VideoDownloadJobFileRow>[
+      for (final VideoDownloadJobFileRow file in files)
+        if (file.finalAbsolutePath?.trim().isNotEmpty == true &&
+            deletedNormalized
+                .contains(normalizeVideoPath(file.finalAbsolutePath!.trim())))
+          file,
+    ];
+    if (hit.isEmpty) continue;
+    final bool terminal = job.lifecycle == VideoDownloadJobLifecycle.completed ||
+        job.lifecycle == VideoDownloadJobLifecycle.cancelled ||
+        job.lifecycle == VideoDownloadJobLifecycle.failed;
+    bool otherVideoRemains = false;
+    if (terminal) {
+      final Set<int> hitIds = <int>{for (final f in hit) f.id};
+      for (final VideoDownloadJobFileRow file in files) {
+        if (hitIds.contains(file.id) || file.kind != 'video') continue;
+        final String path = file.finalAbsolutePath?.trim() ?? '';
+        if (path.isEmpty) continue;
+        if (await File(path).exists()) {
+          otherVideoRemains = true;
+          break;
+        }
+      }
+    }
+    try {
+      if (terminal && !otherVideoRemains) {
+        if (pipeline != null) {
+          await pipeline.deleteJob(job.jobId, deleteFiles: true);
+        } else {
+          await deletePersistedVideoDownloadJob(
+            database: database,
+            job: job,
+            deleteFiles: true,
+          );
+        }
+      } else {
+        final int now = DateTime.now().millisecondsSinceEpoch;
+        for (final VideoDownloadJobFileRow file in hit) {
+          await database.updateVideoDownloadJobFile(
+            file.id,
+            VideoDownloadJobFilesCompanion(
+              status: const Value<String>(VideoDownloadJobFileStatus.skipped),
+              updatedAt: Value<int>(now),
+            ),
+          );
+        }
+      }
+    } on Object catch (error, stack) {
+      ErrorLogService.instance.log(
+        'VideoDownloadJobReconcile',
+        'Failed to reconcile job ${job.jobId} after local delete: $error',
+        stack,
+      );
+    }
+  }
+}
+
 typedef VideoDownloadBackendResolver = Future<VideoDownloadBackendBinding?>
     Function(VideoDownloadJobRow job);
 

--- a/fushi/lib/src/media/video/video_book_repository.dart
+++ b/fushi/lib/src/media/video/video_book_repository.dart
@@ -13,6 +13,7 @@ import 'package:fushi/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
 import 'package:fushi/src/media/video/metadata/video_scrape_operation_gate.dart';
 import 'package:fushi/src/media/video/scraper/collection_member_policy.dart'
     show multiMemberCollectionIdByVideoUid;
+import 'package:fushi/src/media/video/video_local_files.dart';
 import 'package:fushi/src/media/video/video_path_migration.dart';
 import 'package:fushi/src/media/video/video_storage.dart';
 import 'package:fushi/src/sync/deletion_propagation.dart';
@@ -741,12 +742,16 @@ class VideoBookRepository {
     String bookUid, {
     DeleteScope scope = DeleteScope.keepLocalOnly,
     bool compactDatabase = true,
+    bool deleteLocalFiles = false,
+    Future<void> Function(Set<String> deletedPaths)? onLocalFilesDeleted,
     Future<void> Function()? afterDeleteBeforeReclaim,
   }) {
     return deleteVideoBooksAndReclaimAssets(
       <String>[bookUid],
       scope: scope,
       compactDatabase: compactDatabase,
+      deleteLocalFiles: deleteLocalFiles,
+      onLocalFilesDeleted: onLocalFilesDeleted,
       afterDeleteBeforeReclaim: afterDeleteBeforeReclaim,
     ).then((int deletedCount) => deletedCount > 0);
   }
@@ -756,10 +761,19 @@ class VideoBookRepository {
   /// [afterDeleteBeforeReclaim] lets UI callers rebuild and release file-backed
   /// widgets after the rows disappear while still preventing scrape maintenance
   /// from entering before every deleted row's app-owned assets are reclaimed.
+  ///
+  /// [deleteLocalFiles]（删除确认框「同时删除本地文件」）：行删掉、UI 释放句柄之后，
+  /// 再把被删行自己的原始视频文件（`videoPath` + 播放列表各集，见
+  /// [localVideoFileCandidates]）从磁盘删掉。护栏：仍被任何幸存行引用的文件保留；
+  /// 远端流没有文件；只删文件不删目录。真删掉的路径经 [onLocalFilesDeleted] 回调
+  /// 给调用方（用来联动清下载任务——下载记录与库行之间只有路径这一条纽带，而
+  /// 本仓库层不认识下载管线）。
   Future<int> deleteVideoBooksAndReclaimAssets(
     Iterable<String> bookUids, {
     DeleteScope scope = DeleteScope.keepLocalOnly,
     bool compactDatabase = true,
+    bool deleteLocalFiles = false,
+    Future<void> Function(Set<String> deletedPaths)? onLocalFilesDeleted,
     Future<void> Function()? afterDeleteBeforeReclaim,
   }) {
     final VideoScrapeOperationLease? lease =
@@ -772,6 +786,8 @@ class VideoBookRepository {
         bookUids,
         scope: scope,
         compactDatabase: compactDatabase,
+        deleteLocalFiles: deleteLocalFiles,
+        onLocalFilesDeleted: onLocalFilesDeleted,
         afterDeleteBeforeReclaim: afterDeleteBeforeReclaim,
       ),
     ).whenComplete(lease.release);
@@ -781,6 +797,9 @@ class VideoBookRepository {
     Iterable<String> bookUids, {
     required DeleteScope scope,
     required bool compactDatabase,
+    required bool deleteLocalFiles,
+    required Future<void> Function(Set<String> deletedPaths)?
+        onLocalFilesDeleted,
     required Future<void> Function()? afterDeleteBeforeReclaim,
   }) async {
     final deleted =
@@ -790,6 +809,7 @@ class VideoBookRepository {
             String? coverPath,
             String? subtitlePath,
             String videoPath,
+            String? playlistJson,
             List<String> imagePaths,
           })
         >[];
@@ -810,6 +830,7 @@ class VideoBookRepository {
         coverPath: book.coverPath,
         subtitlePath: book.subtitleSource,
         videoPath: book.videoPath,
+        playlistJson: book.playlistJson,
         imagePaths: imagePaths,
       ));
     }
@@ -825,6 +846,29 @@ class VideoBookRepository {
           deletedVideoPath: snapshot.videoPath,
           deletedImagePaths: snapshot.imagePaths,
         );
+      }
+      if (deleteLocalFiles && deleted.isNotEmpty) {
+        // 原件删除排在 app 副本回收之后、compact 之前：行早已消失，这里是尾活；
+        // 单文件失败只记日志（[deleteLocalVideoFiles] 内部），不翻转删除结果。
+        final Set<String> removed = await deleteLocalVideoFiles(
+          candidates: <String>[
+            for (final snapshot in deleted)
+              ...localVideoFileCandidates(
+                videoPath: snapshot.videoPath,
+                playlistJson: snapshot.playlistJson,
+              ),
+          ],
+          stillReferenced: referencedLocalVideoPaths(await listAll()),
+        );
+        if (removed.isNotEmpty && onLocalFilesDeleted != null) {
+          try {
+            await onLocalFilesDeleted(removed);
+          } catch (e, stack) {
+            debugPrint(
+              'VideoBookRepository: onLocalFilesDeleted failed: $e\n$stack',
+            );
+          }
+        }
       }
       if (compactDatabase && deleted.isNotEmpty) {
         await compactAfterVideoDeleteBestEffort();

--- a/fushi/lib/src/media/video/video_library_delete.dart
+++ b/fushi/lib/src/media/video/video_library_delete.dart
@@ -1,0 +1,45 @@
+/// 视频库删除的 UI 侧统一入口：把删除确认框的 [DeleteDecision] 落到仓库层，并在用户
+/// 勾了「同时删除本地文件」时联动对账下载任务。
+///
+/// 为什么不塞进 [VideoBookRepository]：仓库层不认识下载管线（管线依赖仓库，反过来
+/// 会成环）；对账靠仓库回调出的「真删掉的路径」在这一层接线。视频页单删 / 批删共用，
+/// 保证两条路径的语义一字不差。
+library;
+
+import 'package:fushi_core/fushi_core.dart' show FushiDatabase;
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart'
+    show
+        VideoDownloadPipelineService,
+        reconcileVideoDownloadJobsAfterLocalDelete;
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/sync/deletion_propagation.dart';
+
+/// 删掉 [bookUids] 对应的视频行 + app 副本；[decision].deleteLocalFiles 为真时再删
+/// 原始视频文件并对账下载任务。返回真删掉的行数。
+Future<int> deleteVideoBooksWithDecision({
+  required VideoBookRepository repo,
+  required FushiDatabase database,
+  required VideoDownloadPipelineService? pipeline,
+  required Iterable<String> bookUids,
+  required DeleteDecision decision,
+  bool compactDatabase = true,
+  Future<void> Function()? afterDeleteBeforeReclaim,
+}) {
+  return repo.deleteVideoBooksAndReclaimAssets(
+    bookUids,
+    scope: decision.scope,
+    compactDatabase: compactDatabase,
+    deleteLocalFiles: decision.deleteLocalFiles,
+    onLocalFilesDeleted: decision.deleteLocalFiles
+        ? (Set<String> deletedPaths) async {
+            await reconcileVideoDownloadJobsAfterLocalDelete(
+              database: database,
+              deletedPaths: deletedPaths,
+              pipeline: pipeline,
+            );
+            database.notifyVideoLibraryChanged();
+          }
+        : null,
+    afterDeleteBeforeReclaim: afterDeleteBeforeReclaim,
+  );
+}

--- a/fushi/lib/src/media/video/video_local_files.dart
+++ b/fushi/lib/src/media/video/video_local_files.dart
@@ -1,0 +1,115 @@
+/// 视频条目的「本机原始文件」判据与删除（删除确认框「同时删除本地文件」的落地）。
+///
+/// 纯函数部分零 IO，供弹窗决定要不要摆勾选框；[deleteLocalVideoFiles] 是唯一动
+/// 磁盘的入口，只删**文件**、绝不递归删目录，且仍被其它库行引用的路径一律保留。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fushi_core/fushi_core.dart' show VideoBookRow;
+import 'package:fushi/src/media/video/external_video.dart'
+    show normalizeVideoPath;
+import 'package:fushi/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
+import 'package:fushi/src/utils/misc/error_log_service.dart';
+
+/// 纯函数：[path] 形如本机文件路径（裸路径 / 盘符路径），而不是 http(s)、content、
+/// file 等带 scheme 的 URI。远端互联直传、WebDAV、Jellyfin 的 `videoPath` 都是
+/// `http(s)://…`，磁盘上没有文件可删。
+///
+/// scheme 长度 ≤1 视为盘符（`D:\…` 解析出的 scheme 是 `d`），不算 URI。
+bool isLocalVideoFilePath(String path) {
+  final String trimmed = path.trim();
+  if (trimmed.isEmpty) return false;
+  final Uri? uri = Uri.tryParse(trimmed);
+  if (uri != null && uri.scheme.length > 1) return false;
+  return true;
+}
+
+/// 纯函数：从 `playlistJson`（`[{title,path}]`）解出各集路径；空 / 坏 JSON → 空表。
+List<String> playlistEntryPaths(String? playlistJson) {
+  if (playlistJson == null || playlistJson.isEmpty) return const <String>[];
+  try {
+    final dynamic decoded = jsonDecode(playlistJson);
+    if (decoded is! List) return const <String>[];
+    return <String>[
+      for (final dynamic item in decoded)
+        if (item is Map<String, dynamic>) PlaylistEntry.fromJson(item).path,
+    ];
+  } catch (_) {
+    return const <String>[];
+  }
+}
+
+/// 纯函数：这一行视频在本机拥有的原始文件候选（`videoPath` + 播放列表各集），只
+/// 保留形如本地路径的。空表 = 没有任何本地文件可删（远端流 / 空路径）。
+List<String> localVideoFileCandidates({
+  required String videoPath,
+  String? playlistJson,
+}) {
+  final Set<String> seen = <String>{};
+  final List<String> out = <String>[];
+  for (final String raw in <String>[
+    videoPath,
+    ...playlistEntryPaths(playlistJson),
+  ]) {
+    if (!isLocalVideoFilePath(raw)) continue;
+    final String key = normalizeVideoPath(raw.trim());
+    if (seen.add(key)) out.add(raw.trim());
+  }
+  return out;
+}
+
+/// 纯函数：这一行有没有本机可删的原始文件——删除确认框据此决定摆不摆
+/// 「同时删除本地文件」勾选框。
+bool videoBookHasLocalFiles(VideoBookRow row) => localVideoFileCandidates(
+  videoPath: row.videoPath,
+  playlistJson: row.playlistJson,
+).isNotEmpty;
+
+/// 纯函数：[rows] 引用的全部本地文件路径（归一化后），用作删除护栏。
+Set<String> referencedLocalVideoPaths(Iterable<VideoBookRow> rows) => <String>{
+  for (final VideoBookRow row in rows)
+    for (final String path in localVideoFileCandidates(
+      videoPath: row.videoPath,
+      playlistJson: row.playlistJson,
+    ))
+      normalizeVideoPath(path),
+};
+
+/// 删除 [candidates] 中真实存在、且不在 [stillReferenced]（归一化路径集）里的
+/// 文件；返回**真的从磁盘消失**的路径（原样，未归一）。
+///
+/// - 只删 `File`（含符号链接），目录一律跳过——`videoPath` 不该是目录，真遇到
+///   也绝不递归删；
+/// - 单个失败（Windows 句柄占用等）记 ErrorLog 后继续，不翻转其它文件的结果。
+Future<Set<String>> deleteLocalVideoFiles({
+  required Iterable<String> candidates,
+  required Set<String> stillReferenced,
+}) async {
+  final Set<String> removed = <String>{};
+  for (final String path in candidates) {
+    if (stillReferenced.contains(normalizeVideoPath(path))) continue;
+    try {
+      final FileSystemEntityType type = await FileSystemEntity.type(
+        path,
+        followLinks: false,
+      );
+      if (type == FileSystemEntityType.file) {
+        await File(path).delete();
+      } else if (type == FileSystemEntityType.link) {
+        await Link(path).delete();
+      } else {
+        continue;
+      }
+      removed.add(path);
+    } on Object catch (error, stack) {
+      ErrorLogService.instance.log(
+        'VideoLocalFileDelete',
+        'Failed to delete $path: $error',
+        stack,
+      );
+    }
+  }
+  return removed;
+}

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi_core/fushi_core.dart' show VideoBookRow;
 
 import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/anime_download_matching.dart';
@@ -17,6 +18,7 @@ import 'package:fushi/src/media/torrent/torrent_backend.dart';
 import 'package:fushi/src/media/torrent/torrent_task_display.dart';
 import 'package:fushi/src/media/video/anilist_client.dart';
 import 'package:fushi/src/media/video/jimaku_client.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/jimaku_api_key_field.dart';
 import 'package:fushi/src/pages/implementations/jimaku_entry_picker.dart';
@@ -24,6 +26,8 @@ import 'package:fushi/src/pages/implementations/download_actions.dart';
 import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
 import 'package:fushi/src/pages/implementations/downloads_page.dart';
 import 'package:fushi/src/pages/implementations/torrent_detail_dialog.dart';
+import 'package:fushi/src/pages/implementations/video_download_jobs_panel.dart'
+    show showDownloadTaskDeleteConfirm;
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
@@ -1032,15 +1036,45 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     unawaited(ref.read(appProvider).animeDownloadService?.tick());
   }
 
+  /// 删除旧番剧计划：与 v78 任务面板同一确认框（正文 + 「同时删除已下载文件」）。
+  /// 以前这里没有确认框、也从不删文件；勾选后经后端 `removeTorrent(deleteFiles)` 删
+  /// 数据，并把已入库、指向这些文件的视频行一并清掉（否则库里留下一排打不开的壳）。
   Future<void> _deletePlan(AnimeDownloadPlan plan) async {
     final AppModel appModel = ref.read(appProvider);
     final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
     if (store == null) return;
+    final bool? deleteFiles = await showDownloadTaskDeleteConfirm(
+      context,
+      title: plan.seriesTitle.isNotEmpty ? plan.seriesTitle : plan.torrentTitle,
+      keySuffix: plan.id,
+    );
+    if (deleteFiles == null || !mounted) return;
     final AnimeDownloadService? service = appModel.animeDownloadService;
     if (service == null) {
       await store.delete(plan.id);
     } else {
-      await service.deletePlan(plan.id);
+      await service.deletePlan(
+        plan.id,
+        deleteFiles: deleteFiles,
+        onFilesDeleted: (List<String> videoAbsolutePaths) async {
+          final VideoBookRepository repo =
+              VideoBookRepository(appModel.database);
+          bool any = false;
+          for (final String path in videoAbsolutePaths) {
+            final VideoBookRow? row = await repo.findByVideoPath(path);
+            if (row == null) continue;
+            await repo.deleteVideoBookAndReclaimAssets(
+              row.bookUid,
+              compactDatabase: false,
+            );
+            any = true;
+          }
+          if (any) {
+            await repo.compactAfterVideoDeleteBestEffort();
+            appModel.database.notifyVideoLibraryChanged();
+          }
+        },
+      );
     }
     await _reloadPlans();
   }

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -31,6 +31,9 @@ import 'package:fushi/src/media/video/video_cover_extractor.dart'
     show isLocalFrameExtractableVideoSource;
 import 'package:fushi/src/media/video/m3u8_playlist.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_delete.dart';
+import 'package:fushi/src/media/video/video_local_files.dart'
+    show videoBookHasLocalFiles;
 import 'package:fushi/src/media/video/video_subtitle_attach.dart';
 import 'package:fushi/src/media/video/video_subtitle_attach_messages.dart';
 import 'package:fushi/src/media/video/video_import_dialog.dart';
@@ -1110,17 +1113,27 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             ? t.batch_dissolve_confirm(m: collectionCount)
             : t.batch_delete_mixed_confirm(n: mediaCount, m: collectionCount);
     // 混选/纯解散不删媒体本体 → 不展示同步删除选项（合集解散走合集传播机制）；
-    // 纯删媒体才有意义提供「从所有设备删除」。
+    // 纯删媒体才有意义提供「从所有设备删除」与「同时删除本地文件」。
     // 不能写成三元表达式：两分支各含 await 时 analyzer 视互为 async gap，
     // 两处 context 都报 use_build_context_synchronously（CI warning 致命）。
-    final DeleteScope? scope;
+    final DeleteDecision? decision;
     if (collectionCount == 0) {
-      scope = await showDeleteScopeConfirm(context,
+      // 「同时删除本地文件」只在选中集里至少有一条是本地文件时才摆出来
+      // （全是远端流就没有文件可删，与同步勾选框「兑现不了就不显示」同一纪律）。
+      final Set<String> selected = Set<String>.of(_selectedUids);
+      final bool anyLocalFile = (await widget.repo.listAll()).any(
+        (VideoBookRow b) =>
+            selected.contains(b.bookUid) && videoBookHasLocalFiles(b),
+      );
+      if (!mounted) return;
+      decision = await showDeleteScopeConfirm(context,
           title: t.dialog_delete,
           message: message,
-          db: ref.read(appProvider).database);
+          db: ref.read(appProvider).database,
+          offerLocalFiles: anyLocalFile,
+          localFilesSubtitle: t.delete_local_files_video_desc);
     } else {
-      scope = await showAppDialog<DeleteScope>(
+      decision = await showAppDialog<DeleteDecision>(
         context: context,
         builder: (BuildContext ctx) => AlertDialog(
           title: Text(t.dialog_delete),
@@ -1131,7 +1144,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
               child: Text(t.dialog_cancel),
             ),
             TextButton(
-              onPressed: () => Navigator.pop(ctx, DeleteScope.keepLocalOnly),
+              onPressed: () => Navigator.pop(
+                ctx,
+                const DeleteDecision(scope: DeleteScope.keepLocalOnly),
+              ),
               child: Text(
                 t.dialog_delete,
                 style: TextStyle(color: Theme.of(ctx).colorScheme.error),
@@ -1141,9 +1157,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ),
       );
     }
-    if (scope == null || !mounted) return;
+    if (decision == null || !mounted) return;
 
-    final FushiDatabase db = ref.read(appProvider).database;
+    final AppModel appModel = ref.read(appProvider);
+    final FushiDatabase db = appModel.database;
     // 先解散选中合集（只删合集容器 + 成员引用行，绝不删媒体本体）。
     final Set<int> toDissolve = Set<int>.of(_selectedCollectionIds);
     int dissolved = 0;
@@ -1153,9 +1170,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     }
     // 再删选中散卡的媒体本体（现状语义）。
     final Set<String> toDelete = Set<String>.of(_selectedUids);
-    final int deleted = await widget.repo.deleteVideoBooksAndReclaimAssets(
-      toDelete,
-      scope: scope,
+    final int deleted = await deleteVideoBooksWithDecision(
+      repo: widget.repo,
+      database: db,
+      pipeline: appModel.videoDownloadPipelineService,
+      bookUids: toDelete,
+      decision: decision,
       afterDeleteBeforeReclaim: () async {
         if (!mounted) return;
         _exitSelectionMode();
@@ -2356,16 +2376,23 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   Future<void> _confirmDelete(VideoBookRow book) async {
-    final DeleteScope? scope = await showDeleteScopeConfirm(
+    final AppModel appModel = ref.read(appProvider);
+    final DeleteDecision? decision = await showDeleteScopeConfirm(
       context,
       title: t.video_delete_title,
       message: t.video_delete_confirm(title: book.title),
-      db: ref.read(appProvider).database,
+      db: appModel.database,
+      // 远端流（互联直传 / WebDAV / Jellyfin）磁盘上没有文件，不摆勾选框。
+      offerLocalFiles: videoBookHasLocalFiles(book),
+      localFilesSubtitle: t.delete_local_files_video_desc,
     );
-    if (scope == null || !mounted) return;
-    await widget.repo.deleteVideoBookAndReclaimAssets(
-      book.bookUid,
-      scope: scope,
+    if (decision == null || !mounted) return;
+    await deleteVideoBooksWithDecision(
+      repo: widget.repo,
+      database: appModel.database,
+      pipeline: appModel.videoDownloadPipelineService,
+      bookUids: <String>[book.bookUid],
+      decision: decision,
       afterDeleteBeforeReclaim: () async {
         if (!mounted) return;
         _refreshAfterTagChange();

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -1969,30 +1969,34 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     }
   }
 
-  /// 弹删除确认框，返回用户选择的删除范围（[DeleteScope.syncEverywhere] = 同步删除到
-  /// 其他设备 / [DeleteScope.keepLocalOnly] = 仅本机）；取消或已 unmount 返回 null。
-  Future<DeleteScope?> _confirmMediaDelete({
+  /// 弹删除确认框，返回用户的 [DeleteDecision]（scope：[DeleteScope.syncEverywhere]
+  /// = 同步删除到其他设备 / [DeleteScope.keepLocalOnly] = 仅本机；deleteLocalFiles：
+  /// 是否连原始音频文件一起删，仅 [offerLocalFiles] 时可勾）；取消或已 unmount 返回
+  /// null。
+  Future<DeleteDecision?> _confirmMediaDelete({
     required String title,
     required String message,
     DeletionDisclosure? disclosure,
+    bool offerLocalFiles = false,
   }) async {
     // TODO-2470 死角②：本机没有任何删除传播通道时不摆那个兑现不了的勾选框。
     // 纯本地零网络判据，在弹窗弹出前解析完（弹窗自身不做 IO）。
     final bool canSyncEverywhere =
         await hasDeletionPropagationChannel(SyncRepository(appModel.database));
     if (!mounted) return null;
-    final DeleteScope? scope = await showAppDialog<DeleteScope>(
+    final DeleteDecision? decision = await showAppDialog<DeleteDecision>(
       context: context,
       builder: (ctx) => ReaderHistoryDeleteDialog(
         title: title,
         message: message,
         disclosure: disclosure,
         showSyncScope: canSyncEverywhere,
-        onConfirm: (DeleteScope s) => Navigator.pop(ctx, s),
+        offerLocalFiles: offerLocalFiles,
+        onConfirm: (DeleteDecision d) => Navigator.pop(ctx, d),
       ),
     );
     if (!mounted) return null;
-    return scope;
+    return decision;
   }
 
   @override

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -549,8 +549,12 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
     //   ② 本机存在删除传播通道（纯本地零网络判据）。
     final bool canSyncEverywhere = mediaCount > 0 &&
         await hasDeletionPropagationChannel(SyncRepository(appModel.database));
+    // 「同时删除本地文件」只在选中散卡里至少有一条登记了原始音频时才摆出来
+    // （书本体没有可删原件，见 ReaderFushiSource.deleteBook）。
+    final bool anyLocalFiles =
+        mediaCount > 0 && await _selectionHasLocalSourceFiles();
     if (!mounted) return;
-    final DeleteScope? scope = await showAppDialog<DeleteScope>(
+    final DeleteDecision? decision = await showAppDialog<DeleteDecision>(
       context: context,
       builder: (ctx) => ReaderHistoryDeleteDialog(
         title: t.dialog_delete,
@@ -563,10 +567,13 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
                 target: DeletionDisclosureTarget.shelfBook,
               ),
         showSyncScope: canSyncEverywhere,
-        onConfirm: (DeleteScope s) => Navigator.pop(ctx, s),
+        offerLocalFiles: anyLocalFiles,
+        onConfirm: (DeleteDecision d) => Navigator.pop(ctx, d),
       ),
     );
-    if (scope == null || !mounted) return;
+    if (decision == null || !mounted) return;
+    final DeleteScope scope = decision.scope;
+    final bool deleteLocalFiles = decision.deleteLocalFiles;
 
     // 先解散选中合集（只删合集容器 + 成员引用行，绝不删媒体本体）。
     final Set<int> toDissolve = Set<int>.of(_selectedCollectionIds);
@@ -590,6 +597,7 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
               db: appModel.database,
               bookKey: book.bookKey,
               scope: scope,
+              deleteLocalFiles: deleteLocalFiles,
             );
           }
           // BUG-439：以前无条件 deleted++，即便 repo.delete 实际没删到行也计数，
@@ -598,7 +606,8 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
           // scope 以前到这里就被丢弃、勾了「从所有设备删除」完全无效。propagateDeletion
           // 由 repo 按 standalone 判据决定写不写墓碑（srt-backed 已由 deleteBook 写过）。
           final int removed = await repo.delete(uid,
-              propagateDeletion: scope == DeleteScope.syncEverywhere);
+              propagateDeletion: scope == DeleteScope.syncEverywhere,
+              deleteLocalFiles: deleteLocalFiles);
           if (removed > 0) deleted++;
         }
       } else {
@@ -609,6 +618,7 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
             db: appModel.database,
             bookKey: bookKey,
             scope: scope,
+            deleteLocalFiles: deleteLocalFiles,
           );
           if (result.deleted) deleted++;
         }
@@ -638,6 +648,36 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
           ? ToastSeverity.success
           : ToastSeverity.warning,
     );
+  }
+
+  /// 选中的散卡里有没有任何一条登记了原始音频文件（批删确认框据此决定摆不摆
+  /// 「同时删除本地文件」）。纯字幕书看自己的音频列，EPUB 看附带有声书 / 配对字幕书。
+  Future<bool> _selectionHasLocalSourceFiles() async {
+    final FushiDatabase db = appModel.database;
+    for (final String key in _selectedKeys) {
+      if (key.startsWith('srt_')) {
+        final SrtBook? book =
+            await SrtBookRepository(db).findByUid(key.substring(4));
+        if (book == null) continue;
+        if (hasAudiobookSourceFiles(
+            audioPaths: book.audioPaths, audioRoot: book.audioRoot)) {
+          return true;
+        }
+        if (book.bookKey.isNotEmpty &&
+            await ReaderFushiSource.instance
+                .hasLocalSourceFiles(db: db, bookKey: book.bookKey)) {
+          return true;
+        }
+      } else {
+        final String? bookKey = _parseBookKey(key);
+        if (bookKey != null &&
+            await ReaderFushiSource.instance
+                .hasLocalSourceFiles(db: db, bookKey: bookKey)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /// 批量操作前把选中集收敛到真实存在的条目上，真剔掉了就明说。
@@ -910,27 +950,41 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
   }
 
   Future<void> _confirmDeleteSrtBook(SrtBook book) async {
+    final bool offerLocalFiles = hasAudiobookSourceFiles(
+          audioPaths: book.audioPaths,
+          audioRoot: book.audioRoot,
+        ) ||
+        (book.bookKey.isNotEmpty &&
+            await ReaderFushiSource.instance.hasLocalSourceFiles(
+              db: appModel.database,
+              bookKey: book.bookKey,
+            ));
+    if (!mounted) return;
     // P4：确认弹窗给人看，书名过门面（删除本体仍按 raw bookKey/uid 身份执行）。
-    final DeleteScope? scope = await _confirmMediaDelete(
+    final DeleteDecision? decision = await _confirmMediaDelete(
       title: t.srt_delete_title,
       message: t.srt_delete_confirm(title: _srtDisplayTitle(book)),
       disclosure: buildDeletionDisclosure(
         target: DeletionDisclosureTarget.shelfBook,
       ),
+      offerLocalFiles: offerLocalFiles,
     );
-    if (scope == null) return;
+    if (decision == null) return;
+    final DeleteScope scope = decision.scope;
 
     if (book.bookKey.isNotEmpty) {
       await ReaderFushiSource.instance.deleteBook(
         db: appModel.database,
         bookKey: book.bookKey,
         scope: scope,
+        deleteLocalFiles: decision.deleteLocalFiles,
       );
     }
     // TODO-2470 死角①：纯字幕书（bookKey 空）不走上面的 deleteBook，删除范围必须在
     // 这里落地，否则勾了「从所有设备删除」静默无效。
     await SrtBookRepository(appModel.database).delete(book.uid,
-        propagateDeletion: scope == DeleteScope.syncEverywhere);
+        propagateDeletion: scope == DeleteScope.syncEverywhere,
+        deleteLocalFiles: decision.deleteLocalFiles);
     if (mounted) {
       _refreshSrtBooks();
       ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
@@ -975,8 +1029,11 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
 
   Future<void> _confirmDeleteEpub(MediaItem item, String bookKey) async {
     Navigator.pop(context);
+    final bool offerLocalFiles = await ReaderFushiSource.instance
+        .hasLocalSourceFiles(db: appModel.database, bookKey: bookKey);
+    if (!mounted) return;
     // P4：确认弹窗给人看，书名过门面（删除本体仍按 raw bookKey 身份执行）。
-    final DeleteScope? scope = await _confirmMediaDelete(
+    final DeleteDecision? decision = await _confirmMediaDelete(
       title: t.epub_delete_title,
       message: t.srt_delete_confirm(
         title: displayTitleForBook(item: item, rawTitle: item.title),
@@ -984,13 +1041,15 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
       disclosure: buildDeletionDisclosure(
         target: DeletionDisclosureTarget.shelfBook,
       ),
+      offerLocalFiles: offerLocalFiles,
     );
-    if (scope == null) return;
+    if (decision == null) return;
 
     final DeleteBookResult result = await ReaderFushiSource.instance.deleteBook(
       db: appModel.database,
       bookKey: bookKey,
-      scope: scope,
+      scope: decision.scope,
+      deleteLocalFiles: decision.deleteLocalFiles,
     );
     if (!mounted) return;
     if (!result.deleted) {

--- a/fushi/lib/src/pages/implementations/reader_history/dialogs.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/dialogs.part.dart
@@ -1,12 +1,14 @@
 // GENERATED-NOTE: extracted from reader_fushi_history_page.dart (TODO-587).
 part of '../reader_fushi_history_page.dart';
 
-/// 书架删除确认弹窗。[onConfirm] 回传用户在「同步删除」勾选框选择的 [DeleteScope]
-/// （勾选=[DeleteScope.syncEverywhere] 记墓碑传播到其他设备；默认不勾=
-/// [DeleteScope.keepLocalOnly] 只删本机）。[showSyncScope]=false 时把勾选框换成
-/// [DeleteScopeUnavailableNote] 说明行、恒 keepLocalOnly——由调用方按
-/// `hasDeletionPropagationChannel` 传入：本机一个同步通道都没有时，那个勾选框兑现不了
-/// （TODO-2470 死角②）。取消返回 null。
+/// 书架删除确认弹窗。[onConfirm] 回传用户的 [DeleteDecision]：scope 来自「同步删除」
+/// 勾选框（勾选=[DeleteScope.syncEverywhere] 记墓碑传播到其他设备；默认不勾=
+/// [DeleteScope.keepLocalOnly] 只删本机），deleteLocalFiles 来自「同时删除本地文件」
+/// 勾选框（仅 [offerLocalFiles] 时渲染——书/PDF/漫画导入即拷贝进 app 目录、原件路径
+/// 根本没入库，只有记录了原始音频路径的有声书/字幕书才有本机可删的原件）。
+/// [showSyncScope]=false 时把同步勾选框换成 [DeleteScopeUnavailableNote] 说明行、恒
+/// keepLocalOnly——由调用方按 `hasDeletionPropagationChannel` 传入：本机一个同步通道
+/// 都没有时，那个勾选框兑现不了（TODO-2470 死角②）。取消返回 null。
 @visibleForTesting
 class ReaderHistoryDeleteDialog extends StatefulWidget {
   const ReaderHistoryDeleteDialog({
@@ -14,14 +16,16 @@ class ReaderHistoryDeleteDialog extends StatefulWidget {
     required this.message,
     required this.onConfirm,
     this.showSyncScope = true,
+    this.offerLocalFiles = false,
     this.disclosure,
     super.key,
   });
 
   final String title;
   final String message;
-  final ValueChanged<DeleteScope> onConfirm;
+  final ValueChanged<DeleteDecision> onConfirm;
   final bool showSyncScope;
+  final bool offerLocalFiles;
 
   /// 逐项披露真实删除范围；null 表示该入口暂未接入结构化披露。
   final DeletionDisclosure? disclosure;
@@ -33,6 +37,7 @@ class ReaderHistoryDeleteDialog extends StatefulWidget {
 
 class _ReaderHistoryDeleteDialogState extends State<ReaderHistoryDeleteDialog> {
   bool _syncDelete = false;
+  bool _deleteLocalFiles = false;
 
   @override
   Widget build(BuildContext context) {
@@ -63,9 +68,18 @@ class _ReaderHistoryDeleteDialogState extends State<ReaderHistoryDeleteDialog> {
             Text(widget.message, style: tokens.type.listSubtitle),
             if (widget.disclosure != null) ...<Widget>[
               SizedBox(height: tokens.spacing.gap),
-              DeletionDisclosureView(disclosure: widget.disclosure!),
+              DeletionDisclosureView(
+                disclosure: _deleteLocalFiles
+                    ? widget.disclosure!.withLocalFilesDeleted()
+                    : widget.disclosure!,
+              ),
             ],
             SizedBox(height: tokens.spacing.gap),
+            if (widget.offerLocalFiles)
+              DeleteLocalFilesRow(
+                value: _deleteLocalFiles,
+                onChanged: (bool v) => setState(() => _deleteLocalFiles = v),
+              ),
             if (widget.showSyncScope)
               AdaptiveSettingsRow(
                 title: t.delete_scope_sync_everywhere,
@@ -98,9 +112,14 @@ class _ReaderHistoryDeleteDialogState extends State<ReaderHistoryDeleteDialog> {
               context: context,
               isDestructiveAction: true,
               onPressed: () => widget.onConfirm(
-                  widget.showSyncScope && _syncDelete
+                DeleteDecision(
+                  scope: widget.showSyncScope && _syncDelete
                       ? DeleteScope.syncEverywhere
-                      : DeleteScope.keepLocalOnly),
+                      : DeleteScope.keepLocalOnly,
+                  deleteLocalFiles:
+                      widget.offerLocalFiles && _deleteLocalFiles,
+                ),
+              ),
               child: Text(t.dialog_delete),
             ),
           ],

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -25,6 +25,69 @@ typedef VideoDownloadJobLocationLoader = Future<String?> Function(
   VideoDownloadJobRow job,
 );
 
+/// 下载任务「删除任务」确认框：正文 + 「同时删除已下载文件」勾选框。返回 null=取消，
+/// 否则为勾选值。v78 任务面板与旧番剧计划面板共用，两处口径一致；测试按
+/// `video-download-job-delete-files-<keySuffix>` / `…-confirm-<keySuffix>` 定位。
+Future<bool?> showDownloadTaskDeleteConfirm(
+  BuildContext context, {
+  required String title,
+  required String keySuffix,
+}) {
+  bool deleteFiles = false;
+  return showAppDialog<bool>(
+    context: context,
+    builder: (BuildContext dialogContext) => StatefulBuilder(
+      builder: (
+        BuildContext context,
+        void Function(void Function()) setDialogState,
+      ) =>
+          AlertDialog(
+        title: Text(t.download_task_delete),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(t.download_task_delete_confirm(title: title)),
+            const SizedBox(height: 12),
+            // 共享 MD3 行 + 裸 [Checkbox] 作 leading，整行 onTap 翻转——等价旧
+            // CheckboxListTile 的取值/回调/标题，但行高与内边距走设计令牌。
+            FushiListItem(
+              key: ValueKey<String>(
+                'video-download-job-delete-files-$keySuffix',
+              ),
+              density: FushiListDensity.compact,
+              padding: EdgeInsets.zero,
+              onTap: () => setDialogState(
+                () => deleteFiles = !deleteFiles,
+              ),
+              leading: Checkbox(
+                value: deleteFiles,
+                onChanged: (bool? value) => setDialogState(
+                  () => deleteFiles = value ?? false,
+                ),
+              ),
+              title: Text(t.download_task_delete_files),
+            ),
+          ],
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text(t.dialog_cancel),
+          ),
+          FilledButton(
+            key: ValueKey<String>(
+              'video-download-job-delete-confirm-$keySuffix',
+            ),
+            onPressed: () => Navigator.pop(dialogContext, deleteFiles),
+            child: Text(t.dialog_delete),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 typedef VideoDownloadJobDeleteAction = Future<void> Function(
   VideoDownloadJobRow job, {
   required bool deleteFiles,
@@ -286,58 +349,10 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
 
   Future<void> _confirmDelete(VideoDownloadJobRow job) async {
     if (widget.onDelete == null) return;
-    bool deleteFiles = false;
-    final bool? choice = await showAppDialog<bool>(
-      context: context,
-      builder: (BuildContext dialogContext) => StatefulBuilder(
-        builder: (
-          BuildContext context,
-          void Function(void Function()) setDialogState,
-        ) =>
-            AlertDialog(
-          title: Text(t.download_task_delete),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(t.download_task_delete_confirm(title: job.title)),
-              const SizedBox(height: 12),
-              // 共享 MD3 行 + 裸 [Checkbox] 作 leading，整行 onTap 翻转——等价旧
-              // CheckboxListTile 的取值/回调/标题，但行高与内边距走设计令牌。
-              FushiListItem(
-                key: ValueKey<String>(
-                  'video-download-job-delete-files-${job.jobId}',
-                ),
-                density: FushiListDensity.compact,
-                padding: EdgeInsets.zero,
-                onTap: () => setDialogState(
-                  () => deleteFiles = !deleteFiles,
-                ),
-                leading: Checkbox(
-                  value: deleteFiles,
-                  onChanged: (bool? value) => setDialogState(
-                    () => deleteFiles = value ?? false,
-                  ),
-                ),
-                title: Text(t.download_task_delete_files),
-              ),
-            ],
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext),
-              child: Text(t.dialog_cancel),
-            ),
-            FilledButton(
-              key: ValueKey<String>(
-                'video-download-job-delete-confirm-${job.jobId}',
-              ),
-              onPressed: () => Navigator.pop(dialogContext, deleteFiles),
-              child: Text(t.dialog_delete),
-            ),
-          ],
-        ),
-      ),
+    final bool? choice = await showDownloadTaskDeleteConfirm(
+      context,
+      title: job.title,
+      keySuffix: job.jobId,
     );
     if (choice == null || !mounted) return;
     await _runAction(

--- a/fushi/lib/src/sync/deletion_disclosure.dart
+++ b/fushi/lib/src/sync/deletion_disclosure.dart
@@ -21,13 +21,34 @@ enum DeletionDisclosureTarget {
 /// 这是纯数据，不含 Widget，可以在单测里与真实删除行为逐项对照——这正是本类存在的
 /// 理由：确认文案与实际删除范围必须由同一份事实派生，否则又会漂开。
 class DeletionDisclosure {
-  const DeletionDisclosure({required this.willDelete, required this.willKeep});
+  const DeletionDisclosure({
+    required this.willDelete,
+    required this.willKeep,
+    this.localFiles = const <String>[],
+  });
 
   /// 确认后真的会从本机消失的东西。
   final List<String> willDelete;
 
   /// 确认后仍然留着的东西——尤其是用户自己导入的原始文件。
   final List<String> willKeep;
+
+  /// [willKeep] 里描述「用户自己的原始文件」的那些条目：用户勾选「同时删除本地
+  /// 文件」后它们会从「保留」挪到「删除」（[withLocalFilesDeleted]）。必须是
+  /// [willKeep] 的子集；为空表示这个目标没有可删的原件。
+  final List<String> localFiles;
+
+  /// 勾选「同时删除本地文件」后的披露：原件条目挪进「会被删除」。
+  DeletionDisclosure withLocalFilesDeleted() {
+    if (localFiles.isEmpty) return this;
+    return DeletionDisclosure(
+      willDelete: <String>[...willDelete, ...localFiles],
+      willKeep: <String>[
+        for (final String item in willKeep)
+          if (!localFiles.contains(item)) item,
+      ],
+    );
+  }
 }
 
 /// 按 [target] 构造删除披露。
@@ -48,6 +69,9 @@ DeletionDisclosure buildDeletionDisclosure({
       //   3) EpubStorage.deleteBookDir(extractDir) 递归删 `<documents>/fushi_books/<key>`。
       // 不删：epub_books.epubPath 只存文件名，删除路径从不据它删用户原始文件；
       //       reading_statistics / reading_hourly_logs 无人清理，确实留着。
+      // 「同时删除本地文件」只对有声书原始音频有意义（书本体的原件路径没入库，
+      // 见 ReaderFushiSource.deleteBook）；localFiles 用的仍是同一条「原始文件」
+      // 披露，勾选后整条挪进删除区，不另造第二套措辞。
       return DeletionDisclosure(
         willDelete: <String>[
           t.delete_disclosure_book_records,
@@ -58,6 +82,7 @@ DeletionDisclosure buildDeletionDisclosure({
           t.delete_disclosure_source_kept,
           t.delete_disclosure_stats_kept,
         ],
+        localFiles: <String>[t.delete_disclosure_source_kept],
       );
     case DeletionDisclosureTarget.attachedAudiobook:
       // 真实删除集合见 AudiobookRepository.deleteAudiobook：
@@ -72,6 +97,7 @@ DeletionDisclosure buildDeletionDisclosure({
           t.delete_disclosure_audiobook_book_kept,
           t.delete_disclosure_audiobook_source_kept,
         ],
+        localFiles: <String>[t.delete_disclosure_audiobook_source_kept],
       );
   }
 }
@@ -104,6 +130,38 @@ class DeleteScopeUnavailableNote extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// 「同时删除本地文件」勾选行：两个删除确认框（`showDeleteScopeConfirm` /
+/// `ReaderHistoryDeleteDialog`）共用，保证措辞、图标与取值语义一致。勾选态用
+/// error 色——它删的是用户自己的原件，不是 app 的副本，视觉上必须比同步勾选框更重。
+class DeleteLocalFilesRow extends StatelessWidget {
+  const DeleteLocalFilesRow({
+    required this.value,
+    required this.onChanged,
+    this.subtitle,
+    super.key,
+  });
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  /// 省略时用通用说明 `delete_local_files_desc`。
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return AdaptiveSettingsRow(
+      title: t.delete_local_files,
+      subtitle: subtitle ?? t.delete_local_files_desc,
+      onTap: () => onChanged(!value),
+      trailing: Icon(
+        value ? Icons.check_box : Icons.check_box_outline_blank,
+        color: value ? colors.error : colors.onSurfaceVariant,
+      ),
     );
   }
 }

--- a/fushi/lib/src/sync/deletion_prompt.dart
+++ b/fushi/lib/src/sync/deletion_prompt.dart
@@ -8,31 +8,42 @@ import 'package:fushi/src/sync/sync_repository.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi_core/fushi_core.dart';
 
-/// 通用「删除范围」确认弹窗：正文 + 「从所有设备删除」勾选框（默认不勾）。确认返回用户
-/// 选的 [DeleteScope]（勾选=syncEverywhere 传播 / 不勾=keepLocalOnly 仅本机）；取消返回
-/// null。供书架/视频/有声书等各删除入口共用（书架另有 ReaderHistoryDeleteDialog 变体）。
+/// 通用「删除范围」确认弹窗：正文 + 「同时删除本地文件」勾选框（仅
+/// [offerLocalFiles] 时渲染，默认不勾）+ 「从所有设备删除」勾选框（默认不勾）。确认
+/// 返回用户的 [DeleteDecision]（scope：勾选=syncEverywhere 传播 / 不勾=keepLocalOnly
+/// 仅本机；deleteLocalFiles：是否连磁盘上的原始文件一起删）；取消返回 null。供
+/// 书架/视频/有声书等各删除入口共用（书架另有 ReaderHistoryDeleteDialog 变体）。
+///
+/// [offerLocalFiles] 由调用方按「这条目到底有没有本机可删的原件」决定：视频要
+/// `videoPath` 是本地路径（http(s) 远端流没有文件可删），有声书要记录了原始音频
+/// 路径。没有可删原件就别摆勾选框——与下面同步勾选框「兑现不了就不显示」同一纪律。
+/// [localFilesSubtitle] 省略时用通用说明，视频入口传更具体的（连下载任务一起清）。
 ///
 /// TODO-2470 死角②：传 [db] 时先查本机有没有删除传播通道（
 /// [hasDeletionPropagationChannel]，纯本地零网络），没有就不渲染那个兑现不了的勾选框，
 /// 改渲染一行说明。查询在 `showAppDialog` **之前**做完，弹窗自身仍是纯同步 widget、
 /// 不做 IO。[db] 省略时保持旧行为（恒显示），供不便拿到 db 的入口与既有测试使用。
-Future<DeleteScope?> showDeleteScopeConfirm(
+Future<DeleteDecision?> showDeleteScopeConfirm(
   BuildContext context, {
   required String title,
   required String message,
   DeletionDisclosure? disclosure,
   FushiDatabase? db,
+  bool offerLocalFiles = false,
+  String? localFilesSubtitle,
 }) async {
   final bool canSyncEverywhere =
       db == null || await hasDeletionPropagationChannel(SyncRepository(db));
   if (!context.mounted) return null;
-  return showAppDialog<DeleteScope>(
+  return showAppDialog<DeleteDecision>(
     context: context,
     builder: (_) => _DeleteScopeConfirmDialog(
       title: title,
       message: message,
       disclosure: disclosure,
       canSyncEverywhere: canSyncEverywhere,
+      offerLocalFiles: offerLocalFiles,
+      localFilesSubtitle: localFilesSubtitle,
     ),
   );
 }
@@ -43,6 +54,8 @@ class _DeleteScopeConfirmDialog extends StatefulWidget {
     required this.message,
     this.disclosure,
     this.canSyncEverywhere = true,
+    this.offerLocalFiles = false,
+    this.localFilesSubtitle,
   });
   final String title;
   final String message;
@@ -51,6 +64,10 @@ class _DeleteScopeConfirmDialog extends StatefulWidget {
   /// false = 本机无任何删除传播通道，勾了也不可能生效 → 不渲染勾选框，恒 keepLocalOnly。
   final bool canSyncEverywhere;
 
+  /// false = 这条目没有本机可删的原件 → 不渲染勾选框，恒 deleteLocalFiles=false。
+  final bool offerLocalFiles;
+  final String? localFilesSubtitle;
+
   @override
   State<_DeleteScopeConfirmDialog> createState() =>
       _DeleteScopeConfirmDialogState();
@@ -58,6 +75,7 @@ class _DeleteScopeConfirmDialog extends StatefulWidget {
 
 class _DeleteScopeConfirmDialogState extends State<_DeleteScopeConfirmDialog> {
   bool _syncDelete = false;
+  bool _deleteLocalFiles = false;
 
   @override
   Widget build(BuildContext context) {
@@ -79,9 +97,19 @@ class _DeleteScopeConfirmDialogState extends State<_DeleteScopeConfirmDialog> {
             Text(widget.message, style: tokens.type.listSubtitle),
             if (widget.disclosure != null) ...<Widget>[
               SizedBox(height: tokens.spacing.gap),
-              DeletionDisclosureView(disclosure: widget.disclosure!),
+              DeletionDisclosureView(
+                disclosure: _deleteLocalFiles
+                    ? widget.disclosure!.withLocalFilesDeleted()
+                    : widget.disclosure!,
+              ),
             ],
             SizedBox(height: tokens.spacing.gap),
+            if (widget.offerLocalFiles)
+              DeleteLocalFilesRow(
+                value: _deleteLocalFiles,
+                subtitle: widget.localFilesSubtitle,
+                onChanged: (bool v) => setState(() => _deleteLocalFiles = v),
+              ),
             if (widget.canSyncEverywhere)
               AdaptiveSettingsRow(
                 title: t.delete_scope_sync_everywhere,
@@ -114,10 +142,15 @@ class _DeleteScopeConfirmDialogState extends State<_DeleteScopeConfirmDialog> {
               context: context,
               isDestructiveAction: true,
               onPressed: () => Navigator.pop(
-                  context,
-                  widget.canSyncEverywhere && _syncDelete
+                context,
+                DeleteDecision(
+                  scope: widget.canSyncEverywhere && _syncDelete
                       ? DeleteScope.syncEverywhere
-                      : DeleteScope.keepLocalOnly),
+                      : DeleteScope.keepLocalOnly,
+                  deleteLocalFiles:
+                      widget.offerLocalFiles && _deleteLocalFiles,
+                ),
+              ),
               child: Text(t.dialog_delete),
             ),
           ],

--- a/fushi/lib/src/sync/deletion_propagation.dart
+++ b/fushi/lib/src/sync/deletion_propagation.dart
@@ -18,6 +18,34 @@ enum DeleteScope {
   syncEverywhere,
 }
 
+/// 用户在删除确认框里做出的完整决定：传播范围 + 要不要连本地原始文件一起删。
+///
+/// 两个维度正交：[scope] 只管「其他设备删不删」（墓碑），[deleteLocalFiles] 只管
+/// 「本机磁盘上用户自己的原件删不删」（视频文件 / 有声书原始音频）。默认后者为
+/// false——现有所有入口的语义（只删库记录 + app 自己的副本）一个字都不变。
+class DeleteDecision {
+  const DeleteDecision({
+    required this.scope,
+    this.deleteLocalFiles = false,
+  });
+
+  final DeleteScope scope;
+  final bool deleteLocalFiles;
+
+  @override
+  bool operator ==(Object other) =>
+      other is DeleteDecision &&
+      other.scope == scope &&
+      other.deleteLocalFiles == deleteLocalFiles;
+
+  @override
+  int get hashCode => Object.hash(scope, deleteLocalFiles);
+
+  @override
+  String toString() =>
+      'DeleteDecision(${scope.name}, deleteLocalFiles: $deleteLocalFiles)';
+}
+
 /// 删除传播的方向：远端也删 / 本地也删。
 enum DeletionPropagationDirection {
   /// 本地已删（有墓碑）而远端仍在库 → 提示用户「远端也删除？」。

--- a/fushi/test/media/video/download/reconcile_after_local_delete_test.dart
+++ b/fushi/test/media/video/download/reconcile_after_local_delete_test.dart
@@ -1,0 +1,230 @@
+/// 库侧删视频 + 「同时删除本地文件」→ 原始文件真从磁盘消失 → 下载任务按路径对账：
+/// 部分集被删 → 文件行标 skipped、任务保留；全部视频没了 → 任务整条删除。
+/// 以及仓储层护栏：仍被别的行引用的文件不删；不勾就一个文件都不动。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FushiDatabase db;
+  late VideoBookRepository repo;
+  late Directory tmp;
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    repo = VideoBookRepository(db);
+    tmp = await Directory.systemTemp.createTemp('fushi-reconcile-');
+  });
+  tearDown(() async {
+    await db.close();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  File touch(String name) =>
+      File(p.join(tmp.path, name))..writeAsStringSync(name);
+
+  Future<void> insertJob(String jobId, {required String lifecycle}) {
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    return db.upsertVideoDownloadJob(
+      VideoDownloadJobsCompanion.insert(
+        jobId: jobId,
+        resourceProvider: 'nyaa:test',
+        selectedResourceId: 'r1',
+        mediaKind: 'tv',
+        title: 'Show',
+        backendKind: 'embedded',
+        fingerprint: 'fp',
+        lifecycle: Value<String>(lifecycle),
+        stage: const Value<String>(VideoDownloadJobStage.scrape),
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  Future<void> insertFile(String jobId, File file, {int index = 0}) {
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    return db.upsertVideoDownloadJobFile(
+      VideoDownloadJobFilesCompanion.insert(
+        jobId: jobId,
+        backendFileIndex: Value<int?>(index),
+        originalRelativePath: p.basename(file.path),
+        currentRelativePath: p.basename(file.path),
+        finalAbsolutePath: Value<String?>(file.path),
+        kind: const Value<String>('video'),
+        status: const Value<String>(VideoDownloadJobFileStatus.imported),
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+  }
+
+  Future<void> insertVideo(String uid, String path) => repo.saveVideoBook(
+    VideoBooksCompanion.insert(bookUid: uid, title: uid, videoPath: path),
+  );
+
+  group('reconcileVideoDownloadJobsAfterLocalDelete', () {
+    test('部分集被删 → 命中的文件行 skipped、任务保留', () async {
+      final File e1 = touch('e1.mkv');
+      final File e2 = touch('e2.mkv');
+      await insertJob('job', lifecycle: VideoDownloadJobLifecycle.completed);
+      await insertFile('job', e1, index: 0);
+      await insertFile('job', e2, index: 1);
+      e1.deleteSync();
+
+      await reconcileVideoDownloadJobsAfterLocalDelete(
+        database: db,
+        deletedPaths: <String>{e1.path},
+      );
+
+      expect(await db.getVideoDownloadJob('job'), isNotNull);
+      final List<VideoDownloadJobFileRow> files = await db
+          .getVideoDownloadJobFiles('job');
+      final Map<String, String> status = <String, String>{
+        for (final VideoDownloadJobFileRow f in files)
+          f.originalRelativePath: f.status,
+      };
+      expect(status['e1.mkv'], VideoDownloadJobFileStatus.skipped);
+      expect(status['e2.mkv'], VideoDownloadJobFileStatus.imported);
+      expect(e2.existsSync(), isTrue);
+    });
+
+    test('视频文件全没了 → 任务整条删除（db-only 路径）', () async {
+      final File e1 = touch('e1.mkv');
+      final File e2 = touch('e2.mkv');
+      final File sub = touch('e1.srt');
+      await insertJob('job', lifecycle: VideoDownloadJobLifecycle.completed);
+      await insertFile('job', e1, index: 0);
+      await insertFile('job', e2, index: 1);
+      // 附带的字幕行：任务整删时随 deleteFiles:true 一起清。
+      final int now = DateTime.now().millisecondsSinceEpoch;
+      final int e1RowId = (await db.getVideoDownloadJobFiles('job'))
+          .firstWhere(
+            (VideoDownloadJobFileRow f) => f.originalRelativePath == 'e1.mkv',
+          )
+          .id;
+      await db.upsertVideoDownloadJobSubtitle(
+        VideoDownloadJobSubtitlesCompanion.insert(
+          subtitleId: 'sub1',
+          jobId: 'job',
+          jobFileId: Value<int?>(e1RowId),
+          provider: 'jimaku',
+          finalPath: Value<String?>(sub.path),
+          status: const Value<String>(VideoDownloadJobSubtitleStatus.placed),
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+      e1.deleteSync();
+      e2.deleteSync();
+
+      await reconcileVideoDownloadJobsAfterLocalDelete(
+        database: db,
+        deletedPaths: <String>{e1.path, e2.path},
+      );
+
+      expect(await db.getVideoDownloadJob('job'), isNull);
+      expect(sub.existsSync(), isFalse, reason: '整任务删除连残余字幕一起清');
+    });
+
+    test('任务还在跑 → 只标 skipped，绝不整删', () async {
+      final File e1 = touch('e1.mkv');
+      await insertJob('job', lifecycle: VideoDownloadJobLifecycle.active);
+      await insertFile('job', e1);
+      e1.deleteSync();
+
+      await reconcileVideoDownloadJobsAfterLocalDelete(
+        database: db,
+        deletedPaths: <String>{e1.path},
+      );
+
+      expect(await db.getVideoDownloadJob('job'), isNotNull);
+      expect(
+        (await db.getVideoDownloadJobFiles('job')).single.status,
+        VideoDownloadJobFileStatus.skipped,
+      );
+    });
+
+    test('路径不命中任何任务 → 无副作用', () async {
+      final File e1 = touch('e1.mkv');
+      await insertJob('job', lifecycle: VideoDownloadJobLifecycle.completed);
+      await insertFile('job', e1);
+      await reconcileVideoDownloadJobsAfterLocalDelete(
+        database: db,
+        deletedPaths: <String>{p.join(tmp.path, 'other.mkv')},
+      );
+      expect(await db.getVideoDownloadJob('job'), isNotNull);
+      expect(
+        (await db.getVideoDownloadJobFiles('job')).single.status,
+        VideoDownloadJobFileStatus.imported,
+      );
+    });
+  });
+
+  group('VideoBookRepository.deleteVideoBooksAndReclaimAssets', () {
+    test('deleteLocalFiles=true → 原件删掉并回调路径', () async {
+      final File v = touch('movie.mkv');
+      await insertVideo('video/movie', v.path);
+      Set<String>? reported;
+
+      final int deleted = await repo.deleteVideoBooksAndReclaimAssets(
+        <String>['video/movie'],
+        deleteLocalFiles: true,
+        compactDatabase: false,
+        onLocalFilesDeleted: (Set<String> paths) async => reported = paths,
+      );
+
+      expect(deleted, 1);
+      expect(v.existsSync(), isFalse);
+      expect(reported, <String>{v.path});
+      expect(await repo.getByBookUid('video/movie'), isNull);
+    });
+
+    test('默认不删原件（现有语义一个字不变）', () async {
+      final File v = touch('movie.mkv');
+      await insertVideo('video/movie', v.path);
+      await repo.deleteVideoBooksAndReclaimAssets(<String>[
+        'video/movie',
+      ], compactDatabase: false);
+      expect(v.existsSync(), isTrue);
+    });
+
+    test('仍被别的行引用的文件不删、也不回调', () async {
+      final File v = touch('shared.mkv');
+      await insertVideo('video/a', v.path);
+      await insertVideo('video/ext/b', v.path.replaceAll('\\', '/'));
+      bool called = false;
+      await repo.deleteVideoBooksAndReclaimAssets(
+        <String>['video/a'],
+        deleteLocalFiles: true,
+        compactDatabase: false,
+        onLocalFilesDeleted: (_) async => called = true,
+      );
+      expect(v.existsSync(), isTrue);
+      expect(called, isFalse);
+      expect(await repo.getByBookUid('video/ext/b'), isNotNull);
+    });
+
+    test('远端流行：勾了也没有文件可删，不回调', () async {
+      await insertVideo('video/remote', 'https://host/stream?token=1');
+      bool called = false;
+      await repo.deleteVideoBooksAndReclaimAssets(
+        <String>['video/remote'],
+        deleteLocalFiles: true,
+        compactDatabase: false,
+        onLocalFilesDeleted: (_) async => called = true,
+      );
+      expect(called, isFalse);
+    });
+  });
+}

--- a/fushi/test/media/video/video_local_files_test.dart
+++ b/fushi/test/media/video/video_local_files_test.dart
@@ -1,0 +1,117 @@
+/// 删除确认框「同时删除本地文件」（视频侧）的判据与删除护栏：
+/// 远端流没有文件可删、播放列表各集算本地文件、仍被别的行引用的文件保留、目录绝不删。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/external_video.dart'
+    show normalizeVideoPath;
+import 'package:fushi/src/media/video/video_local_files.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('isLocalVideoFilePath', () {
+    test('裸路径 / 盘符路径算本地', () {
+      expect(isLocalVideoFilePath(r'D:\Videos\ep01.mkv'), isTrue);
+      expect(isLocalVideoFilePath('/home/u/ep01.mkv'), isTrue);
+      expect(isLocalVideoFilePath('relative/ep01.mkv'), isTrue);
+    });
+
+    test('带 scheme 的 URI 不算本地（远端直传 / WebDAV / content）', () {
+      expect(isLocalVideoFilePath('https://host/stream?token=1'), isFalse);
+      expect(isLocalVideoFilePath('http://192.168.1.2:8080/a.mkv'), isFalse);
+      expect(isLocalVideoFilePath('content://media/external/video/1'), isFalse);
+      expect(isLocalVideoFilePath('file:///tmp/a.mkv'), isFalse);
+    });
+
+    test('空 / 空白不算', () {
+      expect(isLocalVideoFilePath(''), isFalse);
+      expect(isLocalVideoFilePath('   '), isFalse);
+    });
+  });
+
+  group('playlistEntryPaths', () {
+    test('解出各集路径；坏 JSON / 非列表 → 空', () {
+      final String json = jsonEncode(<Map<String, Object>>[
+        <String, Object>{'title': 'e1', 'path': r'D:\v\e1.mkv'},
+        <String, Object>{
+          'title': 'e2',
+          'path': r'D:\v\e2.mkv',
+          'positionMs': 3,
+        },
+      ]);
+      expect(playlistEntryPaths(json), <String>[
+        r'D:\v\e1.mkv',
+        r'D:\v\e2.mkv',
+      ]);
+      expect(playlistEntryPaths(null), isEmpty);
+      expect(playlistEntryPaths(''), isEmpty);
+      expect(playlistEntryPaths('{not json'), isEmpty);
+      expect(playlistEntryPaths('{"a":1}'), isEmpty);
+    });
+  });
+
+  group('localVideoFileCandidates', () {
+    test('videoPath + 播放列表各集，去重、剔远端', () {
+      final String json = jsonEncode(<Map<String, Object>>[
+        <String, Object>{'title': 'e1', 'path': 'D:/v/e1.mkv'},
+        <String, Object>{'title': 'e1-dup', 'path': r'D:\v\e1.mkv'},
+        <String, Object>{'title': 'remote', 'path': 'https://h/e2.mkv'},
+      ]);
+      expect(
+        localVideoFileCandidates(
+          videoPath: r'D:\v\list.m3u8',
+          playlistJson: json,
+        ),
+        <String>[r'D:\v\list.m3u8', 'D:/v/e1.mkv'],
+      );
+    });
+
+    test('远端流 → 无候选 → 弹窗不摆勾选框', () {
+      expect(
+        localVideoFileCandidates(videoPath: 'https://h/stream?token=x'),
+        isEmpty,
+      );
+    });
+  });
+
+  group('deleteLocalVideoFiles', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('fushi-local-del-');
+    });
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('删未被引用的文件；被引用的保留；目录与缺失路径跳过', () async {
+      final File a = File(p.join(tmp.path, 'a.mkv'))..writeAsStringSync('a');
+      final File b = File(p.join(tmp.path, 'b.mkv'))..writeAsStringSync('b');
+      final Directory d = Directory(p.join(tmp.path, 'dir'))..createSync();
+      final String missing = p.join(tmp.path, 'missing.mkv');
+
+      final Set<String> removed = await deleteLocalVideoFiles(
+        candidates: <String>[a.path, b.path, d.path, missing],
+        stillReferenced: <String>{normalizeVideoPath(b.path)},
+      );
+
+      expect(removed, <String>{a.path});
+      expect(a.existsSync(), isFalse);
+      expect(b.existsSync(), isTrue, reason: '仍被别的库行引用的文件不能删');
+      expect(d.existsSync(), isTrue, reason: '目录绝不删');
+    });
+
+    test('护栏比对经路径归一（分隔符差异不放行误删）', () async {
+      final File a = File(p.join(tmp.path, 'a.mkv'))..writeAsStringSync('a');
+      final String flipped = a.path.replaceAll('\\', '/');
+      final Set<String> removed = await deleteLocalVideoFiles(
+        candidates: <String>[a.path],
+        stillReferenced: <String>{normalizeVideoPath(flipped)},
+      );
+      expect(removed, isEmpty);
+      expect(a.existsSync(), isTrue);
+    });
+  });
+}

--- a/fushi/test/pages/video_delete_reclaim_entry_guard_test.dart
+++ b/fushi/test/pages/video_delete_reclaim_entry_guard_test.dart
@@ -24,18 +24,30 @@ void main() {
         'lib/src/media/video/download/video_download_pipeline_service.dart',
       ).readAsStringSync();
 
+      final String libraryDelete = File(
+        'lib/src/media/video/video_library_delete.dart',
+      ).readAsStringSync();
       final Map<String, ({String body, String operation})>
       entries = <String, ({String body, String operation})>{
+        // 视频页两个入口经 deleteVideoBooksWithDecision（同时删本地文件 + 联动
+        // 下载任务）落到仓库层；helper 自身再由下一条守住「必须走 reclaim 操作」。
         'home batch delete': (
           body: methodBody(home, 'Future<void> _batchDeleteConfirm() async'),
-          operation: 'deleteVideoBooksAndReclaimAssets',
+          operation: 'deleteVideoBooksWithDecision',
         ),
         'home single delete': (
           body: methodBody(
             home,
             'Future<void> _confirmDelete(VideoBookRow book) async',
           ),
-          operation: 'deleteVideoBookAndReclaimAssets',
+          operation: 'deleteVideoBooksWithDecision',
+        ),
+        'library delete helper': (
+          body: topLevelFunctionBody(
+            libraryDelete,
+            'deleteVideoBooksWithDecision',
+          )!,
+          operation: 'deleteVideoBooksAndReclaimAssets',
         ),
         'missing-resource delete': (
           body: methodBody(

--- a/fushi/test/sync/delete_local_files_dialog_test.dart
+++ b/fushi/test/sync/delete_local_files_dialog_test.dart
@@ -1,0 +1,178 @@
+/// 删除确认框「同时删除本地文件」勾选框：两个弹窗（通用 showDeleteScopeConfirm /
+/// 书架 ReaderHistoryDeleteDialog）只在 offerLocalFiles 时渲染、默认不勾、勾了才把
+/// DeleteDecision.deleteLocalFiles 置真；勾选后披露把「原始文件」从保留挪到删除。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/pages/implementations/reader_fushi_history_page.dart';
+import 'package:fushi/src/sync/deletion_disclosure.dart';
+import 'package:fushi/src/sync/deletion_prompt.dart';
+import 'package:fushi/src/sync/deletion_propagation.dart';
+
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  Widget app(Widget home) =>
+      TranslationProvider(child: MaterialApp(home: home));
+
+  group('showDeleteScopeConfirm', () {
+    testWidgets('offerLocalFiles=false → 不渲染勾选框，决定恒不删文件', (
+      WidgetTester tester,
+    ) async {
+      DeleteDecision? got;
+      await tester.pumpWidget(
+        app(
+          Builder(
+            builder: (BuildContext ctx) => TextButton(
+              onPressed: () async {
+                got = await showDeleteScopeConfirm(
+                  ctx,
+                  title: t.video_delete_title,
+                  message: 'msg',
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.delete_local_files), findsNothing);
+      await tester.tap(find.text(t.dialog_delete));
+      await tester.pumpAndSettle();
+      expect(got, const DeleteDecision(scope: DeleteScope.keepLocalOnly));
+    });
+
+    testWidgets('offerLocalFiles=true → 默认不勾；勾了才 deleteLocalFiles=true', (
+      WidgetTester tester,
+    ) async {
+      DeleteDecision? got;
+      await tester.pumpWidget(
+        app(
+          Builder(
+            builder: (BuildContext ctx) => TextButton(
+              onPressed: () async {
+                got = await showDeleteScopeConfirm(
+                  ctx,
+                  title: t.video_delete_title,
+                  message: 'msg',
+                  offerLocalFiles: true,
+                  localFilesSubtitle: t.delete_local_files_video_desc,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.delete_local_files), findsOneWidget);
+      expect(
+        find.text(t.delete_local_files_video_desc),
+        findsOneWidget,
+        reason: '视频入口用带「下载任务一并清除」的说明',
+      );
+
+      // 不勾直接删 → false。
+      await tester.tap(find.text(t.dialog_delete));
+      await tester.pumpAndSettle();
+      expect(got!.deleteLocalFiles, isFalse);
+
+      // 勾了再删 → true。
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.delete_local_files));
+      await tester.pump();
+      await tester.tap(find.text(t.dialog_delete));
+      await tester.pumpAndSettle();
+      expect(got!.deleteLocalFiles, isTrue);
+      expect(
+        got!.scope,
+        DeleteScope.keepLocalOnly,
+        reason: '两个勾选框正交：删文件不代表同步删除',
+      );
+    });
+  });
+
+  group('ReaderHistoryDeleteDialog', () {
+    testWidgets('勾选后披露把「原始文件」从保留挪到删除', (WidgetTester tester) async {
+      // 披露 + 两个勾选行比默认 800×600 视口高，按钮会被挤到屏幕外；这条测的是
+      // 披露语义，不是紧凑布局（那由 reader_history_delete_dialog_test 守）。
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(900, 1400);
+      addTearDown(tester.view.reset);
+      DeleteDecision? got;
+      await tester.pumpWidget(
+        app(
+          ReaderHistoryDeleteDialog(
+            title: t.epub_delete_title,
+            message: 'msg',
+            offerLocalFiles: true,
+            disclosure: buildDeletionDisclosure(
+              target: DeletionDisclosureTarget.shelfBook,
+            ),
+            onConfirm: (DeleteDecision d) => got = d,
+          ),
+        ),
+      );
+
+      DeletionDisclosure shown() => tester
+          .widget<DeletionDisclosureView>(find.byType(DeletionDisclosureView))
+          .disclosure;
+      expect(shown().willKeep, contains(t.delete_disclosure_source_kept));
+      expect(
+        shown().willDelete,
+        isNot(contains(t.delete_disclosure_source_kept)),
+      );
+
+      await tester.tap(find.text(t.delete_local_files));
+      await tester.pump();
+      expect(shown().willDelete, contains(t.delete_disclosure_source_kept));
+      expect(
+        shown().willKeep,
+        isNot(contains(t.delete_disclosure_source_kept)),
+      );
+
+      await tester.tap(find.text(t.dialog_delete));
+      await tester.pump();
+      expect(got!.deleteLocalFiles, isTrue);
+    });
+
+    testWidgets('offerLocalFiles=false → 无勾选框', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        app(
+          ReaderHistoryDeleteDialog(
+            title: t.epub_delete_title,
+            message: 'msg',
+            onConfirm: (_) {},
+          ),
+        ),
+      );
+      expect(find.text(t.delete_local_files), findsNothing);
+    });
+  });
+
+  test('DeletionDisclosure.withLocalFilesDeleted 只挪 localFiles 子集', () {
+    final DeletionDisclosure audiobook = buildDeletionDisclosure(
+      target: DeletionDisclosureTarget.attachedAudiobook,
+    );
+    final DeletionDisclosure moved = audiobook.withLocalFilesDeleted();
+    expect(
+      moved.willDelete,
+      contains(t.delete_disclosure_audiobook_source_kept),
+    );
+    expect(moved.willKeep, <String>[t.delete_disclosure_audiobook_book_kept]);
+    // 没有可删原件的披露原样返回。
+    const DeletionDisclosure plain = DeletionDisclosure(
+      willDelete: <String>['a'],
+      willKeep: <String>['b'],
+    );
+    expect(identical(plain.withLocalFilesDeleted(), plain), isTrue);
+  });
+}

--- a/fushi/test/sync/delete_scope_no_channel_widget_test.dart
+++ b/fushi/test/sync/delete_scope_no_channel_widget_test.dart
@@ -52,18 +52,20 @@ void main() {
     });
 
     testWidgets('无通道时确认 → 恒 keepLocalOnly', (WidgetTester tester) async {
-      DeleteScope? got;
+      DeleteDecision? got;
       await tester.pumpWidget(app(ReaderHistoryDeleteDialog(
         title: t.epub_delete_title,
         message: 'msg',
         showSyncScope: false,
-        onConfirm: (DeleteScope s) => got = s,
+        onConfirm: (DeleteDecision d) => got = d,
       )));
 
       await tester.tap(find.text(t.dialog_delete));
       await tester.pump();
 
-      expect(got, DeleteScope.keepLocalOnly);
+      expect(got?.scope, DeleteScope.keepLocalOnly);
+      expect(got?.deleteLocalFiles, isFalse,
+          reason: '没摆「同时删除本地文件」勾选框时恒为 false');
     });
   });
 

--- a/packages/fushi_audio/lib/fushi_audio.dart
+++ b/packages/fushi_audio/lib/fushi_audio.dart
@@ -16,6 +16,7 @@ export 'src/audiobook/audiobook_health.dart';
 export 'src/audiobook/audiobook_controller.dart';
 export 'src/audiobook/audiobook_repository.dart';
 export 'src/audiobook/audiobook_storage.dart';
+export 'src/audiobook/audiobook_source_files.dart';
 export 'src/audiobook/audiobook_path_relocator.dart';
 export 'src/audiobook/audio_file_sort.dart';
 export 'src/audiobook/srt_book_model.dart';

--- a/packages/fushi_audio/lib/src/audiobook/audiobook_repository.dart
+++ b/packages/fushi_audio/lib/src/audiobook/audiobook_repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'audiobook_health.dart';
 import 'audiobook_model.dart';
+import 'audiobook_source_files.dart';
 import 'audiobook_storage.dart';
 
 class AudiobookRepository {
@@ -165,13 +166,26 @@ class AudiobookRepository {
   /// [propagateDeletion]（默认 false）：true 时记一条 `audiobook` sync 删除墓碑，供同步
   /// 发布到远端标记、其他设备逐条确认后也删（对应删除弹窗「同步删除」）。false（含消费
   /// 远端删除标记路径）只删本机，绝不回写墓碑造成循环。app 层按 DeleteScope 传入。
+  ///
+  /// [deleteLocalFiles]（默认 false）：true 时连用户自己导入的原始音频文件一起删
+  /// （[deleteAudiobookSourceFiles]，对应删除弹窗「同时删除本地文件」）。原件位置
+  /// 在行上，必须删行**前**快照。
   Future<void> deleteAudiobook(
     String bookKey, {
     bool propagateDeletion = false,
+    bool deleteLocalFiles = false,
   }) async {
+    final Audiobook? before =
+        deleteLocalFiles ? await findByBookKey(bookKey) : null;
     // deleteAudiobookByBookKey 内部已先删 audioCues 再删 audiobooks。
     await _db.deleteAudiobookByBookKey(bookKey);
     await AudiobookStorage.deletePersistDir(bookKey);
+    if (before != null) {
+      await deleteAudiobookSourceFiles(
+        audioPaths: before.audioPaths,
+        audioRoot: before.audioRoot,
+      );
+    }
     if (propagateDeletion) {
       try {
         await _db.writeSyncDeletionTombstone(

--- a/packages/fushi_audio/lib/src/audiobook/audiobook_source_files.dart
+++ b/packages/fushi_audio/lib/src/audiobook/audiobook_source_files.dart
@@ -1,0 +1,74 @@
+/// 有声书 / 字幕书登记的**原始音频文件**（用户自己导入的原件，不是 app 复制进
+/// 持久目录的副本）：判据、解析与删除。
+///
+/// 两张表（`audiobooks` / `srt_books`）都用同一对列编码原件位置：
+/// - `audioPathsJson`：显式文件列表（优先）；
+/// - `audioRoot`：旧式「目录 + 按名排序」记录，文件列表要现场枚举。
+///
+/// 删除只在用户在删除确认框明确勾选「同时删除本地文件」时发生；本文件只删
+/// **文件**、绝不递归删目录——`audioRoot` 可能就是用户的音乐文件夹。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'audio_file_sort.dart';
+import 'audiobook_storage.dart';
+
+/// 纯函数：这条记录有没有登记原始音频（显式路径列表非空，或有 audioRoot）。
+bool hasAudiobookSourceFiles({
+  required List<String>? audioPaths,
+  required String? audioRoot,
+}) =>
+    (audioPaths != null && audioPaths.isNotEmpty) ||
+    (audioRoot != null && audioRoot.trim().isNotEmpty);
+
+/// 解析原始音频文件列表：[audioPaths] 非空取其中真实存在的；否则枚举 [audioRoot]
+/// 直接子文件里的音频文件（不递归），按 [compareAudioFilePath] 排序——与播放会话
+/// 装载时的口径完全一致（这就是它播的那些文件）。
+Future<List<File>> resolveAudiobookSourceFiles({
+  required List<String>? audioPaths,
+  required String? audioRoot,
+}) async {
+  if (audioPaths != null && audioPaths.isNotEmpty) {
+    final List<File> files = <File>[];
+    for (final String path in audioPaths) {
+      final File f = File(path);
+      if (await f.exists()) files.add(f);
+    }
+    return files;
+  }
+  if (audioRoot != null && audioRoot.trim().isNotEmpty) {
+    final Directory dir = Directory(audioRoot);
+    if (!await dir.exists()) return <File>[];
+    final List<FileSystemEntity> entries = await dir.list().toList();
+    return entries
+        .whereType<File>()
+        .where((File f) => AudiobookStorage.isAudioFile(f.path))
+        .toList()
+      ..sort((File a, File b) => compareAudioFilePath(a.path, b.path));
+  }
+  return <File>[];
+}
+
+/// 删除 [resolveAudiobookSourceFiles] 解析出的原件；返回真删掉的路径。
+/// 单文件失败（句柄占用等）只打日志并继续，不抛。
+Future<Set<String>> deleteAudiobookSourceFiles({
+  required List<String>? audioPaths,
+  required String? audioRoot,
+}) async {
+  final Set<String> removed = <String>{};
+  for (final File file in await resolveAudiobookSourceFiles(
+    audioPaths: audioPaths,
+    audioRoot: audioRoot,
+  )) {
+    try {
+      await file.delete();
+      removed.add(file.path);
+    } catch (e) {
+      debugPrint('[fushi-audio] delete source file failed: ${file.path}: $e');
+    }
+  }
+  return removed;
+}

--- a/packages/fushi_audio/lib/src/audiobook/srt_book_repository.dart
+++ b/packages/fushi_audio/lib/src/audiobook/srt_book_repository.dart
@@ -7,6 +7,7 @@ import 'package:fushi_core/fushi_core.dart';
 import 'audiobook_model.dart';
 import 'audiobook_path_relocator.dart';
 import 'audiobook_repository.dart';
+import 'audiobook_source_files.dart';
 import 'srt_book_model.dart';
 import 'audiobook_storage.dart';
 import '../parsers/srt_parser.dart';
@@ -352,11 +353,24 @@ class SrtBookRepository {
   /// 跨设备身份就是 uid。srt-backed 行（`bookKey` 非空）的身份是 bookKey，它的墓碑由
   /// `ReaderFushiSource.deleteBook` 写成 `book` 种类——两者互斥，同一资产绝不会产生
   /// 两条墓碑、也就不会在对端弹出两条重复的删除确认。
-  Future<int> delete(String uid, {bool propagateDeletion = false}) async {
-    // 身份判据要在删行前读（删完就查不到 bookKey 了）。
-    final bool standalone = propagateDeletion &&
-        ((await _db.getSrtBookByUid(uid))?.bookKey.isEmpty ?? false);
+  /// [deleteLocalFiles]（默认 false）：true 时连登记的原始音频文件一起删
+  /// （[deleteAudiobookSourceFiles]，对应删除弹窗「同时删除本地文件」）。
+  Future<int> delete(
+    String uid, {
+    bool propagateDeletion = false,
+    bool deleteLocalFiles = false,
+  }) async {
+    // 身份判据与原件位置都要在删行前读（删完就查不到了）。
+    final SrtBookRow? before = await _db.getSrtBookByUid(uid);
+    final bool standalone =
+        propagateDeletion && (before?.bookKey.isEmpty ?? false);
     final int deleted = await _db.deleteSrtBookByUid(uid);
+    if (deleteLocalFiles && before != null) {
+      await deleteAudiobookSourceFiles(
+        audioPaths: _decodeAudioPaths(before.audioPathsJson),
+        audioRoot: before.audioRoot,
+      );
+    }
     // 墓碑写在磁盘清理**之前**：DB 行是唯一真相源，此刻这本书对用户已经消失；持久化
     // 目录删除是删完再打扫的尾活，Windows 上可能因句柄占用抛 errno 32/145。若把墓碑
     // 排在它后面，一次尾活失败就会静默吞掉用户「从所有设备删除」的意图（同 TODO-1359
@@ -371,6 +385,16 @@ class SrtBookRepository {
     }
     await AudiobookStorage.deletePersistDir(uid);
     return deleted;
+  }
+
+  /// 删行前快照原件列表用；坏 JSON 当作没登记（与路径修复的容错口径一致）。
+  static List<String>? _decodeAudioPaths(String? raw) {
+    if (raw == null) return null;
+    try {
+      return (jsonDecode(raw) as List<dynamic>).cast<String>();
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<List<AudioCue>> cuesFor(String uid) async {

--- a/packages/fushi_audio/test/audiobook/audiobook_source_files_test.dart
+++ b/packages/fushi_audio/test/audiobook/audiobook_source_files_test.dart
@@ -1,0 +1,84 @@
+/// 有声书 / 字幕书原始音频文件的判据、解析与删除（删除确认框「同时删除本地文件」）。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_audio/src/audiobook/audiobook_source_files.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('hasAudiobookSourceFiles', () {
+    test('显式列表或 audioRoot 任一非空即有原件', () {
+      expect(
+        hasAudiobookSourceFiles(audioPaths: null, audioRoot: null),
+        isFalse,
+      );
+      expect(
+        hasAudiobookSourceFiles(audioPaths: <String>[], audioRoot: '  '),
+        isFalse,
+      );
+      expect(
+        hasAudiobookSourceFiles(
+          audioPaths: <String>['/a.mp3'],
+          audioRoot: null,
+        ),
+        isTrue,
+      );
+      expect(
+        hasAudiobookSourceFiles(audioPaths: null, audioRoot: '/music'),
+        isTrue,
+      );
+    });
+  });
+
+  group('resolve / delete', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('fushi-audio-src-');
+    });
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('显式列表：只取真实存在的', () async {
+      final File a = File(p.join(tmp.path, 'a.mp3'))..writeAsStringSync('a');
+      final List<File> files = await resolveAudiobookSourceFiles(
+        audioPaths: <String>[a.path, p.join(tmp.path, 'gone.mp3')],
+        audioRoot: tmp.path,
+      );
+      expect(files.map((File f) => f.path), <String>[a.path]);
+    });
+
+    test('audioRoot：直接子文件里的音频、按名排序、不递归', () async {
+      File(p.join(tmp.path, '02.mp3')).writeAsStringSync('2');
+      File(p.join(tmp.path, '01.mp3')).writeAsStringSync('1');
+      File(p.join(tmp.path, 'cover.jpg')).writeAsStringSync('x');
+      final Directory sub = Directory(p.join(tmp.path, 'sub'))..createSync();
+      File(p.join(sub.path, '03.mp3')).writeAsStringSync('3');
+
+      final List<File> files = await resolveAudiobookSourceFiles(
+        audioPaths: null,
+        audioRoot: tmp.path,
+      );
+      expect(files.map((File f) => p.basename(f.path)).toList(), <String>[
+        '01.mp3',
+        '02.mp3',
+      ]);
+    });
+
+    test('删除只删解析出的文件，目录与非音频文件保留', () async {
+      final File a = File(p.join(tmp.path, '01.mp3'))..writeAsStringSync('1');
+      final File cover = File(p.join(tmp.path, 'cover.jpg'))
+        ..writeAsStringSync('x');
+      final Set<String> removed = await deleteAudiobookSourceFiles(
+        audioPaths: null,
+        audioRoot: tmp.path,
+      );
+      expect(removed, <String>{a.path});
+      expect(a.existsSync(), isFalse);
+      expect(cover.existsSync(), isTrue);
+      expect(tmp.existsSync(), isTrue, reason: 'audioRoot 可能是用户的音乐文件夹');
+    });
+  });
+}


### PR DESCRIPTION
## 背景

删除视频/书只删库记录，磁盘上几 GB 的下载文件和下载任务原样留着；用户要求删除确认框加「删除本地文件」（含漫画等），并与下载页联动，下载页也要能删文件。

## 改动

### 删除确认框（两处共用语义）
- `showDeleteScopeConfirm` / `ReaderHistoryDeleteDialog` 返回 `DeleteDecision{scope, deleteLocalFiles}`（`deletion_propagation.dart`）。
- 新增「同时删除本地文件」勾选行 `DeleteLocalFilesRow`（`deletion_disclosure.dart`），**只在条目真有本机可删原件时渲染**、默认不勾、勾选态 error 色；与「从所有设备删除」正交。
- 勾选后 `DeletionDisclosure.withLocalFilesDeleted()` 把「你导入的原始文件」从「会保留」挪到「会删除」，披露与真实行为一致。

### 视频
- `VideoBookRepository.deleteVideoBooksAndReclaimAssets(deleteLocalFiles:, onLocalFilesDeleted:)`：行删掉、UI 释放句柄、app 副本回收之后，再删 `videoPath` + 播放列表各集（`video_local_files.dart`）。护栏：http(s) 远端流没文件；仍被幸存行引用的文件保留；只删文件绝不删目录。
- 新增 `reconcileVideoDownloadJobsAfterLocalDelete`（`video_download_pipeline_service.dart`）：按 `VideoDownloadJobFiles.finalAbsolutePath` 对账——任务已终态且视频文件全没了 → `pipeline.deleteJob(deleteFiles: true)` 整任务删除（摘后端种子 + 残余字幕/附件）；部分集或任务还在跑 → 命中文件行标 `skipped`，任务保留，并经 `pipeline.skipBackendFile` 把该文件在后端标 `TorrentFilePriority.skip`（否则做种一校验就撞缺失文件把整个种子停掉；后端不支持/离线时静默跳过）。
- 视频页单删/批删经 `deleteVideoBooksWithDecision`（`video_library_delete.dart`）接线；批删的勾选框在选中集里至少一条是本地文件时才出现。

### 有声书 / 字幕书
- `fushi_audio` 新增 `audiobook_source_files.dart`：`hasAudiobookSourceFiles` / `resolveAudiobookSourceFiles` / `deleteAudiobookSourceFiles`（`audioPaths` 优先，否则 `audioRoot` 直接子文件里的音频、不递归）；播放会话装载改为复用同一解析。
- `AudiobookRepository.deleteAudiobook` / `SrtBookRepository.delete` / `ReaderFushiSource.deleteBook` 加 `deleteLocalFiles`，删行前快照原件位置。
- 书架单删/批删、附加有声书删除按 `ReaderFushiSource.hasLocalSourceFiles` 决定摆不摆勾选框。

### 下载页
- v78 任务面板已有「同时删除已下载文件」（真删磁盘 + 联删库行），抽成共用 `showDownloadTaskDeleteConfirm`。
- **旧番剧计划**删除以前没有确认框、不删文件：现走同一确认框，`AnimeDownloadService.deletePlan(deleteFiles:, onFilesDeleted:)` 摘种子前先 `listFiles` 反查视频路径，删后清掉指向这些文件的视频库行。

### 明确不做（如实说明）
- **书 / PDF / 漫画本体**：导入即拷贝进 app 目录，`epubPath` 只存文件名、原件路径根本没入库；现有删除已经删 app 副本（漫画页图也在里面）。原始 `.mokuro` 文件夹 / EPUB 无从得知、不可能删，故这三类不摆勾选框（只有附带有声书原始音频时才摆）。
- 经发现页 torrent 下载的书/漫画/游戏包（`discovery-<kind>` 任务）与书架条目之间没有任何纽带（导入器只返回计数），书架删除不会联动那些任务；用户可在下载页删该任务并勾「同时删除已下载文件」。

## i18n
`delete_local_files` / `delete_local_files_desc` / `delete_local_files_video_desc`（`i18n_sync --add`，17 语言；`strings.g.dart` 按 short style 纯插入 233 行、零删除）。

## 验证
- `flutter analyze`（含 test）无 issue；`dart analyze` fushi_audio 无 issue。
- 新增测试：`video_local_files_test`（判据 + 删除护栏）、`delete_local_files_dialog_test`（两个弹窗 + 披露挪动）、`reconcile_after_local_delete_test`（部分/整任务/active 三档 + 仓储删原件与引用护栏）、fushi_audio `audiobook_source_files_test`。
- 相邻定向：`delete_scope_no_channel_widget_test`、`video_delete_reclaim_entry_guard_test`（守卫链延长到新 helper）、`deletion_disclosure_test`、`reader_history_delete_dialog_test`、`video_existence_guard_test`、`video_download_jobs_panel_test`、`anime_download_service_test`、`video_book_repository_test`、`video_download_pipeline_service_test`、`reader_fushi_source_test`、`md3_design_system_static_test`、`test/i18n` 全绿（Windows 本机）。
- 未做真机 E2E（删视频后观察磁盘与下载页）。

https://claude.ai/code/session_01W6JNRe6HeAYtNdEDAp98Ug
