### PR TITLE
feat(extension): 查词框大小设置入口 + 侧栏空间不足自动收敛 + 自绘整句字幕替代原生

### DIFF
--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -1411,41 +1411,83 @@ try {
 // 隐藏字幕就等于同时废掉制卡，那是把功能做成 bug。Netflix 批量录制路径 (fushiRunNetflixBatch)
 // 用的也是 visibility:hidden，此处与之同策。
 //
-// 所有权：本模块是 subtitleHidden 的**唯一**持有者（读 storage、注入 style、翻转、toast）。
+// 所有权：本模块是**字幕遮蔽**的唯一持有者（读 storage、注入 style、翻转、toast）。
 // subtitle-panel.js 只是把快捷键转发过来——因为面板整体受 netflixSubtitlePanel 门控且默认关，
 // 状态若放在面板里，用户没开面板时隐藏字幕就会失效。
+//
+// 遮蔽有**两个互不相干的来源**，故状态是「原因集合」而不是一个 bool：
+//   'manual'  = 用户主动隐藏字幕（Shift+H / options 开关，storage.subtitleHidden）→ 站点原生
+//               字幕和扩展自绘覆盖层**一起**藏（用户就是想什么都别看，先听后看）。
+//   'replace' = 「用 Fushi 字幕替代站点原生字幕」生效中（subtitle-panel.js 判定并推过来）→
+//               只藏站点原生字幕，**必须保留**自绘覆盖层，否则替代模式等于把字幕全关了。
+// 两者同时成立时取并集（manual 更强，全藏）。用 bool + 特例分支会立刻长出
+// 「谁把 style 摘掉了」的竞态，原因集合让「谁要求藏什么」变成可直接读的数据。
 const FUSHI_HIDE_SUBS_ID = 'fushi-hide-subs';
-let fushiSubtitleHidden = false;
+let fushiSubtitleHidden = false;                       // 'manual' 原因的镜像（storage 同步用）
+const fushiSubtitleHideReasons = new Set();
 
-function fushiSubtitleHideSelectors() {
+// 站点原生字幕渲染层。制卡取词（fushiSubtitleTextNow / fushiSubtitleCaretAtPoint）要读这些
+// 节点的 textContent 和 rect，所以只能 visibility 不能 display:none（见上）。
+function fushiNativeSubtitleSelectors() {
   return [
     '.player-timedtext',             // Netflix
     '.ytp-caption-window-container', // YouTube
     '.captions-text',                // 通用（部分播放器）
     '.libassjs-canvas-parent',       // ASS/SSA 渲染层
-    '#fushi-subtitle-overlay',      // 扩展自绘覆盖层
   ];
 }
+// 扩展自绘覆盖层（subtitle-panel.js 的 #fushi-subtitle-overlay）。
+function fushiOwnSubtitleSelectors() {
+  return ['#fushi-subtitle-overlay'];
+}
+// 兼容旧调用点/测试：默认（manual 语义）= 原生 + 自绘全藏。
+function fushiSubtitleHideSelectors() {
+  return fushiNativeSubtitleSelectors().concat(fushiOwnSubtitleSelectors());
+}
 
-function fushiApplySubtitleHiding(hide) {
+// 按当前原因集合重算注入样式。样式内容随原因变化，所以「已存在就 return」是错的——
+// manual→replace 的降级必须真的把自绘覆盖层从选择器里摘掉，否则替代模式下一片空白。
+function fushiApplySubtitleHiding() {
   const existing = document.getElementById(FUSHI_HIDE_SUBS_ID);
-  if (!hide) { if (existing) { try { existing.remove(); } catch (_) {} } return; }
-  if (existing) return;
-  const style = document.createElement('style');
-  style.id = FUSHI_HIDE_SUBS_ID;
+  if (!fushiSubtitleHideReasons.size) {
+    if (existing) { try { existing.remove(); } catch (_) {} }
+    return;
+  }
+  const manual = fushiSubtitleHideReasons.has('manual');
+  const selectors = manual ? fushiSubtitleHideSelectors() : fushiNativeSubtitleSelectors();
   // ::cue（原生 <track> 字幕）必须单独成一条规则：它只接受受限属性集，且与普通选择器
   // 并列时若被浏览器判为无效会**整条规则**失效，连带把上面的站点字幕也藏不掉。
-  style.textContent =
-      fushiSubtitleHideSelectors().join(',') + '{visibility:hidden!important}' +
+  const css = selectors.join(',') + '{visibility:hidden!important}' +
       'video::cue{visibility:hidden!important}';
-  try { (document.head || document.documentElement).appendChild(style); } catch (_) {}
+  const style = existing || document.createElement('style');
+  style.id = FUSHI_HIDE_SUBS_ID;
+  if (style.textContent !== css) style.textContent = css;
+  if (!existing) {
+    try { (document.head || document.documentElement).appendChild(style); } catch (_) {}
+  }
 }
+
+// 置位/清除一个遮蔽原因。幂等；变化才重算样式。
+function fushiSetSubtitleHideReason(reason, on) {
+  const had = fushiSubtitleHideReasons.has(reason);
+  if (!!on === had) return;
+  if (on) fushiSubtitleHideReasons.add(reason);
+  else fushiSubtitleHideReasons.delete(reason);
+  fushiApplySubtitleHiding();
+}
+
+// 「用 Fushi 字幕替代站点原生字幕」的执行端。判定在 subtitle-panel.js（它才知道当前活动轨
+// 是不是真的整集轨、有没有 cue）；这里只负责按结果藏/放站点原生字幕。判定方一旦发现
+// 「整轨没到 / 用户关了替代 / 切了视频」就会推 false，绝不会让用户落到「原生藏了、自绘也没有」。
+window.fushiSetNativeSubtitleReplaced = function (on) {
+  fushiSetSubtitleHideReason('replace', on === true);
+};
 
 // 快捷键执行端（subtitle-panel.js 的 fushiSubtitleShortcut 转发过来）。翻转 → 立即生效 →
 // 落 storage（options 页的开关与之双向同步）→ toast 反馈。返回 true 表示已接管这次按键。
 window.fushiToggleSubtitleHiding = function () {
   fushiSubtitleHidden = !fushiSubtitleHidden;
-  fushiApplySubtitleHiding(fushiSubtitleHidden);
+  fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
   try { chrome.storage.local.set({ subtitleHidden: fushiSubtitleHidden }); } catch (_) {}
   try {
     if (typeof window.fushiToast === 'function') {
@@ -1459,7 +1501,7 @@ function fushiReadSubtitleHidden() {
   try {
     chrome.storage.local.get(['subtitleHidden'], (r) => {
       fushiSubtitleHidden = !!(r && r.subtitleHidden === true);
-      fushiApplySubtitleHiding(fushiSubtitleHidden);
+      fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
     });
   } catch (_) {}
 }
@@ -1468,7 +1510,7 @@ try {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.subtitleHidden) {
       fushiSubtitleHidden = changes.subtitleHidden.newValue === true;
-      fushiApplySubtitleHiding(fushiSubtitleHidden);
+      fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
     }
   });
 } catch (_) {}
@@ -2231,11 +2273,11 @@ function fushiComputeResizedSize(start, delta, zoom, bounds) {
   return { width: width, height: height };
 }
 
-// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
-// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽与滑杆写同一
-// 真值，故边界必须一致，否则拖拽能写出滑杆写不出的越界值（app 侧仍会再 clamp 一次兜底）。
-const FUSHI_POPUP_MIN_WIDTH = 250;
-const FUSHI_POPUP_MIN_HEIGHT = 200;
+// 基准最大宽/高的允许范围（逻辑像素）定义在 popup-size.js（FUSHI_POPUP_MIN_WIDTH /
+// FUSHI_POPUP_MIN_HEIGHT，manifest 里排在本文件之前）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽把手、
+// 扩展「查词框大小」覆盖、滑杆写的是同一个真值，故边界必须一致，否则某条路径能写出别的
+// 路径写不出的越界值（app 侧仍会再 clamp 一次兜底）。这里不再复制这两个数字。
 const FUSHI_RESIZE_GRIP_SIZE = 18;
 
 // 把拖拽把手移到弹窗当前渲染矩形的右下角（视口坐标；host 是 fixed，坐标即视口系）。
@@ -2388,6 +2430,20 @@ function fushiRenderEntries(popupJson) {
   return true;
 }
 
+// 把 app 下发的弹窗尺寸镜像进 storage，供扩展设置页回显「当前多大」（它拿不到查词响应）。
+// 只写变化值（storage.set 会触发 onChanged，无脑写会让设置页每次查词都闪一下）。
+let fushiMirroredPopupSize = null;
+function fushiMirrorPopupSize(width, height) {
+  const w = Math.round(width);
+  const h = Math.round(height);
+  if (fushiMirroredPopupSize &&
+      fushiMirroredPopupSize.width === w && fushiMirroredPopupSize.height === h) {
+    return;
+  }
+  fushiMirroredPopupSize = { width: w, height: h };
+  try { chrome.storage.local.set({ popupSizeFromApp: fushiMirroredPopupSize }); } catch (_) {}
+}
+
 // 把查词响应下发的主题变量套到弹窗上。applyBox=false 时只套颜色/行为类变量，**不碰 host 的
 // 尺寸盒**（width/maxWidth/maxHeight/zoom）——嵌套查词是原地换内容，弹窗尺寸以及 place() 按
 // 「不遮被查词」夹出来的 maxHeight 必须原样保持；重写尺寸盒会把那次夹取悄悄丢掉。
@@ -2428,15 +2484,21 @@ function fushiApplyTheme(c, theme, applyBox) {
   }
   // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
   if (applyBox && fushiHost) {
-    fushiHost.style.width = theme['--fushi-popup-max-width'] || '400px';
+    // 尺寸真相源是 app 下发的 theme（扩展设置页「查词框大小」写的也是它，经
+    // POST /api/extension/popup-size）。视口夹取交给下面 fushiPlacePopup 的既有逻辑
+    // （它还要额外满足「不遮住被查词」），这里只解析出基准尺度的宽/高/zoom，不传 viewport。
+    const box = fushiResolvePopupBox(theme, null);
+    // 设置页要显示「当前多大」，但它读不到查词响应。这里把下发值镜像进 storage 供其回显。
+    // 只是镜像，不参与任何决策——真相源仍是 app。
+    fushiMirrorPopupSize(box.width, box.maxHeight);
+    fushiHost.style.width = box.width + 'px';
     fushiHost.style.maxWidth = 'calc(100vw - 16px)';
-    // BUG-1726：记住 theme 原始 maxHeight（CSS 串 + px 数）。落点/复算写 maxHeight 时把
+    // BUG-1726：记住原始 maxHeight（CSS 串 + px 数）。落点/复算写 maxHeight 时把
     // 「所选一侧可用空间」与它取 min 写回——夹取只缩不放，不放大用户配置的弹窗上限。
-    fushiHostBaseMaxHeight =
-        'min(' + (theme['--fushi-popup-max-height'] || '360px') + ', 80vh)';
-    fushiThemeMaxHeightPx = parseFloat(theme['--fushi-popup-max-height']) || 360;
+    fushiHostBaseMaxHeight = 'min(' + box.maxHeight + 'px, 80vh)';
+    fushiThemeMaxHeightPx = box.maxHeight;
     fushiHost.style.maxHeight = fushiHostBaseMaxHeight;
-    fushiHost.style.zoom = theme['--fushi-popup-zoom'] || '1';
+    fushiHost.style.zoom = String(box.zoom);
   }
 }
 

--- a/fushi/assets/browser_extension/manifest.json
+++ b/fushi/assets/browser_extension/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
+      "js": ["bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
       "css": ["vendor/content.css"]
     },
     {

--- a/fushi/assets/browser_extension/options.css
+++ b/fushi/assets/browser_extension/options.css
@@ -156,6 +156,21 @@ summary:focus-visible {
   line-height: 1.55;
 }
 
+/* 「查词框大小」的数值输入：与开关同一列宽，右对齐，空值时显示「跟随应用」占位。 */
+.size-input {
+  flex: 0 0 auto;
+  width: 118px;
+  padding: 9px 11px;
+  border: 1px solid var(--outline);
+  border-radius: 10px;
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+  text-align: right;
+}
+
+.size-input:focus-visible { outline: 2px solid var(--primary); outline-offset: 1px; }
+
 .switch {
   position: relative;
   flex: 0 0 auto;

--- a/fushi/assets/browser_extension/options.html
+++ b/fushi/assets/browser_extension/options.html
@@ -10,6 +10,45 @@
   <div class="shell">
     <div class="layout">
       <main class="main-column">
+        <section class="section" aria-labelledby="popup-size-heading">
+          <div class="section-heading">
+            <div>
+              <p class="section-kicker">查词弹窗</p>
+              <h2 id="popup-size-heading">查词框大小</h2>
+            </div>
+            <span class="section-note">下次查词生效</span>
+          </div>
+
+          <div class="setting-list">
+            <label class="setting-row" for="popupSizeWidth">
+              <span class="setting-copy">
+                <strong>最大宽度</strong>
+                <small>250–2000 像素。改这里等于在 Fushi 设置页调「浏览器扩展独立尺寸」的宽度滑杆
+                  —— 同一个值，改哪边都一样，不会互相盖。</small>
+              </span>
+              <input class="size-input" id="popupSizeWidth" type="number" min="250" max="2000" step="10"
+                     inputmode="numeric" placeholder="查词后读取">
+            </label>
+            <label class="setting-row" for="popupSizeHeight">
+              <span class="setting-copy">
+                <strong>最大高度</strong>
+                <small>200–1600 像素。超出即在框内滚动。首次填写会自动打开 Fushi 的
+                  「浏览器扩展独立尺寸」，此后浏览器里的查词框不再跟随 app 内弹窗尺寸。</small>
+              </span>
+              <input class="size-input" id="popupSizeHeight" type="number" min="200" max="1600" step="10"
+                     inputmode="numeric" placeholder="查词后读取">
+            </label>
+            <div class="setting-row">
+              <span class="setting-copy">
+                <strong>侧边栏空间不足时</strong>
+                <small>侧边栏比查词框窄时自动按可用宽度收敛，必要时整窗等比缩小，不再把右半边裁掉。
+                  此行为恒开，不占设置。想让浏览器查词框重新跟随 app 内弹窗，去 Fushi 设置页关掉
+                  「浏览器扩展独立尺寸」。</small>
+              </span>
+            </div>
+          </div>
+        </section>
+
         <section class="section" aria-labelledby="subtitle-heading">
           <div class="section-heading">
             <div>
@@ -47,6 +86,15 @@
                 <small>播放时自动把当前字幕滚到列表中部。</small>
               </span>
               <span class="switch"><input id="subtitleAutoScroll" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleReplaceNative">
+              <span class="setting-copy">
+                <strong>用 Fushi 字幕替代站点原生字幕</strong>
+                <small>预先取回整条字幕轨，按整句自绘在视频上，并藏掉站点原生字幕。专治 YouTube
+                  自动生成字幕——它是一个词一个词往外蹦的，划词和制卡永远只能拿到半句。整轨没取到时
+                  自动保持原生字幕可见。</small>
+              </span>
+              <span class="switch"><input id="subtitleReplaceNative" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
             <label class="setting-row" for="subtitleOverlayAllTracks">
               <span class="setting-copy">
@@ -272,6 +320,7 @@
 
   <div class="save-toast" id="status" role="status" aria-live="polite"></div>
   <script src="fushi-defaults.js"></script>
+  <script src="popup-size.js"></script>
   <script src="connection-diagnostics.js"></script>
   <script src="self-update.js"></script>
   <script src="options.js"></script>

--- a/fushi/assets/browser_extension/options.js
+++ b/fushi/assets/browser_extension/options.js
@@ -20,6 +20,8 @@ const settingDefaults = Object.freeze({
   subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,
+  // 用扩展预取的整集轨自绘整句字幕并藏掉站点原生字幕（默认关：改变站点观感的行为要用户点头）。
+  subtitleReplaceNative: false,
   // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
   videoShortcutPrevCue: true,
@@ -44,6 +46,7 @@ const toggleIds = Object.freeze({
   subtitleOverlayAutoLookup: 'subtitleOverlayAutoLookup',
   subtitleOverlayBlur: 'subtitleOverlayBlur',
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
+  subtitleReplaceNative: 'subtitleReplaceNative',
   subtitleHidden: 'subtitleHidden',
   videoShortcutPrevCue: 'videoShortcutPrevCue',
   videoShortcutNextCue: 'videoShortcutNextCue',
@@ -125,8 +128,8 @@ async function loadSettings() {
 
   // 旧 subtitleHoverPause / videoShortcutsEnabled 只作一次向后兼容读取：
   // 新键已有显式值时永远优先；旧键不再由 UI 写入。
-  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled']
-    .concat(Object.values(toggleIds));
+  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled',
+    'popupSizeFromApp'].concat(Object.values(toggleIds));
   const saved = await chrome.storage.local.get(keys);
   if (saved.host != null && saved.host !== '') $('host').value = saved.host;
   if (saved.port != null && saved.port !== 0) $('port').value = saved.port;
@@ -147,6 +150,52 @@ async function loadSettings() {
       await chrome.storage.local.set({ [key]: input.checked });
       toast('已更新：' + input.closest('.setting-row').querySelector('strong').textContent);
     });
+  }
+  await loadPopupSize(saved);
+}
+
+// ── 查词框大小 ──
+// 尺寸真相源是 app 的 `extension_popup_max_width/height` 偏好；写入口只有一条
+// `POST /api/extension/popup-size`（弹窗拖拽把手、侧边栏拖拽把手、这里三处共用，
+// background.js 的 'popupSize' 消息就是它）。**这里绝不在扩展本地另存一份尺寸**——
+// 那会变成第二个真相源，用户在 app 设置页调完发现不生效。
+// 回显值来自 content.js 在每次查词时镜像下来的 `popupSizeFromApp`（只读，不参与决策）。
+const popupSizeIds = Object.freeze(['popupSizeWidth', 'popupSizeHeight']);
+
+function fillPopupSizeInputs(mirror) {
+  const m = mirror && typeof mirror === 'object' ? mirror : null;
+  const w = $('popupSizeWidth');
+  const h = $('popupSizeHeight');
+  // 输入框正被编辑时不覆盖用户正在打的字（镜像会随每次查词更新）。
+  if (w && document.activeElement !== w) w.value = m && m.width > 0 ? String(Math.round(m.width)) : '';
+  if (h && document.activeElement !== h) h.value = m && m.height > 0 ? String(Math.round(m.height)) : '';
+}
+
+async function submitPopupSize() {
+  const size = fushiClampPopupSize($('popupSizeWidth').value, $('popupSizeHeight').value);
+  if (!size) {
+    // 两个都得有值才能提交（端点契约是 {maxWidth, maxHeight} 一对）。清空 = 不改。
+    return;
+  }
+  $('popupSizeWidth').value = String(size.width);   // 让用户当场看到被夹住的值
+  $('popupSizeHeight').value = String(size.height);
+  const resp = await runtimeMessage(
+    { type: 'popupSize', maxWidth: size.width, maxHeight: size.height });
+  if (resp && resp.ok) {
+    toast('查词框大小已更新（下次查词生效）');
+  } else {
+    toast('没连上 Fushi，尺寸没保存');
+  }
+}
+
+async function loadPopupSize(saved) {
+  const store = saved && Object.prototype.hasOwnProperty.call(saved, 'popupSizeFromApp')
+    ? saved
+    : await chrome.storage.local.get(['popupSizeFromApp']);
+  fillPopupSizeInputs(store.popupSizeFromApp);
+  for (const id of popupSizeIds) {
+    // change（失焦/回车）而非 input：边打字边发请求会把「4」当成 4px 提交上去。
+    on(id, 'change', submitPopupSize);
   }
 }
 
@@ -276,6 +325,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     const input = $(id);
     if (input) input.checked = changes[key].newValue === true;
   }
+  if (changes.popupSizeFromApp) fillPopupSizeInputs(changes.popupSizeFromApp.newValue);
   if (changes.fushiUpdateStale) refreshUpdateCard();
 });
 

--- a/fushi/assets/browser_extension/popup-size.js
+++ b/fushi/assets/browser_extension/popup-size.js
@@ -1,0 +1,123 @@
+// 查词弹窗尺寸盒的**唯一**决策器（纯函数，无 DOM）。
+//
+// 尺寸真相源只有一个：app 的 `extension_popup_max_width/height` 偏好（设置页「浏览器扩展
+// 独立尺寸」+ 两个滑杆），经查词响应的 theme 变量 `--fushi-popup-max-width/height/zoom`
+// 下发。写入口也只有一条：`POST /api/extension/popup-size {maxWidth,maxHeight}`——弹窗
+// 右下角拖拽把手、侧边栏拖拽把手、扩展设置页「查词框大小」三处都走它（app 侧统一 clamp +
+// 「拖即解锁」independentSize + 只写扩展键）。**扩展本地不得再存一份尺寸**，否则用户在
+// app 设置页调完发现不生效，两套值互相盖。
+//
+// 本模块负责的是真相源之外的那件事：**把下发的尺寸夹进当前视口**。
+// 起因：侧边栏文档可以窄到 300px，而 theme 宽度是按 app 窗口定的（400~600px），且这些
+// px 长度写在 CSS `zoom` **之下**——zoom=1.4 时 400px 渲染成 560px，连
+// `max-width: calc(100vw - 16px)` 这个上限本身也一起被 zoom 放大，根本拦不住 → 弹窗横向
+// 溢出，被 `.lookup-pane{overflow-x:hidden}` 硬切掉右半边（用户看到「查词框被切了」）。
+// content.js 的落点计算早已把 zoom 折回基准尺度（BUG-1726），侧边栏漏了这一步。
+//
+// 尺度约定（与 content.js fushiPlacePopup / side-panel.js positionLookup 同源）：
+//   「基准尺度」= 写进 style.width / style.maxHeight 的数值，渲染尺寸 = 基准 × zoom。
+//   视口尺寸是渲染尺度。所以任何视口上限要除以 zoom 才能与基准值比较。
+
+// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——扩展覆盖、
+// 拖拽把手、滑杆写的是同一个真值，边界必须一致，否则某条路径能写出别的路径写不出的越界值。
+// 「弹窗内部布局低于此宽度就崩排版」用的也是这一个数：可用空间不足以在当前 zoom 下容纳它时，
+// 压的是 zoom 而不是宽度（见 fushiResolvePopupBox）。content.js 的拖拽下限直接引用本常量。
+var FUSHI_POPUP_MIN_WIDTH = 250;    // = kLookupPopupMinWidth
+var FUSHI_POPUP_MAX_WIDTH = 2000;   // = kLookupPopupMaxWidth
+var FUSHI_POPUP_MIN_HEIGHT = 200;   // = kLookupPopupMinHeight
+var FUSHI_POPUP_MAX_HEIGHT = 1600;  // = kLookupPopupMaxHeight
+// zoom 压到这个下限就不再压——再小字就不可读了，剩下的溢出交给横向滚动。
+var FUSHI_POPUP_MIN_ZOOM = 0.5;
+
+// CSS 长度串 → px 数。接受 '400px' / '400' / 400；无法解析返回 fallback。
+// `min(...)` / `calc(...)` 这类函数式长度不是数值，返回 fallback（调用方本就只在
+// 「纯 px 主题值」上做算术，函数式串按原样交给 CSS）。
+function fushiParsePx(value, fallback) {
+  if (typeof value === 'number') return isFinite(value) && value > 0 ? value : fallback;
+  if (typeof value !== 'string') return fallback;
+  var m = value.trim().match(/^(-?\d+(?:\.\d+)?)\s*px$/i) || value.trim().match(/^(-?\d+(?:\.\d+)?)$/);
+  if (!m) return fallback;
+  var n = parseFloat(m[1]);
+  return isFinite(n) && n > 0 ? n : fallback;
+}
+
+// 设置页输入框 → 回写 app 之前的本地 clamp。app 侧 `_onExtensionPopupSize` sink 也会
+// clamp 一次（那才是权威），这里只是让用户当场看到被夹住的值，而不是提交完才莫名变化。
+// 非数/0/负数返回 null = 「这个值填得不成立，别提交」。
+function fushiClampPopupSize(width, height) {
+  var w = Number(width);
+  var h = Number(height);
+  if (!isFinite(w) || w <= 0 || !isFinite(h) || h <= 0) return null;
+  return {
+    width: Math.min(FUSHI_POPUP_MAX_WIDTH, Math.max(FUSHI_POPUP_MIN_WIDTH, Math.round(w))),
+    height: Math.min(FUSHI_POPUP_MAX_HEIGHT, Math.max(FUSHI_POPUP_MIN_HEIGHT, Math.round(h))),
+  };
+}
+
+// 决策弹窗尺寸盒。输入全是数据、输出全是数据，两个消费端（页面弹窗 / 侧边栏弹窗）共用。
+//
+// theme：app 下发的 CSS 变量对象（唯一尺寸真相源，可缺 → 用内置默认）。
+// viewport：{width, height} 渲染尺度的可用视口（侧边栏传自身文档视口）。缺省不做视口夹取。
+// opts.margin：视口两侧留白（渲染尺度，缺省 16）。
+//
+// 返回 { width, maxHeight, zoom, clamped }：
+//   width / maxHeight 是**基准尺度 px 数**（直接 + 'px' 写进 style）；
+//   zoom 是最终 zoom（空间实在不足时会低于下发值——宁可整体缩小也不横向切内容）；
+//   clamped 标记本次是否因视口不足收敛过（供调用方决定要不要提示/记录，非必须消费）。
+function fushiResolvePopupBox(theme, viewport, opts) {
+  var t = theme && typeof theme === 'object' ? theme : {};
+  var margin = opts && isFinite(opts.margin) ? opts.margin : 16;
+
+  var width = fushiParsePx(t['--fushi-popup-max-width'], 400);
+  var maxHeight = fushiParsePx(t['--fushi-popup-max-height'], 360);
+  var zoom = parseFloat(t['--fushi-popup-zoom']) || 1;
+  if (!(zoom > 0)) zoom = 1;
+
+  var clamped = false;
+  var vw = viewport && isFinite(viewport.width) ? viewport.width : 0;
+  var vh = viewport && isFinite(viewport.height) ? viewport.height : 0;
+
+  if (vw > 0) {
+    var availW = Math.max(1, vw - margin); // 真实可用渲染宽（不许抬高——抬高就掩盖了「放不下」）
+    // ① 先在当前 zoom 下压宽度。渲染宽 = width × zoom，故基准上限 = availW / zoom。
+    var maxBaseW = availW / zoom;
+    if (width > maxBaseW) { width = maxBaseW; clamped = true; }
+    // ② 压完仍低于「弹窗内部布局的最小基准宽」= 当前 zoom 下这点空间根本排不开内容。
+    //    此时该动的是 zoom 不是宽度：把宽度还原到最小基准宽，改让整窗等比缩小到放得下。
+    //    这消除了「只能横向切内容」这个特殊情况。
+    if (width < FUSHI_POPUP_MIN_WIDTH) {
+      width = FUSHI_POPUP_MIN_WIDTH;
+      zoom = Math.max(FUSHI_POPUP_MIN_ZOOM, availW / FUSHI_POPUP_MIN_WIDTH);
+      clamped = true;
+      // zoom 已到可读下限仍放不下（侧边栏窄到极端）：宽度按下限 zoom 再压回可用空间，
+      // 剩余溢出交给 .lookup-pane 的横向滚动，绝不静默切掉内容。
+      if (width * zoom > availW) width = availW / zoom;
+    }
+  }
+  if (vh > 0) {
+    // 与既有 `min(<theme px>, 80vh)` 语义对齐：vh 是渲染尺度，折回基准要除以 zoom。
+    var maxBaseH = (vh * 0.8) / zoom;
+    if (maxHeight > maxBaseH) { maxHeight = Math.max(64, maxBaseH); clamped = true; }
+  }
+
+  return {
+    width: Math.round(width * 100) / 100,
+    maxHeight: Math.round(maxHeight * 100) / 100,
+    zoom: Math.round(zoom * 1000) / 1000,
+    clamped: clamped,
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    FUSHI_POPUP_MIN_WIDTH,
+    FUSHI_POPUP_MIN_HEIGHT,
+    FUSHI_POPUP_MAX_WIDTH,
+    FUSHI_POPUP_MAX_HEIGHT,
+    FUSHI_POPUP_MIN_ZOOM,
+    fushiParsePx,
+    fushiClampPopupSize,
+    fushiResolvePopupBox,
+  };
+}

--- a/fushi/assets/browser_extension/side-panel.css
+++ b/fushi/assets/browser_extension/side-panel.css
@@ -185,7 +185,10 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   width: 400px;
   max-width: calc(100vw - 16px);
   max-height: min(360px, 80vh);
-  overflow-x: hidden;
+  /* 尺寸盒由 side-panel.js 的 applyLookupBox 按侧边栏实际视口夹取（zoom 已折算）。
+     这里保留 auto 而非 hidden 作为最后兜底：极端窄侧栏 + 不可断的长串（罗马音、URL、
+     宽表格）仍可能超出夹后的宽度，hidden 是**永久丢内容**，auto 至少还能横向滚出来。 */
+  overflow-x: auto;
   overflow-y: auto;
   overscroll-behavior: contain;
   visibility: hidden;

--- a/fushi/assets/browser_extension/side-panel.html
+++ b/fushi/assets/browser_extension/side-panel.html
@@ -44,6 +44,7 @@
   </main>
   <section id="lookup-pane" class="lookup-pane" aria-label="查词结果" hidden></section>
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
+  <script src="popup-size.js"></script>
   <script src="vendor/selection.js"></script>
   <script src="vendor/dict-media.js"></script>
   <script src="side-panel.js"></script>

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -168,9 +168,10 @@
       lookupPaneEl.style.left = '0px';
       lookupPaneEl.style.top = '0px';
     }
-    if (!lookupUserResized) {
-      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
-    }
+    // lookupBaseMaxHeight 已由 applyLookupBox 按「视口 80% ÷ zoom」折算成基准尺度 px，
+    // 这里不能再套一层 `min(..., 80vh)`：vh 不随 zoom 缩放，zoom>1 时那个上限会被放大到
+    // 视口之外，等于没夹（正是弹窗纵向超出侧边栏的原因）。
+    if (!lookupUserResized) lookupPaneEl.style.maxHeight = lookupBaseMaxHeight;
     requestAnimationFrame(function () {
       if (requestId !== lookupRequestId || lookupPaneEl.hidden) return;
       var gap = 4;
@@ -221,13 +222,27 @@
     window.__fushiPopupWheelSpeed = isFinite(wheelSpeed) && wheelSpeed > 0 ? wheelSpeed : 1;
     // 用户拖过尺寸（lookupUserResized）后，本会话内不再让主题下发的宽高盖掉用户的选择；
     // 拖拽结果经 popupSize 回写 app，下次会话由主题带回来。
-    if (!lookupUserResized) {
-      lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
-      lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
-      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
-    }
+    lookupThemeForBox = theme;
+    applyLookupBox();
+  }
+
+  // 侧边栏弹窗的尺寸盒。与页面弹窗（content.js fushiApplyTheme）同一个决策器，额外把
+  // **本文档视口**交给它做夹取——侧边栏可以窄到 300px，而主题宽度是按 app 窗口定的
+  // （400~600px），且这些 px 长度写在 CSS `zoom` 之下：zoom=1.4 时 400px 渲染成 560px，
+  // 连 `max-width: calc(100vw - 16px)` 这个上限本身也一起被 zoom 放大，根本拦不住 →
+  // 弹窗横向溢出，被 `.lookup-pane{overflow-x:hidden}` 硬切掉右半边（用户看到「查词框被切了」）。
+  // fushiResolvePopupBox 把上限折回基准尺度；压到最窄可读宽度仍放不下时改压 zoom，
+  // 让整窗等比缩小而不是切内容。
+  var lookupThemeForBox = null;
+  function applyLookupBox() {
+    if (lookupUserResized) return; // 用户手动拖过尺寸：本会话内不再自动改写
+    var box = fushiResolvePopupBox(
+      lookupThemeForBox, { width: window.innerWidth, height: window.innerHeight });
+    lookupPaneEl.style.width = box.width + 'px';
+    lookupBaseMaxHeight = box.maxHeight + 'px';
+    lookupPaneEl.style.maxHeight = lookupBaseMaxHeight;
     lookupPaneEl.style.maxWidth = 'calc(100vw - 16px)';
-    lookupPaneEl.style.zoom = theme['--fushi-popup-zoom'] || '1';
+    lookupPaneEl.style.zoom = String(box.zoom);
   }
 
   function renderLookupData(value, data, cacheHit) {
@@ -1019,6 +1034,14 @@
       lookupPaneEl.addEventListener('wheel', window.__fushiPopupWheelListener, { passive: false });
     }
   }, { once: true });
+
+  // 侧边栏宽度是用户随时可拖的：变窄后原尺寸盒必然溢出被裁。视口一变就按新可用空间
+  // 重算尺寸盒，并对开着的弹窗重跑落点（positionLookup 内部自带 hidden 守卫）。
+  window.addEventListener('resize', function () {
+    applyLookupBox();
+    if (!lookupPaneEl.hidden) positionLookup();
+  });
+
 
   try {
     chrome.tabs.onActivated.addListener(function () { refresh(true); });

--- a/fushi/assets/browser_extension/subtitle-panel.js
+++ b/fushi/assets/browser_extension/subtitle-panel.js
@@ -22,7 +22,9 @@
 
   // enabled 由扩展 options 的 netflixSubtitlePanel 开关驱动（默认 false）。
   var st = {
-    activeLang: null, videoId: null, cues: [], currentIndex: -1,
+    // videoId 初始值是 '' 而非 null：与 videoKey() 的非空字符串契约同型，
+    // 首次 tick 仍会因 '' !== <真实 key> 而触发一次 refreshHeadless（语义不变）。
+    activeLang: null, videoId: '', cues: [], currentIndex: -1,
     tickTimer: null, enabled: false,
     overlayEnabled: true, dragDropEnabled: true, autoScroll: true,
     overlayEl: null, overlayCue: null, dropHint: null,
@@ -76,7 +78,14 @@
   // 契约）。契约缺失（加载顺序异常/单测隔离）时本地回落同构实现。
   function videoKey() {
     try {
-      if (typeof window.fushiVideoKey === 'function') return window.fushiVideoKey();
+      if (typeof window.fushiVideoKey === 'function') {
+        // 契约：videoKey() 永远返回非空字符串。返回值会直接拼进轨 key
+        // （`${videoKey}|${lang}`），漏出 undefined/'' 就会生成 "undefined|ja" 这种脏 key；
+        // 而身份比较（videoKey() !== st.videoId）会因两侧类型不同而永远判「换了视频」。
+        // 上游给不出有效值时落回下面的通用回落，不把脏值传出去。
+        var k = window.fushiVideoKey();
+        if (typeof k === 'string' && k) return k;
+      }
     } catch (_) {}
     var m = (location.pathname || '').match(/\/watch\/(\d+)/);
     if (/(^|\.)netflix\.com$/.test(location.hostname) && m) return m[1];

--- a/fushi/assets/browser_extension/subtitle-panel.js
+++ b/fushi/assets/browser_extension/subtitle-panel.js
@@ -34,6 +34,12 @@
     overlayAutoLookup: false,
     overlayBlur: false, overlayAllTracks: false,
     overlayHovered: false, autoLookupLastX: -1, autoLookupLastY: -1,
+    // 「用 Fushi 字幕替代站点原生字幕」：用预取的整集轨自绘一整句，并藏掉站点原生字幕。
+    // 针对 YouTube 自动生成字幕——它是**逐词滚动**渲染的（DOM 里每帧多一个词），
+    // 拿它划词/制卡永远只能拿到半句；而 youtube-bridge.js 早就把整集 srv3 轨按 <p> 段
+    // 预取进 store 了，只是渲染侧默认不用（站点自带轨不叠加，避免双份字幕）。
+    // replaceNativeActive = 本轮判定「替代确实生效中」，推给 content.js 决定藏不藏原生。
+    replaceNative: false, replaceNativeActive: false,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -52,6 +58,9 @@
   function teardownAll() {
     hideSubtitleOverlay();
     hideDropHint();
+    // 面板整体被关掉时替代模式也随之失效（replaceNativeEffective 已含 st.enabled），
+    // 必须把站点原生字幕放回来——否则用户关掉字幕列表后既没有自绘覆盖层也没有原生字幕。
+    syncNativeSubtitleReplacement();
   }
   function applyEnabled(on) {
     st.enabled = !!on;
@@ -161,7 +170,9 @@
     st.overlayAutoLookup = c.subtitleOverlayAutoLookup === true;
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
+    st.replaceNative = c.subtitleReplaceNative === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
+    syncNativeSubtitleReplacement();
   }
 
   // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
@@ -173,6 +184,7 @@
       subtitleOverlayAutoLookup: st.overlayAutoLookup,
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
+      subtitleReplaceNative: st.replaceNative,
     };
   }
 
@@ -180,7 +192,7 @@
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleOverlayAutoLookup',
-      'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+      'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -189,7 +201,45 @@
     } catch (_) {}
   }
 
+  // 替代模式是否**真的**生效。四个条件缺一不可，任何一个不成立都必须放回原生字幕——
+  // 「藏了原生、自绘又没内容」= 用户一句字幕都看不到，比不做还糟：
+  //   ① 用户开了这个设置；② 覆盖层没被关掉（它就是替代品本身）；
+  //   ③ 当前活动轨不是 live 轨（live 轨就是从原生 DOM 逐词采来的，拿它替代原生毫无意义）；
+  //   ④ 这条轨真有 cue（整轨还没到 / 抓取失败时保持原生字幕可见）。
+  function replaceNativeEffective() {
+    return st.enabled && st.replaceNative && st.overlayEnabled &&
+      !!st.activeLang && st.activeLang !== LIVE_LANG && st.cues.length > 0;
+  }
+
+  // 把判定结果推给 content.js（遮蔽原因 'replace' 的唯一写入点）。幂等：状态没变不发。
+  function syncNativeSubtitleReplacement() {
+    var active = replaceNativeEffective();
+    if (active === st.replaceNativeActive) return;
+    st.replaceNativeActive = active;
+    try {
+      if (typeof window.fushiSetNativeSubtitleReplaced === 'function') {
+        window.fushiSetNativeSubtitleReplaced(active);
+      }
+    } catch (_) {}
+  }
+
   function tick() {
+    // 面板被关掉时 tick 直接停手。下面的身份检测会调 refreshHeadless，那是 sync() /
+    // fushiSubtitlePanelOnCues 的 enabled 门之外的第三条入口——不挡住的话，关掉的面板仍会
+    // 每 200ms 遍历整个 cue store 并拷一份 shiftedCues（整集轨可达数千条 × 多轨）。
+    // 注：这是**性能与语义一致性**门，不是正确性门——替代模式的撤销由 replaceNativeEffective
+    // 里的 st.enabled 保证，覆盖层的摘除由 teardownAll 保证，故变异掉这一行不会让测试变红。
+    if (!st.enabled) return;
+    // SPA 换视频先于一切：YouTube 只换 `?v=`，pathname 不变，下面那条 500ms 的 pathname
+    // 轮询根本看不见——不在这里认出身份变化，st.cues 会一直留着上一个视频的整轨，
+    // 替代模式就会拿旧字幕盖住新视频（且原生字幕已被藏）。refreshHeadless 内部会重跑 tick。
+    if (videoKey() !== st.videoId) {
+      st.activeLang = null;
+      refreshHeadless();
+      return;
+    }
+    // 先同步替代状态再走空轨短路：切视频/换轨导致 cues 清空时，原生字幕必须立刻放回来。
+    syncNativeSubtitleReplacement();
     if (!st.cues.length) { hideSubtitleOverlay(); return; }
     var nowMs = videoTimeMs();
     var idx = cueIndexAt(st.cues, nowMs);
@@ -262,9 +312,10 @@
 
   function updateSubtitleOverlay(cue) {
     // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
-    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）。
+    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）或「替代原生字幕」——
+    // 后者本来就是「原生藏掉、这里补上整句」，此时不叠字反而是空屏。
     if (!st.overlayEnabled || !cue ||
-        (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
+        (!isExternalLang(st.activeLang) && !st.overlayAllTracks && !replaceNativeEffective())) {
       hideSubtitleOverlay();
       return;
     }
@@ -690,7 +741,7 @@
       var keys = [
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
         'subtitleOverlayAutoLookup',
-        'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+        'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
       ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -25,7 +25,8 @@ Anki 能力——一切经本机 Fushi 桌面 App 内置的 yomitan API server�
 | `connection-diagnostics.js` | SW/options | 连接六态分类 + 中文文案（纯函数） |
 | `fushi-defaults.js` | SW/options | 安装助手写入的自动配置（host/port/token/build 指纹） |
 | `offscreen.html/js` | offscreen | tabCapture MediaRecorder（Netflix 逐句回放录制） |
-| `options.html/css/js` | options | 设置页：连接、字幕偏好、逐动作视频快捷键、版本与更新卡片 |
+| `options.html/css/js` | options | 设置页：连接、字幕偏好、查词框大小、逐动作视频快捷键、版本与更新卡片 |
+| `popup-size.js` | 隔离 + 扩展页 | 查词弹窗尺寸盒的唯一决策器（纯函数）：扩展独立尺寸覆盖 + 视口不足时的收敛；页面弹窗与侧边栏弹窗共用 |
 | `vendor/` | — | `popup.{js,css,html}`+`selection.js` = app 查词弹窗原样拷贝（上游 `fushi/assets/popup/`）；`dict-media.js` 允许扩展分叉；`content.css` 由生成器产出；`action-popup.*` 扩展独有 |
 | `scripts/` | 开发 | `generate-content-css.mjs`（popup.css → 零特异性重根 content.css）、`sync-mirrors.mjs`（镜像同步） |
 
@@ -77,6 +78,28 @@ app 升级
 YouTube 整集字幕 `/api/youtube/captions` · 外挂字幕解析 `/api/subtitle/parse`。
 服务端实现：`fushi/lib/src/sync/yomitan_api_server.dart`。
 
+## 查词框大小（单一真相源 + 窄侧边栏自动收敛）
+
+**尺寸真相源只有一个**：app 的 `extension_popup_max_width/height` 偏好（app 设置页「浏览器
+扩展独立尺寸」开关 + 两个滑杆），经查词响应的 theme 变量 `--fushi-popup-max-width/height/zoom`
+下发。**写入口也只有一条**：`POST /api/extension/popup-size {maxWidth,maxHeight}`——
+① 页面弹窗右下角拖拽把手 ② 侧边栏弹窗拖拽把手 ③ 扩展设置页「查词框大小」，三处都发
+background.js 的 `popupSize` 消息走它（app 侧统一 clamp 250-2000/200-1600 + 「拖即解锁」
+`extensionPopupIndependentSize=true` + 只写扩展键）。扩展本地**不存**任何尺寸值；设置页
+回显的是 content.js 每次查词镜像下来的 `popupSizeFromApp`（只读，不参与决策）。
+边界常量 `FUSHI_POPUP_MIN/MAX_WIDTH/HEIGHT` 与 Dart 侧 `kLookupPopupMin/MaxWidth/Height`
+逐个对齐，四条写入路径写同一个真值。
+
+**窄侧边栏自动收敛**（`popup-size.js` 的 `fushiResolvePopupBox(theme, viewport)`，页面弹窗与
+侧边栏弹窗共用）：侧边栏可以窄到 300px，而 theme 宽度是按 app 窗口定的，且这些 px 长度写在
+CSS `zoom` **之下**——`zoom=1.4` 时 400px 渲染成 560px，连 `max-width: calc(100vw - 16px)`
+这个上限本身也一起被放大，根本拦不住，右半边被 `overflow-x` 切掉。决策器把上限**折回基准
+尺度**（渲染尺寸 = 基准 × zoom，故视口上限要 ÷ zoom）；压到最小可用宽度仍放不下时改压
+zoom，让整窗等比缩小而不是切内容。侧边栏宽度可拖，`resize` 即重算。
+
+行为测试 `popup-size.test.js`（含 zoom 折算的根因回归 + 「不得出现第二真相源」守卫）+
+源码守卫在 `side-panel-performance.test.js`，均已变异实测。
+
 ## 字幕轨数据流（原生 Side Panel 零站点特例）
 
 所有来源写同一个 store：`window.fushiEpisodeCues['${videoKey}|${lang}'] = [{startMs,endMs,text}]`，
@@ -86,6 +109,20 @@ YouTube 整集字幕 `/api/youtube/captions` · 外挂字幕解析 `/api/subtitl
 播放器运行态完整 captionTracks（youtube-bridge；本地服务端仅作超时兜底）④ 原生
 `video.textTracks` 收割 ⑤ DOM 字幕采样 live 轨兜底 ⑥ 用户外挂文件（`外挂:` 前缀轨）。
 时轴偏移是**读取侧**的（store 永远存原始 cue），任意轨可偏移，会话内记忆。
+
+### 用 Fushi 字幕替代站点原生字幕（`subtitleReplaceNative`，默认关）
+
+YouTube 的自动生成（ASR）字幕在 DOM 里是**逐词滚动**渲染的——一句话要好几秒才凑齐，
+`⑤ DOM 采样 live 轨` 采到的因此永远是半句，划词和制卡都跟着残缺。而 `③ youtube-bridge`
+早就把整集 srv3 轨（`<p>` 段 = 整句）预取进 store 了，只是渲染侧默认不用它（站点自带轨
+不叠加，免得双份字幕）。打开这个开关后：当前活动轨是整集轨时，用自绘覆盖层显示整句，
+并让 `content.js` 藏掉站点原生字幕层。
+
+判定在 `subtitle-panel.js` 的 `replaceNativeEffective()`，四个条件缺一不可（面板启用 /
+覆盖层启用 / 活动轨非 `live` / 该轨真有 cue）——任一不成立立刻放回原生字幕，绝不出现
+「原生藏了、自绘也没有」。执行在 `content.js`：遮蔽状态是**原因集合**而非 bool，
+`'manual'`（Shift+H / 设置开关）藏原生 + 自绘，`'replace'` 只藏原生。
+行为测试 `subtitle-replace-native.test.js`（9 条不变式已变异实测）。
 
 ## 站点适配状态
 

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1411,41 +1411,83 @@ try {
 // 隐藏字幕就等于同时废掉制卡，那是把功能做成 bug。Netflix 批量录制路径 (fushiRunNetflixBatch)
 // 用的也是 visibility:hidden，此处与之同策。
 //
-// 所有权：本模块是 subtitleHidden 的**唯一**持有者（读 storage、注入 style、翻转、toast）。
+// 所有权：本模块是**字幕遮蔽**的唯一持有者（读 storage、注入 style、翻转、toast）。
 // subtitle-panel.js 只是把快捷键转发过来——因为面板整体受 netflixSubtitlePanel 门控且默认关，
 // 状态若放在面板里，用户没开面板时隐藏字幕就会失效。
+//
+// 遮蔽有**两个互不相干的来源**，故状态是「原因集合」而不是一个 bool：
+//   'manual'  = 用户主动隐藏字幕（Shift+H / options 开关，storage.subtitleHidden）→ 站点原生
+//               字幕和扩展自绘覆盖层**一起**藏（用户就是想什么都别看，先听后看）。
+//   'replace' = 「用 Fushi 字幕替代站点原生字幕」生效中（subtitle-panel.js 判定并推过来）→
+//               只藏站点原生字幕，**必须保留**自绘覆盖层，否则替代模式等于把字幕全关了。
+// 两者同时成立时取并集（manual 更强，全藏）。用 bool + 特例分支会立刻长出
+// 「谁把 style 摘掉了」的竞态，原因集合让「谁要求藏什么」变成可直接读的数据。
 const FUSHI_HIDE_SUBS_ID = 'fushi-hide-subs';
-let fushiSubtitleHidden = false;
+let fushiSubtitleHidden = false;                       // 'manual' 原因的镜像（storage 同步用）
+const fushiSubtitleHideReasons = new Set();
 
-function fushiSubtitleHideSelectors() {
+// 站点原生字幕渲染层。制卡取词（fushiSubtitleTextNow / fushiSubtitleCaretAtPoint）要读这些
+// 节点的 textContent 和 rect，所以只能 visibility 不能 display:none（见上）。
+function fushiNativeSubtitleSelectors() {
   return [
     '.player-timedtext',             // Netflix
     '.ytp-caption-window-container', // YouTube
     '.captions-text',                // 通用（部分播放器）
     '.libassjs-canvas-parent',       // ASS/SSA 渲染层
-    '#fushi-subtitle-overlay',      // 扩展自绘覆盖层
   ];
 }
+// 扩展自绘覆盖层（subtitle-panel.js 的 #fushi-subtitle-overlay）。
+function fushiOwnSubtitleSelectors() {
+  return ['#fushi-subtitle-overlay'];
+}
+// 兼容旧调用点/测试：默认（manual 语义）= 原生 + 自绘全藏。
+function fushiSubtitleHideSelectors() {
+  return fushiNativeSubtitleSelectors().concat(fushiOwnSubtitleSelectors());
+}
 
-function fushiApplySubtitleHiding(hide) {
+// 按当前原因集合重算注入样式。样式内容随原因变化，所以「已存在就 return」是错的——
+// manual→replace 的降级必须真的把自绘覆盖层从选择器里摘掉，否则替代模式下一片空白。
+function fushiApplySubtitleHiding() {
   const existing = document.getElementById(FUSHI_HIDE_SUBS_ID);
-  if (!hide) { if (existing) { try { existing.remove(); } catch (_) {} } return; }
-  if (existing) return;
-  const style = document.createElement('style');
-  style.id = FUSHI_HIDE_SUBS_ID;
+  if (!fushiSubtitleHideReasons.size) {
+    if (existing) { try { existing.remove(); } catch (_) {} }
+    return;
+  }
+  const manual = fushiSubtitleHideReasons.has('manual');
+  const selectors = manual ? fushiSubtitleHideSelectors() : fushiNativeSubtitleSelectors();
   // ::cue（原生 <track> 字幕）必须单独成一条规则：它只接受受限属性集，且与普通选择器
   // 并列时若被浏览器判为无效会**整条规则**失效，连带把上面的站点字幕也藏不掉。
-  style.textContent =
-      fushiSubtitleHideSelectors().join(',') + '{visibility:hidden!important}' +
+  const css = selectors.join(',') + '{visibility:hidden!important}' +
       'video::cue{visibility:hidden!important}';
-  try { (document.head || document.documentElement).appendChild(style); } catch (_) {}
+  const style = existing || document.createElement('style');
+  style.id = FUSHI_HIDE_SUBS_ID;
+  if (style.textContent !== css) style.textContent = css;
+  if (!existing) {
+    try { (document.head || document.documentElement).appendChild(style); } catch (_) {}
+  }
 }
+
+// 置位/清除一个遮蔽原因。幂等；变化才重算样式。
+function fushiSetSubtitleHideReason(reason, on) {
+  const had = fushiSubtitleHideReasons.has(reason);
+  if (!!on === had) return;
+  if (on) fushiSubtitleHideReasons.add(reason);
+  else fushiSubtitleHideReasons.delete(reason);
+  fushiApplySubtitleHiding();
+}
+
+// 「用 Fushi 字幕替代站点原生字幕」的执行端。判定在 subtitle-panel.js（它才知道当前活动轨
+// 是不是真的整集轨、有没有 cue）；这里只负责按结果藏/放站点原生字幕。判定方一旦发现
+// 「整轨没到 / 用户关了替代 / 切了视频」就会推 false，绝不会让用户落到「原生藏了、自绘也没有」。
+window.fushiSetNativeSubtitleReplaced = function (on) {
+  fushiSetSubtitleHideReason('replace', on === true);
+};
 
 // 快捷键执行端（subtitle-panel.js 的 fushiSubtitleShortcut 转发过来）。翻转 → 立即生效 →
 // 落 storage（options 页的开关与之双向同步）→ toast 反馈。返回 true 表示已接管这次按键。
 window.fushiToggleSubtitleHiding = function () {
   fushiSubtitleHidden = !fushiSubtitleHidden;
-  fushiApplySubtitleHiding(fushiSubtitleHidden);
+  fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
   try { chrome.storage.local.set({ subtitleHidden: fushiSubtitleHidden }); } catch (_) {}
   try {
     if (typeof window.fushiToast === 'function') {
@@ -1459,7 +1501,7 @@ function fushiReadSubtitleHidden() {
   try {
     chrome.storage.local.get(['subtitleHidden'], (r) => {
       fushiSubtitleHidden = !!(r && r.subtitleHidden === true);
-      fushiApplySubtitleHiding(fushiSubtitleHidden);
+      fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
     });
   } catch (_) {}
 }
@@ -1468,7 +1510,7 @@ try {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.subtitleHidden) {
       fushiSubtitleHidden = changes.subtitleHidden.newValue === true;
-      fushiApplySubtitleHiding(fushiSubtitleHidden);
+      fushiSetSubtitleHideReason('manual', fushiSubtitleHidden);
     }
   });
 } catch (_) {}
@@ -2231,11 +2273,11 @@ function fushiComputeResizedSize(start, delta, zoom, bounds) {
   return { width: width, height: height };
 }
 
-// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
-// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽与滑杆写同一
-// 真值，故边界必须一致，否则拖拽能写出滑杆写不出的越界值（app 侧仍会再 clamp 一次兜底）。
-const FUSHI_POPUP_MIN_WIDTH = 250;
-const FUSHI_POPUP_MIN_HEIGHT = 200;
+// 基准最大宽/高的允许范围（逻辑像素）定义在 popup-size.js（FUSHI_POPUP_MIN_WIDTH /
+// FUSHI_POPUP_MIN_HEIGHT，manifest 里排在本文件之前）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽把手、
+// 扩展「查词框大小」覆盖、滑杆写的是同一个真值，故边界必须一致，否则某条路径能写出别的
+// 路径写不出的越界值（app 侧仍会再 clamp 一次兜底）。这里不再复制这两个数字。
 const FUSHI_RESIZE_GRIP_SIZE = 18;
 
 // 把拖拽把手移到弹窗当前渲染矩形的右下角（视口坐标；host 是 fixed，坐标即视口系）。
@@ -2388,6 +2430,20 @@ function fushiRenderEntries(popupJson) {
   return true;
 }
 
+// 把 app 下发的弹窗尺寸镜像进 storage，供扩展设置页回显「当前多大」（它拿不到查词响应）。
+// 只写变化值（storage.set 会触发 onChanged，无脑写会让设置页每次查词都闪一下）。
+let fushiMirroredPopupSize = null;
+function fushiMirrorPopupSize(width, height) {
+  const w = Math.round(width);
+  const h = Math.round(height);
+  if (fushiMirroredPopupSize &&
+      fushiMirroredPopupSize.width === w && fushiMirroredPopupSize.height === h) {
+    return;
+  }
+  fushiMirroredPopupSize = { width: w, height: h };
+  try { chrome.storage.local.set({ popupSizeFromApp: fushiMirroredPopupSize }); } catch (_) {}
+}
+
 // 把查词响应下发的主题变量套到弹窗上。applyBox=false 时只套颜色/行为类变量，**不碰 host 的
 // 尺寸盒**（width/maxWidth/maxHeight/zoom）——嵌套查词是原地换内容，弹窗尺寸以及 place() 按
 // 「不遮被查词」夹出来的 maxHeight 必须原样保持；重写尺寸盒会把那次夹取悄悄丢掉。
@@ -2428,15 +2484,21 @@ function fushiApplyTheme(c, theme, applyBox) {
   }
   // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
   if (applyBox && fushiHost) {
-    fushiHost.style.width = theme['--fushi-popup-max-width'] || '400px';
+    // 尺寸真相源是 app 下发的 theme（扩展设置页「查词框大小」写的也是它，经
+    // POST /api/extension/popup-size）。视口夹取交给下面 fushiPlacePopup 的既有逻辑
+    // （它还要额外满足「不遮住被查词」），这里只解析出基准尺度的宽/高/zoom，不传 viewport。
+    const box = fushiResolvePopupBox(theme, null);
+    // 设置页要显示「当前多大」，但它读不到查词响应。这里把下发值镜像进 storage 供其回显。
+    // 只是镜像，不参与任何决策——真相源仍是 app。
+    fushiMirrorPopupSize(box.width, box.maxHeight);
+    fushiHost.style.width = box.width + 'px';
     fushiHost.style.maxWidth = 'calc(100vw - 16px)';
-    // BUG-1726：记住 theme 原始 maxHeight（CSS 串 + px 数）。落点/复算写 maxHeight 时把
+    // BUG-1726：记住原始 maxHeight（CSS 串 + px 数）。落点/复算写 maxHeight 时把
     // 「所选一侧可用空间」与它取 min 写回——夹取只缩不放，不放大用户配置的弹窗上限。
-    fushiHostBaseMaxHeight =
-        'min(' + (theme['--fushi-popup-max-height'] || '360px') + ', 80vh)';
-    fushiThemeMaxHeightPx = parseFloat(theme['--fushi-popup-max-height']) || 360;
+    fushiHostBaseMaxHeight = 'min(' + box.maxHeight + 'px, 80vh)';
+    fushiThemeMaxHeightPx = box.maxHeight;
     fushiHost.style.maxHeight = fushiHostBaseMaxHeight;
-    fushiHost.style.zoom = theme['--fushi-popup-zoom'] || '1';
+    fushiHost.style.zoom = String(box.zoom);
   }
 }
 

--- a/tools/browser-extension/manifest.json
+++ b/tools/browser-extension/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
+      "js": ["bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
       "css": ["vendor/content.css"]
     },
     {

--- a/tools/browser-extension/nested-lookup.test.js
+++ b/tools/browser-extension/nested-lookup.test.js
@@ -277,6 +277,10 @@ function loadWorld(opts) {
   vm.runInContext(fs.readFileSync(POPUP, 'utf8'), sandbox, { filename: 'popup.js' });
   vm.runInContext(fs.readFileSync(SHIM, 'utf8'), sandbox, { filename: 'bridge-shim.js' });
   loadFushiDictMedia(sandbox);
+  // manifest 里 popup-size.js 排在 content.js 之前（同隔离世界的顶层函数），
+  // content.js 的 fushiApplyTheme 直接调它的 fushiResolvePopupBox。
+  vm.runInContext(fs.readFileSync(path.join(__dirname, 'popup-size.js'), 'utf8'), sandbox,
+    { filename: 'popup-size.js' });
   vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox, { filename: 'content.js' });
 
   const flushRaf = () => { while (rafQueue.length) rafQueue.shift()(); };

--- a/tools/browser-extension/options.css
+++ b/tools/browser-extension/options.css
@@ -156,6 +156,21 @@ summary:focus-visible {
   line-height: 1.55;
 }
 
+/* 「查词框大小」的数值输入：与开关同一列宽，右对齐，空值时显示「跟随应用」占位。 */
+.size-input {
+  flex: 0 0 auto;
+  width: 118px;
+  padding: 9px 11px;
+  border: 1px solid var(--outline);
+  border-radius: 10px;
+  background: var(--surface);
+  color: inherit;
+  font: inherit;
+  text-align: right;
+}
+
+.size-input:focus-visible { outline: 2px solid var(--primary); outline-offset: 1px; }
+
 .switch {
   position: relative;
   flex: 0 0 auto;

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -10,6 +10,45 @@
   <div class="shell">
     <div class="layout">
       <main class="main-column">
+        <section class="section" aria-labelledby="popup-size-heading">
+          <div class="section-heading">
+            <div>
+              <p class="section-kicker">查词弹窗</p>
+              <h2 id="popup-size-heading">查词框大小</h2>
+            </div>
+            <span class="section-note">下次查词生效</span>
+          </div>
+
+          <div class="setting-list">
+            <label class="setting-row" for="popupSizeWidth">
+              <span class="setting-copy">
+                <strong>最大宽度</strong>
+                <small>250–2000 像素。改这里等于在 Fushi 设置页调「浏览器扩展独立尺寸」的宽度滑杆
+                  —— 同一个值，改哪边都一样，不会互相盖。</small>
+              </span>
+              <input class="size-input" id="popupSizeWidth" type="number" min="250" max="2000" step="10"
+                     inputmode="numeric" placeholder="查词后读取">
+            </label>
+            <label class="setting-row" for="popupSizeHeight">
+              <span class="setting-copy">
+                <strong>最大高度</strong>
+                <small>200–1600 像素。超出即在框内滚动。首次填写会自动打开 Fushi 的
+                  「浏览器扩展独立尺寸」，此后浏览器里的查词框不再跟随 app 内弹窗尺寸。</small>
+              </span>
+              <input class="size-input" id="popupSizeHeight" type="number" min="200" max="1600" step="10"
+                     inputmode="numeric" placeholder="查词后读取">
+            </label>
+            <div class="setting-row">
+              <span class="setting-copy">
+                <strong>侧边栏空间不足时</strong>
+                <small>侧边栏比查词框窄时自动按可用宽度收敛，必要时整窗等比缩小，不再把右半边裁掉。
+                  此行为恒开，不占设置。想让浏览器查词框重新跟随 app 内弹窗，去 Fushi 设置页关掉
+                  「浏览器扩展独立尺寸」。</small>
+              </span>
+            </div>
+          </div>
+        </section>
+
         <section class="section" aria-labelledby="subtitle-heading">
           <div class="section-heading">
             <div>
@@ -47,6 +86,15 @@
                 <small>播放时自动把当前字幕滚到列表中部。</small>
               </span>
               <span class="switch"><input id="subtitleAutoScroll" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleReplaceNative">
+              <span class="setting-copy">
+                <strong>用 Fushi 字幕替代站点原生字幕</strong>
+                <small>预先取回整条字幕轨，按整句自绘在视频上，并藏掉站点原生字幕。专治 YouTube
+                  自动生成字幕——它是一个词一个词往外蹦的，划词和制卡永远只能拿到半句。整轨没取到时
+                  自动保持原生字幕可见。</small>
+              </span>
+              <span class="switch"><input id="subtitleReplaceNative" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
             <label class="setting-row" for="subtitleOverlayAllTracks">
               <span class="setting-copy">
@@ -272,6 +320,7 @@
 
   <div class="save-toast" id="status" role="status" aria-live="polite"></div>
   <script src="fushi-defaults.js"></script>
+  <script src="popup-size.js"></script>
   <script src="connection-diagnostics.js"></script>
   <script src="self-update.js"></script>
   <script src="options.js"></script>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -20,6 +20,8 @@ const settingDefaults = Object.freeze({
   subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,
+  // 用扩展预取的整集轨自绘整句字幕并藏掉站点原生字幕（默认关：改变站点观感的行为要用户点头）。
+  subtitleReplaceNative: false,
   // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
   videoShortcutPrevCue: true,
@@ -44,6 +46,7 @@ const toggleIds = Object.freeze({
   subtitleOverlayAutoLookup: 'subtitleOverlayAutoLookup',
   subtitleOverlayBlur: 'subtitleOverlayBlur',
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
+  subtitleReplaceNative: 'subtitleReplaceNative',
   subtitleHidden: 'subtitleHidden',
   videoShortcutPrevCue: 'videoShortcutPrevCue',
   videoShortcutNextCue: 'videoShortcutNextCue',
@@ -125,8 +128,8 @@ async function loadSettings() {
 
   // 旧 subtitleHoverPause / videoShortcutsEnabled 只作一次向后兼容读取：
   // 新键已有显式值时永远优先；旧键不再由 UI 写入。
-  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled']
-    .concat(Object.values(toggleIds));
+  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled',
+    'popupSizeFromApp'].concat(Object.values(toggleIds));
   const saved = await chrome.storage.local.get(keys);
   if (saved.host != null && saved.host !== '') $('host').value = saved.host;
   if (saved.port != null && saved.port !== 0) $('port').value = saved.port;
@@ -147,6 +150,52 @@ async function loadSettings() {
       await chrome.storage.local.set({ [key]: input.checked });
       toast('已更新：' + input.closest('.setting-row').querySelector('strong').textContent);
     });
+  }
+  await loadPopupSize(saved);
+}
+
+// ── 查词框大小 ──
+// 尺寸真相源是 app 的 `extension_popup_max_width/height` 偏好；写入口只有一条
+// `POST /api/extension/popup-size`（弹窗拖拽把手、侧边栏拖拽把手、这里三处共用，
+// background.js 的 'popupSize' 消息就是它）。**这里绝不在扩展本地另存一份尺寸**——
+// 那会变成第二个真相源，用户在 app 设置页调完发现不生效。
+// 回显值来自 content.js 在每次查词时镜像下来的 `popupSizeFromApp`（只读，不参与决策）。
+const popupSizeIds = Object.freeze(['popupSizeWidth', 'popupSizeHeight']);
+
+function fillPopupSizeInputs(mirror) {
+  const m = mirror && typeof mirror === 'object' ? mirror : null;
+  const w = $('popupSizeWidth');
+  const h = $('popupSizeHeight');
+  // 输入框正被编辑时不覆盖用户正在打的字（镜像会随每次查词更新）。
+  if (w && document.activeElement !== w) w.value = m && m.width > 0 ? String(Math.round(m.width)) : '';
+  if (h && document.activeElement !== h) h.value = m && m.height > 0 ? String(Math.round(m.height)) : '';
+}
+
+async function submitPopupSize() {
+  const size = fushiClampPopupSize($('popupSizeWidth').value, $('popupSizeHeight').value);
+  if (!size) {
+    // 两个都得有值才能提交（端点契约是 {maxWidth, maxHeight} 一对）。清空 = 不改。
+    return;
+  }
+  $('popupSizeWidth').value = String(size.width);   // 让用户当场看到被夹住的值
+  $('popupSizeHeight').value = String(size.height);
+  const resp = await runtimeMessage(
+    { type: 'popupSize', maxWidth: size.width, maxHeight: size.height });
+  if (resp && resp.ok) {
+    toast('查词框大小已更新（下次查词生效）');
+  } else {
+    toast('没连上 Fushi，尺寸没保存');
+  }
+}
+
+async function loadPopupSize(saved) {
+  const store = saved && Object.prototype.hasOwnProperty.call(saved, 'popupSizeFromApp')
+    ? saved
+    : await chrome.storage.local.get(['popupSizeFromApp']);
+  fillPopupSizeInputs(store.popupSizeFromApp);
+  for (const id of popupSizeIds) {
+    // change（失焦/回车）而非 input：边打字边发请求会把「4」当成 4px 提交上去。
+    on(id, 'change', submitPopupSize);
   }
 }
 
@@ -276,6 +325,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
     const input = $(id);
     if (input) input.checked = changes[key].newValue === true;
   }
+  if (changes.popupSizeFromApp) fillPopupSizeInputs(changes.popupSizeFromApp.newValue);
   if (changes.fushiUpdateStale) refreshUpdateCard();
 });
 

--- a/tools/browser-extension/popup-size.js
+++ b/tools/browser-extension/popup-size.js
@@ -1,0 +1,123 @@
+// 查词弹窗尺寸盒的**唯一**决策器（纯函数，无 DOM）。
+//
+// 尺寸真相源只有一个：app 的 `extension_popup_max_width/height` 偏好（设置页「浏览器扩展
+// 独立尺寸」+ 两个滑杆），经查词响应的 theme 变量 `--fushi-popup-max-width/height/zoom`
+// 下发。写入口也只有一条：`POST /api/extension/popup-size {maxWidth,maxHeight}`——弹窗
+// 右下角拖拽把手、侧边栏拖拽把手、扩展设置页「查词框大小」三处都走它（app 侧统一 clamp +
+// 「拖即解锁」independentSize + 只写扩展键）。**扩展本地不得再存一份尺寸**，否则用户在
+// app 设置页调完发现不生效，两套值互相盖。
+//
+// 本模块负责的是真相源之外的那件事：**把下发的尺寸夹进当前视口**。
+// 起因：侧边栏文档可以窄到 300px，而 theme 宽度是按 app 窗口定的（400~600px），且这些
+// px 长度写在 CSS `zoom` **之下**——zoom=1.4 时 400px 渲染成 560px，连
+// `max-width: calc(100vw - 16px)` 这个上限本身也一起被 zoom 放大，根本拦不住 → 弹窗横向
+// 溢出，被 `.lookup-pane{overflow-x:hidden}` 硬切掉右半边（用户看到「查词框被切了」）。
+// content.js 的落点计算早已把 zoom 折回基准尺度（BUG-1726），侧边栏漏了这一步。
+//
+// 尺度约定（与 content.js fushiPlacePopup / side-panel.js positionLookup 同源）：
+//   「基准尺度」= 写进 style.width / style.maxHeight 的数值，渲染尺寸 = 基准 × zoom。
+//   视口尺寸是渲染尺度。所以任何视口上限要除以 zoom 才能与基准值比较。
+
+// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——扩展覆盖、
+// 拖拽把手、滑杆写的是同一个真值，边界必须一致，否则某条路径能写出别的路径写不出的越界值。
+// 「弹窗内部布局低于此宽度就崩排版」用的也是这一个数：可用空间不足以在当前 zoom 下容纳它时，
+// 压的是 zoom 而不是宽度（见 fushiResolvePopupBox）。content.js 的拖拽下限直接引用本常量。
+var FUSHI_POPUP_MIN_WIDTH = 250;    // = kLookupPopupMinWidth
+var FUSHI_POPUP_MAX_WIDTH = 2000;   // = kLookupPopupMaxWidth
+var FUSHI_POPUP_MIN_HEIGHT = 200;   // = kLookupPopupMinHeight
+var FUSHI_POPUP_MAX_HEIGHT = 1600;  // = kLookupPopupMaxHeight
+// zoom 压到这个下限就不再压——再小字就不可读了，剩下的溢出交给横向滚动。
+var FUSHI_POPUP_MIN_ZOOM = 0.5;
+
+// CSS 长度串 → px 数。接受 '400px' / '400' / 400；无法解析返回 fallback。
+// `min(...)` / `calc(...)` 这类函数式长度不是数值，返回 fallback（调用方本就只在
+// 「纯 px 主题值」上做算术，函数式串按原样交给 CSS）。
+function fushiParsePx(value, fallback) {
+  if (typeof value === 'number') return isFinite(value) && value > 0 ? value : fallback;
+  if (typeof value !== 'string') return fallback;
+  var m = value.trim().match(/^(-?\d+(?:\.\d+)?)\s*px$/i) || value.trim().match(/^(-?\d+(?:\.\d+)?)$/);
+  if (!m) return fallback;
+  var n = parseFloat(m[1]);
+  return isFinite(n) && n > 0 ? n : fallback;
+}
+
+// 设置页输入框 → 回写 app 之前的本地 clamp。app 侧 `_onExtensionPopupSize` sink 也会
+// clamp 一次（那才是权威），这里只是让用户当场看到被夹住的值，而不是提交完才莫名变化。
+// 非数/0/负数返回 null = 「这个值填得不成立，别提交」。
+function fushiClampPopupSize(width, height) {
+  var w = Number(width);
+  var h = Number(height);
+  if (!isFinite(w) || w <= 0 || !isFinite(h) || h <= 0) return null;
+  return {
+    width: Math.min(FUSHI_POPUP_MAX_WIDTH, Math.max(FUSHI_POPUP_MIN_WIDTH, Math.round(w))),
+    height: Math.min(FUSHI_POPUP_MAX_HEIGHT, Math.max(FUSHI_POPUP_MIN_HEIGHT, Math.round(h))),
+  };
+}
+
+// 决策弹窗尺寸盒。输入全是数据、输出全是数据，两个消费端（页面弹窗 / 侧边栏弹窗）共用。
+//
+// theme：app 下发的 CSS 变量对象（唯一尺寸真相源，可缺 → 用内置默认）。
+// viewport：{width, height} 渲染尺度的可用视口（侧边栏传自身文档视口）。缺省不做视口夹取。
+// opts.margin：视口两侧留白（渲染尺度，缺省 16）。
+//
+// 返回 { width, maxHeight, zoom, clamped }：
+//   width / maxHeight 是**基准尺度 px 数**（直接 + 'px' 写进 style）；
+//   zoom 是最终 zoom（空间实在不足时会低于下发值——宁可整体缩小也不横向切内容）；
+//   clamped 标记本次是否因视口不足收敛过（供调用方决定要不要提示/记录，非必须消费）。
+function fushiResolvePopupBox(theme, viewport, opts) {
+  var t = theme && typeof theme === 'object' ? theme : {};
+  var margin = opts && isFinite(opts.margin) ? opts.margin : 16;
+
+  var width = fushiParsePx(t['--fushi-popup-max-width'], 400);
+  var maxHeight = fushiParsePx(t['--fushi-popup-max-height'], 360);
+  var zoom = parseFloat(t['--fushi-popup-zoom']) || 1;
+  if (!(zoom > 0)) zoom = 1;
+
+  var clamped = false;
+  var vw = viewport && isFinite(viewport.width) ? viewport.width : 0;
+  var vh = viewport && isFinite(viewport.height) ? viewport.height : 0;
+
+  if (vw > 0) {
+    var availW = Math.max(1, vw - margin); // 真实可用渲染宽（不许抬高——抬高就掩盖了「放不下」）
+    // ① 先在当前 zoom 下压宽度。渲染宽 = width × zoom，故基准上限 = availW / zoom。
+    var maxBaseW = availW / zoom;
+    if (width > maxBaseW) { width = maxBaseW; clamped = true; }
+    // ② 压完仍低于「弹窗内部布局的最小基准宽」= 当前 zoom 下这点空间根本排不开内容。
+    //    此时该动的是 zoom 不是宽度：把宽度还原到最小基准宽，改让整窗等比缩小到放得下。
+    //    这消除了「只能横向切内容」这个特殊情况。
+    if (width < FUSHI_POPUP_MIN_WIDTH) {
+      width = FUSHI_POPUP_MIN_WIDTH;
+      zoom = Math.max(FUSHI_POPUP_MIN_ZOOM, availW / FUSHI_POPUP_MIN_WIDTH);
+      clamped = true;
+      // zoom 已到可读下限仍放不下（侧边栏窄到极端）：宽度按下限 zoom 再压回可用空间，
+      // 剩余溢出交给 .lookup-pane 的横向滚动，绝不静默切掉内容。
+      if (width * zoom > availW) width = availW / zoom;
+    }
+  }
+  if (vh > 0) {
+    // 与既有 `min(<theme px>, 80vh)` 语义对齐：vh 是渲染尺度，折回基准要除以 zoom。
+    var maxBaseH = (vh * 0.8) / zoom;
+    if (maxHeight > maxBaseH) { maxHeight = Math.max(64, maxBaseH); clamped = true; }
+  }
+
+  return {
+    width: Math.round(width * 100) / 100,
+    maxHeight: Math.round(maxHeight * 100) / 100,
+    zoom: Math.round(zoom * 1000) / 1000,
+    clamped: clamped,
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    FUSHI_POPUP_MIN_WIDTH,
+    FUSHI_POPUP_MIN_HEIGHT,
+    FUSHI_POPUP_MAX_WIDTH,
+    FUSHI_POPUP_MAX_HEIGHT,
+    FUSHI_POPUP_MIN_ZOOM,
+    fushiParsePx,
+    fushiClampPopupSize,
+    fushiResolvePopupBox,
+  };
+}

--- a/tools/browser-extension/popup-size.test.js
+++ b/tools/browser-extension/popup-size.test.js
@@ -1,0 +1,134 @@
+// popup-size.js 的行为测试：扩展独立尺寸覆盖 + 侧边栏空间不足时的收敛。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  FUSHI_POPUP_MIN_WIDTH,
+  FUSHI_POPUP_MIN_HEIGHT,
+  FUSHI_POPUP_MAX_WIDTH,
+  FUSHI_POPUP_MAX_HEIGHT,
+  FUSHI_POPUP_MIN_ZOOM,
+  fushiParsePx,
+  fushiClampPopupSize,
+  fushiResolvePopupBox,
+} = require('./popup-size.js');
+
+const THEME = {
+  '--fushi-popup-max-width': '520px',
+  '--fushi-popup-max-height': '400px',
+  '--fushi-popup-zoom': '1.4',
+};
+
+test('无覆盖、无视口时原样采用 app 下发的 theme 尺寸', () => {
+  const box = fushiResolvePopupBox(THEME, null);
+  assert.strictEqual(box.width, 520);
+  assert.strictEqual(box.maxHeight, 400);
+  assert.strictEqual(box.zoom, 1.4);
+  assert.strictEqual(box.clamped, false);
+});
+
+test('theme 缺失时回落到内置默认，不产生 NaN/0 尺寸', () => {
+  const box = fushiResolvePopupBox(null, null);
+  assert.strictEqual(box.width, 400);
+  assert.strictEqual(box.maxHeight, 360);
+  assert.strictEqual(box.zoom, 1);
+});
+
+// ── 尺寸真相源唯一：app 的 extension_popup_* 偏好，经 theme 下发 ──
+// 扩展设置页「查词框大小」写的是同一条通道（POST /api/extension/popup-size），
+// **不得**在扩展本地另存一份尺寸——那会变成第二个真相源，用户在 app 设置页调完不生效。
+test('扩展本地不得存尺寸：三个消费端都不读任何本地尺寸键', () => {
+  const fsx = require('node:fs');
+  const pathx = require('node:path');
+  for (const f of ['content.js', 'side-panel.js', 'options.js']) {
+    const src = fsx.readFileSync(pathx.join(__dirname, f), 'utf8');
+    assert.doesNotMatch(src, /popupSizeOverride/,
+      f + ' 不得引入本地尺寸覆盖键（第二真相源）');
+  }
+  // 设置页只能经既有的 popupSize 消息写回 app，不能自己 storage.set 尺寸。
+  const options = fsx.readFileSync(pathx.join(__dirname, 'options.js'), 'utf8');
+  assert.match(options, /type: 'popupSize', maxWidth: size\.width, maxHeight: size\.height/);
+});
+
+test('本地 clamp 与 app 滑杆同源，非法输入返回 null（不提交）', () => {
+  const big = fushiClampPopupSize(99999, 99999);
+  assert.strictEqual(big.width, FUSHI_POPUP_MAX_WIDTH);
+  assert.strictEqual(big.height, FUSHI_POPUP_MAX_HEIGHT);
+  const small = fushiClampPopupSize(10, 10);
+  assert.strictEqual(small.width, FUSHI_POPUP_MIN_WIDTH);
+  assert.strictEqual(small.height, FUSHI_POPUP_MIN_HEIGHT);
+  for (const bad of [['', ''], ['abc', 300], [0, 300], [-1, 300], [400, 0]]) {
+    assert.strictEqual(fushiClampPopupSize(bad[0], bad[1]), null,
+      JSON.stringify(bad) + ' 应判为不成立、不提交');
+  }
+});
+
+// 边界必须与 content.js 拖拽把手、app 设置页滑杆、Dart kLookupPopup* 同源——四条路径
+// 写同一个真值，数字各写一份迟早分叉（拖拽能拖出滑杆写不出的尺寸）。
+test('最小宽/高常量是唯一定义：content.js 不得再复制这两个数字', () => {
+  const content = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, 'content.js'), 'utf8');
+  assert.doesNotMatch(content, /const FUSHI_POPUP_MIN_WIDTH\s*=/);
+  assert.doesNotMatch(content, /const FUSHI_POPUP_MIN_HEIGHT\s*=/);
+  assert.match(content, /minW: FUSHI_POPUP_MIN_WIDTH/, '拖拽下限仍引用同一常量');
+});
+
+test('边界值与 Dart 侧 kLookupPopup* 一致（250-2000 / 200-1600）', () => {
+  assert.strictEqual(FUSHI_POPUP_MIN_WIDTH, 250);
+  assert.strictEqual(FUSHI_POPUP_MAX_WIDTH, 2000);
+  assert.strictEqual(FUSHI_POPUP_MIN_HEIGHT, 200);
+  assert.strictEqual(FUSHI_POPUP_MAX_HEIGHT, 1600);
+});
+
+// ── 根因回归：CSS zoom 之下的 px 宽度在窄侧边栏里必定溢出 ──
+// 修复前 side-panel.js 直接写 `width: <theme>px` + `max-width: calc(100vw - 16px)`：
+// vw 上限本身也被 zoom 放大，拦不住，弹窗渲染宽 = 520 × 1.4 = 728px 落在 320px 的
+// 侧边栏里，右半边被 overflow-x:hidden 永久切掉。
+test('窄侧边栏：渲染宽度（基准 × zoom）绝不超过可用宽度', () => {
+  const viewport = { width: 320, height: 900 };
+  const box = fushiResolvePopupBox(THEME, viewport);
+  const rendered = box.width * box.zoom;
+  assert.ok(rendered <= 320 - 16 + 0.5,
+    '渲染宽 ' + rendered + ' 必须 <= 可用宽 ' + (320 - 16));
+  assert.strictEqual(box.clamped, true);
+});
+
+test('宽视口下不做任何收敛（夹取只缩不放）', () => {
+  const box = fushiResolvePopupBox(THEME, { width: 1600, height: 1200 });
+  assert.strictEqual(box.width, 520);
+  assert.strictEqual(box.zoom, 1.4);
+  assert.strictEqual(box.clamped, false);
+});
+
+test('极窄侧边栏：压到最窄可读宽度仍放不下时改压 zoom，而不是继续切内容', () => {
+  const viewport = { width: 200, height: 900 };
+  const box = fushiResolvePopupBox(THEME, viewport);
+  assert.ok(box.zoom < 1.4, 'zoom 应被降下来，实际 ' + box.zoom);
+  assert.ok(box.zoom >= FUSHI_POPUP_MIN_ZOOM, 'zoom 不得低于可读下限');
+  assert.ok(box.width * box.zoom <= 200 - 16 + 0.5,
+    '渲染宽 ' + box.width * box.zoom + ' 仍须落在可用宽内');
+});
+
+test('高度上限按「视口 80% ÷ zoom」折回基准尺度', () => {
+  const box = fushiResolvePopupBox(THEME, { width: 1600, height: 500 });
+  // 80% × 500 = 400 渲染 px；zoom=1.4 → 基准上限 ≈ 285.7
+  assert.ok(box.maxHeight < 400, '高度应被夹小，实际 ' + box.maxHeight);
+  assert.ok(box.maxHeight * box.zoom <= 500 * 0.8 + 0.5,
+    '渲染高 ' + box.maxHeight * box.zoom + ' 必须 <= 视口 80%');
+});
+
+test('zoom=1 时视口夹取退化为「不超过可用宽/80% 高」，与旧 CSS 语义一致', () => {
+  const theme = { '--fushi-popup-max-width': '400px', '--fushi-popup-max-height': '360px' };
+  const box = fushiResolvePopupBox(theme, { width: 300, height: 400 });
+  assert.strictEqual(box.zoom, 1);
+  assert.strictEqual(box.width, 284, '300 - 16');
+  assert.strictEqual(box.maxHeight, 320, '400 × 0.8');
+});
+
+test('fushiParsePx 只接受纯 px 数值，函数式长度回落 fallback', () => {
+  assert.strictEqual(fushiParsePx('400px', 1), 400);
+  assert.strictEqual(fushiParsePx('400', 1), 400);
+  assert.strictEqual(fushiParsePx(400, 1), 400);
+  assert.strictEqual(fushiParsePx('min(400px, 80vh)', 7), 7);
+  assert.strictEqual(fushiParsePx('', 7), 7);
+  assert.strictEqual(fushiParsePx(undefined, 7), 7);
+});

--- a/tools/browser-extension/popup-wheel-lazy.test.js
+++ b/tools/browser-extension/popup-wheel-lazy.test.js
@@ -142,6 +142,10 @@ function loadWorld() {
   vm.runInContext(fs.readFileSync(POPUP, 'utf8'), sandbox,
       { filename: 'popup.js' });
   loadFushiDictMedia(sandbox);
+  // manifest 里 popup-size.js 排在 content.js 之前（同隔离世界的顶层函数），
+  // content.js 的 fushiApplyTheme 直接调它的 fushiResolvePopupBox。
+  vm.runInContext(fs.readFileSync(path.join(__dirname, 'popup-size.js'), 'utf8'), sandbox,
+    { filename: 'popup-size.js' });
   vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox,
       { filename: 'content.js' });
   return { sandbox, documentObj, windowObj, docWheelRegs, windowScrollBy };

--- a/tools/browser-extension/side-panel-performance.test.js
+++ b/tools/browser-extension/side-panel-performance.test.js
@@ -53,7 +53,16 @@ test('lookup pane is user-resizable and persists via the popupSize channel', () 
   assert.match(css, /\.lookup-pane \{[^}]*resize: both/);
   assert.match(SIDE_PANEL, /lookupUserResized = true;[\s\S]*?type: 'popupSize'/);
   // 用户拖过后主题下发不得再覆盖宽高。
-  assert.match(SIDE_PANEL, /if \(!lookupUserResized\) \{[\s\S]*?--fushi-popup-max-width/);
+  assert.match(SIDE_PANEL, /if \(lookupUserResized\) return;/);
+  // 尺寸盒必须经 popup-size.js 的决策器并带上**本文档视口**：直接写 theme px 的老写法
+  // 在 CSS zoom 之下必然溢出窄侧边栏（右半边被 overflow-x 切掉）。
+  assert.match(
+    SIDE_PANEL,
+    /fushiResolvePopupBox\(\s*lookupThemeForBox, \{ width: window\.innerWidth, height: window\.innerHeight \}\)/,
+  );
+  assert.doesNotMatch(SIDE_PANEL, /style\.width = theme\[/);
+  // 侧边栏宽度可拖：视口一变就重算尺寸盒，否则变窄后仍按旧宽渲染 = 又被切。
+  assert.match(SIDE_PANEL, /addEventListener\('resize', function \(\) \{\s*applyLookupBox\(\)/);
 });
 
 test('side-panel lookup reuses the Shift popup host model and parsed results', () => {

--- a/tools/browser-extension/side-panel.css
+++ b/tools/browser-extension/side-panel.css
@@ -185,7 +185,10 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   width: 400px;
   max-width: calc(100vw - 16px);
   max-height: min(360px, 80vh);
-  overflow-x: hidden;
+  /* 尺寸盒由 side-panel.js 的 applyLookupBox 按侧边栏实际视口夹取（zoom 已折算）。
+     这里保留 auto 而非 hidden 作为最后兜底：极端窄侧栏 + 不可断的长串（罗马音、URL、
+     宽表格）仍可能超出夹后的宽度，hidden 是**永久丢内容**，auto 至少还能横向滚出来。 */
+  overflow-x: auto;
   overflow-y: auto;
   overscroll-behavior: contain;
   visibility: hidden;

--- a/tools/browser-extension/side-panel.html
+++ b/tools/browser-extension/side-panel.html
@@ -44,6 +44,7 @@
   </main>
   <section id="lookup-pane" class="lookup-pane" aria-label="查词结果" hidden></section>
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
+  <script src="popup-size.js"></script>
   <script src="vendor/selection.js"></script>
   <script src="vendor/dict-media.js"></script>
   <script src="side-panel.js"></script>

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -168,9 +168,10 @@
       lookupPaneEl.style.left = '0px';
       lookupPaneEl.style.top = '0px';
     }
-    if (!lookupUserResized) {
-      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
-    }
+    // lookupBaseMaxHeight 已由 applyLookupBox 按「视口 80% ÷ zoom」折算成基准尺度 px，
+    // 这里不能再套一层 `min(..., 80vh)`：vh 不随 zoom 缩放，zoom>1 时那个上限会被放大到
+    // 视口之外，等于没夹（正是弹窗纵向超出侧边栏的原因）。
+    if (!lookupUserResized) lookupPaneEl.style.maxHeight = lookupBaseMaxHeight;
     requestAnimationFrame(function () {
       if (requestId !== lookupRequestId || lookupPaneEl.hidden) return;
       var gap = 4;
@@ -221,13 +222,27 @@
     window.__fushiPopupWheelSpeed = isFinite(wheelSpeed) && wheelSpeed > 0 ? wheelSpeed : 1;
     // 用户拖过尺寸（lookupUserResized）后，本会话内不再让主题下发的宽高盖掉用户的选择；
     // 拖拽结果经 popupSize 回写 app，下次会话由主题带回来。
-    if (!lookupUserResized) {
-      lookupPaneEl.style.width = theme['--fushi-popup-max-width'] || '400px';
-      lookupBaseMaxHeight = theme['--fushi-popup-max-height'] || '360px';
-      lookupPaneEl.style.maxHeight = 'min(' + lookupBaseMaxHeight + ', 80vh)';
-    }
+    lookupThemeForBox = theme;
+    applyLookupBox();
+  }
+
+  // 侧边栏弹窗的尺寸盒。与页面弹窗（content.js fushiApplyTheme）同一个决策器，额外把
+  // **本文档视口**交给它做夹取——侧边栏可以窄到 300px，而主题宽度是按 app 窗口定的
+  // （400~600px），且这些 px 长度写在 CSS `zoom` 之下：zoom=1.4 时 400px 渲染成 560px，
+  // 连 `max-width: calc(100vw - 16px)` 这个上限本身也一起被 zoom 放大，根本拦不住 →
+  // 弹窗横向溢出，被 `.lookup-pane{overflow-x:hidden}` 硬切掉右半边（用户看到「查词框被切了」）。
+  // fushiResolvePopupBox 把上限折回基准尺度；压到最窄可读宽度仍放不下时改压 zoom，
+  // 让整窗等比缩小而不是切内容。
+  var lookupThemeForBox = null;
+  function applyLookupBox() {
+    if (lookupUserResized) return; // 用户手动拖过尺寸：本会话内不再自动改写
+    var box = fushiResolvePopupBox(
+      lookupThemeForBox, { width: window.innerWidth, height: window.innerHeight });
+    lookupPaneEl.style.width = box.width + 'px';
+    lookupBaseMaxHeight = box.maxHeight + 'px';
+    lookupPaneEl.style.maxHeight = lookupBaseMaxHeight;
     lookupPaneEl.style.maxWidth = 'calc(100vw - 16px)';
-    lookupPaneEl.style.zoom = theme['--fushi-popup-zoom'] || '1';
+    lookupPaneEl.style.zoom = String(box.zoom);
   }
 
   function renderLookupData(value, data, cacheHit) {
@@ -1019,6 +1034,14 @@
       lookupPaneEl.addEventListener('wheel', window.__fushiPopupWheelListener, { passive: false });
     }
   }, { once: true });
+
+  // 侧边栏宽度是用户随时可拖的：变窄后原尺寸盒必然溢出被裁。视口一变就按新可用空间
+  // 重算尺寸盒，并对开着的弹窗重跑落点（positionLookup 内部自带 hidden 守卫）。
+  window.addEventListener('resize', function () {
+    applyLookupBox();
+    if (!lookupPaneEl.hidden) positionLookup();
+  });
+
 
   try {
     chrome.tabs.onActivated.addListener(function () { refresh(true); });

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -22,7 +22,9 @@
 
   // enabled 由扩展 options 的 netflixSubtitlePanel 开关驱动（默认 false）。
   var st = {
-    activeLang: null, videoId: null, cues: [], currentIndex: -1,
+    // videoId 初始值是 '' 而非 null：与 videoKey() 的非空字符串契约同型，
+    // 首次 tick 仍会因 '' !== <真实 key> 而触发一次 refreshHeadless（语义不变）。
+    activeLang: null, videoId: '', cues: [], currentIndex: -1,
     tickTimer: null, enabled: false,
     overlayEnabled: true, dragDropEnabled: true, autoScroll: true,
     overlayEl: null, overlayCue: null, dropHint: null,
@@ -76,7 +78,14 @@
   // 契约）。契约缺失（加载顺序异常/单测隔离）时本地回落同构实现。
   function videoKey() {
     try {
-      if (typeof window.fushiVideoKey === 'function') return window.fushiVideoKey();
+      if (typeof window.fushiVideoKey === 'function') {
+        // 契约：videoKey() 永远返回非空字符串。返回值会直接拼进轨 key
+        // （`${videoKey}|${lang}`），漏出 undefined/'' 就会生成 "undefined|ja" 这种脏 key；
+        // 而身份比较（videoKey() !== st.videoId）会因两侧类型不同而永远判「换了视频」。
+        // 上游给不出有效值时落回下面的通用回落，不把脏值传出去。
+        var k = window.fushiVideoKey();
+        if (typeof k === 'string' && k) return k;
+      }
     } catch (_) {}
     var m = (location.pathname || '').match(/\/watch\/(\d+)/);
     if (/(^|\.)netflix\.com$/.test(location.hostname) && m) return m[1];

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -34,6 +34,12 @@
     overlayAutoLookup: false,
     overlayBlur: false, overlayAllTracks: false,
     overlayHovered: false, autoLookupLastX: -1, autoLookupLastY: -1,
+    // 「用 Fushi 字幕替代站点原生字幕」：用预取的整集轨自绘一整句，并藏掉站点原生字幕。
+    // 针对 YouTube 自动生成字幕——它是**逐词滚动**渲染的（DOM 里每帧多一个词），
+    // 拿它划词/制卡永远只能拿到半句；而 youtube-bridge.js 早就把整集 srv3 轨按 <p> 段
+    // 预取进 store 了，只是渲染侧默认不用（站点自带轨不叠加，避免双份字幕）。
+    // replaceNativeActive = 本轮判定「替代确实生效中」，推给 content.js 决定藏不藏原生。
+    replaceNative: false, replaceNativeActive: false,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -52,6 +58,9 @@
   function teardownAll() {
     hideSubtitleOverlay();
     hideDropHint();
+    // 面板整体被关掉时替代模式也随之失效（replaceNativeEffective 已含 st.enabled），
+    // 必须把站点原生字幕放回来——否则用户关掉字幕列表后既没有自绘覆盖层也没有原生字幕。
+    syncNativeSubtitleReplacement();
   }
   function applyEnabled(on) {
     st.enabled = !!on;
@@ -161,7 +170,9 @@
     st.overlayAutoLookup = c.subtitleOverlayAutoLookup === true;
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
+    st.replaceNative = c.subtitleReplaceNative === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
+    syncNativeSubtitleReplacement();
   }
 
   // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
@@ -173,6 +184,7 @@
       subtitleOverlayAutoLookup: st.overlayAutoLookup,
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
+      subtitleReplaceNative: st.replaceNative,
     };
   }
 
@@ -180,7 +192,7 @@
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleOverlayAutoLookup',
-      'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+      'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -189,7 +201,45 @@
     } catch (_) {}
   }
 
+  // 替代模式是否**真的**生效。四个条件缺一不可，任何一个不成立都必须放回原生字幕——
+  // 「藏了原生、自绘又没内容」= 用户一句字幕都看不到，比不做还糟：
+  //   ① 用户开了这个设置；② 覆盖层没被关掉（它就是替代品本身）；
+  //   ③ 当前活动轨不是 live 轨（live 轨就是从原生 DOM 逐词采来的，拿它替代原生毫无意义）；
+  //   ④ 这条轨真有 cue（整轨还没到 / 抓取失败时保持原生字幕可见）。
+  function replaceNativeEffective() {
+    return st.enabled && st.replaceNative && st.overlayEnabled &&
+      !!st.activeLang && st.activeLang !== LIVE_LANG && st.cues.length > 0;
+  }
+
+  // 把判定结果推给 content.js（遮蔽原因 'replace' 的唯一写入点）。幂等：状态没变不发。
+  function syncNativeSubtitleReplacement() {
+    var active = replaceNativeEffective();
+    if (active === st.replaceNativeActive) return;
+    st.replaceNativeActive = active;
+    try {
+      if (typeof window.fushiSetNativeSubtitleReplaced === 'function') {
+        window.fushiSetNativeSubtitleReplaced(active);
+      }
+    } catch (_) {}
+  }
+
   function tick() {
+    // 面板被关掉时 tick 直接停手。下面的身份检测会调 refreshHeadless，那是 sync() /
+    // fushiSubtitlePanelOnCues 的 enabled 门之外的第三条入口——不挡住的话，关掉的面板仍会
+    // 每 200ms 遍历整个 cue store 并拷一份 shiftedCues（整集轨可达数千条 × 多轨）。
+    // 注：这是**性能与语义一致性**门，不是正确性门——替代模式的撤销由 replaceNativeEffective
+    // 里的 st.enabled 保证，覆盖层的摘除由 teardownAll 保证，故变异掉这一行不会让测试变红。
+    if (!st.enabled) return;
+    // SPA 换视频先于一切：YouTube 只换 `?v=`，pathname 不变，下面那条 500ms 的 pathname
+    // 轮询根本看不见——不在这里认出身份变化，st.cues 会一直留着上一个视频的整轨，
+    // 替代模式就会拿旧字幕盖住新视频（且原生字幕已被藏）。refreshHeadless 内部会重跑 tick。
+    if (videoKey() !== st.videoId) {
+      st.activeLang = null;
+      refreshHeadless();
+      return;
+    }
+    // 先同步替代状态再走空轨短路：切视频/换轨导致 cues 清空时，原生字幕必须立刻放回来。
+    syncNativeSubtitleReplacement();
     if (!st.cues.length) { hideSubtitleOverlay(); return; }
     var nowMs = videoTimeMs();
     var idx = cueIndexAt(st.cues, nowMs);
@@ -262,9 +312,10 @@
 
   function updateSubtitleOverlay(cue) {
     // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
-    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）。
+    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）或「替代原生字幕」——
+    // 后者本来就是「原生藏掉、这里补上整句」，此时不叠字反而是空屏。
     if (!st.overlayEnabled || !cue ||
-        (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
+        (!isExternalLang(st.activeLang) && !st.overlayAllTracks && !replaceNativeEffective())) {
       hideSubtitleOverlay();
       return;
     }
@@ -690,7 +741,7 @@
       var keys = [
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
         'subtitleOverlayAutoLookup',
-        'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+        'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
       ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }

--- a/tools/browser-extension/subtitle-replace-native.test.js
+++ b/tools/browser-extension/subtitle-replace-native.test.js
@@ -282,3 +282,36 @@ test('在设置页开关经 storage.onChanged 实时生效，无需刷新页面'
   w.tick();
   assert.ok(w.styleText(), '改设置后当前页面应立刻进入替代模式');
 });
+
+test('videoKey 契约：上游给不出有效 key 时落回 host+path，不外泄 undefined', () => {
+  // 为什么钉这条：videoKey() 的返回值有两个消费面——① 直接拼进轨 key
+  // (`${videoKey}|${lang}`)，漏出 undefined 会生成 "undefined|English" 这种永远命不中的脏
+  // key；② 身份比较 videoKey() !== st.videoId，两侧类型一旦不同就会每 200ms 都判「换了
+  // 视频」并空转 refreshHeadless。上游 window.fushiVideoKey 是跨文件全局（video-shortcuts.js
+  // 那边也早就用 String() 兜过它），面板这侧不能假定它一定给字符串。
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.sandbox.window.fushiVideoKey = () => undefined;
+
+  const fallbackKey = 'www.youtube.com/watch';
+  w.sandbox.window.fushiEpisodeCues[fallbackKey + '|English'] = CUES;
+  w.sandbox.window.fushiSubtitlePanelOnCues(fallbackKey + '|English');
+  w.tick();
+
+  const overlay = w.overlayEl();
+  assert.ok(overlay,
+    '上游给不出 key 时必须落回 host+path 继续选轨，而不是拿 undefined 去拼一把命不中的 key');
+  assert.strictEqual(overlay.textContent, CUES[0].text);
+  assert.ok(w.styleText(), '落回 key 选中整轨后，替代照常生效');
+});
+
+test('videoKey 契约：上游返回空字符串同样落回，不会被当成有效身份', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.sandbox.window.fushiVideoKey = () => '';
+
+  const fallbackKey = 'www.youtube.com/watch';
+  w.sandbox.window.fushiEpisodeCues[fallbackKey + '|English'] = CUES;
+  w.sandbox.window.fushiSubtitlePanelOnCues(fallbackKey + '|English');
+  w.tick();
+
+  assert.ok(w.overlayEl(), '空字符串不是有效身份，必须落回通用回落');
+});

--- a/tools/browser-extension/subtitle-replace-native.test.js
+++ b/tools/browser-extension/subtitle-replace-native.test.js
@@ -1,0 +1,284 @@
+// 「用 Fushi 字幕替代站点原生字幕」的行为测试。
+//
+// 动机（用户报告，YouTube 自动生成字幕）：YouTube 的 ASR 字幕是**逐词滚动**渲染的——DOM 里
+// 每隔几百毫秒多蹦一个词，一句话要好几秒才凑齐。扩展原本的 live 轨就是从这个 DOM 采样来的，
+// 于是划词/制卡拿到的永远是半句。asbplayer 的做法是预取整条字幕轨、按整句显示；本仓的
+// youtube-bridge.js 早就把整集 srv3 轨（<p> 段 = 整句）预取进 store 了，缺的只是渲染侧
+// 「用它替代原生字幕」这一步。
+//
+// 本测试在受控 vm 里真加载 content.js + subtitle-panel.js，钉住四条不变式：
+//   ① 替代生效时藏站点原生字幕，但**必须保留**自绘覆盖层——藏错一个就是满屏没字幕。
+//   ② 整轨没到 / 当前是 live 轨 / 覆盖层被关 → 一律不藏原生（宁可双份也不能一份都没有）。
+//   ③ 切视频导致轨清空时立刻放回原生字幕。
+//   ④ 用户主动隐藏字幕（manual）仍然全藏，替代模式不得把它降级。
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const CONTENT = path.join(__dirname, 'content.js');
+const PANEL = path.join(__dirname, 'subtitle-panel.js');
+const POPUP_SIZE = path.join(__dirname, 'popup-size.js');
+const DICT_MEDIA = path.join(__dirname, 'vendor', 'dict-media.js');
+const STYLE_ID = 'fushi-hide-subs';
+const OVERLAY_ID = 'fushi-subtitle-overlay';
+
+function makeEl(tag) {
+  const el = {
+    tagName: (tag || 'div').toUpperCase(),
+    _id: '',
+    className: '',
+    textContent: '',
+    style: { cssText: '', setProperty() {}, getPropertyValue: () => '' },
+    dataset: {},
+    children: [],
+    parentNode: null,
+    setAttribute(k, v) { if (k === 'id') el._id = v; },
+    getAttribute() { return null; },
+    classList: { add() {}, remove() {}, toggle() {} },
+    addEventListener() {},
+    appendChild(child) { child.parentNode = el; el.children.push(child); return child; },
+    removeChild(child) {
+      const i = el.children.indexOf(child);
+      if (i >= 0) el.children.splice(i, 1);
+      child.parentNode = null;
+      return child;
+    },
+    remove() { if (el.parentNode) el.parentNode.removeChild(el); },
+    contains(x) { return x === el || el.children.some((c) => c.contains && c.contains(x)); },
+    getBoundingClientRect() {
+      return { x: 0, y: 0, left: 0, top: 0, right: 1280, bottom: 720, width: 1280, height: 720 };
+    },
+  };
+  Object.defineProperty(el, 'id', { get: () => el._id, set: (v) => { el._id = v; } });
+  return el;
+}
+
+function findById(root, id) {
+  if (root._id === id) return root;
+  for (const c of root.children) {
+    const hit = findById(c, id);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+// 建一个装好 content.js + subtitle-panel.js 的世界。
+// prefs：写进 chrome.storage.local 的初始偏好（含 subtitleReplaceNative / subtitleHidden）。
+function loadWorld(prefs) {
+  const head = makeEl('head');
+  const body = makeEl('body');
+  const html = makeEl('html');
+  html.appendChild(head);
+  html.appendChild(body);
+  const stored = Object.assign({ netflixSubtitlePanel: true }, prefs || {});
+  const changeListeners = [];
+  const intervals = [];
+  // 覆盖层的落点直接读 video 的 rect（放不出几何就不画），所以桩必须给出真实矩形。
+  const video = {
+    currentTime: 0, paused: false, playbackRate: 1, textTracks: [],
+    getBoundingClientRect: () => (
+      { x: 0, y: 0, left: 0, top: 0, right: 1280, bottom: 720, width: 1280, height: 720 }),
+  };
+
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout: () => 0,
+    clearTimeout() {},
+    setInterval: (fn, ms) => { intervals.push({ fn, ms }); return intervals.length; },
+    clearInterval() {},
+    requestAnimationFrame: () => 0,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    URL,
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    location: {
+      hostname: 'www.youtube.com',
+      href: 'https://www.youtube.com/watch?v=abc123',
+      pathname: '/watch',
+      search: '?v=abc123',
+    },
+  };
+  sandbox.document = {
+    documentElement: html,
+    head,
+    body,
+    fullscreenElement: null,
+    addEventListener() {},
+    getElementById: (id) => findById(html, id),
+    querySelector: (sel) => (sel === 'video' ? video : null),
+    querySelectorAll: () => [],
+    createElement: (tag) => makeEl(tag),
+    createTreeWalker: () => ({ nextNode: () => null }),
+  };
+  sandbox.chrome = {
+    runtime: {
+      id: 'test-ext-id',
+      getURL: (rel) => `chrome-extension://test-ext-id/${rel}`,
+      lastError: null,
+      onMessage: { addListener() {} },
+      sendMessage() {},
+    },
+    storage: {
+      local: {
+        // 面板用 `chrome.storage.local.get(key)` 的 Promise 形式读开关；真 Promise 会把
+        // st.enabled 的置位推迟到微任务，而本测试是同步泵 tick 的 —— 那样面板永远是
+        // disabled，所有断言都会变成「没轨所以没生效」的假绿。返回**同步 thenable**，
+        // 让读取在加载期就完成，与真实运行里「tick 前偏好早已读好」一致。
+        get: (keys, cb) => {
+          const out = {};
+          for (const k of [].concat(keys)) if (k in stored) out[k] = stored[k];
+          if (cb) { cb(out); return undefined; }
+          return { then: (fn) => { fn(out); return { catch() {} }; }, catch() {} };
+        },
+        set: (patch, cb) => { Object.assign(stored, patch); if (cb) cb(); return Promise.resolve(); },
+      },
+      onChanged: { addListener: (fn) => changeListeners.push(fn) },
+    },
+  };
+  sandbox.window = {
+    addEventListener() {},
+    postMessage() {},
+    innerWidth: 1280,
+    innerHeight: 800,
+    matchMedia: () => ({ matches: false }),
+    fushiSelection: {
+      getCharacterAtPoint: () => null,
+      selectFromPosition: () => '',
+      clearSelection() {},
+    },
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.self = sandbox.window;
+  sandbox.globalThis = sandbox;
+  sandbox.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(DICT_MEDIA, 'utf8'), sandbox, { filename: 'vendor/dict-media.js' });
+  vm.runInContext(fs.readFileSync(POPUP_SIZE, 'utf8'), sandbox, { filename: 'popup-size.js' });
+  vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox, { filename: 'content.js' });
+  vm.runInContext(fs.readFileSync(PANEL, 'utf8'), sandbox, { filename: 'subtitle-panel.js' });
+
+  // 面板的 tick 由 setInterval(tick, 200) 驱动；测试手动泵它，行为与真实运行一致。
+  const tick = () => {
+    for (const it of intervals) if (it.ms === 200) it.fn();
+  };
+  const styleText = () => {
+    const el = findById(html, STYLE_ID);
+    return el ? el.textContent : null;
+  };
+  const overlayEl = () => findById(body, OVERLAY_ID);
+  // 写 store + 走 content.js 真实的通知链（fushiNotifyPanel → fushiSubtitlePanelOnCues），
+  // 面板据此重新选轨。绕过通知直接改 store 是测试世界独有的假路径，不用。
+  const setTrack = (lang, cues) => {
+    const key = 'yt-abc123|' + lang;
+    sandbox.window.fushiEpisodeCues[key] = cues;
+    sandbox.window.fushiSubtitlePanelOnCues(key);
+  };
+  return { sandbox, html, body, stored, changeListeners, tick, styleText, overlayEl, setTrack, video };
+}
+
+const CUES = [
+  { startMs: 0, endMs: 3000, text: 'not spending the next 40 years of your' },
+  { startMs: 3000, endMs: 6000, text: 'life chasing some vision of yourself' },
+];
+
+test('替代生效：藏站点原生字幕，但自绘覆盖层必须留着（否则满屏没字幕）', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+
+  const css = w.styleText();
+  assert.ok(css, '替代生效时必须注入遮蔽样式');
+  assert.match(css, /\.ytp-caption-window-container/, '必须藏 YouTube 原生字幕层');
+  assert.match(css, /visibility:hidden/, '只能用 visibility（display:none 会连制卡取词一起废掉）');
+  assert.doesNotMatch(css, /#fushi-subtitle-overlay/,
+    '替代模式绝不能连自绘覆盖层一起藏——那等于把字幕全关了');
+
+  const overlay = w.overlayEl();
+  assert.ok(overlay, '替代模式必须画出自绘覆盖层');
+  assert.strictEqual(overlay.textContent, CUES[0].text,
+    '覆盖层显示的应是整轨里的**整句**，不是逐词快照');
+});
+
+test('live 轨不触发替代：它本身就是从原生 DOM 逐词采来的，替代毫无意义', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.setTrack('live', CUES);
+  w.tick();
+  assert.strictEqual(w.styleText(), null, 'live 轨不得藏原生字幕');
+});
+
+test('整轨还没到（轨空）时保持原生字幕可见', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.tick();
+  assert.strictEqual(w.styleText(), null, '没有任何轨时不得藏原生字幕');
+});
+
+test('覆盖层被用户关掉时不替代（替代品都没了还藏原生 = 一句字幕都看不到）', () => {
+  const w = loadWorld({ subtitleReplaceNative: true, subtitleOverlayEnabled: false });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  assert.strictEqual(w.styleText(), null);
+});
+
+test('设置关着时行为不变：站点原生字幕照常可见，自绘覆盖层不叠字', () => {
+  const w = loadWorld({ subtitleReplaceNative: false });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  assert.strictEqual(w.styleText(), null, '未开启替代时不得动站点字幕');
+  assert.strictEqual(w.overlayEl(), null, '检测轨默认不重复叠字（既有行为）');
+});
+
+test('切视频/换轨导致轨清空：立刻把原生字幕放回来', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  assert.ok(w.styleText(), '前置条件：替代已生效');
+
+  // SPA 换视频：store 里旧 key 还在，但 videoKey 变了 → 当前视频一条轨都没有。
+  w.sandbox.location.search = '?v=zzz999';
+  w.sandbox.location.href = 'https://www.youtube.com/watch?v=zzz999';
+  w.tick();
+  assert.strictEqual(w.styleText(), null,
+    '换到没有字幕轨的视频后必须撤销遮蔽，否则用户看不到任何字幕');
+});
+
+test('用户主动隐藏字幕（Shift+H）仍然全藏：替代模式不得把它降级', () => {
+  const w = loadWorld({ subtitleReplaceNative: true, subtitleHidden: true });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  const css = w.styleText();
+  assert.ok(css);
+  assert.match(css, /#fushi-subtitle-overlay/,
+    'manual 隐藏语义是「什么都别显示」，自绘覆盖层也要藏');
+  assert.match(css, /\.ytp-caption-window-container/);
+});
+
+test('关掉字幕列表功能时撤销替代：把站点原生字幕放回来', () => {
+  const w = loadWorld({ subtitleReplaceNative: true });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  assert.ok(w.styleText(), '前置条件：替代已生效');
+
+  for (const fn of w.changeListeners) {
+    fn({ netflixSubtitlePanel: { newValue: false } }, 'local');
+  }
+  assert.strictEqual(w.styleText(), null,
+    '面板关掉后自绘覆盖层没了，必须立刻把原生字幕放回来');
+  w.tick();
+  assert.strictEqual(w.styleText(), null, 'tick 不得把关掉的面板又「唤醒」');
+  assert.strictEqual(w.overlayEl(), null, '关掉面板后不得再画自绘覆盖层');
+});
+
+test('在设置页开关经 storage.onChanged 实时生效，无需刷新页面', () => {
+  const w = loadWorld({ subtitleReplaceNative: false });
+  w.setTrack('English (自动)', CUES);
+  w.tick();
+  assert.strictEqual(w.styleText(), null);
+
+  for (const fn of w.changeListeners) {
+    fn({ subtitleReplaceNative: { newValue: true } }, 'local');
+  }
+  w.tick();
+  assert.ok(w.styleText(), '改设置后当前页面应立刻进入替代模式');
+});

--- a/tools/browser-extension/universal-subtitle-providers.test.js
+++ b/tools/browser-extension/universal-subtitle-providers.test.js
@@ -111,6 +111,10 @@ function loadContent(opts) {
   const ctx = vm.createContext(sandbox);
   vm.runInContext(fs.readFileSync(ADAPTERS, 'utf8'), ctx, { filename: 'subtitle-adapters.js' });
   loadFushiDictMedia(ctx);
+  // manifest 里 popup-size.js 排在 content.js 之前（同隔离世界的顶层函数），
+  // content.js 的 fushiApplyTheme 直接调它的 fushiResolvePopupBox。
+  vm.runInContext(fs.readFileSync(path.join(__dirname, 'popup-size.js'), 'utf8'), sandbox,
+    { filename: 'popup-size.js' });
   vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), ctx, { filename: 'content.js' });
   const sampler = intervals.find((i) => i.ms === 200);
   const harvester = intervals.find((i) => i.ms === 1200);

--- a/tools/browser-extension/youtube-server-captions.test.js
+++ b/tools/browser-extension/youtube-server-captions.test.js
@@ -113,6 +113,10 @@ function loadYoutube(opts) {
   const ctx = vm.createContext(sandbox);
   vm.runInContext(fs.readFileSync(ADAPTERS, 'utf8'), ctx, { filename: 'subtitle-adapters.js' });
   loadFushiDictMedia(ctx);
+  // manifest 里 popup-size.js 排在 content.js 之前（同隔离世界的顶层函数），
+  // content.js 的 fushiApplyTheme 直接调它的 fushiResolvePopupBox。
+  vm.runInContext(fs.readFileSync(path.join(__dirname, 'popup-size.js'), 'utf8'), sandbox,
+    { filename: 'popup-size.js' });
   vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), ctx, { filename: 'content.js' });
   const fetcher = intervals.find((i) => i.ms === 1500);
   return {


### PR DESCRIPTION
浏览器扩展三项改动：查词框大小设置入口、侧栏空间不足自动收敛、自绘整句字幕替代站点原生字幕。

## 1. 查词框大小设置入口（不造第二真相源）

app 侧**早就有**「浏览器扩展独立尺寸」这套东西：偏好 `extension_popup_max_width` / `extension_popup_max_height`、设置页滑杆、以及拖拽把手回写用的 `POST /api/extension/popup-size`。缺的只是**浏览器里的入口**。

所以这里**没有**在扩展本地新开一份尺寸存储（初版写过 `popupSizeOverride`，审到 app 侧打包路径时发现会变成第二真相源 —— 用户在 app 里调完发现扩展不生效 —— 已推翻）。最终形态：

- 设置页两个输入框写的是**同一条既有通道** `POST /api/extension/popup-size`；
- 扩展本地**不存任何尺寸值**，回显走 content.js 每次查词时镜像下来的只读值 `popupSizeFromApp`；
- 边界常量与 Dart 侧 `kLookupPopupMinWidth/MaxWidth/MinHeight/MaxHeight` 逐个对齐（250–2000 / 200–1600），并把 content.js 里重复的那两个数字删掉改为引用 `popup-size.js`。

新增 `popup-size.js` 作为尺寸决策的唯一实现，页面弹窗与侧边栏共用。

## 2. 侧栏空间不足自动收敛（真 bug，根因修复）

**根因**：`side-panel.js` 的 `applyLookupTheme` 把 `width` / `maxWidth` / `maxHeight` 写在 CSS `zoom` **之下**。px 长度会被 zoom 放大，而 `max-width: calc(100vw - 16px)` 这个上限**本身也一起被放大**，根本拦不住 —— zoom=1.4 时 400px 的弹窗实际渲染 560px，在 320px 宽的侧边栏里必然横向溢出，再被 `overflow-x: hidden` 硬切掉右半边。

content.js 早就修过同一类问题（BUG-1726，把上限折回基准尺度），侧边栏漏了。

修复：

- 所有视口上限一律**折回基准尺度**（÷ zoom）后再比较；
- 压到最小可用宽仍放不下时**改压 zoom**（整窗等比缩小，而不是切内容），下限 0.5；
- `resize` 事件重算，不再只在应用主题时算一次；
- 去掉 `positionLookup` 里重复的 `min(..., 80vh)` 二次夹取；
- `.lookup-pane` 的 `overflow-x` 由 `hidden` 改 `auto` —— `hidden` 是永久丢内容，`auto` 至少留下滚动这条兜底路。

## 3. 用 Fushi 字幕替代站点原生字幕（`subtitleReplaceNative`，默认关）

YouTube 自动字幕是**一个词一个词**长出来的，不适合查词/制卡。asbplayer 的做法是预取整轨、按句显示。

数据层**本来就完备** —— `youtube-bridge.js` 已经是同款整轨预取（srv3，`<p>` 段即整句）。缺的只有渲染层：

- 新增开关；活动轨是整集轨（非 live 轨）且有内容时，自绘整句覆盖层 + 藏掉站点原生逐词字幕；
- content.js 的字幕遮蔽状态从单 bool 改成**原因集合**（`manual` 藏原生+自绘，`replace` 只藏原生）。用 bool 加特例分支必然长出「谁把 style 摘掉了」的竞态；
- 四条生效条件保证**绝不会在没有替代物的情况下藏掉原生字幕**；
- 遮蔽一律 `visibility:hidden`，不用 `display:none` —— 制卡/caret 代码要读这些节点的 textContent 和 rect。

顺带修了两个真缺陷：

- YouTube SPA 换视频只改 `?v=`、pathname 不变，原轮询看不见，旧字幕轨会盖在新视频上；
- 字幕面板关掉后 `tick()` 仍会把刚摘掉的覆盖层画回来。

## 验证

- `node --test`（`tools/browser-extension`）：**263 tests / 263 pass / 0 fail**，新增 23 条断言（`popup-size.test.js` 12 条 + `subtitle-replace-native.test.js` 11 条，后者含追加提交的 2 条 videoKey 契约测试）
- **13 个变异逐一实测全部被抓到**，每次 sha256 校验干净还原（不用 `git checkout` 还原）：zoom 折算（宽/高各一）、降 zoom 回退、侧栏直接写主题 px、侧栏丢掉 resize 重算、替代模式误藏自绘层、live 轨误触发替代、丢掉 SPA 身份检测、空轨误触发替代、teardown 不撤销替代、content.js 重新引入本地尺寸键、设置页绕开 app 通道、宽度边界与 Dart 分叉
  - 唯一未被抓到的变异（`tick()` 里去掉 `if (!st.enabled) return;`）已核实**无可观测行为差异** —— 撤销由 `replaceNativeEffective()` 内的 `st.enabled` 与 `teardownAll` 双重保证，该处注释已改成如实说明，没有编造覆盖
- 镜像：`node scripts/sync-mirrors.mjs` 同步 10 个文件，`--check` 报「镜像一致 ✓」

## 已知缺口

- **无真浏览器 E2E**：三项功能都没有在真实 YouTube 页面上跑过端到端验证，字幕替代的实站表现待复验。

---

## 追加提交 `433dd50f95`：锁死 `videoKey()` 非空字符串契约

SonarCloud 在本 PR 上报 `subtitle-panel.js` 的 `videoKey() !== st.videoId` 恒真
（`new_reliability_rating=3`）。

**该报告本身是假阳性** —— `st.videoId` 在 `refreshHeadless()` 第一行被无条件赋成
`videoKey()`，Sonar 只跟到了对象字面量里的 `videoId: null` 初始化。反证：若真恒真，
`updateSubtitleOverlay` 将永不执行，「覆盖层显示整句」那条测试必红，而它是绿的。

**但假阳性的根在这边**：`videoKey()` 没有锁死返回契约，而它的返回值有两个消费面 ——

1. 直接拼进轨 key（`${videoKey}|${lang}`），漏出 `undefined` 会生成 `"undefined|English"`
   这种永远命不中的脏 key；
2. 身份比较 `videoKey() !== st.videoId`，两侧类型不同就会每 200ms 判一次「换了视频」并空转
   `refreshHeadless`。

而 `window.fushiVideoKey` 是跨文件全局，`video-shortcuts.js:133` 那侧早就用 `String()`
兜过它，面板这侧却在直接透传。

修复：`videoKey()` 只在上游给出**非空字符串**时采信，否则落回 host+path 通用回落；
`st.videoId` 初值改 `''` 与该契约同型（首次 tick 仍因 `'' !== 真实 key` 触发一次
`refreshHeadless`，语义不变）。

新增 2 条契约测试；变异实测「去掉非空校验」→ `fail=2`、「只校验类型不校验非空」→ `fail=1`，
均 sha256 校验干净还原。`node --test` **263/263**，镜像逐字节一致。

修复后 Quality Gate：`new_reliability_rating` 已从 3 回到 **1（A 级）**。

## Quality Gate 仍挂的一条：`new_duplicated_lines_density` = 19.4%（阈值 3%）

这条**不是本 PR 引入的代码重复**，是仓库既有镜像架构的必然产物：

- 本 PR 新增行 —— `tools/browser-extension/` **946** 行，`fushi/assets/browser_extension/`
  **431** 行；
- 后者按 Dart 守卫 `browser_extension_mirror_full_guard_test.dart` 的要求，**必须**与前者
  逐字节相同（`scripts/sync-mirrors.mjs` 生成）；
- 于是这 431 行在 Sonar 眼里是 100% 重复。任何改扩展文件的 PR 都会撞这条。

消掉它需要新建仓库根 `sonar-project.properties` 把 `fushi/assets/browser_extension/**`
排除出分析范围 —— 那会改变**全仓所有 PR** 的 Sonar 配置，超出本 PR 范围，**故本 PR 未动**，
留给维护者决定。

## 本地全量 Flutter 套件（并发伪红说明）

`dart run tool/flutter_test_failures.dart --no-pub`：20919 测试完成、21 error。定性为**并发伪红**：

- 本 PR **零 `.dart` 改动**（28 文件 = 17 js + 4 html + 4 css + 2 json + 1 md），失败的 5 个
  suite 与 JS/CSS/HTML 无调用关系；
- 这 5 个 suite 单独复跑 **85/85 全绿**；
- 失败原因全是环境互抢，无一是断言逻辑：`OS Error errno=32 另一个程序正在使用此文件`、
  `No reachable Fushi server address`、10 个 `TimeoutException`、`bug.dart` 子进程输出为空字符串。

CI 侧的真单测门（APK workflow 的 `build`）在上一个 commit 上已 pass。
