### PR TITLE
feat(windows): add immersive app chrome and reader fullscreen

### DIFF
--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -84,11 +84,6 @@ import 'package:fushi/src/storage/legacy_support_dir_migration.dart';
 
 Color? _savedSplashColor;
 
-/// True only after Windows accepted the hidden native-caption style. Keeping
-/// this as an explicit startup capability avoids rendering two title bars if
-/// the plugin is unavailable or rejects the request on an unusual host.
-bool _windowsCustomTitleBarEnabled = false;
-
 /// 桌面端「从 app 外打开视频文件」时，runner 经 `set_dart_entrypoint_arguments`
 /// 把视频路径传进 `main(List<String> args)`；这里暂存，待 app 初始化完成后由
 /// [_FushiReaderAppState] 打开播放页并加入书架。null 表示本次启动不是外部打开视频。
@@ -199,7 +194,7 @@ void main([List<String> args = const <String>[]]) {
             TitleBarStyle.hidden,
             windowButtonVisibility: false,
           );
-          _windowsCustomTitleBarEnabled = true;
+          FushiWindowsTitleBar.isEnabled = true;
         } catch (e) {
           debugPrint('[Fushi] custom Windows title bar unavailable: $e');
         }
@@ -1709,7 +1704,7 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
           builder: (context, child) {
             _scheduleWindowsUpdateHandoffReconcile();
             final cs = Theme.of(context).colorScheme;
-            if (Platform.isWindows && !_windowsCustomTitleBarEnabled) {
+            if (Platform.isWindows && !FushiWindowsTitleBar.isEnabled) {
               // Preserve the previous themed native caption as a graceful
               // fallback when hidden-title-bar support was unavailable.
               WindowCaptionChannel.setCaptionColors(
@@ -1828,7 +1823,7 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                         );
                       }
                       if (Platform.isWindows &&
-                          _windowsCustomTitleBarEnabled) {
+                          FushiWindowsTitleBar.isEnabled) {
                         navigation = FushiWindowsTitleBar(
                           leadingInset: viewport.width >= 600 ? 80 : 0,
                           title: ValueListenableBuilder<HomeTab>(

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/src/utils/misc/present_watchdog.dart';
 import 'package:fushi/src/utils/misc/wgc_capture_log.dart';
 import 'package:fushi/src/utils/window_caption_channel.dart';
+import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
 import 'package:fushi/src/utils/adaptive/fushi_macos_theme.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/shortcuts/global_navigation.dart';
@@ -82,6 +83,11 @@ import 'package:share_plus/share_plus.dart';
 import 'package:fushi/src/storage/legacy_support_dir_migration.dart';
 
 Color? _savedSplashColor;
+
+/// True only after Windows accepted the hidden native-caption style. Keeping
+/// this as an explicit startup capability avoids rendering two title bars if
+/// the plugin is unavailable or rejects the request on an unusual host.
+bool _windowsCustomTitleBarEnabled = false;
 
 /// 桌面端「从 app 外打开视频文件」时，runner 经 `set_dart_entrypoint_arguments`
 /// 把视频路径传进 `main(List<String> args)`；这里暂存，待 app 初始化完成后由
@@ -187,6 +193,17 @@ void main([List<String> args = const <String>[]]) {
     await recoverLegacyMacosPrefsFromSharedPreferences();
     if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
       await windowManager.ensureInitialized();
+      if (Platform.isWindows) {
+        try {
+          await windowManager.setTitleBarStyle(
+            TitleBarStyle.hidden,
+            windowButtonVisibility: false,
+          );
+          _windowsCustomTitleBarEnabled = true;
+        } catch (e) {
+          debugPrint('[Fushi] custom Windows title bar unavailable: $e');
+        }
+      }
       // BUG-1619：主窗前台真值的唯一来源，必须在 window_manager 初始化之后、
       // 任何页面挂载之前起来——焦点闸门与焦点控制器都读它。
       MainWindowForegroundWatcher.instance.start();
@@ -1692,13 +1709,14 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
           builder: (context, child) {
             _scheduleWindowsUpdateHandoffReconcile();
             final cs = Theme.of(context).colorScheme;
-            // Keep the native Windows title bar in sync with the live app theme
-            // (surface background + onSurface text). No-op on other platforms.
-            // The channel de-dupes identical values so this is cheap per rebuild.
-            WindowCaptionChannel.setCaptionColors(
-              caption: cs.surface,
-              text: cs.onSurface,
-            );
+            if (Platform.isWindows && !_windowsCustomTitleBarEnabled) {
+              // Preserve the previous themed native caption as a graceful
+              // fallback when hidden-title-bar support was unavailable.
+              WindowCaptionChannel.setCaptionColors(
+                caption: cs.surface,
+                text: cs.onSurface,
+              );
+            }
             // Drive the status/navigation bar icon brightness from the *live*
             // theme so switching themes repaints the system bars. The builder
             // reruns on every theme change, so the AnnotatedRegion re-emits the
@@ -1807,6 +1825,20 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                             },
                             child: navigation,
                           ),
+                        );
+                      }
+                      if (Platform.isWindows &&
+                          _windowsCustomTitleBarEnabled) {
+                        navigation = FushiWindowsTitleBar(
+                          leadingInset: viewport.width >= 600 ? 80 : 0,
+                          title: ValueListenableBuilder<HomeTab>(
+                            valueListenable: homeShellTabNotifier,
+                            builder: (BuildContext context, HomeTab tab,
+                                Widget? child) {
+                              return Text(homeNavItemFor(tab).label);
+                            },
+                          ),
+                          child: navigation,
                         );
                       }
                       return FushiAppUiScale(scale: uiScale, child: navigation);

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1822,10 +1822,17 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                           ),
                         );
                       }
+                      navigation = FushiAppUiScale(
+                        scale: uiScale,
+                        child: navigation,
+                      );
                       if (Platform.isWindows &&
                           FushiWindowsTitleBar.isEnabled) {
                         navigation = FushiWindowsTitleBar(
-                          leadingInset: viewport.width >= 600 ? 80 : 0,
+                          // The native-sized frame sits outside app UI zoom;
+                          // align its title with the visually scaled home rail.
+                          leadingInset:
+                              viewport.width >= 600 ? 80 * uiScale : 0,
                           title: ValueListenableBuilder<HomeTab>(
                             valueListenable: homeShellTabNotifier,
                             builder: (BuildContext context, HomeTab tab,
@@ -1836,7 +1843,7 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                           child: navigation,
                         );
                       }
-                      return FushiAppUiScale(scale: uiScale, child: navigation);
+                      return navigation;
                     },
                   ),
                 ),

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:path/path.dart' as p;
+import 'package:window_manager/window_manager.dart';
 
 import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi_audio/fushi_audio.dart';
@@ -48,6 +49,11 @@ import 'package:fushi/src/media/manga/reader/manga_zoom_preference_debouncer.dar
 import 'package:fushi/src/focus/page_focus_ownership.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show GamepadButtonIntent;
+import 'package:fushi/src/shortcuts/global_navigation.dart'
+    show
+        desktopWindowFullscreenSupported,
+        readDesktopWindowFullscreen,
+        setDesktopWindowFullscreen;
 import 'package:fushi/src/shortcuts/input_binding.dart'
     show
         GamepadButton,
@@ -121,6 +127,10 @@ enum MangaReaderInputAction {
   /// 隐藏界面的方式，这两块恒挂在画面上遮住页图；移动端还联动系统栏沉浸，隐藏
   /// 界面即真全屏。
   toggleChrome,
+
+  /// Toggle the desktop window's fullscreen presentation without rebuilding
+  /// the manga WebView or losing its current OCR/selection state.
+  toggleFullscreen,
 }
 
 /// 一次键盘平移移动的视口比例。按比例而非像素，1080p 与 4K 手感一致。
@@ -372,6 +382,9 @@ class MangaFushiPage extends BaseSourcePage {
     required MangaReadingMode mode,
   }) {
     if (action == null) return null;
+    if (action == ShortcutAction.globalToggleFullscreen) {
+      return MangaReaderInputAction.toggleFullscreen;
+    }
     if (action == ShortcutAction.mangaDismissDict) {
       return dictionaryShown ? MangaReaderInputAction.dismissDictionary : null;
     }
@@ -434,7 +447,13 @@ class MangaFushiPage extends BaseSourcePage {
   @visibleForTesting
   static final String navigationKeyBridgeScript = webViewKeyBridgeScript(
     handlerName: 'onMangaNavigationKey',
-    keys: const <String>['ArrowLeft', 'ArrowRight', 'Escape', 'Esc'],
+    keys: const <String>[
+      'ArrowLeft',
+      'ArrowRight',
+      'Escape',
+      'Esc',
+      'F11',
+    ],
     forwardRepeats: false,
     stopPropagation: true,
   );
@@ -657,7 +676,7 @@ class MangaFushiPage extends BaseSourcePage {
 }
 
 class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, WindowListener {
   InAppWebViewController? _controller;
   EpubBookRow? _bookRow;
 
@@ -690,6 +709,10 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
   /// 「显示界面」按钮——漫画正文是原生 WebView，空白点击手势全在注入的 JS 里且
   /// 已被翻页占用，没有这个按钮的话触屏设备再没有第二条通道能把界面唤回来。
   bool _chromeVisible = true;
+
+  bool _isWindowFullscreen = false;
+  bool _ownsWindowFullscreen = false;
+  bool _fullscreenTransitioning = false;
 
   /// 双页布局偏好：页内菜单运行时切换，不持久化，默认自动（横屏双页/竖屏单页）。
   MangaSpreadPreference _spreadPreference = MangaSpreadPreference.auto;
@@ -931,6 +954,12 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
       ),
     );
     WidgetsBinding.instance.addObserver(this);
+    if (Platform.isWindows || Platform.isLinux) {
+      windowManager.addListener(this);
+    }
+    if (desktopWindowFullscreenSupported) {
+      unawaited(_readInitialFullscreenState());
+    }
     // 进程退出兜底：把未落盘的页码 flush 掉（与 EPUB/PDF 阅读器同纪律）。
     ExitFlushRegistry.instance.register(_flushPosition);
     WidgetsBinding.instance.addPostFrameCallback((_) => _loadBook());
@@ -947,6 +976,13 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
 
   @override
   void dispose() {
+    if (Platform.isWindows || Platform.isLinux) {
+      windowManager.removeListener(this);
+    }
+    if (_ownsWindowFullscreen) {
+      _ownsWindowFullscreen = false;
+      unawaited(_restoreOwnedFullscreenAfterDispose());
+    }
     // 交还音量键所有权：必须早于其它拆栈，且无条件执行。
     _volumeKeyPagingController.dispose();
     ExitFlushRegistry.instance.unregister(_flushPosition);
@@ -978,6 +1014,76 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     super.dispose();
   }
 
+  Future<void> _readInitialFullscreenState() async {
+    final bool? fullscreen = await readDesktopWindowFullscreen();
+    if (!mounted || fullscreen == null || fullscreen == _isWindowFullscreen) {
+      return;
+    }
+    setState(() => _isWindowFullscreen = fullscreen);
+  }
+
+  Future<void> _changeMangaFullscreen({bool? requested}) async {
+    if (!desktopWindowFullscreenSupported || _fullscreenTransitioning) return;
+    _fullscreenTransitioning = true;
+    try {
+      final bool fullscreen = requested ??
+          !((await readDesktopWindowFullscreen()) ?? _isWindowFullscreen);
+      if (!mounted) return;
+      // Claim ownership before the native transition starts. If the route is
+      // removed while the platform call is in flight, dispose can still issue
+      // the matching exit instead of leaking a borderless fullscreen window.
+      if (fullscreen) {
+        _ownsWindowFullscreen = true;
+      }
+      final bool? applied = await setDesktopWindowFullscreen(fullscreen);
+      if (!mounted) {
+        if (fullscreen && _ownsWindowFullscreen) {
+          _ownsWindowFullscreen = false;
+          await _restoreOwnedFullscreenAfterDispose();
+        }
+        return;
+      }
+      if (applied == null) {
+        if (fullscreen) _ownsWindowFullscreen = false;
+        return;
+      }
+      _ownsWindowFullscreen = applied;
+      if (_isWindowFullscreen != applied) {
+        setState(() => _isWindowFullscreen = applied);
+      }
+    } finally {
+      _fullscreenTransitioning = false;
+    }
+  }
+
+  Future<void> _setMangaFullscreen(bool fullscreen) =>
+      _changeMangaFullscreen(requested: fullscreen);
+
+  Future<void> _toggleMangaFullscreen() => _changeMangaFullscreen();
+
+  Future<bool> _exitOwnedFullscreenBeforePop() async {
+    if (!_ownsWindowFullscreen) return false;
+    await _setMangaFullscreen(false);
+    return true;
+  }
+
+  Future<void> _restoreOwnedFullscreenAfterDispose() async {
+    await setDesktopWindowFullscreen(false);
+  }
+
+  @override
+  void onWindowEnterFullScreen() {
+    if (!mounted || _isWindowFullscreen) return;
+    setState(() => _isWindowFullscreen = true);
+  }
+
+  @override
+  void onWindowLeaveFullScreen() {
+    _ownsWindowFullscreen = false;
+    if (!mounted || !_isWindowFullscreen) return;
+    setState(() => _isWindowFullscreen = false);
+  }
+
   Future<void> _closePageSession(MangaReaderSession session) async {
     await session.close();
   }
@@ -1000,6 +1106,9 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
 
   @override
   Future<void> onSourcePagePop() async {
+    if (_ownsWindowFullscreen) {
+      await _setMangaFullscreen(false);
+    }
     // 返回书架的正常路径：await 落盘，保证书架 recency/进度立刻正确。
     await _flushPosition();
     _readingTimeTracker?.stop();
@@ -2110,6 +2219,10 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     MangaReaderInputAction action, {
     required _MangaReaderInputSource source,
   }) {
+    if (action == MangaReaderInputAction.toggleFullscreen) {
+      unawaited(_toggleMangaFullscreen());
+      return;
+    }
     // 框选识别模式独占键盘：「返回上一级」/ 关词典键（默认都是 Escape）退出模式，
     // 翻页键一律吞掉——框选途中翻走当前页会让松手时算出的 pageIndex 指向另一页，
     // 回写就落错页。放在去抖之前：两条输入源（Flutter / 原生 WebView 桥）共用这一个
@@ -2195,6 +2308,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         // 「返回上一级」（默认 Esc）：弹窗持焦时也要能关弹窗。它在 universal scope，
         // [resolveDictionaryPopupInputToken] 会在 manga 未命中后回落到 universal。
         ShortcutAction.globalBack,
+        ShortcutAction.globalToggleFullscreen,
       };
 
   @override
@@ -2245,6 +2359,11 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
           key,
           modifiers: modifiers,
           scope: ShortcutScope.universal,
+        ) ??
+        registry.resolveKeyboard(
+          key,
+          modifiers: modifiers,
+          scope: ShortcutScope.global,
         );
     final ShortcutAction? corrected = resolveMangaArrowPageTurn(
           key: key,
@@ -2281,6 +2400,10 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         registry.resolveGamepad(
           button,
           scope: ShortcutScope.universal,
+        ) ??
+        registry.resolveGamepad(
+          button,
+          scope: ShortcutScope.global,
         );
     final ShortcutAction? corrected = resolveMangaDpadPageTurn(
           button: button,
@@ -3661,6 +3784,9 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
       canPop: false,
       onPopInvokedWithResult: (bool didPop, dynamic result) async {
         if (didPop) return;
+        // Fullscreen is a presentation layer above the reader route. Back/Esc
+        // leaves that layer first and keeps the current WebView/page intact.
+        if (await _exitOwnedFullscreenBeforePop()) return;
         // 在 await 前拿住 navigator：onWillPop 是异步长操作（落位置 + closeMedia）。
         final NavigatorState navigator = Navigator.of(context);
         final bool shouldPop = await onWillPop();
@@ -3949,6 +4075,24 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
             onPressed: _toggleMangaChrome,
           ),
         ),
+        if (desktopWindowFullscreenSupported)
+          Tooltip(
+            message: t.shortcut_action_global_toggle_fullscreen,
+            child: IconButton(
+              key: const ValueKey<String>('manga_fullscreen_button'),
+              icon: Icon(
+                _isWindowFullscreen
+                    ? Icons.fullscreen_exit_rounded
+                    : Icons.fullscreen_rounded,
+                color: Colors.white,
+              ),
+              // The method itself serializes native transitions. Keeping the
+              // button enabled avoids rebuilding it as permanently disabled
+              // when the final state update occurs before the transition's
+              // finally block clears its guard.
+              onPressed: () => unawaited(_toggleMangaFullscreen()),
+            ),
+          ),
       ],
     );
   }

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -3784,11 +3784,12 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
       canPop: false,
       onPopInvokedWithResult: (bool didPop, dynamic result) async {
         if (didPop) return;
+        // Cache the navigator before either async cleanup step; this callback
+        // must not read BuildContext after an await.
+        final NavigatorState navigator = Navigator.of(context);
         // Fullscreen is a presentation layer above the reader route. Back/Esc
         // leaves that layer first and keeps the current WebView/page intact.
         if (await _exitOwnedFullscreenBeforePop()) return;
-        // 在 await 前拿住 navigator：onWillPop 是异步长操作（落位置 + closeMedia）。
-        final NavigatorState navigator = Navigator.of(context);
         final bool shouldPop = await onWillPop();
         if (!mounted || !shouldPop) return;
         navigator.pop();

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -1118,29 +1118,6 @@ class _HomePageState extends BasePageState<HomePage>
   }
 
   Widget _buildDesktopLayout(WindowSizeClass sizeClass) {
-    if (_visibleTab == HomeTab.settings) {
-      // 设置标签（全部设计系统）：隐藏 3 图标侧栏，全屏二栏（内部
-      // MaterialSupportingPaneLayout），左上返回箭头切回来源 tab（参考 Mihon
-      // 宽屏设置）。Cupertino 桌面也走这里——叶子控件保持 Cupertino 皮肤，但外壳
-      // 复用同一 Material 架构；返回出口由 SettingsHomePage 的嵌入页头提供
-      // （BUG-009 R2）。否则会退化成「3 图标 rail + 嵌入式 Cupertino 设置」三栏
-      // 混排、无返回出口、且详情面板溢出。
-      return Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: SafeArea(
-          // macOS 透明标题栏 + full-size content view 下，交通灯不计入
-          // MediaQuery.padding，返回箭头会被压在按钮下方。预留标题栏高度作为
-          // SafeArea 下限，让顶部内容整体让位（BUG-869）。其它平台 top=0 无影响。
-          minimum: EdgeInsets.only(
-            top: Platform.isMacOS ? kMacTitleBarHeight : 0,
-          ),
-          child: FocusTraversalGroup(
-            child: _buildSettingsTabContent(showBackButton: true),
-          ),
-        ),
-      );
-    }
-
     final List<HomeTab> tabs = _activeTabs();
     final bool reversed = appModel.reverseNavigationBar;
     final List<AdaptiveNavItem> items = _navItems(tabs);
@@ -2322,9 +2299,9 @@ class _HomePageState extends BasePageState<HomePage>
     }
   }
 
-  /// 设置 tab 的内容外壳。[showBackButton] 为 true 时（宽屏隐藏 3 图标侧栏的全屏
-  /// 设置）显示页头左上返回箭头；为 false 时（移动底栏 / 宽屏侧栏在侧，可直接切回）不
-  /// 显示箭头，系统返回手势仍由 [HomeSettingsTabContent] 内的 PopScope 拦截。
+  /// 设置 tab 的内容外壳。[showBackButton] 仅供没有主导航出口的宿主显示页头返回箭头；
+  /// 常规移动底栏 / 宽屏侧栏都可直接切回，系统返回手势仍由
+  /// [HomeSettingsTabContent] 内的 PopScope 拦截。
   Widget _buildSettingsTabContent({required bool showBackButton}) {
     return HomeSettingsTabContent(
       showBackButton: showBackButton,
@@ -2354,7 +2331,7 @@ class HomeSettingsTabContent extends StatelessWidget {
   /// 系统返回键被拦截后调用：切回进入设置前的来源 tab。
   final VoidCallback onReturnToPreviousTab;
 
-  /// 是否在设置页头左侧显示返回箭头（宽屏隐藏图标侧栏的全屏设置场景）。
+  /// 是否在设置页头左侧显示返回箭头（仅用于没有主导航出口的宿主）。
   final bool showBackButton;
 
   /// 设置内容；为空时回落到默认的 [FushiSettingsContent]。

--- a/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
@@ -319,7 +319,29 @@ extension _VideoFullscreen on _VideoFushiPageState {
   /// （改动前窗口侧 Video 未传回调、落 media_kit 默认 = 桌面真全屏），属本修复范围外的
   /// 桌面回归，故桌面转调默认回调原样保留。
   Future<void> _enterVideoNativeFullscreen() async {
-    if (!isMobilePlatform) return defaultEnterNativeFullscreen();
+    if (!isMobilePlatform) {
+      if (Platform.isWindows) {
+        // media_kit directly edits the HWND and never emits window_manager's
+        // fullscreen event. Hide the app frame before that transition so no
+        // title-bar frame remains above the native fullscreen surface.
+        FushiWindowsTitleBar.setContentFullscreen(
+          owner: this,
+          enabled: true,
+        );
+      }
+      try {
+        await defaultEnterNativeFullscreen();
+      } catch (_) {
+        if (Platform.isWindows) {
+          FushiWindowsTitleBar.setContentFullscreen(
+            owner: this,
+            enabled: false,
+          );
+        }
+        rethrow;
+      }
+      return;
+    }
     await SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.immersiveSticky,
       overlays: <SystemUiOverlay>[],
@@ -343,12 +365,23 @@ extension _VideoFullscreen on _VideoFushiPageState {
   /// 设备方向，无竖屏问题。
   Future<void> _exitVideoNativeFullscreen() async {
     if (!isMobilePlatform) {
-      await defaultExitNativeFullscreen();
-      // BUG-973: AppKit 的 `toggleFullScreen` 退出原生全屏会重建标题栏视图、可能把
-      // `standardWindowButton.isHidden` 复位 → 交通灯在窗口化播放态重新遮住左上角控件。
-      // 退全屏后重新断言隐藏（与 initState 的隐藏一致）。仅 macOS 有交通灯；
-      // Windows / Linux 桌面 no-op。
-      await setMacOSTrafficLightsHidden(true);
+      try {
+        await defaultExitNativeFullscreen();
+        // BUG-973: AppKit 的 `toggleFullScreen` 退出原生全屏会重建标题栏视图、可能把
+        // `standardWindowButton.isHidden` 复位 → 交通灯在窗口化播放态重新遮住左上角控件。
+        // 退全屏后重新断言隐藏（与 initState 的隐藏一致）。仅 macOS 有交通灯；
+        // Windows / Linux 桌面 no-op。
+        await setMacOSTrafficLightsHidden(true);
+      } finally {
+        if (Platform.isWindows) {
+          // Wait until media_kit has restored the HWND rectangle and style;
+          // showing the frame earlier causes a visible flash during exit.
+          FushiWindowsTitleBar.setContentFullscreen(
+            owner: this,
+            enabled: false,
+          );
+        }
+      }
       return;
     }
     await SystemChrome.setEnabledSystemUIMode(

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -29,6 +29,7 @@ import 'package:fushi/src/media/tracking/media_tracking_service.dart'
     show kMediaTrackingEnabled;
 import 'package:fushi/src/pages/implementations/video_loading_overlay.dart';
 import 'package:fushi/src/utils/misc/lookup_dismiss_barrier.dart';
+import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
 // 只取语义枚举与调色板：视频页的通知一律走左上角 _showOsd，不得用 FushiToast
 // （BUG-931 有守卫），故刻意不 import 整套 toast API。
 import 'package:fushi/src/utils/misc/toast_severity.dart';
@@ -3696,6 +3697,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   void dispose() {
     if (Platform.isWindows) {
       WindowsImeSpaceChannel.clearHandler(this);
+      // Abnormal route teardown must never leave the app frame hidden. The
+      // normal fullscreen exit releases this owner only after HWND restoration.
+      FushiWindowsTitleBar.setContentFullscreen(
+        owner: this,
+        enabled: false,
+      );
     }
     WidgetsBinding.instance.removeObserver(this);
     // TODO-658/BUG-383: 摘除系统栏可见性回调（全局单例，避免退页后仍回调已释放 State）。

--- a/fushi/lib/src/settings/material_settings_renderer.dart
+++ b/fushi/lib/src/settings/material_settings_renderer.dart
@@ -9,6 +9,49 @@ import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/utils/components/settings_shared.dart';
 
+enum _MaterialDestinationGroup {
+  application,
+  content,
+  lookup,
+  data;
+
+  String get title => switch (this) {
+    _MaterialDestinationGroup.application =>
+      '${t.settings_section_app_shell} · ${t.settings_destination_appearance}',
+    _MaterialDestinationGroup.content => t.library_view_media,
+    _MaterialDestinationGroup.lookup =>
+      '${t.settings_destination_lookup} · ${t.settings_destination_card_creation}',
+    _MaterialDestinationGroup.data =>
+      '${t.settings_destination_system} · ${t.settings_destination_storage}',
+  };
+}
+
+_MaterialDestinationGroup _destinationGroup(SettingsDestinationId id) {
+  return switch (id) {
+    SettingsDestinationId.appearance ||
+    SettingsDestinationId.appIcon => _MaterialDestinationGroup.application,
+    SettingsDestinationId.reading ||
+    SettingsDestinationId.manga ||
+    SettingsDestinationId.listening ||
+    SettingsDestinationId.video ||
+    SettingsDestinationId.mediaTracking ||
+    SettingsDestinationId.downloads ||
+    SettingsDestinationId.services ||
+    SettingsDestinationId.game ||
+    SettingsDestinationId.readerQuickSettings ||
+    SettingsDestinationId.videoQuickSettings =>
+      _MaterialDestinationGroup.content,
+    SettingsDestinationId.lookup ||
+    SettingsDestinationId.cardCreation => _MaterialDestinationGroup.lookup,
+    SettingsDestinationId.profiles ||
+    SettingsDestinationId.syncBackup ||
+    SettingsDestinationId.storage ||
+    SettingsDestinationId.system ||
+    SettingsDestinationId.interconnect ||
+    SettingsDestinationId.shortcuts => _MaterialDestinationGroup.data,
+  };
+}
+
 class MaterialSettingsRenderer implements SettingsRenderer {
   const MaterialSettingsRenderer();
 
@@ -55,8 +98,14 @@ class MaterialSettingsRenderer implements SettingsRenderer {
     final BuildContext context = settingsContext.context;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
-    final List<Widget> rows = <Widget>[
-      for (final SettingsDestination destination in destinations)
+    final Map<_MaterialDestinationGroup, List<Widget>> rowsByGroup =
+        <_MaterialDestinationGroup, List<Widget>>{
+          for (final _MaterialDestinationGroup group
+              in _MaterialDestinationGroup.values)
+            group: <Widget>[],
+        };
+    for (final SettingsDestination destination in destinations) {
+      rowsByGroup[_destinationGroup(destination.id)]!.add(
         FushiListItem(
           selected: destination.id == selectedDestinationId,
           // Master-detail (pushRoutes:false) keeps selection in-pane, so use the
@@ -70,8 +119,9 @@ class MaterialSettingsRenderer implements SettingsRenderer {
           // 标签（如「同步与备份（实验性）」）用 FushiListItem 默认 titleMaxLines:1
           // 截成「同步与…」。放行第二行；全宽布局本就不换行，无害。
           titleMaxLines: 2,
-          subtitle:
-              destination.summary != null ? Text(destination.summary!) : null,
+          subtitle: destination.summary != null
+              ? Text(destination.summary!)
+              : null,
           // Chevron implies push navigation; only show it when tapping actually
           // pushes a detail route (narrow layout), not in the master-detail pane.
           trailing: pushRoutes ? const Icon(Icons.chevron_right) : null,
@@ -85,7 +135,8 @@ class MaterialSettingsRenderer implements SettingsRenderer {
             );
           },
         ),
-    ];
+      );
+    }
 
     return ListView(
       padding: EdgeInsets.fromLTRB(
@@ -95,10 +146,15 @@ class MaterialSettingsRenderer implements SettingsRenderer {
         tokens.spacing.page + mediaPadding.bottom,
       ),
       children: <Widget>[
-        AdaptiveSettingsSection(
-          surfaceColor: tokens.surfaces.card,
-          children: rows,
-        ),
+        for (final _MaterialDestinationGroup group
+            in _MaterialDestinationGroup.values)
+          if (rowsByGroup[group]!.isNotEmpty)
+            AdaptiveSettingsSection(
+              key: ValueKey<String>('settings-destination-group-${group.name}'),
+              title: group.title,
+              surfaceColor: tokens.surfaces.card,
+              children: rowsByGroup[group]!,
+            ),
       ],
     );
   }
@@ -128,8 +184,9 @@ class MaterialSettingsRenderer implements SettingsRenderer {
   }) {
     final BuildContext context = settingsContext.context;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final List<SettingsSection> sections =
-        destination.visibleSections(settingsContext);
+    final List<SettingsSection> sections = destination.visibleSections(
+      settingsContext,
+    );
     final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
     // Left side hugs the pane divider; give it MD3 expanded breathing room
     // (page + gap = 28) so detail content isn't glued to the nav pane. Horizontal
@@ -143,8 +200,9 @@ class MaterialSettingsRenderer implements SettingsRenderer {
     // pane's bespoke 导航 / 有声书 sub-pages instead of double-indenting and
     // rendering narrower (TODO-1321). Mirrors the Cupertino renderer, whose
     // detail body never owns a horizontal inset.
-    final EdgeInsets horizontal =
-        insetHorizontally ? detailHorizontalInsets(tokens) : EdgeInsets.zero;
+    final EdgeInsets horizontal = insetHorizontally
+        ? detailHorizontalInsets(tokens)
+        : EdgeInsets.zero;
     final EdgeInsets padding = EdgeInsets.fromLTRB(
       horizontal.left,
       tokens.spacing.gap,
@@ -153,17 +211,17 @@ class MaterialSettingsRenderer implements SettingsRenderer {
     );
 
     Widget section(int index) => SettingsSchemaSection(
-          section: sections[index],
-          settingsContext: settingsContext,
-          showIcons: true,
-          routeBuilder: (BuildContext context, WidgetBuilder builder) {
-            return MaterialPageRoute<void>(builder: builder);
-          },
-          footerStyle: (BuildContext context) =>
-              Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: FushiDesignTokens.of(context).surfaces.onVariant,
-                  ),
-        );
+      section: sections[index],
+      settingsContext: settingsContext,
+      showIcons: true,
+      routeBuilder: (BuildContext context, WidgetBuilder builder) {
+        return MaterialPageRoute<void>(builder: builder);
+      },
+      footerStyle: (BuildContext context) => Theme.of(context)
+          .textTheme
+          .bodySmall
+          ?.copyWith(color: FushiDesignTokens.of(context).surfaces.onVariant),
+    );
 
     // 整页正文逃生口（见 SettingsDestination.body）：接在所有 schema section 之后，
     // 与它们共享同一个滚动容器与内边距。

--- a/fushi/lib/src/settings/material_settings_renderer.dart
+++ b/fushi/lib/src/settings/material_settings_renderer.dart
@@ -7,49 +7,34 @@ import 'package:fushi/src/settings/settings_renderer.dart';
 import 'package:fushi/src/settings/settings_schema_widgets.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
-import 'package:fushi/src/utils/components/settings_shared.dart';
 
-enum _MaterialDestinationGroup {
-  application,
-  content,
-  lookup,
-  data;
+class _BorderlessDestinationList extends StatelessWidget {
+  const _BorderlessDestinationList({required this.rows});
 
-  String get title => switch (this) {
-    _MaterialDestinationGroup.application =>
-      '${t.settings_section_app_shell} · ${t.settings_destination_appearance}',
-    _MaterialDestinationGroup.content => t.library_view_media,
-    _MaterialDestinationGroup.lookup =>
-      '${t.settings_destination_lookup} · ${t.settings_destination_card_creation}',
-    _MaterialDestinationGroup.data =>
-      '${t.settings_destination_system} · ${t.settings_destination_storage}',
-  };
-}
+  final List<Widget> rows;
 
-_MaterialDestinationGroup _destinationGroup(SettingsDestinationId id) {
-  return switch (id) {
-    SettingsDestinationId.appearance ||
-    SettingsDestinationId.appIcon => _MaterialDestinationGroup.application,
-    SettingsDestinationId.reading ||
-    SettingsDestinationId.manga ||
-    SettingsDestinationId.listening ||
-    SettingsDestinationId.video ||
-    SettingsDestinationId.mediaTracking ||
-    SettingsDestinationId.downloads ||
-    SettingsDestinationId.services ||
-    SettingsDestinationId.game ||
-    SettingsDestinationId.readerQuickSettings ||
-    SettingsDestinationId.videoQuickSettings =>
-      _MaterialDestinationGroup.content,
-    SettingsDestinationId.lookup ||
-    SettingsDestinationId.cardCreation => _MaterialDestinationGroup.lookup,
-    SettingsDestinationId.profiles ||
-    SettingsDestinationId.syncBackup ||
-    SettingsDestinationId.storage ||
-    SettingsDestinationId.system ||
-    SettingsDestinationId.interconnect ||
-    SettingsDestinationId.shortcuts => _MaterialDestinationGroup.data,
-  };
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return Column(
+      key: const ValueKey<String>('settings-destination-list'),
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (int index = 0; index < rows.length; index++) ...<Widget>[
+          if (index > 0) SizedBox(height: tokens.spacing.gap / 4),
+          ClipRRect(
+            borderRadius: BorderRadius.vertical(
+              top: index == 0 ? tokens.radii.groupRadius.topLeft : Radius.zero,
+              bottom: index == rows.length - 1
+                  ? tokens.radii.groupRadius.bottomLeft
+                  : Radius.zero,
+            ),
+            child: ColoredBox(color: tokens.surfaces.card, child: rows[index]),
+          ),
+        ],
+      ],
+    );
+  }
 }
 
 class MaterialSettingsRenderer implements SettingsRenderer {
@@ -98,21 +83,13 @@ class MaterialSettingsRenderer implements SettingsRenderer {
     final BuildContext context = settingsContext.context;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
-    final Map<_MaterialDestinationGroup, List<Widget>> rowsByGroup =
-        <_MaterialDestinationGroup, List<Widget>>{
-          for (final _MaterialDestinationGroup group
-              in _MaterialDestinationGroup.values)
-            group: <Widget>[],
-        };
-    for (final SettingsDestination destination in destinations) {
-      rowsByGroup[_destinationGroup(destination.id)]!.add(
+    final List<Widget> rows = <Widget>[
+      for (final SettingsDestination destination in destinations)
         FushiListItem(
           selected: destination.id == selectedDestinationId,
-          // Master-detail (pushRoutes:false) keeps selection in-pane, so use the
-          // MD3 rounded pill highlight; the narrow push list keeps full-bleed fill.
-          selectedShape: pushRoutes
-              ? FushiListItemSelectedShape.fill
-              : FushiListItemSelectedShape.pill,
+          // 左侧导航是一整列无框线列表：选中态铺满整行，首尾圆角由外层按行位置
+          // 裁切；不再叠一层内缩胶囊描边。
+          selectedShape: FushiListItemSelectedShape.fill,
           leading: Icon(destination.icon),
           title: Text(destination.title),
           // TODO-1143：左父菜单在窄布局（clamp 280..360，最窄 280px）下曾把长分类
@@ -135,8 +112,7 @@ class MaterialSettingsRenderer implements SettingsRenderer {
             );
           },
         ),
-      );
-    }
+    ];
 
     return ListView(
       padding: EdgeInsets.fromLTRB(
@@ -145,17 +121,7 @@ class MaterialSettingsRenderer implements SettingsRenderer {
         tokens.spacing.page,
         tokens.spacing.page + mediaPadding.bottom,
       ),
-      children: <Widget>[
-        for (final _MaterialDestinationGroup group
-            in _MaterialDestinationGroup.values)
-          if (rowsByGroup[group]!.isNotEmpty)
-            AdaptiveSettingsSection(
-              key: ValueKey<String>('settings-destination-group-${group.name}'),
-              title: group.title,
-              surfaceColor: tokens.surfaces.card,
-              children: rowsByGroup[group]!,
-            ),
-      ],
+      children: <Widget>[_BorderlessDestinationList(rows: rows)],
     );
   }
 

--- a/fushi/lib/src/settings/settings_home_page.dart
+++ b/fushi/lib/src/settings/settings_home_page.dart
@@ -9,6 +9,7 @@ import 'package:fushi/src/settings/settings_detail_page.dart';
 import 'package:fushi/src/settings/settings_renderer.dart';
 import 'package:fushi/src/settings/settings_schema.dart';
 import 'package:fushi/src/settings/settings_search.dart';
+import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
 import 'package:fushi/utils.dart';
 
 class SettingsHomePage extends BasePage {
@@ -233,6 +234,11 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
 
   Widget _buildEmbeddedShell(Widget content) {
     if (!widget.embedded) {
+      return content;
+    }
+    // Windows 主窗口已经由应用壳层提供当前 tab 标题；设置仍是普通 home tab，
+    // 左侧主导航始终可见，因此无需再画第二条「返回 + 设置」页头。
+    if (FushiWindowsTitleBar.isEnabled) {
       return content;
     }
     // Cupertino 手机（compact 走底栏导航、onBack 为空、无需返回出口）保持原生

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show
         arrowFocusMoveDirection,
@@ -284,7 +285,8 @@ bool gamepadBackMustBeSwallowed(KeyEvent event) =>
 /// way [DesktopWindowPlacement.saveCurrentBoundsNow] does
 /// ([WindowManager.isFullScreen]). Only meaningful on desktop (Windows / macOS /
 /// Linux) where a native window exists; on mobile there is no such window, so the
-/// binding resolves but the toggle is a no-op (guarded by [_isDesktopWindow]).
+/// binding resolves but the toggle is a no-op (guarded by
+/// [desktopWindowFullscreenSupported]).
 ///
 /// Resolution is synchronous so [Focus.onKeyEvent] can return a [KeyEventResult]
 /// immediately; the actual (async) [WindowManager] round-trip is fired
@@ -319,7 +321,7 @@ KeyEventResult _handleGlobalToggleFullscreen(
   }
   // Bound but no desktop window (mobile): consume the key (it is intentionally
   // assigned) but do nothing — there is no window to toggle.
-  if (_isDesktopWindow) {
+  if (desktopWindowFullscreenSupported) {
     unawaited(_toggleWindowFullscreen());
   }
   return KeyEventResult.handled;
@@ -327,7 +329,7 @@ KeyEventResult _handleGlobalToggleFullscreen(
 
 /// Whether the running platform has a desktop window whose fullscreen state can
 /// be toggled via [WindowManager] (mirrors [DesktopWindowPlacement] desktop gate).
-bool get _isDesktopWindow =>
+bool get desktopWindowFullscreenSupported =>
     Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
 /// 裸空格中和：焦点确认永不走空格（确认键统一 Enter / 手柄 A，由框架默认提供），故在
@@ -368,20 +370,102 @@ KeyEventResult _neutralizeBareSpace(KeyEvent event) {
 /// 任何 platform-channel 失败都以 debug 日志吞掉，杂散按键永不崩应用。
 Future<void> _toggleWindowFullscreen() async {
   try {
-    if (Platform.isMacOS) {
-      final bool current = await WindowManipulator.isWindowFullscreened();
-      if (current) {
-        await WindowManipulator.exitFullscreen();
-      } else {
-        await WindowManipulator.enterFullscreen();
-      }
-      return;
-    }
-    final bool current = await windowManager.isFullScreen();
-    await windowManager.setFullScreen(!current);
+    await toggleDesktopWindowFullscreen();
   } catch (e) {
     debugPrint('[Fushi] window fullscreen toggle skipped: $e');
   }
+}
+
+/// Reads the desktop window fullscreen state from its single native owner.
+/// Mobile returns null.
+Future<bool?> readDesktopWindowFullscreen() async {
+  try {
+    if (Platform.isMacOS) {
+      return WindowManipulator.isWindowFullscreened();
+    }
+    if (Platform.isWindows) {
+      final bool fullscreen = await windowManager.isFullScreen();
+      FushiWindowsTitleBar.setWindowManagerFullscreen(fullscreen);
+      return fullscreen;
+    }
+    if (Platform.isLinux) {
+      return windowManager.isFullScreen();
+    }
+  } catch (e) {
+    debugPrint('[Fushi] window fullscreen state unavailable: $e');
+  }
+  return null;
+}
+
+/// Sets the desktop window fullscreen state through the platform's single
+/// native-window owner and returns the resulting state. Mobile returns null.
+Future<bool?> setDesktopWindowFullscreen(bool fullscreen) async {
+  try {
+    if (Platform.isMacOS) {
+      final bool current = await WindowManipulator.isWindowFullscreened();
+      if (current != fullscreen) {
+        if (fullscreen) {
+          await WindowManipulator.enterFullscreen();
+        } else {
+          await WindowManipulator.exitFullscreen();
+        }
+      }
+      return fullscreen;
+    }
+    if (Platform.isWindows) {
+      // Update the app frame explicitly. window_manager's Windows plugin does
+      // not emit leave-full-screen when a fullscreen window returns to its
+      // previous maximized state, so WindowListener alone can remain stuck.
+      final bool previousChromeState =
+          FushiWindowsTitleBar.isWindowManagerFullscreen;
+      if (fullscreen) {
+        FushiWindowsTitleBar.setWindowManagerFullscreen(true);
+      }
+      bool mutationCompleted = false;
+      try {
+        await windowManager.setFullScreen(fullscreen);
+        mutationCompleted = true;
+        FushiWindowsTitleBar.setWindowManagerFullscreen(fullscreen);
+        final bool applied = await windowManager.isFullScreen();
+        FushiWindowsTitleBar.setWindowManagerFullscreen(applied);
+        return applied;
+      } catch (error) {
+        try {
+          final bool current = await windowManager.isFullScreen();
+          FushiWindowsTitleBar.setWindowManagerFullscreen(current);
+          // Even if the mutation threw, the native read is authoritative. If
+          // only the verification read failed after a completed mutation,
+          // this retry also preserves the caller's fullscreen ownership.
+          return current;
+        } catch (_) {
+          if (mutationCompleted) {
+            // The mutation completed but both reads failed. Keep the requested
+            // state as the best available truth so a reader that entered
+            // fullscreen retains ownership and can restore the window later.
+            FushiWindowsTitleBar.setWindowManagerFullscreen(fullscreen);
+            return fullscreen;
+          }
+          FushiWindowsTitleBar.setWindowManagerFullscreen(previousChromeState);
+        }
+        debugPrint('[Fushi] window fullscreen mutation failed: $error');
+        rethrow;
+      }
+    }
+    if (Platform.isLinux) {
+      await windowManager.setFullScreen(fullscreen);
+      return windowManager.isFullScreen();
+    }
+  } catch (e) {
+    debugPrint('[Fushi] window fullscreen change skipped: $e');
+  }
+  return null;
+}
+
+/// Flips the main desktop window between fullscreen and windowed.
+Future<bool?> toggleDesktopWindowFullscreen() async {
+  final bool? current = await readDesktopWindowFullscreen();
+  if (current == null) return null;
+  return setDesktopWindowFullscreen(!current);
 }
 
 /// Wrap [child] (typically MaterialApp's builder child) with app-wide keyboard /

--- a/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
+++ b/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// App-themed Windows frame used after the native caption is hidden.
+///
+/// The frame keeps resizing, dragging, double-click maximize/restore and the
+/// existing intercepted close lifecycle, while avoiding Win32 caption chrome.
+class FushiWindowsTitleBar extends StatefulWidget {
+  const FushiWindowsTitleBar({
+    required this.title,
+    required this.child,
+    this.leadingInset = 0,
+    super.key,
+  });
+
+  static const double height = 52;
+
+  final Widget title;
+  final Widget child;
+  final double leadingInset;
+
+  @override
+  State<FushiWindowsTitleBar> createState() => _FushiWindowsTitleBarState();
+}
+
+class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
+    with WindowListener {
+  bool _isMaximized = false;
+  bool _isFullScreen = false;
+
+  @override
+  void initState() {
+    super.initState();
+    windowManager.addListener(this);
+    unawaited(_readInitialWindowState());
+  }
+
+  Future<void> _readInitialWindowState() async {
+    try {
+      final List<bool> state = await Future.wait<bool>(<Future<bool>>[
+        windowManager.isMaximized(),
+        windowManager.isFullScreen(),
+      ]);
+      if (!mounted) return;
+      setState(() {
+        _isMaximized = state[0];
+        _isFullScreen = state[1];
+      });
+    } catch (error) {
+      debugPrint('[Fushi] failed to read initial window state: $error');
+    }
+  }
+
+  @override
+  void dispose() {
+    windowManager.removeListener(this);
+    super.dispose();
+  }
+
+  @override
+  void onWindowMaximize() {
+    setState(() => _isMaximized = true);
+  }
+
+  @override
+  void onWindowUnmaximize() {
+    setState(() => _isMaximized = false);
+  }
+
+  @override
+  void onWindowEnterFullScreen() {
+    setState(() => _isFullScreen = true);
+  }
+
+  @override
+  void onWindowLeaveFullScreen() {
+    setState(() => _isFullScreen = false);
+  }
+
+  void _minimize() {
+    unawaited(windowManager.minimize());
+  }
+
+  void _toggleMaximize() {
+    if (_isMaximized) {
+      unawaited(windowManager.unmaximize());
+    } else {
+      unawaited(windowManager.maximize());
+    }
+  }
+
+  void _close() {
+    // main.dart installs setPreventClose(true), so this still runs the existing
+    // bounded data flush and fast-exit path instead of destroying the engine.
+    unawaited(windowManager.close());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return VirtualWindowFrame(
+      child: ColoredBox(
+        color: colors.surface,
+        child: Column(
+          children: <Widget>[
+            if (!_isFullScreen)
+              SizedBox(
+                height: FushiWindowsTitleBar.height,
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: DragToMoveArea(
+                        child: Row(
+                          children: <Widget>[
+                            SizedBox(width: widget.leadingInset),
+                            Expanded(
+                              child: Align(
+                                alignment: AlignmentDirectional.centerStart,
+                                child: Padding(
+                                  padding: const EdgeInsetsDirectional.only(
+                                    start: 24,
+                                  ),
+                                  child: DefaultTextStyle(
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleLarge!
+                                        .copyWith(
+                                          color: colors.onSurface,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                    child: widget.title,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    _FushiCaptionButton(
+                      icon: Icons.remove_rounded,
+                      onPressed: _minimize,
+                    ),
+                    _FushiCaptionButton(
+                      icon: _isMaximized
+                          ? Icons.filter_none_rounded
+                          : Icons.crop_square_rounded,
+                      onPressed: _toggleMaximize,
+                    ),
+                    _FushiCaptionButton(
+                      icon: Icons.close_rounded,
+                      isClose: true,
+                      onPressed: _close,
+                    ),
+                    const SizedBox(width: 6),
+                  ],
+                ),
+              ),
+            Expanded(child: widget.child),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FushiCaptionButton extends StatelessWidget {
+  const _FushiCaptionButton({
+    required this.icon,
+    required this.onPressed,
+    this.isClose = false,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final bool isClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 20),
+        style: ButtonStyle(
+          minimumSize: const WidgetStatePropertyAll<Size>(Size(40, 40)),
+          maximumSize: const WidgetStatePropertyAll<Size>(Size(40, 40)),
+          padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
+            EdgeInsets.zero,
+          ),
+          shape: WidgetStatePropertyAll<OutlinedBorder>(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          ),
+          foregroundColor: WidgetStateProperty.resolveWith<Color>((states) {
+            if (isClose && states.contains(WidgetState.hovered)) {
+              return colors.onError;
+            }
+            return colors.onSurfaceVariant;
+          }),
+          backgroundColor: WidgetStateProperty.resolveWith<Color?>((states) {
+            if (isClose && states.contains(WidgetState.hovered)) {
+              return colors.error;
+            }
+            if (states.contains(WidgetState.hovered) ||
+                states.contains(WidgetState.focused)) {
+              return colors.surfaceContainerHighest;
+            }
+            return Colors.transparent;
+          }),
+          overlayColor: const WidgetStatePropertyAll<Color>(Colors.transparent),
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
+++ b/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
@@ -17,6 +17,10 @@ class FushiWindowsTitleBar extends StatefulWidget {
 
   static const double height = 52;
 
+  /// Set only after Windows accepts [TitleBarStyle.hidden]. Widgets below the
+  /// app frame use this to avoid rendering a second, redundant page header.
+  static bool isEnabled = false;
+
   final Widget title;
   final Widget child;
   final double leadingInset;

--- a/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
+++ b/fushi/lib/src/utils/components/fushi_windows_title_bar.dart
@@ -15,11 +15,51 @@ class FushiWindowsTitleBar extends StatefulWidget {
     super.key,
   });
 
-  static const double height = 52;
+  /// Keep the app frame as compact as the native Windows caption it replaces.
+  /// This is intentionally outside [FushiAppUiScale], so the window controls do
+  /// not grow with content zoom.
+  static const double height = 32;
 
   /// Set only after Windows accepts [TitleBarStyle.hidden]. Widgets below the
   /// app frame use this to avoid rendering a second, redundant page header.
   static bool isEnabled = false;
+
+  /// Fullscreen surfaces that do not flow through `window_manager` (notably
+  /// media_kit on Windows) acquire an owner here while they directly manipulate
+  /// the HWND. Owner semantics prevent one surface from restoring the frame
+  /// while another fullscreen surface is still active.
+  static final Set<Object> _contentFullscreenOwners = <Object>{};
+  static final Object _windowManagerFullscreenOwner = Object();
+  static final ValueNotifier<bool> _contentFullscreen =
+      ValueNotifier<bool>(false);
+
+  static void setContentFullscreen({
+    required Object owner,
+    required bool enabled,
+  }) {
+    final bool changed = enabled
+        ? _contentFullscreenOwners.add(owner)
+        : _contentFullscreenOwners.remove(owner);
+    if (!changed) return;
+    _contentFullscreen.value = _contentFullscreenOwners.isNotEmpty;
+  }
+
+  /// Keep the app frame in sync with the fullscreen state owned by
+  /// `window_manager`.
+  ///
+  /// On Windows, window_manager only emits `leave-full-screen` when WM_SIZE is
+  /// `SIZE_RESTORED`. Exiting fullscreen back to a previously maximized window
+  /// remains `SIZE_MAXIMIZED`, so that event never arrives. Callers which set or
+  /// read native fullscreen therefore update this stable owner directly.
+  static void setWindowManagerFullscreen(bool enabled) {
+    setContentFullscreen(
+      owner: _windowManagerFullscreenOwner,
+      enabled: enabled,
+    );
+  }
+
+  static bool get isWindowManagerFullscreen =>
+      _contentFullscreenOwners.contains(_windowManagerFullscreenOwner);
 
   final Widget title;
   final Widget child;
@@ -32,7 +72,6 @@ class FushiWindowsTitleBar extends StatefulWidget {
 class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
     with WindowListener {
   bool _isMaximized = false;
-  bool _isFullScreen = false;
 
   @override
   void initState() {
@@ -48,9 +87,9 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
         windowManager.isFullScreen(),
       ]);
       if (!mounted) return;
+      FushiWindowsTitleBar.setWindowManagerFullscreen(state[1]);
       setState(() {
         _isMaximized = state[0];
-        _isFullScreen = state[1];
       });
     } catch (error) {
       debugPrint('[Fushi] failed to read initial window state: $error');
@@ -75,12 +114,12 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
 
   @override
   void onWindowEnterFullScreen() {
-    setState(() => _isFullScreen = true);
+    FushiWindowsTitleBar.setWindowManagerFullscreen(true);
   }
 
   @override
   void onWindowLeaveFullScreen() {
-    setState(() => _isFullScreen = false);
+    FushiWindowsTitleBar.setWindowManagerFullscreen(false);
   }
 
   void _minimize() {
@@ -88,10 +127,22 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
   }
 
   void _toggleMaximize() {
-    if (_isMaximized) {
-      unawaited(windowManager.unmaximize());
-    } else {
-      unawaited(windowManager.maximize());
+    unawaited(_toggleMaximizeAndSync());
+  }
+
+  Future<void> _toggleMaximizeAndSync() async {
+    try {
+      final bool maximized = await windowManager.isMaximized();
+      if (maximized) {
+        await windowManager.unmaximize();
+      } else {
+        await windowManager.maximize();
+      }
+      final bool applied = await windowManager.isMaximized();
+      if (!mounted || _isMaximized == applied) return;
+      setState(() => _isMaximized = applied);
+    } catch (error) {
+      debugPrint('[Fushi] failed to toggle window maximize state: $error');
     }
   }
 
@@ -104,70 +155,108 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
-    return VirtualWindowFrame(
-      child: ColoredBox(
-        color: colors.surface,
-        child: Column(
-          children: <Widget>[
-            if (!_isFullScreen)
-              SizedBox(
-                height: FushiWindowsTitleBar.height,
-                child: Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: DragToMoveArea(
-                        child: Row(
-                          children: <Widget>[
-                            SizedBox(width: widget.leadingInset),
-                            Expanded(
-                              child: Align(
-                                alignment: AlignmentDirectional.centerStart,
-                                child: Padding(
-                                  padding: const EdgeInsetsDirectional.only(
-                                    start: 24,
-                                  ),
-                                  child: DefaultTextStyle(
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .titleLarge!
-                                        .copyWith(
-                                          color: colors.onSurface,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                    child: widget.title,
+    return ValueListenableBuilder<bool>(
+      valueListenable: FushiWindowsTitleBar._contentFullscreen,
+      builder: (BuildContext context, bool contentFullscreen, Widget? child) {
+        final bool hideFrame = contentFullscreen;
+        final Widget frame = ColoredBox(
+          color: colors.surface,
+          child: Column(
+            children: <Widget>[
+              if (!hideFrame)
+                SizedBox(
+                  height: FushiWindowsTitleBar.height,
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: DragToMoveArea(
+                          child: Row(
+                            children: <Widget>[
+                              SizedBox(width: widget.leadingInset),
+                              Expanded(
+                                child: Align(
+                                  alignment: AlignmentDirectional.centerStart,
+                                  child: Padding(
+                                    padding: const EdgeInsetsDirectional.only(
+                                      start: 16,
+                                    ),
+                                    child: DefaultTextStyle(
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleSmall!
+                                          .copyWith(
+                                            color: colors.onSurface,
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                      child: widget.title,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
                       ),
-                    ),
-                    _FushiCaptionButton(
-                      icon: Icons.remove_rounded,
-                      onPressed: _minimize,
-                    ),
-                    _FushiCaptionButton(
-                      icon: _isMaximized
-                          ? Icons.filter_none_rounded
-                          : Icons.crop_square_rounded,
-                      onPressed: _toggleMaximize,
-                    ),
-                    _FushiCaptionButton(
-                      icon: Icons.close_rounded,
-                      isClose: true,
-                      onPressed: _close,
-                    ),
-                    const SizedBox(width: 6),
-                  ],
+                      _FushiCaptionButton(
+                        icon: Icons.remove_rounded,
+                        onPressed: _minimize,
+                      ),
+                      _FushiCaptionButton(
+                        icon: _isMaximized
+                            ? Icons.filter_none_rounded
+                            : Icons.crop_square_rounded,
+                        onPressed: _toggleMaximize,
+                      ),
+                      _FushiCaptionButton(
+                        icon: Icons.close_rounded,
+                        isClose: true,
+                        onPressed: _close,
+                      ),
+                      const SizedBox(width: 4),
+                    ],
+                  ),
+                ),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (
+                    BuildContext context,
+                    BoxConstraints constraints,
+                  ) {
+                    // The title bar consumes real layout height. Rebase the
+                    // Navigator's MediaQuery to the remaining viewport so
+                    // native WebViews paginate against their actual surface,
+                    // rather than clipping the last title-bar-height pixels.
+                    final MediaQueryData mediaQuery = MediaQuery.of(context);
+                    return MediaQuery(
+                      data: mediaQuery.copyWith(size: constraints.biggest),
+                      child: widget.child,
+                    );
+                  },
                 ),
               ),
-            Expanded(child: widget.child),
-          ],
-        ),
-      ),
+            ],
+          ),
+        );
+        // Keep resize ownership in the same state machine as the caption.
+        // VirtualWindowFrame maintains its own event-only maximized/fullscreen
+        // cache, which is vulnerable to the same missing Windows leave event.
+        // Fullscreen omits resize hit targets entirely; maximized windows keep
+        // them disabled until the native state is explicitly re-read above.
+        return hideFrame
+            ? frame
+            : DragToResizeArea(
+                enableResizeEdges: _isMaximized
+                    ? const <ResizeEdge>[]
+                    : const <ResizeEdge>[
+                        ResizeEdge.topLeft,
+                        ResizeEdge.top,
+                        ResizeEdge.topRight,
+                      ],
+                child: frame,
+              );
+      },
     );
   }
 }
@@ -190,15 +279,15 @@ class _FushiCaptionButton extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 2),
       child: IconButton(
         onPressed: onPressed,
-        icon: Icon(icon, size: 20),
+        icon: Icon(icon, size: 16),
         style: ButtonStyle(
-          minimumSize: const WidgetStatePropertyAll<Size>(Size(40, 40)),
-          maximumSize: const WidgetStatePropertyAll<Size>(Size(40, 40)),
+          minimumSize: const WidgetStatePropertyAll<Size>(Size(40, 28)),
+          maximumSize: const WidgetStatePropertyAll<Size>(Size(40, 28)),
           padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
             EdgeInsets.zero,
           ),
           shape: WidgetStatePropertyAll<OutlinedBorder>(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
           foregroundColor: WidgetStateProperty.resolveWith<Color>((states) {
             if (isClose && states.contains(WidgetState.hovered)) {

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.2.1+1229
+version: 2.2.1+1230
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
+++ b/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
@@ -31,17 +31,32 @@ void main() {
     // 根因：window_manager.setFullScreen 与 macos_window_utils（NSWindow.delegate
     // 所有者）抢同一 NSWindow。macOS 全屏必须由 delegate 所有者 WindowManipulator
     // 统一驱动；windowManager.setFullScreen 只留给非 macOS 桌面。
-    final int toggleStart =
-        nav.indexOf('Future<void> _toggleWindowFullscreen()');
-    expect(toggleStart, isNonNegative);
-    final String body = nav.substring(toggleStart);
-    final int end = body.indexOf('\n}');
-    final String fn = end >= 0 ? body.substring(0, end) : body;
-    expect(fn, contains('Platform.isMacOS'),
-        reason: 'fullscreen toggle must branch macOS onto the single owner.');
-    expect(fn, contains('WindowManipulator.enterFullscreen'));
-    expect(fn, contains('WindowManipulator.exitFullscreen'));
-    expect(fn, contains('WindowManipulator.isWindowFullscreened'));
+    final String toggle = methodBody(
+      nav,
+      'Future<void> _toggleWindowFullscreen() async {',
+    );
+    final String read = methodBody(
+      nav,
+      'Future<bool?> readDesktopWindowFullscreen() async {',
+    );
+    final String set = methodBody(
+      nav,
+      'Future<bool?> setDesktopWindowFullscreen(bool fullscreen) async {',
+    );
+    expect(
+      toggle,
+      contains('toggleDesktopWindowFullscreen()'),
+      reason: 'the shortcut executor must delegate to the shared owner.',
+    );
+    expect(
+      read,
+      contains('Platform.isMacOS'),
+      reason: 'fullscreen toggle must branch macOS onto the single owner.',
+    );
+    expect(read, contains('WindowManipulator.isWindowFullscreened'));
+    expect(set, contains('Platform.isMacOS'));
+    expect(set, contains('WindowManipulator.enterFullscreen'));
+    expect(set, contains('WindowManipulator.exitFullscreen'));
   });
 
   test(

--- a/fushi/test/pages/video_orientation_fullscreen_guard_test.dart
+++ b/fushi/test/pages/video_orientation_fullscreen_guard_test.dart
@@ -105,10 +105,17 @@ void main() {
       final String exitBody =
           methodBody(src, 'Future<void> _exitVideoNativeFullscreen() async {');
       expect(
-        enterBody.contains(
-            'if (!isMobilePlatform) return defaultEnterNativeFullscreen();'),
+        enterBody.contains('!isMobilePlatform') &&
+            enterBody.contains('defaultEnterNativeFullscreen()'),
         isTrue,
         reason: '进全屏桌面分支必须转调 defaultEnterNativeFullscreen (保留桌面真全屏)',
+      );
+      expect(
+        enterBody.contains('FushiWindowsTitleBar.setContentFullscreen') &&
+            enterBody.contains('owner: this') &&
+            enterBody.contains('enabled: true'),
+        isTrue,
+        reason: 'Windows 进全屏前必须认领应用顶栏隐藏状态',
       );
       // BUG-973: 桌面退全屏分支在 `defaultExitNativeFullscreen()` 之后追加
       // `setMacOSTrafficLightsHidden(true)` re-hide（AppKit 退全屏重建标题栏会复位

--- a/fushi/test/settings/settings_renderer_test.dart
+++ b/fushi/test/settings/settings_renderer_test.dart
@@ -116,6 +116,18 @@ SettingsDestination _fixtureDestination() {
   );
 }
 
+SettingsDestination _navigationFixture({
+  required SettingsDestinationId id,
+  required String title,
+}) {
+  return SettingsDestination(
+    id: id,
+    title: title,
+    icon: Icons.settings_outlined,
+    sections: const <SettingsSection>[],
+  );
+}
+
 Widget _buildHome(
   CupertinoThemeData? cupertinoTheme,
   Widget Function(SettingsContext) builder,
@@ -524,6 +536,48 @@ void main() {
     expect(item.selected, isTrue);
     expect(item.selectedShape, FushiListItemSelectedShape.pill);
     expect(item.trailing, isNull);
+  });
+
+  testWidgets('material destination list separates semantic groups', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        platform: TargetPlatform.android,
+        builder: (SettingsContext settingsContext) {
+          return MaterialSettingsRenderer().buildDestinationList(
+            settingsContext: settingsContext,
+            destinations: <SettingsDestination>[
+              _navigationFixture(
+                id: SettingsDestinationId.appearance,
+                title: 'Appearance',
+              ),
+              _navigationFixture(
+                id: SettingsDestinationId.reading,
+                title: 'Reading',
+              ),
+              _navigationFixture(
+                id: SettingsDestinationId.lookup,
+                title: 'Lookup',
+              ),
+              _navigationFixture(
+                id: SettingsDestinationId.profiles,
+                title: 'Profiles',
+              ),
+            ],
+            selectedDestinationId: SettingsDestinationId.appearance,
+            onDestinationSelected: (_) {},
+            pushRoutes: false,
+          );
+        },
+      ),
+    );
+
+    expect(find.byType(AdaptiveSettingsSection), findsNWidgets(4));
+    expect(find.text('App · Appearance'), findsOneWidget);
+    expect(find.text('Library'), findsOneWidget);
+    expect(find.text('Lookup · Card creation'), findsOneWidget);
+    expect(find.text('System · Storage'), findsOneWidget);
   });
 
   testWidgets('material push destination list keeps fill selection and chevron',

--- a/fushi/test/settings/settings_renderer_test.dart
+++ b/fushi/test/settings/settings_renderer_test.dart
@@ -512,8 +512,8 @@ void main() {
   });
 
   testWidgets(
-      'material master-detail destination list is one grouped surface with '
-      'pill selection', (WidgetTester tester) async {
+      'material master-detail destination list is one borderless list with '
+      'full-row selection', (WidgetTester tester) async {
     await tester.pumpWidget(
       _harness(
         platform: TargetPlatform.android,
@@ -529,16 +529,20 @@ void main() {
       ),
     );
 
-    expect(find.byType(AdaptiveSettingsSection), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('settings-destination-list')),
+      findsOneWidget,
+    );
+    expect(find.byType(AdaptiveSettingsSection), findsNothing);
     FushiListItem item = tester.widget<FushiListItem>(
       find.widgetWithText(FushiListItem, 'Appearance'),
     );
     expect(item.selected, isTrue);
-    expect(item.selectedShape, FushiListItemSelectedShape.pill);
+    expect(item.selectedShape, FushiListItemSelectedShape.fill);
     expect(item.trailing, isNull);
   });
 
-  testWidgets('material destination list separates semantic groups', (
+  testWidgets('material destination list only rounds its outer row edges', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
@@ -556,14 +560,6 @@ void main() {
                 id: SettingsDestinationId.reading,
                 title: 'Reading',
               ),
-              _navigationFixture(
-                id: SettingsDestinationId.lookup,
-                title: 'Lookup',
-              ),
-              _navigationFixture(
-                id: SettingsDestinationId.profiles,
-                title: 'Profiles',
-              ),
             ],
             selectedDestinationId: SettingsDestinationId.appearance,
             onDestinationSelected: (_) {},
@@ -573,11 +569,22 @@ void main() {
       ),
     );
 
-    expect(find.byType(AdaptiveSettingsSection), findsNWidgets(4));
-    expect(find.text('App · Appearance'), findsOneWidget);
-    expect(find.text('Library'), findsOneWidget);
-    expect(find.text('Lookup · Card creation'), findsOneWidget);
-    expect(find.text('System · Storage'), findsOneWidget);
+    final Finder list = find.byKey(
+      const ValueKey<String>('settings-destination-list'),
+    );
+    final List<ClipRRect> clips = tester
+        .widgetList<ClipRRect>(
+          find.descendant(of: list, matching: find.byType(ClipRRect)),
+        )
+        .toList(growable: false);
+    expect(clips, hasLength(2));
+    final BorderRadius first = clips.first.borderRadius as BorderRadius;
+    final BorderRadius last = clips.last.borderRadius as BorderRadius;
+    expect(first.topLeft, isNot(Radius.zero));
+    expect(first.bottomLeft, Radius.zero);
+    expect(last.topLeft, Radius.zero);
+    expect(last.bottomLeft, isNot(Radius.zero));
+    expect(find.byType(AdaptiveSettingsSection), findsNothing);
   });
 
   testWidgets('material push destination list keeps fill selection and chevron',
@@ -596,7 +603,11 @@ void main() {
       ),
     );
 
-    expect(find.byType(AdaptiveSettingsSection), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('settings-destination-list')),
+      findsOneWidget,
+    );
+    expect(find.byType(AdaptiveSettingsSection), findsNothing);
     final FushiListItem item = tester.widget<FushiListItem>(
       find.widgetWithText(FushiListItem, 'Appearance'),
     );

--- a/fushi/test/shortcuts/global_toggle_fullscreen_test.dart
+++ b/fushi/test/shortcuts/global_toggle_fullscreen_test.dart
@@ -101,9 +101,12 @@ void main() {
       );
     });
 
-    test('executor calls WindowManager.setFullScreen with inverted state', () {
-      expect(navSrc.contains('windowManager.isFullScreen()'), isTrue);
-      expect(navSrc.contains('windowManager.setFullScreen(!current)'), isTrue);
+    test('executor toggles through the shared desktop fullscreen owner', () {
+      expect(navSrc.contains('readDesktopWindowFullscreen()'), isTrue);
+      expect(
+        navSrc.contains('setDesktopWindowFullscreen(!current)'),
+        isTrue,
+      );
     });
 
     test('the toggle is fired from the global-navigation key handler', () {

--- a/fushi/windows/runner/win32_window.cpp
+++ b/fushi/windows/runner/win32_window.cpp
@@ -286,6 +286,19 @@ Win32Window::MessageHandler(HWND hwnd,
       return 0;
     }
 
+    case WM_ERASEBKGND:
+      // kSplashBackgroundColor is a pre-Flutter-frame fallback only. Once the
+      // Flutter child is attached it owns every client pixel. Letting
+      // DefWindowProc erase the parent with the class brush during live resize
+      // briefly covers the child with a large #1F4959 rectangle before the
+      // renderer presents its next frame. Acknowledge the erase instead; the
+      // child keeps its previous frame visible until Flutter repaints. Before
+      // SetChildContent, fall through so cold start still gets the splash color.
+      if (child_content_ != nullptr) {
+        return TRUE;
+      }
+      break;
+
     // Braced: this case declares locals, and without its own scope MSVC rejects
     // the switch outright (C2360, initialization skipped by a later case label).
     case WM_ACTIVATE: {


### PR DESCRIPTION
## Summary

- restyle the settings destination pane as a grouped, borderless list while keeping the primary app sidebar visible
- replace the Win32 caption with a compact app-themed 32 px title bar that stays outside UI scaling and keeps drag, resize, maximize, and close behavior
- rebase the app content viewport below the custom title bar so novel and WebView reader content is no longer clipped
- coordinate Windows fullscreen ownership across `window_manager` and media_kit so video and manga fullscreen reliably hide and restore app chrome
- add manga fullscreen controls and F11 handling while preserving the upstream manga interface-visibility controls

## Verification

- `flutter build windows --debug` — passed
- `git diff --check upstream/develop...HEAD` — passed
- Automated tests were intentionally not run, per the user's explicit request.
