### PR TITLE
fix(anki): 查重与制卡判重同源，重复卡不再画成可制卡 +（BUG-1915）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1769 条。点号进各自文件。
+> 共 1770 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1915](bugs/BUG-1915-anki-dup-check-cross-model.md) | ✅ | ✅ | 查词弹窗查重与制卡判重不同源：跨笔记类型的重复卡画成可制卡 + |
 | [BUG-1904](bugs/BUG-1904-dict-import-entry-cap-silent-truncation.md) | ✅ | ✅ | 词条数撞 100 万每 bank 上限被静默截断，仍报导入成功 |
 | [BUG-1903](bugs/BUG-1903-dict-zip-multi-mdx-only-first-imported.md) | ✅ | ✅ | 一个压缩包内含多本 MDX 词典时只导入第一本，其余静默丢弃且报成功 |
 | [BUG-1895](bugs/BUG-1895-lookup-popup-plus-short.md) | ✅ | ✅ | 查词弹窗静息加号比相邻操作图标矮 |

--- a/docs/bugs/BUG-1915-anki-dup-check-cross-model.md
+++ b/docs/bugs/BUG-1915-anki-dup-check-cross-model.md
@@ -1,0 +1,102 @@
+## BUG-1915 · 查词弹窗查重与制卡判重不同源：跨笔记类型的重复卡画成可制卡 +
+
+- **报告**：2026-08-28（用户：视频页查词弹窗，点 + 弹「重复卡片，未导出」，但 + 号毫无变化）
+- **真实性**：✅ 真 bug（本机真机 AnkiConnect 取证复现）
+
+### 现象
+
+视频页查词弹窗里 `たっぷり` 的制卡按钮显示可制卡 `+`。点下去弹 toast「重复卡片，未导出。」，
+而按钮**一点变化都没有**，仍是 `+`。用户看到的是「提示说重复、按钮说可制卡」两个互相打架的说法。
+
+### 根因
+
+**两条判重根本不是同一件事**，而且实测给出相反答案。
+
+- 画 `+` / `✓` 的查重：`AnkiConnectRepository.isDuplicate`
+  → `AnkiConnectService.isDuplicate` → `findNotes 'deck:"…" "<第一字段名>:<词>"'`
+  —— 按**字段名**匹配。
+- 真正拒绝制卡的判重：`AnkiConnectService.addNote` 的 `duplicateScopeOptions`
+  （`packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart:864` `_addNoteDuplicateOptions`，
+  含 `checkAllModels: true`）—— Anki 内建的**第一字段 checksum**，跨全部笔记类型，
+  不管那个字段叫什么名字。
+
+用户的目标卡组 `正在背::Kaishi 1.5k  zh-CH` 里混装两种笔记类型：1501 张 `Kaishi 1.5k zh-CH`
+（第一字段名 `Word`）+ 12 张 `Lapis`（第一字段名 `Expression`，制卡目标）。`たっぷり` 已作为
+一张 Kaishi 卡存在（`noteId=1758347126448`）。真机 AnkiConnect 实测：
+
+| 查询 | 结果 |
+|---|---|
+| `deck:"正在背::Kaishi 1.5k  zh-CH" "Expression:たっぷり"`（Hibiki 查重发的那条） | **0 命中** → 画 `+` |
+| 同卡组内「第一字段 == たっぷり」（Anki 自己的判据） | **1 命中** → `addNote` 拒绝 |
+
+Kaishi 笔记类型压根没有 `Expression` 字段，按字段名永远查不到它。于是**凡是 Kaishi 里已有的词，
+Lapis 卡都永远制不出来，而且事前 UI 一点提示都没有**——不止 `たっぷり` 一个词。
+
+**回归点**：`08b899ecd4`（2026-07-29 `fix(anki): avoid GUI-thread duplicate preflight`）把**制卡侧**
+的判重从「自己发 findNotes」改成「交给 Anki 内建 checksum」，并加 `checkAllModels: true` 想保持
+跨模型范围，但**只改了制卡侧**，`isDuplicate()` 留在旧路径上没动。那行注释里的
+"Preserve that cross-model scope" 是个误解——`Expression:value` 从来就不是跨模型的。
+两条判据从那天起分家。
+
+**次生根因（按钮连重画都没重画）**：`fushi/assets/popup/popup.js` 制卡后的重画被
+`if (result.ankiConnect)` 门控，而 `MinePopupResult` 把 duplicate / 未配置 / 出错 / addNote 响应
+丢失**四种结局压成同一个 `const MinePopupResult()`**（`ankiConnect: false`）。这个布尔表达不了
+「发生了什么」，弹窗无从区分「Anki 明说卡在库里」与「这次 addNote 结果未知」，于是干脆全都不重画。
+
+### [x] ① 已修复
+
+不是「让两边的条件长得一样」（那还会再漂移一次），而是**删掉第二条判据**：
+
+1. `AnkiConnectService.isDuplicate`（按字段名查）**删除**，换成 `isDuplicateForAdd` —— 直接调
+   AnkiConnect 的 `canAddNotesWithErrorDetail`，它内部走的就是 `addNote` 用的同一个
+   `isNoteDuplicateOrEmptyInScope`；options 复用同一个 `_addNoteDuplicateOptions`，不再手写一份。
+   只传第一字段（Anki 判重只看它），不在查词渲染路径上构造整张卡。
+   探测恒传 `allowDuplicate: false`（问的是「Anki 认不认为重复」，与用户的「允许重复」偏好无关）。
+   `canAdd:false` 只有在 Anki **明说是重复**时才算重复——把「卡组过期」当成「已制卡」会让每个词
+   都画上 ✓。老版 AnkiConnect 不认识该动作时退回旧判据，不让这些用户的 ✓ 集体消失。
+2. `MinePopupResult` 增加语义精确的 `duplicate` 字段 + `MinePopupResult.failed(outcome)`
+   工厂，8 个表面的「制卡后失败」分支统一带回真实结局。popup.js 三镜像据此在**重复**时也重画
+   按钮。**只把 duplicate 加进重画门，不是所有失败**——TODO-448 刻意不让失败/结果未知的制卡
+   触发延迟 duplicateCheck 把按钮翻成 ✓（addNote 送达但响应丢失的情形，会读成「先失败后成功」）。
+   duplicate 不是未知：Anki 查过了，卡就在那儿。
+
+提交：见本分支 `worktree-anki-dup-check-samesource`。
+
+改动文件：
+- `packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart`（判据同源 + 共享重复文案常量）
+- `packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart`（改走同源判据 + 老版回退）
+- `fushi/lib/src/pages/implementations/dictionary_popup_webview.dart`（`MinePopupResult.duplicate`）
+- 8 个制卡表面的失败分支（mixin / reader / reader_pdf / texthooker / video / manga）
+- `fushi/assets/popup/popup.js` + 浏览器扩展两镜像（重画门 + `parseMineResult`）
+
+### [x] ② 已加自动化测试
+
+- `packages/fushi_anki/test/duplicate_check_same_source_test.dart`（新增，8 条）——假 AnkiConnect
+  **照上表实测行为建模**：按字段名查恒 0 命中、按 Anki 自己的第一字段判恒重复。两条判据在这台
+  假机上给出相反答案，正是判别力所在。覆盖：跨笔记类型重复必须为 true / 探测与 addNote 发出的
+  options 逐字段相同 / `checkAllModels` 必须开着 / `allowDupes=true` 时探测仍问 `allowDuplicate:false`
+  / 只发第一字段 / `canAdd:false` 但非重复不画 ✓ / 老版回退 / 空词不问 Anki。
+- `packages/fushi_anki/test/ankiconnect_service_test.dart`——旧 `isDuplicate` 组改写为
+  `findNotesByField` 查询串 + `isDuplicateForAdd` 语义两组。
+- `fushi/test/utils/misc/popup_asset_behavior_test.js`——新增
+  `testDuplicateOutcomeStillRepaintsFromAnki`：制卡被判重复后按钮必须重画成 ✓。
+- 三个旧 fake（commit_unknown / error_garble / note_id_and_update）里「制卡不得另跑一次查重」的
+  计数器守卫改接新探测入口，避免守卫变空转。
+
+**变异实测**（证明守卫有判别力，不是空转）：
+- repo 退回旧 `findNotesByField` 判据 → 新测试 8 条中 7 条红（含核心那条）。
+- `checkAllModels: true → false` → **精确**只红 `checkAllModels` 那一条。
+- popup.js 重画门去掉 `|| result.duplicate` → **精确**只红新增的 JS 行为用例。
+- 三次变异后均按 sha256 核对还原（`a63228e0…` / `3e310fce…` / `cdf047e6…`）。
+
+### 备注
+
+**已知边界（无法在查词阶段消除）**：探测传的第一字段值是词条本身，而制卡时那一格是
+`fieldMappings` 渲染的结果。第一字段映射成 `{expression}`（Lapis 出厂默认，也是本用户的配置）
+时两者逐字节相同；映射成依赖句子/媒体的模板时，查词阶段根本拿不到那些数据，任何实现都无法
+预知制卡时的第一字段——此时探测退化为「按词查」，与旧行为一致，不比现状差。
+AnkiDroid 后端同理（`anki_repository.dart` 的 `isDuplicate` 传 `expression`、制卡侧传第一字段
+渲染值），且其 `checkForDuplicates` 本就限定同一笔记类型，不存在本 bug 的跨模型分叉。
+
+**未做真机 E2E**：本轮只做到单测 + 变异实测；用户原始失败路径（视频页查 `たっぷり` → 按钮应显示 ✓）
+未在真机复测。

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -310,9 +310,17 @@ function parseMineResult(reply) {
         const noteId = (typeof rawId === 'number' && Number.isFinite(rawId))
             ? rawId
             : null;
-        return { ankiConnect: reply.ankiConnect === true, noteId };
+        // BUG-1915: `duplicate` says Anki REFUSED the add because the card is
+        // already there — a definitively KNOWN state, unlike the other failures.
+        // Hosts that predate the field simply never set it (undefined -> false),
+        // so they keep the old behaviour exactly.
+        return {
+            ankiConnect: reply.ankiConnect === true,
+            noteId,
+            duplicate: reply.duplicate === true,
+        };
     }
-    return { ankiConnect: reply === true, noteId: null };
+    return { ankiConnect: reply === true, noteId: null, duplicate: false };
 }
 
 // Records the just-mined word as the editable "latest" card when the backend
@@ -3136,6 +3144,21 @@ function createEntryHeader(entry, idx) {
                     // the new "latest editable"; this also supersedes any prior
                     // latest word (only one editable card at a time).
                     rememberLatestMined(expression, reading, result.noteId);
+                }
+                // BUG-1915: a duplicate refusal must repaint too. `ankiConnect`
+                // only says "the host handed back a note id", so it is false for
+                // duplicate, not-configured, error and lost-response alike — and
+                // gating the repaint on it left the button showing `+` right after
+                // Anki refused the add as a duplicate: the toast said 重复卡片，
+                // the button said 可制卡.
+                //
+                // Only `duplicate` is added to the gate, NOT every failure:
+                // TODO-448 deliberately keeps a failed/uncertain mine from a
+                // delayed duplicateCheck that would flip the button to ✓ and read
+                // as "first it failed, then it succeeded" (the addNote-reached-Anki
+                // -but-the-response-was-lost case). Duplicate is not uncertain:
+                // Anki looked and the card is there, so ✓ is simply the truth.
+                if (result.ankiConnect || result.duplicate) {
                     await refreshFromAnki();
                 }
             } catch (e) {

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -310,9 +310,17 @@ function parseMineResult(reply) {
         const noteId = (typeof rawId === 'number' && Number.isFinite(rawId))
             ? rawId
             : null;
-        return { ankiConnect: reply.ankiConnect === true, noteId };
+        // BUG-1915: `duplicate` says Anki REFUSED the add because the card is
+        // already there — a definitively KNOWN state, unlike the other failures.
+        // Hosts that predate the field simply never set it (undefined -> false),
+        // so they keep the old behaviour exactly.
+        return {
+            ankiConnect: reply.ankiConnect === true,
+            noteId,
+            duplicate: reply.duplicate === true,
+        };
     }
-    return { ankiConnect: reply === true, noteId: null };
+    return { ankiConnect: reply === true, noteId: null, duplicate: false };
 }
 
 // Records the just-mined word as the editable "latest" card when the backend
@@ -3136,6 +3144,21 @@ function createEntryHeader(entry, idx) {
                     // the new "latest editable"; this also supersedes any prior
                     // latest word (only one editable card at a time).
                     rememberLatestMined(expression, reading, result.noteId);
+                }
+                // BUG-1915: a duplicate refusal must repaint too. `ankiConnect`
+                // only says "the host handed back a note id", so it is false for
+                // duplicate, not-configured, error and lost-response alike — and
+                // gating the repaint on it left the button showing `+` right after
+                // Anki refused the add as a duplicate: the toast said 重复卡片，
+                // the button said 可制卡.
+                //
+                // Only `duplicate` is added to the gate, NOT every failure:
+                // TODO-448 deliberately keeps a failed/uncertain mine from a
+                // delayed duplicateCheck that would flip the button to ✓ and read
+                // as "first it failed, then it succeeded" (the addNote-reached-Anki
+                // -but-the-response-was-lost case). Duplicate is not uncertain:
+                // Anki looked and the card is there, so ✓ is simply the truth.
+                if (result.ankiConnect || result.duplicate) {
                     await refreshFromAnki();
                 }
             } catch (e) {

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -3281,7 +3281,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
       if (described.success) {
         return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
       }
-      return const MinePopupResult();
+      return MinePopupResult.failed(outcome);
     } catch (e, stack) {
       ErrorLogService.instance.log('MangaFushiPage.onMineFromPopup', e, stack);
       return const MinePopupResult();

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -372,7 +372,7 @@ mixin DictionaryPageMixin {
       // （AnkiConnect 非空，AnkiDroid 恒 null = 优雅降级进不了第三态）。
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
-    return const MinePopupResult();
+    return MinePopupResult.failed(outcome);
   }
 
   /// TODO-270 D：覆盖「最新制的那张卡」（[noteId]）的字段——走 repo.updateMinedNote
@@ -404,7 +404,7 @@ mixin DictionaryPageMixin {
     if (described.success) {
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
-    return const MinePopupResult();
+    return MinePopupResult.failed(outcome);
   }
 
   /// Resolves and plays the audio for [expression] / [reading]. [popupState] is

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi_anki/fushi_anki.dart' show MineOutcome, MineResult;
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_input_bridge.dart';
@@ -57,7 +58,28 @@ const Duration kPopupNativeSelectLongPressDuration =
 /// 再点 ✓ 时按 id 走 `updateEntry` 覆盖而非新建。AnkiDroid 恒 `null` → 永远进不了
 /// 第三态（优雅降级）。失败/重复/未配置时 [noteId] 为 `null`。
 class MinePopupResult {
-  const MinePopupResult({this.ankiConnect = false, this.noteId});
+  const MinePopupResult({
+    this.ankiConnect = false,
+    this.noteId,
+    this.duplicate = false,
+  });
+
+  /// BUG-1915：一次**未成功**的制卡结果。
+  ///
+  /// 此前所有失败结局（重复 / 未配置 / 出错 / addNote 响应丢失）都被压成同一个
+  /// `const MinePopupResult()`，弹窗只能看到 `ankiConnect:false`，于是它无法区分
+  /// 「Anki 明说这张卡已经在库里」和「这次 addNote 的结果根本不知道」。
+  ///
+  /// 两者该走相反的动作：
+  ///   * [MineResult.duplicate] 是**确定已知**的状态——Anki 查过了，卡就在那儿。
+  ///     弹窗应当立刻按真实状态把按钮重画成已制卡 ✓，否则就会出现「toast 说重复、
+  ///     按钮说可制卡」两个互相打架的说法。
+  ///   * 其余失败（尤其 addNote 送达但响应丢失的 commit-unknown）结果未知，必须
+  ///     维持 TODO-448 定的「不重画」——把未知结局粉饰成成功比不刷新更糟。
+  MinePopupResult.failed(MineOutcome outcome)
+      : ankiConnect = false,
+        noteId = null,
+        duplicate = outcome.result == MineResult.duplicate;
 
   /// 旧 `isAnkiConnect` 语义：true 表示制卡后可同步刷新 ✓ 状态。
   final bool ankiConnect;
@@ -65,10 +87,14 @@ class MinePopupResult {
   /// 后端返回的 note id；仅 AnkiConnect 成功制卡时非空。
   final int? noteId;
 
+  /// Anki 明确以「已存在同一张卡」拒绝了这次制卡（见 [MinePopupResult.failed]）。
+  final bool duplicate;
+
   /// 序列化成 JS 可读的 Map（经 inappwebview callHandler 回传）。
   Map<String, Object?> toJson() => <String, Object?>{
         'ankiConnect': ankiConnect,
         'noteId': noteId,
+        'duplicate': duplicate,
       };
 }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
@@ -271,7 +271,7 @@ extension _ReaderMining on _ReaderFushiPageState {
       // 第三态）。ankiConnect 沿用旧的「成功即可同步刷新 ✓」语义。
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
-    return const MinePopupResult();
+    return MinePopupResult.failed(outcome);
   }
 
   Future<MinePopupResult> _onUpdateFromPopupInner(
@@ -305,7 +305,7 @@ extension _ReaderMining on _ReaderFushiPageState {
     if (described.success) {
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
-    return const MinePopupResult();
+    return MinePopupResult.failed(outcome);
   }
 
   /// TODO-948/952：制卡『句子为空 / 字段未映射』诊断（加性、零行为改动）。

--- a/fushi/lib/src/pages/implementations/reader_pdf_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_pdf_page.dart
@@ -607,7 +607,7 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
       if (described.success) {
         return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
       }
-      return const MinePopupResult();
+      return MinePopupResult.failed(outcome);
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderPdfPage.onMineFromPopup', e, stack);
       return const MinePopupResult();

--- a/fushi/lib/src/pages/implementations/texthooker_page.dart
+++ b/fushi/lib/src/pages/implementations/texthooker_page.dart
@@ -712,7 +712,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     if (described.success) {
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
-    return const MinePopupResult();
+    return MinePopupResult.failed(outcome);
   }
 
   Future<void> _toggleExternalWindowMode() async {

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -424,7 +424,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
     final MineOutcome outcome = res.outcome! as MineOutcome;
     final MinePopupResult result = outcome.result == MineResult.success
         ? MinePopupResult(ankiConnect: true, noteId: outcome.noteId)
-        : const MinePopupResult();
+        : MinePopupResult.failed(outcome);
     if (!context.mounted) return result;
     // 牌组名由后端随成功结果带回（outcome.deckName，BUG-1549）。
     // overwrite=true（updateNoteId 非空）→ 收口产 card_overwritten + record=false；

--- a/fushi/test/anki/anki_duplicate_check_cooldown_test.dart
+++ b/fushi/test/anki/anki_duplicate_check_cooldown_test.dart
@@ -141,9 +141,16 @@ void main() {
         client: MockClient((http.Request request) async {
           calls++;
           if (fail) throw const SocketException('Connection refused');
+          // BUG-1915：查重现在问 `canAddNotesWithErrorDetail`（与 addNote 同源），
+          // 应答形状随之改变；本用例断言的冷却语义不变。
           return http.Response(
             jsonEncode({
-              'result': [123],
+              'result': [
+                {
+                  'canAdd': false,
+                  'error': 'cannot create note because it is a duplicate',
+                },
+              ],
               'error': null,
             }),
             200,

--- a/fushi/test/pages/popup_mine_button_anki_truth_static_test.dart
+++ b/fushi/test/pages/popup_mine_button_anki_truth_static_test.dart
@@ -8,9 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 // PRIMARY MECHANISM: when the popup renders a word (createEntryHeader runs as
 // part of renderPopup, which rebuilds the DOM on every lookup), the initial
 // `duplicateCheck` is scheduled when that header approaches the viewport and
-// queries Anki live (AnkiConnect findNotes / AnkiDroid
-// findDuplicateNotes — see packages/fushi_anki/test/ankiconnect_service_test
-// .dart's "isDuplicate" group) and sets a real `data-mined` state via
+// queries Anki live (AnkiConnect canAddNotesWithErrorDetail — the SAME judgement
+// addNote uses, BUG-1915 / AnkiDroid findDuplicateNotes — see
+// packages/fushi_anki/test/duplicate_check_same_source_test.dart) and sets a real
+// `data-mined` state via
 // setMineState: card in Anki -> 已制卡 ✓, card absent -> 可制卡 +. The ✓ is NOT
 // decorative; data-mined is the source of truth for what a click does.
 //
@@ -36,7 +37,9 @@ void main() {
 
   setUpAll(() {
     source = File('assets/popup/popup.js').readAsStringSync();
-    final int start = source.indexOf("className: 'mine-button'");
+    // 锚点必须是 popup.js 里真实存在的那串。类名后来加了 `inline-action-button`
+    // 前缀，而这里的锚点没跟着改，于是 indexOf 恒 -1、整条守卫空转（红在 setUpAll）。
+    final int start = source.indexOf("className: 'inline-action-button mine-button'");
     expect(
       start,
       greaterThanOrEqualTo(0),

--- a/fushi/test/utils/misc/popup_asset_behavior_test.js
+++ b/fushi/test/utils/misc/popup_asset_behavior_test.js
@@ -2665,3 +2665,50 @@ testInAppOpenInAnkiStillGoesToHost().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
+
+// BUG-1915：制卡被 Anki 以「重复」拒绝后，按钮必须按 Anki 的真实状态重画成 ✓。
+//
+// 旧行为：制卡后的重画被 `if (result.ankiConnect)` 门控，而 duplicate / 未配置 /
+// 出错三种结局的宿主都回 `{ankiConnect: false}`——于是弹「重复卡片，未导出」的同时，
+// 按钮一动不动仍是 `+`。用户看到的是「提示说重复、按钮说可制卡」两个互相打架的说法。
+async function testDuplicateOutcomeStillRepaintsFromAnki() {
+  const context = loadPopup();
+  context.window.allowDupes = false;
+  const mined = [];
+  // 查词那一刻 Anki 还没有这张卡（弹窗画 +），点下去时 Anki 判重复并拒绝。
+  // 这正是「卡组里混着别的笔记类型、同词已存在」的现场。
+  let cardExists = false;
+  context.window.flutter_inappwebview.callHandler = (name, payload) => {
+    if (name === 'duplicateCheck') return Promise.resolve(cardExists);
+    if (name === 'mineEntry') {
+      mined.push(payload);
+      cardExists = true; // Anki：这个词已经有卡了，拒绝新增
+      // 宿主把「Anki 明说是重复」原样回传（MinePopupResult.failed）。
+      return Promise.resolve({
+        ankiConnect: false,
+        noteId: null,
+        duplicate: true,
+      });
+    }
+    return Promise.resolve(null);
+  };
+
+  const mineButton = buildMineHeader(context);
+  await flush();
+  assert.notEqual(mineButton.dataset.mined, '1',
+    '查词时 Anki 还没这张卡 -> 可制卡 +');
+
+  await mineButton.onclick();
+  await flush();
+
+  assert.equal(mined.length, 1, '点击确实发起了一次制卡');
+  assert.equal(mineButton.dataset.mined, '1',
+    '制卡被判重复后，按钮必须按 Anki 真实状态重画成 已制卡 ✓');
+  assert.notEqual(mineButton.textContent, '+',
+    '按钮不能在提示「重复卡片」之后还显示可制卡 +');
+}
+
+testDuplicateOutcomeStillRepaintsFromAnki().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -954,6 +954,11 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     seconds: 30,
   );
 
+  /// AnkiConnect 对不认识的 action 固定回 `unsupported action`。用它把「这台
+  /// AnkiConnect 太老」与真正的业务/传输错误区分开——只有前者才该退回旧判据。
+  static bool _isUnsupportedActionError(AnkiConnectException e) =>
+      e.message.toLowerCase().contains('unsupported action');
+
   static DateTime? _duplicateCheckUnreachableUntil;
 
   /// 测试用：清掉进程级查重冷却，避免用例间互相污染。
@@ -1003,14 +1008,39 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     if (deck == null || noteType == null || noteType.fields.isEmpty) {
       return false;
     }
+    // 空词问 Anki 只会拿到「第一字段为空」，不是重复；提前退，别浪费一次往返。
+    if (expression.isEmpty) return false;
     try {
       final service = _serviceForSettings(settings);
-      final bool duplicate = await service.isDuplicate(
-        deckName: deck.name,
-        fieldName: noteType.fields.first,
-        fieldValue: expression,
-        scope: settings.duplicateScope,
-      );
+      bool duplicate;
+      try {
+        // BUG-1915：与 addNote 物理同源的判据
+        // （见 [AnkiConnectService.isDuplicateForAdd]）。
+        duplicate = await service.isDuplicateForAdd(
+          deckName: deck.name,
+          modelName: noteType.name,
+          firstFieldName: noteType.fields.first,
+          firstFieldValue: expression,
+          scope: settings.duplicateScope,
+        );
+      } on AnkiConnectException catch (e) {
+        // 老版 AnkiConnect 没有 `canAddNotesWithErrorDetail`。只有这一种错误才退回
+        // 按字段名查的旧判据——它在「卡组里只有一种笔记类型」时给的是对的答案，正是
+        // 这些用户今天已有的行为。宁可保住旧行为，也不要让他们的 ✓ 集体消失
+        // （Never break userspace）。这**不是**把两条判据并存回来：新版走的永远只有
+        // 上面那一条。
+        //
+        // 其余异常一律 rethrow 到下面那个 catch：本方法对调用方的契约是 fail-soft
+        // （查不到就当不重复，绝不抛给查词渲染路径），冷却是否武装也只在那里判。
+        if (!_isUnsupportedActionError(e)) rethrow;
+        duplicate = (await service.findNotesByField(
+          deckName: deck.name,
+          fieldName: noteType.fields.first,
+          fieldValue: expression,
+          scope: settings.duplicateScope,
+        ))
+            .isNotEmpty;
+      }
       // 拿到应答即证明主机活着，立刻解除冷却（不必等窗口自然到期）。
       _duplicateCheckUnreachableUntil = null;
       return duplicate;

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart
@@ -146,8 +146,7 @@ class AnkiConnectService {
     }
     if (result['error'] != null) {
       final String message = result['error'].toString();
-      if (action == 'addNote' &&
-          message == 'cannot create note because it is a duplicate') {
+      if (action == 'addNote' && message == kAnkiConnectDuplicateError) {
         throw AnkiConnectDuplicateException(message);
       }
       throw AnkiConnectException(message);
@@ -460,21 +459,75 @@ class AnkiConnectService {
     return result is int ? result : int.tryParse(result.toString());
   }
 
-  /// [scope] 默认 [AnkiDuplicateScope.deck]（= 旧行为：只查选中卡组及其子卡组），
-  /// 所以未传该参数的旧调用点与测试行为逐字不变。
-  Future<bool> isDuplicate({
+  /// 查重：把「这张卡加不加得进去」原样问 Anki 自己，与 [addNote] **物理同源**。
+  ///
+  /// BUG-1915 根因。此前这里走 `findNotes "<第一字段名>:<词>"`，而 [addNote] 的判重是
+  /// Anki 内建的**第一字段 checksum**（`duplicateScopeOptions`，含 `checkAllModels`）。
+  /// 两者判的根本不是一件事：
+  ///
+  ///   * `findNotes` 按**字段名**匹配 → 只能命中「恰好也有同名字段」的笔记类型；
+  ///   * Anki 按**第一字段位置**匹配 → 跨全部笔记类型，不管那个字段叫什么。
+  ///
+  /// 于是一个卡组里混装两种笔记类型（实测：1501 张第一字段名为 `Word` 的旧卡 +
+  /// 12 张第一字段名为 `Expression` 的新卡）时，旧卡里已有的词查重恒判「不重复」→
+  /// 弹窗画可制卡 `+`，用户一点却被 [addNote] 以重复拒绝。两条判据必须是同一条。
+  ///
+  /// 做法不是「让两边的条件长得一样」（那还会再漂移一次），而是**删掉第二条判据**：
+  /// 直接调 AnkiConnect 的 `canAddNotesWithErrorDetail`，它内部走的就是 [addNote]
+  /// 用的同一个 `isNoteDuplicateOrEmptyInScope`。options 也复用同一个
+  /// [_addNoteDuplicateOptions]，不再手写一份。
+  ///
+  /// 只传第一字段：Anki 的判重只看第一字段，其余字段留空不影响判定，也省掉在查词
+  /// 渲染路径上构造整张卡的开销。
+  ///
+  /// 已知边界（无法在查词时消除）：探测传的第一字段值是词条本身（[firstFieldValue]），
+  /// 而制卡时那一格是 `fieldMappings` 渲染的结果。第一字段映射成 `{expression}`
+  /// （Lapis 出厂默认）时两者逐字节相同；映射成依赖句子/媒体的模板时，查词阶段根本
+  /// 拿不到那些数据，任何实现都无法预知制卡时的第一字段。此时探测退化为「按词查」，
+  /// 与旧行为一致，不比现状差。
+  Future<bool> isDuplicateForAdd({
     required String deckName,
-    required String fieldName,
-    required String fieldValue,
+    required String modelName,
+    required String firstFieldName,
+    required String firstFieldValue,
     AnkiDuplicateScope scope = AnkiDuplicateScope.deck,
   }) async {
-    return (await findNotesByField(
-      deckName: deckName,
-      fieldName: fieldName,
-      fieldValue: fieldValue,
-      scope: scope,
-    ))
-        .isNotEmpty;
+    final Map<String, Object?> note = <String, Object?>{
+      'deckName': deckName,
+      'modelName': modelName,
+      'fields': <String, String>{firstFieldName: firstFieldValue},
+      // 探测问的是「Anki 认不认为这是重复」，与用户的「允许重复」偏好无关：
+      // 恒传 allowDuplicate:false。若跟随 settings.allowDupes，开了允许重复的
+      // 用户就永远等不到 canAdd:false，✓ 再也画不出来。
+      'options': _addNoteDuplicateOptions(
+        deckName: deckName,
+        allowDuplicate: false,
+        scope: scope,
+      ),
+    };
+    final dynamic result = await _request(
+      'canAddNotesWithErrorDetail',
+      <String, dynamic>{
+        'notes': <Object?>[note],
+      },
+    );
+    if (result is! List || result.isEmpty) {
+      throw AnkiConnectException(
+        'Unexpected AnkiConnect response for canAddNotesWithErrorDetail '
+        '(expected a non-empty list)',
+      );
+    }
+    final dynamic first = result.first;
+    if (first is! Map) {
+      throw AnkiConnectException(
+        'Unexpected AnkiConnect response for canAddNotesWithErrorDetail '
+        '(expected an object per note)',
+      );
+    }
+    if (first['canAdd'] == true) return false;
+    // canAdd:false 有多种原因（卡组/笔记类型不存在、第一字段为空……）。只有 Anki
+    // 明说是重复才算重复——把「配置过期」当成「已制卡」会让每个词都画上 ✓。
+    return first['error']?.toString() == kAnkiConnectDuplicateError;
   }
 
   Future<List<int>> findNotesByField({
@@ -779,6 +832,12 @@ class AnkiConnectService {
     await _request('guiBrowse', {'query': 'nid:$noteId'});
   }
 }
+
+/// AnkiConnect 在 `createNote` 里对重复卡抛出的固定文案。`addNote` 与
+/// `canAddNotesWithErrorDetail` 走的是同一段代码、同一句文案，所以两处判定复用
+/// 这一个字面量（BUG-1915：判据同源的前提是连错误文本都别各写一份）。
+const String kAnkiConnectDuplicateError =
+    'cannot create note because it is a duplicate';
 
 String _escapeAnkiQuery(String value) => value.replaceAll('"', '\\"');
 

--- a/packages/fushi_anki/test/ankiconnect_commit_unknown_test.dart
+++ b/packages/fushi_anki/test/ankiconnect_commit_unknown_test.dart
@@ -27,10 +27,11 @@ class _CommitUnknownService extends AnkiConnectService {
   }
 
   @override
-  Future<bool> isDuplicate({
+  Future<bool> isDuplicateForAdd({
     required String deckName,
-    required String fieldName,
-    required String fieldValue,
+    required String modelName,
+    required String firstFieldName,
+    required String firstFieldValue,
     AnkiDuplicateScope scope = AnkiDuplicateScope.deck,
   }) async {
     duplicateChecks += 1;
@@ -68,10 +69,11 @@ class _DuplicateService extends AnkiConnectService {
   }
 
   @override
-  Future<bool> isDuplicate({
+  Future<bool> isDuplicateForAdd({
     required String deckName,
-    required String fieldName,
-    required String fieldValue,
+    required String modelName,
+    required String firstFieldName,
+    required String firstFieldValue,
     AnkiDuplicateScope scope = AnkiDuplicateScope.deck,
   }) async {
     duplicateChecks += 1;

--- a/packages/fushi_anki/test/ankiconnect_error_garble_test.dart
+++ b/packages/fushi_anki/test/ankiconnect_error_garble_test.dart
@@ -28,10 +28,11 @@ class _FailingService extends AnkiConnectService {
   final Object toThrow;
 
   @override
-  Future<bool> isDuplicate({
+  Future<bool> isDuplicateForAdd({
     required String deckName,
-    required String fieldName,
-    required String fieldValue,
+    required String modelName,
+    required String firstFieldName,
+    required String firstFieldValue,
     AnkiDuplicateScope scope = AnkiDuplicateScope.deck,
   }) async =>
       throw toThrow;

--- a/packages/fushi_anki/test/ankiconnect_service_test.dart
+++ b/packages/fushi_anki/test/ankiconnect_service_test.dart
@@ -224,11 +224,13 @@ void main() {
     });
   });
 
-  group('isDuplicate query shaping', () {
+  // findNotesByField 仍是「按字段名反查 note id」的实现（覆写目标 / 在 Anki 中打开
+  // 用它拿 id）。BUG-1915 之后它**不再**用于查重——查重见 isDuplicateForAdd。
+  group('findNotesByField query shaping', () {
     test('builds a deck/field scoped findNotes query', () async {
       final issued = <http.Request>[];
       await withMock(
-        (s) => s.isDuplicate(
+        (s) => s.findNotesByField(
             deckName: 'Mining', fieldName: 'Expression', fieldValue: '勉強'),
         sink: issued,
         result: const <int>[],
@@ -241,7 +243,7 @@ void main() {
     test('escapes double quotes in the field value', () async {
       final issued = <http.Request>[];
       await withMock(
-        (s) => s.isDuplicate(
+        (s) => s.findNotesByField(
             deckName: 'Mining', fieldName: 'Expression', fieldValue: 'a"b'),
         sink: issued,
         result: const <int>[],
@@ -249,23 +251,86 @@ void main() {
       expect((bodyOf(issued.single)['params'] as Map)['query'],
           r'deck:"Mining" "Expression:a\"b"');
     });
+  });
 
-    test('returns true when findNotes returns matches', () async {
+  group('isDuplicateForAdd — 与 addNote 同源的查重（BUG-1915）', () {
+    test('问的是 canAddNotesWithErrorDetail，不是 findNotes', () async {
+      final issued = <http.Request>[];
+      await withMock(
+        (s) => s.isDuplicateForAdd(
+          deckName: 'Mining',
+          modelName: 'Lapis',
+          firstFieldName: 'Expression',
+          firstFieldValue: 'たっぷり',
+        ),
+        sink: issued,
+        result: const <Map<String, Object?>>[
+          <String, Object?>{'canAdd': true, 'error': null},
+        ],
+      );
+      final body = bodyOf(issued.single);
+      expect(body['action'], 'canAddNotesWithErrorDetail');
+      final note =
+          ((body['params'] as Map)['notes'] as List).single as Map<String, Object?>;
+      expect(note['deckName'], 'Mining');
+      expect(note['modelName'], 'Lapis');
+      // 只发第一字段：Anki 的判重只看它，其余字段不影响判定。
+      expect(note['fields'], <String, String>{'Expression': 'たっぷり'});
+    });
+
+    test('Anki 明说重复 → true', () async {
       final issued = <http.Request>[];
       final dup = await withMock(
-        (s) => s.isDuplicate(deckName: 'D', fieldName: 'F', fieldValue: 'v'),
+        (s) => s.isDuplicateForAdd(
+          deckName: 'D',
+          modelName: 'M',
+          firstFieldName: 'F',
+          firstFieldValue: 'v',
+        ),
         sink: issued,
-        result: <int>[1, 2, 3],
+        result: const <Map<String, Object?>>[
+          <String, Object?>{
+            'canAdd': false,
+            'error': 'cannot create note because it is a duplicate',
+          },
+        ],
       );
       expect(dup, isTrue);
     });
 
-    test('returns false when findNotes returns no matches', () async {
+    test('canAdd:true → false', () async {
       final issued = <http.Request>[];
       final dup = await withMock(
-        (s) => s.isDuplicate(deckName: 'D', fieldName: 'F', fieldValue: 'v'),
+        (s) => s.isDuplicateForAdd(
+          deckName: 'D',
+          modelName: 'M',
+          firstFieldName: 'F',
+          firstFieldValue: 'v',
+        ),
         sink: issued,
-        result: const <int>[],
+        result: const <Map<String, Object?>>[
+          <String, Object?>{'canAdd': true, 'error': null},
+        ],
+      );
+      expect(dup, isFalse);
+    });
+
+    test('canAdd:false 但原因不是重复（卡组过期等）→ false，不能画成已制卡', () async {
+      final issued = <http.Request>[];
+      final dup = await withMock(
+        (s) => s.isDuplicateForAdd(
+          deckName: 'Gone',
+          modelName: 'M',
+          firstFieldName: 'F',
+          firstFieldValue: 'v',
+        ),
+        sink: issued,
+        result: const <Map<String, Object?>>[
+          <String, Object?>{
+            'canAdd': false,
+            'error': 'deck was not found: Gone',
+          },
+        ],
       );
       expect(dup, isFalse);
     });

--- a/packages/fushi_anki/test/duplicate_check_same_source_test.dart
+++ b/packages/fushi_anki/test/duplicate_check_same_source_test.dart
@@ -1,0 +1,270 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// BUG-1915：查词弹窗的「可制卡 +」与 `addNote` 的判重必须是**同一条判据**。
+///
+/// 用户实测现场（本仓 2026-08-28 用真机 AnkiConnect 取证，本文件的 fake 就是照它建的）：
+/// 目标卡组 `正在背::Kaishi 1.5k  zh-CH` 里混装两种笔记类型——1501 张 `Kaishi 1.5k zh-CH`
+/// （第一字段名 `Word`）+ 12 张 `Lapis`（第一字段名 `Expression`）。词 `たっぷり` 已作为
+/// 一张 Kaishi 卡存在。于是：
+///
+///   * `findNotes 'deck:"…" "Expression:たっぷり"'` → **0 命中**（Kaishi 笔记类型
+///     压根没有 `Expression` 这个字段，按字段名永远查不到它）；
+///   * Anki 自己按**第一字段**判 → **命中**，`addNote` 以重复拒绝。
+///
+/// 旧实现拿前者画按钮、拿后者拒绝制卡，于是弹窗画 `+`、点下去弹「重复卡片，未导出」，
+/// 而按钮纹丝不动。这里钉死修复后的行为：查重问的是 Anki 自己。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const String kWord = 'たっぷり';
+  const String kDeck = '正在背::Kaishi 1.5k  zh-CH';
+  const String kDuplicateError = 'cannot create note because it is a duplicate';
+
+  const AnkiNoteType lapis = AnkiNoteType(
+    id: 6,
+    name: 'Lapis',
+    fields: <String>[
+      'Expression',
+      'ExpressionFurigana',
+      'ExpressionReading',
+      'Sentence',
+    ],
+  );
+
+  Future<void> installSettings({bool allowDupes = false}) async {
+    final AnkiSettings settings = AnkiSettings(
+      selectedDeckId: 21,
+      selectedDeckName: kDeck,
+      selectedNoteTypeId: lapis.id,
+      selectedNoteTypeName: lapis.name,
+      availableDecks: const <AnkiDeck>[AnkiDeck(id: 21, name: kDeck)],
+      availableNoteTypes: const <AnkiNoteType>[lapis],
+      fieldMappings: const <String, String>{'Expression': '{expression}'},
+      allowDupes: allowDupes,
+      duplicateScope: AnkiDuplicateScope.deck,
+    );
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+    await AnkiConnectRepository().saveSettings(settings);
+  }
+
+  /// 一台**照实测行为建模**的假 AnkiConnect：
+  /// 按字段名查恒 0 命中，按 Anki 自己的第一字段判恒重复。
+  /// 两条判据在这台机器上给出相反答案——这正是回归的判别力所在。
+  MockClient crossModelDuplicateHost(List<Map<String, dynamic>> sink) {
+    return MockClient((http.Request request) async {
+      final Map<String, dynamic> body =
+          jsonDecode(request.body) as Map<String, dynamic>;
+      sink.add(body);
+      final String action = body['action'] as String;
+      Object? result;
+      Object? error;
+      switch (action) {
+        case 'findNotes':
+          // 按 `Expression:` 查不到那张 Kaishi 卡。
+          result = const <int>[];
+        case 'canAddNotesWithErrorDetail':
+          result = const <Map<String, Object?>>[
+            <String, Object?>{'canAdd': false, 'error': kDuplicateError},
+          ];
+        case 'addNote':
+          error = kDuplicateError;
+        default:
+          error = 'unsupported action';
+      }
+      return http.Response(
+        jsonEncode(<String, Object?>{'result': result, 'error': error}),
+        200,
+        headers: <String, String>{'content-type': 'application/json'},
+      );
+    });
+  }
+
+  AnkiConnectRepository repoWith(http.Client client) {
+    AnkiConnectRepository.resetDuplicateCheckCooldown();
+    return AnkiConnectRepository(
+      service: AnkiConnectService(host: '127.0.0.1', port: 8765, client: client),
+    );
+  }
+
+  Map<String, dynamic> onlyCall(
+    List<Map<String, dynamic>> sink,
+    String action,
+  ) =>
+      sink.singleWhere((Map<String, dynamic> b) => b['action'] == action);
+
+  group('BUG-1915 跨笔记类型的重复必须被查重看见', () {
+    test('第一字段撞车但字段名不同的卡 → isDuplicate 为 true', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      final repo = repoWith(crossModelDuplicateHost(sink));
+
+      expect(await repo.isDuplicate(kWord, ''), isTrue);
+
+      // 判别力：旧实现走 findNotes（这台假机恒回 0 命中）会得到 false。
+      expect(
+        sink.map((Map<String, dynamic> b) => b['action']),
+        contains('canAddNotesWithErrorDetail'),
+      );
+      expect(
+        sink.map((Map<String, dynamic> b) => b['action']),
+        isNot(contains('findNotes')),
+      );
+    });
+
+    test('查重与 addNote 发出的 duplicate options 逐字段相同', () async {
+      await installSettings();
+
+      final probeSink = <Map<String, dynamic>>[];
+      await repoWith(crossModelDuplicateHost(probeSink)).isDuplicate(kWord, '');
+
+      final addSink = <Map<String, dynamic>>[];
+      final AnkiConnectService service = AnkiConnectService(
+        host: '127.0.0.1',
+        port: 8765,
+        client: crossModelDuplicateHost(addSink),
+      );
+      await expectLater(
+        service.addNote(
+          deckName: kDeck,
+          modelName: lapis.name,
+          fields: const <String, String>{'Expression': kWord},
+          duplicateScope: AnkiDuplicateScope.deck,
+        ),
+        throwsA(isA<AnkiConnectDuplicateException>()),
+      );
+
+      // 两侧来自两条独立调用路径（repo.isDuplicate / service.addNote），
+      // 比的是各自真正发出去的 HTTP 请求体，不是同一次取值。
+      final Map<String, dynamic> probeNote =
+          ((onlyCall(probeSink, 'canAddNotesWithErrorDetail')['params']
+                  as Map)['notes'] as List)
+              .single as Map<String, dynamic>;
+      final Map<String, dynamic> addedNote =
+          (onlyCall(addSink, 'addNote')['params'] as Map)['note']
+              as Map<String, dynamic>;
+
+      expect(probeNote['options'], addedNote['options']);
+      expect(probeNote['deckName'], addedNote['deckName']);
+      expect(probeNote['modelName'], addedNote['modelName']);
+    });
+
+    test('探测的 duplicateScopeOptions 必须开着 checkAllModels', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      await repoWith(crossModelDuplicateHost(sink)).isDuplicate(kWord, '');
+
+      final Map<String, dynamic> note =
+          ((onlyCall(sink, 'canAddNotesWithErrorDetail')['params']
+                  as Map)['notes'] as List)
+              .single as Map<String, dynamic>;
+      final Map<String, dynamic> options =
+          note['options'] as Map<String, dynamic>;
+      final Map<String, dynamic> scopeOptions =
+          options['duplicateScopeOptions'] as Map<String, dynamic>;
+
+      // 这一条就是「跨笔记类型也算重复」的开关；关掉它本 bug 立刻复发。
+      expect(scopeOptions['checkAllModels'], isTrue);
+      expect(scopeOptions['deckName'], kDeck);
+      expect(options['duplicateScope'], 'deck');
+    });
+
+    test('用户开了「允许重复」时，探测仍以 allowDuplicate:false 提问', () async {
+      // 探测问的是「Anki 认不认为这是重复」，不是「用户允不允许」。跟着 allowDupes
+      // 走会让这些用户的 ✓ 永远画不出来。
+      await installSettings(allowDupes: true);
+      final sink = <Map<String, dynamic>>[];
+      final repo = repoWith(crossModelDuplicateHost(sink));
+
+      expect(await repo.isDuplicate(kWord, ''), isTrue);
+
+      final Map<String, dynamic> note =
+          ((onlyCall(sink, 'canAddNotesWithErrorDetail')['params']
+                  as Map)['notes'] as List)
+              .single as Map<String, dynamic>;
+      expect(
+        (note['options'] as Map<String, dynamic>)['allowDuplicate'],
+        isFalse,
+      );
+    });
+
+    test('只发第一字段，不在查词路径上构造整张卡', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      await repoWith(crossModelDuplicateHost(sink)).isDuplicate(kWord, '');
+
+      final Map<String, dynamic> note =
+          ((onlyCall(sink, 'canAddNotesWithErrorDetail')['params']
+                  as Map)['notes'] as List)
+              .single as Map<String, dynamic>;
+      expect(note['fields'], <String, String>{'Expression': kWord});
+    });
+  });
+
+  group('BUG-1915 边界', () {
+    test('canAdd:false 但原因不是重复 → 不画已制卡', () async {
+      await installSettings();
+      final client = MockClient((http.Request request) async {
+        final String action =
+            (jsonDecode(request.body) as Map<String, dynamic>)['action']
+                as String;
+        final Object? result = action == 'canAddNotesWithErrorDetail'
+            ? const <Map<String, Object?>>[
+                <String, Object?>{
+                  'canAdd': false,
+                  'error': 'deck was not found: 正在背::Kaishi 1.5k  zh-CH',
+                },
+              ]
+            : null;
+        return http.Response(
+          jsonEncode(<String, Object?>{'result': result, 'error': null}),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      });
+      expect(await repoWith(client).isDuplicate(kWord, ''), isFalse);
+    });
+
+    test('老版 AnkiConnect 不认识该动作 → 退回按字段名查的旧判据，不集体失去 ✓',
+        () async {
+      await installSettings();
+      final actions = <String>[];
+      final client = MockClient((http.Request request) async {
+        final String action =
+            (jsonDecode(request.body) as Map<String, dynamic>)['action']
+                as String;
+        actions.add(action);
+        if (action == 'canAddNotesWithErrorDetail') {
+          return http.Response(
+            jsonEncode(
+              <String, Object?>{'result': null, 'error': 'unsupported action'},
+            ),
+            200,
+            headers: <String, String>{'content-type': 'application/json'},
+          );
+        }
+        return http.Response(
+          jsonEncode(<String, Object?>{'result': const <int>[42], 'error': null}),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      });
+
+      expect(await repoWith(client).isDuplicate(kWord, ''), isTrue);
+      expect(actions, <String>['canAddNotesWithErrorDetail', 'findNotes']);
+    });
+
+    test('空词不问 Anki', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      expect(await repoWith(crossModelDuplicateHost(sink)).isDuplicate('', ''),
+          isFalse);
+      expect(sink, isEmpty);
+    });
+  });
+}

--- a/packages/fushi_anki/test/note_id_and_update_test.dart
+++ b/packages/fushi_anki/test/note_id_and_update_test.dart
@@ -55,10 +55,11 @@ class _RecordingService extends AnkiConnectService {
   }
 
   @override
-  Future<bool> isDuplicate({
+  Future<bool> isDuplicateForAdd({
     required String deckName,
-    required String fieldName,
-    required String fieldValue,
+    required String modelName,
+    required String firstFieldName,
+    required String firstFieldValue,
     AnkiDuplicateScope scope = AnkiDuplicateScope.deck,
   }) async =>
       false;

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -310,9 +310,17 @@ function parseMineResult(reply) {
         const noteId = (typeof rawId === 'number' && Number.isFinite(rawId))
             ? rawId
             : null;
-        return { ankiConnect: reply.ankiConnect === true, noteId };
+        // BUG-1915: `duplicate` says Anki REFUSED the add because the card is
+        // already there — a definitively KNOWN state, unlike the other failures.
+        // Hosts that predate the field simply never set it (undefined -> false),
+        // so they keep the old behaviour exactly.
+        return {
+            ankiConnect: reply.ankiConnect === true,
+            noteId,
+            duplicate: reply.duplicate === true,
+        };
     }
-    return { ankiConnect: reply === true, noteId: null };
+    return { ankiConnect: reply === true, noteId: null, duplicate: false };
 }
 
 // Records the just-mined word as the editable "latest" card when the backend
@@ -3136,6 +3144,21 @@ function createEntryHeader(entry, idx) {
                     // the new "latest editable"; this also supersedes any prior
                     // latest word (only one editable card at a time).
                     rememberLatestMined(expression, reading, result.noteId);
+                }
+                // BUG-1915: a duplicate refusal must repaint too. `ankiConnect`
+                // only says "the host handed back a note id", so it is false for
+                // duplicate, not-configured, error and lost-response alike — and
+                // gating the repaint on it left the button showing `+` right after
+                // Anki refused the add as a duplicate: the toast said 重复卡片，
+                // the button said 可制卡.
+                //
+                // Only `duplicate` is added to the gate, NOT every failure:
+                // TODO-448 deliberately keeps a failed/uncertain mine from a
+                // delayed duplicateCheck that would flip the button to ✓ and read
+                // as "first it failed, then it succeeded" (the addNote-reached-Anki
+                // -but-the-response-was-lost case). Duplicate is not uncertain:
+                // Anki looked and the card is there, so ✓ is simply the truth.
+                if (result.ankiConnect || result.duplicate) {
                     await refreshFromAnki();
                 }
             } catch (e) {


### PR DESCRIPTION
fix(anki): 查重与制卡判重同源，重复卡不再画成可制卡 +（BUG-1915）

用户报：视频页查词弹窗 `たっぷり` 显示可制卡 +，点下去弹「重复卡片，未导出」，
按钮却毫无变化。

根因是两条判重根本不是同一件事，真机 AnkiConnect 实测给出相反答案：
- 画 +/✓ 的 isDuplicate 走 `findNotes "<第一字段名>:<词>"`，按**字段名**匹配；
- 拒绝制卡的 addNote 走 Anki 内建**第一字段 checksum**（checkAllModels 跨全部
  笔记类型，不管字段叫什么）。

目标卡组里混装 1501 张 `Kaishi 1.5k zh-CH`（第一字段名 Word）+ 12 张 `Lapis`
（第一字段名 Expression）。`たっぷり` 已是一张 Kaishi 卡：按字段名查 0 命中 →
画 +；Anki 自己判 → 命中 → 拒绝。凡 Kaishi 里已有的词，Lapis 卡永远制不出来。

回归点 08b899ecd4 只把制卡侧换成 Anki 内建判重，isDuplicate 留在旧路径没动。

修法不是让两边条件长得一样（还会再漂移），而是删掉第二条判据：
- AnkiConnectService.isDuplicate（按字段名查）删除，换成 isDuplicateForAdd →
  canAddNotesWithErrorDetail，与 addNote 复用同一个 _addNoteDuplicateOptions；
  只发第一字段；恒传 allowDuplicate:false；只有 Anki 明说重复才算重复（把「卡组
  过期」当已制卡会让每个词都画 ✓）；老版 AnkiConnect 退回旧判据，零破坏。
- isDuplicate 保持 fail-soft：非「不支持该动作」的异常一律落到统一 catch。

次生根因：MinePopupResult 把 duplicate/未配置/出错/响应丢失四种结局压成同一个
`ankiConnect:false`，popup.js 据此跳过重画，按钮连重画都没重画。新增语义精确的
`duplicate` 字段 + MinePopupResult.failed(outcome)，8 个制卡表面统一带回真实结局，
三镜像 popup.js 据此在重复时重画。只把 duplicate 加进重画门、不是所有失败——
TODO-448 刻意不让结果未知的制卡把按钮翻成 ✓（addNote 送达但响应丢失会读成
「先失败后成功」）；duplicate 不是未知。

测试：
- packages/fushi_anki/test/duplicate_check_same_source_test.dart（新增 8 条），
  假 AnkiConnect 照实测行为建模（按字段名查恒 0、按第一字段判恒重复）。
- popup_asset_behavior_test.js 新增「判重复后按钮必须重画成 ✓」。
- 旧 fake 的「制卡不得另跑查重」计数器改接新探测入口，避免守卫空转。
- 变异实测：退回旧判据 → 8 条红 7；checkAllModels→false → 精确红 1；
  去掉 `|| result.duplicate` → 精确红新增 JS 用例；三次均按 sha256 还原。

顺带：popup_mine_button_anki_truth_static_test 的锚点 `className: 'mine-button'`
在 base 上就已失效（类名早已加 inline-action-button 前缀），indexOf 恒 -1、
整条守卫红在 setUpAll。改成真实字面量后 6 条断言恢复执行。

验证：packages/fushi_anki 440 条全绿；fushi 定向（anki/lookup/popup/bug 守卫）
1009 条全绿；flutter analyze（fushi + fushi_anki）零问题。未做真机 E2E。

Claude-Session: https://claude.ai/code/session_01335HdTaMBGHudNrVVUV6R6
