### PR TITLE
fix(dict): 词典样式可视化编辑器闪退 + 预览白屏（BUG-1918），尺寸对齐 Lapis

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1792 条。点号进各自文件。
+> 共 1793 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1918](bugs/BUG-1918-dict-style-preview-crash.md) | ✅ | ✅ | 打开词典样式可视化编辑器闪退（Windows） |
 | [BUG-1915](bugs/BUG-1915-anki-dup-check-cross-model.md) | ✅ | ✅ | 查词弹窗查重与制卡判重不同源：跨笔记类型的重复卡画成可制卡 + |
 | [BUG-1913](bugs/BUG-1913-wa2-directsound-audio-timeline.md) | ✅ | ✅ | WA2 DirectSound 制卡炸音且未取得 VOICE.PAK 源语音 |
 | [BUG-1912](bugs/BUG-1912-gal-ingame-same-line-replay-destroys-selection.md) | ✅ | ✅ | KiriKiri 人物动画重发同句时销毁游戏内查词 WebView 选区 |

--- a/docs/bugs/BUG-1918-dict-style-preview-crash.md
+++ b/docs/bugs/BUG-1918-dict-style-preview-crash.md
@@ -44,5 +44,26 @@
   与之完全对齐（缺了红、多了也红）；② 源码扫描钉住 `CallJsHandlerCallback::decodeResult`
   的 `!value` → `std::nullopt` 空守卫（C++ 崩点 flutter test 跑不到，但那行的有无是二元的）。
   两条都做了变异实测：删 `'reportJsError'` → ①红；删 C++ 里的 `if (!value) return std::nullopt;` → ②红。
+- **同轮查出的第二个真缺陷（同一条链，白屏而非闪退）**：
+  `dict_style_preview.dart` 调的是**裸的** `DictionaryPopupWebViewState.buildInlinePopupHtml(...)`，
+  而那个构造函数假定四份内联资产（popup.css / dict-media.js / selection.js / popup.js）
+  已装载。装载只有两条路径：`main.dart:444` 启动时 fire-and-forget 的
+  `preloadInlinePopupAssets()`，和真弹窗 `build()` 里的同步兜底
+  `_ensureInlinePopupAssetsLoaded()` + 四项非空校验（不满足就回退 file:// URL）。
+  预览两条都没走 → 预读未完成时拼出 `<style></style><script></script>` 空壳：
+  没有 popup.js，预览白屏，`window.renderPopup` 都不存在。
+  真 WebView2 集成测试里 `document.querySelectorAll('.entry').length` 恒为 0 就是这一支。
+
+  修法：把「确保装载 + 四项非空 + 拼装」收成一个原语
+  `buildInlinePopupHtmlIfReady`（未就绪返回 null，调用方回退 file://），
+  **真弹窗的 build 也改用它** —— 两个入口不可能再漂移出两种加载行为。
+  测试 `fushi/test/pages/popup_inline_assets_readiness_test.dart` 三条。
+
+- **真机证据**：Windows 集成测试
+  `fushi/integration_test/dict_style_preview_null_reply_crash_itest.dart`
+  （`.\tool\run_windows_itest.ps1`，离屏、隔离 WebView2 profile）。
+  用例① 在真 WebView2 里已通过：调未注册 handler → promise resolve 成 null，
+  之后再发一次 JS 仍有回应（进程存活）；修前这一步即 0xC0000005。
+
 - **备注**：同一轮把该编辑器尺寸改成与 `LapisStyleEditorPage` 一致（对话框 maxWidth 640 → 1180、
   去掉写死的 0.55 屏高、宽于 820 时左预览右控件 340 的分栏），见同分支提交。

--- a/docs/bugs/BUG-1918-dict-style-preview-crash.md
+++ b/docs/bugs/BUG-1918-dict-style-preview-crash.md
@@ -1,0 +1,48 @@
+## BUG-1918 · 打开词典样式可视化编辑器闪退（Windows）
+
+- **报告**：2026-08-28（用户：设置 → 查词 → 词典样式，打开就闪退）
+- **真实性**：✅ 真 bug。Windows 事件日志 + 完整 minidump 双证：
+  - `Application Error`：`fushi.exe 2.2.1.12458` / 模块 `flutter_inappwebview_windows_plugin.dll` / `0xC0000005` / 偏移 `0x6c768`，2026-08-28 20:04:09 与 20:05:25 两次同一 fault bucket（可复现，非偶发）。
+  - `cdb -z C:\Users\wrds\AppData\Local\CrashDumps\fushi.exe.80380.dmp` → `.ecxr`：
+    `movzx eax, byte ptr [rdx+40h]`，`rdx = 0`，即**空指针解引用**；上一条是 `mov rdx,[rdx]`，
+    调用链 `user32!DispatchMessageWorker → flutter_windows → plugin`（平台线程上处理 method channel 回复）。
+    崩点所在函数就地构造 `std::string("null")`（`mov dword ptr [rbp-40h], 6C6C756Eh`，size 4 / cap 15），
+    对应 `in_app_webview.cpp:772` 的 `std::string json = "null";`。
+- **根因**：
+  `packages/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp:35`
+  （修前）`CallJsHandlerCallback::decodeResult = [](const flutter::EncodableValue* value) { return value; };`
+  —— `T = const EncodableValue*`，返回值要转成 `std::optional<T>`。Dart 侧回复 **null** 时，
+  Flutter 的 `StandardMethodCodec::DecodeAndProcessResponseEnvelopeInternal`（cpp_client_wrapper
+  `standard_codec.cc`）走的是**无参** `result->Success()` → 这里收到的 `value == nullptr`。
+  直接 `return value` 会装出一个 `has_value() == true` 但值为 `nullptr` 的 optional，于是
+  `types/base_callback_result.h:28` 的 `nonNullSuccess(result.value())` 判为「非空成功」，
+  最终 `in_app_webview.cpp:773` 的守卫
+  `if (response.has_value() && !response.value()->IsNull())` 直接解引用空指针 → 进程级闪退
+  （EncodableValue 是 `std::variant`，判别位在 +0x40，正是崩指令读的偏移）。
+
+  **触发条件**：JS 调了一个 Dart 侧**没有 `addJavaScriptHandler` 注册**的 handler 名 ——
+  `flutter_inappwebview_windows` 的 `_handleMethod` 在 `onCallJsHandler` 里查不到名字就走到末尾
+  `return null`（已注册的走 `jsonEncode(...)`，null 也会变成字符串 `"null"`，不触发）。
+
+  `fushi/lib/src/pages/implementations/dict_style_preview.dart` 跑的是**真的** popup.js，
+  popup.html 加载的脚本一共能发起 21 个桥调用，而预览只注册了 4 个
+  （`favoriteCheck` / `duplicateCheck` / `popupRendered` / `resolveWordAudio`）。
+  漏掉的里面有 `reportJsError`（预览环境里任何 JS 报错都会调）和 `tapOutside`（点空白处就调），
+  所以一进可视化页几乎必崩。
+
+  同文件的 `PermissionRequestCallback::decodeResult` 是同一个缺陷形状（裸 `*value`），一并修。
+
+- **[x] ① 已修复** — 两层：
+  - 原生根因：`webview_channel_delegate.cpp` 两处 `decodeResult` 补空守卫，空回复降成
+    `std::nullopt`，让下游 `has_value()` 守卫真的能拦住（这一层修掉的是**整类**崩溃：
+    今天任何未注册 handler 名都能把 app 打死）。
+  - 消费端：`dict_style_preview.dart` 把 popup 脚本能调的 21 个名字全注册成 no-op
+    （`kDictStylePreviewNoopHandlers`）——预览里制卡 / 播音 / 跳转 / 上报都不该真发生，
+    但每个桥调用都得有确定的 Dart 侧语义，不靠平台兜底空回复。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/dict_style_preview_handler_coverage_test.dart`：
+  ① 扫 popup.html 实际加载的脚本里的 `callHandler('X')`，断言 `kDictStylePreviewNoopHandlers`
+  与之完全对齐（缺了红、多了也红）；② 源码扫描钉住 `CallJsHandlerCallback::decodeResult`
+  的 `!value` → `std::nullopt` 空守卫（C++ 崩点 flutter test 跑不到，但那行的有无是二元的）。
+  两条都做了变异实测：删 `'reportJsError'` → ①红；删 C++ 里的 `if (!value) return std::nullopt;` → ②红。
+- **备注**：同一轮把该编辑器尺寸改成与 `LapisStyleEditorPage` 一致（对话框 maxWidth 640 → 1180、
+  去掉写死的 0.55 屏高、宽于 820 时左预览右控件 340 的分栏），见同分支提交。

--- a/fushi/integration_test/dict_style_preview_null_reply_crash_itest.dart
+++ b/fushi/integration_test/dict_style_preview_null_reply_crash_itest.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/dictionary/dict_style_rules.dart';
+import 'package:fushi/src/pages/implementations/dict_style_preview.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// BUG-1918 端到端验证：JS 调一个 Dart 侧**没注册**的 handler 名不再打死进程，
+/// 且真实的「词典样式 → 可视化」预览能跑完 popup.js 而不闪退。
+///
+/// 为什么必须端到端：崩点在 C++（`flutter_inappwebview_windows` 的
+/// `CallJsHandlerCallback::decodeResult` 把 Dart 的 null 答复当非空指针解引用），
+/// `flutter test` 根本加载不到那段代码；崩溃又是**进程级** 0xC0000005，Dart 侧
+/// 连异常都收不到。唯一能回答「还崩不崩」的只有真 WebView2 + 真插件。
+///
+/// 两个用例是一对：
+///   ① 最小复现——裸 WebView、一个 handler 都不注册，JS 调一个不存在的名字。
+///      修前：答复回到平台线程那一刻整个进程消失。修后：promise 正常 resolve 成
+///      null，进程活着（用「之后还能再跑一次 JS」来证明活着，而不是靠没抛异常）。
+///   ② 真实入口——直接挂生产的 [DictStylePreview]，等真 popup.js 渲染出词条，
+///      再触发它的全局错误上报（`reportJsError`，正是原先漏注册的名字之一）。
+///
+/// 跑法（仓库 fushi/ 下，离屏、不抢焦点、隔离 WebView2 profile）：
+///   .\tool\run_windows_itest.ps1 integration_test\dict_style_preview_null_reply_crash_itest.dart
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  /// 轮询读一个**同步**的 window 变量。不能直接 return promise：
+  /// `evaluateJavascript` 不 await Promise，拿到的只是序列化后的 `{}`。
+  Future<String> pollProbe(
+    WidgetTester tester,
+    InAppWebViewController controller,
+    String variable, {
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    final DateTime deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 250));
+      final Object? value =
+          await controller.evaluateJavascript(source: 'String($variable)');
+      final String text = value?.toString() ?? 'null';
+      if (text != 'pending' && text != 'null' && text != 'undefined') {
+        return text;
+      }
+    }
+    return 'timeout';
+  }
+
+  testWidgets('调用未注册的 JS handler 不再打死进程（BUG-1918 最小复现）',
+      (WidgetTester tester) async {
+    final Completer<InAppWebViewController> ready =
+        Completer<InAppWebViewController>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InAppWebView(
+            initialData: InAppWebViewInitialData(
+              data: '<!DOCTYPE html><html><head><meta charset="utf-8">'
+                  '</head><body>bug1918</body></html>',
+            ),
+            // 故意一个 addJavaScriptHandler 都不注册：插件的 Dart 侧
+            // `_handleMethod` 查不到名字就走末尾 `return null`，于是原生侧收到
+            // 的是无参 `Success()` → value == nullptr，正是崩溃入口。
+            onLoadStop: (InAppWebViewController controller, _) {
+              if (!ready.isCompleted) ready.complete(controller);
+            },
+          ),
+        ),
+      ),
+    );
+
+    final InAppWebViewController controller =
+        await ready.future.timeout(const Duration(seconds: 60));
+    for (int i = 0; i < 8; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+    }
+
+    await controller.evaluateJavascript(source: '''
+      window.__fushiCrashProbe = 'pending';
+      window.flutter_inappwebview
+        .callHandler('bug1918_definitely_not_registered', 1, 2)
+        .then(function (v) {
+          window.__fushiCrashProbe = 'resolved:' + JSON.stringify(v);
+        })
+        .catch(function (e) {
+          window.__fushiCrashProbe = 'rejected:' + e;
+        });
+    ''');
+
+    final String probe =
+        await pollProbe(tester, controller, 'window.__fushiCrashProbe');
+    // 修前这里根本走不到——答复到达平台线程即 0xC0000005，测试进程一起没。
+    expect(probe, 'resolved:null',
+        reason: '未注册的 handler 应当让 JS 侧 promise 正常 resolve 成 null');
+
+    // 「进程还活着」得由一次**新的**往返来证明，而不是靠上一句没抛异常。
+    final Object? alive = await controller.evaluateJavascript(source: '1 + 1');
+    expect(alive.toString(), '2');
+  });
+
+  testWidgets('真 DictStylePreview 跑完 popup.js 且 reportJsError 不闪退',
+      (WidgetTester tester) async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    DictStylePreviewDebug.lastController = null;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 700,
+            height: 500,
+            child: DictStylePreview(
+              css: '.expression { color: rgb(1, 2, 3) !important; }',
+              highlightPart: DictStylePart.expression,
+              onPickPart: (DictStylePart _) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // 冷启动 WebView2 + 载入内联 popup.html + 手动 renderPopup()。
+    InAppWebViewController? controller;
+    for (int i = 0; i < 240 && controller == null; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      // ignore: invalid_use_of_visible_for_testing_member
+      controller = DictStylePreviewDebug.lastController;
+    }
+    expect(controller, isNotNull, reason: '预览的 WebView 没被创建出来');
+
+    // ① 真 popup.js 真的渲染出了样例词条（不是白屏）。这一步能为真，说明
+    //    favoriteCheck / duplicateCheck / popupRendered / resolveWordAudio
+    //    这些渲染期就会发的桥调用全都往返过了。
+    String entryCount = '0';
+    for (int i = 0; i < 80; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      final Object? value = await controller!.evaluateJavascript(
+        source: 'String(document.querySelectorAll(".entry").length)',
+      );
+      entryCount = value?.toString() ?? '0';
+      if (entryCount != '0' && entryCount != 'null') break;
+    }
+    expect(int.tryParse(entryCount) ?? 0, greaterThan(0),
+        reason: '预览应渲染出样例词条；0 说明 popup.js 中途挂了');
+
+    // ② 触发全局错误上报 —— `reportJsError` 正是修前漏注册、一调即崩的那个名字。
+    await controller!.evaluateJavascript(source: '''
+      window.__fushiStyleProbe = 'pending';
+      window.__fushiReportJsError('bug1918-itest', 'probe', '');
+      window.__fushiStyleProbe = 'sent';
+    ''');
+    final String sent =
+        await pollProbe(tester, controller, 'window.__fushiStyleProbe');
+    expect(sent, 'sent');
+
+    // 答复要走完平台线程那一趟才谈得上「没崩」，多等几拍再做一次新的往返。
+    for (int i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+    }
+    final Object? alive = await controller.evaluateJavascript(source: '2 + 3');
+    expect(alive.toString(), '5', reason: '上报之后进程必须还活着');
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/fushi/lib/src/pages/implementations/dict_style_preview.dart
+++ b/fushi/lib/src/pages/implementations/dict_style_preview.dart
@@ -128,14 +128,7 @@ class _DictStylePreviewState extends State<DictStylePreview> {
         ),
         onWebViewCreated: (InAppWebViewController controller) {
           _controller = controller;
-          // popup.js 在渲染词条头时**无保护地**调这两个 handler；没注册就抛
-          // TypeError，被 renderPopup 的 try/catch 吞掉 → 整张卡片不渲染（白屏）。
-          for (final String name in const <String>[
-            'favoriteCheck',
-            'duplicateCheck',
-            'popupRendered',
-            'resolveWordAudio',
-          ]) {
+          for (final String name in kDictStylePreviewNoopHandlers) {
             controller.addJavaScriptHandler(
               handlerName: name,
               callback: (List<dynamic> _) => null,
@@ -175,6 +168,44 @@ class _DictStylePreviewState extends State<DictStylePreview> {
     return '#${(argb & 0xFFFFFF).toRadixString(16).padLeft(6, '0')}';
   }
 }
+
+/// popup.js / selection.js 能发起的**全部** JS 桥调用名，在预览里一律 no-op。
+///
+/// 两件事各自成立：
+/// * 行为上——预览只是调样式，制卡 / 播音 / 跳转 / 上报都不该真发生；
+///   `favoriteCheck` / `duplicateCheck` 这类在渲染词条头时**无保护地**被调，
+///   没注册就抛 TypeError、被 renderPopup 的 try/catch 吞掉 → 整张卡片白屏。
+/// * 存活上——BUG-1918：Dart 侧没注册的 handler 名会让插件回一个 **null**
+///   答复（`_handleMethod` 末尾 `return null`），Windows 原生侧把它当非空指针
+///   解引用 → 0xC0000005 整个 app 闪退。原生已根治（webview_channel_delegate.cpp
+///   的 decodeResult 空守卫），但预览本身也不应该依赖平台兜底：每个桥调用
+///   都得有确定的 Dart 侧语义。
+///
+/// 这份名单必须覆盖 popup.html 加载的所有脚本里的 `callHandler('X')`，
+/// 守卫测试：`fushi/test/pages/dict_style_preview_handler_coverage_test.dart`。
+const List<String> kDictStylePreviewNoopHandlers = <String>[
+  'clearSentenceDraft',
+  'duplicateCheck',
+  'favoriteCheck',
+  'favoriteEntry',
+  'findMinedMatches',
+  'mineEntry',
+  'minedCardAction',
+  'onLinkClick',
+  'openInAnki',
+  'openLink',
+  'openMinedNote',
+  'openSentenceContextModal',
+  'overwriteTargetNoteId',
+  'panelSentenceLookup',
+  'popupRendered',
+  'reportJsError',
+  'resolveWordAudio',
+  'setSentenceContext',
+  'tapOutside',
+  'textSelected',
+  'updateEntry',
+];
 
 /// 注入预览 WebView 的点选逻辑。
 ///

--- a/fushi/lib/src/pages/implementations/dict_style_preview.dart
+++ b/fushi/lib/src/pages/implementations/dict_style_preview.dart
@@ -110,23 +110,29 @@ class _DictStylePreviewState extends State<DictStylePreview> {
 
   @override
   Widget build(BuildContext context) {
-    final bool inline = DictionaryPopupWebViewState.shouldInlinePopupAssets;
     final ThemeData theme = Theme.of(context);
+    // 与真弹窗同一个原语：它内部先确保内联资产装载，未就绪才返回 null。
+    // 不能再调裸的构造函数——启动时的预读是 fire-and-forget，早开设置就会拼出
+    // 空 <script>，预览白屏（BUG-1918 ②）。
+    final String? inlineHtml =
+        DictionaryPopupWebViewState.shouldInlinePopupAssets
+            ? DictionaryPopupWebViewState.buildInlinePopupHtmlIfReady(
+                themeAttr:
+                    theme.brightness == Brightness.dark ? 'dark' : 'light',
+                bgHex: _hex(theme.colorScheme.surface),
+              )
+            : null;
     return KeyedSubtree(
       key: _deathGuard.rebuildKey,
       child: InAppWebView(
-        initialData: inline
+        initialData: inlineHtml != null
             ? InAppWebViewInitialData(
-                data: DictionaryPopupWebViewState.buildInlinePopupHtml(
-                  themeAttr:
-                      theme.brightness == Brightness.dark ? 'dark' : 'light',
-                  bgHex: _hex(theme.colorScheme.surface),
-                ),
+                data: inlineHtml,
                 mimeType: 'text/html',
                 encoding: 'utf-8',
               )
             : null,
-        initialUrlRequest: inline
+        initialUrlRequest: inlineHtml != null
             ? null
             : URLRequest(
                 url: WebUri(webViewAssetUrl('assets/popup/popup.html')),

--- a/fushi/lib/src/pages/implementations/dict_style_preview.dart
+++ b/fushi/lib/src/pages/implementations/dict_style_preview.dart
@@ -38,6 +38,18 @@ class DictStylePreview extends StatefulWidget {
   State<DictStylePreview> createState() => _DictStylePreviewState();
 }
 
+/// 集成测试用的取控制器口子（BUG-1918 的端到端验证要在真 WebView2 里发 JS）。
+///
+/// 预览本身不对外暴露 controller，而这条链路的失败方式是**进程级闪退**，只有真
+/// WebView2 能回答「还崩不崩」。给一个静态引用比给构造参数轻，也不动任何调用点
+/// 的签名；生产代码只写不读。
+@visibleForTesting
+class DictStylePreviewDebug {
+  DictStylePreviewDebug._();
+
+  static InAppWebViewController? lastController;
+}
+
 class _DictStylePreviewState extends State<DictStylePreview> {
   InAppWebViewController? _controller;
   final WebViewDeathGuard _deathGuard =
@@ -128,6 +140,7 @@ class _DictStylePreviewState extends State<DictStylePreview> {
         ),
         onWebViewCreated: (InAppWebViewController controller) {
           _controller = controller;
+          DictStylePreviewDebug.lastController = controller;
           for (final String name in kDictStylePreviewNoopHandlers) {
             controller.addJavaScriptHandler(
               handlerName: name,

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -1489,15 +1489,33 @@ JSON.stringify((function(){
   /// 平台清单，迟早在某个平台上分叉成两种加载行为。
   static bool get shouldInlinePopupAssets => _shouldInlinePopupAssets;
 
-  /// 构造内联资产版的 popup HTML，供 [shouldInlinePopupAssets] 为真的平台使用。
+  /// 内联资产**就绪时**返回内联 popup HTML，否则返回 null（调用方回退 file:// URL）。
   ///
   /// 与 in-app 弹窗同一份 memo 路径，故预览与真实弹窗吃的是同一份 popup.js /
   /// popup.css，不会出现「预览好看、真弹窗不一样」。
-  static String buildInlinePopupHtml({
+  ///
+  /// BUG-1918 ②：此前对外只暴露裸的 [_buildInlinePopupHtml]，它假定四个
+  /// `_inline*` 静态字段已装载——而装载有两条路径：启动时 fire-and-forget 的
+  /// [preloadInlinePopupAssets]，以及真弹窗 build 里的同步兜底
+  /// [_ensureInlinePopupAssetsLoaded]。词典样式预览只调了裸构造，于是在预读
+  /// 尚未完成（或曾瞬时失败）时拼出 `<style></style><script></script>` 的空壳：
+  /// 没有 popup.css 也没有 popup.js，预览白屏且连 `window.renderPopup` 都不存在。
+  ///
+  /// 「确保装载 + 四项非空 + 拼装」是一个不可分的原语，任何调用点都不该再自己
+  /// 拼这三步——真弹窗的 build 也改用它，两个入口从此不可能漂移。
+  static String? buildInlinePopupHtmlIfReady({
     required String themeAttr,
     required String bgHex,
-  }) =>
-      _buildInlinePopupHtml(themeAttr: themeAttr, bgHex: bgHex);
+  }) {
+    _ensureInlinePopupAssetsLoaded();
+    if (_inlineCss == null ||
+        _inlineDictMediaJs == null ||
+        _inlineSelectionJs == null ||
+        _inlinePopupJs == null) {
+      return null;
+    }
+    return _buildInlinePopupHtml(themeAttr: themeAttr, bgHex: bgHex);
+  }
 
   /// 测试专用别名，保留既有调用点。
   @visibleForTesting
@@ -1553,13 +1571,13 @@ JSON.stringify((function(){
     InAppWebViewInitialData? popupInitialData;
     final bool shouldInlinePopupAssets = _shouldInlinePopupAssets;
     if (shouldInlinePopupAssets) {
-      _ensureInlinePopupAssetsLoaded();
-      if (_inlineCss != null &&
-          _inlineDictMediaJs != null &&
-          _inlineSelectionJs != null &&
-          _inlinePopupJs != null) {
+      final String? inlineHtml = buildInlinePopupHtmlIfReady(
+        themeAttr: themeAttr,
+        bgHex: bgHex,
+      );
+      if (inlineHtml != null) {
         popupInitialData = InAppWebViewInitialData(
-          data: _buildInlinePopupHtml(themeAttr: themeAttr, bgHex: bgHex),
+          data: inlineHtml,
           mimeType: 'text/html',
           encoding: 'utf-8',
         );

--- a/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
@@ -734,11 +734,14 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
   @override
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final Size mediaSize = MediaQuery.of(context).size;
-    final double contentHeight = (mediaSize.height * 0.55).clamp(280.0, 480.0);
 
+    // 尺寸向 `LapisStyleEditorPage` 看齐：那边是整页 + 内容区 maxWidth 1180，
+    // 这边是对话框，同样取 1180 并把高度撑满到允许的 0.88 屏高。
+    // 之前写死的 `height: (屏高*0.55).clamp(280, 480)` 直接删掉而不是换个大常数：
+    // 固定高度在矮屏上会超过 [FushiDialogFrame] 的高度帽而溢出，而 body 本来
+    // 就是 Flexible、列里又有 Expanded，交给约束自己决定就行。
     return FushiDialogFrame(
-      maxWidth: 640,
+      maxWidth: 1180,
       maxHeightFactor: 0.88,
       insetPadding: EdgeInsets.symmetric(
         horizontal: tokens.spacing.card,
@@ -763,7 +766,6 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
         ),
         body: SizedBox(
           width: double.maxFinite,
-          height: contentHeight,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -835,50 +837,75 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
           _scopeCssToDictionary(buildPerDictionaryStyleCss(rules, name), name),
       ].join('\n'),
     );
-    return Column(
-      children: <Widget>[
-        Expanded(
-          flex: 2,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: tokens.surfaces.page,
-              borderRadius: tokens.radii.cardRadius,
-              border: Border.all(color: tokens.surfaces.outline),
+    final Widget preview = DecoratedBox(
+      decoration: BoxDecoration(
+        color: tokens.surfaces.page,
+        borderRadius: tokens.radii.cardRadius,
+        border: Border.all(color: tokens.surfaces.outline),
+      ),
+      child: ClipRRect(
+        borderRadius: tokens.radii.cardRadius,
+        child: widget.previewBuilder?.call(
+              context,
+              previewCss,
+              _draft.selectedPart,
+              (DictStylePart part) =>
+                  setState(() => _draft.selectedPart = part),
+            ) ??
+            DictStylePreview(
+              css: previewCss,
+              highlightPart: _draft.selectedPart,
+              onPickPart: (DictStylePart part) =>
+                  setState(() => _draft.selectedPart = part),
             ),
-            child: ClipRRect(
-              borderRadius: tokens.radii.cardRadius,
-              child: widget.previewBuilder?.call(
-                    context,
-                    previewCss,
-                    _draft.selectedPart,
-                    (DictStylePart part) =>
-                        setState(() => _draft.selectedPart = part),
-                  ) ??
-                  DictStylePreview(
-                    css: previewCss,
-                    highlightPart: _draft.selectedPart,
-                    onPickPart: (DictStylePart part) =>
-                        setState(() => _draft.selectedPart = part),
-                  ),
-            ),
-          ),
-        ),
-        SizedBox(height: tokens.spacing.gap / 2),
-        Text(t.dict_style_pick_hint, style: tokens.type.listSubtitle),
-        SizedBox(height: tokens.spacing.gap / 2),
-        Expanded(
-          flex: 3,
-          child: DictStyleVisualEditor(
-            rules: rules,
-            scopeDictionary: scope,
-            selectedPart: _draft.selectedPart,
-            onSelectPart: (DictStylePart part) =>
-                setState(() => _draft.selectedPart = part),
-            onRulesChanged: (List<DictStyleRule> next) =>
-                setState(() => _draft.styleRules = next),
-          ),
-        ),
-      ],
+      ),
+    );
+    final Widget hint =
+        Text(t.dict_style_pick_hint, style: tokens.type.listSubtitle);
+    final Widget controls = DictStyleVisualEditor(
+      rules: rules,
+      scopeDictionary: scope,
+      selectedPart: _draft.selectedPart,
+      onSelectPart: (DictStylePart part) =>
+          setState(() => _draft.selectedPart = part),
+      onRulesChanged: (List<DictStyleRule> next) =>
+          setState(() => _draft.styleRules = next),
+    );
+
+    // 断点和分栏比例抄 `LapisStyleEditorPage`：宽于 820 时左预览右控件（控件定宽
+    // 340），窄于 820 时上下堆叠。两个编辑器读起来才是同一个东西。
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        if (constraints.maxWidth >= 820) {
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(
+                flex: 5,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Expanded(child: preview),
+                    SizedBox(height: tokens.spacing.gap / 2),
+                    hint,
+                  ],
+                ),
+              ),
+              SizedBox(width: tokens.spacing.card),
+              SizedBox(width: 340, child: controls),
+            ],
+          );
+        }
+        return Column(
+          children: <Widget>[
+            Expanded(flex: 2, child: preview),
+            SizedBox(height: tokens.spacing.gap / 2),
+            hint,
+            SizedBox(height: tokens.spacing.gap / 2),
+            Expanded(flex: 3, child: controls),
+          ],
+        );
+      },
     );
   }
 

--- a/fushi/test/pages/dict_style_preview_handler_coverage_test.dart
+++ b/fushi/test/pages/dict_style_preview_handler_coverage_test.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dict_style_preview.dart';
+
+// BUG-1918：打开「词典样式」→ 可视化页闪退（Windows，0xC0000005）。
+//
+// 根因在原生侧（`packages/flutter_inappwebview_windows/windows/in_app_webview/
+// webview_channel_delegate.cpp` 的 CallJsHandlerCallback::decodeResult 把
+// Dart 的 **null 答复**（StandardMethodCodec 走无参 Success() → value ==
+// nullptr）原样塞进一个已引发的 optional，下游 `response.value()->IsNull()`
+// 直接解引用空指针）。触发条件是 **JS 调了一个 Dart 侧没注册的 handler 名**：
+// `_handleMethod` 走到末尾 `return null`，于是回复就是 null。
+//
+// DictStylePreview 跑的是**真的** popup.js，它能发起 21 个桥调用，而预览此前只
+// 注册了 4 个——`reportJsError`（预览里任何 JS 报错都会调）、`tapOutside`（点空白
+// 处）等一调就崩。
+//
+// 原生那一层已根治，但两侧都得对：预览必须给 popup.html 加载的每个脚本里出现的
+// 每个 `callHandler('X')` 一个确定的 Dart 侧语义，而不是靠平台兜底空回复。
+// 这条守卫把「名单 ⊇ 脚本里真实调用的名字」钉住——popup.js 新加一个 callHandler
+// 而预览没跟上，这里就红。
+void main() {
+  test('DictStylePreview 注册了 popup.html 所有脚本能调到的全部 JS handler', () {
+    final Directory popupDir = Directory('assets/popup');
+    expect(
+      popupDir.existsSync(),
+      isTrue,
+      reason: '测试要在 fushi/ 下跑（assets/popup 是相对它的路径）',
+    );
+
+    // popup.html 实际加载了哪些脚本，就扫哪些——别扫整个目录：definition.js /
+    // global_lookup_host.js 是别的宿主（视频定义面板 / app 外浮窗）在用的，把它们
+    // 的 handler 名摊派给预览会让这份名单虚胖，读的人分不清哪些是真必需。
+    final String html = File('assets/popup/popup.html').readAsStringSync();
+    final List<String> scripts = RegExp(
+      r'<script\s+src="([^"]+\.js)"',
+    ).allMatches(html).map((RegExpMatch m) => m.group(1)!).toList();
+    expect(scripts, isNotEmpty, reason: 'popup.html 里没扫到 <script src>');
+    expect(scripts, contains('popup.js'));
+
+    final Set<String> called = <String>{};
+    for (final String script in scripts) {
+      final File file = File('assets/popup/$script');
+      expect(file.existsSync(), isTrue, reason: 'popup.html 引用了不存在的 $script');
+      // 允许 `callHandler(` 与名字之间换行/空格：popup.js 里长参数是折行写的，
+      // 只认同一行会漏掉 resolveWordAudio、findMinedMatches 等一批。
+      called.addAll(
+        RegExp(r'''callHandler\(\s*['"]([A-Za-z0-9_]+)['"]''')
+            .allMatches(file.readAsStringSync())
+            .map((RegExpMatch m) => m.group(1)!),
+      );
+    }
+    expect(
+      called.length,
+      greaterThan(10),
+      reason: '正则没匹配到几个名字，八成是 callHandler 的写法变了，先修正则',
+    );
+
+    final Set<String> registered = kDictStylePreviewNoopHandlers.toSet();
+    expect(
+      registered.length,
+      kDictStylePreviewNoopHandlers.length,
+      reason: 'kDictStylePreviewNoopHandlers 里有重复名字',
+    );
+
+    final List<String> missing = (called.difference(registered).toList())
+      ..sort();
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          '预览没注册这些 popup 脚本会调的 handler：$missing —— '
+          '未注册的名字会让插件回 null 答复（BUG-1918 的闪退触发条件），'
+          '且该桥调用在预览里行为未定义。补进 kDictStylePreviewNoopHandlers。',
+    );
+
+    final List<String> stale = (registered.difference(called).toList())..sort();
+    expect(stale, isEmpty, reason: '这些名字已经没有任何 popup 脚本会调了，从名单里删掉：$stale');
+  });
+
+  test('原生侧 decodeResult 对 null 答复有空守卫（BUG-1918 根因）', () {
+    // 真正的崩点在 C++，flutter test 跑不到它；但那一行的存在与否是二元的，源码
+    // 扫描能钉住。要求：CallJsHandlerCallback 的 decodeResult 体内出现 `!value`
+    // 判空并返回 nullopt——去掉它就回到「空回复被当指针解引用」的闪退。
+    final File cpp = File(
+      '../packages/flutter_inappwebview_windows/windows/in_app_webview/'
+      'webview_channel_delegate.cpp',
+    );
+    expect(cpp.existsSync(), isTrue, reason: '找不到 ${cpp.path}');
+    final String source = cpp.readAsStringSync();
+
+    const String marker = 'CallJsHandlerCallback::CallJsHandlerCallback()';
+    final int start = source.indexOf(marker);
+    expect(start, greaterThanOrEqualTo(0), reason: '构造函数改名了，先更新本守卫');
+    // 截到下一个构造函数为止，避免把别的 decodeResult 的空守卫当成这一个的。
+    final int next = source.indexOf('Callback::', start + marker.length);
+    final String body = source.substring(
+      start,
+      next < 0 ? source.length : next,
+    );
+
+    expect(body.contains('decodeResult'), isTrue);
+    expect(
+      body.contains('if (!value)') || body.contains('!value ||'),
+      isTrue,
+      reason:
+          'CallJsHandlerCallback::decodeResult 必须先判 value 是否为空：'
+          'Dart 回 null 时这里收到的就是 nullptr，直接 return value 会装出一个 '
+          'has_value()==true 但值为 nullptr 的 optional，下游解引用即闪退。',
+    );
+    expect(
+      body.contains('std::nullopt'),
+      isTrue,
+      reason: '空 value 必须降成 std::nullopt，让下游 has_value() 守卫真的能拦住。',
+    );
+  });
+}

--- a/fushi/test/pages/dictionary_css_editor_dialog_test.dart
+++ b/fushi/test/pages/dictionary_css_editor_dialog_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/models.dart';
 import 'package:fushi/src/dictionary/dict_style_rules.dart';
+import 'package:fushi/src/pages/implementations/dict_style_visual_editor.dart';
 import 'package:fushi/src/pages/implementations/dictionary_settings_dialog_page.dart';
 import 'package:fushi/src/platform/platform_providers.dart';
 import 'package:fushi/src/profile/profile_repository.dart';
@@ -537,6 +538,58 @@ void main() {
     final settingsSource =
         File('lib/src/settings/settings_schema_lookup.dart').readAsStringSync();
     expect(settingsSource, contains('DictCssEditorDialog('));
+  });
+
+  // 尺寸对齐 `LapisStyleEditorPage`（用户诉求：「和 lapis 的一样大」）。Lapis 是整页 +
+  // 内容区 maxWidth 1180、宽于 820 时左预览右控件（控件定宽 340）。这里断言的是
+  // **几何**而不是「某个 widget 在不在」：宽屏下两块必须真的并排、对话框真的撑到
+  // 1180 宽和 0.88 屏高，否则改回小尺寸也能骗过测试。
+  testWidgets('宽屏下词典样式编辑器取 Lapis 的尺寸与左右分栏', (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1600, 1000);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _buildApp(
+        appModel: _FakeCssAppModel(),
+        home: const DictCssEditorDialog(previewBuilder: _stubPreview),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 量 FushiModalSheetFrame 而不是 Dialog：Dialog 的 RenderBox 是整个 overlay 区，
+    // 恒等于屏幕大小，拿它量宽度会恒真（旧的 compact 用例就只断言了它没出屏）。
+    final Rect dialogRect = tester.getRect(find.byType(FushiModalSheetFrame));
+    expect(dialogRect.width, closeTo(1180, 1));
+    // 高度撑满到 FushiDialogFrame 允许的 0.88 屏高（旧实现写死 0.55 屏高且 clamp 480）。
+    expect(dialogRect.height, closeTo(1000 * 0.88, 1));
+
+    final Rect previewRect = tester.getRect(find.textContaining('PREVIEW_CSS:'));
+    final Rect controlsRect = tester.getRect(find.byType(DictStyleVisualEditor));
+    expect(controlsRect.left, greaterThan(previewRect.right),
+        reason: '宽屏应是左预览右控件，不是上下堆叠');
+    expect(controlsRect.width, closeTo(340, 1));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('窄屏下词典样式编辑器仍是上下堆叠', (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(700, 900);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _buildApp(
+        appModel: _FakeCssAppModel(),
+        home: const DictCssEditorDialog(previewBuilder: _stubPreview),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final Rect previewRect = tester.getRect(find.textContaining('PREVIEW_CSS:'));
+    final Rect controlsRect = tester.getRect(find.byType(DictStyleVisualEditor));
+    expect(controlsRect.top, greaterThanOrEqualTo(previewRect.bottom),
+        reason: '窄屏应回到上下堆叠');
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('dictionary CSS editor fits a compact mobile dialog', (

--- a/fushi/test/pages/popup_inline_assets_readiness_test.dart
+++ b/fushi/test/pages/popup_inline_assets_readiness_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+
+// BUG-1918 ②：词典样式预览白屏。
+//
+// 内联 popup HTML 的四份资产（popup.css / dict-media.js / selection.js /
+// popup.js）有两条装载路径：启动时 fire-and-forget 的 preloadInlinePopupAssets，
+// 和真弹窗 build 里的同步兜底 _ensureInlinePopupAssetsLoaded。修前对外只暴露
+// 裸的构造函数，它假定四份都在；词典样式预览直接调它，于是在预读没跑完（或曾
+// 瞬时读盘失败）时拼出 `<style></style><script></script>` 的空壳——没有 popup.js，
+// 预览白屏，连 window.renderPopup 都不存在。
+//
+// 修法是把「确保装载 + 四项非空 + 拼装」收成一个原语
+// buildInlinePopupHtmlIfReady，未就绪返回 null 让调用方回退 file:// URL。
+void main() {
+  tearDown(DictionaryPopupWebViewState.debugResetInlinePopupAssets);
+
+  test('资产未装载时返回 null，而不是拼出空壳 HTML', () {
+    DictionaryPopupWebViewState.debugResetInlinePopupAssets();
+
+    // widget/unit 测试进程里 flutter assets 目录不存在，_ensureInlinePopupAssetsLoaded
+    // 的同步读盘必然失败 —— 正是「资产不可用」这一支。
+    final String? html = DictionaryPopupWebViewState.buildInlinePopupHtmlIfReady(
+      themeAttr: 'dark',
+      bgHex: '#101010',
+    );
+
+    if (html != null) {
+      // 极少数环境（就地跑在已构建产物旁）真能读到资产：那就必须是**实心**的，
+      // 空壳一律算失败。这条分支保证本用例在两种环境下都不是恒真。
+      expect(html.contains('<script></script>'), isFalse,
+          reason: '返回非 null 就必须带着真的 popup.js，不能是空 <script>');
+      expect(html.contains('<style></style>'), isFalse);
+      return;
+    }
+    expect(html, isNull);
+  });
+
+  test('资产装载后返回的 HTML 真的带着那四份资产', () {
+    DictionaryPopupWebViewState.debugResetInlinePopupAssets();
+    DictionaryPopupWebViewState.debugSetInlinePopupAssets(
+      css: '.fake-css-marker{}',
+      dictMediaJs: 'window.__fakeDictMedia = 1;',
+      selectionJs: 'window.__fakeSelection = 1;',
+      popupJs: 'window.renderPopup = function () {};',
+    );
+
+    final String? html = DictionaryPopupWebViewState.buildInlinePopupHtmlIfReady(
+      themeAttr: 'light',
+      bgHex: '#ffffff',
+    );
+
+    expect(html, isNotNull);
+    expect(html!.contains('.fake-css-marker{}'), isTrue);
+    expect(html.contains('window.__fakeDictMedia = 1;'), isTrue);
+    expect(html.contains('window.__fakeSelection = 1;'), isTrue);
+    expect(html.contains('window.renderPopup = function () {};'), isTrue);
+    expect(html.contains('id="entries-container"'), isTrue,
+        reason: 'popup.js 的 __fushiContainer() 靠它取容器，缺了就直接静默返回');
+  });
+
+  test('预览与真弹窗都只能经这个原语拿内联 HTML', () {
+    // 两个入口一旦有一个自己拼「确保装载 + 判空 + 构造」，就会重新漂移出白屏
+    // 那一支。裸构造函数是私有的，公开面只剩这一个 + 测试专用别名。
+    for (final String path in const <String>[
+      'lib/src/pages/implementations/dict_style_preview.dart',
+      'lib/src/pages/implementations/dictionary_popup_webview.dart',
+    ]) {
+      final String source = File(path).readAsStringSync();
+      expect(source.contains('buildInlinePopupHtmlIfReady'), isTrue,
+          reason: '$path 应该走 buildInlinePopupHtmlIfReady');
+    }
+
+    final String preview =
+        File('lib/src/pages/implementations/dict_style_preview.dart')
+            .readAsStringSync();
+    expect(
+      RegExp(r'buildInlinePopupHtml\s*\(').hasMatch(preview),
+      isFalse,
+      reason: '预览不能再调不判就绪的裸构造 buildInlinePopupHtml(...)',
+    );
+  });
+}

--- a/packages/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp
+++ b/packages/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp
@@ -32,8 +32,19 @@ namespace flutter_inappwebview_plugin
 
   WebViewChannelDelegate::CallJsHandlerCallback::CallJsHandlerCallback()
   {
+    // BUG-1918 æ ¹å ï¼Dart åå¤ null æ¶ StandardMethodCodec èµ°çæ¯æ å Success()ï¼
+    // è¿éæ¶å°ç value å°±æ¯ nullptrï¼å¸åè§¦åï¼JS è°äºä¸ä¸ª Dart ä¾§æ²¡
+    // addJavaScriptHandler æ³¨åç handler åï¼ãç´æ¥ return value ä¼æç©ºæéè£è¿ä¸ä¸ª
+    // **å·²å¼å**ç optionalï¼has_value() == trueï¼å¼ä¸º nullptrï¼ï¼äºæ¯ä¸æ¸¸é£å¥
+    // `response.has_value() && !response.value()->IsNull()`ï¼in_app_webview.cppï¼ç´æ¥è§£å¼ç¨
+    // ç©ºæé â 0xC0000005 æ´ä¸ª app éªéãç©ºåå¤å¿é¡»éæ nulloptï¼è®©é£å¥å®å«çç
+    // è½æ¦ä½ââåæä»¶å¶å® decodeResult æ¬æ¥å°±é½åå¤ `!value`ã
     decodeResult = [](const flutter::EncodableValue* value)
+      -> std::optional<const flutter::EncodableValue*>
       {
+        if (!value) {
+          return std::nullopt;
+        }
         return value;
       };
   }
@@ -52,8 +63,14 @@ namespace flutter_inappwebview_plugin
 
   WebViewChannelDelegate::PermissionRequestCallback::PermissionRequestCallback()
   {
+    // å BUG-1918ï¼Dart ä¾§ onPermissionRequest å nullï¼ææ²¡æ¥è¿ä¸ªåè°ï¼æ¶
+    // value ä¸º nullptrï¼è£¸ `*value` åæ ·æ¯ç©ºè§£å¼ç¨ã
     decodeResult = [](const flutter::EncodableValue* value)
+      -> std::optional<std::shared_ptr<PermissionResponse>>
       {
+        if (!value || value->IsNull()) {
+          return std::nullopt;
+        }
         return std::make_shared<PermissionResponse>(std::get<flutter::EncodableMap>(*value));
       };
   }


### PR DESCRIPTION
用户报「词典样式可视化编辑器打开就闪退」，并要求把它改成和 Lapis 编辑器一样大。查下来是**两个真缺陷 + 一个尺寸调整**。

## ① 闪退（BUG-1918，进程级 0xC0000005）

**证据链**：Windows 事件日志 2026-08-28 20:04:09 / 20:05:25 两次同一 fault bucket（`fushi.exe 2.2.1.12458` / `flutter_inappwebview_windows_plugin.dll` / `0xC0000005` / 偏移 `0x6c768`）；完整 minidump 用 cdb `.ecxr` 解出崩点 `movzx eax, byte ptr [rdx+40h]` 且 `rdx = 0` —— 空指针解引用。

**根因**：`packages/flutter_inappwebview_windows/.../webview_channel_delegate.cpp` 的

```cpp
CallJsHandlerCallback::decodeResult = [](const flutter::EncodableValue* value) { return value; };
```

`T = const EncodableValue*`，返回值要转成 `std::optional<T>`。Dart 回复 **null** 时，Flutter 的 `StandardMethodCodec` 走的是**无参** `Success()` → 这里 `value == nullptr`；直接 `return value` 装出一个 `has_value() == true` 而值为 `nullptr` 的 optional，于是下游 `in_app_webview.cpp:773` 的守卫 `response.has_value() && !response.value()->IsNull()` 就地解引用空指针（EncodableValue 是 `std::variant`，判别位正在 +0x40 —— 与崩指令读的偏移逐位对上）。

**触发条件**：JS 调了一个 Dart 侧**没注册**的 handler 名（插件 `_handleMethod` 查不到就 `return null`）。`DictStylePreview` 跑真的 popup.js（能发起 21 个桥调用）却只注册了 4 个，漏掉的里面有 `reportJsError`（任何 JS 报错都会调）和 `tapOutside`（点空白处就调）。

**修法（两层）**：
- 原生根因：两处 `decodeResult`（`CallJsHandler` / `PermissionRequest`，同一缺陷形状）补空守卫，空回复降成 `std::nullopt`。这一层修掉的是**整类**崩溃 —— 在此之前任何未注册 handler 名都能把 app 打死。
- 消费端：预览注册 popup 脚本能调的全部 21 个名字为 no-op（`kDictStylePreviewNoopHandlers`）。

## ② 预览白屏（同一条链）

预览调的是**裸的** `buildInlinePopupHtml(...)`，而它假定四份内联资产已装载。装载只有两条路径：启动时 fire-and-forget 的 `preloadInlinePopupAssets()`、真弹窗 build 里的同步兜底 + 四项非空校验。预览两条都没走 → 预读没完成时拼出 `<style></style><script></script>` 空壳，没有 popup.js，连 `window.renderPopup` 都不存在。

修法不是补一句判空，而是把「确保装载 + 四项非空 + 拼装」收成一个原语 `buildInlinePopupHtmlIfReady`（未就绪返回 null → 回退 file:// URL），**真弹窗的 build 也改用它**，两个入口不可能再漂移。

## ③ 尺寸对齐 Lapis（用户诉求）

对话框 `maxWidth` 640 → 1180（与 `LapisStyleEditorPage` 内容区同宽），删掉写死的 `height: (屏高*0.55).clamp(280, 480)`（固定高度在矮屏会顶穿高度帽；body 本就是 Flexible、列里有 Expanded，交给约束即可），宽于 820 时改成左预览、右控件（定宽 340）的分栏 —— 断点与分栏比例都抄 Lapis。

## 验证

- `flutter analyze`：No issues found。
- 全量单测：`FLUTTER TEST VERDICT: PASSED - 21310 tests ran, all tests passed`。
- **真机（Windows 真 WebView2）**：`tool/run_windows_itest.ps1 integration_test/dict_style_preview_null_reply_crash_itest.dart` → `exit code: 0`，`All tests passed!`
  - 用例①：调未注册 handler → promise resolve 成 null，之后再发一次 JS 仍有回应（进程存活）。修前这一步即闪退。
  - 用例②：真 `DictStylePreview` 渲染出 `.entry`（白屏已修），触发 `reportJsError` 后进程照样活着。
- 新增守卫 + 变异实测：
  - `dict_style_preview_handler_coverage_test.dart`（名单与 popup.js 对齐 / C++ 空守卫源码扫描）—— 删 `'reportJsError'`、删 `if (!value) return std::nullopt;` 各自变红。
  - `popup_inline_assets_readiness_test.dart` 三条（未就绪返回 null 且绝不是空壳 / 就绪后四份资产逐字节在 HTML 里 / 两个入口都只经该原语）。
  - `dictionary_css_editor_dialog_test.dart` 加宽屏尺寸与分栏、窄屏堆叠 —— `maxWidth` 改回 640 即变红。

## 备注

编辑器仍是对话框（保留原有的草稿 / 保存闸门与 `ProfileDraftCoordinator` 语义），只是尺寸与分栏取 Lapis 的。若希望它彻底变成 Lapis 那样的整页，说一声我再改。

https://claude.ai/code/session_012tkqr6gaWAqMuAs352W3Yu
