### PR TITLE
fix(sync): 删除墓碑读失败的一轮不得推进消费基线（BUG-1934）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1801 条。点号进各自文件。
+> 共 1802 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1934](bugs/BUG-1934-tombstone-partial-read-baseline.md) | ✅ | ✅ | 远端删除墓碑单条读失败被跳过，基线照常推进 → 该条删除永久不再提示 |
 | [BUG-1925](bugs/BUG-1925-sync-collections-resurrect-flaky.md) | 🚧 | 🚧 | 全量下 sync_orchestrator_collections 的 peer-republish 用例偶发红（4 次全量红 2 次，单跑绿） |
 | [BUG-1922](bugs/BUG-1922-macos-aidoku-runtime-not-bundled.md) | ✅ | ✅ | macOS 发布包缺 Aidoku runtime，删除再添加 Aidoku 仓库报 RUNTIME_MISSING |
 | [BUG-1921](bugs/BUG-1921-settings-module-labels-mismatch.md) | ✅ | ✅ | 设置里的功能模块开关名字与底栏/侧栏对不上 |

--- a/docs/bugs/BUG-1934-tombstone-partial-read-baseline.md
+++ b/docs/bugs/BUG-1934-tombstone-partial-read-baseline.md
@@ -1,0 +1,53 @@
+## BUG-1934 · 远端删除墓碑单条读失败被跳过，基线照常推进 → 该条删除永久不再提示
+
+- **报告**：2026-08-29（用户：同步报告里出现 4 条
+  `deletion tombstone "favoritesentence__…_video_Hibike__Euphonium_2_-_01…json" unreadable:
+  HandshakeException: Connection terminated during handshake`）
+- **真实性**：✅ 真 bug（不是单纯网络噪音——它会留下**永久**后果）
+  - 根因 `fushi/lib/src/sync/sync_orchestrator.dart:1119-1131`（消费循环里读失败只
+    `report.noteError(...) + continue`）配合 `:1155-1160`（候选循环无条件
+    `report.noteDeletionHighWater(_scope, at)`）。
+  - 删除消费基线（`sync_deletion_tombstones_baseline_ms`，`SyncRepository
+    .setDeletionTombstonesBaselineMs`）是**标量**：UI 复核完一批候选后
+    （`fushi/lib/src/sync/deletion_prompt.dart:356-363`）把它推到本轮最大 deletedAt。
+  - 于是「本轮没读出来的标记」被本轮读出来的同伴连坐：设 early(deletedAt=1000) 读失败、
+    late(deletedAt=9000) 读成功，用户复核 late 后 baseline=9000；下一轮 early 读得出来了，
+    却落进 `if (at == null || at <= baseline) continue;` 的旧闻分支——**永远**不再进候选。
+    对端删掉的东西在本机静默留存，用户永远看不到那条确认框。远端标记不做 GC（Phase F），
+    所以它就这么一直躺着且永远不可行动。
+  - 一次 TLS 握手失败就够触发；用户日志里的 4 条正是这个形态（同一云通道、部分失败）。
+  - 同源第二形态：`fushi/lib/src/sync/sftp_sync_backend.dart:372-383` 把读失败
+    （`SyncBackendError`）映射成 `null` 而不是抛，于是消费侧 `parseDeletionTombstoneJson(null)`
+    返回 null → 静默 `continue`，**连一条错误都不记**，同样的永久压制无声发生。
+  - 互联（interconnect）通道无此问题：`_syncDeletionTombstonesLive` 一次
+    `getRemoteDeletionTombstones()` 取回全部墓碑，失败即整体抛出，不存在部分观测。
+    推送侧 `_pushDeletionTombstonesLive` 早已用 `retryable` 标志实现了同一条纪律
+    （异常 → 不推进基线），消费侧只是漏了。
+
+- **[x] ① 已修复** — `sync_orchestrator.dart` 引入「完整观测不变式」：本轮把列出的标记
+  **全部**读成 marker 才登记 high-water（=允许 UI 推进基线），少读一条就闭嘴、候选照常上报，
+  下轮读全了再推进。三种形态分开对待：
+  - 抛异常 → `scanComplete = false`（扣住基线，自愈）；
+  - 读回 `null`（后端吞错，如 SFTP）→ 同样按未观测处理，并补记一条 `unreadable`；
+  - 内容非法（截断上传/坏文件）→ 这是**永久**状态，重试不会变好，**不**扣基线（否则一个坏
+    文件把基线永久钉死、用户每轮重看同一批确认框），但改为如实记一条 `malformed`，不再静默丢。
+  扣住基线时额外记一条 `deletion tombstones scan incomplete; consumption baseline held
+  until a complete read`，让「为什么这轮没推进」在报告里留痕。
+  提交：见本分支 `worktree-tombstone-partial-read-baseline`。
+
+- **[x] ② 已加自动化测试** — `fushi/test/sync/deletion_tombstone_partial_read_test.dart`
+  （5 条，跑真的 `SyncOrchestrator.syncDeletionTombstones` + 可控故障后端 `_FlakyBackend`）：
+  - 基准：全读成功照常登记 high-water（防止修过头 → 反复骚扰）；
+  - 一条抛异常：候选照出、high-water 为空、报告里有 `scan incomplete`；
+  - **核心回归**：第一轮部分失败 + 用户复核推进基线 → 第二轮读全后，被跳过的 early 仍能弹出；
+  - 读回 null 同样扣基线；
+  - 内容非法不扣基线但记 `malformed`。
+  变异实测：把 `if (scanComplete)` 改成 `if (true)`（=还原 bug）后 5 条里红 3 条（含核心回归
+  条），另 2 条按设计不依赖该守卫；源文件已按 SHA-256 校验字节还原。
+
+- **备注**：
+  - 未动 SFTP 后端那处 `SyncBackendError → null` 的映射（它分不清「文件不存在」和「读失败」，
+    根治要在 `_guarded`/`_downloadJson` 层区分 not-found）。消费侧现在把 `null` 当未观测，
+    已经堵住它造成的静默压制；后端层的区分留作独立改动。
+  - 代价：观测不完整的那一轮，用户若在确认框里**保留**（不勾）某条候选，下一轮会再问一次。
+    这是有意的取舍——「多问一次」可见可恢复，「静默丢删除」不可见不可恢复。

--- a/fushi/lib/src/sync/sync_orchestrator.dart
+++ b/fushi/lib/src/sync/sync_orchestrator.dart
@@ -267,6 +267,9 @@ class SyncRunReport {
   final Map<String, int> deletionTombstonesHighWaterMsByScope = <String, int>{};
 
   /// 记一条通道本轮复核到的删除时刻（取该通道的 max）。
+  ///
+  /// 调用方**必须**先确认本轮完整读到了该通道的全部远端墓碑：这个值一旦落地就成了
+  /// 「此刻之前的删除都已复核」的断言，而没读到的那些标记会被它连坐压制（BUG-1934）。
   void noteDeletionHighWater(SyncChannelScope scope, int deletedAt) {
     final int? prev = deletionTombstonesHighWaterMsByScope[scope.id];
     if (prev == null || deletedAt > prev) {
@@ -1092,6 +1095,10 @@ class SyncOrchestrator {
   /// 不自动 GC 远端标记：本设备仍持有该资产且 deletedAt <= 基线时，无法区分「保留」与
   /// 「删后重加」，误删标记会破坏其它设备的删除传播——书/视频不自动重导入，标记长存只是
   /// 极小的存储/新设备重弹成本，GC 留待 Phase F。整段 try/catch，错误进 report.errors。
+  ///
+  /// **完整观测不变式**（BUG-1934）：只有本轮把列出的标记**全部**读成了 marker，才登记
+  /// [SyncRunReport.noteDeletionHighWater]（=允许 UI 推进基线）。少读一条就闭嘴——基线
+  /// 是标量，推过头会把那条没读到的、deletedAt 更小的删除永久压成「旧闻」。
   Future<void> syncDeletionTombstones(SyncRunReport report) async {
     try {
       final String ns =
@@ -1116,6 +1123,10 @@ class SyncOrchestrator {
       // ── 消费：读远端标记 → deleteLocal 候选（过基线守卫）──
       final Map<String, Set<String>> remoteTombstones = <String, Set<String>>{};
       final Map<String, int> remoteDeletedAt = <String, int>{};
+      // 本轮是否**完整**观测了远端标记集合：列出来了却没读成 marker 的每一条都置假。
+      // 基线的语义是「已复核到此时刻的删除」，只有完整观测撑得起这句话（BUG-1934，
+      // 见下方推进点的长注释）。
+      bool scanComplete = true;
       final List<AssetEntry> children = await _backend.listChildren(ns);
       for (final AssetEntry e in children) {
         if (e.isFolder) continue;
@@ -1123,11 +1134,29 @@ class SyncOrchestrator {
         try {
           json = await _backend.getJsonAsset(e.id);
         } catch (err) {
+          scanComplete = false;
           report.noteError('deletion tombstone "${e.name}" unreadable', err);
           continue;
         }
+        if (json == null) {
+          // listChildren 刚列到它、读回来却是空：要么本轮被对端删了（下轮不再列出，
+          // 自愈），要么后端把读失败映射成了 null 而不是抛（[SftpSyncBackend
+          // .getJsonAsset] 就是这样吞 SyncBackendError 的）。两种都不是「已观测」，
+          // 按不完整处理——静默 continue 会让后者变成一次无声的永久压制。
+          scanComplete = false;
+          report.noteError(
+              'deletion tombstone "${e.name}" unreadable', 'empty response');
+          continue;
+        }
         final parsed = parseDeletionTombstoneJson(json);
-        if (parsed == null) continue;
+        if (parsed == null) {
+          // 读到了但内容不合法（截断上传 / 非本协议文件）。这是**永久**状态，重试不会
+          // 变好，故不置 scanComplete=false（否则基线被一个坏文件永久钉死，用户每轮
+          // 重看同一批确认框）。只如实记一条，别再静默丢。
+          report.noteError(
+              'deletion tombstone "${e.name}" malformed', 'skipped');
+          continue;
+        }
         remoteTombstones
             .putIfAbsent(parsed.mediaType, () => <String>{})
             .add(parsed.itemKey);
@@ -1143,6 +1172,7 @@ class SyncOrchestrator {
           await _collectPresentDeletionKeys();
       int baseline = await repo.getDeletionTombstonesBaselineMs(_scope);
       if (baseline > nextBaseline) baseline = nextBaseline; // 时钟回拨钳制。
+      bool heldBaseline = false;
 
       // deleteLocal 方向：远端有标记 ∧ 本地在库。localTombstones/remotePresent 传空
       // ⇒ 只产 deleteLocal，不产 deleteRemote（本设备的删除靠发布标记让对端各自消费）。
@@ -1157,7 +1187,21 @@ class SyncOrchestrator {
         final int? at = remoteDeletedAt['${c.mediaType}\u0000${c.itemKey}'];
         if (at == null || at <= baseline) continue; // 旧闻 / 已处理，不再弹。
         report.deletionCandidates.add(c);
-        report.noteDeletionHighWater(_scope, at);
+        // BUG-1934：读失败的标记必须挡住基线推进。基线是**标量**，UI 复核完这批就把它
+        // 推到本轮最大 deletedAt，于是任何 deletedAt 更小、本轮恰好没读出来的标记，下轮
+        // 就落进上面那句 `at <= baseline` 的旧闻分支——永久不再弹，用户在对端删掉的东西
+        // 在本机静默留存。触发它只要一次 TLS 握手失败（HandshakeException）。候选照常
+        // 上报（该弹的还得弹），只是不认领「已复核到此刻」这个断言，下轮读全了再推进。
+        // 互联通道无需同样处理：它一次 GET 取回全部墓碑，失败即整体抛出，无部分观测。
+        if (scanComplete) {
+          report.noteDeletionHighWater(_scope, at);
+        } else {
+          heldBaseline = true;
+        }
+      }
+      if (heldBaseline) {
+        report.errors.add('deletion tombstones scan incomplete; '
+            'consumption baseline held until a complete read');
       }
     } catch (e) {
       report.noteError('deletion tombstones sync', e);

--- a/fushi/test/sync/deletion_tombstone_partial_read_test.dart
+++ b/fushi/test/sync/deletion_tombstone_partial_read_test.dart
@@ -1,0 +1,213 @@
+/// BUG-1934：远端删除墓碑「列出来了但没读成」的那一轮，不得推进删除消费基线。
+///
+/// 基线是**标量**（`sync_deletion_tombstones_baseline_ms`），UI 复核完一批候选就把它推到
+/// 本轮最大 deletedAt。于是只要有一条标记本轮没读出来、而它的 deletedAt 又比推上去的值
+/// 小，下轮它就落进 `at <= baseline` 的旧闻分支——**永久**不再弹确认，用户在对端删掉的东
+/// 西在本机静默留存。触发它只需要一次 TLS 握手失败（真实报告里是
+/// `HandshakeException: Connection terminated during handshake`）。
+///
+/// 这里跑真的 [SyncOrchestrator.syncDeletionTombstones]，把三种读失败形态（抛异常 / 读回
+/// null / 内容非法）与基线推进的关系一起钉住。
+library;
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/deletion_propagation.dart';
+import 'package:fushi/src/sync/sync_asset_store.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_orchestrator.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'fake_asset_store.dart';
+
+void main() {
+  late FushiDatabase db;
+  late FakeAssetStore store;
+  late _FlakyBackend backend;
+  late Directory tmp;
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    store = FakeAssetStore();
+    backend = _FlakyBackend(store);
+    tmp = await Directory.systemTemp.createTemp('tombstone_partial_read');
+  });
+  tearDown(() async {
+    await db.close();
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  SyncOrchestrator orchestrator() => SyncOrchestrator(
+        db: db,
+        backend: backend,
+        dictionaryResourceRoot: tmp,
+        audioDatabaseRoot: tmp,
+        tempDir: tmp,
+        syncStats: false,
+        syncAudioBookPosition: false,
+        syncContent: false,
+        syncAudioBookFiles: false,
+        syncDictionary: false,
+      );
+
+  final String kind = SyncTombstoneKind.srtbook.dbValue;
+
+  Future<void> addSrt(String uid) => db.upsertSrtBook(SrtBooksCompanion.insert(
+        uid: uid,
+        title: uid,
+        srtPath: '/tmp/$uid.srt',
+        importedAt: 0,
+      ));
+
+  /// 造一条「对端删了这本书」的远端标记，返回它的资产 id。
+  Future<String> putRemoteTombstone(String uid, int deletedAt) async {
+    final String ns = await backend.ensureNamespace(kSyncTombstonesNamespace);
+    final String name = deletionTombstoneAssetName(kind, uid);
+    await backend.putJsonAsset(
+        ns, name, deletionTombstoneJson(kind, uid, deletedAt));
+    return '$ns/$name';
+  }
+
+  /// 模仿 UI 复核完一批候选后的动作（`DeletionPromptPrompter` 的基线推进段）。
+  Future<void> commitBaseline(SyncRunReport report) async {
+    final SyncRepository repo = SyncRepository(db);
+    for (final MapEntry<String, int> e
+        in report.deletionTombstonesHighWaterMsByScope.entries) {
+      if (e.value <= 0) continue;
+      await repo.setDeletionTombstonesBaselineMs(
+          SyncChannelScope.byId(e.key), e.value);
+    }
+  }
+
+  test('基准：全部标记读得出来时，照常登记 high-water', () async {
+    await addSrt('srt/a');
+    await putRemoteTombstone('srt/a', 5000);
+
+    final SyncRunReport report = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(report);
+
+    expect(report.deletionCandidates, hasLength(1));
+    expect(report.deletionTombstonesHighWaterMsByScope,
+        <String, int>{SyncChannelScope.unscoped.id: 5000},
+        reason: '完整观测的一轮必须照常推进基线，否则用户复核过的删除会反复骚扰');
+  });
+
+  test('一条读失败（抛）→ 候选照出，但本轮不登记 high-water', () async {
+    await addSrt('srt/early');
+    await addSrt('srt/late');
+    // early 的 deletedAt 更小：它正是会被「推过头的基线」永久压制的那条。
+    backend.failIds.add(await putRemoteTombstone('srt/early', 1000));
+    await putRemoteTombstone('srt/late', 9000);
+
+    final SyncRunReport report = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(report);
+
+    expect(
+        report.deletionCandidates
+            .map((DeletionPropagationCandidate c) => c.itemKey),
+        <String>['srt/late'],
+        reason: '读得出来的那条照常上报，不能因为同伴失败就一起哑掉');
+    expect(report.deletionTombstonesHighWaterMsByScope, isEmpty,
+        reason: '本轮观测不完整，不得认领「已复核到 9000」——那会把 deletedAt=1000 的 '
+            'early 永久压成旧闻');
+    expect(report.errors.any((String s) => s.contains('scan incomplete')),
+        isTrue,
+        reason: '基线被扣住这件事要在报告里留痕，否则只能靠猜');
+  });
+
+  test('回归：一轮部分失败 + 用户复核 → 下一轮读全后，被跳过的那条仍能弹出', () async {
+    await addSrt('srt/early');
+    await addSrt('srt/late');
+    final String earlyId = await putRemoteTombstone('srt/early', 1000);
+    await putRemoteTombstone('srt/late', 9000);
+
+    // 第一轮：early 握手失败。
+    backend.failIds.add(earlyId);
+    final SyncRunReport run1 = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(run1);
+    await commitBaseline(run1); // 用户处理完 late 的确认框。
+
+    // 第二轮：网络恢复，early 读得出来了。
+    backend.failIds.clear();
+    final SyncRunReport run2 = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(run2);
+
+    expect(
+        run2.deletionCandidates
+            .map((DeletionPropagationCandidate c) => c.itemKey),
+        contains('srt/early'),
+        reason: '这是本 bug 的要害：修复前 baseline 已被推到 9000，deletedAt=1000 的 '
+            'early 从此永远进不了候选，对端的删除在本机静默丢失');
+  });
+
+  test('读回 null（后端把读失败映射成空）→ 同样扣住基线', () async {
+    await addSrt('srt/early');
+    await addSrt('srt/late');
+    backend.nullIds.add(await putRemoteTombstone('srt/early', 1000));
+    await putRemoteTombstone('srt/late', 9000);
+
+    final SyncRunReport report = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(report);
+
+    expect(report.deletionTombstonesHighWaterMsByScope, isEmpty,
+        reason: 'SftpSyncBackend.getJsonAsset 把 SyncBackendError 吞成 null，'
+            '按「已观测」处理会让同一次永久压制悄无声息地发生');
+    expect(report.errors.any((String s) => s.contains('unreadable')), isTrue);
+  });
+
+  test('内容非法（永久坏文件）→ 记一条错误，但不扣住基线', () async {
+    await addSrt('srt/late');
+    final String ns = await backend.ensureNamespace(kSyncTombstonesNamespace);
+    await backend.putJsonAsset(ns, 'junk.json', <String, Object?>{'x': 1});
+    await putRemoteTombstone('srt/late', 9000);
+
+    final SyncRunReport report = SyncRunReport();
+    await orchestrator().syncDeletionTombstones(report);
+
+    expect(report.deletionTombstonesHighWaterMsByScope,
+        <String, int>{SyncChannelScope.unscoped.id: 9000},
+        reason: '坏文件重试一万次还是坏的；为它永久钉住基线只会让用户每轮重看同一批确认框');
+    expect(report.errors.any((String s) => s.contains('malformed')), isTrue,
+        reason: '不再静默丢弃：坏标记要看得见');
+  });
+}
+
+/// [FakeAssetStore] 之上的可控故障层：[failIds] 抛（模拟 TLS 握手中断），[nullIds] 返回
+/// null（模拟把读失败映射成空的后端）。其余成员照旧委托，未用到的当场炸。
+class _FlakyBackend implements SyncBackend {
+  _FlakyBackend(this._store);
+  final FakeAssetStore _store;
+  final Set<String> failIds = <String>{};
+  final Set<String> nullIds = <String>{};
+
+  @override
+  Future<String> ensureNamespace(String name) => _store.ensureNamespace(name);
+  @override
+  Future<List<AssetEntry>> listChildren(String namespaceId) =>
+      _store.listChildren(namespaceId);
+
+  @override
+  Future<Object?> getJsonAsset(String assetId) async {
+    if (failIds.contains(assetId)) {
+      throw const HandshakeException('Connection terminated during handshake');
+    }
+    if (nullIds.contains(assetId)) return null;
+    return _store.getJsonAsset(assetId);
+  }
+
+  @override
+  Future<void> putJsonAsset(String namespaceId, String name, Object? json) =>
+      _store.putJsonAsset(namespaceId, name, json);
+
+  @override
+  Future<bool> get isAuthenticated async => true;
+  @override
+  Future<bool> restoreAuth(SyncRepository repo) async => true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('_FlakyBackend.${invocation.memberName}');
+}


### PR DESCRIPTION
## 起因

用户同步报告里出现 4 条：

```
deletion tombstone "favoritesentence__…_video_Hibike__Euphonium_2_-_01…json" unreadable:
HandshakeException: Connection terminated during handshake
```

看着像纯网络抖动，其实会留下**永久**后果。

## 根因

`fushi/lib/src/sync/sync_orchestrator.dart` 的云通道消费循环里，单条墓碑读失败只
`report.noteError(...) + continue`，而下面的候选循环仍**无条件**
`report.noteDeletionHighWater(_scope, at)`。

删除消费基线（`sync_deletion_tombstones_baseline_ms`）是**标量**：UI 复核完这批候选后
把它推到本轮最大 deletedAt。于是没读出来的标记被读出来的同伴连坐——

- early(deletedAt=1000) 读失败、late(deletedAt=9000) 读成功；
- 用户复核 late → baseline = 9000；
- 下一轮 early 读得出来了，却落进 `if (at == null || at <= baseline) continue;` 的旧闻分支
  → **永远**不再进候选。

对端删掉的东西在本机静默留存，用户永远看不到那条确认框。远端标记不做 GC（Phase F），
它就一直躺着且永远不可行动。一次 TLS 握手失败就够触发。

同源第二形态：`sftp_sync_backend.dart:372-383` 把读失败（`SyncBackendError`）映射成
`null` 而不是抛，消费侧 `parseDeletionTombstoneJson(null)` → 静默 `continue`，**连错误都不记**。

互联通道无此问题（一次 GET 取全部，失败整体抛出，无部分观测）；而且它的**推送**侧
`_pushDeletionTombstonesLive` 早就用 `retryable` 标志实现了同一条纪律——消费侧只是漏了。

## 修复

引入「完整观测不变式」：本轮把列出的标记**全部**读成 marker 才登记 high-water
（=允许 UI 推进基线）。少读一条就闭嘴，候选照常上报，下轮读全了再推进。三种形态分开对待：

| 形态 | 处理 | 为什么 |
|---|---|---|
| 抛异常（网络/TLS） | 扣住基线 | 暂时性，下轮自愈 |
| 读回 `null`（后端吞错，如 SFTP） | 扣住基线 + 补记 `unreadable` | 同样不是「已观测」，静默 continue 会让永久压制无声发生 |
| 内容非法（截断上传/坏文件） | **不**扣基线，改记 `malformed` | 永久状态，重试不会变好；为它钉死基线会让用户每轮重看同一批确认框 |

扣住基线时额外记一条 `deletion tombstones scan incomplete; consumption baseline held
until a complete read`，让「这轮为什么没推进」在报告里留痕。

## 测试

新增 `fushi/test/sync/deletion_tombstone_partial_read_test.dart`（5 条，跑真的
`SyncOrchestrator.syncDeletionTombstones` + 可控故障后端）：

- 基准：全读成功照常登记 high-water（防止修过头 → 反复骚扰）
- 一条抛异常：候选照出、high-water 为空、报告里有 `scan incomplete`
- **核心回归**：第一轮部分失败 + 用户复核推进基线 → 第二轮读全后，被跳过的 early 仍能弹出
- 读回 null 同样扣基线
- 内容非法不扣基线但记 `malformed`

**变异实测**：把 `if (scanComplete)` 改成 `if (true)`（=还原 bug）后 5 条里红 3 条
（含核心回归条），另 2 条按设计不依赖该守卫；源文件已按 SHA-256 校验字节还原。

## 验证

- `flutter analyze`（fushi 全量，含 test）：No issues found
- `flutter test`（本文件 + 7 个相邻同步/墓碑测试文件）：58 passed，exit 0

## 取舍

观测不完整的那一轮，用户若在确认框里**保留**（不勾）某条候选，下一轮会再问一次。
这是有意的——「多问一次」可见可恢复，「静默丢删除」不可见不可恢复。

## 遗留

未动 SFTP 后端那处 `SyncBackendError → null` 的映射（它分不清「文件不存在」和「读失败」，
根治要在 `_guarded`/`_downloadJson` 层区分 not-found）。消费侧现在把 `null` 当未观测，
已堵住它造成的静默压制；后端层的区分留作独立改动。

详见 `docs/bugs/BUG-1934-tombstone-partial-read-baseline.md`。

https://claude.ai/code/session_01Vd499pWkVkSSBfia5rrRuK
