### PR TITLE
fix(test): mokuro 退避取消测试改用假时钟，并补上恒绿的弱断言（BUG-1944）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1801 条。点号进各自文件。
+> 共 1802 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1944](bugs/BUG-1944-mokuro-retry-cancel-test-wall-clock-race.md) | ✅ | ✅ | mokuro 退避取消测试拿真时钟当同步原语，CI 上偶发红 |
 | [BUG-1925](bugs/BUG-1925-sync-collections-resurrect-flaky.md) | 🚧 | 🚧 | 全量下 sync_orchestrator_collections 的 peer-republish 用例偶发红（4 次全量红 2 次，单跑绿） |
 | [BUG-1922](bugs/BUG-1922-macos-aidoku-runtime-not-bundled.md) | ✅ | ✅ | macOS 发布包缺 Aidoku runtime，删除再添加 Aidoku 仓库报 RUNTIME_MISSING |
 | [BUG-1921](bugs/BUG-1921-settings-module-labels-mismatch.md) | ✅ | ✅ | 设置里的功能模块开关名字与底栏/侧栏对不上 |

--- a/docs/bugs/BUG-1944-mokuro-retry-cancel-test-wall-clock-race.md
+++ b/docs/bugs/BUG-1944-mokuro-retry-cancel-test-wall-clock-race.md
@@ -1,0 +1,7 @@
+## BUG-1944 · mokuro 退避取消测试拿真时钟当同步原语，CI 上偶发红
+- **报告**：2026-08-29（发现于 PR #1054 的 CI：该 PR 只改浏览器扩展，却红在这条与它无关的测试上）
+- **真实性**：✅ 真 bug（测试自身的缺陷，不是被测代码）。根因 `fushi/test/media/manga/online/mokuro_moe_download_queue_test.dart:238`：退避被设成 `Duration(milliseconds: 10)`，随后用 `await pumpEventQueue()` 让错误传播，再断言 `task.status == waitingRetry`。`pumpEventQueue()` 会反复 yield 回事件循环，在负载高的 CI runner 上真实耗时轻易超过 10ms——重试定时器先烧掉，回调把状态推回 `queued` 并 `_pump()` 起下一次下载，断言拿到的是 `running`。即测试把**真实墙钟**当成了同步原语。
+  - 实证：`Build Release APK` job 99085845373（PR #1054，head 与 mokuro 队列零交集）`FLUTTER TEST VERDICT: FAILED`，唯一失败即本条，`Expected: waitingRetry / Actual: running`；同期 develop 上同一 workflow 连续 12 次 success。
+- **[x] ① 已修复** — 改用假时钟：`fakeAsync` + `async.flushMicrotasks()` 让错误传播，`async.elapse()` 显式推进过退避。退避时长同时从 10ms 提到 10s，进一步与任何真实耗时脱钩。被测代码 `mokuro_moe_download_queue.dart` **未改动**（`_finish` 全同步、不碰 DB，落在 `fakeAsync` 可控范围内）。
+- **[x] ② 已加自动化测试** — 同文件同名用例。顺带修掉一个既有的**弱断言**：原用例只断言 `r.calls` 长度，但 `cancel()` 对非执行中的任务只做 `_tasks.remove(task)`、**不改 `task.status`**，所以定时器即使没被掐掉，到期回调里的 `_pump()` 也扫不到这条已移出队列的任务，`r.calls` 恒为 1——变异实测（删掉 `mokuro_moe_download_queue.dart:187` 的 `_retryTimers.remove(task)?.cancel();`）证明原断言**恒绿、抓不住它声称要抓的回归**。现补断言到期后 `task.status` 仍为 `waitingRetry`（定时器活着的话会被翻成 `queued`），同一变异下确认转红。
+- **备注**：这是「测试拿真时钟当同步原语」的通用形状——同批 review 中未发现其他同型用例；本文件内其余退避用例走 `instantBackoff`（`Duration.zero`，下一轮事件循环触发，`pumpEventQueue` 可靠等到），不受影响。

--- a/fushi/test/media/manga/online/mokuro_moe_download_queue_test.dart
+++ b/fushi/test/media/manga/online/mokuro_moe_download_queue_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/native.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_client.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_download_queue.dart';
@@ -235,25 +236,37 @@ void main() {
       r.queue.dispose();
     });
 
-    test('退避中取消：移出队列，且到期后不会被偷偷重排', () async {
-      // 退避设短但非零：cancel 掐掉定时器后，即使等过这个时长也不该再起下载。
-      final r =
-          makeQueue(backoff: const <Duration>[Duration(milliseconds: 10)]);
-      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
-      final MokuroMoeDownloadTask task = r.queue.tasks.single;
+    test('退避中取消：移出队列，且到期后不会被偷偷重排', () {
+      // 退避非零，且必须用假时钟推进：真时钟下 `pumpEventQueue()` 自身的耗时就
+      // 可能超过退避（CI 机器负载高时几十毫秒很常见），重试定时器先烧掉，断言
+      // 前状态已从 waitingRetry 翻成 running —— 那是测试拿真时钟当同步原语，不
+      // 是被测代码有问题。假时钟下「退避未到期」和「取消后推进过期」都是确定的。
+      fakeAsync((FakeAsync async) {
+        final r =
+            makeQueue(backoff: const <Duration>[Duration(seconds: 10)]);
+        r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+        final MokuroMoeDownloadTask task = r.queue.tasks.single;
 
-      r.ctrls[0].addError(timeout);
-      await r.ctrls[0].close();
-      await pumpEventQueue();
-      expect(task.status, MokuroMoeTaskStatus.waitingRetry);
+        r.ctrls[0].addError(timeout);
+        unawaited(r.ctrls[0].close());
+        async.flushMicrotasks();
+        expect(task.status, MokuroMoeTaskStatus.waitingRetry);
 
-      r.queue.cancel(task);
-      expect(r.queue.tasks, isEmpty);
+        r.queue.cancel(task);
+        expect(r.queue.tasks, isEmpty);
 
-      await Future<void>.delayed(const Duration(milliseconds: 40));
-      await pumpEventQueue();
-      expect(r.calls, hasLength(1), reason: '取消后定时器必须已被掐掉');
-      r.queue.dispose();
+        async.elapse(const Duration(seconds: 30));
+        expect(r.calls, hasLength(1), reason: '取消后定时器必须已被掐掉');
+        // `cancel` 只把任务移出 `_tasks`、不动 status，所以「定时器被掐掉」唯一
+        // 能观测到的地方就是这里：定时器还活着的话，到期回调会把这条已经不在
+        // 队列里的任务翻成 queued（`_pump` 扫不到它，calls 反而看不出差别）。
+        expect(
+          task.status,
+          MokuroMoeTaskStatus.waitingRetry,
+          reason: '到期回调不得再碰这条已移出队列的任务',
+        );
+        r.queue.dispose();
+      });
     });
 
     test('404 不自动重试（该卷就是没有，重试只是白等）；503 才重试', () async {


### PR DESCRIPTION
## 背景

PR #1054 只改浏览器扩展（`tools/browser-extension/` + `fushi/assets/browser_extension/`），却在 CI 的真单测门上红了，唯一失败是 `mokuro_moe_download_queue_test.dart` —— 一条与它零交集的测试。定性为该测试自身的缺陷。

## 根因

`fushi/test/media/manga/online/mokuro_moe_download_queue_test.dart:238` 把退避设成 `Duration(milliseconds: 10)`，然后用 `await pumpEventQueue()` 让错误传播，再断言状态是 `waitingRetry`。

`pumpEventQueue()` 会反复 yield 回事件循环，在负载高的 CI runner 上真实耗时轻易超过 10ms。重试定时器先烧掉，回调把状态推回 `queued` 并 `_pump()` 起下一次下载，断言拿到 `running`。**测试把真实墙钟当成了同步原语。**

实证：job `99085845373` `FLUTTER TEST VERDICT: FAILED`，`Expected: waitingRetry / Actual: running`；同期 develop 上同一 workflow 连续 12 次 success。

## 修复

改用假时钟：`fakeAsync` + `async.flushMicrotasks()` 让错误传播，`async.elapse()` 显式推进过退避。退避同时提到 10s，与任何真实耗时脱钩。

**被测代码 `mokuro_moe_download_queue.dart` 未改动** —— `_finish` 全同步、不碰 DB，落在 `fakeAsync` 可控范围内。

## 顺带修掉一个恒绿断言

变异实测时发现原用例抓不住它声称要抓的回归：`cancel()` 对非执行中的任务只做 `_tasks.remove(task)`、**不改 `task.status`**，所以定时器即使没被掐掉，到期回调里的 `_pump()` 也扫不到这条已移出队列的任务，`r.calls` 恒为 1。

删掉 `mokuro_moe_download_queue.dart:187` 的 `_retryTimers.remove(task)?.cancel();` 后，原断言**仍然全绿**。

现补断言：到期后 `task.status` 必须仍是 `waitingRetry`（定时器活着的话会被翻成 `queued`）。同一变异下确认转红。

## 验证

- `flutter test test/media/manga/online/mokuro_moe_download_queue_test.dart --no-pub` → 17 条全绿
- 变异实测：删 `_retryTimers.remove(task)?.cancel()` → 转红；还原后 sha256 与原文件一致

https://claude.ai/code/session_0181LaPWjn5JYpYwB7tM8KWA
