### PR TITLE
fix(manga): Aidoku 封面抓取走统一代理出口，修 develop 上的守卫红

### DIFF
--- a/fushi/lib/src/media/manga/library/online_manga_runtime_adapter.dart
+++ b/fushi/lib/src/media/manga/library/online_manga_runtime_adapter.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_reader_chapter.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
+import 'package:fushi/src/utils/net/app_http.dart';
 
 /// 一条在线漫画书架条目**不可用**的原因。
 ///
@@ -426,7 +427,10 @@ class AidokuLibraryAdapter implements OnlineMangaRuntimeAdapter {
   ) async {
     // Aidoku 封面是普通 https 资源（源包不提供图片代理接口），带上作品页作为
     // referer 就够——与 AidokuMangaPageProvider 取页图时的做法一致。
-    final HttpClient client = HttpClient();
+    //
+    // 走 `createAppHttpClient()` 而不是裸 `HttpClient()`：封面是**公网**请求，
+    // 必须跟随应用的统一代理出口（`outbound_http_discipline_guard` 钉住这条）。
+    final HttpClient client = createAppHttpClient();
     try {
       final HttpClientRequest request = await client.getUrl(Uri.parse(url));
       final String? referer = entry.series.raw['url']?.toString();


### PR DESCRIPTION
## 背景

PR #1049 合入后，`outbound_http_discipline_guard_test` 在 `develop` 上红了：

```
Expected: empty
  Actual: {
            'fushi/lib/src/media/manga/library/online_manga_runtime_adapter.dart': Set:['HttpClient(']
          }
```

## 根因

`OnlineMangaRuntimeAdapter.fetchCover`（Aidoku 分支）用裸 `HttpClient()` 抓封面，绕过了统一代理装配点。封面是**公网**请求，用户配了代理时这一条会直连。

## 修复

改用 `createAppHttpClient()`（`lib/src/utils/net/app_http.dart`）——逐点一行的机械替换，顺带带上统一的 `connectionTimeout`。

## 为什么定向测试没抓到

这条守卫用 `listSync(recursive: true)` 扫 7 个源码根**全树**，触发面与功能域正交；#1049 的定向测试按 manga 功能域挑，结构上永远挑不到它。是「每条 PR 合入 develop 后固定加跑目录枚举型守卫整批」这条纪律抓到的。

## 验证

- `outbound_http_discipline_guard_test` 转绿（含 11 条判据自校验）
- `FLUTTER TEST VERDICT: PASSED - 634 tests ran`（manga 域全部 + 该守卫）
- `flutter analyze`：No issues found

https://claude.ai/code/session_0181LaPWjn5JYpYwB7tM8KWA
