### PR TITLE
fix(video): 落位闸的分隔符改用 \u0000 转义，去掉源码里的裸 NUL 字节

### DIFF
--- a/fushi/lib/src/media/video/download/video_download_organizer.dart
+++ b/fushi/lib/src/media/video/download/video_download_organizer.dart
@@ -300,7 +300,7 @@ class VideoDownloadOrganizer {
             .map((VideoOrganizationFilePlan f) => f.finalLocalPath)
             .toList()
           ..sort())
-        .join(' ');
+        .join('\u0000');
     return _withTargetLock(lockKey, () async {
       for (final VideoOrganizationFilePlan file in planned.files) {
         if (await File(file.finalLocalPath).exists()) {


### PR DESCRIPTION
## 根因

PR #1063 新增的落位串行闸里，键的分隔符被写成了**裸 NUL 字节**：

```dart
.join('<raw 0x00>');
```

git 会把含裸 NUL 的文件判成 binary —— diff 看不了、合并时静默丢改动。

## 修复

改成 Dart 的 4 位十六进制转义 `''`：运行时字节等价，文件仍是纯文本。

## 怎么发现的

`develop` 上跑「合并后必跑的目录枚举型守卫整批」时，`dart_source_no_raw_nul_guard_test` 当场抓到：

```
Expected: empty
  Actual: ['…/video_download_organizer.dart：1 处裸 NUL']
```

该守卫扫 `fushi/{lib,test}` + 5 个 `packages/*/lib` **全树**，而 #1063 的定向测试按 video/download 功能域挑，结构上挑不到它 —— 正是这批守卫存在的理由。

## 验证

- `dart_source_no_raw_nul_guard_test` + `video_download_organizer_test` 共 13 条全绿
- `flutter analyze`：No issues found

https://claude.ai/code/session_0181LaPWjn5JYpYwB7tM8KWA
