### PR TITLE
test(video): 观看时长四条用例改用注入时钟，修 develop 上的三条红

### DIFF
--- a/fushi/test/media/video/video_watch_tracker_test.dart
+++ b/fushi/test/media/video/video_watch_tracker_test.dart
@@ -293,15 +293,18 @@ void main() {
       // fire-and-forget）会让本断言转红——锁住退出时统计不丢。
       final _Sink sink = _Sink(delay: const Duration(milliseconds: 20));
       final _FakeSource src = _FakeSource()..isPlaying = true;
+      // 段时长走注入时钟，不靠墙钟：落库门槛是「≥1 秒或有内容账」，等 30ms 真实
+      // 时间造出来的段过不了门槛，测的就成了墙钟而不是接线。
+      DateTime now = DateTime(2026, 1, 1, 12);
       final VideoWatchTracker tracker = VideoWatchTracker(
         bookUid: 'u1',
-        clock: _clock(sink),
+        clock: _clock(sink, now: () => now),
         markCompleted: (_) async {},
       )..attach(src);
 
       tracker.start();
       // 制造一段连续播放窗口（>0 且 <= kMaxReadingGap）。
-      await Future<void>.delayed(const Duration(milliseconds: 30));
+      now = now.add(const Duration(seconds: 30));
       await tracker.stop();
 
       expect(sink.writes, isNotEmpty,
@@ -342,14 +345,15 @@ void main() {
     test('一次观看 session 结束落一条段，携带净观看时长', () async {
       final _Sink sink = _Sink();
       final _FakeSource src = _FakeSource()..isPlaying = true;
+      DateTime now = DateTime(2026, 1, 1, 12);
       final VideoWatchTracker tracker = VideoWatchTracker(
         bookUid: 'u1',
-        clock: _clock(sink),
+        clock: _clock(sink, now: () => now),
         markCompleted: (_) async {},
       )..attach(src);
 
       tracker.start();
-      await Future<void>.delayed(const Duration(milliseconds: 30));
+      now = now.add(const Duration(seconds: 30));
       await tracker.stop();
 
       expect(sink.writes, hasLength(1));
@@ -362,14 +366,15 @@ void main() {
     test('二次 stop 幂等：不重复写段（时钟已封段、无累计器可再结算）', () async {
       final _Sink sink = _Sink();
       final _FakeSource src = _FakeSource()..isPlaying = true;
+      DateTime now = DateTime(2026, 1, 1, 12);
       final VideoWatchTracker tracker = VideoWatchTracker(
         bookUid: 'u1',
-        clock: _clock(sink),
+        clock: _clock(sink, now: () => now),
         markCompleted: (_) async {},
       )..attach(src);
 
       tracker.start();
-      await Future<void>.delayed(const Duration(milliseconds: 30));
+      now = now.add(const Duration(seconds: 30));
       await tracker.stop();
       await tracker.stop(); // 第二次不应再写（段已封、时钟已停）
       expect(sink.writes, hasLength(1));
@@ -378,14 +383,17 @@ void main() {
     test('从未播放（isPlaying=false，无净时长）不落段', () async {
       final _Sink sink = _Sink();
       final _FakeSource src = _FakeSource()..isPlaying = false;
+      // 同样推过 1 秒门槛：不推的话「没到门槛」也会让断言绿，这条就分不清是
+      // 活跃态守卫在起作用还是段太短，等于没测。
+      DateTime now = DateTime(2026, 1, 1, 12);
       final VideoWatchTracker tracker = VideoWatchTracker(
         bookUid: 'u1',
-        clock: _clock(sink),
+        clock: _clock(sink, now: () => now),
         markCompleted: (_) async {},
       )..attach(src);
 
       tracker.start();
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      now = now.add(const Duration(seconds: 30));
       await tracker.stop();
       expect(sink.writes, isEmpty,
           reason: '活跃态守卫（isPlaying）拒绝的窗口整窗丢弃，不开段不写');


### PR DESCRIPTION
`test/media/video/video_watch_tracker_test.dart` 在 develop 上有三条红，是 PR#1070（统计域重构）合入时带进来的——那条 PR 的定向测试跑了 `test/media/audiobook`，没跑 `test/media/video`。

## 根因

`StudyClock._worthWriting` 的落库门槛是「段 ≥ 1 秒，或有字数 / 页数」：不足 1 秒又没有内容账的段是生命周期抖动（开页秒关、失焦回焦），按设计就不该落库。

这几条用例用 `await Future<void>.delayed(const Duration(milliseconds: 30))` 造段，只有几十毫秒，天然过不了门槛，于是断言「必须落一条段」恒红。不是实现坏了，是测试在拿墙钟当时间源。

## 修法

改用 `_clock(sink, now: ...)` 本来就支持的可注入时钟，把段推过 1 秒。测的才是接线本身。

## 顺带修掉一条假绿

「从未播放（isPlaying=false）不落段」原来也只等 20ms——不足 1 秒本来就不写，断言 `isEmpty` 分不清是活跃态守卫拒绝了还是段太短，等于没测。同样推过 1 秒之后 `isPlaying=false` 仍然 0 条，才真的证明是守卫在起作用。

## 实测

`flutter test test/media/video/video_watch_tracker_test.dart` → 22 条全过（修前 -3）。
