### PR TITLE
test(lookup): 隐藏词典守卫的循环锚点改成跨行正则（修 develop 上的红）

### DIFF
--- a/fushi/test/pages/popup_hidden_dictionary_filter_test.dart
+++ b/fushi/test/pages/popup_hidden_dictionary_filter_test.dart
@@ -148,9 +148,16 @@ void main() {
 
     final int builderAt = lang.indexOf('String buildPopupJsonFromLookup(');
     expect(builderAt, greaterThanOrEqualTo(0));
-    final int glossaryLoop =
-        lang.indexOf('for (final g in r.term.glossaries) {', builderAt);
-    expect(glossaryLoop, greaterThan(builderAt));
+    // 锚点用正则而不是整串字面量：循环头会折行，中间还可能套一层排序包装
+    // （PR#1085 的 _glossariesInDictionaryOrder 就是）。要钉的是「遍历
+    // r.term.glossaries 的那个循环」，不是它当天的格式。
+    final RegExpMatch? loopMatch = RegExp(
+      r'for \(final g\s+in\s+[^)]*r\.term\.glossaries[^{]*\{',
+      dotAll: true,
+    ).firstMatch(lang.substring(builderAt));
+    expect(loopMatch, isNotNull,
+        reason: 'buildPopupJsonFromLookup 里必须有遍历 r.term.glossaries 的循环');
+    final int glossaryLoop = builderAt + loopMatch!.end;
 
     // 断言字面量：'if (hiddenDictionaries.contains(g.dictName)) continue;'
     // 必须 continue 整个 glossary 迭代，而不是只跳 groupGlossaries.add——


### PR DESCRIPTION
`test/pages/popup_hidden_dictionary_filter_test.dart` 的 `popupJson drops hidden dictionaries at the source (all hosts)` 在 develop 上红了。

## 根因是**锚点**，不是行为

PR#1085（查词弹窗遵循词典管理顺序）把释义迭代包了一层：

```dart
for (final g
    in _glossariesInDictionaryOrder(r.term.glossaries, dictionaryOrder)) {
```

守卫用的是整串字面量 `'for (final g in r.term.glossaries) {'`，折行 + 套包装函数之后恒 `-1`。被守的不变式一点没变：隐藏词典的 `continue` 仍在循环体最前、仍在建组之前。

## 修法

锚点改成跨行正则 `for \(final g\s+in\s+[^)]*r\.term\.glossaries[^{]*\{`（`dotAll`）。要钉的是「遍历 `r.term.glossaries` 的那个循环」，不是它当天的格式——下次谁再包一层或换个格式化，守卫仍然守得住它该守的东西。

## 实测

该文件 4 条全过（修前 -1）。
