### PR TITLE
test(startup): FlutterError 守卫改钉 logFatal 而非来源字面量（修 develop 上的红）

### DIFF
--- a/fushi/test/startup/platform_dispatcher_error_guard_test.dart
+++ b/fushi/test/startup/platform_dispatcher_error_guard_test.dart
@@ -45,12 +45,33 @@ void main() {
   });
 
   test('致命级错误（FlutterError / UncaughtZone）走 logFatal 同步 flush', () {
+    // 判据是「处理体里调的是 logFatal」，不是来源字符串长什么样：来源已由
+    // flutterErrorLogSource(details) 按 details 推导（这样日志里能看到
+    // FlutterError/RenderFlex 这类可读上下文），点名旧字面量只会挡住改进。
+    final int flutterErrorAt = src.indexOf('FlutterError.onError = (details) {');
+    expect(flutterErrorAt, isNonNegative, reason: '必须装 FlutterError.onError');
+    final int flutterErrorEnd = src.indexOf(
+      'PlatformDispatcher.instance.onError',
+      flutterErrorAt,
+    );
+    expect(flutterErrorEnd, greaterThan(flutterErrorAt));
+    final String flutterErrorBody =
+        src.substring(flutterErrorAt, flutterErrorEnd);
     expect(
-      src.contains(
-              "ErrorLogService.instance.logFatal(\n        'FlutterError") ||
-          RegExp(r"logFatal\(\s*'FlutterError").hasMatch(src),
+      flutterErrorBody.contains('ErrorLogService.instance.logFatal('),
       isTrue,
       reason: 'FlutterError 是致命级，须 logFatal 同步落盘（崩溃前存活）',
+    );
+    expect(
+      RegExp(r'ErrorLogService\.instance\.log\(').hasMatch(flutterErrorBody),
+      isFalse,
+      reason: '这条守卫真正要挡的退化：换回普通 log（异步 append）——'
+          '错误若紧接着把进程带崩就来不及写盘',
+    );
+    expect(
+      flutterErrorBody.contains('flutterErrorLogSource(details)'),
+      isTrue,
+      reason: '来源须按 details 推导，别退回一律 FlutterError（那正是 BUG-1966）',
     );
     expect(
       RegExp(r"logFatal\('UncaughtZone'").hasMatch(src),


### PR DESCRIPTION
`test/startup/platform_dispatcher_error_guard_test.dart` 的「致命级错误（FlutterError / UncaughtZone）走 logFatal 同步 flush」在 develop 上红了。

## 根因是**判据选错**，不是行为退化

PR#1084 把 FlutterError 的日志来源从硬编码 `'FlutterError'` 改成 `flutterErrorLogSource(details)` —— 那正是这条 PR 的目的：让日志显示可读上下文（`FlutterError/RenderFlex` 之类），而不是一律 `FlutterError`。

守卫断言的是 `logFatal('FlutterError` 这个字面量，于是把改进本身判成了退化。

## 修法

真正的不变式是「FlutterError 走 `logFatal`（同步 flush 落盘），不是普通 `log`（异步 append）」—— 这条错误可能紧接着把进程带崩，异步 append 来不及写盘。

改成在 `FlutterError.onError` 的处理体内断言三件事：
- `logFatal(` 在；
- **普通 `ErrorLogService.instance.log(` 不在** —— 这才是守卫真正要挡的退化；
- 来源由 `flutterErrorLogSource(details)` 推导，别退回一律 `FlutterError`。

## 变异实测

把处理体里的 `logFatal` 换回 `log` → 守卫转红（`+3 -1`）；还原后文件 sha256 一致。
该文件 4 条全过（修前 -1）。
