### PR TITLE
fix(runner): 三个 attached 测试补 #undef NDEBUG（release 下 78 条断言原本整批空跑）

### DIFF
--- a/fushi/windows/runner/tests/attached_overlayability_source_test.cpp
+++ b/fushi/windows/runner/tests/attached_overlayability_source_test.cpp
@@ -1,3 +1,8 @@
+// release 也要真断言：NDEBUG 会把 assert 编成空语句，本文件的断言就会整批
+// 消失、测试空跑照样"通过"（CI 的 C4189「变量没人引用」正是它漏出来的痕迹）。
+// 与 attached_mouse_hook_nonblocking_source_test.cpp 同一写法。
+#undef NDEBUG
+
 #include <cassert>
 #include <fstream>
 #include <iterator>

--- a/fushi/windows/runner/tests/attached_overlayability_test.cpp
+++ b/fushi/windows/runner/tests/attached_overlayability_test.cpp
@@ -1,3 +1,8 @@
+// release 也要真断言：NDEBUG 会把 assert 编成空语句，本文件的断言就会整批
+// 消失、测试空跑照样"通过"（CI 的 C4189「变量没人引用」正是它漏出来的痕迹）。
+// 与 attached_mouse_hook_nonblocking_source_test.cpp 同一写法。
+#undef NDEBUG
+
 #include "../attached_overlayability.h"
 
 #include <cassert>

--- a/fushi/windows/runner/tests/attached_shield_status_policy_test.cpp
+++ b/fushi/windows/runner/tests/attached_shield_status_policy_test.cpp
@@ -1,3 +1,8 @@
+// release 也要真断言：NDEBUG 会把 assert 编成空语句，本文件的断言就会整批
+// 消失、测试空跑照样"通过"（CI 的 C4189「变量没人引用」正是它漏出来的痕迹）。
+// 与 attached_mouse_hook_nonblocking_source_test.cpp 同一写法。
+#undef NDEBUG
+
 #include "../attached_shield_status_policy.h"
 
 #include <cassert>


### PR DESCRIPTION
`Build Desktop and Apple Release Artifacts` 的 windows job 在 develop 上红着（[run 33322418792](https://github.com/hajisensai/Fushi/actions/runs/33322418792)），`Build Windows release` 步失败于 C2220（warning 当错误），底下是 10 条 C4189「局部变量初始化了但没被引用」。

## 变量不是多余的，它们是断言的操作数

```cpp
const size_t admission = publish.find("CurrentOverlayability()");
const size_t snapshot  = publish.find("UpdateLowLevelAttachedGlyphHitRegions(");
assert(admission != std::string::npos);
assert(admission < snapshot);
```

release 定义 `NDEBUG`，`assert` 被编译成空语句，于是「变量没人用」。

**C4189 是这件事唯一漏出来的痕迹**：这三个文件共 **78 条断言全是 `assert()`、零条其它形式**，在 release 构建里全部消失，测试空跑照样「通过」。真正的缺陷不是编译不过，而是这批守卫在发布构建里根本没执行过。

## 修法

本仓已有先例：`attached_mouse_hook_nonblocking_source_test.cpp` 第一行就是 `#undef NDEBUG`（在 `<cassert>` 之前）。PR#1093 新加的这三个文件漏了这一行，照先例补上。

**不采用**的两种「修法」：把变量改成 `(void)`、或删掉断言 —— 那才是真把测试掏空，而且会让 C4189 这条唯一的痕迹也一起消失。

## 实测

本地 `flutter build windows --release`：C4189 归零、无编译错误。构建最终停在本 worktree 缺 `fushi_torrent_ffi.dll` 的 INSTALL 步（每 worktree 需单独跑 `build_windows_dll.ps1`），与本改动无关，CI 上有该产物。
