### PR TITLE
fix(windows): repair hook and lookup overlay regressions

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -34,7 +34,7 @@
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
-| [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | ✅ | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |
+| [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | 🚧 | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |
 | [BUG-1981](bugs/BUG-1981-hook-overlay-dead-window-reopen.md) | ✅ | ✅ | Hook 浮窗 HWND 失效后自动与手动打开都无窗口 |
 | [BUG-1978](bugs/BUG-1978-hunex-toolbar-thread-merged.md) | ✅ | ✅ | HUNEX 顶部控制栏线程被并入剧情台词 |
 | [BUG-1977](bugs/BUG-1977-hunex-hfa-voice-resource-pairing.md) | 🚧 | ✅ | HUNEX HFA/HW 源语音未与台词配对 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1855 条。点号进各自文件。
+> 共 1858 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
+| [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | ✅ | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |
+| [BUG-1981](bugs/BUG-1981-hook-overlay-dead-window-reopen.md) | ✅ | ✅ | Hook 浮窗 HWND 失效后自动与手动打开都无窗口 |
 | [BUG-1978](bugs/BUG-1978-hunex-toolbar-thread-merged.md) | ✅ | ✅ | HUNEX 顶部控制栏线程被并入剧情台词 |
 | [BUG-1977](bugs/BUG-1977-hunex-hfa-voice-resource-pairing.md) | 🚧 | ✅ | HUNEX HFA/HW 源语音未与台词配对 |
 | [BUG-1976](bugs/BUG-1976-lookup-webview-text-blur.md) | ✅ | ✅ | Windows 查词 WebView 被超分通路无条件重采样导致字体发糊 |

--- a/docs/bugs/BUG-1981-hook-overlay-dead-window-reopen.md
+++ b/docs/bugs/BUG-1981-hook-overlay-dead-window-reopen.md
@@ -1,0 +1,6 @@
+## BUG-1981 · Hook 浮窗 HWND 失效后自动与手动打开都无窗口
+- **报告**：2026-08-31（用户：「游戏的hook浮窗打不开了，点击hook浮窗按钮也打不开」）
+- **真实性**：✅ 真 bug。`fushi/windows/runner/floating_lyric_window.cpp:398` 的 `Show()` 只判 `hwnd_ == nullptr`，没有像 `GlobalLookupWindow` 一样核对 `IsWindow + GWLP_USERDATA`；HWND 被 `WM_CLOSE`/外部 teardown 销毁后，成员仍非空，`ShowWindow`/`SetWindowPos` 对死句柄失败但函数无条件回 `true`。同时 `fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart:716` 只信上次 `show=true` 的 `_visible` 镜像，后续自动同步只发 `updateText`，手动入口也可能再次接受假成功，故屏幕始终没有窗口。
+- **[x] ① 已修复** — `ad52944d70`：Win32 侧新增 `OwnsLiveWindow()`（含 back-pointer 防 HWND 复用）、在 `WM_NCDESTROY` 生命周期边界清句柄/交互状态、`Show()` 先丢死句柄再重建并在 `SetWindowPos` 失败时回 `false`；Dart 每轮显示同步用 `isShowing()` 对账真实 HWND，失配即重走 `show`。
+- **[x] ② 已加自动化测试** — `fushi/test/lookup/gal_hook_overlay_window_lifetime_guard_test.dart` 钉死 Win32 所有权/销毁/失败应答不变量；`fushi/test/lookup/gal_hook_text_overlay_controller_test.dart` 模拟 Dart 仍记可见而 native HWND 已消失，断言下一行会再次调用 `show`。
+- **备注**：聚焦 Flutter 测试在执行任何 case 前被 `pdfium_dart` 下载 `pdfium-win-x64.tgz` 的 GitHub release-assets 超时阻塞；未做 Windows 构建、真实游戏/设备 E2E，不能把本条记为真机已验证。

--- a/docs/bugs/BUG-1982-global-lookup-stale-route-flash.md
+++ b/docs/bugs/BUG-1982-global-lookup-stale-route-flash.md
@@ -1,0 +1,6 @@
+## BUG-1982 · 全局查词旧尺寸消息冒充新查询导致首次闪跳
+- **报告**：2026-08-31（用户：「全局查词弹窗会先出现一下，然后再闪到对应位置」）
+- **真实性**：✅ 真 bug。`global_lookup_host.js` 的 `postToHost` 已在事件生成时写入不可变 `__source/__routeEpoch/__lookupEpoch`，但 `fushi/lib/src/lookup/overlay_window_channel.dart:331` 解包时反而优先采用 native envelope。`FlutterWindow::BindRouteContext` 会在新 `showAt` 到来时立刻改写同一 HWND 的当前路由；旧页面此前排队的 `overlaySize` 随后被 envelope 盖成新 epoch，绕过 `_acceptsRoute` 后提前 Reveal 旧几何，新页面的正确尺寸再到时二次移动，形成可见闪跳。
+- **[x] ① 已修复** — `ad52944d70`：反向 JS 消息优先采用事件发生时内嵌的完整路由三元组；只有三字段不完整的旧 host 才回退 mutable native envelope，且不允许两套时钟混字段。
+- **[x] ② 已加自动化测试** — `fushi/test/lookup/overlay_window_channel_test.dart` 构造“消息 epoch=2/3、native HWND 已改绑 epoch=9/10”的延迟 `overlaySize`，断言事件仍按 2/3 派发并会被当前路由门拒绝。
+- **备注**：聚焦 Flutter 测试在执行任何 case 前被 `pdfium_dart` 原生资产下载超时阻塞；未做 Windows WebView2 真实像素复测。

--- a/docs/bugs/BUG-1982-global-lookup-stale-route-flash.md
+++ b/docs/bugs/BUG-1982-global-lookup-stale-route-flash.md
@@ -1,6 +1,6 @@
 ## BUG-1982 · 全局查词旧尺寸消息冒充新查询导致首次闪跳
 - **报告**：2026-08-31（用户：「全局查词弹窗会先出现一下，然后再闪到对应位置」）
-- **真实性**：✅ 真 bug。`global_lookup_host.js` 的 `postToHost` 已在事件生成时写入不可变 `__source/__routeEpoch/__lookupEpoch`，但 `fushi/lib/src/lookup/overlay_window_channel.dart:331` 解包时反而优先采用 native envelope。`FlutterWindow::BindRouteContext` 会在新 `showAt` 到来时立刻改写同一 HWND 的当前路由；旧页面此前排队的 `overlaySize` 随后被 envelope 盖成新 epoch，绕过 `_acceptsRoute` 后提前 Reveal 旧几何，新页面的正确尺寸再到时二次移动，形成可见闪跳。
-- **[x] ① 已修复** — `ad52944d70`：反向 JS 消息优先采用事件发生时内嵌的完整路由三元组；只有三字段不完整的旧 host 才回退 mutable native envelope，且不允许两套时钟混字段。
-- **[x] ② 已加自动化测试** — `fushi/test/lookup/overlay_window_channel_test.dart` 构造“消息 epoch=2/3、native HWND 已改绑 epoch=9/10”的延迟 `overlaySize`，断言事件仍按 2/3 派发并会被当前路由门拒绝。
-- **备注**：聚焦 Flutter 测试在执行任何 case 前被 `pdfium_dart` 原生资产下载超时阻塞；未做 Windows WebView2 真实像素复测。
+- **真实性**：⚠️ 用户现象（弹窗先出现一下再闪到对应位置）尚未复现定性，**初版记录的根因经复核不成立**：`global_lookup_host.js:280` 的 `postToHost` 对每条消息都无条件 `stampRoute`（`:268`）写全 `__source/__routeEpoch/__lookupEpoch`，而 native `GlobalLookupWindow::RouteForMessage`（`global_lookup_window.cpp:951`）正是逐字段优先采用这三个内嵌值、只在缺字段时才回退 `route_context_`。也就是说 envelope 的 epoch **本来就等于**消息自带的 epoch，"envelope 盖成新 epoch"这条因果链不存在。真正的闪跳根因待定位（候选：Reveal 时序、shellRects/overlaySize 的 HRGN 应用顺序、DPI 换算），需要 Windows WebView2 真实像素复测。
+- **[ ] ① 未修复（已做一处加固）** — `ad52944d70`：Dart 侧改成「三字段齐全才整体采用内嵌三元组，否则整体回退 envelope」。这堵住的是 native `RouteForMessage` 逐字段回退**理论上**能拼出 old/new 混合三元组的口子；对 `postToHost` 产出的正常消息是等价变换，**不改变现网行为，不构成对用户所报闪跳的修复**。真正修复需先定位根因。
+- **[x] ② 已加自动化测试（覆盖的是上面那处加固，不是闪跳）** — `fushi/test/lookup/overlay_window_channel_test.dart` 构造“消息 epoch=2/3、native envelope epoch=9/10”的延迟 `overlaySize`，断言按内嵌的 2/3 派发。注意这个信封形状**生产路径产不出来**（见「真实性」），它钉的是"混字段不得发生"这条不变式。
+- **备注**：未做 Windows WebView2 真实像素复测，闪跳是否消失无证据。定位根因前不得把本条记为已修复。

--- a/docs/bugs/BUG-1983-gal-layout-whitespace-fold.md
+++ b/docs/bugs/BUG-1983-gal-layout-whitespace-fold.md
@@ -1,0 +1,6 @@
+## BUG-1983 · Gal 同句换行快照未原地折叠导致换行错乱
+- **报告**：2026-08-31（用户：「而且gal弹窗还有换行问题」；截图为 SiglusEngine 同一句台词的游戏内换行与 Hook 浮窗）
+- **真实性**：✅ 真 bug。Gal 引擎会对同一句先吐连续文本、再按文本框重绘带换行的快照；`fushi/lib/src/sync/texthooker_line_fold.dart:85` 的渐进折叠刻意拒绝归一化后等长文本，`fushi/lib/src/sync/texthooker_service.dart:828` 因而把“字符完全相同、只改空白/换行”的后到快照追加成另一句。浮窗跟随最新项时会丢稳定 lineId/出现重复或采用错误的当前排版，字数也可能重复累计。
+- **[x] ① 已修复** — `ad52944d70`：新增 `isWhitespaceOnlyLayoutRefresh`，仅在同一 Windows engineHook 端点/线程内把“去空白后完全相同、原文确有变化”的快照原地折叠；保留最早 lineId、采用后到原文和 ruby 坐标、字数增量为零。逐字相同的两次真实台词仍不折。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/texthooker_progressive_fold_test.dart` 覆盖纯换行刷新判据，并以截图同形的日文句验证只留一行、lineId 不变、后到换行被保留、学习字数不重复。
+- **备注**：聚焦 Flutter 测试在执行任何 case 前被 `pdfium_dart` 原生资产下载超时阻塞；未在原始 SiglusEngine 启动路径做真实 Hook/换行 E2E，能力状态只能算 implemented_unverified。

--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -720,6 +720,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
       _visible = false;
       notifyListeners();
     }
+    // 上面这个 await 是新开的挂起点：用户在它挂起期间点「关闭浮窗」会置位
+    // `_suppressedForSession` 并把窗口收掉，恢复执行时 `_visible` 恰好是 false，
+    // 于是下面这段会把用户刚关掉的浮窗又弹回来。挂起点之后必须重检一次。
+    if (_suppressedForSession) return;
     if (!_visible) {
       await GalHookTextOverlayChannel.updateText(
         lineId: latest.id,

--- a/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/fushi/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -713,6 +713,13 @@ class GalHookTextOverlayController extends ChangeNotifier {
     if (_suppressedForSession) return;
     if (lines.isEmpty) return;
     final TexthookerLineEntry latest = lines.last;
+    // BUG-1981：`_visible` 只是上一次 MethodChannel show 的应答镜像，不是 HWND
+    // 真值。窗口被系统/外部 WM_CLOSE 销毁后，session 仍会继续送文本；若只信镜像，
+    // 后续永远只发 updateText，工具栏的“显示 Hook 浮窗”也没有可见窗口可抬起。
+    if (_visible && !await GalHookTextOverlayChannel.isShowing()) {
+      _visible = false;
+      notifyListeners();
+    }
     if (!_visible) {
       await GalHookTextOverlayChannel.updateText(
         lineId: latest.id,

--- a/fushi/lib/src/lookup/overlay_window_channel.dart
+++ b/fushi/lib/src/lookup/overlay_window_channel.dart
@@ -335,18 +335,24 @@ class OverlayWindowChannel {
               // the native envelope reads a mutable HWND route later. Consume
               // the embedded identity only as one complete tuple so malformed
               // content cannot mix old/new fields across those two clocks.
+              //
+              // 这四个局部必须保持 `final` 且不得重新赋值：`hasEmbeddedRoute` 的
+              // true 分支靠 Dart 的布尔局部变量提升把三个 `Object?` 提升成
+              // String/num/num，所以下面读它们时不需要 cast（写了反而是
+              // `unnecessary_cast`，CI 的 analyze 直接判红）。改成 `var` 或中途
+              // 赋值会让提升失效，这三行立刻变编译错误——不会静默降级。
               final bool hasEmbeddedRoute =
                   embeddedSource is String &&
                   embeddedRoute is num &&
                   embeddedLookup is num;
               final String source = hasEmbeddedRoute
-                  ? embeddedSource as String
+                  ? embeddedSource
                   : (envelope?['source'] as String?) ?? 'desktop';
               final int route = hasEmbeddedRoute
-                  ? (embeddedRoute as num).toInt()
+                  ? embeddedRoute.toInt()
                   : (envelope?['routeEpoch'] as num?)?.toInt() ?? 0;
               final int lookup = hasEmbeddedRoute
-                  ? (embeddedLookup as num).toInt()
+                  ? embeddedLookup.toInt()
                   : (envelope?['lookupEpoch'] as num?)?.toInt() ?? 0;
               final event = OverlayReverseEvent(
                 route: source == 'galCard'

--- a/fushi/lib/src/lookup/overlay_window_channel.dart
+++ b/fushi/lib/src/lookup/overlay_window_channel.dart
@@ -328,18 +328,26 @@ class OverlayWindowChannel {
             final Object? decoded = jsonDecode(raw);
             if (decoded is Map) {
               final message = decoded.cast<String, Object?>();
-              final String source =
-                  (envelope?['source'] as String?) ??
-                  (message['__source'] as String?) ??
-                  'desktop';
-              final int route =
-                  (envelope?['routeEpoch'] as num?)?.toInt() ??
-                  (message['__routeEpoch'] as num?)?.toInt() ??
-                  0;
-              final int lookup =
-                  (envelope?['lookupEpoch'] as num?)?.toInt() ??
-                  (message['__lookupEpoch'] as num?)?.toInt() ??
-                  0;
+              final Object? embeddedSource = message['__source'];
+              final Object? embeddedRoute = message['__routeEpoch'];
+              final Object? embeddedLookup = message['__lookupEpoch'];
+              // BUG-1982：The JSON fields are stamped when the browser event is emitted;
+              // the native envelope reads a mutable HWND route later. Consume
+              // the embedded identity only as one complete tuple so malformed
+              // content cannot mix old/new fields across those two clocks.
+              final bool hasEmbeddedRoute =
+                  embeddedSource is String &&
+                  embeddedRoute is num &&
+                  embeddedLookup is num;
+              final String source = hasEmbeddedRoute
+                  ? embeddedSource as String
+                  : (envelope?['source'] as String?) ?? 'desktop';
+              final int route = hasEmbeddedRoute
+                  ? (embeddedRoute as num).toInt()
+                  : (envelope?['routeEpoch'] as num?)?.toInt() ?? 0;
+              final int lookup = hasEmbeddedRoute
+                  ? (embeddedLookup as num).toInt()
+                  : (envelope?['lookupEpoch'] as num?)?.toInt() ?? 0;
               final event = OverlayReverseEvent(
                 route: source == 'galCard'
                     ? GlobalLookupRoute.galCard(

--- a/fushi/lib/src/sync/texthooker_line_fold.dart
+++ b/fushi/lib/src/sync/texthooker_line_fold.dart
@@ -94,3 +94,14 @@ bool isProgressiveTextUpdate(String previous, String next) {
 
   return longer.startsWith(shorter) || longer.endsWith(shorter);
 }
+
+/// BUG-1983：是否为同一句的纯排版快照更新（只改变空白/换行，字符内容完全相同）。
+///
+/// Gal 引擎常先吐一条连续字符串，再按实际文本框重绘成带换行的同一句。它不是重复
+/// 台词：下游应保留同一个 lineId，并以**后到的原文**作为当前排版真值。完全相同的
+/// 两行仍返回 false，继续保留既有的“允许真实重复台词”语义。
+bool isWhitespaceOnlyLayoutRefresh(String previous, String next) {
+  if (previous == next) return false;
+  final String a = normalizeForFold(previous);
+  return a.isNotEmpty && a == normalizeForFold(next);
+}

--- a/fushi/lib/src/sync/texthooker_service.dart
+++ b/fushi/lib/src/sync/texthooker_service.dart
@@ -204,23 +204,21 @@ class TexthookerTextThread {
     int? observedArtifactCount,
     bool? previewIsArtifact,
     List<String>? recentPreviewTexts,
-  }) =>
-      TexthookerTextThread(
-        key: key,
-        label: label ?? this.label,
-        hookCode: hookCode,
-        nativeThreadId: nativeThreadId,
-        lineCount: lineCount,
-        latestAt: latestAt,
-        latestText: latestText,
-        audioLineCount: audioLineCount,
-        previewText: previewText ?? this.previewText,
-        observedLineCount: observedLineCount ?? this.observedLineCount,
-        observedArtifactCount:
-            observedArtifactCount ?? this.observedArtifactCount,
-        previewIsArtifact: previewIsArtifact ?? this.previewIsArtifact,
-        recentPreviewTexts: recentPreviewTexts ?? this.recentPreviewTexts,
-      );
+  }) => TexthookerTextThread(
+    key: key,
+    label: label ?? this.label,
+    hookCode: hookCode,
+    nativeThreadId: nativeThreadId,
+    lineCount: lineCount,
+    latestAt: latestAt,
+    latestText: latestText,
+    audioLineCount: audioLineCount,
+    previewText: previewText ?? this.previewText,
+    observedLineCount: observedLineCount ?? this.observedLineCount,
+    observedArtifactCount: observedArtifactCount ?? this.observedArtifactCount,
+    previewIsArtifact: previewIsArtifact ?? this.previewIsArtifact,
+    recentPreviewTexts: recentPreviewTexts ?? this.recentPreviewTexts,
+  );
 
   final String key;
   final String label;
@@ -363,15 +361,13 @@ class TexthookerLineEntry {
   /// 本行是否已有可用句音：matched（配到游戏资源）/ encoded（音频已提取进卡）/
   /// fallback（回退环回声）三态即有音频；pending/missing/unavailable 视作无。
   bool get hasAudio => switch (audioStatus) {
-        TexthookerLineAudioStatus.matched ||
-        TexthookerLineAudioStatus.encoded ||
-        TexthookerLineAudioStatus.fallback =>
-          true,
-        TexthookerLineAudioStatus.pending ||
-        TexthookerLineAudioStatus.missing ||
-        TexthookerLineAudioStatus.unavailable =>
-          false,
-      };
+    TexthookerLineAudioStatus.matched ||
+    TexthookerLineAudioStatus.encoded ||
+    TexthookerLineAudioStatus.fallback => true,
+    TexthookerLineAudioStatus.pending ||
+    TexthookerLineAudioStatus.missing ||
+    TexthookerLineAudioStatus.unavailable => false,
+  };
 
   TexthookerLineEntry copyWith({
     String? text,
@@ -404,11 +400,13 @@ class TexthookerLineEntry {
       receivedAt: receivedAt,
       audioStatus: audioStatus ?? this.audioStatus,
       audioBackend: audioBackend ?? this.audioBackend,
-      audioResourceId:
-          clearAudioResourceId ? null : audioResourceId ?? this.audioResourceId,
+      audioResourceId: clearAudioResourceId
+          ? null
+          : audioResourceId ?? this.audioResourceId,
       audioDurationMs: audioDurationMs ?? this.audioDurationMs,
-      fallbackReason:
-          clearFallbackReason ? null : fallbackReason ?? this.fallbackReason,
+      fallbackReason: clearFallbackReason
+          ? null
+          : fallbackReason ?? this.fallbackReason,
       mined: mined ?? this.mined,
       minedNoteId: clearMinedNoteId ? null : minedNoteId ?? this.minedNoteId,
       favorited: favorited ?? this.favorited,
@@ -436,8 +434,7 @@ class TexthookerService extends ChangeNotifier {
   ///
   /// [entries] 每次都要复制整张表；折叠判定是**每条 hook 行**都要做一次的热路径，
   /// 走这个 O(1) 的入口。
-  TexthookerLineEntry? get lastEntry =>
-      _entries.isEmpty ? null : _entries.last;
+  TexthookerLineEntry? get lastEntry => _entries.isEmpty ? null : _entries.last;
 
   /// 折叠「同一句台词的多次快照」（见 [isProgressiveTextUpdate]）。
   ///
@@ -493,11 +490,11 @@ class TexthookerService extends ChangeNotifier {
   List<TexthookerTextThread> textThreadsSince(DateTime? startedAt) {
     final Map<String, TexthookerTextThread> byKey =
         <String, TexthookerTextThread>{
-      for (final MapEntry<String, TexthookerTextThread> entry
-          in _discoveredTextThreads.entries)
-        if (startedAt == null || !entry.value.latestAt.isBefore(startedAt))
-          entry.key: entry.value,
-    };
+          for (final MapEntry<String, TexthookerTextThread> entry
+              in _discoveredTextThreads.entries)
+            if (startedAt == null || !entry.value.latestAt.isBefore(startedAt))
+              entry.key: entry.value,
+        };
     for (final TexthookerLineEntry entry in _entries) {
       if (startedAt != null && entry.receivedAt.isBefore(startedAt)) continue;
       final String? key = entry.textThreadKey;
@@ -601,9 +598,11 @@ class TexthookerService extends ChangeNotifier {
     }
     // 干净线程排在脏线程之前：伪影占比低者优先。脏线程仍然可见可选（对齐 Luna），
     // 只是不该挡在真台词前面。
-    final bool aDirty = a.observedArtifactCount * 2 > a.observedLineCount &&
+    final bool aDirty =
+        a.observedArtifactCount * 2 > a.observedLineCount &&
         a.observedLineCount > 0;
-    final bool bDirty = b.observedArtifactCount * 2 > b.observedLineCount &&
+    final bool bDirty =
+        b.observedArtifactCount * 2 > b.observedLineCount &&
         b.observedLineCount > 0;
     if (aDirty != bDirty) return aDirty ? 1 : -1;
     if (a.observedLineCount != b.observedLineCount) {
@@ -826,9 +825,18 @@ class TexthookerService extends ChangeNotifier {
             tail.textThreadKey != textThreadKey) {
           break;
         }
-        if (!isProgressiveTextUpdate(tail.text, mergedText)) break;
-        if (normalizeForFold(tail.text).length >
-            normalizeForFold(mergedText).length) {
+        final bool layoutRefresh = isWhitespaceOnlyLayoutRefresh(
+          tail.text,
+          mergedText,
+        );
+        if (!layoutRefresh && !isProgressiveTextUpdate(tail.text, mergedText)) {
+          break;
+        }
+        // 纯换行/空白刷新时，字符信息量相等但**后到快照**才是当前游戏排版；不要
+        // 因为长度相等又退回旧文本。真正的前/后缀折叠仍保留信息量更大的那份。
+        if (!layoutRefresh &&
+            normalizeForFold(tail.text).length >
+                normalizeForFold(mergedText).length) {
           mergedText = tail.text;
           mergedSpans = tail.rubySpans;
         }
@@ -858,13 +866,15 @@ class TexthookerService extends ChangeNotifier {
       // 制卡 / 收藏位取并集：被吞的那几条里只要有一条已制卡（或已收藏），合并
       // 结果就该带着那个徽章 —— 只从 base 继承的话，用户刚给第 ② 拍制的卡会在
       // 第 ③ 拍折叠后从工作台上「消失」。
-      final bool anyMined =
-          absorbed.any((TexthookerLineEntry e) => e.mined);
-      final bool anyFavorited =
-          absorbed.any((TexthookerLineEntry e) => e.favorited);
+      final bool anyMined = absorbed.any((TexthookerLineEntry e) => e.mined);
+      final bool anyFavorited = absorbed.any(
+        (TexthookerLineEntry e) => e.favorited,
+      );
       final int? mergedNoteId = absorbed
-          .firstWhere((TexthookerLineEntry e) => e.minedNoteId != null,
-              orElse: () => base)
+          .firstWhere(
+            (TexthookerLineEntry e) => e.minedNoteId != null,
+            orElse: () => base,
+          )
           .minedNoteId;
       final TexthookerLineEntry merged = base.copyWith(
         text: mergedText,
@@ -1041,13 +1051,14 @@ class TexthookerService extends ChangeNotifier {
 /// 实时台词筛选的唯一 predicate：枚举驱动、无特殊分支。页面/服务共用，
 /// 保证「有音频 / 已制卡 / 已收藏」的判据单一真相源。
 bool lineMatchesFilter(
-        TexthookerLineEntry entry, TexthookerLineFilter filter) =>
-    switch (filter) {
-      TexthookerLineFilter.all => true,
-      TexthookerLineFilter.withAudio => entry.hasAudio,
-      TexthookerLineFilter.mined => entry.mined,
-      TexthookerLineFilter.favorited => entry.favorited,
-    };
+  TexthookerLineEntry entry,
+  TexthookerLineFilter filter,
+) => switch (filter) {
+  TexthookerLineFilter.all => true,
+  TexthookerLineFilter.withAudio => entry.hasAudio,
+  TexthookerLineFilter.mined => entry.mined,
+  TexthookerLineFilter.favorited => entry.favorited,
+};
 
 /// 「全部文本线程」的展示投影：折叠同一渲染瞬间被不同 Luna 线程各回传一次的同文行。
 ///
@@ -1070,8 +1081,8 @@ List<TexthookerLineEntry> collapseParallelTextThreadDuplicates(
     final int? currentHookAt = entry.hookTimestampMs;
     final String? previousThread = previous.textThreadKey;
     final String? currentThread = entry.textThreadKey;
-    final bool parallelDuplicate = previous.source ==
-            TexthookerLineSource.engineHook &&
+    final bool parallelDuplicate =
+        previous.source == TexthookerLineSource.engineHook &&
         entry.source == TexthookerLineSource.engineHook &&
         previousThread != null &&
         currentThread != null &&

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.2.4+1237
+version: 2.2.4+1238
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/lookup/gal_hook_overlay_window_lifetime_guard_test.dart
+++ b/fushi/test/lookup/gal_hook_overlay_window_lifetime_guard_test.dart
@@ -2,40 +2,203 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+/// BUG-1981：Hook 台词浮窗的 HWND 被外部 WM_CLOSE / teardown 销毁后，旧
+/// `FloatingLyricWindow` 对象仍跨 gal 会话复用。契约与姊妹窗
+/// `global_lookup_dead_window_recreate_guard_test.dart` 完全对齐：
+///
+/// 1. `OwnsLiveWindow()`：IsWindow + WM_NCCREATE back-pointer 双判据（HWND 会被
+///    系统回收给别的窗口，只判 IsWindow 会把别人的窗口认成自己的）。
+/// 2. `ResetWindowInteractionState()`：窗口没了以后要归零的**全部**每窗口交互
+///    状态，只此一份。
+/// 3. `ForgetDeadWindow()`：句柄非我方活窗时清 `hwnd_` + 走上面那张表。
+/// 4. `Show()` 在创建/幂等守卫前先 `ForgetDeadWindow()`。
+/// 5. `IsShowing()` 用 `OwnsLiveWindow()` 而不是裸 `hwnd_ != nullptr`。
+///
+/// 浮窗真弹出依赖 native Direct2D + 桌面合成，headless 测不了，故用源码扫描钉住。
 void main() {
-  test('BUG-1981 Hook 浮窗在 HWND 生命周期结束后清句柄并可重建', () {
-    final String source = File(
-      'windows/runner/floating_lyric_window.cpp',
-    ).readAsStringSync().replaceAll(RegExp(r'\s+'), '');
-    final String header = File(
+  /// 注释必须先剥掉再扫：本文件钉的判据（尤其第 5 条的**否定**断言）在注释里
+  /// 也会以自然语言形式出现，不剥就会被注释那份先命中，断言退化成恒真空转。
+  String maskComments(String src) {
+    final StringBuffer out = StringBuffer();
+    bool inLine = false;
+    bool inBlock = false;
+    bool inString = false;
+    for (int i = 0; i < src.length; i++) {
+      final String c = src[i];
+      final String next = i + 1 < src.length ? src[i + 1] : '';
+      if (inLine) {
+        if (c == '\n') {
+          inLine = false;
+          out.write(c);
+        }
+        continue;
+      }
+      if (inBlock) {
+        if (c == '*' && next == '/') {
+          inBlock = false;
+          i++;
+        }
+        continue;
+      }
+      if (inString) {
+        if (c == r'\') {
+          i++;
+          continue;
+        }
+        if (c == '"') inString = false;
+        out.write(c);
+        continue;
+      }
+      if (c == '/' && next == '/') {
+        inLine = true;
+        continue;
+      }
+      if (c == '/' && next == '*') {
+        inBlock = true;
+        i++;
+        continue;
+      }
+      if (c == '"') inString = true;
+      out.write(c);
+    }
+    return out.toString();
+  }
+
+  /// 取顶层函数体（到第一个位于行首的 `}` 为止），再压掉空白。
+  String functionBody(String src, String signature) {
+    final int start = src.indexOf(signature);
+    expect(start, greaterThanOrEqualTo(0), reason: '找不到 $signature（改名了？）');
+    final int end = src.indexOf('\n}', start);
+    expect(end, greaterThan(start), reason: '$signature 的函数体没有正常闭合');
+    return src.substring(start, end).replaceAll(RegExp(r'\s+'), '');
+  }
+
+  late String cpp;
+  late String compact;
+  late String header;
+
+  setUpAll(() {
+    cpp = maskComments(
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync(),
+    );
+    compact = cpp.replaceAll(RegExp(r'\s+'), '');
+    header = File(
       'windows/runner/floating_lyric_window.h',
     ).readAsStringSync().replaceAll(RegExp(r'\s+'), '');
+  });
 
-    expect(header, contains('boolOwnsLiveWindow()const;'));
+  test(
+    '头文件声明 OwnsLiveWindow / ResetWindowInteractionState / ForgetDeadWindow',
+    () {
+      expect(header, contains('boolOwnsLiveWindow()const;'));
+      expect(header, contains('voidResetWindowInteractionState();'));
+      expect(header, contains('voidForgetDeadWindow();'));
+    },
+  );
+
+  test('OwnsLiveWindow 核对实例 back-pointer，不只判 IsWindow', () {
+    final String body = functionBody(
+      cpp,
+      'bool FloatingLyricWindow::OwnsLiveWindow() const {',
+    );
+    expect(body, contains('IsWindow(hwnd_)'));
     expect(
-      source,
+      body,
       contains('GetWindowLongPtr(hwnd_,GWLP_USERDATA))==this;'),
       reason: 'IsWindow 单独不足以排除 HWND 被系统复用，必须核对实例 back-pointer',
     );
-    expect(
-      source,
-      contains('if(hwnd_!=nullptr&&!OwnsLiveWindow()){hwnd_=nullptr;'),
-      reason: 'Show 必须先丢弃死/被复用句柄，随后走 CreateWindowExW 重建',
+  });
+
+  test('死窗复位表是唯一一份，且覆盖全部每窗口交互状态', () {
+    final String body = functionBody(
+      cpp,
+      'void FloatingLyricWindow::ResetWindowInteractionState() {',
+    );
+    // 前四项是 BUG-1981 初版在两条死窗路径上双双漏掉的。`tracking_mouse_leave_`
+    // 卡 true 会让 WM_MOUSEMOVE 的 `if (!tracking_mouse_leave_)` 恒假 → 新 HWND
+    // 上永不再调 TrackMouseEvent → 永不收 WM_MOUSELEAVE → hovered_ 也清不掉，
+    // 悬停查词与工具条自动隐藏本会话整个作废。
+    for (final String reset in <String>[
+      'hovered_=false;',
+      'tracking_mouse_leave_=false;',
+      'toolbar_revealed_=false;',
+      'ResetHoverLookupAnchor();',
+      'visible_=false;',
+      'CancelPointerGesture();',
+      'StopHoverLookupPolling();',
+      'StopToolbarRevealPolling();',
+      'slot_tooltip_.Hide();',
+      'pass_through_toolbar_.Hide();',
+    ]) {
+      expect(body, contains(reset), reason: '死窗复位表漏了 $reset');
+    }
+  });
+
+  test('ForgetDeadWindow 只在句柄非我方活窗时清零，活窗时是 no-op', () {
+    final String body = functionBody(
+      cpp,
+      'void FloatingLyricWindow::ForgetDeadWindow() {',
     );
     expect(
-      source,
-      contains('if(!SetWindowPos(hwnd_,topmost_?HWND_TOPMOST:HWND_NOTOPMOST'),
-      reason: '抬窗失败必须回 false，不能让 Dart 把无窗口记成已显示',
+      body,
+      contains('if(OwnsLiveWindow()){return;}'),
+      reason: '活窗必须原样返回，否则 Show() 开头无条件调用会把好窗口拆了',
+    );
+    expect(body, contains('hwnd_=nullptr;'));
+    expect(
+      body,
+      contains('ResetWindowInteractionState();'),
+      reason: '不得再就地手写第二份复位表（BUG-1981 初版就是这么漏项的）',
+    );
+  });
+
+  test('Show 在重建前先 ForgetDeadWindow', () {
+    final String body = functionBody(cpp, 'bool FloatingLyricWindow::Show(');
+    final int forget = body.indexOf('ForgetDeadWindow();');
+    final int create = body.indexOf('if(hwnd_==nullptr)');
+    expect(forget, greaterThanOrEqualTo(0), reason: '死掉的窗口必须被重建');
+    expect(
+      create,
+      greaterThan(forget),
+      reason: 'ForgetDeadWindow 必须在「已有窗口就复用」的守卫之前',
+    );
+  });
+
+  test('IsShowing 用 OwnsLiveWindow 而非裸 hwnd_ != nullptr', () {
+    final String body = functionBody(
+      cpp,
+      'bool FloatingLyricWindow::IsShowing() const {',
     );
     expect(
-      source,
+      body,
+      contains('OwnsLiveWindow()'),
+      reason: '否则悬垂/回收句柄让 IsShowing 报 true，Dart 镜像永不复位',
+    );
+    expect(
+      body.contains('hwnd_!=nullptr&&IsWindowVisible'),
+      isFalse,
+      reason: '不得退回裸 hwnd_ != nullptr 判据（BUG 回归 signature）',
+    );
+  });
+
+  test('WM_NCDESTROY 走同一张复位表并撤回 back-pointer', () {
+    expect(
+      compact,
       contains('caseWM_NCDESTROY:'),
       reason: '窗口生命周期结束点必须同步清 Dart 复用对象持有的原生句柄',
     );
+    expect(compact, contains('ResetWindowInteractionState();'));
     expect(
-      source,
+      compact,
       contains('SetWindowLongPtr(destroyed,GWLP_USERDATA,0);hwnd_=nullptr;'),
       reason: 'WM_NCDESTROY 必须同时撤回 back-pointer 与成员句柄',
+    );
+  });
+
+  test('抬窗失败回 false，不让 Dart 把无窗口记成已显示', () {
+    expect(
+      compact,
+      contains('if(!SetWindowPos(hwnd_,topmost_?HWND_TOPMOST:HWND_NOTOPMOST'),
     );
   });
 }

--- a/fushi/test/lookup/gal_hook_overlay_window_lifetime_guard_test.dart
+++ b/fushi/test/lookup/gal_hook_overlay_window_lifetime_guard_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('BUG-1981 Hook 浮窗在 HWND 生命周期结束后清句柄并可重建', () {
+    final String source = File(
+      'windows/runner/floating_lyric_window.cpp',
+    ).readAsStringSync().replaceAll(RegExp(r'\s+'), '');
+    final String header = File(
+      'windows/runner/floating_lyric_window.h',
+    ).readAsStringSync().replaceAll(RegExp(r'\s+'), '');
+
+    expect(header, contains('boolOwnsLiveWindow()const;'));
+    expect(
+      source,
+      contains('GetWindowLongPtr(hwnd_,GWLP_USERDATA))==this;'),
+      reason: 'IsWindow 单独不足以排除 HWND 被系统复用，必须核对实例 back-pointer',
+    );
+    expect(
+      source,
+      contains('if(hwnd_!=nullptr&&!OwnsLiveWindow()){hwnd_=nullptr;'),
+      reason: 'Show 必须先丢弃死/被复用句柄，随后走 CreateWindowExW 重建',
+    );
+    expect(
+      source,
+      contains('if(!SetWindowPos(hwnd_,topmost_?HWND_TOPMOST:HWND_NOTOPMOST'),
+      reason: '抬窗失败必须回 false，不能让 Dart 把无窗口记成已显示',
+    );
+    expect(
+      source,
+      contains('caseWM_NCDESTROY:'),
+      reason: '窗口生命周期结束点必须同步清 Dart 复用对象持有的原生句柄',
+    );
+    expect(
+      source,
+      contains('SetWindowLongPtr(destroyed,GWLP_USERDATA,0);hwnd_=nullptr;'),
+      reason: 'WM_NCDESTROY 必须同时撤回 back-pointer 与成员句柄',
+    );
+  });
+}

--- a/fushi/test/lookup/gal_hook_text_overlay_controller_test.dart
+++ b/fushi/test/lookup/gal_hook_text_overlay_controller_test.dart
@@ -61,14 +61,21 @@ void main() {
   late GalHookSessionController session;
   late GalHookTextOverlayController controller;
   late Map<String, Object?> preferences;
+  late bool nativeShowing;
 
   setUp(() {
     nativeCalls = <MethodCall>[];
     preferences = <String, Object?>{};
+    nativeShowing = false;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall call) async {
           nativeCalls.add(call);
-          if (call.method == 'show' || call.method == 'isShowing') return true;
+          if (call.method == 'show') {
+            nativeShowing = true;
+            return true;
+          }
+          if (call.method == 'hide') nativeShowing = false;
+          if (call.method == 'isShowing') return nativeShowing;
           return null;
         });
     GalHookTextOverlayChannel.platformOverride = true;
@@ -198,6 +205,31 @@ void main() {
       expect(controller.isSuppressedForSession, isFalse);
     },
   );
+
+  test('native HWND 消失后自动重建，手动按钮不再只信 Dart 可见镜像', () async {
+    await controller.start(appModel: AppModel(testPlatformServices()));
+    await startSession();
+    final TexthookerLineEntry first = textService.appendLine(
+      '最初の台詞',
+      source: TexthookerLineSource.websocket,
+    )!;
+    await _waitUntil(() => controller.displayedLineId == first.id);
+    final int initialShows = nativeCalls
+        .where((MethodCall call) => call.method == 'show')
+        .length;
+
+    // 模拟 HWND 被系统销毁：Dart 仍保留上一次 show=true 的镜像。
+    nativeShowing = false;
+    textService.appendLine('次の台詞', source: TexthookerLineSource.websocket);
+
+    await _waitUntil(
+      () =>
+          nativeCalls.where((MethodCall call) => call.method == 'show').length >
+          initialShows,
+    );
+    expect(nativeShowing, isTrue);
+    expect(controller.isVisible, isTrue);
+  });
 
   test('selected text thread alone drives the floating line', () async {
     await controller.start(appModel: AppModel(testPlatformServices()));

--- a/fushi/test/lookup/overlay_window_channel_test.dart
+++ b/fushi/test/lookup/overlay_window_channel_test.dart
@@ -189,4 +189,38 @@ void main() {
     );
     expect(r.monitorDpr, 0);
   });
+
+  test('JS 自带的查询路由优先于 native 窗口当前路由', () async {
+    const StandardMethodCodec codec = StandardMethodCodec();
+    const OverlayWindowChannel panel = OverlayWindowChannel(kSecondChannel);
+    OverlayReverseEvent? received;
+    panel.setHandlers(
+      onGetMedia: (_) async => Uint8List(0),
+      onJsMessage: (_) {},
+      onRoutedJsMessage: (OverlayReverseEvent event) => received = event,
+    );
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          kSecondChannel.name,
+          codec.encodeMethodCall(
+            const MethodCall('jsMessage', <String, Object?>{
+              'payload':
+                  '{"handler":"overlaySize","__source":"desktop",'
+                  '"__routeEpoch":2,"__lookupEpoch":3}',
+              // ShowAt 已把 native HWND 改绑到新查询，但这条消息是在改绑前
+              // 由旧页面排队的；消息内 epoch 才是事件发生时的不可变身份。
+              'source': 'desktop',
+              'routeEpoch': 9,
+              'lookupEpoch': 10,
+            }),
+          ),
+          (_) {},
+        );
+
+    expect(
+      received?.route,
+      const GlobalLookupRoute.desktop(routeEpoch: 2, lookupEpoch: 3),
+    );
+  });
 }

--- a/fushi/test/sync/texthooker_progressive_fold_test.dart
+++ b/fushi/test/sync/texthooker_progressive_fold_test.dart
@@ -16,10 +16,7 @@ const String kZatoFullLine =
 void main() {
   group('折叠判据', () {
     test('前缀增长（同一句越写越长）算同一句', () {
-      expect(
-        isProgressiveTextUpdate(kZatoFirst, kZatoFullLine),
-        isTrue,
-      );
+      expect(isProgressiveTextUpdate(kZatoFirst, kZatoFullLine), isTrue);
     });
 
     test('后缀增长（引擎补画整行，旧文本落在末尾）算同一句', () {
@@ -32,10 +29,7 @@ void main() {
     });
 
     test('两句无关的台词不折', () {
-      expect(
-        isProgressiveTextUpdate('おはようございます。', 'いってきます。'),
-        isFalse,
-      );
+      expect(isProgressiveTextUpdate('おはようございます。', 'いってきます。'), isFalse);
     });
 
     test('完全相同的两行不折（游戏确实会连着输出两遍同样的「……」）', () {
@@ -47,20 +41,16 @@ void main() {
     });
 
     test('中缀不算（只认前缀 / 后缀）', () {
-      expect(
-        isProgressiveTextUpdate('abcdefg', 'xxxxabcdefgxxxx'),
-        isFalse,
-      );
+      expect(isProgressiveTextUpdate('abcdefg', 'xxxxabcdefgxxxx'), isFalse);
     });
 
     test('比较前去空白：引擎在段间插的换行不该让同一句判成两句', () {
-      expect(
-        isProgressiveTextUpdate(
-          'あのね、',
-          'あのね、\n  きょうはいいてんきですね',
-        ),
-        isTrue,
-      );
+      expect(isProgressiveTextUpdate('あのね、', 'あのね、\n  きょうはいいてんきですね'), isTrue);
+    });
+
+    test('字符相同但换行变化是排版刷新，完全相同文本仍不是', () {
+      expect(isWhitespaceOnlyLayoutRefresh('前半後半', '前半\n後半'), isTrue);
+      expect(isWhitespaceOnlyLayoutRefresh('前半後半', '前半後半'), isFalse);
     });
   });
 
@@ -93,33 +83,39 @@ void main() {
       // 浏览器扩展），那条通道 5 平台都跑；而逃生开关在 Windows-only 的 game
       // 设置页里。收窄成 engineHook 之后，这个来源门同时就是平台门。
       TexthookerLineEntry? ws(String text, {int? seq}) => service.appendLine(
-            text,
-            source: TexthookerLineSource.websocket,
-            sourceLabel: 'ws://127.0.0.1:6677',
-            sourceSequence: seq,
-          );
+        text,
+        source: TexthookerLineSource.websocket,
+        sourceLabel: 'ws://127.0.0.1:6677',
+        sourceSequence: seq,
+      );
       ws(kZatoFirst, seq: 1);
       ws(kZatoFullLine, seq: 2);
-      expect(service.entries.length, 2,
-          reason: 'WS 送来的是外部工具已经成句的输出，前缀关系不代表同一句');
+      expect(
+        service.entries.length,
+        2,
+        reason: 'WS 送来的是外部工具已经成句的输出，前缀关系不代表同一句',
+      );
     });
 
     test('同为 WS 的两个端点不得互折（守卫必须认 sourceLabel）', () {
       // WS 路径下 textThreadKey 恒 null、source 恒 websocket，能区分 Textractor /
       // mpv / 浏览器扩展的**只有** sourceLabel。这里借 engineHook 源验判据本身
       // （WS 源已被上面那条门挡住，测不到这层）。
-      service.appendLine(kZatoFirst,
-          source: TexthookerLineSource.engineHook,
-          sourceLabel: 'engine_hook_a',
-          sourceSequence: 1,
-          textThreadKey: 'thread-a');
-      service.appendLine(kZatoFullLine,
-          source: TexthookerLineSource.engineHook,
-          sourceLabel: 'engine_hook_b',
-          sourceSequence: 2,
-          textThreadKey: 'thread-a');
-      expect(service.entries.length, 2,
-          reason: '不同端点的输出折成一条就是丢行');
+      service.appendLine(
+        kZatoFirst,
+        source: TexthookerLineSource.engineHook,
+        sourceLabel: 'engine_hook_a',
+        sourceSequence: 1,
+        textThreadKey: 'thread-a',
+      );
+      service.appendLine(
+        kZatoFullLine,
+        source: TexthookerLineSource.engineHook,
+        sourceLabel: 'engine_hook_b',
+        sourceSequence: 2,
+        textThreadKey: 'thread-a',
+      );
+      expect(service.entries.length, 2, reason: '不同端点的输出折成一条就是丢行');
     });
 
     test('折叠增量保留内部空白：拉丁文按词计数不能被焊成一个词', () {
@@ -127,12 +123,19 @@ void main() {
       append(kZatoSecondSegment, seq: 2);
       final String delta = service.lastAppendedDelta;
       expect(delta, isNotEmpty);
-      expect(delta.contains(' '), isTrue,
-          reason: '在 normalizeForFold 的去空白坐标系里切增量，会把 '
-              '"a lovely way to put it" 焊成一个词 —— countGalgameChars 对拉丁'
-              '文本按词计数，空白是唯一的词边界，整段英文台词会被算成 1。');
-      expect(delta, kZatoSecondSegment,
-          reason: '第 ② 拍整段都是新字，增量应当就是它本身（两端 trim）');
+      expect(
+        delta.contains(' '),
+        isTrue,
+        reason:
+            '在 normalizeForFold 的去空白坐标系里切增量，会把 '
+            '"a lovely way to put it" 焊成一个词 —— countGalgameChars 对拉丁'
+            '文本按词计数，空白是唯一的词边界，整段英文台词会被算成 1。',
+      );
+      expect(
+        delta,
+        kZatoSecondSegment,
+        reason: '第 ② 拍整段都是新字，增量应当就是它本身（两端 trim）',
+      );
     });
 
     test('折叠吞掉的行 id 必须被报出来（下游那批 map/timer 还拿它当活键）', () {
@@ -144,11 +147,18 @@ void main() {
       expect(merged, isNotNull);
       // 合并结果复用**最早**那条的 id，所以它不算「被吞」；第 ② 拍那条才是。
       expect(merged!.id, first!.id);
-      expect(service.lastFoldedLineIds, contains(second!.id),
-          reason: '不报出来的话，晚到的语音会写进死 id 被静默丢弃，'
-              '用户的手动裁决也随之失效');
-      expect(service.lastFoldedLineIds, isNot(contains(merged.id)),
-          reason: '合并结果自己的 id 还活着，重定向链不该形成');
+      expect(
+        service.lastFoldedLineIds,
+        contains(second!.id),
+        reason:
+            '不报出来的话，晚到的语音会写进死 id 被静默丢弃，'
+            '用户的手动裁决也随之失效',
+      );
+      expect(
+        service.lastFoldedLineIds,
+        isNot(contains(merged.id)),
+        reason: '合并结果自己的 id 还活着，重定向链不该形成',
+      );
     });
 
     test('制卡 / 收藏位取并集，徽章不会因折叠消失', () {
@@ -157,8 +167,7 @@ void main() {
       expect(second0, isNotNull);
       service.markLineMined(second!.id, noteId: 42);
       final TexthookerLineEntry? merged = append(kZatoFullLine, seq: 3);
-      expect(merged!.mined, isTrue,
-          reason: '用户刚给第 ② 拍制的卡不该在第 ③ 拍折叠后从工作台上消失');
+      expect(merged!.mined, isTrue, reason: '用户刚给第 ② 拍制的卡不该在第 ③ 拍折叠后从工作台上消失');
       expect(merged.minedNoteId, 42);
     });
 
@@ -167,10 +176,24 @@ void main() {
       append(kZatoSecondSegment, seq: 2);
       append(kZatoFullLine, seq: 3);
 
-      expect(service.entries.length, 1,
-          reason: '① 是 ③ 的前缀、② 是 ③ 的后缀，尾巴要一次性回吞干净；'
-              '只折紧邻上一条的话 ① 会留下，第一句照样出现两次。');
+      expect(
+        service.entries.length,
+        1,
+        reason:
+            '① 是 ③ 的前缀、② 是 ③ 的后缀，尾巴要一次性回吞干净；'
+            '只折紧邻上一条的话 ① 会留下，第一句照样出现两次。',
+      );
       expect(service.entries.single.text, kZatoFullLine);
+    });
+
+    test('同句仅更新换行时原地采用最新排版，不新增重复行', () {
+      final TexthookerLineEntry? first = append('大丈夫、話してみた感じ、後半', seq: 1);
+      final TexthookerLineEntry? refreshed = append('大丈夫、話してみた感じ、\n後半', seq: 2);
+
+      expect(service.entries, hasLength(1));
+      expect(refreshed!.id, first!.id, reason: '排版刷新不能换掉制卡/查词使用的行身份');
+      expect(service.entries.single.text, '大丈夫、話してみた感じ、\n後半');
+      expect(service.lastAppendedDelta, isEmpty, reason: '仅换行不应重复计入学习字数');
     });
 
     test('折叠后 lineId 保持最早那条（浮窗/游戏内卡片的身份不跳）', () {
@@ -194,12 +217,18 @@ void main() {
       expect(service.lastAppendedDelta, kZatoFirst);
 
       append(kZatoSecondSegment, seq: 2);
-      expect(service.lastAppendedDelta, kZatoSecondSegment,
-          reason: '② 与 ① 无前后缀关系，是货真价实的新字。');
+      expect(
+        service.lastAppendedDelta,
+        kZatoSecondSegment,
+        reason: '② 与 ① 无前后缀关系，是货真价实的新字。',
+      );
 
       append(kZatoFullLine, seq: 3);
-      expect(service.lastAppendedDelta, isEmpty,
-          reason: '③ = ① + ②，两头都已被计过，这一拍一个新字都没有。');
+      expect(
+        service.lastAppendedDelta,
+        isEmpty,
+        reason: '③ = ① + ②，两头都已被计过，这一拍一个新字都没有。',
+      );
     });
 
     test('纯前缀累积：只计新长出来的那一段', () {
@@ -251,8 +280,10 @@ void main() {
       append('Nothing in common with the previous line.', seq: 3);
 
       expect(service.entries.length, 2);
-      expect(service.entries.last.text,
-          'Nothing in common with the previous line.');
+      expect(
+        service.entries.last.text,
+        'Nothing in common with the previous line.',
+      );
     });
   });
 }

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -203,6 +203,39 @@ bool FloatingLyricWindow::OwnsLiveWindow() const {
              GetWindowLongPtr(hwnd_, GWLP_USERDATA)) == this;
 }
 
+// 窗口没了以后必须归零的**全部**每窗口交互状态。只此一份。
+//
+// BUG-1981 初版在 Show() 的死句柄分支和 WM_NCDESTROY 里各写了一份复位表，两份
+// 还互不相等，都漏了 `tracking_mouse_leave_`：它卡在 true 之后，WM_MOUSEMOVE 里
+// 的 `if (!tracking_mouse_leave_)` 恒假 → 新 HWND 上永远不再调 TrackMouseEvent
+// → 永远收不到 WM_MOUSELEAVE → `hovered_` 也清不掉，悬停效果和工具条自动隐藏
+// 本会话整个作废。逐路径补复位早晚会再漏一项，所以收成这一个原语。
+//
+// 与 Hide() 的状态复位半段逐项一致；Hide() 另有窗口操作（ApplyPassThroughExStyle /
+// ShowWindow）和「窗口还活着，只是藏起来」的语义，故不并入这里。
+void FloatingLyricWindow::ResetWindowInteractionState() {
+  visible_ = false;
+  hovered_ = false;
+  tracking_mouse_leave_ = false;
+  toolbar_revealed_ = false;
+  pass_through_toolbar_.Hide();
+  slot_tooltip_.Hide();
+  CancelPointerGesture();
+  StopHoverLookupPolling();
+  StopToolbarRevealPolling();
+  ResetHoverLookupAnchor();
+}
+
+// 句柄已不是我方活窗（外部 WM_CLOSE、teardown，或被系统回收）时把它彻底忘掉，
+// 让下一次 Show() 从零重建。活窗时是 no-op，可以无条件在 Show() 开头调。
+void FloatingLyricWindow::ForgetDeadWindow() {
+  if (OwnsLiveWindow()) {
+    return;
+  }
+  hwnd_ = nullptr;
+  ResetWindowInteractionState();
+}
+
 bool FloatingLyricWindow::EnsureDeviceResources() {
   if (d2d_factory_ == nullptr) {
     HRESULT hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
@@ -404,12 +437,7 @@ bool FloatingLyricWindow::Show(HWND owner) {
   // BUG-1981：WM_CLOSE/外部 teardown 会销毁 HWND，但旧对象仍跨 gal 会话复用。
   // 对失效（或已被系统复用）的句柄调用 ShowWindow/SetWindowPos 都不会抛，旧实现却
   // 无条件返回 true，Dart 因而永久把一个不存在的窗口记成“已显示”。
-  if (hwnd_ != nullptr && !OwnsLiveWindow()) {
-    hwnd_ = nullptr;
-    visible_ = false;
-    pass_through_toolbar_.Hide();
-    slot_tooltip_.Hide();
-  }
+  ForgetDeadWindow();
 
   if (hwnd_ == nullptr) {
     // Initial position: bottom-centre of the active monitor, like a desktop
@@ -521,7 +549,10 @@ void FloatingLyricWindow::Hide() {
 }
 
 bool FloatingLyricWindow::IsShowing() const {
-  return visible_ && hwnd_ != nullptr && IsWindowVisible(hwnd_);
+  // 裸 `hwnd_ != nullptr` 是 BUG 回归 signature：HWND 会被系统回收给别的窗口，
+  // 那时 IsWindowVisible(回收句柄) 照样返 true，Dart 侧镜像便永远不复位、
+  // 自动重开和工具栏按钮双双失灵（BUG-1981）。身份判据只能是 OwnsLiveWindow()。
+  return visible_ && OwnsLiveWindow() && IsWindowVisible(hwnd_);
 }
 
 void FloatingLyricWindow::UpdateText(const std::wstring& text,
@@ -1159,12 +1190,10 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // Clear ownership at the actual HWND lifetime boundary. Show() can then
       // rebuild the body on the next automatic line or manual-open request.
       HWND destroyed = hwnd_;
-      visible_ = false;
-      pass_through_toolbar_.Hide();
-      slot_tooltip_.Hide();
-      CancelPointerGesture();
-      StopHoverLookupPolling();
-      StopToolbarRevealPolling();
+      // 走与 Show() 死句柄分支同一张复位表。这里不能用 ForgetDeadWindow()：
+      // WM_NCDESTROY 期间窗口尚未真正消失，OwnsLiveWindow() 仍为真，会被它的
+      // 幂等守卫挡掉。
+      ResetWindowInteractionState();
       SetWindowLongPtr(destroyed, GWLP_USERDATA, 0);
       hwnd_ = nullptr;
       return DefWindowProc(destroyed, message, wparam, lparam);

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -193,6 +193,16 @@ void FloatingLyricWindow::EnsureWindowClass() {
   class_registered_ = true;
 }
 
+bool FloatingLyricWindow::OwnsLiveWindow() const {
+  if (hwnd_ == nullptr || !IsWindow(hwnd_)) {
+    return false;
+  }
+  // IsWindow alone is insufficient because HWND values are recycled. The
+  // WM_NCCREATE back-pointer proves that this handle still names our body.
+  return reinterpret_cast<FloatingLyricWindow*>(
+             GetWindowLongPtr(hwnd_, GWLP_USERDATA)) == this;
+}
+
 bool FloatingLyricWindow::EnsureDeviceResources() {
   if (d2d_factory_ == nullptr) {
     HRESULT hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
@@ -391,6 +401,16 @@ bool FloatingLyricWindow::Show(HWND owner) {
     return false;
   }
 
+  // BUG-1981：WM_CLOSE/外部 teardown 会销毁 HWND，但旧对象仍跨 gal 会话复用。
+  // 对失效（或已被系统复用）的句柄调用 ShowWindow/SetWindowPos 都不会抛，旧实现却
+  // 无条件返回 true，Dart 因而永久把一个不存在的窗口记成“已显示”。
+  if (hwnd_ != nullptr && !OwnsLiveWindow()) {
+    hwnd_ = nullptr;
+    visible_ = false;
+    pass_through_toolbar_.Hide();
+    slot_tooltip_.Hide();
+  }
+
   if (hwnd_ == nullptr) {
     // Initial position: bottom-centre of the active monitor, like a desktop
     // lyric bar. WS_EX_LAYERED for per-pixel alpha, WS_EX_TOPMOST to float over
@@ -449,8 +469,12 @@ bool FloatingLyricWindow::Show(HWND owner) {
   }
 
   ShowWindow(hwnd_, SW_SHOWNOACTIVATE);
-  SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+  if (!SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0,
+                    0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
+                           SWP_SHOWWINDOW)) {
+    visible_ = false;
+    return false;
+  }
   visible_ = true;
   // BUG-951: a re-show while pass-through is still on must re-create the
   // escape-hatch toolbar and re-arm the body's click-through in one place.
@@ -1131,6 +1155,20 @@ LRESULT CALLBACK FloatingLyricWindow::WndProc(HWND hwnd, UINT message,
 LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
                                            LPARAM lparam) noexcept {
   switch (message) {
+    case WM_NCDESTROY: {
+      // Clear ownership at the actual HWND lifetime boundary. Show() can then
+      // rebuild the body on the next automatic line or manual-open request.
+      HWND destroyed = hwnd_;
+      visible_ = false;
+      pass_through_toolbar_.Hide();
+      slot_tooltip_.Hide();
+      CancelPointerGesture();
+      StopHoverLookupPolling();
+      StopToolbarRevealPolling();
+      SetWindowLongPtr(destroyed, GWLP_USERDATA, 0);
+      hwnd_ = nullptr;
+      return DefWindowProc(destroyed, message, wparam, lparam);
+    }
     case WM_MOUSEMOVE: {
       // Mouse messages arrive immediately because the strip is not born
       // transparent. Here we drive hover affordances, drag, and the press->drag

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -239,6 +239,8 @@ class FloatingLyricWindow {
 
   void EnsureWindowClass();
   bool OwnsLiveWindow() const;
+  void ResetWindowInteractionState();
+  void ForgetDeadWindow();
   bool EnsureDeviceResources();
   void DiscardDeviceResources();
   bool EnsureTextResources();

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -238,6 +238,7 @@ class FloatingLyricWindow {
   LRESULT HandleMessage(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
 
   void EnsureWindowClass();
+  bool OwnsLiveWindow() const;
   bool EnsureDeviceResources();
   void DiscardDeviceResources();
   bool EnsureTextResources();


### PR DESCRIPTION
## 变更

- 修复 Hook 台词浮窗 HWND 被销毁后，Dart/Win32 仍把死句柄当作已显示，导致自动同步和手动按钮都无法重新打开的问题
- 修复全局查词反向消息用 mutable native HWND 路由覆盖 JS 事件原始 epoch，旧尺寸回报冒充新查询造成首次闪跳的问题
- 修复 Gal 同一句只改变换行/空白时未原地折叠，造成重复行、换行快照漂移和重复字数的问题
- build number: 2.2.4+1238

## 验证

- `dart run tool/bug.dart check --strict`：通过（1858 条，三个新 BUG 号唯一且索引同步）
- `git diff --check` / `git diff --cached --check`：通过
- `verify-change`：通过，代码、测试、BUG 文档均有同步
- 聚焦 `flutter test`：阻塞，`pdfium_dart` 在执行 0 个 case 前下载 `pdfium-win-x64.tgz` 超时
- 定向 `dart analyze`：阻塞，分析完成收尾时 Analysis Server 因无法删除 `%LOCALAPPDATA%\Dart\perf\*` 文件崩溃，退出码 1

## 未验证

- 未跑完整 Flutter 测试 / analyze
- 未构建 Windows 安装包
- 未做真实 Windows Hook 浮窗、WebView2 全局查词像素复测
- 未回到原始 SiglusEngine 启动路径做文本 Hook / 换行 / 制卡 E2E