### PR TITLE
fix(video): 文本框让位收成单一模型，加载态 Esc 下沉到执行点

### DIFF
--- a/fushi/lib/src/media/video/video_player_shortcuts.dart
+++ b/fushi/lib/src/media/video/video_player_shortcuts.dart
@@ -298,10 +298,15 @@ Map<ShortcutAction, VoidCallback> videoActionCallbacks(
 /// 长按**不**连发的视频动作（按一下翻一次）。TODO-840 Part B 起是模糊切换 / 遮蔽
 /// 循环 / 隐藏切换；进入选词光标与制卡同属此类（长按不该连发查词 / 连发制卡）。
 ///
-/// 两条键盘通道共用这一份真相源：弹窗复用的 activator 表把它翻译成
-/// `includeRepeats: false`（[buildVideoPlayerShortcutsFromRegistry]），页级
-/// press-time 通道把它翻译成「[KeyRepeatEvent] 不消费」
-/// （[resolveVideoKeyboardShortcut]）。
+/// **真正逐条生效的只有页级 press-time 通道**：[resolveVideoKeyboardShortcut] 把本集合
+/// 翻译成「[KeyRepeatEvent] 不消费」，5 个成员条条管用。
+///
+/// 还在用 activator 表的那条路径（[buildVideoPlayerShortcutsFromRegistry]，只服务字幕
+/// 对轴弹窗与网页视频页）只翻译得到其中 3 个：`videoEnterCaret` 被那个函数显式
+/// `continue` 掉、根本不进表；`popupMineEntry` 属 dictionaryPopup scope，压根不在
+/// [videoActionCallbacks] 里、也就不在被遍历的动作集合里。所以这不是「两条通道逐字
+/// 等价」的真相源，而是「press-time 通道的真相源 + activator 表尽力翻译的子集」——
+/// 读成前者就会以为往集合里加一个动作两边都生效，那正是漏改一侧的起点。
 const Set<ShortcutAction> kVideoPressEdgeOnlyActions = <ShortcutAction>{
   ShortcutAction.videoToggleSubtitleBlur,
   ShortcutAction.videoCycleSubtitleObscure,
@@ -482,19 +487,24 @@ HoldSpeedKeyTransition resolveHoldSpeedKeyTransition({
 ///
 /// 修饰键取 [HardwareKeyboard] 实时状态（与 SingleActivator 同口径）；physicalKey
 /// 透传给 [FushiShortcutRegistry.resolveKeyboard] 供 IME 改写回退（TODO-847）。
-/// [hasEditableFocus] 为 true（文本框持焦）时恒不命中，避免输入时误触加速。
+/// [hasEditableFocus] 为 true 时按**与主通道同一条** [editableFocusClaimsKey] 判：文本框
+/// 自己会用的键让位（默认裸 E 正是这一类，输入时不会误触加速），它用不上的硬修饰组合
+/// 照常命中。这条通道排在主通道之前，判据必须与主通道同源，否则两条路径会在同一个键上
+/// 给出相反答案。
 bool keyDownMatchesHoldSpeed(
   FushiShortcutRegistry registry,
   KeyDownEvent event, {
   required bool hasEditableFocus,
 }) {
-  if (hasEditableFocus) return false;
-  final Set<ModifierKey> modifiers = <ModifierKey>{
-    if (HardwareKeyboard.instance.isControlPressed) ModifierKey.ctrl,
-    if (HardwareKeyboard.instance.isShiftPressed) ModifierKey.shift,
-    if (HardwareKeyboard.instance.isAltPressed) ModifierKey.alt,
-    if (HardwareKeyboard.instance.isMetaPressed) ModifierKey.meta,
-  };
+  final Set<ModifierKey> modifiers =
+      currentKeyboardModifiers(HardwareKeyboard.instance);
+  if (hasEditableFocus &&
+      editableFocusClaimsKey(
+        logicalKey: event.logicalKey,
+        modifiers: modifiers,
+      )) {
+    return false;
+  }
   return registry.resolveKeyboard(
         event.logicalKey,
         modifiers: modifiers,
@@ -529,8 +539,11 @@ bool isVideoPanelFocusNavButton(GamepadButton button) {
 /// 它绑着 [ShortcutAction.videoEnterCaret]，由「视频画面**精确**持焦才算选词键」
 /// 那条 contextual 判据天然让位（面板持焦时画面必不持焦），不必在这里重复列一遍。
 ///
-/// 只对**无修饰**方向键成立：Ctrl+←/→（上/下一句字幕）、Ctrl+Shift+←/→（字幕偏移
-/// 对齐）是明确的视频动作，面板开着时照常执行——这条判据由调用方
+/// 让位只对**不带硬修饰**（Ctrl/Alt/Meta）的方向键成立：Ctrl+←/→（上/下一句字幕）、
+/// Ctrl+Shift+←/→（字幕偏移对齐）是明确的视频动作，面板开着时照常执行。Shift 不算硬
+/// 修饰（Shift+方向键在列表里是扩选，仍归焦点遍历），用的是与
+/// [videoCaretKeyboardTakesPrecedence] / [editableFocusClaimsKey] 同一条
+/// [hasHardModifier]。这条判据与「焦点确实已不在画面上」一起由调用方
 /// [resolveVideoKeyboardShortcut] 施加。
 bool isVideoPanelFocusNavKey(LogicalKeyboardKey key) {
   return key == LogicalKeyboardKey.arrowUp ||
@@ -604,6 +617,71 @@ Set<ModifierKey> currentKeyboardModifiers(HardwareKeyboard keyboard) {
   };
 }
 
+/// 「硬修饰键」= Ctrl / Alt / Meta。**Shift 不算**。
+///
+/// 视频页有两个会临时抢走键盘的模态输入宿主——字级选词光标与文本框——「这次按键归
+/// 宿主还是归视频通道」用的是同一条线：宿主只认领**不带硬修饰**的键。理由两边一致：
+/// 裸键与 Shift 组合是宿主的正常输入（移动光标 / Shift+Tab 后退一字 / 打大写字母），
+/// 而 Ctrl/Alt/Meta 组合从来不是「输入一个字符」，那是命令。面板持焦时的方向键让位
+/// （[isVideoPanelFocusNavKey]）同理。
+///
+/// 两个宿主之间**只有一处差异，且是宿主自身能力的差异、不是第二套模型**：文本框对一小
+/// 撮硬修饰组合另有用途（Ctrl+←/→ 按词移动、Ctrl+A/C/V/X/Z 编辑），那份清单在
+/// [isTextEditingCombination]；光标那份是空集，所以它不需要第二个判据。
+bool hasHardModifier(Set<ModifierKey> modifiers) {
+  return modifiers.contains(ModifierKey.ctrl) ||
+      modifiers.contains(ModifierKey.alt) ||
+      modifiers.contains(ModifierKey.meta);
+}
+
+/// 文本框在**带硬修饰**时仍会自己消费的键。
+///
+/// 这不是「所有能在文本框里按的键」，而是 Flutter 桌面端 `DefaultTextEditingShortcuts`
+/// 真正注册了 Ctrl/Alt/Meta 组合的那一小撮：按词 / 按行移动与扩选（方向键、Home/End）、
+/// 按词删除（Backspace/Delete）、剪贴板与撤销重做（A/C/V/X/Z/Y）。
+///
+/// 为什么必须显式列出来，而不是「有硬修饰就一律归视频」：video scope 的 Ctrl+←/→ 是
+/// 「上/下一句字幕」。不排除的话，用户在 mpv.conf 编辑框 / 弹幕规则框 / 侧栏搜索框里按
+/// Ctrl+← 就不再是按词左移而是跳字幕——那是**新造**的回归（旧实现里文本框根本够不到那张
+/// 表）。反过来 Ctrl+Enter（制卡）、Ctrl+F（字幕列表搜索）、Ctrl+D（收藏句子）不在表里，
+/// 文本框对它们没有任何用途，交回视频通道才是对的。
+///
+/// 判据只看**逻辑键**、不看按的是哪个修饰键：macOS 的 Meta+←/A/C/V 与 Windows/Linux 的
+/// Ctrl+… 是同一批键，一份清单同时覆盖两端。
+bool isTextEditingCombination(LogicalKeyboardKey key) {
+  return key == LogicalKeyboardKey.arrowLeft ||
+      key == LogicalKeyboardKey.arrowRight ||
+      key == LogicalKeyboardKey.arrowUp ||
+      key == LogicalKeyboardKey.arrowDown ||
+      key == LogicalKeyboardKey.home ||
+      key == LogicalKeyboardKey.end ||
+      key == LogicalKeyboardKey.backspace ||
+      key == LogicalKeyboardKey.delete ||
+      key == LogicalKeyboardKey.keyA ||
+      key == LogicalKeyboardKey.keyC ||
+      key == LogicalKeyboardKey.keyV ||
+      key == LogicalKeyboardKey.keyX ||
+      key == LogicalKeyboardKey.keyY ||
+      key == LogicalKeyboardKey.keyZ;
+}
+
+/// 文本框持焦时，这次按键是否归**文本框**（= 视频键盘通道必须整条让位）。
+///
+/// BUG-962 的本体是第一条：不带硬修饰的键一律让位——裸空格、裸字母、裸方向键、
+/// Shift+字母（打大写）、Shift+方向键（扩选）全在内。少了它就是在 mpv.conf 多行框里
+/// 打一个 `f` 直接切全屏。
+///
+/// 第二条只在带硬修饰时才问：那是不是文本框自己也要用的组合（[isTextEditingCombination]）。
+/// 两条合起来正好是「宿主认领它用得上的键，用不上的交回视频」，与
+/// [videoCaretKeyboardTakesPrecedence] 同一个模型（光标那侧第二条恒为假）。
+bool editableFocusClaimsKey({
+  required LogicalKeyboardKey logicalKey,
+  required Set<ModifierKey> modifiers,
+}) {
+  if (!hasHardModifier(modifiers)) return true;
+  return isTextEditingCombination(logicalKey);
+}
+
 /// 字级选词光标激活期，一次键盘事件是否**先于注册表解析**交给光标路由
 /// （`ReaderCaretRouter.decideKeyboard`）。
 ///
@@ -611,6 +689,8 @@ Set<ModifierKey> currentKeyboardModifiers(HardwareKeyboard keyboard) {
 /// （Ctrl/Alt/Meta）的组合键不是光标键**——Ctrl+←/→ 是上/下一句字幕、Ctrl+Shift+←/→
 /// 是字幕偏移对齐，光标激活时照常执行（跳句后页面会自动重锚）。Shift 不算硬修饰：
 /// 它是光标语义的一部分（Shift+Tab = 后退一字，与阅读器一致），透传给光标路由。
+/// 判据就是共享的 [hasHardModifier]——与文本框那侧同一条线；光标不像文本框那样对硬
+/// 修饰组合另有用途，所以这里不需要 [isTextEditingCombination] 那份清单。
 ///
 /// 方案 D 之前这条豁免写在套在 media_kit 表外面的 caret 守卫里，键盘通道合并为一条
 /// 之后搬到这里。少了它，光标一开 Ctrl+← 就变成「光标左移一字」。
@@ -623,9 +703,7 @@ bool videoCaretKeyboardTakesPrecedence({
   if (!caretActive) return false;
   if (event is! KeyDownEvent && event is! KeyRepeatEvent) return false;
   if (hasEditableFocus) return false;
-  return !modifiers.contains(ModifierKey.ctrl) &&
-      !modifiers.contains(ModifierKey.alt) &&
-      !modifiers.contains(ModifierKey.meta);
+  return !hasHardModifier(modifiers);
 }
 
 /// 给仍使用 activator 表的网页视频页增加「词典浮层优先关闭」语义。
@@ -633,6 +711,12 @@ bool videoCaretKeyboardTakesPrecedence({
 /// 原生视频页已经改为 [resolveVideoKeyboardShortcut] 的页级 press-time 单通道，不再
 /// 调用本函数；网页视频页仍持有短生命周期的 [CallbackShortcuts] 表，因此继续复用
 /// 这个无页面依赖的包装器。浮层可见时只关闭顶层浮层并消费按键，否则执行原动作。
+///
+/// 与主通道的两处**有意**差异（网页视频页那张表的形状决定的，不要照抄原生页语义）：
+/// ① 无条件包住表里**每一个** activator，没有制卡豁免——`popupMineEntry` 不在
+///    [videoActionCallbacks] 里，那张表里根本没有制卡键可豁免；
+/// ② 只作用于表里已有的键，未绑定的键不进表、也就不会被吞。
+/// 回归覆盖在 `test/media/video/web_video_popup_dismiss_guard_test.dart`。
 Map<ShortcutActivator, VoidCallback> guardVideoShortcutsWithPopupDismiss(
   Map<ShortcutActivator, VoidCallback> base, {
   required bool Function() isPopupVisible,
@@ -672,20 +756,35 @@ VideoKeyboardResolution resolveVideoKeyboardShortcut(
   required bool hasEditableFocus,
   required bool hasVisiblePopup,
   required bool videoSurfaceHoldsFocus,
-  required bool panelHoldsFocusNavigation,
+  required bool videoNavigablePanelOpen,
 }) {
   // 只解析按下 / 重复沿。keyup 属于按住倍速状态机（页面在本函数之前一层处理）。
   if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
     return VideoKeyboardResolution.ignored;
   }
-  // 文本框持焦（含 IME composing）：整条键盘通道让位给输入，一个视频动作都不解析。
-  if (hasEditableFocus) return VideoKeyboardResolution.ignored;
+  // 文本框持焦（含 IME composing）：文本框认领的键整条通道让位，一个视频动作都不解析。
+  // 判据是 [editableFocusClaimsKey]——与选词光标那侧同一条修饰键模型：不带硬修饰的键
+  // 全让（BUG-962 的本体），带硬修饰的只让文本框自己也要用的那一小撮编辑组合。
+  if (hasEditableFocus &&
+      editableFocusClaimsKey(
+        logicalKey: event.logicalKey,
+        modifiers: modifiers,
+      )) {
+    return VideoKeyboardResolution.ignored;
+  }
 
-  // 手柄重设计 P3 的键盘对应物：面板持焦时裸方向键让位给通用焦点遍历（见
-  // [isVideoPanelFocusNavKey]）。必须在解析之前——方向键在注册表里绑着 seek / 音量，
-  // 解析之后再让位就等于「先执行再后悔」。
-  if (panelHoldsFocusNavigation &&
-      modifiers.isEmpty &&
+  // 手柄重设计 P3 的键盘对应物：可导航面板打开、且焦点确实已不在画面上时，不带硬修饰
+  // 的方向键让位给通用焦点遍历（见 [isVideoPanelFocusNavKey]）。必须在解析之前——方向
+  // 键在注册表里绑着 seek / 音量，解析之后再让位就等于「先执行再后悔」。
+  //
+  // `!videoSurfaceHoldsFocus` 这一半不是冗余：让位的**理由**是「焦点在面板里、方向键
+  // 此刻是在面板内选行」。今天这个前提由**另一个模块**的门控间接成立（页面的
+  // `_canOwnVideoFocus` 在面板打开时不抢焦），本函数拿不到任何保证。那条门控一改，
+  // 面板开着而焦点仍在画面上时裸方向键就既不移焦、也不 seek——静默失效，没有任何报错。
+  // 把前提就地判掉，这个远程依赖就不存在了。
+  if (videoNavigablePanelOpen &&
+      !videoSurfaceHoldsFocus &&
+      !hasHardModifier(modifiers) &&
       isVideoPanelFocusNavKey(event.logicalKey)) {
     return VideoKeyboardResolution.ignored;
   }

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -72,10 +72,13 @@ extension _VideoLayout on _VideoFushiPageState {
     // 两层主题嵌套：[AdaptiveVideoControls] 按平台互斥择一渲染（桌面读 Desktop
     // 主题、移动读 Material 主题），故同时提供两套互不干扰，让字幕/音轨/设置入口
     // 在桌面、移动、全屏三种场景都可达。嵌套顺序不影响——各自被对应平台 controls 读取。
-    // 'B' 切换字幕模糊（TODO-134）现已并入可重映射注册表（video scope），随其它视频键
-    // 一起经 media_kit 的 keyboardShortcuts 整表安装，不再需要本页内层的独立
-    // CallbackShortcuts；press-edge-only（includeRepeats:false）由
-    // buildVideoPlayerShortcutsFromRegistry 对该 action 保留。
+    // 'B' 切换字幕模糊（TODO-134）已并入可重映射注册表（video scope），随其它视频键
+    // 一起走**页级 press-time 单通道**（[_handleVideoKeyboardShortcut] →
+    // [resolveVideoKeyboardShortcut]，挂在 [_wrapVideoGamepadControls] 上），不再需要
+    // 本页内层的独立 CallbackShortcuts。media_kit 那层的 `keyboardShortcuts` 现在是
+    // 显式空表（见 controls_theme.part.dart）——它只包 `AdaptiveVideoControls` 子树，
+    // 够不到面板，正是 BUG-1864 的 scope≠mount 根因。「长按不连发」由
+    // [kVideoPressEdgeOnlyActions] 在那条通道上翻译成「重复沿不消费」。
     return VideoControlsThemePair(
       mobile: controlsTheme.mobile,
       desktop: controlsTheme.desktop,
@@ -173,22 +176,27 @@ extension _VideoLayout on _VideoFushiPageState {
   /// BUG-1862：把「返回上一级」键的兜底装在 controls builder 的**最外层**，覆盖那些
   /// 挂在 media_kit controls 旁边、却不在它快捷键表作用域里的自建 overlay。
   ///
-  /// media_kit 的整表快捷键（[_videoKeyboardShortcuts]）由它自己的 [CallbackShortcuts]
-  /// 承载，而那层只包住 media_kit 的 controls 子树；本页的设置 / 速度 / 章节侧栏、side
-  /// rail、控制按钮 popover、布局编辑层都是本 builder 里 [Stack] 的**兄弟节点**。侧栏
-  /// 打开时 `PanelFocusScope` 会把键盘焦点领进侧栏，于是 Esc 的冒泡路径根本不经过那张
-  /// 表，一路走到全局 back 把整页 pop 掉——用户看到「侧栏开着按 Esc，页面退了、侧栏还
-  /// 在」。本层是这些 overlay 的共同祖先，且窗口与全屏复用同一 controls builder，两种
-  /// 场景一并覆盖。
+  /// 历史成因：当时视频快捷键是一张冻结的 activator 表，装在 media_kit 自己的
+  /// [CallbackShortcuts] 上，而那层只包住 media_kit 的 controls 子树；本页的设置 / 速度
+  /// / 章节侧栏、side rail、控制按钮 popover、布局编辑层都是本 builder 里 [Stack] 的
+  /// **兄弟节点**。侧栏打开时 `PanelFocusScope` 会把键盘焦点领进侧栏，于是 Esc 的冒泡
+  /// 路径根本不经过那张表，一路走到全局 back 把整页 pop 掉——用户看到「侧栏开着按 Esc，
+  /// 页面退了、侧栏还在」。本层是这些 overlay 的共同祖先，两种场景一并覆盖。
   ///
-  /// **覆盖面到此为止**：只盖得住本 builder [Stack] 内的兄弟层（side panel / rail /
-  /// popover / 布局编辑层）。push-aside 字幕跳转列表（TODO-314）与剧集轨（TODO-638）由
-  /// [_videoWithSubtitlePanel] 包在 `Video` **外面**（`Row[Expanded(video), 面板列]`），
-  /// 是 controls builder 的兄弟而非后代，本层不在它们的祖先链上。窗口模式下它们的 Esc
-  /// 仍由本页 [PopScope] → [_dismissTopForegroundLayer] 接住，闭合；**全屏模式下是已知
-  /// 缺口**——全屏路由没有 [PopScope]，焦点被 `PanelFocusScope` 领进这两个面板后按 Esc
-  /// 会走全局 back 把全屏路由 pop 掉（退出全屏），面板仍开着。该缺口 BUG-1862 之前就
-  /// 存在、本次未修；要修得把兜底层再上提到 [_videoWithSubtitlePanel] 之外。
+  /// **BUG-1864 之后那个根因已经在上游修掉**：整表上提到 [_wrapVideoGamepadControls] 的
+  /// press-time 单通道（窗口 `build()` 与全屏路由 `pageBuilder` 的唯一共同外层，也是
+  /// 面板的祖先），media_kit 那层只留一张显式空表。当年「面板持焦 ⇒ 够不着那张表」的
+  /// 缺口——包括这段注释原来记为「全屏模式下是已知缺口」的 push-aside 字幕跳转列表
+  /// （TODO-314）与剧集轨（TODO-638）——都由页级通道覆盖了。
+  ///
+  /// 本层因此**不再是 Esc 的唯一依靠，但也不是死代码**：它是页级通道的后代，冒泡先到
+  /// 这里，且判据比页级那条宽一档——页级通道在文本框持焦时按 [editableFocusClaimsKey]
+  /// 整条让位（裸 Esc 属于让位范围），本层不看文本框、照常吃 Esc 去关一层。于是「本
+  /// builder [Stack] 内某个兄弟层（侧栏等）的输入框里按 Esc 先关掉那一层」只有本层给得
+  /// 出。覆盖面仍以本 builder 的 [Stack] 为界：push-aside 字幕跳转列表与剧集轨由
+  /// [_videoWithSubtitlePanel] 包在 `Video` **外面**，是本 builder 的兄弟而非后代，它们
+  /// 的 Esc 走页级通道。两层的执行体是同一个 [_dismissTopForegroundLayer]，且本层只在
+  /// **真的关掉了一层**时消费，语义不会打架。
   ///
   /// 只在 [_dismissTopForegroundLayer] **真的关掉了一层**时消费按键；没有前台层可关时
   /// 返回 [KeyEventResult.ignored] 原样放行，退全屏 / 退页仍走既有路径——不新增第二条

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -4841,24 +4841,36 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       // videoEnterCaret：进入字级选词光标 / 已激活时对光标字符查词（双语义，
       // 沉浸查词门控在 _enterSubtitleCaret 内按 _immersiveAllowsLookup 判）。
       enterCaret: () => _handleEnterCaretAction(controller),
-      escape: () {
-        // 逐级退出：字幕跳转列表 / 剧集列表 / 侧栏 / 沉浸锁等前台层开着时先关一层，
-        // 不退页也不退全屏。层级表是 [_dismissTopForegroundLayer] 单点（BUG-1862 起与
-        // [PopScope]、系统返回键、手柄 B、屏幕返回按钮共用同一份），这里只保留「没有前台
-        // 层可关」之后的两级：全屏 → 退全屏；窗口 → 退页。
-        //
-        // 「退全屏」这一级**只**能留在这里、进不了 [_handleBackOrExit]：全屏是推到根
-        // navigator 的独立路由，全屏期间栈顶是它、本页 [PopScope] 根本轮不到（框架先 pop
-        // 全屏路由），把它并进汇聚点等于写一条永远不执行的分支。
-        if (_dismissTopForegroundLayer()) return;
-        final BuildContext? ctx = _videoControlsContext;
-        if (ctx != null && ctx.mounted && isFullscreen(ctx)) {
-          unawaited(_exitVideoFullscreen(ctx));
-        } else {
-          unawaited(_handleBackOrExit());
-        }
-      },
+      escape: _handleVideoEscapeAction,
     );
+  }
+
+  /// 「返回上一级」（[ShortcutAction.globalBack]，默认 Esc / Alt+← / 手柄 B）在视频页的
+  /// 执行体：逐级退出阶梯。
+  ///
+  /// 抽成具名方法、不留在 [_buildVideoShortcutActions] 的闭包里，是因为它是整张表里
+  /// **唯一一个不碰 [VideoPlayerController] 的动作**，而那张表只能用一个非空 controller
+  /// 构造。加载态 / 资源缺失态（`_controller == null`）下两条输入通道要能单独调到它——
+  /// 否则转圈时按 Esc / 手柄 B 根本不经本页解析，一路落到全局 universal 兜底，而
+  /// [_buildLoadingBody] 专门留了「转圈时随时可退出」的返回入口，那条可达性在键盘和
+  /// 手柄上就断了。
+  ///
+  /// 逐级退出：字幕跳转列表 / 剧集列表 / 侧栏 / 沉浸锁等前台层开着时先关一层，
+  /// 不退页也不退全屏。层级表是 [_dismissTopForegroundLayer] 单点（BUG-1862 起与
+  /// [PopScope]、系统返回键、手柄 B、屏幕返回按钮共用同一份），这里只保留「没有前台
+  /// 层可关」之后的两级：全屏 → 退全屏；窗口 → 退页。
+  ///
+  /// 「退全屏」这一级**只**能留在这里、进不了 [_handleBackOrExit]：全屏是推到根
+  /// navigator 的独立路由，全屏期间栈顶是它、本页 [PopScope] 根本轮不到（框架先 pop
+  /// 全屏路由），把它并进汇聚点等于写一条永远不执行的分支。
+  void _handleVideoEscapeAction() {
+    if (_dismissTopForegroundLayer()) return;
+    final BuildContext? ctx = _videoControlsContext;
+    if (ctx != null && ctx.mounted && isFullscreen(ctx)) {
+      unawaited(_exitVideoFullscreen(ctx));
+    } else {
+      unawaited(_handleBackOrExit());
+    }
   }
 
   /// TODO-1342：把一次手柄按键解析成视频动作并执行。桌面（GameInput/GameController
@@ -4876,7 +4888,6 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _videoInputClock.elapsed,
     );
     final VideoPlayerController? controller = _controller;
-    if (controller == null) return false;
     // videoEnterCaret：选词光标激活期，方向/确认/退出等在注册表解析**之前**截获
     // （阅读器 caret.part 同款 contextual 路由）；未激活返回 false 走正常解析
     // （进入光标本身是注册表动作 videoEnterCaret，经下方 callback 执行）。
@@ -4915,6 +4926,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _dismissTopVisiblePopup();
       return true;
     }
+    // 与键盘通道同款：「返回上一级」（手柄 B）的执行体不碰播放器，必须分流在
+    // controller 门之前，否则加载态下手柄 B 退不出转圈中的视频页。
+    if (action == ShortcutAction.globalBack) {
+      _handleVideoEscapeAction();
+      return true;
+    }
+    if (controller == null) return false;
     final VoidCallback? callback =
         videoActionCallbacks(_buildVideoShortcutActions(controller))[action];
     if (callback == null) return false;
@@ -5061,7 +5079,6 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 同一动作时行为逐字一致（含 [_runWhenImmersiveAllowsShortcuts] 沉浸锁门控）。
   bool _handleVideoKeyboardShortcut(KeyEvent event) {
     final VideoPlayerController? controller = _controller;
-    if (controller == null) return false;
     final VideoKeyboardResolution resolution = resolveVideoKeyboardShortcut(
       appModel.shortcutRegistry,
       event,
@@ -5071,7 +5088,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       // 「视频画面精确持焦」与 [_focusOwnership] 是同一个真相源（它 reclaim 的就是
       // 这个节点）：焦点落到控制条按钮或面板行上时 hasPrimaryFocus 自然为 false。
       videoSurfaceHoldsFocus: _videoFocusNode.hasPrimaryFocus,
-      panelHoldsFocusNavigation: _videoNavigablePanelOpen,
+      videoNavigablePanelOpen: _videoNavigablePanelOpen,
     );
     switch (resolution.dispatch) {
       case VideoKeyboardDispatch.ignore:
@@ -5089,6 +5106,17 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
           _mineFromTopPopup();
           return true;
         }
+        // 「返回上一级」的执行体是本页的逐级退出阶梯，整条不碰播放器
+        // （[_handleVideoEscapeAction]），所以它必须分流在下面那道 controller 门**之前**：
+        // 加载态 / 资源缺失态下 `_controller` 恒为 null，跟着整表一起被挡在门外就等于
+        // 转圈时 Esc 不再走本页阶梯（[_buildLoadingBody] 的「随时可退出」在键盘上够不着）。
+        if (action == ShortcutAction.globalBack) {
+          _handleVideoEscapeAction();
+          return true;
+        }
+        // 其余动作的执行体全部从 [_buildVideoShortcutActions] 取，而它要求一个非空
+        // controller——播放器还没建好时那些动作本来也无事可做。不消费，交回既有路径。
+        if (controller == null) return false;
         final Map<ShortcutAction, VoidCallback> callbacks =
             videoActionCallbacks(_buildVideoShortcutActions(controller));
         final VoidCallback? callback = callbacks[action];

--- a/fushi/test/media/video/video_escape_dismiss_guard_test.dart
+++ b/fushi/test/media/video/video_escape_dismiss_guard_test.dart
@@ -59,11 +59,12 @@ void main() {
 
   test('Escape 快捷键回调复用同一个层级表，不另抄一份 if 链', () {
     final String src = read(page);
-    final int at = src.indexOf('      escape: () {');
-    expect(at, greaterThan(0), reason: '找不到 escape 快捷键回调');
-    final int end = src.indexOf('\n      },\n', at);
-    expect(end, greaterThan(at), reason: 'escape 回调没有闭合');
-    final String body = src.substring(at, end);
+    // 执行体已从 `escape: () { … }` 闭包抽成具名方法 [_handleVideoEscapeAction]：它是
+    // 整张动作表里唯一不需要 VideoPlayerController 的动作，加载态（`_controller == null`）
+    // 下键盘 / 手柄必须能绕开表、单独调到它。锚点跟着搬。
+    expect(src.contains('escape: _handleVideoEscapeAction,'), isTrue,
+        reason: 'globalBack 的执行体必须仍接在 VideoPlayerShortcutActions.escape 上');
+    final String body = methodBody(src, 'void _handleVideoEscapeAction() {');
     expect(
       body.contains('if (_dismissTopForegroundLayer()) return;'),
       isTrue,
@@ -105,11 +106,8 @@ void main() {
         methodBody(src, 'bool _dismissTopForegroundLayer() {');
     final String exitPoint =
         methodBody(src, 'Future<void> _handleBackOrExit() async {');
-    final int escapeAt = src.indexOf('      escape: () {');
-    expect(escapeAt, greaterThan(0), reason: '找不到 escape 快捷键回调');
-    final int escapeEnd = src.indexOf('\n      },\n', escapeAt);
-    expect(escapeEnd, greaterThan(escapeAt), reason: 'escape 回调没有闭合');
-    final String escapeBody = src.substring(escapeAt, escapeEnd);
+    final String escapeBody =
+        methodBody(src, 'void _handleVideoEscapeAction() {');
 
     // 判据是**作用域**不是出现次数：数次数会被任何一处合法的新调用点误伤，报错
     // 文案还会误导成「层级表被抄了一份」。真正的不变式是「关闭动作只在层级表里

--- a/fushi/test/media/video/video_ime_space_playpause_test.dart
+++ b/fushi/test/media/video/video_ime_space_playpause_test.dart
@@ -35,9 +35,10 @@ import '../../pages/video_fushi_page_source_corpus.dart';
 /// BUG-853 回归守卫：日语输入法（Windows 微软 IME）激活时，视频页按空格无法暂停。
 ///
 /// 根因：IME 激活时裸 Space 的 `logicalKey` 被引擎改写成 [LogicalKeyboardKey.process]，
-/// 视频页两条空格「播放/暂停」路径（media_kit controls 的 `keyboardShortcuts` 与页级
-/// `_withPageSpaceOverride`）都用 `SingleActivator(LogicalKeyboardKey.space)` 匹配
-/// `logicalKey`，故 IME 下按空格既不被内层消费、也不被页级兜底消费 → 按了没反应。
+/// 视频页当时的两条空格「播放/暂停」路径（media_kit controls 的 `keyboardShortcuts` 与
+/// 页级 `_withPageSpaceOverride`，两者均已删除，见下）都用
+/// `SingleActivator(LogicalKeyboardKey.space)` 匹配 `logicalKey`，故 IME 下按空格既不被
+/// 内层消费、也不被页级兜底消费 → 按了没反应。
 /// 修复与阅读器 TODO-847（[resolveReaderSpaceOverride]）同范式：在最外层 Focus 的
 /// onKeyEvent 里按**物理键**还原 Space 语义（[isVideoImeSpacePlayPause]）。
 ///
@@ -143,7 +144,8 @@ void main() {
     expect(body, contains('focusedEditableText()'),
         reason: '必须在文本框 composing 时关闭回退');
     expect(body, contains('_runWhenImmersiveAllowsShortcuts'),
-        reason: '必须经沉浸锁快捷键门控（与页级 _withPageSpaceOverride 同语义）');
+        reason: '必须经沉浸锁快捷键门控（与主通道 _handleVideoKeyboardShortcut 走的 '
+            'videoActionCallbacks 执行体同语义）');
     expect(body, contains('controller.playOrPause()'),
         reason: 'IME 空格应触发播放/暂停');
 

--- a/fushi/test/media/video/video_keyboard_editable_focus_test.dart
+++ b/fushi/test/media/video/video_keyboard_editable_focus_test.dart
@@ -40,7 +40,7 @@ void main() {
         hasEditableFocus: hasEditableFocus,
         hasVisiblePopup: hasVisiblePopup,
         videoSurfaceHoldsFocus: false,
-        panelHoldsFocusNavigation: false,
+        videoNavigablePanelOpen: false,
       );
 
   final KeyDownEvent spaceDown =
@@ -51,6 +51,18 @@ void main() {
       down(LogicalKeyboardKey.keyF, PhysicalKeyboardKey.keyF);
   final KeyRepeatEvent rightRepeat =
       repeat(LogicalKeyboardKey.arrowRight, PhysicalKeyboardKey.arrowRight);
+  final KeyDownEvent enterDown =
+      down(LogicalKeyboardKey.enter, PhysicalKeyboardKey.enter);
+  final KeyDownEvent leftDown =
+      down(LogicalKeyboardKey.arrowLeft, PhysicalKeyboardKey.arrowLeft);
+  final KeyDownEvent downArrow =
+      down(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown);
+  const Set<ModifierKey> ctrl = <ModifierKey>{ModifierKey.ctrl};
+  const Set<ModifierKey> shift = <ModifierKey>{ModifierKey.shift};
+  const Set<ModifierKey> ctrlShift = <ModifierKey>{
+    ModifierKey.ctrl,
+    ModifierKey.shift,
+  };
 
   group('前置条件', () {
     test('没有文本框时这两个键确实各自命中一个视频动作', () {
@@ -89,6 +101,145 @@ void main() {
             '这正是旧页级覆盖层没有、统一到单通道之后才出现的新暴露面',
       );
     });
+
+    test('Shift+字母（打大写）同样让位——Shift 不是硬修饰', () {
+      expect(
+        resolve(fDown, hasEditableFocus: true, modifiers: shift),
+        VideoKeyboardResolution.ignored,
+        reason: 'Shift+F 就是在打一个大写 F。把 Shift 当成「这不是文本输入」的信号，'
+            '用户在弹幕规则框里打大写字母就会切全屏',
+      );
+    });
+
+    test('Shift+方向键（扩选）让位', () {
+      expect(
+        resolve(downArrow, hasEditableFocus: true, modifiers: shift),
+        VideoKeyboardResolution.ignored,
+      );
+    });
+  });
+
+  /// 统一修饰键模型：文本框与选词光标共用 [hasHardModifier]——宿主只认领**不带硬
+  /// 修饰**的键。文本框比光标多一份 [isTextEditingCombination] 清单，那是宿主自身
+  /// 能力的差异（文本框对 Ctrl+←/A/C/V 另有用途），不是第二套模型。
+  group('文本框持焦 + 硬修饰：宿主用不上的组合交回视频通道', () {
+    test('Ctrl+Enter 在侧栏搜索框里仍然制卡', () {
+      expect(
+        resolve(enterDown, hasEditableFocus: true, modifiers: ctrl),
+        const VideoKeyboardResolution(
+            VideoKeyboardDispatch.run, ShortcutAction.popupMineEntry),
+        reason: '制卡是浮层的动作、文本框对 Ctrl+Enter 没有任何用途。一刀切让位整条'
+            '通道时它直接死掉——查到词想制卡，光标恰好还在搜索框里就按不出来',
+      );
+    });
+
+    test('Ctrl+F 在文本框里仍然打开字幕列表搜索', () {
+      expect(
+        resolve(fDown, hasEditableFocus: true, modifiers: ctrl).action,
+        ShortcutAction.videoSearchSubtitleList,
+      );
+    });
+
+    test('负向对照：Ctrl+← 仍归文本框（按词左移），不得变成「上一句字幕」', () {
+      // 这条是整个模型的安全阀。`videoPreviousSubtitle` 的默认键就是 Ctrl+←，若判据
+      // 简化成「有硬修饰就归视频」，用户在 mpv.conf 编辑框里按 Ctrl+← 就不再是按词
+      // 移动光标而是跳字幕——旧实现里文本框根本够不到那张表，这会是**新造**的回归。
+      expect(
+        resolve(leftDown, hasEditableFocus: true, modifiers: ctrl),
+        VideoKeyboardResolution.ignored,
+      );
+      expect(
+        resolve(leftDown, hasEditableFocus: false, modifiers: ctrl).action,
+        ShortcutAction.videoPreviousSubtitle,
+        reason: '前置条件：没有文本框时 Ctrl+← 确实是个视频动作，上一条才有意义',
+      );
+    });
+
+    test('负向对照：Ctrl+Shift+← 仍归文本框（按词扩选），不得变成字幕偏移对齐', () {
+      expect(
+        resolve(leftDown, hasEditableFocus: true, modifiers: ctrlShift),
+        VideoKeyboardResolution.ignored,
+      );
+      expect(
+        resolve(leftDown, hasEditableFocus: false, modifiers: ctrlShift).action,
+        ShortcutAction.videoAlignSubtitleToPrev,
+        reason: '前置条件：没有文本框时 Ctrl+Shift+← 确实是个视频动作',
+      );
+    });
+  });
+
+  group('修饰键模型的三个纯谓词', () {
+    test('hasHardModifier：Ctrl/Alt/Meta 算，Shift 不算', () {
+      expect(hasHardModifier(const <ModifierKey>{}), isFalse);
+      expect(hasHardModifier(shift), isFalse,
+          reason: 'Shift 是「同一个键的另一个字符」，不是命令修饰键');
+      for (final ModifierKey m in const <ModifierKey>[
+        ModifierKey.ctrl,
+        ModifierKey.alt,
+        ModifierKey.meta,
+      ]) {
+        expect(hasHardModifier(<ModifierKey>{m}), isTrue, reason: '$m 是硬修饰');
+      }
+      expect(hasHardModifier(ctrlShift), isTrue,
+          reason: '混合修饰只要含一个硬修饰就算');
+    });
+
+    test('isTextEditingCombination：只认文本框自己也要用的那一小撮', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowLeft,
+        LogicalKeyboardKey.arrowRight,
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.arrowDown,
+        LogicalKeyboardKey.home,
+        LogicalKeyboardKey.end,
+        LogicalKeyboardKey.backspace,
+        LogicalKeyboardKey.delete,
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.keyC,
+        LogicalKeyboardKey.keyV,
+        LogicalKeyboardKey.keyX,
+        LogicalKeyboardKey.keyY,
+        LogicalKeyboardKey.keyZ,
+      ]) {
+        expect(isTextEditingCombination(key), isTrue,
+            reason: '${key.keyLabel} 带 Ctrl/Meta 时是文本框的编辑动作');
+      }
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.enter,
+        LogicalKeyboardKey.space,
+        LogicalKeyboardKey.keyF,
+        LogicalKeyboardKey.keyD,
+        LogicalKeyboardKey.keyL,
+        LogicalKeyboardKey.escape,
+      ]) {
+        expect(isTextEditingCombination(key), isFalse,
+            reason: '${key.keyLabel} 带硬修饰时文本框没有用途，应交回视频通道');
+      }
+    });
+
+    test('editableFocusClaimsKey：无硬修饰全认领，有硬修饰只认领编辑组合', () {
+      expect(
+        editableFocusClaimsKey(
+            logicalKey: LogicalKeyboardKey.keyF,
+            modifiers: const <ModifierKey>{}),
+        isTrue,
+      );
+      expect(
+        editableFocusClaimsKey(
+            logicalKey: LogicalKeyboardKey.keyF, modifiers: shift),
+        isTrue,
+      );
+      expect(
+        editableFocusClaimsKey(
+            logicalKey: LogicalKeyboardKey.keyF, modifiers: ctrl),
+        isFalse,
+      );
+      expect(
+        editableFocusClaimsKey(
+            logicalKey: LogicalKeyboardKey.arrowLeft, modifiers: ctrl),
+        isTrue,
+      );
+    });
   });
 
   group('长按不连发', () {
@@ -111,10 +262,52 @@ void main() {
       expect(r.action, ShortcutAction.videoSeekForward);
     });
 
-    test('press-edge-only 动作的重复沿仍是不消费（与 swallow 是两种结论）', () {
-      // 这批动作旧表就是 includeRepeats:false，放行给上层，不是吃掉。
-      expect(kVideoPressEdgeOnlyActions, isNotEmpty,
-          reason: '前置条件：这个集合空了下面这条就恒真');
+    test('press-edge-only 动作的重复沿是不消费（与 swallowRepeat 是两种结论）', () {
+      // 这批动作旧表就是 includeRepeats:false：放行给上层，不是吃掉。
+      final KeyRepeatEvent bRepeat =
+          repeat(LogicalKeyboardKey.keyB, PhysicalKeyboardKey.keyB);
+      expect(resolve(bRepeat, hasEditableFocus: false).action,
+          isNull,
+          reason: '长按 B 不该按 OS 重复率连翻字幕模糊');
+      expect(resolve(bRepeat, hasEditableFocus: false),
+          VideoKeyboardResolution.ignored,
+          reason: '与 swallowRepeat 的区别是这次按键**不**被吃掉，继续冒泡');
+      expect(
+        resolve(down(LogicalKeyboardKey.keyB, PhysicalKeyboardKey.keyB),
+                hasEditableFocus: false)
+            .action,
+        ShortcutAction.videoToggleSubtitleBlur,
+        reason: '前置条件：按下沿仍然照常翻，上一条才是「只吃重复沿」而不是「B 失效」',
+      );
+    });
+
+    test('kVideoPressEdgeOnlyActions 的成员就是这 5 个（直测，不经 resolver）', () {
+      // 只经 resolver 间接覆盖时，「集合里少一个动作」会退化成「那个动作的重复沿
+      // 照常连发」——而连发本身是别的动作的正确行为，间接用例分不出来。
+      expect(
+        kVideoPressEdgeOnlyActions,
+        <ShortcutAction>{
+          ShortcutAction.videoToggleSubtitleBlur,
+          ShortcutAction.videoCycleSubtitleObscure,
+          ShortcutAction.videoToggleSubtitleHide,
+          ShortcutAction.videoEnterCaret,
+          ShortcutAction.popupMineEntry,
+        },
+        reason: '按一下翻一次的动作（模糊 / 遮蔽循环 / 隐藏 / 进选词光标 / 制卡）'
+            '——长按不该连发查词、更不该连发制卡',
+      );
+      // 连续型动作绝不能混进来：混进去 = 长按方向键不能连续快进 / 长按不能持续调音量。
+      for (final ShortcutAction continuous in <ShortcutAction>[
+        ShortcutAction.videoSeekForward,
+        ShortcutAction.videoSeekBackward,
+        ShortcutAction.videoVolumeUp,
+        ShortcutAction.videoVolumeDown,
+        ShortcutAction.videoPreviousFrame,
+        ShortcutAction.videoNextFrame,
+      ]) {
+        expect(kVideoPressEdgeOnlyActions.contains(continuous), isFalse,
+            reason: '$continuous 是连续型动作，进了这个集合就是把长按连发删掉');
+      }
     });
   });
 }

--- a/fushi/test/media/video/video_player_keyboard_static_test.dart
+++ b/fushi/test/media/video/video_player_keyboard_static_test.dart
@@ -85,8 +85,12 @@ void main() {
           defaultHasKey(ShortcutAction.globalBack, LogicalKeyboardKey.escape),
           isTrue,
           reason: 'globalBack default must bind Escape');
-      expect(page.contains('escape: () {'), isTrue,
+      // 执行体抽成了具名方法（整张表里唯一不碰 controller 的动作，加载态要能单独
+      // 调到），接线点仍必须在 VideoPlayerShortcutActions.escape 上。
+      expect(page.contains('escape: _handleVideoEscapeAction,'), isTrue,
           reason: 'page must wire the Escape action to real exit logic');
+      expect(page.contains('void _handleVideoEscapeAction() {'), isTrue,
+          reason: 'the named exit-ladder method must exist');
       expect(page.contains('isFullscreen('), isTrue,
           reason: 'fullscreen Escape exits fullscreen');
       expect(page.contains('_exitVideoFullscreen('), isTrue,
@@ -101,7 +105,8 @@ void main() {
       // `topVideoForegroundLayer`（纯函数）单点后，escape 回调只剩「先关一层，关不动
       // 才退全屏 / 退页」。断言的行为没变：编辑态必须在任何退出动作之前被吃掉，只是
       // 门从 escape 回调里挪到了那张共用层级表上（[PopScope] / 手柄 B 因此也照吃）。
-      final String escapeBody = region(page, 'escape: () {', '},\n      ),');
+      final String escapeBody =
+          methodBody(page, 'void _handleVideoEscapeAction() {');
       final int dismissGate =
           escapeBody.indexOf('_dismissTopForegroundLayer()');
       final int fullscreenExit = escapeBody.indexOf('_exitVideoFullscreen(');

--- a/fushi/test/media/video/video_player_shortcuts_dispatch_test.dart
+++ b/fushi/test/media/video/video_player_shortcuts_dispatch_test.dart
@@ -231,7 +231,7 @@ Future<void> _pumpEnterCaretHarness(
           hasEditableFocus: false,
           hasVisiblePopup: false,
           videoSurfaceHoldsFocus: videoNode.hasPrimaryFocus,
-          panelHoldsFocusNavigation: false,
+          videoNavigablePanelOpen: false,
         );
         switch (resolution.dispatch) {
           case VideoKeyboardDispatch.swallowRepeat:

--- a/fushi/test/media/video/video_popup_dismiss_guard_test.dart
+++ b/fushi/test/media/video/video_popup_dismiss_guard_test.dart
@@ -38,7 +38,7 @@ void main() {
       hasVisiblePopup: hasVisiblePopup,
       // 画面持焦：让 videoEnterCaret 那条 contextual 判据不干扰本组的浮层语义。
       videoSurfaceHoldsFocus: true,
-      panelHoldsFocusNavigation: false,
+      videoNavigablePanelOpen: false,
     );
   }
 

--- a/fushi/test/media/video/video_subtitle_caret_test.dart
+++ b/fushi/test/media/video/video_subtitle_caret_test.dart
@@ -270,7 +270,7 @@ void main() {
           hasEditableFocus: false,
           hasVisiblePopup: false,
           videoSurfaceHoldsFocus: true,
-          panelHoldsFocusNavigation: false,
+          videoNavigablePanelOpen: false,
         ),
         const VideoKeyboardResolution(
             VideoKeyboardDispatch.run, ShortcutAction.videoPreviousSubtitle),

--- a/fushi/test/media/video/web_video_popup_dismiss_guard_test.dart
+++ b/fushi/test/media/video/web_video_popup_dismiss_guard_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/video_player_shortcuts.dart';
+
+import '../../helpers/source_guard.dart';
+
+/// BUG-924 在**网页视频页**那一半的守卫：[guardVideoShortcutsWithPopupDismiss]。
+///
+/// 原生视频页已经改成页级 press-time 单通道（[resolveVideoKeyboardShortcut]，覆盖在
+/// `video_popup_dismiss_guard_test.dart`），但 `web_video_fushi_page.dart` 仍持有一张
+/// 短生命周期的 [CallbackShortcuts] 表，`_keyboardShortcuts()` 就是
+/// `guardVideoShortcutsWithPopupDismiss(buildVideoPlayerShortcutsFromRegistry(...))`。
+/// 迁移那一轮把这个包装器的 4 条用例整体改写成了新 resolver 的用例，于是这条路径
+/// **一条覆盖都不剩**——函数还活着、还在生产里被调，却没有任何东西钉住它。
+///
+/// 本文件按网页视频页的**实际契约**写，不照抄原生页语义。两处有意的不同：
+/// ① **没有制卡豁免**。原生通道要给 `popupMineEntry` 开后门（浮层可见时按 Ctrl+Enter
+///    是制卡，不是关浮层）；而网页页那张表是 [videoActionCallbacks] 的产物，
+///    `popupMineEntry` 属 dictionaryPopup scope、根本不在里面，没有键需要豁免。
+/// ② **只作用于表里已有的键**。未绑定的键压根不进表，不存在「误吞导航键」的形态，
+///    所以这里断言的是「键集合不增不减」而不是「未绑定的键放行」。
+void main() {
+  const ShortcutActivator seekForward =
+      SingleActivator(LogicalKeyboardKey.keyD);
+  const ShortcutActivator escape = SingleActivator(LogicalKeyboardKey.escape);
+  const ShortcutActivator space = SingleActivator(LogicalKeyboardKey.space);
+
+  /// 与 `buildVideoPlayerShortcutsFromRegistry` 的产物同形状
+  /// （`Map<ShortcutActivator, VoidCallback>`）的最小替身。
+  Map<ShortcutActivator, VoidCallback> baseMap(List<String> log) {
+    return <ShortcutActivator, VoidCallback>{
+      seekForward: () => log.add('seekForward'),
+      escape: () => log.add('escape'),
+      space: () => log.add('togglePlayPause'),
+    };
+  }
+
+  test('浮层可见：任一键先关浮层、不跑原动作', () {
+    final List<String> actions = <String>[];
+    final List<String> dismisses = <String>[];
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => true,
+      dismissPopup: () => dismisses.add('dismiss'),
+    );
+
+    guarded[seekForward]!();
+    guarded[escape]!();
+    guarded[space]!();
+
+    expect(actions, isEmpty,
+        reason: '浮层开着按 d 竟然快进 / 按空格竟然暂停后台视频，正是 BUG-924 的症状');
+    expect(dismisses, <String>['dismiss', 'dismiss', 'dismiss'],
+        reason: '每次按键关一层浮层');
+  });
+
+  test('浮层不可见：原动作照跑一次、不关浮层', () {
+    final List<String> actions = <String>[];
+    final List<String> dismisses = <String>[];
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => false,
+      dismissPopup: () => dismisses.add('dismiss'),
+    );
+
+    guarded[seekForward]!();
+    guarded[escape]!();
+    guarded[space]!();
+
+    expect(actions, <String>['seekForward', 'escape', 'togglePlayPause'],
+        reason: '没有浮层时快捷键必须保持原行为——把它们无条件吞掉等于把网页视频页的'
+            '快捷键整表删了');
+    expect(dismisses, isEmpty, reason: '没有浮层就不该调关闭');
+  });
+
+  test('浮层可见性每次按键实时求值（不在建表时冻结）', () {
+    final List<String> actions = <String>[];
+    bool visible = true;
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => visible,
+      dismissPopup: () {},
+    );
+
+    guarded[seekForward]!();
+    expect(actions, isEmpty, reason: '第一次按 d：浮层还开着 → 关浮层');
+
+    visible = false;
+    guarded[seekForward]!();
+    expect(actions, <String>['seekForward'],
+        reason: '浮层关掉后同一个键必须恢复原动作。谓词若在建表时求过一次值就冻住，'
+            '网页视频页的表是随 build 重建的短生命周期表，症状会退化成随机时灵时不灵');
+  });
+
+  test('键集合不增不减：包装器只换执行体，不动 activator', () {
+    final Map<ShortcutActivator, VoidCallback> base = baseMap(<String>[]);
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      base,
+      isPopupVisible: () => false,
+      dismissPopup: () {},
+    );
+    expect(guarded.keys.toSet(), base.keys.toSet(),
+        reason: '少一个键 = 那个快捷键在网页视频页失效；多一个键 = 凭空吞掉一个'
+            '本该冒泡的按键');
+  });
+
+  test('网页视频页确实还在用这个包装器（否则上面四条守的是死代码）', () {
+    // 这个函数在原生视频页已经下岗，唯一的生产消费者就是网页视频页的
+    // `_keyboardShortcuts()`。它一旦也改走 press-time 通道，本文件应当整体删除，
+    // 而不是留着守一段没人调的代码。
+    final String page = File(
+      'lib/src/pages/implementations/web_video_fushi_page.dart',
+    ).readAsStringSync();
+    const String signature =
+        'Map<ShortcutActivator, VoidCallback> _keyboardShortcuts()';
+    final String body = methodBody(page, signature);
+    expect(containsIdentifierCall(body, 'guardVideoShortcutsWithPopupDismiss'),
+        isTrue,
+        reason: '网页视频页的快捷键表必须仍经 guardVideoShortcutsWithPopupDismiss 包一层，'
+            '否则浮层开着按键会穿透去控制后面的视频（BUG-924 在网页页复发）');
+    expect(
+        containsIdentifierCall(body, 'buildVideoPlayerShortcutsFromRegistry'),
+        isTrue,
+        reason: '被包的必须是注册表产物，改键才生效');
+  });
+}

--- a/fushi/test/pages/video_immersive_lock_guard_test.dart
+++ b/fushi/test/pages/video_immersive_lock_guard_test.dart
@@ -111,20 +111,35 @@ void main() {
         reason: '字幕查词 overlay 必须叠在 controls 之上，锁定态点字幕仍能查词');
     // 锁定态绝不能把整条键盘通道 gate 掉。方案 D 之后快捷键不再是传给 media_kit 的
     // 一张表，而是页级 press-time 派发 [_handleVideoKeyboardShortcut]；沉浸锁的门控
-    // 只允许落在**单个动作**上（_runWhenImmersiveAllowsShortcuts，见 exitLock 等
-    // 白名单），绝不允许提到派发入口上——提上去就等于锁定态整表失效。
-    final String masked = maskComments(src);
-    final int dispatchAt =
-        masked.indexOf('_handleVideoKeyboardShortcut(event)');
-    expect(dispatchAt, greaterThanOrEqualTo(0),
-        reason: '视频快捷键主通道派发点必须存在（锁定态快捷键不被禁用的前提）');
-    // 派发点所在那一行不得带任何沉浸锁条件（`if (_immersiveAllowsShortcuts) ...`）。
-    final int lineStart = masked.lastIndexOf('\n', dispatchAt) + 1;
-    final int lineEnd = masked.indexOf('\n', dispatchAt);
+    // 只允许落在**单个动作**上（_runWhenImmersiveAllowsShortcuts），绝不允许提到通道
+    // 上——提上去就等于锁定态整表失效。
+    //
+    // 判据必须覆盖**整条通道的两段**，不能只看派发那一行：上一行加个
+    // `if (_immersiveAllowsShortcuts)` 就能绕过单行否定，而那正是要禁的形态。
+    // 两段 = 派发方法体（判决与执行）+ 挂载它的 wrapper（键事件入口）。
+    for (final String signature in <String>[
+      'bool _handleVideoKeyboardShortcut(',
+      'Widget _wrapVideoGamepadControls(',
+    ]) {
+      final String body = maskComments(methodBody(src, signature));
+      expect(
+        body.contains('_immersiveAllows'),
+        isFalse,
+        reason: '$signature 的方法体里出现了沉浸锁条件——门控只能落在单个动作上，'
+            '门住通道的任何一段都等于锁定态整表失效（快捷键 / 查词全死，'
+            '而锁定的本意只是挡触摸误触）',
+      );
+    }
+    // 活性自证：上面两条是**否定**断言，门控被整个删光时它们也全绿。真相是门控确实
+    // 存在、且落在逐个动作上（[_buildVideoShortcutActions] 里几乎每个实参都包了一层）。
+    final String actions =
+        maskComments(methodBody(src, 'VideoPlayerShortcutActions '
+            '_buildVideoShortcutActions('));
     expect(
-      masked.substring(lineStart, lineEnd).contains('_immersiveAllows'),
-      isFalse,
-      reason: '沉浸锁门控只能落在单个动作上，不能门住整条键盘派发',
+      '_runWhenImmersiveAllowsShortcuts('.allMatches(actions).length,
+      greaterThan(20),
+      reason: '沉浸锁门控必须真的逐个动作包着——它整个消失时上面两条否定断言会一起'
+          '变成空转，这条负责把「门控还在」钉住',
     );
   });
 
@@ -293,16 +308,24 @@ void main() {
     // BUG-1862：逐级退出的层级表收进 `_dismissTopForegroundLayer` 单点（键盘 Esc /
     // [PopScope] 系统返回键 / 手柄 B 共用），escape 回调只剩「先关一层，关不动才退全屏
     // / 退页」。断言的行为没变：锁定态必须在任何退出动作之前被吃掉。
-    final int escIdx = src.indexOf('escape: () {');
-    expect(escIdx, greaterThanOrEqualTo(0), reason: '缺 escape 回调');
-    final int dismissIdx = src.indexOf('_dismissTopForegroundLayer()', escIdx);
+    // 执行体已从 `escape: () { … }` 闭包抽成具名方法（它是整张动作表里唯一不需要
+    // VideoPlayerController 的动作，加载态下键盘 / 手柄要能单独调到它）。锚点跟着换成
+    // 方法体本身——比原来「从 `escape: () {` 起在**整份剩余语料**里 indexOf」更严：
+    // 那种写法即使执行体搬到别处、闭包里什么都不做，也照样能在后文里撞到这三个 token。
+    final String escapeBody =
+        maskComments(methodBody(src, 'void _handleVideoEscapeAction() {'));
+    final int dismissIdx = escapeBody.indexOf('_dismissTopForegroundLayer()');
     final int fullscreenExitIdx =
-        src.indexOf('_exitVideoFullscreen(ctx)', escIdx);
-    final int exitIdx = src.indexOf('_handleBackOrExit()', escIdx);
+        escapeBody.indexOf('_exitVideoFullscreen(ctx)');
+    final int exitIdx = escapeBody.indexOf('_handleBackOrExit()');
     expect(dismissIdx, greaterThanOrEqualTo(0), reason: 'Esc 未先逐级关前台层');
-    expect(dismissIdx, lessThan(fullscreenExitIdx),
+    expect(fullscreenExitIdx, greaterThan(dismissIdx),
         reason: 'Esc 关前台层必须排在退全屏之前');
-    expect(dismissIdx, lessThan(exitIdx), reason: 'Esc 关前台层必须排在退页之前（逐级退出）');
+    expect(exitIdx, greaterThan(dismissIdx),
+        reason: 'Esc 关前台层必须排在退页之前（逐级退出）');
+    // 它确实还是 globalBack 的执行体（抽成具名方法之后不能忘了接回去）。
+    expect(src.contains('escape: _handleVideoEscapeAction,'), isTrue,
+        reason: 'globalBack 的执行体必须仍接在 VideoPlayerShortcutActions.escape 上');
 
     // 解锁确实还在那张共用层级表里。
     final int tableIdx = src.indexOf('bool _dismissTopForegroundLayer() {');

--- a/fushi/test/pages/video_space_playpause_override_test.dart
+++ b/fushi/test/pages/video_space_playpause_override_test.dart
@@ -12,6 +12,16 @@ import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 import '../helpers/source_guard.dart';
 import 'video_fushi_page_source_corpus.dart';
 
+/// 键盘通道的挂载位（负向对照靠它表达「拓扑挂错了」，而不是「干脆没挂」）。
+enum _ChannelMount {
+  /// 与生产 `_wrapVideoGamepadControls` 同位：窗口 `build()` 与全屏路由
+  /// `pageBuilder` 的唯一共同外层。
+  route,
+
+  /// 回归形状：挂在页面 Scaffold 上——全屏路由不在它的祖先链上。
+  scaffold,
+}
+
 /// 回归守卫（TODO-755 回归 c152fcd91 / BUG-1864）：面板持焦后视频快捷键失效。
 ///
 /// 根因两层：
@@ -32,6 +42,22 @@ import 'video_fushi_page_source_corpus.dart';
 /// [VideoFushiPage] 驱动 media_kit、无法离屏整页 widget 测试，故本测试用与真实拓扑同构
 /// 的最小 widget 树 + **生产的判决函数与真注册表默认绑定**（不在测试里另写一份键位）。
 void main() {
+  // 全局导航层在生产里挂在 `MaterialApp.builder`（见 `main.dart`），也就是 Navigator 的
+  // **祖先**——推到根 navigator 的全屏路由同样在它之下。测试里必须用同一个挂载位，否则
+  // 「裸空格冒到 _neutralizeBareSpace 被吞」这个负向对照的机制根本不成立（用 `home:` 时
+  // 全局层落在 Navigator 之内，全屏路由压根看不见它，空 log 是别的原因造成的）。
+  Widget appWithGlobalNavigation({
+    required GlobalKey<NavigatorState> navKey,
+    required Widget home,
+  }) {
+    return MaterialApp(
+      navigatorKey: navKey,
+      builder: (BuildContext context, Widget? child) =>
+          wrapWithGlobalNavigation(navigatorKey: navKey, child: child!),
+      home: home,
+    );
+  }
+
   FushiShortcutRegistry defaults() =>
       FushiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
 
@@ -41,7 +67,7 @@ void main() {
   KeyEventResult Function(FocusNode, KeyEvent) videoKeyboardChannel({
     required FushiShortcutRegistry registry,
     required List<ShortcutAction> log,
-    bool panelHoldsFocusNavigation = false,
+    bool videoNavigablePanelOpen = false,
     bool videoSurfaceHoldsFocus = false,
   }) {
     return (FocusNode node, KeyEvent event) {
@@ -52,7 +78,7 @@ void main() {
         hasEditableFocus: false,
         hasVisiblePopup: false,
         videoSurfaceHoldsFocus: videoSurfaceHoldsFocus,
-        panelHoldsFocusNavigation: panelHoldsFocusNavigation,
+        videoNavigablePanelOpen: videoNavigablePanelOpen,
       );
       switch (resolution.dispatch) {
         case VideoKeyboardDispatch.swallowRepeat:
@@ -94,12 +120,9 @@ void main() {
     }
 
     await tester.pumpWidget(
-      MaterialApp(
-        navigatorKey: navKey,
-        home: wrapWithGlobalNavigation(
-          navigatorKey: navKey,
-          child: Scaffold(body: Center(child: child)),
-        ),
+      appWithGlobalNavigation(
+        navKey: navKey,
+        home: Scaffold(body: Center(child: child)),
       ),
     );
 
@@ -139,60 +162,77 @@ void main() {
   );
 
   /// BUG-1864 的真实拓扑复刻：**全屏是推到根 navigator 的独立路由**，页面 Scaffold
-  /// 不在它的祖先链上。路由内容包一层与生产 `_wrapVideoGamepadControls` 同位的 wrapper
-  /// （[routeLevelChannel] 决定它是否带页级键盘通道），里面挂真的 [PanelFocusScope]——
-  /// 它正是字幕列表 / 剧集轨 / 侧栏打开时把焦点从视频画面抢走的那个组件。
+  /// 不在它的祖先链上。路由内容里挂真的 [PanelFocusScope]——它正是字幕列表 / 剧集轨 /
+  /// 侧栏打开时把焦点从视频画面抢走的那个组件。
+  ///
+  /// [mount] 决定**那唯一一份键盘通道挂在哪**。两个取值下通道都真实存在、真实接线，
+  /// 差别只有挂载位：
+  /// · [_ChannelMount.route] = 修复后的形状（与生产 `_wrapVideoGamepadControls` 同位，
+  ///   窗口 `build()` 与全屏路由 `pageBuilder` 共用）；
+  /// · [_ChannelMount.scaffold] = 回归形状（挂在页面 Scaffold 上）。负向对照要证的是
+  ///   **「Scaffold 不在全屏路由的祖先链上」这个拓扑事实**；若改成「路由里干脆不挂
+  ///   handler」，证到的只是「没接线就没动作」——那条恒真，换成任何实现都还是绿的。
+  ///
+  /// [enterFullscreen] 为 false 时不推路由，面板直接留在 Scaffold 里，用作**装置活性
+  /// 自证**：同一个 [_ChannelMount.scaffold] 挂载在不进全屏时必须产出**非空** log。
+  /// 少了这一条，负向用例的「空 log」就不再是证据——键名写错、判决函数整个不工作、面板
+  /// 没抢到焦点，都会给出同一个空。
   Future<List<ShortcutAction>> pumpFullscreenRouteAndCollect(
     WidgetTester tester, {
-    required bool routeLevelChannel,
+    required _ChannelMount mount,
+    bool enterFullscreen = true,
   }) async {
     final List<ShortcutAction> log = <ShortcutAction>[];
     final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
 
+    Widget withChannel(Widget child) => Focus(
+          canRequestFocus: false,
+          skipTraversal: true,
+          onKeyEvent: videoKeyboardChannel(
+            registry: defaults(),
+            log: log,
+            // 面板开着 —— 但空格不是焦点导航键，不该受让位影响。
+            videoNavigablePanelOpen: true,
+          ),
+          child: child,
+        );
+
+    Widget panel() => PanelFocusScope(
+          visible: true,
+          child: Material(
+            child: TextButton(
+              onPressed: () {},
+              child: const Text('面板里的按钮'),
+            ),
+          ),
+        );
+
+    // 面板住在哪：进全屏时住在路由里（Scaffold 只剩空壳），不进全屏时就住在 Scaffold。
+    Widget scaffoldBody = enterFullscreen ? const SizedBox.expand() : panel();
+    if (mount == _ChannelMount.scaffold) {
+      scaffoldBody = withChannel(scaffoldBody);
+    }
     await tester.pumpWidget(
-      MaterialApp(
-        navigatorKey: navKey,
-        home: wrapWithGlobalNavigation(
-          navigatorKey: navKey,
-          child: const Scaffold(body: SizedBox.expand()),
-        ),
+      appWithGlobalNavigation(
+        navKey: navKey,
+        home: Scaffold(body: scaffoldBody),
       ),
     );
 
-    // 全屏：推到 root navigator 的独立路由（与 fullscreen.part.dart 同构）。
-    unawaited(
-      navKey.currentState!.push<void>(
-        PageRouteBuilder<void>(
-          transitionDuration: Duration.zero,
-          reverseTransitionDuration: Duration.zero,
-          pageBuilder: (_, __, ___) {
-            Widget content = PanelFocusScope(
-              visible: true,
-              child: Material(
-                child: TextButton(
-                  onPressed: () {},
-                  child: const Text('面板里的按钮'),
-                ),
-              ),
-            );
-            if (routeLevelChannel) {
-              content = Focus(
-                canRequestFocus: false,
-                skipTraversal: true,
-                onKeyEvent: videoKeyboardChannel(
-                  registry: defaults(),
-                  log: log,
-                  // 面板开着 —— 但空格不是焦点导航键，不该受让位影响。
-                  panelHoldsFocusNavigation: true,
-                ),
-                child: content,
-              );
-            }
-            return content;
-          },
+    if (enterFullscreen) {
+      // 全屏：推到 root navigator 的独立路由（与 fullscreen.part.dart 同构）。
+      unawaited(
+        navKey.currentState!.push<void>(
+          PageRouteBuilder<void>(
+            transitionDuration: Duration.zero,
+            reverseTransitionDuration: Duration.zero,
+            pageBuilder: (_, __, ___) => mount == _ChannelMount.route
+                ? withChannel(panel())
+                : panel(),
+          ),
         ),
-      ),
-    );
+      );
+    }
     await tester.pumpAndSettle();
 
     // PanelFocusScope 自己把焦点移进面板（不在测试里手动 requestFocus 视频节点），
@@ -212,7 +252,7 @@ void main() {
     'BUG-1864：全屏路由内面板持焦时裸空格仍触发播放/暂停（修复）',
     (WidgetTester tester) async {
       expect(
-        await pumpFullscreenRouteAndCollect(tester, routeLevelChannel: true),
+        await pumpFullscreenRouteAndCollect(tester, mount: _ChannelMount.route),
         <ShortcutAction>[ShortcutAction.videoTogglePlayPause],
         reason: '键盘通道挂到窗口/全屏共用的 wrapper 后，全屏下打开字幕列表'
             '（PanelFocusScope 抢焦）按空格必须照常播放/暂停',
@@ -221,13 +261,33 @@ void main() {
   );
 
   testWidgets(
-    'BUG-1864 负向对照：全屏路由没有键盘通道时裸空格被全局中和吞掉（复现）',
+    'BUG-1864 负向对照：同一份通道挂在 Scaffold 上时全屏路由够不到它（真拓扑）',
     (WidgetTester tester) async {
       expect(
-        await pumpFullscreenRouteAndCollect(tester, routeLevelChannel: false),
+        await pumpFullscreenRouteAndCollect(
+          tester,
+          mount: _ChannelMount.scaffold,
+        ),
         isEmpty,
-        reason: '通道只挂在页面 Scaffold（不在全屏路由祖先链上）时即回归 BUG-1864：'
-            '面板持焦后裸空格一路冒到 _neutralizeBareSpace 被吞，「按了没反应」',
+        reason: '通道接线完全相同，只是挂在页面 Scaffold 上——而全屏是推到根 navigator '
+            '的独立路由，Scaffold 不在它的祖先链上。裸空格因此一路冒到全局 '
+            '_neutralizeBareSpace 被吞，「按了没反应」= BUG-1864 原样复现',
+      );
+    },
+  );
+
+  testWidgets(
+    'BUG-1864 活性自证：同一个 Scaffold 挂载在不进全屏时必须产出非空',
+    (WidgetTester tester) async {
+      expect(
+        await pumpFullscreenRouteAndCollect(
+          tester,
+          mount: _ChannelMount.scaffold,
+          enterFullscreen: false,
+        ),
+        <ShortcutAction>[ShortcutAction.videoTogglePlayPause],
+        reason: '这条一旦也变成空，上面那条负向用例的「空 log」就不再是「够不到通道」'
+            '的证据，而只是「这套装置本来就产不出东西」——负向对照必须自带活性证明',
       );
     },
   );
@@ -238,7 +298,7 @@ void main() {
   Future<({List<ShortcutAction> log, bool focusMoved})>
       pumpPanelArrowAndCollect(
     WidgetTester tester, {
-    required bool panelHoldsFocusNavigation,
+    required bool videoNavigablePanelOpen,
   }) async {
     final List<ShortcutAction> log = <ShortcutAction>[];
     final FocusNode first = FocusNode(debugLabel: 'panel-row-1');
@@ -254,7 +314,7 @@ void main() {
           onKeyEvent: videoKeyboardChannel(
             registry: defaults(),
             log: log,
-            panelHoldsFocusNavigation: panelHoldsFocusNavigation,
+            videoNavigablePanelOpen: videoNavigablePanelOpen,
           ),
           child: Material(
             child: Column(
@@ -286,7 +346,7 @@ void main() {
 
   testWidgets('面板持焦：裸方向键让位给焦点遍历，不解析成音量', (WidgetTester tester) async {
     final ({List<ShortcutAction> log, bool focusMoved}) r =
-        await pumpPanelArrowAndCollect(tester, panelHoldsFocusNavigation: true);
+        await pumpPanelArrowAndCollect(tester, videoNavigablePanelOpen: true);
     expect(r.log, isEmpty, reason: '面板持焦时裸 ↓ 不得被解析成 videoVolumeDown');
     expect(r.focusMoved, isTrue,
         reason: '不消费 → 冒泡到 WidgetsApp 的 DirectionalFocusIntent，焦点应移到下一行');
@@ -295,7 +355,7 @@ void main() {
   testWidgets('负向对照：没有面板时裸方向键照常调音量、焦点不动', (WidgetTester tester) async {
     final ({List<ShortcutAction> log, bool focusMoved}) r =
         await pumpPanelArrowAndCollect(
-            tester, panelHoldsFocusNavigation: false);
+            tester, videoNavigablePanelOpen: false);
     expect(r.log, <ShortcutAction>[ShortcutAction.videoVolumeDown],
         reason: '没有面板时方向键仍是视频动作——让位判据必须真的由面板态驱动，'
             '而不是无条件放行（那等于把方向键从视频快捷键里删掉）');
@@ -303,60 +363,79 @@ void main() {
   });
 
   test('视频快捷键的唯一键盘挂载点是窗口/全屏共用的 wrapper（源码守卫）', () {
-    final String src = maskComments(readVideoFushiSource());
+    final String src = readVideoFushiSource();
 
     // ① press-time 派发方法存在，且判据走生产纯函数（不在页面里另写一份解析）。
-    final int start = src.indexOf('bool _handleVideoKeyboardShortcut(');
-    expect(start, greaterThanOrEqualTo(0),
-        reason: '_handleVideoKeyboardShortcut 派发方法必须存在');
-    final int end = src.indexOf('\n  }', start);
-    expect(end, greaterThan(start));
-    final String body = src.substring(start, end);
-    expect(body, contains('resolveVideoKeyboardShortcut('),
+    // 方法体用 [methodBody] 括号配对取，不再手搓 `indexOf('\n  }')`：那个锚点被
+    // 方法体里任意一个 2 空格缩进的闭合花括号（switch 的 case 体、闭包）截断在中途，
+    // 后面的断言就在**残缺窗口**上跑，红绿都不代表实现。
+    final String body = methodBody(src, 'bool _handleVideoKeyboardShortcut(');
+    expect(containsIdentifierCall(body, 'resolveVideoKeyboardShortcut'), isTrue,
         reason: '判据必须走生产纯函数，页面不得另写一份键位解析');
-    expect(body, contains('videoActionCallbacks('),
+    expect(containsIdentifierCall(body, 'videoActionCallbacks'), isTrue,
         reason: '执行体必须与手柄通道共用 videoActionCallbacks，两条通道行为才一致');
-    expect(body, contains('_videoNavigablePanelOpen'),
+    expect(containsCodeLine(body, '_videoNavigablePanelOpen'), isTrue,
         reason: '面板态必须喂进判决，否则方向键在面板里不会让位给焦点遍历');
-    expect(body, contains('_videoFocusNode.hasPrimaryFocus'),
-        reason: '画面持焦是 videoEnterCaret 放行判据的输入，不能省');
-    expect(body, contains('hasEditableFocus: focusedEditableText() != null'),
+    expect(containsCodeLine(body, '_videoFocusNode.hasPrimaryFocus'), isTrue,
+        reason: '画面持焦是 videoEnterCaret 放行判据 + 面板让位前提的共同输入，不能省');
+    expect(
+        containsCodeLine(
+            body, 'hasEditableFocus: focusedEditableText() != null'),
+        isTrue,
         reason: 'BUG-962：文本框持焦判据必须真的接进判决输入。纯函数那半是对的，'
             '页面不喂这个参数就等于没有——而现在**整张表**都过这条通道，'
             '它一坏就是在 mpv.conf / 弹幕规则框里打 f 直接切全屏，'
             '不再是旧实现那样「最多打不出空格」');
-    expect(body, contains('if (controller == null) return false;'),
-        reason: '加载态 / 资源缺失态没有 controller，主通道必须整条放行给全局路径，'
-            '不能解析出动作再去空指针（旧 decidePageSpaceOverride 有专条断言）');
+
+    // ①' 加载态可达性：controller 的必要性必须落在**执行点**，不得在入口把整条通道
+    // 关掉。整条关掉时 `_controller == null`（转圈 / 资源缺失）下连 globalBack 都不再
+    // 经本页解析，逐级退出阶梯不走、落到全局 universal 兜底，而 _buildLoadingBody 专门
+    // 留了「转圈时随时可退出」的返回入口——那条可达性在键盘上就断了。
+    final String masked = maskComments(body);
+    final int resolveAt = masked.indexOf('resolveVideoKeyboardShortcut(');
+    final int escapeAt = masked.indexOf('_handleVideoEscapeAction()');
+    final int nullGate =
+        masked.indexOf('if (controller == null) return false;');
+    expect(nullGate, greaterThanOrEqualTo(0),
+        reason: '需要 controller 的动作仍必须有一道门，不能解析出来就直接空指针');
+    expect(resolveAt, lessThan(nullGate),
+        reason: '解析必须无条件先做：controller 门提到 resolve 之前 = 加载态整条通道关闭');
+    expect(escapeAt, greaterThanOrEqualTo(0),
+        reason: 'globalBack 的执行体必须能在没有 controller 时单独调到'
+            '（_handleVideoEscapeAction，整表里唯一不碰播放器的动作）');
+    expect(escapeAt, lessThan(nullGate),
+        reason: 'globalBack 分流必须排在 controller 门之前，否则加载态 Esc 仍走不到'
+            '本页退出阶梯');
 
     // ② 挂载点必须是 [_wrapVideoGamepadControls]——窗口 build() 与全屏路由
     // pageBuilder 的**唯一共同外层**。挂在 _buildScaffold 上时全屏路由（推到根
     // navigator 的独立路由）根本没有这层（BUG-1864）。
-    final int wrapperStart = src.indexOf('Widget _wrapVideoGamepadControls(');
-    expect(wrapperStart, greaterThanOrEqualTo(0),
-        reason: '_wrapVideoGamepadControls 必须存在（窗口/全屏共用输入层）');
-    final int wrapperEnd = src.indexOf('\n  }', wrapperStart);
-    expect(wrapperEnd, greaterThan(wrapperStart));
-    final String wrapper = src.substring(wrapperStart, wrapperEnd);
-    expect(wrapper, contains('_handleVideoKeyboardShortcut(event)'),
+    final String wrapper = methodBody(src, 'Widget _wrapVideoGamepadControls(');
+    expect(containsCodeLine(wrapper, '_handleVideoKeyboardShortcut(event)'),
+        isTrue,
         reason: '键盘通道必须挂在窗口/全屏共用的 _wrapVideoGamepadControls 内，'
             '否则全屏路径没有快捷键（BUG-1864 回归）');
 
     // ③ 全屏路由的 pageBuilder 必须真的走这个 wrapper（BUG-697 已确立的边界）。
-    final int fullscreenAt = src.indexOf('pageBuilder: (_, __, ___) =>');
-    expect(fullscreenAt, greaterThanOrEqualTo(0),
-        reason: '全屏路由 pageBuilder 必须存在');
-    expect(
-      src.substring(fullscreenAt, fullscreenAt + 200),
-      contains('_wrapVideoGamepadControls('),
-      reason: '全屏路由内容必须包进同一个 _wrapVideoGamepadControls，'
-          '窗口与全屏的键盘/手柄语义才一致',
-    );
+    // 窗口由括号配对给出（[namedArgumentValues]），不再是 `substring(at, at + 200)`
+    // 那种定长窗口——包装器名字一变长、实参多折一行，定长窗口就凭空变假。
+    final List<String> pageBuilders = namedArgumentValues(src, 'pageBuilder');
+    expect(pageBuilders, hasLength(1),
+        reason: '合并语料里应当只有全屏路由这一个 pageBuilder；多出一个说明有第二条'
+            '全屏路径，本守卫钉不住它');
+    expect(containsIdentifierCall(pageBuilders.single,
+            '_wrapVideoGamepadControls'),
+        isTrue,
+        reason: '全屏路由内容必须包进同一个 _wrapVideoGamepadControls，'
+            '窗口与全屏的键盘/手柄语义才一致');
 
     // ④ 按住倍速的 keyup 边沿必须排在主通道之前——主通道只看按下 / 重复沿，松开沿
-    // 只有 _handleHoldSpeedKey 认；顺序反了就永远卡在加速态。
-    final int holdAt = wrapper.indexOf('_handleHoldSpeedKey(event)');
-    final int mainAt = wrapper.indexOf('_handleVideoKeyboardShortcut(event)');
+    // 只有 _handleHoldSpeedKey 认；顺序反了就永远卡在加速态。注释必须先剥掉：这段
+    // wrapper 的注释里逐字提到了两个方法名。
+    final String maskedWrapper = maskComments(wrapper);
+    final int holdAt = maskedWrapper.indexOf('_handleHoldSpeedKey(event)');
+    final int mainAt =
+        maskedWrapper.indexOf('_handleVideoKeyboardShortcut(event)');
     expect(holdAt, greaterThanOrEqualTo(0), reason: 'wrapper 里缺按住倍速分支');
     expect(holdAt, lessThan(mainAt), reason: '按住倍速必须排在主通道之前');
   });

--- a/fushi/test/pages/video_subtitle_jump_list_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_jump_list_guard_test.dart
@@ -88,8 +88,12 @@ void main() {
     // `_dismissTopForegroundLayer`，键盘 Esc / [PopScope] 系统返回键 / 手柄 B 共用同一
     // 份（此前 [PopScope] 那条只关词典浮层，侧栏开着按 Esc 会直接退掉整页）。这里断言
     // 的行为没变：字幕列表比侧栏更前台，两者都排在退页之前。
-    final int escIdx = src.indexOf('escape: () {');
-    expect(escIdx, greaterThanOrEqualTo(0), reason: '缺 escape 回调');
+    // 执行体已抽成具名方法 [_handleVideoEscapeAction]（整张动作表里唯一不需要
+    // VideoPlayerController 的动作，加载态下键盘 / 手柄要能绕开表单独调到它）。
+    final int escIdx = src.indexOf('void _handleVideoEscapeAction() {');
+    expect(escIdx, greaterThanOrEqualTo(0), reason: '缺 escape 执行体');
+    expect(src.contains('escape: _handleVideoEscapeAction,'), isTrue,
+        reason: 'globalBack 的执行体必须仍接在 VideoPlayerShortcutActions.escape 上');
     final int dismissIdx = src.indexOf('_dismissTopForegroundLayer()', escIdx);
     final int exitIdx = src.indexOf('_handleBackOrExit()', escIdx);
     expect(dismissIdx, greaterThanOrEqualTo(0), reason: 'Esc 未先逐级关前台层');

--- a/fushi/test/shortcuts/video_panel_focus_nav_test.dart
+++ b/fushi/test/shortcuts/video_panel_focus_nav_test.dart
@@ -1,12 +1,20 @@
 import 'dart:io';
 
+import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/video/video_player_shortcuts.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 
 import '../helpers/source_guard.dart';
 
 /// 手柄重设计 P3：视频浮层面板的焦点导航让位（分类器 + 接线源码守卫）。
+///
+/// 手柄侧 [isVideoPanelFocusNavButton] 与键盘侧 [isVideoPanelFocusNavKey] 是同一条
+/// 语义的两个投影，两边都要有**直测**：只靠 `resolveVideoKeyboardShortcut` 间接覆盖
+/// 的话，分类器少认一个键 / 多认一个键都可能被上层别的判据（未绑定 → ignored）掩盖成
+/// 同一个结论。
 void main() {
   group('isVideoPanelFocusNavButton', () {
     test('dpad 四向 + A 让位给焦点导航', () {
@@ -39,6 +47,157 @@ void main() {
         expect(isVideoPanelFocusNavButton(button), isFalse,
             reason: '${button.label} 不该被面板抢走');
       }
+    });
+  });
+
+  group('isVideoPanelFocusNavKey（[isVideoPanelFocusNavButton] 的键盘对应物）', () {
+    test('四向方向键让位给焦点遍历', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.arrowDown,
+        LogicalKeyboardKey.arrowLeft,
+        LogicalKeyboardKey.arrowRight,
+      ]) {
+        expect(isVideoPanelFocusNavKey(key), isTrue,
+            reason: '${key.keyLabel} 应在面板持焦时让位给焦点遍历');
+      }
+    });
+
+    test('确认 / 翻页 / 播放控制键不让位', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        // Enter 绑着 videoEnterCaret，由「画面精确持焦才算选词键」那条 contextual
+        // 判据天然让位，不在本分类器里重复列一遍（列进来 = 两处真相源）。
+        LogicalKeyboardKey.enter,
+        LogicalKeyboardKey.space,
+        LogicalKeyboardKey.tab,
+        LogicalKeyboardKey.escape,
+        LogicalKeyboardKey.pageUp,
+        LogicalKeyboardKey.pageDown,
+        LogicalKeyboardKey.home,
+        LogicalKeyboardKey.end,
+        LogicalKeyboardKey.keyL,
+        LogicalKeyboardKey.keyF,
+      ]) {
+        expect(isVideoPanelFocusNavKey(key), isFalse,
+            reason: '${key.keyLabel} 不该被面板抢走——面板开着时 L / F / 空格等'
+                '仍是视频动作');
+      }
+    });
+  });
+
+  group('面板让位的两个前提（判据由 resolveVideoKeyboardShortcut 施加）', () {
+    FushiShortcutRegistry defaults() =>
+        FushiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
+
+    VideoKeyboardResolution resolve(
+      LogicalKeyboardKey key,
+      PhysicalKeyboardKey physical, {
+      required bool videoNavigablePanelOpen,
+      required bool videoSurfaceHoldsFocus,
+      Set<ModifierKey> modifiers = const <ModifierKey>{},
+      FushiShortcutRegistry? registry,
+    }) {
+      return resolveVideoKeyboardShortcut(
+        registry ?? defaults(),
+        KeyDownEvent(
+          logicalKey: key,
+          physicalKey: physical,
+          timeStamp: Duration.zero,
+        ),
+        modifiers: modifiers,
+        hasEditableFocus: false,
+        hasVisiblePopup: false,
+        videoSurfaceHoldsFocus: videoSurfaceHoldsFocus,
+        videoNavigablePanelOpen: videoNavigablePanelOpen,
+      );
+    }
+
+    test('前置条件：裸 ↓ 在没有面板时是 videoVolumeDown', () {
+      expect(
+        resolve(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown,
+                videoNavigablePanelOpen: false, videoSurfaceHoldsFocus: false)
+            .action,
+        ShortcutAction.videoVolumeDown,
+        reason: '前置条件塌了下面几条就测了个寂寞',
+      );
+    });
+
+    test('面板开着 + 焦点已不在画面上 → 裸 ↓ 让位', () {
+      expect(
+        resolve(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown,
+            videoNavigablePanelOpen: true, videoSurfaceHoldsFocus: false),
+        VideoKeyboardResolution.ignored,
+      );
+    });
+
+    test('面板开着但画面仍持焦 → 裸 ↓ 照常调音量（不静默失效）', () {
+      // 让位的**理由**是「焦点在面板里、方向键此刻是在面板内选行」。今天这个前提由
+      // 页面的 `_canOwnVideoFocus`（面板打开就不抢焦）间接成立，那是另一个模块的门控
+      // ——它一改，面板开着而焦点仍在画面上时裸方向键就既不移焦也不 seek，静默失效
+      // 且没有任何报错。判据必须把前提就地判掉，不能靠远程不变式。
+      expect(
+        resolve(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown,
+                videoNavigablePanelOpen: true, videoSurfaceHoldsFocus: true)
+            .action,
+        ShortcutAction.videoVolumeDown,
+      );
+    });
+
+    test('硬修饰组合不让位：Ctrl+← 在面板持焦时仍是「上一句字幕」', () {
+      expect(
+        resolve(LogicalKeyboardKey.arrowLeft, PhysicalKeyboardKey.arrowLeft,
+                videoNavigablePanelOpen: true,
+                videoSurfaceHoldsFocus: false,
+                modifiers: const <ModifierKey>{ModifierKey.ctrl})
+            .action,
+        ShortcutAction.videoPreviousSubtitle,
+        reason: 'Ctrl+←/→ 是明确的视频动作，面板开着时照常执行',
+      );
+    });
+
+    test('Shift 不算硬修饰：Shift+↓ 在面板持焦时仍让位（列表里那是扩选）', () {
+      // 旧判据是 `modifiers.isEmpty`，于是 Shift+↓ 会掉进注册表解析——与 caret 那侧
+      // 「只有 Ctrl/Alt/Meta 才算硬修饰」的模型不一致。两处现在共用 hasHardModifier。
+      //
+      // ⚠️ 判据必须**能分辨两种模型**：默认表里 Shift+↓ 没有任何绑定，于是两种模型都
+      // 落到 `ignored`——用默认表写这条断言是同义反复（变异实测：把判据换回
+      // `modifiers.isEmpty` 仍然全绿）。所以这里显式把 Shift+↓ 绑成一个视频动作
+      // （用户在快捷键设置里完全做得到），让「让位」与「解析成动作」成为两个不同答案。
+      final FushiShortcutRegistry rebound = defaults();
+      rebound.updateBinding(
+        ShortcutAction.videoVolumeDown,
+        ShortcutBindingSet(
+          keyboardBindings: <InputBinding>[
+            ...rebound
+                .bindingsFor(ShortcutAction.videoVolumeDown)
+                .keyboardBindings,
+            const InputBinding(
+              key: LogicalKeyboardKey.arrowDown,
+              modifiers: <ModifierKey>{ModifierKey.shift},
+            ),
+          ],
+        ),
+      );
+      expect(
+        resolve(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown,
+                videoNavigablePanelOpen: false,
+                videoSurfaceHoldsFocus: false,
+                modifiers: const <ModifierKey>{ModifierKey.shift},
+                registry: rebound)
+            .action,
+        ShortcutAction.videoVolumeDown,
+        reason: '前置条件：改键之后 Shift+↓ 确实是个视频动作，下一条才有分辨力',
+      );
+      expect(
+        resolve(LogicalKeyboardKey.arrowDown, PhysicalKeyboardKey.arrowDown,
+            videoNavigablePanelOpen: true,
+            videoSurfaceHoldsFocus: false,
+            modifiers: const <ModifierKey>{ModifierKey.shift},
+            registry: rebound),
+        VideoKeyboardResolution.ignored,
+        reason: '面板持焦时 Shift+方向键在列表里是扩选，仍归焦点遍历；'
+            '判据退回 modifiers.isEmpty 就会在这里改调音量',
+      );
     });
   });
 


### PR DESCRIPTION
PR #1105 合入后的剩余根因修复。审查列出的欠账逐条做掉，不留「记账跟进」。

## 1. `guardVideoShortcutsWithPopupDismiss` 是零覆盖的活代码
函数还活着、`web_video_fushi_page.dart` 还在调，但原有 4 条测试全被改写成新 resolver 的测试 → **网页视频页的 BUG-924 语义无守卫**。新建 `web_video_popup_dismiss_guard_test.dart`，先读调用点确认真实契约（网页页那张表是 `videoActionCallbacks` 的产物，`popupMineEntry` 不在里面，所以**没有制卡豁免**、也不存在「未绑定的键放行」这个形态），5 条，含一条「网页页确实还在用这个包装器」——否则前 4 条守的是死代码。

## 2. `panelHoldsFocusNavigation` 参数名撒谎 → 把前提就地判掉
喂进去的是 `_videoNavigablePanelOpen`（面板**打开**）。今天等价靠的是**另一个模块**的门控（`_canOwnVideoFocus` 里 `if (_videoNavigablePanelOpen) return false;`）——那是个远程不变式，本函数拿不到任何保证；它一改，面板开着而焦点仍在画面上时裸方向键**既不移焦也不 seek，静默失效零报错**。

参数改名与实参一致，并把前提就地判掉：让位条件加 `!videoSurfaceHoldsFocus`（这个值本来就传进来了），远程依赖消失。修饰键模型从 `modifiers.isEmpty` 换成与 caret 侧同一条谓词。

## 3. 两套「用户正在打字时这个键归谁」→ 收成一个模型
**没有按「带硬修饰就执行视频动作」做，那会造回归**：`videoPreviousSubtitle`/`videoNextSubtitle` 的默认键就是 **Ctrl+←/→**，那样会让用户在 mpv.conf 编辑框 / 弹幕规则框里按 Ctrl+← 从「按词左移」变成「跳字幕」。旧实现里文本框根本够不到那张表，所以这是**新造**的回归。

抽三个纯谓词，仍是一个模型：`hasHardModifier`（Ctrl/Alt/Meta 算，Shift 不算）、`isTextEditingCombination`、`editableFocusClaimsKey` = 无硬修饰全让 + 有硬修饰只让编辑组合。表述是「模态输入宿主只认领它用得上的键」，两个宿主的唯一差异是那份清单（光标那份是空集）——**宿主能力差异，不是第二套判据**。清单对着 Flutter SDK 的 `default_text_editing_shortcuts.dart` 三平台核过。

结果：Ctrl+Enter 制卡 / Ctrl+F 在文本框里活了；裸空格、裸字母、裸方向键、Shift+字母、Shift+方向键完整让位；Ctrl+←/→ 仍归文本框。

## 4. `_controller == null` 早退挡住加载态 Esc → 必要性下沉到执行点
`escape`(globalBack) 是整张表里唯一不碰播放器的动作，`_handleBackOrExit` 里那句 `await _controller?.flushPosition()` 本来就 null-safe。把 controller 的必要性下沉：`escape` 闭包抽成具名 `_handleVideoEscapeAction()`，解析照常无条件做，`run` 分支里先分流再判 null 门。**手柄通道同款缺口一并修**（手柄 B 在转圈时同样退不出去）。

连带把 4 个原来锚在 `escape: () {` 上的源码守卫重锚到 `methodBody` —— 原来那种「从 `escape: () {` 起在整份剩余语料里 indexOf」很松：执行体搬走、闭包里啥都不做也能在后文撞到那三个 token。

## 5. BUG-1864 负向对照退化成同义反复
新 harness 的 `home:` 里根本没挂通道，证的是「没 handler 所以没动作」。**另有一个更早的问题**：`wrapWithGlobalNavigation` 在生产里挂在 `MaterialApp.builder`（Navigator 的**祖先**），测试挂在 `home:` 里 —— 推到根 navigator 的全屏路由压根看不见全局中和层，那条 reason 当时就是假的。改用 `MaterialApp.builder`；引入 `_ChannelMount{route, scaffold}`，两个取值下通道**都真实存在真实接线**、差别只有挂载位；加回活性自证。

## 6. 沉浸锁守卫被削弱
单行否定，上一行加个 `if` 就绕过。换成「整条通道的两段都不许出现 `_immersiveAllows`」+ 一条**活性自证**（动作表里门控出现 >20 次，实际 36）——否定断言在「门控被整个删光」时也全绿。

## 7-10
`kVideoPressEdgeOnlyActions` 注释改成真实作用域；`layout.part.dart` 两处与新架构相反的文档改写 + 全仓 grep 已删符号；两个纯函数补直测；源码守卫锚点从裸 `indexOf` 换回 `methodBody` / `containsIdentifierCall` / `namedArgumentValues` + `hasLength(1)`。

## 有意不做：39 项闭包表不加缓存
实测 `videoActionCallbacks` **2.76 µs/次**，含闭包分配约 5 µs/次按键，OS 重复率上限 ~30Hz ⇒ ~150 µs/s ≈ **一帧预算的 0.03%**，而命中后要跑的 libmpv IPC 高好几个数量级。更重要的是按 controller 身份缓存会引入一个**新的远程不变式**：那 38 个闭包现在是在闭包**体内**读 `_asbConfig`/`_volumeStep` 等字段，缓存「暂时」安全；哪天有人把字段读提到闭包外（很自然的重构），缓存就静默给出陈旧值且无人报错。为 5 µs 换一个静默失效的隐藏契约，方向与第 2 条正好相反。

## 验证
- `flutter analyze`（fushi 全量含 test）：**No issues found**
- `flutter test test/media/video test/pages test/shortcuts test/focus`：**6818 条全绿**
- 合并 develop 前跑过全量：`FLUTTER TEST VERDICT: PASSED - 21746 tests ran`
- **22 条变异实测全部转红**。其中一条第一轮是绿的——Shift+↓ 断言是同义反复（默认表里它没绑定，两种模型都落到 `ignored`），改成先 `updateBinding` 绑成真动作再断言后转红，理由写进了测试注释。还原一律用变异前字节快照写回 + sha256 复核，全程无 `git checkout`。

## 未验证
未做真机 / 集成测试 —— 「加载态按 Esc 退出」最好在真机走一遍原始路径。

https://claude.ai/code/session_01LkCB8sPTupitepyWbL6YmE
