### PR TITLE
fix(ui): 返回箭头与页面标题同行

### DIFF
--- a/fushi/lib/src/media/manga/aidoku/aidoku_source_browse_page.dart
+++ b/fushi/lib/src/media/manga/aidoku/aidoku_source_browse_page.dart
@@ -175,7 +175,7 @@ class _AidokuSourceBrowsePageState extends State<AidokuSourceBrowsePage> {
   @override
   Widget build(BuildContext context) => FushiPageScaffold(
         title: widget.package.name,
-        showAppBar: false,
+        automaticallyImplyLeading: false,
         headerCompact: true,
         leading: BackButton(
           key: const ValueKey<String>('aidoku_source_back'),

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -648,14 +648,11 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
     // 单行页头：返回按钮和标题同一行。
     //
-    // `showAppBar: true`（默认）会先排一条 title 为空、只有返回按钮的 AppBar，再在
-    // 它下面排一行大标题——两行，返回按钮和「新手引导」四个字对不上，向导这种
-    // 「一屏一步」的页面还白白吃掉一整行高度。`showAppBar: false` 时 [leading] 交给
-    // 页头自己那一行渲染（与 aidoku 源浏览页同一写法），脚手架的
-    // PrimaryScrollController / PageScrollRegistry（手柄 LB/RB 翻页）也照旧保留——
-    // 换成 FushiToolScaffold 就会把这两样一起丢掉。
+    // 手动返回按钮与标题共用 [FushiPageHeader]；关闭自动推导，避免将来本页在可返回
+    // route 中嵌套时重复插入第二个返回按钮。脚手架的 PrimaryScrollController /
+    // PageScrollRegistry（手柄 LB/RB 翻页）照旧保留。
     return FushiPageScaffold(
-      showAppBar: false,
+      automaticallyImplyLeading: false,
       headerCompact: true,
       leading: BackButton(
         key: const ValueKey<String>('onboarding_back'),

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -2043,9 +2043,13 @@ class _FushiPageHeaderRowState extends State<_FushiPageHeaderRow> {
         if (leading != null) {
           children.add(
             Padding(
-              padding: EdgeInsets.only(
+              // 方向性内边距：RTL（ar / he）下 [Row] 会把 leading 排到行尾（视觉右
+              // 侧），此时「leading 与标题之间的空隙」在它的**左**边。写死物理 right
+              // 会让空隙跑到屏幕边缘那侧，返回键直接贴上标题。以前只有两个页面显式
+              // 传 leading，现在脚手架默认给每个可返回页插一个，这条必须是 directional。
+              padding: EdgeInsetsDirectional.only(
                 top: tokens.spacing.gap / 2,
-                right: leadingGap,
+                end: leadingGap,
               ),
               child: leading,
             ),
@@ -2249,12 +2253,31 @@ class _FushiPageScaffoldState extends State<FushiPageScaffold> {
     );
   }
 
+  /// 页头默认返回键（[leading] 为 null 且当前路由可 pop 时插入）。
+  ///
+  /// 命中盒必须撑到 [kMinInteractiveDimension]（48）：被它取代的
+  /// `Scaffold.appBar` 自动 [BackButton] 本就是 48×48 的 [IconButton]，而
+  /// [FushiIconButton] 在 `padding: EdgeInsets.zero` + 无 constraints 下只有图标
+  /// 本体那么大（24×24）——手机触屏上就成了「点不中的返回箭头」，也与
+  /// 本脚手架**显式**传入的 [BackButton]（aidoku 源浏览 / 新手引导）不是
+  /// 同一命中口径。图标视觉尺寸不变，只把 InkWell 命中盒撑开。
+  ///
+  /// 与 [FushiToolScaffold] 同名方法看着一样但**不能合并**：那边整条工具条
+  /// 只有 44 高，它在外层用 `SizedBox.square(40)` 自己撑命中盒，塞不下 48。
+  ///
+  /// [Navigator.maybeOf]：脚手架被用在没有 Navigator 的场景（裸组件测试 /
+  /// 嵌入式外壳）时只是没有返回键，不该整页抛异常。
   Widget? _defaultLeading(BuildContext context) {
-    if (!Navigator.of(context).canPop()) return null;
+    final NavigatorState? navigator = Navigator.maybeOf(context);
+    if (navigator == null || !navigator.canPop()) return null;
     return FushiIconButton(
       tooltip: MaterialLocalizations.of(context).backButtonTooltip,
       icon: Icons.arrow_back,
       padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(
+        minWidth: kMinInteractiveDimension,
+        minHeight: kMinInteractiveDimension,
+      ),
       onTap: () => Navigator.of(context).maybePop(),
     );
   }

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -2148,7 +2148,7 @@ class FushiPageScaffold extends StatefulWidget {
     this.subtitle,
     this.actions = const <Widget>[],
     this.leading,
-    this.showAppBar = true,
+    this.automaticallyImplyLeading = true,
     this.floatingActionButton,
     this.floatingActionButtonLocation,
     this.headerBottom,
@@ -2161,7 +2161,13 @@ class FushiPageScaffold extends StatefulWidget {
   final Widget body;
   final List<Widget> actions;
   final Widget? leading;
-  final bool showAppBar;
+
+  /// Whether a route back button is inserted when [leading] is null.
+  ///
+  /// The button is rendered inside [FushiPageHeader], beside the title. Older
+  /// versions put it in a separate, otherwise-empty [AppBar], which wasted a
+  /// full row and left the title visually detached from its navigation action.
+  final bool automaticallyImplyLeading;
   final Widget? floatingActionButton;
   final FloatingActionButtonLocation? floatingActionButtonLocation;
   final Widget? headerBottom;
@@ -2201,6 +2207,8 @@ class _FushiPageScaffoldState extends State<FushiPageScaffold> {
   @override
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final Widget? effectiveLeading = widget.leading ??
+        (widget.automaticallyImplyLeading ? _defaultLeading(context) : null);
     return PrimaryScrollController(
       controller: _scrollController,
       // Inherit on EVERY platform. The default is mobile-only, which would
@@ -2212,21 +2220,10 @@ class _FushiPageScaffoldState extends State<FushiPageScaffold> {
       automaticallyInheritForPlatforms: TargetPlatform.values.toSet(),
       child: Scaffold(
         backgroundColor: tokens.surfaces.page,
-        appBar: widget.showAppBar
-            ? AppBar(
-                leading: widget.leading,
-                title: const SizedBox.shrink(),
-                backgroundColor: tokens.surfaces.page,
-                surfaceTintColor: Colors.transparent,
-                elevation: 0,
-                scrolledUnderElevation: 0,
-              )
-            : null,
         floatingActionButton: widget.floatingActionButton,
         floatingActionButtonLocation: widget.floatingActionButtonLocation,
         bottomNavigationBar: widget.bottomNavigationBar,
         body: SafeArea(
-          top: !widget.showAppBar,
           // stretch (not start) so every page body receives a tight full-width
           // constraint. Under start the cross axis stays loose, and any body
           // that shrink-wraps its width (e.g. a vertical SingleChildScrollView
@@ -2239,16 +2236,26 @@ class _FushiPageScaffoldState extends State<FushiPageScaffold> {
               FushiPageHeader(
                 title: widget.title,
                 subtitle: widget.subtitle,
-                leading: widget.showAppBar ? null : widget.leading,
+                leading: effectiveLeading,
                 actions: widget.actions,
                 bottom: widget.headerBottom,
-                compact: widget.headerCompact ?? widget.showAppBar,
+                compact: widget.headerCompact ?? effectiveLeading != null,
               ),
               Expanded(child: widget.body),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget? _defaultLeading(BuildContext context) {
+    if (!Navigator.of(context).canPop()) return null;
+    return FushiIconButton(
+      tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+      icon: Icons.arrow_back,
+      padding: EdgeInsets.zero,
+      onTap: () => Navigator.of(context).maybePop(),
     );
   }
 }

--- a/fushi/test/settings/settings_renderer_test.dart
+++ b/fushi/test/settings/settings_renderer_test.dart
@@ -239,7 +239,7 @@ void main() {
     );
 
     expect(find.byType(Scaffold), findsOneWidget);
-    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.byType(AppBar), findsNothing);
     expect(find.text('Action'), findsOneWidget);
     expect(
       find.byWidgetPredicate(

--- a/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
+++ b/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
@@ -12,6 +12,45 @@ import 'package:fushi/src/utils/misc/platform_utils.dart';
 import 'widget_test_helpers.dart';
 
 void main() {
+  testWidgets('back button and title share one page-header row',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) => TextButton(
+          onPressed: () => Navigator.of(context).push<void>(
+            MaterialPageRoute<void>(
+              builder: (_) => const FushiPageScaffold(
+                title: 'Sync & backup',
+                subtitle: 'Cloud, LAN, and local backups',
+                body: SizedBox.shrink(),
+              ),
+            ),
+          ),
+          child: const Text('Open'),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppBar), findsNothing,
+        reason: 'the back action must not occupy a separate empty app-bar row');
+    final Finder back = find.byIcon(Icons.arrow_back);
+    final Finder title = find.text('Sync & backup');
+    expect(back, findsOneWidget);
+    expect(title, findsOneWidget);
+    expect(
+      tester.getCenter(back).dy,
+      moreOrLessEquals(tester.getCenter(title).dy, epsilon: 12),
+      reason: 'back action and title must read as one header row',
+    );
+
+    await tester.tap(back);
+    await tester.pumpAndSettle();
+    expect(find.text('Open'), findsOneWidget);
+  });
+
   testWidgets(
       'FushiPageScaffold page-scrolls its body from a header-area context '
       '(where the gamepad focus actually sits) via PrimaryScrollController',

--- a/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
+++ b/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
@@ -12,24 +12,44 @@ import 'package:fushi/src/utils/misc/platform_utils.dart';
 import 'widget_test_helpers.dart';
 
 void main() {
-  testWidgets('back button and title share one page-header row',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: Builder(
-        builder: (BuildContext context) => TextButton(
-          onPressed: () => Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (_) => const FushiPageScaffold(
-                title: 'Sync & backup',
-                subtitle: 'Cloud, LAN, and local backups',
-                body: SizedBox.shrink(),
+  /// è¿åé®ç**å½ä¸­ç**ï¼InkWellï¼ç©å½¢ââä¸æ¯å¾æ å­å½¢ç©å½¢ã
+  /// ä¸¤èå¨ `padding: EdgeInsets.zero` ä¸æ  constraints æ¶æ°å¥½éåï¼
+  /// æä»¥å¿é¡»é InkWellï¼å¦å 24Ã24 çéåå¨æ­è¨éçä¸åºæ¥ã
+  Rect backHitRect(WidgetTester tester) => tester.getRect(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.arrow_back),
+              matching: find.byType(InkWell),
+            )
+            .first,
+      );
+
+  Widget headerProbeApp({TextDirection? textDirection}) => MaterialApp(
+        builder: textDirection == null
+            ? null
+            : (BuildContext context, Widget? child) => Directionality(
+                  textDirection: textDirection,
+                  child: child!,
+                ),
+        home: Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => Navigator.of(context).push<void>(
+              MaterialPageRoute<void>(
+                builder: (_) => const FushiPageScaffold(
+                  title: 'Sync & backup',
+                  subtitle: 'Cloud, LAN, and local backups',
+                  body: SizedBox.shrink(),
+                ),
               ),
             ),
+            child: const Text('Open'),
           ),
-          child: const Text('Open'),
         ),
-      ),
-    ));
+      );
+
+  testWidgets('back button and title share one page-header row',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(headerProbeApp());
 
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
@@ -40,15 +60,41 @@ void main() {
     final Finder title = find.text('Sync & backup');
     expect(back, findsOneWidget);
     expect(title, findsOneWidget);
-    expect(
-      tester.getCenter(back).dy,
-      moreOrLessEquals(tester.getCenter(title).dy, epsilon: 12),
-      reason: 'back action and title must read as one header row',
-    );
+    final Rect backRect = backHitRect(tester);
+    final Rect titleRect = tester.getRect(title);
+    // ãåä¸è¡ã= ä¸¤èçºµååºé´ç¸äº¤ãæ¯æ¯ä¸­å¿è·ç¨³ï¼æ é¢
+    // åé«åº¦éå¯æ é¢/æè¡/æå­ç¼©æ¾åï¼ä¸­å¿è·ä¼è·çæ¼ï¼åæ¥ç
+    // epsilon: 12 æ°å¥½å¡å¨è¨çå¼ä¸ï¼ï¼èãå æä¸¤è¡ãçéåæ¯çºµååºé´ä¸ç¸äº¤ã
+    expect(backRect.top, lessThan(titleRect.bottom),
+        reason: 'back action and title must read as one header row');
+    expect(titleRect.top, lessThan(backRect.bottom),
+        reason: 'back action and title must read as one header row');
+    // è§¦å±å¯è¾¾æ§ä¸éï¼è¢«åä»£ç AppBar èªå¨ BackButton æ¬å°±æ¯ 48Ã48ã
+    expect(backRect.width, greaterThanOrEqualTo(kMinInteractiveDimension),
+        reason: 'header back button must keep a 48dp-wide tap target');
+    expect(backRect.height, greaterThanOrEqualTo(kMinInteractiveDimension),
+        reason: 'header back button must keep a 48dp-tall tap target');
 
     await tester.tap(back);
     await tester.pumpAndSettle();
     expect(find.text('Open'), findsOneWidget);
+  });
+
+  testWidgets('RTL: the header keeps the gap between back action and title',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(headerProbeApp(textDirection: TextDirection.rtl));
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final Rect backRect = backHitRect(tester);
+    final Rect titleRect = tester.getRect(find.text('Sync & backup'));
+    // RTL ä¸ leading æå°è¡å°¾ï¼è§è§å³ä¾§ï¼ï¼é´è·å¨å®çå·¦è¾¹ã
+    // åæ­»ç©ç `right` ä¼æé´è·æ¾å°å±å¹è¾¹ç¼é£ä¾§ï¼è¿åé®ç´æ¥è´´ä¸æ é¢ã
+    expect(backRect.left - titleRect.right, greaterThanOrEqualTo(8.0),
+        reason: 'the leading gap must be directional, not a hard-coded right '
+            'padding that lands on the screen edge under RTL');
+    expect(backRect.left, greaterThanOrEqualTo(titleRect.right),
+        reason: 'RTL puts the back action after the title');
   });
 
   testWidgets(


### PR DESCRIPTION
## 修改
- 将 `FushiPageScaffold` 的自动返回按钮并入 `FushiPageHeader`，标题、副标题、返回按钮和操作区共用同一行页头
- 移除原先只有返回箭头的空 AppBar，覆盖同步与备份、统计、日志、漫画详情等所有共用页面
- 保留手动 leading 页面，并新增同行对齐与返回交互回归测试

## 验证
- `git diff --cached --check` 通过
- `flutter analyze` 在主工作区发现并修正 `_defaultLeading` 缺失后停止；worktree 定向 `dart analyze` 被本机 Analysis Server 的 perf 文件删除错误中断
- 定向 Flutter 测试未执行：sqlite3 native asset 从 GitHub 下载 Windows DLL 时网络超时，测试在用例启动前阻塞

按要求未等待测试，直接提交 PR。