### PR TITLE
fix(home): BUG-2005 「最近添加」行视频卡按封面朝向自适应

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1860 条。点号进各自文件。
+> 共 1861 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2005](bugs/BUG-2005-recent-added-portrait-slot.md) | ✅ | ✅ | 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条 |
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
 | [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | 🚧 | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |
 | [BUG-1981](bugs/BUG-1981-hook-overlay-dead-window-reopen.md) | ✅ | ✅ | Hook 浮窗 HWND 失效后自动与手动打开都无窗口 |

--- a/docs/bugs/BUG-2005-recent-added-portrait-slot.md
+++ b/docs/bugs/BUG-2005-recent-added-portrait-slot.md
@@ -1,0 +1,6 @@
+## BUG-2005 · 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条
+- **报告**：2026-09-01（用户：截图标注「最近添加和继续一样改成自适应」——「继续」行的视频卡已按封面朝向横竖混排，「最近添加」行同一批视频却挤在窄竖槽里，截帧上下留白条）
+- **真实性**：✅ 真 bug。`_buildRecentlyAddedSection` 调共享行组件时没传 `videoLandscape`，走默认 `false`（`fushi/lib/src/pages/implementations/home_dashboard_page.dart:1327`），于是 `_buildContinueCard` 的朝向探测分支整个被跳过（同文件 `:1446`），视频卡恒 94×132 竖槽；16:9 抽帧进竖槽后由 `PortraitCoverImage` 模糊垫底 + contain，看上去就是上下两条白边。「继续」行传的是 `true`，同一批条目在那行是正常横卡——两行口径不一致而已，不是取图或缓存问题。
+- **[x] ① 已修复** — 根因修复：「最近添加」行改传 `videoLandscape: true`，与「继续」行共用同一条朝向探测路径（`CoverOrientationBuilder` 按解码宽高比分流：横图 → 132×16/9 横槽，竖版海报 → 94×132 竖槽；书/游戏恒竖版不变）。零新增分支、零新常量，只是把已有参数在第二个调用点也传上。提交：见本分支。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_dashboard_page_test.dart`「「最近添加」与「继续」同口径：横版封面的视频卡走 16:9 横槽」：塞真实可解码的 16×9 PNG 当封面，按区块分别量卡宽，两行都必须 > 竖槽宽。变异实测：把 `videoLandscape` 改回 `false` → 最近添加行量到 94（要求 >141）即红。
+- **备注**：测试踩坑记一笔——卡片是 `_loadDashboardData` 回填后才建的，封面解码这段真异步 I/O 必须和那次 pump 一起放进 **同一个 `runAsync`** 窗口；退出 `runAsync` 再 pump 的话 ImageStream 永不完成，探测停在「朝向未知 → 竖卡」，两行都恒量到 94，断言看着「通过不了」实际是测试装配没跑到被测分支。

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1214,10 +1214,11 @@ class _HomeDashboardPageState
 
   /// 横滑卡片行本体（「继续」与「最近添加」共用）：定高横向 ListView。
   ///
-  /// [videoLandscape]：续播区传 true——视频卡 16:9 横槽（用户拍板「续播行只对
-  /// 视频改横版，书/游戏维持竖版」，Jellyfin Continue Watching 口径）；「最近
-  /// 添加」传 false 维持全竖版现状。行高不变：两种卡封面同高、宽度不同，底边
-  /// 天然对齐（video_home_layout 同款几何）。
+  /// [videoLandscape]：传 true——视频卡朝向随封面自适应（探测到横图走 16:9 横槽，
+  /// 只有竖版海报才留竖槽；书/游戏恒竖版，Jellyfin Continue Watching 口径）。
+  /// 「继续」与「最近添加」两行同口径（BUG-2005：后者原先恒竖版，16:9 抽帧被塞
+  /// 进 94×132 竖槽只能模糊垫底出白条）。行高不变：两种卡封面同高、宽度不同，
+  /// 底边天然对齐（video_home_layout 同款几何）。
   Widget _continueCardsRow(
     FushiDesignTokens tokens,
     AppModel appModel,
@@ -1323,7 +1324,7 @@ class _HomeDashboardPageState
     return _sectionCard(
       tokens,
       title: t.home_recently_added,
-      child: _continueCardsRow(tokens, appModel, top),
+      child: _continueCardsRow(tokens, appModel, top, videoLandscape: true),
     );
   }
 
@@ -1437,11 +1438,12 @@ class _HomeDashboardPageState
     _ContinueEntry entry, {
     bool videoLandscape = false,
   }) {
-    // 续播区视频卡：单行允许横竖混排（用户拍板「继续观看只有一行，混排不破
-    // 排版；书架里不可以」）——朝向随**选图链选中的那张图**探测：titleCard /
+    // 首页横滑行的视频卡：单行允许横竖混排（用户拍板「继续观看只有一行，混排
+    // 不破排版；书架里不可以」）——朝向随**选图链选中的那张图**探测：titleCard /
     // backdrop（天然 16:9）→ 横卡；只有竖版海报 → 自然竖卡，不强制模糊垫底成
-    // 16:9。书 / 游戏 /「最近添加」行恒竖版（BUG-1299 口径不变）。探测与卡内
-    // 渲染共用同一 provider 键，零额外解码（CoverOrientationBuilder 契约）。
+    // 16:9。「继续」与「最近添加」两行同口径（BUG-2005）；书 / 游戏恒竖版
+    // （BUG-1299 口径不变）。探测与卡内渲染共用同一 provider 键，零额外解码
+    // （CoverOrientationBuilder 契约）。
     if (videoLandscape && entry.isVideo) {
       final ImageProvider? probe =
           _continueArtworkProvider(entry) ?? _continueVideoCoverProvider(entry);

--- a/fushi/test/pages/home_dashboard_page_test.dart
+++ b/fushi/test/pages/home_dashboard_page_test.dart
@@ -593,6 +593,67 @@ void main() {
     );
   });
 
+  testWidgets('BUG-2005：「最近添加」与「继续」同口径，横版封面的视频卡走 16:9 横槽',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 真实可解码的 16:9 封面：朝向探测读的是解码宽高比，假路径只会走占位（恒竖卡）。
+    final File cover = File('${storeDir.path}/landscape_cover.png')
+      ..writeAsBytesSync(_kLandscapePng);
+    // 只导入 → 只进「最近添加」；有断点 → 只进「继续」。两行各一张视频卡，断言
+    // 按区块隔开（同名文本会互相兜住）。
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('recent-landscape'),
+      title: const Value('刚导入的横版视频'),
+      videoPath: const Value('/abs/recent-landscape.mp4'),
+      coverPath: Value(cover.path),
+      importedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('continue-landscape'),
+      title: const Value('在看的横版视频'),
+      videoPath: const Value('/abs/continue-landscape.mp4'),
+      coverPath: Value(cover.path),
+      lastPositionMs: const Value(60000),
+    ));
+
+    // 两段都必须在**同一个** runAsync 里：卡片是 `_loadDashboardData` 回填后才建
+    // 的，那次 pump 之前根本没有 ImageStream；而退出 runAsync 再 pump 的话，解码
+    // 这段真异步 I/O 在 fakeAsync 下永不完成，探测停在「朝向未知 → 竖卡」，两行
+    // 都恒量到竖槽宽（实测踩过）。
+    await tester.runAsync(() async {
+      await tester.pumpWidget(buildApp());
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      await tester.pump(); // 用真数据重建 → 卡出现 → 封面开始解码
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      await tester.pump(); // 应用探测回来的朝向
+    });
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    // 卡宽 = 封面槽宽：竖槽 94，横槽 132×16/9 ≈ 234.7。断言「明显宽于竖槽」而不是
+    // 精确值，免得日后调封面高度就得改数字（数字变了不代表行为坏了）。
+    const double portraitWidth = 94;
+    for (final (String, String) row in <(String, String)>[
+      (t.home_recently_added, '刚导入的横版视频'),
+      (t.home_continue, '在看的横版视频'),
+    ]) {
+      final Finder card = inSection(
+        row.$1,
+        find.ancestor(of: find.text(row.$2), matching: find.byType(InkWell)),
+      ).first;
+      expect(
+        tester.getSize(card).width,
+        greaterThan(portraitWidth * 1.5),
+        reason: '${row.$1} 行的视频卡应随横版封面自适应成 16:9 横槽，'
+            '恒竖槽会把 16:9 抽帧模糊垫底成白条',
+      );
+    }
+  });
+
   /// BUG-1111/BUG-1112 公共装配：塞一个游戏行；[playedAt] 非空则再塞一条游玩会话
   /// （仓储的 lastPlayedMs 由 `galgame_sessions` 现算，不是 `galgames` 上的列）。
   Future<void> seedGame({
@@ -1464,6 +1525,21 @@ void main() {
     });
   });
 }
+
+/// 16x9 横版 PNG：朝向探测（`CoverOrientationBuilder`）读的是**解码出来的固有
+/// 宽高比**，1x1 方图会被判成竖卡，测不出横卡分流，故另备一张真横图。
+const List<int> _kLandscapePng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x09,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x3B, 0x2A, 0xAC,
+  0x32, 0x00, 0x00, 0x00, 0x16, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0xDA, 0x63, 0xF8, 0xCF, 0xC0, 0xF0,
+  0x9F, 0x12, 0xCC, 0x30, 0x6A, 0xC0, 0xA8, 0x01,
+  0x40, 0x0C, 0x00, 0xDC, 0x62, 0x1E, 0xF0, 0xA7,
+  0x42, 0xC0, 0xCB, 0x00, 0x00, 0x00, 0x00, 0x49,
+  0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+];
 
 /// 1x1 透明 PNG：BUG-1112 需要一个**真实可解码**的封面文件（`Image.file` 对不存在
 /// 或损坏的文件走 errorBuilder，断言不到 FileImage）。


### PR DESCRIPTION
## 问题（BUG-2005）

用户截图标注：「最近添加和继续一样改成自适应」。首页「继续」行的视频卡已经按封面朝向横竖混排，「最近添加」行同一批视频却全挤在窄竖槽里，16:9 抽帧上下各留一条白边。

## 根因

`_buildRecentlyAddedSection` 调共享横滑行组件 `_continueCardsRow` 时没传 `videoLandscape`，吃默认值 `false`；于是 `_buildContinueCard` 里的朝向探测分支（`CoverOrientationBuilder`）整个被跳过，视频卡恒 94×132 竖槽。16:9 抽帧塞进竖槽后由 `PortraitCoverImage` 模糊垫底 + contain 渲染 —— 那两条白边就是垫底层。「继续」行传的是 `true`，所以同一条目在两行长得不一样。不是取图、缓存或封面数据的问题，纯粹是两个调用点口径不一致。

## 改动

「最近添加」行同样传 `videoLandscape: true`，与「继续」行共用同一条探测路径：按解码出的固有宽高比分流，横图走 132×16/9 横槽、竖版海报仍走 94×132 竖槽；书 / 游戏恒竖版（BUG-1299 口径不变）。零新增分支、零新常量、行高不变（两种卡封面同高，底边天然对齐）。

## 测试

`fushi/test/pages/home_dashboard_page_test.dart` 新增用例：塞一张真实可解码的 16×9 PNG 当封面，两行各放一张视频卡（只导入 → 只进最近添加；有断点 → 只进继续），按区块隔开分别量卡宽，都必须明显宽于竖槽。

变异实测：把 `videoLandscape` 改回 `false` → 最近添加行量到 94（要求 >141）即红，继续行仍绿。

测试装配踩坑已写进 BUG 文件备注：卡片是 `_loadDashboardData` 回填后才建的，封面解码这段真异步 I/O 必须和那次 pump 放进**同一个** `runAsync` 窗口；否则 ImageStream 永不完成，探测停在「朝向未知 → 竖卡」，两行都恒量到 94，看着像断言写错了，其实是没跑到被测分支。

## 验证

- `flutter analyze`（含 test）：No issues found
- 定向：`home_dashboard_page_test` + `continue_cover_portrait_guard` + `video_card_cover_aspect_guard` + `unified_collections_architecture_guard` + `video_home_layout_test` → PASSED - 84 tests ran
- 目录枚举型守卫整批（36 条）→ PASSED - 252 tests ran
- `dart format --language-version=3.6` 零变动（本机 3.44 tall style 会重排整文件，已回退后手工按仓库风格贴改动）
- 未做真机截图复验（改动是既有探测路径的第二个调用点，行为由上面的宽度断言锁住）

https://claude.ai/code/session_01GGBZcZATGYZkmJg2g9vzsL
