### PR TITLE
fix(scroll): 桌面滚轮删掉距离折扣，平滑只由补间给（BUG-2009）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1861 条。点号进各自文件。
+> 共 1862 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2009](bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md) | 🚧 | 🚧 | 桌面滚轮平滑修复把滚动速度砍半 |
 | [BUG-2005](bugs/BUG-2005-recent-added-portrait-slot.md) | ✅ | ✅ | 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条 |
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
 | [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | 🚧 | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-2009](bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md) | 🚧 | 🚧 | 桌面滚轮平滑修复把滚动速度砍半 |
+| [BUG-2009](bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md) | ✅ | ✅ | 桌面滚轮平滑修复把滚动速度砍半 |
 | [BUG-2005](bugs/BUG-2005-recent-added-portrait-slot.md) | ✅ | ✅ | 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条 |
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
 | [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | 🚧 | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |

--- a/docs/bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md
+++ b/docs/bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md
@@ -1,0 +1,9 @@
+## BUG-2009 · 桌面滚轮平滑修复把滚动速度砍半
+- **报告**：2026-09-01（用户：「拖动窗口掉帧修了然后我发现引入了新的问题，不掉帧了但是速度慢了」→「优化到又快帧率又高」）
+- **真实性**：✅ 真 bug，且是 BUG-1960 修复引入的回归。根因 `fushi/lib/src/utils/misc/platform_utils.dart` 的 `refinedDesktopPointerScrollDelta`：Windows/Linux 上把绝对值 ≥ 80 的粗滚轮 delta **乘 0.5 再封顶 120px**，一档从系统给的约 100–120px 变成约 48–60px。经 `FushiScrollController` 接在首页 `ListView`（`home_dashboard_page.dart`）和页面骨架（`fushi_material_components.dart:2181`）上，等于全 app 主纵滚都减半。
+  - 用户话里的「拖动窗口掉帧」指的是另一条线（BUG-1916/1917 拖边缩放），那条**没有回归**：同负载下 8/16 修复前旧包 vs 当前 12909 交错各两轮，放大 p50 15.5→11.4~12.5ms、p90 23.0→14.7~15.3ms，缩小 p50 15.0→13.8~14.1ms、p90 21.5→16.4~16.6ms，窗口边跟光标滞后 4.1~4.8px→3.5~4.2px；拖标题栏移动 120 次/s、滞后 8px。另外实测 BUG-1916 加在每个 `WM_SIZE` 上的 `FillSurfaceBackdrop` 在 3840×2160 只要 0.058ms（p99 0.127ms），不是开销来源。真正变慢的是滚轮。
+- **[x] ① 已修复** — 距离与平滑是正交的两件事，BUG-1960 把「一滚跳一整段」误判成「距离太大」，于是两重手段叠着上：`_FushiScrollPosition` 的 `kDesktopWheelScrollDuration`（140ms `animateTo`）已经把瞬移变成补间，×0.5 + 封顶只扣速度、不加流畅。本次直接删掉 `refinedDesktopPointerScrollDelta` 整个函数（连同 0.5 和 120px 两个没有依据的旋钮），粗/细分类只保留一个用途：**要不要补间**。粗滚轮走 `animateTo` 累积目标，细指针（触控板/高精度滚轮）走原生同步路径，距离一律 1:1，一档走多远回归系统「每次滚动行数」设置。手势内锁定分类保留且理由变了——尾帧若改走同步路径，`pointerScroll` 会先 `goIdle` 掐断飞行中的 `DrivenScrollActivity` 再 `forcePixels`，一次拨动的距离反而被吃掉。
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/desktop_wheel_scroll_controller_test.dart`（8 条）把每条距离断言改成平台无关的 1:1（120→120、12+120→132），平台差异只留在「分帧到达还是单帧到达」；新增「粗滚轮分帧到达，不是单帧瞬移」（Windows/Linux 断言中途 0<offset<120，macOS 断言单帧 120）与「粗滚轮手势里的小尾帧不得走同步路径掐断动画」。`fushi/test/utils/misc/desktop_scroll_physics_test.dart` 反向钉死 `refinedDesktopPointerScrollDelta` 不得复活（源码扫描）。`fushi/test/widgets/fushi_page_scaffold_scroll_test.dart` 的四处期望换成字面值 120/132/240。
+- **备注**：
+  - 词典弹窗内部另有一套 `POPUP_WHEEL_PIXEL_FACTOR = 0.48`（`fushi/assets/popup/popup.js`，BUG-870），成因不同——那是 WebView 原生粗步长被 zoom 放大，且用户没报，本次**刻意不动**。
+  - 「帧率」那半边不是本次改动引入的自由度：滚动多远不影响每帧的绘制成本，把距离恢复回 1:1 不会掉帧。真机复测见下方证据。

--- a/docs/bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md
+++ b/docs/bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md
@@ -6,4 +6,6 @@
 - **[x] ② 已加自动化测试** — `fushi/test/utils/misc/desktop_wheel_scroll_controller_test.dart`（8 条）把每条距离断言改成平台无关的 1:1（120→120、12+120→132），平台差异只留在「分帧到达还是单帧到达」；新增「粗滚轮分帧到达，不是单帧瞬移」（Windows/Linux 断言中途 0<offset<120，macOS 断言单帧 120）与「粗滚轮手势里的小尾帧不得走同步路径掐断动画」。`fushi/test/utils/misc/desktop_scroll_physics_test.dart` 反向钉死 `refinedDesktopPointerScrollDelta` 不得复活（源码扫描）。`fushi/test/widgets/fushi_page_scaffold_scroll_test.dart` 的四处期望换成字面值 120/132/240。
 - **备注**：
   - 词典弹窗内部另有一套 `POPUP_WHEEL_PIXEL_FACTOR = 0.48`（`fushi/assets/popup/popup.js`，BUG-870），成因不同——那是 WebView 原生粗步长被 zoom 放大，且用户没报，本次**刻意不动**。
-  - 「帧率」那半边不是本次改动引入的自由度：滚动多远不影响每帧的绘制成本，把距离恢复回 1:1 不会掉帧。真机复测见下方证据。
+  - **真机实测（2026-09-01，本机 3840×2160 客户区，profile 包 + VM service 时间线，`wheelinject` 注入 40 档 @120ms）**：滚动过程中引擎产帧 **131 帧/s**，UI 线程 `Animator::BeginFrame` p50 **1.30ms** / p90 5.94 / max 8.44（>8.3ms 仅 1 帧，>16.7ms **0 帧**），raster `GPURasterizer::Draw` p50 **0.83ms** / max 2.91，`FlutterCompositorPresentLayers` p50 0.06ms。「又快」和「帧率高」同时成立。
+  - **一档实际位移**：屏幕采样探针（垂直位移 SAD 匹配）在本机量到系统一档 = **116px**（3 档 358px，119.3px/档）。这就是新代码原样透传的量；旧代码 `magnitude * 0.5` 会把它压到 **58px**。
+  - ⚠️ 上面这条位移是在**设置页**量的，而设置页右栏有自己的 `ScrollController`，**不走** `FushiScrollController`（后者是 `FushiPageScaffold` 持有的 *primary* controller，只接管没有显式 controller 的 primary ScrollView），所以新旧包在那一页都是 116px——它证明的是探针可信 + 系统一档的真实量，不是折扣被去掉。折扣路径（首页 dashboard `ListView` / scaffold primary 滚动区）在空 profile 的隔离实例里内容不够长、滚不动，没能在真机上做成 before/after；那一半由 widget 测试覆盖（120→120，塞回 ×0.5 立刻变 60）。

--- a/fushi/lib/src/utils/misc/platform_utils.dart
+++ b/fushi/lib/src/utils/misc/platform_utils.dart
@@ -68,34 +68,25 @@ ScrollPhysics desktopAwareScrollPhysics() {
       : const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics());
 }
 
-/// Windows/Linux 的传统鼠标滚轮通常一档上报约 100–120 logical px；Flutter 默认
-/// [ScrollPositionWithSingleContext.pointerScroll] 会把这个 delta 原样同步跳过去，
-/// 视觉上就是「一滚跳一整段」。触控板/高精度滚轮则连续上报小 delta，必须保持 1:1。
+/// Windows/Linux 的传统鼠标滚轮一档上报约 100–120 logical px；Flutter 默认的
+/// [ScrollPositionWithSingleContext.pointerScroll] 把这个 delta 单帧
+/// `forcePixels` 过去，视觉上就是「一滚跳一整段」。
 ///
-/// 因此只收敛绝对值 >= 80 的粗粒度事件：减半并把单事件封顶 120px。小 delta、方向、
-/// macOS 和移动端全部原样保留。
+/// 🔴 不流畅的根因是**缺插值**，不是**距离太大**。一档该走多远由系统「每次滚动
+/// 行数」决定，那是用户自己的设置，app 无权打折。BUG-1960 首版把粗滚轮 delta
+/// 减半、再把单事件封顶 120px 当平滑手段，于是滚动速度直接砍半（BUG-2009 用户
+/// 实报「不掉帧了但是速度慢了」）；平滑那一半本来就由 [_FushiScrollPosition] 的
+/// [kDesktopWheelScrollDuration] 动画负责，减半是叠在上面的第二重手段，只扣速度
+/// 不加流畅。现在距离一律 1:1，平滑只由动画给。
 ///
-/// 本函数只负责**步长**。要不要补一段动画由 [_FushiScrollPosition] 决定，它只对粗
-/// 滚轮动画、且连续同向事件向同一个目标累积（不互相取消，所以不产生输入延迟）；
-/// 触控板的小 delta 走原生同步路径，不会被加上拖尾。
-/// [asCoarse] = 本次事件所属的**手势**已经被判成粗滚轮，即使这一帧的绝对值低于
-/// 阈值也照粗滚轮缩放。滚轮一档并不总是同一个 delta，一次拨动的尾帧可能只有十几
-/// px；只缩放超阈值的那几帧会让同一次拨动前段减半、尾段全量，总距离对不上手感。
-double refinedDesktopPointerScrollDelta(double delta, {bool asCoarse = false}) {
-  if (!(Platform.isWindows || Platform.isLinux)) return delta;
-  final double magnitude = delta.abs();
-  if (!asCoarse && magnitude < 80) return delta;
-  final double reduced = magnitude * 0.5;
-  final double refined = reduced > 120 ? 120 : reduced;
-  return delta.isNegative ? -refined : refined;
-}
-
+/// 分类本身仍然要保留：粗滚轮一档一个大 delta，需要补间；触控板 / 高精度滚轮本来
+/// 就连续上报小 delta，再套一层动画只会拖尾，必须走原生同步路径。
 bool isCoarseDesktopPointerScrollDelta(double delta) =>
     (Platform.isWindows || Platform.isLinux) && delta.abs() >= 80;
 
 const Duration kDesktopWheelScrollDuration = Duration(milliseconds: 140);
 
-/// 为 app 主纵向滚动区提供细化后的桌面滚轮步长。
+/// 给 app 主纵向滚动区的粗鼠标滚轮补上补间动画（距离不变，1:1）。
 ///
 /// 通过自定义 [ScrollPosition] 改写真正消费 pointer delta 的边界；仅换
 /// [ScrollPhysics] 无效，因为 Flutter 的 pointerScroll 会直接 forcePixels。
@@ -180,14 +171,13 @@ class _FushiScrollPosition extends ScrollPositionWithSingleContext {
     final bool coarse =
         _gestureIsCoarse ??= isCoarseDesktopPointerScrollDelta(delta);
 
-    // 分类锁定后，缩放也照分类走：粗滚轮手势里的小尾帧同样减半，否则同一次拨动
-    // 前段减半、尾段全量。细指针手势整段 1:1。
-    final double refined =
-        coarse ? refinedDesktopPointerScrollDelta(delta, asCoarse: true) : delta;
+    // 分类按**手势**锁定，动画与否也照分类走：粗滚轮手势里的小尾帧同样走动画。
+    // 尾帧若改走同步路径，会在动画飞行途中 forcePixels 把 DrivenScrollActivity
+    // 掐断在半路，一次拨动的距离反而被吃掉。细指针手势整段同步。
     if (!coarse ||
         MediaQuery.maybeDisableAnimationsOf(context.storageContext) == true) {
       _resetWheelTarget();
-      super.pointerScroll(refined);
+      super.pointerScroll(delta);
       return;
     }
 
@@ -197,13 +187,13 @@ class _FushiScrollPosition extends ScrollPositionWithSingleContext {
     final bool continuesDrivenScroll = activity is DrivenScrollActivity &&
         _wheelTarget != null &&
         _lastCoarseDelta != null &&
-        _lastCoarseDelta!.isNegative == refined.isNegative;
+        _lastCoarseDelta!.isNegative == delta.isNegative;
     final double base = continuesDrivenScroll ? _wheelTarget! : pixels;
-    final double target = (base + refined)
+    final double target = (base + delta)
         .clamp(minScrollExtent, maxScrollExtent)
         .toDouble();
     _wheelTarget = target;
-    _lastCoarseDelta = refined;
+    _lastCoarseDelta = delta;
     if (target == pixels) return;
 
     unawaited(super.animateTo(

--- a/fushi/test/utils/misc/desktop_scroll_physics_test.dart
+++ b/fushi/test/utils/misc/desktop_scroll_physics_test.dart
@@ -17,14 +17,19 @@ void main() {
     }
   });
 
-  test('粗滚轮减半并封顶，小 delta 与非 MD3 桌面保持原样', () {
-    final bool refined = Platform.isWindows || Platform.isLinux;
-    expect(refinedDesktopPointerScrollDelta(120), refined ? 60 : 120);
-    expect(refinedDesktopPointerScrollDelta(-120), refined ? -60 : -120);
-    expect(refinedDesktopPointerScrollDelta(400), refined ? 120 : 400);
-    expect(refinedDesktopPointerScrollDelta(12), 12,
-        reason: '触控板/高精度滚轮的小 delta 必须保持 1:1');
-    expect(isCoarseDesktopPointerScrollDelta(120), refined);
-    expect(isCoarseDesktopPointerScrollDelta(12), isFalse);
+  test('粗/细分类只决定要不要补间，不决定距离', () {
+    final bool md3Desktop = Platform.isWindows || Platform.isLinux;
+    expect(isCoarseDesktopPointerScrollDelta(120), md3Desktop);
+    expect(isCoarseDesktopPointerScrollDelta(-120), md3Desktop);
+    expect(isCoarseDesktopPointerScrollDelta(12), isFalse,
+        reason: '触控板/高精度滚轮的小 delta 走原生同步路径，不加补间');
+    // BUG-2009：这里刻意不存在「把 delta 缩小」的入口。一档走多远是系统「每次
+    // 滚动行数」设置说了算，app 只补插值不打折；曾经的
+    // refinedDesktopPointerScrollDelta（×0.5、封顶 120px）把滚动速度砍了一半。
+    expect(
+      File('lib/src/utils/misc/platform_utils.dart').readAsStringSync(),
+      isNot(contains('refinedDesktopPointerScrollDelta')),
+      reason: '粗滚轮距离折扣不得复活',
+    );
   });
 }

--- a/fushi/test/utils/misc/desktop_wheel_scroll_controller_test.dart
+++ b/fushi/test/utils/misc/desktop_wheel_scroll_controller_test.dart
@@ -5,16 +5,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/misc/platform_utils.dart';
 
-/// BUG-1960 守卫：Windows 粗鼠标滚轮的「一格一大跳」。
+/// BUG-1960 / BUG-2009 守卫：Windows 粗鼠标滚轮的「一格一大跳」。
 ///
-/// 全仓只有 [FushiScrollController] **一套**桌面滚轮细化实现（BUG-1959 引入，
-/// 本 bug 把「手势内锁定设备分类」并了进去）。别再另起一个平行控制器：两套都拦
-/// `pointerScroll`，同时在场就是两层折扣，而且阈值/倍率/要不要动画会在两处各写一遍。
+/// 全仓只有 [FushiScrollController] **一套**桌面滚轮处理（BUG-1959 引入，BUG-1960
+/// 把「手势内锁定设备分类」并了进去）。别再另起一个平行控制器：两套都拦
+/// `pointerScroll`，同时在场就是两层处理，阈值和策略还要在两处各写一遍。
 ///
-/// 缩放只在 Windows/Linux 生效（macOS 的滚轮/触控板由系统给连续 delta，不该动），
-/// 所以本文件的数值断言按宿主平台分流。
+/// 🔴 BUG-2009：这套东西**只补插值、不改距离**。BUG-1960 首版额外把粗滚轮 delta
+/// 减半并封顶 120px，用户实报「不掉帧了但是速度慢了」——一档走多远是系统「每次
+/// 滚动行数」设置说了算。下面每条距离断言都是平台无关的 1:1，平台差异只体现在
+/// 「这一段是分帧到达还是单帧到达」。
 void main() {
-  final bool scales = Platform.isWindows || Platform.isLinux;
+  final bool animates = Platform.isWindows || Platform.isLinux;
 
   Widget buildList(ScrollController controller) {
     return MaterialApp(
@@ -40,7 +42,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 16));
   }
 
-  testWidgets('粗滚轮一档减半（120 → 60）', (WidgetTester tester) async {
+  testWidgets('粗滚轮一档走满系统给的距离（120 → 120）', (WidgetTester tester) async {
     final FushiScrollController controller = FushiScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
@@ -48,34 +50,62 @@ void main() {
     await tick(tester, 120);
     await tester.pumpAndSettle();
 
-    expect(controller.offset, scales ? 60 : 120);
+    // 距离与平台无关：app 不打折。变异「乘 0.5」→ 60，红。
+    expect(controller.offset, 120);
   });
 
-  testWidgets('细 delta 开头的手势整段保持 1:1', (WidgetTester tester) async {
+  testWidgets('粗滚轮分帧到达，不是单帧瞬移', (WidgetTester tester) async {
     final FushiScrollController controller = FushiScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
 
-    // 首帧 12 判为细指针；紧接着的 120 仍属同一手势，不得突然改按粗滚轮减半。
+    // tick 里那一帧只把 Ticker 起起来（首帧 elapsed 恒为 0，位移还是 0），
+    // 再推进 40ms 才落在动画中途。
+    await tick(tester, 120);
+    await tester.pump(const Duration(milliseconds: 40));
+
+    if (animates) {
+      expect(
+        controller.offset,
+        allOf(greaterThan(0.0), lessThan(120.0)),
+        reason: '粗滚轮应在多帧内逐步到达目标，流畅由这段补间给，不由缩短距离给',
+      );
+    } else {
+      expect(controller.offset, 120,
+          reason: 'macOS/移动端保持平台原生 pointer delta，单帧到位');
+    }
+    await tester.pumpAndSettle();
+    expect(controller.offset, 120);
+  });
+
+  testWidgets('细 delta 开头的手势整段保持同步 1:1', (WidgetTester tester) async {
+    final FushiScrollController controller = FushiScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(buildList(controller));
+
+    // 首帧 12 判为细指针；紧接着的 120 仍属同一手势，不得改判成粗滚轮去加补间。
     await tick(tester, 12);
     await tick(tester, 120);
+    expect(controller.offset, 132, reason: '细指针手势整段同步到位，无补间拖尾');
     await tester.pumpAndSettle();
-
     expect(controller.offset, 132);
   });
 
-  testWidgets('粗滚轮手势里的小尾帧也照粗滚轮缩放', (WidgetTester tester) async {
+  testWidgets('粗滚轮手势里的小尾帧不得走同步路径掐断动画',
+      (WidgetTester tester) async {
     final FushiScrollController controller = FushiScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
 
-    // 首帧 120 判为粗滚轮；尾帧 12 若按 1:1 走，同一次拨动就成了「前段减半、尾段
-    // 全量」，总距离对不上手感 —— 60 + 12 = 72 是**错**的，应当是 60 + 6 = 66。
+    // 首帧 120 判为粗滚轮，动画在飞。尾帧 12 若按「本帧不够阈值就走同步」处理，
+    // `pointerScroll` 会先 goIdle 掐掉飞行中的 DrivenScrollActivity 再 forcePixels，
+    // 这一次拨动的距离就只剩「动画走到一半的位置 + 12」。
     await tick(tester, 120);
+    await tester.pump(const Duration(milliseconds: 40));
     await tick(tester, 12);
     await tester.pumpAndSettle();
 
-    expect(controller.offset, scales ? 66 : 132);
+    expect(controller.offset, 132);
   });
 
   testWidgets('静默超过 200ms 后重新分类（滚轮之后换触控板）',
@@ -84,36 +114,40 @@ void main() {
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
 
-    await tick(tester, 120); // 粗滚轮：60
+    await tick(tester, 120);
     await tester.pumpAndSettle();
+    expect(controller.offset, 120);
     await tester.pump(const Duration(milliseconds: 400)); // 手势结束
-    await tick(tester, 12); // 新手势，细指针：1:1
-    await tester.pumpAndSettle();
 
-    expect(controller.offset, scales ? 72 : 132);
+    // 新手势按细指针判：同步到位，一帧之内就是 132（仍挂着粗滚轮分类的话，
+    // 这一帧只会走到 120 和 132 之间）。
+    await tick(tester, 12);
+    expect(controller.offset, 132);
   });
 
-  testWidgets('delta 0（惯性取消）立刻清掉分类', (WidgetTester tester) async {
+  testWidgets('delta 0（惯性取消）立刻清掉分类且不丢已拨出的距离',
+      (WidgetTester tester) async {
     final FushiScrollController controller = FushiScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
 
-    // 三个事件都在同一个 200ms 窗内。没有惯性取消这条复位，尾帧 12 会继承
-    // 「粗滚轮」分类被减半成 6（总 66）；有复位才是重新判定为细指针的 12（总 72）。
-    //
     // 🔴 惯性取消**不是** `PointerScrollEvent(scrollDelta: 0)`：Scrollable 的
     // `_receivedPointerSignal` 对零位移的 scroll 事件直接不派发（`delta != 0` 门），
     // 那种写法连 pointerScroll 都进不去、断言恒等于「没复位」。真实入口是独立的
     // `PointerScrollInertiaCancelEvent`，framework 收到后调 `pointerScroll(0)`。
     await tick(tester, 120);
+    await tester.pump(const Duration(milliseconds: 40)); // 动画还在飞
     await tester.sendEventToBinding(
       const PointerScrollInertiaCancelEvent(position: Offset(20, 20)),
     );
     await tester.pump(const Duration(milliseconds: 16));
-    await tick(tester, 12);
-    await tester.pumpAndSettle();
+    // 取消要停的是动画，不是已经拨出去的距离。
+    expect(controller.offset, 120);
 
-    expect(controller.offset, scales ? 72 : 132);
+    // 三个事件都在同一个 200ms 窗内；没有这条复位，尾帧 12 会继承「粗滚轮」分类
+    // 走补间，这一帧就到不了 132。
+    await tick(tester, 12);
+    expect(controller.offset, 132);
   });
 
   testWidgets('钳到可滚动范围内，不越界', (WidgetTester tester) async {
@@ -121,8 +155,8 @@ void main() {
     addTearDown(controller.dispose);
     await tester.pumpWidget(buildList(controller));
 
-    // 30000 高、600 视口 -> max 29400；一档 60px，留足余量确保真的滚到底。
-    for (int i = 0; i < 700; i++) {
+    // 30000 高、600 视口 -> max 29400；一档 120px，留足余量确保真的滚到底。
+    for (int i = 0; i < 400; i++) {
       await tick(tester, 120);
     }
     await tester.pumpAndSettle();

--- a/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
+++ b/fushi/test/widgets/fushi_page_scaffold_scroll_test.dart
@@ -7,7 +7,6 @@ import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
-import 'package:fushi/src/utils/misc/platform_utils.dart';
 
 import 'widget_test_helpers.dart';
 
@@ -135,7 +134,7 @@ void main() {
         reason: 'the scaffold must pop its controller on dispose (no leak)');
   });
 
-  testWidgets('BUG-1959：粗鼠标滚轮不再一格跳过完整原始 delta',
+  testWidgets('BUG-1959/2004：粗鼠标滚轮分帧到达，距离仍是完整原始 delta',
       (WidgetTester tester) async {
     PageScrollRegistry.debugClear();
     await tester.pumpWidget(buildTestApp(
@@ -167,7 +166,7 @@ void main() {
         controller.offset,
         allOf(
           greaterThan(0),
-          lessThan(refinedDesktopPointerScrollDelta(120)),
+          lessThan(120.0),
         ),
         reason: '粗滚轮应在多帧内逐步到达目标，而不是第一帧瞬移',
       );
@@ -175,13 +174,14 @@ void main() {
       expect(controller.offset, 120, reason: 'macOS 保持平台原生 pointer delta');
     }
     await tester.pumpAndSettle();
-    expect(controller.offset, refinedDesktopPointerScrollDelta(120));
+    // BUG-2009：距离 1:1，补间只改「怎么到」不改「到哪」。
+    expect(controller.offset, 120);
 
     await tester.sendEventToBinding(wheel.scroll(const Offset(0, 12)));
     await tester.pump();
     expect(
       controller.offset,
-      refinedDesktopPointerScrollDelta(120) + 12,
+      132,
       reason: '小 delta 不得跟着粗滚轮一起打折',
     );
 
@@ -196,7 +196,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       controller.offset,
-      refinedDesktopPointerScrollDelta(120) * 2,
+      240,
       reason: '连续同向滚轮必须累积目标，不能因重启动画吃掉滚动距离',
     );
   });


### PR DESCRIPTION
## 背景

用户报「拖动窗口掉帧修了，但不掉帧了、速度慢了」，随后明确要求「优化到又快帧率又高」。

先排除了误指的那条线：**BUG-1916/1917 的拖边缩放没有回归**。同负载下 8/16 修复前旧包 vs 当前 12909 交错各两轮实测——放大 p50 15.5→11.4~12.5ms、p90 23.0→14.7~15.3ms；缩小 p50 15.0→13.8~14.1ms、p90 21.5→16.4~16.6ms；窗口边跟光标滞后 4.1~4.8px→3.5~4.2px；拖标题栏移动 120 次/s、滞后 8px。另外 BUG-1916 加在每个 `WM_SIZE` 上的 `FillSurfaceBackdrop`，在 3840×2160 实测一次 0.058ms（p99 0.127ms），不是开销来源。

真正变慢的是**滚轮**。

## 根因

BUG-1960 把「一滚跳一整段」误判成「一档距离太大」，于是两重手段叠着上：

- `_FushiScrollPosition` 的 `kDesktopWheelScrollDuration`（140ms `animateTo`）——把瞬移变成补间，**这一重才是流畅的来源**；
- `refinedDesktopPointerScrollDelta` 的 `×0.5` + 单事件封顶 120px——**只扣速度，不加流畅**。

经 `FushiScrollController` 接在首页 `ListView` 和 `FushiPageScaffold` 的 primary controller 上，全 app 主纵滚一档从系统给的约 116px 压到约 58px。

## 改动

删掉 `refinedDesktopPointerScrollDelta` 整个函数（连同 0.5 和 120px 两个没有依据的旋钮）。粗/细分类只保留一个用途：**要不要补间**。粗滚轮走 `animateTo` 累积目标，细指针（触控板/高精度滚轮）走原生同步路径，距离一律 1:1，一档走多远回归系统「每次滚动行数」设置。

手势内锁定分类保留，但理由变了：尾帧若改走同步路径，`pointerScroll` 会先 `goIdle` 掐断飞行中的 `DrivenScrollActivity` 再 `forcePixels`，一次拨动的距离反而被吃掉（变异实测 132 → 90.9）。

词典弹窗内那套 `POPUP_WHEEL_PIXEL_FACTOR = 0.48`（BUG-870，成因是 WebView 原生粗步长被 zoom 放大）不在本次范围，刻意不动。

## 验证

**单测（8 条，变异实测三条全抓红）**

- 塞回 `×0.5` → 一档 120 变 60，红
- 删掉补间 → 中途已经是 120（应 <120），红
- 去掉手势内锁定 → 一次拨动 132 变 90.9，红

**真机（profile 包 + VM service 时间线，注入 40 档 @120ms，3840×2160 客户区）**

- 滚动中引擎产帧 **131 帧/s**
- UI `Animator::BeginFrame` p50 **1.30ms** / p90 5.94 / max 8.44，>16.7ms **零帧**
- raster `GPURasterizer::Draw` p50 **0.83ms** / max 2.91
- 屏幕采样探针量到本机系统一档 = **116px**（3 档 119.3px/档）

⚠️ 位移那条是在设置页量的，而设置页右栏自带 `ScrollController`、不走 `FushiScrollController`，所以新旧包在那页都是 116px——它证明的是探针可信 + 系统一档的真实量，不是折扣被去掉。折扣路径在空 profile 的隔离实例里内容不够长滚不动，没做成真机 before/after，那一半由 widget 测试覆盖。

`flutter analyze` 绿（含 test 目录）；全量测试结果见评论。

https://claude.ai/code/session_01MbqqkCehUvms7jVyy8Yh4t
