### PR TITLE
fix(video): 片段导出按源编码门控，丢源章节并修掉多出的 GOP 前导（BUG-2011）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1862 条。点号进各自文件。
+> 共 1863 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2011](bugs/BUG-2011-clip-export-container-portability.md) | ✅ | ✅ | 视频片段导出产物只有 mpv 能播，进度条显示整集时长 |
 | [BUG-2009](bugs/BUG-2009-desktop-wheel-scroll-speed-halved.md) | ✅ | ✅ | 桌面滚轮平滑修复把滚动速度砍半 |
 | [BUG-2005](bugs/BUG-2005-recent-added-portrait-slot.md) | ✅ | ✅ | 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条 |
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |

--- a/docs/bugs/BUG-2011-clip-export-container-portability.md
+++ b/docs/bugs/BUG-2011-clip-export-container-portability.md
@@ -44,8 +44,25 @@
   变异实测（三处根因各改回坏的样子，改完 sha256 对账回原状）：去掉 `-map_chapters -1`
   → 红 4 条（含专门守卫）；`-avoid_negative_ts` 改回无条件 → 红 3 条；把 8-bit 白名单换成
   「按名字尾巴猜位深」→ 精确红 `nv12` 那条。
+- **同根因全仓排查**（已完成，19 个 ffmpeg 参数构建器 + 3 处内联探测逐个过）：根因 ①
+  （章节被继承）不只在视频片段导出。判据 = **输出是 mp4 系容器 且 输入可能带章节**。
+  - `fushi/lib/src/utils/misc/desktop_audio_clipper.dart` 的 `buildFfmpegClipArgs`
+    （制卡/句子音频）**真中招，已一并修**。桌面/Android 输出 `.aac`（裸 ADTS，无容器，
+    不受影响），但 **iOS 走 `.m4a`**（`immersionMiningAudioExtensionFor`）—— 覆盖沉浸制卡
+    （Netflix/YouTube/应用内视频）、galgame 制卡、外部窗口制卡、互联 host 端裁剪全部路径。
+    实测：源=上报样本，裁 3 秒 → `.m4a` 产物 `MVHD 1272.124s` + 一条整集长 text 轨；
+    加 `-map_chapters -1` 后 `MVHD 3.000s`、text 轨消失。**无条件给而不按扩展名分支**：
+    实测 `.aac` 加与不加产出字节数完全一致（25349 = 25349），多一个分支只多一处能写错的地方。
+  - `fushi/lib/src/media/audiobook/audiobook_clip_export.dart` 的
+    `buildFfmpegImageAudioToVideoArgs` / `buildFfmpegImageSeqAudioToVideoArgs`：输出是 mp4，
+    但两路输入（图片/帧序列 + 已由 `extractAudioSegmentViaFfmpeg` 裁好的裸 `.aac`）今天都
+    不带章节，**当前不会复现**。不过那是个靠调用方维持的**隐式契约**，所以仍就地补上
+    `-map_chapters -1` 钉死 —— 没有章节可丢时它是空操作，代价为零。
+  - 不需要修的：输出为图片（cover/frame/embedded cover）、gif/webp/avif（这些 muxer 没有
+    「为章节建等长 text track」的语义）、字幕文本（srt/ass）、以及全部纯探测调用
+    （`-f null -`、ffprobe、`-i` only、dump-attachment —— 不产出容器）。
+    `transcodeVoiceResourceToMiningAudio` 在 iOS 虽产 `.m4a`，但输入是 hook dump 的游戏
+    语音资源（OGG/WAV/xWMA），不是带章节的媒体容器。
+  根因 ②③ 只对「`-c copy` 裁剪」成立，上述路径全是重编码，不适用。
 - **备注**：`-map 0:a?` 带全部音轨是 BUG-345 的有意设计（多音轨番剧默认轨常不是 0，赌错
   会导出错语言），本次不动它；门控保证的是这些音轨条条可播，而不是砍到一条。
-  同构的有声书片段导出 `fushi/lib/src/media/audiobook/audiobook_clip_export.dart`
-  （文件头自述「镜像 `exportVideoClipViaFfmpeg`」）未在本轮排查范围内，若它也 `-c copy`
-  且不丢章节，同样的三条根因可能成立 —— 留作后续单独核查。

--- a/docs/bugs/BUG-2011-clip-export-container-portability.md
+++ b/docs/bugs/BUG-2011-clip-export-container-portability.md
@@ -1,0 +1,51 @@
+## BUG-2011 · 视频片段导出产物只有 mpv 能播，进度条显示整集时长
+- **报告**：2026-09-01（用户：）
+- **真实性**：✅ 真 bug，三条独立根因叠在同一条导出链路上。用户样本
+  `_2_2016_-_S02E13_000227_314-000232_736.mp4`（文件名声称 5.422 秒）实测：
+  1. **进度条显示整集时长** — `fushi/lib/src/media/video/video_clip_exporter.dart`
+     两个参数构建器都没给 `-map_chapters`，ffmpeg 默认等价 `-map_chapters 0`，把**源整集**
+     的章节表原样搬进片段；mp4 muxer 为此建一条与最后一个章节等长的 chapter text track，
+     `mvhd.duration` 被它拉满。样本解出：`MVHD duration=1274124 (1274.124s)`，
+     `track 6 · HDLR handler=text · duration=1274.124s`，而媒体轨只有 10.7 秒。
+     mpv 自己按媒体轨重算时长所以正常，读 `mvhd` 画进度条的播放器全部显示 21 分 14 秒。
+  2. **产物播不了** — `exportVideoClipViaFfmpeg` 的决策模型是「跑 `-c copy`，**退出码非 0**
+     才降级重编码」（`video_clip_exporter.dart` 的 `attempt()`）。可 `hev1` / 10-bit /
+     FLAC 全都能成功封进 mp4、退出码 0，于是重编码兜底**永远不触发**，产物播不了却被判成功。
+     样本流表：`Video: hevc (Main 10) (hev1) yuv420p10le` + `Audio: flac (fLaC)`（还是
+     default 轨）+ aac ×2。`hev1`（参数集带内）Apple 生态 / 浏览器 / Windows Media
+     Foundation 基本只认 `hvc1`；FLAC-in-mp4 系统解码器不认；10-bit 硬解路径大多不支持。
+  3. **时长多一个 GOP** — copy 路径给了 `-avoid_negative_ts make_zero`。`-c copy` 下
+     `-ss` 必然从请求点**之前**的关键帧起，那段前导本该由 mp4 edit list 表达成「播放时
+     跳过」；`make_zero` 把这段负时间戳整体平移成正片内容。样本 5.422 秒的请求实际落成
+     10.760 秒 = `27.314 + 5.422 - 关键帧 20.0` 的形状。
+     60 秒合成源（关键帧 0/10/20/30/40/50）复现：`-ss 27.314 -t 5.422` → 实得 **12.76s**
+     （= 27.314+5.422−20.0）；把 `-t` 挪到 `-i` 之后**同样** 12.76s（挪位置不是解法），
+     去掉 `make_zero` 后得 **5.437s** 且 `ELST media_time=7.314s` 精确跳过前导。
+- **[x] ① 已修复** — `fushi/lib/src/media/video/video_clip_exporter.dart`：
+  - 新增 `ClipSourceCodecs` / `parseClipSourceCodecs()`（解析 `ffmpeg -i` 日志）与
+    `ClipCodecPlan` / `resolveClipCodecPlan()` / `buildClipCodecArgs()`：**把「导出成功」的
+    判据从「退出码 0」前移到「产物能不能被通用播放器播」**，按流编码逐条决定 copy 还是
+    重编码。h264/hevc + 8-bit 才 copy；hevc copy 时改写 `-tag:v hvc1`；音频只有全部
+    aac/mp3 才 copy，否则整体转 AAC。探测失败/解析不出一律退回 `ClipCodecPlan.fullCopy`，
+    与加门控之前逐参数等价 —— 探测是优化判据，不是导出的前置条件。
+  - 两条路径（copy 与重编码兜底）都加 `-map_chapters -1`。
+  - `-avoid_negative_ts make_zero` 改为**只在视频重编码时**给：视频 copy 时把关键帧前导
+    留给 edit list 表达；重编码时 accurate seek 精确切在请求点，归零无副作用。
+  - 保留 `-map 0:a?`（BUG-345 的「不赌音轨语言」承诺不动），改为保证**每条**音轨都可播。
+  - 实测（源=用户那个真实产物，请求 3.0 秒）：`MVHD 1272.124s → 3.087s`；chapter text
+    track 消失；实际时长 `5.09s → 3.02s`；视频 `hevc 10bit/hev1 → h264 High/avc1/yuv420p`；
+    音频 `flac+aac×2 → aac×3`。h264+aac 源的对照仍走 `-c copy`（MVHD 3.016s，速度不变）。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_clip_exporter_test.dart`
+  新增 group `source codec gating (BUG-2011)` 共 10 条，含：用**用户那份真实 `ffmpeg -i`
+  日志**断言解析结果、10-bit HEVC + FLAC 必须全重编码、已通用可播的源保持 `-c copy` 快路径、
+  8-bit HEVC 保持 copy 但改 `hvc1`、只有音频不可播时只转音频、`nv12` 不得被当成 12-bit、
+  探测不可用时退回门控前行为、两个构建器恒带 `-map_chapters -1`、`-avoid_negative_ts`
+  只在视频重编码时出现、探测调用在裁剪之前且不带 `-ss`。
+  变异实测（三处根因各改回坏的样子，改完 sha256 对账回原状）：去掉 `-map_chapters -1`
+  → 红 4 条（含专门守卫）；`-avoid_negative_ts` 改回无条件 → 红 3 条；把 8-bit 白名单换成
+  「按名字尾巴猜位深」→ 精确红 `nv12` 那条。
+- **备注**：`-map 0:a?` 带全部音轨是 BUG-345 的有意设计（多音轨番剧默认轨常不是 0，赌错
+  会导出错语言），本次不动它；门控保证的是这些音轨条条可播，而不是砍到一条。
+  同构的有声书片段导出 `fushi/lib/src/media/audiobook/audiobook_clip_export.dart`
+  （文件头自述「镜像 `exportVideoClipViaFfmpeg`」）未在本轮排查范围内，若它也 `-c copy`
+  且不丢章节，同样的三条根因可能成立 —— 留作后续单独核查。

--- a/fushi/lib/src/media/audiobook/audiobook_clip_export.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_clip_export.dart
@@ -512,6 +512,16 @@ List<String> buildFfmpegImageAudioToVideoArgs({
     '0:v:0',
     '-map',
     '1:a:0',
+    // BUG-2011：输出是 mp4，而 ffmpeg 默认等价 `-map_chapters 0` —— 一旦某个输入带
+    // 章节，mp4 muxer 就会建一条与最后一个章节等长的 chapter text track，把
+    // `mvhd.duration` 拉满（几秒的片段显示成整本的进度条）。
+    //
+    // 今天两路输入都不带章节（图片/帧序列 + 已由 extractAudioSegmentViaFfmpeg 裁好
+    // 的裸 ADTS `.aac`），所以现在是安全的 —— 但那是个**隐式契约**，靠调用方永远传
+    // 中间产物而不是原始 m4b/视频来维持。就地钉死，比指望远处的约定不被改动可靠；
+    // 代价为零（没有章节可丢时这两个参数是空操作）。
+    '-map_chapters',
+    '-1',
     ..._clipVideoCodecArgs,
     '-r',
     '$fps',
@@ -657,6 +667,16 @@ List<String> buildFfmpegImageSeqAudioToVideoArgs({
     '0:v:0',
     '-map',
     '1:a:0',
+    // BUG-2011：输出是 mp4，而 ffmpeg 默认等价 `-map_chapters 0` —— 一旦某个输入带
+    // 章节，mp4 muxer 就会建一条与最后一个章节等长的 chapter text track，把
+    // `mvhd.duration` 拉满（几秒的片段显示成整本的进度条）。
+    //
+    // 今天两路输入都不带章节（图片/帧序列 + 已由 extractAudioSegmentViaFfmpeg 裁好
+    // 的裸 ADTS `.aac`），所以现在是安全的 —— 但那是个**隐式契约**，靠调用方永远传
+    // 中间产物而不是原始 m4b/视频来维持。就地钉死，比指望远处的约定不被改动可靠；
+    // 代价为零（没有章节可丢时这两个参数是空操作）。
+    '-map_chapters',
+    '-1',
     // TODO-2357：全平台 H.264（帧间压缩把逐句高亮的大量重复帧压到近零）。
     ..._clipVideoCodecArgs,
     '-vf',

--- a/fushi/lib/src/media/video/video_clip_exporter.dart
+++ b/fushi/lib/src/media/video/video_clip_exporter.dart
@@ -55,6 +55,250 @@ class VideoClipExportResult {
   bool get isSuccess => outputPath != null && failure == null;
 }
 
+/// 探测源编码用的超时。探测只读文件头，正常在几十毫秒内返回；给足 30 秒是为了网络
+/// 挂载/机械盘冷启动这类慢 IO，超时就按「探不到」退回全 copy，不拖累导出本身。
+const Duration _kClipProbeTimeout = Duration(seconds: 30);
+
+/// 源视频的编码画像：从 `ffmpeg -hide_banner -i <file>` 的日志里解析出来。
+///
+/// 为什么不用 ffprobe：随包的 ffmpeg-min 确实并排放着同一次 configure 编出的 ffprobe
+/// （`test/tools/ffmpeg_min_vendored_recipe_guard_test.dart` 守着），但那只覆盖**随包**
+/// 这一种情形——用户用 `FUSHI_FFMPEG` 指向自己的 ffmpeg、或回退到 PATH 上的 ffmpeg 时，
+/// 同目录未必有 ffprobe。`ffmpeg -i` 用的是 [resolveFfmpegExecutable] 解析出的那一个
+/// 二进制：只要这台机器裁得动片段，就一定探得到编码。仓库里也已有同款「解析 ffmpeg
+/// 日志拿流信息」的先例（`parseSubtitleStreamsFromFfmpegLog`）。
+@immutable
+class ClipSourceCodecs {
+  const ClipSourceCodecs({
+    this.videoCodec,
+    this.videoPixFmt,
+    this.audioCodecs = const <String>[],
+  });
+
+  /// 首条视频流的编码名（`h264` / `hevc` / `vp9`…）；解析不出为 null。
+  final String? videoCodec;
+
+  /// 首条视频流的像素格式（`yuv420p` / `yuv420p10le`…）；解析不出为 null。
+  final String? videoPixFmt;
+
+  /// 全部音频流的编码名，按 ffmpeg 枚举顺序（`['flac', 'aac', 'aac']`）。
+  /// 收全部而不只收第一条，是因为 `-map 0:a?` 会把**所有**音轨带进输出（BUG-345），
+  /// 只要其中一条不可播，产物在那台播放器上就是坏的。
+  final List<String> audioCodecs;
+
+  /// 一条流都没解析出来 —— 探测失败，调用方必须退回「原样 copy」的既有行为。
+  bool get isEmpty => videoCodec == null && audioCodecs.isEmpty;
+}
+
+/// 剥掉一行里所有 `(...)` 段：ffmpeg 的流描述行在括号里塞了带逗号的子字段
+/// （`yuv420p10le(tv, bt709/unknown/unknown)`），不剥就没法按逗号切字段。
+String _stripParenGroups(String line) {
+  final StringBuffer out = StringBuffer();
+  int depth = 0;
+  for (int i = 0; i < line.length; i++) {
+    final String ch = line[i];
+    if (ch == '(') {
+      depth++;
+    } else if (ch == ')') {
+      if (depth > 0) depth--;
+    } else if (depth == 0) {
+      out.write(ch);
+    }
+  }
+  return out.toString();
+}
+
+/// 纯函数：从 `ffmpeg -i` 的日志文本解析源流编码画像。
+///
+/// 目标行形如（括号内容先由 [_stripParenGroups] 剥掉，再按 `,` 切）：
+/// ```
+///   Stream #0:0[0x1](und): Video: hevc (Main 10) (hev1 / 0x…), yuv420p10le(tv, …), 1920x1080, …
+///   Stream #0:1[0x2](jpn): Audio: flac (fLaC / 0x…), 48000 Hz, stereo, …
+/// ```
+/// 只认输入流（`Stream #`…）；`ffmpeg -i` 不带输出文件，日志里本就只有输入流。
+@visibleForTesting
+ClipSourceCodecs parseClipSourceCodecs(String ffmpegLog) {
+  String? videoCodec;
+  String? videoPixFmt;
+  final List<String> audioCodecs = <String>[];
+
+  for (final String raw in const LineSplitter().convert(ffmpegLog)) {
+    final String line = raw.trim();
+    if (!line.startsWith('Stream #')) continue;
+
+    final int videoAt = line.indexOf('Video: ');
+    final int audioAt = line.indexOf('Audio: ');
+    if (videoAt >= 0) {
+      if (videoCodec != null) continue; // 只取首条视频流
+      final List<String> fields = _stripParenGroups(line.substring(videoAt + 7))
+          .split(',')
+          .map((String s) => s.trim())
+          .where((String s) => s.isNotEmpty)
+          .toList(growable: false);
+      if (fields.isEmpty) continue;
+      videoCodec = fields.first.toLowerCase();
+      // 第二个字段是像素格式；畸形日志可能没有第二段，留 null，由
+      // [_isCopyableVideoPixFmt] 按「探测失败 → 保持 copy」处理。
+      if (fields.length >= 2) videoPixFmt = fields[1].toLowerCase();
+    } else if (audioAt >= 0) {
+      final List<String> fields = _stripParenGroups(line.substring(audioAt + 7))
+          .split(',')
+          .map((String s) => s.trim())
+          .where((String s) => s.isNotEmpty)
+          .toList(growable: false);
+      if (fields.isNotEmpty) audioCodecs.add(fields.first.toLowerCase());
+    }
+  }
+
+  return ClipSourceCodecs(
+    videoCodec: videoCodec,
+    videoPixFmt: videoPixFmt,
+    audioCodecs: List<String>.unmodifiable(audioCodecs),
+  );
+}
+
+/// mp4 里「随便哪台机器都放得动」的视频编码。10-bit / VP9 / AV1 / MPEG-2 都不在内。
+const Set<String> _kClipCopyableVideoCodecs = <String>{'h264', 'hevc'};
+
+/// 同上，音频侧。FLAC-in-mp4 是标准里较晚才有的组合，Windows 系统解码器不认；
+/// Opus / DTS / TrueHD / PCM 同理，一律转 AAC。
+const Set<String> _kClipCopyableAudioCodecs = <String>{'aac', 'mp3'};
+
+/// 8-bit 像素格式白名单。用「笨但清晰」的枚举而不是「按名字尾巴猜位深」——后者会把
+/// `nv12`（8-bit）误判成 12-bit。名单外的格式一律重编码：宁可慢一次，也不要导出一个
+/// 播不了的片段。
+const Set<String> _kClipEightBitPixFmts = <String>{
+  'yuv420p',
+  'yuvj420p',
+  'yuva420p',
+  'yuv422p',
+  'yuvj422p',
+  'yuva422p',
+  'yuv444p',
+  'yuvj444p',
+  'yuva444p',
+  'nv12',
+  'nv21',
+  'gray',
+  'gbrp',
+  'rgb24',
+  'bgr24',
+  'rgba',
+  'bgra',
+};
+
+/// pixFmt 为 null（没解析出来）按「可 copy」处理：探测是优化判据，探测失败绝不能把
+/// 原本瞬时的导出变成整段重编码。只有**明确认出**是名单外格式才降级重编码。
+bool _isCopyableVideoPixFmt(String? pixFmt) {
+  if (pixFmt == null || pixFmt.isEmpty) return true;
+  return _kClipEightBitPixFmts.contains(pixFmt);
+}
+
+/// 「这一轮导出每条流该 copy 还是重编码」的决策结果。
+@immutable
+class ClipCodecPlan {
+  const ClipCodecPlan({
+    required this.copyVideo,
+    required this.copyAudio,
+    this.videoTag,
+  });
+
+  /// 中性计划：与加这层门控之前的行为**逐参数等价**（`-c copy`、不改 tag）。
+  /// 探测不可用、解析不出、或源本来就通用可播时用它。
+  static const ClipCodecPlan fullCopy =
+      ClipCodecPlan(copyVideo: true, copyAudio: true);
+
+  final bool copyVideo;
+  final bool copyAudio;
+
+  /// copy HEVC 时强制改写的 sample entry tag（恒 `hvc1`）。源里常见的 `hev1` 把参数集
+  /// 放在带内，Apple 生态、浏览器和 Windows Media Foundation 基本只认 `hvc1`；改 tag
+  /// 不碰码流，零成本。视频重编码时为 null（那时输出是 H.264）。
+  final String? videoTag;
+
+  bool get isFullCopy => copyVideo && copyAudio;
+}
+
+/// 纯函数：由源编码画像决出导出编码计划。
+///
+/// 这是「导出成功」判据的**前移**：原先的模型是「跑 `-c copy`，退出码非 0 才降级重编
+/// 码」，可 hev1 / 10-bit / FLAC 全都能成功封进 mp4、退出码 0——于是兜底永不触发，产物
+/// 播不了却被判成功。真正的判据是「产物能不能被通用播放器播」，只能在跑之前按流编码
+/// 判定。
+@visibleForTesting
+ClipCodecPlan resolveClipCodecPlan(ClipSourceCodecs codecs) {
+  if (codecs.isEmpty) return ClipCodecPlan.fullCopy;
+
+  final String? video = codecs.videoCodec;
+  final bool copyVideo = video == null ||
+      (_kClipCopyableVideoCodecs.contains(video) &&
+          _isCopyableVideoPixFmt(codecs.videoPixFmt));
+
+  // 空列表 = 没探到音频流信息，保持原 copy 行为；探到了就要求**每一条**都可播，
+  // 因为 `-map 0:a?` 会把它们全部带进输出。
+  final bool copyAudio = codecs.audioCodecs.isEmpty ||
+      codecs.audioCodecs.every(_kClipCopyableAudioCodecs.contains);
+
+  return ClipCodecPlan(
+    copyVideo: copyVideo,
+    copyAudio: copyAudio,
+    videoTag: copyVideo && video == 'hevc' ? 'hvc1' : null,
+  );
+}
+
+/// 纯函数：把 [plan] 摊成 ffmpeg 的编码参数段。
+///
+/// 全 copy 时**逐参数**回到加门控之前的 `-c copy`（外加可能的 `-tag:v hvc1`，它只改
+/// sample entry 四字符码、不碰码流），保证「源本来就通用可播」这条最常见路径的行为
+/// 和性能一个字节都没变。
+@visibleForTesting
+List<String> buildClipCodecArgs({required ClipCodecPlan plan}) {
+  final List<String> tag = plan.videoTag == null
+      ? const <String>[]
+      : <String>['-tag:v', plan.videoTag!];
+  if (plan.isFullCopy) return <String>['-c', 'copy', ...tag];
+  return <String>[
+    '-c:v',
+    if (plan.copyVideo) 'copy' else 'libx264',
+    if (!plan.copyVideo) ...<String>[
+      '-preset',
+      'veryfast',
+      '-crf',
+      '20',
+      '-pix_fmt',
+      'yuv420p',
+    ],
+    ...tag,
+    '-c:a',
+    if (plan.copyAudio) 'copy' else 'aac',
+    if (!plan.copyAudio) ...<String>['-b:a', '192k'],
+  ];
+}
+
+/// 跑一次 `ffmpeg -hide_banner -i <input>` 拿源编码画像并决出编码计划。
+///
+/// 没有输出文件，ffmpeg 必然以非 0 退出（`At least one output file must be
+/// specified`），但流信息此时已经打进日志——所以这里**不看退出码**，只解析输出。
+///
+/// 任何异常、解析不出、探测超时都退回 [ClipCodecPlan.fullCopy]：探测是优化判据，不是
+/// 导出的前置条件，它坏了不能让导出跟着坏。
+Future<ClipCodecPlan> _probeClipCodecPlan(
+  FfmpegBackend backend,
+  String inputPath,
+  Duration timeout,
+) async {
+  try {
+    final FfmpegRunResult probe = await backend.run(
+      <String>['-hide_banner', '-i', inputPath],
+      timeout,
+    );
+    return resolveClipCodecPlan(parseClipSourceCodecs(probe.output));
+  } catch (e, stack) {
+    ErrorLogService.instance.log('VideoClipExport', e, stack);
+    return ClipCodecPlan.fullCopy;
+  }
+}
+
 /// 纯函数：拼 `-map` 段，copy 与 reencode 两条裁剪路径共用（唯一真相源）。
 ///
 /// [subtitleInputCount] 是**额外字幕输入文件**的条数（输入下标从 1 起，0 是源视频）。
@@ -104,6 +348,7 @@ List<String> buildFfmpegVideoClipExportArgs({
   int? audioStreamCount,
   List<String> subtitlePaths = const <String>[],
   String? subtitleCodec,
+  ClipCodecPlan codecPlan = ClipCodecPlan.fullCopy,
 }) {
   final double startSeconds = startMs / 1000.0;
   final double durationSeconds = (endMs - startMs) / 1000.0;
@@ -136,12 +381,21 @@ List<String> buildFfmpegVideoClipExportArgs({
     // 此时绝不能加 `-sn`——它会把刚 map 进来的字幕流一起禁掉。
     if (!withSubtitles) '-sn',
     '-dn',
-    '-c',
-    'copy',
+    // 章节：ffmpeg 默认等价于 `-map_chapters 0`，会把**源整集**的章节表原样搬进片段，
+    // mp4 muxer 为此建一条与最后一个章节等长（≈整集时长）的 text track，把
+    // mvhd.duration 一路拉满——于是一个 5 秒的片段在播放器里显示成 21 分钟的进度条
+    // （BUG-2011）。片段继承整集章节本就没有意义，两条路径一律丢弃。
+    '-map_chapters',
+    '-1',
+    ...buildClipCodecArgs(plan: codecPlan),
     // 字幕流单独指定编码：Matroska 能直接 copy SRT，mp4/mov 系必须转 mov_text。
     if (withSubtitles) ...<String>['-c:s', subtitleCodec],
-    '-avoid_negative_ts',
-    'make_zero',
+    // `-avoid_negative_ts make_zero` 只在**视频重编码**时给（BUG-2011）：
+    // - 视频 copy 时输出必然从 `-ss` 之前的那个关键帧起，多出来的前导本该由 mp4 edit
+    //   list 表达成「播放时跳过」；make_zero 把这段负时间戳整体平移成正片内容，5.4 秒
+    //   的片段于是变成 10.8 秒、开头多出整整一个 GOP。
+    // - 视频重编码时 accurate seek 精确切在请求点，没有前导可跳，归零无副作用。
+    if (!codecPlan.copyVideo) ...<String>['-avoid_negative_ts', 'make_zero'],
     outputPath,
   ];
 }
@@ -201,6 +455,10 @@ List<String> buildFfmpegVideoClipReencodeArgs({
     ),
     if (!withSubtitles) '-sn',
     '-dn',
+    // 与 copy 路径同因：不丢章节，5 秒的片段会带着整集的章节表和一条整集长的 text
+    // track 落盘，进度条显示成整集时长（BUG-2011）。
+    '-map_chapters',
+    '-1',
     if (withSubtitles) ...<String>['-c:s', subtitleCodec],
     '-c:v',
     'libx264',
@@ -294,6 +552,13 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
   try {
     output.parent.createSync(recursive: true);
     final FfmpegBackend resolved = backend ?? resolveFfmpegBackend();
+    // 先探源编码，决定这一轮哪些流能 copy、哪些必须重编码（BUG-2011）。探测失败退回
+    // 全 copy，也就是加这层门控之前的行为。
+    final ClipCodecPlan codecPlan = await _probeClipCodecPlan(
+      resolved,
+      inputPath,
+      _kClipProbeTimeout,
+    );
     bool produced(FfmpegRunResult r) =>
         r.isSuccess && output.existsSync() && output.lengthSync() > 0;
 
@@ -325,6 +590,7 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
           audioStreamCount: audioStreamCount,
           subtitlePaths: subs,
           subtitleCodec: subtitleCodec,
+          codecPlan: codecPlan,
         ),
         timeout,
       );

--- a/fushi/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/fushi/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -489,6 +489,17 @@ List<String> buildFfmpegClipArgs({
     '-i',
     inputPath,
     '-vn',
+    // BUG-2011：源整集/整本的章节表绝不能跟进句子音频。ffmpeg 默认等价
+    // `-map_chapters 0`，mp4 系容器的 muxer 会为此建一条与最后一个章节等长的
+    // chapter text track，把 `mvhd.duration` 拉满 —— 一段 3 秒的句子音频，容器头
+    // 会写着整集的 21 分钟，播放器据此画进度条。
+    //
+    // 桌面/Android 的输出是 `.aac`（裸 ADTS，无容器，本就不受影响），但 **iOS 走
+    // `.m4a`**（[immersionMiningAudioExtensionFor]），那条链路是真中招的。这里无
+    // 条件给而不按扩展名分支：实测 `.aac` 加与不加产出的字节数完全一致，多一个
+    // 分支只会多一处能写错的地方。
+    '-map_chapters',
+    '-1',
     if (explicitAudio != null) ...<String>[
       '-map',
       // 尾随 '?'：越界音轨映射降级回退默认轨而非硬失败（BUG-345）。

--- a/fushi/test/media/audiobook/audiobook_clip_export_contract_test.dart
+++ b/fushi/test/media/audiobook/audiobook_clip_export_contract_test.dart
@@ -70,6 +70,12 @@ void main() {
         containsAllInOrder(<String>['-map', '0:v:0', '-map', '1:a:0']),
       );
       expect(args, containsAllInOrder(<String>['-c:a', 'aac']));
+      // BUG-2011：输出是 mp4，ffmpeg 默认等价 `-map_chapters 0`。只要有一路输入带
+      // 章节，mp4 muxer 就会建一条与最后一个章节等长的 chapter text track，把
+      // mvhd.duration 拉满（几秒的片段显示成整本的进度条）。今天两路输入都不带章节
+      // （图片/帧序列 + 已裁好的裸 ADTS .aac），但那是靠调用方维持的隐式契约；
+      // 就地钉死比指望远处的约定不被改动可靠，且没有章节可丢时它是空操作。
+      expect(args, containsAllInOrder(<String>['-map_chapters', '-1']));
     }
 
     test('static card maps video input 0 and audio input 1', () {

--- a/fushi/test/media/video/video_clip_exporter_test.dart
+++ b/fushi/test/media/video/video_clip_exporter_test.dart
@@ -37,10 +37,14 @@ void main() {
         '0:a:1?',
         '-sn',
         '-dn',
+        // 片段绝不继承源整集的章节表（BUG-2011）：不丢的话 mp4 muxer 会建一条与整集
+        // 等长的 text track，把 mvhd.duration 拉满，5 秒的片段显示成整集的进度条。
+        '-map_chapters',
+        '-1',
         '-c',
         'copy',
-        '-avoid_negative_ts',
-        'make_zero',
+        // 这里**没有** `-avoid_negative_ts make_zero`：视频 copy 时它会把关键帧前导
+        // 从「edit list 跳过」变成正片内容，片段平白多出一个 GOP（BUG-2011）。
         '/video/clip.mkv',
       ]);
     });
@@ -193,9 +197,9 @@ void main() {
       expect(result.isSuccess, isTrue);
       expect(result.outputPath, output.path);
       // Both attempts ran: first stream-copy, then the libx264 fallback.
-      expect(backend.calls.length, 2);
-      expect(backend.calls.first.contains('copy'), isTrue);
-      expect(backend.calls[1].contains('libx264'), isTrue);
+      expect(backend.clipCalls.length, 2);
+      expect(backend.clipCalls.first.contains('copy'), isTrue);
+      expect(backend.clipCalls[1].contains('libx264'), isTrue);
       expect(output.existsSync(), isTrue);
     });
 
@@ -221,7 +225,7 @@ void main() {
       );
 
       expect(result.failure, VideoClipExportFailure.ffmpegFailed);
-      expect(backend.calls.length, 2);
+      expect(backend.clipCalls.length, 2);
       expect(output.existsSync(), isFalse);
     });
 
@@ -439,12 +443,14 @@ void main() {
         '-map',
         '2:s:0',
         '-dn',
+        // 带字幕这条路径同样不继承源章节（BUG-2011）。
+        '-map_chapters',
+        '-1',
         '-c',
         'copy',
         '-c:s',
         'mov_text',
-        '-avoid_negative_ts',
-        'make_zero',
+        // 视频 copy → 不给 `-avoid_negative_ts`，关键帧前导交给 edit list（BUG-2011）。
         '/video/clip.mp4',
       ]);
       // -sn 会把刚 map 进来的字幕流一起禁掉，带字幕时绝不能出现。
@@ -612,10 +618,10 @@ void main() {
       expect(result.subtitleTrackCount, 0, reason: '降级后不能谎称带了字幕');
       expect(output.existsSync(), isTrue);
       // 带字幕的 copy + 重编码两轮失败后，才重跑无字幕的 copy 轮。
-      expect(backend.calls.length, 3);
-      expect(backend.calls[0].contains('-c:s'), isTrue);
-      expect(backend.calls[1].contains('-c:s'), isTrue);
-      expect(backend.calls[2].contains('-c:s'), isFalse);
+      expect(backend.clipCalls.length, 3);
+      expect(backend.clipCalls[0].contains('-c:s'), isTrue);
+      expect(backend.clipCalls[1].contains('-c:s'), isTrue);
+      expect(backend.clipCalls[2].contains('-c:s'), isFalse);
     });
 
     test('skips subtitles entirely for containers that cannot carry them',
@@ -645,9 +651,9 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.subtitleTrackCount, 0);
-      expect(
-          backend.calls.single.any((String a) => a.endsWith('.srt')), isFalse);
-      expect(backend.calls.single.contains('-sn'), isTrue);
+      expect(backend.clipCalls.single.any((String a) => a.endsWith('.srt')),
+          isFalse);
+      expect(backend.clipCalls.single.contains('-sn'), isTrue);
     });
 
     test('blank subtitle content is ignored', () async {
@@ -676,7 +682,7 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.subtitleTrackCount, 0);
-      expect(backend.calls.single.contains('-c:s'), isFalse);
+      expect(backend.clipCalls.single.contains('-c:s'), isFalse);
     });
   });
 
@@ -763,6 +769,205 @@ Input #0, matroska,webm, from 'a.mkv':
       expect(result.detail, isNot(contains('Input #0')));
     });
   });
+
+  // BUG-2011：导出的片段在 mpv 之外播不了、进度条显示成整集时长。三条独立根因，
+  // 这一组把它们各钉一条守卫。
+  group('source codec gating (BUG-2011)', () {
+    const String realWorldLog =
+        '''Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'clip.mp4':
+  Metadata:
+    encoder         : Lavf61.7.103
+  Duration: 00:00:10.59, start: 0.000000, bitrate: 5541 kb/s
+  Chapters:
+    Chapter #0:0: start 0.000000, end 339.630000
+  Stream #0:0[0x1](und): Video: hevc (Main 10) (hev1 / 0x31766568), yuv420p10le(tv, bt709/unknown/unknown), 1920x1080, 3774 kb/s, SAR 1:1 DAR 16:9, 23.98 fps, 23.98 tbr, 16k tbn, start 0.083000 (default)
+  Stream #0:1[0x2](jpn): Audio: flac (fLaC / 0x43614C66), 48000 Hz, stereo, s32 (24 bit), 1444 kb/s, start 0.110000 (default)
+  Stream #0:2[0x3](jpn): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 185 kb/s, start 0.087000
+  Stream #0:4[0x5](und): Subtitle: mov_text (tx3g / 0x67337874), 0 kb/s (default)
+At least one output file must be specified''';
+
+    test('parses the real ffmpeg -i log of the reported file', () {
+      final ClipSourceCodecs codecs = parseClipSourceCodecs(realWorldLog);
+      expect(codecs.videoCodec, 'hevc');
+      // 括号里的 `(tv, bt709/unknown/unknown)` 自带逗号，不剥括号就会把像素格式切碎。
+      expect(codecs.videoPixFmt, 'yuv420p10le');
+      // 全部音轨都要收：`-map 0:a?` 会把它们统统带进输出，一条不可播产物就是坏的。
+      expect(codecs.audioCodecs, <String>['flac', 'aac']);
+      expect(codecs.isEmpty, isFalse);
+    });
+
+    test('plans a full re-encode for the reported file', () {
+      final ClipCodecPlan plan =
+          resolveClipCodecPlan(parseClipSourceCodecs(realWorldLog));
+      // 10-bit HEVC：Windows / 浏览器的通用解码路径放不了。
+      expect(plan.copyVideo, isFalse);
+      // FLAC-in-mp4：系统解码器不认，而且它还是 default 轨。
+      expect(plan.copyAudio, isFalse);
+      // 视频重编码后输出是 H.264，绝不能再挂 hvc1 tag。
+      expect(plan.videoTag, isNull);
+      expect(plan.isFullCopy, isFalse);
+    });
+
+    test('keeps the fast path for an already portable source', () {
+      final ClipCodecPlan plan = resolveClipCodecPlan(
+        const ClipSourceCodecs(
+          videoCodec: 'h264',
+          videoPixFmt: 'yuv420p',
+          audioCodecs: <String>['aac'],
+        ),
+      );
+      expect(plan.isFullCopy, isTrue);
+      expect(plan.videoTag, isNull);
+      expect(buildClipCodecArgs(plan: plan), <String>['-c', 'copy']);
+    });
+
+    test('8-bit HEVC stays a copy but gets retagged hvc1', () {
+      final ClipCodecPlan plan = resolveClipCodecPlan(
+        const ClipSourceCodecs(
+          videoCodec: 'hevc',
+          videoPixFmt: 'yuv420p',
+          audioCodecs: <String>['aac'],
+        ),
+      );
+      expect(plan.copyVideo, isTrue);
+      expect(plan.copyAudio, isTrue);
+      // `hev1` 把参数集放带内，Apple 生态 / 浏览器 / Media Foundation 只认 `hvc1`；
+      // 改 tag 不碰码流，所以仍然是瞬时的 copy。
+      expect(plan.videoTag, 'hvc1');
+      expect(buildClipCodecArgs(plan: plan),
+          <String>['-c', 'copy', '-tag:v', 'hvc1']);
+    });
+
+    test('re-encodes only the audio when just the audio is unplayable', () {
+      final ClipCodecPlan plan = resolveClipCodecPlan(
+        const ClipSourceCodecs(
+          videoCodec: 'h264',
+          videoPixFmt: 'yuv420p',
+          audioCodecs: <String>['aac', 'flac'],
+        ),
+      );
+      // 视频照旧 copy（瞬时），只有音频转 AAC —— 5 秒音频的编码代价可以忽略。
+      expect(plan.copyVideo, isTrue);
+      expect(plan.copyAudio, isFalse);
+      expect(buildClipCodecArgs(plan: plan),
+          <String>['-c:v', 'copy', '-c:a', 'aac', '-b:a', '192k']);
+    });
+
+    test('nv12 is 8-bit and must not be mistaken for 12-bit', () {
+      // 守卫「按名字尾巴猜位深」这个诱人但错误的实现：nv12 结尾是 12，却是 8-bit。
+      final ClipCodecPlan plan = resolveClipCodecPlan(
+        const ClipSourceCodecs(
+          videoCodec: 'h264',
+          videoPixFmt: 'nv12',
+          audioCodecs: <String>['aac'],
+        ),
+      );
+      expect(plan.copyVideo, isTrue);
+    });
+
+    test('an unparseable probe degrades to the pre-gating behaviour', () {
+      // 探测是优化判据，不是导出的前置条件：探不出来就按老样子全 copy，
+      // 绝不能把原本瞬时的导出变成整段重编码。
+      final ClipSourceCodecs codecs =
+          parseClipSourceCodecs('ffmpeg: command not found');
+      expect(codecs.isEmpty, isTrue);
+      final ClipCodecPlan plan = resolveClipCodecPlan(codecs);
+      expect(plan.isFullCopy, isTrue);
+      expect(buildClipCodecArgs(plan: plan), <String>['-c', 'copy']);
+    });
+
+    test('both arg builders always drop the source chapters', () {
+      // 不丢章节，mp4 muxer 会按源整集的章节表建一条整集长的 text track，
+      // 把 mvhd.duration 拉满 —— 这就是「5 秒片段显示 21 分钟进度条」的直接来源。
+      final List<String> copyArgs = buildFfmpegVideoClipExportArgs(
+        inputPath: '/v/in.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/v/out.mp4',
+      );
+      final List<String> reencodeArgs = buildFfmpegVideoClipReencodeArgs(
+        inputPath: '/v/in.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/v/out.mp4',
+      );
+      for (final List<String> args in <List<String>>[copyArgs, reencodeArgs]) {
+        expect(args, containsAllInOrder(<String>['-map_chapters', '-1']));
+      }
+    });
+
+    test('avoid_negative_ts is given only when the video is re-encoded', () {
+      // 视频 copy 时输出必然从 `-ss` 之前那个关键帧起；那段前导本该由 mp4 edit list
+      // 表达成「播放时跳过」。make_zero 会把它平移成正片内容，5.4 秒的片段于是变成
+      // 10.8 秒。重编码时 accurate seek 精确切在请求点，没有前导可跳，归零无副作用。
+      List<String> argsFor(ClipCodecPlan plan) =>
+          buildFfmpegVideoClipExportArgs(
+            inputPath: '/v/in.mkv',
+            startMs: 1000,
+            endMs: 6000,
+            outputPath: '/v/out.mp4',
+            codecPlan: plan,
+          );
+
+      expect(argsFor(ClipCodecPlan.fullCopy).contains('-avoid_negative_ts'),
+          isFalse);
+      expect(
+          argsFor(const ClipCodecPlan(copyVideo: true, copyAudio: false))
+              .contains('-avoid_negative_ts'),
+          isFalse);
+      expect(argsFor(const ClipCodecPlan(copyVideo: false, copyAudio: false)),
+          containsAllInOrder(<String>['-avoid_negative_ts', 'make_zero']));
+      // 重编码兜底路径恒重编码视频，那条必须一直带着。
+      expect(
+          buildFfmpegVideoClipReencodeArgs(
+            inputPath: '/v/in.mkv',
+            startMs: 1000,
+            endMs: 6000,
+            outputPath: '/v/out.mp4',
+          ),
+          containsAllInOrder(<String>['-avoid_negative_ts', 'make_zero']));
+    });
+
+    test('the probe runs before the clip and does not carry -ss', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_probe');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mp4')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          if (!args.contains('-ss')) {
+            // 探测那一轮：ffmpeg 没有输出文件时**必然**非 0 退出，流信息却已经打进
+            // 日志。所以探测只能读输出、不能看退出码。
+            return const FfmpegRunResult(
+              returnCode: 1,
+              output: realWorldLog,
+            );
+          }
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(backend.calls.first, <String>['-hide_banner', '-i', input.path]);
+      // 探测认出 10-bit HEVC + FLAC，于是这一轮裁剪必须是重编码，而不是 `-c copy`。
+      final List<String> clip = backend.clipCalls.single;
+      expect(clip.contains('libx264'), isTrue);
+      expect(clip, containsAllInOrder(<String>['-c:a', 'aac']));
+      expect(clip.contains('copy'), isFalse);
+      expect(clip, containsAllInOrder(<String>['-map_chapters', '-1']));
+    });
+  });
 }
 
 typedef _RunHandler = FutureOr<FfmpegRunResult> Function(List<String> args);
@@ -776,6 +981,13 @@ class _FakeFfmpegBackend implements FfmpegBackend {
 
   final _RunHandler? onRun;
   final List<List<String>> calls = <List<String>>[];
+
+  /// 只含**裁剪**命令的调用记录：滤掉 BUG-2011 引入的源编码探测那一次
+  /// （`-hide_banner -i <input>`，是全部调用里唯一不带 `-ss` 的）。断言裁剪参数一律
+  /// 用它，否则探测调用会把下标和条数全部推移一位。
+  List<List<String>> get clipCalls => calls
+      .where((List<String> args) => args.contains('-ss'))
+      .toList(growable: false);
 
   @override
   Future<FfmpegRunResult> run(List<String> args, Duration timeout) async {

--- a/fushi/test/utils/desktop_audio_clipper_test.dart
+++ b/fushi/test/utils/desktop_audio_clipper_test.dart
@@ -34,6 +34,10 @@ void main() {
         '-i',
         '/a/in.m4b',
         '-vn',
+        // BUG-2011：源整本/整集的章节表不能跟进句子音频，否则 mp4 系容器（iOS 的
+        // `.m4a`）的 mvhd.duration 会被章节轨拉满成整集时长。
+        '-map_chapters',
+        '-1',
         '-c:a',
         'aac',
         // TODO-646 近无损压缩：单声道 64k AAC。
@@ -136,6 +140,8 @@ void main() {
         '-i',
         '/a/in.mkv',
         '-vn',
+        '-map_chapters',
+        '-1',
         '-map',
         // 尾随 '?'：越界时降级回退默认轨而非硬失败（BUG-345）。
         '0:a:1?',
@@ -148,6 +154,24 @@ void main() {
         '64k',
         '/a/out.aac',
       ]);
+    });
+
+    test('always drops the source chapters (BUG-2011)', () {
+      // 桌面/Android 的句子音频落 `.aac`（裸 ADTS，无容器，本就不受影响），但
+      // **iOS 走 `.m4a`**（immersionMiningAudioExtensionFor）——那条链路上不丢章节，
+      // mp4 muxer 会建一条与源最后一个章节等长的 chapter text track，把
+      // mvhd.duration 拉满：一段 3 秒的句子音频，容器头写着整集的 21 分钟。
+      // 实测 `.aac` 加与不加这两个参数产出的字节数完全一致，所以无条件给，
+      // 不按扩展名分支。
+      for (final String out in <String>['/a/out.aac', '/a/out.m4a']) {
+        final List<String> args = buildFfmpegClipArgs(
+          inputPath: '/a/in.m4b',
+          startMs: 0,
+          endMs: 3000,
+          outputPath: out,
+        );
+        expect(args, containsAllInOrder(<String>['-map_chapters', '-1']));
+      }
     });
 
     test('audio map always carries the optional "?" suffix', () {


### PR DESCRIPTION
用户报告：视频页导出的片段**只有 mpv 放得动**，别的播放器打不开，而且进度条显示成 **24 分钟**（实际片段 5.4 秒）。

样本 `_2_2016_-_S02E13_000227_314-000232_736.mp4`（文件名声称 5.422 秒）。沿真实代码路径验真伪后，是**三条独立根因叠在同一条导出链路上**，详见 [BUG-2011](../blob/worktree-fix-clip-export-container/docs/bugs/BUG-2011-clip-export-container-portability.md)。

## 根因

**① 进度条显示整集时长** — 两个参数构建器都没给 `-map_chapters`，ffmpeg 默认等价 `-map_chapters 0`，把**源整集**的章节表原样搬进片段；mp4 muxer 为此建一条与最后一个章节等长的 chapter text track，`mvhd.duration` 被它拉满。样本容器解出：

```
MVHD timescale=1000 duration=1274124 -> 1274.124s   ← 进度条读的是它
  track 1 vide hev1  10.760s
  track 6 text text  1274.124s                      ← 整集章节轨
```

mpv 自己按媒体轨重算时长所以正常 —— 这正好解释了「mpv 没问题、别的播放器有问题」。

**② 产物播不了** — `exportVideoClipViaFfmpeg` 的决策模型是「跑 `-c copy`，**退出码非 0** 才降级重编码」。可 `hev1` / 10-bit / FLAC 全都能成功封进 mp4、退出码 0，于是重编码兜底**永远不触发**，产物播不了却被判成功。样本流表：`Video: hevc (Main 10) (hev1) yuv420p10le` + `Audio: flac (fLaC)`（还是 default 轨）+ aac ×2。

**把「ffmpeg 退出码 0」当成「导出成功」，是这个 bug 的数据模型层根因。**真正的判据是「产物能不能被通用播放器播」。

**③ 时长多一个 GOP** — copy 路径给了 `-avoid_negative_ts make_zero`。`-c copy` 下 `-ss` 必然从请求点**之前**的关键帧起，那段前导本该由 mp4 edit list 表达成「播放时跳过」；`make_zero` 把这段负时间戳整体平移成了正片内容。样本 5.422 秒的请求实际落成 10.760 秒。

60 秒合成源（关键帧 0/10/20/30/40/50）复现：

| 参数 | 实得时长 |
|---|---|
| `-ss 27.314 -t 5.422 -i`（现状） | **12.76s** = 27.314+5.422−20.0 |
| `-ss 27.314 -i … -t 5.422`（把 `-t` 挪到 `-i` 后） | **12.76s** —— 挪位置不是解法 |
| output seek `-i … -ss 27.314` | 5.42s，但头部 **2.686s empty edit** = 开头黑屏，不可用 |
| 去掉 `make_zero` | **5.437s**，`ELST media_time=7.314s` 精确跳过前导 ✅ |

## 修法

- 新增 `ClipSourceCodecs` / `parseClipSourceCodecs()`（解析 `ffmpeg -i` 日志）与 `ClipCodecPlan` / `resolveClipCodecPlan()` / `buildClipCodecArgs()`：**把可播性判定前移到跑 ffmpeg 之前**，按流编码逐条决定 copy 还是重编码。h264/hevc + 8-bit 才 copy；hevc copy 时改写 `-tag:v hvc1`（不碰码流）；音频只有全部 aac/mp3 才 copy，否则整体转 AAC。
- 探测失败/解析不出一律退回 `ClipCodecPlan.fullCopy`，与加门控之前**逐参数等价** —— 探测是优化判据，不是导出的前置条件。
- 两条路径（copy 与重编码兜底）都加 `-map_chapters -1`。
- `-avoid_negative_ts make_zero` 改为**只在视频重编码时**给。
- 不用 ffprobe 而用 `ffmpeg -i` 日志：随包 ffmpeg-min 确实并排带 ffprobe，但用户用 `FUSHI_FFMPEG` 指向自己的 ffmpeg 或回退 PATH 时未必有；`ffmpeg -i` 用的是同一个必然存在的二进制，仓库里也已有同款解析先例（`parseSubtitleStreamsFromFfmpegLog`）。
- **`-map 0:a?` 的「不赌音轨语言」承诺（BUG-345）保持不动** —— 门控保证的是这些音轨条条可播，而不是砍到一条。

## 验证

**端到端**（真实 builder 拼参数 + 真实 ffmpeg 执行 + 解真实产物容器，源=用户上报的样本）：

```
探测:  -hide_banner -i <源>
裁剪:  -ss 2.000 -t 3.000 -i <源> -sn -dn -map_chapters -1
       -c:v libx264 -preset veryfast -crf 20 -pix_fmt yuv420p
       -c:a aac -b:a 192k -avoid_negative_ts make_zero <输出>
```

| | 修复前 | 修复后 |
|---|---|---|
| MVHD duration | 1272.124s（21分12秒）| **3.087s** |
| 章节 text 轨 | 有 | **无** |
| 实际时长 | 5.09s（请求 3.0）| **3.02s** |
| 视频 | `hevc 10bit / hev1` | **`h264 High / avc1 / yuv420p`** |
| 音频 | `flac`(default) + aac×2 | **aac** |

h264+aac 的源对照仍走 `-c copy`（MVHD 3.016s 精确，速度不变）。

**自动化测试**：`video_clip_exporter_test.dart` 新增 group `source codec gating (BUG-2011)` 共 10 条，含用**用户那份真实 `ffmpeg -i` 日志**做解析断言。三处根因各做变异实测（改完 sha256 对账回原状）：去掉 `-map_chapters -1` → 红 4 条；`-avoid_negative_ts` 改回无条件 → 红 3 条；把 8-bit 白名单换成「按名字尾巴猜位深」→ 精确红 `nv12` 那条。

- `flutter test test/media/video/video_clip_exporter_test.dart` → 39 passed
- 相邻定向（`audio_stream_map_tolerant_guard` / `video_player_remote_uri` / `ffmpeg_min_vendored_recipe_guard` / `ffmpeg_min_clip_muxer_guard`）→ 25 passed
- 全量 `flutter analyze` → No issues found

## 合入前待办

- [ ] 本地全量 `dart run tool/flutter_test_failures.dart --no-pub`（判绿只认 VERDICT 行）
- [ ] 合并后加跑目录枚举型守卫整批
- [ ] 同构的有声书片段导出 `fushi/lib/src/media/audiobook/audiobook_clip_export.dart`（文件头自述「镜像 `exportVideoClipViaFfmpeg`」）未在本轮排查范围内，若它也 `-c copy` 且不丢章节，同样三条根因可能成立 —— 建议单独核查

https://claude.ai/code/session_013aHBJipGKUeGjocyBvD153
