### PR TITLE
feat(fullscreen): 窗口全屏收窄到内容模块，小说页补入口，Esc 可退全屏

### DIFF
--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -53,6 +53,8 @@ import 'package:fushi/src/shortcuts/global_navigation.dart'
         desktopWindowFullscreenSupported,
         readDesktopWindowFullscreen,
         setDesktopWindowFullscreen;
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart'
+    show WindowFullscreenHost;
 import 'package:fushi/src/shortcuts/input_binding.dart'
     show
         GamepadButton,
@@ -1080,8 +1082,20 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
 
   Future<void> _toggleMangaFullscreen() => _changeMangaFullscreen();
 
+  /// 「返回上一级」在漫画页的一级：全屏中先退全屏，返回 true 吞掉这次返回。
+  ///
+  /// 判据不再只认 [_ownsWindowFullscreen]（「这次全屏是我进的」）：用户用快捷键
+  /// （默认 F11）进的全屏不会置那个标志，可他眼里那和按全屏按钮进的是同一个全屏，
+  /// Esc 都该先把它退掉，而不是连人带全屏一起退出漫画。所有权标志仍然保留——它管的是
+  /// 另一件事（页面在 native 往返途中被拆掉时由谁负责把全屏还回去）。
+  ///
+  /// 非全屏时只多读一次窗口状态，随后照常退页。
   Future<bool> _exitOwnedFullscreenBeforePop() async {
-    if (!_ownsWindowFullscreen) return false;
+    if (!_ownsWindowFullscreen &&
+        (await readDesktopWindowFullscreen()) != true) {
+      return false;
+    }
+    if (!mounted) return false;
     await _setMangaFullscreen(false);
     return true;
   }
@@ -3948,7 +3962,10 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
+    // 漫画页是**窗口全屏的合法宿主**之一：全屏键（默认 F11）只在小说 / 漫画 / 视频里
+    // 能进入全屏，靠的就是下面那层 [WindowFullscreenHost] 声明。用局部变量而不是把
+    // 整棵树往里缩一级，纯粹是为了不给这个文件制造一次全量重缩进的 diff。
+    final Widget page = PopScope(
       canPop: false,
       onPopInvokedWithResult: (bool didPop, dynamic result) async {
         if (didPop) return;
@@ -4045,6 +4062,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         ),
       ),
     );
+    return WindowFullscreenHost(child: page);
   }
 
   /// BUG-1888：切换界面可见性。移动端联动系统栏——隐藏界面即进入沉浸式全屏；

--- a/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
@@ -555,7 +555,10 @@ extension _ReaderCaret on _ReaderFushiPageState {
           clearDictionaryResult();
           return KeyEventResult.handled;
         }
-        unawaited(Navigator.of(context).maybePop());
+        // ③ 窗口全屏中 → 先退全屏、留在书里；不在全屏才真的退书。用户裁定「Esc 也可以
+        //    退出全屏」，次序见 [_exitWindowFullscreenOrPopReader]。非全屏时它只多读一次
+        //    窗口状态就落回原来的 maybePop，退书路径本身没变。
+        unawaited(_exitWindowFullscreenOrPopReader());
         return KeyEventResult.handled;
       case ShortcutAction.readerToggleChrome:
         if (isDictionaryShown) {

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -1480,6 +1480,48 @@ extension _ReaderChrome on _ReaderFushiPageState {
     );
   }
 
+  /// 小说页的窗口全屏切换（底栏按钮的执行体）。
+  ///
+  /// 与漫画页 `_changeMangaFullscreen` 同一范式：**先读 native 真值再取反**，而不是翻
+  /// 自己那份镜像——用户可能刚用快捷键（默认 F11）切过，镜像会落后，按镜像取反就会
+  /// 出现「点一下没反应、要点两下」。镜像只用来选图标。
+  ///
+  /// 串行闸 [_ReaderFushiPageState._windowFullscreenTransitioning] 挡住 native 往返
+  /// 期间的重入；按钮本身不置灰（状态更新常早于 finally 清闸，置灰会让按钮闪一下）。
+  Future<void> _changeReaderWindowFullscreen() async {
+    if (!desktopWindowFullscreenSupported || _windowFullscreenTransitioning) {
+      return;
+    }
+    _windowFullscreenTransitioning = true;
+    try {
+      final bool next =
+          !((await readDesktopWindowFullscreen()) ?? _isWindowFullscreen);
+      if (!mounted) return;
+      final bool? applied = await setDesktopWindowFullscreen(next);
+      if (!mounted || applied == null) return;
+      if (_isWindowFullscreen != applied) {
+        _rebuild(() => _isWindowFullscreen = applied);
+      }
+    } finally {
+      _windowFullscreenTransitioning = false;
+    }
+  }
+
+  /// 「返回上一级」在小说页的最后一级：**先退窗口全屏，没有全屏才退书**。
+  ///
+  /// 用户裁定 Esc 也要能退全屏。放在退书之前是唯一合理的次序——全屏是盖在书上面的一层
+  /// 呈现态，而「返回」在本页一贯是「退掉最上面那层」（词典弹窗先于退书是同一条阶梯）。
+  /// 漫画页的 PopScope 里有等价的一级，视频页则由它自己的全屏路由阶梯负责。
+  ///
+  /// [Navigator.of] 必须在第一个 await **之前**取：await 之后 context 可能已失效，
+  /// 跨 async gap 用 BuildContext 是 lint 明令禁止的（也确实会炸）。
+  Future<void> _exitWindowFullscreenOrPopReader() async {
+    final NavigatorState navigator = Navigator.of(context);
+    if (await exitWindowFullscreenIfActive()) return;
+    if (!mounted) return;
+    await navigator.maybePop();
+  }
+
   Widget _buildSettingsBar() {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final bool reversed = appModel.reverseReaderBottomBar;
@@ -1500,6 +1542,26 @@ extension _ReaderChrome on _ReaderFushiPageState {
         onPressed: _openGallery,
       ),
       const Spacer(),
+      // 小说页此前**没有任何全屏入口**，只能靠全局快捷键（默认 F11）。全屏收窄到内容
+      // 模块之后，一个看得见的入口是必需的，否则「小说能全屏」这件事对不用快捷键的
+      // 用户等于不存在。与漫画页同图标、同 tooltip（复用同一条快捷键文案）。
+      // 桌面才有窗口可全屏，移动端不渲染这颗按钮。
+      if (desktopWindowFullscreenSupported)
+        Semantics(
+          identifier: 'hibiki.reader.bottom.fullscreen',
+          child: IconButton(
+            key: const ValueKey<String>('fushi_reader_fullscreen_button'),
+            icon: Icon(
+              _isWindowFullscreen
+                  ? Icons.fullscreen_exit_rounded
+                  : Icons.fullscreen_rounded,
+              color: _themeTextColor(),
+            ),
+            iconSize: 22,
+            tooltip: t.shortcut_action_global_toggle_fullscreen,
+            onPressed: () => unawaited(_changeReaderWindowFullscreen()),
+          ),
+        ),
       Semantics(
         identifier: 'hibiki.reader.bottom.settings',
         child: IconButton(

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -1517,9 +1517,33 @@ extension _ReaderChrome on _ReaderFushiPageState {
   /// 跨 async gap 用 BuildContext 是 lint 明令禁止的（也确实会炸）。
   Future<void> _exitWindowFullscreenOrPopReader() async {
     final NavigatorState navigator = Navigator.of(context);
-    if (await exitWindowFullscreenIfActive()) return;
+    if (await exitWindowFullscreenIfActive()) {
+      // 镜像必须在**这条**路径上也复位。只在按钮那条成功路径上复位是不够的：Esc 退掉
+      // 的是同一个全屏，不同步的话底栏图标会稳定停在「退出全屏」上，而窗口早已不是全屏
+      // 了 —— 图标撒谎，而且不会自愈（下一次按按钮读的是 native 真值，图标只是在那之后
+      // 才碰巧变对）。
+      if (mounted && _isWindowFullscreen) {
+        _rebuild(() => _isWindowFullscreen = false);
+      }
+      return;
+    }
     if (!mounted) return;
     await navigator.maybePop();
+  }
+
+  /// 进页时把底栏全屏按钮的图标镜像对到 native 真值一次。
+  ///
+  /// 没有这一次读取，「在别处（漫画页 / 视频页 / 上一本书）进的全屏里打开本书」会让图标
+  /// 从第一帧起就是错的 —— 镜像默认 false，而窗口是全屏的。漫画页的
+  /// `_readInitialFullscreenState` 是同一件事的同一份做法。
+  ///
+  /// 只读不写：读到什么就照着画什么图标，绝不在进页时替用户改窗口状态。
+  Future<void> _readInitialWindowFullscreenState() async {
+    final bool? fullscreen = await readDesktopWindowFullscreen();
+    if (!mounted || fullscreen == null || fullscreen == _isWindowFullscreen) {
+      return;
+    }
+    _rebuild(() => _isWindowFullscreen = fullscreen);
   }
 
   Widget _buildSettingsBar() {

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -1991,6 +1991,12 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
       return true;
     }());
     WidgetsBinding.instance.addObserver(this);
+    // 底栏全屏按钮的图标镜像：进页时问一次 native 真值。不问的话，「在已经全屏的窗口里
+    // 打开这本书」从第一帧起图标就是错的（镜像默认 false）。与漫画页的
+    // `_readInitialFullscreenState` 同款；桌面才有窗口可全屏。
+    if (desktopWindowFullscreenSupported) {
+      unawaited(_readInitialWindowFullscreenState());
+    }
     _exitFlushCallback =
         ExitFlushRegistry.instance.register(_flushAllForProcessExit);
     // BUG-1744：macOS 全屏进出必须重算顶部让位并把新 inset 回喂给 WebView。

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -123,6 +123,14 @@ import 'package:fushi/src/shortcuts/dictionary_caret_controller.dart';
 export 'package:fushi/src/shortcuts/dictionary_caret_controller.dart'
     show CaretSurface;
 import 'package:fushi/src/shortcuts/reader_space_override.dart';
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart'
+    show WindowFullscreenHost;
+import 'package:fushi/src/shortcuts/global_navigation.dart'
+    show
+        desktopWindowFullscreenSupported,
+        exitWindowFullscreenIfActive,
+        readDesktopWindowFullscreen,
+        setDesktopWindowFullscreen;
 
 part 'reader_fushi/lyrics.part.dart';
 part 'reader_fushi/mining.part.dart';
@@ -1786,6 +1794,16 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   // TODO-291 阶段2：audioHandler 控制流（play/seek/skip/悬浮字幕翻转）订阅已上移到
   // [AudiobookSession]（进程级），reader 不再持有这些订阅。
 
+  /// 底栏全屏按钮的图标状态（进/出全屏两个图标）。
+  ///
+  /// 只是**显示用的镜像**，不是真相源：真相在 native 窗口那边，每次切换都先读它再取反
+  /// （见 `_changeReaderWindowFullscreen`）。用户改用快捷键（默认 F11）切换时这份镜像
+  /// 会短暂落后一帧图标——不影响任何行为，下一次按按钮仍按真值走。
+  bool _isWindowFullscreen = false;
+
+  /// 全屏切换的串行闸：native 往返期间再点按钮不重入。
+  bool _windowFullscreenTransitioning = false;
+
   bool _showChrome = true;
   // TODO-975: floating chrome (顶部进度 / 底栏) 的「被点击唤出、临时可见」态。挤压
   // 模式恒忽略此旗；悬浮模式下唤出置 true + 武装 _chromeAutoHideTimer，计时到 / 再点
@@ -2852,7 +2870,10 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     // reader 子树。constraints.biggest 与 _syncPageSize 读的 MediaQuery.size 同处反缩放
     // 还原后的坐标空间，数值等价，故两条 resize 通道靠 _lastSyncedWidth/Height 基线去重。
     // 约束由布局系统每帧驱动，比 didChangeMetrics 更早更可靠（Windows 拖边框时后者滞后）。
-    return LayoutBuilder(
+    // 小说页是**窗口全屏的合法宿主**之一：全屏键（默认 F11）只在小说 / 漫画 / 视频里
+    // 能进入全屏，靠的就是下面那层 [WindowFullscreenHost] 声明。用局部变量而不是把整棵
+    // 树往里缩一级，纯粹是为了不给这个文件制造一次全量重缩进的 diff。
+    final Widget page = LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         _onReaderConstraintsChanged(constraints);
         return Actions(
@@ -3014,6 +3035,7 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
         );
       },
     );
+    return WindowFullscreenHost(child: page);
   }
 
   Widget _buildBody() {

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -109,6 +109,8 @@ import 'package:fushi/src/shortcuts/input_binding.dart'
     show GamepadButton, InputBinding, activeModifierKeys;
 import 'package:fushi/src/shortcuts/reader_caret_router.dart'
     show CaretAction, ReaderCaretRouter;
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart'
+    show WindowFullscreenHost;
 import 'package:fushi/src/shortcuts/shortcut_action.dart'
     show ShortcutAction, ShortcutScope;
 import 'package:fushi/src/media/video/video_foreground_layers.dart'
@@ -7105,24 +7107,30 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     final VideoPlayerController? controller = _controller;
     final VideoController? videoController = controller?.videoController;
     final ColorScheme cs = Theme.of(context).colorScheme;
+    // 视频页是**窗口全屏的合法宿主**之一：全屏键（默认 F11）只在小说 / 漫画 / 视频
+    // 里能进入全屏，靠的就是这层声明（见 [WindowFullscreenHosts]）。它零布局、零行为，
+    // 只在挂载期间登记自己所在的路由。
+    //
     // TODO-1342：最外层包一层手柄输入层，让桌面轮询的 [GamepadButtonIntent] 与
     // Android 原生手柄按键都能落到本页的视频动作（play/pause、seek、音量、字幕、全屏、
     // 返回）。放在 [PopScope] 之上 ⇒ 是 [_videoFocusNode] 及所有子焦点节点的祖先，
     // 冒泡/派发都能命中；wrapper 自身不夺焦（见 [_wrapVideoGamepadControls]）。
-    return _wrapVideoGamepadControls(
-      PopScope(
-        // 始终 `canPop: false` 自管退出：① 浮层栈非空时 back 先关栈（一层一层退），
-        // 浮层在根 Overlay 退出视频路由不会自动清它，必须在 pop 前拦截；② 栈空真退出
-        // 时，**先 await `flushPosition()` 把退出瞬间位置可靠落库再手动 pop**——否则只剩
-        // controller.dispose() 里 fire-and-forget 的 `_forceSavePositionSync()`，drift
-        // 写库 Future 与 Navigator 同步销毁 State 竞争、常写不完，导致「退出再进没回到
-        // 上次位置」（对齐阅读器 `onWillPop` 先 await 落库再 pop 的做法）。
-        canPop: false,
-        onPopInvokedWithResult: (bool didPop, Object? _) async {
-          if (didPop) return;
-          await _handleBackOrExit();
-        },
-        child: _buildScaffold(controller, videoController, cs),
+    return WindowFullscreenHost(
+      child: _wrapVideoGamepadControls(
+        PopScope(
+          // 始终 `canPop: false` 自管退出：① 浮层栈非空时 back 先关栈（一层一层退），
+          // 浮层在根 Overlay 退出视频路由不会自动清它，必须在 pop 前拦截；② 栈空真退出
+          // 时，**先 await `flushPosition()` 把退出瞬间位置可靠落库再手动 pop**——否则只剩
+          // controller.dispose() 里 fire-and-forget 的 `_forceSavePositionSync()`，drift
+          // 写库 Future 与 Navigator 同步销毁 State 竞争、常写不完，导致「退出再进没回到
+          // 上次位置」（对齐阅读器 `onWillPop` 先 await 落库再 pop 的做法）。
+          canPop: false,
+          onPopInvokedWithResult: (bool didPop, Object? _) async {
+            if (didPop) return;
+            await _handleBackOrExit();
+          },
+          child: _buildScaffold(controller, videoController, cs),
+        ),
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -53,6 +53,8 @@ import 'package:fushi/src/pages/implementations/video_fushi_page.dart'
     show resolveVideoLookupAnchorCue, subtitleLookupTerm;
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart'
+    show WindowFullscreenHost;
 import 'package:fushi/src/sync/fushi_library_host_service.dart'
     show videoRemotePositionEpisodeAtPrefKey, videoRemotePositionEpisodePrefKey;
 import 'package:fushi/src/utils/adaptive/adaptive_widgets.dart'
@@ -1561,7 +1563,10 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
     if (row == null || scripts == null) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    return CallbackShortcuts(
+    // 网页流媒体页属于视频模块，同样是**窗口全屏的合法宿主**（见
+    // [WindowFullscreenHosts]）。上面两条早退分支（加载失败 / 尚未就绪）故意不声明：
+    // 那两种状态下页面还没有内容，没有可全屏的东西。
+    final Widget page = CallbackShortcuts(
       bindings: _keyboardShortcuts(),
       child: Focus(
         focusNode: _focusNode,
@@ -1604,6 +1609,7 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
         ),
       ),
     );
+    return WindowFullscreenHost(child: page);
   }
 
   PreferredSizeWidget _buildAppBar(VideoBookRow row, ColorScheme cs) {

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/utils/window_caption_channel.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart';
 import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show
@@ -371,10 +372,41 @@ KeyEventResult _neutralizeBareSpace(KeyEvent event) {
 /// 任何 platform-channel 失败都以 debug 日志吞掉，杂散按键永不崩应用。
 Future<void> _toggleWindowFullscreen() async {
   try {
+    // 用户裁定：全屏是**内容模块**（小说 / 漫画 / 视频）的能力，首页 / 书架 / 设置页
+    // 按全屏键不该把整个窗口变成无边框全屏。判据不写成「路由名 == …」的 if 阶梯
+    // （那是把页面清单硬编码进快捷键层，新增内容页必漏改），而是问一个由内容页自己
+    // 声明的布尔量——见 [WindowFullscreenHosts]。
+    //
+    // 门是**非对称**的，这不是疏漏而是必须：只门住「进入」，「退出」永远放行。若两边
+    // 都门住，用户在内容页进全屏、退回首页之后，就再没有任何键能退出全屏——桌面全屏
+    // 是 runner 自绘的保边框巨窗（BUG-1933），系统并不提供第二个出口，那等于把人锁死
+    // 在全屏里。宿主可见时布尔量直接短路，不会多花一次 platform channel 往返；只有
+    // 「非宿主页面按了全屏键」这一种情况才需要读一次真值来判断是不是退出。
+    if (!WindowFullscreenHosts.hasVisibleHost &&
+        (await readDesktopWindowFullscreen()) != true) {
+      return;
+    }
     await toggleDesktopWindowFullscreen();
   } catch (e) {
     debugPrint('[Fushi] window fullscreen toggle skipped: $e');
   }
+}
+
+/// 当前若处于窗口全屏就退出它，并返回「确实退了」。
+///
+/// 两个调用场景共用这一个原语：
+///   · 内容页「返回上一级」阶梯里的**先退全屏**那一级（用户裁定：Esc 也能退全屏）。
+///     返回 true 表示这次返回已被全屏消费，调用方**不该**再退页。
+///   · 最后一个 [WindowFullscreenHost] 离场时的归还（见该类文档）。
+///
+/// 判据只认 native 真值，不认「这次全屏是不是我进的」：用户按 F11 进的全屏和按页面
+/// 全屏按钮进的全屏，在他眼里是同一个全屏，Esc 都该先把它退掉。先读后写而不是无条件
+/// 写 false，是为了不在「本来就不是全屏」的常态路径上白打一次 platform channel。
+Future<bool> exitWindowFullscreenIfActive() async {
+  if (!desktopWindowFullscreenSupported) return false;
+  if ((await readDesktopWindowFullscreen()) != true) return false;
+  await setDesktopWindowFullscreen(false);
+  return true;
 }
 
 /// Reads the desktop window fullscreen state from its single native owner.

--- a/fushi/lib/src/shortcuts/window_fullscreen_hosts.dart
+++ b/fushi/lib/src/shortcuts/window_fullscreen_hosts.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:fushi/src/shortcuts/global_navigation.dart';
+
+/// 「窗口级全屏」的宿主声明表。
+///
+/// 窗口全屏是**窗口级**能力（整个 HWND / NSWindow 变全屏），不是页面级的：小说、
+/// 漫画、视频三个模块渲染在同一个 Flutter 视图、同一个原生窗口里。所以「只在内容
+/// 模块里能全屏」这条产品规则，改变不了 native 侧怎么全屏，它只能限定 **Dart 侧什么
+/// 时候允许进入全屏**。
+///
+/// 判据不能写成「当前路由名 == 阅读器 / 漫画 / 视频」那种 if 阶梯——那是把页面清单
+/// 硬编码进快捷键层，新增内容页必然漏改。改为**由内容页面自己声明**：页面在子树里包
+/// 一层 [WindowFullscreenHost]，挂载即登记、卸载即注销。快捷键层只问一个布尔量
+/// [hasVisibleHost]，不认识任何具体页面。
+///
+/// 登记的是页面所在的 [ModalRoute]，可见性判据是 [ModalRoute.isCurrent]——「宿主还在
+/// 栈里」不等于「宿主在最上面」：从阅读器 push 设置页后，阅读器的 route 仍然 active
+/// 但不再 current，此时按全屏键**不该**生效（用户看到的是设置页，不是内容）。
+///
+/// route 为 null（页面没被 push 成路由，如 widget 测试直接 pumpWidget 的宿主）视为
+/// 可见：此时它就是当前 UI，没有「被别的整页盖住」这回事。
+class WindowFullscreenHosts {
+  WindowFullscreenHosts._();
+
+  /// token（[WindowFullscreenHost] 的 State 实例）→ 它所在的路由（可为 null）。
+  ///
+  /// 用 Map 而非 Set 是因为同一个 token 的路由会随 didChangeDependencies 重算，
+  /// 必须**覆盖**而不是堆积第二条登记。
+  static final Map<Object, ModalRoute<dynamic>?> _hosts =
+      <Object, ModalRoute<dynamic>?>{};
+
+  /// 登记 / 更新一个宿主。同一 [token] 重复调用即更新它的路由。
+  static void register(Object token, ModalRoute<dynamic>? route) {
+    _hosts[token] = route;
+  }
+
+  static void unregister(Object token) {
+    _hosts.remove(token);
+  }
+
+  /// 当前是否有**可见**的全屏宿主（栈顶那层就是内容模块）。
+  static bool get hasVisibleHost => _hosts.values.any(
+        (ModalRoute<dynamic>? route) => route == null || route.isCurrent,
+      );
+
+  @visibleForTesting
+  static int get debugHostCount => _hosts.length;
+
+  @visibleForTesting
+  static void debugReset() => _hosts.clear();
+}
+
+/// 声明「本子树是窗口全屏的合法宿主」。
+///
+/// 包在内容页（小说 / 漫画 / 视频）的页面子树外层即可；除登记外零行为、零布局影响，
+/// 直接透传 [child]。
+class WindowFullscreenHost extends StatefulWidget {
+  const WindowFullscreenHost({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<WindowFullscreenHost> createState() => _WindowFullscreenHostState();
+}
+
+class _WindowFullscreenHostState extends State<WindowFullscreenHost> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 在 didChangeDependencies 而非 initState 里取路由：ModalRoute.of 建立的是
+    // inherited 依赖，路由变化（如页面被 pushReplacement 到新 route）会重跑这里，
+    // 登记随之更新；initState 里读一次会把旧 route 永久钉死。
+    WindowFullscreenHosts.register(this, ModalRoute.of(context));
+  }
+
+  @override
+  void dispose() {
+    WindowFullscreenHosts.unregister(this);
+    _releaseWindowFullscreenIfNoHostLeft();
+    super.dispose();
+  }
+
+  /// 最后一个宿主离场时归还窗口全屏。
+  ///
+  /// 这是「全屏只属于内容模块」的另一半：进入被门在宿主内（见
+  /// [WindowFullscreenHosts]），离场就必须还回去，否则退回首页会留下一个全屏窗口，
+  /// 而首页的全屏键已经被门掉——用户没有任何出口。Esc 阶梯（
+  /// [exitWindowFullscreenForBack]）覆盖的是「人主动退全屏」，这里覆盖的是「页面以
+  /// 别的方式没了」（返回按钮、换书、被替换掉）。归还走的是同一个
+  /// [exitWindowFullscreenIfActive]：它先读真值，非全屏时一次 channel 都不打。
+  ///
+  /// **判定必须推到帧末**，不能在 dispose 里当场做：`pushReplacement` 换集 / 换章时，
+  /// 旧页 dispose 与新页挂载发生在同一帧内，dispose 这一刻注册表恰好是空的。当场判
+  /// 就会在每次换集时把全屏闪掉一次（BUG-839 那条「连播全屏不被换集打断」正是这个
+  /// 场景）。帧末才是稳定态：那时新宿主已经登记完毕。
+  void _releaseWindowFullscreenIfNoHostLeft() {
+    if (!desktopWindowFullscreenSupported) return;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (WindowFullscreenHosts.hasVisibleHost) return;
+      unawaited(exitWindowFullscreenIfActive());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/fushi/lib/src/shortcuts/window_fullscreen_hosts.dart
+++ b/fushi/lib/src/shortcuts/window_fullscreen_hosts.dart
@@ -89,7 +89,7 @@ class _WindowFullscreenHostState extends State<WindowFullscreenHost> {
   /// 这是「全屏只属于内容模块」的另一半：进入被门在宿主内（见
   /// [WindowFullscreenHosts]），离场就必须还回去，否则退回首页会留下一个全屏窗口，
   /// 而首页的全屏键已经被门掉——用户没有任何出口。Esc 阶梯（
-  /// [exitWindowFullscreenForBack]）覆盖的是「人主动退全屏」，这里覆盖的是「页面以
+  /// [exitWindowFullscreenIfActive]）覆盖的是「人主动退全屏」，这里覆盖的是「页面以
   /// 别的方式没了」（返回按钮、换书、被替换掉）。归还走的是同一个
   /// [exitWindowFullscreenIfActive]：它先读真值，非全屏时一次 channel 都不打。
   ///

--- a/fushi/test/pages/video_fullscreen_gamepad_wiring_static_test.dart
+++ b/fushi/test/pages/video_fullscreen_gamepad_wiring_static_test.dart
@@ -36,10 +36,31 @@ void main() {
   });
 
   test('窗口模式 build() 仍由 _wrapVideoGamepadControls 包住整页（两表面共享一份语义）', () {
+    // build 的返回树根是零布局的 [WindowFullscreenHost]（视频页据此声明自己是窗口
+    // 全屏的合法宿主，见 lib/src/shortcuts/window_fullscreen_hosts.dart），手柄输入层
+    // 是它的独生子、仍然包住整页。判据钉的是「手柄层包住整页」这条不变式，故连着
+    // Host 一起匹配——只写 `_wrapVideoGamepadControls(` 会被页面里任何一处调用蒙混，
+    // 而这里要的是 build 的返回树本身。
+    final int idxHost = mainShell.indexOf('return WindowFullscreenHost(');
     expect(
-      mainShell,
-      contains('return _wrapVideoGamepadControls('),
+      idxHost,
+      isNonNegative,
+      reason: '视频页必须声明自己是窗口全屏宿主，否则它的全屏键会被门掉',
+    );
+    final int idxWrap =
+        mainShell.indexOf('child: _wrapVideoGamepadControls(', idxHost);
+    expect(
+      idxWrap,
+      isNonNegative,
       reason: '窗口侧手柄输入层被拆掉会让 TODO-1342 的整套视频手柄映射失效',
+    );
+    // 相邻性而不是「两者都出现」：手柄层必须**直接**挂在 Host 之下、包住整页，
+    // 中间塞进任何一层都会改变输入/布局语义。留 80 字符余量容得下换行与缩进重排，
+    // 但容不下一个真的 widget。
+    expect(
+      idxWrap - idxHost,
+      lessThan(80),
+      reason: '手柄输入层必须是 WindowFullscreenHost 的独生子（两者之间不得夹东西）',
     );
     // wrapper 本体仍把 GamepadButtonIntent 派发到注册表解析入口（两表面共用）。
     final String wrapper = _slice(

--- a/fushi/test/reader/reader_window_resize_repaginate_guard_test.dart
+++ b/fushi/test/reader/reader_window_resize_repaginate_guard_test.dart
@@ -26,10 +26,17 @@ void main() {
         () {
       // LayoutBuilder 必须在 build 里包住 reader 子树（return Actions 前），builder
       // 第一件事就是把 constraints 交给 resize 通道（零几何变换，原样返回子树）。
+      //
+      // 全屏收窄之后 build 的返回树根是零布局的 [WindowFullscreenHost]（小说页据此
+      // 声明自己是窗口全屏的合法宿主，见 lib/src/shortcuts/window_fullscreen_hosts.dart），
+      // LayoutBuilder 落在它的独生子上、改由局部变量承接。resize 通道的不变式一条没
+      // 变，变的只是它不再是字面上的 `return`——所以锚点跟着挪，并**补一条**断言钉住
+      // 「LayoutBuilder 就是那棵被包起来的 reader 子树」，免得日后有人在中间塞进一层
+      // 真的会改几何的 widget。
       final int idxBuild = src.indexOf('Widget build(BuildContext context) {');
       expect(idxBuild, greaterThan(0), reason: 'build 方法必须存在');
       final int idxLayoutBuilder =
-          src.indexOf('return LayoutBuilder(', idxBuild);
+          src.indexOf('final Widget page = LayoutBuilder(', idxBuild);
       expect(idxLayoutBuilder, greaterThan(idxBuild),
           reason: 'build 必须用透明 LayoutBuilder 包裹 reader 子树（TODO-690 resize 通道）');
       final int idxConstraintsCall = src.indexOf(
@@ -42,6 +49,13 @@ void main() {
       expect(idxReturnActions, greaterThan(idxConstraintsCall),
           reason:
               'builder 必须先调 _onReaderConstraintsChanged 再返回原 reader 子树（零几何变换）');
+      expect(
+        src.indexOf(
+            'return WindowFullscreenHost(child: page);', idxReturnActions),
+        greaterThan(idxReturnActions),
+        reason: 'build 的返回树根只允许是零布局的 WindowFullscreenHost，'
+            '它的独生子必须就是上面那棵 LayoutBuilder（resize 通道不得被隔开）',
+      );
     });
 
     test('_onReaderConstraintsChanged 用纯谓词判定 + 共享 50ms 尾沿防抖调 _syncPageSize',

--- a/fushi/test/shortcuts/universal_back_test.dart
+++ b/fushi/test/shortcuts/universal_back_test.dart
@@ -359,16 +359,41 @@ void main() {
           reason: '无弹窗时不消费（ignored），不得吞键');
     });
 
-    test('阅读器 globalBack 分支 = 先关词典、再 maybePop 退书（BUG-782 闸门）', () {
+    test('阅读器 globalBack 分支 = 先关词典、再退全屏、最后 maybePop 退书（BUG-782 闸门）', () {
       final String slice =
           caseSlice(File(readerPath).readAsStringSync(), 'globalBack');
       expect(slice.contains('isDictionaryShown'), isTrue,
           reason: '第一级：词典弹窗可见时只关弹窗，留在书里');
       expect(slice.contains('clearDictionaryResult'), isTrue);
-      expect(slice.contains('maybePop('), isTrue,
-          reason: '第二级：退书必须经 maybePop 触发 PopScope→onWillPop');
+      // 第二级（用户裁定「Esc 也可以退出全屏」）：窗口全屏中先退全屏、留在书里。退书
+      // 这一级随之搬进同一个 helper，所以 BUG-782 那条不变式（退书必须经 maybePop、
+      // 不得裸 pop）跟着挪到下面对 helper 的断言上——**钉的位置变了，强度没放宽**：
+      // 两处切片各自都要证明自己没有绕过 PopScope 的裸 pop()。
+      expect(
+        slice.contains('_exitWindowFullscreenOrPopReader('),
+        isTrue,
+        reason: '第二/三级：全屏 → 退书的阶梯统一由该 helper 承担',
+      );
       expect(
         RegExp(r'(?<!maybe)\.pop\(').hasMatch(slice),
+        isFalse,
+        reason: '不得出现绕过 PopScope 的裸 pop()（BUG-782）',
+      );
+
+      final String helper = methodBody(
+        File('lib/src/pages/implementations/reader_fushi/chrome.part.dart')
+            .readAsStringSync(),
+        'Future<void> _exitWindowFullscreenOrPopReader() async {',
+      );
+      expect(
+        helper.contains('exitWindowFullscreenIfActive('),
+        isTrue,
+        reason: '退全屏必须排在退书之前，否则 Esc 会连人带全屏一起退出书籍',
+      );
+      expect(helper.contains('maybePop('), isTrue,
+          reason: '最后一级：退书必须经 maybePop 触发 PopScope→onWillPop');
+      expect(
+        RegExp(r'(?<!maybe)\.pop\(').hasMatch(helper),
         isFalse,
         reason: '不得出现绕过 PopScope 的裸 pop()（BUG-782）',
       );

--- a/fushi/test/shortcuts/window_fullscreen_hosts_test.dart
+++ b/fushi/test/shortcuts/window_fullscreen_hosts_test.dart
@@ -1,0 +1,212 @@
+/// 窗口全屏**收窄到内容模块**这条规则的守卫（用户裁定）。
+///
+/// 规则有三条，缺一条就会退化成一个可以把人锁死在全屏里的功能：
+///   ① 只有内容模块（小说 / 漫画 / 视频）能**进入**窗口全屏；
+///   ② 退出永远放行——门若对称，用户在内容页进全屏、退回首页后就再没有出口，
+///      桌面全屏是 runner 自绘的保边框巨窗，系统不提供第二个退出方式；
+///   ③ 最后一个宿主离场时把全屏还回去，且判定必须推到帧末（`pushReplacement`
+///      换集时旧页 dispose 与新页挂载同帧，当场判会把全屏闪掉）。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart';
+
+import '../helpers/source_guard.dart';
+
+void main() {
+  setUp(WindowFullscreenHosts.debugReset);
+  tearDown(WindowFullscreenHosts.debugReset);
+
+  group('宿主注册表', () {
+    test('没有宿主时不可见', () {
+      expect(WindowFullscreenHosts.hasVisibleHost, isFalse);
+    });
+
+    test('route 为 null 的宿主视为可见', () {
+      // 页面没被 push 成路由（widget 测试直接 pumpWidget 的宿主）时，它就是当前
+      // UI，没有「被别的整页盖住」这回事。
+      final Object token = Object();
+      WindowFullscreenHosts.register(token, null);
+      expect(WindowFullscreenHosts.hasVisibleHost, isTrue);
+      WindowFullscreenHosts.unregister(token);
+      expect(WindowFullscreenHosts.hasVisibleHost, isFalse);
+    });
+
+    test('同一 token 重复登记是更新而不是堆积', () {
+      // 路由会随 didChangeDependencies 重算，同一个宿主必须覆盖自己那条登记；
+      // 堆积的话第一次 unregister 清不干净，宿主离场后全屏永远还不回去。
+      final Object token = Object();
+      WindowFullscreenHosts.register(token, null);
+      WindowFullscreenHosts.register(token, null);
+      expect(WindowFullscreenHosts.debugHostCount, 1);
+      WindowFullscreenHosts.unregister(token);
+      expect(WindowFullscreenHosts.debugHostCount, 0);
+    });
+  });
+
+  group('WindowFullscreenHost widget', () {
+    testWidgets('挂载即登记、卸载即注销', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: WindowFullscreenHost(child: SizedBox.shrink()),
+        ),
+      );
+      expect(WindowFullscreenHosts.hasVisibleHost, isTrue);
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      expect(WindowFullscreenHosts.hasVisibleHost, isFalse);
+    });
+
+    testWidgets('宿主被另一个整页路由盖住时不再可见', (WidgetTester tester) async {
+      // 这条是「收窄」的核心判据：宿主还在栈里 ≠ 宿主在最上面。从阅读器 push 一个
+      // 设置页之后，用户看到的是设置页，此时按全屏键不该把窗口变成全屏。
+      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: const WindowFullscreenHost(child: SizedBox.shrink()),
+        ),
+      );
+      expect(WindowFullscreenHosts.hasVisibleHost, isTrue);
+
+      unawaitedPush(navKey);
+      await tester.pumpAndSettle();
+      expect(
+        WindowFullscreenHosts.hasVisibleHost,
+        isFalse,
+        reason: '宿主被整页路由盖住后，全屏键不该还能进入全屏',
+      );
+
+      navKey.currentState!.pop();
+      await tester.pumpAndSettle();
+      expect(
+        WindowFullscreenHosts.hasVisibleHost,
+        isTrue,
+        reason: '盖在上面的页面退掉后，宿主重新成为栈顶，全屏键该恢复',
+      );
+    });
+  });
+
+  group('源码守卫', () {
+    final String navSrc = File(
+      'lib/src/shortcuts/global_navigation.dart',
+    ).readAsStringSync();
+
+    test('全屏快捷键的执行体读宿主声明，且只门住「进入」', () {
+      final String toggle = methodBody(
+        navSrc,
+        'Future<void> _toggleWindowFullscreen() async {',
+      );
+      expect(
+        toggle,
+        contains('WindowFullscreenHosts.hasVisibleHost'),
+        reason: '进入全屏必须由内容页的宿主声明门控，而不是页面清单 if 阶梯',
+      );
+      expect(
+        toggle,
+        contains('readDesktopWindowFullscreen()'),
+        reason: '非宿主页面按全屏键时要读一次真值，才能判断这是不是一次「退出」',
+      );
+      expect(
+        toggle,
+        contains('toggleDesktopWindowFullscreen()'),
+        reason: '真正的切换仍须委托给单一 native 窗口所有者',
+      );
+    });
+
+    test('退出全屏的原语不看宿主，只看真值', () {
+      // 对称的门 = 把用户锁死在全屏里。这条断言钉的就是「退出路径上没有宿主判据」。
+      final String exit = methodBody(
+        navSrc,
+        'Future<bool> exitWindowFullscreenIfActive() async {',
+      );
+      expect(
+        exit,
+        isNot(contains('hasVisibleHost')),
+        reason: '退出全屏必须无条件放行，一旦加上宿主门用户就再也退不出来',
+      );
+      expect(exit, contains('setDesktopWindowFullscreen(false)'));
+    });
+
+    test('四个内容页都声明了自己是宿主', () {
+      const Map<String, String> hosts = <String, String>{
+        '小说': 'lib/src/pages/implementations/reader_fushi_page.dart',
+        '漫画': 'lib/src/media/manga/reader/manga_fushi_page.dart',
+        '视频': 'lib/src/pages/implementations/video_fushi_page.dart',
+        '网页流媒体': 'lib/src/pages/implementations/web_video_fushi_page.dart',
+      };
+      for (final MapEntry<String, String> entry in hosts.entries) {
+        final String src = maskComments(File(entry.value).readAsStringSync());
+        expect(
+          src,
+          contains('WindowFullscreenHost('),
+          reason: '${entry.key}页没有声明全屏宿主，它的全屏键会被门掉',
+        );
+      }
+    });
+
+    test('宿主离场时的归还判定推到帧末', () {
+      // 当场判 = 每次 pushReplacement 换集都把全屏闪掉一次（BUG-839 场景）。
+      final String hostSrc = maskComments(
+        File('lib/src/shortcuts/window_fullscreen_hosts.dart')
+            .readAsStringSync(),
+      );
+      final String release = methodBody(
+        hostSrc,
+        'void _releaseWindowFullscreenIfNoHostLeft() {',
+      );
+      expect(
+        release,
+        contains('addPostFrameCallback'),
+        reason: '同帧内 dispose→挂载 的换集场景要求判定发生在帧末',
+      );
+      expect(release, contains('exitWindowFullscreenIfActive()'));
+    });
+
+    test('小说页底栏有全屏按钮，Esc 先退全屏再退书', () {
+      final String chrome = maskComments(
+        File('lib/src/pages/implementations/reader_fushi/chrome.part.dart')
+            .readAsStringSync(),
+      );
+      expect(
+        chrome,
+        contains("ValueKey<String>('fushi_reader_fullscreen_button')"),
+        reason: '小说页此前没有任何全屏入口，收窄后必须补一个看得见的',
+      );
+
+      final String caret = maskComments(
+        File('lib/src/pages/implementations/reader_fushi/caret.part.dart')
+            .readAsStringSync(),
+      );
+      expect(
+        caret,
+        contains('_exitWindowFullscreenOrPopReader()'),
+        reason: '用户裁定 Esc 也要能退全屏：退书之前必须先过全屏这一级',
+      );
+    });
+
+    test('漫画页的返回阶梯不再只认「自己进的」全屏', () {
+      // 用户用 F11 进的全屏不会置所有权标志，但在他眼里那和按钮进的是同一个全屏，
+      // Esc 都该先退它，而不是连人带全屏一起退出漫画。
+      final String manga = maskComments(
+        File('lib/src/media/manga/reader/manga_fushi_page.dart')
+            .readAsStringSync(),
+      );
+      final String exitBeforePop = methodBody(
+        manga,
+        'Future<bool> _exitOwnedFullscreenBeforePop() async {',
+      );
+      expect(exitBeforePop, contains('readDesktopWindowFullscreen()'));
+    });
+  });
+}
+
+/// 往栈上推一个**整页**路由（不是弹层）：模拟「从内容页进设置页」。
+void unawaitedPush(GlobalKey<NavigatorState> navKey) {
+  navKey.currentState!.push(
+    MaterialPageRoute<void>(builder: (BuildContext _) => const SizedBox()),
+  );
+}

--- a/fushi/test/shortcuts/window_fullscreen_hosts_test.dart
+++ b/fushi/test/shortcuts/window_fullscreen_hosts_test.dart
@@ -188,6 +188,75 @@ void main() {
       );
     });
 
+    test('小说页底栏全屏图标的镜像三条路径都同步', () {
+      // 镜像型 bool 的经典塌法：只有「自己那条成功路径」会复位，其余入口改了状态它
+      // 一无所知，于是图标停在一个稳定的错值上、而且不会自愈。这里把三条会改变窗口
+      // 全屏状态的路径各钉一条：
+      //   ① 进页 —— 在别处进的全屏里打开本书，镜像默认 false 就是错的；
+      //   ② 底栏按钮 —— 自己那条路；
+      //   ③ Esc 阶梯 —— 退的是同一个全屏，不复位图标就撒谎。
+      final String chrome = maskComments(
+        File('lib/src/pages/implementations/reader_fushi/chrome.part.dart')
+            .readAsStringSync(),
+      );
+
+      final String initial = methodBody(
+        chrome,
+        'Future<void> _readInitialWindowFullscreenState() async {',
+      );
+      expect(
+        initial,
+        contains('readDesktopWindowFullscreen()'),
+        reason: '① 进页必须问一次 native 真值，而不是相信镜像的初值',
+      );
+      expect(initial, contains('_isWindowFullscreen = fullscreen'));
+
+      final String change = methodBody(
+        chrome,
+        'Future<void> _changeReaderWindowFullscreen() async {',
+      );
+      expect(
+        change,
+        contains('_isWindowFullscreen = applied'),
+        reason: '② 按钮那条路必须按 native 回读的实际结果更新镜像',
+      );
+
+      final String esc = methodBody(
+        chrome,
+        'Future<void> _exitWindowFullscreenOrPopReader() async {',
+      );
+      expect(
+        esc,
+        contains('_isWindowFullscreen = false'),
+        reason: '③ Esc 退掉全屏后图标必须跟着回到「进入全屏」，否则它稳定撒谎',
+      );
+    });
+
+    test('小说页进页时真的会去读一次全屏真值', () {
+      // 上一条只证明 helper 写对了；这条证明它**被调用**——helper 存在但没人调，
+      // 是同一个 bug 的另一种活法。
+      final String page = maskComments(
+        File('lib/src/pages/implementations/reader_fushi_page.dart')
+            .readAsStringSync(),
+      );
+      final int idxInit = page.indexOf('void initState() {');
+      expect(idxInit, isNonNegative, reason: 'initState 锚点没了，守卫失去判据');
+      final int idxDispose = page.indexOf('void dispose() {', idxInit);
+      expect(idxDispose, greaterThan(idxInit));
+      final int idxCall =
+          page.indexOf('_readInitialWindowFullscreenState()', idxInit);
+      expect(
+        idxCall,
+        inInclusiveRange(idxInit, idxDispose),
+        reason: '初次读取必须发生在 initState 里，否则第一帧的图标就是错的',
+      );
+      expect(
+        page.indexOf('desktopWindowFullscreenSupported', idxInit),
+        lessThan(idxCall),
+        reason: '移动端没有可全屏的窗口，这次读取必须被桌面门控挡住',
+      );
+    });
+
     test('漫画页的返回阶梯不再只认「自己进的」全屏', () {
       // 用户用 F11 进的全屏不会置所有权标志，但在他眼里那和按钮进的是同一个全屏，
       // Esc 都该先退它，而不是连人带全屏一起退出漫画。


### PR DESCRIPTION
## 做了什么

按用户裁定把**窗口全屏收窄到内容模块**（小说 / 漫画 / 视频），并补上两个缺失入口。

### 1. 收窄：全屏只属于内容模块

判据没有写成「当前路由名 == 阅读器 / 漫画 / 视频」的 if 阶梯——那是把页面清单硬编码进快捷键层，新增内容页必然漏改。改为**由内容页自己声明**：页面包一层零布局的 `WindowFullscreenHost`，快捷键层只问一个布尔量 `hasVisibleHost`，不认识任何具体页面。

可见性判据是 `ModalRoute.isCurrent`：**宿主还在栈里 ≠ 宿主在最上面**。从阅读器 push 设置页之后，阅读器的 route 仍然 active 但不再 current，此时按全屏键不该生效（用户看到的是设置页，不是内容）。

### 2. 门是非对称的（这是必须，不是疏漏）

| 方向 | 规则 |
|---|---|
| 进入全屏 | 只在宿主页面放行 |
| 退出全屏 | **永远**放行 |

门若对称，用户在内容页进全屏、退回首页之后就再没有任何键能退出全屏——桌面全屏是 runner 自绘的保边框巨窗（BUG-1933），系统并不提供第二个出口，那等于把人锁死在全屏里。

第二道保险：**最后一个宿主离场时自动归还全屏**，且判定推到帧末——`pushReplacement` 换集 / 换章时旧页 dispose 与新页挂载在同一帧内，当场判会把全屏闪掉（BUG-839 那条「连播全屏不被换集打断」正是这个场景）。

### 3. 补两个入口（用户要求）

- **小说页底栏新增全屏按钮**：它此前是唯一没有任何全屏入口的内容页，只能靠全局快捷键。收窄后不补，等于「小说不能全屏」。图标 / tooltip 与漫画页同源。
- **Esc 也能退全屏**：小说页返回阶梯插入「先退全屏、留在书里」一级（词典弹窗 → 全屏 → 退书）。漫画页的同名一级不再只认「自己进的」全屏——用户按 F11 进的全屏不会置所有权标志，但在他眼里那和按钮进的是同一个全屏。

## 三条既有守卫跟着更新（强度不放宽）

改动动了三处被源码守卫钉住的字面形状。每条都确认过守的**不变式**仍然成立，只把锚点挪到新位置：

| 守卫 | 处理 |
|---|---|
| `universal_back`：退书必须经 `maybePop` | 该级随实现搬进 helper，断言跟着挪，**两处切片各自**都要证明没有绕过 PopScope 的裸 `pop()` |
| `reader resize`：LayoutBuilder 包住 reader 子树 | 锚点从 `return LayoutBuilder(` 改为局部变量，**补一条**断言钉住外层只有零布局的 Host |
| `video 手柄接线` | 改判相邻性：手柄层必须是 Host 的独生子，中间不得夹东西 |

## 验证

- `flutter analyze`（含 test）：**No issues found**
- 新增守卫 11 条；**两次变异实测**均按预期红、哈希还原干净：
  - 把 `isCurrent` 判据变成恒真 → 「被整页盖住」那条行为断言红
  - 拿掉宿主进入门 → 「只门住进入」那条源码守卫红
- 定向测试全绿：`shortcuts+macos+focus` 667 条、`reader+build+media` 7465 条、`pages+lookup+settings` 4294 条、`tools+startup+platform` 623 条

## 未做

- **真机未验证**：桌面全屏是 native 行为，widget 测试只能钉接线与判据，进出全屏的实际观感需要真机走一遍。
- 快捷键设置页里 F11 的文案没改（没有说明「只在内容模块生效」）。改它要动 17 个语言文件，且会留 15 种语言的翻译欠账，故未纳入本轮。行为上非内容页按 F11 是静默无操作。
- 视频页在 media_kit 全屏路由内按 F11 的语义与改动前一致（未恶化，也未修）。
