### PR TITLE
ci(torrent): PR 阶段的 libtorrent Android/Linux 编译门（BUG-2021）

### DIFF
--- a/.github/scripts/verify_torrent_abi.sh
+++ b/.github/scripts/verify_torrent_abi.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# 产物校验：刚构建出来的 fushi_torrent bridge 共享库，必须把 C ABI 头文件里声明的
+# **每一个** HT_EXPORT 符号都真的导出到动态符号表。
+#
+# 为什么这一层单独存在：build_windows_dll.ps1 / build_android_so.sh 的自检只到
+# 「文件存在」。而 FFI 的失败形态恰恰是「文件在、符号不在」——
+# `DynamicLibrary.lookup` 要等用户装上新包、点到那个功能才抛，CI 全绿。
+# 纯文本层的头文件 <-> Dart 绑定漂移由
+# fushi/test/media/torrent/torrent_ffi_bindings_parity_guard_test.dart 兜底；
+# 这里补的是「头文件 <-> 真实二进制」那一段，只有真编出产物的地方才做得到。
+#
+# 用法: verify_torrent_abi.sh <so-path> <nm-binary>
+#   nm-binary 可以是 host `nm`，也可以是 NDK 的 llvm-nm（交叉产物用后者更稳）。
+set -euo pipefail
+
+SO="${1:?usage: verify_torrent_abi.sh <so-path> <nm-binary>}"
+NM="${2:?usage: verify_torrent_abi.sh <so-path> <nm-binary>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HEADER="$REPO_ROOT/native/fushi_torrent/fushi_torrent_include/fushi_torrent.h"
+
+[[ -f "$SO" ]] || { echo "::error::artifact not found: $SO" >&2; exit 1; }
+[[ -f "$HEADER" ]] || { echo "::error::header not found: $HEADER" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# 期望集：头文件里 `HT_EXPORT <ret> ht_xxx(` 的函数名。
+grep -oE 'HT_EXPORT[^;(]*\bht_[a-z0-9_]+[[:space:]]*\(' "$HEADER" \
+  | grep -oE '\bht_[a-z0-9_]+' | sort -u > "$work/expected.txt"
+
+expected_count="$(wc -l < "$work/expected.txt" | tr -d ' ')"
+echo "C ABI symbols declared in fushi_torrent.h: $expected_count"
+
+# 扫描规模哨兵：正则被格式化/改写打断时，期望集会静默塌成 0 条，于是「全都导出了」
+# 恒真、这道校验变成空转。下界取当前 37 的保守值；真删符号是破坏性 ABI 变更，
+# 应当同时改这里，而不是让哨兵默默放行。
+if [[ "$expected_count" -lt 30 ]]; then
+  echo "::error title=ABI symbol extraction collapsed::只从 $HEADER 解析出 $expected_count 个 HT_EXPORT 符号（<30）。要么头文件被大改，要么本脚本的正则失效了 —— 两种都不能当通过。" >&2
+  exit 1
+fi
+
+# 实际集：动态符号表里已定义的 ht_* 符号。
+"$NM" -D --defined-only "$SO" > "$work/nm.txt"
+awk '{ print $NF }' "$work/nm.txt" | grep -E '^ht_[a-z0-9_]+$' | sort -u > "$work/actual.txt" || true
+
+actual_count="$(wc -l < "$work/actual.txt" | tr -d ' ')"
+echo "ht_* symbols exported by $(basename "$SO"): $actual_count"
+
+comm -23 "$work/expected.txt" "$work/actual.txt" > "$work/missing.txt"
+if [[ -s "$work/missing.txt" ]]; then
+  echo "::error title=C ABI symbols missing from artifact::头文件声明了但产物没导出的符号：" >&2
+  sed 's/^/  - /' "$work/missing.txt" >&2
+  exit 1
+fi
+
+echo "OK: all $expected_count declared C ABI symbols are exported."

--- a/.github/workflows/native-torrent-gate.yml
+++ b/.github/workflows/native-torrent-gate.yml
@@ -1,0 +1,189 @@
+# 内置 libtorrent 引擎（native/fushi_torrent）的 **PR 阶段 Android/Linux 编译门**。
+#
+# ── 补的是哪个缺口 ────────────────────────────────────────────────────────────
+# C ABI bridge + libtorrent 在本仓一共有三个构建入口，本 workflow 之前它们的 CI
+# 消费面是：
+#
+#   build_windows_dll.ps1   -> build-multiplatform.yml 的 windows job（有
+#                              `pull_request` 触发、paths 含 `native/**`）
+#                              + release-desktop.yml（发布路径）
+#                              ⇒ Windows 侧 **PR 上本来就有真编译门**，还顺带跑
+#                                packages/fushi_torrent 的 dlopen FFI 测试。
+#   build_android_so.sh     -> **只**被 release.yml 消费，而 release.yml 没有
+#                              `pull_request` 触发，push 触发的 paths 里也**没有**
+#                              `native/**`。
+#   build_android_so.ps1    -> 无 CI 消费（开发者本机 Windows 用）。
+#
+# 也就是说：一个只改 `native/fushi_torrent/**` 的 PR，Android 侧的 vcpkg 交叉编译
+# （NDK clang + arm64-android overlay triplet + 静态链 boost/openssl/libtorrent）
+# **在合进主干之前从未跑过一次**；更糟的是合进 develop 之后那次 push 同样不触发
+# release.yml（paths 不含 native/**），断供要等到下一个碰 fushi/** 的提交才暴露。
+# 本 workflow 就是把这条从未被跑过的边补成 PR 阶段的硬门。
+#
+# ── 它**不**负责什么（别误以为它覆盖了这些）────────────────────────────────────
+#   * 不覆盖 Windows DLL：那条已由 build-multiplatform.yml 的 windows job 在 PR 上
+#     真编真测，这里重复跑等于白烧一台 Windows runner 换零新增信息。
+#   * 不覆盖发布路径：release.yml / release-desktop.yml 的产物随包、签名、通道逻辑
+#     一概不碰。本 workflow 全程只读，`permissions: contents: read`，不上传产物、
+#     不建 tag、不碰任何 release。
+#   * 不覆盖运行期行为：这里只到「编得出、链得上、符号齐、ELF 形状对」，真机
+#     下载/做种/代理行为不在射程内。
+#   * 不覆盖 armeabi-v7a / x86 / x86_64：与 release.yml 的范围决策一致，只编
+#     arm64-v8a（其余 ABI 无 .so 时运行期回退外接 qBittorrent，不是静默破坏）。
+#
+# ── 退出码纪律 ────────────────────────────────────────────────────────────────
+# 两个 job 都跑在 ubuntu-latest、`shell: bash` + `set -euo pipefail`，刻意绕开
+# `shell: pwsh` 「只认最后一条命令退出码」的坑（native/galgame_hook 的
+# run_guards.ps1 里那个 Invoke-Checked 就是为那个坑存在的）。没有任何
+# `continue-on-error`：任何一步失败都把 job 打红。缓存未命中只会让构建变慢（冷编），
+# 不会让 job 变绿 —— 没有任何一步的成功条件挂在 cache-hit 上。
+name: native-torrent-gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['main', 'develop']
+    paths:
+      - 'native/fushi_torrent/**'
+      - 'packages/fushi_torrent/**'
+      - '.github/scripts/verify_torrent_abi.sh'
+      - '.github/workflows/native-torrent-gate.yml'
+
+# 全程只读：不构建发布产物、不碰任何 release/tag/发布通道。
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # 快车道（~3 min）：host GCC + Ubuntu 自带 libtorrent-rasterbar 2.0.10 直接编
+  # bridge。它与下面的 Android job 是**不同工具链**（GCC/libstdc++ vs NDK
+  # clang/libc++），bridge 源码里的语法/API/链接错误在这里几分钟内就红，不用等
+  # 那边几十分钟的 vcpkg 冷编。CMakeLists 的非 Windows 分支也只有这里走得到。
+  bridge-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install libtorrent-rasterbar (host toolchain)
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libtorrent-rasterbar-dev libboost-dev libssl-dev ninja-build
+          # 版本必须仍是 2.0.x：fushi_torrent_ffi.cpp 用的是 2.0 API，2.1 移除或改名
+          # 了其中五处（native/fushi_torrent/vcpkg.json 的 why-pinned 有完整清单）。
+          # 发行版某天升到 2.1 时这一行会当场红，而不是让下面的编译吐一串看不懂的
+          # 模板错，把人往「bridge 写错了」的方向带。
+          ver="$(dpkg-query -W -f='${Version}' libtorrent-rasterbar-dev)"
+          echo "libtorrent-rasterbar-dev = $ver"
+          case "$ver" in
+            2.0.*) : ;;
+            *) echo "::error title=libtorrent ABI line drifted::期望 2.0.x，实际 $ver（bridge 是 2.0 API）"; exit 1 ;;
+          esac
+
+      - name: Configure + build bridge (Linux x86_64)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -G Ninja -B "$RUNNER_TEMP/build-linux" -S native/fushi_torrent \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$RUNNER_TEMP/build-linux"
+
+      - name: Verify exported C ABI surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          so="$RUNNER_TEMP/build-linux/libfushi_torrent_ffi.so"
+          test -f "$so" || { echo "::error::missing artifact $so"; exit 1; }
+          file "$so"
+          bash .github/scripts/verify_torrent_abi.sh "$so" nm
+
+  # 真门（冷编 ~40 min，命中二进制缓存后 ~5 min）：跑 release.yml 消费的**同一个**
+  # 脚本，参数也一样。故意不把脚本内容复制到这里 —— 门要守的是那条真实构建路径，
+  # 复制一份就等于守了个替身。
+  android-arm64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      # 缓存 key 与 release.yml 的同名步骤**逐字一致**，这样 PR 上的这个 job 能直接
+      # 复用 develop push 时 release.yml 存下的条目（PR run 可读 base 分支与默认分支
+      # 的缓存）。key 必须带 runner ImageVersion：镜像决定 vcpkg 修订与工具链，也就
+      # 决定所有包的 ABI hash；常量 key 只装得下一种镜像，而 actions/cache 命中即不
+      # 回存，另一种镜像会永远冷编（TODO-2668 实测）。
+      - name: Resolve vcpkg cache identity
+        id: vcpkg_cache_id
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${ImageVersion:-unknown-image}"
+          image="$(echo "$image" | tr -c '0-9A-Za-z._-' '-')"
+          echo "vcpkg cache identity (runner ImageVersion): $image"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - name: Cache vcpkg source distfiles (libtorrent android)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}/vcpkg-downloads
+            !${{ runner.temp }}/vcpkg-downloads/tools
+          key: ${{ runner.os }}-vcpkg-downloads-libtorrent-android-v1-${{ steps.vcpkg_cache_id.outputs.image }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-downloads-libtorrent-android-v1-
+
+      - name: Cache vcpkg binary archives (libtorrent android)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/vcpkg/archives
+          key: ${{ runner.os }}-vcpkg-libtorrent-arm64-android-v2-${{ steps.vcpkg_cache_id.outputs.image }}
+
+      # 这一步就是缺口本身：`build_android_so.sh` 会做 vcpkg baseline 断言、按
+      # manifest（libtorrent 2.0.11 + overrides）装依赖、用 overlay triplet 交叉编、
+      # 链接、strip。overlay ports（若有）里的 `git apply` 补丁也在这一步真跑，
+      # 不是静态 --check。
+      - name: Build embedded libtorrent Android .so (vcpkg, arm64-v8a)
+        shell: bash
+        env:
+          VCPKG_DOWNLOADS: ${{ runner.temp }}/vcpkg-downloads
+        run: |
+          set -euo pipefail
+          chmod +x native/fushi_torrent/build_android_so.sh
+          bash native/fushi_torrent/build_android_so.sh \
+            "$VCPKG_INSTALLATION_ROOT" "$ANDROID_NDK_LATEST_HOME" arm64-v8a
+
+      # 「编出来了」不等于「编对了」：脚本自己只断言文件存在。这里再验产物形状。
+      - name: Verify .so shape and exported C ABI surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          so="native/fushi_torrent/prebuilt/android/arm64-v8a/libfushi_torrent_ffi.so"
+          test -f "$so" || { echo "::error::missing artifact $so"; exit 1; }
+          file "$so"
+
+          nm_bin="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm"
+          if [ ! -x "$nm_bin" ]; then nm_bin=nm; fi
+          bash .github/scripts/verify_torrent_abi.sh "$so" "$nm_bin"
+
+          # 目标机器类型必须是 AArch64（triplet / ANDROID_ABI 串了会静默产出别的架构）。
+          machine="$(readelf -h "$so" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p')"
+          echo "ELF machine: $machine"
+          case "$machine" in
+            *AArch64*) : ;;
+            *) echo "::error title=wrong target arch::期望 AArch64，实际 $machine"; exit 1 ;;
+          esac
+
+          # Android 15+ 的 16KB page size 设备要求 LOAD segment 按 16KB 对齐；
+          # CMakeLists 用 -Wl,-z,max-page-size=16384 恒设。掉了的话 APK 在 16KB
+          # 设备上装不上，而构建本身完全成功 —— 正是要靠产物校验才抓得到的一类。
+          if ! readelf -lW "$so" | awk '$1 == "LOAD" { print $NF }' | grep -qx '0x4000'; then
+            echo "::error title=16KB alignment lost::LOAD segment 不是 0x4000 对齐（检查 CMakeLists 的 max-page-size）"
+            readelf -lW "$so" | sed -n '1,25p'
+            exit 1
+          fi
+          ls -lh "$so"

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1891 条。点号进各自文件。
+> 共 1894 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2021](bugs/BUG-2021-libtorrent-ci-compile-gate.md) | ✅ | ✅ | libtorrent native 构建在 PR 阶段无编译门（Android 侧从未在 CI 编译过） |
 | [BUG-2020](bugs/BUG-2020-identity-json-path-rebase-unregistered.md) | ✅ | ✅ | 刮削 P1 新增的 identityJson 两列漏登记 kPathRebaseColumns，合入即把 develop 打红 |
 | [BUG-2018](bugs/BUG-2018-manga-7z-archive-mokuro-ignored.md) | 🚧 | 🚧 | RAR/CBR/CB7 漫画包内嵌与旁挂 mokuro OCR 不被识别 |
 | [BUG-2017](bugs/BUG-2017-epub-selfclosing-script-empty-plaintext.md) | ✅ | ✅ | EPUB 自闭合 script 标签吞掉正文导致章节纯文本为空、有声书匹配率 0 |

--- a/docs/bugs/BUG-2021-libtorrent-ci-compile-gate.md
+++ b/docs/bugs/BUG-2021-libtorrent-ci-compile-gate.md
@@ -1,0 +1,46 @@
+## BUG-2021 · libtorrent native 构建在 PR 阶段无编译门（Android 侧从未在 CI 编译过）
+- **报告**：2026-09-02（用户：CI 缺口审查，PR #1129 前置）
+- **真实性**：✅ 真 bug（部分修正了报告时的说法：Windows 侧其实**有**门，Android 侧才是真空）
+
+### 现状台账（对 develop@d7c762cd5a 逐条核实）
+
+`native/fushi_torrent` 有三个构建入口，改动前的 CI 消费面：
+
+| 构建脚本 | 被谁消费 | 消费方有 PR 触发吗 |
+|---|---|---|
+| `native/fushi_torrent/build_windows_dll.ps1` | `.github/workflows/build-multiplatform.yml:586`（windows job）<br>`.github/workflows/release-desktop.yml:350`（发布路径） | ✅ 有：`build-multiplatform.yml:29-31` 的 `pull_request` + `paths` 含 `native/**`（YAML anchor `&multiplatform_paths` 定义在 `:16`，`native/**` 在 `:21`，PR 侧 `:31` 复用 `*multiplatform_paths`）。该 job 还在 `:597-613` 跑 `packages/fushi_torrent` 的 dlopen FFI 测试 |
+| `native/fushi_torrent/build_android_so.sh` | **只有** `.github/workflows/release.yml:406-409` | ❌ **无**：`release.yml:13/24/26` 的触发只有 `push`(main/develop) + `release` + `workflow_dispatch`，**没有 `pull_request`** |
+| `native/fushi_torrent/build_android_so.ps1` | 无 CI 消费（开发者本机 Windows 用） | — |
+
+### 根因
+
+两层，第二层更隐蔽：
+
+1. **PR 路径真空**：`release.yml` 是发布 workflow，本就没有 `pull_request` 触发（`main.yml` 的头注释明说「release.yml has no pull_request trigger」）。于是唯一编译 Android `.so` 的地方落在合并**之后**。改 C ABI bridge、`vcpkg.json` 钉版、overlay triplet/port 的 PR，NDK clang 交叉编译 + 静态链 boost/openssl/libtorrent 这条路在合进主干前**一次都没跑过**。
+2. **push 路径也漏**：`release.yml:15-23` 的 push `paths` 是 `fushi/** packages/** ci/** tool/** third_party/** .github/workflows/** pubspec.yaml pubspec.lock` —— **不含 `native/**`**（对比 `build-multiplatform.yml:21` 与 `release-desktop.yml:19` 都显式补了 `native/**`，且各自留了「只改 native/ 的 PR 以前触发不了任何构建」的注释）。所以一个纯 `native/fushi_torrent/**` 的改动合进 develop 之后，那次 push 同样不触发 Android `.so` 构建；断供要等到下一个碰 `fushi/**` 的提交才暴露，而那时归因会指向无辜的提交（BUG-1772 就是这个形态：develop 上连红，且不是任何一个 commit 引入的）。
+
+危害是实测过的：BUG-1772 里 libtorrent 从 2.0.11 漂到 2.1.1，Windows 4 个 DLL 和 Android `.so` 一起编不出来，`build_windows_dll.ps1` 对 Release 缺 DLL 即 throw = Windows 正式包直接断供。Android 侧同款风险至今没有任何合并前的信号。
+
+- **[x] ① 已修复** — 新增 `.github/workflows/native-torrent-gate.yml`（PR 阶段只读编译门，两个 job）+ `.github/scripts/verify_torrent_abi.sh`（产物符号校验）。提交见本文件末尾。
+- **[x] ② 已加自动化测试** — `fushi/test/build/libtorrent_version_pin_guard_test.dart` 追加 4 条（同一域已有的 BUG-1772 守卫扩写，不另起文件）：
+  - 「`build_android_so.sh` 必须被至少一个带 `pull_request` 触发的 workflow 消费」——这条直接钉住本 bug 的根因，门被删或触发被摘掉会当场红；
+  - 「overlay ports 存在时三个构建脚本都必须传 `VCPKG_OVERLAY_PORTS`」——给 PR #1129 准备的：漏给 CI 消费的 `.sh` 版传 overlay，Windows 本机编得出、Android CI 编的却是没打补丁的上游 port；
+  - 「门只读、不发布、不得 `continue-on-error`、paths 覆盖自身」；
+  - 判据自校验（合成语料）：`hasPullRequestTrigger` 不得退化成全文 `contains`（注释、job 级 `if: github.event_name == 'pull_request'`、步骤名里都有这个字面量），`consumesScript` 必须剥注释。
+  - 变异实测：把门的 `pull_request:` 改成 `push:` → 8 条里精确红 1 条（`libtorrent_version_pin_guard_test.dart:183`）；改回后 sha256 逐字还原。
+
+### 这道门覆盖到哪一层（以及**没**覆盖什么）
+
+覆盖：**配置 → 编译 → 链接 → 产物校验**，两个工具链。
+- `bridge-linux`（~3 min）：host GCC + Ubuntu `libtorrent-rasterbar-dev` 2.0.10，cmake configure + build + `nm -D` 符号全覆盖断言。快信号，且是 `CMakeLists.txt` 非 Windows 分支唯一被跑到的地方。
+- `android-arm64`（冷编 ~40 min / 命中二进制缓存 ~5 min）：跑 `release.yml` 消费的**同一个** `build_android_so.sh`（不复制脚本内容，避免守卫守到替身），再验产物：文件存在 → ELF Machine 必须是 AArch64 → 37 个 `HT_EXPORT` 符号全部在动态符号表里 → LOAD segment 16KB 对齐（Android 15 的 16KB page size 要求，掉了的话构建照样成功、APK 却装不上）。
+
+**没覆盖**（别误以为它管这些）：
+- **Windows DLL**：已由 `build-multiplatform.yml` 的 windows job 在 PR 上真编真测（还跑 dlopen FFI 测试），这里重复跑 = 白烧一台 Windows runner 换零新增信息。
+- **发布路径**：`release.yml` / `release-desktop.yml` 的产物随包、签名、发布通道一概不碰。门 `permissions: contents: read`，不上传产物、不建 tag、不碰 release。
+- **`release.yml` push paths 缺 `native/**` 这个洞本身没补**：本 PR 只加 PR 阶段的门，不动发布 workflow 的触发面。后果仍在：纯 native 改动合进 develop 后不会立刻产出新的 Android `.so`。要补应是另一条 PR（改发布 workflow 触发面属于发布路径改动，风险面不同，不该和一条只读门混在一起）。
+- **运行期行为**：只到「编得出、链得上、符号齐、ELF 形状对」。真机下载/做种/代理行为不在射程内。
+- **其它 ABI**：只编 arm64-v8a，与 `release.yml` 的范围决策一致（其余 ABI 无 `.so` 时运行期回退外接 qBittorrent，不是静默破坏）。
+- **`build_android_so.ps1`**：仍无 CI 消费（Windows 本机开发用）；守卫只保证它与 `.sh` 版的 overlay 参数不分叉。
+
+- **备注**：报告时的说法「全仓没有任何 CI job 会编译 libtorrent」不准确——Windows 侧一直有 PR 门（`build-multiplatform.yml`）。真空只在 Android/Linux 侧，本条按实测事实收敛了范围。

--- a/fushi/test/build/libtorrent_version_pin_guard_test.dart
+++ b/fushi/test/build/libtorrent_version_pin_guard_test.dart
@@ -17,8 +17,55 @@ import 'package:flutter_test/flutter_test.dart';
 ///
 /// 修复是 native/fushi_torrent/vcpkg.json（manifest + overrides 钉 2.0.11）。
 /// 这个守卫钉住让它继续生效的三个条件；任何一条被破坏，都会重演一次同款断供。
+///
+/// BUG-2021 起本文件还钉住第二件事：**这条 native 构建链在 PR 上必须有门**。
+/// 版本钉得再准，也挡不住「Android 侧的交叉编译从来没在合并前跑过」——
+/// build_android_so.sh 此前只被 release.yml 消费，而那个 workflow 没有
+/// pull_request 触发、push 的 paths 里也没有 native/**。
+/// 详见 docs/bugs/BUG-2021-libtorrent-ci-compile-gate.md。
+
+/// 去掉整行注释（`#` 开头）。判据必须剥注释：本仓注释极其详尽，
+/// 「release.yml 没有 pull_request 触发」这种说明文字本身就含判据字面量，
+/// 不剥的话每个 workflow 看起来都像有 PR 触发。
+String _stripComments(String text) {
+  return const LineSplitter()
+      .convert(text)
+      .where((String line) => !line.trimLeft().startsWith('#'))
+      .join('\n');
+}
+
+/// workflow 是否真有 `pull_request:` 触发。
+///
+/// 只认 `on:` 块里缩进 1~4 空格的独立 key，不做全文 contains：
+/// 全文里 `pull_request` 还会出现在 `if: github.event_name == 'pull_request'`、
+/// `cancel-in-progress` 表达式和步骤名里，那些都不是触发器。
+bool hasPullRequestTrigger(String workflowText) {
+  final List<String> lines =
+      const LineSplitter().convert(_stripComments(workflowText));
+  bool inOnBlock = false;
+  for (final String line in lines) {
+    if (line.trim().isEmpty) continue;
+    final bool topLevel = !line.startsWith(' ') && !line.startsWith('\t');
+    if (topLevel) {
+      // `on:` / `on: [push]` / YAML 1.1 里没引号的 on 会被解析成 true，但文本层
+      // 看到的仍是 `on:`。遇到下一个顶格 key 就退出 on 块。
+      inOnBlock = RegExp(r'^(on|"on"|true):').hasMatch(line.trim());
+      continue;
+    }
+    if (!inOnBlock) continue;
+    if (RegExp(r'^ {1,4}pull_request:').hasMatch(line)) return true;
+  }
+  return false;
+}
+
+/// workflow 是否消费了某个构建脚本（按仓库相对路径匹配，剥注释后）。
+bool consumesScript(String workflowText, String scriptRepoPath) {
+  return _stripComments(workflowText).contains(scriptRepoPath);
+}
+
 void main() {
   const String nativeDir = '../native/fushi_torrent';
+  const String workflowDir = '../.github/workflows';
 
   test('vcpkg.json 把 libtorrent 钉在 2.0.x（overrides + builtin-baseline）', () {
     final File manifest = File('$nativeDir/vcpkg.json');
@@ -100,5 +147,152 @@ void main() {
         reason: 'fushi_torrent_ffi.cpp 已经不含任何 2.0-only 调用了？如果 bridge 真的'
             '迁到了 2.1 API，请同时把 vcpkg.json 的 libtorrent overrides 一起改掉，'
             '并删掉这条断言 —— 否则钉定和源码会各说各话（BUG-1772）');
+  });
+
+  // ── BUG-2021：构建链必须在 PR 上有门 ───────────────────────────────────────
+  //
+  // 钉版守住的是「装哪个版本」，守不住「有没有人在合并前编过一次」。
+  // build_android_so.sh 曾经只被 release.yml 消费，而那个 workflow 没有
+  // pull_request 触发 —— 改 native/fushi_torrent 的 PR 从来没被交叉编译验证过。
+
+  test('build_android_so.sh 必须被至少一个带 pull_request 触发的 workflow 消费', () {
+    final Directory dir = Directory(workflowDir);
+    expect(dir.existsSync(), isTrue, reason: '$workflowDir 不存在？');
+
+    final List<File> workflows = dir
+        .listSync()
+        .whereType<File>()
+        .where((File f) =>
+            f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+        .toList();
+
+    // 扫描规模哨兵：枚举塌了的话下面的 firstWhere 会变成「没找到 = 没门」的假红，
+    // 或者反过来在别的断言里变成空转。实测 develop 上是 13 个 workflow。
+    expect(workflows.length, greaterThanOrEqualTo(10),
+        reason: '只枚举到 ${workflows.length} 个 workflow 文件，扫描面塌了');
+
+    const String script = 'native/fushi_torrent/build_android_so.sh';
+    final List<String> gates = <String>[];
+    for (final File wf in workflows) {
+      final String text = wf.readAsStringSync();
+      if (!consumesScript(text, script)) continue;
+      if (!hasPullRequestTrigger(text)) continue;
+      gates.add(wf.uri.pathSegments.last);
+    }
+
+    expect(gates, isNotEmpty,
+        reason: '没有任何带 pull_request 触发的 workflow 跑 $script。'
+            '这正是 BUG-2021 的原状：Android 侧的 vcpkg 交叉编译只在 release.yml '
+            '里跑，而它是发布路径（无 PR 触发，push 的 paths 里也没有 native/**）——'
+            '改 C ABI bridge 或 overlay 的 PR 合并前一次都没编过。'
+            '新的门在 .github/workflows/native-torrent-gate.yml，别把它删了或把它的 '
+            'pull_request 触发去掉。');
+  });
+
+  test('overlay ports 存在时，三个构建脚本都必须把它传给 cmake', () {
+    final Directory ports = Directory('$nativeDir/vcpkg-ports');
+    if (!ports.existsSync() || ports.listSync().isEmpty) {
+      // 目前 develop 上没有 overlay ports（只有 overlay triplets）。这条断言是给
+      // 「引入 overlay port 补丁」的那条 PR 准备的：漏给 CI 消费的 .sh 版传
+      // OVERLAY_PORTS，Windows 本机编得出、Android CI 编的却是没打补丁的上游 port。
+      return;
+    }
+    for (final String name in <String>[
+      'build_android_so.sh',
+      'build_android_so.ps1',
+      'build_windows_dll.ps1',
+    ]) {
+      final String text = File('$nativeDir/$name').readAsStringSync();
+      expect(text.contains('VCPKG_OVERLAY_PORTS'), isTrue,
+          reason: '$nativeDir/vcpkg-ports 里有 overlay port，但 $name 没给 cmake 传 '
+              '-DVCPKG_OVERLAY_PORTS。与 OVERLAY_TRIPLETS 同一个坑：manifest 模式下'
+              '装依赖的是 cmake 工具链，overlay 不传就静默装上游未打补丁的 port，'
+              '而三个入口里恰恰是 CI 消费的 .sh 版最容易漏。');
+    }
+  });
+
+  test('native-torrent-gate 只读、不发布、不得 continue-on-error', () {
+    final File gate = File('$workflowDir/native-torrent-gate.yml');
+    expect(gate.existsSync(), isTrue,
+        reason: 'BUG-2021 的门文件不见了');
+    final String text = gate.readAsStringSync();
+    final String body = _stripComments(text);
+
+    expect(body.contains('contents: read'), isTrue,
+        reason: '门必须只读（permissions: contents: read）');
+    expect(body.contains('continue-on-error'), isFalse,
+        reason: 'continue-on-error 会让失败不打红，门就不是门了');
+    for (final String publish in <String>[
+      'action-gh-release',
+      'gh release',
+      'softprops',
+    ]) {
+      expect(body.contains(publish), isFalse,
+          reason: '门里出现发布动作 $publish：仓库硬规则禁止 push/PR 路径创建或更新 '
+              'release');
+    }
+    for (final String path in <String>[
+      'native/fushi_torrent/**',
+      'packages/fushi_torrent/**',
+      '.github/workflows/native-torrent-gate.yml',
+    ]) {
+      expect(body.contains(path), isTrue,
+          reason: '门的 paths 必须覆盖 $path，否则改动它的 PR 触发不了它自己');
+    }
+  });
+
+  test('判据自校验：hasPullRequestTrigger / consumesScript 认得出合成语料', () {
+    // 禁止型/存在型判据在健康仓库里对真实文件永远是同一个答案，判据本身坏掉时
+    // 扫盘那条路检验不到。合成语料与磁盘扫描互不依赖，独立枚举。
+    const String withTrigger = '''
+name: x
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['develop']
+jobs:
+  a:
+    steps:
+      - run: bash native/fushi_torrent/build_android_so.sh a b c
+''';
+    const String pushOnly = '''
+name: y
+# 这个 workflow 没有 pull_request 触发（注释里出现判据字面量，必须被剥掉）
+on:
+  push:
+    branches: ['develop']
+jobs:
+  a:
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: something about pull_request:
+        run: bash native/fushi_torrent/build_android_so.sh a b c
+''';
+    const String triggerButNoScript = '''
+name: z
+on:
+  pull_request:
+    branches: ['develop']
+jobs:
+  a:
+    steps:
+      # 只在注释里提到 native/fushi_torrent/build_android_so.sh
+      - run: echo hi
+''';
+
+    expect(hasPullRequestTrigger(withTrigger), isTrue);
+    expect(hasPullRequestTrigger(pushOnly), isFalse,
+        reason: '注释、job 级 if 表达式和步骤名里的 pull_request 都不是触发器；'
+            '判到 true 说明判据退化成了全文 contains');
+    expect(hasPullRequestTrigger(triggerButNoScript), isTrue);
+
+    expect(
+        consumesScript(withTrigger, 'native/fushi_torrent/build_android_so.sh'),
+        isTrue);
+    expect(
+        consumesScript(
+            triggerButNoScript, 'native/fushi_torrent/build_android_so.sh'),
+        isFalse,
+        reason: '只在注释里出现不算消费；判到 true 说明没剥注释');
   });
 }


### PR DESCRIPTION
## 补的是哪个缺口

`native/fushi_torrent` 三个构建入口，改动前的 CI 消费面（对 `develop@d7c762cd5a` 逐条核实）：

| 构建脚本 | 被谁消费 | 消费方有 PR 触发吗 |
|---|---|---|
| `build_windows_dll.ps1` | `build-multiplatform.yml:586`（windows job）+ `release-desktop.yml:350`（发布路径） | ✅ **有**：`build-multiplatform.yml:29-31` 的 `pull_request`，paths anchor 定义在 `:16`、`native/**` 在 `:21`。该 job 还在 `:597-613` 跑 `packages/fushi_torrent` 的 dlopen FFI 测试 |
| `build_android_so.sh` | **只有** `release.yml:406-409` | ❌ **无**：`release.yml` 的触发是 `push`(`:13`) + `release`(`:24`) + `workflow_dispatch`(`:26`)，**没有 `pull_request`** |
| `build_android_so.ps1` | 无 CI 消费（本机 Windows 开发用） | — |

所以：**Windows 侧一直有 PR 编译门**（这一点修正了立项时「全仓没有任何 CI job 会编译 libtorrent」的说法），真空只在 **Android/Linux 侧** —— NDK clang 交叉编译 + arm64-android overlay triplet + 静态链 boost/openssl/libtorrent 这条路，**在合进主干之前一次都没跑过**。

第二层更隐蔽：`release.yml:15-23` 的 push `paths` 里**也没有** `native/**`（`build-multiplatform.yml:21` 与 `release-desktop.yml:19` 都补了）。于是纯 `native/fushi_torrent/**` 的改动合进 develop 后，那次 push 同样不触发 Android `.so` 构建，断供要等下一个碰 `fushi/**` 的提交才暴露 —— 归因会指向无辜的提交。BUG-1772 就是这个形态。

## 这道门覆盖到哪一层

**配置 → 编译 → 链接 → 产物校验**，两个工具链：

- **`bridge-linux`**（~3 min）：host GCC + Ubuntu `libtorrent-rasterbar-dev` 2.0.x（版本线不是 2.0.x 就当场红，避免发行版漂到 2.1 时吐一串看不懂的模板错），cmake configure + build + `nm -D` 符号全覆盖断言。这是 `CMakeLists.txt` 非 Windows 分支唯一被跑到的地方，也是给下面那条慢 job 的快信号。
- **`android-arm64`**（冷编 ~40 min / 命中二进制缓存 ~5 min）：跑 `release.yml` 消费的**同一个** `build_android_so.sh`，参数也一样 —— 刻意不把脚本内容复制进 workflow，复制一份就等于守了个替身。overlay ports（若有）里的 `git apply` 补丁在这一步真跑，不是静态 `--check`。构建完再验产物：文件存在 → ELF Machine 必须是 AArch64 → 头文件里 37 个 `HT_EXPORT` 符号全部在动态符号表里 → LOAD segment 16KB 对齐（Android 15 的 16KB page size 要求；掉了的话构建照样成功、APK 却装不上，只有产物校验抓得到）。

缓存 key 与 `release.yml` 同名步骤**逐字一致**，PR run 可直接复用 develop push 存下的条目。

## 明确**没**覆盖的部分

- **Windows DLL**：已由 `build-multiplatform.yml` 的 windows job 在 PR 上真编真测，这里重复跑 = 白烧一台 Windows runner 换零新增信息。
- **发布路径**：`release.yml` / `release-desktop.yml` 的产物随包、签名、发布通道一概不碰。门 `permissions: contents: read`，不上传产物、不建 tag、不碰任何 release（仓库硬规则：push 不得创建或更新 Latest/正式 release）。
- **`release.yml` push paths 缺 `native/**` 这个洞本身没补**：本 PR 只加 PR 阶段的门，不动任何发布 workflow 的触发面。后果仍在，要补应是另一条 PR（改发布 workflow 触发面风险面不同，不该和一条只读门混在一起）。
- **运行期行为**：只到「编得出、链得上、符号齐、ELF 形状对」。真机下载/做种/代理行为不在射程内。
- **其它 ABI**：只编 `arm64-v8a`，与 `release.yml` 的范围决策一致（其余 ABI 无 `.so` 时运行期回退外接 qBittorrent，不是静默破坏）。
- **`build_android_so.ps1`**：仍无 CI 消费；守卫只保证它与 `.sh` 版的 overlay 参数不分叉。

## 退出码纪律

两个 job 都是 `ubuntu-latest` + `shell: bash` + `set -euo pipefail`，刻意绕开 `shell: pwsh`「只认最后一条命令退出码」的坑（`native/galgame_hook/tools/run_guards.ps1` 的 `Invoke-Checked` 就是为那个坑存在的）。没有任何 `continue-on-error`。缓存未命中只让构建变慢（冷编），**不会让 job 变绿** —— 没有任何一步的成功条件挂在 `cache-hit` 上。

## 守卫（BUG-2021 ②）

扩写同一域已有的 `fushi/test/build/libtorrent_version_pin_guard_test.dart`（BUG-1772 那条），不另起文件，新增 4 条：

1. **`build_android_so.sh` 必须被至少一个带 `pull_request` 触发的 workflow 消费** —— 直接钉住本 bug 的根因；门被删或触发被摘掉会当场红。带扫描规模哨兵（workflow 文件数 ≥ 10）。
2. **overlay ports 存在时，三个构建脚本都必须传 `VCPKG_OVERLAY_PORTS`** —— 给 PR #1129 准备的：漏给 CI 消费的 `.sh` 版传 overlay，Windows 本机编得出、Android CI 编的却是没打补丁的上游 port。develop 上还没有 `vcpkg-ports/`，所以这条当前是条件断言，由第 4 条的合成语料保证判据本身没坏。
3. **门只读、不发布、不得 `continue-on-error`、paths 覆盖自身**。
4. **判据自校验（合成语料）**：`hasPullRequestTrigger` 不得退化成全文 `contains` —— `pull_request` 这个字面量在注释、job 级 `if: github.event_name == 'pull_request'`、步骤名里都出现；`consumesScript` 必须剥注释。

## 验证

- `flutter analyze`（全量含 test）：`No issues found! (ran in 35.9s)`
- 定向：`FLUTTER TEST VERDICT: PASSED - 8 tests ran`（`libtorrent_version_pin_guard_test.dart`）
- 按 `tests_for_changes.dart` 推导的受影响面 84 个测试文件：`FLUTTER TEST VERDICT: PASSED - 799 tests ran, all tests passed`
- **变异实测**：把门的 `pull_request:` 改成 `push:` → 8 条里**精确红 1 条**（`libtorrent_version_pin_guard_test.dart:183`），其余 7 条仍绿；改回后 sha256 逐字还原（不用 `git checkout`）。
- `verify_torrent_abi.sh` 三向变异：全导出 → PASS；少一个符号 → FAIL 并点名 `ht_session_create`；符号集塌成 2 条 → 哨兵 FAIL（防「正则失效导致恒真」的空转）。
- 14 个 workflow 全部 `yaml.safe_load` 通过；`git diff --cached --stat` 确认未触碰任何发布 workflow。

记账：`docs/bugs/BUG-2021-libtorrent-ci-compile-gate.md`
