### PR TITLE
fix(test): schema 升到 94 后补齐 43 处版本断言（BUG-2022）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1894 条。点号进各自文件。
+> 共 1895 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2022](bugs/BUG-2022-schema-v94-test-assertions-stale.md) | ✅ | ✅ | 刮削 P1 升 schema 到 94 但漏改 43 处测试断言，堆叠 PR 拿不到真单测门导致一路合进 develop |
 | [BUG-2021](bugs/BUG-2021-libtorrent-ci-compile-gate.md) | ✅ | ✅ | libtorrent native 构建在 PR 阶段无编译门（Android 侧从未在 CI 编译过） |
 | [BUG-2020](bugs/BUG-2020-identity-json-path-rebase-unregistered.md) | ✅ | ✅ | 刮削 P1 新增的 identityJson 两列漏登记 kPathRebaseColumns，合入即把 develop 打红 |
 | [BUG-2018](bugs/BUG-2018-manga-7z-archive-mokuro-ignored.md) | 🚧 | 🚧 | RAR/CBR/CB7 漫画包内嵌与旁挂 mokuro OCR 不被识别 |

--- a/docs/bugs/BUG-2022-schema-v94-test-assertions-stale.md
+++ b/docs/bugs/BUG-2022-schema-v94-test-assertions-stale.md
@@ -1,0 +1,17 @@
+## BUG-2022 · 刮削 P1 升 schema 到 94 但漏改 43 处测试断言，堆叠 PR 拿不到真单测门导致一路合进 develop
+- **报告**：2026-09-02（读 develop 的 `Build Release APK` 失败日志时发现，非用户报告）
+- **真实性**：✅ 真 bug。PR #1126（刮削重设计 P1，v94）把 `packages/fushi_core/lib/src/database/database.dart:726` 的 `schemaVersion` 从 93 升到 94 并加了 `identity_json` 两列的迁移，但没有同步更新测试里的版本断言。develop 上 `release.yml` 的 `tests` job → `Run unit tests (main app)` 因此连续三次 failure：
+  ```
+  The Flutter test harness reported failures (39 error event(s), 21926 test(s) completed).
+    suite: fushi/test/database/migration_test.dart
+    Expected: <93>
+      Actual: <94>
+  ```
+- **不是合并时弄丢的**：在 #1126 的分支原始 head `61893e6a15` 上实测，`database.dart` 已是 `schemaVersion => 94` 而 `collection_relations_test.dart:53` 仍是 `expect(db.schemaVersion, 93)` —— **PR 自己分支上就是坏的**。
+- **为什么没被发现（结构性根因）**：刮削三条 PR 是堆叠的，真实方向是 **P2 → P1 → P3**（`#1124` base=develop，`#1126` base=`worktree-scrape-redesign-p2`，`#1127` base=`worktree-scrape-redesign-p1`）。而 `main.yml`（唯一跑 `flutter_test_failures.dart` 与 R8/proguard/native 校验的 workflow）的触发是 `pull_request: branches: ['main','develop']` —— **base 不是 develop 的 PR 从不触发**。所以 #1126 / #1127 的检查列表里永远只有 SonarCloud，它们显示 `MERGEABLE/CLEAN` 时，那个 CLEAN 只代表没冲突、不代表测过。同族事实：**PR 处于 CONFLICTING 时 GitHub 建不出 `refs/pull/N/merge`，所有 `pull_request` 触发的 workflow 整批不跑**，DIRTY 的 PR 同样会静默失去 CI。
+- **[x] ① 已修复** — 共 43 处，分两类，**判据不同、不能盲替**：
+  - **34 处 `expect(db.schemaVersion, 93)`**（24 个文件）→ 94。这是「迁移完成后当前 schema 版本」。
+  - **9 处 on-disk `user_version` 断言**（7 个文件）→ 94。分两种写法：`expect(version.read<int>('user_version'), 93)` 与 `expect(probe.select('PRAGMA user_version').first.values.first, 93)`，都出现在 `openUpgraded()` 或 `migrated.close()` **之后**，读的是迁移后的磁盘版本。
+  - **刻意不改**：`migration_v94_download_identity_json_test.dart` 里的 93（`PRAGMA user_version = 93` 建种子库、以及 `seedV93()` 之后断言迁移前状态）。它们是**迁移起点**，下一行还断言 `identity_json` 列 `isFalse` 佐证。盲目全仓替换会把这条测试变成空转。
+- **[x] ② 已加自动化测试** — 这些断言本身即测试（版本字面量是刻意的绊线：升 schema 必须逐条确认每条迁移路径仍落地正确）。修复前 `test/database` 实测 `VERDICT: FAILED`（先 39 条，改完 `db.schemaVersion` 后仍余 9 条 `user_version`），修复后 `FLUTTER TEST VERDICT: PASSED - 618 tests ran, all tests passed`。
+- **备注**：修法刻意**不是**把字面量换成 `db.schemaVersion` 之类的自反断言——那会让绊线永久失效（`expect(db.schemaVersion, db.schemaVersion)` 恒真）。`packages/*/test` 侧另有守卫 `package_schema_version_literal_guard_test.dart` 禁止等值断言，那是不同作用域的不同约定，本次不涉及。

--- a/fushi/test/database/collection_relations_test.dart
+++ b/fushi/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final FushiDatabase db = await openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/fushi/test/database/migration_test.dart
+++ b/fushi/test/database/migration_test.dart
@@ -1080,7 +1080,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 paired peers 表). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 93,
+      expect(db.schemaVersion, 94,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1157,7 +1157,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 93,
+      expect(db.schemaVersion, 94,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1315,7 +1315,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 93,
+      expect(db.schemaVersion, 94,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1366,7 +1366,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
     });
 
     test(
@@ -1375,7 +1375,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 93,
+      expect(db.schemaVersion, 94,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1409,7 +1409,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 93,
+      expect(db.schemaVersion, 94,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1449,7 +1449,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1480,7 +1480,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1514,7 +1514,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1526,7 +1526,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1562,7 +1562,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 93);
+      expect(db.schemaVersion, 94);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/fushi/test/database/migration_v40_collections_test.dart
+++ b/fushi/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
   });
 }

--- a/fushi/test/database/migration_v51_pdf_format_test.dart
+++ b/fushi/test/database/migration_v51_pdf_format_test.dart
@@ -109,6 +109,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
   });
 }

--- a/fushi/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/fushi/test/database/migration_v53_manga_reading_mode_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
   });
 }

--- a/fushi/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/fushi/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
   });
 }

--- a/fushi/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/fushi/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v57_naming_unification_test.dart
+++ b/fushi/test/database/migration_v57_naming_unification_test.dart
@@ -191,7 +191,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v60_reading_pages_test.dart
+++ b/fushi/test/database/migration_v60_reading_pages_test.dart
@@ -64,7 +64,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 94, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/fushi/test/database/migration_v61_collection_cover_path_test.dart
+++ b/fushi/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
-    expect(db.schemaVersion, 93);
+    expect(version.read<int>('user_version'), 94);
+    expect(db.schemaVersion, 94);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -305,7 +305,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
+    expect(version.read<int>('user_version'), 94);
   });
 
   test(
@@ -336,7 +336,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 93);
+      expect(probe.select('PRAGMA user_version').first.values.first, 94);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,7 +105,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
     expect(await _userVersion(db), db.schemaVersion);
 
     // v63 真跑了：两处废弃偏好都没了。

--- a/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
+++ b/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
@@ -77,7 +77,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v75 给 galgames 加 japanese_locale_mode（每游戏转区档位）');
 
     final List<QueryRow> columns =

--- a/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
+++ b/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
@@ -86,7 +86,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v76 给 lookup_mining_counters 的 book_key 进唯一键');
 
     final List<LookupMiningCounterRow> rows =

--- a/fushi/test/database/migration_v79_tag_assignments_test.dart
+++ b/fushi/test/database/migration_v79_tag_assignments_test.dart
@@ -114,7 +114,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
 
     final List<TagAssignmentRow> rows = await db.getAllTagAssignments();
     expect(rows, hasLength(5), reason: '5 张表各 1 行有效映射（孤儿 srt 行丢弃）');

--- a/fushi/test/database/migration_v80_media_open_history_test.dart
+++ b/fushi/test/database/migration_v80_media_open_history_test.dart
@@ -61,7 +61,7 @@ CREATE TABLE media_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93);
+    expect(db.schemaVersion, 94);
 
     final rows = await db.getAllMediaOpenHistory();
     expect(rows, hasLength(2), reason: '迁移零丢行');

--- a/fushi/test/database/migration_v82_subtable_uid_test.dart
+++ b/fushi/test/database/migration_v82_subtable_uid_test.dart
@@ -131,7 +131,7 @@ CREATE TABLE revealed_images (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93, reason: 'v82 = 四子表书键切 uid');
+    expect(db.schemaVersion, 94, reason: 'v82 = 四子表书键切 uid');
 
     // ── reader_positions：跨书族，epub 命中换 uid，SRT 照抄 ──
     expect(await count(db, 'reader_positions'), 2, reason: '迁移零丢行');

--- a/fushi/test/database/migration_v83_entrykey_uid_test.dart
+++ b/fushi/test/database/migration_v83_entrykey_uid_test.dart
@@ -128,7 +128,7 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 93,
+    expect(db.schemaVersion, 94,
         reason: 'v83 = shelf_entries / media_collection_items epub 键切 uid');
 
     // ── shelf_entries：epub 命中换 uid、透传照抄、非 epub 照抄、零丢行 ──

--- a/fushi/test/database/migration_v84_preferences_updated_at_test.dart
+++ b/fushi/test/database/migration_v84_preferences_updated_at_test.dart
@@ -53,8 +53,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
-    expect(db.schemaVersion, 93);
+    expect(version.read<int>('user_version'), 94);
+    expect(db.schemaVersion, 94);
 
     // 存量行零丢失——改名是用户数据，迁移丢一行就是丢一个书名。
     expect(await db.getPref(_overrideKey), 's:母设备改的名');

--- a/fushi/test/database/migration_v85_video_last_played_at_test.dart
+++ b/fushi/test/database/migration_v85_video_last_played_at_test.dart
@@ -94,8 +94,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
-    expect(db.schemaVersion, 93);
+    expect(version.read<int>('user_version'), 94);
+    expect(db.schemaVersion, 94);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(4), reason: '迁移丢一行就是丢一部视频的观看记录');

--- a/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
+++ b/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
@@ -87,8 +87,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
-    expect(db.schemaVersion, 93);
+    expect(version.read<int>('user_version'), 94);
+    expect(db.schemaVersion, 94);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(2), reason: '迁移丢一行就是丢一部视频的记录');

--- a/fushi/test/database/migration_v88_content_language_rest_test.dart
+++ b/fushi/test/database/migration_v88_content_language_rest_test.dart
@@ -94,7 +94,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 93);
+      expect(probe.select('PRAGMA user_version').first.values.first, 94);
       expect(hasColumn(probe, 'video_books', 'language'), isTrue);
       expect(hasColumn(probe, 'srt_books', 'language'), isTrue);
       expect(hasColumn(probe, 'galgames', 'language'), isTrue);

--- a/fushi/test/database/migration_v90_download_proxy_merge_test.dart
+++ b/fushi/test/database/migration_v90_download_proxy_merge_test.dart
@@ -129,8 +129,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 93);
-    expect(db.schemaVersion, 93);
+    expect(version.read<int>('user_version'), 94);
+    expect(db.schemaVersion, 94);
 
     expect(await _prefs(db), <String, String>{
       'theme': 's:dark',

--- a/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
+++ b/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
@@ -95,7 +95,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 93);
+      expect(probe.select('PRAGMA user_version').first.values.first, 94);
       expect(
           hasColumn(probe, 'media_collections', 'subtitle_language'), isTrue);
       expect(hasColumn(probe, 'media_collections', 'subtitle_release_group'),


### PR DESCRIPTION
develop 的 `release.yml` → `tests` job → `Run unit tests (main app)` **连续三次 failure**（`@d7c762cd5a` / `@168cf7fde8` / `@33217a9290`）：

```
The Flutter test harness reported failures (39 error event(s), 21926 test(s) completed).
  suite: fushi/test/database/migration_test.dart
  Expected: <93>
    Actual: <94>
```

## 不是合并时弄丢的

在 #1126 的分支**原始 head `61893e6a15`** 上实测：`database.dart:726` 已是 `schemaVersion => 94`，而 `collection_relations_test.dart:53` 仍是 `expect(db.schemaVersion, 93)`。**PR 自己分支上就是坏的。**

## 为什么没被发现（结构性根因）

刮削三条是堆叠 PR，真实方向是 **P2 → P1 → P3**：`#1124` base=`develop`，`#1126` base=`worktree-scrape-redesign-p2`，`#1127` base=`worktree-scrape-redesign-p1`。

而 `main.yml`（唯一跑 `flutter_test_failures.dart` 和 R8/proguard/native 校验的 workflow）触发是：

```yaml
on:
  pull_request:
    branches: ['main', 'develop']
```

**base 不是 develop 的 PR 从不触发。** 所以 #1126 / #1127 的检查列表里永远只有 SonarCloud —— 它们显示 `MERGEABLE/CLEAN` 时，那个 CLEAN 只代表没冲突、不代表测过。

同族事实（这一轮另外踩到的）：**PR 处于 CONFLICTING 时 GitHub 建不出 `refs/pull/N/merge`，所有 `pull_request` 触发的 workflow 整批不跑** —— DIRTY 的 PR 同样会静默失去 CI。

## 修了什么：43 处，两类判据不同，不能盲替

| 类别 | 处数 | 判据 |
|---|---|---|
| `expect(db.schemaVersion, 93)` | 34（24 文件） | 迁移完成后的当前 schema 版本 |
| on-disk `user_version` | 9（7 文件） | `openUpgraded()` / `migrated.close()` **之后**读的磁盘版本，两种写法：`version.read<int>('user_version')` 与 `probe.select('PRAGMA user_version').first.values.first` |

**刻意不改**：`migration_v94_download_identity_json_test.dart` 里的 93。那是**迁移起点**（`PRAGMA user_version = 93` 建种子库、`seedV93()` 之后断言迁移前状态），下一行还断言 `identity_json` 列 `isFalse` 佐证。全仓盲替会把这条测试变成空转 —— 它恰恰是验证 v94 迁移本身的那条。

**也没有把字面量换成自反断言**（如 `expect(db.schemaVersion, db.schemaVersion)`）。版本字面量是刻意的绊线：升 schema 必须逐条确认每条迁移路径仍落地正确，换成自反就永久失效了。

## 验证

```
修复前（只改 db.schemaVersion 那 34 处）：
  FLUTTER TEST VERDICT: FAILED - ... (9 error event(s), 618 test(s) completed)
修复后（补上 9 处 user_version）：
  FLUTTER TEST VERDICT: PASSED - 618 tests ran, all tests passed
```

分两步是有意的：先改一类、再看剩下什么，避免一次性盲替把「迁移起点」那种反向语义一起吃掉。
