### PR TITLE
fix(popup): 词典分组展开/收起不再改变卡头位置与卡片高度 (BUG-2049)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1903 条。点号进各自文件。
+> 共 1904 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2049](bugs/BUG-2049-popup-disclosure-toggle-shifts-header.md) | ✅ | ✅ | 查词弹窗词典分组展开/收起时卡头位移且卡片凭空增高 |
 | [BUG-2048](bugs/BUG-2048-galgame-hunex-native-structural-complexity.md) | 🚧 | 🚧 | HUNEX 原生适配层 9 处结构性复杂度待清（认知复杂度 55/44/43/40/35、24 字段类、13/12/8 参函数） |
 | [BUG-2028](bugs/BUG-2028-krkr-risk-acceptance-entry-focus-loss.md) | ✅ | ✅ | KRKR 风险确认入口在切回 Fushi 后消失 |
 | [BUG-2027](bugs/BUG-2027-gal-native-input-admission-transaction.md) | 🚧 | 🚧 | Gal 原生查词风险未授权时仍吞输入，事务瞬态会拆半 |

--- a/docs/bugs/BUG-2049-popup-disclosure-toggle-shifts-header.md
+++ b/docs/bugs/BUG-2049-popup-disclosure-toggle-shifts-header.md
@@ -1,0 +1,31 @@
+## BUG-2049 · 查词弹窗词典分组展开/收起时卡头位移且卡片凭空增高
+- **报告**：2026-09-02（用户：两张同一词条弹窗截图，唯一差别是右栏「実用日本語表現辞典」一张 `▼` 展开、一张 `▶` 收起；原话「展开没展开高度和词典头位置会变动」）
+- **真实性**：✅ 真 bug，两处独立根因、同一病理「几何随展开状态变化」。
+  - 根因 A（**卡头横向位移**）`fushi/assets/popup/popup.css:982`（`.glossary-group[open] > summary::before`）：TODO-1337 把折叠三角从字体字形改成纯 CSS 边框三角形是对的，但展开态是靠**重设四条边框**换朝向的。边框三角的布局盒尺寸 = 它两组对边之和，所以「换朝向」必然「换盒子」：收起态 `border-left:5px` + 上下各 4px 透明 → 盒 **5px 宽 × 8px 高**；展开态 `border-top:5px` + 左右各 4px 透明 → 盒 **8px 宽 × 5px 高**。`::before` 是 `inline-block`，盒宽 5→8 把后面的 `.dict-name` 整体右推 3px。
+  - 根因 B（**卡片凭空增高**）`fushi/assets/popup/popup.css:994`（`.glossary-group > div[data-dictionary] { padding-top: 2px }`）：卡头与释义之间的 2px 呼吸挂在内容 div 上，而该 div **只在展开态参与布局**（`<details>` 收起时子节点不生成盒子）。于是展开一本在此词条下没有可见释义的词典（截图里的「実用日本語表現辞典」正是展开后空白）也会凭空长高 2px；popup.js `layoutMasonry` 逐列绝对定位重排，再把这 2px 放大成整列上下跳动，即用户看到的「NHK 那张卡跟着挪」。
+  - **实测**（headless Edge = Windows WebView2 引擎，加载真 `popup.css` + 真 DOM 形状 `<details.glossary-group><summary.dict-label><span.dict-name>`，Noto CJK / Yu Gothic / Meiryo / 系统默认 四种字体结论完全一致）：
+
+    | | 收起 `▶` | 展开 `▼`（内容为空） | delta |
+    |---|---|---|---|
+    | `.dict-name` 相对 summary 左偏移 | 10px | 13px | **+3px** |
+    | summary 行高 | 15px | 15px | 0 |
+    | 卡片高 | 29px | 31px | **+2px** |
+
+    三角盒高 8→5 未吃到行盒（`.dict-label` 是 10px 字号，行盒够高），所以位移**只**来自盒宽与内容 div 的 padding，与字体无关。
+- **[x] ① 已修复** — 两处各一条最小改动，都把「随状态变化的几何」改成「恒定几何」：
+  - A：展开态**只旋转不重画**——删掉 `[open]` 的四条 border 重设，改 `transform: rotate(90deg)`。transform 不参与布局，布局盒恒为 5×8，两态 `.dict-name` 左偏移恒等；同一份右向三角绕盒心旋转 90° 后的形状（底边 8、高 5）与旧展开态逐像素相同。
+  - B：2px 间距的拥有者从「只在展开态存在的内容 div」改成「恒存在的卡头」——`.glossary-group > div[data-dictionary]` 去掉 `padding-top`，`.glossary-group > summary` 加 `padding-bottom: 2px`。卡片基线高度与展开状态无关，展开只增加真实内容的高度；有内容时卡头与释义之间仍是同样的 2px。
+  - 修后同一套实测：**四项 delta 全为 0.000**（左偏移恒 10px、行高恒 17px、卡高恒 31px）；有真实释义的卡片高度修前修后同为 50.594px，即**有内容的卡观感逐像素不变**，只有收起态卡片随基线对齐长高 2px。另用 6× 缩放截图肉眼复核：旋转所得 `▼` 形状正确、未被卡片内边距裁剪，收起/展开两张卡的词典名左边界完全对齐。
+  - 五镜像同步：真源 `fushi/assets/popup/popup.css` → `cp` 进两份 vendor `popup.css` → `node tools/browser-extension/scripts/generate-content-css.mjs` 重新生成两份 `content.css` → `node tools/browser-extension/scripts/sync-mirrors.mjs`。三份 popup.css 与两份 content.css 各自 sha256 一致。
+- **[x] ② 已加自动化测试** — 加强既有守卫 `fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart`（原 TODO-1337 守卫断言的正是本次删掉的 `border-top: 5px solid currentColor` / `border-bottom: 0`，若只改 CSS 不改守卫必红）：
+  - 保留 TODO-1337 的两条原始不变式（禁字体字形 ▶/▼、收起态是 `border-left` 边框三角）；
+  - 新增 **`[open]` 属性白名单**：只允许 `transform` / `transform-origin`，出现任何 `border-*` / `width` / `height` / `margin` / `padding` 等会改布局盒的属性即红。是白名单不是黑名单——新属性必须先想清楚会不会改盒子；
+  - 新增 **间距归属**断言：`div[data-dictionary]` 不得声明 `padding-top` / `margin-top`，`.glossary-group > summary` 必须声明 `padding-bottom: 2px`；
+  - 扫描面从 3 个 popup.css 扩到 **5 个**，把两份**生成的** `content.css` 一并纳入，才抓得到「改了真源忘了重新跑 generate-content-css.mjs」；
+  - 规则体匹配前先 `stripComments()` 剥 `/* */`——本次修复的注释里天然出现 `padding-top` / `border-top` 字样，不剥就会把解释文字当成真声明。
+  - **变异实测**（非空转证明）：把 A 改回四条 border 重设 → `+19 -1` 红；把 B 的 `padding-top: 2px` 加回内容 div → `+19 -1` 红；两次均从备份文件还原，还原后 popup.css sha256 = `395ee12d4731fb9a`，与变异前逐字节一致。守卫本身 20 例全绿。
+  - 相邻守卫回归：`browser_extension_popup_parity_guard` / `popup_css_eink_guard` / `browser_extension_dict_media_mirror_guard` / `popup_pitch_noselect_guard` / `popup_mine_button_visual_guard` / `popup_glossary_overflow_wrap_guard` / `popup_cards_nav_icon_guard` / `global_lookup_popup_style_guard` 共 200 例全绿。
+- **备注**：
+  - 与 BUG-636 / TODO-1337 是同一处代码的**接续**而非回归：那轮解决的是「三角在某些字体下渲染不出来」（字体依赖），本轮解决的是它引入的「换朝向即换盒子」（状态相关几何）。两条不变式现在由同一个守卫一起锁。
+  - 与 BUG-1923（制卡 `+` 用字形冒充图标导致光学中心偏低）同一族病理：**可见形状不该由会改变布局的载体绘制**。BUG-1923 的解法是把字形换成几何，本轮的解法是把「改盒子的几何变换」换成「不改盒子的 transform」。
+  - **未在本 bug 范围内**：截图里「実用日本語表現辞典」展开后没有任何可见释义，这本身值得单独查（是该词典在此词条下真为空、还是渲染链把内容吃了）。本轮只消除了它带来的布局跳动，没有查为什么空——若确认是渲染缺陷应另开一条。

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -893,6 +893,13 @@
 
 .glossary-group > summary {
     list-style: none;
+    /* BUG-2049: 词典名与释义之间的 2px 呼吸原本挂在 `div[data-dictionary]` 的
+       padding-top 上，而那个 div 只在展开态参与布局——于是「展开一本此词条下没有可见
+       释义的词典」也会凭空长高 2px（headless Edge 实测：卡片高 29px → 31px），
+       masonry 逐列重排再把这 2px 放大成整列上下跳动。
+       间距的拥有者改成恒存在的卡头：卡片基线高度与展开状态无关，展开只增加真实内容的
+       高度；有内容时卡头与释义之间仍是同样的 2px，观感不变。 */
+    padding-bottom: 2px;
 }
 
 .glossary-group > summary::-webkit-details-marker {
@@ -904,7 +911,16 @@
    (html,body{font-family:<custom>,...})；若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
    某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成空白/彩色
    emoji/豆腐块，即「展开收起图标渲染不出来」。边框三角是纯几何，零字体依赖，全平台/全字体
-   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。 */
+   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。
+
+   BUG-2049: 展开态**只旋转，不重画边框**。边框三角的布局盒尺寸就是它两组对边之和，
+   所以「换朝向」必然「换盒子」：旧写法收起态是 5px 宽 × 8px 高（左边框 5 + 上下各 4），
+   展开态被重设成 8px 宽 × 5px 高（上边框 5 + 左右各 4）。盒宽 5→8 把后面的词典名
+   整体右推 3px，用户看到「展开/收起时词典头位置会动」。headless Edge 实测（真 popup.css，
+   Noto CJK / Yu Gothic / Meiryo / 默认 四种字体一致）：.dict-name 相对 summary 的
+   左偏移 收起 10px → 展开 13px。
+   transform 不参与布局：同一份右向三角旋转 90° 后，布局盒恒为 5×8，两态词典名左偏移
+   恒等；而旋转所得形状（底边 8、高 5、绕盒心）与旧展开态逐像素相同。 */
 .glossary-group > summary::before {
     content: '';
     display: inline-block;
@@ -921,18 +937,18 @@
 }
 
 .glossary-group[open] > summary::before {
-    /* 展开态：下向三角（顶点朝下）——显式重设四边，避免残留收起态边框 */
-    border-top: 5px solid currentColor;
-    border-right: 4px solid transparent;
-    border-bottom: 0;
-    border-left: 4px solid transparent;
+    /* 展开态：下向三角（顶点朝下）。只旋转，不碰任何 border——布局盒必须与收起态恒等，
+       否则词典名会随展开状态横向跳动（BUG-2049）。 */
+    transform: rotate(90deg);
 }
 
 .glossary-group > div[data-dictionary] {
     display: block;
     font-size: 14px;
     line-height: 1.4;
-    padding-top: 2px;
+    /* BUG-2049: 这里不再放 padding-top——间距挂在 `.glossary-group > summary` 的
+       padding-bottom 上，见那条规则的注释。本 div 只在展开态存在，任何挂在它上面的
+       固定间距都会变成「展开就长高」的状态相关几何。 */
 }
 
 .glossary-group > div[data-dictionary] > ol {

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -952,6 +952,13 @@ html[data-theme="dark"] .glossary-group {
 
 .glossary-group > summary {
     list-style: none;
+    /* BUG-2049: 词典名与释义之间的 2px 呼吸原本挂在 `div[data-dictionary]` 的
+       padding-top 上，而那个 div 只在展开态参与布局——于是「展开一本此词条下没有可见
+       释义的词典」也会凭空长高 2px（headless Edge 实测：卡片高 29px → 31px），
+       masonry 逐列重排再把这 2px 放大成整列上下跳动。
+       间距的拥有者改成恒存在的卡头：卡片基线高度与展开状态无关，展开只增加真实内容的
+       高度；有内容时卡头与释义之间仍是同样的 2px，观感不变。 */
+    padding-bottom: 2px;
 }
 
 .glossary-group > summary::-webkit-details-marker {
@@ -963,7 +970,16 @@ html[data-theme="dark"] .glossary-group {
    (html,body{font-family:<custom>,...})；若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
    某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成空白/彩色
    emoji/豆腐块，即「展开收起图标渲染不出来」。边框三角是纯几何，零字体依赖，全平台/全字体
-   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。 */
+   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。
+
+   BUG-2049: 展开态**只旋转，不重画边框**。边框三角的布局盒尺寸就是它两组对边之和，
+   所以「换朝向」必然「换盒子」：旧写法收起态是 5px 宽 × 8px 高（左边框 5 + 上下各 4），
+   展开态被重设成 8px 宽 × 5px 高（上边框 5 + 左右各 4）。盒宽 5→8 把后面的词典名
+   整体右推 3px，用户看到「展开/收起时词典头位置会动」。headless Edge 实测（真 popup.css，
+   Noto CJK / Yu Gothic / Meiryo / 默认 四种字体一致）：.dict-name 相对 summary 的
+   左偏移 收起 10px → 展开 13px。
+   transform 不参与布局：同一份右向三角旋转 90° 后，布局盒恒为 5×8，两态词典名左偏移
+   恒等；而旋转所得形状（底边 8、高 5、绕盒心）与旧展开态逐像素相同。 */
 .glossary-group > summary::before {
     content: '';
     display: inline-block;
@@ -980,18 +996,18 @@ html[data-theme="dark"] .glossary-group {
 }
 
 .glossary-group[open] > summary::before {
-    /* 展开态：下向三角（顶点朝下）——显式重设四边，避免残留收起态边框 */
-    border-top: 5px solid currentColor;
-    border-right: 4px solid transparent;
-    border-bottom: 0;
-    border-left: 4px solid transparent;
+    /* 展开态：下向三角（顶点朝下）。只旋转，不碰任何 border——布局盒必须与收起态恒等，
+       否则词典名会随展开状态横向跳动（BUG-2049）。 */
+    transform: rotate(90deg);
 }
 
 .glossary-group > div[data-dictionary] {
     display: block;
     font-size: 14px;
     line-height: 1.4;
-    padding-top: 2px;
+    /* BUG-2049: 这里不再放 padding-top——间距挂在 `.glossary-group > summary` 的
+       padding-bottom 上，见那条规则的注释。本 div 只在展开态存在，任何挂在它上面的
+       固定间距都会变成「展开就长高」的状态相关几何。 */
 }
 
 .glossary-group > div[data-dictionary] > ol {

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -952,6 +952,13 @@ html[data-theme="dark"] .glossary-group {
 
 .glossary-group > summary {
     list-style: none;
+    /* BUG-2049: 词典名与释义之间的 2px 呼吸原本挂在 `div[data-dictionary]` 的
+       padding-top 上，而那个 div 只在展开态参与布局——于是「展开一本此词条下没有可见
+       释义的词典」也会凭空长高 2px（headless Edge 实测：卡片高 29px → 31px），
+       masonry 逐列重排再把这 2px 放大成整列上下跳动。
+       间距的拥有者改成恒存在的卡头：卡片基线高度与展开状态无关，展开只增加真实内容的
+       高度；有内容时卡头与释义之间仍是同样的 2px，观感不变。 */
+    padding-bottom: 2px;
 }
 
 .glossary-group > summary::-webkit-details-marker {
@@ -963,7 +970,16 @@ html[data-theme="dark"] .glossary-group {
    (html,body{font-family:<custom>,...})；若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
    某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成空白/彩色
    emoji/豆腐块，即「展开收起图标渲染不出来」。边框三角是纯几何，零字体依赖，全平台/全字体
-   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。 */
+   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。
+
+   BUG-2049: 展开态**只旋转，不重画边框**。边框三角的布局盒尺寸就是它两组对边之和，
+   所以「换朝向」必然「换盒子」：旧写法收起态是 5px 宽 × 8px 高（左边框 5 + 上下各 4），
+   展开态被重设成 8px 宽 × 5px 高（上边框 5 + 左右各 4）。盒宽 5→8 把后面的词典名
+   整体右推 3px，用户看到「展开/收起时词典头位置会动」。headless Edge 实测（真 popup.css，
+   Noto CJK / Yu Gothic / Meiryo / 默认 四种字体一致）：.dict-name 相对 summary 的
+   左偏移 收起 10px → 展开 13px。
+   transform 不参与布局：同一份右向三角旋转 90° 后，布局盒恒为 5×8，两态词典名左偏移
+   恒等；而旋转所得形状（底边 8、高 5、绕盒心）与旧展开态逐像素相同。 */
 .glossary-group > summary::before {
     content: '';
     display: inline-block;
@@ -980,18 +996,18 @@ html[data-theme="dark"] .glossary-group {
 }
 
 .glossary-group[open] > summary::before {
-    /* 展开态：下向三角（顶点朝下）——显式重设四边，避免残留收起态边框 */
-    border-top: 5px solid currentColor;
-    border-right: 4px solid transparent;
-    border-bottom: 0;
-    border-left: 4px solid transparent;
+    /* 展开态：下向三角（顶点朝下）。只旋转，不碰任何 border——布局盒必须与收起态恒等，
+       否则词典名会随展开状态横向跳动（BUG-2049）。 */
+    transform: rotate(90deg);
 }
 
 .glossary-group > div[data-dictionary] {
     display: block;
     font-size: 14px;
     line-height: 1.4;
-    padding-top: 2px;
+    /* BUG-2049: 这里不再放 padding-top——间距挂在 `.glossary-group > summary` 的
+       padding-bottom 上，见那条规则的注释。本 div 只在展开态存在，任何挂在它上面的
+       固定间距都会变成「展开就长高」的状态相关几何。 */
 }
 
 .glossary-group > div[data-dictionary] > ol {

--- a/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
+++ b/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 查词弹窗「词典分组展开/收起三角」的两条几何不变式守卫。
 ///
 /// TODO-1337（原始不变式）：三角必须是**纯 CSS 边框几何**，禁止回退到字体字形
@@ -29,12 +31,6 @@ import 'package:flutter_test/flutter_test.dart';
 /// 此处只锁三角与间距的几何不变式）。
 void main() {
   String read(String p) => File(p).readAsStringSync();
-
-  /// 剥掉 `/* ... */` 注释再做规则匹配。注释里天然会出现被禁的字面量（本文件锁的
-  /// `padding-top` / `border-top` 在修复说明里都被提到），不剥就会把解释文字当成
-  /// 真声明命中，守卫恒红或恒绿都可能。
-  String stripComments(String css) =>
-      css.replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '');
 
   /// 抽取 `<selector> { ... }` 规则块内容（popup 这些规则无嵌套花括号）。
   String ruleBody(String css, String selector) {
@@ -67,7 +63,11 @@ void main() {
   mirrors.forEach((String name, String relPath) {
     group('[$name] 折叠三角：字体无关 + 展开收起零布局变化', () {
       late final String css;
-      setUpAll(() => css = stripComments(read(relPath)));
+      // 注释里天然会出现被禁的字面量（本文件锁的 `padding-top` /
+      // `border-top` 在修复说明里都被提到），不剥就会把解释文字当成真声明
+      // 命中。用共享的 maskCssComments（等长掩码，不是删除）：下面 ruleBody 靠
+      // indexOf/substring 定位，删除式剥离会让下标与原文错位。
+      setUpAll(() => css = maskCssComments(read(relPath)));
 
       test('TODO-1337 不再用字体字形 ▶ / ▼（旧的脆弱做法）', () {
         expect(css.contains("content: '▶"), isFalse,

--- a/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
+++ b/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
@@ -91,6 +91,10 @@ void main() {
         expect(props, isNotEmpty, reason: '展开态必须有朝向声明，否则三角不会变成指下');
         expect(props, contains('transform'),
             reason: '展开态朝向必须靠 transform 旋转（transform 不参与布局）');
+        expect(ruleBody(css, '.glossary-group[open] > summary::before'),
+            contains('transform: rotate(90deg)'),
+            reason: '展开态必须是绕盒心旋转 90° 的下向三角；'
+                '只声明 transform 属性名不够——transform: none / rotate(0deg) 会让两态图标同形');
         // 白名单而非黑名单：任何新属性都得先想清楚它会不会改盒子。border-* 会（边框
         // 三角的盒尺寸=两组对边之和），width/height/margin/padding/display/font-size
         // 也会——它们一旦出现，词典名就会随展开状态横向跳动（BUG-2049 原始症状）。

--- a/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
+++ b/fushi/test/dictionary/popup_disclosure_triangle_guard_test.dart
@@ -2,19 +2,39 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// TODO-1337 守卫：查词弹窗「词典分组展开/收起三角」用纯 CSS 边框三角形，禁止回退到
-/// 字体字形（旧: `content: '▶'` / `content: '▼'`）。
+/// 查词弹窗「词典分组展开/收起三角」的两条几何不变式守卫。
 ///
-/// 根因：字体字形三角会继承弹窗当前字体——包括用户注入的自定义词典字体
-/// (`html,body{font-family:<custom>,...}`)。若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
-/// 某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成
-/// 空白/彩色 emoji/豆腐块，即用户报的「展开收起图标渲染不出来」。边框三角是纯几何、
-/// 零字体依赖，全平台/全字体一致渲染（与 Niratan 的 `.entry-current::before` 同法）。
+/// TODO-1337（原始不变式）：三角必须是**纯 CSS 边框几何**，禁止回退到字体字形
+/// （旧: `content: '▶'` / `content: '▼'`）。字体字形三角会继承弹窗当前字体——包括用户
+/// 注入的自定义词典字体 (`html,body{font-family:<custom>,...}`)。若该字体缺 U+25B6/
+/// U+25BC 或按 emoji 呈现，某些平台/WebView（Android WebView、自定义词典字体、emoji
+/// 回退）下三角会渲染成空白/彩色 emoji/豆腐块，即用户报的「展开收起图标渲染不出来」。
 ///
-/// 三镜像同守：in-app 弹窗 + 两份浏览器扩展 vendor 副本（`popup_pitch_noselect_guard`
-/// 另有「两 vendor 逐字节一致」守卫，此处只锁三角形状）。
+/// BUG-2049（本轮加强）：**切换展开/收起不得改变任何布局几何**。TODO-1337 的修法给
+/// `[open]` 重设了四条边框，而边框三角的布局盒尺寸就是它两组对边之和——换朝向即换盒子：
+/// 收起 5px 宽 × 8px 高，展开 8px 宽 × 5px 高。盒宽 5→8 把后面的词典名整体右推 3px，
+/// 用户报「展开没展开高度和词典头位置会变动」。同一根因的第二处：卡头与释义之间的 2px
+/// 间距原本挂在 `div[data-dictionary]` 的 `padding-top` 上，而那个 div 只在展开态参与
+/// 布局，于是展开一本没有可见释义的词典也会凭空长高 2px。
+///
+/// headless Edge 实测（真 popup.css，Noto CJK / Yu Gothic / Meiryo / 默认 四种字体
+/// 结论一致），`.dict-name` 相对 summary 的左偏移 与 卡片高度：
+///   修前  收起 10px / 29px  →  展开 13px / 31px   （横跳 3px、凭空高 2px）
+///   修后  收起 10px / 31px  →  展开 10px / 31px   （四项 delta 全 0）
+/// 有真实释义的卡片高度修前修后同为 50.594px，观感不变。
+///
+/// 五镜像同守：in-app 弹窗 popup.css + 两份扩展 vendor popup.css + 两份**生成的**
+/// content.css。把生成产物一起纳入扫描面，才抓得到「改了真源忘了重新跑
+/// generate-content-css.mjs」（`popup_pitch_noselect_guard` 另有逐字节一致守卫，
+/// 此处只锁三角与间距的几何不变式）。
 void main() {
   String read(String p) => File(p).readAsStringSync();
+
+  /// 剥掉 `/* ... */` 注释再做规则匹配。注释里天然会出现被禁的字面量（本文件锁的
+  /// `padding-top` / `border-top` 在修复说明里都被提到），不剥就会把解释文字当成
+  /// 真声明命中，守卫恒红或恒绿都可能。
+  String stripComments(String css) =>
+      css.replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '');
 
   /// 抽取 `<selector> { ... }` 规则块内容（popup 这些规则无嵌套花括号）。
   String ruleBody(String css, String selector) {
@@ -27,24 +47,35 @@ void main() {
     return css.substring(open + 1, close);
   }
 
+  /// 把规则体拆成 `属性名` 列表，用于「只允许出现哪些属性」这类白名单断言。
+  List<String> declaredProperties(String body) => body
+      .split(';')
+      .map((String d) => d.trim())
+      .where((String d) => d.isNotEmpty)
+      .map((String d) => d.split(':').first.trim())
+      .toList();
+
   const Map<String, String> mirrors = <String, String>{
     'in-app popup': 'assets/popup/popup.css',
     'extension vendor (assets)': 'assets/browser_extension/vendor/popup.css',
     'extension vendor (tools)': '../tools/browser-extension/vendor/popup.css',
+    'extension content (assets)': 'assets/browser_extension/vendor/content.css',
+    'extension content (tools)':
+        '../tools/browser-extension/vendor/content.css',
   };
 
   mirrors.forEach((String name, String relPath) {
-    group('[$name] 折叠三角为字体无关的边框三角形', () {
+    group('[$name] 折叠三角：字体无关 + 展开收起零布局变化', () {
       late final String css;
-      setUpAll(() => css = read(relPath));
+      setUpAll(() => css = stripComments(read(relPath)));
 
-      test('不再用字体字形 ▶ / ▼（旧的脆弱做法）', () {
+      test('TODO-1337 不再用字体字形 ▶ / ▼（旧的脆弱做法）', () {
         expect(css.contains("content: '▶"), isFalse,
             reason: '禁止用 ▶ 字体字形（缺字体/emoji 回退会渲染不出来）');
         expect(css.contains("content: '▼"), isFalse, reason: '禁止用 ▼ 字体字形');
       });
 
-      test('收起态 = 右向边框三角（border-left currentColor）', () {
+      test('TODO-1337 收起态 = 右向边框三角（border-left currentColor）', () {
         final String body = ruleBody(css, '.glossary-group > summary::before');
         expect(body, contains("content: ''"),
             reason: '::before 需空 content 生成盒子承载边框三角');
@@ -54,13 +85,32 @@ void main() {
             reason: '上/下边框透明夹出三角高度');
       });
 
-      test('展开态 = 下向边框三角（border-top currentColor）', () {
-        final String body =
-            ruleBody(css, '.glossary-group[open] > summary::before');
-        expect(body, contains('border-top: 5px solid currentColor'),
-            reason: '展开态下向三角：上边框实心 currentColor（顶点朝下）');
-        expect(body, contains('border-bottom: 0'),
-            reason: '展开态显式重设下边框，避免残留收起态边框');
+      test('BUG-2049 展开态只旋转，不声明任何影响布局盒的属性', () {
+        final List<String> props = declaredProperties(
+            ruleBody(css, '.glossary-group[open] > summary::before'));
+        expect(props, isNotEmpty, reason: '展开态必须有朝向声明，否则三角不会变成指下');
+        expect(props, contains('transform'),
+            reason: '展开态朝向必须靠 transform 旋转（transform 不参与布局）');
+        // 白名单而非黑名单：任何新属性都得先想清楚它会不会改盒子。border-* 会（边框
+        // 三角的盒尺寸=两组对边之和），width/height/margin/padding/display/font-size
+        // 也会——它们一旦出现，词典名就会随展开状态横向跳动（BUG-2049 原始症状）。
+        expect(props, everyElement(anyOf('transform', 'transform-origin')),
+            reason: '展开态只允许 transform / transform-origin；'
+                '出现 $props 中的其它属性说明布局盒又随状态变了');
+      });
+
+      test('BUG-2049 卡头与释义的间距不挂在「只在展开态存在」的内容 div 上', () {
+        final List<String> contentProps = declaredProperties(
+            ruleBody(css, '.glossary-group > div[data-dictionary]'));
+        expect(contentProps.contains('padding-top'), isFalse,
+            reason: 'div[data-dictionary] 只在展开态参与布局，挂在它上面的固定上间距'
+                '会让「展开一本没有可见释义的词典」凭空长高');
+        expect(contentProps.contains('margin-top'), isFalse,
+            reason: 'margin-top 与 padding-top 同病：状态相关的上间距');
+
+        final String summaryBody = ruleBody(css, '.glossary-group > summary');
+        expect(summaryBody, contains('padding-bottom: 2px'),
+            reason: '间距的拥有者必须是恒存在的卡头，卡片基线高度才与展开状态无关');
       });
     });
   });

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -893,6 +893,13 @@
 
 .glossary-group > summary {
     list-style: none;
+    /* BUG-2049: 词典名与释义之间的 2px 呼吸原本挂在 `div[data-dictionary]` 的
+       padding-top 上，而那个 div 只在展开态参与布局——于是「展开一本此词条下没有可见
+       释义的词典」也会凭空长高 2px（headless Edge 实测：卡片高 29px → 31px），
+       masonry 逐列重排再把这 2px 放大成整列上下跳动。
+       间距的拥有者改成恒存在的卡头：卡片基线高度与展开状态无关，展开只增加真实内容的
+       高度；有内容时卡头与释义之间仍是同样的 2px，观感不变。 */
+    padding-bottom: 2px;
 }
 
 .glossary-group > summary::-webkit-details-marker {
@@ -904,7 +911,16 @@
    (html,body{font-family:<custom>,...})；若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
    某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成空白/彩色
    emoji/豆腐块，即「展开收起图标渲染不出来」。边框三角是纯几何，零字体依赖，全平台/全字体
-   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。 */
+   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。
+
+   BUG-2049: 展开态**只旋转，不重画边框**。边框三角的布局盒尺寸就是它两组对边之和，
+   所以「换朝向」必然「换盒子」：旧写法收起态是 5px 宽 × 8px 高（左边框 5 + 上下各 4），
+   展开态被重设成 8px 宽 × 5px 高（上边框 5 + 左右各 4）。盒宽 5→8 把后面的词典名
+   整体右推 3px，用户看到「展开/收起时词典头位置会动」。headless Edge 实测（真 popup.css，
+   Noto CJK / Yu Gothic / Meiryo / 默认 四种字体一致）：.dict-name 相对 summary 的
+   左偏移 收起 10px → 展开 13px。
+   transform 不参与布局：同一份右向三角旋转 90° 后，布局盒恒为 5×8，两态词典名左偏移
+   恒等；而旋转所得形状（底边 8、高 5、绕盒心）与旧展开态逐像素相同。 */
 .glossary-group > summary::before {
     content: '';
     display: inline-block;
@@ -921,18 +937,18 @@
 }
 
 .glossary-group[open] > summary::before {
-    /* 展开态：下向三角（顶点朝下）——显式重设四边，避免残留收起态边框 */
-    border-top: 5px solid currentColor;
-    border-right: 4px solid transparent;
-    border-bottom: 0;
-    border-left: 4px solid transparent;
+    /* 展开态：下向三角（顶点朝下）。只旋转，不碰任何 border——布局盒必须与收起态恒等，
+       否则词典名会随展开状态横向跳动（BUG-2049）。 */
+    transform: rotate(90deg);
 }
 
 .glossary-group > div[data-dictionary] {
     display: block;
     font-size: 14px;
     line-height: 1.4;
-    padding-top: 2px;
+    /* BUG-2049: 这里不再放 padding-top——间距挂在 `.glossary-group > summary` 的
+       padding-bottom 上，见那条规则的注释。本 div 只在展开态存在，任何挂在它上面的
+       固定间距都会变成「展开就长高」的状态相关几何。 */
 }
 
 .glossary-group > div[data-dictionary] > ol {

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -952,6 +952,13 @@ html[data-theme="dark"] .glossary-group {
 
 .glossary-group > summary {
     list-style: none;
+    /* BUG-2049: 词典名与释义之间的 2px 呼吸原本挂在 `div[data-dictionary]` 的
+       padding-top 上，而那个 div 只在展开态参与布局——于是「展开一本此词条下没有可见
+       释义的词典」也会凭空长高 2px（headless Edge 实测：卡片高 29px → 31px），
+       masonry 逐列重排再把这 2px 放大成整列上下跳动。
+       间距的拥有者改成恒存在的卡头：卡片基线高度与展开状态无关，展开只增加真实内容的
+       高度；有内容时卡头与释义之间仍是同样的 2px，观感不变。 */
+    padding-bottom: 2px;
 }
 
 .glossary-group > summary::-webkit-details-marker {
@@ -963,7 +970,16 @@ html[data-theme="dark"] .glossary-group {
    (html,body{font-family:<custom>,...})；若该字体缺 U+25B6/U+25BC 或按 emoji 呈现，
    某些平台/WebView（Android WebView、自定义词典字体、emoji 回退）下三角会渲染成空白/彩色
    emoji/豆腐块，即「展开收起图标渲染不出来」。边框三角是纯几何，零字体依赖，全平台/全字体
-   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。 */
+   一致渲染（与 Niratan 的 .entry-current::before 边框三角同法）。收起=指右▶，展开=指下▼。
+
+   BUG-2049: 展开态**只旋转，不重画边框**。边框三角的布局盒尺寸就是它两组对边之和，
+   所以「换朝向」必然「换盒子」：旧写法收起态是 5px 宽 × 8px 高（左边框 5 + 上下各 4），
+   展开态被重设成 8px 宽 × 5px 高（上边框 5 + 左右各 4）。盒宽 5→8 把后面的词典名
+   整体右推 3px，用户看到「展开/收起时词典头位置会动」。headless Edge 实测（真 popup.css，
+   Noto CJK / Yu Gothic / Meiryo / 默认 四种字体一致）：.dict-name 相对 summary 的
+   左偏移 收起 10px → 展开 13px。
+   transform 不参与布局：同一份右向三角旋转 90° 后，布局盒恒为 5×8，两态词典名左偏移
+   恒等；而旋转所得形状（底边 8、高 5、绕盒心）与旧展开态逐像素相同。 */
 .glossary-group > summary::before {
     content: '';
     display: inline-block;
@@ -980,18 +996,18 @@ html[data-theme="dark"] .glossary-group {
 }
 
 .glossary-group[open] > summary::before {
-    /* 展开态：下向三角（顶点朝下）——显式重设四边，避免残留收起态边框 */
-    border-top: 5px solid currentColor;
-    border-right: 4px solid transparent;
-    border-bottom: 0;
-    border-left: 4px solid transparent;
+    /* 展开态：下向三角（顶点朝下）。只旋转，不碰任何 border——布局盒必须与收起态恒等，
+       否则词典名会随展开状态横向跳动（BUG-2049）。 */
+    transform: rotate(90deg);
 }
 
 .glossary-group > div[data-dictionary] {
     display: block;
     font-size: 14px;
     line-height: 1.4;
-    padding-top: 2px;
+    /* BUG-2049: 这里不再放 padding-top——间距挂在 `.glossary-group > summary` 的
+       padding-bottom 上，见那条规则的注释。本 div 只在展开态存在，任何挂在它上面的
+       固定间距都会变成「展开就长高」的状态相关几何。 */
 }
 
 .glossary-group > div[data-dictionary] > ol {


### PR DESCRIPTION
用户报「展开没展开高度和词典头位置会变动」，附两张同一词条的弹窗截图，唯一差别是右栏「実用日本語表現辞典」一张 `▼` 展开、一张 `▶` 收起。

## 根因（两处独立，同一病理：几何随展开状态变化）

**A · 卡头横向位移** — `fushi/assets/popup/popup.css` `.glossary-group[open] > summary::before`

TODO-1337 把折叠三角从字体字形改成纯 CSS 边框三角形是对的，但展开态是靠**重设四条边框**换朝向的。边框三角的布局盒尺寸 = 它两组对边之和，所以「换朝向」必然「换盒子」：

- 收起 `▶`：`border-left:5px` + 上下各 4px 透明 → 盒 **5px 宽 × 8px 高**
- 展开 `▼`：`border-top:5px` + 左右各 4px 透明 → 盒 **8px 宽 × 5px 高**

`::before` 是 `inline-block`，盒宽 5→8 把后面的 `.dict-name` 整体右推 3px。

**B · 卡片凭空增高** — `.glossary-group > div[data-dictionary] { padding-top: 2px }`

卡头与释义之间的 2px 呼吸挂在内容 div 上，而该 div **只在展开态参与布局**（`<details>` 收起时子节点不生成盒子）。于是展开一本在此词条下没有可见释义的词典（截图里那本正是展开后空白）也会凭空长高 2px；`layoutMasonry` 逐列绝对定位重排，再把这 2px 放大成整列上下跳动，即用户看到的「下面那张卡跟着挪」。

## 实测

headless Edge（= Windows WebView2 引擎）加载**真** `popup.css` + 真 DOM 形状，Noto CJK / Yu Gothic / Meiryo / 系统默认四种字体结论完全一致：

| | 收起 `▶` | 展开 `▼`（内容为空） | delta |
|---|---|---|---|
| `.dict-name` 相对 summary 左偏移 | 10px | 13px | **+3px** |
| summary 行高 | 15px | 15px | 0 |
| 卡片高 | 29px | 31px | **+2px** |

三角盒高 8→5 未吃到行盒（`.dict-label` 是 10px 字号，行盒够高），所以位移**只**来自盒宽与内容 div 的 padding，与字体无关。

## 修复

两条最小改动，都把「随状态变化的几何」改成「恒定几何」：

- **A**：删掉 `[open]` 的四条 border 重设，改 `transform: rotate(90deg)`。transform 不参与布局，布局盒恒为 5×8；同一份右向三角绕盒心旋转 90° 后的形状（底边 8、高 5）与旧展开态逐像素相同。
- **B**：2px 间距的拥有者从「只在展开态存在的内容 div」改成「恒存在的卡头」——内容 div 去掉 `padding-top`，`.glossary-group > summary` 加 `padding-bottom: 2px`。

修后同一套实测：**四项 delta 全为 0.000**（左偏移恒 10px、行高恒 17px、卡高恒 31px）；**有真实释义的卡片高度修前修后同为 50.594px**，即有内容的卡观感逐像素不变，只有收起态卡片随基线对齐长高 2px。另用 6× 缩放截图肉眼复核：旋转所得 `▼` 形状正确、未被卡片内边距裁剪，收起/展开两张卡的词典名左边界完全对齐。

五镜像同步走官方脚本：真源 popup.css → 两份 vendor popup.css → `generate-content-css.mjs` 重生成两份 content.css → `sync-mirrors.mjs`。三份 popup.css 与两份 content.css 各自 sha256 一致。

## 守卫

加强既有的 `popup_disclosure_triangle_guard_test.dart`——**旧守卫断言的正是本次删掉的 `border-top: 5px solid currentColor` / `border-bottom: 0`**，只改 CSS 不改守卫必红，所以必须连意图一起升级：

- 保留 TODO-1337 两条原始不变式（禁字体字形 ▶/▼、收起态是 `border-left` 边框三角）；
- 新增 **`[open]` 属性白名单**：只允许 `transform` / `transform-origin`，出现任何 `border-*` / `width` / `height` / `margin` / `padding` 等会改布局盒的属性即红。白名单不是黑名单——新属性必须先想清楚会不会改盒子；
- 新增**间距归属**断言：内容 div 不得声明 `padding-top` / `margin-top`，卡头必须声明 `padding-bottom: 2px`；
- 扫描面 3 → **5** 个文件，把两份**生成的** `content.css` 一并纳入，才抓得到「改了真源忘了重新跑 generate-content-css.mjs」；
- 规则体匹配前先 `stripComments()` 剥 `/* */`——本次修复的注释里天然出现 `padding-top` / `border-top` 字样，不剥就会把解释文字当成真声明（变异前守卫为绿即反证剥离生效）。

**变异实测（非空转证明）**：A 改回四条 border 重设 → `+19 -1` 红；B 的 `padding-top: 2px` 加回内容 div → `+19 -1` 红。两次均从备份文件还原，还原后 popup.css sha256 = `395ee12d4731fb9a`，与变异前逐字节一致。

## 验证

- 本守卫 20 例全绿
- **全仓 55 个读 popup.css / content.css 的测试文件共 632 例全绿**（横跨 `test/build`、`test/dictionary`、`test/lookup`、`test/pages`、`test/reader`、`test/settings`——定向按功能域挑不到的那批）
- `tools/browser-extension/popup-mine-button-visual.test.js` 10/10 绿
- `flutter analyze`（含 test 目录）：**No issues found**

## 遗留（未在本 PR 范围内）

截图里「実用日本語表現辞典」展开后没有任何可见释义，这本身值得单独查（是该词典在此词条下真为空，还是渲染链把内容吃了）。本轮只消除了它带来的布局跳动，没有查为什么空。

https://claude.ai/code/session_01DKocQjagraJcgFkhfp2daU
