### PR TITLE
feat(torrent): 内置公开 tracker 扩到 23 条并收口成单一常量

### DIFF
--- a/fushi/lib/src/media/torrent/nyaa_client.dart
+++ b/fushi/lib/src/media/torrent/nyaa_client.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
 
 import 'package:fushi/src/media/torrent/anime_release_descriptor.dart';
+import 'package:fushi/src/media/torrent/public_trackers.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 
@@ -47,13 +48,12 @@ class NyaaFeedFormatException extends FormatException {
   final NyaaFeedErrorCode code;
 }
 
-/// Nyaa 磁链标准 tracker 列表（nyaa.si 站点磁链默认附带的公开 tracker）。
+/// Nyaa 磁链 tracker 列表：站点专属 tracker 排最前，后面跟内置公开兜底集
+/// [kPublicTrackers]。nyaa 自己的 tracker 只覆盖本站种子，公开的那批才是
+/// 「站点 tracker 挂了/种子已从本站下架」时还能连上 peer 的那条路。
 const List<String> kNyaaTrackers = <String>[
   'http://nyaa.tracker.wf:7777/announce',
-  'udp://open.stunner.irish:80/announce',
-  'udp://tracker.opentrackr.org:1337/announce',
-  'udp://open.tracker.cl:1337/announce',
-  'udp://exodus.desync.com:6969/announce',
+  ...kPublicTrackers,
 ];
 
 /// 成对括号块（字幕组 / 画质 / 年份 tag）：`[...]` `(...)`。

--- a/fushi/lib/src/media/torrent/public_trackers.dart
+++ b/fushi/lib/src/media/torrent/public_trackers.dart
@@ -1,13 +1,23 @@
-/// 内置公开 tracker 兜底集（磁链 `&tr=` 用）。
+/// 内置公开 tracker 兜底集（拼磁链时的 `&tr=`）。
 ///
-/// 用户可以在下载设置里开 tracker 订阅（`kDefaultTrackerSubscriptionUrl`），但那
-/// 条链路要联网、会失败，而且只对**加进引擎的**种子生效；磁链本身带的 tracker 是
-/// 离线也成立的那一份。两者不是替代关系：订阅补的是「引擎侧全局」，这里补的是
-/// 「磁链自带」，所以这份列表要能独立把种子连起来，不能只留三五条。
+/// 与 tracker 订阅（`kDefaultTrackerSubscriptionUrl`，默认指向 trackerslist 的
+/// best.txt 镜像）不是替代关系：订阅要联网、会失败，而且只作用于**已经加进引擎
+/// 的**种子；磁链自己带的这份是离线也成立的那一批。所以它必须能独立把种子连起
+/// 来，不能只留三五条。
 ///
-/// 只收长期存活的公开 tracker，UDP 优先（announce 开销远低于 HTTP）。索引器专属
-/// tracker（如 nyaa 的 `nyaa.tracker.wf`）不进这里，由各 client 自己在前面拼。
+/// **列表来源（2026-09-02 取样，更新时照做一遍）**：凭印象写 tracker 不行——形
+/// 状合法的死 tracker 只会安静地永不响应，没有任何报错。这份是两个持续实测源的
+/// 并集，再并上仓库原有的几条（只加不减，免得动到用户已在下的种子）：
+///  - `ngosang/trackerslist` 的 `trackers_best.txt`（默认订阅那份的上游）；
+///  - `newtrackon.com/api/stable`（uptime ≥ 95%）。
+///
+/// 注意本机若开着 fake-ip 代理，直接对这些域名发 BEP 15 握手会全部超时（DNS 被
+/// 解析成 198.18.x.x），那是环境问题，不能当成 tracker 已死的证据。
+///
+/// 索引器专属 tracker（如 nyaa 的 `nyaa.tracker.wf`）不进这里，由各 client 自己
+/// 拼在最前面。
 const List<String> kPublicTrackers = <String>[
+  // 仓库原有（保留）。
   'udp://tracker.opentrackr.org:1337/announce',
   'udp://open.demonii.com:1337/announce',
   'udp://open.stealth.si:80/announce',
@@ -15,17 +25,22 @@ const List<String> kPublicTrackers = <String>[
   'udp://exodus.desync.com:6969/announce',
   'udp://open.tracker.cl:1337/announce',
   'udp://open.stunner.irish:80/announce',
-  'udp://tracker.openbittorrent.com:6969/announce',
-  'udp://explodie.org:6969/announce',
-  'udp://opentracker.i2p.rocks:6969/announce',
-  'udp://tracker.dler.org:6969/announce',
-  'udp://tracker1.bt.moack.co.kr:80/announce',
-  'udp://tracker.tiny-vps.com:6969/announce',
-  'udp://tracker.theoks.net:6969/announce',
-  'udp://bt.ktrackers.com:6666/announce',
+  // 两个源都收录（best + uptime ≥ 95%）。
   'udp://tracker-udp.gbitt.info:80/announce',
-  'udp://tracker.bittor.pw:1337/announce',
-  'udp://p4p.arenabg.com:1337/announce',
+  'udp://tracker.qu.ax:6969/announce',
+  'udp://tracker.peerfect.org:6969/announce',
+  'udp://tracker.opentrackr.com:6969/announce',
+  'udp://tracker.ilibr.org:6969/announce',
+  'udp://tr4ck3r.duckdns.org:6969/announce',
+  'udp://torrentclub.online:1984/announce',
+  // 仅 trackers_best.txt 收录。
+  'udp://zer0day.ch:1337/announce',
+  'udp://tracker.therarbg.to:6969/announce',
+  'udp://tracker.publictracker.xyz:6969/announce',
+  'udp://tracker2.dler.org:80/announce',
+  'udp://tracker.wildkat.net:6969/announce',
   'udp://tracker.filemail.com:6969/announce',
-  'https://tracker.tamersunion.org:443/announce',
+  'udp://tracker.ducks.party:1984/announce',
+  'udp://tracker.bittor.pw:1337/announce',
+  'udp://tracker.auctor.tv:6969/announce',
 ];

--- a/fushi/lib/src/media/torrent/public_trackers.dart
+++ b/fushi/lib/src/media/torrent/public_trackers.dart
@@ -1,0 +1,31 @@
+/// 内置公开 tracker 兜底集（磁链 `&tr=` 用）。
+///
+/// 用户可以在下载设置里开 tracker 订阅（`kDefaultTrackerSubscriptionUrl`），但那
+/// 条链路要联网、会失败，而且只对**加进引擎的**种子生效；磁链本身带的 tracker 是
+/// 离线也成立的那一份。两者不是替代关系：订阅补的是「引擎侧全局」，这里补的是
+/// 「磁链自带」，所以这份列表要能独立把种子连起来，不能只留三五条。
+///
+/// 只收长期存活的公开 tracker，UDP 优先（announce 开销远低于 HTTP）。索引器专属
+/// tracker（如 nyaa 的 `nyaa.tracker.wf`）不进这里，由各 client 自己在前面拼。
+const List<String> kPublicTrackers = <String>[
+  'udp://tracker.opentrackr.org:1337/announce',
+  'udp://open.demonii.com:1337/announce',
+  'udp://open.stealth.si:80/announce',
+  'udp://tracker.torrent.eu.org:451/announce',
+  'udp://exodus.desync.com:6969/announce',
+  'udp://open.tracker.cl:1337/announce',
+  'udp://open.stunner.irish:80/announce',
+  'udp://tracker.openbittorrent.com:6969/announce',
+  'udp://explodie.org:6969/announce',
+  'udp://opentracker.i2p.rocks:6969/announce',
+  'udp://tracker.dler.org:6969/announce',
+  'udp://tracker1.bt.moack.co.kr:80/announce',
+  'udp://tracker.tiny-vps.com:6969/announce',
+  'udp://tracker.theoks.net:6969/announce',
+  'udp://bt.ktrackers.com:6666/announce',
+  'udp://tracker-udp.gbitt.info:80/announce',
+  'udp://tracker.bittor.pw:1337/announce',
+  'udp://p4p.arenabg.com:1337/announce',
+  'udp://tracker.filemail.com:6969/announce',
+  'https://tracker.tamersunion.org:443/announce',
+];

--- a/fushi/lib/src/media/torrent/public_video_index_client.dart
+++ b/fushi/lib/src/media/torrent/public_video_index_client.dart
@@ -3,21 +3,14 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'package:fushi/src/media/torrent/anime_release_descriptor.dart';
+import 'package:fushi/src/media/torrent/public_trackers.dart';
 import 'package:fushi/src/utils/net/app_http.dart';
 
-/// 公共索引器（apibay / Knaben）磁链附带的公开 tracker。
-///
-/// 两家 API 的返回形状不同——apibay 只给 `info_hash`（磁链要自己拼），Knaben 直接
-/// 给 `magnetUrl`——但落到下载引擎的必须是同一种东西。所以拼磁链的那一半在这里
-/// 统一，两家共用同一份 tracker，省得「同一个种子从 A 源加进来能连上、从 B 源加
-/// 进来连不上」。
-const List<String> kPublicVideoIndexTrackers = <String>[
-  'udp://tracker.opentrackr.org:1337/announce',
-  'udp://open.demonii.com:1337/announce',
-  'udp://open.stealth.si:80/announce',
-  'udp://tracker.torrent.eu.org:451/announce',
-  'udp://exodus.desync.com:6969/announce',
-];
+// 公共索引器（apibay / Knaben）磁链附带的 tracker 就是 [kPublicTrackers]：两家
+// API 的返回形状不同——apibay 只给 `info_hash`（磁链要自己拼），Knaben 直接给
+// `magnetUrl`——但落到下载引擎的必须是同一种东西。所以拼磁链的那一半在这里统
+// 一，两家共用同一份 tracker，省得「同一个种子从 A 源加进来能连上、从 B 源加进
+// 来连不上」。这两家没有站点专属 tracker，所以不另起名字，直接用共享常量。
 
 /// 公共索引器返回的一条种子。
 ///
@@ -70,7 +63,7 @@ String buildPublicVideoIndexMagnet({
   if (name.isNotEmpty) {
     buffer.write('&dn=${Uri.encodeQueryComponent(name)}');
   }
-  for (final String tracker in kPublicVideoIndexTrackers) {
+  for (final String tracker in kPublicTrackers) {
     buffer.write('&tr=${Uri.encodeQueryComponent(tracker)}');
   }
   return buffer.toString();

--- a/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
+++ b/fushi/lib/src/media/video/download/video_download_pipeline_service.dart
@@ -19,8 +19,8 @@ import 'package:fushi/src/media/metadata/credential_redaction.dart';
 import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/magnet_utils.dart';
 import 'package:fushi/src/media/torrent/nyaa_client.dart' show kNyaaTrackers;
-import 'package:fushi/src/media/torrent/public_video_index_client.dart'
-    show kPublicVideoIndexTrackers;
+import 'package:fushi/src/media/torrent/public_trackers.dart'
+    show kPublicTrackers;
 import 'package:fushi/src/media/torrent/public_video_index_provider.dart'
     show kApibayResourceProviderId, kKnabenResourceProviderId;
 import 'package:fushi/src/media/torrent/torrent_add_coordinator.dart';
@@ -1994,7 +1994,7 @@ class VideoDownloadPipelineService {
     // apibay 联网走的也是同一份常量 tracker（`NyaaTorrent.magnet` /
     // `buildPublicVideoIndexMagnet`），完全等价；**Knaben 例外**——它的 API 直接
     // 给 `magnetUrl`，联网时原样透传，离线路径统一换成
-    // `kPublicVideoIndexTrackers`，可能丢掉 knaben 自带的少量 tracker。公共
+    // `kPublicTrackers`，可能丢掉 knaben 自带的少量 tracker。公共
     // tracker + DHT 足以补齐，用一条必然发生的 notFound 误报换它不划算。
     // 真正必须重搜的只剩私有 Torznab：它的 .torrent 走临时凭据 URL，不落库。
     final TorrentMagnetPayload? offline = _publicIndexerMagnetPayload(job);
@@ -2034,7 +2034,7 @@ class VideoDownloadPipelineService {
         ? kNyaaTrackers
         : isProvider(kApibayResourceProviderId) ||
               isProvider(kKnabenResourceProviderId)
-        ? kPublicVideoIndexTrackers
+        ? kPublicTrackers
         : null;
     if (trackers == null) return null;
     final String hash = (job.torrentHash ?? job.selectedResourceId)

--- a/fushi/test/media/torrent/public_video_index_client_test.dart
+++ b/fushi/test/media/torrent/public_video_index_client_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/public_trackers.dart';
 import 'package:fushi/src/media/torrent/public_video_index_client.dart';
 import 'package:fushi/src/media/torrent/public_video_index_provider.dart';
 import 'package:fushi/src/media/torrent/search_query_script.dart';
@@ -57,8 +58,28 @@ void main() {
     );
     expect(magnet, startsWith('magnet:?xt=urn:btih:$_hashA'));
     expect(magnet, contains('dn=Some+Show+S01E01'));
-    for (final String tracker in kPublicVideoIndexTrackers) {
+    for (final String tracker in kPublicTrackers) {
       expect(magnet, contains(Uri.encodeQueryComponent(tracker)));
+    }
+    expect('&tr='.allMatches(magnet), hasLength(kPublicTrackers.length));
+  });
+
+  test('kPublicTrackers 每条都是合法 announce URL 且互不重复', () {
+    // 打错一个字符的 tracker 不会报错，只会安静地永远连不上；重复一条则让每个
+    // 种子对同一个 host 多打一轮 announce。两种都要等用户抱怨才可能被发现。
+    //
+    // 形状判据走原始字符串正则，不用 `Uri.hasPort`：后者问的是「端口是否非本
+    // 协议默认值」，`https://host:443/announce` 明明写了端口也返回 false。
+    final RegExp announceUrl = RegExp(
+      r'^(?:udp|https?)://[A-Za-z0-9.-]+:\d{1,5}/announce$',
+    );
+    expect(kPublicTrackers.toSet(), hasLength(kPublicTrackers.length));
+    for (final String tracker in kPublicTrackers) {
+      expect(
+        announceUrl.hasMatch(tracker),
+        isTrue,
+        reason: '不是 <scheme>://<host>:<port>/announce 形状：$tracker',
+      );
     }
   });
 

--- a/fushi/test/torrent/nyaa_client_test.dart
+++ b/fushi/test/torrent/nyaa_client_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 
 import 'package:fushi/src/media/torrent/anime_release_descriptor.dart';
 import 'package:fushi/src/media/torrent/nyaa_client.dart';
+import 'package:fushi/src/media/torrent/public_trackers.dart';
 
 /// 构造只关心 [title] / [infoHash] 的最小 [NyaaTorrent]，供派生 getter 测试用。
 NyaaTorrent makeTorrent(String title, {String infoHash = ''}) {
@@ -155,7 +156,7 @@ void main() {
   });
 
   group('magnet', () {
-    test('拼 infoHash + dn + 5 个 tracker', () {
+    test('拼 infoHash + dn + 全部内置 tracker', () {
       final NyaaTorrent t = makeTorrent(
         'My Show [x]',
         infoHash: '0123456789abcdef0123456789abcdef01234567',
@@ -167,7 +168,11 @@ void main() {
           '&dn=My%20Show%20%5Bx%5D',
         ),
       );
-      expect('&tr='.allMatches(t.magnet), hasLength(5));
+      // 数量跟着常量走，但不是同源恒真：它抓的是拼接漏写了其中某几条。
+      expect('&tr='.allMatches(t.magnet), hasLength(kNyaaTrackers.length));
+      for (final String tracker in kNyaaTrackers) {
+        expect(t.magnet, contains('&tr=${Uri.encodeComponent(tracker)}'));
+      }
       expect(
         t.magnet,
         contains('&tr=http%3A%2F%2Fnyaa.tracker.wf%3A7777%2Fannounce'),
@@ -176,6 +181,13 @@ void main() {
         t.magnet,
         contains('&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce'),
       );
+    });
+
+    test('内置 tracker 列表无重复、站点专属排最前', () {
+      // 上面按 `&tr=` 出现次数计数，列表里混进重复项它抓不到。
+      expect(kNyaaTrackers.toSet(), hasLength(kNyaaTrackers.length));
+      expect(kNyaaTrackers.first, 'http://nyaa.tracker.wf:7777/announce');
+      expect(kNyaaTrackers, containsAll(kPublicTrackers));
     });
   });
 


### PR DESCRIPTION
## 做了什么

把磁链自带的默认 tracker 从 **9 条（分两份写死、重叠 3 条）扩到 23 条，并收口成一个共享常量**。

原状是两份各写各的：

| 常量 | 条数 | 用在哪 |
|---|---|---|
| `kNyaaTrackers` | 5（含 nyaa 专属 1 条） | nyaa 磁链 |
| `kPublicVideoIndexTrackers` | 5 | apibay / Knaben 磁链 |

两份重叠 3 条却各维护各的，加一条要改两处。

现在：

- 新增 `kPublicTrackers`（23 条，UDP 优先），两处消费点共用；
- `kNyaaTrackers` = 站点专属 `nyaa.tracker.wf` + `kPublicTrackers`；
- 删掉与之完全等价的 `kPublicVideoIndexTrackers`，消费点改引用共享常量。

## 为什么不靠 tracker 订阅就够

`kDefaultTrackerSubscriptionUrl`（默认 `cf.trackerslist.com/best.txt`）确实默认开着，但那条链路**要联网、会失败，而且只作用于已经加进引擎的种子**——磁链自己带的 tracker 是离线也成立的那一份，两者不是替代关系。所以这份内置列表必须能独立把种子连起来。

## 列表怎么来的

第一版 20 条是凭印象写的，**拿实测源一核对只有 7 条被印证**——形状合法的死 tracker 不报任何错，只会安静地永不响应，「看着像真的」不是证据。第二个提交把它重建了：

- 仓库原有的 7 条**全部保留**（只加不减，不动用户已在下的种子）；
- 新增 16 条全部取自 `ngosang/trackerslist` 的 `trackers_best.txt`（就是默认订阅那份的上游）与 `newtrackon.com/api/stable`（uptime ≥ 95%），其中 7 条同时被两个源收录。

23 条里 20 条有当前实测背书，另 3 条是仓库原有。取样日期、来源和更新做法都写进了常量的文档注释。

⚠️ 注释里也记了一个坑：**本机开 fake-ip 代理时直接对这些域名发 BEP 15 握手会全部超时**（DNS 返回 `198.18.x.x` 假 IP），那是环境问题，不能当成 tracker 已死的证据——我就是先这么测的，`0/20 responded`。

## 测试

原来的 `hasLength(5)` 是硬编码数字，改成跟着常量长度走，并新增两条守卫：

1. 列表内**无重复**（重复项会让每个种子对同一个 host 多打一轮 announce，而按 `&tr=` 出现次数计数的断言抓不到它）；
2. 每条都是 `<scheme>://<host>:<port>/announce` 形状。

形状判据刻意**不用 `Uri.hasPort`**——它问的是「端口是否非协议默认值」，`https://host:443/announce` 明明写了端口也返回 `false`。这条是写守卫时实测踩到的，第一版守卫因此直接把自己的列表判红。

两条新守卫都做了变异实测：塞一条重复项 → 去重断言红；去掉某条的端口 → 形状断言红；还原后复绿。

## 验证

- `flutter analyze` 全绿（含 test 目录）
- torrent / 下载域定向 8 个文件：**160 tests PASSED**
- 36 条目录枚举型守卫整批：**252 tests PASSED**（基线 250，+2 来自基线记录 2026-08-11 之后 develop 上的其它 PR，本 PR 没往这批里加用例）

### 一条与本 PR 无关的 develop 既有红

`test/media/video/download/video_download_pipeline_service_test.dart` 的「long enqueue renews its lease」在本机高负载下会红（90ms lease + 240ms 等待，靠续租线程跑赢 wall-clock；实测差 65ms）。

**已在未改动的基底 `0439ff2a60`（= 当时的 `origin/develop`）上复现同一条红**，与本 PR 无关，未在此处修。本机当时有 6+ 个 agent 并发在跑 flutter test。

因为同样的并发负载，本地全量套件没有跑出可信结果（并发 ≥ 3 时全量会互抢 `sqlite3.dll`），按仓库既定判据以「analyze 全量 + 定向 + 守卫整批绿」交付，全量由 PR CI 兜底。

https://claude.ai/code/session_01Ezyr1TYbWQDfNX7CqoRadb
