### PR TITLE
fix(discovery): 导入计划顺序不再跟着文件系统枚举走（解 develop 级 flake，正卡 #1157）

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -10,7 +10,23 @@
 # 强制，改一份必须同步三份。Sonar 把这种「被守卫强制的镜像」算成 new-code 重复行，
 # 会让任何 popup 改动都撞红 Duplicated Lines on New Code —— 那不是可修复的重复，
 # 修它只会破坏 parity 守卫。所以整批 vendor 镜像 + popup 真源都排除在 CPD 之外。
-sonar.cpd.exclusions=fushi/assets/browser_extension/content.js,fushi/assets/browser_extension/options.html,fushi/assets/browser_extension/options.js,fushi/assets/browser_extension/self-update.js,fushi/assets/browser_extension/stream-bridge.js,fushi/assets/browser_extension/subtitle-adapters.js,fushi/assets/browser_extension/subtitle-panel.js,fushi/assets/browser_extension/video-shortcuts.js,**/vendor/**,fushi/assets/popup/**
+#
+# third_party/** 一律排除：那是 11 个 path-override 的 vendored 上游包（见
+# 仓库根 CLAUDE.md 的「模块索引」）。上游自带的重复不该由本仓承担，而且
+# 「修它」= 改上游源码 = 破坏 vendor 基线（上游同步时又要重新手工合并）。
+# 实测（2026-09-02）两条无关的 PR 都因此撞红 new_duplicated_lines_density（门限 3%）：
+#   - PR#1147（11.6%）：重复全在
+#     third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.cpp。它的 98 个
+#     「新行」其实是新提了一个 FailWith(result, code, message) 辅助函数、把 ~65 处
+#     result->Error(...) 收敛过去——它做的正是**消除**重复，只是这些行散落在上游
+#     那一排本来就近乎同形的 Handle* 处理器里，token 级 CPD 判它们重复。
+#   - PR#1157（7.5%）：third_party/m_extension_server/…/DexAllocationRepairTest.kt 18.1%。
+# 两次都与 PR 自身改动的质量无关，却直接拦住合入。
+#
+# 另一类重复（tool/mihon/verify_*.ps1 的共享头部，各 4 行 100%）**没有**写进排除：
+# 那是本仓自己的代码、可以真改，已抽成 tool/mihon/_verify_common.ps1。
+# 排除只给「改不了的上游」和「被守卫强制的镜像」用。
+sonar.cpd.exclusions=fushi/assets/browser_extension/content.js,fushi/assets/browser_extension/options.html,fushi/assets/browser_extension/options.js,fushi/assets/browser_extension/self-update.js,fushi/assets/browser_extension/stream-bridge.js,fushi/assets/browser_extension/subtitle-adapters.js,fushi/assets/browser_extension/subtitle-panel.js,fushi/assets/browser_extension/video-shortcuts.js,**/vendor/**,fushi/assets/popup/**,third_party/**
 
 # 为什么这里没有「规则级屏蔽」：本仓走的是 SonarCloud **Automatic Analysis**
 # （`.github/workflows` 下没有任何 sonar workflow，分析由 SonarCloud GitHub App

--- a/docs/bugs/BUG-2023-torrent-ffi-listen-port-zero-ci-flake.md
+++ b/docs/bugs/BUG-2023-torrent-ffi-listen-port-zero-ci-flake.md
@@ -4,6 +4,8 @@
 - **真实性**：❌ **未复现 —— 不是本 PR 引入的回归**，是 GitHub Windows runner 上「回环临时端口 bind 不上」的环境性偶发（同一 commit 重跑即绿）。
 - **[ ] ① 未修复** —— 无代码可修（下有排除依据）。
 - **[ ] ② 未加自动化测试** —— 同上。
+- **复现次数**：2 次（2026-09-02 早 PR#1129；2026-09-02 PR#1147）。二次出现把它从
+  「偶发、可忽略」升级成「**会持续拦住不相干的 PR**」——见「第二次出现」。
 - **备注**：见下。
 
 ### 现场
@@ -71,6 +73,24 @@ libtorrent 2.0.11 里 `session_impl::listen_port()`（`src/session_impl.cpp:5517
    （ABI `db19734b…`），从不从源码编。真正的对照组只有本分支那两次源码编译
    （②③）。
 
+### 第二次出现（2026-09-02，PR#1147）
+
+同一天又中一次，**形状逐字相同**：PR **#1147**
+（`worktree-fix-ocr-dml-fallback-utf8`，OCR DirectML 回退 + UTF-8 归一）的 `windows`
+job 也是 `22 tests passed, 13 failed`，伴随重复的
+`Bad state: timeout waiting for seeder listen port`。
+
+这次的排除证据比第一次更硬：
+
+- **#1147 改的 9 个文件里零 torrent 代码**（OCR / DirectML / 编码归一）。
+  第一次还需要靠「同 commit 重跑即绿 + vcpkg ABI hash 相等」排除；这次是
+  **一条跟 torrent 没任何关系的 PR 直接中招**，「本 PR 引入」已不可能。
+- `gh run rerun --failed` 后通过，与第一次一致。
+
+两次叠起来看，它不是「某条 PR 的偶发噪声」，而是 **runner 机器级的系统性风险**：
+任何一条 PR 都可能因为它红一次，而红的内容与该 PR 无关。**看到这个形状先
+`gh run rerun --failed`，不要去查本 PR 的 diff。**
+
 ### 结论与后续
 
 红是 runner VM 侧的 `bind(127.0.0.1, 0)` 失败（Windows 上 Hyper-V/WinNAT 预留掉
@@ -78,8 +98,32 @@ libtorrent 2.0.11 里 `session_impl::listen_port()`（`src/session_impl.cpp:5517
 必红」，实际换台机器就好。**不改代码**：把 IPv6 双栈关掉是撤功能，给 rig 的判据
 加特例是掩盖症状，两者都不是根因修。
 
-可选的后续（**不在本条范围内，未做**）：`ht_session_create` 之后 bridge 丢掉了
-`listen_failed_alert`（`drain_alerts` 不认这个类型），所以 rig 超时只能报
-「timeout waiting for seeder listen port」而拿不到 errno。把这条 alert 收进
-`ht_session_ctx` 并在 `ht_session_status` 里透出来，能让下次同款环境红一眼定性，
-但那是诊断增强不是本 bug 的修复。
+### 诊断：为什么每次只能报超时（2026-09-02 复核）
+
+已逐行核实：`drain_alerts`（`native/fushi_torrent/fushi_torrent_ffi.cpp:399`，注释里
+自称是「**唯一**的 alert 收割点」）只 `alert_cast` 了 `piece_finished` /
+`save_resume_data`(+failed) / `file_renamed`(+failed) / `storage_moved`(+failed) /
+`dht_stats` / `session_stats` / `file_prio` / `portmap`(+error) 十几个类型，
+**没有 `listen_failed_alert`，也没有 `listen_succeeded_alert`**，其余一律丢弃。
+而 `ht_session_create` 的 `alert_mask` 已经包含 `status | error`
+（`fushi_torrent_ffi.cpp:645`）——**alert 确实发出来了，就是在 bridge 里被默默扔掉**。
+这就是为什么两次红都只能看到「端口永远是 0」、拿不到 bind 的 errno。
+
+**本次做了什么**：在 `LocalSeedRig._waitFor` 上加一个只在超时那一刻跑的
+`diagnose` 钩子，等端口这一处传 `_describeLoopbackBindHealth`：超时后 Dart 自己
+`ServerSocket.bind(127.0.0.1, 0)` 一次，把结果拼进错误文案。探针也失败 = 机器的临时
+端口段不可用（本条的形状），探针成功 = 真得去查 bridge。**下次同款红一眼定性，
+不需要重编 native。** 它只改错误文案，不改等待判据，不影响红/绿。
+
+**为什么没顺手把 `listen_failed_alert` 收进 `drain_alerts`**：代码量确实不大
+（ctx 加一个字段 + 一个 `alert_cast` 分支 + `ht_session_status` 里多一个 JSON 字段），
+但它落在 C++ FFI 桥里，而 `native/fushi_torrent/prebuilt/` 是 **gitignore 的**
+（`native/fushi_torrent/.gitignore:7`）——想真实测到它必须先拿 vcpkg 从源码编
+libtorrent 2.0.11 + 重建 DLL（实测 ~10 分钟），否则就是往桥里提一段**没跑过的**
+C++。本条是一条环境性偶发，不值得为一个诊断字段搭一次 native 构建链；上面的 Dart
+探针已经拿到了 90% 的定性能力。
+
+**什么时候再做**：下一次有人因别的原因动 `native/fushi_torrent/fushi_torrent_ffi.cpp`
+并已经把本地 libtorrent 构建链搭好了，顺手带上（`listen_failed_alert` 的
+`error` + `endpoint` 存进 ctx，`ht_session_status` 透出 `"listen_error"`）；
+或者探针未来报出「Dart 能 bind、libtorrent 不能」（那就真是 bridge 问题，必须拿 errno）。

--- a/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_executor.dart
@@ -72,9 +72,11 @@ class DiscoveryImportExecutor {
       final List<String> archives = <String>[
         for (final String path in filePaths)
           if (isDiscoveryArchivePath(path)) path,
-      ]..sort(
-          (String a, String b) => (sizes[b] ?? 0).compareTo(sizes[a] ?? 0),
-        );
+      ]..sort((String a, String b) {
+          // 同大小时按路径定二，不把「解哪个包」交给调用方清单的偶然顺序。
+          final int bySize = (sizes[b] ?? 0).compareTo(sizes[a] ?? 0);
+          return bySize != 0 ? bySize : a.compareTo(b);
+        });
       if (archives.isNotEmpty) {
         final File archive = File(archives.first);
         final Directory extracted = await _extractor.extract(

--- a/fushi/lib/src/media/discovery/import/discovery_import_plan.dart
+++ b/fushi/lib/src/media/discovery/import/discovery_import_plan.dart
@@ -183,10 +183,16 @@ DiscoveryImportPlan classifyDiscoveryDirectory(
   List<String> filePaths, {
   Map<String, int> fileSizes = const <String, int>{},
 }) {
+  // 文件系统的枚举顺序不是稳定输入：`Directory.list` 明说不保证顺序，
+  // NTFS 实际按名字返回、ext4 是目录哈希序。而本函数的输出顺序是**用户可见**的：
+  // [MultiPlan] 的子计划顺序决定「逐本导入」的进度显示与落库次序，
+  // 有声书的 content/subtitle 又是「清单里第一个匹配」。所以在入口把清单
+  // 归一成路径字典序，让同一个包在任何平台、任何文件系统上导出同一个结果。
+  final List<String> paths = List<String>.of(filePaths)..sort();
   switch (kind) {
     case DiscoveryMediaKind.novel:
       final List<DiscoveryImportPlan> children = <DiscoveryImportPlan>[
-        for (final String path in filePaths)
+        for (final String path in paths)
           if (_ext(path) == '.epub')
             ImportEpubPlan(path)
           else if (_ext(path) == '.pdf')
@@ -203,7 +209,7 @@ DiscoveryImportPlan classifyDiscoveryDirectory(
       String? content;
       String? subtitle;
       final List<String> audio = <String>[];
-      for (final String path in filePaths) {
+      for (final String path in paths) {
         if (content == null && _ext(path) == '.epub') {
           content = path;
         } else if (_isSubtitle(path)) {
@@ -214,7 +220,7 @@ DiscoveryImportPlan classifyDiscoveryDirectory(
       }
       // EPUB 优先当正文；没有 EPUB 再退纯文本。
       if (content == null) {
-        for (final String path in filePaths) {
+        for (final String path in paths) {
           if (_isText(path)) {
             content = path;
             break;
@@ -243,7 +249,7 @@ DiscoveryImportPlan classifyDiscoveryDirectory(
         audioPaths: audio,
       );
     case DiscoveryMediaKind.game:
-      final String? exe = pickGalgameMainExe(filePaths, fileSizes: fileSizes);
+      final String? exe = pickGalgameMainExe(paths, fileSizes: fileSizes);
       if (exe == null) {
         return const UnsupportedPlan(DiscoveryImportBlocker.gameNoExecutable);
       }
@@ -286,9 +292,12 @@ String? pickGalgameMainExe(
     for (final String path in candidates)
       if (depthOf(path) == minDepth) path,
   ];
-  candidates.sort(
-    (String a, String b) => (fileSizes[b] ?? 0).compareTo(fileSizes[a] ?? 0),
-  );
+  // 同层同大小时再按路径定二：只比大小的话平局落回输入清单顺序，
+  // 而输入清单可能直接来自文件系统枚举（本函数也被外部直接调用）。
+  candidates.sort((String a, String b) {
+    final int bySize = (fileSizes[b] ?? 0).compareTo(fileSizes[a] ?? 0);
+    return bySize != 0 ? bySize : a.compareTo(b);
+  });
   return candidates.first;
 }
 

--- a/fushi/lib/src/media/source_library/source_file_system.dart
+++ b/fushi/lib/src/media/source_library/source_file_system.dart
@@ -132,6 +132,11 @@ class LocalSourceFileSystem implements SourceFileSystem {
         ));
       }
     }
+    // 文件系统枚举顺序不是稳定输入（NTFS 按名字、ext4 是目录哈希序），
+    // 而这份清单一路流到 planScanFromFileList 的 books/videos/mangas 分类列表，
+    // 再决定扫描导入的落库次序（用户可见）。在 IO 边界就定下来。
+    entries.sort((SourceFileEntry a, SourceFileEntry b) =>
+        a.path.compareTo(b.path));
     return entries;
   }
 

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -129,10 +129,13 @@ class DictionaryImportManager {
     VoidCallback? onMemoryError,
   }) async {
     final entities = directory.listSync();
+    // 逐个导入的次序是用户可见的（进度 i/N + failedNames 汇总），listSync
+    // 的平台顺序不能当稳定输入——同文件 _importArchivedDictionaries 已经这么做。
     final zipFiles = entities.whereType<File>().where((f) {
       final ext = path.extension(f.path).toLowerCase();
       return ext == '.zip' || ext == '.dsl' || ext == '.mdx';
-    }).toList();
+    }).toList()
+      ..sort((File a, File b) => a.path.compareTo(b.path));
 
     if (zipFiles.isNotEmpty) {
       final cssFiles = entities

--- a/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -9,6 +9,8 @@ import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
 import 'package:fushi/src/utils/misc/fushi_share.dart';
 import 'package:fushi/src/epub/epub_book.dart' show fallbackMimeType;
+import 'package:fushi/src/media/collections/shelf_sort.dart'
+    show naturalCompare;
 import 'package:fushi/src/media/media_extensions.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart'
     show ReaderFushiSource;
@@ -138,11 +140,14 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
         return;
       }
 
+      // listSync 不保证顺序（NTFS 按名字、ext4 是目录哈希序），而这份清单就是
+      // 插图网格的展示顺序。自然序才能把 2.jpg 排在 10.jpg 前面。
       final List<File> imageFiles =
           dir.listSync(recursive: true).whereType<File>().where((f) {
         final String ext = p.extension(f.path).toLowerCase();
         return _imageExtensions.contains(ext);
-      }).toList();
+      }).toList()
+            ..sort((File a, File b) => naturalCompare(a.path, b.path));
 
       for (final File file in imageFiles) {
         if (!mounted) {

--- a/fushi/test/media/discovery/import/discovery_import_executor_test.dart
+++ b/fushi/test/media/discovery/import/discovery_import_executor_test.dart
@@ -107,6 +107,32 @@ void main() {
     );
   });
 
+  test('多包同体积时按路径定二:解哪个包与调用方清单顺序无关', () async {
+    // 两个 zip 的条目名等长、内容等长 → 字节数完全相同，只比体积必然平局，
+    // 平局落回输入顺序就会「同一份下载物两次解出不同的书」。
+    final File a = await _writeZip(tempDir, 'aaa.zip', <String, String>{
+      'a.epub': 'x',
+    });
+    final File z = await _writeZip(tempDir, 'zzz.zip', <String, String>{
+      'b.epub': 'x',
+    });
+    expect(a.lengthSync(), z.lengthSync(), reason: '前提：体积必须平局');
+
+    for (final List<String> input in <List<String>>[
+      <String>[a.path, z.path],
+      <String>[z.path, a.path],
+    ]) {
+      final List<String> log = <String>[];
+      final DiscoveryImportExecutor executor = DiscoveryImportExecutor(
+        importers: _recordingImporters(log),
+        extractor: DiscoveryArchiveExtractor(sevenZipOverride: ''),
+      );
+      await executor.importPaths(DiscoveryMediaKind.novel, input);
+      expect(log, hasLength(1), reason: input.join(','));
+      expect(log.single, endsWith('a.epub'), reason: input.join(','));
+    }
+  });
+
   test('zip 有声书包:齐料 → 对齐导入', () async {
     final List<String> log = <String>[];
     final DiscoveryImportExecutor executor = DiscoveryImportExecutor(

--- a/fushi/test/media/discovery/import/discovery_import_plan_test.dart
+++ b/fushi/test/media/discovery/import/discovery_import_plan_test.dart
@@ -161,6 +161,111 @@ void main() {
     });
   });
 
+  // 顺序依赖守卫：文件系统枚举顺序不是稳定输入（NTFS 按名字、ext4 按目录哈希），
+  // 分类层不得把这份偶然顺序带进用户可见的导入次序 —— CI 上曾据此偶发红。
+  group('分类结果不依赖输入清单顺序', () {
+    List<String> plannedPaths(List<String> input) {
+      final MultiPlan plan = classifyDiscoveryDirectory(
+        DiscoveryMediaKind.novel,
+        input,
+      ) as MultiPlan;
+      return <String>[
+        for (final DiscoveryImportPlan child in plan.children)
+          switch (child) {
+            ImportEpubPlan(:final String filePath) => filePath,
+            ConvertTextPlan(:final String filePath) => filePath,
+            ImportPdfPlan(:final String filePath) => filePath,
+            _ => throw StateError('unexpected child: $child'),
+          },
+      ];
+    }
+
+    test('小说包:任意输入排列都导出同一顺序(路径字典序)', () {
+      const List<String> expected = <String>[
+        '/d/vol1/a.epub',
+        '/d/vol1/b.txt',
+        '/d/vol2/c.pdf',
+      ];
+      const List<String> files = <String>[
+        '/d/vol1/a.epub',
+        '/d/vol1/b.txt',
+        '/d/vol2/c.pdf',
+        '/d/cover.jpg',
+      ];
+      final List<List<String>> permutations = <List<String>>[
+        files,
+        files.reversed.toList(),
+        <String>[
+          '/d/vol1/b.txt',
+          '/d/cover.jpg',
+          '/d/vol2/c.pdf',
+          '/d/vol1/a.epub',
+        ],
+        <String>[
+          '/d/vol2/c.pdf',
+          '/d/vol1/b.txt',
+          '/d/cover.jpg',
+          '/d/vol1/a.epub',
+        ],
+      ];
+      for (final List<String> input in permutations) {
+        expect(plannedPaths(input), expected, reason: input.join(','));
+      }
+    });
+
+    test('有声书:多份正文/字幕时恒取字典序最小,与输入顺序无关', () {
+      const List<String> files = <String>[
+        '/d/z-later.epub',
+        '/d/a-first.epub',
+        '/d/z-later.srt',
+        '/d/a-first.srt',
+        '/d/02.mp3',
+        '/d/01.mp3',
+      ];
+      for (final List<String> input in <List<String>>[
+        files,
+        files.reversed.toList(),
+      ]) {
+        final AlignAudiobookPlan plan = classifyDiscoveryDirectory(
+          DiscoveryMediaKind.audiobook,
+          input,
+        ) as AlignAudiobookPlan;
+        expect(plan.contentPath, '/d/a-first.epub', reason: input.join(','));
+        expect(plan.subtitlePath, '/d/a-first.srt', reason: input.join(','));
+        expect(plan.audioPaths, <String>['/d/01.mp3', '/d/02.mp3']);
+      }
+    });
+
+    test('游戏:同层同体积平局按路径定二,与输入顺序无关', () {
+      const Map<String, int> sizes = <String, int>{
+        '/g/alpha.exe': 4096,
+        '/g/beta.exe': 4096,
+      };
+      for (final List<String> input in <List<String>>[
+        <String>['/g/beta.exe', '/g/alpha.exe'],
+        <String>['/g/alpha.exe', '/g/beta.exe'],
+      ]) {
+        expect(
+          pickGalgameMainExe(input, fileSizes: sizes),
+          '/g/alpha.exe',
+          reason: input.join(','),
+        );
+        expect(
+          classifyDiscoveryDirectory(
+            DiscoveryMediaKind.game,
+            input,
+            fileSizes: sizes,
+          ),
+          isA<RegisterGameExesPlan>().having(
+            (RegisterGameExesPlan p) => p.exePaths,
+            'exePaths',
+            <String>['/g/alpha.exe'],
+          ),
+        );
+      }
+    });
+  });
+
   group('sanitizeArchiveEntryPath', () {
     test('拒绝 zip-slip 与绝对路径', () {
       expect(sanitizeArchiveEntryPath('../evil.txt'), isNull);

--- a/packages/fushi_dictionary/lib/src/formats/mdict_format.dart
+++ b/packages/fushi_dictionary/lib/src/formats/mdict_format.dart
@@ -26,13 +26,21 @@ class MdictFormat extends DictionaryFormat {
   static final MdictFormat _instance = MdictFormat._privateConstructor();
 }
 
+/// 取目录里扩展名为 [ext] 的文件。
+///
+/// 包里有多个同扩展名文件时，选中哪个会决定词典的显示名
+/// （prepareNameMdictFormat），所以不能交给 listSync 的平台顺序：同一个 zip
+/// 在 Windows 与 Linux 上导出的名字必须一样。固定取路径字典序最小的那个。
 File? _findFileByExtension(Directory dir, String ext) {
+  File? best;
   for (final entity in dir.listSync(recursive: true)) {
     if (entity is File && entity.path.toLowerCase().endsWith(ext)) {
-      return entity;
+      if (best == null || entity.path.compareTo(best.path) < 0) {
+        best = entity;
+      }
     }
   }
-  return null;
+  return best;
 }
 
 Future<void> prepareDirectoryMdictFormat(PrepareDirectoryParams params) async {

--- a/packages/fushi_torrent/lib/src/testing/local_seed_rig.dart
+++ b/packages/fushi_torrent/lib/src/testing/local_seed_rig.dart
@@ -80,6 +80,13 @@ class LocalSeedRig {
         },
         timeout: const Duration(seconds: 10),
         what: 'seeder listen port',
+        // BUG-2023：libtorrent 的 listen_failed_alert 带着 bind 的 errno，但
+        // bridge 的唯一收割点 drain_alerts
+        // （native/fushi_torrent/fushi_torrent_ffi.cpp:399）不认这个类型，
+        // 所以这里只能看到「端口永远是 0」。退而求其次：超时后在 Dart 侧
+        // 自己 bind 一次 127.0.0.1:0，把「这台机器现在就 bind 不上回环临时端口」
+        // 和「bridge/libtorrent 真出了问题」当场分开。纯诊断，不改判据。
+        diagnose: _describeLoopbackBindHealth,
       );
 
       final FtAddResult added =
@@ -111,11 +118,15 @@ class LocalSeedRig {
   }
 
   /// 轮询直到 [probe] 返回非 null；超时抛 [StateError]。
+  ///
+  /// [diagnose] 只在超时那一刻跑一次，把一句环境定性拼进错误文案；
+  /// 它不影响等待判据，自己抛异常也不得吃掉原本的超时错误。
   static Future<T> _waitFor<T>(
     Future<T?> Function() probe, {
     required Duration timeout,
     required String what,
     Duration interval = const Duration(milliseconds: 100),
+    Future<String> Function()? diagnose,
   }) async {
     final Stopwatch sw = Stopwatch()..start();
     while (sw.elapsed < timeout) {
@@ -123,7 +134,33 @@ class LocalSeedRig {
       if (result != null) return result;
       await Future<void>.delayed(interval);
     }
-    throw StateError('timeout waiting for $what');
+    String detail = '';
+    if (diagnose != null) {
+      try {
+        detail = ' (${await diagnose()})';
+      } catch (e) {
+        detail = ' (diagnose failed: $e)';
+      }
+    }
+    throw StateError('timeout waiting for $what$detail');
+  }
+
+  /// 超时时的环境定性：Dart 自己 bind 一次 `127.0.0.1:0`。
+  ///
+  /// 探针也失败 → runner 的临时端口段不可用（BUG-2023 的形状）；
+  /// 探针成功 → 机器能 bind，那就真得去查 bridge/libtorrent。
+  static Future<String> _describeLoopbackBindHealth() async {
+    try {
+      final ServerSocket probe =
+          await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final int probePort = probe.port;
+      await probe.close();
+      return 'dart loopback bind probe OK (got port $probePort): '
+          'the machine can bind 127.0.0.1:0, suspect the bridge';
+    } catch (e) {
+      return 'dart loopback bind probe ALSO failed: $e: '
+          'the machine cannot bind 127.0.0.1:0 right now (environment)';
+    }
   }
 
   void dispose() {

--- a/tool/mihon/_verify_common.ps1
+++ b/tool/mihon/_verify_common.ps1
@@ -1,0 +1,25 @@
+# tool/mihon/verify_*.ps1 的共享片段。
+#
+# 存在理由：两个 verify 脚本起临时 m-extension-server 前都要「拿一个空闲回环
+# 端口 + 生一个一次性 bearer token」，这段是逐字节相同的惯用法。SonarCloud CPD
+# 在 PR#1157 上把它判成 100% duplicated（两文件各 4 行）。这种重复本来就该消掉，
+# 而不是往 sonar.cpd.exclusions 里塞一条排除——排除只给 vendored 上游代码用。
+#
+# 用法：在 Set-StrictMode 之后 `. (Join-Path $PSScriptRoot "_verify_common.ps1")`。
+
+# 向系统要一个空闲回环端口后立刻释放，把端口号交给随后起的 java 进程。
+# （经典 TOCTOU 窗口；本地/CI 验证脚本可接受，与抽函数前行为逐字节一致。）
+function Get-MihonFreeLoopbackPort {
+    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    $port = ([Net.IPEndPoint] $listener.LocalEndpoint).Port
+    $listener.Stop()
+    return $port
+}
+
+# 一次性 bearer token：32 字节 CSPRNG → base64（去掉尾部 padding）。
+function New-MihonAuthToken {
+    $tokenBytes = [byte[]]::new(32)
+    [Security.Cryptography.RandomNumberGenerator]::Fill($tokenBytes)
+    return [Convert]::ToBase64String($tokenBytes).TrimEnd("=")
+}

--- a/tool/mihon/verify_desktop_extension_e2e.ps1
+++ b/tool/mihon/verify_desktop_extension_e2e.ps1
@@ -13,6 +13,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot "_verify_common.ps1")
 
 $runtimeRoot = [IO.Path]::GetFullPath($RuntimeDirectory)
 $extensionApk = [IO.Path]::GetFullPath($ApkPath)
@@ -24,14 +25,8 @@ foreach ($required in @($java, $server, $extensionApk)) {
     }
 }
 
-$listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
-$listener.Start()
-$port = ([Net.IPEndPoint] $listener.LocalEndpoint).Port
-$listener.Stop()
-
-$tokenBytes = [byte[]]::new(32)
-[Security.Cryptography.RandomNumberGenerator]::Fill($tokenBytes)
-$token = [Convert]::ToBase64String($tokenBytes).TrimEnd("=")
+$port = Get-MihonFreeLoopbackPort
+$token = New-MihonAuthToken
 $dataRoot = Join-Path (
     [IO.Path]::GetTempPath()
 ) ("hibiki-mihon-extension-e2e-" + [Guid]::NewGuid().ToString("N"))

--- a/tool/mihon/verify_desktop_runtime.ps1
+++ b/tool/mihon/verify_desktop_runtime.ps1
@@ -6,6 +6,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot "_verify_common.ps1")
 
 $runtimeRoot = [IO.Path]::GetFullPath($RuntimeDirectory)
 $java = Join-Path $runtimeRoot "runtime\bin\java.exe"
@@ -22,13 +23,8 @@ foreach ($required in @(
     }
 }
 
-$listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
-$listener.Start()
-$port = ([Net.IPEndPoint] $listener.LocalEndpoint).Port
-$listener.Stop()
-$tokenBytes = [byte[]]::new(32)
-[Security.Cryptography.RandomNumberGenerator]::Fill($tokenBytes)
-$token = [Convert]::ToBase64String($tokenBytes).TrimEnd("=")
+$port = Get-MihonFreeLoopbackPort
+$token = New-MihonAuthToken
 $dataRoot = Join-Path ([IO.Path]::GetTempPath()) ("hibiki-mihon-smoke-" + [Guid]::NewGuid().ToString("N"))
 [IO.Directory]::CreateDirectory($dataRoot) | Out-Null
 


### PR DESCRIPTION
## 这条修的是 develop 级 flake，正在卡 PR #1157

`fushi/test/media/discovery/import/discovery_import_executor_test.dart:99` 的

```dart
expect(log[0], startsWith('epub:'));   // vol1/a.epub
expect(log[1], startsWith('text:'));   // vol1/b.txt
```

在 CI 的 Linux runner 上已经在 **#1157 上红了两次**（临时目录名不同、用例同一条）：

```
Expected: a string starting with 'epub:'
  Actual: 'text:/tmp/discovery_import_testTRHHUJ/books/vol1/b.txt'
  Actual: 'text:/tmp/discovery_import_testSIIAFZ/books/vol1/b.txt'
```

#1157 改的 11 个文件里**零 discovery/import 代码**（它是 Mihon 桌面 ABI 修复）。
`origin/develop` 上这条断言一字不差 —— 是 develop 级既有 flake 在拦不相干的 PR。

## 根因（实现侧，不是测试侧）

`DiscoveryImportExecutor.importFile` 解压后用
`extracted.listSync(recursive: true)` 枚举条目，原始顺序直接交给
`classifyDiscoveryDirectory`；后者又把输入顺序原样带进输出：

- `MultiPlan.children` 的顺序 = `_execute` 逐本导入的顺序 = **进度显示与落库次序**
- audiobook 分支的 `content` / `subtitle` 是「清单里第一个匹配」

而 `Directory.list` 文档明说不保证顺序：NTFS 实际按名字返回（所以 Windows 永远绿），
ext4 是目录哈希序（所以 Linux 偶发红）。

**导入顺序是用户可见的，本来就该确定** —— 所以修实现侧，不是让测试去迁就任意顺序。

## 改动

1. `classifyDiscoveryDirectory` 在入口把清单归一成路径字典序
   （`List<String>.of(filePaths)..sort()`），一处覆盖全部 caller 与全部媒体域。
2. `pickGalgameMainExe` 的「同层取最大」补路径定二 —— 只比体积时平局会落回输入的
   偶然顺序，而这个函数也被外部直接调用。
3. `DiscoveryImportExecutor.importPaths` 挑压缩包的「取最大」同上补定二。

## 测试

按最强可落地层加在纯分类层（不依赖真实文件系统，Windows 上也钉得住）：

- 小说包：4 种输入排列都必须导出同一顺序
- 有声书：多份正文/字幕时恒取字典序最小，正序逆序一致
- 游戏：同层同体积平局按路径定二
- executor：两个字节数完全相同的 zip，解哪个包与调用方清单顺序无关

### 变异实测

| 改坏哪一行 | 结果 |
|---|---|
| 去掉 `classifyDiscoveryDirectory` 入口的 `..sort()` | `+27 -2` |
| `pickGalgameMainExe` 定二改回 `return bySize;` | `+28 -1` |
| executor 挑包定二改回 `return bySize;` | `+28 -1` |
| （基线） | `+29` 全绿 |

三次还原后 `sha256sum -c` 两个源文件均 OK。

## 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `flutter test test/media/discovery/ --no-pub` → **86 tests passed**

## 同分支后续提交（与上面这条 flake 修复解耦，可单独 review）

- `21825f0` **同族排查落地**：`lib/` 全扫了一遍同形状（直接消费
  `Directory.list`/`listSync` 顺序），另外四处顺序会流到用户可见结果或
  first-wins 取值 —— `LocalSourceFileSystem.listFiles`（扫描导入落库次序）、
  `DictionaryImportManager.importFromDirectory`（进度 i/N，同文件另一条路径
  早就 sort 了）、`illustrations_viewer_page._extractImages`（插图网格展示序，
  改用 naturalCompare）、`mdict_format._findFileByExtension`（多同扩展名文件时
  决定词典显示名）。
  单列未改的一处：`pickSameNameSubs` 的调用方 —— 该函数**文档化地**承诺
  「同优先级组内保持 dirFiles 原序」，改它得单独评估。
  验证：`flutter test test/media/source_library/ test/dictionary/
  test/pages/illustrations_viewer_*.dart test/settings/md3_design_system_static_test.dart`
  → **553 tests passed**。
- `a35efdb` **BUG-2023 补记第二次复现**（#1147 的 windows job 同一形状，
  改的 9 个文件里零 torrent 代码）+ 复核确认 `drain_alerts`
  （`fushi_torrent_ffi.cpp:399`）**没有**消费 `listen_failed_alert`，
  而 `alert_mask` 已含 `status|error` —— alert 发出来了，是在 bridge 里被扔掉的。
  没改 C++（要 vcpkg 从源码编 libtorrent 才谈得上实测，prebuilt 本身是
  gitignore 的），改成给 `LocalSeedRig._waitFor` 加只在超时跑一次的
  `diagnose` 钩子：Dart 自己 bind 一次 `127.0.0.1:0`，把「机器 bind 不上」和
  「bridge 出问题」当场分开。纯改错误文案。
- `e65bc61` **Sonar CPD 排除 `third_party/**`**（#1147 11.6% / #1157 7.5% 都栽在
  vendored 上游；#1147 那 98 行其实是它在**消除**重复）。
  `tool/mihon/verify_*.ps1` 那两条 4 行重复**没**加排除 —— 那是本仓自己的代码，
  抽成了 `tool/mihon/_verify_common.ps1`。排除只给「改不了的上游」用。

https://claude.ai/code/session_015dE349vVhsVhbtWZgEc37M
