### PR TITLE
test(guard): 把 indexOf('//') 截断式剥注释迁到 maskComments 并加进禁用表

### DIFF
--- a/fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart
+++ b/fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 回归守卫：Fushi 改名的「旧名残留清理」必须在 ssPostInstall 执行，
 /// 不得放回 `[InstallDelete]`。
 ///
@@ -61,10 +63,11 @@ void main() {
       reason: '必须存在 procedure CurStepChanged(CurStep: TSetupStep); '
           '旧名清理只能在它的 ssPostInstall 分支里做。',
     );
-    return match!.group(1)!.split('\n').map((String line) {
-      final int comment = line.indexOf('//');
-      return comment < 0 ? line : line.substring(0, comment);
-    }).join('\n');
+    // 只掩这一段 Pascal 过程体，**不掩整份 .iss**：`[Setup]` 段的
+    // `AppUpdatesURL=https://…` 之类是 ini 行、不是字符串字面量，整份掩会把它们
+    // 从 `//` 起截到行尾；`;` 注释也不归 [maskComments] 管（`directiveLines` 另行
+    // 处理）。过程体本身是纯 Pascal 代码，掩码等长且字符串字面量原样保留。
+    return maskComments(match!.group(1)!);
   }
 
   test('[InstallDelete] no longer deletes legacy binaries or shortcuts', () {

--- a/fushi/test/dictionary/dictionary_download_proxy_progress_test.dart
+++ b/fushi/test/dictionary/dictionary_download_proxy_progress_test.dart
@@ -7,6 +7,8 @@ import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:fushi/src/pages/implementations/dictionary_dialog_page.dart';
 import 'package:fushi/src/utils/net/dictionary_dio.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1493：**「更新这么慢，是网络原因吗」** —— 词典更新长时间没有任何可归因的反馈。
 ///
 /// 查下来是两件独立的事，都在这里钉住：
@@ -133,31 +135,6 @@ void main() {
   });
 
   group('BUG-1493 回归守卫：词典链路不得再用裸 Dio', () {
-    /// 剥掉注释再扫——本文件与被扫文件的文档注释里都写着这条根因的名字，不剥就是
-    /// 一条稳定的假阳性（守卫的第一版正是这么红的）。
-    String stripComments(String code) {
-      final StringBuffer out = StringBuffer();
-      bool inBlock = false;
-      for (final String rawLine in code.split('\n')) {
-        String line = rawLine;
-        if (inBlock) {
-          final int end = line.indexOf('*/');
-          if (end < 0) continue;
-          line = line.substring(end + 2);
-          inBlock = false;
-        }
-        final int blockStart = line.indexOf('/*');
-        if (blockStart >= 0) {
-          line = line.substring(0, blockStart);
-          inBlock = true;
-        }
-        final int lineComment = line.indexOf('//');
-        if (lineComment >= 0) line = line.substring(0, lineComment);
-        out.writeln(line);
-      }
-      return out.toString();
-    }
-
     test('downloader / update service 的出站一律经 createDictionaryDio', () {
       final List<String> paths = <String>[
         '../packages/fushi_dictionary/lib/src/formats/dictionary_downloader.dart',
@@ -167,7 +144,10 @@ void main() {
       for (final String p in paths) {
         final File file = File(p);
         expect(file.existsSync(), isTrue, reason: '守卫扫描目标不存在：$p');
-        final String code = stripComments(file.readAsStringSync());
+        // 剥掉注释再扫——本文件与被扫文件的文档注释里都写着这条根因的名字，
+        // 不剥就是一条稳定的假阳性（守卫的第一版正是这么红的）。共享词法掩码
+        // 等长，且保留字符串字面量（手写的按行截断会把 URL 里的 `//` 当注释）。
+        final String code = maskComments(file.readAsStringSync());
 
         // 唯一允许的裸构造是 `createDictionaryDio` 内部「工厂未接线」的回退
         // （`?? Dio()`）；别处再直接 new 一个就是绕开代理与超时装配。
@@ -182,12 +162,12 @@ void main() {
       }
     });
 
-    test('剥注释器本身有效：注释里的裸构造不算命中，代码里的算', () {
-      expect(stripComments('// 用裸 Dio() 出站\nfinal x = 1;'),
+    test('掩码器在本判据上有效：注释里的裸构造不算命中，代码里的算', () {
+      expect(maskComments('// 用裸 Dio() 出站\nfinal x = 1;'),
           isNot(contains('Dio()')));
-      expect(stripComments('/// 回退裸 Dio()\nfinal Dio d = Dio();'),
+      expect(maskComments('/// 回退裸 Dio()\nfinal Dio d = Dio();'),
           contains('Dio()'));
-      expect(stripComments('/* 块注释 Dio() */\nfinal y = 2;'),
+      expect(maskComments('/* 块注释 Dio() */\nfinal y = 2;'),
           isNot(contains('Dio()')));
     });
   });

--- a/fushi/test/helpers/banned_comment_strip.dart
+++ b/fushi/test/helpers/banned_comment_strip.dart
@@ -16,4 +16,11 @@ const Map<String, String> kBannedCommentStripPatterns = <String, String>{
   // （source.replaceAll(...)）会被 dart format 折行，锚在单行稳定的部分。
   r"RegExp(r'//[^\n]*": 'maskComments（共享词法掩码，行+块注释一起掩）',
   r"replaceAll(RegExp(r'<!--": 'maskHtmlComments（等长掩码，别用删除式）',
+  // 第 24 个手写形态：按行 `line.indexOf(...)` 截断到行尾。它错得很具体——把行内
+  // 第一个斜杠对当注释起点，于是**字符串字面量里的 `https:` 双斜杠、`//host/path`
+  // 被当成注释**，整行后半截被吃掉：要求型断言（isTrue）因此假红，禁止型断言
+  // （isFalse）因此假绿。块注释同样一概放行。JS 语料还多一层：正则字面量里的
+  // 转义斜杠也会被砍掉半行，必须走 maskJsComments。
+  r"indexOf('//')": 'maskComments（JS 语料用 maskJsComments；CSS 用 maskCssComments）',
+  r'indexOf("//")': 'maskComments（JS 语料用 maskJsComments）',
 };

--- a/fushi/test/lookup/apostrophe_word_scan_bug2056_test.dart
+++ b/fushi/test/lookup/apostrophe_word_scan_bug2056_test.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/reader/reader_selection_scripts.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-2056：英文正文/字幕里点 `don’t` 的 don 只查到 "don"，点 t 只查到 "t"；
 /// `it’s` / `John’s` / `we’ve` 这类**缩合形与所有格**整类匹配不到词条。
 ///
@@ -36,10 +38,20 @@ void main() {
 
   /// 四份实现的**真值**：三份 selection.js 从盘上读，阅读器那份来自
   /// `ReaderSelectionScripts.source()`（与真机注入的是同一个字符串）。
+  ///
+  /// 读进来就先过 [maskJsComments]：四份都是 **JS**，两处修复的说明注释里都写着
+  /// isIntraWordApostrophe / isScanStop 这些标识符，不掩的话下面的顺序判据会先
+  /// 命中注释、退化成恒真；被注释掉的旧 `scanDelimiters:` 行同样能骗过字面量提取。
+  /// 掩码等长（下标不错位）且保留串 / 模板串 / 正则字面量的内容，所以
+  /// `intraWordApostrophePattern: /[…]/` 与 `scanDelimiters: '…'` 照常提得出来。
+  ///
+  /// 用 JS 版而不是 [maskComments]：后者不认正则字面量，正则里的 `//` 会被读成
+  /// 「除号 + 行注释」，从正则处到行尾整段凭空消失。
   final Map<String, String> sources = <String, String>{
     for (final String path in selectionCopies)
-      path: File(path).readAsStringSync(),
-    'reader_selection_scripts.dart (source())': ReaderSelectionScripts.source(),
+      path: maskJsComments(File(path).readAsStringSync()),
+    'reader_selection_scripts.dart (source())':
+        maskJsComments(ReaderSelectionScripts.source()),
   };
 
   test(
@@ -102,11 +114,10 @@ void main() {
   test(
       'intra-word apostrophe is bridged before the scan-stop test, and the '
       'word-start back-off stays untouched', () {
-    sources.forEach((String label, String src) {
-      // 顺序判据必须在**剥掉注释**的代码上算：两处修复的说明注释里都写着
-      // isIntraWordApostrophe / isScanStop 这些标识符，裸 indexOf 会先命中注释，
-      // 顺序断言就变成恒真（见 docs/agent 的顺序守卫纪律）。
-      final String code = _stripLineComments(src);
+    sources.forEach((String label, String code) {
+      // `code` 在 sources 构造处已过 maskJsComments：顺序判据必须在**掩掉注释**的
+      // 代码上算，否则裸 indexOf 会先命中说明注释、顺序断言退化成恒真
+      // （见 docs/agent 的顺序守卫纪律）。
 
       const String bridge =
           'if (this.isIntraWordApostrophe(content, scanOffset)) {';
@@ -186,14 +197,6 @@ void main() {
               '不到这个变化（实测 ③ 仍绿），只有这条源码守卫拦得住');
     });
   });
-}
-
-/// 去掉 `//` 行注释（保留换行，偏移仍然单调），供顺序判据使用。
-String _stripLineComments(String src) {
-  return src.split('\n').map((String line) {
-    final int idx = line.indexOf('//');
-    return idx < 0 ? line : line.substring(0, idx);
-  }).join('\n');
 }
 
 /// Resolve a usable `node` executable, returning null when none is on PATH.

--- a/fushi/test/mining/gal_hook_session_controller_test.dart
+++ b/fushi/test/mining/gal_hook_session_controller_test.dart
@@ -17,6 +17,8 @@ import 'package:fushi/src/sync/texthooker_service.dart';
 import 'package:fushi/src/sync/texthooker_ws_client.dart';
 import 'package:path/path.dart' as p;
 
+import '../helpers/source_guard.dart';
+
 void main() {
   // BUG-1027 音轨快照自动刷新会在会话激活后触发（未 mock 的）voice_hook channel 的
   // listAudioTracks——必须先初始化 binding，让调用以 MissingPluginException 收敛为
@@ -2237,11 +2239,10 @@ void _playTrackerWiringGuard() {
   test('P4 B1 守卫：launch 路径必须接线游玩计时器并落 galgame_sessions', () {
     final File src = File('lib/src/mining/gal_hook_session_controller.dart');
     expect(src.existsSync(), isTrue);
-    // 注释里出现的同名字面量不算接线：先剥掉行注释再匹配。
-    final String body = src.readAsStringSync().split('\n').map((String line) {
-      final int at = line.indexOf('//');
-      return at >= 0 ? line.substring(0, at) : line;
-    }).join('\n');
+    // 注释里出现的同名字面量不算接线：先过共享词法掩码（行注释 + 块注释一起掩，
+    // 字符串字面量原样保留）再匹配。掩码等长，下面 indexOf/substring 的下标仍与
+    // 原文对齐。
+    final String body = maskComments(src.readAsStringSync());
     expect(
       body.contains('GalgamePlayTracker('),
       isTrue,

--- a/fushi/test/mining/netflix_still_frame_mine_time_test.dart
+++ b/fushi/test/mining/netflix_still_frame_mine_time_test.dart
@@ -7,6 +7,8 @@ import 'package:fushi/src/mining/immersion_mining_request.dart';
 import 'package:fushi/src/sync/immersion_mine_payload.dart';
 import 'package:fushi/src/utils/misc/desktop_audio_clipper.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1416：Netflix（沉浸捕获）选「静态帧」时，取的必须是**制卡那一刻**对应时间点的帧。
 ///
 /// 用户拍板：「肯定是按制卡时候的时间来，不要后续点击再回来制卡」。这否掉了「取录制片段
@@ -367,20 +369,19 @@ void main() {
   });
 
   group('源码扫描守卫：这条路不能再被结构性吞掉', () {
-    /// 剥掉注释再扫：散文里为解释这条断链必然写出同样的符号名，让文档喂绿守卫是假阳性。
-    String codeOnly(String src) => src.split('\n').map((String line) {
-          final int i = line.indexOf('//');
-          return i < 0 ? line : line.substring(0, i);
-        }).join('\n');
+    // 三处语料都在**读进来那一刻**就掩掉注释：散文里为解释这条断链必然写出同样的
+    // 符号名，让文档喂绿守卫是假阳性。Dart 侧用 maskComments、JS 侧用
+    // maskJsComments（后者认模板串与正则字面量，正则里的 `//` 不会被当成
+    // 「除号 + 行注释」砍掉半行）。两者都等长，下面 indexOf/substring 的下标不错位。
 
     test('mineImmersion 的 Netflix 段必须把静态帧目标下发给 transcodeClipToCapture', () {
-      final String src =
-          File('lib/src/models/app_model.dart').readAsStringSync();
+      final String src = maskComments(
+          File('lib/src/models/app_model.dart').readAsStringSync());
       final int start = src.indexOf('Future<RemoteMineResult> mineImmersion(');
       expect(start, greaterThan(0), reason: 'mineImmersion 改名了？守卫锚点失效，请同步更新。');
       final int end = src.indexOf('void recordHistory(', start);
       expect(end, greaterThan(start));
-      final String body = codeOnly(src.substring(start, end));
+      final String body = src.substring(start, end);
       final int netflix = body.indexOf('ImmersionCaptureResult cap =');
       expect(netflix, greaterThan(0),
           reason: 'YouTube/Netflix 分界锚点失效，请同步更新守卫。');
@@ -396,7 +397,7 @@ void main() {
     });
 
     test('浏览器扩展在制卡入口就地采样制卡时刻，并随 mineClip 发出', () {
-      final String content = codeOnly(
+      final String content = maskJsComments(
           File('../tools/browser-extension/content.js').readAsStringSync());
       expect(content, contains('mineAtV'),
           reason: '入队时不采样「制卡那一刻」的视频时间，之后的回放录制就永远拿不回它。');
@@ -404,7 +405,7 @@ void main() {
       expect(content, contains('clipAnchorMs:'),
           reason: '片段时间基锚点必须实测下发 —— 假设它等于 seek 目标就是几百毫秒的系统性偏差。');
 
-      final String background = codeOnly(
+      final String background = maskJsComments(
           File('../tools/browser-extension/background.js').readAsStringSync());
       expect(background, contains('clipAnchorMs'),
           reason: 'background 的 mineClip 转发漏掉字段 = content 采了也白采。');

--- a/fushi/test/pages/popup_image_lightbox_close_guard_test.dart
+++ b/fushi/test/pages/popup_image_lightbox_close_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 // BUG-107: clicking a dictionary image opens a full-viewport lightbox
 // (`.dict-image-lightbox`, the enlarged image with max-width/height:100% nearly
 // fills the popup). The lightbox closes on a tap of the overlay, but the image
@@ -14,7 +16,13 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('image lightbox closes on any tap (no stopPropagation on the image)',
       () {
-    final String source = File('assets/popup/popup.js').readAsStringSync();
+    // Mask JS comments at read time so neither the function-body window nor
+    // the assertions below can be fooled by a comment. maskJsComments keeps
+    // string / template / regex literal *content* intact and is
+    // length-preserving, so the indexOf/substring offsets below still line up
+    // with the real file.
+    final String source =
+        maskJsComments(File('assets/popup/popup.js').readAsStringSync());
 
     final int openIdx = source.indexOf('function openImageLightbox(');
     expect(openIdx, greaterThanOrEqualTo(0),
@@ -32,18 +40,14 @@ void main() {
     // The image must NOT carry its own click handler — an
     // `image.addEventListener('click', …)` was used to stopPropagation, which
     // swallowed taps on the image (the only hittable part) and broke close.
-    // Strip JS line comments first so a comment mentioning the old pattern
-    // doesn't trip the guard.
-    final String code = body.split('\n').map((String line) {
-      final int c = line.indexOf('//');
-      return c >= 0 ? line.substring(0, c) : line;
-    }).join('\n');
-    expect(code.contains("image.addEventListener('click'"), isFalse,
+    // `body` is already comment-masked (see the read above), so a comment
+    // mentioning the old pattern cannot trip the guard.
+    expect(body.contains("image.addEventListener('click'"), isFalse,
         reason:
             'the lightbox image must not have its own click handler — tapping '
             'the enlarged image (which fills the viewport) must bubble to the '
             'overlay and close the lightbox (BUG-107)');
-    expect(code.contains('stopPropagation'), isFalse,
+    expect(body.contains('stopPropagation'), isFalse,
         reason: 'no stopPropagation inside openImageLightbox code (BUG-107)');
   });
 }

--- a/fushi/test/pages/video_fullscreen_switch_flatten_guard_test.dart
+++ b/fushi/test/pages/video_fullscreen_switch_flatten_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-839 / BUG-2043 守卫：全屏下连播/换集不得漏栈旧集页，也不得先退原生全屏再进。
 ///
 /// 根因（BUG-839）：全屏播放时 app 全屏路由被推到 **root navigator**（`fullscreen.part.dart`
@@ -43,12 +45,6 @@ void main() {
   late String fullscreenSrc;
   late String pageSrc;
 
-  /// 剥掉 `//` 行注释，避免注释里提到的符号被 indexOf 先命中。
-  String stripLineComments(String src) => src
-      .split('\n')
-      .where((String line) => !line.trimLeft().startsWith('//'))
-      .join('\n');
-
   setUpAll(() {
     for (final File f in <File>[episodePart, fullscreenPart, pageFile]) {
       expect(f.existsSync(), isTrue, reason: '缺文件 ${f.path}');
@@ -62,12 +58,19 @@ void main() {
     // 方法体终点锚：下一个 `\n  /// ` 文档注释（_showEpisodeList 前）。
     final int end = episodeSrc.indexOf('\n  /// ', start);
     expect(end, greaterThan(start), reason: '找不到 _switchEpisode 方法体终点');
-    switchBody = stripLineComments(episodeSrc.substring(start, end));
+    // 掩掉注释，避免注释里提到的符号被 contains / indexOf 先命中。
+    // [maskComments] 等长（行注释 + 块注释一起换成空白、字符串字面量原样保留），
+    // 所以下面所有顺序判据的下标仍与原文对齐——旧的「整行以 // 开头就丢掉」既放行
+    // 块注释与行尾注释，又会让 indexOf 的下标与原文错位。
+    //
+    // 窗口本身只能在**原文**上切：`_switchEpisode` 方法体的终点锚是下一条文档
+    // 注释 `\n  /// `，掩码之后它变成空白就找不着了。
+    switchBody = maskComments(episodeSrc.substring(start, end));
 
-    fullscreenSrc = stripLineComments(
+    fullscreenSrc = maskComments(
       fullscreenPart.readAsStringSync().replaceAll('\r\n', '\n'),
     );
-    pageSrc = stripLineComments(
+    pageSrc = maskComments(
       pageFile.readAsStringSync().replaceAll('\r\n', '\n'),
     );
   });

--- a/fushi/test/utils/misc/update_install_evidence_test.dart
+++ b/fushi/test/utils/misc/update_install_evidence_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/utils/misc/update_handoff.dart';
 
+import '../../helpers/source_guard.dart';
+
 /// BUG-1836 根因修复：「这次更新到底装上了没有」的三源证据表。
 ///
 /// 现场（2026-08-24）：用户照 BUG-1786 / BUG-1831 的指引**手动双击**装完
@@ -314,7 +316,9 @@ void main() {
         // 先剔掉注释再断言。`settings_schema_system.dart` 是几千行的大文件，光是
         // 解释这条规矩的注释里就出现了 `resolveCurrentAppVersion`；裸 `contains`
         // 会被散文喂饱，把「删掉真实调用、只留注释」的改动放行。
-        final String code = stripDartLineComments(file.readAsStringSync());
+        // 共享词法掩码：行注释 + 块注释一起掩、等长、字符串字面量原样保留
+        // （手写的按行截断会把 URL 里的 `//` 当注释起点、吃掉半行）。
+        final String code = maskComments(file.readAsStringSync());
         // 断言布尔而不是把整份源码丢给 `contains` matcher：这两个文件都是几千行，
         // 失败时 matcher 会把全文当 `Actual` 打出来，真正的失败原因被埋掉。
         expect(
@@ -450,18 +454,4 @@ void main() {
       expect(result!.status, WindowsUpdateHandoffStatus.launchFailed);
     });
   });
-}
-
-/// 剔除 Dart 行注释（`//` 与 `///`），只留代码。
-///
-/// 只处理行注释：本守卫的目标文件里没有 `/* */` 块注释，多一层状态机只是多一个
-/// 出错面。也不识别字符串字面量——会被误剔的只有字面量里的 `//`（如 URL），而本
-/// 守卫断言的 token 都不会出现在 URL 里。
-String stripDartLineComments(String source) {
-  final StringBuffer out = StringBuffer();
-  for (final String line in const LineSplitter().convert(source)) {
-    final int idx = line.indexOf('//');
-    out.writeln(idx < 0 ? line : line.substring(0, idx));
-  }
-  return out.toString();
 }


### PR DESCRIPTION
## 这个形态错在哪

`test/tools/source_guard_adoption_test.dart` 禁止源码扫描守卫手写注释剥离，禁用形态表在 `test/helpers/banned_comment_strip.dart`。**`line.indexOf('//')` 不在表里**，于是它在全仓复制了 7 份。

它有两个独立的失效方向：

1. **字符串字面量被腰斩**：`indexOf('//')` 把行内第一个 `//` 当注释起点，`'https://x'` / `'//host/path'` 里的 `//` 照样命中，整行后半截被截掉。
   - 要求型断言（`isTrue`）→ **假红**（判据字面量在 URL 之后，看不见了）
   - 禁止型断言（`isFalse`）→ **假绿**（违规代码在 URL 之后，看不见了）
2. **块注释一概放行**：`/* needle */` 不被剥掉 ⇒ 要求型断言可以被「把实现删光、只在块注释里留下那串字面量」骗绿。

这个坑此前已经被踩过并写进注释（`test/utils/share_entry_point_guard_test.dart:45`、`test/widgets/dcomp_compositor_shutdown_guard_test.dart:11`），但没有落到守卫上。

## 改了什么

**(A) 迁移 7 处存量违规**——逐处看语料类型选原语，不做机械替换：

| 文件 | 原本在干什么 | 改成了什么 |
|---|---|---|
| `test/build/windows_installer_legacy_cleanup_guard_test.dart:65` | 手写按行截断 `CurStepChanged` 的 Pascal 过程体 | `maskComments(match.group(1))`——**只掩过程体，不掩整份 `.iss`**：`[Setup]` 段的 `AppUpdatesURL=https://…` 是 ini 行不是字符串字面量，整份掩会把它们从 `//` 起截到行尾；`;` 注释也不归 `maskComments` 管（`directiveLines` 另行处理） |
| `test/dictionary/dictionary_download_proxy_progress_test.dart:154` | 手写 `stripComments` 状态机（行 + 块注释），扫两个 Dart 生产文件 | 在读文件处 `maskComments(file.readAsStringSync())`，删掉整个状态机；自校验用例改为直接喂 `maskComments` |
| `test/lookup/apostrophe_word_scan_bug2056_test.dart:194` | `_stripLineComments` 供顺序判据用 | 语料是**四份 JS**（3 个 `selection.js` + `ReaderSelectionScripts.source()`）→ 在 `sources` 构造处统一 `maskJsComments`，删掉 `_stripLineComments`。用 JS 版而不是 `maskComments`：后者不认正则字面量，正则里的 `//` 会被读成「除号 + 行注释」砍掉半行 |
| `test/mining/gal_hook_session_controller_test.dart:2242` | 手写按行截断 Dart 生产文件，随后做 `contains` + `indexOf` 顺序判据 | 读入处 `maskComments`（等长，`indexOf`/`substring` 下标不错位） |
| `test/mining/netflix_still_frame_mine_time_test.dart:372` | 一个 `codeOnly` 同时喂 **1 份 Dart + 2 份 JS** | 拆成两个原语：`app_model.dart` 用 `maskComments`（并提到读入处，顺带让 `mineImmersion(` 锚点不会先命中注释）；`content.js` / `background.js` 用 `maskJsComments` |
| `test/pages/popup_image_lightbox_close_guard_test.dart:38` | 手写按行截断 `openImageLightbox` 函数体 | 语料是 `assets/popup/popup.js` → 读入处 `maskJsComments`；顺带让 `source.indexOf('\n}')` 的函数体窗口不再被块注释里的 `}` 提前收口 |
| `test/utils/misc/update_install_evidence_test.dart:463` | `stripDartLineComments`（`LineSplitter` 逐行截断） | `maskComments`，删掉该函数（`dart:convert` 仍被 `jsonEncode` 用着，保留） |

没有一处是「其实不是剥注释」的合法用法，**豁免表 `allowed` 没有新增项**。

**(B) 禁用表新增两条**（`test/helpers/banned_comment_strip.dart`）：

```dart
r"indexOf('//')": 'maskComments（JS 语料用 maskJsComments；CSS 用 maskCssComments）',
r'indexOf("//")': 'maskComments（JS 语料用 maskJsComments）',
```

(A)(B) 必须同一个 commit，否则先加禁用表会让 7 个既有文件立刻变红。

**顺带修 `develop` 上的既有红**：`test/pages/video_fullscreen_switch_flatten_guard_test.dart`（`718cfa6cea` / BUG-2043 合入时带进来的 `startsWith('//')`，触的是禁用表里**早就有**的形态）。不修则 `source_guard_adoption_test.dart` 在 `develop` 上本来就是红的，这条 PR 无法验绿。这正是 `docs/agent/fast-workflow.md`「合并后必跑：目录枚举型守卫清单」描述的失效形态。

## 验证

- `dart format`：**没有对存量文件整文件跑**——本机 dart 3.44 是 tall style，实测整文件 format 会产生 3000+ 行无关重排（`gal_hook_session_controller_test.dart` 一个文件 3052 行）。改为手写匹配旧风格，新增行全部 ≤ 80 列。
- `flutter analyze`（`fushi/` 下）：**exit 0**，`No issues found!`
- `flutter test`（`dart run tool/flutter_test_failures.dart --no-pub`，9 个文件）：**exit 0**，`FLUTTER TEST VERDICT: PASSED - 120 tests ran, all tests passed`

## 变异实测

还原一律用「唯一锚点精确反向替换 + sha256 逐字节比对基线」，**没有用 `git checkout`**。每一批都确认 `120 tests ran`（没有退化成编译失败的零执行无效变异）。

### A 组：存活性（反向变异生产代码 → 守卫必须红）

一次性对 8 个生产文件各做一处编译安全的变异（改标识符 / 加空格 / 加裸构造），跑同一批 9 个测试：

| 守卫 | 变异内容（生产文件） |
|---|---|
| installer | `fushi.iss`：`DeleteFile(ExpandConstant('{app}\hibiki_torrent_ffi.dll'));` → `…_MUT.dll` |
| dict-dio | `dictionary_downloader.dart`：加一行代码里的裸 `Dio()` |
| apostrophe | `selection.js`：`this.isIntraWordApostrophe(` → `…ApostropheMUT(` |
| gal-play-tracker | `gal_hook_session_controller.dart`：`GalgamePlayTracker(` → `GalgamePlayTracker (` |
| netflix-still | `app_model.dart`：`resolveClipStillTarget(` → `resolveClipStillTarget (` |
| popup-lightbox | `popup.js`：`overlay.addEventListener('click'` → `'clickMUT'` |
| update-version | `settings_schema_system.dart`：`resolveCurrentAppVersion(` → `resolveCurrentAppVersion (` |
| fullscreen-switch | `episode.part.dart`：`resolveEpisodeSwitchPlan(` → `resolveEpisodeSwitchPlan (` |

**结果：8 个守卫全红**（`9 error event(s), 120 test(s) completed`），`source_guard_adoption_test.dart` 保持绿。`revertA` → 8 个文件 sha256 **逐条 SHA-OK，REVERT CLEAN**。

### B 组：掩码方向（判据字面量只剩在块注释里 → 要求型必须红）

A 组变异 **+** 把原字面量原样塞进 `/* … */`：

- **7 个要求型守卫全红**（installer / apostrophe / gal-play-tracker / netflix-still / popup-lightbox / update-version / fullscreen-switch）。旧的按行 `indexOf('//')` 在这里会**放行块注释 ⇒ 假绿**；现在红了，说明掩码方向正确。
- **dict-dio 绿**——它是**禁止型**判据（裸 `Dio()` 不得出现），块注释里的裸构造本来就不该算命中。绿是正确结果。
- `8 error event(s), 120 test(s) completed`，`revertB` → sha256 **全部 SHA-OK，REVERT CLEAN**。

### C 组：钉死本 PR 修的那个具体缺陷（`https://` 腰斩）

`dictionary_downloader.dart` 里插入**同一行**：

```dart
const String mutProbeUrl = 'https://example.com/x'; final Dio mutProbeDio = Dio();
```

- 迁移后（`maskComments`，保留字符串字面量）：守卫**红**，报 `…出现裸 Dio()：那条请求会绕开代理与超时装配，正是 BUG-1493 的根因形态`。
- 旧写法会怎样：用一次性探针测试直接对照（跑完已删），三条断言全绿：
  - `legacyPerLineStrip(line).contains('Dio()')` → `false`（**假绿的成因**）
  - `maskComments(line).contains('Dio()')` → `true`，且 `length` 与原串相等（等长掩码）
  - `legacyPerLineStrip('/* GalgamePlayTracker( */')` 仍含该字面量 → `true`（**块注释假绿的成因**）；`maskComments` 同一串 → `false`
- `revert` → sha256 **SHA-OK, REVERT CLEAN**。

### D 组：证明新禁用项不是摆设

在已迁移的 `popup_image_lightbox_close_guard_test.dart` 里写回 `line.indexOf('//')`：

- `source_guard_adoption_test.dart` **红**，并**点名**：
  `test/pages/popup_image_lightbox_close_guard_test.dart:46  用了 indexOf('//') —— 改用 maskComments（JS 语料用 maskJsComments；CSS 用 maskCssComments）`
- 还原后 sha256 回到基线 `d47c00a9b9d13df847f0421fc1e8cf5334fe46f5723f6a8810d3ac0e5feaf036`，整批 9 个文件 `PASSED - 120 tests ran`。
