### PR TITLE
fix(anki): open-in-Anki resolves decks and notes by id, not by name (BUG-2051)

### DIFF
--- a/docs/bugs/BUG-2051-anki-open-in-anki-not-same-source.md
+++ b/docs/bugs/BUG-2051-anki-open-in-anki-not-same-source.md
@@ -41,14 +41,19 @@ Yomitan 只有一条判据，两个 UI 天然一致；我们有两条，所以�
 
 不是「让两条查询长得一样」（那还会再漂移一次），而是**让 ↗ 不再有自己的判据**：
 
-1. `AnkiConnectService.guiBrowseQuery(query)`（新）：把 Anki 浏览器过滤到任意查询串，
-   并回传**被选中的 card id**——`guiBrowse` 的应答本来就是命中列表，所以「打开」与
-   「到底有没有卡」是同一次往返的两个产物，不必再另发一条 `findNotes` 去问同一个问题。
+1. `AnkiConnectService.guiBrowseQuery(query)`（新）：把 Anki 浏览器过滤到任意查询串。
+   ↗ 只喂它 `nid:a,b,c`（见下），**不把它的返回值当第二次匹配判定**。
 2. `ankiDuplicateSearchQuery(...)`（新，`ankiconnect_service.dart`）：把 checksum 判据用
-   搜索语法表达一遍 —— `deckFilter ("dupe:<mid1>,<词>" OR "dupe:<mid2>,<词>" …)`，mid 取
-   **全部**笔记类型（`modelNamesAndIds`，也是新增），卡组过滤器复用查重那一个
-   `ankiDuplicateDeckFilter`。`canAddNotes` 只回布尔、给不出 note id，`dupe:` 是唯一
-   既同源又能拿到卡的路子。
+   搜索语法表达一遍 —— `(did:… OR did:…) ("dupe:<mid1>,<词>" OR "dupe:<mid2>,<词>" …)`，
+   mid 取**全部**笔记类型（`modelNamesAndIds`，也是新增）。`canAddNotes` 只回布尔、给不出
+   note id，`dupe:` 是唯一既同源又能拿到卡的路子。
+2b. **不按名字查**（第二轮，用户提出）：卡组范围先用 `deckNamesAndIds` 把名字**精确**
+   解析成 id（`ankiDuplicateDeckIds`：`名 == 目标` 或 `名.startsWith('目标::')`，字符串
+   比较在 Dart 里做），查询串里用 `did:`；命中的 note id 再用 `ankiNoteIdBrowseQuery`
+   变成 `nid:a,b,c` 交给浏览器。于是**查询串里唯一还留着的名字是 `dupe:` 里那个词，
+   而它恰好是 Anki 唯一做精确比较的地方**。理由是实测出来的，见「按名字查的实测」。
+   代价是多一次 `findNotes` 往返——它不是第二条判据：`nid:` 按上一步的**结果 id**
+   定位，不重新匹配任何东西。
 3. `BaseAnkiRepository.openWordInAnki(expression, reading) -> AnkiOpenWordOutcome`（新契约，
    三态 `opened / noMatch / failed`）。AnkiConnect 覆写成上面那条；**基类默认实现**走
    `findMatchingNotes` + `openNoteInAnki` 打开最近一张，给没有「按词打开」能力的后端
@@ -78,7 +83,7 @@ Yomitan 只有一条判据，两个 UI 天然一致；我们有两条，所以�
 
 ### [x] ② 已加自动化测试
 
-- `packages/fushi_anki/test/open_word_in_anki_test.dart`（新增，14 条）——假 AnkiConnect
+- `packages/fushi_anki/test/open_word_in_anki_test.dart`（新增，第一轮 14 条 → 第二轮 20 条）——假 AnkiConnect
   **照上表实测行为建模**：按字段名查恒 0 命中、`dupe:` 命中那张 Kaishi 卡。覆盖：✓ 判重
   与 ↗ 必须给同一答案 / ↗ 不得再发 findNotes / 查询串形状（卡组过滤 + 全量 mid + 括号分组
   + 不含 `Expression:`）/ collection scope 不带卡组 / 空选中 → noMatch / 传输失败 → failed
@@ -142,13 +147,58 @@ Yomitan 只有一条判据，两个 UI 天然一致；我们有两条，所以�
 | 新建 `packages/fushi_anki/lib/src/_mutation_probe_browse.dart` 调 `guiBrowseQuery` | ✅ 第三条守卫红 | `Which: larger than expected` | 同上 |
 
 后两行的「PR 原有 8 条守卫全绿」就是 control：旧护栏结构上抓不到新入口，是新守卫在承重。
+**第二轮（改按 id 查）新增用例**：浏览器那句只能是 `nid:`（不含词/`deck:`/`dupe:`）、
+判命中那句按 `did:` 过滤、`ankiDeckIdFilter` 与 `ankiNoteIdBrowseQuery` 的形状、以及
+「卡组范围按 id 解析」5 条（子组按 `::` 精确展开 / 带 `_` 的卡组名只解析出它自己、兄弟
+卡组不得被通配进来 / deckRoot 取根 / collection·空名·卡组已删 → 不加过滤 / `Lapis2` 不算
+`Lapis` 的子组）。假 AnkiConnect 改成：`findNotes` 才是判命中的那一步，**`guiBrowse`
+故意没有判别力**（只回传 `nid:` 里点到的），否则又是两条判据。共 20 条。
+
+**第二轮变异实测**（每条按 sha256 核对还原）：
+- 子卡组用裸前缀（丢掉 `::`）→ **精确 1 条红**（`Lapis2` 那条）。
+- `nid:` 只列第一张而不是全部同名 → **精确 1 条红**。
+- 把带词的 `dupe:` 串直接丢给 `guiBrowse`（退回第一轮的形状）→ 单测 1 条红 + 静态守卫 1 条红。
+- `deck` scope 失效（不再限定卡组）→ **4 条红**。
+- 查不到也照样去开浏览器 → **精确 1 条红**。
+
+守卫自查：静态守卫取函数体时 `indexOf('\n}')` 会先命中**命名参数表**的 `})`（同样在列 0），
+把函数体截成一个参数表、后续 `contains` 断言全部恒假。已改成跳过后面紧跟 `)` 的那些
+（`topLevelBodyEnd`），并加了「取到的片段必须含 `dupe:`」的非空转自检。
+
+### 按名字查的实测（第二轮的依据）
+
+用户指出「anki 按名字查会非常灾难」。在本机真 Anki 上量了一遍，属实，而且第一轮的修复
+**只同源了一半**：`dupe:` 那半对了，卡组那半我用的 `deck:"<名字>"` 走的是 Anki 搜索的
+**通配匹配**，而画 ✓ 那侧（`duplicateScopeOptions.deckName`）是**精确名**。
+
+| 卡组条件 | ↗ 侧 `findNotes` | ✓ 侧 `canAddNotesWithErrorDetail` |
+|---|---|---|
+| 真名 `eggrolls-JLPT10k-v3` / `正在背::Kaishi 1.5k  zh-CH` | 10164 条 | 判重复 |
+| 把一个字换成 `_` | **同样 10164 条**（`_` = 单字通配） | **判不重复**（名字不存在） |
+| `e*` / `正在背::*` | **整棵树 10164 条** | **判不重复** |
+| 不存在的名字 | 0 条 | 判不重复（静默，不报错） |
+
+也就是说：只要卡组名里有 `_` 或 `*`（本机就有 `galgame_card_test` / `galgame_track_test`），
+两侧对「哪些卡在范围内」的答案就不一样——判据的下一个漂移入口。id 没有这个问题。
+
+另外两条实测事实：`did:` **只匹配该卡组自己、不含子卡组**（父卡组 `did:` n=1 而
+`deck:` n=10164），所以子卡组要在 Dart 侧按 `::` 前缀精确展开，对齐查重侧的
+`checkChildren: true`；卡组名里的连续空格不会被 Anki 吞（`deck:"…1.5k  zh-CH"` n=1501，
+改成单空格 n=0）。
 
 ### 备注
 
-**真机验证**：本机真 Anki 上直接发新实现构造的那条查询串，`guiBrowse` 返回
-`[1758347126448]`，`cardsInfo` 确认打开的正是笔记类型 `Kaishi 1.5k zh-CH`、第一字段
-`たっぷり` 的那张卡；同一时刻旧查询串返回 `[]`。原始失败路径（app 内点 ↗）**未**在真机
-app 里复测——本轮做到「同一条查询串在真 Anki 上给出正确结果」这一层。
+**真机验证**：本机真 Anki 上跑完整新链路。单卡词 `たっぷり`：
+`(did:1771332842760) ("dupe:…,たっぷり" OR …)` → `[1758347126448]` →
+`guiBrowse('nid:1758347126448')` → `cardsInfo` 确认正是笔记类型 `Kaishi 1.5k zh-CH`、
+第一字段 `たっぷり` 的那张卡；同一时刻旧的按字段名查询返回 `[]`。
+**多卡词** `与える`（本 bug 的原型形状：同一个词同时是一张 Kaishi 笔记、第一字段名
+`Word`，和一张 Lapis 笔记、第一字段名 `Expression`）：同源查询返回
+`[1788020832613, 1758347125581]`，与逐条枚举第一字段的结果完全一致，
+`guiBrowse('nid:1758347125581,1788020832613')` 在浏览器里一次列出两张。该库 `正在背`
+树下 2894 条笔记里，**44 个词跨 ≥2 种笔记类型**——旧实现对这些词只能看见一半。
+原始失败路径（app 内点 ↗）**未**在真机 app 里复测：本轮做到「同一条链路在真 Anki 上给出
+正确结果」这一层。
 
 **`dupe:` 语法的实测边界**（同机取证）：按**第一个逗号**切（`"dupe:mid,x,たっぷり"` 不
 命中，排除了「按最后一个逗号切」，故词里含逗号不会截断文本）；未知 mid 只是不命中、不

--- a/fushi/test/pages/open_in_anki_wiring_static_test.dart
+++ b/fushi/test/pages/open_in_anki_wiring_static_test.dart
@@ -12,6 +12,21 @@ import '../helpers/source_guard.dart';
 /// BUG-2051 之后这条链路只剩**一条判据**：宿主把 Anki 浏览器过滤到「Anki 认为这个词
 /// 已有的卡」（第一字段 checksum，与画 ✓ 的查重同源），不再先按第一字段**名**反查
 /// note id——那条反查看不见笔记类型不同的重复卡，于是 ✓ 说已制卡、↗ 说没有卡。
+/// 顶层函数体的结束位置：从 [from] 起找**列 0 的 `}`**。
+///
+/// 不能直接 `indexOf('\n}')`：命名参数表的 `})` 同样在列 0，先命中它就会把「函数体」
+/// 截成只剩一个参数表，后面所有 `contains` 断言随之恒假——那是个不会报错、只会悄悄
+/// 失去判别力的守卫。所以跳过后面紧跟 `)` 的那些。
+int topLevelBodyEnd(String src, int from) {
+  int i = from;
+  while (true) {
+    i = src.indexOf('\n}', i + 1);
+    if (i < 0) return -1;
+    final int next = i + 2;
+    if (next >= src.length || src[next] != ')') return i;
+  }
+}
+
 void main() {
   String read(String relativePath) {
     final file = File(relativePath);
@@ -94,12 +109,9 @@ void main() {
     expect(base.contains('repo.openWordInAnki(expression, reading)'), isTrue);
   });
 
-  test('BUG-2051 仓库层：↗ 与查重同源，且没有第二条反查', () {
+  test('BUG-2051 仓库层：↗ 与查重同源，且查询串里不放名字', () {
     final repo = read(
         '../packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart');
-    // 查询串来自与查重共用的构造器，直接喂给 guiBrowse——不再先 findNotes 拿 id。
-    expect(repo.contains('ankiDuplicateSearchQuery('), isTrue);
-    expect(repo.contains('service.guiBrowseQuery(query)'), isTrue);
     final int openWordAt =
         repo.indexOf('Future<AnkiOpenWordOutcome> openWordInAnki(');
     expect(openWordAt, greaterThan(-1));
@@ -108,9 +120,33 @@ void main() {
     final int nextOverride = repo.indexOf('\n  @override', openWordAt);
     expect(nextOverride, greaterThan(openWordAt));
     final String body = repo.substring(openWordAt, nextOverride);
+    // 判命中：与查重共用的 dupe 构造器。
+    expect(body.contains('ankiDuplicateSearchQuery('), isTrue);
     expect(body.contains('findNotesByField('), isFalse,
         reason: '按第一字段名查是被删掉的那条判据，不得在 ↗ 路径上复活');
-    expect(body.contains('ankiDuplicateSearchQuery('), isTrue);
+    // 卡组范围按 **id** 解析：Anki 搜索的 `deck:` 是通配匹配（`_`/`*`），而查重侧
+    // 是精确名——把卡组名塞回搜索串就是给判据留第二个漂移入口。
+    expect(body.contains('ankiDuplicateDeckIds('), isTrue,
+        reason: '卡组必须先按名字精确解析成 id，不能交给 Anki 的通配匹配');
+    // 打开：只喂 note id。词与卡组名都不进浏览器的查询串。
+    expect(body.contains('ankiNoteIdBrowseQuery('), isTrue);
+    expect(body.contains('service.guiBrowseQuery(browseQuery)'), isTrue);
+
+    // 构造器自己也不许再拼卡组名：`ankiDuplicateDeckFilter` 产出的是 `deck:"名字"`，
+    // 那条通配路径只留给尚未改造的旧字段名查询（见 BUG-2051 备注），不得回流到这里。
+    final service = read(
+        '../packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart');
+    final int qAt = service.indexOf('String ankiDuplicateSearchQuery(');
+    expect(qAt, greaterThan(-1));
+    final int qEnd = topLevelBodyEnd(service, qAt);
+    expect(qEnd, greaterThan(qAt));
+    final String queryBody = service.substring(qAt, qEnd);
+    // 非空转自检：真取到了函数体（不是被参数表截断成一小段）。
+    expect(queryBody, contains('dupe:'));
+    expect(queryBody.contains('ankiDeckIdFilter('), isTrue);
+    expect(queryBody.contains('ankiDuplicateDeckFilter('), isFalse,
+        reason: '卡组名进搜索串 = 交给 Anki 的通配匹配，与查重侧的精确名不同源');
+    expect(queryBody.contains('deck:'), isFalse);
 
     // 没有原生「按词打开」能力的后端走基类默认（按 note id，两者本就同源）。
     final base =

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1232,12 +1232,19 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   /// （Anki 内建第一字段 checksum，见 [ankiDuplicateSearchQuery]），所以 ✓ 亮着
   /// 时这里在物理上不可能查不到——包括那张笔记类型不同、字段名叫 `Word` 的旧卡。
   ///
-  /// 不先反查 note id：`guiBrowse` 的应答就是被选中的 card id 列表，「打开」与
-  /// 「有没有卡」是同一次往返的两个产物。这也是为什么这里没有第二条查询可以漂移。
+  /// 两步、两个查询串，但**只有一条判据**：
+  /// 1. 用同源的 `dupe:` 串 `findNotes` → 这个词**全部同名笔记**的 id（跨笔记类型）；
+  /// 2. 把它们变成 `nid:a,b,c` 交给 `guiBrowse` 打开。
   ///
-  /// 卡组解析失败（配置过期）不早退：[AnkiDuplicateScope.collection] 本来就不看
-  /// 卡组，其余 scope 下 [ankiDuplicateDeckFilter] 对空卡组名会退化成不限卡组
-  /// （fail-open，与查重同一口径），宁可多列几张也好过打不开。
+  /// 第 2 步不是第二条判据——它按第 1 步的**结果 id** 定位，不重新匹配任何东西。
+  /// 反过来说也别把 `guiBrowse` 的返回值当命中数：见 [AnkiConnectService.guiBrowseQuery]。
+  ///
+  /// 为什么要多这一次往返：查询串里从此不出现卡组名，浏览器地址栏里也不出现词。
+  /// Anki 搜索的 `deck:` 是通配匹配（`_`/`*`），而查重侧是精确名——把名字留在串里
+  /// 就等于给判据留了第二个漂移入口（见 [ankiDuplicateDeckIds] 的实测）。
+  ///
+  /// 卡组解析失败（配置过期）不早退：[ankiDuplicateDeckIds] 对空的/已不存在的卡组名
+  /// 退化成不限卡组（fail-open），宁可多列几张也好过对着一张确实存在的卡说没有。
   @override
   Future<AnkiOpenWordOutcome> openWordInAnki(
     String expression,
@@ -1256,27 +1263,32 @@ class AnkiConnectRepository extends BaseAnkiRepository {
               : null);
       final service = _serviceForSettings(settings);
       final Map<String, int> models = await service.getModelNamesAndIds();
+      final Map<String, int> decks = await service.getDeckNamesAndIds();
       final String query = ankiDuplicateSearchQuery(
-        deckName: deck?.name ?? '',
         value: expression,
-        scope: settings.duplicateScope,
         modelIds: models.values,
+        deckIds: ankiDuplicateDeckIds(
+          deckName: deck?.name ?? '',
+          scope: settings.duplicateScope,
+          deckNamesAndIds: decks,
+        ),
       );
       // 一个笔记类型都没有 = 这台 Anki 还没建过卡，不该发一条空搜索把整库摊开。
       if (query.isEmpty) return AnkiOpenWordOutcome.noMatch;
+      final List<int> noteIds = await service.findNotesByQuery(query);
+      final String browseQuery = ankiNoteIdBrowseQuery(noteIds);
+      if (browseQuery.isEmpty) return AnkiOpenWordOutcome.noMatch;
       final int? ankiPid = ankiConnectHostIsLoopback(service.host)
           ? AnkiDesktopForeground.grantForegroundToAnki(
               ankiConnectPort: service.port)
           : null;
-      final List<int>? cardIds = await service.guiBrowseQuery(query);
+      // 返回值**一概不读**：命中与否已经由上一步的 `findNotes` 定死，这里只是
+      // 「打开」。旧版 AnkiConnect 的 `guiBrowse` 只回 null、新版回 card id 列表，
+      // 两种机器在这条路径上从此没有行为差异——那条「浏览器明明开着却说没有卡」
+      // 的错话，成因被结构性地拿掉了，而不是靠 null/[] 分流去躲开。
+      await service.guiBrowseQuery(browseQuery);
       await AnkiDesktopForeground.raiseAnkiWindow(ankiPid);
-      // null = 这台 AnkiConnect 不回传命中列表（旧版 `guiBrowse` 只回 null）：
-      // 浏览器**已经**打开并过滤到了这条查询，只是拿不到计数。此时报 noMatch 就
-      // 是「浏览器开着却说没有卡」，正是本 bug 的那句错话。只有明确答「空」才是
-      // 真的没有卡。
-      return cardIds != null && cardIds.isEmpty
-          ? AnkiOpenWordOutcome.noMatch
-          : AnkiOpenWordOutcome.opened;
+      return AnkiOpenWordOutcome.opened;
     } catch (e, stack) {
       debugPrint('AnkiConnectRepository.openWordInAnki: $e');
       debugPrint('$stack');

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_service.dart
@@ -414,6 +414,16 @@ class AnkiConnectService {
     return _asStringList(await _request('deckNames'), 'deckNames');
   }
 
+  /// BUG-2051：卡组名 → id。查询串里**不放卡组名**的前提（见
+  /// [ankiDuplicateDeckIds]）：Anki 搜索里的 `deck:` 是**通配匹配**（`_` 单字、
+  /// `*` 任意），而查重那侧（AnkiConnect `duplicateScopeOptions.deckName`）是
+  /// **精确名**。本机实测同一个真卡组名：`deck:"…zh-C_"` 命中 1501 条，而查重侧
+  /// 同样把最后一个字换成 `_` 就判「不重复」。带 `_` 的卡组名（本机确有
+  /// `galgame_card_test`）会让两侧对「哪些卡在范围内」给出不同答案。
+  Future<Map<String, int>> getDeckNamesAndIds() async {
+    return _asNameIdMap(await _request('deckNamesAndIds'), 'deckNamesAndIds');
+  }
+
   Future<List<String>> getModelNames() async {
     return _asStringList(await _request('modelNames'), 'modelNames');
   }
@@ -423,11 +433,15 @@ class AnkiConnectService {
   /// 到全部 id。识别不出 id 的表项直接跳过（宁可少查一个笔记类型，也不要让整次打开
   /// 因为一条脏数据失败）。
   Future<Map<String, int>> getModelNamesAndIds() async {
-    final dynamic result = await _request('modelNamesAndIds');
+    return _asNameIdMap(await _request('modelNamesAndIds'), 'modelNamesAndIds');
+  }
+
+  /// `{名字: id}` 应答的共用解析。识别不出 id 的表项直接跳过（宁可少一个条目，
+  /// 也不要让整次调用因为一条脏数据失败）。
+  Map<String, int> _asNameIdMap(dynamic result, String action) {
     if (result is! Map) {
       throw AnkiConnectException(
-        'Unexpected AnkiConnect response for modelNamesAndIds '
-        '(expected an object)',
+        'Unexpected AnkiConnect response for $action (expected an object)',
       );
     }
     final out = <String, int>{};
@@ -853,11 +867,12 @@ class AnkiConnectService {
     await guiBrowseQuery('nid:$noteId');
   }
 
-  /// BUG-2051：把 Anki 浏览器过滤到任意[query]，并回传**被选中的 card id**。
+  /// BUG-2051：把 Anki 浏览器过滤到任意 [query]，并回传**被选中的 card id**。
   ///
-  /// `guiBrowse` 的应答本来就是命中的 card id 列表，所以「打开」和「到底有没有卡」
-  /// 是同一次往返的两个产物——调用方据此区分「打开了」与「一张都没有」，不必再另发
-  /// 一条 `findNotes` 去问同一个问题（那正是两条判据漂移的老路）。
+  /// ↗ 的调用方只喂 [ankiNoteIdBrowseQuery] 产出的 `nid:a,b,c`：命中与否已经由
+  /// 上一步（同源的 `dupe:` 查询）定死，这里只负责「打开」，**返回值不参与任何
+  /// 判定**。这是「返回值是附加信息、不是成败标志」的最强形式：调用方连读都不读，
+  /// 也就没有第二条判据可以漂移。下面的 `null` / `[]` 区分保留给其它调用方。
   ///
   /// 应答**不是列表**时返回 `null`，而不是空列表——这两件事不是一回事：
   ///
@@ -1030,23 +1045,24 @@ Map<String, Object> _addNoteDuplicateOptions({
 /// `canAddNotes` 只回布尔、给不出 note id，所以「同源」不能靠复用它。Anki 搜索语法
 /// 里的 `dupe:<笔记类型id>,<文本>` **就是**那条 checksum 判据的搜索版本（Anki 浏览器
 /// 侧栏的「重复」用的也是它），于是跨全部笔记类型 = 每个 id 一个 `dupe:` 子句 OR 起来，
-/// 再按 [scope] 前置同一个卡组过滤器（[ankiDuplicateDeckFilter]，与查重共用）。
+/// 再按 [deckIds] 前置一个**按 id** 的卡组过滤器（`did:`，见 [ankiDuplicateDeckIds]）。
 ///
 /// 实测（本机真 Anki，AnkiConnect 25.x）：
-/// - `deck:"…" ("dupe:1758278161949,たっぷり" OR …)` → `[1758347126448]`，正是 ✓ 认的那张；
+/// - `(did:1771332842760) ("dupe:1758278161949,たっぷり" OR …)` → `[1758347126448]`，
+///   正是 ✓ 认的那张；换成 `deck:"<同一卡组名>"` 结果相同，但见下面的通配符陷阱；
 /// - `dupe:` 按**第一个逗号**切（`"dupe:mid,x,たっぷり"` 不命中，排除了按最后一个逗号切），
 ///   所以词里含逗号不会截断文本；
 /// - 未知的笔记类型 id 只是不命中、不报错，故全量 OR 安全；
 /// - 值里的引号/反斜杠/空格/冒号/括号/星号在整体加引号后都能解析，且 `*` 不当通配符
-///   （`dupe:` 是精确文本比较，不是模糊匹配）。
+///   （`dupe:` 是精确文本比较，不是模糊匹配）——**这是查询串里唯一还留着的名字，
+///   而它恰好是精确比较的那一个**。
 ///
 /// [value] 为空或 [modelIds] 为空时返回空串——调用方据此不发这次请求（空搜索串会把
-/// 整个收藏集摊开，绝不能当成「这个词的卡」）。
+/// 整个收藏集摊开，绝不能当成「这个词的卡」）。[deckIds] 为空 = 不限卡组。
 String ankiDuplicateSearchQuery({
-  required String deckName,
   required String value,
-  required AnkiDuplicateScope scope,
   required Iterable<int> modelIds,
+  required Iterable<int> deckIds,
 }) {
   if (value.isEmpty) return '';
   final List<int> ids = modelIds.toList(growable: false);
@@ -1055,11 +1071,71 @@ String ankiDuplicateSearchQuery({
   // 每个子句整体加引号：值里的空格/冒号/括号否则会被 Anki 的查询解析器切开。
   final String dupeTerms =
       ids.map((int mid) => '"dupe:$mid,$escaped"').join(' OR ');
-  // 单个笔记类型也照样套括号：与 deck 过滤器并置时 `A B OR C` 的结合律会把
+  // 单个笔记类型也照样套括号：与卡组过滤器并置时 `A B OR C` 的结合律会把
   // 卡组条件只绑到第一个子句上，那是一句悄悄查错范围的查询。
   final String dupeGroup = '($dupeTerms)';
-  final String deckFilter = ankiDuplicateDeckFilter(deckName, scope);
+  final String deckFilter = ankiDeckIdFilter(deckIds);
   return deckFilter.isEmpty ? dupeGroup : '$deckFilter $dupeGroup';
+}
+
+/// BUG-2051：把卡组**范围**解析成一组卡组 id，替代往搜索串里塞卡组名。
+///
+/// 为什么不能按名字查：Anki 搜索里的 `deck:` 是**通配匹配**，`_` 匹配任一字符、
+/// `*` 匹配任意串；而画 ✓ 的那侧（AnkiConnect `duplicateScopeOptions.deckName`）
+/// 是**精确名**。本机实测（同一个真卡组）：
+/// `deck:"…zh-CH"` → 1501 条、`deck:"…zh-C_"` → 同样 1501 条、`deck:"e*"` → 整棵
+/// eggrolls 树；而查重侧把最后一个字换成 `_` 或用 `正在背::*` 都判「不重复」。
+/// 也就是说：只要卡组名里有 `_` 或 `*`（本机就有 `galgame_card_test`），两侧对
+/// 「哪些卡在范围内」的答案就不一样——那正是判据漂移的下一个入口。id 没有这个问题。
+///
+/// `did:` **只匹配该卡组自己、不含子卡组**（实测：父卡组 `did:` n=1，
+/// `deck:` n=10164），所以子卡组要在这里按名字前缀**精确**展开（`名 == 目标` 或
+/// `名.startsWith('目标::')`）——这与查重侧 `checkChildren: true` 的口径一致。
+/// 字符串比较在 Dart 里做，不经过 Anki 的查询解析器，也就没有通配符语义。
+///
+/// 返回空列表 = 不加卡组过滤（整个收藏集）：[AnkiDuplicateScope.collection] 本来
+/// 就不看卡组；卡组名为空或**已不存在**（配置过期）时同样退化成不限卡组——fail-open，
+/// 宁可多列几张也好过对着一张确实存在的卡说「没有找到」。
+List<int> ankiDuplicateDeckIds({
+  required String deckName,
+  required AnkiDuplicateScope scope,
+  required Map<String, int> deckNamesAndIds,
+}) {
+  final String target = switch (scope) {
+    AnkiDuplicateScope.collection => '',
+    // `::` 是 Anki 的层级分隔符；没有分隔符时根卡组就是它自己。
+    AnkiDuplicateScope.deckRoot => deckName.split('::').first,
+    AnkiDuplicateScope.deck => deckName,
+  };
+  if (target.isEmpty) return const <int>[];
+  final String childPrefix = '$target::';
+  final List<int> ids = <int>[
+    for (final MapEntry<String, int> e in deckNamesAndIds.entries)
+      if (e.key == target || e.key.startsWith(childPrefix)) e.value,
+  ];
+  ids.sort();
+  return ids;
+}
+
+/// `(did:a OR did:b)`；空列表 → 空串（不限卡组）。
+String ankiDeckIdFilter(Iterable<int> deckIds) {
+  final List<int> ids = deckIds.toList(growable: false);
+  if (ids.isEmpty) return '';
+  // 与 dupe 组同样的理由套括号：`did:a OR did:b (X)` 的结合律会查错范围。
+  return '(${ids.map((int did) => 'did:$did').join(' OR ')})';
+}
+
+/// BUG-2051：把一批 note id 变成 Anki 浏览器的查询串 `nid:a,b,c`。
+///
+/// ↗ 最终喂给 `guiBrowse` 的**只有这一句**：浏览器地址栏里不出现词、不出现卡组名，
+/// 于是「浏览器里列出来的」与「我们判定命中的」在物理上是同一批笔记，中间没有第二次
+/// 匹配可以漂移。实测 `nid:a,b,c` 多 id 逗号形式被 Anki 接受（n=3）。
+///
+/// 空列表返回空串——调用方据此不发这次 `guiBrowse`（空搜索串会把整库摊开）。
+String ankiNoteIdBrowseQuery(Iterable<int> noteIds) {
+  final List<int> ids = noteIds.toList(growable: false);
+  if (ids.isEmpty) return '';
+  return 'nid:${ids.join(',')}';
 }
 
 String _fieldValueQuery({

--- a/packages/fushi_anki/test/open_word_in_anki_test.dart
+++ b/packages/fushi_anki/test/open_word_in_anki_test.dart
@@ -17,12 +17,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// |---|---|
 /// | `canAddNotesWithErrorDetail`（画 ✓ 的判据） | 判重复 → 画 ✓ |
 /// | `deck:"…" "Expression:たっぷり"`（↗ 旧的反查） | `[]` → 「没有找到已制的卡片」 |
-/// | `deck:"…" ("dupe:1758278161949,たっぷり" OR …)` | `[1758347126448]` |
+/// | `(did:1771332842760) ("dupe:1758278161949,たっぷり" OR …)` | `[1758347126448]` |
 ///
 /// BUG-1915 把**查重**换成了 Anki 内建的第一字段 checksum，却把 ↗ 的反查留在按字段名
 /// 查的老路上，于是同一个词一边说已制卡、一边说没有卡。`canAddNotes` 只回布尔、给不出
 /// note id，所以「同源」不能靠复用它——`dupe:<笔记类型id>,<文本>` 是那条 checksum 判据
 /// 的搜索语法版本，这里钉死 ↗ 走的就是它。
+///
+/// **不按名字查**：卡组范围先按名字**精确**解析成 id（[ankiDuplicateDeckIds]）再用
+/// `did:`，最后只把 note id 以 `nid:a,b,c` 交给浏览器。原因是实测出来的——Anki 搜索
+/// 的 `deck:` 是通配匹配（`deck:"e_grolls-…"` 与真名同样命中 10164 条、`deck:"e*"`
+/// 圈走整棵树），而查重那侧是精确名（把一个字换成 `_` 或用 `正在背::*` 都判「不重复」）。
+/// 名字留在查询串里 = 给判据留第二个漂移入口。真机 E2E：`与える` 在库里同时是一张
+/// Kaishi（第一字段 `Word`）和一张 Lapis（`Expression`）笔记，同源查询两张都返回，
+/// `nid:1758347125581,1788020832613` 一次列全；该库 `正在背` 树下有 44 个这样的词。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -30,7 +38,8 @@ void main() {
   const String kDeck = '正在背::Kaishi 1.5k  zh-CH';
   const int kKaishiMid = 1758278161949;
   const int kLapisMid = 1667218449922;
-  const int kExistingCardId = 1758347126448;
+  const int kExistingNoteId = 1758347126448;
+  const int kDeckDid = 1771332842760;
 
   const AnkiNoteType lapis = AnkiNoteType(
     id: kLapisMid,
@@ -56,15 +65,21 @@ void main() {
   }
 
   /// 一台**照实测行为建模**的假 AnkiConnect：
-  /// - `findNotes`（按字段名的老判据）恒 0 命中；
-  /// - `guiBrowse` 只有在查询串里带上 **Kaishi 那个 mid 的 `dupe:` 子句**时才命中。
+  /// - `findNotes` 只在查询串同时满足「带 **Kaishi 那个 mid 的 `dupe:` 子句**」
+  ///   与「卡组范围覆盖 [kDeckDid]（或压根没限卡组）」时命中那张已存在的笔记；
+  /// - 按第一字段**名**查（`"Expression:…"`）恒 0 命中——真机上就是如此，那张卡的
+  ///   第一字段叫 `Word`；
+  /// - `guiBrowse` 不做任何匹配，只回传 `nid:` 里点到的那些（真机行为：它就是个打开
+  ///   动作）。**故意不让 guiBrowse 有判别力**：命中与否必须由上一步决定，否则又是
+  ///   两条判据。
   ///
-  /// 两条判据在这台机器上给出相反答案——这正是守卫的判别力所在：退回按字段名查、
-  /// 或漏掉非当前笔记类型的 mid，本组用例立刻变红。
+  /// 判别力：退回按字段名查、漏掉非当前笔记类型的 mid、或把卡组名当搜索词（`deck:`）
+  /// 而不是 id，本组用例立刻变红。
   MockClient crossModelHost(
     List<Map<String, dynamic>> sink, {
     bool transportFails = false,
     bool guiBrowseReturnsNull = false,
+    bool guiBrowseReturnsEmpty = false,
   }) {
     return MockClient((http.Request request) async {
       if (transportFails) throw const SocketExceptionStub();
@@ -80,14 +95,37 @@ void main() {
             'Lapis': kLapisMid,
             'Kaishi 1.5k zh-CH': kKaishiMid,
           };
+        case 'deckNamesAndIds':
+          result = const <String, Object?>{
+            kDeck: kDeckDid,
+            '正在背': 1779901350674,
+            '正在背::Lapis': 1771326371415,
+            // 名字里带 `_` 的真实卡组：只要谁把它塞进 `deck:` 搜索串，`_` 就变成
+            // 单字通配符，把下面那个兄弟卡组一起圈进来（本机实测）。
+            'galgame_card_test': 1784372258515,
+            'galgameXcard_test': 1784372258516,
+          };
         case 'findNotes':
-          result = const <int>[];
+          final String query = (body['params'] as Map)['query'].toString();
+          final bool sameSourceHit =
+              query.contains('"dupe:$kKaishiMid,$kWord"');
+          final bool inScope =
+              !query.contains('did:') || query.contains('did:$kDeckDid');
+          result = sameSourceHit && inScope
+              ? const <int>[kExistingNoteId]
+              : const <int>[];
         case 'guiBrowse':
           if (guiBrowseReturnsNull) break;
+          if (guiBrowseReturnsEmpty) {
+            result = const <int>[];
+            break;
+          }
           final String query = (body['params'] as Map)['query'].toString();
-          result = query.contains('"dupe:$kKaishiMid,$kWord"')
-              ? const <int>[kExistingCardId]
-              : const <int>[];
+          final String ids = query.startsWith('nid:') ? query.substring(4) : '';
+          result = <int>[
+            for (final String s in ids.split(','))
+              if (int.tryParse(s) case final int id) id,
+          ];
         case 'canAddNotesWithErrorDetail':
           result = const <Map<String, Object?>>[
             <String, Object?>{
@@ -114,10 +152,19 @@ void main() {
     );
   }
 
-  String browseQuery(List<Map<String, dynamic>> sink) => (sink.singleWhere(
-              (Map<String, dynamic> b) => b['action'] == 'guiBrowse')['params']
-          as Map)['query']
-      .toString();
+  String queryOf(List<Map<String, dynamic>> sink, String action) =>
+      (sink.singleWhere(
+                  (Map<String, dynamic> b) => b['action'] == action)['params']
+              as Map)['query']
+          .toString();
+
+  /// 判命中的那一句（同源的 `dupe:` 串）。
+  String matchQuery(List<Map<String, dynamic>> sink) =>
+      queryOf(sink, 'findNotes');
+
+  /// 真正交给 Anki 浏览器的那一句。
+  String browseQuery(List<Map<String, dynamic>> sink) =>
+      queryOf(sink, 'guiBrowse');
 
   setUp(() {
     // 前台让位是 Win32 副作用，单测里注入无害替身（非 Windows 上本就是 null）。
@@ -142,35 +189,34 @@ void main() {
       );
     });
 
-    test('↗ 不再另发一条 findNotes——没有第二条判据可以漂移', () async {
-      await installSettings();
-      final sink = <Map<String, dynamic>>[];
-      await repoWith(crossModelHost(sink)).openWordInAnki(kWord, '');
-
-      expect(
-        sink.map((Map<String, dynamic> b) => b['action']),
-        isNot(contains('findNotes')),
-      );
-      expect(
-        sink.map((Map<String, dynamic> b) => b['action']),
-        containsAll(<String>['modelNamesAndIds', 'guiBrowse']),
-      );
-    });
-
-    test('查询串：卡组过滤 + 每个笔记类型一个 dupe 子句，整组带括号', () async {
+    test('交给浏览器的那一句只有 nid:——词和卡组名都不进查询串', () async {
       await installSettings();
       final sink = <Map<String, dynamic>>[];
       await repoWith(crossModelHost(sink)).openWordInAnki(kWord, '');
 
       final String query = browseQuery(sink);
-      expect(query, startsWith('deck:"$kDeck" ('));
+      expect(query, 'nid:$kExistingNoteId');
+      // 名字进了搜索串就等于把判定交给 Anki 的通配匹配（`_`/`*`），那是第二条判据。
+      expect(query, isNot(contains(kWord)));
+      expect(query, isNot(contains('deck:')));
+      expect(query, isNot(contains('dupe:')));
+    });
+
+    test('判命中的那一句：卡组按 id 过滤 + 每个笔记类型一个 dupe 子句', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      await repoWith(crossModelHost(sink)).openWordInAnki(kWord, '');
+
+      final String query = matchQuery(sink);
+      expect(query, startsWith('(did:$kDeckDid) ('));
       expect(query, endsWith(')'));
       expect(query, contains('"dupe:$kLapisMid,$kWord"'));
       // 当前笔记类型之外的 mid 必须也在——本 bug 的整个要害就是那张 Kaishi 卡。
       expect(query, contains('"dupe:$kKaishiMid,$kWord"'));
       expect(query, contains(' OR '));
-      // 绝不能退回按字段名查。
+      // 绝不能退回按字段名查，也绝不能把卡组名塞回搜索串。
       expect(query, isNot(contains('Expression:')));
+      expect(query, isNot(contains('deck:')));
     });
 
     test('scope=collection 时不带卡组过滤（与查重同一口径）', () async {
@@ -178,18 +224,23 @@ void main() {
       final sink = <Map<String, dynamic>>[];
       await repoWith(crossModelHost(sink)).openWordInAnki(kWord, '');
 
-      final String query = browseQuery(sink);
-      expect(query, isNot(contains('deck:')));
+      final String query = matchQuery(sink);
+      expect(query, isNot(contains('did:')));
       expect(query, startsWith('('));
     });
 
-    test('Anki 应答「一张都没选中」→ noMatch（不是 failed）', () async {
+    test('一张都没查到 → noMatch（不是 failed），且不去开浏览器', () async {
       await installSettings();
       final sink = <Map<String, dynamic>>[];
       // 词换一个：假机只对 たっぷり 命中。
       expect(
         await repoWith(crossModelHost(sink)).openWordInAnki('未収録', ''),
         AnkiOpenWordOutcome.noMatch,
+      );
+      // 空的 `nid:` 会把整库摊开，绝不能发出去。
+      expect(
+        sink.map((Map<String, dynamic> b) => b['action']),
+        isNot(contains('guiBrowse')),
       );
     });
 
@@ -208,6 +259,19 @@ void main() {
       expect(
         sink.map((Map<String, dynamic> b) => b['action']),
         contains('guiBrowse'),
+      );
+    });
+
+    // 上面那条担心（旧版 `guiBrowse` 不回列表 → 不许说「没有卡」）在改按 id 查之后
+    // 是**结构性**成立的：返回值根本不参与判定。这条把它钉死——连「明确答空列表」
+    // 都不该改变结局，否则就是又把第二条判据接回来了。
+    test('guiBrowse 明确回空列表也不改变结局：判据在上一步的 findNotes', () async {
+      await installSettings();
+      final sink = <Map<String, dynamic>>[];
+      expect(
+        await repoWith(crossModelHost(sink, guiBrowseReturnsEmpty: true))
+            .openWordInAnki(kWord, ''),
+        AnkiOpenWordOutcome.opened,
       );
     });
 
@@ -254,20 +318,18 @@ void main() {
   group('BUG-2051 查询串构造', () {
     test('单个笔记类型也套括号：否则卡组条件只绑到第一个子句', () {
       final String query = ankiDuplicateSearchQuery(
-        deckName: kDeck,
         value: kWord,
-        scope: AnkiDuplicateScope.deck,
         modelIds: const <int>[kLapisMid],
+        deckIds: const <int>[kDeckDid],
       );
-      expect(query, 'deck:"$kDeck" ("dupe:$kLapisMid,$kWord")');
+      expect(query, '(did:$kDeckDid) ("dupe:$kLapisMid,$kWord")');
     });
 
     test('值里的引号被转义（否则整条查询被解析器截断）', () {
       final String query = ankiDuplicateSearchQuery(
-        deckName: '',
         value: 'a"b',
-        scope: AnkiDuplicateScope.collection,
         modelIds: const <int>[7],
+        deckIds: const <int>[],
       );
       expect(query, '("dupe:7,a\\"b")');
     });
@@ -275,32 +337,124 @@ void main() {
     test('没有笔记类型 / 空词 → 空串（绝不发一条把整库摊开的搜索）', () {
       expect(
         ankiDuplicateSearchQuery(
-          deckName: kDeck,
           value: kWord,
-          scope: AnkiDuplicateScope.deck,
           modelIds: const <int>[],
+          deckIds: const <int>[kDeckDid],
         ),
         isEmpty,
       );
       expect(
         ankiDuplicateSearchQuery(
-          deckName: kDeck,
           value: '',
-          scope: AnkiDuplicateScope.deck,
           modelIds: const <int>[kLapisMid],
+          deckIds: const <int>[kDeckDid],
         ),
         isEmpty,
       );
     });
 
-    test('deckRoot 取根卡组（与 ankiDuplicateDeckFilter 同一口径）', () {
-      final String query = ankiDuplicateSearchQuery(
-        deckName: '正在背::Lapis',
-        value: kWord,
-        scope: AnkiDuplicateScope.deckRoot,
-        modelIds: const <int>[kLapisMid],
+    test('多个卡组 id 也套括号：否则 `did:a OR did:b (X)` 查错范围', () {
+      expect(ankiDeckIdFilter(const <int>[1, 2]), '(did:1 OR did:2)');
+      expect(ankiDeckIdFilter(const <int>[]), isEmpty);
+    });
+
+    test('nid:a,b,c —— 全部同名笔记一次列出；空列表不产生查询串', () {
+      expect(ankiNoteIdBrowseQuery(const <int>[1, 2, 3]), 'nid:1,2,3');
+      expect(ankiNoteIdBrowseQuery(const <int>[7]), 'nid:7');
+      expect(ankiNoteIdBrowseQuery(const <int>[]), isEmpty);
+    });
+  });
+
+  /// 卡组名 → 卡组 id。这一组是「不按名字查」的判别力所在：名字一旦进 `deck:` 搜索串，
+  /// `_` 就成了单字通配符（本机实测 `deck:"e_grolls-…"` 与真名同样命中 10164 条），
+  /// 而画 ✓ 那侧是精确名（同样把一个字换成 `_` 就判「不重复」）。
+  group('BUG-2051 卡组范围按 id 解析（不进 Anki 的通配匹配）', () {
+    const Map<String, int> decks = <String, int>{
+      '正在背': 100,
+      '正在背::Lapis': 101,
+      '正在背::Lapis::N5': 102,
+      '正在背::Kaishi': 103,
+      '别的': 200,
+      'galgame_card_test': 300,
+      // 只差一个字符的兄弟卡组：`deck:"galgame_card_test"` 会把它一起圈进来。
+      'galgameXcard_test': 301,
+    };
+
+    test('deck：本组 + 子组，按名字前缀精确展开（对齐 checkChildren: true）', () {
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: '正在背::Lapis',
+          scope: AnkiDuplicateScope.deck,
+          deckNamesAndIds: decks,
+        ),
+        const <int>[101, 102],
       );
-      expect(query, startsWith('deck:"正在背" ('));
+    });
+
+    test('带 `_` 的卡组名只解析出它自己——兄弟卡组不得被通配进来', () {
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: 'galgame_card_test',
+          scope: AnkiDuplicateScope.deck,
+          deckNamesAndIds: decks,
+        ),
+        const <int>[300],
+      );
+    });
+
+    test('deckRoot 取根卡组，整棵树都在范围内', () {
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: '正在背::Lapis::N5',
+          scope: AnkiDuplicateScope.deckRoot,
+          deckNamesAndIds: decks,
+        ),
+        const <int>[100, 101, 102, 103],
+      );
+    });
+
+    test('collection / 空名 / 卡组已不存在 → 不加过滤（fail-open）', () {
+      for (final AnkiDuplicateScope scope in AnkiDuplicateScope.values) {
+        expect(
+          ankiDuplicateDeckIds(
+            deckName: '',
+            scope: scope,
+            deckNamesAndIds: decks,
+          ),
+          isEmpty,
+        );
+      }
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: '正在背::Lapis',
+          scope: AnkiDuplicateScope.collection,
+          deckNamesAndIds: decks,
+        ),
+        isEmpty,
+      );
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: '已被删掉的卡组',
+          scope: AnkiDuplicateScope.deck,
+          deckNamesAndIds: decks,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('前缀相同但不是子组的卡组不被卷入（`Lapis2` ≠ `Lapis::*`）', () {
+      expect(
+        ankiDuplicateDeckIds(
+          deckName: '正在背::Lapis',
+          scope: AnkiDuplicateScope.deck,
+          deckNamesAndIds: const <String, int>{
+            '正在背::Lapis': 1,
+            '正在背::Lapis2': 2,
+            '正在背::Lapis::N5': 3,
+          },
+        ),
+        const <int>[1, 3],
+      );
     });
   });
 


### PR DESCRIPTION
接 #1171（已合并）。用户指出：「最好不要按名字查，anki 按名字查会非常灾难。改成获取全部同名的 id 呢」。

## #1171 只同源了一半

`dupe:` 那半对了，**卡组那半没有**：我用的是 `deck:"<名字>"`，走 Anki 搜索的**通配匹配**；而画 ✓ 那侧（AnkiConnect `duplicateScopeOptions.deckName`）是**精确名**。本机真机实测：

| 卡组条件 | ↗ 侧 `findNotes` | ✓ 侧 `canAddNotesWithErrorDetail` |
|---|---|---|
| 真名 `eggrolls-JLPT10k-v3` | 10164 条 | 判重复 |
| 把一个字换成 `_` | **同样 10164 条**（`_` = 单字通配） | **判不重复** |
| `e*` / `正在背::*` | **整棵树** | **判不重复** |
| 不存在的名字 | 0 条 | 判不重复（静默，不报错） |

只要卡组名里有 `_` 或 `*`（本机就有 `galgame_card_test` / `galgame_track_test`），两侧对「哪些卡在范围内」就给出不同答案——判据的下一个漂移入口，和本 bug 同一个形状。

## 改法：查询串里不留名字

- **卡组名 → 卡组 id**：新增 `deckNamesAndIds` + `ankiDuplicateDeckIds`。名字在 Dart 里做**精确**匹配（`名 == 目标` 或 `名.startsWith('目标::')`，对齐查重侧的 `checkChildren: true`），查询串用 `did:`。实测 `did:` 不含子卡组（父卡组 `did:` n=1 而 `deck:` n=10164），所以子树必须自己展开。
- **命中 → note id → `nid:a,b,c`**：新增 `ankiNoteIdBrowseQuery`。浏览器那句里没有词、没有卡组名，只有 id——「浏览器里列出来的」与「我们判定命中的」在物理上是同一批笔记。
- 于是**查询串里唯一还留着的名字是 `dupe:` 里那个词，而它恰好是 Anki 唯一做精确文本比较的地方**（`*` 在那里不是通配符，已实测）。这条路没有替代品：`canAddNotes` 只回布尔、给不出 id。
- 代价是多一次 `findNotes` 往返。它**不是**第二条判据：`nid:` 按上一步的结果 id 定位，不重新匹配任何东西。

顺带把 #1171 审查里那条「旧版 AnkiConnect 的 `guiBrowse` 不回列表时不许说没有卡」变成结构性成立的：**返回值现在根本不参与判定**，新旧版机器在这条路径上没有行为差异。`guiBrowseQuery` 的 `null` / `[]` 区分保留给其它调用方。

## 验证

- **真机 E2E**（本机 AnkiConnect 25.x）：`与える` 同时是一张 Kaishi 笔记（第一字段名 `Word`）和一张 Lapis 笔记（`Expression`）——正是本 bug 的原型形状。同源查询返回 `[1788020832613, 1758347125581]`，与逐条枚举第一字段的结果完全一致，`guiBrowse('nid:1758347125581,1788020832613')` 一次列出两张，`cardsInfo` 确认卡组/笔记类型/第一字段。该库 `正在背` 树下 2894 条笔记里 **44 个词跨 ≥2 种笔记类型**。原始失败路径（app 内点 ↗）未在真机 app 里复测。
- `flutter analyze --no-pub`（fushi）+ `dart analyze`（fushi_anki，`flutter analyze` 覆盖不到 path 依赖包）全绿。
- `test/anki` + 四个守卫 + `test/utils/misc`：`FLUTTER TEST VERDICT: PASSED - 1148 tests ran`；`packages/fushi_anki` 23 条（14 → 23）。
- **变异实测**（每条按唯一锚点还原 + sha256 核对，不用 `git checkout`）：子卡组用裸前缀 → 精确 1 条红；`nid:` 只列第一张 → 精确 1 条红；把带词的 `dupe:` 串直接丢给浏览器（退回 #1171 形状）→ 单测 1 条 + 静态守卫 1 条红；`deck` scope 失效 → 4 条红；查不到照样开浏览器 → 精确 1 条红。
- 顺带修掉静态守卫的一个空转风险：取函数体用 `indexOf('\n}')` 会先命中**命名参数表**的 `})`（同样在列 0），把函数体截成参数表、后续断言全部恒假。改成跳过后面紧跟 `)` 的（`topLevelBodyEnd`），并加了「取到的片段必须含 `dupe:`」的非空转自检。

## 已知遗留（未变，另开）

点 ✓ 的操作面板仍走 `findMatchingNotes`（按第一字段**名**查），跨笔记类型时拿到空集 → popup.js 落回「当新卡制」→ 又被 Anki 以重复拒绝。同根不同入口；它的卡组过滤也还是 `deck:"<名字>"` 那条通配路径。

详见 `docs/bugs/BUG-2051-anki-open-in-anki-not-same-source.md`。

https://claude.ai/code/session_01U9HiURpKMQj58CzFE3L9fX
