### PR TITLE
test(ext): 修 develop 上的渐进渲染守卫红，并补钉调度器本身真让出

### DIFF
--- a/tools/browser-extension/side-panel-performance.test.js
+++ b/tools/browser-extension/side-panel-performance.test.js
@@ -105,18 +105,44 @@ test('shared popup mouse listeners ignore events outside the dictionary shadow r
 
 test('shared popup yields between remaining dictionary entries', () => {
   // 真实实现叫 renderNextDictionaryBlock（vendor/popup.js），语义是「每个宏任务最多建
-  // 一个词典块」：首词条首块渲染完就先 _firePopupRendered，余块/余词条全部排进宏任务队列。
+  // 一个时间片的词典块」：首词条首块渲染完就先 _firePopupRendered，余块/余词条全部排进
+  // 宏任务队列。BUG-2039 把让出点从裸 setTimeout 换成 scheduleRenderTail（MessageChannel
+  // 优先、setTimeout 兜底），**让出这件事本身没变**，所以判据跟着换调度器名字即可。
   assert.match(POPUP, /const renderNextDictionaryBlock = \(\) => \{/);
-  // 还有未建的块或词条时必须 setTimeout(..., 0) 让出宏任务，而不是同步 while/for 一次建完。
+  // 还有未建的块或词条时必须让出宏任务，而不是同步 while/for 一次建完。
   assert.match(
     POPUP,
-    /if \(activeEntryElement \|\| nextEntryIndex < entries\.length\) \{\s*\n\s*setTimeout\(renderNextDictionaryBlock, 0\);/,
+    /if \(activeEntryElement \|\| nextEntryIndex < entries\.length\) \{\s*\n\s*scheduleRenderTail\(renderNextDictionaryBlock\);/,
   );
-  // 两处调度：首批渲染后启动队列 + 每建一块后续跑。少一处就说明某条路径退回同步渲染。
-  const yieldSites = POPUP.match(/setTimeout\(renderNextDictionaryBlock, 0\)/g) || [];
+  // 两处调度：首批渲染后启动队列 + 每建一片后续跑。少一处就说明某条路径退回同步渲染。
+  const yieldSites = POPUP.match(/scheduleRenderTail\(renderNextDictionaryBlock\)/g) || [];
   assert.strictEqual(yieldSites.length, 2, '渐进渲染的宏任务让出点必须有且仅有 2 处');
   // 让出点之外不得再有同步续跑的直呼（renderNextDictionaryBlock() 裸调用）。
   assert.doesNotMatch(POPUP, /(?<!function )renderNextDictionaryBlock\(\)\s*;/);
+});
+
+// BUG-2039 之后补的一环：上面那条只证明「调用了调度器」，证明不了「调度器真的让出」。
+// 把 scheduleRenderTail 的函数体换成 `task()` 同步直呼，上面四条断言**全部照绿**——而渐进
+// 渲染已经退化成一次同步建完。所以调度器自己也必须被钉住。
+test('scheduleRenderTail 真的让出宏任务，不得同步执行 task', () => {
+  const head = 'function scheduleRenderTail(task) {';
+  const start = POPUP.indexOf(head);
+  assert.notStrictEqual(start, -1, '找不到 scheduleRenderTail —— 判据锚点已失效');
+  const end = POPUP.indexOf('\n}', start);
+  assert.notStrictEqual(end, -1, '取不到 scheduleRenderTail 函数体');
+  // 剥注释再判：实测过一次——把函数体换成 `task();` 但在注释里留下
+  // `postMessage` / `setTimeout(task, 0)` 字面量，下面两条**要求型**断言会被注释满足。
+  // （本函数很短、体内无正则字面量也无含 `//` 的字符串，这个朴素剥法足够。）
+  const body = POPUP.slice(start + head.length, end)
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/\/\/[^\n]*/g, ' ');
+  // 自校验：窗口没塌成空壳（下面的否定断言在空串上恒真）。
+  assert.ok(body.length > 40, 'scheduleRenderTail 函数体窗口异常小，判据已失效');
+  assert.match(body, /setTimeout\(task, 0\)/, '必须保留 setTimeout 兜底路径');
+  assert.match(body, /postMessage\(/, '快路径必须经消息队列让出，而不是直接跑');
+  // 核心不变式：函数体里不得出现同步直呼。
+  assert.doesNotMatch(body, /(?<![.\w])task\(\)/,
+      'scheduleRenderTail 不得同步执行 task —— 那等于取消了渐进渲染');
 });
 
 test('lookup latency is logged by stage and exposed from extension settings', () => {


### PR DESCRIPTION
## develop 当前是红的

`tools/browser-extension/side-panel-performance.test.js` 的 `shared popup yields between remaining dictionary entries` 在 `develop`（`e48c11af11`）上**失败**：

```
AssertionError: The input did not match the regular expression
  /if \(activeEntryElement \|\| nextEntryIndex < entries\.length\) \{\s*\n\s*setTimeout\(renderNextDictionaryBlock, 0\);/
```

来源是 BUG-2039（PR #1152）的弹窗渲染尾巴改造：让出点从裸 `setTimeout(renderNextDictionaryBlock, 0)` 换成了 `scheduleRenderTail(renderNextDictionaryBlock)`（MessageChannel 优先、`setTimeout` 兜底），守卫没跟着改。

**为什么漏过了 CI**：这是 node 测试，不在 `flutter test` 覆盖面里，本仓的真单测门（Build Release APK 的 Run unit tests）跑不到它。PR #1152 自己的分支基底早于合入，在分支上跑是绿的——红只在合入后的 develop 上出现。

## 改动

1. **判据跟上新调度器**：四条断言（函数存在 / 续跑处让出 / 有且仅有 2 处调度 / 不得裸调）逐条把 `setTimeout(renderNextDictionaryBlock, 0)` 换成 `scheduleRenderTail(renderNextDictionaryBlock)`。**让出这件事本身没变**，所以是换名字不是放宽。

2. **补上原来就缺的一环**（这条比修红更重要）：上面四条只证明「调用了调度器」，证明不了「调度器真的让出」。新增 `scheduleRenderTail 真的让出宏任务，不得同步执行 task`——取出函数体，要求两条路径都在（`postMessage(` 快路径 + `setTimeout(task, 0)` 兜底），并禁止体内出现同步直呼 `task()`。带函数体窗口自校验（长度下界），防止锚点失效后否定断言在空串上恒真。

## 变异实测

| 变异 | 结果 | 还原 |
|---|---|---|
| **MUT-1** `scheduleRenderTail` 体改成 `task();`（同步直呼） | 12 绿 → **11 绿 / 1 红**，**唯一红的是新加那条**，旧四条全绿 | `vendor/popup.js` sha256 `3d76806e…` 逐字节一致 |
| **MUT-2** 同上，且在注释里塞齐 `postMessage(` 与 `setTimeout(task, 0)` 两个要求型字面量 | **11 绿 / 1 红** | sha256 一致 |

MUT-1 就是这个洞的存在性证明：**渐进渲染退化成一次同步建完，旧守卫全绿**。MUT-2 是给判据本身做的自校验——第一轮实测时注释里的字面量确实满足了两条要求型断言，于是给函数体加了剥注释再判（该函数很短、体内无正则字面量也无含 `//` 的字符串，朴素剥法足够）。

两次还原均用唯一锚点精确替换，**未用 `git checkout`**。

## 验证

- `node --test`（`tools/browser-extension` 全部 `*.test.js`）**exit 0**
- `node scripts/sync-mirrors.mjs --check` **exit 0**，镜像一致（本 PR 只改测试文件，`.test.js` 按既有约定不镜像）
