### PR TITLE
fix(video): 副字幕的持久化指针也要补进字幕轨菜单（BUG-2094）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1964 条。点号进各自文件。
+> 共 1965 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2094](bugs/BUG-2094-secondary-subtitle-import-not-listed.md) | ✅ | ✅ | 导入的副字幕在字幕列表里消失，但画面仍在渲染它 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |
 | [BUG-2088](bugs/BUG-2088-release-notes-never-reach-update-dialog.md) | ✅ | ✅ | 正式版更新公告进不了应用内更新弹窗，用户看到的是一行占位符 |

--- a/docs/bugs/BUG-2094-secondary-subtitle-import-not-listed.md
+++ b/docs/bugs/BUG-2094-secondary-subtitle-import-not-listed.md
@@ -1,0 +1,8 @@
+## BUG-2094 · 导入的副字幕在字幕列表里消失，但画面仍在渲染它
+- **报告**：2026-09-03（用户：截图，视频设置 → 字幕）
+- **现象**：画面上同时渲染主 + 副两行字幕，但设置面板「字幕轨」列表和「副字幕」分组里都只剩一条 sidecar/主字幕，用户导入的那条副字幕档在两个列表里都没有；副字幕组里没有任何一行是高亮的（当前副字幕源不在列表里），因此也切不回来、删不掉。
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/media/video/video_subtitle_source.dart:844` `includeCurrentPersistedSubtitleForMenu` 只补**主**字幕一条持久化指针。
+- **根因**：字幕轨菜单的最终列表由三份拼成——① `listAllSubtitleSources` 枚举（按设计只看内封轨 + 视频**同目录** sidecar，永远看不到导入档所在的 `<dataRoot>/documents/video_subtitles/`）；② `_importedSubtitleSources`（**本会话**登记，换视频/换集清空，`video_fushi_page.dart:2396` 一带）；③ `includeCurrentPersistedSubtitleForMenu` 补「当前持久化的导入档」。第 ③ 层是跨会话唯一的补齐通道，而它只认 `currentSubtitleSource`（主字幕）一条指针，副字幕指针 `_currentSecondarySubtitleSource`（`video_fushi_page.dart:2204` 从 `row.secondarySubtitleSource` 恢复）从来没有对应的补齐。于是重开视频后：副字幕 cue 照常从库里重放继续渲染，而列表里没有任何一行承载那个档案。这正是 BUG-1861 在主字幕那半已经修掉的同一个洞（「字幕应用上了、列表里却没有它」），副字幕这半没修。
+- **[x] ① 已修复** — `includeCurrentPersistedSubtitleForMenu` 改为对「当前正在使用的每一条持久化指针」（主、副）跑**同一条**补齐规则（是导入档 + 文件在盘上 + 能解析出 cue），用循环而不是主/副两套分支；主副选同一档时按归一化路径去重只列一行，主字幕仍排最前。调用点 `_subtitleSourcesForMenu` / `_ensureSubtitleMenuSourcesLoaded` 把 `_currentSecondarySubtitleSource` + `controller.secondaryCues` 传下去。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_source_test.dart`：只作副字幕用的导入档要被列出、主副两档都在且主在前、主副同档只列一行；`fushi/test/pages/video_subtitle_fixes_guard_test.dart` 的 TODO-016 守卫补了 wiring 断言（helper 与枚举入口都必须把副字幕指针/cue 传下去）。
+- **备注**：**远端（互联/YouTube）模式同形缺口未修**——远端分支的字幕行不读 `_menuSubtitleSources`，本机落盘档只由本会话的 `_importedSubtitleSources` 承载，跨会话恢复后同样没有行。本次只修用户报告的本地视频路径，远端那半需要各自的持久化指针补齐，待单独一条处理。

--- a/fushi/lib/src/media/video/video_subtitle_source.dart
+++ b/fushi/lib/src/media/video/video_subtitle_source.dart
@@ -831,46 +831,71 @@ typedef SubtitleCueLoader = Future<List<AudioCue>> Function(
   String bookUid,
 );
 
-/// Adds the currently persisted imported subtitle to a menu source list.
+/// Adds the currently persisted imported subtitles to a menu source list.
 ///
 /// [listAllSubtitleSources] intentionally sees only embedded tracks and sidecar
 /// files next to [videoPath]. User-imported subtitles live in app documents, so
-/// the menu needs this one explicit persisted path. It never scans the import
+/// the menu needs these explicit persisted paths. It never scans the import
 /// directory and never adds unrelated historical imports.
 ///
-/// The current persisted import is placed before enumerated tracks. The subtitle
-/// sheet has a capped viewport; appending after embedded tracks can keep the
-/// active import below the initially visible menu items after reopening.
+/// The current persisted imports are placed before enumerated tracks. The
+/// subtitle sheet has a capped viewport; appending after embedded tracks can
+/// keep the active import below the initially visible menu items after
+/// reopening.
+///
+/// BUG-2094：**主字幕和副字幕各是一条独立的持久化指针，两条都要被补齐**。此前只补
+/// [currentSubtitleSource] 一条，于是「只被选作副字幕的导入档」在重开视频后从列表里
+/// 彻底消失：枚举按设计看不到 `<dataRoot>/documents/video_subtitles/`，本会话登记的
+/// [mergeImportedSubtitleSourcesForMenu] 输入又按视频源作用域清空，而副字幕 cue 仍从
+/// 库里重放——用户看到「副字幕没了，但视频里还在显示」，且副字幕组里没有任何一行是
+/// 高亮的（当前源不在列表里）。这正是 BUG-1861 在主字幕那半已修掉的同一个洞。
+/// 两条指针走**同一条**补齐规则（导入档 + 文件在盘上 + 能解析出 cue），用循环而不是
+/// 主/副两套分支；主字幕排在副字幕前，与「当前主字幕最靠前」的既有约定一致。
 Future<List<SubtitleSource>> includeCurrentPersistedSubtitleForMenu(
   List<SubtitleSource> sources, {
   required String videoPath,
   required String bookUid,
   required String? currentSubtitleSource,
+  String? currentSecondarySubtitleSource,
   List<AudioCue> currentCues = const <AudioCue>[],
+  List<AudioCue> currentSecondaryCues = const <AudioCue>[],
   SubtitleCueLoader? loadCues,
 }) async {
   final List<SubtitleSource> result = List<SubtitleSource>.of(sources);
-  if (currentSubtitleSource == null ||
-      !isImportedExternalSubtitlePath(currentSubtitleSource) ||
-      !File(currentSubtitleSource).existsSync()) {
-    return result;
+  final List<SubtitleSource> extras = <SubtitleSource>[];
+  final List<(String?, List<AudioCue>)> persistedSelections =
+      <(String?, List<AudioCue>)>[
+    (currentSubtitleSource, currentCues),
+    (currentSecondarySubtitleSource, currentSecondaryCues),
+  ];
+
+  for (final (String? persisted, List<AudioCue> cues) in persistedSelections) {
+    if (persisted == null ||
+        !isImportedExternalSubtitlePath(persisted) ||
+        !File(persisted).existsSync()) {
+      continue;
+    }
+    // 已被枚举列出（视频同目录 sidecar）或已被另一条指针补进来（主副选同一档）
+    // 都不重复列出——去重判据与列表高亮同一个（大小写 / 分隔符归一）。
+    if (result.any((SubtitleSource source) =>
+            sameExternalSubtitlePathForMenu(source, persisted)) ||
+        extras.any((SubtitleSource source) =>
+            sameExternalSubtitlePathForMenu(source, persisted))) {
+      continue;
+    }
+    final SubtitleSource source = SubtitleSource.external(
+      externalPath: persisted,
+      label: p.basename(persisted),
+    );
+    final bool hasUsableCues = cues.isNotEmpty ||
+        (await (loadCues ?? loadCuesForSource)(source, videoPath, bookUid))
+            .isNotEmpty;
+    if (!hasUsableCues) continue;
+    extras.add(source);
   }
 
-  if (result.any((SubtitleSource source) =>
-      sameExternalSubtitlePathForMenu(source, currentSubtitleSource))) {
-    return result;
-  }
-
-  final SubtitleSource source = SubtitleSource.external(
-    externalPath: currentSubtitleSource,
-    label: p.basename(currentSubtitleSource),
-  );
-  final bool hasUsableCues = currentCues.isNotEmpty ||
-      (await (loadCues ?? loadCuesForSource)(source, videoPath, bookUid))
-          .isNotEmpty;
-  if (!hasUsableCues) return result;
-
-  return <SubtitleSource>[source, ...result];
+  if (extras.isEmpty) return result;
+  return <SubtitleSource>[...extras, ...result];
 }
 
 bool subtitleSourceMatchesPersistedForMenu(

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -787,6 +787,8 @@ extension _VideoSubtitle on _VideoFushiPageState {
         videoPath: videoPath,
         currentSubtitleSource: _currentSubtitleSource,
         currentCues: controller.cues,
+        currentSecondarySubtitleSource: _currentSecondarySubtitleSource,
+        currentSecondaryCues: controller.secondaryCues,
       );
     } catch (_) {
       enumerated = null;

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -3088,10 +3088,15 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   }
 
   /// 字幕菜单来源：保留当前视频枚举结果，再只补入「当前视频已持久化」的导入字幕。
+  ///
+  /// BUG-2094：主字幕与副字幕**两条**持久化指针都要补——只被选作副字幕的导入档否则
+  /// 在重开视频后从列表里消失（画面还在显示它）。
   Future<List<SubtitleSource>> _subtitleSourcesForMenu({
     required String videoPath,
     required String? currentSubtitleSource,
     required List<AudioCue> currentCues,
+    required String? currentSecondarySubtitleSource,
+    required List<AudioCue> currentSecondaryCues,
   }) async {
     final List<SubtitleSource> sources = await listAllSubtitleSources(
       videoPath,
@@ -3103,6 +3108,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       bookUid: widget.bookUid,
       currentSubtitleSource: currentSubtitleSource,
       currentCues: currentCues,
+      currentSecondarySubtitleSource: currentSecondarySubtitleSource,
+      currentSecondaryCues: currentSecondaryCues,
     );
   }
 

--- a/fushi/test/media/video/video_subtitle_source_test.dart
+++ b/fushi/test/media/video/video_subtitle_source_test.dart
@@ -784,6 +784,95 @@ TODO016 imported subtitle survives reopen.
       expect(sources, hasLength(1));
       expect(sources.single.label, 'already-listed.srt');
     });
+
+    // BUG-2094：只被选作**副**字幕的导入档也必须有一行。此前菜单只补主字幕那条
+    // 持久化指针，重开视频后（本会话登记的导入档已按视频源作用域清空、枚举又永远
+    // 看不到 video_subtitles/）副字幕那个档在列表里彻底消失，而它的 cue 仍从库里
+    // 重放——「副字幕没了，但视频里还在显示」。
+    test('lists an import that is only used as the secondary subtitle',
+        () async {
+      final List<SubtitleSource> sources =
+          await includeCurrentPersistedSubtitleForMenu(
+        const <SubtitleSource>[
+          SubtitleSource.embedded(streamIndex: 0, label: '内封 0: jpn / ass'),
+        ],
+        videoPath: video.path,
+        bookUid: 'video/todo016',
+        currentSubtitleSource: 'embedded:0',
+        currentSecondarySubtitleSource: imported.path,
+        currentSecondaryCues: <AudioCue>[
+          _cue('video/todo016', 'secondary line'),
+        ],
+        loadCues: (_, __, ___) {
+          fail('已有副字幕 cues 时不应再二次解析');
+        },
+      );
+
+      expect(
+        sources.map((SubtitleSource s) => s.label).toList(),
+        <String>[
+          'todo016-imported-reentry.srt',
+          '内封 0: jpn / ass',
+        ],
+      );
+    });
+
+    test('lists both persisted imports with the primary one first', () async {
+      final File secondaryImported = File(p.join(
+        tempDir.path,
+        'video_subtitles',
+        'todo016-secondary.srt',
+      ))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+1
+00:00:00,000 --> 00:00:01,000
+BUG-2094 secondary import.
+''');
+
+      final List<SubtitleSource> sources =
+          await includeCurrentPersistedSubtitleForMenu(
+        const <SubtitleSource>[
+          SubtitleSource.embedded(streamIndex: 0, label: '内封 0: jpn / ass'),
+        ],
+        videoPath: video.path,
+        bookUid: 'video/todo016',
+        currentSubtitleSource: imported.path,
+        currentCues: <AudioCue>[_cue('video/todo016', 'primary line')],
+        currentSecondarySubtitleSource: secondaryImported.path,
+        currentSecondaryCues: <AudioCue>[
+          _cue('video/todo016', 'secondary line'),
+        ],
+      );
+
+      expect(
+        sources.map((SubtitleSource s) => s.label).toList(),
+        <String>[
+          'todo016-imported-reentry.srt',
+          'todo016-secondary.srt',
+          '内封 0: jpn / ass',
+        ],
+      );
+    });
+
+    test('lists a single row when primary and secondary share one file',
+        () async {
+      final List<SubtitleSource> sources =
+          await includeCurrentPersistedSubtitleForMenu(
+        const <SubtitleSource>[],
+        videoPath: video.path,
+        bookUid: 'video/todo016',
+        currentSubtitleSource: imported.path,
+        currentCues: <AudioCue>[_cue('video/todo016', 'primary line')],
+        currentSecondarySubtitleSource: p.normalize(imported.path),
+        currentSecondaryCues: <AudioCue>[
+          _cue('video/todo016', 'secondary line'),
+        ],
+      );
+
+      expect(sources, hasLength(1));
+      expect(sources.single.externalPath, imported.path);
+    });
   });
 
   group('embedded subtitle cache prewarm (TODO-011)', () {

--- a/fushi/test/pages/video_subtitle_fixes_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_fixes_guard_test.dart
@@ -122,6 +122,31 @@ void main() {
         reason: '已有 DB cues 的重进路径必须把当前 controller cues 传给菜单 helper');
     expect(helper.contains('Directory('), isFalse,
         reason: 'TODO-016 的保守方案禁止扫描整个 video_subtitles 目录');
+
+    // BUG-2094：副字幕是**另一条**独立的持久化指针，同样要补进菜单。少传这两个参数
+    // 时，只被选作副字幕的导入档在重开视频后没有任何一行承载它，而它的 cue 仍从库里
+    // 重放——「副字幕没了，但视频里还在显示」。
+    expect(
+        helper.contains(
+            'currentSecondarySubtitleSource: currentSecondarySubtitleSource'),
+        isTrue,
+        reason: '副字幕的持久化指针也要补进菜单，否则只作副字幕用的导入档会消失（BUG-2094）');
+    expect(
+        helper.contains('currentSecondaryCues: currentSecondaryCues'), isTrue,
+        reason: '已恢复的副字幕 cues 要作为「这个档能用」的证据传下去（BUG-2094）');
+
+    final String ensure = region(
+      'Future<void> _ensureSubtitleMenuSourcesLoaded()',
+      'void _registerImportedSubtitleSource(',
+    );
+    expect(
+        ensure.contains(
+            'currentSecondarySubtitleSource: _currentSecondarySubtitleSource'),
+        isTrue,
+        reason: '枚举入口须把当前副字幕持久化指针传给菜单 helper（BUG-2094）');
+    expect(ensure.contains('currentSecondaryCues: controller.secondaryCues'),
+        isTrue,
+        reason: '枚举入口须把当前副字幕 cues 传给菜单 helper（BUG-2094）');
   });
 
   test('BUG-133: 视频页有页级拖放目标 + 导入去重防护', () {


### PR DESCRIPTION
## 现象

用户报「导入的副字幕没了但是视频里还是显示的」。截图里画面上主 + 副两行字幕都在渲染，但「字幕轨」列表和「副字幕」分组里都只剩那条 sidecar，用户导入的副字幕档在两个列表里都没有；副字幕组里没有任何一行是高亮的——当前副字幕源不在列表里，因此也切不回来、删不掉。

## 根因

`fushi/lib/src/media/video/video_subtitle_source.dart:844` `includeCurrentPersistedSubtitleForMenu` 只补**主**字幕一条持久化指针。

字幕轨菜单的最终列表由三份拼成：

1. `listAllSubtitleSources` 枚举 —— 按设计只看内封轨 + 视频**同目录** sidecar，永远看不到导入档所在的 `<dataRoot>/documents/video_subtitles/`；
2. `_importedSubtitleSources` —— **本会话**登记，换视频/换集清空；
3. `includeCurrentPersistedSubtitleForMenu` —— 补「当前持久化的导入档」。

第 ③ 层是跨会话唯一的补齐通道，而它只认 `currentSubtitleSource`，副字幕指针 `_currentSecondarySubtitleSource`（从 `row.secondarySubtitleSource` 恢复）从来没有对应的补齐。于是重开视频后：副字幕 cue 照常从库里重放继续渲染，而列表里没有任何一行承载那个档案。这正是 BUG-1861 在主字幕那半已经修掉的同一个洞。

## 改动

把补齐规则从「一条指针」推广成「当前正在使用的每一条指针」：主、副走**同一条**规则的循环（是导入档 + 文件在盘上 + 能解析出 cue），而不是主/副两套分支；主副选同一档时按归一化路径去重只列一行，主字幕仍排最前。调用点 `_subtitleSourcesForMenu` / `_ensureSubtitleMenuSourcesLoaded` 把 `_currentSecondarySubtitleSource` + `controller.secondaryCues` 传下去。

## 测试

- `fushi/test/media/video/video_subtitle_source_test.dart` 新增 3 条行为用例：只作副字幕用的导入档要被列出、主副两档都在且主在前、主副同档只列一行。
- `fushi/test/pages/video_subtitle_fixes_guard_test.dart` 的 TODO-016 守卫补 4 条 wiring 断言。
- **变异实测**：去掉补齐循环里的副字幕项 → 2 条行为用例红；枚举入口改传 `null` → 守卫红在新断言上（还原后 sha256 与变异前一致）。

## 验证

- `flutter analyze`：No issues found（48.6s，exit 0）。
- 定向：**193 tests passed**（`video_subtitle_source` / `video_subtitle_fixes_guard` / `video_quick_settings_sheet` / `video_remote_subtitle_menu_guard`），exit 0。
- 未做真机复测；合入前的本地全量测试按仓库纪律仍需补。

## 已知边界

**远端（互联 / YouTube）模式的同形缺口未在本次修**：远端分支的字幕行不读 `_menuSubtitleSources`，本机落盘档只由本会话的 `_importedSubtitleSources` 承载，跨会话恢复后同样没有行。已记在 `docs/bugs/BUG-2094-*.md` 备注里，待单独一条处理。

https://claude.ai/code/session_01WkFh5nvxQSHuKRFe45N1Zz
