### PR TITLE
feat(video): 库页卡片与详情页标注清晰度/HDR/编码/音轨（schema v95）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71060 (4180 per locale)
+/// Strings: 71264 (4192 per locale)
 ///
-/// Built on 2026-09-03 at 03:52 UTC
+/// Built on 2026-09-03 at 08:48 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5734,6 +5734,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connected. Root catalog has ${count} entries';
   String discovery_opds_test_failed({required Object reason}) =>
       'Connection failed: ${reason}';
+  String get video_specs_title => 'Media info';
+  String get video_specs_resolution => 'Resolution';
+  String get video_specs_dynamic_range => 'Dynamic range';
+  String get video_specs_video_codec => 'Video codec';
+  String get video_specs_bit_depth => 'Bit depth';
+  String get video_specs_frame_rate => 'Frame rate';
+  String get video_specs_bitrate => 'Bitrate';
+  String get video_specs_audio_tracks => 'Audio tracks';
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  String get video_specs_track_commentary => 'Commentary';
+  String get video_specs_track_forced => 'Forced';
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -15474,6 +15486,30 @@ class _StringsAr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'فشل الاتصال: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -25441,6 +25477,30 @@ class _StringsDe extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbindung fehlgeschlagen: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -35460,6 +35520,30 @@ class _StringsEs extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Error de conexión: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -45514,6 +45598,30 @@ class _StringsFr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Échec de la connexion : ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -55373,6 +55481,30 @@ class _StringsId extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Koneksi gagal: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -65323,6 +65455,30 @@ class _StringsIt extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Connessione non riuscita: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -74661,6 +74817,30 @@ class _StringsJa extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '接続に失敗しました: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -84009,6 +84189,30 @@ class _StringsKo extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '연결 실패: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -93914,6 +94118,30 @@ class _StringsNl extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbinding mislukt: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -103873,6 +104101,30 @@ class _StringsPtBr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Falha na conexão: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -113811,6 +114063,30 @@ class _StringsRu extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Не удалось подключиться: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -123547,6 +123823,30 @@ class _StringsTh extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'เชื่อมต่อไม่สำเร็จ: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -133400,6 +133700,30 @@ class _StringsTr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Bağlantı başarısız: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -143224,6 +143548,30 @@ class _StringsVi extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Kết nối thất bại: ${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 // Path: <root>
@@ -152251,6 +152599,30 @@ class _StringsZhCn extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '连接失败：${reason}';
+  @override
+  String get video_specs_title => '媒体信息';
+  @override
+  String get video_specs_resolution => '清晰度';
+  @override
+  String get video_specs_dynamic_range => '动态范围';
+  @override
+  String get video_specs_video_codec => '视频编码';
+  @override
+  String get video_specs_bit_depth => '色深';
+  @override
+  String get video_specs_frame_rate => '帧率';
+  @override
+  String get video_specs_bitrate => '码率';
+  @override
+  String get video_specs_audio_tracks => '音轨';
+  @override
+  String get video_specs_subtitle_tracks => '字幕轨';
+  @override
+  String get video_specs_track_commentary => '评论音轨';
+  @override
+  String get video_specs_track_forced => '强制';
+  @override
+  String get video_specs_track_default => '默认';
 }
 
 // Path: <root>
@@ -161283,6 +161655,30 @@ class _StringsZhHk extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '連線失敗：${reason}';
+  @override
+  String get video_specs_title => 'Media info';
+  @override
+  String get video_specs_resolution => 'Resolution';
+  @override
+  String get video_specs_dynamic_range => 'Dynamic range';
+  @override
+  String get video_specs_video_codec => 'Video codec';
+  @override
+  String get video_specs_bit_depth => 'Bit depth';
+  @override
+  String get video_specs_frame_rate => 'Frame rate';
+  @override
+  String get video_specs_bitrate => 'Bitrate';
+  @override
+  String get video_specs_audio_tracks => 'Audio tracks';
+  @override
+  String get video_specs_subtitle_tracks => 'Subtitle tracks';
+  @override
+  String get video_specs_track_commentary => 'Commentary';
+  @override
+  String get video_specs_track_forced => 'Forced';
+  @override
+  String get video_specs_track_default => 'Default';
 }
 
 /// Flat map(s) containing all translations.
@@ -169859,6 +170255,30 @@ extension on _StringsEn {
             'Connected. Root catalog has ${count} entries';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Connection failed: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -178430,6 +178850,30 @@ extension on _StringsAr {
             'تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'فشل الاتصال: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -187046,6 +187490,30 @@ extension on _StringsDe {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Verbindung fehlgeschlagen: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -195653,6 +196121,30 @@ extension on _StringsEs {
             'Conectado. El catálogo raíz tiene ${count} entradas';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Error de conexión: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -204269,6 +204761,30 @@ extension on _StringsFr {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Échec de la connexion : ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -212856,6 +213372,30 @@ extension on _StringsId {
             'Terhubung. Katalog akar berisi ${count} entri';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Koneksi gagal: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -221465,6 +222005,30 @@ extension on _StringsIt {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Connessione non riuscita: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -230001,6 +230565,30 @@ extension on _StringsJa {
         return ({required Object count}) => '接続しました。ルートカタログに ${count} 件あります';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '接続に失敗しました: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -238541,6 +239129,30 @@ extension on _StringsKo {
             '연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '연결 실패: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -247143,6 +247755,30 @@ extension on _StringsNl {
             'Verbonden. De hoofdcatalogus heeft ${count} items';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Verbinding mislukt: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -255740,6 +256376,30 @@ extension on _StringsPtBr {
             'Conectado. O catálogo raiz tem ${count} itens';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Falha na conexão: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -264344,6 +265004,30 @@ extension on _StringsRu {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Не удалось подключиться: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -272920,6 +273604,30 @@ extension on _StringsTh {
             'เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'เชื่อมต่อไม่สำเร็จ: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -281511,6 +282219,30 @@ extension on _StringsTr {
             'Bağlanıldı. Kök katalogda ${count} girdi var';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Bağlantı başarısız: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -290096,6 +290828,30 @@ extension on _StringsVi {
             'Đã kết nối. Danh mục gốc có ${count} mục';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Kết nối thất bại: ${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }
@@ -298609,6 +299365,30 @@ extension on _StringsZhCn {
         return ({required Object count}) => '连接成功，根目录有 ${count} 个条目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '连接失败：${reason}';
+      case 'video_specs_title':
+        return '媒体信息';
+      case 'video_specs_resolution':
+        return '清晰度';
+      case 'video_specs_dynamic_range':
+        return '动态范围';
+      case 'video_specs_video_codec':
+        return '视频编码';
+      case 'video_specs_bit_depth':
+        return '色深';
+      case 'video_specs_frame_rate':
+        return '帧率';
+      case 'video_specs_bitrate':
+        return '码率';
+      case 'video_specs_audio_tracks':
+        return '音轨';
+      case 'video_specs_subtitle_tracks':
+        return '字幕轨';
+      case 'video_specs_track_commentary':
+        return '评论音轨';
+      case 'video_specs_track_forced':
+        return '强制';
+      case 'video_specs_track_default':
+        return '默认';
       default:
         return null;
     }
@@ -307123,6 +307903,30 @@ extension on _StringsZhHk {
         return ({required Object count}) => '連線成功，根目錄有 ${count} 個項目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '連線失敗：${reason}';
+      case 'video_specs_title':
+        return 'Media info';
+      case 'video_specs_resolution':
+        return 'Resolution';
+      case 'video_specs_dynamic_range':
+        return 'Dynamic range';
+      case 'video_specs_video_codec':
+        return 'Video codec';
+      case 'video_specs_bit_depth':
+        return 'Bit depth';
+      case 'video_specs_frame_rate':
+        return 'Frame rate';
+      case 'video_specs_bitrate':
+        return 'Bitrate';
+      case 'video_specs_audio_tracks':
+        return 'Audio tracks';
+      case 'video_specs_subtitle_tracks':
+        return 'Subtitle tracks';
+      case 'video_specs_track_commentary':
+        return 'Commentary';
+      case 'video_specs_track_forced':
+        return 'Forced';
+      case 'video_specs_track_default':
+        return 'Default';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Needed for a self-hosted server on your local network",
   "discovery_opds_test": "Test connection",
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
-  "discovery_opds_test_failed": "Connection failed: ${reason}"
+  "discovery_opds_test_failed": "Connection failed: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "مطلوب لخادم ذاتي الاستضافة على شبكتك المحلية",
   "discovery_opds_test": "اختبار الاتصال",
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
-  "discovery_opds_test_failed": "فشل الاتصال: ${reason}"
+  "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Nötig für einen selbst gehosteten Server im lokalen Netzwerk",
   "discovery_opds_test": "Verbindung testen",
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
-  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}"
+  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Necesario para un servidor autoalojado en tu red local",
   "discovery_opds_test": "Probar conexión",
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
-  "discovery_opds_test_failed": "Error de conexión: ${reason}"
+  "discovery_opds_test_failed": "Error de conexión: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Nécessaire pour un serveur auto-hébergé sur votre réseau local",
   "discovery_opds_test": "Tester la connexion",
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
-  "discovery_opds_test_failed": "Échec de la connexion : ${reason}"
+  "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Diperlukan untuk server milik sendiri di jaringan lokal",
   "discovery_opds_test": "Uji koneksi",
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
-  "discovery_opds_test_failed": "Koneksi gagal: ${reason}"
+  "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Necessario per un server self-hosted sulla rete locale",
   "discovery_opds_test": "Prova connessione",
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
-  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}"
+  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "ローカルネットワークの自前サーバーに必要です",
   "discovery_opds_test": "接続をテスト",
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
-  "discovery_opds_test_failed": "接続に失敗しました: ${reason}"
+  "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "로컬 네트워크의 자체 호스팅 서버에 필요합니다",
   "discovery_opds_test": "연결 테스트",
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
-  "discovery_opds_test_failed": "연결 실패: ${reason}"
+  "discovery_opds_test_failed": "연결 실패: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Nodig voor een zelfgehoste server in je lokale netwerk",
   "discovery_opds_test": "Verbinding testen",
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
-  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}"
+  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Necessário para um servidor auto-hospedado na sua rede local",
   "discovery_opds_test": "Testar conexão",
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
-  "discovery_opds_test_failed": "Falha na conexão: ${reason}"
+  "discovery_opds_test_failed": "Falha na conexão: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Нужно для сервера, размещённого в вашей локальной сети",
   "discovery_opds_test": "Проверить соединение",
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
-  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}"
+  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "จำเป็นสำหรับเซิร์ฟเวอร์ที่โฮสต์เองในเครือข่ายภายใน",
   "discovery_opds_test": "ทดสอบการเชื่อมต่อ",
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
-  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}"
+  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Yerel ağdaki kendi sunucun için gerekli",
   "discovery_opds_test": "Bağlantıyı sına",
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
-  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}"
+  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "Cần thiết cho máy chủ tự dựng trong mạng nội bộ",
   "discovery_opds_test": "Kiểm tra kết nối",
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
-  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}"
+  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "局域网自建服务器需要打开",
   "discovery_opds_test": "测试连接",
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
-  "discovery_opds_test_failed": "连接失败：${reason}"
+  "discovery_opds_test_failed": "连接失败：${reason}",
+  "video_specs_title": "媒体信息",
+  "video_specs_resolution": "清晰度",
+  "video_specs_dynamic_range": "动态范围",
+  "video_specs_video_codec": "视频编码",
+  "video_specs_bit_depth": "色深",
+  "video_specs_frame_rate": "帧率",
+  "video_specs_bitrate": "码率",
+  "video_specs_audio_tracks": "音轨",
+  "video_specs_subtitle_tracks": "字幕轨",
+  "video_specs_track_commentary": "评论音轨",
+  "video_specs_track_forced": "强制",
+  "video_specs_track_default": "默认"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4178,5 +4178,17 @@
   "discovery_opds_allow_http_hint": "區域網絡自建伺服器需要開啟",
   "discovery_opds_test": "測試連線",
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
-  "discovery_opds_test_failed": "連線失敗：${reason}"
+  "discovery_opds_test_failed": "連線失敗：${reason}",
+  "video_specs_title": "Media info",
+  "video_specs_resolution": "Resolution",
+  "video_specs_dynamic_range": "Dynamic range",
+  "video_specs_video_codec": "Video codec",
+  "video_specs_bit_depth": "Bit depth",
+  "video_specs_frame_rate": "Frame rate",
+  "video_specs_bitrate": "Bitrate",
+  "video_specs_audio_tracks": "Audio tracks",
+  "video_specs_subtitle_tracks": "Subtitle tracks",
+  "video_specs_track_commentary": "Commentary",
+  "video_specs_track_forced": "Forced",
+  "video_specs_track_default": "Default"
 }

--- a/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
@@ -12,7 +12,6 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:fushi/src/media/video/video_duration_probe.dart';
 import 'package:fushi/src/media/video/video_specs_display.dart';
 import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/utils/components/cover_badge.dart';
@@ -57,17 +56,26 @@ class _VideoSpecsBadgeStripState extends ConsumerState<VideoSpecsBadgeStrip> {
   Widget build(BuildContext context) {
     final String? path = widget.filePath;
     if (path == null || path.isEmpty) return const SizedBox.shrink();
-    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
-    final List<String> badges = videoSpecsCoverBadges(facts);
-    if (badges.isEmpty) return const SizedBox.shrink();
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        for (final String badge in badges) ...<Widget>[
-          if (badge != badges.first) const SizedBox(width: 4),
-          CoverBadge(label: badge),
-        ],
-      ],
+    // videoSpecsProvider 是普通 Provider（它交出的是 AppModel 持有的实例，
+    // 不能让 riverpod 接管其生命周期，见该 provider 的注释），所以变化要靠
+    // ListenableBuilder 显式订阅——重建面仍然只有这一小块。
+    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    return ListenableBuilder(
+      listenable: service,
+      builder: (BuildContext context, Widget? _) {
+        final List<String> badges =
+            videoSpecsCoverBadges(service.specsFor(path));
+        if (badges.isEmpty) return const SizedBox.shrink();
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            for (final String badge in badges) ...<Widget>[
+              if (badge != badges.first) const SizedBox(width: 4),
+              CoverBadge(label: badge),
+            ],
+          ],
+        );
+      },
     );
   }
 }

--- a/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
@@ -1,0 +1,83 @@
+/// 封面左下角的规格角标（v95）：`4K` / `HDR10`。
+///
+/// 单独一个 widget 而不是在 `_buildCard` 里内联，是为了**把重建面钉死在角标本身**。
+/// [VideoSpecsService] 每探完一个文件就通知一次（滚一屏几十次），如果在库页
+/// `build` 顶部 `ref.watch(videoSpecsProvider)`，那 3000 行的整页会跟着反复重建。
+/// 这里自己订阅、自己重建，卡片其余部分一动不动。
+///
+/// 探测也由它发起：卡片进入视口才 build，于是天然只探可见的那些——库里有几千个
+/// 文件也不会一次全 ffprobe。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_specs_display.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
+import 'package:fushi/src/utils/components/cover_badge.dart';
+
+/// 压在封面左下角的规格角标条。规格未知时**整个不占位**（返回 SizedBox.shrink）。
+class VideoSpecsBadgeStrip extends ConsumerStatefulWidget {
+  const VideoSpecsBadgeStrip({required this.filePath, super.key});
+
+  /// 视频文件绝对路径。null / 空（流媒体条目、远端占位卡）时不探也不显示。
+  final String? filePath;
+
+  @override
+  ConsumerState<VideoSpecsBadgeStrip> createState() =>
+      _VideoSpecsBadgeStripState();
+}
+
+class _VideoSpecsBadgeStripState extends ConsumerState<VideoSpecsBadgeStrip> {
+  @override
+  void initState() {
+    super.initState();
+    // initState 里不能 ref.watch，用 read 拿服务发起探测即可——结果通过 build 里的
+    // watch 回来。prime 幂等，已知/在队列里的路径会短路。
+    _prime();
+  }
+
+  @override
+  void didUpdateWidget(VideoSpecsBadgeStrip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // GridView 复用 element：同一个 widget 位置可能换成另一个文件。
+    if (oldWidget.filePath != widget.filePath) _prime();
+  }
+
+  void _prime() {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty) return;
+    // 流 URL 不是本地文件，ffprobe 探不了，别白起进程。
+    if (isProbableStreamUrl(path)) return;
+    ref.read(videoSpecsProvider).prime(<String>[path]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty) return const SizedBox.shrink();
+    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
+    final List<String> badges = videoSpecsCoverBadges(facts);
+    if (badges.isEmpty) return const SizedBox.shrink();
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (final String badge in badges) ...<Widget>[
+          if (badge != badges.first) const SizedBox(width: 4),
+          CoverBadge(label: badge),
+        ],
+      ],
+    );
+  }
+}
+
+/// 是不是 http(s) 流地址（`VideoBooks.videoPath` 的三态之一）。
+///
+/// 放在这里而不是 service 里：service 拿到什么探什么，「这条路径值不值得探」是调用
+/// 侧的判断。流地址 ffprobe 理论上能探，但那会在滚动列表时对每个远端条目发起网络
+/// 请求——库页绝不做这种事。
+bool isProbableStreamUrl(String path) {
+  final String lower = path.trim().toLowerCase();
+  return lower.startsWith('http://') || lower.startsWith('https://');
+}

--- a/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_badges.dart
@@ -2,38 +2,46 @@
 ///
 /// 单独一个 widget 而不是在 `_buildCard` 里内联，是为了**把重建面钉死在角标本身**。
 /// [VideoSpecsService] 每探完一个文件就通知一次（滚一屏几十次），如果在库页
-/// `build` 顶部 `ref.watch(videoSpecsProvider)`，那 3000 行的整页会跟着反复重建。
-/// 这里自己订阅、自己重建，卡片其余部分一动不动。
+/// `build` 顶部订阅，那 3000 行的整页会跟着反复重建。这里自己订阅、自己重建，
+/// 卡片其余部分一动不动。
 ///
 /// 探测也由它发起：卡片进入视口才 build，于是天然只探可见的那些——库里有几千个
 /// 文件也不会一次全 ffprobe。
+///
+/// **服务由调用方注入，本 widget 不碰 riverpod。** 规格 UI 要落在几个不同宿主上，
+/// 其中 `MediaCollectionDetailPage` / `VideoWorkDetailPage` 是普通 StatefulWidget，
+/// 它们的既有 widget 测试没有（也不需要）`ProviderScope`——在里面塞 ConsumerWidget
+/// 会让那些测试全部抛。注入让依赖显式，也让「不传就不显示」成为测试宿主的默认行为。
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/src/media/video/video_specs_display.dart';
 import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/utils/components/cover_badge.dart';
 
 /// 压在封面左下角的规格角标条。规格未知时**整个不占位**（返回 SizedBox.shrink）。
-class VideoSpecsBadgeStrip extends ConsumerStatefulWidget {
-  const VideoSpecsBadgeStrip({required this.filePath, super.key});
+class VideoSpecsBadgeStrip extends StatefulWidget {
+  const VideoSpecsBadgeStrip({
+    required this.service,
+    required this.filePath,
+    super.key,
+  });
+
+  /// 规格服务；null = 宿主没提供（测试或未接线），不显示也不探测。
+  final VideoSpecsService? service;
 
   /// 视频文件绝对路径。null / 空（流媒体条目、远端占位卡）时不探也不显示。
   final String? filePath;
 
   @override
-  ConsumerState<VideoSpecsBadgeStrip> createState() =>
-      _VideoSpecsBadgeStripState();
+  State<VideoSpecsBadgeStrip> createState() => _VideoSpecsBadgeStripState();
 }
 
-class _VideoSpecsBadgeStripState extends ConsumerState<VideoSpecsBadgeStrip> {
+class _VideoSpecsBadgeStripState extends State<VideoSpecsBadgeStrip> {
   @override
   void initState() {
     super.initState();
-    // initState 里不能 ref.watch，用 read 拿服务发起探测即可——结果通过 build 里的
-    // watch 回来。prime 幂等，已知/在队列里的路径会短路。
     _prime();
   }
 
@@ -41,25 +49,28 @@ class _VideoSpecsBadgeStripState extends ConsumerState<VideoSpecsBadgeStrip> {
   void didUpdateWidget(VideoSpecsBadgeStrip oldWidget) {
     super.didUpdateWidget(oldWidget);
     // GridView 复用 element：同一个 widget 位置可能换成另一个文件。
-    if (oldWidget.filePath != widget.filePath) _prime();
+    if (oldWidget.filePath != widget.filePath ||
+        oldWidget.service != widget.service) {
+      _prime();
+    }
   }
 
   void _prime() {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty) return;
+    if (service == null || path == null || path.isEmpty) return;
     // 流 URL 不是本地文件，ffprobe 探不了，别白起进程。
     if (isProbableStreamUrl(path)) return;
-    ref.read(videoSpecsProvider).prime(<String>[path]);
+    service.prime(<String>[path]);
   }
 
   @override
   Widget build(BuildContext context) {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty) return const SizedBox.shrink();
-    // videoSpecsProvider 是普通 Provider（它交出的是 AppModel 持有的实例，
-    // 不能让 riverpod 接管其生命周期，见该 provider 的注释），所以变化要靠
-    // ListenableBuilder 显式订阅——重建面仍然只有这一小块。
-    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    if (service == null || path == null || path.isEmpty) {
+      return const SizedBox.shrink();
+    }
     return ListenableBuilder(
       listenable: service,
       builder: (BuildContext context, Widget? _) {

--- a/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
@@ -1,0 +1,256 @@
+/// 作品详情页的技术规格区块（v95）。
+///
+/// 呈现粒度**跟着数据粒度走**：规格属于文件，不属于作品。所以完整规格表只出现在
+/// 「一个文件 = 一部作品」的地方（单文件作品详情页、某一集的媒体信息弹窗）；合集
+/// 详情页的作品级信息区**刻意不放**——一个合集十几集，各集分辨率/音轨可以完全不同，
+/// 在作品级摆一份规格必然是在骗人（挑第一集还是最常见的？都不对）。合集里逐集看，
+/// 走集卡上的 [VideoSpecsInlineLine] 与集卡菜单的媒体信息弹窗。
+///
+/// 注意 slang 的 `t`：`Translations.of(context)` 返回的是 library-private 类型，
+/// **不能写成字段/参数类型**（只能 `final t = ...` 靠推断）。所以下面每个需要文案的
+/// widget 都在自己的 `build` 里取一次 t，而不是层层传递。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart'
+    show isProbableStreamUrl;
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_specs_display.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
+import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+
+/// 完整规格表：分辨率 / 动态范围 / 编码 / 色深 / 帧率 / 码率 / 音轨 / 字幕轨。
+///
+/// 规格未探到时**整块不渲染**（返回 SizedBox.shrink），不显示「加载中」骨架——探测
+/// 通常几十毫秒就回来，先闪一个骨架再换成内容比直接出现更晃眼。
+class VideoSpecsPanel extends ConsumerStatefulWidget {
+  const VideoSpecsPanel({
+    required this.filePath,
+    this.showTitle = true,
+    super.key,
+  });
+
+  final String? filePath;
+
+  /// 是否显示「媒体信息」小标题（弹窗里已有标题栏，就不重复）。
+  final bool showTitle;
+
+  @override
+  ConsumerState<VideoSpecsPanel> createState() => _VideoSpecsPanelState();
+}
+
+class _VideoSpecsPanelState extends ConsumerState<VideoSpecsPanel> {
+  @override
+  void initState() {
+    super.initState();
+    _resolve();
+  }
+
+  @override
+  void didUpdateWidget(VideoSpecsPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.filePath != widget.filePath) _resolve();
+  }
+
+  void _resolve() {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty || isProbableStreamUrl(path)) return;
+    // 详情页只有一个文件，值得直接 resolve（而不是排队）——用户就是为看它才点进来。
+    ref.read(videoSpecsProvider).resolve(path);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty) return const SizedBox.shrink();
+    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
+    if (facts == null) return const SizedBox.shrink();
+
+    final t = Translations.of(context);
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+
+    final List<(String, String)> rows = <(String, String)>[
+      for (final (VideoSpecField field, String value) in videoSpecsFields(facts))
+        (
+          switch (field) {
+            VideoSpecField.resolution => t.video_specs_resolution,
+            VideoSpecField.dynamicRange => t.video_specs_dynamic_range,
+            VideoSpecField.videoCodec => t.video_specs_video_codec,
+            VideoSpecField.bitDepth => t.video_specs_bit_depth,
+            VideoSpecField.frameRate => t.video_specs_frame_rate,
+            VideoSpecField.bitrate => t.video_specs_bitrate,
+            VideoSpecField.audioTracks => t.video_specs_audio_tracks,
+            VideoSpecField.subtitleTracks => t.video_specs_subtitle_tracks,
+          },
+          value,
+        ),
+    ];
+
+    final List<TrackDisplay> audio =
+        facts.audioTracks.map(audioTrackDisplay).toList();
+    final List<TrackDisplay> subtitles =
+        facts.subtitleTracks.map(subtitleTrackDisplay).toList();
+
+    if (rows.isEmpty && audio.isEmpty && subtitles.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (widget.showTitle) ...<Widget>[
+          Text(
+            t.video_specs_title,
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          SizedBox(height: tokens.spacing.gap),
+        ],
+        for (final (String label, String value) in rows)
+          _SpecRow(label: label, value: value),
+        if (audio.isNotEmpty)
+          _TrackRow(label: t.video_specs_audio_tracks, tracks: audio),
+        if (subtitles.isNotEmpty)
+          _TrackRow(label: t.video_specs_subtitle_tracks, tracks: subtitles),
+      ],
+    );
+  }
+}
+
+/// 一行 label / value，与合集详情页既有事实行同款排布（116px label 列）。
+class _SpecRow extends StatelessWidget {
+  const _SpecRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: 116,
+            child: Text(
+              label,
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+          Expanded(child: SelectableText(value, style: text.bodySmall)),
+        ],
+      ),
+    );
+  }
+}
+
+/// 音轨 / 字幕轨行：一条轨道一行，标志位跟在名字后面。
+class _TrackRow extends StatelessWidget {
+  const _TrackRow({required this.label, required this.tracks});
+
+  final String label;
+  final List<TrackDisplay> tracks;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+    final TextTheme text = Theme.of(context).textTheme;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    String line(TrackDisplay track) {
+      final List<String> flags = <String>[
+        if (track.isDefault) t.video_specs_track_default,
+        if (track.isCommentary) t.video_specs_track_commentary,
+        if (track.isForced) t.video_specs_track_forced,
+      ];
+      return flags.isEmpty
+          ? track.headline
+          : '${track.headline}（${flags.join('、')}）';
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: 116,
+            child: Text(
+              label,
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                for (final TrackDisplay track in tracks)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 2),
+                    child:
+                        SelectableText(line(track), style: text.bodySmall),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 一行紧凑规格，给集卡状态行用：`1080p · HDR10 · HEVC`。
+class VideoSpecsInlineLine extends ConsumerStatefulWidget {
+  const VideoSpecsInlineLine({required this.filePath, this.style, super.key});
+
+  final String? filePath;
+  final TextStyle? style;
+
+  @override
+  ConsumerState<VideoSpecsInlineLine> createState() =>
+      _VideoSpecsInlineLineState();
+}
+
+class _VideoSpecsInlineLineState extends ConsumerState<VideoSpecsInlineLine> {
+  @override
+  void initState() {
+    super.initState();
+    _prime();
+  }
+
+  @override
+  void didUpdateWidget(VideoSpecsInlineLine oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.filePath != widget.filePath) _prime();
+  }
+
+  void _prime() {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty || isProbableStreamUrl(path)) return;
+    ref.read(videoSpecsProvider).prime(<String>[path]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String? path = widget.filePath;
+    if (path == null || path.isEmpty) return const SizedBox.shrink();
+    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
+    final String? summary = videoSpecsInlineSummary(facts);
+    // 未探到时不占位：集卡高度是钳死的，多一行会把简介挤掉。
+    if (summary == null) return const SizedBox.shrink();
+    return Text(
+      summary,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: widget.style ??
+          Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+    );
+  }
+}

--- a/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
@@ -12,7 +12,6 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart'
@@ -26,12 +25,16 @@ import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 ///
 /// 规格未探到时**整块不渲染**（返回 SizedBox.shrink），不显示「加载中」骨架——探测
 /// 通常几十毫秒就回来，先闪一个骨架再换成内容比直接出现更晃眼。
-class VideoSpecsPanel extends ConsumerStatefulWidget {
+class VideoSpecsPanel extends StatefulWidget {
   const VideoSpecsPanel({
+    required this.service,
     required this.filePath,
     this.showTitle = true,
     super.key,
   });
+
+  /// 规格服务；null = 宿主没提供（测试或未接线），整块不渲染也不探测。
+  final VideoSpecsService? service;
 
   final String? filePath;
 
@@ -39,10 +42,10 @@ class VideoSpecsPanel extends ConsumerStatefulWidget {
   final bool showTitle;
 
   @override
-  ConsumerState<VideoSpecsPanel> createState() => _VideoSpecsPanelState();
+  State<VideoSpecsPanel> createState() => _VideoSpecsPanelState();
 }
 
-class _VideoSpecsPanelState extends ConsumerState<VideoSpecsPanel> {
+class _VideoSpecsPanelState extends State<VideoSpecsPanel> {
   @override
   void initState() {
     super.initState();
@@ -52,22 +55,28 @@ class _VideoSpecsPanelState extends ConsumerState<VideoSpecsPanel> {
   @override
   void didUpdateWidget(VideoSpecsPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.filePath != widget.filePath) _resolve();
+    if (oldWidget.filePath != widget.filePath ||
+        oldWidget.service != widget.service) {
+      _resolve();
+    }
   }
 
   void _resolve() {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty || isProbableStreamUrl(path)) return;
+    if (service == null || path == null || path.isEmpty) return;
+    if (isProbableStreamUrl(path)) return;
     // 详情页只有一个文件，值得直接 resolve（而不是排队）——用户就是为看它才点进来。
-    ref.read(videoSpecsProvider).resolve(path);
+    service.resolve(path);
   }
 
   @override
   Widget build(BuildContext context) {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty) return const SizedBox.shrink();
-    // 见 videoSpecsProvider 注释：它是普通 Provider，变化靠 ListenableBuilder 订阅。
-    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    if (service == null || path == null || path.isEmpty) {
+      return const SizedBox.shrink();
+    }
     return ListenableBuilder(
       listenable: service,
       builder: (BuildContext context, Widget? _) =>
@@ -82,7 +91,8 @@ class _VideoSpecsPanelState extends ConsumerState<VideoSpecsPanel> {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
 
     final List<(String, String)> rows = <(String, String)>[
-      for (final (VideoSpecField field, String value) in videoSpecsFields(facts))
+      for (final (VideoSpecField field, String value)
+          in videoSpecsFields(facts))
         (
           switch (field) {
             VideoSpecField.resolution => t.video_specs_resolution,
@@ -201,8 +211,7 @@ class _TrackRow extends StatelessWidget {
                 for (final TrackDisplay track in tracks)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 2),
-                    child:
-                        SelectableText(line(track), style: text.bodySmall),
+                    child: SelectableText(line(track), style: text.bodySmall),
                   ),
               ],
             ),
@@ -214,18 +223,25 @@ class _TrackRow extends StatelessWidget {
 }
 
 /// 一行紧凑规格，给集卡状态行用：`1080p · HDR10 · HEVC`。
-class VideoSpecsInlineLine extends ConsumerStatefulWidget {
-  const VideoSpecsInlineLine({required this.filePath, this.style, super.key});
+class VideoSpecsInlineLine extends StatefulWidget {
+  const VideoSpecsInlineLine({
+    required this.service,
+    required this.filePath,
+    this.style,
+    super.key,
+  });
+
+  /// 规格服务；null = 宿主没提供，整行不渲染也不探测。
+  final VideoSpecsService? service;
 
   final String? filePath;
   final TextStyle? style;
 
   @override
-  ConsumerState<VideoSpecsInlineLine> createState() =>
-      _VideoSpecsInlineLineState();
+  State<VideoSpecsInlineLine> createState() => _VideoSpecsInlineLineState();
 }
 
-class _VideoSpecsInlineLineState extends ConsumerState<VideoSpecsInlineLine> {
+class _VideoSpecsInlineLineState extends State<VideoSpecsInlineLine> {
   @override
   void initState() {
     super.initState();
@@ -235,25 +251,31 @@ class _VideoSpecsInlineLineState extends ConsumerState<VideoSpecsInlineLine> {
   @override
   void didUpdateWidget(VideoSpecsInlineLine oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.filePath != widget.filePath) _prime();
+    if (oldWidget.filePath != widget.filePath ||
+        oldWidget.service != widget.service) {
+      _prime();
+    }
   }
 
   void _prime() {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty || isProbableStreamUrl(path)) return;
-    ref.read(videoSpecsProvider).prime(<String>[path]);
+    if (service == null || path == null || path.isEmpty) return;
+    if (isProbableStreamUrl(path)) return;
+    service.prime(<String>[path]);
   }
 
   @override
   Widget build(BuildContext context) {
+    final VideoSpecsService? service = widget.service;
     final String? path = widget.filePath;
-    if (path == null || path.isEmpty) return const SizedBox.shrink();
-    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    if (service == null || path == null || path.isEmpty) {
+      return const SizedBox.shrink();
+    }
     return ListenableBuilder(
       listenable: service,
       builder: (BuildContext context, Widget? _) {
-        final String? summary =
-            videoSpecsInlineSummary(service.specsFor(path));
+        final String? summary = videoSpecsInlineSummary(service.specsFor(path));
         // 未探到时不占位：集卡高度是钳死的，多一行会把简介挤掉。
         if (summary == null) return const SizedBox.shrink();
         return Text(

--- a/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
+++ b/fushi/lib/src/media/video/cover_ui/video_specs_panel.dart
@@ -66,7 +66,16 @@ class _VideoSpecsPanelState extends ConsumerState<VideoSpecsPanel> {
   Widget build(BuildContext context) {
     final String? path = widget.filePath;
     if (path == null || path.isEmpty) return const SizedBox.shrink();
-    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
+    // 见 videoSpecsProvider 注释：它是普通 Provider，变化靠 ListenableBuilder 订阅。
+    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    return ListenableBuilder(
+      listenable: service,
+      builder: (BuildContext context, Widget? _) =>
+          _buildPanel(context, service.specsFor(path)),
+    );
+  }
+
+  Widget _buildPanel(BuildContext context, VideoProbeFacts? facts) {
     if (facts == null) return const SizedBox.shrink();
 
     final t = Translations.of(context);
@@ -239,18 +248,24 @@ class _VideoSpecsInlineLineState extends ConsumerState<VideoSpecsInlineLine> {
   Widget build(BuildContext context) {
     final String? path = widget.filePath;
     if (path == null || path.isEmpty) return const SizedBox.shrink();
-    final VideoProbeFacts? facts = ref.watch(videoSpecsProvider).specsFor(path);
-    final String? summary = videoSpecsInlineSummary(facts);
-    // 未探到时不占位：集卡高度是钳死的，多一行会把简介挤掉。
-    if (summary == null) return const SizedBox.shrink();
-    return Text(
-      summary,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: widget.style ??
-          Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
+    final VideoSpecsService service = ref.watch(videoSpecsProvider);
+    return ListenableBuilder(
+      listenable: service,
+      builder: (BuildContext context, Widget? _) {
+        final String? summary =
+            videoSpecsInlineSummary(service.specsFor(path));
+        // 未探到时不占位：集卡高度是钳死的，多一行会把简介挤掉。
+        if (summary == null) return const SizedBox.shrink();
+        return Text(
+          summary,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: widget.style ??
+              Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+        );
+      },
     );
   }
 }

--- a/fushi/lib/src/media/video/video_duration_probe.dart
+++ b/fushi/lib/src/media/video/video_duration_probe.dart
@@ -1,50 +1,359 @@
-/// 探一个本地视频文件的两件事实：容器时长，与音轨自报的语言。
+/// 一次 ffprobe 探出一个本地视频文件的**全部容器事实**：时长、容器码率、视频流规格
+/// （分辨率 / 编码 / 色深 / 帧率 / 色彩标签）、以及每一条音轨与字幕轨。
 ///
-/// 存在的理由都在字幕自动获取链路上：
+/// 起初这里只探两件事（时长 + 音轨语言），都是给字幕自动获取链路用的：
 /// - **时长**给「这条字幕真的是这个视频的吗」校验用（`subtitle/subtitle_timing_check.dart`）。
 ///   `VideoBooks` 没有 duration 列，播放器时长又只在 controller 打开后才有，下载
 ///   流水线拿不到，只能现探。
-/// - **音轨语言**给「默认下视频语言的字幕」用。它是「视频语言」最直接的一手来源，
-///   而且**与时长同一次 ffprobe 就能拿到**——分两次探是白付一次进程/IO。
+/// - **音轨语言**给「默认下视频语言的字幕」用。
+///
+/// 后来库页卡片与作品详情页要展示技术规格（清晰度 / HDR / 编码 / 音轨），而这些事实
+/// **与上面两件出自同一次 ffprobe**——多问几个 `-show_entries` 字段是免费的，再起一次
+/// 进程不是。所以这里扩成完整探测，[VideoProbeFacts] 相应长大；老调用点只读
+/// [VideoProbeFacts.durationMs] / [VideoProbeFacts.audioLanguages]，语义逐字未变。
+///
+/// （文件名仍是 `video_duration_probe`，已窄于实际职责；改名是纯机械改动，留给独立提交，
+/// 不混进功能改动里。）
 ///
 /// 走既有 [FfmpegBackend.runProbe]，所以桌面（ffprobe 进程）与移动端
 /// （ffmpeg-kit 进程内）同一条路径，不新增平台分支。
 library;
 
 import 'dart:convert';
+import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/foundation.dart' show debugPrint, immutable, visibleForTesting;
 
 import 'package:fushi/src/media/video/ffmpeg_backend.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
 
 /// ffprobe 探测的超时。只读 header，不解码，几十毫秒级；给足 20s 覆盖冷缓存
 /// 与机械盘。**超时按失败处理并返回空结果**——校验拿不到时长时会退化成「只做内容
 /// 自检」，绝不因为探测失败就拒收字幕。
 const Duration kVideoDurationProbeTimeout = Duration(seconds: 20);
 
-/// 一次 ffprobe 的产出。两个字段各自可空：探到什么算什么，绝不因为一半缺失就把
+/// 探测器请求的字段集版本。
+///
+/// 落库缓存拿它当失效判据之一：字段集扩了（比如以后加 side_data 里的 Dolby Vision），
+/// 旧行即便文件没变也必须重探，否则新字段永远是空的。**改动下面的 `-show_entries`
+/// 就必须 +1**。
+const int kVideoProbeFieldSetVersion = 2;
+
+/// 一次 ffprobe 的产出。每个字段各自可空：探到什么算什么，绝不因为一半缺失就把
 /// 另一半也丢掉。
+@immutable
 class VideoProbeFacts {
-  const VideoProbeFacts(
-      {this.durationMs, this.audioLanguages = const <String>[]});
+  const VideoProbeFacts({
+    this.durationMs,
+    this.fileSizeBytes,
+    this.containerBitrate,
+    this.video,
+    this.audioTracks = const <AudioTrackFacts>[],
+    this.subtitleTracks = const <SubtitleTrackFacts>[],
+  });
 
   static const VideoProbeFacts empty = VideoProbeFacts();
 
   /// 容器时长（毫秒）；探不到为 null。
   final int? durationMs;
 
-  /// 音轨自报的语言标签，**按流顺序**（第一条通常是主音轨）。未标注的流不入列。
+  /// 容器文件大小（字节，`format.size`）；探不到为 null。
+  final int? fileSizeBytes;
+
+  /// 整个容器的平均码率（bit/s，`format.bit_rate`）。
   ///
-  /// 原样返回不归一：归一是 `subtitle_language_preference.dart` 的职责，本模块
-  /// 只负责「ffprobe 说了什么」。
-  final List<String> audioLanguages;
+  /// **视频流自己的码率经常没有**（实测：mkv 的视频/音频流都不给 `bit_rate`，只有 mp4
+  /// 给），所以展示码率时通常只能用这个容器级的值。
+  final int? containerBitrate;
+
+  /// 第一条视频流的规格；纯音频文件或探测失败为 null。
+  final VideoStreamFacts? video;
+
+  /// 全部音轨，**按流顺序**（第一条通常是主音轨）。
+  final List<AudioTrackFacts> audioTracks;
+
+  /// 全部字幕轨（内封），按流顺序。
+  final List<SubtitleTrackFacts> subtitleTracks;
+
+  /// 音轨自报的语言标签，**按流顺序**。未标注的流不入列。
+  ///
+  /// 从 [audioTracks] 派生而不是单独存一份——同一事实存两处早晚会不一致。语义与扩展
+  /// 前逐字相同：原样返回不归一（归一是 `subtitle_language_preference.dart` 的职责），
+  /// 且 `und` 不入列。
+  List<String> get audioLanguages {
+    final List<String> out = <String>[];
+    for (final AudioTrackFacts track in audioTracks) {
+      final String? language = track.language;
+      if (language == null) continue;
+      out.add(language);
+    }
+    return List<String>.unmodifiable(out);
+  }
 
   /// 主音轨语言（第一条带 language tag 的音轨）；没有返回 null。
   String? get primaryAudioLanguage =>
       audioLanguages.isEmpty ? null : audioLanguages.first;
+
+  /// 是否什么都没探到（用于判断要不要落库）。
+  bool get isEmpty =>
+      durationMs == null &&
+      video == null &&
+      audioTracks.isEmpty &&
+      subtitleTracks.isEmpty;
 }
 
-/// 一次 ffprobe 拿到 [path] 的时长 + 音轨语言。任何失败返回 [VideoProbeFacts.empty]。
+/// 视频流规格。
+@immutable
+class VideoStreamFacts {
+  const VideoStreamFacts({
+    this.codec,
+    this.width,
+    this.height,
+    this.pixelFormat,
+    this.bitDepth,
+    this.frameRateMilli,
+    this.bitrate,
+    this.colorPrimaries,
+    this.colorTransfer,
+    this.colorSpace,
+  });
+
+  /// ffprobe `codec_name`，如 `h264` / `hevc` / `av1`。
+  final String? codec;
+
+  final int? width;
+  final int? height;
+
+  /// 如 `yuv420p10le`。色深主要从它推（见 [bitDepth]）。
+  final String? pixelFormat;
+
+  /// 每分量位深。
+  ///
+  /// **不能只信 `bits_per_raw_sample`**：实测 10-bit HEVC 流根本不给这个字段，而
+  /// 8-bit H.264 给。所以优先从 [pixelFormat] 的 `p10le` / `p12le` 后缀推，推不出
+  /// 再退回 `bits_per_raw_sample`。
+  final int? bitDepth;
+
+  /// 帧率 ×1000（23.976fps → 23976）。
+  ///
+  /// 用整数存是因为 ffprobe 给的是 `"2997/125"` 这样的**精确分数**，转 double 再比较
+  /// 会引入浮点误差；×1000 的整数足够区分 23.976 / 24 / 25 / 29.97 / 30 / 60。
+  final int? frameRateMilli;
+
+  /// 视频流码率（bit/s）。**mkv 通常没有**，见 [VideoProbeFacts.containerBitrate]。
+  final int? bitrate;
+
+  final String? colorPrimaries;
+  final String? colorTransfer;
+  final String? colorSpace;
+
+  /// 归一后的动态范围。判据收口在 `video_dynamic_range.dart`，与播放器侧同一份。
+  VideoDynamicRange get dynamicRange => dynamicRangeFromFfprobe(
+        colorPrimaries: colorPrimaries,
+        colorTransfer: colorTransfer,
+      );
+
+  /// 帧率（fps），[frameRateMilli] 为空时返回 null。
+  double? get frameRate =>
+      frameRateMilli == null ? null : frameRateMilli! / 1000.0;
+
+  /// 清晰度短标：`4K` / `1080p` / `720p` …
+  ///
+  /// 按**长边**分档，不按高度：2.35:1 的电影片源高度只有 800~872，按高度会被误判成
+  /// 720p；竖屏视频则反过来。长边同时覆盖这两种情况，不需要为横竖屏各写一个分支。
+  /// 阈值取得比标准分辨率低一档，是为了容纳裁边后的非标准尺寸（1920×804 仍是 1080p）。
+  String? get resolutionLabel {
+    final int? w = width;
+    final int? h = height;
+    if (w == null || h == null || w <= 0 || h <= 0) return null;
+    final int longEdge = math.max(w, h);
+    if (longEdge >= 3800) return '4K';
+    if (longEdge >= 2500) return '1440p';
+    if (longEdge >= 1800) return '1080p';
+    if (longEdge >= 1200) return '720p';
+    if (longEdge >= 940) return '576p';
+    if (longEdge >= 600) return '480p';
+    return '${longEdge}p';
+  }
+
+  /// 编码显示名：`hevc` → `HEVC`、`h264` → `H.264`。
+  String? get codecLabel => _videoCodecLabel(codec);
+}
+
+/// 一条音轨。
+@immutable
+class AudioTrackFacts {
+  const AudioTrackFacts({
+    required this.index,
+    this.codec,
+    this.channels,
+    this.channelLayout,
+    this.sampleRate,
+    this.bitrate,
+    this.language,
+    this.title,
+    this.isDefault = false,
+    this.isForced = false,
+    this.isCommentary = false,
+  });
+
+  /// ffprobe `index`（容器内的全局流序号，不是「第几条音轨」）。
+  final int index;
+
+  /// `codec_name`，如 `aac` / `flac` / `eac3` / `truehd`。
+  final String? codec;
+
+  final int? channels;
+
+  /// `channel_layout`，如 `stereo` / `5.1`。
+  final String? channelLayout;
+
+  final int? sampleRate;
+  final int? bitrate;
+
+  /// 自报语言；`und` 与未标注一律为 null（放行 `und` 会让下游把「未知」当成一个真语言
+  /// 去匹配，永远匹配不上，还挡住后面真有标注的音轨）。
+  final String? language;
+
+  final String? title;
+  final bool isDefault;
+  final bool isForced;
+
+  /// `disposition.comment`：导演评论等副音轨。
+  final bool isCommentary;
+
+  /// 编码显示名：`eac3` → `E-AC-3`。
+  String? get codecLabel => _audioCodecLabel(codec);
+
+  /// 落库用。键名短且稳定——这串 JSON 会存进 `video_file_specs.audio_tracks_json`，
+  /// 改键名等于让所有已缓存的行解不出来（届时靠 `kVideoProbeFieldSetVersion` 兜底重探）。
+  Map<String, Object?> toJson() => <String, Object?>{
+        'i': index,
+        if (codec != null) 'c': codec,
+        if (channels != null) 'ch': channels,
+        if (channelLayout != null) 'cl': channelLayout,
+        if (sampleRate != null) 'sr': sampleRate,
+        if (bitrate != null) 'br': bitrate,
+        if (language != null) 'l': language,
+        if (title != null) 't': title,
+        if (isDefault) 'd': 1,
+        if (isForced) 'f': 1,
+        if (isCommentary) 'm': 1,
+      };
+
+  static AudioTrackFacts fromJson(Map<String, Object?> json) => AudioTrackFacts(
+        index: _intFrom(json['i']) ?? 0,
+        codec: _stringFrom(json['c']),
+        channels: _intFrom(json['ch']),
+        channelLayout: _stringFrom(json['cl']),
+        sampleRate: _intFrom(json['sr']),
+        bitrate: _intFrom(json['br']),
+        language: _stringFrom(json['l']),
+        title: _stringFrom(json['t']),
+        isDefault: _intFrom(json['d']) == 1,
+        isForced: _intFrom(json['f']) == 1,
+        isCommentary: _intFrom(json['m']) == 1,
+      );
+
+  /// 声道显示名：`5.1` / `2.0`（`stereo` 与 `mono` 归一成数字写法，与 `5.1` 同形）。
+  String? get channelLabel {
+    final String? layout = channelLayout?.trim().toLowerCase();
+    if (layout != null && layout.isNotEmpty) {
+      switch (layout) {
+        case 'stereo':
+          return '2.0';
+        case 'mono':
+          return '1.0';
+        default:
+          // `5.1(side)` 这类带括号后缀的，取括号前的主体。
+          final int paren = layout.indexOf('(');
+          return paren > 0 ? layout.substring(0, paren) : layout;
+      }
+    }
+    final int? c = channels;
+    if (c == null || c <= 0) return null;
+    return switch (c) {
+      1 => '1.0',
+      2 => '2.0',
+      6 => '5.1',
+      8 => '7.1',
+      _ => '$c.0',
+    };
+  }
+}
+
+/// 一条内封字幕轨。
+@immutable
+class SubtitleTrackFacts {
+  const SubtitleTrackFacts({
+    required this.index,
+    this.codec,
+    this.language,
+    this.title,
+    this.isDefault = false,
+    this.isForced = false,
+  });
+
+  final int index;
+
+  /// `codec_name`，如 `subrip` / `ass` / `hdmv_pgs_subtitle`。
+  final String? codec;
+
+  final String? language;
+  final String? title;
+  final bool isDefault;
+  final bool isForced;
+
+  /// 字幕格式显示名：`subrip` → `SRT`、`hdmv_pgs_subtitle` → `PGS`。
+  String? get codecLabel => _subtitleCodecLabel(codec);
+
+  /// 落库用，键名约定同 [AudioTrackFacts.toJson]。
+  Map<String, Object?> toJson() => <String, Object?>{
+        'i': index,
+        if (codec != null) 'c': codec,
+        if (language != null) 'l': language,
+        if (title != null) 't': title,
+        if (isDefault) 'd': 1,
+        if (isForced) 'f': 1,
+      };
+
+  static SubtitleTrackFacts fromJson(Map<String, Object?> json) =>
+      SubtitleTrackFacts(
+        index: _intFrom(json['i']) ?? 0,
+        codec: _stringFrom(json['c']),
+        language: _stringFrom(json['l']),
+        title: _stringFrom(json['t']),
+        isDefault: _intFrom(json['d']) == 1,
+        isForced: _intFrom(json['f']) == 1,
+      );
+}
+
+/// 把一串轨道编码成落库的 JSON 文本。
+String encodeTrackListJson(List<Map<String, Object?>> tracks) =>
+    jsonEncode(tracks);
+
+/// 解码落库的轨道 JSON 文本。**任何格式异常都退化成空列表**——规格是装饰性信息，
+/// 一条坏缓存不该让作品详情页整页打不开。
+List<T> decodeTrackListJson<T>(
+  String? json,
+  T Function(Map<String, Object?>) fromJson,
+) {
+  if (json == null || json.trim().isEmpty) return <T>[];
+  try {
+    final Object? decoded = jsonDecode(json);
+    if (decoded is! List) return <T>[];
+    final List<T> out = <T>[];
+    for (final Object? item in decoded) {
+      if (item is! Map<String, dynamic>) continue;
+      out.add(fromJson(item));
+    }
+    return List<T>.unmodifiable(out);
+  } catch (_) {
+    return <T>[];
+  }
+}
+
+/// 一次 ffprobe 拿到 [path] 的全部容器事实。任何失败返回 [VideoProbeFacts.empty]。
 Future<VideoProbeFacts> probeVideoFacts(
   String path, {
   @visibleForTesting FfmpegBackend? backend,
@@ -58,7 +367,7 @@ Future<VideoProbeFacts> probeVideoFacts(
         '-print_format',
         'json',
         '-show_entries',
-        'format=duration:stream=index,codec_type:stream_tags=language',
+        kVideoProbeShowEntries,
         path,
       ],
       kVideoDurationProbeTimeout,
@@ -72,6 +381,23 @@ Future<VideoProbeFacts> probeVideoFacts(
   }
 }
 
+/// `-show_entries` 的字段集。
+///
+/// 三段各有各的语法，**不能合并**（实测踩过：把 `disposition` 写进 `stream=` 段里
+/// 不会有任何输出，必须单独用 `stream_disposition=`）：
+/// - `format=` 容器级
+/// - `stream=` 流的固有属性
+/// - `stream_disposition=` 流的 default/forced/comment 标志
+/// - `stream_tags=` 流的元数据 tag
+///
+/// 改这里必须同步 +1 [kVideoProbeFieldSetVersion]，否则已落库的旧行不会重探。
+const String kVideoProbeShowEntries = 'format=duration,size,bit_rate:'
+    'stream=index,codec_type,codec_name,width,height,pix_fmt,'
+    'color_primaries,color_transfer,color_space,bits_per_raw_sample,'
+    'r_frame_rate,bit_rate,channels,channel_layout,sample_rate:'
+    'stream_disposition=default,forced,comment:'
+    'stream_tags=language,title';
+
 /// 只要时长的窄入口（老调用点保持原样）。
 Future<int?> probeVideoDurationMs(
   String path, {
@@ -82,17 +408,23 @@ Future<int?> probeVideoDurationMs(
 /// 解析 ffprobe `-print_format json` 的 stdout。纯函数，便于单测。
 ///
 /// 容错到底：ffprobe 对无时长容器给 `"N/A"` 或干脆不给 `duration`；`streams` 可能
-/// 整个缺失（`-show_entries` 只要了 format 时）；单个 stream 可能没有 `tags`。
-/// 任何一处不合预期都只让那一项为空，**不让整次探测作废**。
+/// 整个缺失；单个 stream 可能没有 `tags` / `disposition`；**未标注的色彩字段整个键都
+/// 不出现**。任何一处不合预期都只让那一项为空，**不让整次探测作废**。
 VideoProbeFacts parseFfprobeFacts(String stdout) {
   final String trimmed = stdout.trim();
   if (trimmed.isEmpty) return VideoProbeFacts.empty;
   try {
     final Object? decoded = jsonDecode(trimmed);
     if (decoded is! Map<String, dynamic>) return VideoProbeFacts.empty;
+    final Object? format = decoded['format'];
+    final Object? streams = decoded['streams'];
     return VideoProbeFacts(
-      durationMs: _durationMsFrom(decoded['format']),
-      audioLanguages: _audioLanguagesFrom(decoded['streams']),
+      durationMs: _durationMsFrom(format),
+      fileSizeBytes: _intFrom(_mapOrNull(format)?['size']),
+      containerBitrate: _intFrom(_mapOrNull(format)?['bit_rate']),
+      video: _videoFrom(streams),
+      audioTracks: _audioTracksFrom(streams),
+      subtitleTracks: _subtitleTracksFrom(streams),
     );
   } catch (_) {
     return VideoProbeFacts.empty;
@@ -104,8 +436,9 @@ int? parseFfprobeDurationMs(String stdout) =>
     parseFfprobeFacts(stdout).durationMs;
 
 int? _durationMsFrom(Object? format) {
-  if (format is! Map<String, dynamic>) return null;
-  final Object? duration = format['duration'];
+  final Map<String, dynamic>? map = _mapOrNull(format);
+  if (map == null) return null;
+  final Object? duration = map['duration'];
   final double? seconds = switch (duration) {
     final num value => value.toDouble(),
     final String value => double.tryParse(value),
@@ -115,21 +448,192 @@ int? _durationMsFrom(Object? format) {
   return (seconds * 1000).round();
 }
 
-List<String> _audioLanguagesFrom(Object? streams) {
-  if (streams is! List) return const <String>[];
-  final List<String> out = <String>[];
+VideoStreamFacts? _videoFrom(Object? streams) {
+  for (final Map<String, dynamic> stream in _streamsOfType(streams, 'video')) {
+    final String? pixelFormat = _stringFrom(stream['pix_fmt']);
+    return VideoStreamFacts(
+      codec: _stringFrom(stream['codec_name']),
+      width: _intFrom(stream['width']),
+      height: _intFrom(stream['height']),
+      pixelFormat: pixelFormat,
+      bitDepth: bitDepthFromPixelFormat(pixelFormat) ??
+          _intFrom(stream['bits_per_raw_sample']),
+      frameRateMilli: frameRateMilliFromFraction(
+        _stringFrom(stream['r_frame_rate']),
+      ),
+      bitrate: _intFrom(stream['bit_rate']),
+      colorPrimaries: _stringFrom(stream['color_primaries']),
+      colorTransfer: _stringFrom(stream['color_transfer']),
+      colorSpace: _stringFrom(stream['color_space']),
+    );
+  }
+  return null;
+}
+
+List<AudioTrackFacts> _audioTracksFrom(Object? streams) {
+  final List<AudioTrackFacts> out = <AudioTrackFacts>[];
+  for (final Map<String, dynamic> stream in _streamsOfType(streams, 'audio')) {
+    final Map<String, dynamic>? disposition = _mapOrNull(stream['disposition']);
+    out.add(AudioTrackFacts(
+      index: _intFrom(stream['index']) ?? out.length,
+      codec: _stringFrom(stream['codec_name']),
+      channels: _intFrom(stream['channels']),
+      channelLayout: _stringFrom(stream['channel_layout']),
+      sampleRate: _intFrom(stream['sample_rate']),
+      bitrate: _intFrom(stream['bit_rate']),
+      language: _languageFrom(stream),
+      title: _tagFrom(stream, 'title'),
+      isDefault: _flagFrom(disposition, 'default'),
+      isForced: _flagFrom(disposition, 'forced'),
+      isCommentary: _flagFrom(disposition, 'comment'),
+    ));
+  }
+  return List<AudioTrackFacts>.unmodifiable(out);
+}
+
+List<SubtitleTrackFacts> _subtitleTracksFrom(Object? streams) {
+  final List<SubtitleTrackFacts> out = <SubtitleTrackFacts>[];
+  for (final Map<String, dynamic> stream
+      in _streamsOfType(streams, 'subtitle')) {
+    final Map<String, dynamic>? disposition = _mapOrNull(stream['disposition']);
+    out.add(SubtitleTrackFacts(
+      index: _intFrom(stream['index']) ?? out.length,
+      codec: _stringFrom(stream['codec_name']),
+      language: _languageFrom(stream),
+      title: _tagFrom(stream, 'title'),
+      isDefault: _flagFrom(disposition, 'default'),
+      isForced: _flagFrom(disposition, 'forced'),
+    ));
+  }
+  return List<SubtitleTrackFacts>.unmodifiable(out);
+}
+
+Iterable<Map<String, dynamic>> _streamsOfType(Object? streams, String type) sync* {
+  if (streams is! List) return;
   for (final Object? stream in streams) {
     if (stream is! Map<String, dynamic>) continue;
-    if (stream['codec_type'] != 'audio') continue;
-    final Object? tags = stream['tags'];
-    if (tags is! Map<String, dynamic>) continue;
-    final Object? language = tags['language'];
-    if (language is! String) continue;
-    final String trimmed = language.trim();
-    // `und` 是 ffmpeg 对「未标注」的显式写法，等同于没有——放行它会让下游把
-    // 「未知」当成一个真语言去匹配，永远匹配不上，还挡住后面真有标注的音轨。
-    if (trimmed.isEmpty || trimmed.toLowerCase() == 'und') continue;
-    out.add(trimmed);
+    if (stream['codec_type'] != type) continue;
+    yield stream;
   }
-  return List<String>.unmodifiable(out);
+}
+
+/// `und` 是 ffmpeg 对「未标注」的显式写法，等同于没有。
+String? _languageFrom(Map<String, dynamic> stream) {
+  final String? language = _tagFrom(stream, 'language');
+  if (language == null) return null;
+  return language.toLowerCase() == 'und' ? null : language;
+}
+
+String? _tagFrom(Map<String, dynamic> stream, String key) {
+  final Map<String, dynamic>? tags = _mapOrNull(stream['tags']);
+  if (tags == null) return null;
+  return _stringFrom(tags[key]);
+}
+
+/// ffprobe 的 disposition 值是 0/1 整数。
+bool _flagFrom(Map<String, dynamic>? disposition, String key) =>
+    _intFrom(disposition?[key]) == 1;
+
+/// 从 `yuv420p10le` 这样的 pix_fmt 推每分量位深。
+///
+/// 规则是「`p` 后紧跟的数字」：`yuv420p10le` → 10、`yuv444p12le` → 12、`p010le` → 10；
+/// `yuv420p` 没有后缀数字 → 8（未标位深的都是 8-bit）。
+@visibleForTesting
+int? bitDepthFromPixelFormat(String? pixelFormat) {
+  final String? value = _stringFrom(pixelFormat)?.toLowerCase();
+  if (value == null) return null;
+  final RegExpMatch? match = RegExp(r'p(\d+)').firstMatch(value);
+  if (match == null) return 8;
+  final int? depth = int.tryParse(match.group(1)!);
+  if (depth == null || depth <= 0) return 8;
+  return depth;
+}
+
+/// 解析 ffprobe 的分数帧率 `"2997/125"` → 23976（fps×1000）。
+///
+/// `"0/0"` 是 ffprobe 对「这条流没有帧率」的写法（音轨/字幕轨全是它），返回 null。
+@visibleForTesting
+int? frameRateMilliFromFraction(String? fraction) {
+  final String? value = _stringFrom(fraction);
+  if (value == null) return null;
+  final List<String> parts = value.split('/');
+  if (parts.length != 2) {
+    final double? plain = double.tryParse(value);
+    if (plain == null || !plain.isFinite || plain <= 0) return null;
+    return (plain * 1000).round();
+  }
+  final double? numerator = double.tryParse(parts[0]);
+  final double? denominator = double.tryParse(parts[1]);
+  if (numerator == null || denominator == null) return null;
+  if (denominator == 0 || numerator <= 0) return null;
+  final double fps = numerator / denominator;
+  if (!fps.isFinite || fps <= 0) return null;
+  return (fps * 1000).round();
+}
+
+String? _videoCodecLabel(String? codec) {
+  final String? value = _stringFrom(codec)?.toLowerCase();
+  if (value == null) return null;
+  return switch (value) {
+    'h264' || 'avc' || 'avc1' => 'H.264',
+    'hevc' || 'h265' => 'HEVC',
+    'av1' => 'AV1',
+    'vp9' => 'VP9',
+    'vp8' => 'VP8',
+    'mpeg4' => 'MPEG-4',
+    'mpeg2video' => 'MPEG-2',
+    'vc1' => 'VC-1',
+    _ => value.toUpperCase(),
+  };
+}
+
+String? _audioCodecLabel(String? codec) {
+  final String? value = _stringFrom(codec)?.toLowerCase();
+  if (value == null) return null;
+  return switch (value) {
+    'aac' => 'AAC',
+    'ac3' => 'AC-3',
+    'eac3' => 'E-AC-3',
+    'truehd' => 'TrueHD',
+    'dts' => 'DTS',
+    'flac' => 'FLAC',
+    'opus' => 'Opus',
+    'vorbis' => 'Vorbis',
+    'mp3' => 'MP3',
+    'pcm_s16le' || 'pcm_s24le' || 'pcm_s32le' => 'PCM',
+    _ => value.toUpperCase(),
+  };
+}
+
+String? _subtitleCodecLabel(String? codec) {
+  final String? value = _stringFrom(codec)?.toLowerCase();
+  if (value == null) return null;
+  return switch (value) {
+    'subrip' => 'SRT',
+    'ass' || 'ssa' => 'ASS',
+    'webvtt' => 'WebVTT',
+    'mov_text' => 'MP4TT',
+    'hdmv_pgs_subtitle' => 'PGS',
+    'dvd_subtitle' => 'VobSub',
+    'dvb_subtitle' => 'DVB',
+    _ => value.toUpperCase(),
+  };
+}
+
+Map<String, dynamic>? _mapOrNull(Object? value) =>
+    value is Map<String, dynamic> ? value : null;
+
+/// ffprobe 的数值字段有的给 int、有的给字符串（`"5443344"`），两种都要认。
+int? _intFrom(Object? value) => switch (value) {
+      final int v => v,
+      final num v => v.toInt(),
+      final String v => int.tryParse(v.trim()),
+      _ => null,
+    };
+
+/// 空串按「没有」处理——与 ffprobe「未标注就整个省略键」同义。
+String? _stringFrom(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
 }

--- a/fushi/lib/src/media/video/video_duration_probe.dart
+++ b/fushi/lib/src/media/video/video_duration_probe.dart
@@ -37,7 +37,10 @@ const Duration kVideoDurationProbeTimeout = Duration(seconds: 20);
 /// 落库缓存拿它当失效判据之一：字段集扩了（比如以后加 side_data 里的 Dolby Vision），
 /// 旧行即便文件没变也必须重探，否则新字段永远是空的。**改动下面的 `-show_entries`
 /// 就必须 +1**。
-const int kVideoProbeFieldSetVersion = 2;
+///
+/// v3：加 `attached_pic` disposition——此前拿第一条 video 流当视频轨，内嵌封面图会把
+/// 4K 片子标成「480p · MJPEG」；已缓存的错行靠这次 +1 自动重探。
+const int kVideoProbeFieldSetVersion = 3;
 
 /// 一次 ffprobe 的产出。每个字段各自可空：探到什么算什么，绝不因为一半缺失就把
 /// 另一半也丢掉。
@@ -395,7 +398,7 @@ const String kVideoProbeShowEntries = 'format=duration,size,bit_rate:'
     'stream=index,codec_type,codec_name,width,height,pix_fmt,'
     'color_primaries,color_transfer,color_space,bits_per_raw_sample,'
     'r_frame_rate,bit_rate,channels,channel_layout,sample_rate:'
-    'stream_disposition=default,forced,comment:'
+    'stream_disposition=default,forced,comment,attached_pic:'
     'stream_tags=language,title';
 
 /// 只要时长的窄入口（老调用点保持原样）。
@@ -450,6 +453,16 @@ int? _durationMsFrom(Object? format) {
 
 VideoStreamFacts? _videoFrom(Object? streams) {
   for (final Map<String, dynamic> stream in _streamsOfType(streams, 'video')) {
+    // 内嵌封面图在 ffprobe 眼里也是一条 video 流，codec 是 mjpeg/png、尺寸是海报
+    // 尺寸。它若排在真正的视频轨前面，卡片就会把一个 4K 片子标成「600x900 · MJPEG」。
+    // **必须跳过**，不能拿第一条 video 流了事。
+    //
+    // 实测（ffprobe n7.1.5）：`attached_pic` 是 **mp4/mov** 的机制，封面流上为 1、
+    // 真视频轨为 0。**mkv 设不上这个 disposition**（Matroska 走 Attachments，封面
+    // 根本不作为 stream 出现），所以 mkv 不需要也无法靠这个判据——那边天然没有这个
+    // 问题，别因为 mkv 测不出来就以为判据没用。
+    final Map<String, dynamic>? disposition = _mapOrNull(stream['disposition']);
+    if (_flagFrom(disposition, 'attached_pic')) continue;
     final String? pixelFormat = _stringFrom(stream['pix_fmt']);
     return VideoStreamFacts(
       codec: _stringFrom(stream['codec_name']),
@@ -534,19 +547,26 @@ String? _tagFrom(Map<String, dynamic> stream, String key) {
 bool _flagFrom(Map<String, dynamic>? disposition, String key) =>
     _intFrom(disposition?[key]) == 1;
 
-/// 从 `yuv420p10le` 这样的 pix_fmt 推每分量位深。
+/// 从 `yuv420p10le` 这样的 pix_fmt 推每分量位深；**推不出返回 null**。
 ///
-/// 规则是「`p` 后紧跟的数字」：`yuv420p10le` → 10、`yuv444p12le` → 12、`p010le` → 10；
-/// `yuv420p` 没有后缀数字 → 8（未标位深的都是 8-bit）。
+/// 规则是「`p` 后紧跟的数字」：`yuv420p10le` → 10、`yuv444p12le` → 12、`p010le` → 10。
+/// `yuv420p` 这类以 `p` 结尾、无后缀数字的平面格式 → 8（未标位深的都是 8-bit）。
+///
+/// 但**不以 `p` 收尾的格式（`rgb48le`、`xyz12le`、`nv20`…）一律返回 null**，好让调用
+/// 方回退到 ffprobe 的 `bits_per_raw_sample`。此前这里无条件兜底成 8，等于把那些格式
+/// 的真实位深（16 / 12）永久盖成 8，而回退值明明就在同一条 JSON 里。
 @visibleForTesting
 int? bitDepthFromPixelFormat(String? pixelFormat) {
   final String? value = _stringFrom(pixelFormat)?.toLowerCase();
   if (value == null) return null;
   final RegExpMatch? match = RegExp(r'p(\d+)').firstMatch(value);
-  if (match == null) return 8;
-  final int? depth = int.tryParse(match.group(1)!);
-  if (depth == null || depth <= 0) return 8;
-  return depth;
+  if (match != null) {
+    final int? depth = int.tryParse(match.group(1)!);
+    if (depth != null && depth > 0) return depth;
+  }
+  // 平面格式以 `p` 结尾（yuv420p / gbrp / yuvj444p）= 8-bit。
+  if (value.endsWith('p')) return 8;
+  return null;
 }
 
 /// 解析 ffprobe 的分数帧率 `"2997/125"` → 23976（fps×1000）。

--- a/fushi/lib/src/media/video/video_dynamic_range.dart
+++ b/fushi/lib/src/media/video/video_dynamic_range.dart
@@ -1,0 +1,179 @@
+/// 片源动态范围（SDR / HDR10 / HLG）的**唯一值域**与各来源的归一入口。
+///
+/// 存在的理由是收口：同一个「这片子是不是 HDR」，仓库里原本有三套互不相识的表示——
+/// - libmpv `video-params`：`primaries=bt.2020` + `gamma=pq|hlg`（`video_hdr_output.dart`
+///   的 [isHdrVideoParams]，只服务 Windows HDR 直通判据）；
+/// - ffprobe：`color_primaries=bt2020` + `color_transfer=smpte2084|arib-std-b67`
+///   （**字符串与 mpv 全不同名**，不能互相直接比较）；
+/// - 种子发布标题解析：`AnimeDynamicRange`（`media/torrent/anime_release_descriptor.dart`），
+///   只认标题里的 `HDR10` / `HLG` 字样。
+///
+/// 三套各判各的，库页和播放器就会对同一个文件给出不一致的 HDR 结论。这里只做一件事：
+/// 定义一个值域，并给每个来源一个归一函数。**判据本身在各来源之间保持一致**（见下），
+/// 不因为来源不同而放宽或收紧。
+library;
+
+import 'package:flutter/foundation.dart' show immutable;
+
+/// 片源动态范围。
+///
+/// [unknown] 与 [sdr] **是两回事，不可互相顶替**：容器里没写色彩标签时，ffprobe 会
+/// 直接省略 `color_primaries` / `color_transfer` 字段（实测：未显式给编码器写 VUI 的
+/// 文件，连 `-show_streams` 全量输出里也没有这两个键）。此时正确答案是「不知道」，
+/// 而不是「SDR」——把未知当 SDR 会让 UI 对一个真 HDR 片源打上 SDR 标，比不显示更糟。
+enum VideoDynamicRange {
+  /// 标准动态范围（BT.709 等）。
+  sdr,
+
+  /// HDR10：PQ 曲线（ffprobe `smpte2084` / mpv `pq`）。
+  hdr10,
+
+  /// HLG：混合对数伽马（ffprobe `arib-std-b67` / mpv `hlg`）。
+  hlg,
+
+  /// 色彩标签缺失或无法识别——**不等于 SDR**。
+  unknown;
+
+  /// 是否属于高动态范围。[unknown] 一律为 false（不猜）。
+  bool get isHdr => this == hdr10 || this == hlg;
+
+  /// 给 UI 的短标签；[unknown] 无标签（UI 不应为「不知道」占一个角标位）。
+  String? get badgeLabel => switch (this) {
+        VideoDynamicRange.hdr10 => 'HDR10',
+        VideoDynamicRange.hlg => 'HLG',
+        VideoDynamicRange.sdr => 'SDR',
+        VideoDynamicRange.unknown => null,
+      };
+
+  /// 持久化 / 比较用的稳定字符串（不用 [name] 以免日后改枚举名时静默改变存储值）。
+  String get storageValue => switch (this) {
+        VideoDynamicRange.sdr => 'sdr',
+        VideoDynamicRange.hdr10 => 'hdr10',
+        VideoDynamicRange.hlg => 'hlg',
+        VideoDynamicRange.unknown => 'unknown',
+      };
+
+  static VideoDynamicRange fromStorage(String? value) {
+    for (final VideoDynamicRange r in values) {
+      if (r.storageValue == value) return r;
+    }
+    return VideoDynamicRange.unknown;
+  }
+}
+
+/// 一组色彩标签（primaries + transfer），与来源无关。
+///
+/// 两个来源的字符串拼写不同，先各自归一成这个中间形状，再走同一条判据——判据只写
+/// 一次，就不会出现「mpv 说 HDR、ffprobe 说 SDR」。
+@immutable
+class VideoColorTags {
+  const VideoColorTags({this.primaries, this.transfer});
+
+  /// 是否 BT.2020 色域。null = 容器没写。
+  final bool? primaries;
+
+  /// 传递函数；null = 容器没写。
+  final VideoTransferFunction? transfer;
+}
+
+/// 传递函数（归一后的值域）。
+enum VideoTransferFunction { sdr, pq, hlg }
+
+/// **唯一判据**：BT.2020 色域 **且** PQ/HLG 曲线才算 HDR。
+///
+/// 用「与」而不是只看 transfer，是为了与既有的 Windows HDR 直通行为逐位一致
+/// （[isHdrVideoParams] 从一开始就是这个与逻辑，改判据会改变哪些片源触发宿主窗，
+/// 属于破坏既有行为）。代价是「只写了 PQ 却没写 primaries」的畸形文件会判成
+/// [VideoDynamicRange.unknown] 而非 HDR——这类文件极罕见，且判 unknown 只是不显示
+/// 角标，不会显示错误信息。
+VideoDynamicRange resolveDynamicRange(VideoColorTags tags) {
+  // 两个标签都缺 = 容器没写色彩信息，诚实返回「不知道」。
+  if (tags.primaries == null && tags.transfer == null) {
+    return VideoDynamicRange.unknown;
+  }
+  final bool bt2020 = tags.primaries ?? false;
+  switch (tags.transfer) {
+    case VideoTransferFunction.pq:
+      return bt2020 ? VideoDynamicRange.hdr10 : VideoDynamicRange.unknown;
+    case VideoTransferFunction.hlg:
+      return bt2020 ? VideoDynamicRange.hlg : VideoDynamicRange.unknown;
+    case VideoTransferFunction.sdr:
+      return VideoDynamicRange.sdr;
+    case null:
+      // 有 primaries 没 transfer：BT.2020 色域本身不足以断定 HDR（存在 BT.2020 的
+      // SDR 素材），信息不足。
+      return VideoDynamicRange.unknown;
+  }
+}
+
+/// ffprobe `color_primaries` / `color_transfer` → [VideoDynamicRange]。
+///
+/// 取值实测自捆绑的 ffprobe n7.1.5（样本见计划记录）：
+/// - HDR10：`color_primaries=bt2020`、`color_transfer=smpte2084`
+/// - HLG：  `color_primaries=bt2020`、`color_transfer=arib-std-b67`
+/// - SDR：  `color_primaries=bt709`、 `color_transfer=bt709`
+/// - 未标注：**两个键都不出现在 JSON 里**（不是空串、不是 "unknown"）。
+VideoDynamicRange dynamicRangeFromFfprobe({
+  String? colorPrimaries,
+  String? colorTransfer,
+}) =>
+    resolveDynamicRange(VideoColorTags(
+      primaries: _bt2020FromFfprobe(colorPrimaries),
+      transfer: _transferFromFfprobe(colorTransfer),
+    ));
+
+/// libmpv `video-params/primaries` / `video-params/gamma` → [VideoDynamicRange]。
+///
+/// mpv 的拼写与 ffprobe 不同：色域是 `bt.2020`（**带点**），曲线是 `pq` / `hlg`。
+VideoDynamicRange dynamicRangeFromMpv({
+  String? primaries,
+  String? gamma,
+}) =>
+    resolveDynamicRange(VideoColorTags(
+      primaries: _bt2020FromMpv(primaries),
+      transfer: _transferFromMpv(gamma),
+    ));
+
+bool? _bt2020FromFfprobe(String? value) {
+  final String? v = _normalized(value);
+  if (v == null) return null;
+  // ffprobe 对 BT.2020 有两种拼法（`bt2020` 与旧的 `bt2020nc`/`bt2020_ncl` 属于
+  // color_space，不是 primaries；primaries 侧只会是 `bt2020`）。
+  return v == 'bt2020';
+}
+
+VideoTransferFunction? _transferFromFfprobe(String? value) {
+  final String? v = _normalized(value);
+  if (v == null) return null;
+  return switch (v) {
+        'smpte2084' => VideoTransferFunction.pq,
+        'arib-std-b67' => VideoTransferFunction.hlg,
+        _ => VideoTransferFunction.sdr,
+      };
+}
+
+bool? _bt2020FromMpv(String? value) {
+  final String? v = _normalized(value);
+  if (v == null) return null;
+  return v == 'bt.2020';
+}
+
+VideoTransferFunction? _transferFromMpv(String? value) {
+  final String? v = _normalized(value);
+  if (v == null) return null;
+  return switch (v) {
+        'pq' => VideoTransferFunction.pq,
+        'hlg' => VideoTransferFunction.hlg,
+        _ => VideoTransferFunction.sdr,
+      };
+}
+
+/// 空串按「没写」处理：mpv 在属性未就绪时给空串，与 ffprobe 的「省略键」同义。
+String? _normalized(String? value) {
+  if (value == null) return null;
+  final String trimmed = value.trim().toLowerCase();
+  if (trimmed.isEmpty || trimmed == 'unknown' || trimmed == 'unspecified') {
+    return null;
+  }
+  return trimmed;
+}

--- a/fushi/lib/src/media/video/video_hdr_output.dart
+++ b/fushi/lib/src/media/video/video_hdr_output.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
 import 'package:fushi/src/models/preferences_repository.dart' show VideoFitMode;
 
 /// Windows HDR 直通 / 10-bit 输出（计划 `docs/plans/2026-08-30-video-hdr-passthrough.md`）。
@@ -99,9 +100,13 @@ class HdrDisplayInfo {
 }
 
 /// 片源是否 HDR：libmpv `video-params/primaries` 为 bt.2020 且 `gamma` 为 PQ / HLG。
-bool isHdrVideoParams({required String? primaries, required String? gamma}) {
-  return primaries == 'bt.2020' && (gamma == 'pq' || gamma == 'hlg');
-}
+///
+/// 判据本体已收口到 [VideoDynamicRange]（`video_dynamic_range.dart`）——同一个「这片子
+/// 是不是 HDR」原先在 mpv、ffprobe、种子标题三处各写一遍、字符串还各不相同。这里保留
+/// 成薄壳是因为直通链路只关心一个 bool，且调用点/单测都以这个名字为准；语义与归一后的
+/// [dynamicRangeFromMpv] 逐位等价。
+bool isHdrVideoParams({required String? primaries, required String? gamma}) =>
+    dynamicRangeFromMpv(primaries: primaries, gamma: gamma).isHdr;
 
 /// 唯一的模式判据（计划 §4.4）——所有「要不要走宿主窗」都只问这里。
 bool shouldUseHdrHostWindow({

--- a/fushi/lib/src/media/video/video_specs_display.dart
+++ b/fushi/lib/src/media/video/video_specs_display.dart
@@ -1,0 +1,194 @@
+/// 把 [VideoProbeFacts] 变成给人看的字符串（v95）。
+///
+/// 单独一层是因为**同一份事实有两种展示密度**：库页卡片只有一个角落放得下两个词，
+/// 作品详情页要摊开成十来行。格式化写在各自的 widget 里，两边迟早对同一个码率给出
+/// 不同写法（一边 15.6 Mbps 一边 15586 kbps）。
+///
+/// **本层不碰 i18n**：slang 生成的 `t` 是 library-private 类型，跨文件当参数传不了；
+/// 更重要的是值的格式化（`23.976 fps`、`5.1`、`10 bit`）本来就与语言无关，而 label
+/// 与标志词才需要翻译。所以这里只产出「字段 + 值」，label 的映射留给 widget 层——
+/// 顺带让这一整层可以脱离 widget 测试。
+library;
+
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
+
+/// 详情页规格表里的一项。widget 层据此取对应的 i18n label。
+enum VideoSpecField {
+  resolution,
+  dynamicRange,
+  videoCodec,
+  bitDepth,
+  frameRate,
+  bitrate,
+  audioTracks,
+  subtitleTracks,
+}
+
+/// 卡片封面角标：**最多两个**，依次是清晰度与动态范围。
+///
+/// 刻意只给两个：封面是给人认片子的，不是规格表。四个角已被标签/集数/云/进度条占住，
+/// 再多塞就开始盖画面。完整规格在作品详情页。
+///
+/// SDR 不出角标——「这片子是 SDR」不是信息，绝大多数片源都是；只有 HDR10 / HLG 值得
+/// 占位（unknown 更是绝不出，见 [VideoDynamicRange] 的 unknown≠sdr 说明）。
+List<String> videoSpecsCoverBadges(VideoProbeFacts? facts) {
+  final VideoStreamFacts? video = facts?.video;
+  if (video == null) return const <String>[];
+  final List<String> out = <String>[];
+  final String? resolution = video.resolutionLabel;
+  if (resolution != null) out.add(resolution);
+  final VideoDynamicRange range = video.dynamicRange;
+  if (range.isHdr) {
+    final String? label = range.badgeLabel;
+    if (label != null) out.add(label);
+  }
+  return List<String>.unmodifiable(out);
+}
+
+/// 一行紧凑摘要，给卡片文字区/集卡状态行用：`1080p · HDR10 · HEVC`。
+///
+/// 没有任何可显示项时返回 null 而不是空串——调用方据此决定「整行不渲染」，空串会白
+/// 占一行高度。
+String? videoSpecsInlineSummary(VideoProbeFacts? facts) {
+  final VideoStreamFacts? video = facts?.video;
+  if (video == null) return null;
+  final List<String> parts = <String>[
+    ...videoSpecsCoverBadges(facts),
+    if (video.codecLabel != null) video.codecLabel!,
+  ];
+  return parts.isEmpty ? null : parts.join(' · ');
+}
+
+/// 详情页的规格项（字段 + 已格式化的值）。
+///
+/// **探不到的项整行不出现**，不显示「未知」——一行「色深：未知」对用户毫无价值，
+/// 只会把真正有信息的行挤下去。
+List<(VideoSpecField field, String value)> videoSpecsFields(
+  VideoProbeFacts? facts,
+) {
+  if (facts == null) return const <(VideoSpecField, String)>[];
+  final List<(VideoSpecField, String)> rows = <(VideoSpecField, String)>[];
+  final VideoStreamFacts? video = facts.video;
+
+  if (video != null) {
+    final String? resolution = video.resolutionLabel;
+    if (resolution != null) {
+      // 「4K」后面补真实像素：4K 是档位不是尺寸（3840×2160 与 4096×1716 同档不同
+      // 形），而用户比较片源时在意的正是这个差别。
+      final String pixels = (video.width != null && video.height != null)
+          ? ' (${video.width}×${video.height})'
+          : '';
+      rows.add((VideoSpecField.resolution, '$resolution$pixels'));
+    }
+
+    final String? rangeLabel = video.dynamicRange.badgeLabel;
+    if (rangeLabel != null) {
+      rows.add((VideoSpecField.dynamicRange, rangeLabel));
+    }
+
+    final String? codec = video.codecLabel;
+    if (codec != null) rows.add((VideoSpecField.videoCodec, codec));
+
+    final int? bitDepth = video.bitDepth;
+    if (bitDepth != null) rows.add((VideoSpecField.bitDepth, '$bitDepth bit'));
+
+    final String? frameRate = formatFrameRate(video.frameRateMilli);
+    if (frameRate != null) rows.add((VideoSpecField.frameRate, frameRate));
+  }
+
+  // 码率优先用视频流自己的；mkv 不给流级码率，退回容器级（见 VideoProbeFacts 注释）。
+  final String? bitrate =
+      formatBitrate(video?.bitrate ?? facts.containerBitrate);
+  if (bitrate != null) rows.add((VideoSpecField.bitrate, bitrate));
+
+  return List<(VideoSpecField, String)>.unmodifiable(rows);
+}
+
+/// 一条音轨的展示形态。标志位留给 widget 层配语言（「默认」「评论音轨」「强制」）。
+class TrackDisplay {
+  const TrackDisplay({
+    required this.name,
+    required this.detail,
+    required this.isDefault,
+    required this.isForced,
+    required this.isCommentary,
+  });
+
+  /// 已按「自报标题 → 语言 tag → #序号」回落好的名字。
+  final String name;
+
+  /// `FLAC · 5.1` 这类技术细节；无可显示项时为空串。
+  final String detail;
+
+  final bool isDefault;
+  final bool isForced;
+  final bool isCommentary;
+
+  /// `日本語 · FLAC · 5.1`（不含标志位）。
+  String get headline => detail.isEmpty ? name : '$name · $detail';
+}
+
+/// 音轨 → 展示形态。
+///
+/// 轨道名的回落链与播放器侧音轨菜单一致（title → language → 序号），免得同一条轨道
+/// 在详情页叫「Japanese 5.1」、在播放器里叫「音轨 2」。
+TrackDisplay audioTrackDisplay(AudioTrackFacts track) => TrackDisplay(
+      name: trackDisplayName(track.title, track.language, track.index),
+      detail: <String>[
+        if (track.codecLabel != null) track.codecLabel!,
+        if (track.channelLabel != null) track.channelLabel!,
+      ].join(' · '),
+      isDefault: track.isDefault,
+      isForced: track.isForced,
+      isCommentary: track.isCommentary,
+    );
+
+/// 字幕轨 → 展示形态。
+TrackDisplay subtitleTrackDisplay(SubtitleTrackFacts track) => TrackDisplay(
+      name: trackDisplayName(track.title, track.language, track.index),
+      detail: track.codecLabel ?? '',
+      isDefault: track.isDefault,
+      isForced: track.isForced,
+      isCommentary: false,
+    );
+
+/// 轨道名回落：自报标题 → 语言 tag（大写）→ `#序号`。
+String trackDisplayName(String? title, String? language, int index) {
+  final String? trimmedTitle = title?.trim();
+  if (trimmedTitle != null && trimmedTitle.isNotEmpty) return trimmedTitle;
+  final String? trimmedLanguage = language?.trim();
+  if (trimmedLanguage != null && trimmedLanguage.isNotEmpty) {
+    return trimmedLanguage.toUpperCase();
+  }
+  return '#$index';
+}
+
+/// 帧率：23976 → `23.976 fps`；24000 → `24 fps`（整数不留小数点）。
+String? formatFrameRate(int? frameRateMilli) {
+  if (frameRateMilli == null || frameRateMilli <= 0) return null;
+  if (frameRateMilli % 1000 == 0) return '${frameRateMilli ~/ 1000} fps';
+  final String text = (frameRateMilli / 1000).toStringAsFixed(3);
+  // 去掉尾随 0：23.976 原样保留，25.500 → 25.5。
+  String trimmed = text.replaceAll(RegExp(r'0+$'), '');
+  if (trimmed.endsWith('.')) {
+    trimmed = trimmed.substring(0, trimmed.length - 1);
+  }
+  return '$trimmed fps';
+}
+
+/// 码率：15586453 → `15.6 Mbps`；800000 → `800 kbps`。
+///
+/// 用 1000 而不是 1024 进制：码率历来按十进制记（ffprobe、播放器、发布组标题都是），
+/// 按 1024 折算会与用户在别处看到的数字对不上。
+String? formatBitrate(int? bitsPerSecond) {
+  if (bitsPerSecond == null || bitsPerSecond <= 0) return null;
+  if (bitsPerSecond >= 1000000) {
+    final double mbps = bitsPerSecond / 1000000;
+    // 10 Mbps 以上不留小数位：差 0.1 Mbps 对用户没有意义。
+    return mbps >= 10
+        ? '${mbps.round()} Mbps'
+        : '${mbps.toStringAsFixed(1)} Mbps';
+  }
+  return '${(bitsPerSecond / 1000).round()} kbps';
+}

--- a/fushi/lib/src/media/video/video_specs_service.dart
+++ b/fushi/lib/src/media/video/video_specs_service.dart
@@ -29,10 +29,22 @@ import 'package:fushi/src/models/app_model.dart' show appProvider;
 /// 机械盘/网络盘上互相抢寻道，反而更慢，还会跟正在播放的视频抢 IO。
 const int kVideoSpecsProbeConcurrency = 2;
 
-/// 订阅面。生命周期归 `AppModel`（那里懒建、db 关闭时销毁），这里只负责让 widget
-/// 订阅到它，**且只重建 watch 它的那个子树**——服务通知频率高（滚一屏几十次），
-/// 绝不能经 AppModel 的 `notifyListeners` 转发出去。
-final videoSpecsProvider = ChangeNotifierProvider<VideoSpecsService>(
+/// 取服务实例。生命周期归 `AppModel`（那里懒建、db 关闭时销毁）。
+///
+/// **必须是普通 [Provider]，不能是 `ChangeNotifierProvider`**：后者会给它返回的
+/// notifier 注册 `onDispose(notifier.dispose)`，也就是说 provider 一旦重算，上一次
+/// 的返回值就被 dispose。而这里返回的是 AppModel 持有并复用的那一个实例——它会被
+/// 就地打死，AppModel 毫不知情、继续把这个死实例发给所有人（`_disposed` 让全部探测
+/// 短路，重算时的 `addListener` 还会直接抛断言）。
+///
+/// 触发条件一点也不罕见：`appProvider` 本身是 `ChangeNotifierProvider<AppModel>`，
+/// riverpod 对 ChangeNotifier 恒判 `updateShouldNotify = true`，于是**每一次**
+/// `AppModel.notifyListeners()`（写设置、扫描、播放进度…）都会让本 provider 重算。
+/// 机制由 `test/media/video/video_specs_provider_lifecycle_test.dart` 钉住。
+///
+/// 消费方拿到实例后用 `ListenableBuilder` 订阅变化——重建面照样收敛在角标子树，
+/// 服务通知频率高（滚一屏几十次），绝不能经 AppModel 的 `notifyListeners` 转发。
+final videoSpecsProvider = Provider<VideoSpecsService>(
   (ref) => ref.watch(appProvider).videoSpecsService,
 );
 
@@ -51,6 +63,12 @@ class VideoSpecsService extends ChangeNotifier {
 
   final Queue<String> _queue = Queue<String>();
   final Set<String> _queued = <String>{};
+
+  /// 在途探测：路径 → 那一次探测的 Future。队列与详情页直探共用，保证同一文件
+  /// 同时只有一个 ffprobe（见 [_startProbe]）。
+  final Map<String, Future<VideoProbeFacts?>> _inFlight =
+      <String, Future<VideoProbeFacts?>>{};
+
   int _running = 0;
   bool _disposed = false;
 
@@ -79,8 +97,17 @@ class VideoSpecsService extends ChangeNotifier {
     if (unknown.isEmpty) return;
 
     // 先批量读库：绝大多数情况下这一步就够了，一条 IN 查询换掉几十次 ffprobe。
-    final Map<String, VideoFileSpecRow> rows =
-        await _db.videoFileSpecsByPath(unknown);
+    //
+    // 整段裹 try：本方法是从 widget 的 initState 里 fire-and-forget 调用的，抛出去
+    // 就是无人接管的异步错误。db 在卡片还挂着时被关掉是真实场景（数据根迁移、切
+    // Profile、恢复备份都会 close/reopen FushiDatabase），那时应当安静地退化成
+    // 「这批没读到」，而不是把异常抛进 zone。
+    Map<String, VideoFileSpecRow> rows = const <String, VideoFileSpecRow>{};
+    try {
+      rows = await _db.videoFileSpecsByPath(unknown);
+    } catch (e) {
+      debugPrint('[VideoSpecsService] prime read failed: $e');
+    }
     if (_disposed) return;
 
     bool changed = false;
@@ -100,18 +127,71 @@ class VideoSpecsService extends ChangeNotifier {
 
   /// 立刻探一个文件并等结果（详情页用：只有一个文件，值得等）。
   ///
-  /// 与队列共用缓存与失效判据，不会重复探。
+  /// 与队列共用缓存、失效判据**和在途集合**，不会重复探。
   Future<VideoProbeFacts?> resolve(String filePath) async {
     if (filePath.isEmpty) return null;
     if (_cache.containsKey(filePath)) return _cache[filePath];
-    final VideoFileSpecRow? row = await _db.videoFileSpec(filePath);
+
+    // 同一个文件很容易两条路径同时进来：集卡渲染 prime() 把它排进队列，用户紧接着
+    // 打开该集的「媒体信息」弹窗触发 resolve()。共用在途表就只探一次——否则会起第二个
+    // ffprobe，正好废掉 kVideoSpecsProbeConcurrency 想守的东西（别跟正在播放的视频抢 IO）。
+    final Future<VideoProbeFacts?>? inFlight = _inFlight[filePath];
+    if (inFlight != null) return inFlight;
+
+    VideoFileSpecRow? row;
+    try {
+      row = await _db.videoFileSpec(filePath);
+    } catch (e) {
+      // 与 prime() 同理：db 可能已在别处被关掉，安静退化成「没缓存」去现探。
+      debugPrint('[VideoSpecsService] resolve read failed for "$filePath": $e');
+    }
+    if (_disposed) return null;
     if (row != null && await _rowIsFresh(row)) {
       final VideoProbeFacts facts = videoProbeFactsFromRow(row);
       _cache[filePath] = facts;
-      if (!_disposed) notifyListeners();
+      notifyListeners();
       return facts;
     }
-    return _probeAndStore(filePath);
+
+    return _startProbe(filePath);
+  }
+
+  /// 起一次探测，**同一路径共用同一个 Future**。
+  ///
+  /// 队列与详情页的直探都经过这里，所以「一个文件同时被探两次」在结构上不可能发生，
+  /// 而不是靠两处各自记得检查对方的集合。
+  Future<VideoProbeFacts?> _startProbe(String path) {
+    final Future<VideoProbeFacts?>? existing = _inFlight[path];
+    if (existing != null) return existing;
+    final Future<VideoProbeFacts?> future =
+        _probeAndStore(path).whenComplete(() {
+      // **必须是块体，不能写成 `() => _inFlight.remove(path)`**：
+      // `Map.remove` 返回被移除的值（这里正是这个 future 自己），而
+      // `Future.whenComplete` 的契约是「回调返回 Future 就等它完成」——
+      // 于是 future 等自己，永久挂死。箭头函数会把返回值隐式带出去。
+      _inFlight.remove(path);
+    });
+    _inFlight[path] = future;
+    return future;
+  }
+
+  /// 等队列与在途探测全部落地。
+  ///
+  /// 只给测试用。测试若靠「让出 N 轮事件循环」来等异步队列，N 就成了一个随实现层数
+  /// 漂移的魔数——探测链上多包一层 `whenComplete` 就可能不够，表现为随机的
+  /// 「should have been probed」失败，且会把未完成的任务漏给下一个用例。
+  @visibleForTesting
+  Future<void> drain() async {
+    while (!_disposed && (_inFlight.isNotEmpty || _queue.isNotEmpty)) {
+      if (_inFlight.isEmpty) {
+        // 队列里还有，但还没被 _pump 拉起来——让出一轮再看。
+        await Future<void>.delayed(Duration.zero);
+        continue;
+      }
+      await Future.wait<VideoProbeFacts?>(
+        _inFlight.values.toList(growable: false),
+      );
+    }
   }
 
   /// 丢弃一个文件的缓存（文件被删/被替换时）。
@@ -134,7 +214,7 @@ class VideoSpecsService extends ChangeNotifier {
         _queue.isNotEmpty) {
       final String path = _queue.removeFirst();
       _running++;
-      unawaited(_probeAndStore(path).whenComplete(() {
+      unawaited(_startProbe(path).whenComplete(() {
         _running--;
         _queued.remove(path);
         _pump();
@@ -142,36 +222,48 @@ class VideoSpecsService extends ChangeNotifier {
     }
   }
 
-  /// 真探一次并落库。任何失败都在 [_cache] 里记 null（已问过，别再问）。
+  /// 真探一次并落库。
+  ///
+  /// **探测失败与落库失败分开处理**：探测失败才在 [_cache] 里记 null（已问过，别再问）；
+  /// 落库失败只是丢了跨启动的缓存，本次会话探到的事实照样有效——把它一起判死会让角标
+  /// 在 ffprobe 明明成功的情况下消失，而且 `isResolved` 已为 true，再也不会重试。
   Future<VideoProbeFacts?> _probeAndStore(String path) async {
+    final FileStat stat;
+    final VideoProbeFacts facts;
     try {
-      final FileStat stat = await FileStat.stat(path);
+      stat = await FileStat.stat(path);
       if (stat.type == FileSystemEntityType.notFound) {
         _cache[path] = null;
         return null;
       }
-      final VideoProbeFacts facts = await probe(path);
-      if (_disposed) return null;
-      if (facts.isEmpty) {
-        // 探不出就不落库——写一个空壳会让它永远「命中缓存」，再也不会重试。
-        _cache[path] = null;
-        notifyListeners();
-        return null;
-      }
-      _cache[path] = facts;
+      facts = await probe(path);
+    } catch (e) {
+      debugPrint('[VideoSpecsService] probe failed for "$path": $e');
+      _cache[path] = null;
+      return null;
+    }
+    if (_disposed) return null;
+    if (facts.isEmpty) {
+      // 探不出就不落库——写一个空壳会让它永远「命中缓存」，再也不会重试。
+      _cache[path] = null;
+      notifyListeners();
+      return null;
+    }
+    _cache[path] = facts;
+    try {
       await _db.upsertVideoFileSpec(videoFileSpecCompanion(
         filePath: path,
         facts: facts,
         fileSizeBytes: stat.size,
         fileModifiedAt: stat.modified.millisecondsSinceEpoch,
       ));
-      if (!_disposed) notifyListeners();
-      return facts;
     } catch (e) {
-      debugPrint('[VideoSpecsService] probe failed for "$path": $e');
-      _cache[path] = null;
-      return null;
+      // 库写不进去（磁盘满 / 迁移中把 db 关了 / 约束冲突）不影响本次结果，
+      // 只是下次启动要重探一遍。
+      debugPrint('[VideoSpecsService] persist failed for "$path": $e');
     }
+    if (!_disposed) notifyListeners();
+    return facts;
   }
 
   /// 缓存行是否仍代表磁盘上那个文件。

--- a/fushi/lib/src/media/video/video_specs_service.dart
+++ b/fushi/lib/src/media/video/video_specs_service.dart
@@ -1,0 +1,271 @@
+/// 视频文件技术规格的读取与按需探测（v95）。
+///
+/// UI 的约束决定了这个模块的形状：库页在 `build` 里同步渲染几十张卡，**不能 await**。
+/// 所以对外只有一个同步读 [specsFor]（命中内存缓存就给，没有就返回 null），另有一个
+/// [prime] 让调用方把「我这一屏要用到的路径」交进来——GridView 只 build 可见项与缓存
+/// 区，于是天然只探可见的那些，不会因为库里有几千个文件就把它们全 ffprobe 一遍。
+///
+/// 三层：内存 map（渲染读它）→ `video_file_specs` 表（跨启动持久）→ ffprobe（最后手段）。
+///
+/// 失效判据是「文件大小 + 修改时刻 + 探测器字段集版本」三者全等，任一不同就重探：
+/// 用户换了个同名的高清片源、补录了音轨，或者我们自己扩了探测字段，缓存都必须让路。
+library;
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/models/app_model.dart' show appProvider;
+
+/// 同时在跑的 ffprobe 进程数上限。
+///
+/// 2 而不是更多：探测只读 header（几十毫秒），瓶颈是进程启动与磁盘寻道；开太多会在
+/// 机械盘/网络盘上互相抢寻道，反而更慢，还会跟正在播放的视频抢 IO。
+const int kVideoSpecsProbeConcurrency = 2;
+
+/// 订阅面。生命周期归 `AppModel`（那里懒建、db 关闭时销毁），这里只负责让 widget
+/// 订阅到它，**且只重建 watch 它的那个子树**——服务通知频率高（滚一屏几十次），
+/// 绝不能经 AppModel 的 `notifyListeners` 转发出去。
+final videoSpecsProvider = ChangeNotifierProvider<VideoSpecsService>(
+  (ref) => ref.watch(appProvider).videoSpecsService,
+);
+
+/// 规格服务。挂在 [AppModel] 之下，库页与详情页共用一份缓存。
+class VideoSpecsService extends ChangeNotifier {
+  VideoSpecsService(this._db, {this.probe = probeVideoFacts});
+
+  final FushiDatabase _db;
+
+  /// 探测入口，可注入以便单测不真起 ffprobe。
+  final Future<VideoProbeFacts> Function(String path) probe;
+
+  /// 已知规格。**value 可为 null**：null = 已经查过、这个文件探不出规格（没装
+  /// ffprobe / 文件损坏 / 是流 URL），用来防止对同一个失败文件反复重试。
+  final Map<String, VideoProbeFacts?> _cache = <String, VideoProbeFacts?>{};
+
+  final Queue<String> _queue = Queue<String>();
+  final Set<String> _queued = <String>{};
+  int _running = 0;
+  bool _disposed = false;
+
+  /// 同步读一个文件的规格。没探过或探不出返回 null。
+  ///
+  /// **不触发探测**——渲染路径必须是纯读。要探请先调 [prime]。
+  VideoProbeFacts? specsFor(String? filePath) {
+    if (filePath == null || filePath.isEmpty) return null;
+    return _cache[filePath];
+  }
+
+  /// 是否已经对这个路径有过结论（不论探到与否）。
+  bool isResolved(String? filePath) =>
+      filePath != null && _cache.containsKey(filePath);
+
+  /// 把一批路径纳入视野：先一条查询批量读库，仍缺的排进后台探测队列。
+  ///
+  /// 幂等且可高频调用——库页每次滚动都会调它，已知的路径直接跳过。
+  Future<void> prime(Iterable<String> filePaths) async {
+    if (_disposed) return;
+    final List<String> unknown = <String>[
+      for (final String path in filePaths.toSet())
+        if (path.isNotEmpty && !_cache.containsKey(path) && !_queued.contains(path))
+          path,
+    ];
+    if (unknown.isEmpty) return;
+
+    // 先批量读库：绝大多数情况下这一步就够了，一条 IN 查询换掉几十次 ffprobe。
+    final Map<String, VideoFileSpecRow> rows =
+        await _db.videoFileSpecsByPath(unknown);
+    if (_disposed) return;
+
+    bool changed = false;
+    for (final String path in unknown) {
+      final VideoFileSpecRow? row = rows[path];
+      if (row != null && await _rowIsFresh(row)) {
+        _cache[path] = videoProbeFactsFromRow(row);
+        changed = true;
+        continue;
+      }
+      // 库里没有、或已过期 → 排队现探。
+      _enqueue(path);
+    }
+    if (changed) notifyListeners();
+    _pump();
+  }
+
+  /// 立刻探一个文件并等结果（详情页用：只有一个文件，值得等）。
+  ///
+  /// 与队列共用缓存与失效判据，不会重复探。
+  Future<VideoProbeFacts?> resolve(String filePath) async {
+    if (filePath.isEmpty) return null;
+    if (_cache.containsKey(filePath)) return _cache[filePath];
+    final VideoFileSpecRow? row = await _db.videoFileSpec(filePath);
+    if (row != null && await _rowIsFresh(row)) {
+      final VideoProbeFacts facts = videoProbeFactsFromRow(row);
+      _cache[filePath] = facts;
+      if (!_disposed) notifyListeners();
+      return facts;
+    }
+    return _probeAndStore(filePath);
+  }
+
+  /// 丢弃一个文件的缓存（文件被删/被替换时）。
+  Future<void> invalidate(String filePath) async {
+    _cache.remove(filePath);
+    await _db.deleteVideoFileSpec(filePath);
+    if (!_disposed) notifyListeners();
+  }
+
+  void _enqueue(String path) {
+    if (_queued.contains(path)) return;
+    _queued.add(path);
+    _queue.add(path);
+  }
+
+  /// 把队列跑到并发上限。每完成一个就再拉一个，不用定时器轮询。
+  void _pump() {
+    while (!_disposed &&
+        _running < kVideoSpecsProbeConcurrency &&
+        _queue.isNotEmpty) {
+      final String path = _queue.removeFirst();
+      _running++;
+      unawaited(_probeAndStore(path).whenComplete(() {
+        _running--;
+        _queued.remove(path);
+        _pump();
+      }));
+    }
+  }
+
+  /// 真探一次并落库。任何失败都在 [_cache] 里记 null（已问过，别再问）。
+  Future<VideoProbeFacts?> _probeAndStore(String path) async {
+    try {
+      final FileStat stat = await FileStat.stat(path);
+      if (stat.type == FileSystemEntityType.notFound) {
+        _cache[path] = null;
+        return null;
+      }
+      final VideoProbeFacts facts = await probe(path);
+      if (_disposed) return null;
+      if (facts.isEmpty) {
+        // 探不出就不落库——写一个空壳会让它永远「命中缓存」，再也不会重试。
+        _cache[path] = null;
+        notifyListeners();
+        return null;
+      }
+      _cache[path] = facts;
+      await _db.upsertVideoFileSpec(videoFileSpecCompanion(
+        filePath: path,
+        facts: facts,
+        fileSizeBytes: stat.size,
+        fileModifiedAt: stat.modified.millisecondsSinceEpoch,
+      ));
+      if (!_disposed) notifyListeners();
+      return facts;
+    } catch (e) {
+      debugPrint('[VideoSpecsService] probe failed for "$path": $e');
+      _cache[path] = null;
+      return null;
+    }
+  }
+
+  /// 缓存行是否仍代表磁盘上那个文件。
+  Future<bool> _rowIsFresh(VideoFileSpecRow row) async {
+    if (row.probeVersion != kVideoProbeFieldSetVersion) return false;
+    final FileStat stat = await FileStat.stat(row.filePath);
+    if (stat.type == FileSystemEntityType.notFound) return false;
+    return stat.size == row.fileSizeBytes &&
+        stat.modified.millisecondsSinceEpoch == row.fileModifiedAt;
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _queue.clear();
+    _queued.clear();
+    super.dispose();
+  }
+}
+
+/// DB 行 → 探测事实。
+///
+/// 刻意复用 [VideoProbeFacts] 而不是另立一个「已落库的规格」类：两者是同一份事实的
+/// 两种存放形态，各写一个类就得写一套互转，还得保证两边字段永远同步。
+VideoProbeFacts videoProbeFactsFromRow(VideoFileSpecRow row) => VideoProbeFacts(
+      durationMs: row.durationMs,
+      fileSizeBytes: row.fileSizeBytes,
+      containerBitrate: row.containerBitrate,
+      video: _videoStreamFromRow(row),
+      audioTracks: decodeTrackListJson<AudioTrackFacts>(
+        row.audioTracksJson,
+        AudioTrackFacts.fromJson,
+      ),
+      subtitleTracks: decodeTrackListJson<SubtitleTrackFacts>(
+        row.subtitleTracksJson,
+        SubtitleTrackFacts.fromJson,
+      ),
+    );
+
+/// 视频流那部分全为空时返回 null——纯音频文件与「探到了但没视频流」应当同形。
+VideoStreamFacts? _videoStreamFromRow(VideoFileSpecRow row) {
+  if (row.width == null &&
+      row.height == null &&
+      row.videoCodec == null &&
+      row.pixelFormat == null) {
+    return null;
+  }
+  return VideoStreamFacts(
+    codec: row.videoCodec,
+    width: row.width,
+    height: row.height,
+    pixelFormat: row.pixelFormat,
+    bitDepth: row.bitDepth,
+    frameRateMilli: row.frameRateMilli,
+    bitrate: row.videoBitrate,
+    colorPrimaries: row.colorPrimaries,
+    colorTransfer: row.colorTransfer,
+    colorSpace: row.colorSpace,
+  );
+}
+
+/// 探测事实 → 待写入的 DB 行。
+VideoFileSpecsCompanion videoFileSpecCompanion({
+  required String filePath,
+  required VideoProbeFacts facts,
+  required int fileSizeBytes,
+  required int fileModifiedAt,
+  DateTime? now,
+}) {
+  final VideoStreamFacts? video = facts.video;
+  return VideoFileSpecsCompanion.insert(
+    filePath: filePath,
+    fileSizeBytes: fileSizeBytes,
+    fileModifiedAt: fileModifiedAt,
+    probedAt: (now ?? DateTime.now()).millisecondsSinceEpoch,
+    probeVersion: kVideoProbeFieldSetVersion,
+    durationMs: Value<int?>(facts.durationMs),
+    containerBitrate: Value<int?>(facts.containerBitrate),
+    videoCodec: Value<String?>(video?.codec),
+    width: Value<int?>(video?.width),
+    height: Value<int?>(video?.height),
+    pixelFormat: Value<String?>(video?.pixelFormat),
+    bitDepth: Value<int?>(video?.bitDepth),
+    frameRateMilli: Value<int?>(video?.frameRateMilli),
+    videoBitrate: Value<int?>(video?.bitrate),
+    colorPrimaries: Value<String?>(video?.colorPrimaries),
+    colorTransfer: Value<String?>(video?.colorTransfer),
+    colorSpace: Value<String?>(video?.colorSpace),
+    audioTracksJson: Value<String>(encodeTrackListJson(<Map<String, Object?>>[
+      for (final AudioTrackFacts t in facts.audioTracks) t.toJson(),
+    ])),
+    subtitleTracksJson:
+        Value<String>(encodeTrackListJson(<Map<String, Object?>>[
+      for (final SubtitleTrackFacts t in facts.subtitleTracks) t.toJson(),
+    ])),
+  );
+}

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -97,6 +97,7 @@ import 'package:fushi/src/media/torrent/anime_download_subscription.dart';
 import 'package:fushi/src/media/torrent/torrent_memory.dart';
 import 'package:fushi/src/media/video/dandanplay_client.dart';
 import 'package:fushi/src/media/video/video_lua_capability.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/media/video/download/video_download_backend_identity.dart';
 import 'package:fushi/src/media/video/download/video_download_path_mapping.dart';
 import 'package:fushi/src/media/video/download/video_download_pipeline_service.dart';
@@ -3608,6 +3609,16 @@ class AppModel with ChangeNotifier {
             MokuroMoeClient(baseUrl: mangaOnlineCatalogBaseUrl),
       );
 
+  /// 视频文件技术规格缓存（v95，懒建）：库页卡片的清晰度/HDR 角标与作品详情页的
+  /// 规格表共用一份，跨页面存活以免来回切页反复 ffprobe。
+  ///
+  /// **刻意不接 `addListener(notifyListeners)`**：它每探完一个文件就通知一次（滚一屏
+  /// 几十次），转发成 AppModel 的全局通知会让每个 `ref.watch(appProvider)` 的页面
+  /// 跟着重建。消费方走 [videoSpecsProvider] 单独订阅，重建面收敛到卡片子树。
+  VideoSpecsService? _videoSpecsService;
+  VideoSpecsService get videoSpecsService =>
+      _videoSpecsService ??= VideoSpecsService(database);
+
   /// Mihon 扩展生态宿主（Android 原生 / Windows、macOS 内置 Java sidecar）。
   ///
   /// 与 mokuro 下载队列一样按首次访问懒建：普通书架和 Mokuro 浏览不会启动 JVM，
@@ -6233,6 +6244,10 @@ class AppModel with ChangeNotifier {
     _animeDownloadSubscriptionService?.stop();
     _mokuroMoeDownloadQueue?.dispose();
     _mokuroMoeDownloadQueue = null;
+    // 服务持有 FushiDatabase 引用，db 关闭/重开时必须一并销毁，否则新库开出来后
+    // 旧实例还拿着已关闭的连接，探测队列一落库就抛。
+    _videoSpecsService?.dispose();
+    _videoSpecsService = null;
     _discoveryDownloadQueue?.dispose();
     _discoveryDownloadQueue = null;
     _mediaDiscoveryService?.close();
@@ -6302,6 +6317,10 @@ class AppModel with ChangeNotifier {
     unawaited(_disposeVideoDownloadPipelineRuntime());
     _mokuroMoeDownloadQueue?.dispose();
     _mokuroMoeDownloadQueue = null;
+    // 服务持有 FushiDatabase 引用，db 关闭/重开时必须一并销毁，否则新库开出来后
+    // 旧实例还拿着已关闭的连接，探测队列一落库就抛。
+    _videoSpecsService?.dispose();
+    _videoSpecsService = null;
     _discoveryDownloadQueue?.dispose();
     _discoveryDownloadQueue = null;
     _mediaDiscoveryService?.close();

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -22,6 +22,7 @@ import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/video_scrape_actions.dart';
 import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/media/video/video_home_layout.dart';
 import 'package:fushi/src/media/video/scraper/auto_scrape_service.dart';
 import 'package:fushi/src/media/video/scraper/cover_meta_store.dart';
@@ -5940,6 +5941,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         context: context,
         builder: (_) => VideoWorkDetailPage(
           database: db,
+          videoSpecs: ref.read(videoSpecsProvider),
           repository: repo,
           workRef: VideoWorkRef.collection(collection.id),
           onChanged: _refresh,
@@ -5967,6 +5969,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         context: context,
         builder: (_) => VideoWorkDetailPage(
           database: ref.read(appProvider).database,
+          videoSpecs: ref.read(videoSpecsProvider),
           repository: widget.repo,
           workRef: VideoWorkRef.book(book.bookUid),
           onChanged: _refresh,
@@ -6119,7 +6122,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                   bottom: 6,
                   left: 6,
                   child: IgnorePointer(
-                    child: VideoSpecsBadgeStrip(filePath: book.videoPath),
+                    child: VideoSpecsBadgeStrip(
+                      service: ref.read(videoSpecsProvider),
+                      filePath: book.videoPath,
+                    ),
                   ),
                 ),
               ],

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -21,6 +21,7 @@ import 'package:fushi/src/media/video/cover_ui/cover_orientation_builder.dart';
 import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/video_scrape_actions.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart';
 import 'package:fushi/src/media/video/video_home_layout.dart';
 import 'package:fushi/src/media/video/scraper/auto_scrape_service.dart';
 import 'package:fushi/src/media/video/scraper/cover_meta_store.dart';
@@ -6111,6 +6112,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                       ),
                     ),
                   ),
+                // v95：清晰度 / HDR 角标。落左下角是因为另外三角已被占满（左上=标签
+                // 与勾选框、右上=集数/新增、右下=云端），bottom 给 6 让开 3px 进度条。
+                // 不随多选态隐藏——它在左下，与左上的勾选框本就不同角，没有让位的必要。
+                Positioned(
+                  bottom: 6,
+                  left: 6,
+                  child: IgnorePointer(
+                    child: VideoSpecsBadgeStrip(filePath: book.videoPath),
+                  ),
+                ),
               ],
             ),
           ),

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -22,6 +22,7 @@ import 'package:fushi/src/media/video/anilist_client.dart' show AniListMedia;
 import 'package:fushi/src/media/video/cover_ui/episode_rename_confirm_dialog.dart';
 import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_panel.dart';
 import 'package:fushi/src/media/video/metadata/video_country_display.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_credit_repository.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
@@ -2206,6 +2207,19 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                                 ),
                               ),
                             ],
+                            // v95：该集的规格摘要（`1080p · HDR10 · HEVC`）。
+                            // 挤进状态行右端而不是新起一行——卡高 _kEpisodeCardHeight
+                            // 是钳死的，两行标题+两行简介已经把 Spacer 余量吃满，
+                            // 多一行会把简介顶掉。Flexible + 内部单行 ellipsis 保证
+                            // 长文件名的规格串不会撑爆这一行。
+                            Flexible(
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: VideoSpecsInlineLine(
+                                  filePath: episode.local?.videoPath,
+                                ),
+                              ),
+                            ),
                           ],
                         ),
                       ],
@@ -2275,6 +2289,19 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
             ],
           ),
         ),
+        // v95：完整技术规格（音轨/字幕轨在集卡上放不下，只能进弹窗）。
+        // 仅本地文件有——远端占位集探不了。
+        if (episode.local != null)
+          PopupMenuItem<_EpisodeMenuAction>(
+            value: _EpisodeMenuAction.mediaInfo,
+            child: Row(
+              children: <Widget>[
+                const Icon(Icons.info_outline, size: 20),
+                const SizedBox(width: 12),
+                Text(t.video_specs_title),
+              ],
+            ),
+          ),
         PopupMenuItem<_EpisodeMenuAction>(
           value: _EpisodeMenuAction.removeFromCollection,
           child: Row(
@@ -2291,11 +2318,37 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     switch (action) {
       case _EpisodeMenuAction.download:
         _openDownloadDialog(episodeNumber: _episodeNumberOf(episode));
+      case _EpisodeMenuAction.mediaInfo:
+        await _showEpisodeMediaInfo(episode);
       case _EpisodeMenuAction.removeFromCollection:
         await _removeEpisode(episode);
       case null:
         break;
     }
+  }
+
+  /// 某一集的完整技术规格弹窗。
+  ///
+  /// 规格是**文件级**事实，所以入口挂在集上而不是作品上——同一合集里各集的分辨率、
+  /// 音轨完全可以不同，作品级摆一份规格是在骗人。
+  Future<void> _showEpisodeMediaInfo(CollectionEpisodeSlot episode) async {
+    final String? path = episode.local?.videoPath;
+    if (path == null || path.isEmpty) return;
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(_episodeDisplayTitle(episode)),
+        content: SingleChildScrollView(
+          child: VideoSpecsPanel(filePath: path, showTitle: false),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(t.dialog_close),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _handleManageAction(_CollectionManageAction action) async {
@@ -2488,6 +2541,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
 /// 集卡上下文菜单动作。
 enum _EpisodeMenuAction {
   download,
+  mediaInfo,
   removeFromCollection,
 }
 

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -23,6 +23,7 @@ import 'package:fushi/src/media/video/cover_ui/episode_rename_confirm_dialog.dar
 import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/video_specs_panel.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/media/video/metadata/video_country_display.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_credit_repository.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
@@ -59,6 +60,7 @@ import 'package:fushi_core/fushi_core.dart';
 class MediaCollectionDetailPage extends StatefulWidget {
   const MediaCollectionDetailPage({
     required this.database,
+    this.videoSpecs,
     required this.collection,
     required this.loadEpisodes,
     required this.onOpenEpisode,
@@ -69,6 +71,11 @@ class MediaCollectionDetailPage extends StatefulWidget {
   });
 
   final FushiDatabase database;
+
+  /// 视频规格服务（v95）。**构造注入而不是从 riverpod 取**：本页是普通
+  /// StatefulWidget，它的既有 widget 测试没有也不需要 `ProviderScope`，在页内塞
+  /// ConsumerWidget 会让那些测试全部抛。null = 不显示规格（测试默认如此）。
+  final VideoSpecsService? videoSpecs;
   final MediaCollectionRow collection;
 
   /// 解析本合集**有序**成员槽（调用方持 repo + collectionId；见
@@ -2216,6 +2223,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                               child: Align(
                                 alignment: Alignment.centerRight,
                                 child: VideoSpecsInlineLine(
+                                  service: widget.videoSpecs,
                                   filePath: episode.local?.videoPath,
                                 ),
                               ),
@@ -2291,7 +2299,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         ),
         // v95：完整技术规格（音轨/字幕轨在集卡上放不下，只能进弹窗）。
         // 仅本地文件有——远端占位集探不了。
-        if (episode.local != null)
+        if (episode.local != null && widget.videoSpecs != null)
           PopupMenuItem<_EpisodeMenuAction>(
             value: _EpisodeMenuAction.mediaInfo,
             child: Row(
@@ -2339,7 +2347,11 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       builder: (BuildContext context) => AlertDialog(
         title: Text(_episodeDisplayTitle(episode)),
         content: SingleChildScrollView(
-          child: VideoSpecsPanel(filePath: path, showTitle: false),
+          child: VideoSpecsPanel(
+            service: widget.videoSpecs,
+            filePath: path,
+            showTitle: false,
+          ),
         ),
         actions: <Widget>[
           TextButton(

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:fushi/src/media/media_cover_source.dart';
 import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_credit_repository.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_panel.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
@@ -320,6 +321,12 @@ class _StandaloneVideoWorkDetailState
                     ),
               ),
             ),
+          // v95：技术规格。这一页是「一个文件 = 一部作品」，规格无歧义，摊开显示。
+          // 探不到时整块不占位（VideoSpecsPanel 内部返回 shrink）。
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+            child: VideoSpecsPanel(filePath: book.videoPath),
+          ),
           _buildTerms(tokens),
           _buildCredits(tokens),
           _buildExtras(tokens),

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -9,6 +9,7 @@ import 'package:fushi/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_credit_repository.dart';
 import 'package:fushi/src/media/video/cover_ui/video_specs_panel.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
@@ -31,6 +32,7 @@ class VideoWorkRef {
 class VideoWorkDetailPage extends StatelessWidget {
   const VideoWorkDetailPage({
     required this.database,
+    this.videoSpecs,
     required this.repository,
     required this.workRef,
     required this.onChanged,
@@ -40,6 +42,10 @@ class VideoWorkDetailPage extends StatelessWidget {
   });
 
   final FushiDatabase database;
+
+  /// 视频规格服务（v95）；构造注入，理由同 [MediaCollectionDetailPage.videoSpecs]。
+  /// null = 不显示规格。
+  final VideoSpecsService? videoSpecs;
   final VideoBookRepository repository;
   final VideoWorkRef workRef;
   final VoidCallback onChanged;
@@ -74,6 +80,7 @@ class VideoWorkDetailPage extends StatelessWidget {
           }
           return MediaCollectionDetailPage(
             database: database,
+            videoSpecs: videoSpecs,
             collection: collection,
             // 成员解析走共享的 [loadCollectionEpisodeSlots]：合集清单是跨端 union，
             // 「本机没有这一行」不等于「这一集不存在」（BUG-1704）。
@@ -104,6 +111,7 @@ class VideoWorkDetailPage extends StatelessWidget {
     }
     return _StandaloneVideoWorkDetail(
       database: database,
+      videoSpecs: videoSpecs,
       repository: repository,
       bookUid: workRef.bookUid!,
       onChanged: onChanged,
@@ -114,12 +122,14 @@ class VideoWorkDetailPage extends StatelessWidget {
 class _StandaloneVideoWorkDetail extends StatefulWidget {
   const _StandaloneVideoWorkDetail({
     required this.database,
+    required this.videoSpecs,
     required this.repository,
     required this.bookUid,
     required this.onChanged,
   });
 
   final FushiDatabase database;
+  final VideoSpecsService? videoSpecs;
   final VideoBookRepository repository;
   final String bookUid;
   final VoidCallback onChanged;
@@ -325,7 +335,10 @@ class _StandaloneVideoWorkDetailState
           // 探不到时整块不占位（VideoSpecsPanel 内部返回 shrink）。
           Padding(
             padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
-            child: VideoSpecsPanel(filePath: book.videoPath),
+            child: VideoSpecsPanel(
+              service: widget.videoSpecs,
+              filePath: book.videoPath,
+            ),
           ),
           _buildTerms(tokens),
           _buildCredits(tokens),

--- a/fushi/lib/src/storage/data_root_migrator.dart
+++ b/fushi/lib/src/storage/data_root_migrator.dart
@@ -963,6 +963,7 @@ class DataRootMigrator {
         if (debugFailMidRebase) {
           throw StateError('debugFailMidRebase');
         }
+        await _rebaseVideoFileSpecs(db, docs);
         await _rebaseGalgames(db, docs);
         await _rebaseMediaCollections(db, docs);
         await _rebaseCollectionScrapeMeta(db, docs);
@@ -1068,6 +1069,33 @@ class DataRootMigrator {
           newSecondary,
           v.bookUid,
         ],
+      );
+    }
+  }
+
+  /// video_file_specs：file_path（v95 规格探测缓存的**主键**）。
+  ///
+  /// 这张表是可重建缓存，理论上不改写也不会丢数据——但键指向旧路径就永远命不中，用户
+  /// 换完数据位置后整个库的清晰度/HDR 角标会集体消失，然后几百个文件挨个重新 ffprobe
+  /// 才慢慢长回来。改写只是一条 UPDATE，没有理由让用户白等这一轮。
+  ///
+  /// 用 `UPDATE OR REPLACE`：主键改写理论上可能撞上一条已存在的目标行（旧根与新根
+  /// 嵌套时两条路径可能归一到同一新值），撞了就让后写的覆盖，**不让整个迁移事务因为
+  /// 一条缓存行的主键冲突而回滚**——缓存的正确性远低于迁移本身。
+  static Future<void> _rebaseVideoFileSpecs(
+    FushiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    final List<QueryRow> rows =
+        await db.customSelect('SELECT file_path FROM video_file_specs').get();
+    for (final QueryRow row in rows) {
+      final String oldPath = row.read<String>('file_path');
+      final String newPath = docs.rebase(oldPath);
+      if (newPath == oldPath) continue;
+      await db.customStatement(
+        'UPDATE OR REPLACE video_file_specs SET file_path = ? '
+        'WHERE file_path = ?',
+        <Object?>[newPath, oldPath],
       );
     }
   }

--- a/fushi/lib/src/storage/path_rebase_coverage.dart
+++ b/fushi/lib/src/storage/path_rebase_coverage.dart
@@ -258,6 +258,28 @@ const List<PathRebaseColumn> kPathRebaseColumns = <PathRebaseColumn>[
       'TODO-1157 流媒体加载凭据 {subtitleUrl,subtitleFileName,referer,userAgent}，'
           '全是远端 URL / HTTP header，无本机路径。'),
 
+  // ── video_file_specs（v95 规格探测缓存）────────────────────────────
+  PathRebaseColumn(
+      'VideoFileSpecs',
+      'filePath',
+      PathRebaseKind.documentsRooted,
+      '本表的**主键**，与 video_books.video_path 同语义（数据根内下载副本 / 用户原位'
+          '外部文件）。不改写 = 数据根搬家后整张规格缓存的键全部指向旧路径，永远命不中，'
+          '每个条目都要重探一遍（几百个文件的 ffprobe）。虽是可重建的缓存，但改写成本'
+          '只是一条 UPDATE，没有理由让用户白等。'),
+  PathRebaseColumn(
+      'VideoFileSpecs',
+      'audioTracksJson',
+      PathRebaseKind.notAPath,
+      'ffprobe 音轨事实数组 [{index,codec,channels,language,title,标志位}]，'
+          '全是流属性与语言 tag，无任何文件系统路径。'),
+  PathRebaseColumn(
+      'VideoFileSpecs',
+      'subtitleTracksJson',
+      PathRebaseKind.notAPath,
+      '内封字幕轨事实数组，与 audioTracksJson 同型——内封轨没有外部文件，'
+          '外挂字幕路径存在 video_books.subtitle_source，不在本表。'),
+
   // ── 统计 / 收藏 ────────────────────────────────────────────────────
   PathRebaseColumn('FavoriteWords', 'sourceType', PathRebaseKind.notAPath,
       '统计桶枚举值（book/video/...），不是路径。'),

--- a/fushi/lib/src/sync/backup_merge_engine.dart
+++ b/fushi/lib/src/sync/backup_merge_engine.dart
@@ -1421,6 +1421,9 @@ List<String> mergeSkippedDeviceLocalTableNames() =>
       'video_download_subscriptions',
       'video_download_subscription_items',
       'web_mine_queue',
+      // v95：ffprobe 规格探测缓存。键是本机绝对路径、内容是本机文件的实测结果，
+      // 换台设备既命不中也可能与对端的同名文件规格不同——必须现探，不能合并进来。
+      'video_file_specs',
     ]);
 
 /// Read-only summary of what a backup MERGE import would change on this device

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -565,9 +565,11 @@ class BackupService {
     'sync_baselines',
     'fushi_paired_peers',
     'web_mine_queue',
+    'video_file_specs',
   ];
 
   static const List<String> _deviceLocalTablesParentFirst = <String>[
+    'video_file_specs',
     'web_mine_queue',
     'sync_baselines',
     'fushi_paired_peers',

--- a/fushi/test/database/collection_relations_test.dart
+++ b/fushi/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final FushiDatabase db = await openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/fushi/test/database/migration_test.dart
+++ b/fushi/test/database/migration_test.dart
@@ -1080,7 +1080,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 paired peers 表). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1157,7 +1157,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1315,7 +1315,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1366,7 +1366,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
     });
 
     test(
@@ -1375,7 +1375,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1409,7 +1409,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1449,7 +1449,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1480,7 +1480,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1514,7 +1514,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1526,7 +1526,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1562,7 +1562,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/fushi/test/database/migration_v40_collections_test.dart
+++ b/fushi/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v51_pdf_format_test.dart
+++ b/fushi/test/database/migration_v51_pdf_format_test.dart
@@ -109,6 +109,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/fushi/test/database/migration_v53_manga_reading_mode_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/fushi/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/fushi/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v57_naming_unification_test.dart
+++ b/fushi/test/database/migration_v57_naming_unification_test.dart
@@ -191,7 +191,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v60_reading_pages_test.dart
+++ b/fushi/test/database/migration_v60_reading_pages_test.dart
@@ -64,7 +64,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 95, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/fushi/test/database/migration_v61_collection_cover_path_test.dart
+++ b/fushi/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -279,6 +279,7 @@ void main() {
         'study_segments',
         'study_segment_tombstones',
         'web_mine_queue',
+        'video_file_specs',
       },
       reason: '除 v64 的 collection_scrape_meta、v65 的 Mihon 五表、v66 的 '
           'collection_relations、v68 的 media_images、v77 视频来源刮削表、'
@@ -286,7 +287,8 @@ void main() {
           'v80 的 media_open_history（取代 media_items）、v89 的 '
           'manga_chapter_states（漫画每章阅读状态）与 v92 的 study_segments / '
           'study_segment_tombstones（学习统计唯一事实表 + 按身份墓碑）、'
-          'v93 的 web_mine_queue（网页播放器自动制卡队列）外，'
+          'v93 的 web_mine_queue（网页播放器自动制卡队列）与 v95 的 '
+          'video_file_specs（视频文件技术规格探测缓存）外，'
           '升级不得新增任何表',
     );
   });
@@ -305,7 +307,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
+    expect(version.read<int>('user_version'), 95);
   });
 
   test(
@@ -336,7 +338,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,7 +105,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
     expect(await _userVersion(db), db.schemaVersion);
 
     // v63 真跑了：两处废弃偏好都没了。

--- a/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
+++ b/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
@@ -77,7 +77,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v75 给 galgames 加 japanese_locale_mode（每游戏转区档位）');
 
     final List<QueryRow> columns =

--- a/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
+++ b/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
@@ -86,7 +86,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v76 给 lookup_mining_counters 的 book_key 进唯一键');
 
     final List<LookupMiningCounterRow> rows =

--- a/fushi/test/database/migration_v79_tag_assignments_test.dart
+++ b/fushi/test/database/migration_v79_tag_assignments_test.dart
@@ -114,7 +114,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
 
     final List<TagAssignmentRow> rows = await db.getAllTagAssignments();
     expect(rows, hasLength(5), reason: '5 张表各 1 行有效映射（孤儿 srt 行丢弃）');

--- a/fushi/test/database/migration_v80_media_open_history_test.dart
+++ b/fushi/test/database/migration_v80_media_open_history_test.dart
@@ -61,7 +61,7 @@ CREATE TABLE media_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
 
     final rows = await db.getAllMediaOpenHistory();
     expect(rows, hasLength(2), reason: '迁移零丢行');

--- a/fushi/test/database/migration_v82_subtable_uid_test.dart
+++ b/fushi/test/database/migration_v82_subtable_uid_test.dart
@@ -131,7 +131,7 @@ CREATE TABLE revealed_images (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94, reason: 'v82 = 四子表书键切 uid');
+    expect(db.schemaVersion, 95, reason: 'v82 = 四子表书键切 uid');
 
     // ── reader_positions：跨书族，epub 命中换 uid，SRT 照抄 ──
     expect(await count(db, 'reader_positions'), 2, reason: '迁移零丢行');

--- a/fushi/test/database/migration_v83_entrykey_uid_test.dart
+++ b/fushi/test/database/migration_v83_entrykey_uid_test.dart
@@ -128,7 +128,7 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v83 = shelf_entries / media_collection_items epub 键切 uid');
 
     // ── shelf_entries：epub 命中换 uid、透传照抄、非 epub 照抄、零丢行 ──

--- a/fushi/test/database/migration_v84_preferences_updated_at_test.dart
+++ b/fushi/test/database/migration_v84_preferences_updated_at_test.dart
@@ -53,8 +53,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     // 存量行零丢失——改名是用户数据，迁移丢一行就是丢一个书名。
     expect(await db.getPref(_overrideKey), 's:母设备改的名');

--- a/fushi/test/database/migration_v85_video_last_played_at_test.dart
+++ b/fushi/test/database/migration_v85_video_last_played_at_test.dart
@@ -94,8 +94,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(4), reason: '迁移丢一行就是丢一部视频的观看记录');

--- a/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
+++ b/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
@@ -87,8 +87,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(2), reason: '迁移丢一行就是丢一部视频的记录');

--- a/fushi/test/database/migration_v88_content_language_rest_test.dart
+++ b/fushi/test/database/migration_v88_content_language_rest_test.dart
@@ -94,7 +94,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(hasColumn(probe, 'video_books', 'language'), isTrue);
       expect(hasColumn(probe, 'srt_books', 'language'), isTrue);
       expect(hasColumn(probe, 'galgames', 'language'), isTrue);

--- a/fushi/test/database/migration_v90_download_proxy_merge_test.dart
+++ b/fushi/test/database/migration_v90_download_proxy_merge_test.dart
@@ -129,8 +129,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     expect(await _prefs(db), <String, String>{
       'theme': 's:dark',

--- a/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
+++ b/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
@@ -95,7 +95,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(
           hasColumn(probe, 'media_collections', 'subtitle_language'), isTrue);
       expect(hasColumn(probe, 'media_collections', 'subtitle_release_group'),

--- a/fushi/test/database/migration_v94_download_identity_json_test.dart
+++ b/fushi/test/database/migration_v94_download_identity_json_test.dart
@@ -99,7 +99,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(hasColumn(probe, 'video_download_jobs', 'identity_json'), isTrue);
       expect(hasColumn(probe, 'video_download_subscriptions', 'identity_json'),
           isTrue);

--- a/fushi/test/database/migration_v95_video_file_specs_test.dart
+++ b/fushi/test/database/migration_v95_video_file_specs_test.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+/// v95（库页/详情页技术规格标注）：新表 `video_file_specs`，缓存 ffprobe 探到的
+/// 分辨率 / HDR 色彩标签 / 编码 / 色深 / 帧率 / 音轨 / 字幕轨。
+///
+/// 守三件事：从真实 v94 库出发表会建出来；存量视频书一行不丢；新表初始为空
+/// （= 旧库升级后不显示任何规格角标，与升级前行为一致，由探测队列按需回填）。
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('fushi_v95_file_specs');
+    dbPath = '${tempDir.path}${Platform.pathSeparator}v94-source.db';
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  /// 建一个真实的 v94 形状库：当前 schema 建满、塞一行存量视频书，
+  /// 再把新表整个 DROP 掉、版本写回 94。
+  Future<void> seedV94() async {
+    final FushiDatabase fresh =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await fresh.customStatement(
+      'INSERT INTO video_books (book_uid, title, video_path, imported_at) '
+      "VALUES ('vid-1', '某电影', 'D:\\media\\movie.mkv', 1700000000)",
+    );
+    await fresh.close();
+
+    final sqlite3.Database raw = sqlite3.sqlite3.open(dbPath);
+    try {
+      raw.execute('DROP TABLE video_file_specs');
+      raw.execute('PRAGMA user_version = 94');
+    } finally {
+      raw.dispose();
+    }
+  }
+
+  bool hasTable(sqlite3.Database db, String table) {
+    final sqlite3.ResultSet rows = db.select(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      <Object?>[table],
+    );
+    return rows.isNotEmpty;
+  }
+
+  test('v94 库确实没有 video_file_specs（前提自检）', () async {
+    await seedV94();
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(hasTable(probe, 'video_file_specs'), isFalse);
+      expect(hasTable(probe, 'video_books'), isTrue, reason: '存量表还在');
+    } finally {
+      probe.dispose();
+    }
+  });
+
+  test('v94 -> v95：建表、初始为空、存量视频书无损', () async {
+    await seedV94();
+
+    final FushiDatabase migrated =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+
+    final List<VideoBookRow> books =
+        await migrated.select(migrated.videoBooks).get();
+    expect(books, hasLength(1), reason: '迁移丢一行就是丢一部片子');
+    expect(books.single.title, '某电影');
+    expect(books.single.videoPath, r'D:\media\movie.mkv');
+
+    final List<VideoFileSpecRow> specs =
+        await migrated.select(migrated.videoFileSpecs).get();
+    expect(specs, isEmpty,
+        reason: '新表初始为空 = 旧库升级后不显示规格角标，与升级前逐像素一致');
+
+    await migrated.close();
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
+      expect(hasTable(probe, 'video_file_specs'), isTrue);
+    } finally {
+      probe.dispose();
+    }
+  });
+
+  test('迁移后新表可正常读写，主键是文件路径', () async {
+    await seedV94();
+
+    final FushiDatabase migrated =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await migrated.customStatement(
+      'INSERT INTO video_file_specs (file_path, file_size_bytes, '
+      'file_modified_at, probed_at, probe_version, width, height, '
+      'video_codec, color_transfer) '
+      r"VALUES ('D:\media\movie.mkv', 123456, 1700000000, 1700000001, 2, "
+      "3840, 2160, 'hevc', 'smpte2084')",
+    );
+
+    final VideoFileSpecRow row =
+        (await migrated.select(migrated.videoFileSpecs).get()).single;
+    expect(row.filePath, r'D:\media\movie.mkv');
+    expect(row.width, 3840);
+    expect(row.height, 2160);
+    expect(row.colorTransfer, 'smpte2084');
+    expect(row.audioTracksJson, '[]', reason: '轨道 JSON 默认空数组，不是 NULL');
+    expect(row.subtitleTracksJson, '[]');
+    expect(row.durationMs, isNull, reason: '没探到的列保持 NULL');
+
+    // 同一路径再写一次 = 覆盖，不是新增（主键是 file_path）。
+    await migrated.customStatement(
+      'INSERT OR REPLACE INTO video_file_specs (file_path, file_size_bytes, '
+      'file_modified_at, probed_at, probe_version, width, height) '
+      r"VALUES ('D:\media\movie.mkv', 999, 1700000000, 1700000002, 2, "
+      '1920, 1080)',
+    );
+    final List<VideoFileSpecRow> after =
+        await migrated.select(migrated.videoFileSpecs).get();
+    expect(after, hasLength(1), reason: '同一文件只该有一行');
+    expect(after.single.width, 1920);
+
+    await migrated.close();
+  });
+
+  test('重复打开幂等：第二次开库不因表已存在而报错', () async {
+    await seedV94();
+
+    final FushiDatabase first =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await first.close();
+    final FushiDatabase second =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    expect(await second.select(second.videoBooks).get(), hasLength(1));
+    expect(await second.select(second.videoFileSpecs).get(), isEmpty);
+    await second.close();
+  });
+}

--- a/fushi/test/media/video/video_dynamic_range_test.dart
+++ b/fushi/test/media/video/video_dynamic_range_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
+import 'package:fushi/src/media/video/video_hdr_output.dart';
+
+/// 动态范围归一的值域与判据。
+///
+/// 取值不是查文档抄的，是拿捆绑的 ffprobe n7.1.5 探三个真实样本得到的（分别用
+/// x265 `colorprim=bt2020:transfer=smpte2084` / `transfer=arib-std-b67` 与 x264
+/// `colorprim=bt709` 编出来）。其中「未标注时两个键整个不出现」这条尤其重要，
+/// 是第一批样本（没往 VUI 写色彩标签）实测出来的。
+void main() {
+  group('ffprobe 归一', () {
+    test('HDR10：bt2020 + smpte2084', () {
+      expect(
+        dynamicRangeFromFfprobe(
+          colorPrimaries: 'bt2020',
+          colorTransfer: 'smpte2084',
+        ),
+        VideoDynamicRange.hdr10,
+      );
+    });
+
+    test('HLG：bt2020 + arib-std-b67', () {
+      expect(
+        dynamicRangeFromFfprobe(
+          colorPrimaries: 'bt2020',
+          colorTransfer: 'arib-std-b67',
+        ),
+        VideoDynamicRange.hlg,
+      );
+    });
+
+    test('SDR：bt709 + bt709', () {
+      expect(
+        dynamicRangeFromFfprobe(
+          colorPrimaries: 'bt709',
+          colorTransfer: 'bt709',
+        ),
+        VideoDynamicRange.sdr,
+      );
+    });
+
+    test('两个键都缺 → unknown，而不是 sdr', () {
+      // 回归护栏：把「没写色彩标签」当成 SDR，会给真 HDR 片源打上 SDR 标。
+      final VideoDynamicRange r = dynamicRangeFromFfprobe();
+      expect(r, VideoDynamicRange.unknown);
+      expect(r, isNot(VideoDynamicRange.sdr));
+      expect(r.isHdr, isFalse);
+      expect(r.badgeLabel, isNull, reason: '不知道就不该占角标位');
+    });
+
+    test('只有 primaries 没有 transfer → unknown（BT.2020 也有 SDR 素材）', () {
+      expect(
+        dynamicRangeFromFfprobe(colorPrimaries: 'bt2020'),
+        VideoDynamicRange.unknown,
+      );
+    });
+
+    test('空串 / unknown / unspecified 等同于没写', () {
+      for (final String blank in <String>['', '  ', 'unknown', 'unspecified']) {
+        expect(
+          dynamicRangeFromFfprobe(colorPrimaries: blank, colorTransfer: blank),
+          VideoDynamicRange.unknown,
+          reason: 'primaries=transfer="$blank"',
+        );
+      }
+    });
+
+    test('大小写与空白不影响判定', () {
+      expect(
+        dynamicRangeFromFfprobe(
+          colorPrimaries: ' BT2020 ',
+          colorTransfer: 'SMPTE2084',
+        ),
+        VideoDynamicRange.hdr10,
+      );
+    });
+  });
+
+  group('mpv 归一', () {
+    test('bt.2020 + pq → HDR10（注意 mpv 的色域带点）', () {
+      expect(
+        dynamicRangeFromMpv(primaries: 'bt.2020', gamma: 'pq'),
+        VideoDynamicRange.hdr10,
+      );
+    });
+
+    test('bt.2020 + hlg → HLG', () {
+      expect(
+        dynamicRangeFromMpv(primaries: 'bt.2020', gamma: 'hlg'),
+        VideoDynamicRange.hlg,
+      );
+    });
+
+    test('bt.709 + bt.1886 → SDR', () {
+      expect(
+        dynamicRangeFromMpv(primaries: 'bt.709', gamma: 'bt.1886'),
+        VideoDynamicRange.sdr,
+      );
+    });
+
+    test('属性未就绪（null / 空串）→ unknown', () {
+      expect(dynamicRangeFromMpv(), VideoDynamicRange.unknown);
+      expect(
+        dynamicRangeFromMpv(primaries: '', gamma: ''),
+        VideoDynamicRange.unknown,
+      );
+    });
+  });
+
+  group('跨来源一致性', () {
+    // 收口的意义：同一个片源，无论从 ffprobe 还是从 mpv 得到色彩标签，结论必须相同。
+    // 否则库页卡片与播放器会对同一文件给出互相矛盾的 HDR 判断。
+    const List<(String, String, String, String, VideoDynamicRange)> cases =
+        <(String, String, String, String, VideoDynamicRange)>[
+      ('bt2020', 'smpte2084', 'bt.2020', 'pq', VideoDynamicRange.hdr10),
+      ('bt2020', 'arib-std-b67', 'bt.2020', 'hlg', VideoDynamicRange.hlg),
+      ('bt709', 'bt709', 'bt.709', 'bt.1886', VideoDynamicRange.sdr),
+    ];
+
+    for (final (
+          String ffPrimaries,
+          String ffTransfer,
+          String mpvPrimaries,
+          String mpvGamma,
+          VideoDynamicRange expected,
+        ) in cases) {
+      test('$ffTransfer / $mpvGamma 两侧同判 ${expected.name}', () {
+        final VideoDynamicRange fromFfprobe = dynamicRangeFromFfprobe(
+          colorPrimaries: ffPrimaries,
+          colorTransfer: ffTransfer,
+        );
+        final VideoDynamicRange fromMpv = dynamicRangeFromMpv(
+          primaries: mpvPrimaries,
+          gamma: mpvGamma,
+        );
+        expect(fromFfprobe, expected);
+        expect(fromMpv, expected);
+        expect(fromFfprobe, fromMpv, reason: '两个来源必须给出同一结论');
+      });
+    }
+  });
+
+  group('isHdrVideoParams 薄壳与归一等价', () {
+    // 直通链路的既有行为不能变（Never break userspace）：逐组比对薄壳与归一结果。
+    const List<(String?, String?)> inputs = <(String?, String?)>[
+      ('bt.2020', 'pq'),
+      ('bt.2020', 'hlg'),
+      ('bt.2020', 'bt.1886'),
+      ('bt.2020', null),
+      ('bt.709', 'pq'),
+      ('bt.709', 'bt.1886'),
+      (null, 'pq'),
+      (null, null),
+      ('', ''),
+    ];
+
+    for (final (String? primaries, String? gamma) in inputs) {
+      test('primaries=$primaries gamma=$gamma', () {
+        expect(
+          isHdrVideoParams(primaries: primaries, gamma: gamma),
+          dynamicRangeFromMpv(primaries: primaries, gamma: gamma).isHdr,
+        );
+      });
+    }
+
+    test('只有 bt.2020 + PQ/HLG 为真（钉住原判据）', () {
+      expect(isHdrVideoParams(primaries: 'bt.2020', gamma: 'pq'), isTrue);
+      expect(isHdrVideoParams(primaries: 'bt.2020', gamma: 'hlg'), isTrue);
+      expect(isHdrVideoParams(primaries: 'bt.2020', gamma: 'bt.1886'), isFalse);
+      expect(isHdrVideoParams(primaries: 'bt.709', gamma: 'pq'), isFalse);
+      expect(isHdrVideoParams(primaries: null, gamma: null), isFalse);
+    });
+  });
+
+  group('storageValue 往返', () {
+    test('每个值都能原样往返', () {
+      for (final VideoDynamicRange r in VideoDynamicRange.values) {
+        expect(VideoDynamicRange.fromStorage(r.storageValue), r);
+      }
+    });
+
+    test('未知字符串落回 unknown', () {
+      expect(VideoDynamicRange.fromStorage('dolby_vision'),
+          VideoDynamicRange.unknown);
+      expect(VideoDynamicRange.fromStorage(null), VideoDynamicRange.unknown);
+    });
+  });
+}

--- a/fushi/test/media/video/video_probe_facts_test.dart
+++ b/fushi/test/media/video/video_probe_facts_test.dart
@@ -1,0 +1,343 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
+
+/// ffprobe JSON 的解析。
+///
+/// 下面每一段 JSON 都是**捆绑的 ffprobe n7.1.5 真跑出来的原样输出**（样本用 ffmpeg
+/// 现造：多音轨多字幕的 mkv、写了 HDR10 VUI 的 HEVC、以及没写任何色彩标签的对照），
+/// 不是照着文档手写的。这很重要——手写 fixture 会把「ffprobe 到底给不给这个字段」
+/// 这类关键事实猜错，而恰恰是这些缺字段决定了解析器要怎么兜底。
+void main() {
+  group('完整形态 mkv（3 音轨 + 2 字幕轨）', () {
+    // 真实输出：1920x1080 h264 / flac 5.1 jpn(default) / aac 2.0 eng /
+    // aac 2.0 eng(comment) / subrip chi(default) / subrip jpn(forced)
+    const String json = '''
+{
+    "streams": [
+        {
+            "index": 0, "codec_name": "h264", "codec_type": "video",
+            "width": 1920, "height": 1080, "pix_fmt": "yuv420p",
+            "r_frame_rate": "24/1", "bits_per_raw_sample": "8",
+            "disposition": { "default": 0, "comment": 0, "forced": 0 },
+            "tags": { }
+        },
+        {
+            "index": 1, "codec_name": "flac", "codec_type": "audio",
+            "sample_rate": "44100", "channels": 6, "channel_layout": "5.1",
+            "r_frame_rate": "0/0", "bits_per_raw_sample": "16",
+            "disposition": { "default": 1, "comment": 0, "forced": 0 },
+            "tags": { "language": "jpn", "title": "Japanese 5.1" }
+        },
+        {
+            "index": 2, "codec_name": "aac", "codec_type": "audio",
+            "sample_rate": "44100", "channels": 2, "channel_layout": "stereo",
+            "r_frame_rate": "0/0",
+            "disposition": { "default": 0, "comment": 0, "forced": 0 },
+            "tags": { "language": "eng", "title": "English Dub" }
+        },
+        {
+            "index": 3, "codec_name": "aac", "codec_type": "audio",
+            "sample_rate": "44100", "channels": 2, "channel_layout": "stereo",
+            "r_frame_rate": "0/0",
+            "disposition": { "default": 0, "comment": 1, "forced": 0 },
+            "tags": { "language": "eng", "title": "Commentary" }
+        },
+        {
+            "index": 4, "codec_name": "subrip", "codec_type": "subtitle",
+            "r_frame_rate": "0/0",
+            "disposition": { "default": 1, "comment": 0, "forced": 0 },
+            "tags": { "language": "chi", "title": "Simplified" }
+        },
+        {
+            "index": 5, "codec_name": "subrip", "codec_type": "subtitle",
+            "r_frame_rate": "0/0",
+            "disposition": { "default": 0, "comment": 0, "forced": 1 },
+            "tags": { "language": "jpn", "title": "Forced Signs" }
+        }
+    ],
+    "format": { "duration": "2.023000", "size": "1453519", "bit_rate": "5747974" }
+}
+''';
+
+    test('容器级事实', () {
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.durationMs, 2023);
+      expect(facts.fileSizeBytes, 1453519);
+      expect(facts.containerBitrate, 5747974);
+      expect(facts.isEmpty, isFalse);
+    });
+
+    test('视频流规格', () {
+      final VideoStreamFacts video = parseFfprobeFacts(json).video!;
+      expect(video.codec, 'h264');
+      expect(video.codecLabel, 'H.264');
+      expect(video.width, 1920);
+      expect(video.height, 1080);
+      expect(video.resolutionLabel, '1080p');
+      expect(video.bitDepth, 8);
+      expect(video.frameRateMilli, 24000);
+      expect(video.frameRate, 24.0);
+      // 这个样本没写色彩标签 → ffprobe 整个省略键 → 必须是 unknown，不是 sdr。
+      expect(video.dynamicRange, VideoDynamicRange.unknown);
+    });
+
+    test('三条音轨按流顺序，标志位正确', () {
+      final List<AudioTrackFacts> tracks = parseFfprobeFacts(json).audioTracks;
+      expect(tracks.length, 3);
+
+      expect(tracks[0].index, 1);
+      expect(tracks[0].codecLabel, 'FLAC');
+      expect(tracks[0].channels, 6);
+      expect(tracks[0].channelLabel, '5.1');
+      expect(tracks[0].language, 'jpn');
+      expect(tracks[0].title, 'Japanese 5.1');
+      expect(tracks[0].isDefault, isTrue);
+      expect(tracks[0].isCommentary, isFalse);
+
+      expect(tracks[1].codecLabel, 'AAC');
+      expect(tracks[1].channelLabel, '2.0', reason: 'stereo 归一成 2.0');
+      expect(tracks[1].isDefault, isFalse);
+
+      expect(tracks[2].isCommentary, isTrue, reason: 'disposition.comment=1');
+      expect(tracks[2].title, 'Commentary');
+    });
+
+    test('两条字幕轨', () {
+      final List<SubtitleTrackFacts> subs =
+          parseFfprobeFacts(json).subtitleTracks;
+      expect(subs.length, 2);
+      expect(subs[0].codecLabel, 'SRT');
+      expect(subs[0].language, 'chi');
+      expect(subs[0].isDefault, isTrue);
+      expect(subs[1].isForced, isTrue);
+      expect(subs[1].title, 'Forced Signs');
+    });
+
+    test('audioLanguages 与扩展前语义逐字相同（老调用点依赖）', () {
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.audioLanguages, <String>['jpn', 'eng', 'eng']);
+      expect(facts.primaryAudioLanguage, 'jpn');
+    });
+  });
+
+  group('HDR10 4K（真实 VUI）', () {
+    // 关键点：10-bit HEVC 流**不给** bits_per_raw_sample，色深只能从 pix_fmt 推。
+    const String json = '''
+{
+    "streams": [
+        {
+            "index": 0, "codec_name": "hevc", "codec_type": "video",
+            "width": 3840, "height": 2160, "pix_fmt": "yuv420p10le",
+            "color_range": "tv", "color_space": "bt2020nc",
+            "color_transfer": "smpte2084", "color_primaries": "bt2020",
+            "r_frame_rate": "24/1"
+        }
+    ],
+    "format": { "duration": "1.000000", "size": "1950255", "bit_rate": "15586453" }
+}
+''';
+
+    test('4K / HDR10 / 10bit / HEVC', () {
+      final VideoStreamFacts video = parseFfprobeFacts(json).video!;
+      expect(video.resolutionLabel, '4K');
+      expect(video.dynamicRange, VideoDynamicRange.hdr10);
+      expect(video.codecLabel, 'HEVC');
+      expect(video.bitDepth, 10,
+          reason: 'bits_per_raw_sample 缺失，必须从 pix_fmt 的 p10le 推');
+      expect(video.colorTransfer, 'smpte2084');
+    });
+
+    test('没有音轨时 audioTracks 为空而不是抛异常', () {
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.audioTracks, isEmpty);
+      expect(facts.audioLanguages, isEmpty);
+      expect(facts.primaryAudioLanguage, isNull);
+    });
+  });
+
+  group('23.976fps 的分数帧率', () {
+    const String json = '''
+{
+    "streams": [
+        {
+            "index": 0, "codec_name": "hevc", "codec_type": "video",
+            "width": 3840, "height": 2160, "pix_fmt": "yuv420p10le",
+            "color_space": "bt2020nc", "r_frame_rate": "2997/125"
+        }
+    ],
+    "format": { "duration": "1.001000" }
+}
+''';
+
+    test('"2997/125" → 23976（×1000 整数，无浮点误差）', () {
+      final VideoStreamFacts video = parseFfprobeFacts(json).video!;
+      expect(video.frameRateMilli, 23976);
+      expect(video.frameRate, closeTo(23.976, 0.0005));
+    });
+
+    test('只有 color_space 没有 primaries/transfer → unknown', () {
+      // 实测形态：给编码器传了 -color_trc 但没写进 VUI 时就长这样。
+      expect(
+        parseFfprobeFacts(json).video!.dynamicRange,
+        VideoDynamicRange.unknown,
+      );
+    });
+  });
+
+  group('帧率解析边界', () {
+    test('"0/0"（音轨/字幕轨的写法）→ null', () {
+      expect(frameRateMilliFromFraction('0/0'), isNull);
+    });
+
+    test('null / 空串 → null', () {
+      expect(frameRateMilliFromFraction(null), isNull);
+      expect(frameRateMilliFromFraction('  '), isNull);
+    });
+
+    test('整常见帧率', () {
+      expect(frameRateMilliFromFraction('24/1'), 24000);
+      expect(frameRateMilliFromFraction('25/1'), 25000);
+      expect(frameRateMilliFromFraction('30000/1001'), 29970);
+      expect(frameRateMilliFromFraction('60/1'), 60000);
+    });
+
+    test('非分数写法也认', () {
+      expect(frameRateMilliFromFraction('24'), 24000);
+    });
+  });
+
+  group('色深从 pix_fmt 推', () {
+    test('无后缀数字 = 8bit', () {
+      expect(bitDepthFromPixelFormat('yuv420p'), 8);
+      expect(bitDepthFromPixelFormat('yuvj420p'), 8);
+    });
+
+    test('10 / 12 bit', () {
+      expect(bitDepthFromPixelFormat('yuv420p10le'), 10);
+      expect(bitDepthFromPixelFormat('yuv444p12le'), 12);
+      expect(bitDepthFromPixelFormat('gbrp10le'), 10);
+    });
+
+    test('null → null（不猜）', () {
+      expect(bitDepthFromPixelFormat(null), isNull);
+      expect(bitDepthFromPixelFormat('  '), isNull);
+    });
+  });
+
+  group('清晰度分档按长边', () {
+    ({int w, int h, String? label}) c(int w, int h, String? label) =>
+        (w: w, h: h, label: label);
+
+    final List<({int w, int h, String? label})> cases =
+        <({int w, int h, String? label})>[
+      c(3840, 2160, '4K'),
+      c(4096, 1716, '4K'),
+      c(2560, 1440, '1440p'),
+      c(1920, 1080, '1080p'),
+      // 2.35:1 的电影裁边片源：高度只有 804，按高度分档会误判成 720p。
+      c(1920, 804, '1080p'),
+      c(1280, 720, '720p'),
+      c(1024, 576, '576p'),
+      c(720, 480, '480p'),
+      // 竖屏：长边是高度。
+      c(1080, 1920, '1080p'),
+    ];
+
+    for (final ({int w, int h, String? label}) item in cases) {
+      test('${item.w}x${item.h} → ${item.label}', () {
+        expect(
+          VideoStreamFacts(width: item.w, height: item.h).resolutionLabel,
+          item.label,
+        );
+      });
+    }
+
+    test('缺尺寸 → null', () {
+      expect(const VideoStreamFacts().resolutionLabel, isNull);
+      expect(const VideoStreamFacts(width: 0, height: 0).resolutionLabel,
+          isNull);
+    });
+  });
+
+  group('容错', () {
+    test('空 stdout → empty', () {
+      expect(parseFfprobeFacts('').isEmpty, isTrue);
+      expect(parseFfprobeFacts('   ').isEmpty, isTrue);
+    });
+
+    test('非 JSON → empty，不抛', () {
+      expect(parseFfprobeFacts('not json at all').isEmpty, isTrue);
+    });
+
+    test('streams 整个缺失（只要了 format 时）仍能拿到时长', () {
+      const String json = '{"format": {"duration": "12.5"}}';
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.durationMs, 12500);
+      expect(facts.video, isNull);
+      expect(facts.audioTracks, isEmpty);
+    });
+
+    test('duration 为 "N/A" → null 而非崩', () {
+      const String json = '{"format": {"duration": "N/A"}}';
+      expect(parseFfprobeFacts(json).durationMs, isNull);
+    });
+
+    test('stream 缺 tags / disposition 时用安全默认', () {
+      const String json = '''
+{"streams":[{"index":1,"codec_name":"aac","codec_type":"audio","channels":2}]}
+''';
+      final AudioTrackFacts track = parseFfprobeFacts(json).audioTracks.single;
+      expect(track.language, isNull);
+      expect(track.title, isNull);
+      expect(track.isDefault, isFalse);
+      expect(track.isForced, isFalse);
+      expect(track.isCommentary, isFalse);
+      expect(track.channelLabel, '2.0', reason: '无 layout 时从 channels 推');
+    });
+
+    test('und 语言不入列（等同未标注）', () {
+      const String json = '''
+{"streams":[
+  {"index":1,"codec_type":"audio","codec_name":"aac","tags":{"language":"und"}},
+  {"index":2,"codec_type":"audio","codec_name":"aac","tags":{"language":"jpn"}}
+]}
+''';
+      final VideoProbeFacts facts = parseFfprobeFacts(json);
+      expect(facts.audioTracks.length, 2, reason: '轨道本身还在');
+      expect(facts.audioTracks[0].language, isNull);
+      expect(facts.audioLanguages, <String>['jpn'], reason: 'und 不入语言列表');
+      expect(facts.primaryAudioLanguage, 'jpn');
+    });
+
+    test('parseFfprobeDurationMs 老入口仍可用', () {
+      expect(parseFfprobeDurationMs('{"format":{"duration":"3.5"}}'), 3500);
+    });
+  });
+
+  group('声道标签', () {
+    String? label(String? layout, int? channels) => AudioTrackFacts(
+          index: 0,
+          channelLayout: layout,
+          channels: channels,
+        ).channelLabel;
+
+    test('layout 优先', () {
+      expect(label('5.1', 6), '5.1');
+      expect(label('7.1', 8), '7.1');
+      expect(label('stereo', 2), '2.0');
+      expect(label('mono', 1), '1.0');
+    });
+
+    test('带括号后缀取主体', () {
+      expect(label('5.1(side)', 6), '5.1');
+    });
+
+    test('无 layout 时按声道数', () {
+      expect(label(null, 6), '5.1');
+      expect(label(null, 8), '7.1');
+      expect(label(null, 2), '2.0');
+      expect(label(null, null), isNull);
+    });
+  });
+}

--- a/fushi/test/media/video/video_probe_facts_test.dart
+++ b/fushi/test/media/video/video_probe_facts_test.dart
@@ -207,16 +207,98 @@ void main() {
     });
   });
 
+  group('内嵌封面图不能被当成视频轨', () {
+    // 真实输出（ffprobe n7.1.5，样本是 ffmpeg 造的 mp4：1080p h264 + 600x900 mjpeg
+    // 封面）。注意 attached_pic 是 mp4/mov 的机制——mkv 走 Attachments，封面根本不
+    // 作为 stream 出现，所以那边天然没这个问题。
+    const String coverAfter = '''
+{
+    "streams": [
+        {
+            "index": 0, "codec_name": "h264", "codec_type": "video",
+            "width": 1920, "height": 1080, "pix_fmt": "yuv420p",
+            "disposition": { "attached_pic": 0 }
+        },
+        {
+            "index": 1, "codec_name": "mjpeg", "codec_type": "video",
+            "width": 600, "height": 900, "pix_fmt": "yuvj420p",
+            "disposition": { "attached_pic": 1 }
+        }
+    ]
+}
+''';
+
+    // 同一份数据，封面排在**前面**——muxer 顺序不保证，这是会真的出错的排列。
+    const String coverFirst = '''
+{
+    "streams": [
+        {
+            "index": 0, "codec_name": "mjpeg", "codec_type": "video",
+            "width": 600, "height": 900, "pix_fmt": "yuvj420p",
+            "disposition": { "attached_pic": 1 }
+        },
+        {
+            "index": 1, "codec_name": "h264", "codec_type": "video",
+            "width": 1920, "height": 1080, "pix_fmt": "yuv420p",
+            "disposition": { "attached_pic": 0 }
+        }
+    ]
+}
+''';
+
+    test('封面在后：取到真视频轨', () {
+      final VideoStreamFacts video = parseFfprobeFacts(coverAfter).video!;
+      expect(video.codecLabel, 'H.264');
+      expect(video.resolutionLabel, '1080p');
+    });
+
+    test('封面在前：仍取到真视频轨，不会标成 MJPEG 海报尺寸', () {
+      final VideoStreamFacts video = parseFfprobeFacts(coverFirst).video!;
+      expect(video.codec, 'h264', reason: '拿第一条 video 流会得到 mjpeg');
+      expect(video.width, 1920);
+      expect(video.height, 1080);
+      expect(video.resolutionLabel, '1080p',
+          reason: '封面是 600x900，误判会显示 900p 一类');
+    });
+
+    test('只有封面没有真视频轨 → 没有视频流（纯音频带封面）', () {
+      const String onlyCover = '''
+{"streams":[{"index":0,"codec_name":"mjpeg","codec_type":"video",
+"width":600,"height":900,"disposition":{"attached_pic":1}},
+{"index":1,"codec_name":"flac","codec_type":"audio","channels":2}]}
+''';
+      final VideoProbeFacts facts = parseFfprobeFacts(onlyCover);
+      expect(facts.video, isNull);
+      expect(facts.audioTracks, hasLength(1));
+    });
+  });
+
   group('色深从 pix_fmt 推', () {
-    test('无后缀数字 = 8bit', () {
+    test('以 p 结尾无后缀数字 = 8bit', () {
       expect(bitDepthFromPixelFormat('yuv420p'), 8);
       expect(bitDepthFromPixelFormat('yuvj420p'), 8);
+      expect(bitDepthFromPixelFormat('gbrp'), 8);
     });
 
     test('10 / 12 bit', () {
       expect(bitDepthFromPixelFormat('yuv420p10le'), 10);
       expect(bitDepthFromPixelFormat('yuv444p12le'), 12);
       expect(bitDepthFromPixelFormat('gbrp10le'), 10);
+    });
+
+    test('不以 p 收尾的格式 → null（回退到 bits_per_raw_sample）', () {
+      // 兜底成 8 会把这些格式的真实位深永久盖掉，而正确值就在同一条 JSON 里。
+      expect(bitDepthFromPixelFormat('rgb48le'), isNull);
+      expect(bitDepthFromPixelFormat('xyz12le'), isNull);
+      expect(bitDepthFromPixelFormat('nv20'), isNull);
+    });
+
+    test('解析器与 bits_per_raw_sample 的协作：pix_fmt 推不出时用后者', () {
+      const String json = '''
+{"streams":[{"index":0,"codec_type":"video","codec_name":"ffv1",
+"width":1920,"height":1080,"pix_fmt":"rgb48le","bits_per_raw_sample":"16"}]}
+''';
+      expect(parseFfprobeFacts(json).video!.bitDepth, 16);
     });
 
     test('null → null（不猜）', () {

--- a/fushi/test/media/video/video_specs_display_test.dart
+++ b/fushi/test/media/video/video_specs_display_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_specs_display.dart';
+
+/// 规格的格式化。纯函数层，不碰 i18n 也不碰 widget。
+void main() {
+  VideoProbeFacts factsWith({
+    int? width,
+    int? height,
+    String? codec,
+    String? transfer,
+    String? primaries,
+    int? bitDepth,
+    int? frameRateMilli,
+    int? videoBitrate,
+    int? containerBitrate,
+    List<AudioTrackFacts> audio = const <AudioTrackFacts>[],
+    List<SubtitleTrackFacts> subtitles = const <SubtitleTrackFacts>[],
+  }) =>
+      VideoProbeFacts(
+        containerBitrate: containerBitrate,
+        video: (width == null && codec == null && transfer == null)
+            ? null
+            : VideoStreamFacts(
+                codec: codec,
+                width: width,
+                height: height,
+                bitDepth: bitDepth,
+                frameRateMilli: frameRateMilli,
+                bitrate: videoBitrate,
+                colorPrimaries: primaries,
+                colorTransfer: transfer,
+              ),
+        audioTracks: audio,
+        subtitleTracks: subtitles,
+      );
+
+  group('封面角标', () {
+    test('4K + HDR10 两个', () {
+      expect(
+        videoSpecsCoverBadges(factsWith(
+          width: 3840,
+          height: 2160,
+          primaries: 'bt2020',
+          transfer: 'smpte2084',
+        )),
+        <String>['4K', 'HDR10'],
+      );
+    });
+
+    test('HLG 也出角标', () {
+      expect(
+        videoSpecsCoverBadges(factsWith(
+          width: 1920,
+          height: 1080,
+          primaries: 'bt2020',
+          transfer: 'arib-std-b67',
+        )),
+        <String>['1080p', 'HLG'],
+      );
+    });
+
+    test('SDR 只出清晰度——「是 SDR」不是信息，不该占角标位', () {
+      expect(
+        videoSpecsCoverBadges(factsWith(
+          width: 1920,
+          height: 1080,
+          primaries: 'bt709',
+          transfer: 'bt709',
+        )),
+        <String>['1080p'],
+      );
+    });
+
+    test('色彩标签缺失（unknown）同样不出动态范围角标', () {
+      expect(
+        videoSpecsCoverBadges(factsWith(width: 1280, height: 720)),
+        <String>['720p'],
+      );
+    });
+
+    test('无规格 / 无视频流 → 空', () {
+      expect(videoSpecsCoverBadges(null), isEmpty);
+      expect(videoSpecsCoverBadges(VideoProbeFacts.empty), isEmpty);
+      expect(videoSpecsCoverBadges(factsWith(audio: const <AudioTrackFacts>[
+        AudioTrackFacts(index: 0, codec: 'flac'),
+      ])), isEmpty, reason: '纯音频没有视频流');
+    });
+
+    test('最多两个，不会因为编码多出第三个', () {
+      final List<String> badges = videoSpecsCoverBadges(factsWith(
+        width: 3840,
+        height: 2160,
+        codec: 'hevc',
+        primaries: 'bt2020',
+        transfer: 'smpte2084',
+      ));
+      expect(badges, hasLength(2));
+    });
+  });
+
+  group('紧凑摘要', () {
+    test('清晰度 · 动态范围 · 编码', () {
+      expect(
+        videoSpecsInlineSummary(factsWith(
+          width: 3840,
+          height: 2160,
+          codec: 'hevc',
+          primaries: 'bt2020',
+          transfer: 'smpte2084',
+        )),
+        '4K · HDR10 · HEVC',
+      );
+    });
+
+    test('SDR 时省掉动态范围', () {
+      expect(
+        videoSpecsInlineSummary(factsWith(
+          width: 1920,
+          height: 1080,
+          codec: 'h264',
+          primaries: 'bt709',
+          transfer: 'bt709',
+        )),
+        '1080p · H.264',
+      );
+    });
+
+    test('无可显示项返回 null 而不是空串（调用方据此整行不渲染）', () {
+      expect(videoSpecsInlineSummary(null), isNull);
+      expect(videoSpecsInlineSummary(VideoProbeFacts.empty), isNull);
+    });
+  });
+
+  group('详情字段', () {
+    test('4K 后面补真实像素（档位不等于尺寸）', () {
+      final List<(VideoSpecField, String)> fields =
+          videoSpecsFields(factsWith(width: 4096, height: 1716));
+      expect(fields.first.$1, VideoSpecField.resolution);
+      expect(fields.first.$2, '4K (4096×1716)');
+    });
+
+    test('探不到的项整行不出现，不显示「未知」', () {
+      final List<(VideoSpecField, String)> fields =
+          videoSpecsFields(factsWith(width: 1920, height: 1080));
+      final Set<VideoSpecField> present =
+          fields.map(((VideoSpecField, String) f) => f.$1).toSet();
+      expect(present, contains(VideoSpecField.resolution));
+      expect(present, isNot(contains(VideoSpecField.bitDepth)));
+      expect(present, isNot(contains(VideoSpecField.frameRate)));
+      expect(present, isNot(contains(VideoSpecField.dynamicRange)),
+          reason: 'unknown 不该被写成一行');
+    });
+
+    test('码率优先流级，缺失时回退容器级（mkv 不给流级）', () {
+      expect(
+        videoSpecsFields(factsWith(
+          width: 1920,
+          videoBitrate: 8000000,
+          containerBitrate: 9000000,
+        )).where((( VideoSpecField, String) f) =>
+            f.$1 == VideoSpecField.bitrate).single.$2,
+        '8.0 Mbps',
+      );
+      expect(
+        videoSpecsFields(factsWith(width: 1920, containerBitrate: 15586453))
+            .where(((VideoSpecField, String) f) =>
+                f.$1 == VideoSpecField.bitrate)
+            .single
+            .$2,
+        '16 Mbps',
+      );
+    });
+
+    test('null facts → 空', () {
+      expect(videoSpecsFields(null), isEmpty);
+    });
+  });
+
+  group('帧率格式化', () {
+    test('整数帧率不留小数点', () {
+      expect(formatFrameRate(24000), '24 fps');
+      expect(formatFrameRate(60000), '60 fps');
+    });
+
+    test('23.976 保留三位', () {
+      expect(formatFrameRate(23976), '23.976 fps');
+    });
+
+    test('尾随 0 去掉', () {
+      expect(formatFrameRate(25500), '25.5 fps');
+    });
+
+    test('null / 0 → null', () {
+      expect(formatFrameRate(null), isNull);
+      expect(formatFrameRate(0), isNull);
+    });
+  });
+
+  group('码率格式化', () {
+    test('10 Mbps 以上取整（差 0.1 无意义）', () {
+      expect(formatBitrate(15586453), '16 Mbps');
+      expect(formatBitrate(10000000), '10 Mbps');
+    });
+
+    test('10 Mbps 以下留一位小数', () {
+      expect(formatBitrate(8000000), '8.0 Mbps');
+      expect(formatBitrate(1500000), '1.5 Mbps');
+    });
+
+    test('1 Mbps 以下用 kbps', () {
+      expect(formatBitrate(800000), '800 kbps');
+      expect(formatBitrate(128000), '128 kbps');
+    });
+
+    test('用十进制而不是 1024 进制（与 ffprobe/发布组标题对齐）', () {
+      // 1024 进制会得到 15.4 Mbps，与用户在别处看到的数字对不上。
+      expect(formatBitrate(16000000), '16 Mbps');
+    });
+
+    test('null / 0 → null', () {
+      expect(formatBitrate(null), isNull);
+      expect(formatBitrate(0), isNull);
+    });
+  });
+
+  group('轨道展示', () {
+    test('音轨：名字 · 编码 · 声道 + 标志位', () {
+      final TrackDisplay d = audioTrackDisplay(const AudioTrackFacts(
+        index: 1,
+        codec: 'flac',
+        channels: 6,
+        channelLayout: '5.1',
+        language: 'jpn',
+        title: '日本語',
+        isDefault: true,
+      ));
+      expect(d.headline, '日本語 · FLAC · 5.1');
+      expect(d.isDefault, isTrue);
+      expect(d.isCommentary, isFalse);
+    });
+
+    test('名字回落：title → language → #序号', () {
+      expect(trackDisplayName('Commentary', 'eng', 3), 'Commentary');
+      expect(trackDisplayName(null, 'eng', 3), 'ENG');
+      expect(trackDisplayName('  ', null, 3), '#3');
+      expect(trackDisplayName(null, null, 3), '#3');
+    });
+
+    test('字幕轨：名字 · 格式', () {
+      final TrackDisplay d = subtitleTrackDisplay(const SubtitleTrackFacts(
+        index: 4,
+        codec: 'subrip',
+        language: 'chi',
+        isForced: true,
+      ));
+      expect(d.headline, 'CHI · SRT');
+      expect(d.isForced, isTrue);
+    });
+
+    test('没有技术细节时 headline 只剩名字（不留悬空分隔符）', () {
+      final TrackDisplay d = subtitleTrackDisplay(
+        const SubtitleTrackFacts(index: 2, language: 'jpn'),
+      );
+      expect(d.headline, 'JPN');
+      expect(d.detail, isEmpty);
+    });
+  });
+}

--- a/fushi/test/media/video/video_specs_provider_lifecycle_test.dart
+++ b/fushi/test/media/video/video_specs_provider_lifecycle_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 回归护栏：**别把「别人持有的 ChangeNotifier」从 ChangeNotifierProvider 里返回。**
+///
+/// `ChangeNotifierProvider` 会给它 create 出来的 notifier 注册
+/// `onDispose(notifier.dispose)`。只要 provider 因依赖变化而重算，上一个返回值就被
+/// dispose——如果那个实例是 AppModel 之类的长生命周期对象持有并复用的，它就被就地
+/// 打死，而持有方毫不知情、继续把这个死实例发给所有人。
+///
+/// 而 `appProvider` 是 `ChangeNotifierProvider<AppModel>`，riverpod 对 ChangeNotifier
+/// 恒判 `updateShouldNotify = true`，所以**每一次** `AppModel.notifyListeners()` 都会
+/// 让 `ref.watch(appProvider)` 的下游 provider 重算。两者相乘 = 服务在第一次全局状态
+/// 变化时就永久失效（`VideoSpecsService` 一旦 `_disposed` 就不再探测任何文件）。
+///
+/// 本测试把这个机制本身钉住，不依赖 AppModel。修法见 `videoSpecsProvider`：用普通
+/// `Provider` 交出实例，消费方用 `ListenableBuilder` 订阅。
+void main() {
+  test('ChangeNotifierProvider 重算会 dispose 上一次返回的 notifier', () {
+    final _Owner owner = _Owner();
+    final ChangeNotifierProvider<_Source> source =
+        ChangeNotifierProvider<_Source>((Ref ref) => _Source());
+    // 反面教材：把 owner 持有的实例从 ChangeNotifierProvider 里交出去。
+    final ChangeNotifierProvider<_Owned> bad =
+        ChangeNotifierProvider<_Owned>((Ref ref) {
+      ref.watch(source);
+      return owner.owned;
+    });
+
+    // 刻意不 addTearDown(container.dispose)：容器里存着已被 dispose 的实例，
+    // 容器销毁时会二次 dispose 再抛一次，与本测试要证明的事无关。
+    final ProviderContainer container = ProviderContainer();
+
+    expect(container.read(bad).disposed, isFalse);
+
+    // 模拟 AppModel.notifyListeners()。
+    container.read(source).bump();
+    // 重算的顺序是「先 dispose 上一次的返回值，再 create」，而 create 拿回的是
+    // owner 缓存的同一个（已死的）实例，于是 addListener 当场抛断言。静默失效与
+    // 直接抛两种后果都是致命的，这里只需证明它确实被 dispose 了。
+    try {
+      container.read(bad);
+    } catch (_) {
+      // 见上：debug 断言，吞掉。
+    }
+
+    expect(
+      owner.owned.disposed,
+      isTrue,
+      reason: 'provider 重算把 owner 还在用的实例 dispose 了——'
+          '这正是 videoSpecsProvider 不能用 ChangeNotifierProvider 的原因',
+    );
+  });
+
+  test('普通 Provider 交出实例时不会 dispose 它', () {
+    final _Owner owner = _Owner();
+    final ChangeNotifierProvider<_Source> source =
+        ChangeNotifierProvider<_Source>((Ref ref) => _Source());
+    // 正确做法：Provider 只负责交出实例，生命周期仍归 owner。
+    final Provider<_Owned> good = Provider<_Owned>((Ref ref) {
+      ref.watch(source);
+      return owner.owned;
+    });
+
+    final ProviderContainer container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(good).disposed, isFalse);
+
+    container.read(source).bump();
+    container.read(good);
+
+    expect(owner.owned.disposed, isFalse,
+        reason: 'Provider 不接管返回值的生命周期');
+    // 仍然是同一个实例，消费方可以安全地 ListenableBuilder 订阅它。
+    expect(identical(container.read(good), owner.owned), isTrue);
+  });
+}
+
+class _Owner {
+  final _Owned owned = _Owned();
+}
+
+class _Owned extends ChangeNotifier {
+  bool disposed = false;
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
+  }
+}
+
+class _Source extends ChangeNotifier {
+  void bump() => notifyListeners();
+}

--- a/fushi/test/media/video/video_specs_service_test.dart
+++ b/fushi/test/media/video/video_specs_service_test.dart
@@ -1,0 +1,324 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart' show NativeDatabase;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_dynamic_range.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
+
+/// 规格服务：缓存三层（内存 → DB → ffprobe）、失效判据、并发上限。
+///
+/// 探测入口是注入的，不真起 ffprobe；但**文件是真的**（写进临时目录），因为失效判据
+/// 依赖真实的 `FileStat.size` / `modified`，拿假 stat 测等于没测。
+void main() {
+  late Directory tempDir;
+  late FushiDatabase db;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('fushi_specs_service');
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  String writeFile(String name, {int size = 1024}) {
+    final File file = File('${tempDir.path}${Platform.pathSeparator}$name');
+    file.writeAsBytesSync(List<int>.filled(size, 0));
+    return file.path;
+  }
+
+  VideoProbeFacts facts({
+    int width = 3840,
+    int height = 2160,
+    String transfer = 'smpte2084',
+    List<AudioTrackFacts> audio = const <AudioTrackFacts>[],
+  }) =>
+      VideoProbeFacts(
+        durationMs: 90 * 60 * 1000,
+        containerBitrate: 15000000,
+        video: VideoStreamFacts(
+          codec: 'hevc',
+          width: width,
+          height: height,
+          pixelFormat: 'yuv420p10le',
+          bitDepth: 10,
+          frameRateMilli: 23976,
+          colorPrimaries: 'bt2020',
+          colorTransfer: transfer,
+        ),
+        audioTracks: audio,
+      );
+
+  test('探一次后可同步读到，且落库', () async {
+    final String path = writeFile('a.mkv');
+    int probeCalls = 0;
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async {
+        probeCalls++;
+        return facts();
+      },
+    );
+    addTearDown(service.dispose);
+
+    expect(service.specsFor(path), isNull, reason: '探之前同步读必须是 null');
+
+    final VideoProbeFacts? resolved = await service.resolve(path);
+    expect(resolved, isNotNull);
+    expect(probeCalls, 1);
+
+    // 同步读now命中
+    final VideoProbeFacts? cached = service.specsFor(path);
+    expect(cached!.video!.resolutionLabel, '4K');
+    expect(cached.video!.dynamicRange, VideoDynamicRange.hdr10);
+
+    // 真落库了
+    final VideoFileSpecRow? row = await db.videoFileSpec(path);
+    expect(row, isNotNull);
+    expect(row!.width, 3840);
+    expect(row.colorTransfer, 'smpte2084');
+    expect(row.probeVersion, kVideoProbeFieldSetVersion);
+    expect(row.fileSizeBytes, 1024, reason: '失效判据要存真实文件大小');
+  });
+
+  test('第二个服务实例从 DB 命中，不再探', () async {
+    final String path = writeFile('b.mkv');
+    final VideoSpecsService first =
+        VideoSpecsService(db, probe: (String p) async => facts());
+    await first.resolve(path);
+    first.dispose();
+
+    int secondProbeCalls = 0;
+    final VideoSpecsService second = VideoSpecsService(
+      db,
+      probe: (String p) async {
+        secondProbeCalls++;
+        return facts();
+      },
+    );
+    addTearDown(second.dispose);
+
+    await second.prime(<String>[path]);
+    expect(secondProbeCalls, 0, reason: 'DB 命中就不该再起 ffprobe');
+    expect(second.specsFor(path)!.video!.resolutionLabel, '4K');
+  });
+
+  group('失效判据', () {
+    test('文件大小变了 → 重探', () async {
+      final String path = writeFile('c.mkv', size: 100);
+      final VideoSpecsService first =
+          VideoSpecsService(db, probe: (String p) async => facts());
+      await first.resolve(path);
+      first.dispose();
+
+      // 换了个更大的同名文件（换片源）。
+      File(path).writeAsBytesSync(List<int>.filled(5000, 1));
+
+      int probeCalls = 0;
+      final VideoSpecsService second = VideoSpecsService(
+        db,
+        probe: (String p) async {
+          probeCalls++;
+          return facts(width: 1920, height: 1080, transfer: 'bt709');
+        },
+      );
+      addTearDown(second.dispose);
+
+      final VideoProbeFacts? fresh = await second.resolve(path);
+      expect(probeCalls, 1, reason: '大小变了必须重探');
+      expect(fresh!.video!.resolutionLabel, '1080p');
+      expect(fresh.video!.dynamicRange, VideoDynamicRange.sdr);
+    });
+
+    test('探测器字段集版本变了 → 重探', () async {
+      final String path = writeFile('d.mkv');
+      final FileStat stat = File(path).statSync();
+      // 直接塞一条「上个版本探的」缓存行。
+      await db.upsertVideoFileSpec(videoFileSpecCompanion(
+        filePath: path,
+        facts: facts(),
+        fileSizeBytes: stat.size,
+        fileModifiedAt: stat.modified.millisecondsSinceEpoch,
+      ).copyWith(probeVersion: const Value<int>(0)));
+
+      int probeCalls = 0;
+      final VideoSpecsService service = VideoSpecsService(
+        db,
+        probe: (String p) async {
+          probeCalls++;
+          return facts();
+        },
+      );
+      addTearDown(service.dispose);
+
+      await service.prime(<String>[path]);
+      await _settle();
+      expect(probeCalls, 1, reason: '字段集扩了，旧行的新字段是空的，必须重探');
+    });
+
+    test('文件不存在 → 不探，记为无结论', () async {
+      final String missing =
+          '${tempDir.path}${Platform.pathSeparator}nope.mkv';
+      int probeCalls = 0;
+      final VideoSpecsService service = VideoSpecsService(
+        db,
+        probe: (String p) async {
+          probeCalls++;
+          return facts();
+        },
+      );
+      addTearDown(service.dispose);
+
+      expect(await service.resolve(missing), isNull);
+      expect(probeCalls, 0, reason: '文件都没有，起 ffprobe 是白起');
+      expect(service.isResolved(missing), isTrue, reason: '记下来别反复重试');
+    });
+  });
+
+  test('探不出规格时不落库（否则永远命中空壳、再也不重试）', () async {
+    final String path = writeFile('e.mkv');
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async => VideoProbeFacts.empty,
+    );
+    addTearDown(service.dispose);
+
+    expect(await service.resolve(path), isNull);
+    expect(await db.videoFileSpec(path), isNull,
+        reason: '空结果不该在库里留一行');
+    expect(service.isResolved(path), isTrue, reason: '本次会话内不重试');
+  });
+
+  test('prime 批量：已知的跳过，只探缺的', () async {
+    final String known = writeFile('f1.mkv');
+    final String unknown = writeFile('f2.mkv');
+
+    final VideoSpecsService seeder =
+        VideoSpecsService(db, probe: (String p) async => facts());
+    await seeder.resolve(known);
+    seeder.dispose();
+
+    final List<String> probed = <String>[];
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async {
+        probed.add(p);
+        return facts();
+      },
+    );
+    addTearDown(service.dispose);
+
+    await service.prime(<String>[known, unknown]);
+    await _settle();
+
+    expect(probed, <String>[unknown], reason: '只该探库里没有的那个');
+    expect(service.specsFor(known), isNotNull);
+    expect(service.specsFor(unknown), isNotNull);
+  });
+
+  test('并发不超过上限', () async {
+    final List<String> paths = <String>[
+      for (int i = 0; i < 8; i++) writeFile('g$i.mkv'),
+    ];
+    int running = 0;
+    int peak = 0;
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async {
+        running++;
+        peak = peak > running ? peak : running;
+        // 让出事件循环，制造真正的重叠窗口。
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        running--;
+        return facts();
+      },
+    );
+    addTearDown(service.dispose);
+
+    await service.prime(paths);
+    await _settle();
+
+    expect(peak, lessThanOrEqualTo(kVideoSpecsProbeConcurrency),
+        reason: '并发上限被突破会跟正在播放的视频抢磁盘');
+    expect(peak, greaterThan(1), reason: '也不能退化成串行');
+    for (final String path in paths) {
+      expect(service.specsFor(path), isNotNull, reason: '$path 应已探完');
+    }
+  });
+
+  test('音轨往返落库不丢字段', () async {
+    final String path = writeFile('h.mkv');
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async => facts(audio: const <AudioTrackFacts>[
+        AudioTrackFacts(
+          index: 1,
+          codec: 'flac',
+          channels: 6,
+          channelLayout: '5.1',
+          sampleRate: 48000,
+          language: 'jpn',
+          title: '日本語 5.1',
+          isDefault: true,
+        ),
+        AudioTrackFacts(
+          index: 2,
+          codec: 'aac',
+          channels: 2,
+          channelLayout: 'stereo',
+          language: 'eng',
+          isCommentary: true,
+        ),
+      ]),
+    );
+    addTearDown(service.dispose);
+
+    await service.resolve(path);
+
+    // 换一个实例，强制走「从 DB 解码」这条路。
+    final VideoSpecsService reader =
+        VideoSpecsService(db, probe: (String p) async => VideoProbeFacts.empty);
+    addTearDown(reader.dispose);
+    await reader.prime(<String>[path]);
+
+    final List<AudioTrackFacts> tracks = reader.specsFor(path)!.audioTracks;
+    expect(tracks, hasLength(2));
+    expect(tracks[0].codecLabel, 'FLAC');
+    expect(tracks[0].channelLabel, '5.1');
+    expect(tracks[0].language, 'jpn');
+    expect(tracks[0].title, '日本語 5.1');
+    expect(tracks[0].isDefault, isTrue);
+    expect(tracks[1].isCommentary, isTrue);
+    expect(tracks[1].channelLabel, '2.0');
+  });
+
+  test('invalidate 清掉内存与库两处', () async {
+    final String path = writeFile('i.mkv');
+    final VideoSpecsService service =
+        VideoSpecsService(db, probe: (String p) async => facts());
+    addTearDown(service.dispose);
+
+    await service.resolve(path);
+    expect(await db.videoFileSpec(path), isNotNull);
+
+    await service.invalidate(path);
+    expect(service.specsFor(path), isNull);
+    expect(service.isResolved(path), isFalse);
+    expect(await db.videoFileSpec(path), isNull);
+  });
+}
+
+/// 等后台队列跑空。队列是「完成即拉下一个」的自驱动链，没有定时器可等，
+/// 让出若干轮事件循环即可。
+Future<void> _settle() async {
+  for (int i = 0; i < 40; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}

--- a/fushi/test/media/video/video_specs_service_test.dart
+++ b/fushi/test/media/video/video_specs_service_test.dart
@@ -158,7 +158,7 @@ void main() {
       addTearDown(service.dispose);
 
       await service.prime(<String>[path]);
-      await _settle();
+      await service.drain();
       expect(probeCalls, 1, reason: '字段集扩了，旧行的新字段是空的，必须重探');
     });
 
@@ -215,7 +215,7 @@ void main() {
     addTearDown(service.dispose);
 
     await service.prime(<String>[known, unknown]);
-    await _settle();
+    await service.drain();
 
     expect(probed, <String>[unknown], reason: '只该探库里没有的那个');
     expect(service.specsFor(known), isNotNull);
@@ -243,7 +243,7 @@ void main() {
     addTearDown(service.dispose);
 
     await service.prime(paths);
-    await _settle();
+    await service.drain();
 
     expect(peak, lessThanOrEqualTo(kVideoSpecsProbeConcurrency),
         reason: '并发上限被突破会跟正在播放的视频抢磁盘');
@@ -299,6 +299,53 @@ void main() {
     expect(tracks[1].channelLabel, '2.0');
   });
 
+  test('落库失败不丢已探到的结果（探测成功 ≠ 持久化成功）', () async {
+    final String path = writeFile('j.mkv');
+    // 制造一个必然写失败的持久化层。**不能用 db.close()**：实测 drift 关闭后的
+    // 查询既不抛也不挂，读返回 null、写返回 0，根本造不出失败。把表 drop 掉才是
+    // 真的会抛（no such table）。
+    await db.customStatement('DROP TABLE video_file_specs');
+
+    final VideoSpecsService service =
+        VideoSpecsService(db, probe: (String p) async => facts());
+    addTearDown(service.dispose);
+
+    final VideoProbeFacts? resolved = await service.resolve(path);
+    expect(resolved, isNotNull, reason: 'ffprobe 明明成功了');
+    expect(service.specsFor(path), isNotNull,
+        reason: '写库失败只是丢了跨启动缓存，本次会话的事实照样有效——'
+            '一起判死会让角标在探测成功时消失，且 isResolved 已 true 不再重试');
+    expect(service.specsFor(path)!.video!.resolutionLabel, '4K');
+  });
+
+  test('resolve 与队列共用在途表：同一文件不会并发探两次', () async {
+    final String path = writeFile('k.mkv');
+    int probeCalls = 0;
+    final VideoSpecsService service = VideoSpecsService(
+      db,
+      probe: (String p) async {
+        probeCalls++;
+        // 留出重叠窗口：prime 起的那次还没落地，resolve 就进来了。
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        return facts();
+      },
+    );
+    addTearDown(service.dispose);
+
+    // 集卡渲染排队 + 用户紧接着开「媒体信息」弹窗。
+    final Future<void> primed = service.prime(<String>[path]);
+    final Future<VideoProbeFacts?> resolved = service.resolve(path);
+    await primed;
+    final VideoProbeFacts? facts0 = await resolved;
+    await service.drain();
+
+    expect(probeCalls, 1,
+        reason: '起第二个 ffprobe 正好废掉并发上限想守的东西（别跟播放中的视频抢 IO）');
+    expect(facts0, isNotNull);
+    expect(service.specsFor(path), isNotNull);
+  });
+
   test('invalidate 清掉内存与库两处', () async {
     final String path = writeFile('i.mkv');
     final VideoSpecsService service =
@@ -313,12 +360,103 @@ void main() {
     expect(service.isResolved(path), isFalse);
     expect(await db.videoFileSpec(path), isNull);
   });
-}
 
-/// 等后台队列跑空。队列是「完成即拉下一个」的自驱动链，没有定时器可等，
-/// 让出若干轮事件循环即可。
-Future<void> _settle() async {
-  for (int i = 0; i < 40; i++) {
-    await Future<void>.delayed(Duration.zero);
-  }
+  group('删书时回收规格缓存（表以文件路径为键、与 book 无 FK，没人清就只增不减）',
+      () {
+    test('单视频：删书清掉它的规格行', () async {
+      const String main = r'D:\media\solo.mkv';
+      await db.customStatement(
+        'INSERT INTO video_books (book_uid, title, video_path, imported_at) '
+        "VALUES ('solo', '单片', '$main', 1700000000)",
+      );
+      await db.upsertVideoFileSpec(videoFileSpecCompanion(
+        filePath: main,
+        facts: facts(),
+        fileSizeBytes: 1,
+        fileModifiedAt: 1,
+      ));
+      expect(await db.videoFileSpec(main), isNotNull);
+
+      await db.deleteVideoBook('solo');
+      expect(await db.videoFileSpec(main), isNull);
+    });
+
+    test('播放列表：每一集的规格行都要清', () async {
+      const String main = r'D:\media\ep1.mkv';
+      const String ep2 = r'D:\media\ep2.mkv';
+      const String ep3 = r'D:\media\ep3.mkv';
+      const String playlist =
+          r'[{"title":"1","path":"D:\\media\\ep1.mkv"},'
+          r'{"title":"2","path":"D:\\media\\ep2.mkv"},'
+          r'{"title":"3","path":"D:\\media\\ep3.mkv"}]';
+      await db.customStatement(
+        'INSERT INTO video_books (book_uid, title, video_path, playlist_json, '
+        'imported_at) VALUES (?, ?, ?, ?, ?)',
+        <Object?>['series', '连续剧', main, playlist, 1700000000],
+      );
+      for (final String path in <String>[main, ep2, ep3]) {
+        await db.upsertVideoFileSpec(videoFileSpecCompanion(
+          filePath: path,
+          facts: facts(),
+          fileSizeBytes: 1,
+          fileModifiedAt: 1,
+        ));
+      }
+
+      await db.deleteVideoBook('series');
+
+      for (final String path in <String>[main, ep2, ep3]) {
+        expect(await db.videoFileSpec(path), isNull, reason: '$path 该被清');
+      }
+    });
+
+    test('别的书的规格行不受牵连', () async {
+      const String mine = r'D:\media\mine.mkv';
+      const String other = r'D:\media\other.mkv';
+      await db.customStatement(
+        'INSERT INTO video_books (book_uid, title, video_path, imported_at) '
+        "VALUES ('mine', 'A', '$mine', 1700000000)",
+      );
+      for (final String path in <String>[mine, other]) {
+        await db.upsertVideoFileSpec(videoFileSpecCompanion(
+          filePath: path,
+          facts: facts(),
+          fileSizeBytes: 1,
+          fileModifiedAt: 1,
+        ));
+      }
+
+      await db.deleteVideoBook('mine');
+
+      expect(await db.videoFileSpec(mine), isNull);
+      expect(await db.videoFileSpec(other), isNotNull,
+          reason: '只清这本书涉及的文件');
+    });
+
+    test('坏 playlist_json 不让删除事务回滚（只清主视频）', () async {
+      const String main = r'D:\media\broken.mkv';
+      await db.customStatement(
+        'INSERT INTO video_books (book_uid, title, video_path, playlist_json, '
+        'imported_at) VALUES (?, ?, ?, ?, ?)',
+        <Object?>['broken', 'B', main, '{not json at all', 1700000000],
+      );
+      await db.upsertVideoFileSpec(videoFileSpecCompanion(
+        filePath: main,
+        facts: facts(),
+        fileSizeBytes: 1,
+        fileModifiedAt: 1,
+      ));
+
+      await db.deleteVideoBook('broken');
+
+      expect(await db.videoFileSpec(main), isNull);
+      expect(
+        await (db.select(db.videoBooks)
+              ..where((t) => t.bookUid.equals('broken')))
+            .getSingleOrNull(),
+        isNull,
+        reason: '书本身必须删掉——不能因为一条脏缓存键让整个事务回滚',
+      );
+    });
+  });
 }

--- a/fushi/test/media/video/video_specs_widgets_test.dart
+++ b/fushi/test/media/video/video_specs_widgets_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:drift/native.dart' show NativeDatabase;
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -97,17 +96,12 @@ void main() {
     VideoSpecsService service,
     Widget child,
   ) async {
+    // 规格 widget 是注入式的（宿主详情页不是 Consumer，见 video_specs_badges.dart
+    // 的说明），所以这里不需要 ProviderScope，直接把 service 传进 widget 即可。
+    addTearDown(service.dispose);
     await tester.pumpWidget(
-      ProviderScope(
-        // 不额外 addTearDown(service.dispose)：ChangeNotifierProvider 在 scope
-        // 销毁时会自己 dispose 这个 notifier，再 dispose 一次会触发
-        // 「A ChangeNotifier was used after being disposed」断言。
-        overrides: <Override>[
-          videoSpecsProvider.overrideWith((Ref ref) => service),
-        ],
-        child: TranslationProvider(
-          child: MaterialApp(home: Scaffold(body: child)),
-        ),
+      TranslationProvider(
+        child: MaterialApp(home: Scaffold(body: child)),
       ),
     );
     await tester.pump();
@@ -118,7 +112,8 @@ void main() {
       final String path = writeFile('a.mkv');
       final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
 
-      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+      await pumpWith(tester, service,
+          VideoSpecsBadgeStrip(service: service, filePath: path));
 
       expect(find.text('4K'), findsOneWidget);
       expect(find.text('HDR10'), findsOneWidget);
@@ -139,7 +134,8 @@ void main() {
         ),
       );
 
-      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+      await pumpWith(tester, service,
+          VideoSpecsBadgeStrip(service: service, filePath: path));
 
       expect(find.text('1080p'), findsOneWidget);
       expect(find.text('SDR'), findsNothing);
@@ -151,7 +147,8 @@ void main() {
       final VideoSpecsService service =
           await serviceWith(tester, path, VideoProbeFacts.empty);
 
-      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+      await pumpWith(tester, service,
+          VideoSpecsBadgeStrip(service: service, filePath: path));
 
       // 没有任何文字，且自身尺寸为零——卡片布局一格不该被撑开。
       expect(find.byType(Text), findsNothing);
@@ -170,12 +167,11 @@ void main() {
           return hdr4k;
         },
       );
-      // 不 addTearDown(dispose)：ProviderScope 销毁时已经 dispose 过一次。
-
       await pumpWith(
         tester,
         service,
-        const VideoSpecsBadgeStrip(
+        VideoSpecsBadgeStrip(
+          service: service,
           filePath: 'https://example.com/stream.m3u8',
         ),
       );
@@ -190,18 +186,19 @@ void main() {
       final String path = writeFile('d.mkv');
       final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
 
-      await pumpWith(tester, service, VideoSpecsInlineLine(filePath: path));
+      await pumpWith(tester, service,
+          VideoSpecsInlineLine(service: service, filePath: path));
 
       expect(find.text('4K · HDR10 · HEVC'), findsOneWidget);
     });
 
-    testWidgets('未探到时不占位（集卡高度钳死，多一行会顶掉简介）',
-        (WidgetTester tester) async {
+    testWidgets('未探到时不占位（集卡高度钳死，多一行会顶掉简介）', (WidgetTester tester) async {
       final String path = writeFile('e.mkv');
       final VideoSpecsService service =
           await serviceWith(tester, path, VideoProbeFacts.empty);
 
-      await pumpWith(tester, service, VideoSpecsInlineLine(filePath: path));
+      await pumpWith(tester, service,
+          VideoSpecsInlineLine(service: service, filePath: path));
 
       expect(tester.getSize(find.byType(VideoSpecsInlineLine)), Size.zero);
     });
@@ -212,7 +209,8 @@ void main() {
       final String path = writeFile('f.mkv');
       final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
 
-      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+      await pumpWith(
+          tester, service, VideoSpecsPanel(service: service, filePath: path));
 
       expect(find.text('4K (3840×2160)'), findsOneWidget);
       expect(find.text('HDR10'), findsOneWidget);
@@ -226,7 +224,8 @@ void main() {
       final String path = writeFile('g.mkv');
       final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
 
-      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+      await pumpWith(
+          tester, service, VideoSpecsPanel(service: service, filePath: path));
 
       expect(find.textContaining('日本語 · FLAC · 5.1'), findsOneWidget);
       expect(find.textContaining('ENG · AAC · 2.0'), findsOneWidget);
@@ -248,7 +247,8 @@ void main() {
       final String path = writeFile('h.mkv');
       final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
 
-      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+      await pumpWith(
+          tester, service, VideoSpecsPanel(service: service, filePath: path));
 
       expect(find.textContaining('CHI · SRT'), findsOneWidget);
     });
@@ -258,7 +258,8 @@ void main() {
       final VideoSpecsService service =
           await serviceWith(tester, path, VideoProbeFacts.empty);
 
-      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+      await pumpWith(
+          tester, service, VideoSpecsPanel(service: service, filePath: path));
 
       expect(tester.getSize(find.byType(VideoSpecsPanel)), Size.zero);
     });

--- a/fushi/test/media/video/video_specs_widgets_test.dart
+++ b/fushi/test/media/video/video_specs_widgets_test.dart
@@ -1,0 +1,266 @@
+import 'dart:io';
+
+import 'package:drift/native.dart' show NativeDatabase;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart';
+import 'package:fushi/src/media/video/cover_ui/video_specs_panel.dart';
+import 'package:fushi/src/media/video/video_duration_probe.dart';
+import 'package:fushi/src/media/video/video_specs_service.dart';
+
+/// 规格 UI：角标条、紧凑摘要行、完整规格面板。
+///
+/// 探测入口注入，但**文件是真的**——service 的失效判据要读真实 FileStat。
+void main() {
+  late Directory tempDir;
+  late FushiDatabase db;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('fushi_specs_widgets');
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  String writeFile(String name) {
+    final File file = File('${tempDir.path}${Platform.pathSeparator}$name');
+    file.writeAsBytesSync(List<int>.filled(64, 0));
+    return file.path;
+  }
+
+  const VideoProbeFacts hdr4k = VideoProbeFacts(
+    containerBitrate: 15586453,
+    video: VideoStreamFacts(
+      codec: 'hevc',
+      width: 3840,
+      height: 2160,
+      pixelFormat: 'yuv420p10le',
+      bitDepth: 10,
+      frameRateMilli: 23976,
+      colorPrimaries: 'bt2020',
+      colorTransfer: 'smpte2084',
+    ),
+    audioTracks: <AudioTrackFacts>[
+      AudioTrackFacts(
+        index: 1,
+        codec: 'flac',
+        channels: 6,
+        channelLayout: '5.1',
+        language: 'jpn',
+        title: '日本語',
+        isDefault: true,
+      ),
+      AudioTrackFacts(
+        index: 2,
+        codec: 'aac',
+        channels: 2,
+        channelLayout: 'stereo',
+        language: 'eng',
+        isCommentary: true,
+      ),
+    ],
+    subtitleTracks: <SubtitleTrackFacts>[
+      SubtitleTrackFacts(
+        index: 3,
+        codec: 'subrip',
+        language: 'chi',
+        isDefault: true,
+      ),
+    ],
+  );
+
+  /// 建一个已经探好某个文件的 service。
+  ///
+  /// **必须包在 `tester.runAsync` 里**：`testWidgets` 的 body 跑在 fake-async zone,
+  /// 里面 await 真实 IO（这里是 FileStat + sqlite 写入）永远不会完成，测试直接挂死。
+  /// 预置缓存又只能走真实 IO——service 的失效判据读的就是真实 FileStat。
+  Future<VideoSpecsService> serviceWith(
+    WidgetTester tester,
+    String path,
+    VideoProbeFacts facts,
+  ) async {
+    final VideoSpecsService service =
+        VideoSpecsService(db, probe: (String p) async => facts);
+    await tester.runAsync(() => service.resolve(path));
+    return service;
+  }
+
+  Future<void> pumpWith(
+    WidgetTester tester,
+    VideoSpecsService service,
+    Widget child,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        // 不额外 addTearDown(service.dispose)：ChangeNotifierProvider 在 scope
+        // 销毁时会自己 dispose 这个 notifier，再 dispose 一次会触发
+        // 「A ChangeNotifier was used after being disposed」断言。
+        overrides: <Override>[
+          videoSpecsProvider.overrideWith((Ref ref) => service),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(home: Scaffold(body: child)),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  group('封面角标条', () {
+    testWidgets('4K HDR10 渲染成两个胶囊', (WidgetTester tester) async {
+      final String path = writeFile('a.mkv');
+      final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
+
+      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+
+      expect(find.text('4K'), findsOneWidget);
+      expect(find.text('HDR10'), findsOneWidget);
+    });
+
+    testWidgets('SDR 只出清晰度', (WidgetTester tester) async {
+      final String path = writeFile('b.mkv');
+      final VideoSpecsService service = await serviceWith(
+        tester,
+        path,
+        const VideoProbeFacts(
+          video: VideoStreamFacts(
+            width: 1920,
+            height: 1080,
+            colorPrimaries: 'bt709',
+            colorTransfer: 'bt709',
+          ),
+        ),
+      );
+
+      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+
+      expect(find.text('1080p'), findsOneWidget);
+      expect(find.text('SDR'), findsNothing);
+      expect(find.text('HDR10'), findsNothing);
+    });
+
+    testWidgets('规格未知时整个不占位', (WidgetTester tester) async {
+      final String path = writeFile('c.mkv');
+      final VideoSpecsService service =
+          await serviceWith(tester, path, VideoProbeFacts.empty);
+
+      await pumpWith(tester, service, VideoSpecsBadgeStrip(filePath: path));
+
+      // 没有任何文字，且自身尺寸为零——卡片布局一格不该被撑开。
+      expect(find.byType(Text), findsNothing);
+      expect(
+        tester.getSize(find.byType(VideoSpecsBadgeStrip)),
+        Size.zero,
+      );
+    });
+
+    testWidgets('流 URL 不探也不显示', (WidgetTester tester) async {
+      int probeCalls = 0;
+      final VideoSpecsService service = VideoSpecsService(
+        db,
+        probe: (String p) async {
+          probeCalls++;
+          return hdr4k;
+        },
+      );
+      // 不 addTearDown(dispose)：ProviderScope 销毁时已经 dispose 过一次。
+
+      await pumpWith(
+        tester,
+        service,
+        const VideoSpecsBadgeStrip(
+          filePath: 'https://example.com/stream.m3u8',
+        ),
+      );
+
+      expect(probeCalls, 0, reason: '滚动列表不该对远端条目发起网络请求');
+      expect(find.byType(Text), findsNothing);
+    });
+  });
+
+  group('紧凑摘要行', () {
+    testWidgets('清晰度 · 动态范围 · 编码 一行', (WidgetTester tester) async {
+      final String path = writeFile('d.mkv');
+      final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
+
+      await pumpWith(tester, service, VideoSpecsInlineLine(filePath: path));
+
+      expect(find.text('4K · HDR10 · HEVC'), findsOneWidget);
+    });
+
+    testWidgets('未探到时不占位（集卡高度钳死，多一行会顶掉简介）',
+        (WidgetTester tester) async {
+      final String path = writeFile('e.mkv');
+      final VideoSpecsService service =
+          await serviceWith(tester, path, VideoProbeFacts.empty);
+
+      await pumpWith(tester, service, VideoSpecsInlineLine(filePath: path));
+
+      expect(tester.getSize(find.byType(VideoSpecsInlineLine)), Size.zero);
+    });
+  });
+
+  group('完整规格面板', () {
+    testWidgets('摊开分辨率/动态范围/编码/色深/帧率/码率', (WidgetTester tester) async {
+      final String path = writeFile('f.mkv');
+      final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
+
+      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+
+      expect(find.text('4K (3840×2160)'), findsOneWidget);
+      expect(find.text('HDR10'), findsOneWidget);
+      expect(find.text('HEVC'), findsOneWidget);
+      expect(find.text('10 bit'), findsOneWidget);
+      expect(find.text('23.976 fps'), findsOneWidget);
+      expect(find.text('16 Mbps'), findsOneWidget);
+    });
+
+    testWidgets('音轨逐条列出，含默认/评论标志', (WidgetTester tester) async {
+      final String path = writeFile('g.mkv');
+      final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
+
+      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+
+      expect(find.textContaining('日本語 · FLAC · 5.1'), findsOneWidget);
+      expect(find.textContaining('ENG · AAC · 2.0'), findsOneWidget);
+      // 标志位跟在名字后面。断言「带左括号」而不是断言具体文案：标志词来自 i18n，
+      // 测试不该钉死在某个语言的值上。
+      expect(
+        find.textContaining('日本語 · FLAC · 5.1（'),
+        findsOneWidget,
+        reason: '默认轨应带标志位后缀',
+      );
+      expect(
+        find.textContaining('ENG · AAC · 2.0（'),
+        findsOneWidget,
+        reason: '评论轨应带标志位后缀',
+      );
+    });
+
+    testWidgets('字幕轨列出', (WidgetTester tester) async {
+      final String path = writeFile('h.mkv');
+      final VideoSpecsService service = await serviceWith(tester, path, hdr4k);
+
+      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+
+      expect(find.textContaining('CHI · SRT'), findsOneWidget);
+    });
+
+    testWidgets('规格未探到时整块不渲染', (WidgetTester tester) async {
+      final String path = writeFile('i.mkv');
+      final VideoSpecsService service =
+          await serviceWith(tester, path, VideoProbeFacts.empty);
+
+      await pumpWith(tester, service, VideoSpecsPanel(filePath: path));
+
+      expect(tester.getSize(find.byType(VideoSpecsPanel)), Size.zero);
+    });
+  });
+}

--- a/fushi/test/migration/bug_1505_import_failure_no_force_restart_test.dart
+++ b/fushi/test/migration/bug_1505_import_failure_no_force_restart_test.dart
@@ -86,7 +86,20 @@ void main() {
       final int start = appModel.indexOf(
           'Future<void> quiesceBackgroundDatabaseWriters({');
       expect(start, isNot(-1));
-      final String body = appModel.substring(start, start + 600);
+      // 取**完整方法体**。原先是 `substring(start, start + 600)`：函数体本身已占
+      // ~500 字符，往里加任何一个新的写手（v95 的规格探测服务就是）都会把
+      // `_disposeVideoDownloadPipelineRuntime(` 挤出窗口，守卫报红的却是「没覆盖
+      // 流水线」——与真实缺陷无关的假信号。固定字符窗口是会随无关改动漂移的锚点。
+      //
+      // 结束锚点必须**先跳过命名参数表**再找 `\n  }`：本方法的签名是多行的
+      // （`({\n    Duration? pipelineDrainTimeout,\n  }) async {`），直接找 `\n  }`
+      // 会命中参数表的收尾，body 只剩签名、每条 contains 都恒假。上面 closeDatabase
+      // 那条能直接找是因为它的签名写在一行里。
+      final int bodyStart = appModel.indexOf(') async {', start);
+      expect(bodyStart, greaterThan(start));
+      final int end = appModel.indexOf('\n  }', bodyStart);
+      expect(end, greaterThan(bodyStart));
+      final String body = appModel.substring(bodyStart, end);
       expect(body, contains('_animeDownloadService?.stop()'));
       expect(body, contains('_animeDownloadSubscriptionService?.stop()'));
       expect(body, contains('_disposeVideoDownloadPipelineRuntime('),

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -693,6 +693,7 @@ void _requireOneVideoMetadataOwner({
   StudySegmentTombstones,
   StudySegments,
   WebMineQueue,
+  VideoFileSpecs,
 ])
 class FushiDatabase extends _$FushiDatabase
     with
@@ -723,7 +724,7 @@ class FushiDatabase extends _$FushiDatabase
   final bool _isMainProcess;
 
   @override
-  int get schemaVersion => 94;
+  int get schemaVersion => 95;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2883,6 +2884,18 @@ class FushiDatabase extends _$FushiDatabase
                     'video_download_subscriptions', 'identity_json')) {
               await m.addColumn(videoDownloadSubscriptions,
                   videoDownloadSubscriptions.identityJson);
+            }
+          }
+          if (from < 95) {
+            // v95（库页/详情页技术规格标注）：新表 video_file_specs，缓存 ffprobe 探到的
+            // 分辨率 / HDR 色彩标签 / 编码 / 色深 / 帧率 / 音轨 / 字幕轨。身份键是**文件
+            // 路径**而非 bookUid——一个 video_books 行可能是多集播放列表，各集规格不同
+            // （详见 tables.dart 的表注释）。
+            // 无损：纯新增表，不动任何既有表和列；旧库升级后表为空 = 规格未探，UI 不显示
+            // 角标，与升级前行为一致，探测队列会按需回填。
+            // 幂等：fresh DB 由 onCreate 的 createAll 建好；重复升级被 `_tableExists` 短路。
+            if (!await _tableExists('video_file_specs')) {
+              await m.createTable(videoFileSpecs);
             }
           }
         },

--- a/packages/fushi_core/lib/src/database/database.g.dart
+++ b/packages/fushi_core/lib/src/database/database.g.dart
@@ -48935,6 +48935,1160 @@ class WebMineQueueCompanion extends UpdateCompanion<WebMineQueueRow> {
   }
 }
 
+class $VideoFileSpecsTable extends VideoFileSpecs
+    with TableInfo<$VideoFileSpecsTable, VideoFileSpecRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $VideoFileSpecsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _filePathMeta = const VerificationMeta(
+    'filePath',
+  );
+  @override
+  late final GeneratedColumn<String> filePath = GeneratedColumn<String>(
+    'file_path',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fileSizeBytesMeta = const VerificationMeta(
+    'fileSizeBytes',
+  );
+  @override
+  late final GeneratedColumn<int> fileSizeBytes = GeneratedColumn<int>(
+    'file_size_bytes',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fileModifiedAtMeta = const VerificationMeta(
+    'fileModifiedAt',
+  );
+  @override
+  late final GeneratedColumn<int> fileModifiedAt = GeneratedColumn<int>(
+    'file_modified_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _probedAtMeta = const VerificationMeta(
+    'probedAt',
+  );
+  @override
+  late final GeneratedColumn<int> probedAt = GeneratedColumn<int>(
+    'probed_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _probeVersionMeta = const VerificationMeta(
+    'probeVersion',
+  );
+  @override
+  late final GeneratedColumn<int> probeVersion = GeneratedColumn<int>(
+    'probe_version',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _durationMsMeta = const VerificationMeta(
+    'durationMs',
+  );
+  @override
+  late final GeneratedColumn<int> durationMs = GeneratedColumn<int>(
+    'duration_ms',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _containerBitrateMeta = const VerificationMeta(
+    'containerBitrate',
+  );
+  @override
+  late final GeneratedColumn<int> containerBitrate = GeneratedColumn<int>(
+    'container_bitrate',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _videoCodecMeta = const VerificationMeta(
+    'videoCodec',
+  );
+  @override
+  late final GeneratedColumn<String> videoCodec = GeneratedColumn<String>(
+    'video_codec',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _widthMeta = const VerificationMeta('width');
+  @override
+  late final GeneratedColumn<int> width = GeneratedColumn<int>(
+    'width',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _heightMeta = const VerificationMeta('height');
+  @override
+  late final GeneratedColumn<int> height = GeneratedColumn<int>(
+    'height',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _pixelFormatMeta = const VerificationMeta(
+    'pixelFormat',
+  );
+  @override
+  late final GeneratedColumn<String> pixelFormat = GeneratedColumn<String>(
+    'pixel_format',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _bitDepthMeta = const VerificationMeta(
+    'bitDepth',
+  );
+  @override
+  late final GeneratedColumn<int> bitDepth = GeneratedColumn<int>(
+    'bit_depth',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _frameRateMilliMeta = const VerificationMeta(
+    'frameRateMilli',
+  );
+  @override
+  late final GeneratedColumn<int> frameRateMilli = GeneratedColumn<int>(
+    'frame_rate_milli',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _videoBitrateMeta = const VerificationMeta(
+    'videoBitrate',
+  );
+  @override
+  late final GeneratedColumn<int> videoBitrate = GeneratedColumn<int>(
+    'video_bitrate',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _colorPrimariesMeta = const VerificationMeta(
+    'colorPrimaries',
+  );
+  @override
+  late final GeneratedColumn<String> colorPrimaries = GeneratedColumn<String>(
+    'color_primaries',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _colorTransferMeta = const VerificationMeta(
+    'colorTransfer',
+  );
+  @override
+  late final GeneratedColumn<String> colorTransfer = GeneratedColumn<String>(
+    'color_transfer',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _colorSpaceMeta = const VerificationMeta(
+    'colorSpace',
+  );
+  @override
+  late final GeneratedColumn<String> colorSpace = GeneratedColumn<String>(
+    'color_space',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _audioTracksJsonMeta = const VerificationMeta(
+    'audioTracksJson',
+  );
+  @override
+  late final GeneratedColumn<String> audioTracksJson = GeneratedColumn<String>(
+    'audio_tracks_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('[]'),
+  );
+  static const VerificationMeta _subtitleTracksJsonMeta =
+      const VerificationMeta('subtitleTracksJson');
+  @override
+  late final GeneratedColumn<String> subtitleTracksJson =
+      GeneratedColumn<String>(
+        'subtitle_tracks_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('[]'),
+      );
+  @override
+  List<GeneratedColumn> get $columns => [
+    filePath,
+    fileSizeBytes,
+    fileModifiedAt,
+    probedAt,
+    probeVersion,
+    durationMs,
+    containerBitrate,
+    videoCodec,
+    width,
+    height,
+    pixelFormat,
+    bitDepth,
+    frameRateMilli,
+    videoBitrate,
+    colorPrimaries,
+    colorTransfer,
+    colorSpace,
+    audioTracksJson,
+    subtitleTracksJson,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'video_file_specs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<VideoFileSpecRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('file_path')) {
+      context.handle(
+        _filePathMeta,
+        filePath.isAcceptableOrUnknown(data['file_path']!, _filePathMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_filePathMeta);
+    }
+    if (data.containsKey('file_size_bytes')) {
+      context.handle(
+        _fileSizeBytesMeta,
+        fileSizeBytes.isAcceptableOrUnknown(
+          data['file_size_bytes']!,
+          _fileSizeBytesMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_fileSizeBytesMeta);
+    }
+    if (data.containsKey('file_modified_at')) {
+      context.handle(
+        _fileModifiedAtMeta,
+        fileModifiedAt.isAcceptableOrUnknown(
+          data['file_modified_at']!,
+          _fileModifiedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_fileModifiedAtMeta);
+    }
+    if (data.containsKey('probed_at')) {
+      context.handle(
+        _probedAtMeta,
+        probedAt.isAcceptableOrUnknown(data['probed_at']!, _probedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_probedAtMeta);
+    }
+    if (data.containsKey('probe_version')) {
+      context.handle(
+        _probeVersionMeta,
+        probeVersion.isAcceptableOrUnknown(
+          data['probe_version']!,
+          _probeVersionMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_probeVersionMeta);
+    }
+    if (data.containsKey('duration_ms')) {
+      context.handle(
+        _durationMsMeta,
+        durationMs.isAcceptableOrUnknown(data['duration_ms']!, _durationMsMeta),
+      );
+    }
+    if (data.containsKey('container_bitrate')) {
+      context.handle(
+        _containerBitrateMeta,
+        containerBitrate.isAcceptableOrUnknown(
+          data['container_bitrate']!,
+          _containerBitrateMeta,
+        ),
+      );
+    }
+    if (data.containsKey('video_codec')) {
+      context.handle(
+        _videoCodecMeta,
+        videoCodec.isAcceptableOrUnknown(data['video_codec']!, _videoCodecMeta),
+      );
+    }
+    if (data.containsKey('width')) {
+      context.handle(
+        _widthMeta,
+        width.isAcceptableOrUnknown(data['width']!, _widthMeta),
+      );
+    }
+    if (data.containsKey('height')) {
+      context.handle(
+        _heightMeta,
+        height.isAcceptableOrUnknown(data['height']!, _heightMeta),
+      );
+    }
+    if (data.containsKey('pixel_format')) {
+      context.handle(
+        _pixelFormatMeta,
+        pixelFormat.isAcceptableOrUnknown(
+          data['pixel_format']!,
+          _pixelFormatMeta,
+        ),
+      );
+    }
+    if (data.containsKey('bit_depth')) {
+      context.handle(
+        _bitDepthMeta,
+        bitDepth.isAcceptableOrUnknown(data['bit_depth']!, _bitDepthMeta),
+      );
+    }
+    if (data.containsKey('frame_rate_milli')) {
+      context.handle(
+        _frameRateMilliMeta,
+        frameRateMilli.isAcceptableOrUnknown(
+          data['frame_rate_milli']!,
+          _frameRateMilliMeta,
+        ),
+      );
+    }
+    if (data.containsKey('video_bitrate')) {
+      context.handle(
+        _videoBitrateMeta,
+        videoBitrate.isAcceptableOrUnknown(
+          data['video_bitrate']!,
+          _videoBitrateMeta,
+        ),
+      );
+    }
+    if (data.containsKey('color_primaries')) {
+      context.handle(
+        _colorPrimariesMeta,
+        colorPrimaries.isAcceptableOrUnknown(
+          data['color_primaries']!,
+          _colorPrimariesMeta,
+        ),
+      );
+    }
+    if (data.containsKey('color_transfer')) {
+      context.handle(
+        _colorTransferMeta,
+        colorTransfer.isAcceptableOrUnknown(
+          data['color_transfer']!,
+          _colorTransferMeta,
+        ),
+      );
+    }
+    if (data.containsKey('color_space')) {
+      context.handle(
+        _colorSpaceMeta,
+        colorSpace.isAcceptableOrUnknown(data['color_space']!, _colorSpaceMeta),
+      );
+    }
+    if (data.containsKey('audio_tracks_json')) {
+      context.handle(
+        _audioTracksJsonMeta,
+        audioTracksJson.isAcceptableOrUnknown(
+          data['audio_tracks_json']!,
+          _audioTracksJsonMeta,
+        ),
+      );
+    }
+    if (data.containsKey('subtitle_tracks_json')) {
+      context.handle(
+        _subtitleTracksJsonMeta,
+        subtitleTracksJson.isAcceptableOrUnknown(
+          data['subtitle_tracks_json']!,
+          _subtitleTracksJsonMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {filePath};
+  @override
+  VideoFileSpecRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return VideoFileSpecRow(
+      filePath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}file_path'],
+      )!,
+      fileSizeBytes: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}file_size_bytes'],
+      )!,
+      fileModifiedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}file_modified_at'],
+      )!,
+      probedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}probed_at'],
+      )!,
+      probeVersion: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}probe_version'],
+      )!,
+      durationMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}duration_ms'],
+      ),
+      containerBitrate: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}container_bitrate'],
+      ),
+      videoCodec: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}video_codec'],
+      ),
+      width: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}width'],
+      ),
+      height: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}height'],
+      ),
+      pixelFormat: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}pixel_format'],
+      ),
+      bitDepth: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}bit_depth'],
+      ),
+      frameRateMilli: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}frame_rate_milli'],
+      ),
+      videoBitrate: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}video_bitrate'],
+      ),
+      colorPrimaries: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}color_primaries'],
+      ),
+      colorTransfer: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}color_transfer'],
+      ),
+      colorSpace: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}color_space'],
+      ),
+      audioTracksJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}audio_tracks_json'],
+      )!,
+      subtitleTracksJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}subtitle_tracks_json'],
+      )!,
+    );
+  }
+
+  @override
+  $VideoFileSpecsTable createAlias(String alias) {
+    return $VideoFileSpecsTable(attachedDatabase, alias);
+  }
+}
+
+class VideoFileSpecRow extends DataClass
+    implements Insertable<VideoFileSpecRow> {
+  /// 视频文件绝对路径 = 身份。与 `VideoBooks.videoPath` 同语义（数据根内副本 / 用户
+  /// 原位外部文件两态；流 URL 不入本表——探的是本地文件）。
+  final String filePath;
+
+  /// 探测当时的文件大小（字节）。失效判据之一。
+  final int fileSizeBytes;
+
+  /// 探测当时的文件修改时刻（毫秒）。失效判据之一。
+  final int fileModifiedAt;
+
+  /// 本行写入时刻（毫秒）。
+  final int probedAt;
+
+  /// 探测器字段集版本（`kVideoProbeFieldSetVersion`）。失效判据之一。
+  final int probeVersion;
+
+  /// 容器时长（毫秒）。探不到为 NULL。
+  final int? durationMs;
+
+  /// 容器平均码率（bit/s）。展示码率通常只能用它——mkv 不给流级码率。
+  final int? containerBitrate;
+
+  /// ffprobe `codec_name`，如 `h264` / `hevc` / `av1`。
+  final String? videoCodec;
+  final int? width;
+  final int? height;
+
+  /// 如 `yuv420p10le`。色深主要由它推出（10-bit HEVC 不给 bits_per_raw_sample）。
+  final String? pixelFormat;
+
+  /// 每分量位深（8 / 10 / 12）。
+  final int? bitDepth;
+
+  /// 帧率 ×1000（23.976fps → 23976）。整数存储避免浮点比较误差。
+  final int? frameRateMilli;
+
+  /// 视频流码率（bit/s）。mkv 通常没有，见 [containerBitrate]。
+  final int? videoBitrate;
+
+  /// ffprobe 原样的色彩标签。**不存归一后的「是不是 HDR」**：那是派生值，
+  /// 判据收口在 `video_dynamic_range.dart`，存派生值等于把同一事实放两处，
+  /// 判据一改这里就成了过期副本。
+  final String? colorPrimaries;
+  final String? colorTransfer;
+  final String? colorSpace;
+
+  /// 音轨数组 JSON（编码/声道/语言/标题/default·forced·comment 标志）。
+  final String audioTracksJson;
+
+  /// 内封字幕轨数组 JSON。
+  final String subtitleTracksJson;
+  const VideoFileSpecRow({
+    required this.filePath,
+    required this.fileSizeBytes,
+    required this.fileModifiedAt,
+    required this.probedAt,
+    required this.probeVersion,
+    this.durationMs,
+    this.containerBitrate,
+    this.videoCodec,
+    this.width,
+    this.height,
+    this.pixelFormat,
+    this.bitDepth,
+    this.frameRateMilli,
+    this.videoBitrate,
+    this.colorPrimaries,
+    this.colorTransfer,
+    this.colorSpace,
+    required this.audioTracksJson,
+    required this.subtitleTracksJson,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['file_path'] = Variable<String>(filePath);
+    map['file_size_bytes'] = Variable<int>(fileSizeBytes);
+    map['file_modified_at'] = Variable<int>(fileModifiedAt);
+    map['probed_at'] = Variable<int>(probedAt);
+    map['probe_version'] = Variable<int>(probeVersion);
+    if (!nullToAbsent || durationMs != null) {
+      map['duration_ms'] = Variable<int>(durationMs);
+    }
+    if (!nullToAbsent || containerBitrate != null) {
+      map['container_bitrate'] = Variable<int>(containerBitrate);
+    }
+    if (!nullToAbsent || videoCodec != null) {
+      map['video_codec'] = Variable<String>(videoCodec);
+    }
+    if (!nullToAbsent || width != null) {
+      map['width'] = Variable<int>(width);
+    }
+    if (!nullToAbsent || height != null) {
+      map['height'] = Variable<int>(height);
+    }
+    if (!nullToAbsent || pixelFormat != null) {
+      map['pixel_format'] = Variable<String>(pixelFormat);
+    }
+    if (!nullToAbsent || bitDepth != null) {
+      map['bit_depth'] = Variable<int>(bitDepth);
+    }
+    if (!nullToAbsent || frameRateMilli != null) {
+      map['frame_rate_milli'] = Variable<int>(frameRateMilli);
+    }
+    if (!nullToAbsent || videoBitrate != null) {
+      map['video_bitrate'] = Variable<int>(videoBitrate);
+    }
+    if (!nullToAbsent || colorPrimaries != null) {
+      map['color_primaries'] = Variable<String>(colorPrimaries);
+    }
+    if (!nullToAbsent || colorTransfer != null) {
+      map['color_transfer'] = Variable<String>(colorTransfer);
+    }
+    if (!nullToAbsent || colorSpace != null) {
+      map['color_space'] = Variable<String>(colorSpace);
+    }
+    map['audio_tracks_json'] = Variable<String>(audioTracksJson);
+    map['subtitle_tracks_json'] = Variable<String>(subtitleTracksJson);
+    return map;
+  }
+
+  VideoFileSpecsCompanion toCompanion(bool nullToAbsent) {
+    return VideoFileSpecsCompanion(
+      filePath: Value(filePath),
+      fileSizeBytes: Value(fileSizeBytes),
+      fileModifiedAt: Value(fileModifiedAt),
+      probedAt: Value(probedAt),
+      probeVersion: Value(probeVersion),
+      durationMs: durationMs == null && nullToAbsent
+          ? const Value.absent()
+          : Value(durationMs),
+      containerBitrate: containerBitrate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(containerBitrate),
+      videoCodec: videoCodec == null && nullToAbsent
+          ? const Value.absent()
+          : Value(videoCodec),
+      width: width == null && nullToAbsent
+          ? const Value.absent()
+          : Value(width),
+      height: height == null && nullToAbsent
+          ? const Value.absent()
+          : Value(height),
+      pixelFormat: pixelFormat == null && nullToAbsent
+          ? const Value.absent()
+          : Value(pixelFormat),
+      bitDepth: bitDepth == null && nullToAbsent
+          ? const Value.absent()
+          : Value(bitDepth),
+      frameRateMilli: frameRateMilli == null && nullToAbsent
+          ? const Value.absent()
+          : Value(frameRateMilli),
+      videoBitrate: videoBitrate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(videoBitrate),
+      colorPrimaries: colorPrimaries == null && nullToAbsent
+          ? const Value.absent()
+          : Value(colorPrimaries),
+      colorTransfer: colorTransfer == null && nullToAbsent
+          ? const Value.absent()
+          : Value(colorTransfer),
+      colorSpace: colorSpace == null && nullToAbsent
+          ? const Value.absent()
+          : Value(colorSpace),
+      audioTracksJson: Value(audioTracksJson),
+      subtitleTracksJson: Value(subtitleTracksJson),
+    );
+  }
+
+  factory VideoFileSpecRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return VideoFileSpecRow(
+      filePath: serializer.fromJson<String>(json['filePath']),
+      fileSizeBytes: serializer.fromJson<int>(json['fileSizeBytes']),
+      fileModifiedAt: serializer.fromJson<int>(json['fileModifiedAt']),
+      probedAt: serializer.fromJson<int>(json['probedAt']),
+      probeVersion: serializer.fromJson<int>(json['probeVersion']),
+      durationMs: serializer.fromJson<int?>(json['durationMs']),
+      containerBitrate: serializer.fromJson<int?>(json['containerBitrate']),
+      videoCodec: serializer.fromJson<String?>(json['videoCodec']),
+      width: serializer.fromJson<int?>(json['width']),
+      height: serializer.fromJson<int?>(json['height']),
+      pixelFormat: serializer.fromJson<String?>(json['pixelFormat']),
+      bitDepth: serializer.fromJson<int?>(json['bitDepth']),
+      frameRateMilli: serializer.fromJson<int?>(json['frameRateMilli']),
+      videoBitrate: serializer.fromJson<int?>(json['videoBitrate']),
+      colorPrimaries: serializer.fromJson<String?>(json['colorPrimaries']),
+      colorTransfer: serializer.fromJson<String?>(json['colorTransfer']),
+      colorSpace: serializer.fromJson<String?>(json['colorSpace']),
+      audioTracksJson: serializer.fromJson<String>(json['audioTracksJson']),
+      subtitleTracksJson: serializer.fromJson<String>(
+        json['subtitleTracksJson'],
+      ),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'filePath': serializer.toJson<String>(filePath),
+      'fileSizeBytes': serializer.toJson<int>(fileSizeBytes),
+      'fileModifiedAt': serializer.toJson<int>(fileModifiedAt),
+      'probedAt': serializer.toJson<int>(probedAt),
+      'probeVersion': serializer.toJson<int>(probeVersion),
+      'durationMs': serializer.toJson<int?>(durationMs),
+      'containerBitrate': serializer.toJson<int?>(containerBitrate),
+      'videoCodec': serializer.toJson<String?>(videoCodec),
+      'width': serializer.toJson<int?>(width),
+      'height': serializer.toJson<int?>(height),
+      'pixelFormat': serializer.toJson<String?>(pixelFormat),
+      'bitDepth': serializer.toJson<int?>(bitDepth),
+      'frameRateMilli': serializer.toJson<int?>(frameRateMilli),
+      'videoBitrate': serializer.toJson<int?>(videoBitrate),
+      'colorPrimaries': serializer.toJson<String?>(colorPrimaries),
+      'colorTransfer': serializer.toJson<String?>(colorTransfer),
+      'colorSpace': serializer.toJson<String?>(colorSpace),
+      'audioTracksJson': serializer.toJson<String>(audioTracksJson),
+      'subtitleTracksJson': serializer.toJson<String>(subtitleTracksJson),
+    };
+  }
+
+  VideoFileSpecRow copyWith({
+    String? filePath,
+    int? fileSizeBytes,
+    int? fileModifiedAt,
+    int? probedAt,
+    int? probeVersion,
+    Value<int?> durationMs = const Value.absent(),
+    Value<int?> containerBitrate = const Value.absent(),
+    Value<String?> videoCodec = const Value.absent(),
+    Value<int?> width = const Value.absent(),
+    Value<int?> height = const Value.absent(),
+    Value<String?> pixelFormat = const Value.absent(),
+    Value<int?> bitDepth = const Value.absent(),
+    Value<int?> frameRateMilli = const Value.absent(),
+    Value<int?> videoBitrate = const Value.absent(),
+    Value<String?> colorPrimaries = const Value.absent(),
+    Value<String?> colorTransfer = const Value.absent(),
+    Value<String?> colorSpace = const Value.absent(),
+    String? audioTracksJson,
+    String? subtitleTracksJson,
+  }) => VideoFileSpecRow(
+    filePath: filePath ?? this.filePath,
+    fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
+    fileModifiedAt: fileModifiedAt ?? this.fileModifiedAt,
+    probedAt: probedAt ?? this.probedAt,
+    probeVersion: probeVersion ?? this.probeVersion,
+    durationMs: durationMs.present ? durationMs.value : this.durationMs,
+    containerBitrate: containerBitrate.present
+        ? containerBitrate.value
+        : this.containerBitrate,
+    videoCodec: videoCodec.present ? videoCodec.value : this.videoCodec,
+    width: width.present ? width.value : this.width,
+    height: height.present ? height.value : this.height,
+    pixelFormat: pixelFormat.present ? pixelFormat.value : this.pixelFormat,
+    bitDepth: bitDepth.present ? bitDepth.value : this.bitDepth,
+    frameRateMilli: frameRateMilli.present
+        ? frameRateMilli.value
+        : this.frameRateMilli,
+    videoBitrate: videoBitrate.present ? videoBitrate.value : this.videoBitrate,
+    colorPrimaries: colorPrimaries.present
+        ? colorPrimaries.value
+        : this.colorPrimaries,
+    colorTransfer: colorTransfer.present
+        ? colorTransfer.value
+        : this.colorTransfer,
+    colorSpace: colorSpace.present ? colorSpace.value : this.colorSpace,
+    audioTracksJson: audioTracksJson ?? this.audioTracksJson,
+    subtitleTracksJson: subtitleTracksJson ?? this.subtitleTracksJson,
+  );
+  VideoFileSpecRow copyWithCompanion(VideoFileSpecsCompanion data) {
+    return VideoFileSpecRow(
+      filePath: data.filePath.present ? data.filePath.value : this.filePath,
+      fileSizeBytes: data.fileSizeBytes.present
+          ? data.fileSizeBytes.value
+          : this.fileSizeBytes,
+      fileModifiedAt: data.fileModifiedAt.present
+          ? data.fileModifiedAt.value
+          : this.fileModifiedAt,
+      probedAt: data.probedAt.present ? data.probedAt.value : this.probedAt,
+      probeVersion: data.probeVersion.present
+          ? data.probeVersion.value
+          : this.probeVersion,
+      durationMs: data.durationMs.present
+          ? data.durationMs.value
+          : this.durationMs,
+      containerBitrate: data.containerBitrate.present
+          ? data.containerBitrate.value
+          : this.containerBitrate,
+      videoCodec: data.videoCodec.present
+          ? data.videoCodec.value
+          : this.videoCodec,
+      width: data.width.present ? data.width.value : this.width,
+      height: data.height.present ? data.height.value : this.height,
+      pixelFormat: data.pixelFormat.present
+          ? data.pixelFormat.value
+          : this.pixelFormat,
+      bitDepth: data.bitDepth.present ? data.bitDepth.value : this.bitDepth,
+      frameRateMilli: data.frameRateMilli.present
+          ? data.frameRateMilli.value
+          : this.frameRateMilli,
+      videoBitrate: data.videoBitrate.present
+          ? data.videoBitrate.value
+          : this.videoBitrate,
+      colorPrimaries: data.colorPrimaries.present
+          ? data.colorPrimaries.value
+          : this.colorPrimaries,
+      colorTransfer: data.colorTransfer.present
+          ? data.colorTransfer.value
+          : this.colorTransfer,
+      colorSpace: data.colorSpace.present
+          ? data.colorSpace.value
+          : this.colorSpace,
+      audioTracksJson: data.audioTracksJson.present
+          ? data.audioTracksJson.value
+          : this.audioTracksJson,
+      subtitleTracksJson: data.subtitleTracksJson.present
+          ? data.subtitleTracksJson.value
+          : this.subtitleTracksJson,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('VideoFileSpecRow(')
+          ..write('filePath: $filePath, ')
+          ..write('fileSizeBytes: $fileSizeBytes, ')
+          ..write('fileModifiedAt: $fileModifiedAt, ')
+          ..write('probedAt: $probedAt, ')
+          ..write('probeVersion: $probeVersion, ')
+          ..write('durationMs: $durationMs, ')
+          ..write('containerBitrate: $containerBitrate, ')
+          ..write('videoCodec: $videoCodec, ')
+          ..write('width: $width, ')
+          ..write('height: $height, ')
+          ..write('pixelFormat: $pixelFormat, ')
+          ..write('bitDepth: $bitDepth, ')
+          ..write('frameRateMilli: $frameRateMilli, ')
+          ..write('videoBitrate: $videoBitrate, ')
+          ..write('colorPrimaries: $colorPrimaries, ')
+          ..write('colorTransfer: $colorTransfer, ')
+          ..write('colorSpace: $colorSpace, ')
+          ..write('audioTracksJson: $audioTracksJson, ')
+          ..write('subtitleTracksJson: $subtitleTracksJson')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    filePath,
+    fileSizeBytes,
+    fileModifiedAt,
+    probedAt,
+    probeVersion,
+    durationMs,
+    containerBitrate,
+    videoCodec,
+    width,
+    height,
+    pixelFormat,
+    bitDepth,
+    frameRateMilli,
+    videoBitrate,
+    colorPrimaries,
+    colorTransfer,
+    colorSpace,
+    audioTracksJson,
+    subtitleTracksJson,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is VideoFileSpecRow &&
+          other.filePath == this.filePath &&
+          other.fileSizeBytes == this.fileSizeBytes &&
+          other.fileModifiedAt == this.fileModifiedAt &&
+          other.probedAt == this.probedAt &&
+          other.probeVersion == this.probeVersion &&
+          other.durationMs == this.durationMs &&
+          other.containerBitrate == this.containerBitrate &&
+          other.videoCodec == this.videoCodec &&
+          other.width == this.width &&
+          other.height == this.height &&
+          other.pixelFormat == this.pixelFormat &&
+          other.bitDepth == this.bitDepth &&
+          other.frameRateMilli == this.frameRateMilli &&
+          other.videoBitrate == this.videoBitrate &&
+          other.colorPrimaries == this.colorPrimaries &&
+          other.colorTransfer == this.colorTransfer &&
+          other.colorSpace == this.colorSpace &&
+          other.audioTracksJson == this.audioTracksJson &&
+          other.subtitleTracksJson == this.subtitleTracksJson);
+}
+
+class VideoFileSpecsCompanion extends UpdateCompanion<VideoFileSpecRow> {
+  final Value<String> filePath;
+  final Value<int> fileSizeBytes;
+  final Value<int> fileModifiedAt;
+  final Value<int> probedAt;
+  final Value<int> probeVersion;
+  final Value<int?> durationMs;
+  final Value<int?> containerBitrate;
+  final Value<String?> videoCodec;
+  final Value<int?> width;
+  final Value<int?> height;
+  final Value<String?> pixelFormat;
+  final Value<int?> bitDepth;
+  final Value<int?> frameRateMilli;
+  final Value<int?> videoBitrate;
+  final Value<String?> colorPrimaries;
+  final Value<String?> colorTransfer;
+  final Value<String?> colorSpace;
+  final Value<String> audioTracksJson;
+  final Value<String> subtitleTracksJson;
+  final Value<int> rowid;
+  const VideoFileSpecsCompanion({
+    this.filePath = const Value.absent(),
+    this.fileSizeBytes = const Value.absent(),
+    this.fileModifiedAt = const Value.absent(),
+    this.probedAt = const Value.absent(),
+    this.probeVersion = const Value.absent(),
+    this.durationMs = const Value.absent(),
+    this.containerBitrate = const Value.absent(),
+    this.videoCodec = const Value.absent(),
+    this.width = const Value.absent(),
+    this.height = const Value.absent(),
+    this.pixelFormat = const Value.absent(),
+    this.bitDepth = const Value.absent(),
+    this.frameRateMilli = const Value.absent(),
+    this.videoBitrate = const Value.absent(),
+    this.colorPrimaries = const Value.absent(),
+    this.colorTransfer = const Value.absent(),
+    this.colorSpace = const Value.absent(),
+    this.audioTracksJson = const Value.absent(),
+    this.subtitleTracksJson = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  VideoFileSpecsCompanion.insert({
+    required String filePath,
+    required int fileSizeBytes,
+    required int fileModifiedAt,
+    required int probedAt,
+    required int probeVersion,
+    this.durationMs = const Value.absent(),
+    this.containerBitrate = const Value.absent(),
+    this.videoCodec = const Value.absent(),
+    this.width = const Value.absent(),
+    this.height = const Value.absent(),
+    this.pixelFormat = const Value.absent(),
+    this.bitDepth = const Value.absent(),
+    this.frameRateMilli = const Value.absent(),
+    this.videoBitrate = const Value.absent(),
+    this.colorPrimaries = const Value.absent(),
+    this.colorTransfer = const Value.absent(),
+    this.colorSpace = const Value.absent(),
+    this.audioTracksJson = const Value.absent(),
+    this.subtitleTracksJson = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : filePath = Value(filePath),
+       fileSizeBytes = Value(fileSizeBytes),
+       fileModifiedAt = Value(fileModifiedAt),
+       probedAt = Value(probedAt),
+       probeVersion = Value(probeVersion);
+  static Insertable<VideoFileSpecRow> custom({
+    Expression<String>? filePath,
+    Expression<int>? fileSizeBytes,
+    Expression<int>? fileModifiedAt,
+    Expression<int>? probedAt,
+    Expression<int>? probeVersion,
+    Expression<int>? durationMs,
+    Expression<int>? containerBitrate,
+    Expression<String>? videoCodec,
+    Expression<int>? width,
+    Expression<int>? height,
+    Expression<String>? pixelFormat,
+    Expression<int>? bitDepth,
+    Expression<int>? frameRateMilli,
+    Expression<int>? videoBitrate,
+    Expression<String>? colorPrimaries,
+    Expression<String>? colorTransfer,
+    Expression<String>? colorSpace,
+    Expression<String>? audioTracksJson,
+    Expression<String>? subtitleTracksJson,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (filePath != null) 'file_path': filePath,
+      if (fileSizeBytes != null) 'file_size_bytes': fileSizeBytes,
+      if (fileModifiedAt != null) 'file_modified_at': fileModifiedAt,
+      if (probedAt != null) 'probed_at': probedAt,
+      if (probeVersion != null) 'probe_version': probeVersion,
+      if (durationMs != null) 'duration_ms': durationMs,
+      if (containerBitrate != null) 'container_bitrate': containerBitrate,
+      if (videoCodec != null) 'video_codec': videoCodec,
+      if (width != null) 'width': width,
+      if (height != null) 'height': height,
+      if (pixelFormat != null) 'pixel_format': pixelFormat,
+      if (bitDepth != null) 'bit_depth': bitDepth,
+      if (frameRateMilli != null) 'frame_rate_milli': frameRateMilli,
+      if (videoBitrate != null) 'video_bitrate': videoBitrate,
+      if (colorPrimaries != null) 'color_primaries': colorPrimaries,
+      if (colorTransfer != null) 'color_transfer': colorTransfer,
+      if (colorSpace != null) 'color_space': colorSpace,
+      if (audioTracksJson != null) 'audio_tracks_json': audioTracksJson,
+      if (subtitleTracksJson != null)
+        'subtitle_tracks_json': subtitleTracksJson,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  VideoFileSpecsCompanion copyWith({
+    Value<String>? filePath,
+    Value<int>? fileSizeBytes,
+    Value<int>? fileModifiedAt,
+    Value<int>? probedAt,
+    Value<int>? probeVersion,
+    Value<int?>? durationMs,
+    Value<int?>? containerBitrate,
+    Value<String?>? videoCodec,
+    Value<int?>? width,
+    Value<int?>? height,
+    Value<String?>? pixelFormat,
+    Value<int?>? bitDepth,
+    Value<int?>? frameRateMilli,
+    Value<int?>? videoBitrate,
+    Value<String?>? colorPrimaries,
+    Value<String?>? colorTransfer,
+    Value<String?>? colorSpace,
+    Value<String>? audioTracksJson,
+    Value<String>? subtitleTracksJson,
+    Value<int>? rowid,
+  }) {
+    return VideoFileSpecsCompanion(
+      filePath: filePath ?? this.filePath,
+      fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
+      fileModifiedAt: fileModifiedAt ?? this.fileModifiedAt,
+      probedAt: probedAt ?? this.probedAt,
+      probeVersion: probeVersion ?? this.probeVersion,
+      durationMs: durationMs ?? this.durationMs,
+      containerBitrate: containerBitrate ?? this.containerBitrate,
+      videoCodec: videoCodec ?? this.videoCodec,
+      width: width ?? this.width,
+      height: height ?? this.height,
+      pixelFormat: pixelFormat ?? this.pixelFormat,
+      bitDepth: bitDepth ?? this.bitDepth,
+      frameRateMilli: frameRateMilli ?? this.frameRateMilli,
+      videoBitrate: videoBitrate ?? this.videoBitrate,
+      colorPrimaries: colorPrimaries ?? this.colorPrimaries,
+      colorTransfer: colorTransfer ?? this.colorTransfer,
+      colorSpace: colorSpace ?? this.colorSpace,
+      audioTracksJson: audioTracksJson ?? this.audioTracksJson,
+      subtitleTracksJson: subtitleTracksJson ?? this.subtitleTracksJson,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (filePath.present) {
+      map['file_path'] = Variable<String>(filePath.value);
+    }
+    if (fileSizeBytes.present) {
+      map['file_size_bytes'] = Variable<int>(fileSizeBytes.value);
+    }
+    if (fileModifiedAt.present) {
+      map['file_modified_at'] = Variable<int>(fileModifiedAt.value);
+    }
+    if (probedAt.present) {
+      map['probed_at'] = Variable<int>(probedAt.value);
+    }
+    if (probeVersion.present) {
+      map['probe_version'] = Variable<int>(probeVersion.value);
+    }
+    if (durationMs.present) {
+      map['duration_ms'] = Variable<int>(durationMs.value);
+    }
+    if (containerBitrate.present) {
+      map['container_bitrate'] = Variable<int>(containerBitrate.value);
+    }
+    if (videoCodec.present) {
+      map['video_codec'] = Variable<String>(videoCodec.value);
+    }
+    if (width.present) {
+      map['width'] = Variable<int>(width.value);
+    }
+    if (height.present) {
+      map['height'] = Variable<int>(height.value);
+    }
+    if (pixelFormat.present) {
+      map['pixel_format'] = Variable<String>(pixelFormat.value);
+    }
+    if (bitDepth.present) {
+      map['bit_depth'] = Variable<int>(bitDepth.value);
+    }
+    if (frameRateMilli.present) {
+      map['frame_rate_milli'] = Variable<int>(frameRateMilli.value);
+    }
+    if (videoBitrate.present) {
+      map['video_bitrate'] = Variable<int>(videoBitrate.value);
+    }
+    if (colorPrimaries.present) {
+      map['color_primaries'] = Variable<String>(colorPrimaries.value);
+    }
+    if (colorTransfer.present) {
+      map['color_transfer'] = Variable<String>(colorTransfer.value);
+    }
+    if (colorSpace.present) {
+      map['color_space'] = Variable<String>(colorSpace.value);
+    }
+    if (audioTracksJson.present) {
+      map['audio_tracks_json'] = Variable<String>(audioTracksJson.value);
+    }
+    if (subtitleTracksJson.present) {
+      map['subtitle_tracks_json'] = Variable<String>(subtitleTracksJson.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('VideoFileSpecsCompanion(')
+          ..write('filePath: $filePath, ')
+          ..write('fileSizeBytes: $fileSizeBytes, ')
+          ..write('fileModifiedAt: $fileModifiedAt, ')
+          ..write('probedAt: $probedAt, ')
+          ..write('probeVersion: $probeVersion, ')
+          ..write('durationMs: $durationMs, ')
+          ..write('containerBitrate: $containerBitrate, ')
+          ..write('videoCodec: $videoCodec, ')
+          ..write('width: $width, ')
+          ..write('height: $height, ')
+          ..write('pixelFormat: $pixelFormat, ')
+          ..write('bitDepth: $bitDepth, ')
+          ..write('frameRateMilli: $frameRateMilli, ')
+          ..write('videoBitrate: $videoBitrate, ')
+          ..write('colorPrimaries: $colorPrimaries, ')
+          ..write('colorTransfer: $colorTransfer, ')
+          ..write('colorSpace: $colorSpace, ')
+          ..write('audioTracksJson: $audioTracksJson, ')
+          ..write('subtitleTracksJson: $subtitleTracksJson, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$FushiDatabase extends GeneratedDatabase {
   _$FushiDatabase(QueryExecutor e) : super(e);
   $FushiDatabaseManager get managers => $FushiDatabaseManager(this);
@@ -49084,6 +50238,7 @@ abstract class _$FushiDatabase extends GeneratedDatabase {
       $StudySegmentTombstonesTable(this);
   late final $StudySegmentsTable studySegments = $StudySegmentsTable(this);
   late final $WebMineQueueTable webMineQueue = $WebMineQueueTable(this);
+  late final $VideoFileSpecsTable videoFileSpecs = $VideoFileSpecsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -49170,6 +50325,7 @@ abstract class _$FushiDatabase extends GeneratedDatabase {
     studySegmentTombstones,
     studySegments,
     webMineQueue,
+    videoFileSpecs,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -86122,6 +87278,506 @@ typedef $$WebMineQueueTableProcessedTableManager =
       WebMineQueueRow,
       PrefetchHooks Function()
     >;
+typedef $$VideoFileSpecsTableCreateCompanionBuilder =
+    VideoFileSpecsCompanion Function({
+      required String filePath,
+      required int fileSizeBytes,
+      required int fileModifiedAt,
+      required int probedAt,
+      required int probeVersion,
+      Value<int?> durationMs,
+      Value<int?> containerBitrate,
+      Value<String?> videoCodec,
+      Value<int?> width,
+      Value<int?> height,
+      Value<String?> pixelFormat,
+      Value<int?> bitDepth,
+      Value<int?> frameRateMilli,
+      Value<int?> videoBitrate,
+      Value<String?> colorPrimaries,
+      Value<String?> colorTransfer,
+      Value<String?> colorSpace,
+      Value<String> audioTracksJson,
+      Value<String> subtitleTracksJson,
+      Value<int> rowid,
+    });
+typedef $$VideoFileSpecsTableUpdateCompanionBuilder =
+    VideoFileSpecsCompanion Function({
+      Value<String> filePath,
+      Value<int> fileSizeBytes,
+      Value<int> fileModifiedAt,
+      Value<int> probedAt,
+      Value<int> probeVersion,
+      Value<int?> durationMs,
+      Value<int?> containerBitrate,
+      Value<String?> videoCodec,
+      Value<int?> width,
+      Value<int?> height,
+      Value<String?> pixelFormat,
+      Value<int?> bitDepth,
+      Value<int?> frameRateMilli,
+      Value<int?> videoBitrate,
+      Value<String?> colorPrimaries,
+      Value<String?> colorTransfer,
+      Value<String?> colorSpace,
+      Value<String> audioTracksJson,
+      Value<String> subtitleTracksJson,
+      Value<int> rowid,
+    });
+
+class $$VideoFileSpecsTableFilterComposer
+    extends Composer<_$FushiDatabase, $VideoFileSpecsTable> {
+  $$VideoFileSpecsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get filePath => $composableBuilder(
+    column: $table.filePath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fileSizeBytes => $composableBuilder(
+    column: $table.fileSizeBytes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fileModifiedAt => $composableBuilder(
+    column: $table.fileModifiedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get probedAt => $composableBuilder(
+    column: $table.probedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get probeVersion => $composableBuilder(
+    column: $table.probeVersion,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get containerBitrate => $composableBuilder(
+    column: $table.containerBitrate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get videoCodec => $composableBuilder(
+    column: $table.videoCodec,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get width => $composableBuilder(
+    column: $table.width,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get height => $composableBuilder(
+    column: $table.height,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get pixelFormat => $composableBuilder(
+    column: $table.pixelFormat,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get bitDepth => $composableBuilder(
+    column: $table.bitDepth,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get frameRateMilli => $composableBuilder(
+    column: $table.frameRateMilli,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get videoBitrate => $composableBuilder(
+    column: $table.videoBitrate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get colorPrimaries => $composableBuilder(
+    column: $table.colorPrimaries,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get colorTransfer => $composableBuilder(
+    column: $table.colorTransfer,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get colorSpace => $composableBuilder(
+    column: $table.colorSpace,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get audioTracksJson => $composableBuilder(
+    column: $table.audioTracksJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get subtitleTracksJson => $composableBuilder(
+    column: $table.subtitleTracksJson,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$VideoFileSpecsTableOrderingComposer
+    extends Composer<_$FushiDatabase, $VideoFileSpecsTable> {
+  $$VideoFileSpecsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get filePath => $composableBuilder(
+    column: $table.filePath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fileSizeBytes => $composableBuilder(
+    column: $table.fileSizeBytes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fileModifiedAt => $composableBuilder(
+    column: $table.fileModifiedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get probedAt => $composableBuilder(
+    column: $table.probedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get probeVersion => $composableBuilder(
+    column: $table.probeVersion,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get containerBitrate => $composableBuilder(
+    column: $table.containerBitrate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get videoCodec => $composableBuilder(
+    column: $table.videoCodec,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get width => $composableBuilder(
+    column: $table.width,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get height => $composableBuilder(
+    column: $table.height,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get pixelFormat => $composableBuilder(
+    column: $table.pixelFormat,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get bitDepth => $composableBuilder(
+    column: $table.bitDepth,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get frameRateMilli => $composableBuilder(
+    column: $table.frameRateMilli,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get videoBitrate => $composableBuilder(
+    column: $table.videoBitrate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get colorPrimaries => $composableBuilder(
+    column: $table.colorPrimaries,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get colorTransfer => $composableBuilder(
+    column: $table.colorTransfer,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get colorSpace => $composableBuilder(
+    column: $table.colorSpace,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get audioTracksJson => $composableBuilder(
+    column: $table.audioTracksJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get subtitleTracksJson => $composableBuilder(
+    column: $table.subtitleTracksJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$VideoFileSpecsTableAnnotationComposer
+    extends Composer<_$FushiDatabase, $VideoFileSpecsTable> {
+  $$VideoFileSpecsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get filePath =>
+      $composableBuilder(column: $table.filePath, builder: (column) => column);
+
+  GeneratedColumn<int> get fileSizeBytes => $composableBuilder(
+    column: $table.fileSizeBytes,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get fileModifiedAt => $composableBuilder(
+    column: $table.fileModifiedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get probedAt =>
+      $composableBuilder(column: $table.probedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get probeVersion => $composableBuilder(
+    column: $table.probeVersion,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get durationMs => $composableBuilder(
+    column: $table.durationMs,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get containerBitrate => $composableBuilder(
+    column: $table.containerBitrate,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get videoCodec => $composableBuilder(
+    column: $table.videoCodec,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get width =>
+      $composableBuilder(column: $table.width, builder: (column) => column);
+
+  GeneratedColumn<int> get height =>
+      $composableBuilder(column: $table.height, builder: (column) => column);
+
+  GeneratedColumn<String> get pixelFormat => $composableBuilder(
+    column: $table.pixelFormat,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get bitDepth =>
+      $composableBuilder(column: $table.bitDepth, builder: (column) => column);
+
+  GeneratedColumn<int> get frameRateMilli => $composableBuilder(
+    column: $table.frameRateMilli,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get videoBitrate => $composableBuilder(
+    column: $table.videoBitrate,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get colorPrimaries => $composableBuilder(
+    column: $table.colorPrimaries,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get colorTransfer => $composableBuilder(
+    column: $table.colorTransfer,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get colorSpace => $composableBuilder(
+    column: $table.colorSpace,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get audioTracksJson => $composableBuilder(
+    column: $table.audioTracksJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get subtitleTracksJson => $composableBuilder(
+    column: $table.subtitleTracksJson,
+    builder: (column) => column,
+  );
+}
+
+class $$VideoFileSpecsTableTableManager
+    extends
+        RootTableManager<
+          _$FushiDatabase,
+          $VideoFileSpecsTable,
+          VideoFileSpecRow,
+          $$VideoFileSpecsTableFilterComposer,
+          $$VideoFileSpecsTableOrderingComposer,
+          $$VideoFileSpecsTableAnnotationComposer,
+          $$VideoFileSpecsTableCreateCompanionBuilder,
+          $$VideoFileSpecsTableUpdateCompanionBuilder,
+          (
+            VideoFileSpecRow,
+            BaseReferences<
+              _$FushiDatabase,
+              $VideoFileSpecsTable,
+              VideoFileSpecRow
+            >,
+          ),
+          VideoFileSpecRow,
+          PrefetchHooks Function()
+        > {
+  $$VideoFileSpecsTableTableManager(
+    _$FushiDatabase db,
+    $VideoFileSpecsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$VideoFileSpecsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$VideoFileSpecsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$VideoFileSpecsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> filePath = const Value.absent(),
+                Value<int> fileSizeBytes = const Value.absent(),
+                Value<int> fileModifiedAt = const Value.absent(),
+                Value<int> probedAt = const Value.absent(),
+                Value<int> probeVersion = const Value.absent(),
+                Value<int?> durationMs = const Value.absent(),
+                Value<int?> containerBitrate = const Value.absent(),
+                Value<String?> videoCodec = const Value.absent(),
+                Value<int?> width = const Value.absent(),
+                Value<int?> height = const Value.absent(),
+                Value<String?> pixelFormat = const Value.absent(),
+                Value<int?> bitDepth = const Value.absent(),
+                Value<int?> frameRateMilli = const Value.absent(),
+                Value<int?> videoBitrate = const Value.absent(),
+                Value<String?> colorPrimaries = const Value.absent(),
+                Value<String?> colorTransfer = const Value.absent(),
+                Value<String?> colorSpace = const Value.absent(),
+                Value<String> audioTracksJson = const Value.absent(),
+                Value<String> subtitleTracksJson = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => VideoFileSpecsCompanion(
+                filePath: filePath,
+                fileSizeBytes: fileSizeBytes,
+                fileModifiedAt: fileModifiedAt,
+                probedAt: probedAt,
+                probeVersion: probeVersion,
+                durationMs: durationMs,
+                containerBitrate: containerBitrate,
+                videoCodec: videoCodec,
+                width: width,
+                height: height,
+                pixelFormat: pixelFormat,
+                bitDepth: bitDepth,
+                frameRateMilli: frameRateMilli,
+                videoBitrate: videoBitrate,
+                colorPrimaries: colorPrimaries,
+                colorTransfer: colorTransfer,
+                colorSpace: colorSpace,
+                audioTracksJson: audioTracksJson,
+                subtitleTracksJson: subtitleTracksJson,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String filePath,
+                required int fileSizeBytes,
+                required int fileModifiedAt,
+                required int probedAt,
+                required int probeVersion,
+                Value<int?> durationMs = const Value.absent(),
+                Value<int?> containerBitrate = const Value.absent(),
+                Value<String?> videoCodec = const Value.absent(),
+                Value<int?> width = const Value.absent(),
+                Value<int?> height = const Value.absent(),
+                Value<String?> pixelFormat = const Value.absent(),
+                Value<int?> bitDepth = const Value.absent(),
+                Value<int?> frameRateMilli = const Value.absent(),
+                Value<int?> videoBitrate = const Value.absent(),
+                Value<String?> colorPrimaries = const Value.absent(),
+                Value<String?> colorTransfer = const Value.absent(),
+                Value<String?> colorSpace = const Value.absent(),
+                Value<String> audioTracksJson = const Value.absent(),
+                Value<String> subtitleTracksJson = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => VideoFileSpecsCompanion.insert(
+                filePath: filePath,
+                fileSizeBytes: fileSizeBytes,
+                fileModifiedAt: fileModifiedAt,
+                probedAt: probedAt,
+                probeVersion: probeVersion,
+                durationMs: durationMs,
+                containerBitrate: containerBitrate,
+                videoCodec: videoCodec,
+                width: width,
+                height: height,
+                pixelFormat: pixelFormat,
+                bitDepth: bitDepth,
+                frameRateMilli: frameRateMilli,
+                videoBitrate: videoBitrate,
+                colorPrimaries: colorPrimaries,
+                colorTransfer: colorTransfer,
+                colorSpace: colorSpace,
+                audioTracksJson: audioTracksJson,
+                subtitleTracksJson: subtitleTracksJson,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$VideoFileSpecsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$FushiDatabase,
+      $VideoFileSpecsTable,
+      VideoFileSpecRow,
+      $$VideoFileSpecsTableFilterComposer,
+      $$VideoFileSpecsTableOrderingComposer,
+      $$VideoFileSpecsTableAnnotationComposer,
+      $$VideoFileSpecsTableCreateCompanionBuilder,
+      $$VideoFileSpecsTableUpdateCompanionBuilder,
+      (
+        VideoFileSpecRow,
+        BaseReferences<_$FushiDatabase, $VideoFileSpecsTable, VideoFileSpecRow>,
+      ),
+      VideoFileSpecRow,
+      PrefetchHooks Function()
+    >;
 
 class $FushiDatabaseManager {
   final _$FushiDatabase _db;
@@ -86332,4 +87988,6 @@ class $FushiDatabaseManager {
       $$StudySegmentsTableTableManager(_db, _db.studySegments);
   $$WebMineQueueTableTableManager get webMineQueue =>
       $$WebMineQueueTableTableManager(_db, _db.webMineQueue);
+  $$VideoFileSpecsTableTableManager get videoFileSpecs =>
+      $$VideoFileSpecsTableTableManager(_db, _db.videoFileSpecs);
 }

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -2353,4 +2353,42 @@ mixin _FushiDbVideoDomain
         await (delete(videoBooks)..where((t) => t.bookUid.equals(bookUid)))
             .go();
       });
+
+  // ── video_file_specs（v95 规格探测缓存）────────────────────────────
+
+  /// 读一个文件的规格；没探过返回 null。
+  Future<VideoFileSpecRow?> videoFileSpec(String filePath) =>
+      (select(videoFileSpecs)..where((t) => t.filePath.equals(filePath)))
+          .getSingleOrNull();
+
+  /// 批量读一屏卡片的规格。
+  ///
+  /// 库页一次要渲染几十张卡，逐张 `videoFileSpec` 会打出几十条查询；这里一条
+  /// `IN` 拿全。返回 **map 而不是 list**：调用方要按路径查，返回 list 会逼每个
+  /// 调用方自己再 build 一次 map（还容易写成 O(n²) 的 firstWhere）。
+  Future<Map<String, VideoFileSpecRow>> videoFileSpecsByPath(
+    Iterable<String> filePaths,
+  ) async {
+    final List<String> paths = filePaths.toSet().toList();
+    if (paths.isEmpty) return const <String, VideoFileSpecRow>{};
+    final List<VideoFileSpecRow> rows =
+        await (select(videoFileSpecs)..where((t) => t.filePath.isIn(paths)))
+            .get();
+    return <String, VideoFileSpecRow>{
+      for (final VideoFileSpecRow row in rows) row.filePath: row,
+    };
+  }
+
+  /// 写入/覆盖一个文件的规格。
+  ///
+  /// 整行覆盖（`InsertMode.insertOrReplace`）是**有意**的：一次 ffprobe 产出的是
+  /// 该文件的完整事实快照，没有「只更新其中几列」的场景；用 upsert-merge 反而会让
+  /// 上次探到、这次探不到的列留下过期值（比如换了个没有内封字幕的同名文件，旧的
+  /// 字幕轨 JSON 会赖着不走）。
+  Future<void> upsertVideoFileSpec(VideoFileSpecsCompanion spec) =>
+      into(videoFileSpecs).insert(spec, mode: InsertMode.insertOrReplace);
+
+  /// 删一个文件的规格缓存（文件被删/被移出库时）。
+  Future<void> deleteVideoFileSpec(String filePath) =>
+      (delete(videoFileSpecs)..where((t) => t.filePath.equals(filePath))).go();
 }

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -2350,6 +2350,17 @@ mixin _FushiDbVideoDomain
         // TODO-616：同事务清 shelf_entry（mediaType='video'、entryKey=bookUid）。
         await deleteShelfEntry(MediaKind.video, bookUid);
         await deleteTagAssignmentsForHost(TagHostKind.video, bookUid);
+        // v95：同事务清该书涉及的规格缓存。缓存以**文件路径**为键、与 book 无 FK，
+        // 不在这里清就永远不会被清——`video_file_specs` 会随「每个曾经扫描过的文件」
+        // 单调增长，删片子也不缩。取主视频 + 播放列表里的每一集。
+        final VideoBookRow? row = await (select(videoBooks)
+              ..where((t) => t.bookUid.equals(bookUid)))
+            .getSingleOrNull();
+        if (row != null) {
+          for (final String path in videoBookFilePaths(row)) {
+            await deleteVideoFileSpec(path);
+          }
+        }
         await (delete(videoBooks)..where((t) => t.bookUid.equals(bookUid)))
             .go();
       });
@@ -2391,4 +2402,33 @@ mixin _FushiDbVideoDomain
   /// 删一个文件的规格缓存（文件被删/被移出库时）。
   Future<void> deleteVideoFileSpec(String filePath) =>
       (delete(videoFileSpecs)..where((t) => t.filePath.equals(filePath))).go();
+}
+
+/// 一本视频书涉及的全部本地文件路径：主视频 + 播放列表里的每一集。
+///
+/// 规格缓存以**文件路径**为键、与 `video_books` 之间没有外键（键的粒度本就比 book 细，
+/// 见 `video_file_specs` 表注释），所以删书时必须由调用方按这份清单去清，否则那些行
+/// 永远没人回收。
+///
+/// `playlistJson` 是 `[{title, path}]` 数组，其中 `path` 与 `videoPath` 同语义。
+/// **坏 JSON 只当作「没有播放列表」**：删书事务绝不能因为一条脏缓存键而整个回滚。
+List<String> videoBookFilePaths(VideoBookRow row) {
+  final Set<String> out = <String>{};
+  if (row.videoPath.isNotEmpty) out.add(row.videoPath);
+  final String? playlist = row.playlistJson;
+  if (playlist != null && playlist.isNotEmpty) {
+    try {
+      final Object? decoded = jsonDecode(playlist);
+      if (decoded is List) {
+        for (final Object? item in decoded) {
+          if (item is! Map) continue;
+          final Object? path = item['path'];
+          if (path is String && path.isNotEmpty) out.add(path);
+        }
+      }
+    } catch (_) {
+      // 见上：只清主视频，不抛。
+    }
+  }
+  return List<String>.unmodifiable(out);
 }

--- a/packages/fushi_core/lib/src/database/tables.dart
+++ b/packages/fushi_core/lib/src/database/tables.dart
@@ -2729,3 +2729,83 @@ class MangaChapterStates extends Table {
   @override
   Set<Column> get primaryKey => {bookUid, chapterKey};
 }
+
+// ── video_file_specs ──────────────────────────────────────────────────
+/// 本地视频文件的技术规格探测缓存（schema v95）。
+///
+/// 库页卡片与作品详情页要标注清晰度 / HDR / 编码 / 音轨，而这些事实此前**在库里一个
+/// 字节都没有**——`VideoBooks` 连 duration 列都没有，规格只在播放时活在 mpv 的内存里
+/// （`video_hdr_output.dart` 的 HDR 判据），播完即丢。列表要显示就必须能在**不播放**的
+/// 前提下拿到，于是有了这张表。
+///
+/// **身份键是文件路径，不是 bookUid**，这是本表唯一重要的设计决定：一个 `VideoBooks`
+/// 行可能是多集播放列表（`playlist_json` 里若干条路径），各集的分辨率/音轨完全可以不同。
+/// 把规格挂到 book 上，多集就只剩一份规格，必然是错的；挂到文件上，单文件与多集走同一
+/// 条路径，不需要为「这本书是不是播放列表」写任何分支。
+///
+/// **纯缓存，可随时重建**：所有列都能由 ffprobe 从文件本身重新探出来。因此
+/// - 探测失败不写行（宁可下次重试，不缓存一个空壳）；
+/// - 文件大小或修改时刻变了就重探（用户换了个片源、补了音轨）；
+/// - [probeVersion] 变了也重探（探测器扩了字段集，旧行的新字段是空的）。
+///
+/// 设备本地：路径与探测结果都只对本机有意义，不进备份/同步（与 `video_download_jobs`
+/// 同列于 backup 的 device-local 清单）。
+@DataClassName('VideoFileSpecRow')
+class VideoFileSpecs extends Table {
+  /// 视频文件绝对路径 = 身份。与 `VideoBooks.videoPath` 同语义（数据根内副本 / 用户
+  /// 原位外部文件两态；流 URL 不入本表——探的是本地文件）。
+  TextColumn get filePath => text()();
+
+  /// 探测当时的文件大小（字节）。失效判据之一。
+  IntColumn get fileSizeBytes => integer()();
+
+  /// 探测当时的文件修改时刻（毫秒）。失效判据之一。
+  IntColumn get fileModifiedAt => integer()();
+
+  /// 本行写入时刻（毫秒）。
+  IntColumn get probedAt => integer()();
+
+  /// 探测器字段集版本（`kVideoProbeFieldSetVersion`）。失效判据之一。
+  IntColumn get probeVersion => integer()();
+
+  /// 容器时长（毫秒）。探不到为 NULL。
+  IntColumn get durationMs => integer().nullable()();
+
+  /// 容器平均码率（bit/s）。展示码率通常只能用它——mkv 不给流级码率。
+  IntColumn get containerBitrate => integer().nullable()();
+
+  /// ffprobe `codec_name`，如 `h264` / `hevc` / `av1`。
+  TextColumn get videoCodec => text().nullable()();
+
+  IntColumn get width => integer().nullable()();
+  IntColumn get height => integer().nullable()();
+
+  /// 如 `yuv420p10le`。色深主要由它推出（10-bit HEVC 不给 bits_per_raw_sample）。
+  TextColumn get pixelFormat => text().nullable()();
+
+  /// 每分量位深（8 / 10 / 12）。
+  IntColumn get bitDepth => integer().nullable()();
+
+  /// 帧率 ×1000（23.976fps → 23976）。整数存储避免浮点比较误差。
+  IntColumn get frameRateMilli => integer().nullable()();
+
+  /// 视频流码率（bit/s）。mkv 通常没有，见 [containerBitrate]。
+  IntColumn get videoBitrate => integer().nullable()();
+
+  /// ffprobe 原样的色彩标签。**不存归一后的「是不是 HDR」**：那是派生值，
+  /// 判据收口在 `video_dynamic_range.dart`，存派生值等于把同一事实放两处，
+  /// 判据一改这里就成了过期副本。
+  TextColumn get colorPrimaries => text().nullable()();
+  TextColumn get colorTransfer => text().nullable()();
+  TextColumn get colorSpace => text().nullable()();
+
+  /// 音轨数组 JSON（编码/声道/语言/标题/default·forced·comment 标志）。
+  TextColumn get audioTracksJson => text().withDefault(const Constant('[]'))();
+
+  /// 内封字幕轨数组 JSON。
+  TextColumn get subtitleTracksJson =>
+      text().withDefault(const Constant('[]'))();
+
+  @override
+  Set<Column> get primaryKey => {filePath};
+}


### PR DESCRIPTION
用户反馈：媒体库里的作品卡片只有封面和标题，看不出清晰度、HDR 等规格，希望标注出来。

## 为什么改动比看上去大

这些规格**此前在库里一个字节都没有**：`VideoBooks` 连 duration 列都没有，
HDR 只在播放时活在 mpv 内存里（`video_hdr_output.dart` 的判据），播完即丢，
且只用来决定要不要走 Windows HDR 直通宿主窗。要在**不播放**的前提下给列表显示，
必须新增探测 + 落库——尤其音轨，文件名猜不出来。

## 数据层（commit 1）

- 扩 `video_duration_probe` 的 `-show_entries`，一次 ffprobe 拿全容器 / 视频流 /
  音轨 / 字幕轨。三个老调用点只读 `durationMs` 与 `audioLanguages`，语义逐字未变
  （`audioLanguages` 改为从 `audioTracks` 派生，消掉同一事实的两份存储）。
- 新表 `video_file_specs`（schema v95），**身份键是文件路径而非 bookUid**：一个 book
  可能是多集播放列表，各集规格不同，挂到 book 上只会剩一份错的；挂到文件上，单文件
  与多集走同一条路径，不需要为「是不是播放列表」写任何分支。
- 新枚举 `VideoDynamicRange` 收口 HDR 判据。此前 mpv（`bt.2020`/`pq`）、ffprobe
  （`bt2020`/`smpte2084`）、种子标题解析三套表示互不相识，不收口则库页与播放器会对
  同一文件给出不一致的 HDR 结论。`isHdrVideoParams` 改为薄壳，行为逐位等价（单测逐组比对）。
- `VideoSpecsService`：内存 → DB → ffprobe 三层，并发上限 2，失效判据 = 文件大小 +
  修改时刻 + 探测器字段集版本三者全等。

## UI（commit 2）

呈现粒度跟着数据粒度走：

- **墙卡封面左下角**角标 `4K` / `HDR10`。左下是四角里唯一空着的（左上=标签与勾选框、
  右上=集数、右下=云端），`bottom: 6` 让开 3px 进度条。只放两项——封面是给人认片子的，
  不是规格表。**不动文字块高度公式**，不触发 `video_card_cover_aspect_guard`。
- **单文件作品详情页**摊开完整规格表（这页一个文件 = 一部作品，无歧义）。
- **合集详情页的作品级信息区刻意不放规格**：一个合集十几集，各集分辨率/音轨可以完全
  不同，在作品级摆一份必然是在骗人（挑第一集还是最常见的？都不对）。改为集卡状态行
  显示该集摘要 + 集卡菜单「媒体信息」开完整弹窗。摘要挤进状态行而非新起一行——集卡高度
  是钳死的，多一行会顶掉简介。

SDR 不出角标（绝大多数片源都是，不是信息）；探不到的项整行不出现，不显示「未知」。

## ffprobe 实测事实（不是查文档，是真跑出来的）

用捆绑的 ffprobe n7.1.5 探三个现造样本，四条与直觉相反、直接决定了实现：

| 事实 | 影响 |
|---|---|
| 未标注时 `color_primaries`/`color_transfer` **整个键不出现**（不是空串/unknown） | 「缺失」必须判 `unknown` 而非 `sdr`——判成 SDR 会给真 HDR 片源打上 SDR 标 |
| 10-bit HEVC **不给** `bits_per_raw_sample`（8-bit H.264 给） | 色深只能从 `pix_fmt` 的 `p10le` 推 |
| mkv 的视频流和音频流**都没有** `bit_rate` | 码率只能退回容器级 |
| `disposition` 写进 `stream=` 段里**静默无输出** | 必须用独立的 `stream_disposition=` 段 |

## 验证

判绿只认 `FLUTTER TEST VERDICT` 行：

- 爆炸半径 `test/media/video + database + storage + sync + i18n`：**6445 tests PASSED**
- 51 条目录枚举型守卫（含 `path_rebase_coverage_guard` / `i18n_completeness` /
  `md3_design_system_static`）：**360 tests PASSED**
- `flutter analyze`（fushi）与 `dart analyze`（fushi_core）均无新增问题
- 迁移测试 `migration_v95_video_file_specs_test.dart`：v94 起点自检 / 建表 / 存量无损 /
  主键覆盖 / 重复打开幂等

过程中被测试抓到并修掉的自身问题：34 处 `schemaVersion` 断言外还漏了 10 处
`PRAGMA user_version` 断言；`migration_v63` 的全表清单守卫没登记新表；widget 测试在
fake-async zone 里 await 真实 IO 导致挂死（须 `tester.runAsync`）。

## 已登记的守卫

- `path_rebase_coverage` 三列。`file_path` 走 `documentsRooted` 并在 `DataRootMigrator`
  里**真改写**——不改写则数据根搬家后整张缓存命不中，几百个文件要重探。
- backup device-local 三处（`_deviceLocalTables` child-first / parent-first +
  `mergeSkippedDeviceLocalTableNames`）：键与结果都只对本机有意义。

## ⚠️ 合并前必看

1. **schema v95 有撞号风险**：另一个 worktree（`material-rename`）已把版本推到 95。
   本 PR 开出时 `origin/develop` 仍是 94，但**合并顺序说了算**——合并前重核
   `git show origin/develop:packages/fushi_core/lib/src/database/database.dart | grep schemaVersion`，
   若对方先落地则顺延 v96，且 `database.dart` 的 `if (from < N)` 块与 `tables.dart`
   表注释里的 `（schema vN）` **必须同改**（`schema_doc_version_matches_migration_guard` 会抓）。
2. **未做真机验证**：角标位置、集卡状态行不溢出只有 widget 测试覆盖，没在真实设备上看过。
3. 本分支落后 develop 若干 commit，未主动 rebase（按仓库规则由 integration owner 决定合并顺序）。
4. Dolby Vision **不做也不宣称**：需要读 stream 的 `side_data_list`，本机造不出 DV 样本，
   无法验证。

https://claude.ai/code/session_01TfR3xd1qTWgCvJHedAGdAb
