### PR TITLE
fix(storage): 存储页明细补上未认领子项，推荐包 9.5GB 收尾删除搬到启动路径（BUG-2096 / BUG-2097）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1964 条。点号进各自文件。
+> 共 1966 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2097](bugs/BUG-2097-recommended-pack-never-deleted.md) | ✅ | ✅ | 推荐包 9.5GB zip 导入后永不删除（清理钩子挂在不再执行的引导页 initState） |
+| [BUG-2096](bugs/BUG-2096-storage-category-detail-gap.md) | ✅ | ✅ | 存储页词典/书籍类目明细不覆盖总量 10.7GB 不可见 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |
 | [BUG-2088](bugs/BUG-2088-release-notes-never-reach-update-dialog.md) | ✅ | ✅ | 正式版更新公告进不了应用内更新弹窗，用户看到的是一行占位符 |

--- a/docs/bugs/BUG-2096-storage-category-detail-gap.md
+++ b/docs/bugs/BUG-2096-storage-category-detail-gap.md
@@ -1,0 +1,38 @@
+## BUG-2096 · 存储页词典/书籍类目明细不覆盖总量 10.7GB 不可见
+- **报告**：2026-09-03（用户：两张「设置 → 存储」截图）
+- **真实性**：✅ 真 bug。用户机器上词典类目显示 **11.3 GB**，展开后 8 部词典明细之和只有
+  **583.7 MB**（142 + 98.9 + 85.2 + 81.6 + 76.9 + 59.8 + 36.0 + 3.3），**10.7 GB 既看不见、
+  也解释不了、更删不掉**。
+  根因是两套口径 + 页面从不显示二者之差：
+  - `fushi/lib/src/storage/storage_usage_service.dart:571` `_scanBooks` /
+    `:621` `_scanDictionaries` —— 类目总量按 `_pathsSizeSync(categoryRoots)`
+    **整树**求和（含孤儿），明细却只铺 **DB 已知条目**（`dictionaryResources/<名>`、
+    每本书的 counted 路径）。
+  - 词典类目的根有三个（`:380` `kStorageCategoryDocumentsChildren`）：
+    `dictionaryResources` / `dictionaryImportWorkingDirectory` / `recommended_pack`，
+    后两个下面的东西**没有任何 DB 行**，结构上永远进不了明细。
+  - `fushi/lib/src/pages/implementations/storage_usage_view.dart:473` `_buildEntryRows`
+    只渲染 `usage.entries`（外加「其余 N 项」折叠行），**没有任何差额行**——两套口径的
+    缺口在 UI 上彻底静默。
+  用户这 10.7 GB 的具体归属见 [BUG-2097](BUG-2097-recommended-pack-never-deleted.md)
+  （新手引导推荐包的 9.5 GB zip 导入后永不删除，就落在 `recommended_pack/`）。本条只
+  管「占了盘却不出现在明细里」这个显示缺陷本身——即使换成别的残留，洞一样在。
+- **[x] ① 已修复** — `_scanBooks` / `_scanDictionaries` 改为：一次 isolate 调用同时取
+  「类目根的直接子项」与「每个已知条目的大小」，再把**未被已知条目认领的直接子项**作为
+  只读明细铺出来（`StorageEntryKind.readOnly`——裸删会绕过墓碑/引用护栏）。类目总量改由
+  子项之和得出（与整树求和恒等，根目录自身不占字节），**扫描量不变**。
+  新增 `_topLevelOwners` 把已知条目的路径收敛到「直接子项」层级再求差集：书的音频可能深在
+  `fushi_books/<bookKey>/audio/` 之下，若按路径全等去重，整个 `fushi_books/<bookKey>` 会被
+  当成没人认领而与那本书重复计一遍。
+  提交：见下方测试提交。
+- **[x] ② 已加自动化测试** — `fushi/test/storage/storage_usage_service_test.dart`
+  - 既有两条断言按新契约更新（旧断言恰恰把病灶写死了：书籍用例造了孤儿目录
+    `fushi_books/orphan` 并断言 `entries.length == 2`，即孤儿**不出现**）；两条都补上
+    「明细之和 == 类目总量」的对账断言。
+  - 新增「BUG-2096：推荐包暂存的整包 zip 出现在词典明细里，而不是只体现为差额」——
+    直接复刻用户现场（`dictionaryResources/JMdict` + `recommended_pack/*.zip`）。
+  - 新增「认领判据按『类目根的直接子项』收敛，不与已知条目重复计数」——守住上面那个
+    重复计数陷阱。
+- **备注**：真机未验证（用户设备未连本机 adb，`adb devices` 为空）。结论全部由代码路径 +
+  临时目录真实落盘的单测得出；用户可自查 `Android/data/<包名>/files/recommended_pack/`
+  确认那 9.5 GB。

--- a/docs/bugs/BUG-2097-recommended-pack-never-deleted.md
+++ b/docs/bugs/BUG-2097-recommended-pack-never-deleted.md
@@ -1,0 +1,39 @@
+## BUG-2097 · 推荐包 9.5GB zip 导入后永不删除（清理钩子挂在不再执行的引导页 initState）
+- **报告**：2026-09-03（用户报「统计显示有问题」，见 [BUG-2096](BUG-2096-storage-category-detail-gap.md)）
+- **真实性**：✅ 真 bug（代码路径闭合，未上真机）。
+  新手引导下载的官方推荐包（词典 + 发音库，**9.5 GB** 整包 zip）落在
+  `<appDirectory>/recommended_pack/`。导入走备份导入流程并**重启进程**，所以没法在导入
+  成功后就地删包——设计是「导入前落 `imported.flag`，重启回来收尾删」。收尾链断在最后一环：
+  - `fushi/lib/src/onboarding/recommended_pack.dart:458` `cleanupIfImported` 的**唯一调用点**
+    是 `fushi/lib/src/pages/implementations/onboarding_wizard_page.dart:168`，即**新手引导页的
+    `initState`**。
+  - 而引导页只在 `fushi/lib/src/pages/implementations/home_page.dart:449`
+    判 `!appModel.onboardingCompleted` 时才自动弹出。
+  - 推荐包**本身就是一份含 settings 类目的备份**，导入是整层替换：
+    `fushi/lib/src/sync/backup_service.dart:2270` 附近明确写着 settings layer
+    "is replaced wholesale"。`preferences` 表连同 `onboarding_completed` 一起被换成备份里
+    那份；而该键的缺省值本来也是 `true`
+    （`fushi/lib/src/models/preferences_repository.dart:798`
+    `getPref('onboarding_completed', defaultValue: true)`）——备份里没有这行也读到 true。
+  - 于是导入后的那次重启，首页判定「引导已完成」，**不再弹引导页**，`initState` 不跑，
+    9.5 GB 的 zip 永久留在盘上。`first_time_setup` 同在 preferences 表里，被一起替换，
+    那条兜底路径同样救不回来。
+  判据（flag）没错，错的是把收尾挂在了一个「导入成功就不会再出现」的页面上。
+- **[x] ① 已修复** — 收尾搬到**启动必经路径**：`fushi/lib/src/models/app_model.dart` 初始化里
+  那组「创建运行时目录」的 IO（已有同构先例 `purgePendingDictionaryDeletes`，且这组由
+  `_guardInitIo` 兜掉盘时的 hang），调
+  `RecommendedPackDownloader.cleanupIfImported(<appDirectory>/recommended_pack)`。
+  引导页那处唯一入口一并移除（只留指向注释），避免两个入口各自漂移。
+  flag 语义**不变**：没导入过、或只下了一半的包都不受影响，续传不会被作废。
+- **[x] ② 已加自动化测试** — 新增 `fushi/test/onboarding/recommended_pack_cleanup_test.dart`
+  - 行为三条：flag 在 → 整个包目录连 zip 一起删；flag 不在 → 原样保留（续传不作废）；
+    包目录不存在 → 不抛（它现在跑在启动路径上，抛了就是启动失败）。
+  - 守卫两条：`app_model.dart` 必须持有 `cleanupIfImported` 调用；引导页**不得**再出现该
+    调用（注释提及允许，红线是调用）。
+  - 两条守卫都做了**变异实测**：把 AppModel 里的调用改名 → 守卫 1 红；把调用加回引导页 →
+    守卫 2 红；变异经 sha256 校验还原（未用 `git checkout`）。
+- **备注**：真机未验证（用户设备未连本机 adb）。用户可自查
+  `Android/data/<包名>/files/recommended_pack/`——若里面躺着 `fushi_recommended_pack.zip`
+  （或 `.mpart` 预分配文件），即为本 bug 现场。本次修复只覆盖**已导入**的包；只下了一半
+  从未导入的 `.mpart`（预分配就是完整 9.5 GB）仍按设计保留以便续传，但修好 BUG-2096 后它
+  至少会在存储页明细里现身。

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -55,6 +55,7 @@ import 'package:fushi/src/models/dictionary_directory.dart';
 import 'package:fushi/src/models/dictionary_repository.dart';
 import 'package:fushi/src/models/media_history_repository.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/onboarding/recommended_pack.dart';
 import 'package:fushi/src/media/manga/library/online_manga_library_entry.dart';
 import 'package:fushi/src/media/manga/library/online_manga_library_service.dart';
 import 'package:fushi/src/media/manga/library/online_manga_runtime_adapter.dart';
@@ -2427,6 +2428,17 @@ class AppModel with ChangeNotifier {
           dictionaryImportWorkingDirectory.create(recursive: true),
           dictionaryResourceDirectory.create(recursive: true).then((_) =>
               purgePendingDictionaryDeletes(dictionaryResourceDirectory)),
+          // BUG-2097：推荐包（9.5 GB zip）导入后的收尾删除。判据是包目录里的
+          // `imported.flag`——没导入过、或只下了一半的包都不受影响。
+          //
+          // 收尾必须挂在**启动必经路径**上，不能挂新手引导页：推荐包本身是一份
+          // 含 settings 类目的备份，导入时 `preferences` 表被整层替换，
+          // `onboarding_completed` 随之变成 true（该键缺省值本来也是 true），于是
+          // 导入后的那次重启首页不再自动弹引导页，挂在引导页 initState 上的清理
+          // 永远等不到执行，9.5 GB 就永久留在盘上（用户实测：存储页词典类目
+          // 11.3 GB，展开的词典明细只有 583 MB）。
+          RecommendedPackDownloader.cleanupIfImported(
+              Directory(path.join(appDirectory.path, 'recommended_pack'))),
           refreshSystemPalette(),
           () async {
             _exportDirectory = await prepareExportDirectory();

--- a/fushi/lib/src/onboarding/recommended_pack.dart
+++ b/fushi/lib/src/onboarding/recommended_pack.dart
@@ -306,8 +306,13 @@ Future<RecommendedPackManifest?> fetchRecommendedPackManifest() async {
 ///
 /// 导入推荐包会走备份导入流程并**重启进程**，没有机会在导入成功后删包——所以
 /// [markImportStarted] 在启动导入前落一个 flag 文件，重启回来后由
-/// [cleanupIfImported]（新手引导页 initState 调）把整个包目录删掉，不让 9.5 GB
-/// 的 zip 静默常驻磁盘。
+/// [cleanupIfImported]（**AppModel 初始化调**，即启动必经路径）把整个包目录删掉，
+/// 不让 9.5 GB 的 zip 静默常驻磁盘。
+///
+/// BUG-2097：这个收尾一度挂在新手引导页的 initState 上，而导入恰恰会把
+/// `preferences` 表整层换成备份里的那份、`onboarding_completed` 变 true，重启后
+/// 首页不再自动弹引导页——清理入口结构上永远等不到执行。判据（flag）没错，错的
+/// 是把它挂在了一个「导入成功就不会再出现」的页面上。
 class RecommendedPackDownloader {
   RecommendedPackDownloader({
     required Directory packDir,

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -163,9 +163,9 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
         appModelNoUpdate.moduleBrowserExtensionEnabled) {
       _selected.add(OnboardingFeature.browserExtension);
     }
-    // 上一轮推荐包导入成功后进程已重启：把落盘的 9.5 GB zip 删掉（flag 判定，
-    // 未导入过 / 半截下载不受影响）。
-    unawaited(RecommendedPackDownloader.cleanupIfImported(_packDir));
+    // 推荐包导入后的收尾删包**不在这里**：见 AppModel 初始化里的
+    // `cleanupIfImported`（BUG-2097）。导入会把 `onboarding_completed` 整层
+    // 替换成 true，重启回来根本不会再打开本页，挂这儿等于永不执行。
     // 落盘名从「URL 尾段推导」改成恒定名之前下的半截包叫 `download*`，搬过来，
     // 别让升级把已下的 9.5 GB 作废。
     RecommendedPackDownloader.migrateLegacyArtifacts(_packDir);

--- a/fushi/lib/src/storage/storage_usage_service.dart
+++ b/fushi/lib/src/storage/storage_usage_service.dart
@@ -593,27 +593,48 @@ class StorageUsageService {
     final List<List<String>> perBookPaths = <List<String>>[
       for (final StorageBookPaths paths in perBook) paths.counted,
     ];
-    final List<int> sizes = await _run(() {
-      return <int>[
-        _pathsSizeSync(categoryRoots),
-        for (final List<String> paths in perBookPaths) _pathsSizeSync(paths),
-      ];
+    // 一次 isolate 调用同时拿「类目根的直接子项」与「每本书的大小」：子项之和
+    // 恒等于整树之和（根目录自身不占字节），所以类目总量改由子项求得，扫描量与
+    // 旧的整树求和一致，却顺带拿到了求差集所需的子项清单。
+    final Map<String, Object> raw = await _run(() {
+      return <String, Object>{
+        'children': _childEntriesSync(categoryRoots),
+        'sizes': <int>[
+          for (final List<String> paths in perBookPaths) _pathsSizeSync(paths),
+        ],
+      };
     });
+    final List<Map<String, Object>> children =
+        (raw['children']! as List<dynamic>).cast<Map<String, Object>>();
+    final List<int> sizes = (raw['sizes']! as List<dynamic>).cast<int>();
     final List<StorageEntryUsage> entries = <StorageEntryUsage>[
       for (int i = 0; i < books.length; i++)
         StorageEntryUsage(
           id: books[i].id,
           label: books[i].title,
-          bytes: sizes[i + 1],
+          bytes: sizes[i],
           paths: perBookPaths[i],
           externalPaths: perBook[i].external,
           kind: books[i].kind,
         ),
+      // BUG-2096：DB 不认识、却确实占着盘的直接子项（删书留下的孤儿目录、导入
+      // 残留）。不铺出来的话它们只活在「类目总量 − 明细之和」的差里，而页面从不
+      // 显示那个差——用户只看见类目行的大数字，展开却对不上账。只读展示：裸删
+      // 会绕过墓碑/引用护栏。
+      ..._childEntries(
+        children,
+        excludePaths: _topLevelOwners(
+          paths: <String>[
+            for (final List<String> paths in perBookPaths) ...paths,
+          ],
+          roots: categoryRoots,
+        ),
+      ),
     ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
         b.bytes.compareTo(a.bytes));
     return StorageCategoryUsage(
       id: StorageCategoryId.books,
-      bytes: sizes[0],
+      bytes: _sumChildBytes(children),
       entries: entries,
     );
   }
@@ -631,26 +652,41 @@ class StorageUsageService {
     final List<String> perDictPaths = <String>[
       for (final String name in dictionaryNames) p.join(resourcesRoot, name),
     ];
-    final List<int> sizes = await _run(() {
-      return <int>[
-        _pathsSizeSync(categoryRoots),
-        for (final String path in perDictPaths) directorySizeSync(path),
-      ];
+    // 口径同 [_scanBooks]：子项之和 == 整树之和，扫描量不变。
+    final Map<String, Object> raw = await _run(() {
+      return <String, Object>{
+        'children': _childEntriesSync(categoryRoots),
+        'sizes': <int>[
+          for (final String path in perDictPaths) directorySizeSync(path),
+        ],
+      };
     });
+    final List<Map<String, Object>> children =
+        (raw['children']! as List<dynamic>).cast<Map<String, Object>>();
+    final List<int> sizes = (raw['sizes']! as List<dynamic>).cast<int>();
     final List<StorageEntryUsage> entries = <StorageEntryUsage>[
       for (int i = 0; i < dictionaryNames.length; i++)
         StorageEntryUsage(
           id: dictionaryNames[i],
           label: dictionaryNames[i],
-          bytes: sizes[i + 1],
+          bytes: sizes[i],
           paths: <String>[perDictPaths[i]],
           kind: StorageEntryKind.dictionary,
         ),
+      // BUG-2096：本类目的三个根里只有 `dictionaryResources/<名>` 是 DB 认识的。
+      // 导入工作目录的残留、删词典留下的孤儿目录，以及新手引导下的推荐包暂存
+      // （`recommended_pack/` 里那个 9.5 GB zip，BUG-2097 之前永不删）全落在差集
+      // 里——正是用户报的「词典 11.3 GB，展开只有 583 MB」。
+      ..._childEntries(
+        children,
+        excludePaths:
+            _topLevelOwners(paths: perDictPaths, roots: categoryRoots),
+      ),
     ]..sort((StorageEntryUsage a, StorageEntryUsage b) =>
         b.bytes.compareTo(a.bytes));
     return StorageCategoryUsage(
       id: StorageCategoryId.dictionaries,
-      bytes: sizes[0],
+      bytes: _sumChildBytes(children),
       entries: entries,
     );
   }
@@ -882,6 +918,36 @@ class StorageUsageService {
 
   static int _sumBytes(final List<StorageEntryUsage> entries) =>
       entries.fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes);
+
+  /// [_childEntriesSync] 产出的子项字节和 == 类目根整树字节和（根目录自身不占
+  /// 字节）；书籍/词典类目的总量由它得出。
+  static int _sumChildBytes(final List<Map<String, Object>> children) =>
+      children.fold<int>(
+          0, (int sum, Map<String, Object> e) => sum + (e['bytes'] as int));
+
+  /// 把已知条目的路径收敛到「类目根的直接子项」层级，供 [_childEntries] 求差集。
+  ///
+  /// 书籍/词典的明细口径是 DB 已知条目，其路径可能深于直接子项（有声书音频在
+  /// `fushi_books/<bookKey>/…` 之下），而孤儿只能按直接子项铺开——两套口径必须
+  /// 先落到同一层级才能相减，否则整个 `fushi_books/<bookKey>` 会被当成没人认领，
+  /// 与那本书的条目重复计一遍。[roots] 之外的路径（桌面「引用原文件」导入留在
+  /// app 目录外的音频）不归任何根，自然不参与。
+  static Set<String> _topLevelOwners({
+    required final Iterable<String> paths,
+    required final List<String> roots,
+  }) {
+    final Set<String> owners = <String>{};
+    for (final String path in paths) {
+      for (final String root in roots) {
+        if (!p.isWithin(root, path)) continue;
+        final List<String> segments = p.split(p.relative(path, from: root));
+        if (segments.isEmpty) continue;
+        owners.add(p.join(root, segments.first));
+        break;
+      }
+    }
+    return owners;
+  }
 
   /// 随包组件占用（桌面端安装目录内、随安装包携带；**只展示不可删**——
   /// 更新 = 安装器整体重写安装目录，删掉的必然回来）。移动端返回空。

--- a/fushi/test/onboarding/recommended_pack_cleanup_test.dart
+++ b/fushi/test/onboarding/recommended_pack_cleanup_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/onboarding/recommended_pack.dart';
+
+/// BUG-2097：推荐包（9.5 GB zip）导入后的收尾删除。
+///
+/// 判据（包目录里的 `imported.flag`）从来没错，错的是**挂在哪儿**：收尾一度只挂
+/// 在新手引导页的 initState 上，而推荐包本身是一份含 settings 类目的备份，导入时
+/// `preferences` 表被整层替换、`onboarding_completed` 变成 true（该键缺省值也是
+/// true），于是导入后的那次重启首页不再自动弹引导页——清理入口结构上永远等不到
+/// 执行。用户实测：存储页词典类目 11.3 GB，展开的词典明细只有 583 MB。
+void main() {
+  late Directory tempRoot;
+  late Directory packDir;
+
+  setUp(() {
+    tempRoot = Directory.systemTemp.createTempSync('recommended_pack_cleanup');
+    packDir = Directory(p.join(tempRoot.path, 'recommended_pack'));
+  });
+
+  tearDown(() {
+    try {
+      tempRoot.deleteSync(recursive: true);
+    } on FileSystemException {
+      // Windows 偶发句柄延迟释放：留给系统临时目录清理。
+    }
+  });
+
+  void writePack(int bytes) {
+    final File f =
+        File(p.join(packDir.path, 'fushi_recommended_pack.zip'));
+    f.parent.createSync(recursive: true);
+    f.writeAsBytesSync(List<int>.filled(bytes, 0x61));
+  }
+
+  group('cleanupIfImported', () {
+    test('导入过（flag 在）：整个包目录连同 zip 一起删掉', () async {
+      writePack(4096);
+      await RecommendedPackDownloader.markImportStarted(packDir);
+      expect(packDir.existsSync(), isTrue);
+
+      await RecommendedPackDownloader.cleanupIfImported(packDir);
+
+      expect(packDir.existsSync(), isFalse);
+    });
+
+    test('只下载过、没导入（flag 不在）：包原样保留，续传不被作废', () async {
+      writePack(4096);
+
+      await RecommendedPackDownloader.cleanupIfImported(packDir);
+
+      expect(
+          File(p.join(packDir.path, 'fushi_recommended_pack.zip')).existsSync(),
+          isTrue);
+    });
+
+    test('包目录压根不存在：不抛（启动路径上跑，抛了就是启动失败）', () async {
+      await RecommendedPackDownloader.cleanupIfImported(packDir);
+      expect(packDir.existsSync(), isFalse);
+    });
+  });
+
+  group('BUG-2097 守卫：收尾必须挂在启动必经路径上', () {
+    final File appModel = File('lib/src/models/app_model.dart');
+    final File wizard =
+        File('lib/src/pages/implementations/onboarding_wizard_page.dart');
+
+    test('AppModel 初始化持有 cleanupIfImported 调用', () {
+      expect(appModel.existsSync(), isTrue,
+          reason: '守卫锚点文件不在了，先修锚点再改断言');
+      // 布尔断言而非 contains matcher：后者失败时会把整份 app_model.dart
+      // （5000+ 行）打进失败信息，淹没掉 reason。
+      expect(
+        appModel
+            .readAsStringSync()
+            .contains('RecommendedPackDownloader.cleanupIfImported('),
+        isTrue,
+        reason: '推荐包收尾删除必须挂在启动必经路径（AppModel 初始化）上；'
+            '任何「只在某个页面打开时才清理」的挂法都会被 onboarding_completed '
+            '在导入时被整层替换成 true 而永不执行',
+      );
+    });
+
+    test('新手引导页不再是清理入口（导入后它根本不会再打开）', () {
+      expect(wizard.existsSync(), isTrue,
+          reason: '守卫锚点文件不在了，先修锚点再改断言');
+      // 注释里提到函数名是允许的（本次修复就留了指向说明），红线是**调用**。
+      final String source = wizard
+          .readAsStringSync()
+          .split('\n')
+          .where((String line) => !line.trimLeft().startsWith('//'))
+          .join('\n');
+      expect(
+        source.contains('cleanupIfImported('),
+        isFalse,
+        reason: '引导页在导入后的那次启动不会再打开，清理挂这儿等于永不执行',
+      );
+    });
+  });
+}

--- a/fushi/test/storage/storage_usage_service_test.dart
+++ b/fushi/test/storage/storage_usage_service_test.dart
@@ -135,15 +135,28 @@ void main() {
 
       final StorageCategoryUsage books = all.singleWhere(
           (StorageCategoryUsage u) => u.id == StorageCategoryId.books);
-      // 100 + 300 + 11（孤儿也计入总量）+ 500 + 40（audiobooks 整树）。
+      // 100 + 300 + 11（孤儿）+ 500 + 40（audiobooks 整树）。
       expect(books.bytes, 951);
-      expect(books.entries.length, 2);
-      // 降序：A = 100 + 500 + 40 = 640 在前，B = 300 在后（B 的 persist 目录
-      // 不存在，计 0）。
+      // BUG-2096：孤儿目录也是一条明细。旧实现只铺 DB 已知的书，孤儿只体现在
+      // 「类目总量 − 明细之和」的差里，而页面从不显示那个差。
+      expect(books.entries.length, 3);
+      // 降序：A = 100 + 500 + 40 = 640 在前，B = 300 次之（B 的 persist 目录
+      // 不存在，计 0），孤儿 11 最后。
       expect(books.entries[0].id, 'keyA');
       expect(books.entries[0].bytes, 640);
       expect(books.entries[1].id, 'keyB');
       expect(books.entries[1].bytes, 300);
+      // label 由 `_childEntriesSync` 用字面 '/' 拼接，跨平台恒定——这里若写
+      // p.join，Windows 绿而 CI Linux 红。
+      expect(books.entries[2].label, 'fushi_books/orphan');
+      expect(books.entries[2].bytes, 11);
+      // 只读：裸删会绕过墓碑/引用护栏。
+      expect(books.entries[2].kind, StorageEntryKind.readOnly);
+      // 账对得上：明细之和 == 类目总量，页面上再没有解释不了的差额。
+      expect(
+          books.entries
+              .fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes),
+          books.bytes);
     });
 
     test('BUG-1893：同步导入的明文音频目录（非哈希）计进明细，且不重复计数', () async {
@@ -299,10 +312,76 @@ void main() {
       final StorageCategoryUsage dicts = all.singleWhere(
           (StorageCategoryUsage u) => u.id == StorageCategoryId.dictionaries);
       expect(dicts.bytes, 1005);
-      expect(dicts.entries.map((StorageEntryUsage e) => e.id).toList(),
-          <String>['JMdict', 'Pixiv']);
+      expect(dicts.entries.length, 3);
+      expect(dicts.entries[0].id, 'JMdict');
       expect(dicts.entries[0].bytes, 800);
+      expect(dicts.entries[1].id, 'Pixiv');
       expect(dicts.entries[1].bytes, 200);
+      // BUG-2096：DB 只认识 `dictionaryResources/<名>`，导入工作目录的残留同样
+      // 占盘，必须自己冒出来。
+      expect(dicts.entries[2].label,
+          'dictionaryImportWorkingDirectory/tmp.bin');
+      expect(dicts.entries[2].bytes, 5);
+      expect(
+          dicts.entries
+              .fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes),
+          dicts.bytes);
+    });
+
+    test('BUG-2096：推荐包暂存的整包 zip 出现在词典明细里，而不是只体现为差额',
+        () async {
+      // 用户实测：词典类目 11.3 GB，展开只有 583 MB 的词典条目——差的 10.7 GB
+      // 是新手引导下载的推荐包（`recommended_pack/` 与 `dictionaryResources/`
+      // 同属词典类目），旧实现下既看不见也删不掉。
+      writeFile(
+          p.join(docs.path, 'dictionaryResources', 'JMdict', 'blobs.bin'), 600);
+      writeFile(
+          p.join(docs.path, 'recommended_pack', 'fushi_recommended_pack.zip'),
+          9500);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: const <StorageBookRef>[],
+        dictionaryNames: const <String>['JMdict'],
+      ).toList();
+
+      final StorageCategoryUsage dicts = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.dictionaries);
+      expect(dicts.bytes, 10100);
+      final StorageEntryUsage pack = dicts.entries.singleWhere(
+          (StorageEntryUsage e) => e.label.contains('recommended_pack'));
+      expect(pack.bytes, 9500);
+      expect(
+          dicts.entries
+              .fold<int>(0, (int sum, StorageEntryUsage e) => sum + e.bytes),
+          dicts.bytes);
+    });
+
+    test('BUG-2096：认领判据按「类目根的直接子项」收敛，不与已知条目重复计数',
+        () async {
+      // 书的 extractDir 深于直接子项时（音频落在 `fushi_books/<key>/audio/`），
+      // 直接子项 `fushi_books/<key>` 整个已被那本书认领——若按路径全等去重，它会
+      // 被当成没人认领而再计一遍，类目总量凭空翻倍。
+      final String bookA = p.join(docs.path, 'fushi_books', 'keyA');
+      writeFile(p.join(bookA, 'ch1.html'), 100);
+      writeFile(p.join(bookA, 'audio', 'a.mp3'), 400);
+
+      final List<StorageCategoryUsage> all = await service().scanCategories(
+        books: <StorageBookRef>[
+          StorageBookRef(
+            id: 'keyA',
+            title: 'A',
+            extractDir: bookA,
+            persistKeys: const <String>['keyA'],
+          ),
+        ],
+        dictionaryNames: const <String>[],
+      ).toList();
+
+      final StorageCategoryUsage books = all.singleWhere(
+          (StorageCategoryUsage u) => u.id == StorageCategoryId.books);
+      expect(books.entries.length, 1);
+      expect(books.entries.single.id, 'keyA');
+      expect(books.bytes, 500);
     });
 
     test('database 类目 = support 根整体减去 OCR 模型；ocrModels 单列', () async {


### PR DESCRIPTION
用户报「统计显示有问题」，附两张「设置 → 存储」截图：词典类目显示 **11.3 GB**，展开后 8 部词典明细之和只有 **583.7 MB**（142 + 98.9 + 85.2 + 81.6 + 76.9 + 59.8 + 36.0 + 3.3），**10.7 GB 既看不见、也解释不了、更删不掉**。

沿代码路径追下去是两个独立缺陷，一个让钱丢了，一个让丢了的钱看不见。

## BUG-2096 · 显示层：明细不覆盖类目总量

`storage_usage_service.dart` 的 `_scanBooks` / `_scanDictionaries` 用两套口径——类目总量按 `_pathsSizeSync(categoryRoots)` **整树**求和（含孤儿），明细却只铺 **DB 已知条目**——而 `storage_usage_view.dart` 的 `_buildEntryRows` 只渲染 `entries`，**从不显示二者之差**。

词典类目有三个根（`kStorageCategoryDocumentsChildren`）：`dictionaryResources` / `dictionaryImportWorkingDirectory` / `recommended_pack`。后两个下面的东西**没有任何 DB 行**，结构上永远进不了明细。

**修复**：把「未被已知条目认领的直接子项」作为只读明细铺出来（`readOnly`——裸删会绕过墓碑/引用护栏）。类目总量改由子项之和得出，与整树求和恒等（根目录自身不占字节），所以**扫描量不增加**：原来是「整树求和 + 逐条目求和」，现在是「子项枚举求和 + 逐条目求和」。

新增 `_topLevelOwners` 把已知条目路径先收敛到直接子项层级再求差集：书的音频可能深在 `fushi_books/<bookKey>/audio/`，若按路径全等去重，整个 `fushi_books/<bookKey>` 会被当成没人认领，与那本书重复计一遍。

## BUG-2097 · 数据层：那 10.7 GB 的来源

新手引导下载的官方推荐包（**9.5 GB** 整包 zip）导入后**永不删除**。

导入走备份导入流程并**重启进程**，所以设计是「导入前落 `imported.flag`，重启回来收尾删包」。链断在最后一环：

1. `cleanupIfImported` 的**唯一调用点**是新手引导页的 `initState`；
2. 引导页只在 `home_page.dart` 判 `!onboardingCompleted` 时才自动弹；
3. 而推荐包**本身就是一份含 settings 类目的备份**，导入是整层替换（`backup_service.dart`：settings layer "is replaced wholesale"），`preferences` 表连同 `onboarding_completed` 一起被换掉；该键缺省值本来也是 `true`（`getPref('onboarding_completed', defaultValue: true)`），备份里没这行也读到 true；
4. 于是导入后的那次重启，首页判定「引导已完成」，**不再弹引导页**，`initState` 不跑，9.5 GB 永久留在盘上。`first_time_setup` 同在 preferences 表里被一起替换，兜底路径同样救不回来。

判据（flag）没错，错的是把收尾挂在了一个「导入成功就不会再出现」的页面上。

**修复**：搬到**启动必经路径**——`AppModel` 初始化那组「创建运行时目录」的 IO（已有同构先例 `purgePendingDictionaryDeletes`，且这组由 `_guardInitIo` 兜掉盘时的 hang）。引导页那处唯一入口移除，只留指向注释。flag 语义**不变**：没导入过、只下了一半的包都不受影响，续传不作废。

## 测试

`fushi/test/storage/storage_usage_service_test.dart`
- 两条既有断言按新契约更新——**旧断言恰恰把病灶写死了**：书籍用例造了孤儿目录 `fushi_books/orphan` 并断言 `entries.length == 2`（孤儿不出现）；两条都补上「明细之和 == 类目总量」的对账断言。
- 新增「推荐包暂存的整包 zip 出现在词典明细里」——直接复刻用户现场。
- 新增「认领判据按直接子项收敛，不与已知条目重复计数」——守住上面那个重复计数陷阱。

`fushi/test/onboarding/recommended_pack_cleanup_test.dart`（新增）
- 行为 3 条：flag 在 → 整个包目录连 zip 删掉；flag 不在 → 原样保留；包目录不存在 → 不抛（它现在跑在启动路径上）。
- 守卫 2 条：`app_model.dart` 必须持有 `cleanupIfImported` 调用；引导页**不得**再出现该调用。
- 两条守卫都做了**变异实测**（改名调用 → 守卫 1 红；调用加回引导页 → 守卫 2 红），变异经 sha256 校验还原，未用 `git checkout`。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- 定向测试 45 条全绿（scan 服务 34 + 存储页 UI 11）。
- **真机未验证**：用户设备未连本机 adb（`adb devices` 为空）。结论全部由代码路径 + 临时目录真实落盘的单测得出。用户可自查 `Android/data/<包名>/files/recommended_pack/`——里面若躺着 `fushi_recommended_pack.zip`（或预分配的 `.mpart`），即为 BUG-2097 现场。

## 已知残留

只下了一半、从未导入的 `.mpart`（**预分配就是完整 9.5 GB**）仍按设计保留以便续传，不在本次删除范围内；但修好 BUG-2096 后它至少会在存储页明细里现身，用户能看见并自行判断。

https://claude.ai/code/session_01VS9PLu54LwwsgHe9FvCsNG
