### PR TITLE
fix(anki): AnkiDroid 权限申请等到用户答复，错误码收口消灭英文原文外泄（BUG-2098）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1964 条。点号进各自文件。
+> 共 1965 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2098](bugs/BUG-2098-ankidroid-permission-not-awaited.md) | ✅ | ✅ | AnkiDroid 权限申请不等结果 + 错误码域不通导致英文原文外泄 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |
 | [BUG-2088](bugs/BUG-2088-release-notes-never-reach-update-dialog.md) | ✅ | ✅ | 正式版更新公告进不了应用内更新弹窗，用户看到的是一行占位符 |

--- a/docs/bugs/BUG-2098-ankidroid-permission-not-awaited.md
+++ b/docs/bugs/BUG-2098-ankidroid-permission-not-awaited.md
@@ -1,0 +1,63 @@
+## BUG-2098 · AnkiDroid 权限申请不等结果 + 错误码域不通导致英文原文外泄
+- **报告**：2026-09-03（用户：Android 制卡设置页截图——「创建 Lapis 卡组」失败，页面红字与 snackbar 都是 `PlatformException(PERMISSION_DENIED, AnkiDroid permission not granted. Please grant and retry., null, null)`，全英文；且从头到尾没弹出过系统权限申请对话框）
+- **真实性**：✅ 真 bug。三个各自独立的根因：
+  1. **权限申请「发完就不管」**（主因）——`AnkiChannelHandler.java:346` 的
+     `case "requestAnkidroidPermissions"` 发起 `ActivityCompat.requestPermissions` 后
+     **立刻** `result.success(true)`；而全 app 没有任何 `onRequestPermissionsResult`
+     实现（`requestCode = AD_PERM_REQUEST = 0` 的结果无人接收），Dart 侧
+     `anki_repository.dart` 6 处 `await invokeMethod('requestAnkidroidPermissions')`
+     拿到 true 后不等用户答复就直接查 provider。于是权限对话框还在屏幕上，错误已经
+     报完了。i18n 文案 `anki_error_permission_denied` 写着「请在刚弹出的系统授权对话
+     框中允许」，代码却从不等那个对话框，逻辑自相矛盾。
+  2. **错误码两个码域不相通**——native 返回裸码 `PERMISSION_DENIED`
+     （`AnkiChannelHandler.java:374`），本地化表 `localizeAnkiMineError`
+     （`error_log_service.dart:564`）匹配的却是
+     `AnkiErrorCode.permissionDenied == 'ANKI_PERMISSION_DENIED'`
+     （`anki_models.dart:1298`）。只有制卡路径有 `_classifyMineError`
+     （`anki_repository.dart:294`）做转换；fetch 路径 `anki_repository.dart:151`
+     直传 `e.code`，`localizeAnkiFetchError` 恒查不中 → 回退 `return message`
+     显示英文原文。**中文文案早就写好了，只是永远显示不出来。**
+     建 Lapis 路径更糟：`_lapisSetupFailureMessage`（`anki_view_model.dart:275`）
+     只对 AnkiConnect 传输层异常本地化，`PlatformException` 直接落进 `e.toString()`，
+     连 code/message 都不拆，整个 `PlatformException(...)` 糊给用户。
+     另外 `createLapisSetup` 里 fetch 失败分支（`anki_view_model.dart:236`）也漏了
+     `localizeAnkiFetchError`——同一个错误走刷新是中文、走建 Lapis 就变英文。
+  3. **三种拒绝态被压成一种**——没有任何 `shouldShowRequestPermissionRationale`
+     判断。权限被永久拒绝（Android 11+ 拒一次即「不再询问」）或 AnkiDroid 未安装
+     （`com.ichi2.anki.permission.READ_WRITE_DATABASE` 是 AnkiDroid 自己定义的权限，
+     没装时系统里根本不存在）时，`requestPermissions` 立即静默判拒且**不弹框**，
+     用户在这个页面上**没有任何路径能把权限授出来**——这就是「没弹出申请」的观感。
+- **[x] ① 已修复** — 三层根治，`fix/bug-2098-ankidroid-permission-flow`：
+  - **native**：`requestAnkidroidPermissions` 改为挂起 `MethodChannel.Result`
+    （`pendingPermissionResult`），由新增的 `AnkiChannelHandler.onRequestPermissionsResult`
+    在系统回调到达时 resolve，返回五态字符串 `granted` / `denied` /
+    `permanently_denied` / `no_activity` / `unavailable`；`MainActivity` 新增
+    `onRequestPermissionsResult` 覆写转发（此前全 app 一个都没有）。永久拒绝判据走
+    新增的 `AnkiDroidHelper.canAskPermissionAgain`（rationale）。`unavailable` 由
+    `AnkiDroidHelper.isApiAvailable` 前置判定，避免把「没装 AnkiDroid」误报成「去设置
+    授权」。新增 `openAnkiPermissionSettings` 跳系统应用详情页。
+    `requirePermission` 守卫不再自己发起请求（发起与等待收归单一职责，否则一次操作
+    弹两次框、且那次请求无人等待）。
+  - **fushi_anki**：6 处裸 `invokeMethod('requestAnkidroidPermissions')` 收口成
+    `_ensurePermission()`，非授权终态短路成带稳定码的 `PlatformException`（旧 native /
+    测试桩返回 `true`/`null` 仍视为已授权，向后兼容）；`_classifyMineError` 提升为
+    唯一分类入口 `classifyPlatformError`，**fetch 路径也走它**（消灭两套码域）；
+    新增错误码 `ANKI_PERMISSION_PERMANENTLY_DENIED` / `ANKI_DROID_UNAVAILABLE`。
+  - **fushi**：`localizeAnkiMineError` 补两个新码的本地化；`_lapisSetupFailure`
+    先过 AnkiDroid 分类再退回原文（且只取 `message` 不再吐整个 `toString()`）；
+    `createLapisSetup` 的 fetch 失败分支补上 `localizeAnkiFetchError`；
+    `LapisSetupResult` 带回 `code`，永久拒绝时 snackbar 给「去设置」按钮。
+    i18n 经 `tool/i18n_sync.dart --add` 新增 3 key × 17 语言。
+- **[x] ② 已加自动化测试** — `packages/fushi_anki/test/ankidroid_permission_flow_test.dart`
+  （16 条，全绿；连同原 BUG-824 守卫 7 条共 23 条绿）：
+  - 行为层：native 回四种非授权终态时**一个 provider 方法都不许被调到**，且错误码
+    必须是带 `ANKI_` 前缀的稳定码；`granted` 正常放行；旧契约 `true`/`null` 仍放行。
+  - 分类层：裸码→稳定码映射、三个权限态互不相等、message 兜底、无关异常不冒领、
+    fetch 失败带回稳定码而非裸码。
+  - native 源码扫描守卫：`Result` 挂起、`onRequestPermissionsResult` 存在、
+    `MainActivity` 转发、永久拒绝/未安装两态分开、`requirePermission` 不再发起请求。
+  - **变异实测**（非空转）：删掉 `MainActivity` 转发那行 → 守卫红；把非授权态改成
+    放行 → 三条行为断言红；两次还原后源文件 sha256 与变异前逐字节一致。
+- **备注**：真机复测（真实 AnkiDroid 上走「拒绝 → 再点 → 弹框 → 允许 → 成功」和
+  「不再询问 → 去设置」两条路径）**未做**——本机无 Android 设备/模拟器接入本次会话，
+  Java 侧行为只由源码扫描守卫覆盖。这是本条已知验证缺口。

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
@@ -5,10 +5,12 @@ import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.Settings;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -35,6 +37,21 @@ public class AnkiChannelHandler {
     private static final String CHANNEL = ChannelNames.ANKI;
     private static final int AD_PERM_REQUEST = 0;
 
+    // BUG-2098：`requestAnkidroidPermissions` 的返回值。此前恒 success(true)——发起
+    // 系统权限请求后**不等用户答复**就返回，Dart 侧紧接着查 provider，于是权限对话框
+    // 还在屏幕上时错误已经报完了；而当系统压根不弹框（用户永久拒绝 / AnkiDroid 没装
+    // 导致这个自定义 dangerous 权限在系统里根本没被任何包定义）时，用户在设置页里
+    // 没有任何路径能把权限授出来。现在返回真实终态，Dart 据此短路并给可操作提示。
+    static final String PERM_GRANTED = "granted";
+    /** 用户拒绝了本次请求，但还能再问（下次仍会弹框）。 */
+    static final String PERM_DENIED = "denied";
+    /** 系统不再弹框（「不再询问」/永久拒绝）——只能去应用设置页手动授予。 */
+    static final String PERM_PERMANENTLY_DENIED = "permanently_denied";
+    /** 副 engine（无 Activity）未授权：弹不了框，须回主 app 授予（BUG-865）。 */
+    static final String PERM_NO_ACTIVITY = "no_activity";
+    /** AnkiDroid 没装（或其 API 被禁）——该权限在系统里不存在，授权无从谈起。 */
+    static final String PERM_UNAVAILABLE = "unavailable";
+
     // BUG-865：AnkiDroid ContentProvider 访问是「进程 + 权限」作用域，只需 Context
     // （AnkiDroidHelper 内部已 getApplicationContext()、AddContentApi/FileProvider/
     // grantUriPermission/getContentResolver/startActivity(NEW_TASK) 均 Context 即可）。
@@ -45,6 +62,14 @@ public class AnkiChannelHandler {
     @Nullable
     private final Activity activity;
     private final AnkiDroidHelper ankiDroid;
+
+    /**
+     * BUG-2098：在途的权限请求——{@code requestAnkidroidPermissions} 把 Dart 侧的
+     * {@link MethodChannel.Result} 挂在这里，直到 {@link #onRequestPermissionsResult}
+     * 拿到系统回调才 resolve。只在主线程读写（channel 回调与权限回调同为主线程）。
+     */
+    @Nullable
+    private MethodChannel.Result pendingPermissionResult;
 
     /** 主 engine（MainActivity）用：Activity 既作 Context 又能弹权限。 */
     public AnkiChannelHandler(Activity activity) {
@@ -344,12 +369,12 @@ public class AnkiChannelHandler {
                         }
                         break;
                     case "requestAnkidroidPermissions":
-                        // BUG-865：副 engine（activity==null）无法弹系统权限框，静默跳过；
-                        // 权限须在主 app 授予。仍回 success(true) 保持契约不变。
-                        if (activity != null && ankiDroid.shouldRequestPermission()) {
-                            ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
-                        }
-                        result.success(true);
+                        requestAnkidroidPermissions(result);
+                        break;
+                    case "openAnkiPermissionSettings":
+                        // BUG-2098：永久拒绝后系统不再弹框，唯一出路是应用详情页里的
+                        // 权限项；把跳转做成显式能力，Dart 侧才能给「去设置」按钮。
+                        result.success(openAppPermissionSettings());
                         break;
                     case "addFileToMedia":
                         if (filename == null || preferredName == null) {
@@ -416,13 +441,96 @@ public class AnkiChannelHandler {
         return "ANKI_PROVIDER_ERROR";
     }
 
+    /**
+     * BUG-2098：发起 AnkiDroid 运行时权限请求，并**等到用户答复**再 resolve。
+     *
+     * <p>此前这里是「发起请求 + 立刻 success(true)」，Dart 侧 await 完马上就去查
+     * provider，系统权限对话框还没被点，错误就已经弹给用户了；对话框根本没弹的两种
+     * 情况（永久拒绝 / AnkiDroid 未安装）更是让用户在这个页面上无路可走。
+     *
+     * <p>五种终态见 {@code PERM_*} 常量。注意先判「是否已授权」再判 activity：副
+     * engine 无 Activity 但权限早在主 app 授予过时，仍须回 {@code granted}（BUG-865）。
+     */
+    private void requestAnkidroidPermissions(MethodChannel.Result result) {
+        if (!ankiDroid.shouldRequestPermission()) {
+            result.success(PERM_GRANTED);
+            return;
+        }
+        if (!AnkiDroidHelper.isApiAvailable(context)) {
+            // AnkiDroid 没装/API 被禁：READ_WRITE_DATABASE 由 AnkiDroid 定义，没有任
+            // 何包定义它时 requestPermissions 会立即静默判拒且不弹框——报「去设置授权」
+            // 是误导，那个权限项在设置里根本不存在。
+            result.success(PERM_UNAVAILABLE);
+            return;
+        }
+        if (activity == null) {
+            result.success(PERM_NO_ACTIVITY);
+            return;
+        }
+        if (pendingPermissionResult != null) {
+            // 已有一次请求在途（系统对话框正开着）。不排队、不覆盖：覆盖会让前一个
+            // Dart Future 永远挂着。当作本次被拒，调用方重试即可。
+            result.success(PERM_DENIED);
+            return;
+        }
+        pendingPermissionResult = result;
+        ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
+    }
+
+    /**
+     * BUG-2098：系统权限回调入口，由 {@code MainActivity.onRequestPermissionsResult}
+     * 转发。返回 {@code true} 表示本次回调属于 AnkiDroid 权限请求。
+     *
+     * <p>拒绝后区分「还能再问」与「不再询问」：请求刚被拒且
+     * {@code shouldShowRequestPermissionRationale} 仍为 false，说明系统已不再弹框，
+     * 只能去应用设置页授予。
+     */
+    public boolean onRequestPermissionsResult(int requestCode, @NonNull int[] grantResults) {
+        if (requestCode != AD_PERM_REQUEST) {
+            return false;
+        }
+        final MethodChannel.Result pending = pendingPermissionResult;
+        pendingPermissionResult = null;
+        if (pending == null) {
+            return true;
+        }
+        final boolean granted = grantResults.length > 0
+            && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+        if (granted) {
+            pending.success(PERM_GRANTED);
+        } else if (activity != null && ankiDroid.canAskPermissionAgain(activity)) {
+            pending.success(PERM_DENIED);
+        } else {
+            pending.success(PERM_PERMANENTLY_DENIED);
+        }
+        return true;
+    }
+
+    /** BUG-2098：打开本应用的系统详情页（权限项所在处）。成功返回 true。 */
+    private boolean openAppPermissionSettings() {
+        try {
+            final Intent intent = new Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", context.getPackageName(), null));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            context.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            android.util.Log.w("fushi-anki", "cannot open app settings", e);
+            return false;
+        }
+    }
+
+    /**
+     * provider 访问前的权限守卫。BUG-824 起每个碰 provider 的分支都过它。
+     *
+     * <p>BUG-2098：这里不再自己发起权限请求——发起与等待是
+     * {@link #requestAnkidroidPermissions} 的单一职责，Dart 侧每个 provider 调用前
+     * 都会先走那条路并等结果。此处只做「没权限就干净失败」的兜底，避免同一次用户
+     * 操作弹两次框、以及本方法发起的那次请求因无人等待而被静默丢弃。
+     */
     private boolean requirePermission(MethodChannel.Result result) {
         if (ankiDroid.shouldRequestPermission()) {
-            // BUG-865：副 engine（activity==null）不能弹系统权限框，只回错误让 Dart
-            // 层提示「去主 app 授予 AnkiDroid 权限」，避免 ActivityCompat 对 null NPE。
-            if (activity != null) {
-                ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
-            }
             result.error("PERMISSION_DENIED",
                 "AnkiDroid permission not granted. Please grant and retry.",
                 null);

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
@@ -67,6 +67,18 @@ public class AnkiDroidHelper {
         ActivityCompat.requestPermissions(callbackActivity, new String[]{READ_WRITE_PERMISSION}, callbackCode);
     }
 
+    /**
+     * BUG-2098：被拒之后系统还愿不愿意再弹框。
+     *
+     * <p>刚被拒绝一次时 Android 会让 rationale 为 true（可以再问）；勾了「不再询问」
+     * 或系统压根没弹（权限未被任何已安装包定义）时恒 false——那种情况下只能引导用户
+     * 去应用设置页手动授予，再调 requestPermissions 只会立刻静默失败。
+     */
+    public boolean canAskPermissionAgain(Activity callbackActivity) {
+        return ActivityCompat.shouldShowRequestPermissionRationale(
+                callbackActivity, READ_WRITE_PERMISSION);
+    }
+
 
     /**
      * Save a mapping from deckName to getDeckId in the SharedPreferences

--- a/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
@@ -299,6 +299,22 @@ public class MainActivity extends AudioServiceActivity {
                 AudioManager.FLAG_SHOW_UI);
     }
 
+    /**
+     * BUG-2098：把系统运行时权限结果转发给 {@link AnkiChannelHandler}。
+     *
+     * <p>此前整个 app 没有任何 onRequestPermissionsResult 实现：AnkiDroid 权限请求
+     * 发出去就没人接结果，Dart 侧也就无从等待，权限对话框还开着错误就已经报完了。
+     * 仍先调 super（Flutter 插件的权限回调也走这里）。
+     */
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (ankiChannelHandler != null) {
+            ankiChannelHandler.onRequestPermissionsResult(requestCode, grantResults);
+        }
+    }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71060 (4180 per locale)
+/// Strings: 71111 (4183 per locale)
 ///
-/// Built on 2026-09-03 at 03:52 UTC
+/// Built on 2026-09-03 at 12:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5734,6 +5734,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connected. Root catalog has ${count} entries';
   String discovery_opds_test_failed({required Object reason}) =>
       'Connection failed: ${reason}';
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -15474,6 +15479,14 @@ class _StringsAr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'فشل الاتصال: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -25441,6 +25454,14 @@ class _StringsDe extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbindung fehlgeschlagen: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -35460,6 +35481,14 @@ class _StringsEs extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Error de conexión: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -45514,6 +45543,14 @@ class _StringsFr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Échec de la connexion : ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -55373,6 +55410,14 @@ class _StringsId extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Koneksi gagal: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -65323,6 +65368,14 @@ class _StringsIt extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Connessione non riuscita: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -74661,6 +74714,14 @@ class _StringsJa extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '接続に失敗しました: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -84009,6 +84070,14 @@ class _StringsKo extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '연결 실패: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -93914,6 +93983,14 @@ class _StringsNl extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbinding mislukt: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -103873,6 +103950,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Falha na conexão: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -113811,6 +113896,14 @@ class _StringsRu extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Не удалось подключиться: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -123547,6 +123640,14 @@ class _StringsTh extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'เชื่อมต่อไม่สำเร็จ: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -133400,6 +133501,14 @@ class _StringsTr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Bağlantı başarısız: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -143224,6 +143333,14 @@ class _StringsVi extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Kết nối thất bại: ${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 // Path: <root>
@@ -152251,6 +152368,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '连接失败：${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid 卡片访问权限已被永久拒绝，系统不再弹出授权对话框。请到应用设置里授予该权限后重试。';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      '未安装 AnkiDroid（或其 API 被禁用），无法授予卡片访问权限。请安装 AnkiDroid 并启用其 API，或改用 AnkiConnect。';
+  @override
+  String get anki_action_open_settings => '去设置';
 }
 
 // Path: <root>
@@ -161283,6 +161408,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '連線失敗：${reason}';
+  @override
+  String get anki_error_permission_permanently_denied =>
+      'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+  @override
+  String get anki_error_ankidroid_unavailable =>
+      'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+  @override
+  String get anki_action_open_settings => 'Open settings';
 }
 
 /// Flat map(s) containing all translations.
@@ -169859,6 +169992,12 @@ extension on _StringsEn {
             'Connected. Root catalog has ${count} entries';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Connection failed: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -178430,6 +178569,12 @@ extension on _StringsAr {
             'تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'فشل الاتصال: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -187046,6 +187191,12 @@ extension on _StringsDe {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Verbindung fehlgeschlagen: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -195653,6 +195804,12 @@ extension on _StringsEs {
             'Conectado. El catálogo raíz tiene ${count} entradas';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Error de conexión: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -204269,6 +204426,12 @@ extension on _StringsFr {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Échec de la connexion : ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -212856,6 +213019,12 @@ extension on _StringsId {
             'Terhubung. Katalog akar berisi ${count} entri';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Koneksi gagal: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -221465,6 +221634,12 @@ extension on _StringsIt {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Connessione non riuscita: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -230001,6 +230176,12 @@ extension on _StringsJa {
         return ({required Object count}) => '接続しました。ルートカタログに ${count} 件あります';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '接続に失敗しました: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -238541,6 +238722,12 @@ extension on _StringsKo {
             '연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '연결 실패: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -247143,6 +247330,12 @@ extension on _StringsNl {
             'Verbonden. De hoofdcatalogus heeft ${count} items';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Verbinding mislukt: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -255740,6 +255933,12 @@ extension on _StringsPtBr {
             'Conectado. O catálogo raiz tem ${count} itens';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Falha na conexão: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -264344,6 +264543,12 @@ extension on _StringsRu {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Не удалось подключиться: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -272920,6 +273125,12 @@ extension on _StringsTh {
             'เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'เชื่อมต่อไม่สำเร็จ: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -281511,6 +281722,12 @@ extension on _StringsTr {
             'Bağlanıldı. Kök katalogda ${count} girdi var';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Bağlantı başarısız: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -290096,6 +290313,12 @@ extension on _StringsVi {
             'Đã kết nối. Danh mục gốc có ${count} mục';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Kết nối thất bại: ${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }
@@ -298609,6 +298832,12 @@ extension on _StringsZhCn {
         return ({required Object count}) => '连接成功，根目录有 ${count} 个条目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '连接失败：${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid 卡片访问权限已被永久拒绝，系统不再弹出授权对话框。请到应用设置里授予该权限后重试。';
+      case 'anki_error_ankidroid_unavailable':
+        return '未安装 AnkiDroid（或其 API 被禁用），无法授予卡片访问权限。请安装 AnkiDroid 并启用其 API，或改用 AnkiConnect。';
+      case 'anki_action_open_settings':
+        return '去设置';
       default:
         return null;
     }
@@ -307123,6 +307352,12 @@ extension on _StringsZhHk {
         return ({required Object count}) => '連線成功，根目錄有 ${count} 個項目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '連線失敗：${reason}';
+      case 'anki_error_permission_permanently_denied':
+        return 'AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.';
+      case 'anki_error_ankidroid_unavailable':
+        return 'AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.';
+      case 'anki_action_open_settings':
+        return 'Open settings';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Needed for a self-hosted server on your local network",
   "discovery_opds_test": "Test connection",
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
-  "discovery_opds_test_failed": "Connection failed: ${reason}"
+  "discovery_opds_test_failed": "Connection failed: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "مطلوب لخادم ذاتي الاستضافة على شبكتك المحلية",
   "discovery_opds_test": "اختبار الاتصال",
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
-  "discovery_opds_test_failed": "فشل الاتصال: ${reason}"
+  "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nötig für einen selbst gehosteten Server im lokalen Netzwerk",
   "discovery_opds_test": "Verbindung testen",
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
-  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}"
+  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necesario para un servidor autoalojado en tu red local",
   "discovery_opds_test": "Probar conexión",
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
-  "discovery_opds_test_failed": "Error de conexión: ${reason}"
+  "discovery_opds_test_failed": "Error de conexión: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nécessaire pour un serveur auto-hébergé sur votre réseau local",
   "discovery_opds_test": "Tester la connexion",
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
-  "discovery_opds_test_failed": "Échec de la connexion : ${reason}"
+  "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Diperlukan untuk server milik sendiri di jaringan lokal",
   "discovery_opds_test": "Uji koneksi",
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
-  "discovery_opds_test_failed": "Koneksi gagal: ${reason}"
+  "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necessario per un server self-hosted sulla rete locale",
   "discovery_opds_test": "Prova connessione",
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
-  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}"
+  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "ローカルネットワークの自前サーバーに必要です",
   "discovery_opds_test": "接続をテスト",
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
-  "discovery_opds_test_failed": "接続に失敗しました: ${reason}"
+  "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "로컬 네트워크의 자체 호스팅 서버에 필요합니다",
   "discovery_opds_test": "연결 테스트",
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
-  "discovery_opds_test_failed": "연결 실패: ${reason}"
+  "discovery_opds_test_failed": "연결 실패: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nodig voor een zelfgehoste server in je lokale netwerk",
   "discovery_opds_test": "Verbinding testen",
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
-  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}"
+  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necessário para um servidor auto-hospedado na sua rede local",
   "discovery_opds_test": "Testar conexão",
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
-  "discovery_opds_test_failed": "Falha na conexão: ${reason}"
+  "discovery_opds_test_failed": "Falha na conexão: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Нужно для сервера, размещённого в вашей локальной сети",
   "discovery_opds_test": "Проверить соединение",
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
-  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}"
+  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "จำเป็นสำหรับเซิร์ฟเวอร์ที่โฮสต์เองในเครือข่ายภายใน",
   "discovery_opds_test": "ทดสอบการเชื่อมต่อ",
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
-  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}"
+  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Yerel ağdaki kendi sunucun için gerekli",
   "discovery_opds_test": "Bağlantıyı sına",
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
-  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}"
+  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Cần thiết cho máy chủ tự dựng trong mạng nội bộ",
   "discovery_opds_test": "Kiểm tra kết nối",
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
-  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}"
+  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "局域网自建服务器需要打开",
   "discovery_opds_test": "测试连接",
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
-  "discovery_opds_test_failed": "连接失败：${reason}"
+  "discovery_opds_test_failed": "连接失败：${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid 卡片访问权限已被永久拒绝，系统不再弹出授权对话框。请到应用设置里授予该权限后重试。",
+  "anki_error_ankidroid_unavailable": "未安装 AnkiDroid（或其 API 被禁用），无法授予卡片访问权限。请安装 AnkiDroid 并启用其 API，或改用 AnkiConnect。",
+  "anki_action_open_settings": "去设置"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "區域網絡自建伺服器需要開啟",
   "discovery_opds_test": "測試連線",
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
-  "discovery_opds_test_failed": "連線失敗：${reason}"
+  "discovery_opds_test_failed": "連線失敗：${reason}",
+  "anki_error_permission_permanently_denied": "AnkiDroid card access was permanently denied, so the system no longer shows the permission dialog. Open app settings and grant the AnkiDroid permission, then try again.",
+  "anki_error_ankidroid_unavailable": "AnkiDroid is not installed (or its API is disabled), so card access cannot be granted. Install AnkiDroid and enable its API, or switch to AnkiConnect.",
+  "anki_action_open_settings": "Open settings"
 }

--- a/fushi/lib/src/anki/anki_config_controls.dart
+++ b/fushi/lib/src/anki/anki_config_controls.dart
@@ -151,7 +151,23 @@ class _AnkiCreateLapisRowState extends State<AnkiCreateLapisRow> {
       case LapisSetupOutcome.failed:
         message = t.anki_create_lapis_failed(error: result.message ?? '');
     }
-    messenger.showSnackBar(SnackBar(content: Text(message)));
+    // BUG-2098：权限被永久拒绝时系统不再弹授权框，光给一句提示等于把用户堵死；
+    // 唯一出路是应用设置页里的权限项，所以直接把它做成 snackbar 上的一个按钮。
+    final bool needsSettings =
+        result.code == AnkiErrorCode.permissionPermanentlyDenied;
+    messenger.showSnackBar(SnackBar(
+      content: Text(message),
+      duration: needsSettings
+          ? const Duration(seconds: 10)
+          : const Duration(seconds: 4),
+      action: needsSettings
+          ? SnackBarAction(
+              label: t.anki_action_open_settings,
+              onPressed: () =>
+                  unawaited(AnkiRepository.openPermissionSettings()),
+            )
+          : null,
+    ));
   }
 
   @override

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi_anki/fushi_anki.dart';
@@ -232,8 +233,17 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
 
       final fetch = await _repository.fetchConfiguration();
       if (fetch is AnkiFetchError) {
-        state = state.copyWith(isFetching: false, errorMessage: fetch.message);
-        return LapisSetupResult(LapisSetupOutcome.failed, fetch.message);
+        // BUG-2098：这里此前直接用 `fetch.message`（后端英文原文），漏了
+        // [localizeAnkiFetchError]——同一个 fetch 失败，走 fetchConfiguration() 是
+        // 中文提示，走建 Lapis 就变英文。两条路径统一过同一个本地化入口。
+        final String message =
+            localizeAnkiFetchError(fetch.message, fetch.code);
+        state = state.copyWith(isFetching: false, errorMessage: message);
+        return LapisSetupResult(
+          LapisSetupOutcome.failed,
+          message,
+          fetch.code,
+        );
       }
 
       final settings = await _repository.loadSettings();
@@ -257,13 +267,18 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
           : LapisSetupOutcome.alreadyExisted);
     } catch (e, stack) {
       debugPrint('AnkiViewModel.createLapisSetup: $e\n$stack');
-      final String message = _lapisSetupFailureMessage(e);
-      state = state.copyWith(isFetching: false, errorMessage: message);
-      return LapisSetupResult(LapisSetupOutcome.failed, message);
+      final failure = _lapisSetupFailure(e);
+      state = state.copyWith(isFetching: false, errorMessage: failure.message);
+      return LapisSetupResult(
+        LapisSetupOutcome.failed,
+        failure.message,
+        failure.code,
+      );
     }
   }
 
-  /// 一键配置 Lapis 失败时给用户看的那句话。
+  /// 一键配置 Lapis 失败时给用户看的那句话（连同稳定错误码，供 UI 决定是否给
+  /// 「去设置」这类可操作按钮）。
   ///
   /// 这里此前是裸的 `e.toString()`，于是 AnkiConnect 端口被别的程序占着（连得上、
   /// 不应答）时，用户在新手引导里拿到的是一句
@@ -271,10 +286,25 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   /// 更看不出下一步该干什么。传输层异常改走与 fetchConfiguration 同一套稳定码分类 +
   /// 本地化（TODO-752a）；其余（payload / 空列表 firstWhere 之类的本地编程错误）不是
   /// 连接问题，不套连接文案，保留原文供排障——它们不经 socket，不是乱码源。
-  static String _lapisSetupFailureMessage(Object e) {
-    if (!isAnkiConnectTransportError(e)) return e.toString();
+  ///
+  /// BUG-2098：AnkiDroid 抛的 [PlatformException] 不是传输错误，此前径直落进
+  /// `e.toString()`，于是整条 `PlatformException(PERMISSION_DENIED, AnkiDroid
+  /// permission not granted...)` 原样糊进 snackbar。现在先过 AnkiDroid 的稳定码
+  /// 分类；仍未分类的才退回原文，且只取 message 而非整个 `toString()`。
+  static ({String message, String? code}) _lapisSetupFailure(Object e) {
+    if (e is PlatformException) {
+      final String? code = AnkiRepository.classifyPlatformError(e);
+      final String? localized = localizeAnkiMineError(code);
+      if (localized != null) return (message: localized, code: code);
+      return (message: e.message ?? e.code, code: code);
+    }
+    if (!isAnkiConnectTransportError(e))
+      return (message: e.toString(), code: null);
     final String code = classifyAnkiConnectError(e);
-    return localizeAnkiFetchError(ankiConnectErrorHint(code), code);
+    return (
+      message: localizeAnkiFetchError(ankiConnectErrorHint(code), code),
+      code: code,
+    );
   }
 
   // ── Lapis 样式客制化（备份/恢复/应用见 LapisTemplateService）──────────
@@ -418,9 +448,13 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
 enum LapisSetupOutcome { created, alreadyExisted, failed }
 
 class LapisSetupResult {
-  const LapisSetupResult(this.outcome, [this.message]);
+  const LapisSetupResult(this.outcome, [this.message, this.code]);
   final LapisSetupOutcome outcome;
   final String? message;
+
+  /// BUG-2098：失败时的稳定错误码（[AnkiErrorCode]），供 UI 决定要不要给可操作
+  /// 按钮——例如权限被永久拒绝时的「去设置」。未分类的失败为 null。
+  final String? code;
 }
 
 /// Anki 仓库 provider。默认返回按平台编译期选择的本地仓库（AnkiConnect/AnkiDroid/

--- a/fushi/lib/src/utils/misc/error_log_service.dart
+++ b/fushi/lib/src/utils/misc/error_log_service.dart
@@ -565,6 +565,12 @@ String? localizeAnkiMineError(String? code) {
       // BUG-824：AnkiDroid 权限未授予。native 侧已同时弹出系统授权对话框，这里给
       // 用户一句可读、可操作的提醒，替代 provider 抛出的英文技术原文。
       return t.anki_error_permission_denied;
+    // BUG-2098：权限拒绝的另外两种终态，下一步动作与上面那条完全不同——「再点一次
+    // 按钮就会弹框」在这两种情况下都是空头支票（系统不再弹 / 权限压根不存在）。
+    case AnkiErrorCode.permissionPermanentlyDenied:
+      return t.anki_error_permission_permanently_denied;
+    case AnkiErrorCode.ankiDroidUnavailable:
+      return t.anki_error_ankidroid_unavailable;
     case AnkiErrorCode.connectionRefused:
       return t.anki_error_connection_refused;
     case AnkiErrorCode.connectionTimeout:

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -1320,6 +1320,21 @@ class AnkiErrorCode {
   /// «Permission not granted for: CardContentProvider.query /decks» 直接塞进 toast。
   static const String permissionDenied = 'ANKI_PERMISSION_DENIED';
 
+  /// BUG-2098：权限被**永久拒绝**（系统不再弹框）。
+  ///
+  /// 与 [permissionDenied] 分开是因为下一步动作完全不同：那个还能靠再点一次按钮
+  /// 弹出系统对话框，这个再怎么点都不会弹——唯一出路是应用设置页里手动授予。
+  /// 沿用同一条「刚弹出的对话框里允许」文案会把用户直接送进死路。
+  static const String permissionPermanentlyDenied =
+      'ANKI_PERMISSION_PERMANENTLY_DENIED';
+
+  /// BUG-2098：AnkiDroid 未安装（或其 API 被禁用）。
+  ///
+  /// `READ_WRITE_DATABASE` 是 AnkiDroid 自己定义的权限：没装 AnkiDroid 时它在系统里
+  /// 根本不存在，请求必然静默失败，设置页里也找不到这一项。此时提示「去设置授权」
+  /// 是误导，正确的话是「先装 AnkiDroid，或改用 AnkiConnect」。
+  static const String ankiDroidUnavailable = 'ANKI_DROID_UNAVAILABLE';
+
   /// TODO-752a：AnkiConnect 网络错误的稳定分类码。给用户看的 toast 文案必须由
   /// 主 app 按这些**与 locale 无关、永不乱码**的码映射本地化文案，而不是透传
   /// `SocketException`/`http.ClientException` 的 `toString()`——后者既是英文，又会在

--- a/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
@@ -17,6 +17,61 @@ class AnkiRepository extends BaseAnkiRepository {
   static const _channel = MethodChannel('app.fushi.reader/anki');
   static const _legacyDeckKey = 'last_selected_deck';
 
+  /// BUG-2098：碰 AnkiDroid provider 之前**确保权限已到手**。
+  ///
+  /// 此前每个入口都是裸的 `invokeMethod('requestAnkidroidPermissions')`：native 发起
+  /// 系统权限请求后立刻回 true，这里 await 完马上就去查 provider——权限对话框还开着，
+  /// 错误已经报完了，而且报的是 provider 的英文原文。现在 native 会等到用户答复再
+  /// 回终态，非 `granted` 一律在此短路成带**稳定码**的 [PlatformException]，由
+  /// [classifyPlatformError] 归类、主 app 映射本地化文案。
+  ///
+  /// 旧 native / 测试桩返回 `true` 或 `null`（没有这个方法的桩），一律视为已授权，
+  /// 保持向后兼容——只有明确的失败终态才短路。
+  Future<void> _ensurePermission() async {
+    final Object? status =
+        await _channel.invokeMethod('requestAnkidroidPermissions');
+    switch (status) {
+      case null:
+      case true:
+      case 'granted':
+        return;
+      case 'unavailable':
+        throw PlatformException(
+          code: 'ANKI_NOT_INSTALLED',
+          message: 'AnkiDroid is not installed or its API is disabled.',
+        );
+      case 'permanently_denied':
+        throw PlatformException(
+          code: 'PERMISSION_PERMANENTLY_DENIED',
+          message: 'AnkiDroid permission was permanently denied. '
+              'Grant it in the system app settings.',
+        );
+      default:
+        // 'denied'（用户刚拒绝）/ 'no_activity'（副 engine 弹不了框，须回主 app 授予）
+        // / false / 任何未知终态：都当作「这次没拿到权限」。
+        throw PlatformException(
+          code: 'PERMISSION_DENIED',
+          message: 'AnkiDroid permission not granted. Please grant and retry.',
+        );
+    }
+  }
+
+  /// BUG-2098：打开本应用的系统设置详情页，让用户手动授予被永久拒绝的
+  /// AnkiDroid 权限——那种状态下系统不再弹框，这是唯一出路。成功返回 true。
+  static Future<bool> openPermissionSettings() async {
+    try {
+      final Object? ok =
+          await _channel.invokeMethod('openAnkiPermissionSettings');
+      return ok == true;
+    } on PlatformException catch (e, stack) {
+      debugPrint('AnkiRepository.openPermissionSettings: $e\n$stack');
+      return false;
+    } on MissingPluginException {
+      // 非 Android（或旧 native）：没有这个能力，调用方据此不显示「去设置」。
+      return false;
+    }
+  }
+
   @override
   Future<AnkiSettings> loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
@@ -48,7 +103,7 @@ class AnkiRepository extends BaseAnkiRepository {
   @override
   Future<AnkiFetchResult> fetchConfiguration() async {
     try {
-      await _channel.invokeMethod('requestAnkidroidPermissions');
+      await _ensurePermission();
       final decksRaw = await _channel.invokeMethod('getDecks') as Map?;
       final modelsRaw = await _channel.invokeMethod('getModelList') as Map?;
       if (decksRaw == null || modelsRaw == null) {
@@ -107,9 +162,14 @@ class AnkiRepository extends BaseAnkiRepository {
       // failure to a localized, actionable hint instead of AnkiDroid's raw
       // English exception text. The verbatim message is still kept as the
       // fallback for unclassified errors (code == null).
+      //
+      // BUG-2098：码必须过 [classifyPlatformError]。此前直传 `e.code`，native 的裸
+      // `PERMISSION_DENIED` 与本地化表的 `ANKI_PERMISSION_DENIED` 对不上，于是
+      // 「AnkiDroid 尚未授予卡片访问权限」这句已译好的话永远显示不出来，用户看到的
+      // 是 PlatformException 的英文原文。未分类的码仍原样上传（如 ADD_NOTE_FAILED）。
       return AnkiFetchResult.error(
         e.message ?? 'Could not access AnkiDroid. Grant permission and retry.',
-        code: e.code,
+        code: classifyPlatformError(e) ?? e.code,
       );
     } catch (e, stack) {
       // HBK-AUDIT-063: a malformed/typed channel response (TypeError,
@@ -278,7 +338,7 @@ class AnkiRepository extends BaseAnkiRepository {
     } on PlatformException catch (e, stack) {
       return MineOutcome.failure(
         'AnkiDroid: ${e.message ?? e.code}',
-        errorCode: _classifyMineError(e),
+        errorCode: classifyPlatformError(e),
         error: e,
         stackTrace: stack,
       );
@@ -290,8 +350,24 @@ class AnkiRepository extends BaseAnkiRepository {
   /// `PERMISSION_DENIED` 码，或极少数漏守卫时 provider 直接抛出的英文
   /// «permission not granted» 原文——统一归到 [AnkiErrorCode.permissionDenied]；
   /// 其余保持未分类（`null`，调用方退回旧的 errorDetail 文案）。
-  static String? _classifyMineError(PlatformException e) {
-    if (e.code == 'PERMISSION_DENIED') return AnkiErrorCode.permissionDenied;
+  ///
+  /// BUG-2098：这里此前叫 `_classifyMineError`，**只有制卡路径**调它。于是 native
+  /// 发的裸码（`PERMISSION_DENIED`）与本地化表查的带前缀码
+  /// （`ANKI_PERMISSION_DENIED`）成了两个不相通的码域：fetch / 建 Lapis 路径把裸码
+  /// 原样往上传，`localizeAnkiFetchError` 恒查不中，于是回退显示 provider 的英文
+  /// 原文——「权限未授予」的中文文案明明早就写好了却永远用不上。现在这是**唯一**
+  /// 的分类入口，凡是从这个 repository 往上冒的 [PlatformException] 都过它。
+  static String? classifyPlatformError(PlatformException e) {
+    switch (e.code) {
+      case 'PERMISSION_DENIED':
+        return AnkiErrorCode.permissionDenied;
+      case 'PERMISSION_PERMANENTLY_DENIED':
+        return AnkiErrorCode.permissionPermanentlyDenied;
+      case 'ANKI_NOT_INSTALLED':
+        return AnkiErrorCode.ankiDroidUnavailable;
+      case AnkiErrorCode.collectionUnavailable:
+        return AnkiErrorCode.collectionUnavailable;
+    }
     final String msg = (e.message ?? '').toLowerCase();
     if (msg.contains('permission not granted')) {
       return AnkiErrorCode.permissionDenied;
@@ -424,7 +500,7 @@ class AnkiRepository extends BaseAnkiRepository {
       } on PlatformException catch (e, stack) {
         return MineOutcome.failure(
           'AnkiDroid: ${e.message ?? e.code}',
-          errorCode: _classifyMineError(e),
+          errorCode: classifyPlatformError(e),
           error: e,
           stackTrace: stack,
         );
@@ -568,7 +644,7 @@ class AnkiRepository extends BaseAnkiRepository {
 
   @override
   Future<bool> createNoteType(AnkiNoteTypeTemplate template) async {
-    await _channel.invokeMethod('requestAnkidroidPermissions');
+    await _ensurePermission();
     final models = await _channel.invokeMethod('getModelList') as Map?;
     final exists =
         models?.values.any((v) => v?.toString() == template.name) ?? false;
@@ -601,7 +677,7 @@ class AnkiRepository extends BaseAnkiRepository {
   Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
     String modelName,
   ) async {
-    await _channel.invokeMethod('requestAnkidroidPermissions');
+    await _ensurePermission();
     final Map? raw = await _channel.invokeMethod(
       'readNoteType',
       <String, dynamic>{'noteTypeName': modelName},
@@ -631,7 +707,7 @@ class AnkiRepository extends BaseAnkiRepository {
 
   @override
   Future<bool> updateNoteTypeStyling(String modelName, String css) async {
-    await _channel.invokeMethod('requestAnkidroidPermissions');
+    await _ensurePermission();
     final bool? ok = await _channel.invokeMethod(
       'updateNoteTypeStyling',
       <String, dynamic>{'noteTypeName': modelName, 'css': css},
@@ -645,7 +721,7 @@ class AnkiRepository extends BaseAnkiRepository {
     List<AnkiCardTemplate> templates,
   ) async {
     if (templates.isEmpty) return false;
-    await _channel.invokeMethod('requestAnkidroidPermissions');
+    await _ensurePermission();
     final bool? ok = await _channel.invokeMethod(
       'updateNoteTypeTemplates',
       <String, dynamic>{
@@ -664,7 +740,7 @@ class AnkiRepository extends BaseAnkiRepository {
 
   @override
   Future<bool> createDeck(String name) async {
-    await _channel.invokeMethod('requestAnkidroidPermissions');
+    await _ensurePermission();
     final decks = await _channel.invokeMethod('getDecks') as Map?;
     final exists = decks?.values.any((v) => v?.toString() == name) ?? false;
     if (exists) return false;

--- a/packages/fushi_anki/test/ankidroid_permission_flow_test.dart
+++ b/packages/fushi_anki/test/ankidroid_permission_flow_test.dart
@@ -1,0 +1,240 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// BUG-2098：AnkiDroid 权限申请「发完就不管」+ 错误码域不通导致英文原文外泄。
+//
+// 三个各自独立的根因，这里一条一条钉死：
+//  ① native `requestAnkidroidPermissions` 此前恒 success(true)——发起系统权限请求后
+//     **不等用户答复**就返回，Dart 侧紧接着查 provider，于是权限对话框还在屏幕上时
+//     错误已经报完了。现在它返回真实终态，Dart 侧 `_ensurePermission` 据此短路，
+//     **非授权状态下一个 provider 方法都不该被调到**。
+//  ② native 发的裸码 `PERMISSION_DENIED` 与本地化表查的 `ANKI_PERMISSION_DENIED`
+//     是两个不相通的码域，只有制卡路径做了转换。fetch 路径直传裸码，于是
+//     `localizeAnkiFetchError` 恒查不中、回退显示 provider 的英文原文——中文文案
+//     明明早写好了却永远用不上。分类现在收口于 `classifyPlatformError`，fetch 也走它。
+//  ③ 「不再询问」与「AnkiDroid 没装」必须与普通拒绝分开：前两者再点一百次也不会弹框，
+//     沿用「请在刚弹出的对话框中允许」那句话等于把用户堵死在设置页里。
+
+const MethodChannel _channel = MethodChannel('app.fushi.reader/anki');
+
+void _mockChannel(Future<Object?> Function(MethodCall call) responder) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_channel, responder);
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  });
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // fetchConfiguration 成功路径会经 updateSettings 落 SharedPreferences；不给内存桩
+  // 就是 MissingPluginException，与被测行为无关。
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  group('BUG-2098 ①：权限没到手就不许碰 provider', () {
+    for (final MapEntry<String, String> entry in <String, String>{
+      'denied': AnkiErrorCode.permissionDenied,
+      'permanently_denied': AnkiErrorCode.permissionPermanentlyDenied,
+      'unavailable': AnkiErrorCode.ankiDroidUnavailable,
+      'no_activity': AnkiErrorCode.permissionDenied,
+    }.entries) {
+      test('native 回 "${entry.key}" → 不查 provider，分类成 ${entry.value}',
+          () async {
+        final List<String> calls = <String>[];
+        _mockChannel((MethodCall call) async {
+          calls.add(call.method);
+          if (call.method == 'requestAnkidroidPermissions') return entry.key;
+          return null;
+        });
+
+        final AnkiFetchResult result =
+            await AnkiRepository().fetchConfiguration();
+
+        expect(result, isA<AnkiFetchError>());
+        expect((result as AnkiFetchError).code, entry.value,
+            reason: '错误码必须过 classifyPlatformError，否则本地化表查不中');
+        // 关键断言：权限没拿到就一个 provider 方法都不该发出去。此前的
+        // fire-and-forget 契约下 getDecks/getModelList 会照发不误。
+        expect(calls, <String>['requestAnkidroidPermissions'],
+            reason: '权限未授予时不得继续访问 AnkiDroid provider');
+      });
+    }
+
+    test('native 回 "granted" → 正常继续查 provider', () async {
+      final List<String> calls = <String>[];
+      _mockChannel((MethodCall call) async {
+        calls.add(call.method);
+        switch (call.method) {
+          case 'requestAnkidroidPermissions':
+            return 'granted';
+          case 'getDecks':
+            return <Object?, Object?>{1: 'Mining'};
+          case 'getModelList':
+            return <Object?, Object?>{2: 'Lapis'};
+          case 'getFieldList':
+            return <Object?>['Word'];
+        }
+        return null;
+      });
+
+      final AnkiFetchResult result = await AnkiRepository().fetchConfiguration();
+
+      expect(result, isA<AnkiFetchSuccess>());
+      expect(calls, contains('getDecks'));
+    });
+
+    test('旧 native / 无此方法的桩（true / null）仍视为已授权，向后兼容', () async {
+      for (final Object? legacy in <Object?>[true, null]) {
+        final List<String> calls = <String>[];
+        _mockChannel((MethodCall call) async {
+          calls.add(call.method);
+          switch (call.method) {
+            case 'requestAnkidroidPermissions':
+              return legacy;
+            case 'getDecks':
+              return <Object?, Object?>{1: 'Mining'};
+            case 'getModelList':
+              return <Object?, Object?>{2: 'Lapis'};
+            case 'getFieldList':
+              return <Object?>['Word'];
+          }
+          return null;
+        });
+
+        expect(
+            await AnkiRepository().fetchConfiguration(), isA<AnkiFetchSuccess>(),
+            reason: '旧契约返回值 $legacy 不得被判成拒绝');
+        expect(calls, contains('getDecks'));
+      }
+    });
+  });
+
+  group('BUG-2098 ②：错误码收口于 classifyPlatformError', () {
+    test('native 裸码全部映射到带 ANKI_ 前缀的稳定码', () {
+      expect(
+        AnkiRepository.classifyPlatformError(
+            PlatformException(code: 'PERMISSION_DENIED')),
+        AnkiErrorCode.permissionDenied,
+      );
+      expect(
+        AnkiRepository.classifyPlatformError(
+            PlatformException(code: 'PERMISSION_PERMANENTLY_DENIED')),
+        AnkiErrorCode.permissionPermanentlyDenied,
+      );
+      expect(
+        AnkiRepository.classifyPlatformError(
+            PlatformException(code: 'ANKI_NOT_INSTALLED')),
+        AnkiErrorCode.ankiDroidUnavailable,
+      );
+      expect(
+        AnkiRepository.classifyPlatformError(
+            PlatformException(code: AnkiErrorCode.collectionUnavailable)),
+        AnkiErrorCode.collectionUnavailable,
+      );
+    });
+
+    test('三个权限态互不相等——合并了就等于给用户指错路', () {
+      expect(AnkiErrorCode.permissionDenied,
+          isNot(AnkiErrorCode.permissionPermanentlyDenied));
+      expect(AnkiErrorCode.permissionDenied,
+          isNot(AnkiErrorCode.ankiDroidUnavailable));
+      expect(AnkiErrorCode.permissionPermanentlyDenied,
+          isNot(AnkiErrorCode.ankiDroidUnavailable));
+    });
+
+    test('漏了守卫时 provider 的英文原文仍按 message 兜底分类', () {
+      expect(
+        AnkiRepository.classifyPlatformError(PlatformException(
+          code: 'ANKI_PROVIDER_ERROR',
+          message: 'Permission not granted for: CardContentProvider.query '
+              '/decks (app.fushi.reader)',
+        )),
+        AnkiErrorCode.permissionDenied,
+      );
+    });
+
+    test('无关异常保持未分类（null），不冒领', () {
+      expect(
+        AnkiRepository.classifyPlatformError(
+            PlatformException(code: 'ADD_NOTE_FAILED', message: 'boom')),
+        isNull,
+      );
+    });
+
+    test('fetch 失败带回稳定码而非裸码', () async {
+      _mockChannel((MethodCall call) async {
+        if (call.method == 'requestAnkidroidPermissions') return 'granted';
+        throw PlatformException(
+          code: 'PERMISSION_DENIED',
+          message: 'AnkiDroid permission not granted. Please grant and retry.',
+        );
+      });
+
+      final AnkiFetchResult result = await AnkiRepository().fetchConfiguration();
+
+      expect(result, isA<AnkiFetchError>());
+      expect((result as AnkiFetchError).code, AnkiErrorCode.permissionDenied,
+          reason: '直传 e.code 会让本地化表恒查不中，英文原文外泄给用户');
+    });
+  });
+
+  group('BUG-2098 ③：native 侧权限链路（源码扫描守卫）', () {
+    // 宿主上没有真 AnkiDroid，Java 侧行为无法运行时验证；退而扫源码，钉住三条
+    // 「回归了就直接复发本 bug」的结构不变式。
+    final File handler = File(
+      '../../fushi/android/app/src/main/java/app/fushi/reader/'
+      'AnkiChannelHandler.java',
+    );
+    final File activity = File(
+      '../../fushi/android/app/src/main/java/app/fushi/reader/'
+      'MainActivity.java',
+    );
+
+    test('两个 native 文件都在预期路径（守卫本身没漂）', () {
+      expect(handler.existsSync(), isTrue, reason: '路径漂了：${handler.path}');
+      expect(activity.existsSync(), isTrue, reason: '路径漂了：${activity.path}');
+    });
+
+    test('权限请求把 Result 挂起，等 onRequestPermissionsResult 再 resolve', () {
+      final String src = handler.readAsStringSync();
+      expect(src.contains('pendingPermissionResult = result;'), isTrue,
+          reason: '不挂起就等于回到「发完就返回」，权限框还开着错误已经报完');
+      expect(src.contains('boolean onRequestPermissionsResult('), isTrue,
+          reason: '没有回调入口，授权结果永远回不到 Dart');
+    });
+
+    test('MainActivity 转发系统权限回调——全 app 曾经一个实现都没有', () {
+      final String src = activity.readAsStringSync();
+      expect(
+        src.contains('ankiChannelHandler.onRequestPermissionsResult('),
+        isTrue,
+        reason: 'Activity 不转发，handler 里挂起的 Result 就永远等不到结果',
+      );
+    });
+
+    test('永久拒绝与普通拒绝在 native 侧被分开', () {
+      final String src = handler.readAsStringSync();
+      expect(src.contains('canAskPermissionAgain('), isTrue,
+          reason: '不查 rationale 就分不出「还能再问」和「不再询问」');
+      expect(src.contains('PERM_PERMANENTLY_DENIED'), isTrue);
+      expect(src.contains('PERM_UNAVAILABLE'), isTrue,
+          reason: 'AnkiDroid 没装时该权限根本不存在，报「去设置授权」是误导');
+    });
+
+    test('requirePermission 守卫不再自己发起请求（避免一次操作弹两次框）', () {
+      final String src = handler.readAsStringSync();
+      final int idx = src.indexOf('private boolean requirePermission(');
+      expect(idx, greaterThanOrEqualTo(0));
+      final String body = src.substring(idx, idx + 600);
+      expect(body.contains('requestPermission('), isFalse,
+          reason: '发起与等待是 requestAnkidroidPermissions 的单一职责；'
+              '守卫里再发一次既弹两次框，那次请求也无人等待');
+    });
+  });
+}


### PR DESCRIPTION
用户在 Android 制卡设置页点「创建 Lapis 卡组」，页面红字与 snackbar 都是整条英文 `PlatformException(PERMISSION_DENIED, AnkiDroid permission not granted. Please grant and retry., null, null)`，而且从头到尾**没弹出过系统权限申请对话框**。

沿真实代码路径查下来是三个各自独立的根因，逐条根治，没有补丁式绕过。

## ① 权限申请「发完就不管」（主因）

`AnkiChannelHandler.java` 的 `case "requestAnkidroidPermissions"` 发起 `ActivityCompat.requestPermissions` 后**立刻** `result.success(true)`；而全 app 没有任何 `onRequestPermissionsResult` 实现（`requestCode = 0` 的授权结果无人接收），Dart 侧 6 处 `await invokeMethod('requestAnkidroidPermissions')` 拿到 true 就直接查 provider。**权限对话框还在屏幕上，错误已经报完了。** i18n 文案写着「请在刚弹出的系统授权对话框中允许」，代码却从不等那个对话框。

修：native 把 `MethodChannel.Result` 挂起（`pendingPermissionResult`），由新增的 `AnkiChannelHandler.onRequestPermissionsResult` 在系统回调到达时 resolve，返回五态 `granted` / `denied` / `permanently_denied` / `no_activity` / `unavailable`；`MainActivity` 新增 `onRequestPermissionsResult` 覆写转发。`requirePermission` 守卫不再自己发起请求——发起与等待收归单一职责，否则一次操作弹两次框，且守卫发的那次请求同样无人等待。

## ② 错误码两个码域不相通

native 返回裸码 `PERMISSION_DENIED`，本地化表 `localizeAnkiMineError` 匹配的却是 `AnkiErrorCode.permissionDenied == 'ANKI_PERMISSION_DENIED'`。只有制卡路径有 `_classifyMineError` 做转换；fetch 路径直传 `e.code` → `localizeAnkiFetchError` 恒查不中 → 回退显示英文原文。**「AnkiDroid 尚未授予卡片访问权限」这句中文早就写好了，只是永远显示不出来。**

建 Lapis 路径更糟：`_lapisSetupFailureMessage` 只对 AnkiConnect 传输层异常本地化，`PlatformException` 直接落进 `e.toString()`，连 code/message 都不拆。顺带修掉 `createLapisSetup` 里 fetch 失败分支漏掉的 `localizeAnkiFetchError`——同一个错误走「刷新牌组」是中文、走「建 Lapis」就变英文。

修：`_classifyMineError` 提升为唯一分类入口 `classifyPlatformError`，fetch 路径也走它。

## ③ 三种拒绝态被压成一种

没有任何 `shouldShowRequestPermissionRationale` 判断。权限被永久拒绝（Android 11+ 拒一次即「不再询问」），或 AnkiDroid 未安装（`com.ichi2.anki.permission.READ_WRITE_DATABASE` 是 AnkiDroid 自己定义的权限，没装时系统里根本不存在）时，`requestPermissions` 立即静默判拒且**不弹框**——用户在这个页面上没有任何路径能把权限授出来。这就是「没弹出申请」的观感。

修：新增 `ANKI_PERMISSION_PERMANENTLY_DENIED` / `ANKI_DROID_UNAVAILABLE` 两个稳定码与对应文案（3 key × 17 语言，经 `tool/i18n_sync.dart --add`），永久拒绝时 snackbar 给「去设置」按钮（native 新增 `openAnkiPermissionSettings`）。

## 向后兼容

- 旧 native / 现有测试桩返回 `true` 或 `null` 仍视为已授权，只有明确失败终态才短路。
- native 仍返回 `PERMISSION_DENIED` 裸码，BUG-824 的 7 条守卫原样通过。
- 副 engine（`activity == null`，BUG-865）先判「是否已授权」再判 activity，主 app 授过权时照常返回 `granted`。

## 测试

`packages/fushi_anki/test/ankidroid_permission_flow_test.dart` 新增 16 条：

- **行为层**：native 回四种非授权终态时**一个 provider 方法都不许被调到**（此前 fire-and-forget 契约下 `getDecks`/`getModelList` 照发不误），且错误码必须是带 `ANKI_` 前缀的稳定码。
- **分类层**：裸码→稳定码映射、三个权限态互不相等、message 兜底、无关异常不冒领、fetch 失败带回稳定码而非裸码。
- **native 源码扫描守卫**：`Result` 挂起、`onRequestPermissionsResult` 存在、`MainActivity` 转发、永久拒绝/未安装两态分开、`requirePermission` 不再发起请求。

**变异实测（守卫非空转）**：删掉 `MainActivity` 转发那行 → 守卫红；把非授权态改成放行 → 三条行为断言红；两次还原后源文件 sha256 与变异前逐字节一致。

## 验证

- `flutter analyze`（fushi）+ `dart analyze`（fushi_anki）全绿
- `packages/fushi_anki` 权限两文件 **23 条绿**（新 16 + 原 BUG-824 守卫 7）
- `fushi/test/anki` **306 条绿**
- `flutter build apk --debug` 通过（Java 侧编译验证，analyze 不覆盖 Android 源码）

**已知验证缺口**：真机 AnkiDroid 上的「拒绝 → 再点 → 弹框 → 允许 → 成功」与「不再询问 → 去设置」两条路径未复测，Java 侧行为目前只由源码扫描守卫覆盖。已记入 `docs/bugs/BUG-2098-ankidroid-permission-not-awaited.md` 备注。

https://claude.ai/code/session_01KMzpyLjZRuztJcbpBq5kwn
