### PR TITLE
feat(ext): 安装引导列出全部受支持 Chromium 浏览器扩展页（brave/vivaldi/opera）

### DIFF
--- a/fushi/lib/src/lookup/browser_extension_installer.dart
+++ b/fushi/lib/src/lookup/browser_extension_installer.dart
@@ -13,8 +13,14 @@ import 'package:path_provider/path_provider.dart';
 /// TODO-1087：解压时把当前 yomitan-api server 的 host/port/token 写进扩展的
 /// `fushi-defaults.js`，于是「加载已解压扩展」后无需用户手填连接信息（自动配置）。
 
-/// 目标浏览器（决定扩展管理页 URL）。
-enum BrowserKind { chrome, edge }
+/// 目标浏览器（决定扩展管理页 URL）。**只收 Chromium 系**：内置扩展是 MV3
+/// （`background.service_worker` + `sidePanel` / `offscreen` / `tabCapture` 权限 +
+/// `world: MAIN` 内容脚本），Firefox / Safari 装不上，把它们的调试页列进引导等于
+/// 指一条走不通的路。
+///
+/// 新增浏览器只需在此加一个值并补 [browserExtensionsPageUrl] 的 case——switch 是
+/// 穷尽的，漏写编译期就报错；引导 UI 按 [BrowserKind.values] 遍历渲染，不必跟着改。
+enum BrowserKind { chrome, edge, brave, vivaldi, opera }
 
 /// 纯函数：浏览器扩展管理页 URL。用于引导用户打开对应页面（外部窗无法直接导航，
 /// 复制给用户粘贴到地址栏）。
@@ -24,6 +30,12 @@ String browserExtensionsPageUrl(BrowserKind kind) {
       return 'chrome://extensions';
     case BrowserKind.edge:
       return 'edge://extensions';
+    case BrowserKind.brave:
+      return 'brave://extensions';
+    case BrowserKind.vivaldi:
+      return 'vivaldi://extensions';
+    case BrowserKind.opera:
+      return 'opera://extensions';
   }
 }
 

--- a/fushi/lib/src/pages/implementations/browser_extension_page.dart
+++ b/fushi/lib/src/pages/implementations/browser_extension_page.dart
@@ -539,7 +539,9 @@ class BrowserExtensionInstallSteps extends StatelessWidget {
           ),
           const SizedBox(height: 16),
         ],
-        // 步骤 1：打开扩展管理页（chrome:// / edge:// 无法程序化导航，给可复制文本）。
+        // 步骤 1：打开扩展管理页（这些私有 scheme 无法程序化导航，给可复制文本）。
+        // 逐个浏览器写死过一次（只有 chrome / edge），新增浏览器要记得同步改这里；
+        // 现按 [BrowserKind.values] 遍历，支持列表的唯一真相源是那个枚举。
         _step(
           context,
           index: 1,
@@ -547,12 +549,10 @@ class BrowserExtensionInstallSteps extends StatelessWidget {
           text: t.browser_extension_step_open_page,
           trailing: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 6,
             children: <Widget>[
-              _copyableField(
-                  context, browserExtensionsPageUrl(BrowserKind.chrome)),
-              const SizedBox(height: 6),
-              _copyableField(
-                  context, browserExtensionsPageUrl(BrowserKind.edge)),
+              for (final BrowserKind kind in BrowserKind.values)
+                _copyableField(context, browserExtensionsPageUrl(kind)),
             ],
           ),
         ),

--- a/fushi/test/lookup/browser_extension_installer_test.dart
+++ b/fushi/test/lookup/browser_extension_installer_test.dart
@@ -6,10 +6,27 @@ import 'package:fushi/src/lookup/browser_extension_installer.dart';
 
 void main() {
   group('browserExtensionsPageUrl', () {
-    test('chrome / edge management page urls', () {
+    test('management page url of every supported Chromium browser', () {
       expect(
           browserExtensionsPageUrl(BrowserKind.chrome), 'chrome://extensions');
       expect(browserExtensionsPageUrl(BrowserKind.edge), 'edge://extensions');
+      expect(browserExtensionsPageUrl(BrowserKind.brave), 'brave://extensions');
+      expect(browserExtensionsPageUrl(BrowserKind.vivaldi),
+          'vivaldi://extensions');
+      expect(browserExtensionsPageUrl(BrowserKind.opera), 'opera://extensions');
+    });
+
+    // 形状守卫：新增 BrowserKind 时，switch 穷尽性已保证「必须给出一个 URL」，
+    // 这里再钉住「URL 长什么样」——不能返回空串、别的浏览器已占用的 scheme，
+    // 或忘了 `://extensions` 后缀（引导页把这串原样给用户粘贴到地址栏）。
+    test('every kind maps to a distinct <scheme>://extensions url', () {
+      final Set<String> seen = <String>{};
+      for (final BrowserKind kind in BrowserKind.values) {
+        final String url = browserExtensionsPageUrl(kind);
+        expect(url, endsWith('://extensions'), reason: '$kind 的扩展页 URL 形状不对');
+        expect(url.split('://').first, isNotEmpty, reason: '$kind 缺 scheme');
+        expect(seen.add(url), isTrue, reason: '$kind 的扩展页 URL 与其它浏览器重复');
+      }
     });
   });
 

--- a/fushi/test/settings/browser_extension_install_dialog_test.dart
+++ b/fushi/test/settings/browser_extension_install_dialog_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/lookup/browser_extension_installer.dart';
 import 'package:fushi/src/pages/implementations/browser_extension_page.dart';
 import 'package:fushi/utils.dart';
 
@@ -10,8 +11,8 @@ import 'package:fushi/utils.dart';
 ///
 /// 引导原为「设置 → 查词」里的 AlertDialog，现已迁到桌面专属顶层页
 /// [BrowserExtensionPage]（仅桌面出现），分步 widget 抽成 [BrowserExtensionInstallSteps]
-/// 复用 + 暴露给测试。验证：① 分步教程渲染（编号 1..5 + chrome:// 与 edge:// 两个扩展页
-/// 步骤 + 扩展路径步骤）；② chrome://extensions / edge://extensions 与扩展路径都是「可复制
+/// 复用 + 暴露给测试。验证：① 分步教程渲染（编号 1..5 + [BrowserKind.values] 每个浏览器
+/// 一条扩展页地址 + 扩展路径步骤）；② 每条扩展页地址与扩展路径都是「可复制
 /// 字段」（点复制按钮写进剪贴板）；③ 自动配置横幅按 server/token 就绪与否切换成功/提醒文案。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -44,7 +45,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('renders numbered steps + chrome://extensions + path',
+  testWidgets('renders numbered steps + every browser extensions url + path',
       (WidgetTester tester) async {
     const String path = r'/data/fushi/fushi-browser-extension';
     await pumpSteps(tester, serverEnabled: true, hasToken: true, path: path);
@@ -53,13 +54,18 @@ void main() {
     for (final String n in <String>['1', '2', '3', '4', '5']) {
       expect(find.text(n), findsOneWidget, reason: 'missing step $n');
     }
-    // chrome://extensions 与 edge://extensions 都作为可复制字段文本存在。
-    expect(find.text('chrome://extensions'), findsOneWidget);
-    expect(find.text('edge://extensions'), findsOneWidget);
+    // 每个受支持浏览器的扩展页地址都作为可复制字段文本存在（步骤 1 按枚举遍历渲染，
+    // 新增 BrowserKind 时这里自动跟着要求它出现在引导里，不会漏渲染）。
+    expect(BrowserKind.values, hasLength(greaterThanOrEqualTo(2)));
+    for (final BrowserKind kind in BrowserKind.values) {
+      expect(find.text(browserExtensionsPageUrl(kind)), findsOneWidget,
+          reason: '$kind 的扩展页地址没渲染出来');
+    }
     // 扩展文件夹路径存在且可选中/复制。
     expect(find.text(path), findsOneWidget);
-    // 三处可复制字段（chrome + edge + 路径）各一个复制按钮。
-    expect(find.byIcon(Icons.copy), findsNWidgets(3));
+    // 可复制字段 = 每个浏览器一个 + 扩展路径一个，各带一个复制按钮。
+    expect(
+        find.byIcon(Icons.copy), findsNWidgets(BrowserKind.values.length + 1));
   });
 
   testWidgets('copy button writes the extensions url to the clipboard',
@@ -126,14 +132,27 @@ void main() {
           reason: '安装弹窗已迁到 browser_extension_page.dart');
     });
 
-    test('page lists both chrome and edge extension pages (no hardcode)', () {
+    // 原守卫断言页面里含 `browserExtensionsPageUrl(BrowserKind.chrome)` /
+    // `(BrowserKind.edge)` 两处字面调用——那正是「加一个浏览器要记得同时改 UI」的
+    // 逐浏览器硬编码。列表改为按枚举遍历后，这里换成同义但更强的判据：支持范围的
+    // 唯一真相源是 BrowserKind，页面既不逐个点名、也不自己拼 URL。
+    test('page drives the browser list from BrowserKind.values (no hardcode)',
+        () {
       final String src =
           File('lib/src/pages/implementations/browser_extension_page.dart')
               .readAsStringSync();
-      expect(src, contains('browserExtensionsPageUrl(BrowserKind.chrome)'),
-          reason: 'Chrome 扩展页地址复用纯函数');
-      expect(src, contains('browserExtensionsPageUrl(BrowserKind.edge)'),
-          reason: 'Edge 扩展页地址复用纯函数');
+      expect(
+          src, contains('for (final BrowserKind kind in BrowserKind.values)'),
+          reason: '扩展页地址列表必须按 BrowserKind.values 遍历渲染');
+      expect(src, contains('browserExtensionsPageUrl(kind)'),
+          reason: '扩展页地址复用纯函数 browserExtensionsPageUrl');
+      for (final BrowserKind kind in BrowserKind.values) {
+        expect(src, isNot(contains('BrowserKind.${kind.name}')),
+            reason: '页面不得逐个点名浏览器（BrowserKind.${kind.name}）：'
+                '新增浏览器只该改枚举，不该回来改 UI');
+      }
+      expect(src, isNot(contains('://extensions')),
+          reason: '页面不得写死扩展页 URL 字面量，一律经 browserExtensionsPageUrl 取');
     });
 
     test('browser extension tab is desktop-only (电脑才有)', () {


### PR DESCRIPTION
## 问题

扩展安装引导的步骤 1「打开浏览器扩展管理页」只给了两条地址（`chrome://extensions` / `edge://extensions`），Brave / Vivaldi / Opera 用户拿不到自己那条。

更根上的问题是：这两条是在页面里**逐个点名** `BrowserKind.chrome` / `BrowserKind.edge` 写死的——「支持哪些浏览器」同时活在枚举和 UI 两处，加一个浏览器要记得两边都改，且旧守卫恰好把这个硬编码形状钉成了不变式。

## 改动

- `BrowserKind` 补 `brave` / `vivaldi` / `opera`，`browserExtensionsPageUrl` 补对应 scheme。switch 是穷尽的，新增值漏写 case 编译期就报错。
- **只收 Chromium 系**：内置扩展是 MV3（`background.service_worker` + `sidePanel` / `offscreen` / `tabCapture` + `world: MAIN` 内容脚本），Firefox / Safari 装不上，把 `about:debugging` 之类列进引导等于指一条走不通的路。
- 引导页改按 `BrowserKind.values` 遍历渲染，支持列表的唯一真相源收敛回枚举；顺手用 `Column(spacing:)` 消掉手插 `SizedBox` 的分隔特例。

## 守卫同步

旧守卫断言页面里含 `browserExtensionsPageUrl(BrowserKind.chrome)` / `(BrowserKind.edge)` 两处字面调用——那正是本 PR 要消灭的硬编码形状，直接改数字就是拆守卫。换成同义但更强的判据：

- 必须按 `BrowserKind.values` 遍历渲染；
- 页面不得逐个点名任何 `BrowserKind.<name>`；
- 页面不得出现 `://extensions` 字面量（防止绕过枚举直接粘 URL）。

widget 断言也从写死 chrome/edge 改成遍历 `BrowserKind.values` 要求每条地址都渲染出来，复制按钮数按枚举长度推——以后加浏览器，测试自动要求它出现在引导里。

## 验证

- `flutter analyze --no-pub`：**No issues found**。
- 定向测试（8 个引用该页面/枚举的文件）：`FLUTTER TEST VERDICT: PASSED - 55 tests ran`。
- **守卫变异实测**：把页面还原成逐浏览器硬编码后，源码守卫（枚举遍历断言）与 widget 渲染断言双双转红；变异已按唯一锚点精确还原，`git diff` 复核只剩预期改动。

## 已知遗留（本 PR 未动）

两条 i18n 文案仍写死浏览器名，与新列表口径不一致，但改值要动 17 个语言文件（15 种语言会欠翻译债），故单独拆出：

- `browser_extension_page_intro`：“… right inside Chrome or Edge …”
- `browser_extension_version_mismatch`：举例仍只提 `(chrome://extensions)`

两条都不算错（Chrome/Edge 确实支持），只是没覆盖新增的三个浏览器。

https://claude.ai/code/session_0119THNHCaNEZcJweLiPSF1X
