### PR TITLE
fix(onboarding): 推荐包下载改由 app 级 controller 持有，走完向导不再被静默取消（BUG-2097）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1964 条。点号进各自文件。
+> 共 1965 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2097](bugs/BUG-2097-onboarding-pack-download-cancelled-on-leave.md) | ✅ | ✅ | 新手引导推荐包下载在离开向导时被静默取消，且没有任何看进度的地方 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |
 | [BUG-2088](bugs/BUG-2088-release-notes-never-reach-update-dialog.md) | ✅ | ✅ | 正式版更新公告进不了应用内更新弹窗，用户看到的是一行占位符 |

--- a/docs/bugs/BUG-2097-onboarding-pack-download-cancelled-on-leave.md
+++ b/docs/bugs/BUG-2097-onboarding-pack-download-cancelled-on-leave.md
@@ -1,0 +1,9 @@
+## BUG-2097 · 新手引导推荐包下载在离开向导时被静默取消，且没有任何看进度的地方
+- **报告**：2026-09-03（用户：走完新手教程时没等推荐包下完就进了下一步，问「会不会在后台下载」，并要求如果是后台下载就得有地方看进度）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/onboarding_wizard_page.dart:176`（修复前）——下载器、进度 notifier 和 `CancelToken` 全是 `_OnboardingWizardPageState` 的字段，`dispose()` 里一句 `_packCancelToken?.cancel()`。于是：
+  - **走完/关掉向导 = 下载被静默掐断**：向导一 pop，State 就 dispose，9.5 GB 的下载当场取消。没有提示、没有通知，用户以为它还在后台跑（半截文件保留可续传，所以进度不算全丢，但不点第二次就永远不会继续）。
+  - **走到下一步 = 进度整个消失**：进度条只画在推荐包那一步里，离开那一步就什么都看不到，也没有第二个入口能看到它。
+  - 文案 `onboarding_pack_action_download_desc`（「后台从多个来源同时下载，下完自动导入」）承诺的「后台」在页面被销毁时并不成立。
+- **[x] ① 已修复** — 任务所有权从向导页 State 上移到 app 级 `RecommendedPackDownloadController`（挂 `AppModel`，与词典下载 BUG-1499 同一条纪律），向导退化成它的一个视图：`dispose()` 不再取消，走下一步/关掉向导下载照跑；下完停在「已下载待导入」（导入要用户确认并重启进程，controller 不替用户按）。新增设置 → 系统里的常驻进度行（下载中报进度+可取消，下完可就地导入），后台下完额外出一次 toast。提交见 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/onboarding/recommended_pack_download_controller_test.dart`（任务与视图脱钩、取消不算失败、真失败写 error、互斥、进场按磁盘定阶段、进度文案）、`fushi/test/onboarding/recommended_pack_download_row_test.dart`（设置行三态渲染 + 导入回调）、`fushi/test/onboarding/recommended_pack_background_download_guard_test.dart`（源码守卫：向导页不得再持有 CancelToken/下载器、所有权在 AppModel、存在不依赖向导的可见入口且订阅阶段变化）。
+- **备注**：真机复测未做（真实路径要下 9.5 GB 整包）；已验证的是 controller 行为、设置行渲染与结构守卫。修复不改下载器本身（分片并发/续传/sha256 校验一行未动）。

--- a/fushi/integration_test/onboarding_pack_background_download_itest.dart
+++ b/fushi/integration_test/onboarding_pack_background_download_itest.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:fushi/main.dart' as app;
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/onboarding/recommended_pack.dart'
+    show kRecommendedPackFileName, kRecommendedPackSizeLabel;
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
+import 'package:fushi/src/pages/implementations/onboarding_wizard_page.dart'
+    show OnboardingWizardPage;
+import 'package:fushi/src/settings/settings_detail_page.dart';
+import 'package:fushi/src/settings/settings_schema_system.dart'
+    show buildSystemDestination;
+import 'package:fushi/utils.dart' show t;
+
+import 'helpers/focus_driver.dart';
+import 'helpers/library_fixture.dart' show readyAppModel;
+
+/// BUG-2097 真机回归：**在真 app 里**走用户报的那条路——新手引导里点下载推荐包，
+/// 不等它下完就走下一步、直到走完整个引导——然后断言下载还活着。
+///
+/// 修复前这里必然红：下载器与 `CancelToken` 活在向导页的 State 上，向导一 pop
+/// 就 `cancel()`，9.5 GB 静默断流且没有任何地方还看得见它。
+///
+/// 整条路径都是真的（真 `app.main()`、真向导、焦点驱动真按钮、真 controller、真
+/// dispose），只有最外层的下载体换成替身——不然这条测试要真下 9.5 GB。
+///
+/// 运行（PowerShell，在 fushi/ 下）：
+///   .\tool\run_windows_itest.ps1
+///     integration_test\onboarding_pack_background_download_itest.dart
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('推荐包下载不随新手引导关闭而被取消，且有常驻进度入口', (WidgetTester tester) async {
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    try {
+      app.main();
+
+      for (
+        int i = 0;
+        i < 120 && find.byType(OnboardingWizardPage).evaluate().isEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      expect(find.byType(OnboardingWizardPage), findsOneWidget);
+
+      final AppModel appModel = await readyAppModel(tester);
+      await appModel.setExperimentalFocusNavigationEnabled(true);
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final RecommendedPackDownloadController controller =
+          appModel.recommendedPackDownloadController;
+      final Completer<File> finishDownload = Completer<File>();
+      bool cancelledByApp = false;
+      controller.runner =
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) {
+            unawaited(
+              cancelToken.whenCancel.then((DioError _) {
+                cancelledByApp = true;
+              }),
+            );
+            progress.value = 0.42;
+            receivedBytes.value = 4 * 1024 * 1024 * 1024;
+            return finishDownload.future;
+          };
+
+      final FocusDriver driver = FocusDriver(tester);
+      final Finder downloadAction = find.text(
+        '${t.onboarding_step_pack_download_action}'
+        ' ($kRecommendedPackSizeLabel)',
+      );
+
+      // 1) 一路「下一步」走到推荐包那一步。
+      bool reachedPackStep = false;
+      for (int guard = 0; guard < 12 && !reachedPackStep; guard++) {
+        if (downloadAction.evaluate().isNotEmpty) {
+          reachedPackStep = true;
+          break;
+        }
+        final Finder next = find.text(t.onboarding_action_next);
+        expect(next, findsOneWidget, reason: '每一步都该有「下一步」');
+        expect(await driver.focusWidget(next, maxSteps: 120), isTrue);
+        await driver.activate();
+        await tester.pump(const Duration(milliseconds: 600));
+      }
+      expect(reachedPackStep, isTrue, reason: '走不到推荐包步骤');
+
+      // 2) 焦点驱动点下「下载并导入」。
+      expect(await driver.focusWidget(downloadAction, maxSteps: 160), isTrue);
+      await driver.activate();
+      for (int i = 0; i < 40 && !controller.isDownloading; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(controller.isDownloading, isTrue, reason: '下载没起来');
+
+      // 进度与「可以走开」的说明都在这一步上可见。
+      expect(find.textContaining('4.0 GB (42%)'), findsOneWidget);
+      expect(
+        find.text(t.onboarding_pack_download_background_hint),
+        findsOneWidget,
+      );
+
+      // 3) 用户报的第一步：不等下完就走下一步。
+      final Finder nextAfterDownload = find.text(t.onboarding_action_next);
+      expect(nextAfterDownload, findsOneWidget);
+      expect(
+        await driver.focusWidget(nextAfterDownload, maxSteps: 160),
+        isTrue,
+      );
+      await driver.activate();
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(
+        controller.isDownloading,
+        isTrue,
+        reason: '走下一步就把下载掐了 —— BUG-2097 的一半',
+      );
+
+      // 4) 用户报的第二步：把整个引导走完（向导 pop → State dispose）。
+      for (
+        int guard = 0;
+        guard < 20 && find.byType(OnboardingWizardPage).evaluate().isNotEmpty;
+        guard++
+      ) {
+        final bool hasNext = find
+            .text(t.onboarding_action_next)
+            .evaluate()
+            .isNotEmpty;
+        final Finder primary = hasNext
+            ? find.text(t.onboarding_action_next)
+            : find.text(t.onboarding_action_start);
+        if (primary.evaluate().isEmpty) break;
+        expect(await driver.focusWidget(primary, maxSteps: 160), isTrue);
+        await driver.activate();
+        await tester.pump(const Duration(milliseconds: 600));
+      }
+      for (
+        int i = 0;
+        i < 40 && find.byType(OnboardingWizardPage).evaluate().isNotEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(find.byType(OnboardingWizardPage), findsNothing);
+      expect(appModel.onboardingCompleted, isTrue);
+
+      expect(
+        cancelledByApp,
+        isFalse,
+        reason: '向导 dispose 取消了下载 —— 这正是 BUG-2097 的根因',
+      );
+      expect(
+        controller.isDownloading,
+        isTrue,
+        reason: '走完引导后下载必须还活着（文案承诺的「后台下载」）',
+      );
+
+      // 5) 「后台在下」必须看得见：设置 → 系统里那一行报同一个任务的进度。
+      final NavigatorState navigator = appModel.navigatorKey.currentState!;
+      unawaited(
+        navigator.push(
+          MaterialPageRoute<void>(
+            builder: (_) =>
+                SettingsDetailPage(destination: buildSystemDestination()),
+          ),
+        ),
+      );
+      for (
+        int i = 0;
+        i < 40 && find.byType(SettingsDetailPage).evaluate().isEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(find.byType(SettingsDetailPage), findsOneWidget);
+      await tester.pump(const Duration(seconds: 1));
+      expect(
+        find.text(t.onboarding_pack_status_downloading),
+        findsOneWidget,
+        reason: '设置里看不到它 = 「在后台跑」等于没跑',
+      );
+      expect(find.text('4.0 GB (42%)'), findsOneWidget);
+
+      // 6) 下完之后停在「待导入」（导入要用户确认并重启进程，不自动按下去）。
+      controller.packDir.createSync(recursive: true);
+      final File packFile = File(
+        '${controller.packDir.path}${Platform.pathSeparator}'
+        '$kRecommendedPackFileName',
+      );
+      packFile.writeAsStringSync('pack');
+      finishDownload.complete(packFile);
+      for (int i = 0; i < 40 && !controller.hasPendingImport; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(controller.hasPendingImport, isTrue);
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.text(t.onboarding_pack_status_ready), findsOneWidget);
+      expect(find.text(t.onboarding_pack_import_now), findsOneWidget);
+
+      expect(tester.takeException(), isNull);
+
+      // 收尾：别把测试用的假包留在磁盘上。
+      if (packFile.existsSync()) packFile.deleteSync();
+      controller.syncStageWithDisk();
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+  });
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71060 (4180 per locale)
+/// Strings: 71145 (4185 per locale)
 ///
-/// Built on 2026-09-03 at 03:52 UTC
+/// Built on 2026-09-03 at 15:35 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5734,6 +5734,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connected. Root catalog has ${count} entries';
   String discovery_opds_test_failed({required Object reason}) =>
       'Connection failed: ${reason}';
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  String get onboarding_pack_import_now => 'Import now';
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -15474,6 +15482,19 @@ class _StringsAr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'فشل الاتصال: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -25441,6 +25462,19 @@ class _StringsDe extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbindung fehlgeschlagen: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -35460,6 +35494,19 @@ class _StringsEs extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Error de conexión: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -45514,6 +45561,19 @@ class _StringsFr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Échec de la connexion : ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -55373,6 +55433,19 @@ class _StringsId extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Koneksi gagal: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -65323,6 +65396,19 @@ class _StringsIt extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Connessione non riuscita: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -74661,6 +74747,19 @@ class _StringsJa extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '接続に失敗しました: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -84009,6 +84108,19 @@ class _StringsKo extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '연결 실패: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -93914,6 +94026,19 @@ class _StringsNl extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbinding mislukt: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -103873,6 +103998,19 @@ class _StringsPtBr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Falha na conexão: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -113811,6 +113949,19 @@ class _StringsRu extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Не удалось подключиться: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -123547,6 +123698,19 @@ class _StringsTh extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'เชื่อมต่อไม่สำเร็จ: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -133400,6 +133564,19 @@ class _StringsTr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Bağlantı başarısız: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -143224,6 +143401,19 @@ class _StringsVi extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Kết nối thất bại: ${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 // Path: <root>
@@ -152251,6 +152441,17 @@ class _StringsZhCn extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '连接失败：${reason}';
+  @override
+  String get onboarding_pack_status_downloading => '推荐包下载中';
+  @override
+  String get onboarding_pack_status_ready => '推荐包已下载完成';
+  @override
+  String get onboarding_pack_import_now => '现在导入';
+  @override
+  String get onboarding_pack_download_finished => '推荐包下载完成。可在「设置 → 系统」里导入。';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      '下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。';
 }
 
 // Path: <root>
@@ -161283,6 +161484,19 @@ class _StringsZhHk extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '連線失敗：${reason}';
+  @override
+  String get onboarding_pack_status_downloading =>
+      'Downloading recommended pack';
+  @override
+  String get onboarding_pack_status_ready => 'Recommended pack downloaded';
+  @override
+  String get onboarding_pack_import_now => 'Import now';
+  @override
+  String get onboarding_pack_download_finished =>
+      'Recommended pack finished downloading. Import it from Settings → System.';
+  @override
+  String get onboarding_pack_download_background_hint =>
+      'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
 }
 
 /// Flat map(s) containing all translations.
@@ -169859,6 +170073,16 @@ extension on _StringsEn {
             'Connected. Root catalog has ${count} entries';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Connection failed: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -178430,6 +178654,16 @@ extension on _StringsAr {
             'تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'فشل الاتصال: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -187046,6 +187280,16 @@ extension on _StringsDe {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Verbindung fehlgeschlagen: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -195653,6 +195897,16 @@ extension on _StringsEs {
             'Conectado. El catálogo raíz tiene ${count} entradas';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Error de conexión: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -204269,6 +204523,16 @@ extension on _StringsFr {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Échec de la connexion : ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -212856,6 +213120,16 @@ extension on _StringsId {
             'Terhubung. Katalog akar berisi ${count} entri';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Koneksi gagal: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -221465,6 +221739,16 @@ extension on _StringsIt {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Connessione non riuscita: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -230001,6 +230285,16 @@ extension on _StringsJa {
         return ({required Object count}) => '接続しました。ルートカタログに ${count} 件あります';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '接続に失敗しました: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -238541,6 +238835,16 @@ extension on _StringsKo {
             '연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '연결 실패: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -247143,6 +247447,16 @@ extension on _StringsNl {
             'Verbonden. De hoofdcatalogus heeft ${count} items';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Verbinding mislukt: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -255740,6 +256054,16 @@ extension on _StringsPtBr {
             'Conectado. O catálogo raiz tem ${count} itens';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Falha na conexão: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -264344,6 +264668,16 @@ extension on _StringsRu {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Не удалось подключиться: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -272920,6 +273254,16 @@ extension on _StringsTh {
             'เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'เชื่อมต่อไม่สำเร็จ: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -281511,6 +281855,16 @@ extension on _StringsTr {
             'Bağlanıldı. Kök katalogda ${count} girdi var';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Bağlantı başarısız: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -290096,6 +290450,16 @@ extension on _StringsVi {
             'Đã kết nối. Danh mục gốc có ${count} mục';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Kết nối thất bại: ${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }
@@ -298609,6 +298973,16 @@ extension on _StringsZhCn {
         return ({required Object count}) => '连接成功，根目录有 ${count} 个条目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '连接失败：${reason}';
+      case 'onboarding_pack_status_downloading':
+        return '推荐包下载中';
+      case 'onboarding_pack_status_ready':
+        return '推荐包已下载完成';
+      case 'onboarding_pack_import_now':
+        return '现在导入';
+      case 'onboarding_pack_download_finished':
+        return '推荐包下载完成。可在「设置 → 系统」里导入。';
+      case 'onboarding_pack_download_background_hint':
+        return '下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。';
       default:
         return null;
     }
@@ -307123,6 +307497,16 @@ extension on _StringsZhHk {
         return ({required Object count}) => '連線成功，根目錄有 ${count} 個項目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '連線失敗：${reason}';
+      case 'onboarding_pack_status_downloading':
+        return 'Downloading recommended pack';
+      case 'onboarding_pack_status_ready':
+        return 'Recommended pack downloaded';
+      case 'onboarding_pack_import_now':
+        return 'Import now';
+      case 'onboarding_pack_download_finished':
+        return 'Recommended pack finished downloading. Import it from Settings → System.';
+      case 'onboarding_pack_download_background_hint':
+        return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Needed for a self-hosted server on your local network",
   "discovery_opds_test": "Test connection",
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
-  "discovery_opds_test_failed": "Connection failed: ${reason}"
+  "discovery_opds_test_failed": "Connection failed: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "مطلوب لخادم ذاتي الاستضافة على شبكتك المحلية",
   "discovery_opds_test": "اختبار الاتصال",
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
-  "discovery_opds_test_failed": "فشل الاتصال: ${reason}"
+  "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Nötig für einen selbst gehosteten Server im lokalen Netzwerk",
   "discovery_opds_test": "Verbindung testen",
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
-  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}"
+  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Necesario para un servidor autoalojado en tu red local",
   "discovery_opds_test": "Probar conexión",
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
-  "discovery_opds_test_failed": "Error de conexión: ${reason}"
+  "discovery_opds_test_failed": "Error de conexión: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Nécessaire pour un serveur auto-hébergé sur votre réseau local",
   "discovery_opds_test": "Tester la connexion",
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
-  "discovery_opds_test_failed": "Échec de la connexion : ${reason}"
+  "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Diperlukan untuk server milik sendiri di jaringan lokal",
   "discovery_opds_test": "Uji koneksi",
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
-  "discovery_opds_test_failed": "Koneksi gagal: ${reason}"
+  "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Necessario per un server self-hosted sulla rete locale",
   "discovery_opds_test": "Prova connessione",
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
-  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}"
+  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "ローカルネットワークの自前サーバーに必要です",
   "discovery_opds_test": "接続をテスト",
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
-  "discovery_opds_test_failed": "接続に失敗しました: ${reason}"
+  "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "로컬 네트워크의 자체 호스팅 서버에 필요합니다",
   "discovery_opds_test": "연결 테스트",
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
-  "discovery_opds_test_failed": "연결 실패: ${reason}"
+  "discovery_opds_test_failed": "연결 실패: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Nodig voor een zelfgehoste server in je lokale netwerk",
   "discovery_opds_test": "Verbinding testen",
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
-  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}"
+  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Necessário para um servidor auto-hospedado na sua rede local",
   "discovery_opds_test": "Testar conexão",
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
-  "discovery_opds_test_failed": "Falha na conexão: ${reason}"
+  "discovery_opds_test_failed": "Falha na conexão: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Нужно для сервера, размещённого в вашей локальной сети",
   "discovery_opds_test": "Проверить соединение",
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
-  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}"
+  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "จำเป็นสำหรับเซิร์ฟเวอร์ที่โฮสต์เองในเครือข่ายภายใน",
   "discovery_opds_test": "ทดสอบการเชื่อมต่อ",
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
-  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}"
+  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Yerel ağdaki kendi sunucun için gerekli",
   "discovery_opds_test": "Bağlantıyı sına",
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
-  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}"
+  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "Cần thiết cho máy chủ tự dựng trong mạng nội bộ",
   "discovery_opds_test": "Kiểm tra kết nối",
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
-  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}"
+  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "局域网自建服务器需要打开",
   "discovery_opds_test": "测试连接",
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
-  "discovery_opds_test_failed": "连接失败：${reason}"
+  "discovery_opds_test_failed": "连接失败：${reason}",
+  "onboarding_pack_status_downloading": "推荐包下载中",
+  "onboarding_pack_status_ready": "推荐包已下载完成",
+  "onboarding_pack_import_now": "现在导入",
+  "onboarding_pack_download_finished": "推荐包下载完成。可在「设置 → 系统」里导入。",
+  "onboarding_pack_download_background_hint": "下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4178,5 +4178,10 @@
   "discovery_opds_allow_http_hint": "區域網絡自建伺服器需要開啟",
   "discovery_opds_test": "測試連線",
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
-  "discovery_opds_test_failed": "連線失敗：${reason}"
+  "discovery_opds_test_failed": "連線失敗：${reason}",
+  "onboarding_pack_status_downloading": "Downloading recommended pack",
+  "onboarding_pack_status_ready": "Recommended pack downloaded",
+  "onboarding_pack_import_now": "Import now",
+  "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -27,6 +27,7 @@ import 'package:fushi/pages.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/media/override_thumbnail_migration.dart';
 import 'package:fushi/src/models/dictionary_download_controller.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
 import 'package:fushi/src/storage/app_paths.dart';
 import 'package:fushi/src/storage/books_directory.dart';
 import 'package:fushi/src/storage/export_directory.dart';
@@ -943,6 +944,16 @@ class AppModel with ChangeNotifier {
   /// 的**唯一互斥点**（两条流程的导入共用同一个 `import_temp` 暂存目录，并发会互删）。
   final DictionaryDownloadController dictionaryDownloadController =
       DictionaryDownloadController();
+
+  /// BUG-2097：新手引导推荐包（9.5 GB 整包）下载任务的所有权持有者。同样挂在
+  /// [AppModel] 上：此前它活在向导页的 State 里，向导 `dispose()` 直接 cancel，
+  /// 于是「点下载 → 走下一步 → 走完向导」就把下载静默掐断，而且没有任何地方还能
+  /// 看到它。包目录惰性求值——本字段在 [appDirectory] 定下来之前就构造。
+  late final RecommendedPackDownloadController
+      recommendedPackDownloadController = RecommendedPackDownloadController(
+    packDirectory: () =>
+        Directory(path.join(appDirectory.path, 'recommended_pack')),
+  );
 
   late FileExportManager _fileExportManager;
   late LocalAudioManager _localAudioManager;
@@ -6315,6 +6326,7 @@ class AppModel with ChangeNotifier {
       _themeListenerAdded = false;
     }
     dictionaryDownloadController.dispose();
+    recommendedPackDownloadController.dispose();
     dictionaryEntriesNotifier.dispose();
     dictionarySearchAgainNotifier.dispose();
     dictionaryMenuNotifier.dispose();

--- a/fushi/lib/src/onboarding/recommended_pack_download_controller.dart
+++ b/fushi/lib/src/onboarding/recommended_pack_download_controller.dart
@@ -1,0 +1,249 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:fushi/src/onboarding/recommended_pack.dart';
+import 'package:fushi/utils.dart';
+
+/// 推荐包（9.5 GB 的词典 + 发音库整包）下载任务所处的阶段。
+///
+/// 「下完」与「已导入」是两件事：导入要用户在确认框里选覆盖/合并、并且**重启
+/// 进程**，controller 不能替用户做这一步 —— 所以下完之后停在
+/// [downloaded] 等一个显式的导入动作，而不是直接回 [idle]。
+enum RecommendedPackDownloadStage {
+  /// 无任务在跑，磁盘上也没有下好待导入的整包。
+  idle,
+
+  /// 正在下载（可取消；取消保留半截文件，下次续传）。
+  downloading,
+
+  /// 整包已下完躺在磁盘上，等用户确认导入。
+  downloaded,
+}
+
+/// 真正干活的下载体。默认实现是 [RecommendedPackDownloadController] 自己的
+/// 清单解析 + 分片并发下载；测试注入替身，不碰真网络。
+typedef RecommendedPackDownloadRunner =
+    Future<File> Function({
+      required Directory packDir,
+      required ValueNotifier<double> progress,
+      required ValueNotifier<int> receivedBytes,
+      required CancelToken cancelToken,
+    });
+
+/// 推荐包下载任务的**所有权持有者**（挂在 `AppModel` 上，生命周期与 app 一致）。
+///
+/// BUG-2097 根因：任务原本活在新手引导页的 State 里 —— 下载器、进度 notifier、
+/// `CancelToken` 全是 `_OnboardingWizardPageState` 的字段，而它的 `dispose()` 里
+/// 有一句 `_packCancelToken?.cancel()`。于是「点了下载 → 走下一步 → 走完向导」
+/// 这条最普通的路径上，向导一 pop，9.5 GB 的下载就被静默取消：没有提示、没有
+/// 通知、也没有任何地方还能看到它。文案（`onboarding_pack_action_download_desc`）
+/// 承诺的「后台下载」在页面被销毁时并不成立。
+///
+/// 修法与词典下载（[DictionaryDownloadController]，BUG-1499）同一条纪律：任务
+/// 所有权上移到本 controller，页面退化成它的一个**视图** —— 关掉向导只是不看，
+/// 下载照跑；进度另有常驻入口（设置 → 系统 → 推荐包那一行）可看、可取消、
+/// 可导入。
+///
+/// 本 controller **不自己发起导入**：导入走
+/// `runBackupImportFlowForFile`（要用户确认覆盖/合并，随后重启进程），由发起
+/// 下载的向导（若还活着）或设置里那一行显式触发。
+class RecommendedPackDownloadController {
+  RecommendedPackDownloadController({
+    required Directory Function() packDirectory,
+    RecommendedPackDownloadRunner? runner,
+    void Function(String message, ToastSeverity severity)? showOutcome,
+  }) : _packDirectory = packDirectory,
+       _runner = runner,
+       _showOutcome = showOutcome ?? _defaultShowOutcome;
+
+  static void _defaultShowOutcome(String message, ToastSeverity severity) {
+    FushiToast.show(
+      msg: message,
+      severity: severity,
+      toastLength: Toast.LENGTH_LONG,
+    );
+  }
+
+  /// 包目录解析器（`<appDirectory>/recommended_pack`）。**惰性**：controller 在
+  /// `AppModel` 字段初始化时就构造，那时 `appDirectory` 还没定。
+  final Directory Function() _packDirectory;
+
+  RecommendedPackDownloadRunner? _runner;
+
+  /// 下载体替身注入点。整包 9.5 GB：集成测试要在**真 app**里验「离开向导下载还在
+  /// 不在」，就不能真去下——但那条路径上的一切（真向导、真按钮、真 controller、
+  /// 真 dispose）都必须是真的，所以替身只换最外面这一层。
+  @visibleForTesting
+  set runner(RecommendedPackDownloadRunner? value) => _runner = value;
+  final void Function(String message, ToastSeverity severity) _showOutcome;
+
+  /// 当前阶段。向导步骤与设置那一行都订阅它决定显示什么。
+  final ValueNotifier<RecommendedPackDownloadStage> stage =
+      ValueNotifier<RecommendedPackDownloadStage>(
+        RecommendedPackDownloadStage.idle,
+      );
+
+  /// 0..1 的下载比例；0 = 总大小未知（进度条退化为不定态）。
+  final ValueNotifier<double> progress = ValueNotifier<double>(0);
+
+  /// 已收字节（含续传前已在磁盘上的半截）。
+  final ValueNotifier<int> receivedBytes = ValueNotifier<int>(0);
+
+  /// 最近一次失败原因；null = 无错。用户取消**不是**失败，不写这里。
+  final ValueNotifier<String?> error = ValueNotifier<String?>(null);
+
+  /// 清单解析出的下载器，整个会话只解析一次 —— 同一会话内 URL 抖动会打断续传。
+  RecommendedPackDownloader? _manifestDownloader;
+
+  CancelToken? _cancelToken;
+
+  Directory get packDir => _packDirectory();
+
+  File get packFile => RecommendedPackDownloader.packFileIn(packDir);
+
+  bool get isDownloading =>
+      stage.value == RecommendedPackDownloadStage.downloading;
+
+  /// 整包已下完、等一个导入动作。
+  bool get hasPendingImport =>
+      stage.value == RecommendedPackDownloadStage.downloaded;
+
+  /// 有任何值得给用户看的状态（下载中 / 下完待导入）。设置里那一行据此显隐。
+  bool get isActive => stage.value != RecommendedPackDownloadStage.idle;
+
+  /// 按磁盘现状对齐阶段（下载中时不动）。向导/设置进场时调，让「上次下完但没
+  /// 导入」「上次导入完已删包」这两种历史状态都能被如实显示。
+  void syncStageWithDisk() {
+    if (isDownloading) return;
+    _settleStageFromDisk();
+  }
+
+  /// 无条件按磁盘定阶段。任务收尾（取消/失败）时用它——那时 [stage] 还停在
+  /// [RecommendedPackDownloadStage.downloading]，[syncStageWithDisk] 的
+  /// 「下载中不动」守卫会把这次收尾整个跳过，任务就永远卡在下载中。
+  void _settleStageFromDisk() {
+    stage.value = RecommendedPackDownloader.hasCompletedFileIn(packDir)
+        ? RecommendedPackDownloadStage.downloaded
+        : RecommendedPackDownloadStage.idle;
+  }
+
+  /// 包目录的进场收尾：删掉「已导入」的残包、把改名前的旧半截文件搬到新名字，
+  /// 再对齐阶段。下载中时整体跳过 —— 这些都是在动同一批文件。
+  Future<void> prepareDiskState() async {
+    if (isDownloading) return;
+    final Directory dir = packDir;
+    await RecommendedPackDownloader.cleanupIfImported(dir);
+    RecommendedPackDownloader.migrateLegacyArtifacts(dir);
+    syncStageWithDisk();
+  }
+
+  /// 开始（或续传）下载。返回下好的整包；被取消/失败返回 null。
+  ///
+  /// **互斥**：已有任务在跑时直接返回 null，不排队、不并发（两份下载写同一个
+  /// 半截文件会互相踩）。任务在本 controller 的作用域里跑完，与发起它的页面是否
+  /// 还活着无关。
+  Future<File?> start() async {
+    if (isDownloading) return null;
+    error.value = null;
+    progress.value = 0;
+    receivedBytes.value = 0;
+    final CancelToken cancelToken = CancelToken();
+    _cancelToken = cancelToken;
+    stage.value = RecommendedPackDownloadStage.downloading;
+    try {
+      final File file = await (_runner ?? _runRealDownload)(
+        packDir: packDir,
+        progress: progress,
+        receivedBytes: receivedBytes,
+        cancelToken: cancelToken,
+      );
+      stage.value = RecommendedPackDownloadStage.downloaded;
+      // 后台下完必须有声响：用户可能早就离开向导了，不然 9.5 GB 下完之后
+      // 屏幕上不会有任何变化。
+      _showOutcome(t.onboarding_pack_download_finished, ToastSeverity.success);
+      return file;
+    } on DioError catch (e) {
+      // 用户取消：半截文件保留，下次续传；非取消才示错。
+      // （仓库钉 dio 5.1，类型名还是 `DioError`，与其余下载路径一致。）
+      if (e.type != DioErrorType.cancel) {
+        _failWith(e.message ?? e.toString());
+      }
+      _settleStageFromDisk();
+      return null;
+    } catch (e) {
+      _failWith(e.toString());
+      _settleStageFromDisk();
+      return null;
+    } finally {
+      _cancelToken = null;
+    }
+  }
+
+  void _failWith(String message) {
+    error.value = message;
+    _showOutcome(
+      t.onboarding_pack_download_failed(message: message),
+      ToastSeverity.error,
+    );
+  }
+
+  /// 请求取消当前下载。半截文件保留供下次续传。
+  void requestCancel() => _cancelToken?.cancel('recommended pack cancelled');
+
+  /// 导入即将真正开始时给包目录落「已导入」flag：导入会重启进程，重启回来由
+  /// [prepareDiskState] 删掉这 9.5 GB。
+  Future<void> markImportStarted() =>
+      RecommendedPackDownloader.markImportStarted(packDir);
+
+  /// 真实下载：先拉稳定清单拿分片表与来源表（换包零发版），拉不到就退到内置的
+  /// 整包直链单流下载。
+  Future<File> _runRealDownload({
+    required Directory packDir,
+    required ValueNotifier<double> progress,
+    required ValueNotifier<int> receivedBytes,
+    required CancelToken cancelToken,
+  }) async {
+    if (_manifestDownloader == null) {
+      final RecommendedPackManifest? manifest =
+          await fetchRecommendedPackManifest();
+      if (manifest != null) {
+        _manifestDownloader = RecommendedPackDownloader.fromManifest(
+          packDir: packDir,
+          manifest: manifest,
+        );
+      }
+    }
+    final RecommendedPackDownloader downloader =
+        _manifestDownloader ??
+        RecommendedPackDownloader(
+          packDir: packDir,
+          url: kRecommendedPackGoogleDriveDirectUrl,
+        );
+    return downloader.download(
+      progress: progress,
+      receivedBytes: receivedBytes,
+      cancelToken: cancelToken,
+    );
+  }
+
+  void dispose() {
+    stage.dispose();
+    progress.dispose();
+    receivedBytes.dispose();
+    error.dispose();
+  }
+}
+
+/// 已下量文案：`3.2 GB (34%)`；总大小未知（服务器不报 length）时只报字节数。
+/// 向导步骤与设置那一行共用，两处不再各写一份 GB 除法。
+String recommendedPackProgressLabel({
+  required double progress,
+  required int receivedBytes,
+}) {
+  final String received = FushiByteFormat.bytes(receivedBytes);
+  if (progress <= 0) return received;
+  final String percent = (progress * 100).clamp(0, 100).toStringAsFixed(0);
+  return '$received ($percent%)';
+}

--- a/fushi/lib/src/onboarding/recommended_pack_download_row.dart
+++ b/fushi/lib/src/onboarding/recommended_pack_download_row.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
+import 'package:fushi/utils.dart';
+
+/// 推荐包下载的**常驻**可见入口（设置 → 系统 → 通用）。
+///
+/// BUG-2097：下载的所有权已上移到 [RecommendedPackDownloadController]，关掉新手
+/// 引导不再取消它 —— 但「在后台跑」如果没有任何地方看得到，等于没跑。这一行就是
+/// 那个地方：下载中报进度并能取消，下完报「待导入」并能就地导入。
+///
+/// 空闲（没在下、也没有下好待导入的包）时整行不渲染：设置页不该常驻一条恒为
+/// 「无任务」的死行。
+class RecommendedPackDownloadRow extends StatelessWidget {
+  const RecommendedPackDownloadRow({
+    required this.controller,
+    required this.onImport,
+    super.key,
+  });
+
+  final RecommendedPackDownloadController controller;
+
+  /// 导入已下好的整包。导入要用户确认覆盖/合并并重启进程，controller 不自己发起，
+  /// 由宿主（设置页 / 新手引导）传进来。
+  final VoidCallback onImport;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: Listenable.merge(<Listenable>[
+        controller.stage,
+        controller.progress,
+        controller.receivedBytes,
+      ]),
+      builder: (BuildContext context, _) {
+        switch (controller.stage.value) {
+          case RecommendedPackDownloadStage.idle:
+            return const SizedBox.shrink();
+          case RecommendedPackDownloadStage.downloading:
+            return AdaptiveSettingsRow(
+              title: t.onboarding_pack_status_downloading,
+              subtitle: recommendedPackProgressLabel(
+                progress: controller.progress.value,
+                receivedBytes: controller.receivedBytes.value,
+              ),
+              icon: Icons.downloading_outlined,
+              showIcon: true,
+              controlBelow: true,
+              trailing: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  LinearProgressIndicator(
+                    value: controller.progress.value > 0
+                        ? controller.progress.value
+                        : null,
+                  ),
+                  Align(
+                    alignment: AlignmentDirectional.centerEnd,
+                    child: TextButton(
+                      onPressed: controller.requestCancel,
+                      child: Text(t.dialog_cancel),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          case RecommendedPackDownloadStage.downloaded:
+            return AdaptiveSettingsRow(
+              title: t.onboarding_pack_status_ready,
+              subtitle: t.onboarding_pack_action_import_existing_desc,
+              icon: Icons.inventory_2_outlined,
+              showIcon: true,
+              trailing: FilledButton(
+                onPressed: onImport,
+                child: Text(t.onboarding_pack_import_now),
+              ),
+            );
+        }
+      },
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show ByteData, rootBundle;
@@ -13,6 +12,7 @@ import 'package:fushi/src/media/audiobook/book_import_dialog.dart';
 import 'package:fushi/src/onboarding/onboarding_sample_text.dart';
 import 'package:fushi/src/onboarding/onboarding_steps.dart';
 import 'package:fushi/src/onboarding/recommended_pack.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
 import 'package:fushi/src/settings/settings_actions.dart'
     show buildLanguageSelector, buildBrightnessSelector;
 import 'package:fushi/src/settings/settings_context.dart';
@@ -36,7 +36,6 @@ import 'package:fushi_anki/fushi_anki.dart'
 import 'package:fushi_audio/fushi_audio.dart'
     show AudiobookRepository, SrtBookRepository;
 import 'package:fushi_dictionary/fushi_dictionary.dart' show Dictionary;
-import 'package:path/path.dart' as p;
 import 'package:url_launcher/url_launcher.dart';
 
 /// Anki 生态外链（Anki 步骤「先把 Anki 装起来」的出口；AnkiConnect 插件不走
@@ -88,32 +87,13 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   int _stepIndex = 0;
 
-  // ── 推荐包下载状态 ────────────────────────────────────────────────
-  late final Directory _packDir = Directory(
-    p.join(appModelNoUpdate.appDirectory.path, 'recommended_pack'),
-  );
-
-  /// 稳定清单解析出的下载器。**来源不给用户选**：清单里同时挂着 GitHub Release 的
-  /// 分片、官网 CF 的同名分片，以及 Drive 整包镜像（每片按 Range 取），分片下载器
-  /// 按实测吞吐在这几家之间派活——哪家快，哪家多下（见 `SourceSpeedLedger`）。
-  RecommendedPackDownloader? _manifestDownloader;
-
-  /// 清单彻底拉不到（官网和 GitHub 两个候选都不可达）时的兜底：内置的 Drive 整包
-  /// 直链，单流下载。没有清单就没有分片表，混源无从谈起，只能退到这一条。
-  late final RecommendedPackDownloader _fallbackDownloader =
-      RecommendedPackDownloader(
-        packDir: _packDir,
-        url: kRecommendedPackGoogleDriveDirectUrl,
-      );
-
-  RecommendedPackDownloader get _activeDownloader =>
-      _manifestDownloader ?? _fallbackDownloader;
-
-  final ValueNotifier<double> _packProgress = ValueNotifier<double>(0);
-  final ValueNotifier<int> _packBytes = ValueNotifier<int>(0);
-  CancelToken? _packCancelToken;
-  bool _packDownloading = false;
-  String? _packError;
+  // ── 推荐包下载 ────────────────────────────────────────────────────
+  /// 下载任务的所有权在 [AppModel] 上的 controller 里，本页只是它的一个视图：
+  /// 走下一步、关掉向导都不再取消下载（BUG-2097）。来源同样不给用户选——清单里
+  /// 挂着 GitHub Release 分片、官网 CF 同名分片和 Drive 整包镜像，下载器按实测
+  /// 吞吐自己派活（见 `SourceSpeedLedger`）。
+  RecommendedPackDownloadController get _packController =>
+      appModelNoUpdate.recommendedPackDownloadController;
 
   bool get _browserExtensionAvailable => DesktopLookupService.isDesktop;
 
@@ -163,21 +143,14 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
         appModelNoUpdate.moduleBrowserExtensionEnabled) {
       _selected.add(OnboardingFeature.browserExtension);
     }
-    // 上一轮推荐包导入成功后进程已重启：把落盘的 9.5 GB zip 删掉（flag 判定，
-    // 未导入过 / 半截下载不受影响）。
-    unawaited(RecommendedPackDownloader.cleanupIfImported(_packDir));
-    // 落盘名从「URL 尾段推导」改成恒定名之前下的半截包叫 `download*`，搬过来，
-    // 别让升级把已下的 9.5 GB 作废。
-    RecommendedPackDownloader.migrateLegacyArtifacts(_packDir);
+    // 包目录进场收尾（删已导入的残包、搬旧命名的半截文件、按磁盘对齐阶段）。
+    // 下载正在跑时 controller 整体跳过——那些都是在动同一批文件。
+    unawaited(_packController.prepareDiskState());
   }
 
-  @override
-  void dispose() {
-    _packCancelToken?.cancel();
-    _packProgress.dispose();
-    _packBytes.dispose();
-    super.dispose();
-  }
+  // dispose 里**没有**取消下载：BUG-2097 的根因就是这里曾经有一句
+  // `_packCancelToken?.cancel()`，于是走完向导 = 9.5 GB 的下载被静默掐断。
+  // 进度/取消/导入现在都由 [RecommendedPackDownloadController] 持有。
 
   Future<void> _complete() async {
     await appModel.setOnboardingCompleted(value: true);
@@ -294,48 +267,13 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   // ── 推荐包 ────────────────────────────────────────────────────────
 
+  /// 下载 → 下完就地导入。下载本身在 controller 里跑完（取消/失败提示也在那边），
+  /// 本页只负责「我还在的话，顺手把导入接上」：向导已经关了就停在「已下载待导入」，
+  /// 由设置 → 系统里那一行接手（BUG-2097）。
   Future<void> _downloadPackAndImport() async {
-    if (_packDownloading) return;
-    setState(() {
-      _packDownloading = true;
-      _packError = null;
-    });
-    _packCancelToken = CancelToken();
-    try {
-      // 先拉稳定清单拿分片表与来源表（换包零发版）。只解析一次并缓存——同一会话
-      // 内 URL 抖动会打断续传。拉不到就走 _fallbackDownloader 的整包直链。
-      if (_manifestDownloader == null) {
-        final RecommendedPackManifest? manifest =
-            await fetchRecommendedPackManifest();
-        if (manifest != null) {
-          _manifestDownloader = RecommendedPackDownloader.fromManifest(
-            packDir: _packDir,
-            manifest: manifest,
-          );
-        }
-      }
-      if (!mounted) return;
-      // 钉住本次下载用的下载器：导入确认回调也要落在同一实例上。
-      final RecommendedPackDownloader downloader = _activeDownloader;
-      final File file = await downloader.download(
-        progress: _packProgress,
-        receivedBytes: _packBytes,
-        cancelToken: _packCancelToken,
-      );
-      if (!mounted) return;
-      await _importPackFile(file.path, deleteAfterImport: true);
-    } on DioError catch (e) {
-      // 用户取消：半截文件保留，下次续传；非取消才示错。
-      // （仓库钉 dio 5.1，类型名还是 `DioError`，与其余下载路径一致。）
-      if (e.type != DioErrorType.cancel) {
-        _packError = e.message ?? e.toString();
-      }
-    } catch (e) {
-      _packError = e.toString();
-    } finally {
-      _packCancelToken = null;
-      if (mounted) setState(() => _packDownloading = false);
-    }
+    final File? file = await _packController.start();
+    if (file == null || !mounted) return;
+    await _importPackFile(file.path, deleteAfterImport: true);
   }
 
   Future<void> _pickPackFileAndImport() async {
@@ -360,7 +298,7 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
       filePath: path,
       // 打标是包目录级操作（写 `<包目录>/imported.flag`），与走哪条线路无关。
       onImportConfirmed: deleteAfterImport
-          ? () => RecommendedPackDownloader.markImportStarted(_packDir)
+          ? _packController.markImportStarted
           : null,
     );
   }
@@ -1195,61 +1133,77 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
 
   Widget _buildPackStep() {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    // 「下好了没」是包目录的属性，不是某条线路的属性：两条线路落同一个文件名。
-    final bool hasDownloaded = RecommendedPackDownloader.hasCompletedFileIn(
-      _packDir,
-    );
-    return ListView(
-      padding: EdgeInsets.all(tokens.spacing.card),
-      children: <Widget>[
-        OnboardingStepHero(
-          icon: Icons.auto_stories_outlined,
-          title: t.onboarding_step_pack_title,
-          body: t.onboarding_pack_intro,
-        ),
-        SizedBox(height: tokens.spacing.card),
-        if (_packError != null) ...<Widget>[
-          Text(
-            t.onboarding_pack_download_failed(message: _packError!),
-            style: textTheme.bodySmall!.copyWith(
-              color: theme.colorScheme.error,
+    // 整步都跟着 controller 走：下载不再属于本页，走开一步再回来（甚至关掉向导
+    // 再从设置重开）看到的都是同一个任务的真实状态（BUG-2097）。
+    return ListenableBuilder(
+      listenable: Listenable.merge(<Listenable>[
+        _packController.stage,
+        _packController.progress,
+        _packController.receivedBytes,
+        _packController.error,
+      ]),
+      builder: (BuildContext context, _) {
+        final String? error = _packController.error.value;
+        return ListView(
+          padding: EdgeInsets.all(tokens.spacing.card),
+          children: <Widget>[
+            OnboardingStepHero(
+              icon: Icons.auto_stories_outlined,
+              title: t.onboarding_step_pack_title,
+              body: t.onboarding_pack_intro,
             ),
-          ),
-          SizedBox(height: tokens.spacing.gap),
-        ],
-        if (_packDownloading)
-          FushiCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                ValueListenableBuilder<double>(
-                  valueListenable: _packProgress,
-                  builder: (_, double value, __) =>
-                      LinearProgressIndicator(value: value > 0 ? value : null),
+            SizedBox(height: tokens.spacing.card),
+            if (error != null) ...<Widget>[
+              Text(
+                t.onboarding_pack_download_failed(message: error),
+                style: textTheme.bodySmall!.copyWith(
+                  color: theme.colorScheme.error,
                 ),
-                SizedBox(height: tokens.spacing.gap),
-                ValueListenableBuilder<int>(
-                  valueListenable: _packBytes,
-                  builder: (_, int bytes, __) => Text(
-                    '${t.onboarding_pack_downloading} · '
-                    '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB',
-                    style: textTheme.bodySmall,
-                  ),
+              ),
+              SizedBox(height: tokens.spacing.gap),
+            ],
+            if (_packController.isDownloading)
+              FushiCard(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    LinearProgressIndicator(
+                      value: _packController.progress.value > 0
+                          ? _packController.progress.value
+                          : null,
+                    ),
+                    SizedBox(height: tokens.spacing.gap),
+                    Text(
+                      '${t.onboarding_pack_downloading} · '
+                      '${recommendedPackProgressLabel(progress: _packController.progress.value, receivedBytes: _packController.receivedBytes.value)}',
+                      style: textTheme.bodySmall,
+                    ),
+                    SizedBox(height: tokens.spacing.gap),
+                    // 用户最想知道的一件事：现在能不能走开。能。
+                    Text(
+                      t.onboarding_pack_download_background_hint,
+                      style: textTheme.bodySmall!.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    SizedBox(height: tokens.spacing.gap),
+                    Align(
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: OutlinedButton(
+                        onPressed: _packController.requestCancel,
+                        child: Text(t.dialog_cancel),
+                      ),
+                    ),
+                  ],
                 ),
-                SizedBox(height: tokens.spacing.gap),
-                Align(
-                  alignment: AlignmentDirectional.centerEnd,
-                  child: OutlinedButton(
-                    onPressed: () => _packCancelToken?.cancel(),
-                    child: Text(t.dialog_cancel),
-                  ),
-                ),
-              ],
-            ),
-          )
-        else
-          OnboardingActionList(actions: _packActions(hasDownloaded)),
-      ],
+              )
+            else
+              OnboardingActionList(
+                actions: _packActions(_packController.hasPendingImport),
+              ),
+          ],
+        );
+      },
     );
   }
 

--- a/fushi/lib/src/settings/settings_detail_page.dart
+++ b/fushi/lib/src/settings/settings_detail_page.dart
@@ -56,6 +56,12 @@ class _SettingsDetailPageState extends BasePageState<SettingsDetailPage>
     // 游戏内查词准入是 hook **异步**报上来的：settingsContext.refresh 只由交互驱动，
     // 事件走不到它。不听这一条，用户开着设置页启动游戏时那一行永远停在旧状态。
     GalIngameLookupController.instance.admission.addListener(_onLogChanged);
+    // 推荐包下载同理（BUG-2097）：它跑在 app 级 controller 里，用户可能是在设置页
+    // 开着的时候点了下载、或者下载在后台跑完了——不听这一条，「推荐包」那一行的
+    // 显隐就停在进页面那一刻的旧状态。
+    appModelNoUpdate.recommendedPackDownloadController.stage.addListener(
+      _onLogChanged,
+    );
   }
 
   @override
@@ -63,6 +69,9 @@ class _SettingsDetailPageState extends BasePageState<SettingsDetailPage>
     ErrorLogService.instance.removeListener(_onLogChanged);
     DebugLogService.instance.removeListener(_onLogChanged);
     GalIngameLookupController.instance.admission.removeListener(_onLogChanged);
+    appModelNoUpdate.recommendedPackDownloadController.stage.removeListener(
+      _onLogChanged,
+    );
     super.dispose();
   }
 

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:fushi/pages.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_row.dart';
 import 'package:fushi/src/settings/settings_actions.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/sync/sync_http.dart';
+import 'package:fushi/src/sync/sync_settings_schema.dart'
+    show runBackupImportFlowForFile;
 import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/utils/misc/crash_dump_locator.dart';
 import 'package:fushi/src/utils/misc/platform_updater.dart';
@@ -84,6 +90,19 @@ SettingsDestination buildSystemDestination() {
                 (_) => const OnboardingWizardPage(),
               );
             },
+          ),
+          // 推荐包下载的常驻可见入口（BUG-2097）。下载归 [AppModel] 上的
+          // controller 所有，关掉向导也照跑——那就必须有一个不依赖向导的地方
+          // 看得到它、停得掉它、下完能就地导入。空闲时整行不渲染，设置页不常驻
+          // 一条恒为「无任务」的死行；本行随 controller 的阶段变化实时显隐，靠
+          // [SettingsDetailPage] 订阅 stage 重建（同 galgame 准入那一行的做法）。
+          SettingsCustomItem(
+            id: 'system.recommended_pack_download',
+            searchTitle: t.onboarding_step_pack_title,
+            subtitle: t.onboarding_pack_intro,
+            visible: (SettingsContext settingsContext) => settingsContext
+                .appModel.recommendedPackDownloadController.isActive,
+            builder: _buildRecommendedPackDownloadRow,
           ),
           SettingsSwitchItem(
             id: 'system.low_memory_mode',
@@ -613,6 +632,26 @@ Widget _buildTmdbAttributionRow(SettingsContext settingsContext) {
       Uri.parse('https://www.themoviedb.org/'),
       mode: LaunchMode.externalApplication,
     ),
+  );
+}
+
+Widget _buildRecommendedPackDownloadRow(SettingsContext settingsContext) {
+  final AppModel appModel = settingsContext.appModel;
+  return RecommendedPackDownloadRow(
+    controller: appModel.recommendedPackDownloadController,
+    onImport: () => unawaited(_importDownloadedRecommendedPack(appModel)),
+  );
+}
+
+/// 就地导入已下好的推荐包，走备份导入的共享编排（确认覆盖/合并 → 导入 → 重启）。
+/// 与新手引导那条路径同一个真相源，只是发起点在设置里。
+Future<void> _importDownloadedRecommendedPack(AppModel appModel) async {
+  final RecommendedPackDownloadController controller =
+      appModel.recommendedPackDownloadController;
+  await runBackupImportFlowForFile(
+    appModel: appModel,
+    filePath: controller.packFile.path,
+    onImportConfirmed: controller.markImportStarted,
   );
 }
 

--- a/fushi/test/onboarding/recommended_pack_background_download_guard_test.dart
+++ b/fushi/test/onboarding/recommended_pack_background_download_guard_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-2097 回归守卫：推荐包下载**不得**再由新手引导页持有。
+///
+/// 根因形态是结构性的，不是某一行文案：下载器、进度 notifier 和 `CancelToken`
+/// 曾是 `_OnboardingWizardPageState` 的字段，而它的 `dispose()` 里有一句
+/// `_packCancelToken?.cancel()`。于是「点下载 → 走下一步 → 走完向导」这条最普通
+/// 的路径上，向导一 pop 就把 9.5 GB 的下载静默掐断，用户既没被告知、也没有任何
+/// 地方还能看到它。所以这里守三件事：
+/// 1. 向导页自己不再持有取消令牌/下载器（否则「后台下载」随时可能被 dispose 掐断）；
+/// 2. 任务的所有权在 `AppModel` 上的 controller 里；
+/// 3. 存在一个**不依赖向导**的可见入口（设置 → 系统那一行），否则「在后台跑」
+///    等于没跑。
+void main() {
+  String read(String relativePath) =>
+      maskCommentsAndStrings(File(relativePath).readAsStringSync());
+
+  const String wizardPath =
+      'lib/src/pages/implementations/onboarding_wizard_page.dart';
+  const String appModelPath = 'lib/src/models/app_model.dart';
+  const String systemSchemaPath =
+      'lib/src/settings/settings_schema_system.dart';
+  const String detailPagePath = 'lib/src/settings/settings_detail_page.dart';
+
+  test('新手引导页不再持有推荐包下载的取消令牌与下载器', () {
+    final String code = read(wizardPath);
+    expect(
+      code.contains('CancelToken'),
+      isFalse,
+      reason:
+          '向导页一旦自己拿着取消令牌，它的 dispose 就能把后台下载掐断'
+          '——BUG-2097 的根因就是这个形状',
+    );
+    expect(
+      code.contains('RecommendedPackDownloader('),
+      isFalse,
+      reason: '下载器实例必须由 app 级 controller 持有，页面只是视图',
+    );
+    expect(
+      code.contains('_packController.start('),
+      isTrue,
+      reason: '下载入口必须走 app 级 controller，页面不再自己发起',
+    );
+  });
+
+  test('推荐包下载任务的所有权挂在 AppModel 上', () {
+    final String code = read(appModelPath);
+    expect(
+      code.contains('RecommendedPackDownloadController('),
+      isTrue,
+      reason: '任务生命周期必须与 app 一致，不能与某个页面的 State 同生共死',
+    );
+    expect(
+      code.contains('recommendedPackDownloadController.dispose()'),
+      isTrue,
+      reason: 'app 级 controller 必须在 AppModel.dispose 里收口',
+    );
+  });
+
+  test('存在一个不依赖新手引导的进度入口，且随阶段实时显隐', () {
+    final String schema = read(systemSchemaPath);
+    expect(
+      schema.contains('RecommendedPackDownloadRow('),
+      isTrue,
+      reason: '「在后台下载」如果没有任何地方看得到，等于没在下载',
+    );
+    expect(
+      schema.contains('recommendedPackDownloadController'),
+      isTrue,
+      reason: '设置里那一行必须读同一个 app 级 controller，不能自建状态',
+    );
+    final String detail = read(detailPagePath);
+    expect(
+      detail.contains('recommendedPackDownloadController.stage.addListener'),
+      isTrue,
+      reason: '下载阶段是异步事件，不订阅它那一行就停在进页面那一刻的旧状态',
+    );
+    expect(
+      detail.contains('recommendedPackDownloadController.stage.removeListener'),
+      isTrue,
+      reason: '订阅必须在 dispose 里摘掉，否则页面走了还在拉活它',
+    );
+  });
+}

--- a/fushi/test/onboarding/recommended_pack_download_controller_test.dart
+++ b/fushi/test/onboarding/recommended_pack_download_controller_test.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/onboarding/recommended_pack.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
+import 'package:fushi/src/utils/misc/toast_severity.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-2097：推荐包下载的所有权从新手引导页的 State 上移到 app 级 controller。
+///
+/// 这里守的是「任务与视图脱钩」这件事本身：下载的开始、进度、结束、取消、失败
+/// 全在 controller 里发生，发起它的页面死不死与它无关；下完之后**停在待导入**，
+/// 因为导入要用户确认并重启进程，controller 不能替用户按下去。
+void main() {
+  late Directory packDir;
+
+  setUp(() {
+    packDir = Directory.systemTemp.createTempSync('recommended_pack_ctl');
+  });
+
+  tearDown(() {
+    if (packDir.existsSync()) packDir.deleteSync(recursive: true);
+  });
+
+  File completedPackFile() {
+    final File file = File(p.join(packDir.path, kRecommendedPackFileName));
+    file.writeAsStringSync('pack');
+    return file;
+  }
+
+  RecommendedPackDownloadController newController({
+    required RecommendedPackDownloadRunner runner,
+    List<String>? outcomes,
+  }) {
+    return RecommendedPackDownloadController(
+      packDirectory: () => packDir,
+      runner: runner,
+      showOutcome: (String message, ToastSeverity severity) =>
+          outcomes?.add(message),
+    );
+  }
+
+  test('发起页消失后下载照跑完，停在「已下载待导入」并出提示', () async {
+    final Completer<File> finish = Completer<File>();
+    final List<String> outcomes = <String>[];
+    final RecommendedPackDownloadController controller = newController(
+      outcomes: outcomes,
+      runner:
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) {
+            progress.value = 0.5;
+            receivedBytes.value = 5 * 1024 * 1024 * 1024;
+            return finish.future;
+          },
+    );
+    addTearDown(controller.dispose);
+
+    final Future<File?> started = controller.start();
+    expect(controller.isDownloading, isTrue);
+    expect(controller.progress.value, 0.5);
+
+    // 「向导被 pop 掉」在这里就是「没有任何人再等这个 future」——任务照跑。
+    finish.complete(completedPackFile());
+    expect(await started, isNotNull);
+
+    expect(controller.stage.value, RecommendedPackDownloadStage.downloaded);
+    expect(controller.hasPendingImport, isTrue);
+    expect(controller.isActive, isTrue);
+    expect(controller.error.value, isNull);
+    expect(outcomes, hasLength(1), reason: '后台下完必须有一次提示，否则 9.5 GB 下完屏幕上毫无变化');
+  });
+
+  test('用户取消不算失败：不写 error、不提示，阶段按磁盘回落', () async {
+    final List<String> outcomes = <String>[];
+    final RecommendedPackDownloadController controller = newController(
+      outcomes: outcomes,
+      runner:
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) async {
+            throw DioError(
+              requestOptions: RequestOptions(path: '/pack'),
+              type: DioErrorType.cancel,
+            );
+          },
+    );
+    addTearDown(controller.dispose);
+
+    expect(await controller.start(), isNull);
+    expect(controller.error.value, isNull);
+    expect(outcomes, isEmpty);
+    expect(controller.stage.value, RecommendedPackDownloadStage.idle);
+  });
+
+  test('真失败写 error 并提示，半截文件留着下次续传', () async {
+    final List<String> outcomes = <String>[];
+    final RecommendedPackDownloadController controller = newController(
+      outcomes: outcomes,
+      runner:
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) async => throw const SocketException('connection reset'),
+    );
+    addTearDown(controller.dispose);
+
+    expect(await controller.start(), isNull);
+    expect(controller.error.value, contains('connection reset'));
+    expect(outcomes, hasLength(1));
+    expect(controller.stage.value, RecommendedPackDownloadStage.idle);
+  });
+
+  test('互斥：跑着的时候再点一次下载不会起第二个任务', () async {
+    final Completer<File> finish = Completer<File>();
+    int runs = 0;
+    final RecommendedPackDownloadController controller = newController(
+      runner:
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) {
+            runs += 1;
+            return finish.future;
+          },
+    );
+    addTearDown(controller.dispose);
+
+    final Future<File?> first = controller.start();
+    expect(await controller.start(), isNull);
+    expect(runs, 1, reason: '两份下载会写同一个半截文件，必须互斥');
+
+    finish.complete(completedPackFile());
+    expect(await first, isNotNull);
+  });
+
+  test('进场收尾：磁盘上已下好的整包会被认成「待导入」', () async {
+    final RecommendedPackDownloadController controller = newController(
+      runner: _neverRuns,
+    );
+    addTearDown(controller.dispose);
+
+    completedPackFile();
+    await controller.prepareDiskState();
+    expect(controller.stage.value, RecommendedPackDownloadStage.downloaded);
+  });
+
+  test('进场收尾：已导入过的包目录被删干净，阶段回 idle', () async {
+    final RecommendedPackDownloadController controller = newController(
+      runner: _neverRuns,
+    );
+    addTearDown(controller.dispose);
+
+    completedPackFile();
+    await controller.markImportStarted();
+    await controller.prepareDiskState();
+
+    expect(controller.stage.value, RecommendedPackDownloadStage.idle);
+    expect(controller.isActive, isFalse);
+    expect(
+      RecommendedPackDownloader.hasCompletedFileIn(packDir),
+      isFalse,
+      reason: '导入完还留着 9.5 GB 的 zip 就是白占盘',
+    );
+  });
+
+  test('进度文案：总大小未知时只报字节数，已知时带百分比', () {
+    expect(
+      recommendedPackProgressLabel(progress: 0, receivedBytes: 3 * 1024 * 1024),
+      '3.0 MB',
+    );
+    expect(
+      recommendedPackProgressLabel(
+        progress: 0.34,
+        receivedBytes: 3 * 1024 * 1024,
+      ),
+      '3.0 MB (34%)',
+    );
+  });
+}
+
+Future<File> _neverRuns({
+  required Directory packDir,
+  required ValueNotifier<double> progress,
+  required ValueNotifier<int> receivedBytes,
+  required CancelToken cancelToken,
+}) async => throw StateError('本用例不该真去下载');

--- a/fushi/test/onboarding/recommended_pack_download_row_test.dart
+++ b/fushi/test/onboarding/recommended_pack_download_row_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_controller.dart';
+import 'package:fushi/src/onboarding/recommended_pack_download_row.dart';
+import 'package:fushi/utils.dart';
+
+/// BUG-2097：设置里那一行是「后台下载」唯一不依赖新手引导的可见入口。
+void main() {
+  late Directory packDir;
+
+  setUp(() {
+    packDir = Directory.systemTemp.createTempSync('recommended_pack_row');
+  });
+
+  tearDown(() {
+    if (packDir.existsSync()) packDir.deleteSync(recursive: true);
+  });
+
+  Widget host(
+    RecommendedPackDownloadController controller,
+    VoidCallback onImport,
+  ) {
+    return MaterialApp(
+      home: Scaffold(
+        body: RecommendedPackDownloadRow(
+          controller: controller,
+          onImport: onImport,
+        ),
+      ),
+    );
+  }
+
+  RecommendedPackDownloadController newController() {
+    return RecommendedPackDownloadController(
+      packDirectory: () => packDir,
+      runner:
+          ({
+            required Directory packDir,
+            required ValueNotifier<double> progress,
+            required ValueNotifier<int> receivedBytes,
+            required CancelToken cancelToken,
+          }) async => throw StateError('本用例不下载'),
+      showOutcome: (String message, ToastSeverity severity) {},
+    );
+  }
+
+  testWidgets('空闲时整行不渲染', (WidgetTester tester) async {
+    final RecommendedPackDownloadController controller = newController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(host(controller, () {}));
+    expect(find.byType(AdaptiveSettingsRow), findsNothing);
+  });
+
+  testWidgets('下载中报进度，取消按钮真的置位令牌', (WidgetTester tester) async {
+    final RecommendedPackDownloadController controller = newController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(host(controller, () {}));
+    controller.stage.value = RecommendedPackDownloadStage.downloading;
+    controller.progress.value = 0.34;
+    controller.receivedBytes.value = 3 * 1024 * 1024 * 1024;
+    await tester.pump();
+
+    expect(find.text(t.onboarding_pack_status_downloading), findsOneWidget);
+    expect(find.text('3.0 GB (34%)'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+    // 取消入口存在且指向 controller（真下载时它会置位 CancelToken）。
+    await tester.tap(find.text(t.dialog_cancel));
+    await tester.pump();
+  });
+
+  testWidgets('下完待导入时给出导入按钮', (WidgetTester tester) async {
+    final RecommendedPackDownloadController controller = newController();
+    addTearDown(controller.dispose);
+    int imports = 0;
+
+    await tester.pumpWidget(host(controller, () => imports += 1));
+    controller.stage.value = RecommendedPackDownloadStage.downloaded;
+    await tester.pump();
+
+    expect(find.text(t.onboarding_pack_status_ready), findsOneWidget);
+    await tester.tap(find.text(t.onboarding_pack_import_now));
+    await tester.pump();
+    expect(imports, 1);
+  });
+}


### PR DESCRIPTION
## 用户报告

新手引导里点了「下载并导入」推荐包，没等下完就走了下一步——它到底还在不在后台下载？如果在，得有个地方能看进度。

## 真伪与根因

真 bug。`onboarding_wizard_page.dart`（修复前）里下载器、进度 notifier 和 `CancelToken` 全是 `_OnboardingWizardPageState` 的字段，`dispose()` 里有一句 `_packCancelToken?.cancel()`：

- **走完 / 关掉引导 = 下载被静默掐断**。向导一 pop，State 就 dispose，9.5 GB 当场取消，没有提示也没有通知（半截文件保留可续传，但不再点一次就永远不会继续）。
- **走到下一步 = 进度整个消失**。进度条只画在推荐包那一步里，离开那一步没有第二个入口能看到它。
- 文案 `onboarding_pack_action_download_desc`（「后台从多个来源同时下载，下完自动导入」）承诺的「后台」在页面被销毁时并不成立。

## 改法

与词典下载（BUG-1499）同一条纪律：把任务所有权从页面 State 上移到 app 级 controller，页面退化成它的一个视图。

- 新增 `RecommendedPackDownloadController`（挂 `AppModel`，生命周期与 app 一致）：持有下载器、进度、已收字节、错误和阶段（`idle` / `downloading` / `downloaded`），互斥、可取消、按磁盘对齐阶段。
- 向导 `dispose()` **不再**取消下载；下完后向导若还活着就照旧接上导入流程，已经关掉就停在「已下载待导入」——导入要用户确认覆盖/合并并重启进程，controller 不替用户按下去。后台下完额外出一次 toast。
- 设置 → 系统新增常驻进度行：下载中报 `3.2 GB (34%)` 并可取消，下完可就地导入（走同一个 `runBackupImportFlowForFile` 真相源）；空闲时整行不渲染。设置详情页订阅 `stage` 实时显隐（同 galgame 准入那一行的做法）。
- 推荐包步骤里补一句说明：下载在后台继续，可以直接走下一步或关掉向导，进度在设置里看。
- 下载器本身（分片并发 / 双源 / 续传 / sha256 校验）一行未动。

## i18n

新增 5 个 key（`onboarding_pack_status_downloading` / `onboarding_pack_status_ready` / `onboarding_pack_import_now` / `onboarding_pack_download_finished` / `onboarding_pack_download_background_hint`），走 `i18n_sync --add` + `dart run slang`。

## 测试

- `test/onboarding/recommended_pack_download_controller_test.dart`：任务与视图脱钩、取消不算失败、真失败写 error、互斥、进场按磁盘定阶段、进度文案。
- `test/onboarding/recommended_pack_download_row_test.dart`：设置行三态渲染与导入回调。
- `test/onboarding/recommended_pack_background_download_guard_test.dart`：源码守卫——向导页不得再持有 `CancelToken` / 下载器，所有权在 `AppModel`，且存在不依赖向导的可见入口并订阅阶段变化。
- `integration_test/onboarding_pack_background_download_itest.dart`：真 app、焦点驱动走用户报的那条路（点下载 → 走下一步 → 走完引导），断言下载没被取消、设置里看得到进度。

**验证状态**：`flutter analyze` 通过；`test/onboarding` 全绿（72 tests）。应作者要求本轮跳过了全量套件与 Windows 集成测试的执行，交由 CI 兜底。

docs/bugs/BUG-2097-onboarding-pack-download-cancelled-on-leave.md

https://claude.ai/code/session_01Q3Vapxe38sTNsuAQ9PZMCh
