### PR TITLE
fix+feat: 互联传配置文件 / 引导选包不再蒸发且失败可见 / 移动端换集不掉全屏 (BUG-2105~2107)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1965 条。点号进各自文件。
+> 共 1967 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2107](bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md) | ✅ | ✅ | 引导选本地包走裸 pickFiles：安卓整份复制进 cache，失败静默无提示 |
+| [BUG-2106](bugs/BUG-2106-backup-validating-overlay-destroys-caller-route.md) | ✅ | ✅ | 备份 validating 遮罩换根摧毁调用方路由：引导选包后引导蒸发且无提示 |
 | [BUG-2105](bugs/BUG-2105-fullscreen-episode-switch-mobile-orientation.md) | ✅ | ✅ | 移动端换集后掉出全屏：旧页 dispose 无条件放开横屏锁并清空系统栏回调 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1964 条。点号进各自文件。
+> 共 1965 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2105](bugs/BUG-2105-fullscreen-episode-switch-mobile-orientation.md) | ✅ | ✅ | 移动端换集后掉出全屏：旧页 dispose 无条件放开横屏锁并清空系统栏回调 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |
 | [BUG-2089](bugs/BUG-2089-inapp-mining-payload-bool-cast-crash.md) | ✅ | ✅ | 应用内制卡全部失败：「导出卡片失败: Invalid card data (payload parse failed): type 'String' is not a subtype of type 'bool?' in type cast」 |
 | [BUG-2088](bugs/BUG-2088-release-notes-never-reach-update-dialog.md) | ✅ | ✅ | 正式版更新公告进不了应用内更新弹窗，用户看到的是一行占位符 |

--- a/docs/bugs/BUG-2105-fullscreen-episode-switch-mobile-orientation.md
+++ b/docs/bugs/BUG-2105-fullscreen-episode-switch-mobile-orientation.md
@@ -1,0 +1,48 @@
+## BUG-2105 · 移动端换集后掉出全屏：旧页 dispose 无条件放开横屏锁并清空系统栏回调
+- **报告**：2026-09-04（用户：「视频全屏跳转到别的集数会退出全屏播放」，附安卓截图）
+- **真实性**：✅ 真 bug（静态可证的时序反序，移动端唯一暴露面）。根因 `fushi/lib/src/pages/implementations/video_fushi_page.dart` 的 `dispose`（原第 3757 / 3791-3794 行：`SystemChrome.setSystemUIChangeCallback(null)` + `_restoreOrientationOnExit()` + `setMacOSTrafficLightsHidden(false)` 三处**无条件**还原）与 `initState`（第 1943-1956 行认领同三件）
+- **[x] ① 已修复** — 本分支 `worktree-worktree-user-batch-0904`（提交见 git log）
+- **[x] ② 已加自动化测试** — 纯函数真值表 `fushi/test/media/video/video_display_claim_test.dart`（7 组，含「新页 initState 先于旧页 dispose」「连续换集三集」两条正是本 bug 的顺序）+ 源码守卫 `fushi/test/media/video/video_lifecycle_static_test.dart` 三条（initState 必须先登记再设；dispose 不得含任一无条件还原；`_releaseVideoDisplayClaim` 的记账门必须排在三件还原之前）。变异实测：把 `if (!VideoDisplayClaim.release(this)) return;` 改成裸调用 → 守卫判红
+- **备注**：视频播放/全屏类。BUG-2043 只修了桌面（全屏路由接管），移动端整段被 `isMobilePlatform` 门控掉，是同一症状的遗漏面。桌面/macOS 也顺带受益（换集不再让 macOS 交通灯闪出）。真机复测缺口见下。
+
+### 根因
+
+移动端**没有全屏路由**（BUG-221 起 `_toggleVideoFullscreen` 在 `isMobilePlatform` 上统一 no-op，横屏沉浸态即唯一「全屏」形态）。因此换集（`video_fushi/episode.part.dart` 的 `_switchEpisode` 本地分支）走 `resolveEpisodeSwitchPlan` 的 `replace` 模式 = 裸 `pushReplacement`，BUG-2043 的接管路径（`push` + `removeRoute` + `initialFullscreen`）在移动端根本不进。
+
+而视频页在 `initState` 认领三件**进程级、全局单槽**的显示态：
+
+1. 横屏锁 `_lockLandscapeForVideo()` → `setPreferredOrientations([landscapeLeft, landscapeRight])`；
+2. 系统栏可见性回调 `_registerSystemBarsVisibilityCallback()` → `SystemChrome.setSystemUIChangeCallback(...)`（**全局单槽**，后设的覆盖前一个）；
+3. macOS 交通灯隐藏 `setMacOSTrafficLightsHidden(true)`。
+
+`dispose` 里原先**无条件**把这三件还原。Flutter 语义下 `pushReplacement` 的旧路由要等新路由入场动画结束才被移除并 `dispose`，所以真实顺序是：
+
+```
+新页 initState（锁横屏 / 注册回调 / 隐交通灯）
+      ↓ 约一个入场动画之后
+旧页 dispose（放开方向 → 置空回调 → 显交通灯）   ← 把新页刚设好的全部掀掉
+```
+
+于是换集后：
+
+- **方向**：`_restoreOrientationOnExit()` 把允许集放宽成 `[portraitUp, landscapeLeft, landscapeRight]`。移动端开着「自动旋转锁定」时，含 `portraitUp` 的允许集会退回用户锁定的竖屏 —— 画面当即从横屏满屏变竖屏小窗，观感就是用户报的「跳转到别的集数会退出全屏播放」。
+- **系统栏几何**：全局回调被置空后 `_systemBarsVisible` 再不更新，`_videoBottomSystemInset` 的门控卡在旧值，进度条 / 字幕避让几何回到 BUG-383 的错态。
+- **macOS**：交通灯在全屏画面左上角闪出（桌面侧走 `takeover` 路径，同样命中这条无条件还原）。
+
+同一形状的第四件（Windows 标题栏 owner）**早就是对的**：`FushiWindowsTitleBar.setContentFullscreen(owner: this, ...)` 用 `_contentFullscreenOwners` 集合按所有者记账，所以标题栏没有这个 bug。
+
+### 修复
+
+抄上面那份既有范式，把「该不该还原」从页面生命周期改成**所有者记账**：
+
+- 新增 `fushi/lib/src/media/video/video_display_claim.dart` 的 `VideoDisplayClaim`（纯 Dart 登记表：`claim(owner)` / `release(owner)`，`release` 返回 true **当且仅当**集合被它清空）。
+- `initState` **先** `VideoDisplayClaim.claim(this)` 再去设三件。
+- `dispose` 的三处无条件还原收敛成一个 `_releaseVideoDisplayClaim()`：`if (!VideoDisplayClaim.release(this)) return;` 之后才还原。换集期间集合短暂同时含新旧两页 → 旧页释放时非空 → 不还原；正常退页时集合空 → 照旧还原。
+
+判据是纯函数，所以「旧页掀掉新页显示态」这条回归可在 headless 单测判红（行为级要真设备方向系统 + 真过渡动画，跑不了）。
+
+### 验证
+
+- `flutter test test/media/video/ test/video/macos_video_trafficlight_hide_guard_test.dart test/pages/video_orientation_fullscreen_guard_test.dart test/pages/video_statusbar_immersive_guard_test.dart --no-pub`：`PASSED - 3086 tests ran`
+- 变异实测：去掉记账门 → `video_lifecycle_static_test.dart` 判红（`FAILED`）；还原后复绿
+- ⚠ **真机复测缺口**：安卓真机上「开着自动旋转锁定 → 横屏看片 → 换集」这一条原始失败路径尚未实测（本轮只做了静态与单测层）。桌面侧 BUG-2043 的离屏 e2e（`integration_test/video_fullscreen_sublist_next_episode_test.dart`）覆盖的是全屏路由掉线，不覆盖移动端方向锁。

--- a/docs/bugs/BUG-2106-backup-validating-overlay-destroys-caller-route.md
+++ b/docs/bugs/BUG-2106-backup-validating-overlay-destroys-caller-route.md
@@ -1,0 +1,32 @@
+## BUG-2106 · 备份 validating 遮罩换根摧毁调用方路由：引导选包后引导蒸发且无提示
+- **报告**：2026-09-04（用户：「选择本地包文件以后，会强制退出引导，并且没有提醒」）
+- **真实性**：✅ 真 bug（静态可证的整树 unmount）。根因 `fushi/lib/main.dart:1713`（原 `if (appModel.backupImportActive)` 分支返回 `TranslationProvider(MaterialApp(...))`，与正常分支 `fushi/lib/main.dart:1802` 的 `KeyedSubtree(TranslationProvider(MaterialApp(navigatorKey: ...)))` **根 widget 类型不同**）+ `fushi/lib/src/models/app_model.dart:1271` `beginBackupValidating()`
+- **[x] ① 已修复** — 本分支 `worktree-worktree-user-batch-0904`（提交见 git log）
+- **[x] ② 已加自动化测试** — 行为测试 `fushi/test/sync/backup_validating_overlay_route_test.dart`（真 Navigator：遮罩在栈上时调用方页面 State **未被 dispose**、其字段原样保留；系统返回被遮罩吃掉、绝不 pop 底下的向导页；取消接线）+ 源码守卫 `fushi/test/sync/backup_import_overlay_test.dart` 五条（根分支必须用 `backupImportOwnsAppRoot` 且不得回退 `backupImportActive`；`backupImportOwnsAppRoot` 必须排除 validating；遮罩必须 push 路由并在 `finally` 摘除；摘除必须 `removeRoute` 不得 `pop`；取消接线搬到路由调用方）。变异实测：根分支判据换回 `backupImportActive` → 判红
+- **备注**：与 BUG-2107（同一次报告的第二个根因：引导那条选文件是裸 `pickFiles`）配套。设置页那条导入路径不受影响（它本来就丢得起一条路由）。
+
+### 根因
+
+`main.dart` 的根 `build` 里，备份导入遮罩分支返回的根 widget 是 `TranslationProvider(MaterialApp(home: BackupImportOverlayView))`，而正常分支返回 `KeyedSubtree(TranslationProvider(MaterialApp(navigatorKey: appModel.navigatorKey, ...)))`。**根 runtimeType 不同 ⇒ Flutter 不复用 element ⇒ 整棵子树连 `MaterialApp` / `Navigator` 一起 unmount。**
+
+而 `runBackupImportFlowForFile`（`backup.part.dart`）选完文件后**第一句**就是 `appModel.beginBackupValidating()` → 相位置 `validating` → `notifyListeners()` → 根重建 → 换根。于是：
+
+1. 引导向导（`OnboardingWizardPage`，由 `home_page.dart:449` 以 `fullscreenDialog` push）连同它的 `_stepIndex` / `_selected` 当场销毁 —— 用户观感就是「选完本地包，引导被强制退出」；
+2. `home_page.dart:450` 那句 `await Navigator.push(...OnboardingWizardPage...)` 的 future 在 Navigator 被 dispose 后**永不完成**，其后的 `setOnboardingCompleted(true)` 永不执行，「引导未完成」标记一直留着；
+3. 校验阶段的提示（`backup_import_invalid` / `backup_schema_newer` / `backup_import_failed`）必须等「切回正常树 + navigator 重新挂载」才能弹，`_rootContextAfterOverlay` 只等 2 帧，拿不到就**静默 return** —— 这就是「并且没有提醒」。
+
+关键在于**相位边界被一刀切了**：`validating` 只是读 zip + 生成合并预览，**DB 仍打开、可取消**，没有任何理由卸载整棵树；只有 `running` / `done` / `failed` 之前调了 `closeDatabase()`，页面再挂着就会查已关闭的库，那才**必须**换根独占并随后重启进程。
+
+### 修复
+
+- `AppModel` 新增派生判据 `backupImportOwnsAppRoot`（相位非空 **且** 不是 `validating`），`main.dart` 的根分支改判它 —— 换根只留给关库后的三个相位。
+- `validating` 相位的遮罩改由**压在调用方页面之上的模态路由**承载：新增 `fushi/lib/src/sync/backup_validating_overlay_route.dart`（`opaque: true` 挡住底下的绘制与命中测试，`PopScope(canPop: false)` 让系统返回不再穿透到底下的向导页）。调用方页面全程留在栈里。
+- 摘除**必须** `Navigator.removeRoute`：路由带 `PopScope(canPop: false)`，`pop` 会被它拦下（与 BUG-2043 的接管同一手法）。句柄 `_BackupValidatingOverlay` 幂等，且每条退出路径 + `finally` 兜底都摘一次（漏一次 app 就被永久挡在遮罩后面）。
+- 失败提示改为**先摘遮罩再弹**（原先遮罩还在栈顶时 snackbar 会被压在底下），且两处「拿不到 root context 就 return」补上 `ErrorLogService` 诊断 —— 提示是这条路径唯一的用户可见产物，丢了就等于「点了没反应」。
+
+### 验证
+
+- `flutter analyze`（lib + test）clean
+- `flutter test test/sync/backup_import_overlay_test.dart test/sync/backup_validating_overlay_route_test.dart test/tools/file_picker_discipline_guard_test.dart test/i18n/ --no-pub`：`PASSED - 51 tests ran`
+- 变异实测：根分支判据换回 `backupImportActive` → `FAILED`；还原后复绿
+- ⚠ **真机复测缺口**：真机上「首次启动引导 → 选本地包 → 校验遮罩 → 确认对话框」整条路径尚未实测（本轮为静态 + widget 层）。

--- a/docs/bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md
+++ b/docs/bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md
@@ -1,0 +1,34 @@
+## BUG-2107 · 引导选本地包走裸 pickFiles：安卓整份复制进 cache，失败静默无提示
+- **报告**：2026-09-04（用户：「再次导入的时候点击导入文件没有任何提醒」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/onboarding_wizard_page.dart:341`（`_pickPackFileAndImport` 裸调 `FilePicker.platform.pickFiles`，`path == null` 与「用户取消」同形静默 return，函数无 try/catch 而调用点是 `unawaited(...)`）
+- **[x] ① 已修复** — 本分支 `worktree-worktree-user-batch-0904`（提交见 git log）
+- **[x] ② 已加自动化测试** — `fushi/test/tools/file_picker_discipline_guard_test.dart`：按「豁免清单只减不增」删掉本文件的豁免条目，该守卫的两条断言从此把回退钉死——① 未登记文件裸调 `pickFiles` 即红；② 清单条目虚挂（文件已不再裸调）也红。i18n 完整性由 `test/i18n/` 覆盖（新增 2 个 key × 17 语言）
+- **备注**：与 BUG-2106（同一次报告的第一个根因：validating 遮罩换根摧毁引导路由）配套。BUG-1667 已把本仓其余大文件入口统一到 `pickRealFilePathDetailed`，引导这条是最后的漏网。
+
+### 根因
+
+`_pickPackFileAndImport` 是全 app 仅剩的几处裸 `FilePicker.platform.pickFiles()` 之一，偏偏承载**体积最大**的文件：推荐包 `kRecommendedPackFileName = fushi-recommended.fushi.zip`，`kRecommendedPackSizeLabel = 9.5 GB`（`fushi/lib/src/onboarding/recommended_pack.dart:43,70`）。
+
+三条失败面：
+
+1. **安卓整份复制**：file_picker 在安卓会先把选中文件同步复制进 app cache 再返回缓存路径（BUG-1667 已取证）。9.5 GB 的包需要约 2 倍内部存储、几分钟全程无进度无取消；多数手机直接失败或看起来永久卡死。
+2. **失败与取消同形**：`final String? path = result?.files.single.path; if (path == null || !mounted) return;` —— 平台只回 bytes 不回 path（BUG-446 已立过「必须可见失败」的规矩）与用户主动取消压成同一条静默 return。
+3. **异常被吞**：函数无 try/catch，调用点是 `onPressed: () => unawaited(_pickPackFileAndImport())`，`PlatformException`（`already_active`、cache 复制失败/空间不足）直接漂到 zone handler，UI 上毫无反应 = 用户报的「点击导入文件没有任何提醒」。
+
+另外这条路径**没有**设置页那条导入的重入守卫（`_BackupImportWidget._isImporting`），连点两次会撞 `already_active`。
+
+### 修复
+
+改走仓内既有的 `pickRealFilePathDetailed`（`fushi/lib/src/media/import/real_path_directory_picker.dart`：安卓先要 `MANAGE_EXTERNAL_STORAGE` 再解析真实路径、零复制；桌面/iOS 本就直接给真实路径），并把三种结果分开：
+
+- 返回 `null` = 用户取消 → 静默（取消不是失败）；
+- `PickedFileWithoutPathException` = 平台交回条目却没给路径 → **可见失败**（新 i18n `onboarding_pack_pick_no_path`，告诉用户把包放进设备存储或授予全文件访问）+ `ErrorLogService` 诊断；
+- 其它异常 → 可见失败（新 i18n `onboarding_pack_pick_failed`）+ 诊断。
+
+同时补 `_packPicking` 重入守卫（与 `_packDownloading` 互斥），并把 `_packError` 的语义从「裸异常串」改成「已组好的用户可见文案」——原先渲染处无条件套「下载失败：{}」，选文件失败也会显示成「下载失败」。
+
+### 验证
+
+- `flutter analyze`（lib + test）clean
+- `flutter test test/sync/backup_import_overlay_test.dart test/sync/backup_validating_overlay_route_test.dart test/tools/file_picker_discipline_guard_test.dart test/i18n/ --no-pub`：`PASSED - 51 tests ran`
+- ⚠ **真机复测缺口**：安卓真机上「选本地包 → 授权 → 零复制拿到路径 → 导入」尚未实测；新增两条失败文案也未在真机触发过。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71060 (4180 per locale)
+/// Strings: 71094 (4182 per locale)
 ///
-/// Built on 2026-09-03 at 03:52 UTC
+/// Built on 2026-09-03 at 16:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5734,6 +5734,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connected. Root catalog has ${count} entries';
   String discovery_opds_test_failed({required Object reason}) =>
       'Connection failed: ${reason}';
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -15474,6 +15478,12 @@ class _StringsAr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'فشل الاتصال: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -25441,6 +25451,12 @@ class _StringsDe extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbindung fehlgeschlagen: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -35460,6 +35476,12 @@ class _StringsEs extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Error de conexión: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -45514,6 +45536,12 @@ class _StringsFr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Échec de la connexion : ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -55373,6 +55401,12 @@ class _StringsId extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Koneksi gagal: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -65323,6 +65357,12 @@ class _StringsIt extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Connessione non riuscita: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -74661,6 +74701,12 @@ class _StringsJa extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '接続に失敗しました: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -84009,6 +84055,12 @@ class _StringsKo extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '연결 실패: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -93914,6 +93966,12 @@ class _StringsNl extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbinding mislukt: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -103873,6 +103931,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Falha na conexão: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -113811,6 +113875,12 @@ class _StringsRu extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Не удалось подключиться: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -123547,6 +123617,12 @@ class _StringsTh extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'เชื่อมต่อไม่สำเร็จ: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -133400,6 +133476,12 @@ class _StringsTr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Bağlantı başarısız: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -143224,6 +143306,12 @@ class _StringsVi extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Kết nối thất bại: ${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 // Path: <root>
@@ -152251,6 +152339,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '连接失败：${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      '选择包文件失败：${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      '系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。';
 }
 
 // Path: <root>
@@ -161283,6 +161377,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '連線失敗：${reason}';
+  @override
+  String onboarding_pack_pick_failed({required Object message}) =>
+      'Could not use the chosen file: ${message}';
+  @override
+  String get onboarding_pack_pick_no_path =>
+      'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
 }
 
 /// Flat map(s) containing all translations.
@@ -169859,6 +169959,11 @@ extension on _StringsEn {
             'Connected. Root catalog has ${count} entries';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Connection failed: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -178430,6 +178535,11 @@ extension on _StringsAr {
             'تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'فشل الاتصال: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -187046,6 +187156,11 @@ extension on _StringsDe {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Verbindung fehlgeschlagen: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -195653,6 +195768,11 @@ extension on _StringsEs {
             'Conectado. El catálogo raíz tiene ${count} entradas';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Error de conexión: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -204269,6 +204389,11 @@ extension on _StringsFr {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Échec de la connexion : ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -212856,6 +212981,11 @@ extension on _StringsId {
             'Terhubung. Katalog akar berisi ${count} entri';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Koneksi gagal: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -221465,6 +221595,11 @@ extension on _StringsIt {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Connessione non riuscita: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -230001,6 +230136,11 @@ extension on _StringsJa {
         return ({required Object count}) => '接続しました。ルートカタログに ${count} 件あります';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '接続に失敗しました: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -238541,6 +238681,11 @@ extension on _StringsKo {
             '연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '연결 실패: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -247143,6 +247288,11 @@ extension on _StringsNl {
             'Verbonden. De hoofdcatalogus heeft ${count} items';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Verbinding mislukt: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -255740,6 +255890,11 @@ extension on _StringsPtBr {
             'Conectado. O catálogo raiz tem ${count} itens';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Falha na conexão: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -264344,6 +264499,11 @@ extension on _StringsRu {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Не удалось подключиться: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -272920,6 +273080,11 @@ extension on _StringsTh {
             'เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'เชื่อมต่อไม่สำเร็จ: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -281511,6 +281676,11 @@ extension on _StringsTr {
             'Bağlanıldı. Kök katalogda ${count} girdi var';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Bağlantı başarısız: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -290096,6 +290266,11 @@ extension on _StringsVi {
             'Đã kết nối. Danh mục gốc có ${count} mục';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Kết nối thất bại: ${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }
@@ -298609,6 +298784,10 @@ extension on _StringsZhCn {
         return ({required Object count}) => '连接成功，根目录有 ${count} 个条目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '连接失败：${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) => '选择包文件失败：${message}';
+      case 'onboarding_pack_pick_no_path':
+        return '系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。';
       default:
         return null;
     }
@@ -307123,6 +307302,11 @@ extension on _StringsZhHk {
         return ({required Object count}) => '連線成功，根目錄有 ${count} 個項目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '連線失敗：${reason}';
+      case 'onboarding_pack_pick_failed':
+        return ({required Object message}) =>
+            'Could not use the chosen file: ${message}';
+      case 'onboarding_pack_pick_no_path':
+        return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71094 (4182 per locale)
+/// Strings: 71281 (4193 per locale)
 ///
-/// Built on 2026-09-03 at 16:55 UTC
+/// Built on 2026-09-03 at 17:09 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5738,6 +5738,26 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Could not use the chosen file: ${message}';
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  String get interconnect_profile_section => 'Configuration file';
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -15484,6 +15504,37 @@ class _StringsAr extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -25457,6 +25508,37 @@ class _StringsDe extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -35482,6 +35564,37 @@ class _StringsEs extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -45542,6 +45655,37 @@ class _StringsFr extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -55407,6 +55551,37 @@ class _StringsId extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -65363,6 +65538,37 @@ class _StringsIt extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -74707,6 +74913,37 @@ class _StringsJa extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -84061,6 +84298,37 @@ class _StringsKo extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -93972,6 +94240,37 @@ class _StringsNl extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -103937,6 +104236,37 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -113881,6 +114211,37 @@ class _StringsRu extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -123623,6 +123984,37 @@ class _StringsTh extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -133482,6 +133874,37 @@ class _StringsTr extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -143312,6 +143735,37 @@ class _StringsVi extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 // Path: <root>
@@ -152345,6 +152799,33 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       '系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。';
+  @override
+  String get interconnect_profile_section => '配置文件';
+  @override
+  String get interconnect_profile_upload => '上传配置到对端';
+  @override
+  String get interconnect_profile_upload_desc => '把本机当前配置发给已配对的对端，在那边落成一份新配置。';
+  @override
+  String get interconnect_profile_download => '从对端下载配置';
+  @override
+  String get interconnect_profile_download_desc =>
+      '把对端当前配置作为一份新配置导入本机，不动你正在用的那份。';
+  @override
+  String get interconnect_profile_host_toggle => '允许已配对设备读写本机配置';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      '默认关闭。需要 HTTPS 与已配对设备令牌；收到的配置一律作为新配置追加，不覆盖现有配置。';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      '配置已上传：${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      '配置已导入：${name}';
+  @override
+  String get interconnect_profile_unsupported => '对端不提供配置传输（需要 HTTPS 且对端版本较新）。';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      '配置传输失败：${message}';
 }
 
 // Path: <root>
@@ -161383,6 +161864,37 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get onboarding_pack_pick_no_path =>
       'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+  @override
+  String get interconnect_profile_section => 'Configuration file';
+  @override
+  String get interconnect_profile_upload => 'Upload configuration to host';
+  @override
+  String get interconnect_profile_upload_desc =>
+      'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+  @override
+  String get interconnect_profile_download =>
+      'Download configuration from host';
+  @override
+  String get interconnect_profile_download_desc =>
+      'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+  @override
+  String get interconnect_profile_host_toggle =>
+      'Allow paired devices to read/write configuration';
+  @override
+  String get interconnect_profile_host_toggle_desc =>
+      'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+  @override
+  String interconnect_profile_uploaded({required Object name}) =>
+      'Configuration uploaded: ${name}';
+  @override
+  String interconnect_profile_downloaded({required Object name}) =>
+      'Configuration imported: ${name}';
+  @override
+  String get interconnect_profile_unsupported =>
+      'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+  @override
+  String interconnect_profile_failed({required Object message}) =>
+      'Configuration transfer failed: ${message}';
 }
 
 /// Flat map(s) containing all translations.
@@ -169964,6 +170476,29 @@ extension on _StringsEn {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -178540,6 +179075,29 @@ extension on _StringsAr {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -187161,6 +187719,29 @@ extension on _StringsDe {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -195773,6 +196354,29 @@ extension on _StringsEs {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -204394,6 +204998,29 @@ extension on _StringsFr {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -212986,6 +213613,29 @@ extension on _StringsId {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -221600,6 +222250,29 @@ extension on _StringsIt {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -230141,6 +230814,29 @@ extension on _StringsJa {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -238686,6 +239382,29 @@ extension on _StringsKo {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -247293,6 +248012,29 @@ extension on _StringsNl {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -255895,6 +256637,29 @@ extension on _StringsPtBr {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -264504,6 +265269,29 @@ extension on _StringsRu {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -273085,6 +273873,29 @@ extension on _StringsTh {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -281681,6 +282492,29 @@ extension on _StringsTr {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -290271,6 +291105,29 @@ extension on _StringsVi {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }
@@ -298788,6 +299645,28 @@ extension on _StringsZhCn {
         return ({required Object message}) => '选择包文件失败：${message}';
       case 'onboarding_pack_pick_no_path':
         return '系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。';
+      case 'interconnect_profile_section':
+        return '配置文件';
+      case 'interconnect_profile_upload':
+        return '上传配置到对端';
+      case 'interconnect_profile_upload_desc':
+        return '把本机当前配置发给已配对的对端，在那边落成一份新配置。';
+      case 'interconnect_profile_download':
+        return '从对端下载配置';
+      case 'interconnect_profile_download_desc':
+        return '把对端当前配置作为一份新配置导入本机，不动你正在用的那份。';
+      case 'interconnect_profile_host_toggle':
+        return '允许已配对设备读写本机配置';
+      case 'interconnect_profile_host_toggle_desc':
+        return '默认关闭。需要 HTTPS 与已配对设备令牌；收到的配置一律作为新配置追加，不覆盖现有配置。';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => '配置已上传：${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => '配置已导入：${name}';
+      case 'interconnect_profile_unsupported':
+        return '对端不提供配置传输（需要 HTTPS 且对端版本较新）。';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) => '配置传输失败：${message}';
       default:
         return null;
     }
@@ -307307,6 +308186,29 @@ extension on _StringsZhHk {
             'Could not use the chosen file: ${message}';
       case 'onboarding_pack_pick_no_path':
         return 'The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.';
+      case 'interconnect_profile_section':
+        return 'Configuration file';
+      case 'interconnect_profile_upload':
+        return 'Upload configuration to host';
+      case 'interconnect_profile_upload_desc':
+        return 'Send this device\'s active configuration to the paired host, where it lands as a new configuration.';
+      case 'interconnect_profile_download':
+        return 'Download configuration from host';
+      case 'interconnect_profile_download_desc':
+        return 'Import the host\'s active configuration as a new configuration here. Your current one is untouched.';
+      case 'interconnect_profile_host_toggle':
+        return 'Allow paired devices to read/write configuration';
+      case 'interconnect_profile_host_toggle_desc':
+        return 'Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.';
+      case 'interconnect_profile_uploaded':
+        return ({required Object name}) => 'Configuration uploaded: ${name}';
+      case 'interconnect_profile_downloaded':
+        return ({required Object name}) => 'Configuration imported: ${name}';
+      case 'interconnect_profile_unsupported':
+        return 'The paired host does not offer configuration transfer (needs HTTPS and a newer version).';
+      case 'interconnect_profile_failed':
+        return ({required Object message}) =>
+            'Configuration transfer failed: ${message}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Needed for a self-hosted server on your local network",
   "discovery_opds_test": "Test connection",
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
-  "discovery_opds_test_failed": "Connection failed: ${reason}"
+  "discovery_opds_test_failed": "Connection failed: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
   "discovery_opds_test_failed": "Connection failed: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "مطلوب لخادم ذاتي الاستضافة على شبكتك المحلية",
   "discovery_opds_test": "اختبار الاتصال",
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
-  "discovery_opds_test_failed": "فشل الاتصال: ${reason}"
+  "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
   "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
   "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Nötig für einen selbst gehosteten Server im lokalen Netzwerk",
   "discovery_opds_test": "Verbindung testen",
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
-  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}"
+  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Necesario para un servidor autoalojado en tu red local",
   "discovery_opds_test": "Probar conexión",
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
-  "discovery_opds_test_failed": "Error de conexión: ${reason}"
+  "discovery_opds_test_failed": "Error de conexión: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
   "discovery_opds_test_failed": "Error de conexión: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Nécessaire pour un serveur auto-hébergé sur votre réseau local",
   "discovery_opds_test": "Tester la connexion",
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
-  "discovery_opds_test_failed": "Échec de la connexion : ${reason}"
+  "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
   "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
   "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Diperlukan untuk server milik sendiri di jaringan lokal",
   "discovery_opds_test": "Uji koneksi",
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
-  "discovery_opds_test_failed": "Koneksi gagal: ${reason}"
+  "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
   "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Necessario per un server self-hosted sulla rete locale",
   "discovery_opds_test": "Prova connessione",
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
-  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}"
+  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "ローカルネットワークの自前サーバーに必要です",
   "discovery_opds_test": "接続をテスト",
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
-  "discovery_opds_test_failed": "接続に失敗しました: ${reason}"
+  "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
   "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "로컬 네트워크의 자체 호스팅 서버에 필요합니다",
   "discovery_opds_test": "연결 테스트",
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
-  "discovery_opds_test_failed": "연결 실패: ${reason}"
+  "discovery_opds_test_failed": "연결 실패: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
   "discovery_opds_test_failed": "연결 실패: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
   "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Nodig voor een zelfgehoste server in je lokale netwerk",
   "discovery_opds_test": "Verbinding testen",
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
-  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}"
+  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Necessário para um servidor auto-hospedado na sua rede local",
   "discovery_opds_test": "Testar conexão",
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
-  "discovery_opds_test_failed": "Falha na conexão: ${reason}"
+  "discovery_opds_test_failed": "Falha na conexão: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
   "discovery_opds_test_failed": "Falha na conexão: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Нужно для сервера, размещённого в вашей локальной сети",
   "discovery_opds_test": "Проверить соединение",
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
-  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}"
+  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
   "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
   "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "จำเป็นสำหรับเซิร์ฟเวอร์ที่โฮสต์เองในเครือข่ายภายใน",
   "discovery_opds_test": "ทดสอบการเชื่อมต่อ",
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
-  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}"
+  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Yerel ağdaki kendi sunucun için gerekli",
   "discovery_opds_test": "Bağlantıyı sına",
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
-  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}"
+  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
   "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "Cần thiết cho máy chủ tự dựng trong mạng nội bộ",
   "discovery_opds_test": "Kiểm tra kết nối",
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
-  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}"
+  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
   "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
   "discovery_opds_test_failed": "连接失败：${reason}",
   "onboarding_pack_pick_failed": "选择包文件失败：${message}",
-  "onboarding_pack_pick_no_path": "系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。"
+  "onboarding_pack_pick_no_path": "系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。",
+  "interconnect_profile_section": "配置文件",
+  "interconnect_profile_upload": "上传配置到对端",
+  "interconnect_profile_upload_desc": "把本机当前配置发给已配对的对端，在那边落成一份新配置。",
+  "interconnect_profile_download": "从对端下载配置",
+  "interconnect_profile_download_desc": "把对端当前配置作为一份新配置导入本机，不动你正在用的那份。",
+  "interconnect_profile_host_toggle": "允许已配对设备读写本机配置",
+  "interconnect_profile_host_toggle_desc": "默认关闭。需要 HTTPS 与已配对设备令牌；收到的配置一律作为新配置追加，不覆盖现有配置。",
+  "interconnect_profile_uploaded": "配置已上传：${name}",
+  "interconnect_profile_downloaded": "配置已导入：${name}",
+  "interconnect_profile_unsupported": "对端不提供配置传输（需要 HTTPS 且对端版本较新）。",
+  "interconnect_profile_failed": "配置传输失败：${message}"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "局域网自建服务器需要打开",
   "discovery_opds_test": "测试连接",
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
-  "discovery_opds_test_failed": "连接失败：${reason}"
+  "discovery_opds_test_failed": "连接失败：${reason}",
+  "onboarding_pack_pick_failed": "选择包文件失败：${message}",
+  "onboarding_pack_pick_no_path": "系统没有交出这个文件的路径。请把包放到手机存储里再选，或授予「所有文件访问」权限。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4180,5 +4180,16 @@
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
   "discovery_opds_test_failed": "連線失敗：${reason}",
   "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
-  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access.",
+  "interconnect_profile_section": "Configuration file",
+  "interconnect_profile_upload": "Upload configuration to host",
+  "interconnect_profile_upload_desc": "Send this device's active configuration to the paired host, where it lands as a new configuration.",
+  "interconnect_profile_download": "Download configuration from host",
+  "interconnect_profile_download_desc": "Import the host's active configuration as a new configuration here. Your current one is untouched.",
+  "interconnect_profile_host_toggle": "Allow paired devices to read/write configuration",
+  "interconnect_profile_host_toggle_desc": "Off by default. Requires HTTPS and a paired-device token. Incoming configurations are always added as new ones.",
+  "interconnect_profile_uploaded": "Configuration uploaded: ${name}",
+  "interconnect_profile_downloaded": "Configuration imported: ${name}",
+  "interconnect_profile_unsupported": "The paired host does not offer configuration transfer (needs HTTPS and a newer version).",
+  "interconnect_profile_failed": "Configuration transfer failed: ${message}"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4178,5 +4178,7 @@
   "discovery_opds_allow_http_hint": "區域網絡自建伺服器需要開啟",
   "discovery_opds_test": "測試連線",
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
-  "discovery_opds_test_failed": "連線失敗：${reason}"
+  "discovery_opds_test_failed": "連線失敗：${reason}",
+  "onboarding_pack_pick_failed": "Could not use the chosen file: ${message}",
+  "onboarding_pack_pick_no_path": "The system did not hand over a path for that file. Move the pack into device storage and pick it again, or grant all-files access."
 }

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1710,7 +1710,10 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
     // 用户误以为崩溃/失败。这里镜像上面的迁移遮罩：running 显「正在导入备份，请勿关闭」
     // + 进度条；done 显结果，导入成功后 ~1s 自动重启（backupImportRestart 走 restartApp 真
     // 拉新进程），「立即重启」按钮保留为手动兜底可提前点；失败态不自动、由用户读完原因手点。
-    if (appModel.backupImportActive) {
+    // BUG-2106：**只有关库后的相位**（running/done/failed）才换根独占。validating 段
+    // DB 仍打开、可取消，换根会把调用方路由连 Navigator 一起销毁（引导向导被整段摧毁），
+    // 改由压在调用方页面之上的模态遮罩路由承载，见 [buildBackupValidatingOverlayRoute]。
+    if (appModel.backupImportOwnsAppRoot) {
       final brightness =
           WidgetsBinding.instance.platformDispatcher.platformBrightness;
       final cs = ColorScheme.fromSeed(
@@ -1728,9 +1731,10 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
             // TODO-1183: 确定进度条监听（只进度条重建，不整树重绘）。
             progress: appModel.backupImportProgress,
             onRestart: () => backupImportRestart(appModel),
-            // TODO-1151: validating 相位的「取消」——作废 in-flight 校验 token 并退出
-            // 遮罩回设置页（其它相位本视图不渲染取消按钮）。
-            onCancel: appModel.cancelBackupValidating,
+            // BUG-2106：这里**不再**接 onCancel。「取消」只属于 validating 相位，而
+            // validating 已不由本根分支承载（它是压在调用方页面之上的模态路由，取消按钮
+            // 由 [buildBackupValidatingOverlayRoute] 的调用方接线）。本分支只剩
+            // running/done/failed，本视图在这三个相位根本不渲染取消按钮。
           ),
         ),
       );

--- a/fushi/lib/src/media/video/video_display_claim.dart
+++ b/fushi/lib/src/media/video/video_display_claim.dart
@@ -1,0 +1,60 @@
+import 'package:meta/meta.dart';
+
+/// 视频页对**进程级显示态**的所有权登记表（BUG-2105）。
+///
+/// 视频页在 `initState` 里认领三件全局显示态（都是进程唯一、没有「谁设的谁看得见」
+/// 的作用域）：
+///   * 移动端横屏锁（`SystemChrome.setPreferredOrientations`）；
+///   * 移动端系统栏可见性回调（`SystemChrome.setSystemUIChangeCallback`，全局单槽）；
+///   * macOS 交通灯隐藏（`setMacOSTrafficLightsHidden`）。
+///
+/// 原先这三件在 `dispose` 里**无条件**还原。换集（`_switchEpisode` 的窗口模式分支）
+/// 用 `pushReplacement`，而 Flutter 语义下**旧路由的 `dispose` 晚于新路由的
+/// `initState`**（旧路由要等新页入场动画结束才被移除并销毁）——于是顺序变成
+/// 「新页认领 → 旧页还原」，新页刚设好的横屏锁被放宽成含竖屏、刚注册的系统栏回调
+/// 被置空。移动端开着「自动旋转锁定」时，方向集一旦含 `portraitUp` 就退回用户锁定
+/// 的竖屏，观感就是「换集后掉出全屏播放」。
+///
+/// 根治形状与仓内 `FushiWindowsTitleBar._contentFullscreenOwners` 一致：**按所有者
+/// 记账，只有最后一个持有者离开才还原**。换集期间集合短暂同时含新旧两页，旧页释放
+/// 时集合非空 → 不还原；正常退页时集合空 → 还原。
+///
+/// 纯 Dart、无平台调用：判据可在 headless 环境单测（`test/media/video/
+/// video_display_claim_test.dart`），页面只消费 [claim] / [release] 的布尔结论，
+/// 不再自己手写「该不该还原」。
+class VideoDisplayClaim {
+  const VideoDisplayClaim._();
+
+  /// 当前持有进程级显示态的视频页（`State` 实例身份，不持有生命周期）。
+  static final Set<Object> _owners = <Object>{};
+
+  /// [owner] 认领显示态。返回 `true` 表示这是**首个**持有者（此前无人持有）。
+  ///
+  /// 重复认领同一个 owner 幂等（返回 `false`）。认领动作本身（锁横屏 / 注册回调 /
+  /// 隐交通灯）由调用方无条件执行——新页必须真的把全局单槽设成自己的，返回值只用来
+  /// 区分「首次进入」这类可选副作用。
+  static bool claim(Object owner) {
+    final bool wasEmpty = _owners.isEmpty;
+    _owners.add(owner);
+    return wasEmpty;
+  }
+
+  /// [owner] 释放显示态。返回 `true` **仅当**它是最后一个持有者（还原全局显示态的
+  /// 唯一判据）。
+  ///
+  /// 从未认领过的 owner 释放返回 `false`（不还原）——它没设过，也就无权还原。
+  static bool release(Object owner) {
+    if (!_owners.remove(owner)) return false;
+    return _owners.isEmpty;
+  }
+
+  /// 是否仍有视频页持有进程级显示态。
+  static bool get held => _owners.isNotEmpty;
+
+  /// 当前持有者数量（测试断言用）。
+  @visibleForTesting
+  static int get ownerCount => _owners.length;
+
+  @visibleForTesting
+  static void resetForTest() => _owners.clear();
+}

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -569,6 +569,39 @@ class AppModel with ChangeNotifier {
       localAudioStagingDir: temporaryDirectory,
       onLocalAudioImported: importSyncedLocalAudioDb,
       audioDatabaseRoot: Directory('${appDirectory.path}/audiobooks'),
+      // 互联「配置文件」（Profile）双向搬运（用户诉求：把一台设备调好的配置搬到另一台）。
+      // 三条依赖都注入回调而不是把 ProfileRepository 拖进 host service：它的构造还要
+      // anki repo 与「词典装没装」的磁盘判据，那两样只有 AppModel 这里凑得齐。
+      isProfileTransferEnabled: () =>
+          SyncRepository(database).isInterconnectProfileTransferEnabled(),
+      exportActiveProfileJson: () async {
+        final ProfileRepository repo = interconnectProfileRepository();
+        final int activeId = await repo.getActiveProfileId();
+        if (activeId < 0) {
+          // 没有激活 Profile（理论上 ensureDefaultProfile 之后不该出现）：如实报错，
+          // 别回一份空 JSON 让对端导入出一个空配置。
+          throw StateError('no active profile to export');
+        }
+        return repo.exportProfileToJson(
+          activeId,
+          // 与「配置管理」页导出同参：把指向本机 custom_fonts/ 的绝对路径剥成相对，
+          // 免得对端拿到一堆指向不存在目录的字体路径。
+          fontsRootDirectory: path.join(appDirectory.path, 'custom_fonts'),
+        );
+      },
+      importProfileJson: (String json) async {
+        final ProfileRepository repo = interconnectProfileRepository();
+        try {
+          // 永远 createNew：入站配置不得覆盖本机任何既有 Profile，也不动当前激活的。
+          final int id = await repo.importProfileFromJson(json);
+          final ProfileRow? row = await repo.getProfileById(id);
+          return row?.name ?? 'profile';
+        } on ProfileImportException catch (e) {
+          // wire 层只认 FormatException → 400（见 InterconnectProfileHost 的契约），
+          // 不让 profile 层的异常类型漏进 sync 层。
+          throw FormatException(e.toString());
+        }
+      },
       videoSubtitleLangCode: JapaneseLanguage.instance.languageCode,
       // client→host 视频上传（syncVideoFiles 开关驱动）：落 <documents>/remote_videos
       // （与 client 下载远端视频落点一致，AppPaths.remoteVideosDirectory 同目录）。
@@ -1389,6 +1422,17 @@ class AppModel with ChangeNotifier {
   bool isDictionaryInstalledOnDisk(String name) =>
       Directory(path.join(_dictionaryResourceDirectory.path, name))
           .existsSync();
+
+  /// 互联「配置文件」搬运用的 [ProfileRepository]。
+  ///
+  /// 与 `profileRepositoryProvider` 同构造参数（同一个 db + anki repo + 「词典装没装」
+  /// 的磁盘判据）。host 侧回调是无 ref 的后台路径，拿不到 Riverpod 容器，故就地建一个
+  /// —— [ProfileRepository] 本身不持状态、不持缓存，重复构造无副作用。
+  ProfileRepository interconnectProfileRepository() => ProfileRepository(
+        database,
+        platformServices.createAnkiRepository(),
+        isDictionaryInstalled: isDictionaryInstalledOnDisk,
+      );
 
   Directory get dictionaryResourceDirectory => _dictionaryResourceDirectory;
   late Directory _dictionaryResourceDirectory;

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1208,6 +1208,21 @@ class AppModel with ChangeNotifier {
   BackupImportPhase? get backupImportPhase => _backupImportPhase;
   bool get backupImportActive => _backupImportPhase != null;
 
+  /// BUG-2106：备份导入遮罩是否要**独占 app 根**（换根、卸载整棵子树含 Navigator）。
+  ///
+  /// 只有 [BackupImportPhase.running] / [BackupImportPhase.done] /
+  /// [BackupImportPhase.failed] 才为真：这三个相位之前已 [closeDatabase]，页面若还挂着
+  /// 就会去查已关闭的库，必须换根独占（且随后重启进程）。
+  ///
+  /// [BackupImportPhase.validating] **恒为假**：那一段只是读 zip + 生成合并预览，DB 仍
+  /// 打开、可取消，换根却会把调用方路由连 Navigator 一起销毁 —— 引导向导因此被整段摧毁
+  /// （进度丢失、`await Navigator.push` 的 future 永不完成、失败提示无处可弹 = 用户报的
+  /// 「选完本地包就强制退出引导且没有任何提醒」）。该相位改由压在调用方页面之上的模态
+  /// 路由承载，见 [buildBackupValidatingOverlayRoute]。
+  bool get backupImportOwnsAppRoot =>
+      _backupImportPhase != null &&
+      _backupImportPhase != BackupImportPhase.validating;
+
   /// 导入完成/失败后展示在确认视图里的文案（成功提示或失败原因）。
   String? _backupImportMessage;
   String? get backupImportMessage => _backupImportMessage;

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show ByteData, rootBundle;
 import 'package:fushi/pages.dart';
@@ -10,6 +9,7 @@ import 'package:fushi/src/anki/anki_config_controls.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/anki/ankiconnect_addon_installer.dart';
 import 'package:fushi/src/media/audiobook/book_import_dialog.dart';
+import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:fushi/src/onboarding/onboarding_sample_text.dart';
 import 'package:fushi/src/onboarding/onboarding_steps.dart';
 import 'package:fushi/src/onboarding/recommended_pack.dart';
@@ -113,6 +113,12 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
   final ValueNotifier<int> _packBytes = ValueNotifier<int>(0);
   CancelToken? _packCancelToken;
   bool _packDownloading = false;
+  /// BUG-2107：本地包「选择文件」的重入守卫。设置页那条导入本来就有
+  /// （`_BackupImportWidget._isImporting`），引导这条漏了 —— 连点两次会撞
+  /// file_picker 的 `already_active`，而异常在 `unawaited(...)` 里静默漂走。
+  bool _packPicking = false;
+  /// 包步骤内可见的失败原因（**已组好的用户可见文案**，不是裸异常串）。
+  /// 下载失败与选文件失败是两条路径、两种文案，故在写入处就地组好。
   String? _packError;
 
   bool get _browserExtensionAvailable => DesktopLookupService.isDesktop;
@@ -328,25 +334,62 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
       // 用户取消：半截文件保留，下次续传；非取消才示错。
       // （仓库钉 dio 5.1，类型名还是 `DioError`，与其余下载路径一致。）
       if (e.type != DioErrorType.cancel) {
-        _packError = e.message ?? e.toString();
+        _packError = t.onboarding_pack_download_failed(
+          message: e.message ?? e.toString(),
+        );
       }
     } catch (e) {
-      _packError = e.toString();
+      _packError = t.onboarding_pack_download_failed(message: e.toString());
     } finally {
       _packCancelToken = null;
       if (mounted) setState(() => _packDownloading = false);
     }
   }
 
+  /// 选一个已经下载好的包文件（备份 zip）并导入。
+  ///
+  /// BUG-2107：原先是全 app 仅剩的几处裸 `FilePicker.platform.pickFiles()` 之一，而它
+  /// 承载的恰是**体积最大**的文件（推荐包 [kRecommendedPackSizeLabel] = 9.5 GB）。安卓上
+  /// file_picker 会先把整份文件同步复制进 app cache 再返回缓存路径 → 需要约 2 倍包体积的
+  /// 内部存储、几分钟没有任何 UI 反馈；失败时 `path == null` 与「用户取消」同形被静默
+  /// 丢弃，`PlatformException` 又被调用点的 `unawaited(...)` 吞掉 —— 用户看到的就是
+  /// 「点了『导入文件』没有任何提醒」。改走 [pickRealFilePathDetailed]（安卓解析真实路径、
+  /// 零复制；BUG-1667 后其余大文件入口都已统一到它），并把三种结果分开：
+  ///   * 返回 null = 用户取消 → 静默（取消不是失败）；
+  ///   * [PickedFileWithoutPathException] = 平台交回条目却没给路径 → **可见失败**（BUG-446）；
+  ///   * 其它异常 → 可见失败 + 诊断日志。
   Future<void> _pickPackFileAndImport() async {
-    final FilePickerResult? result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: <String>['zip'],
-    );
-    final String? path = result?.files.single.path;
-    if (path == null || !mounted) return;
-    // 用户自备的文件不归下载器管，导入后不删。
-    await _importPackFile(path, deleteAfterImport: false);
+    if (_packPicking || _packDownloading) return;
+    setState(() {
+      _packPicking = true;
+      _packError = null;
+    });
+    try {
+      final PickedFilePath? picked = await pickRealFilePathDetailed(
+        context: context,
+        appModel: appModel,
+        allowedExtensions: <String>{'zip'},
+      );
+      // 用户取消：静默返回（不是失败，不写 _packError）。
+      if (picked == null) return;
+      if (!mounted) return;
+      // 用户自备的文件不归下载器管，导入后不删。
+      await _importPackFile(picked.path, deleteAfterImport: false);
+    } on PickedFileWithoutPathException catch (e) {
+      ErrorLogService.instance.log(
+        'OnboardingWizard.pickPackFile',
+        'unexpected file selection: count=${e.count}, pathNull=true',
+      );
+      _packError = t.onboarding_pack_pick_no_path;
+    } catch (e) {
+      ErrorLogService.instance.log(
+        'OnboardingWizard.pickPackFile',
+        'pack file pick failed: $e',
+      );
+      _packError = t.onboarding_pack_pick_failed(message: e.toString());
+    } finally {
+      if (mounted) setState(() => _packPicking = false);
+    }
   }
 
   /// 走备份导入共享编排。导入真正开始（用户已确认）后进程会重启；
@@ -1210,7 +1253,7 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
         SizedBox(height: tokens.spacing.card),
         if (_packError != null) ...<Widget>[
           Text(
-            t.onboarding_pack_download_failed(message: _packError!),
+            _packError!,
             style: textTheme.bodySmall!.copyWith(
               color: theme.colorScheme.error,
             ),

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -43,6 +43,7 @@ import 'package:fushi/src/media/video/danmaku_manual_match_panel.dart';
 import 'package:fushi/src/media/source_library/source_stream_headers.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
 import 'package:fushi/src/media/video/subtitle_embedded_fonts.dart';
+import 'package:fushi/src/media/video/video_display_claim.dart';
 import 'package:fushi/src/media/video/video_episode_start_policy.dart';
 import 'package:fushi/src/media/video/video_import_dialog.dart';
 import 'package:fushi/src/media/video/video_top_bar_slots.dart';
@@ -1939,6 +1940,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // TODO-057: 进入视频即快照系统屏幕亮度（移动端），供亮度手势初值与退出还原；
     // 桌面 no-op。
     unawaited(_ensureEnterBrightness());
+    // BUG-2105：先登记「本页持有进程级显示态」（横屏锁 / 系统栏回调 / macOS 交通灯），
+    // 再去设这三件。换集的窗口模式分支用 `pushReplacement`，旧页 dispose 晚于本页
+    // initState —— 登记表让旧页释放时看到「还有人持有」而不还原，否则新页刚设好的
+    // 横屏锁被放宽成含竖屏（旋转锁定下当即翻竖屏 = 掉出全屏）、刚注册的系统栏回调被
+    // 置空。见 [VideoDisplayClaim] 与 [_releaseVideoDisplayClaim]。
+    VideoDisplayClaim.claim(this);
     // TODO-099: 进入视频页强制横屏（移动端），退出 [dispose] 还原；桌面 no-op。
     unawaited(_lockLandscapeForVideo());
     // BUG-973: 进入视频页隐藏 macOS 系统交通灯（左上角三个圆点），退出 [dispose] 恢复。
@@ -3752,10 +3759,10 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       );
     }
     WidgetsBinding.instance.removeObserver(this);
-    // TODO-658/BUG-383: 摘除系统栏可见性回调（全局单例，避免退页后仍回调已释放 State）。
-    if (isMobilePlatform) {
-      unawaited(SystemChrome.setSystemUIChangeCallback(null));
-    }
+    // BUG-2105：进程级显示态（系统栏回调 / 横屏锁 / macOS 交通灯）统一在
+    // [_releaseVideoDisplayClaim] 里按所有者记账还原——本页不是最后一个持有者
+    // （换集期间新页已认领）就不得还原，否则会把新页刚设好的显示态掰掉。
+    _releaseVideoDisplayClaim();
     final ExitFlushCallback? exitFlush = _exitFlushCallback;
     if (exitFlush != null) {
       ExitFlushRegistry.instance.unregister(exitFlush);
@@ -3787,11 +3794,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     // TODO-057: 退出播放器还原屏幕亮度——把进页快照写回（iOS 系统级亮度），未
     // 取过快照时 Android 侧设回「跟随系统」(-1)。防止把用户系统亮度永久留在拖动后值。
     unawaited(_brightness.restore(previous: _enterBrightness));
-    // TODO-099: 退出视频页还原屏幕方向允许态（移动端），不把其他页锁死在横屏；桌面 no-op。
-    unawaited(_restoreOrientationOnExit());
-    // BUG-973: 退出视频页恢复 macOS 系统交通灯（与 initState 的隐藏对称）；桌面非
-    // macOS / 移动端 no-op。
-    unawaited(setMacOSTrafficLightsHidden(false));
+    // TODO-099 / BUG-973 / BUG-2105：方向允许态与 macOS 交通灯的还原已并入
+    // [_releaseVideoDisplayClaim]（dispose 开头调用，按所有者记账），此处不再各自还原。
     _clearClipExportState();
     // TODO-669：销毁缩略图预览（作废在途取帧 + 销毁离屏 Player + 释放末帧）。
     _disposeThumbnailPreview();
@@ -6610,6 +6614,32 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
+  }
+
+  /// BUG-2105：释放本页对**进程级显示态**的所有权，并**仅在本页是最后一个持有者时**
+  /// 还原它们（系统栏可见性回调 / 屏幕方向允许态 / macOS 交通灯）。
+  ///
+  /// 三件都是进程唯一的全局单槽，谁最后设谁生效。换集的窗口模式分支
+  /// （[_VideoEpisode._switchEpisode]）用 `pushReplacement`，Flutter 语义下旧路由要等
+  /// 新页入场动画结束才被移除并 `dispose` —— 于是真实顺序是「新页 initState 认领并设好
+  /// 三件 → 旧页 dispose」。旧实现在 dispose 里无条件还原，等于把新页刚设的显示态掀掉：
+  /// 方向集被放宽成含 `portraitUp`（移动端开着自动旋转锁定时会退回用户锁定的竖屏，
+  /// 观感就是「换集后掉出全屏播放」）、系统栏可见性回调被置空（此后
+  /// [_systemBarsVisible] 再不更新，进度条 / 字幕避让几何回到 BUG-383 的错态）。
+  ///
+  /// 判据交给 [VideoDisplayClaim.release]（纯 Dart 登记表，真值可单测），这里只消费
+  /// 布尔结论，不在页面里手写「还有没有别人持有」。释放幂等：`release` 对没认领过的
+  /// owner 返回 false。
+  void _releaseVideoDisplayClaim() {
+    if (!VideoDisplayClaim.release(this)) return;
+    // TODO-658/BUG-383: 摘除系统栏可见性回调（全局单例，避免退页后仍回调已释放 State）。
+    if (isMobilePlatform) {
+      unawaited(SystemChrome.setSystemUIChangeCallback(null));
+    }
+    // TODO-099: 还原屏幕方向允许态（移动端），不把其他页锁死在横屏；桌面 no-op。
+    unawaited(_restoreOrientationOnExit());
+    // BUG-973: 恢复 macOS 系统交通灯（与 initState 的隐藏对称）；非 macOS 恒 no-op。
+    unawaited(setMacOSTrafficLightsHidden(false));
   }
 
   Future<void> _setLockWindowAspectRatio(bool value) async {

--- a/fushi/lib/src/sync/app_model_library_host_service.dart
+++ b/fushi/lib/src/sync/app_model_library_host_service.dart
@@ -35,6 +35,7 @@ import 'package:fushi/src/sync/collection_manifest.dart';
 import 'package:fushi/src/sync/collection_sync_engine.dart';
 import 'package:fushi/src/sync/fushi_library_host_service.dart';
 import 'package:fushi/src/sync/interconnect_service_config.dart';
+import 'package:fushi/src/sync/interconnect_profile_transfer.dart';
 import 'package:fushi/src/sync/deletion_propagation.dart';
 import 'package:fushi/src/sync/sync_asset_package_service.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
@@ -75,7 +76,8 @@ class AppModelLibraryHostService
         VideoDeletionHost,
         VideoPlaybackSyncHost,
         AudiobookDelayHost,
-        InterconnectServiceConfigHost {
+        InterconnectServiceConfigHost,
+        InterconnectProfileHost {
   AppModelLibraryHostService({
     required FushiDatabase db,
     required Directory dictionaryResourceRoot,
@@ -89,6 +91,9 @@ class AppModelLibraryHostService
     Future<void> Function(LocalAudioPackageContents)? onLocalAudioImported,
     Directory? audioDatabaseRoot,
     Future<void> Function(String displayName)? removeLocalAudioEntry,
+    Future<bool> Function()? isProfileTransferEnabled,
+    Future<String> Function()? exportActiveProfileJson,
+    Future<String> Function(String json)? importProfileJson,
     String videoSubtitleLangCode = 'ja',
     Directory? uploadedVideoRoot,
     Directory? videoCoversDirectory,
@@ -109,6 +114,9 @@ class AppModelLibraryHostService
        _onLocalAudioImported = onLocalAudioImported,
        _audioDatabaseRoot = audioDatabaseRoot,
        _removeLocalAudioEntry = removeLocalAudioEntry,
+       _isProfileTransferEnabled = isProfileTransferEnabled,
+       _exportActiveProfileJson = exportActiveProfileJson,
+       _importProfileJson = importProfileJson,
        _videoSubtitleLangCode = videoSubtitleLangCode,
        _uploadedVideoRoot = uploadedVideoRoot,
        _videoCoversDirectory = videoCoversDirectory,
@@ -119,6 +127,42 @@ class AppModelLibraryHostService
   final SyncAssetPackageService _packages;
   final Future<void> Function() _refreshDictionaryCache;
   final Future<void> Function(Future<void> Function() body) _runExclusive;
+
+  /// 互联「配置文件」（Profile）搬运的三个可选依赖（与本类其余可选能力同范式：
+  /// 注入回调而不是把 ProfileRepository 的构造依赖整条拖进来）。生产由 AppModel
+  /// 传入；未注入时开关判据恒为 false，端点对外表现为「host 关着」。
+  final Future<bool> Function()? _isProfileTransferEnabled;
+  final Future<String> Function()? _exportActiveProfileJson;
+  final Future<String> Function(String json)? _importProfileJson;
+
+  @override
+  Future<bool> isInterconnectProfileTransferEnabled() async {
+    // 三者缺一即视为不可用：没有导出/导入回调时开着开关也无从服务。
+    final Future<bool> Function()? enabled = _isProfileTransferEnabled;
+    if (enabled == null) return false;
+    if (_exportActiveProfileJson == null || _importProfileJson == null) {
+      return false;
+    }
+    return enabled();
+  }
+
+  @override
+  Future<String> exportInterconnectProfile() async {
+    final Future<String> Function()? export = _exportActiveProfileJson;
+    if (export == null) {
+      throw UnsupportedError('profile export not wired on this host');
+    }
+    return export();
+  }
+
+  @override
+  Future<String> importInterconnectProfile(String json) async {
+    final Future<String> Function(String json)? import = _importProfileJson;
+    if (import == null) {
+      throw UnsupportedError('profile import not wired on this host');
+    }
+    return import(json);
+  }
 
   @override
   Future<InterconnectServiceConfigSnapshot>

--- a/fushi/lib/src/sync/backup_validating_overlay_route.dart
+++ b/fushi/lib/src/sync/backup_validating_overlay_route.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/src/models/app_model.dart' show BackupImportPhase;
+import 'package:fushi/src/sync/backup_import_overlay_view.dart';
+
+/// BUG-2106：「正在读取备份…」（[BackupImportPhase.validating]）遮罩的宿主 = 压在
+/// **调用方页面之上的不可 pop 模态路由**，而不是换根。
+///
+/// 原实现让 `main.dart` 的根 build 在 `backupImportActive` 时返回另一个根 widget
+/// （`TranslationProvider(MaterialApp(home: BackupImportOverlayView))`），与正常分支的
+/// `KeyedSubtree(TranslationProvider(MaterialApp(navigatorKey: ...)))` **根类型不同** →
+/// 整棵 app 子树连 `Navigator` 一起 unmount：调用方页面及其全部 State 当场蒸发。设置页
+/// 丢一条路由无感（导入结束后回首页即可），但**引导向导**丢的是整个流程：
+///   * 向导的 `_stepIndex` / `_selected` 随 State 消失，用户被踢回第 1 步（观感=「强制退出引导」）；
+///   * `home_page.dart` 里 `await Navigator.push(OnboardingWizardPage)` 的 future 在
+///     Navigator 被 dispose 后**永不完成**，其后的 `setOnboardingCompleted(true)` 永不执行；
+///   * 校验阶段的失败/无效提示要在「切回正常树 + navigator 重新挂载」之后才能弹，
+///     `_rootContextAfterOverlay` 只等 2 帧，拿不到就静默 return —— 于是「什么提示都没有」。
+///
+/// 相位边界（不能一刀切）：`validating` 只是读 zip + 生成合并预览，**DB 仍打开**、可取消，
+/// 没有任何理由卸载整棵树；`running` / `done` / `failed` 之前先 `closeDatabase()`，此时页面
+/// 若还挂着就会去查已关闭的库，**必须**换根独占（且随后重启进程）。所以只把 `validating`
+/// 从换根改成模态路由，`running` 之后保持原样。
+///
+/// 用 `opaque: true` 挡住底下页面的绘制与命中测试；`PopScope(canPop: false)` 让系统返回 /
+/// 手势返回在校验期不再把底下的调用方路由 pop 掉（它是本遮罩之下的页面，back 事件由
+/// `WidgetsApp` 的 Navigator 处理，压在栈顶的本路由才是接收方）。**因此摘除它必须走
+/// `Navigator.removeRoute`**：`pop` 会被 `PopScope` 拦下（同 BUG-2043 的接管手法）。
+Route<void> buildBackupValidatingOverlayRoute({
+  required VoidCallback onCancel,
+  Color? background,
+}) {
+  return PageRouteBuilder<void>(
+    opaque: true,
+    barrierDismissible: false,
+    transitionDuration: Duration.zero,
+    reverseTransitionDuration: Duration.zero,
+    pageBuilder: (BuildContext _, Animation<double> __, Animation<double> ___) =>
+        PopScope(
+      canPop: false,
+      child: BackupImportOverlayView(
+        phase: BackupImportPhase.validating,
+        background: background,
+        // validating 相位本视图不渲染「立即重启」出口（只有 done/failed 才渲染），
+        // 故这里给一个不可达的 no-op，而不是把重启能力泄漏到校验期。
+        onRestart: _unreachableRestart,
+        onCancel: onCancel,
+      ),
+    ),
+  );
+}
+
+void _unreachableRestart() {}

--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -15,6 +15,7 @@ import 'package:fushi/src/media/video/video_subtitle_source.dart'
 import 'package:fushi/src/sync/aggregate_snapshot.dart';
 import 'package:fushi/src/sync/collection_manifest.dart';
 import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/interconnect_profile_transfer.dart';
 import 'package:fushi/src/sync/interconnect_service_config.dart';
 import 'package:fushi/src/sync/fushi_manga_ocr_host.dart';
 import 'package:fushi/src/sync/interconnect_device_name.dart';
@@ -619,6 +620,9 @@ class FushiSyncServer {
     }
     if (reqPath == '/api/interconnect/service-config') {
       return _handleInterconnectServiceConfig(request, method);
+    }
+    if (reqPath == kInterconnectProfilePath) {
+      return _handleInterconnectProfile(request, method);
     }
     if (reqPath == '/api/tombstones') {
       return _handleTombstones(request, method);
@@ -1304,6 +1308,11 @@ class FushiSyncServer {
         'videos': lib,
         'serviceConfig': _securityContext != null &&
             _libraryService is InterconnectServiceConfigHost,
+        // 互联「配置文件」（Profile）双向搬运：与 serviceConfig 同门槛（必须 TLS）。
+        // 能力位只说「这台 host 懂这个端点」，不代表此刻允许——端点还会再查一次
+        // 用户开关，关着时返回 403，client 如实报错而不是当成不支持。
+        'profileTransfer': _securityContext != null &&
+            _libraryService is InterconnectProfileHost,
       },
       // TODO-961 M1 能力协商（设计稿 §1.1 / §2.5）：老 client 读不到也不崩。
       'tls': <String, dynamic>{
@@ -2503,6 +2512,64 @@ class FushiSyncServer {
         'Cache-Control': 'no-store',
       },
     );
+  }
+
+  /// GET / PUT `/api/interconnect/profile`：互联「配置文件」（Profile）双向搬运。
+  ///
+  /// 与 `service-config`（自动跟随的小白名单、单向下行）分工不同：这条是用户**显式点
+  /// 一次**的整份 Profile 搬运，双向。安全门与 service-config 同级并更严一档：
+  ///   * **必须 TLS**（`_securityContext != null`）——载荷是用户的整套设置，明文链路上
+  ///     不给（同 BUG-1311 给 service-config 立的规矩）；
+  ///   * **必须已配对 peer token**（`_validatePeerAuth`，未进鉴权豁免名单）；
+  ///   * **host 侧用户开关**：默认关。没有这道门，入站 PUT 就是一条「无 UI 无开关的
+  ///     隐形写入通道」，正是 BUG-988 点名要避免的形状。开关关着返回 403（而不是 404），
+  ///     好让 client 把「host 不支持」与「host 关着」两种情况分开报。
+  ///
+  /// 载荷就是 Profile 的分享 JSON（`.fushiprofile.json` 的内容），凭据剔除与字体路径
+  /// 剥离由 `ProfileRepository.exportProfileToJson` 负责，见
+  /// [InterconnectProfileHost] 的文档。入站一律 `createNew` 导入，绝不覆盖 host 上任何
+  /// 既有 Profile。
+  Future<shelf.Response> _handleInterconnectProfile(
+    shelf.Request request,
+    String method,
+  ) async {
+    if (method != 'GET' && method != 'PUT') return shelf.Response(405);
+    if (_securityContext == null) {
+      return shelf.Response.forbidden('HTTPS required for profile transfer');
+    }
+    if (!await _validatePeerAuth(request.headers['authorization'])) {
+      return shelf.Response.forbidden('Paired-device token required');
+    }
+    final FushiLibraryHostService? library = _libraryService;
+    if (library is! InterconnectProfileHost) {
+      return shelf.Response.notFound('Profile transfer capability off');
+    }
+    final InterconnectProfileHost host = library as InterconnectProfileHost;
+    if (!await host.isInterconnectProfileTransferEnabled()) {
+      return shelf.Response.forbidden('Profile transfer disabled on host');
+    }
+    if (method == 'GET') {
+      final String json = await host.exportInterconnectProfile();
+      return shelf.Response.ok(
+        json,
+        headers: const <String, String>{
+          'Content-Type': 'application/json; charset=utf-8',
+          'Cache-Control': 'no-store',
+        },
+      );
+    }
+    final String body = await request.readAsString();
+    if (body.trim().isEmpty) {
+      return shelf.Response(400, body: 'Empty profile payload');
+    }
+    try {
+      final String name = await host.importInterconnectProfile(body);
+      return _jsonResponse(<String, dynamic>{'name': name});
+    } on FormatException catch (e) {
+      // 载荷不是合法的 Profile 导出（魔数/版本/结构不对）：400，且 host 侧 DB 零改动
+      // （解析在写库之前，见 ProfileRepository.parseProfileExport）。
+      return shelf.Response(400, body: 'Invalid profile payload: ${e.message}');
+    }
   }
 
   /// GET `/api/tombstones`：列 host 全部删除墓碑为 JSON 数组，供 client 拉取后与本地

--- a/fushi/lib/src/sync/interconnect_profile_transfer.dart
+++ b/fushi/lib/src/sync/interconnect_profile_transfer.dart
@@ -1,0 +1,52 @@
+/// 互联通道上的「配置文件」（Profile）传输契约。
+///
+/// 用户诉求：把一台设备上调好的**配置**搬到另一台已配对设备，而不是每台重配一遍。
+/// 本仓中文 UI 里的「配置」就是 Profile（见「配置管理」页），其分享产物是
+/// `<名字>.fushiprofile.json`。
+///
+/// 为什么复用 Profile 的分享 JSON 而不是另造 wire 格式：`ProfileRepository`
+/// 的 `exportProfileToJson` / `importProfileFromJson` 已经把三件难事做完了——
+///   * 凭据剔除（与备份 zip 共用 `PrefRedactionPolicy` 这一唯一真相源）；
+///   * 字体绝对路径剥离（导到别的设备缺文件时优雅降级，也不泄漏本机目录结构）；
+///   * 文件魔数 `hibiki.profile` + `formatVersion` 校验（导入侧先校验再写 DB，
+///     解析失败抛 `ProfileImportException`，事务零破坏）。
+/// 再造一份 wire 格式只会让「哪条 key 能出境」多出第二个真相源，正是
+/// `PrefRedactionPolicy` 文档里点名要消除的那类分叉。
+///
+/// 与 `InterconnectServiceConfigSnapshot`（外部服务身份的小白名单）的分工：
+/// 那条是**自动跟随**的下行同步，只搬 jimaku/qb/TMDB 之类第三方服务身份；本条是
+/// 用户**显式点一次**的整份 Profile 搬运（阅读器排版、制卡字段、快捷键……），
+/// 双向，且两个方向都受 host 侧的接收/交出开关门控。
+///
+/// 备份包（`.fushi.zip`）不走这条：它已有「用互联做备份后端」的既有通道，且恢复
+/// 需要关库 + 重启进程，不属于「一个动作按钮」的语义。
+library;
+
+/// Host 侧可选能力，与 `FushiLibraryHostService` 的大接口分开（同
+/// `InterconnectServiceConfigHost` 的理由：老实现 / 测试 fake 不必跟着实现新方法）。
+abstract interface class InterconnectProfileHost {
+  /// host 侧用户开关：是否允许**已配对设备**读取 / 写入本机配置。默认关。
+  ///
+  /// 没有这道门，入站 PUT 就是「无 UI 无开关的隐形写入通道」（BUG-988 点名要避免的
+  /// 形状）。能力协商只回答「这台 host 懂这个端点」，此刻允不允许由本开关决定 ——
+  /// 所以关着时端点返回 **403 而不是 404**，client 才能把「不支持」与「关着」分开报。
+  Future<bool> isInterconnectProfileTransferEnabled();
+
+  /// 导出 host **当前激活 Profile** 的分享 JSON。
+  ///
+  /// 产物与「配置管理」页的导出完全一致（已剔凭据、已剥字体绝对路径）。
+  Future<String> exportInterconnectProfile();
+
+  /// 把对端上传的 Profile JSON 作为**新** Profile 导入本机，返回新建的 Profile 名。
+  ///
+  /// 永远 `createNew`：入站数据不得覆盖 host 上任何既有 Profile，更不得改动当前
+  /// 激活的那个——用户在 host 上仍要自己去「配置管理」里切过去才生效。
+  ///
+  /// 载荷不是合法的 Profile 导出（魔数 / 版本 / 结构不对）时抛 [FormatException]；
+  /// 实现方负责把 `ProfileImportException` 翻成它，好让 wire 层不必依赖 profile 层的
+  /// 异常类型就能回 400。解析在写库之前完成，失败时 host 的 DB 零改动。
+  Future<String> importInterconnectProfile(String json);
+}
+
+/// 互联「配置文件」端点路径（host 与 client 共用的唯一字面量）。
+const String kInterconnectProfilePath = '/api/interconnect/profile';

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -7,6 +7,7 @@ import 'package:fushi/src/sync/collection_manifest.dart';
 import 'package:fushi/src/sync/deletion_propagation.dart';
 import 'package:fushi/src/sync/fushi_library_host_service.dart';
 import 'package:fushi/src/sync/interconnect_service_config.dart';
+import 'package:fushi/src/sync/interconnect_profile_transfer.dart';
 import 'package:fushi/src/sync/remote_book_client.dart';
 import 'package:fushi/src/sync/remote_cover_fetcher.dart';
 import 'package:fushi/src/sync/remote_library_source.dart';
@@ -816,6 +817,71 @@ class InterconnectSyncBackend extends SyncBackend
     return InterconnectServiceConfigSnapshot.fromJson(
       decoded.cast<String, Object?>(),
     );
+  }
+
+  /// 拉取 host 当前激活 Profile 的分享 JSON（互联「下载配置」动作）。
+  ///
+  /// 与 [getRemoteServiceConfig] 同一条安全边界：整份配置只在 pinned HTTPS 会话上传
+  /// 输，明文会话上 host 必然 403，所以本地就短路返回 null（同 BUG-1311 的判断：答案
+  /// 本地已知，别拿一条注定被拒的请求把每轮同步挂上「N 项失败」）。
+  ///
+  /// 返回 null 的三种情形归一为「对端不提供此能力」：明文会话 / 老 host 404 /
+  /// host 未接线该能力 404。host **开关关着**是 403（不是 404）——那不是「不支持」，
+  /// 而是对端明确拒绝，必须如实报给用户，故走 checkStatus 抛出。
+  Future<String?> getRemoteProfileJson() async {
+    await _ensureResolved();
+    if (Uri.tryParse(_apiBase)?.scheme != 'https') return null;
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'GET',
+      '$_apiBase$kInterconnectProfilePath',
+    );
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      return null;
+    }
+    if (res.statusCode >= 400) {
+      _ops!.checkStatus(
+        res.statusCode,
+        'GET $kInterconnectProfilePath',
+        serverReason: await readSyncErrorBody(res),
+      );
+    }
+    return _readBodyBounded(res);
+  }
+
+  /// 把本机的 Profile 分享 JSON 推给 host（互联「上传配置」动作）。
+  ///
+  /// 返回 host 上新建的 Profile 名；host 不提供该能力（老 host / 未接线）返回 null，
+  /// 由调用方翻成「对端不支持」。host 开关关着 / 明文会话 / 未配对一律经 checkStatus
+  /// 抛出，携带 host 给的拒绝原因。
+  Future<String?> putRemoteProfileJson(String json) async {
+    await _ensureResolved();
+    if (Uri.tryParse(_apiBase)?.scheme != 'https') return null;
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'PUT',
+      '$_apiBase$kInterconnectProfilePath',
+    );
+    req.headers.contentType = ContentType('application', 'json', charset: 'utf-8');
+    req.add(utf8.encode(json));
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      return null;
+    }
+    if (res.statusCode >= 400) {
+      _ops!.checkStatus(
+        res.statusCode,
+        'PUT $kInterconnectProfilePath',
+        serverReason: await readSyncErrorBody(res),
+      );
+    }
+    final Object? decoded = jsonDecode(await _readBodyBounded(res));
+    if (decoded is! Map) {
+      throw const FormatException('Invalid profile upload response');
+    }
+    final Object? name = decoded['name'];
+    return name is String ? name : '';
   }
 
   /// TODO-1235（TODO-961 回归）：把对端封面拉成字节，复用互联其余流量同一条钉扎

--- a/fushi/lib/src/sync/sync_repository.dart
+++ b/fushi/lib/src/sync/sync_repository.dart
@@ -232,6 +232,11 @@ class SyncRepository {
   static const _keyInterconnectSyncAudioBookFiles =
       'interconnect_sync_audiobook_files';
   static const _keyInterconnectSyncVideoFiles = 'interconnect_sync_video_files';
+  // 互联「配置文件」（Profile）双向搬运的 **host 侧**开关：允许已配对设备读取 /
+  // 写入本机配置。默认 false —— 入站写没有显式开关就是「无 UI 的隐形通道」
+  // （BUG-988 立过的规矩），出站也一样：整份 Profile 比四个内容上传开关更敏感。
+  static const _keyInterconnectProfileTransfer =
+      'interconnect_profile_transfer';
   // 互联通道专属的「共享统计 / 共享收藏夹」开关。此前互联的聚合同步（统计 + 收藏
   // 词句）无条件复用云备份的 sync_stats_enabled，用户在互联页既看不到这两类数据
   // 正在跨设备流动，也没法只对互联单独关掉——与 BUG-988 拆四个上传开关时修掉的
@@ -653,6 +658,14 @@ class SyncRepository {
       _db.getPrefTyped<bool>(_keyInterconnectSyncVideoFiles, false);
   Future<void> setInterconnectSyncVideoFilesEnabled(bool v) =>
       _db.setPrefTyped<bool>(_keyInterconnectSyncVideoFiles, v);
+
+  /// host 侧：是否允许已配对设备读取 / 写入本机「配置文件」（Profile）。
+  ///
+  /// 端点还要求 TLS + 已配对 peer token；本开关是**用户意图**那一道，默认关。
+  Future<bool> isInterconnectProfileTransferEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectProfileTransfer, false);
+  Future<void> setInterconnectProfileTransferEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectProfileTransfer, v);
 
   /// 互联通道「共享统计」：阅读/观看时长、字数、逐时桶、查词与制卡计数。关掉后本设备
   /// 既不把统计推给对端，也不把对端统计折进本地——两个方向一起停，否则「关了还在收」

--- a/fushi/lib/src/sync/sync_settings_schema.dart
+++ b/fushi/lib/src/sync/sync_settings_schema.dart
@@ -12,6 +12,7 @@ import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/migration_page.dart';
 import 'package:fushi/src/pages/implementations/migration_import_page.dart';
 import 'package:fushi/src/migration/migration_target_channel.dart';
+import 'package:fushi/src/profile/profile_repository.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/settings/settings_schema_lookup.dart'
@@ -634,6 +635,31 @@ SettingsDestination buildInterconnectDestination() {
                   .setInterconnectServiceConfigSyncEnabled(value);
             },
           ),
+          // 「配置文件」（Profile）双向搬运：用户诉求是把一台设备调好的配置搬到另一
+          // 台，而不是每台重配一遍。做成**一次性动作**而不是自动跟随开关——整份配置
+          // 会在对端落一份新 Profile，什么时候搬该由用户在点的那一刻决定（与云通道
+          // 那四个资产上传/下载行同一取舍，见 sync.dictionary_upload 附近的说明）。
+          // 备份包不走这里：它已有「用互联做备份后端」的既有通道。
+          SettingsCustomItem(
+            id: 'interconnect.profile_upload',
+            searchTitle: t.interconnect_profile_upload,
+            icon: Icons.settings_backup_restore_outlined,
+            builder: (SettingsContext ctx) =>
+                _InterconnectProfileTransferWidget(
+              settingsContext: ctx,
+              direction: _ProfileTransferDirection.upload,
+            ),
+          ),
+          SettingsCustomItem(
+            id: 'interconnect.profile_download',
+            searchTitle: t.interconnect_profile_download,
+            icon: Icons.settings_backup_restore_outlined,
+            builder: (SettingsContext ctx) =>
+                _InterconnectProfileTransferWidget(
+              settingsContext: ctx,
+              direction: _ProfileTransferDirection.download,
+            ),
+          ),
         ],
       ),
       // 本机作为服务器：host 模式开关（与 client 角色互斥，见 _SyncSettingsState
@@ -648,6 +674,22 @@ SettingsDestination buildInterconnectDestination() {
             icon: Icons.router_outlined,
             builder: (SettingsContext ctx) =>
                 _ServerModeWidget(settingsContext: ctx),
+          ),
+          // host 侧「配置文件」读写许可。默认关：入站写没有显式开关就是一条无 UI 的
+          // 隐形通道（BUG-988 立过的规矩），出站同理——整份 Profile 比四个内容上传
+          // 开关更敏感。端点另有 TLS + 已配对 peer token 两道门，本开关是用户意图那道。
+          SettingsSwitchItem(
+            id: 'interconnect.profile_transfer_host',
+            title: t.interconnect_profile_host_toggle,
+            subtitle: t.interconnect_profile_host_toggle_desc,
+            icon: Icons.rule_folder_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectProfileTransfer,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectProfileTransfer = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectProfileTransferEnabled(value);
+            },
           ),
         ],
       ),
@@ -769,6 +811,8 @@ class _SyncSettingsState {
   // apikey 同步设定重设计（2026-08-17）：service-config（host 的外部服务 API key）
   // 接收开关。默认 true = 既有行为；此前这条通道无 UI 无开关，用户不可见也关不掉。
   bool interconnectServiceConfigSync = true;
+  /// host 侧：是否允许已配对设备读写本机「配置文件」（Profile）。默认 false。
+  bool interconnectProfileTransfer = false;
   bool _loaded = false;
   bool _loading = false;
 
@@ -858,6 +902,8 @@ class _SyncSettingsState {
           await _repo.isInterconnectSyncFavoritesEnabled();
       interconnectServiceConfigSync =
           await _repo.isInterconnectServiceConfigSyncEnabled();
+      interconnectProfileTransfer =
+          await _repo.isInterconnectProfileTransferEnabled();
       serverEnabled = await _repo.isServerEnabled();
       hasClientConnection = (await _repo.getFushiClientUrls()).isNotEmpty;
       _loaded = true;

--- a/fushi/lib/src/sync/sync_settings_schema.dart
+++ b/fushi/lib/src/sync/sync_settings_schema.dart
@@ -23,6 +23,7 @@ import 'package:fushi/src/storage/macos_data_root_access.dart';
 import 'package:fushi/src/sync/backup_merge_engine.dart'
     show BackupMergePreview;
 import 'package:fushi/src/sync/backup_service.dart';
+import 'package:fushi/src/sync/backup_validating_overlay_route.dart';
 import 'package:fushi/src/sync/dropbox_sync_backend.dart';
 import 'package:fushi/src/sync/ftp_sync_backend.dart';
 import 'package:fushi/src/sync/interconnect_sync_backend.dart';

--- a/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -873,15 +873,26 @@ Future<void> runBackupImportFlowForFile({
   required String filePath,
   Future<void> Function()? onImportConfirmed,
 }) async {
-  // appModel 驱动全程遮罩：validating/running 遮罩都会切走调用方页面（tree swap），
-  // 此后不依赖任何页面 `mounted`/context；确认对话框由全局 [AppModel.navigatorKey]
-  // 宿主弹出（退出遮罩、切回正常 app 树后再弹）。
+  // appModel 驱动全程遮罩，此后不依赖任何页面 `mounted`/context；确认对话框由全局
+  // [AppModel.navigatorKey] 宿主弹出。
+  //
+  // BUG-2106：两个相位的遮罩宿主**不同**，别再当成同一件事：
+  //   * validating（本函数前半段）：DB 仍打开、可取消 → 遮罩是压在**调用方页面之上的
+  //     模态路由**（[_BackupValidatingOverlay]），调用方路由留在栈里。原先它也走换根，
+  //     整棵 Navigator 被卸载 → 引导向导整段蒸发、`await push` 的 future 永不完成、
+  //     失败提示无处可弹（= 用户报的「选完本地包强制退出引导且没有任何提醒」）。
+  //   * running/done/failed（后半段）：已 closeDatabase，页面再挂着就会查已关闭的库 →
+  //     必须换根独占（`main.dart` 的 [AppModel.backupImportOwnsAppRoot] 分支），随后重启。
   //
   // TODO-1151: 先上屏「正在读取备份…」全屏遮罩（validating 相位），再跑 validate + 合并
   // 预览——大 zip 这段要数十秒，旧版只有设置行 24px 小圈无明显反馈。beginBackupValidating
   // 返回本轮 token；用户点「取消」或新一轮校验会作废它，in-flight 后台 isolate 结果回来
   // 时用 isBackupValidatingCurrent 判断是否仍是最新，陈旧结果直接丢弃（干净 token 判定）。
   final int validatingToken = appModel.beginBackupValidating();
+  // BUG-2106：校验遮罩压成模态路由（不换根），调用方页面留在栈里。
+  final _BackupValidatingOverlay overlay = _BackupValidatingOverlay.show(
+    appModel,
+  );
   BackupMeta? meta;
   BackupMergePreview? mergePreview;
   BackupContentSummary? summary;
@@ -897,12 +908,13 @@ Future<void> runBackupImportFlowForFile({
     // 已取消/被新一轮校验取代 → 丢弃陈旧结果（遮罩已由 cancel 退出，无需再动）。
     if (!appModel.isBackupValidatingCurrent(validatingToken)) return;
     if (validated == null) {
-      await _endValidatingThenSnack(appModel, t.backup_import_invalid);
+      await _endValidatingThenSnack(appModel, overlay, t.backup_import_invalid);
       return;
     }
     if (validated.schemaVersion > appModel.database.schemaVersion) {
       await _endValidatingThenSnack(
         appModel,
+        overlay,
         t.backup_schema_newer(version: validated.schemaVersion.toString()),
       );
       return;
@@ -931,18 +943,32 @@ Future<void> runBackupImportFlowForFile({
     if (appModel.isBackupValidatingCurrent(validatingToken)) {
       await _endValidatingThenSnack(
         appModel,
+        overlay,
         t.backup_import_failed(message: friendlySyncErrorDetail(e)),
       );
     }
     return;
+  } finally {
+    // BUG-2106：遮罩路由 `canPop:false`，任何一条退出路径（成功 / 无效 / 异常 /
+    // token 作废的早退）漏摘一次，app 就被永久挡在遮罩后面。幂等，重复调用无害。
+    overlay.dismiss();
   }
 
-  // 校验成功、合并预览就绪：退出 validating 遮罩，等根 widget 切回正常 app 树、全局
-  // navigator 重新挂载后，在其 context 上弹确认对话框（调用方页面此刻已卸载，不能用其
-  // context——遮罩是根 build 替换模型，宿主是 appModel.navigatorKey 的正常 MaterialApp）。
+  // 校验成功、合并预览就绪：摘掉校验遮罩路由，在全局 navigator 的 context 上弹确认
+  // 对话框（调用方页面仍在栈里，但对话框统一由全局 navigatorKey 宿主，和 running 相位
+  // 的换根模型保持同一个出口）。
   appModel.endBackupValidating();
   final BuildContext? rootCtx = await _rootContextAfterOverlay(appModel);
-  if (rootCtx == null || !rootCtx.mounted) return;
+  if (rootCtx == null || !rootCtx.mounted) {
+    // BUG-2106：这条曾是「点了本地包之后什么都没发生」的最后一道静默门。现在遮罩不再
+    // 换根、navigator 全程挂着，走到这里已属异常；至少留诊断，别再无声吞掉整个流程。
+    ErrorLogService.instance.log(
+      'runBackupImportFlowForFile',
+      'no root context after the validating overlay; import confirm dialog '
+          'could not be shown (file=$filePath)',
+    );
+    return;
+  }
 
   final _BackupImportChoice? choice = await _showBackupImportConfirmDialog(
       rootCtx, meta, mergePreview, summary);
@@ -1041,12 +1067,69 @@ Future<BuildContext?> _rootContextAfterOverlay(AppModel appModel) async {
   return null;
 }
 
-/// validate/preview 阶段的失败/无效出口：退出 validating 遮罩、切回调用方页面后用 root
-/// context 弹 snackbar（调用方页面此刻已卸载，用其 context 无效）。
-Future<void> _endValidatingThenSnack(AppModel appModel, String message) async {
+/// validate/preview 阶段的失败/无效出口：**先摘掉校验遮罩路由**再用 root context 弹
+/// snackbar —— 遮罩是 `opaque` 模态路由，不先摘就把提示压在遮罩底下（BUG-2106：这正是
+/// 「无效备份文件」之类提示从来没被用户看见的原因之一）。
+Future<void> _endValidatingThenSnack(
+  AppModel appModel,
+  _BackupValidatingOverlay overlay,
+  String message,
+) async {
+  overlay.dismiss();
   appModel.endBackupValidating();
   final BuildContext? rootCtx = await _rootContextAfterOverlay(appModel);
-  if (rootCtx != null && rootCtx.mounted) _showSnackBar(rootCtx, message);
+  if (rootCtx != null && rootCtx.mounted) {
+    _showSnackBar(rootCtx, message);
+    return;
+  }
+  // 提示是这条路径的**唯一**用户可见产物，丢了就等于「点了没反应」；至少留诊断。
+  ErrorLogService.instance.log(
+    'runBackupImportFlowForFile',
+    'validating failed but no root context to show the message: $message',
+  );
+}
+
+/// BUG-2106：validating 遮罩路由的句柄。
+///
+/// 遮罩宿主从「换根」改成「压在调用方页面之上的模态路由」（理由见
+/// [buildBackupValidatingOverlayRoute]）。摘除**必须** `removeRoute`：路由带
+/// `PopScope(canPop: false)`（挡系统返回把底下的调用方页面 pop 掉），`pop` 会被它拦下。
+///
+/// 拿不到全局 navigator（极早期 / 无 UI 宿主）时退化成「无遮罩但流程照跑」：校验本身不
+/// 依赖遮罩，宁可少一层视觉反馈，也不能因为没 navigator 就把导入整条流程掐掉。
+class _BackupValidatingOverlay {
+  _BackupValidatingOverlay._(this._navigator, this._route);
+
+  factory _BackupValidatingOverlay.show(AppModel appModel) {
+    final NavigatorState? navigator = appModel.navigatorKey.currentState;
+    if (navigator == null) return _BackupValidatingOverlay._(null, null);
+    late final _BackupValidatingOverlay handle;
+    final Route<void> route = buildBackupValidatingOverlayRoute(
+      onCancel: () {
+        // 用户点「取消」：先摘遮罩，再作废 in-flight 校验 token（回调用方页面）。
+        handle.dismiss();
+        appModel.cancelBackupValidating();
+      },
+    );
+    handle = _BackupValidatingOverlay._(navigator, route);
+    navigator.push<void>(route);
+    return handle;
+  }
+
+  final NavigatorState? _navigator;
+  final Route<void>? _route;
+  bool _dismissed = false;
+
+  /// 摘掉遮罩路由。幂等：每条退出路径都会调，重复调用无害。
+  void dismiss() {
+    if (_dismissed) return;
+    _dismissed = true;
+    final NavigatorState? navigator = _navigator;
+    final Route<void>? route = _route;
+    if (navigator == null || route == null) return;
+    if (!route.isActive) return;
+    navigator.removeRoute<void>(route);
+  }
 }
 
 /// Asks how to apply the backup (TODO-888): OVERWRITE the whole library

--- a/fushi/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -1800,6 +1800,134 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
 //
 // 退路：[_selectableBackends] 恒把当前值插回选项列表，所以设成互联之后，「同步与
 // 备份」的后端选择器里仍能选回 Google Drive / WebDAV 等，不是单向门。
+/// 互联「配置文件」（Profile）搬运的方向。
+enum _ProfileTransferDirection { upload, download }
+
+/// 互联页的「上传配置 / 下载配置」动作行。
+///
+/// 与云通道那四行（[_AssetTransferWidget]）刻意**不共用**实现：那套跑的是
+/// `runManualAssetTransfer`，而它明确跳过互联通道（只服务云备份后端）。这条是互联
+/// 专属的一次性动作，直接打 host 的 `/api/interconnect/profile`。
+///
+/// 语义：
+///   * 上传 = 把本机**当前激活** Profile 的分享 JSON 推给 host，在对端落成一份**新**
+///     Profile（绝不覆盖对端任何既有配置）；
+///   * 下载 = 取 host 当前激活 Profile，在本机同样落成一份**新** Profile，用户自己
+///     去「配置管理」里切过去才生效。
+///
+/// 两个方向都要求 host 开着「允许已配对设备读写本机配置」，且会话是 pinned HTTPS ——
+/// 不满足时 client 侧拿到的分别是 403（如实报原因）与 null（报「对端不提供」）。
+class _InterconnectProfileTransferWidget extends StatefulWidget {
+  const _InterconnectProfileTransferWidget({
+    required this.settingsContext,
+    required this.direction,
+  });
+
+  final SettingsContext settingsContext;
+  final _ProfileTransferDirection direction;
+
+  @override
+  State<_InterconnectProfileTransferWidget> createState() =>
+      _InterconnectProfileTransferWidgetState();
+}
+
+class _InterconnectProfileTransferWidgetState
+    extends State<_InterconnectProfileTransferWidget> {
+  bool _busy = false;
+
+  bool get _isUpload =>
+      widget.direction == _ProfileTransferDirection.upload;
+
+  Future<void> _run() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    final AppModel appModel = widget.settingsContext.appModel;
+    try {
+      final String? name = _isUpload
+          ? await _upload(appModel)
+          : await _download(appModel);
+      if (!mounted) return;
+      if (name == null) {
+        // null = 对端不提供此能力（老 host / 未接线 / 明文会话本地短路），与
+        // 「对端明确拒绝」（403，走 catch）是两回事，文案也不同。
+        _showSnackBar(context, t.interconnect_profile_unsupported);
+        return;
+      }
+      _showSnackBar(
+        context,
+        _isUpload
+            ? t.interconnect_profile_uploaded(name: name)
+            : t.interconnect_profile_downloaded(name: name),
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance.log('Interconnect.profileTransfer', e, stack);
+      if (!mounted) return;
+      // 走统一的友好错误翻译（对端探不到 / 认证失败 / host 关着开关都在这条线上），
+      // 不把裸异常 toString 上屏。
+      _showSnackBar(
+        context,
+        t.interconnect_profile_failed(message: friendlySyncErrorDetail(e)),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<String?> _upload(AppModel appModel) async {
+    final ProfileRepository repo = appModel.interconnectProfileRepository();
+    final int activeId = await repo.getActiveProfileId();
+    if (activeId < 0) throw StateError('no active profile to upload');
+    final String json = await repo.exportProfileToJson(
+      activeId,
+      // 与「配置管理」页导出同参：剥掉指向本机 custom_fonts/ 的绝对路径。
+      fontsRootDirectory: p.join(appModel.appDirectory.path, 'custom_fonts'),
+    );
+    return InterconnectSyncBackend.instance.putRemoteProfileJson(json);
+  }
+
+  Future<String?> _download(AppModel appModel) async {
+    final String? json =
+        await InterconnectSyncBackend.instance.getRemoteProfileJson();
+    if (json == null) return null;
+    final ProfileRepository repo = appModel.interconnectProfileRepository();
+    // createNew（默认）：本机现有配置一份都不动。
+    final int id = await repo.importProfileFromJson(json);
+    final ProfileRow? row = await repo.getProfileById(id);
+    return row?.name ?? '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveSettingsRow(
+      title: _isUpload
+          ? t.interconnect_profile_upload
+          : t.interconnect_profile_download,
+      subtitle: _isUpload
+          ? t.interconnect_profile_upload_desc
+          : t.interconnect_profile_download_desc,
+      icon: Icons.settings_backup_restore_outlined,
+      controlBelow: true,
+      // 行级 onTap 让本行注册成焦点目标（方向导航 / 手柄 A 能触发），与
+      // [_AssetTransferWidget] 同因（BUG-016）。
+      onTap: _busy ? null : _run,
+      trailing: _busy
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : FilledButton.tonal(
+              onPressed: _run,
+              child: Text(
+                _isUpload
+                    ? t.sync_asset_upload_action
+                    : t.sync_asset_download_action,
+              ),
+            ),
+    );
+  }
+}
+
 class _InterconnectBackupBackendWidget extends StatefulWidget {
   const _InterconnectBackupBackendWidget({required this.settingsContext});
   final SettingsContext settingsContext;

--- a/fushi/test/media/video/video_display_claim_test.dart
+++ b/fushi/test/media/video/video_display_claim_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_display_claim.dart';
+
+/// BUG-2105 真值表：视频页对进程级显示态（移动端横屏锁 / 系统栏可见性回调 /
+/// macOS 交通灯）的**所有者记账**。
+///
+/// 行为级复现要真设备方向系统 + 真 `pushReplacement` 过渡动画，headless 跑不了；
+/// 把「该不该还原」抽成纯登记表后，「旧页 dispose 掀掉新页显示态」这条回归就能在
+/// 单测里判红——判据只有一条：`release` 返回 true 当且仅当集合被它清空。
+void main() {
+  setUp(VideoDisplayClaim.resetForTest);
+  tearDown(VideoDisplayClaim.resetForTest);
+
+  group('VideoDisplayClaim 所有者记账 (BUG-2105)', () {
+    test('首个认领者返回 true，后续认领者返回 false', () {
+      final Object a = Object();
+      final Object b = Object();
+      expect(VideoDisplayClaim.claim(a), isTrue, reason: 'a 是首个持有者');
+      expect(VideoDisplayClaim.claim(b), isFalse, reason: '已有人持有');
+      expect(VideoDisplayClaim.ownerCount, 2);
+      expect(VideoDisplayClaim.held, isTrue);
+    });
+
+    test('重复认领同一 owner 幂等，不会把计数刷成两份', () {
+      final Object a = Object();
+      expect(VideoDisplayClaim.claim(a), isTrue);
+      expect(VideoDisplayClaim.claim(a), isFalse);
+      expect(VideoDisplayClaim.ownerCount, 1);
+      expect(VideoDisplayClaim.release(a), isTrue, reason: '一次释放就该清空');
+      expect(VideoDisplayClaim.held, isFalse);
+    });
+
+    test('正常退页：唯一持有者释放 → 该还原', () {
+      final Object a = Object();
+      VideoDisplayClaim.claim(a);
+      expect(VideoDisplayClaim.release(a), isTrue);
+      expect(VideoDisplayClaim.ownerCount, 0);
+    });
+
+    test('换集顺序（新页 initState 先于旧页 dispose）：旧页释放不得还原', () {
+      final Object oldPage = Object();
+      final Object newPage = Object();
+      VideoDisplayClaim.claim(oldPage);
+      // pushReplacement：新页 initState 认领，随后旧页 dispose 才跑。
+      VideoDisplayClaim.claim(newPage);
+      expect(
+        VideoDisplayClaim.release(oldPage),
+        isFalse,
+        reason: '新页仍持有 → 旧页 dispose 不得还原方向 / 系统栏回调 / 交通灯',
+      );
+      expect(VideoDisplayClaim.held, isTrue);
+      // 新页最终退出时才还原。
+      expect(VideoDisplayClaim.release(newPage), isTrue);
+      expect(VideoDisplayClaim.held, isFalse);
+    });
+
+    test('连续换集三集：只有最后一页离开才还原', () {
+      final List<Object> pages = <Object>[Object(), Object(), Object()];
+      VideoDisplayClaim.claim(pages[0]);
+      for (int i = 1; i < pages.length; i++) {
+        VideoDisplayClaim.claim(pages[i]);
+        expect(
+          VideoDisplayClaim.release(pages[i - 1]),
+          isFalse,
+          reason: '第 $i 次换集：新页在册，旧页释放不得还原',
+        );
+      }
+      expect(VideoDisplayClaim.release(pages.last), isTrue);
+    });
+
+    test('未认领过的 owner 释放返回 false（没设过就无权还原）', () {
+      final Object held = Object();
+      VideoDisplayClaim.claim(held);
+      expect(VideoDisplayClaim.release(Object()), isFalse);
+      expect(VideoDisplayClaim.ownerCount, 1, reason: '陌生 owner 的释放不得摘掉真实持有者');
+      expect(VideoDisplayClaim.release(held), isTrue);
+    });
+
+    test('空表上释放返回 false，不把 held 翻真也不抛', () {
+      expect(VideoDisplayClaim.release(Object()), isFalse);
+      expect(VideoDisplayClaim.held, isFalse);
+    });
+  });
+}

--- a/fushi/test/media/video/video_lifecycle_static_test.dart
+++ b/fushi/test/media/video/video_lifecycle_static_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/source_guard.dart';
+
 /// 源码守卫：视频退出 flush 的「时序不变式」——无法用纯单测覆盖（需真实 libmpv
 /// player），故在源码层钉死结构：
 ///
@@ -415,14 +417,75 @@ void main() {
           reason: 'landscape lock must not re-allow portrait');
     });
 
-    test('dispose restores the orientation on leaving the page', () {
+    test('initState claims display ownership before the three (BUG-2105)', () {
+      final RegExpMatch? body = RegExp(
+        r'void initState\(\) \{(.*?)\n  \}',
+        dotAll: true,
+      ).firstMatch(maskComments(page));
+      expect(body, isNotNull, reason: 'initState method body not found');
+      final String b = body!.group(1)!;
+      final int claim = b.indexOf('VideoDisplayClaim.claim(this)');
+      expect(claim, greaterThanOrEqualTo(0),
+          reason: 'initState 必须经 VideoDisplayClaim.claim 登记本页持有进程级显示态');
+      // 登记必须早于设置动作：先登记再设，换集期间新旧两页同时在册，旧页释放时才
+      // 看得到「还有人持有」。
+      for (final String action in <String>[
+        '_lockLandscapeForVideo()',
+        'setMacOSTrafficLightsHidden(true)',
+        '_registerSystemBarsVisibilityCallback()',
+      ]) {
+        final int at = b.indexOf(action);
+        expect(at, greaterThanOrEqualTo(0), reason: 'initState 应仍认领 $action');
+        expect(claim, lessThan(at),
+            reason: 'VideoDisplayClaim.claim 必须排在 $action 之前');
+      }
+    });
+
+    test('dispose restores nothing unconditionally (BUG-2105)', () {
       final RegExpMatch? body = RegExp(
         r'void dispose\(\) \{(.*?)\n  \}',
         dotAll: true,
-      ).firstMatch(page);
+      ).firstMatch(maskComments(page));
       expect(body, isNotNull, reason: 'dispose method body not found');
-      expect(body!.group(1), contains('_restoreOrientationOnExit()'),
-          reason: 'dispose must restore orientation on leaving the page');
+      final String b = body!.group(1)!;
+      expect(b, contains('_releaseVideoDisplayClaim()'),
+          reason: 'dispose 必须经 _releaseVideoDisplayClaim 释放进程级显示态');
+      // BUG-2105：换集的窗口模式分支用 pushReplacement，旧页 dispose 晚于新页
+      // initState。dispose 里任何**无条件**还原都会掀掉新页刚设好的显示态（方向集被
+      // 放宽成含竖屏 → 旋转锁定下当即翻竖屏 = 掉出全屏；系统栏回调被置空）。
+      for (final String unconditional in <String>[
+        '_restoreOrientationOnExit()',
+        'setSystemUIChangeCallback(null)',
+        'setMacOSTrafficLightsHidden(false)',
+      ]) {
+        expect(b.contains(unconditional), isFalse,
+            reason: 'dispose 不得直接调 $unconditional（须经 VideoDisplayClaim 记账门控）');
+      }
+    });
+
+    test('_releaseVideoDisplayClaim restores only for the last owner (BUG-2105)',
+        () {
+      final RegExpMatch? body = RegExp(
+        r'void _releaseVideoDisplayClaim\(\) \{(.*?)\n  \}',
+        dotAll: true,
+      ).firstMatch(maskComments(page));
+      expect(body, isNotNull,
+          reason: '_releaseVideoDisplayClaim method body not found');
+      final String b = body!.group(1)!;
+      final int gate =
+          b.indexOf('if (!VideoDisplayClaim.release(this)) return;');
+      expect(gate, greaterThanOrEqualTo(0),
+          reason: '还原前必须先过 VideoDisplayClaim.release(this) 的记账门（早退即不还原）');
+      for (final String restore in <String>[
+        'setSystemUIChangeCallback(null)',
+        '_restoreOrientationOnExit()',
+        'setMacOSTrafficLightsHidden(false)',
+      ]) {
+        final int at = b.indexOf(restore);
+        expect(at, greaterThanOrEqualTo(0),
+            reason: '最后一个持有者离开时必须还原 $restore');
+        expect(gate, lessThan(at), reason: '$restore 必须在记账门之后');
+      }
     });
 
     test('the restore method is mobile-gated and re-allows portrait', () {

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -53,6 +53,14 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // 底栏真值 homeNavItemFor 的 label（Novels→Books、Galgame→Game、
   // Browser extension→Extension）。键是 `$destId/${row.title}`，两处任一变了本表
   // 就得跟着变。
+  // 互联「允许已配对设备读写本机配置」（host 侧许可，默认关）。写 prefsRepo
+  // （changed=true），生效点在 **HTTP 端点**里：host 收到 GET/PUT
+  // /api/interconnect/profile 时先查这个开关，关着回 403。harness 里没有起 server、
+  // 也没有 TLS 会话与已配对 peer，探不到。由专项测试逐条咬住：开关默认关、开启后
+  // 可用、依赖未接线时即使开着也不可用、以及端点三道门（TLS → peer token → 能力
+  // → 本开关）的顺序守卫。
+  'interconnect/Allow paired devices to read/write configuration':
+      'test/sync/interconnect_profile_transfer_test.dart',
   'appearance/Books': 'test/pages/home_page_tabs_test.dart',
   'appearance/Manga': 'test/pages/home_page_tabs_test.dart',
   'appearance/Video': 'test/pages/home_page_tabs_test.dart',

--- a/fushi/test/sync/backup_import_overlay_test.dart
+++ b/fushi/test/sync/backup_import_overlay_test.dart
@@ -256,8 +256,11 @@ void main() {
       // build 内的分支顺序，所以从 build 起点往后找。
       final int buildIdx = src.indexOf('Widget build(BuildContext context)');
       expect(buildIdx, greaterThan(0), reason: 'main.dart 必须有根 widget 的 build');
+      // BUG-2106：根分支的判据是 backupImportOwnsAppRoot（**排除 validating**）。
+      // validating 段 DB 仍打开、可取消，换根会把调用方路由连 Navigator 一起销毁
+      // （引导向导整段蒸发）；它改由模态遮罩路由承载。
       final int backupIdx =
-          src.indexOf('appModel.backupImportActive', buildIdx);
+          src.indexOf('appModel.backupImportOwnsAppRoot', buildIdx);
       final int loadingIdx =
           src.indexOf('if (!appModel.isInitialised)', buildIdx);
       expect(backupIdx, greaterThan(0), reason: '根 widget 必须有备份导入遮罩分支');
@@ -265,6 +268,15 @@ void main() {
       expect(backupIdx, lessThan(loadingIdx),
           reason: '导入遮罩必须在裸 loading 分支之前命中，否则导入期回退近黑屏');
       expect(src.contains('BackupImportOverlayView('), isTrue);
+      // 禁止回退到「所有相位都换根」：那正是 BUG-2106 的病根。
+      expect(
+        src.contains('if (appModel.backupImportActive) {'),
+        isFalse,
+        reason: 'BUG-2106：根分支不得再用 backupImportActive（会把 validating 也换根，'
+            '摧毁调用方路由与引导向导）',
+      );
+      expect(src.contains('if (appModel.backupImportOwnsAppRoot) {'), isTrue,
+          reason: '根分支必须只在关库后的相位（running/done/failed）独占 app 根');
       // 重启由确认视图按钮 + 导入成功后的自动触发共同驱动（onRestart 注入 backupImportRestart，
       // 需带 appModel 以委托 lifecycle.restartApp 真重启）。
       expect(src.contains('onRestart: () => backupImportRestart(appModel)'),
@@ -389,6 +401,19 @@ void main() {
       expect(src.contains('bool isBackupValidatingCurrent(int token)'), isTrue);
       expect(src.contains('void cancelBackupValidating()'), isTrue);
       expect(src.contains('void endBackupValidating()'), isTrue);
+      // BUG-2106：换根判据必须显式把 validating 排除在外。
+      expect(
+        src.contains('bool get backupImportOwnsAppRoot =>'),
+        isTrue,
+        reason: '必须有「是否独占 app 根」的派生判据，供 main.dart 消费',
+      );
+      final int ownsIdx = src.indexOf('bool get backupImportOwnsAppRoot =>');
+      final String ownsBody = src.substring(ownsIdx, ownsIdx + 240);
+      expect(
+        ownsBody.contains('_backupImportPhase != BackupImportPhase.validating'),
+        isTrue,
+        reason: 'BUG-2106：validating 相位不得独占 app 根（否则调用方路由被销毁）',
+      );
     });
 
     test('backup.part：validate/preview 期用 validating 遮罩，退出后经全局 navigator 弹确认框',
@@ -425,12 +450,71 @@ void main() {
           src.contains('appModel.isBackupValidatingCurrent(validatingToken)'),
           isTrue,
           reason: 'validate/preview 结果消费前必须用 token 判定是否仍是最新');
+      // BUG-2106：validating 遮罩是压在调用方页面之上的模态路由，不换根。
+      final int overlayIdx =
+          src.indexOf('_BackupValidatingOverlay.show(', importIdx);
+      expect(overlayIdx, greaterThan(beginValIdx),
+          reason: 'beginBackupValidating 之后必须压上遮罩路由（而非依赖换根）');
+      expect(overlayIdx, lessThan(endValIdx),
+          reason: '遮罩必须在校验期间就在栈上');
+      // 每条退出路径都得摘掉它：路由 canPop:false，漏一次 app 就被永久挡住。
+      expect(src.contains('overlay.dismiss();'), isTrue,
+          reason: '退出路径必须摘掉遮罩路由');
+      final int finallyIdx = src.indexOf('} finally {', overlayIdx);
+      expect(finallyIdx, greaterThan(overlayIdx),
+          reason: '遮罩摘除必须有 finally 兜底（早退 / 抛出都不能漏）');
+      expect(
+        src.indexOf('overlay.dismiss();', finallyIdx),
+        greaterThan(finallyIdx),
+        reason: 'finally 里必须 dismiss 遮罩路由',
+      );
     });
 
-    test('main.dart：validating 遮罩接线 onCancel（cancelBackupValidating）', () {
-      final String src = readSource('lib/main.dart').readAsStringSync();
-      expect(src.contains('onCancel: appModel.cancelBackupValidating'), isTrue,
-          reason: 'validating 遮罩的取消按钮须接 cancelBackupValidating');
+    test('backup.part：遮罩路由只能 removeRoute 摘除（pop 会被 PopScope 拦下）', () {
+      final String src =
+          readSource('lib/src/sync/sync_settings_schema/backup.part.dart')
+              .readAsStringSync();
+      final int cls = src.indexOf('class _BackupValidatingOverlay {');
+      expect(cls, greaterThan(0), reason: '必须有遮罩路由句柄类');
+      final String body = src.substring(cls);
+      expect(body.contains('navigator.removeRoute<void>(route)'), isTrue,
+          reason: 'BUG-2106：路由带 PopScope(canPop:false)，pop 摘不掉，必须 removeRoute');
+      expect(body.contains('navigator.pop('), isFalse,
+          reason: '禁止用 pop 摘遮罩路由（会被 PopScope 拦下，遮罩永久留在栈上）');
+    });
+
+    test('遮罩路由：不可 pop + 不透明 + 接线取消 (BUG-2106)', () {
+      final String src = readSource(
+        'lib/src/sync/backup_validating_overlay_route.dart',
+      ).readAsStringSync();
+      expect(src.contains('canPop: false'), isTrue,
+          reason: '系统返回不得穿过遮罩去 pop 底下的调用方页面（引导向导）');
+      expect(src.contains('opaque: true'), isTrue,
+          reason: '遮罩必须不透明：挡住底下页面的绘制与命中测试');
+      expect(src.contains('phase: BackupImportPhase.validating'), isTrue,
+          reason: '本路由只承载 validating 相位');
+      expect(src.contains('onCancel: onCancel'), isTrue,
+          reason: '取消按钮必须接调用方注入的回调');
+    });
+
+    test('validating 取消接线搬到遮罩路由的调用方 (BUG-2106)', () {
+      // 取消只属于 validating 相位，而 validating 已不由 main.dart 的根分支承载
+      // （那里只剩 running/done/failed，本视图在这三个相位不渲染取消按钮）。
+      final String main = readSource('lib/main.dart').readAsStringSync();
+      expect(
+        main.contains('onCancel: appModel.cancelBackupValidating'),
+        isFalse,
+        reason: 'BUG-2106：根分支不再承载 validating，取消接线不该留在这里',
+      );
+      final String src =
+          readSource('lib/src/sync/sync_settings_schema/backup.part.dart')
+              .readAsStringSync();
+      expect(src.contains('appModel.cancelBackupValidating();'), isTrue,
+          reason: '遮罩路由的取消回调必须作废 in-flight 校验 token');
+      final int cancelIdx = src.indexOf('appModel.cancelBackupValidating();');
+      final int dismissIdx = src.lastIndexOf('handle.dismiss();', cancelIdx);
+      expect(dismissIdx, greaterThan(0),
+          reason: '取消必须先摘掉遮罩路由再作废 token（否则遮罩留在栈上）');
     });
   });
 }

--- a/fushi/test/sync/backup_validating_overlay_route_test.dart
+++ b/fushi/test/sync/backup_validating_overlay_route_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/backup_import_overlay_view.dart';
+import 'package:fushi/src/sync/backup_validating_overlay_route.dart';
+
+/// BUG-2106 行为测试：「正在读取备份…」遮罩必须**压在调用方页面之上**，而不是把整棵
+/// app 树换掉。
+///
+/// 原实现让 `main.dart` 根 build 在校验期返回另一个根 widget（不同 runtimeType）→ 整棵
+/// MaterialApp/Navigator unmount → 调用方页面（新手引导向导）与其全部 State 当场蒸发，
+/// `await Navigator.push(向导)` 的 future 永不完成。这里用真 Navigator 把不变式钉死：
+/// 遮罩在栈上时调用方页面仍在树里、其 State 未被销毁，摘掉遮罩后原页面原样回来。
+void main() {
+  Widget host({
+    required GlobalKey<NavigatorState> navigatorKey,
+    required Widget caller,
+  }) {
+    return MaterialApp(
+      navigatorKey: navigatorKey,
+      home: caller,
+    );
+  }
+
+  testWidgets('遮罩路由压在调用方页面之上：调用方 State 不被销毁', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    final _CallerProbeState probe = _CallerProbeState();
+    await tester.pumpWidget(
+      host(navigatorKey: navKey, caller: _CallerProbe(state: probe)),
+    );
+    expect(find.text('caller'), findsOneWidget);
+    expect(probe.disposed, isFalse);
+    // 调用方在自己的 State 里存了进度（向导的 _stepIndex 同理）。
+    probe.step = 7;
+
+    final Route<void> route = buildBackupValidatingOverlayRoute(
+      onCancel: () {},
+    );
+    navKey.currentState!.push<void>(route);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(find.byType(BackupImportOverlayView), findsOneWidget,
+        reason: '校验遮罩应已在栈顶');
+    expect(
+      probe.disposed,
+      isFalse,
+      reason: 'BUG-2106：调用方页面（引导向导）不得随遮罩上屏而被销毁',
+    );
+    expect(find.text('caller', skipOffstage: false), findsOneWidget,
+        reason: '调用方页面仍在树里（只是被不透明遮罩盖住）');
+
+    // 摘除必须走 removeRoute：路由带 PopScope(canPop:false)，pop 摘不掉。
+    navKey.currentState!.removeRoute<void>(route);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(find.byType(BackupImportOverlayView), findsNothing);
+    expect(find.text('caller'), findsOneWidget);
+    expect(probe.disposed, isFalse);
+    expect(probe.step, 7, reason: '调用方 State 的进度必须原样还在（没被重建过）');
+  });
+
+  testWidgets('系统返回不得穿过遮罩把调用方页面 pop 掉', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    final _CallerProbeState probe = _CallerProbeState();
+    await tester.pumpWidget(
+      host(navigatorKey: navKey, caller: _CallerProbe(state: probe)),
+    );
+    // 调用方页面之上再压一层「向导页」，模拟真实栈：home → 向导 → 遮罩。
+    navKey.currentState!.push<void>(
+      MaterialPageRoute<void>(builder: (_) => const Text('wizard')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(find.text('wizard'), findsOneWidget);
+
+    final Route<void> route = buildBackupValidatingOverlayRoute(
+      onCancel: () {},
+    );
+    navKey.currentState!.push<void>(route);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    // 安卓系统返回 / 手势返回：事件走 WidgetsApp → Navigator.maybePop，栈顶是遮罩。
+    final bool popped = await tester.binding.handlePopRoute();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(popped, isTrue, reason: '返回事件应被栈顶的遮罩路由消费（而不是冒泡到 app 退出）');
+    expect(find.byType(BackupImportOverlayView), findsOneWidget,
+        reason: 'PopScope(canPop:false)：遮罩自身也不该被返回键弹掉');
+    expect(find.text('wizard', skipOffstage: false), findsOneWidget,
+        reason: 'BUG-2106：返回键绝不能把遮罩底下的向导页 pop 掉');
+
+    navKey.currentState!.removeRoute<void>(route);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(find.text('wizard'), findsOneWidget);
+  });
+
+  testWidgets('取消按钮接线到调用方注入的回调', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    int cancelled = 0;
+    await tester.pumpWidget(
+      host(navigatorKey: navKey, caller: const Text('caller')),
+    );
+    final Route<void> route = buildBackupValidatingOverlayRoute(
+      onCancel: () => cancelled++,
+    );
+    navKey.currentState!.push<void>(route);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    final Finder cancel = find.byType(OutlinedButton);
+    expect(cancel, findsOneWidget, reason: 'validating 相位必须有取消出口');
+    await tester.tap(cancel);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(cancelled, 1);
+  });
+}
+
+/// 调用方页面的存活探针：`dispose` 被调用即说明整棵树被换掉了（BUG-2106 的病征）。
+class _CallerProbeState {
+  bool disposed = false;
+  int step = 0;
+}
+
+class _CallerProbe extends StatefulWidget {
+  const _CallerProbe({required this.state});
+
+  final _CallerProbeState state;
+
+  @override
+  State<_CallerProbe> createState() => _CallerProbeStateWidget();
+}
+
+class _CallerProbeStateWidget extends State<_CallerProbe> {
+  @override
+  void dispose() {
+    widget.state.disposed = true;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Text('caller');
+}

--- a/fushi/test/sync/interconnect_profile_transfer_test.dart
+++ b/fushi/test/sync/interconnect_profile_transfer_test.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/app_model_library_host_service.dart';
+import 'package:fushi/src/sync/fushi_sync_server.dart';
+import 'package:fushi/src/sync/interconnect_profile_transfer.dart';
+import 'package:fushi/src/sync/sync_asset_package_service.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:http/http.dart' as http;
+
+/// 互联「配置文件」（Profile）搬运的端点与门控测试。
+///
+/// 三道门必须**同时**成立才允许：TLS 会话、已配对 peer token、host 侧用户开关。
+/// 这里覆盖不需要真 TLS 也能判定的两类不变式：
+///   * 明文会话上端点恒 403（整份配置不允许降级到明文，与 service-config 同规矩）；
+///   * host 能力位与「开关默认关 / 依赖未接线即不可用」的判据。
+void main() {
+  group('端点安全门（明文会话）', () {
+    late Directory tempDir;
+    late FushiSyncServer server;
+    const String token = 'shared-token';
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('hbk_profile_xfer');
+      server = FushiSyncServer(
+        syncDataDir: tempDir.path,
+        port: 0,
+        token: token,
+        allowLan: false,
+      );
+      await server.start();
+    });
+
+    tearDown(() async {
+      await server.stop();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    Uri profileUri() =>
+        Uri.parse('http://127.0.0.1:${server.port}$kInterconnectProfilePath');
+
+    Map<String, String> authHeaders() => <String, String>{
+          'Authorization': 'Basic ${base64Encode(utf8.encode('hibiki:$token'))}',
+        };
+
+    test('GET 在明文会话上被拒（403 HTTPS required）', () async {
+      final http.Response res = await http.get(
+        profileUri(),
+        headers: authHeaders(),
+      );
+      expect(res.statusCode, 403);
+      expect(res.body, contains('HTTPS required'));
+    });
+
+    test('PUT 在明文会话上同样被拒（入站写不得走明文）', () async {
+      final http.Response res = await http.put(
+        profileUri(),
+        headers: authHeaders(),
+        body: '{}',
+      );
+      expect(res.statusCode, 403);
+      expect(res.body, contains('HTTPS required'));
+    });
+
+    test('其它方法一律 405（端点只认 GET/PUT）', () async {
+      final http.Response res = await http.delete(
+        profileUri(),
+        headers: authHeaders(),
+      );
+      expect(res.statusCode, 405);
+    });
+
+    test('capabilities 广播 profileTransfer，明文 host 上为 false', () async {
+      final http.Response res = await http.get(
+        Uri.parse('http://127.0.0.1:${server.port}/api/capabilities'),
+        headers: authHeaders(),
+      );
+      expect(res.statusCode, 200);
+      final Map<String, dynamic> json =
+          jsonDecode(res.body) as Map<String, dynamic>;
+      final Map<String, dynamic> live =
+          (json['liveLibrary'] as Map).cast<String, dynamic>();
+      expect(live.containsKey('profileTransfer'), isTrue,
+          reason: 'client 靠这个字段决定要不要显示配置传输入口');
+      expect(live['profileTransfer'], false,
+          reason: '无 TLS 时能力位必须为 false（与端点的 403 一致，别让 UI 给出假承诺）');
+    });
+  });
+
+  group('host 侧开关判据', () {
+    late FushiDatabase db;
+    late Directory tempDir;
+
+    AppModelLibraryHostService buildHost({
+      required bool wireProfileCallbacks,
+    }) {
+      return AppModelLibraryHostService(
+        db: db,
+        dictionaryResourceRoot: tempDir,
+        packages: SyncAssetPackageService(db: db),
+        refreshDictionaryCache: () async {},
+        runExclusive: (Future<void> Function() body) => body(),
+        isProfileTransferEnabled: wireProfileCallbacks
+            ? () => SyncRepository(db).isInterconnectProfileTransferEnabled()
+            : null,
+        exportActiveProfileJson:
+            wireProfileCallbacks ? () async => '{"type":"hibiki.profile"}' : null,
+        importProfileJson: wireProfileCallbacks ? (String _) async => 'p' : null,
+      );
+    }
+
+    setUp(() {
+      db = FushiDatabase.forTesting(NativeDatabase.memory());
+      tempDir = Directory.systemTemp.createTempSync('hbk_profile_host');
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('默认关：接线了回调但用户没开，仍然不可用', () async {
+      final AppModelLibraryHostService host =
+          buildHost(wireProfileCallbacks: true);
+      expect(await host.isInterconnectProfileTransferEnabled(), isFalse,
+          reason: '整份配置的读写必须是用户显式 opt-in（BUG-988 的规矩）');
+    });
+
+    test('用户开启后可用', () async {
+      await SyncRepository(db).setInterconnectProfileTransferEnabled(true);
+      final AppModelLibraryHostService host =
+          buildHost(wireProfileCallbacks: true);
+      expect(await host.isInterconnectProfileTransferEnabled(), isTrue);
+    });
+
+    test('依赖未接线时即使开关为真也不可用（不会抛给对端 500）', () async {
+      await SyncRepository(db).setInterconnectProfileTransferEnabled(true);
+      final AppModelLibraryHostService host =
+          buildHost(wireProfileCallbacks: false);
+      expect(await host.isInterconnectProfileTransferEnabled(), isFalse);
+      // 端点在开关判据为假时就 403 了，永远走不到这两个方法；真被调到也要如实抛，
+      // 不能静默返回空串让对端导入一份空配置。
+      expect(host.exportInterconnectProfile(), throwsUnsupportedError);
+      expect(
+        host.importInterconnectProfile('{}'),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('开关是设备本地的持久化偏好，读回与写入一致', () async {
+      final SyncRepository repo = SyncRepository(db);
+      expect(await repo.isInterconnectProfileTransferEnabled(), isFalse);
+      await repo.setInterconnectProfileTransferEnabled(true);
+      expect(await repo.isInterconnectProfileTransferEnabled(), isTrue);
+      await repo.setInterconnectProfileTransferEnabled(false);
+      expect(await repo.isInterconnectProfileTransferEnabled(), isFalse);
+    });
+  });
+
+  group('端点源码守卫：三道门的顺序不得被抽掉', () {
+    late String src;
+
+    setUpAll(() {
+      src = File('lib/src/sync/fushi_sync_server.dart').readAsStringSync();
+    });
+
+    test('handler 依次过 TLS → peer token → 能力探测 → 用户开关', () {
+      final int at = src.indexOf('Future<shelf.Response> _handleInterconnectProfile(');
+      expect(at, greaterThan(0), reason: '找不到配置传输端点 handler');
+      final String body = src.substring(at, at + 2400);
+      final int tls = body.indexOf('_securityContext == null');
+      final int auth = body.indexOf('_validatePeerAuth(');
+      final int cap = body.indexOf('library is! InterconnectProfileHost');
+      final int gate = body.indexOf('isInterconnectProfileTransferEnabled()');
+      expect(tls, greaterThan(0), reason: '必须要求 TLS');
+      expect(auth, greaterThan(tls), reason: '必须要求已配对 peer token');
+      expect(cap, greaterThan(auth), reason: '能力探测在鉴权之后');
+      expect(gate, greaterThan(cap), reason: 'host 侧用户开关是最后一道门');
+      // 开关关着必须是 403（明确拒绝），不能是 404（会被 client 当成「不支持」而静默）。
+      final String gateTail = body.substring(gate, gate + 240);
+      expect(gateTail, contains('shelf.Response.forbidden'),
+          reason: '开关关着要 403，让 client 能把「关着」与「不支持」分开报');
+    });
+
+    test('入站导入永不覆盖 host 既有配置（契约写在接口文档里）', () {
+      final String iface =
+          File('lib/src/sync/interconnect_profile_transfer.dart')
+              .readAsStringSync();
+      expect(iface, contains('createNew'),
+          reason: '入站一律新建 Profile 的契约必须留在接口文档里');
+    });
+  });
+}

--- a/fushi/test/sync/sync_settings_visibility_test.dart
+++ b/fushi/test/sync/sync_settings_visibility_test.dart
@@ -375,14 +375,21 @@ void main() {
       expect(dest.sections[3].footer, isNotNull,
           reason: '双向 + 默认开启这件事必须在 UI 上说清楚');
       // 交给已配对设备：制卡到已配对设备（原在「制卡」分类）+ 用互联做备份后端
-      // + 从 host 同步外部服务配置（BUG-1693 的 apikey 同步开关）。
+      // + 从 host 同步外部服务配置（BUG-1693 的 apikey 同步开关）+ 配置文件
+      // （Profile）双向搬运的两个一次性动作。
       expect(idsOf(dest.sections[4]), <String>[
         'interconnect.mine_to_server',
         'interconnect.backup_backend',
         'interconnect.service_config_sync',
+        'interconnect.profile_upload',
+        'interconnect.profile_download',
       ]);
       expect(dest.sections[4].visible, isNotNull);
-      expect(idsOf(dest.sections[5]), <String>['sync.server_mode']);
+      // 本机作为服务器：host 模式开关 + host 侧「允许对端读写本机配置」许可。
+      expect(idsOf(dest.sections[5]), <String>[
+        'sync.server_mode',
+        'interconnect.profile_transfer_host',
+      ]);
       expect(dest.sections[5].visible, isNotNull);
     });
 

--- a/fushi/test/tools/file_picker_discipline_guard_test.dart
+++ b/fushi/test/tools/file_picker_discipline_guard_test.dart
@@ -74,9 +74,10 @@ const Map<String, String> kFilePickerAllowlist = <String, String>{
   'lib/src/pages/implementations/profile_management_page.dart':
       'Profile JSON：选中即读入并落库',
   'lib/src/sync/sync_settings_schema/backup.part.dart': '备份 zip：选中即校验并恢复，不长期引用',
-  'lib/src/pages/implementations/onboarding_wizard_page.dart':
-      '新手引导「选择本地推荐包」：备份 zip 选中即走 runBackupImportFlowForFile 校验并恢复，'
-          '与 backup.part.dart 同语义，不长期引用',
+  // 原有一条 'lib/src/pages/implementations/onboarding_wizard_page.dart'（新手引导
+  // 「选择本地推荐包」）已于 BUG-2107 修掉并按「清单只减不增」删除：推荐包是 9.5 GB 的
+  // 备份 zip，安卓上裸 pickFiles 先整份复制进 app cache（≈2 倍体积、几分钟无反馈），
+  // 失败还与「用户取消」同形被静默丢弃。现改走 pickRealFilePathDetailed（同 BUG-1667）。
   'lib/src/utils/misc/gallery_image_picker.dart': '制卡图片：选中即读字节写进卡片，不长期引用',
   'lib/src/pages/implementations/video_shader_dialog.dart':
       '着色器文件：选中即拷进 mpv_shaders 目录',


### PR DESCRIPTION
用户一次报了三件事，本 PR 三条独立提交各修一件。

## ① 互联新增「上传/下载配置文件」（新功能）

「配置文件」在本仓中文 UI 里就是 **Profile**（「配置管理」页，产物 `.fushiprofile.json`）；备份包早有「用互联做备份后端」的既有通道，缺的正是这条。

- wire：新增 `GET/PUT /api/interconnect/profile`，**三道门必须同时成立**——TLS 会话（整份配置不允许降级明文，同 BUG-1311 给 service-config 立的规矩）、已配对 peer token（`_validatePeerAuth`，不接受共享 token）、host 侧用户开关（默认关；没有它，入站 PUT 就是 BUG-988 点名的「无 UI 无开关的隐形写入通道」）。开关关着返回 **403 而非 404**，好让 client 把「不支持」与「关着」分开报。
- `capabilities.liveLibrary` 加 `profileTransfer` 能力位；老 host 无此字段 → client 按「不提供」处理，零破坏。
- 载荷复用 Profile 的分享 JSON：凭据剔除（`PrefRedactionPolicy` 唯一真相源）、字体绝对路径剥离、魔数 + 版本校验都已在 `exportProfileToJson` / `importProfileFromJson` 里。另造 wire 格式只会让「哪条 key 能出境」多出第二个真相源。
- 入站一律 `createNew`：绝不覆盖对端任何既有 Profile，也不动当前激活的那份。
- UI：互联页「交给已配对设备」区加两个一次性动作行，「本机作为服务器」区加 host 侧许可开关。做成动作而非自动跟随开关，与云通道那四行同一取舍。

## ② 引导里选本地包 → 引导蒸发且无提示（BUG-2106 + BUG-2107）

同一次报告，两个独立根因：

**BUG-2106**：`main.dart` 的备份导入遮罩分支返回的根 widget 与正常分支**类型不同**（`TranslationProvider` vs `KeyedSubtree`），一进 `validating` 相位整棵 MaterialApp/Navigator 就被 unmount。设置页丢一条路由无感，引导向导丢的是整个流程：`_stepIndex` 蒸发、`home_page` 里 `await Navigator.push(向导)` 的 future 永不完成（`onboarding_completed` 再也写不回）、校验失败提示因为取不到 root context 而被静默吞掉。

相位边界本就不该一刀切：`validating` 只是读 zip + 生成合并预览，**DB 仍打开、可取消**；`running/done/failed` 之前已 `closeDatabase`，那才必须换根独占并重启。于是新增派生判据 `AppModel.backupImportOwnsAppRoot`（排除 validating），validating 改由**压在调用方页面之上的模态路由**承载（`opaque` + `PopScope(canPop:false)`，摘除走 `removeRoute`——`pop` 会被 PopScope 拦下）。失败提示改为先摘遮罩再弹；两处「拿不到 root context 就 return」补诊断日志。

**BUG-2107**：引导那条「选择本地包文件」是**裸 `pickFiles`**，而它承载 9.5 GB 的推荐包——安卓会先整份复制进 app cache（约 2 倍体积、几分钟无反馈），失败时 `path == null` 与用户取消同形静默 return，异常又被 `unawaited(...)` 吞掉 = 「点了导入文件没有任何提醒」。改走 `pickRealFilePathDetailed`（同 BUG-1667），取消 / 无路径 / 异常三态分开，后两者可见失败 + 诊断；补重入守卫；`_packError` 改存已成文的文案（原先选文件失败也显示成「下载失败」）。`file_picker` 豁免清单按「只减不增」删掉该条目。

## ③ 全屏跳转到别的集数会退出全屏（BUG-2105，移动端）

桌面侧 BUG-2043 的接管修复已随 **v2.2.4**（09-03）发布，所以这条落在**移动端**——那半整段被 `isMobilePlatform` 门控掉了。

移动端没有全屏路由（BUG-221 起横屏沉浸即唯一全屏形态），换集走裸 `pushReplacement`；而 Flutter 语义下旧路由要等新页入场动画结束才 `dispose`，于是顺序是「新页 initState 锁横屏 / 注册系统栏回调 / 隐交通灯 → 旧页 dispose **无条件**全部还原」。方向允许集被放宽成含 `portraitUp`，开着自动旋转锁定的设备当即翻竖屏 = 用户看到的「换集退出全屏播放」；系统栏可见性回调（全局单槽）被置空后避让几何回到 BUG-383 错态。

按仓内 `FushiWindowsTitleBar._contentFullscreenOwners` 的既有范式改成**所有者记账**：新增纯 Dart 登记表 `VideoDisplayClaim`，initState 先 claim 再设，dispose 收敛成 `_releaseVideoDisplayClaim()` 且只在 release 清空集合时才还原。桌面 / macOS 顺带受益（换集不再让 macOS 交通灯在全屏画面里闪出）。

## 验证

- `flutter analyze`（lib + test）clean
- **全量** `dart run tool/flutter_test_failures.dart --no-pub`：`PASSED - 22553 tests ran, all tests passed`（退出码 0）
- 三处变异实测各自判红后复绿：去掉显示态记账门 / 根分支判据换回 `backupImportActive` / 抽掉互联端点的 host 开关门
- ⚠ **真机复测缺口**（三条都未做，本轮止于静态 + widget/单测层）：安卓「开旋转锁定 → 横屏看片 → 换集」、真机「首启引导 → 选本地包 → 校验遮罩 → 确认框」、以及互联配置传输的 TLS + 已配对双机 E2E。

https://claude.ai/code/session_01TfCYWRb75x6ZWt4HKuWXZH
