### PR TITLE
fix(shortcuts): 右键菜单纳入绑定表，消除「绑到右键的动作与菜单双触发」(BUG-2111)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1966 条。点号进各自文件。
+> 共 1967 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2111](bugs/BUG-2111-context-menu-hardwired-secondary-button.md) | ✅ | ✅ | 右键菜单硬绑鼠标次按钮，把动作绑到右键会双触发 |
 | [BUG-2104](bugs/BUG-2104-release-event-ships-debug-apk-on-formal.md) | ✅ | ✅ | 手动发 GitHub Release 会把 debug APK 捎带上正式版 |
 | [BUG-2099](bugs/BUG-2099-android-saf-mdx-greyed.md) | ✅ | ✅ | 安卓文件选择器把 .mdx/.dsl/.ifo/.ass 置灰选不中 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |

--- a/docs/bugs/BUG-2111-context-menu-hardwired-secondary-button.md
+++ b/docs/bugs/BUG-2111-context-menu-hardwired-secondary-button.md
@@ -1,0 +1,31 @@
+## BUG-2111 · 右键菜单硬绑鼠标次按钮，把动作绑到右键会双触发
+- **报告**：2026-09-04（用户：把快捷键绑到鼠标右键上，按一下在跑那个动作的同时还会唤出右键菜单）
+- **真实性**：✅ 真 bug。根因不在某一个页面，而在「右键这个物理按钮没有唯一的归属仲裁者」：
+  鼠标绑定通道走 `lib/src/shortcuts/mouse_binding_dispatch.dart:33`（页面根 / app 根的
+  `Listener.onPointerDown` → 解析阶梯 → `dispatchClaimedMouseAction` 单槽认领），而上下文菜单
+  走的是各表面**各自硬编码**的 `GestureDetector.onSecondaryTap*`（改造前 lib/ 下 23 处，例如
+  `video_fushi/layout.part.dart:340`、`reader_fushi/webview.part.dart:2617`、
+  `fushi_material_components.dart:111`）。两条路互不知情，也不共享那个单槽仲裁，所以同一次
+  右键按下会被两边各消费一次。
+- **[x] ① 已修复** — 把菜单本身纳入绑定表：新增 `ShortcutAction.globalContextMenu`
+  （`global` scope，三平台默认 `MouseBinding(2)` = 右键，与改造前逐字一致），新增
+  `lib/src/shortcuts/context_menu_trigger.dart` 作为菜单的唯一触发口（`ContextMenuTrigger`
+  用 `Listener` 按绑定表判据触发，并复用 `dispatchClaimedMouseAction` 的单槽认领），把 23 处
+  硬绑入口全部改接它；`wrapWithGlobalNavigation` 增挂 `ShortcutBindingScope` 把注册表递进子树。
+  于是让位由**解析阶梯**决定：页面 scope 先命中别的动作 → 菜单自动让位，用户不必先解绑菜单。
+  顺带补了 `kVideoMouseLadder` 缺失的 `global` 尾段（reader/manga/home 三条早就有），否则
+  视频页解析不到住在 global 的新动作。
+  设置页的撞键流程同时从「替换 / 取消」二选一改成三态（新增「两者都保留」），因为撞键并不
+  蕴含其中一个必须让出——同一个键完全可以同时留在两个动作上，按下时由阶梯仲裁。
+- **[x] ② 已加自动化测试** — `fushi/test/shortcuts/context_menu_binding_test.dart`（15 条）：
+  默认表三平台都绑右键且无页面动作默认占用右键；判据的四种形态（没改键 / 右键被页面动作占用
+  时**只在那条阶梯上**让位、其它表面照常 / 菜单改绑中键 / 绑定清空）；`ContextMenuTrigger` 的
+  widget 行为（右键触发并带坐标、左键零影响、onInvoke 为 null 时不挂 Listener、无
+  `ShortcutBindingScope` 时回退硬绑右键）；以及「同一次按下只被认领一次」——内层菜单弹出后
+  外层鼠标绑定不再派发，这条就是本 bug 症状的直接回归门。另加两条源码守卫（`lib/` 不得再出现
+  `onSecondaryTapDown` / `onSecondaryTapUp`；三个共享卡片组件的 `onSecondaryTap` 参数只能经
+  `ContextMenuTrigger` 落地），两条都做过变异实测（注入后确实转红）。
+- **备注**：行为上唯一的可感差异是视频画面的菜单从「右键抬起」变成「右键按下」触发——
+  改造前 app 内四个媒体表面里已有三个（阅读器 / 漫画 / 字幕）用的就是 `onSecondaryTapDown`，
+  这一步把剩下那个不一致也抹平了。移动端默认表原先对 `global` scope 丢弃鼠标绑定，一并补回
+  （Android 接鼠标时右键菜单否则会整个消失）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71060 (4180 per locale)
+/// Strings: 71111 (4183 per locale)
 ///
-/// Built on 2026-09-03 at 03:52 UTC
+/// Built on 2026-09-03 at 18:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5734,6 +5734,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connected. Root catalog has ${count} entries';
   String discovery_opds_test_failed({required Object reason}) =>
       'Connection failed: ${reason}';
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  String get shortcut_conflict_keep_both => 'Keep both';
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -15474,6 +15478,13 @@ class _StringsAr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'فشل الاتصال: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -25441,6 +25452,13 @@ class _StringsDe extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbindung fehlgeschlagen: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -35460,6 +35478,13 @@ class _StringsEs extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Error de conexión: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -45514,6 +45539,13 @@ class _StringsFr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Échec de la connexion : ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -55373,6 +55405,13 @@ class _StringsId extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Koneksi gagal: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -65323,6 +65362,13 @@ class _StringsIt extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Connessione non riuscita: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -74661,6 +74707,13 @@ class _StringsJa extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '接続に失敗しました: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -84009,6 +84062,13 @@ class _StringsKo extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '연결 실패: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -93914,6 +93974,13 @@ class _StringsNl extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Verbinding mislukt: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -103873,6 +103940,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Falha na conexão: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -113811,6 +113885,13 @@ class _StringsRu extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Не удалось подключиться: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -123547,6 +123628,13 @@ class _StringsTh extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'เชื่อมต่อไม่สำเร็จ: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -133400,6 +133488,13 @@ class _StringsTr extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Bağlantı başarısız: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -143224,6 +143319,13 @@ class _StringsVi extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       'Kết nối thất bại: ${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 // Path: <root>
@@ -152251,6 +152353,13 @@ class _StringsZhCn extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '连接失败：${reason}';
+  @override
+  String get shortcut_action_global_context_menu => '打开右键菜单';
+  @override
+  String get shortcut_conflict_keep_both => '两者都保留';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      '两个动作都保留这个绑定，按下时由作用域先后仲裁，先命中的那个生效。';
 }
 
 // Path: <root>
@@ -161283,6 +161392,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String discovery_opds_test_failed({required Object reason}) =>
       '連線失敗：${reason}';
+  @override
+  String get shortcut_action_global_context_menu => 'Open context menu';
+  @override
+  String get shortcut_conflict_keep_both => 'Keep both';
+  @override
+  String get shortcut_conflict_keep_both_hint =>
+      'Both actions keep this binding. Whichever scope resolves first wins at press time.';
 }
 
 /// Flat map(s) containing all translations.
@@ -169859,6 +169975,12 @@ extension on _StringsEn {
             'Connected. Root catalog has ${count} entries';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Connection failed: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -178430,6 +178552,12 @@ extension on _StringsAr {
             'تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'فشل الاتصال: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -187046,6 +187174,12 @@ extension on _StringsDe {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Verbindung fehlgeschlagen: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -195653,6 +195787,12 @@ extension on _StringsEs {
             'Conectado. El catálogo raíz tiene ${count} entradas';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Error de conexión: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -204269,6 +204409,12 @@ extension on _StringsFr {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Échec de la connexion : ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -212856,6 +213002,12 @@ extension on _StringsId {
             'Terhubung. Katalog akar berisi ${count} entri';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Koneksi gagal: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -221465,6 +221617,12 @@ extension on _StringsIt {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Connessione non riuscita: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -230001,6 +230159,12 @@ extension on _StringsJa {
         return ({required Object count}) => '接続しました。ルートカタログに ${count} 件あります';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '接続に失敗しました: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -238541,6 +238705,12 @@ extension on _StringsKo {
             '연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '연결 실패: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -247143,6 +247313,12 @@ extension on _StringsNl {
             'Verbonden. De hoofdcatalogus heeft ${count} items';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Verbinding mislukt: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -255740,6 +255916,12 @@ extension on _StringsPtBr {
             'Conectado. O catálogo raiz tem ${count} itens';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Falha na conexão: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -264344,6 +264526,12 @@ extension on _StringsRu {
       case 'discovery_opds_test_failed':
         return ({required Object reason}) =>
             'Не удалось подключиться: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -272920,6 +273108,12 @@ extension on _StringsTh {
             'เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'เชื่อมต่อไม่สำเร็จ: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -281511,6 +281705,12 @@ extension on _StringsTr {
             'Bağlanıldı. Kök katalogda ${count} girdi var';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Bağlantı başarısız: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -290096,6 +290296,12 @@ extension on _StringsVi {
             'Đã kết nối. Danh mục gốc có ${count} mục';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => 'Kết nối thất bại: ${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }
@@ -298609,6 +298815,12 @@ extension on _StringsZhCn {
         return ({required Object count}) => '连接成功，根目录有 ${count} 个条目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '连接失败：${reason}';
+      case 'shortcut_action_global_context_menu':
+        return '打开右键菜单';
+      case 'shortcut_conflict_keep_both':
+        return '两者都保留';
+      case 'shortcut_conflict_keep_both_hint':
+        return '两个动作都保留这个绑定，按下时由作用域先后仲裁，先命中的那个生效。';
       default:
         return null;
     }
@@ -307123,6 +307335,12 @@ extension on _StringsZhHk {
         return ({required Object count}) => '連線成功，根目錄有 ${count} 個項目';
       case 'discovery_opds_test_failed':
         return ({required Object reason}) => '連線失敗：${reason}';
+      case 'shortcut_action_global_context_menu':
+        return 'Open context menu';
+      case 'shortcut_conflict_keep_both':
+        return 'Keep both';
+      case 'shortcut_conflict_keep_both_hint':
+        return 'Both actions keep this binding. Whichever scope resolves first wins at press time.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Needed for a self-hosted server on your local network",
   "discovery_opds_test": "Test connection",
   "discovery_opds_test_ok": "Connected. Root catalog has ${count} entries",
-  "discovery_opds_test_failed": "Connection failed: ${reason}"
+  "discovery_opds_test_failed": "Connection failed: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "مطلوب لخادم ذاتي الاستضافة على شبكتك المحلية",
   "discovery_opds_test": "اختبار الاتصال",
   "discovery_opds_test_ok": "تم الاتصال. يحتوي الفهرس الجذر على ${count} عنصرًا",
-  "discovery_opds_test_failed": "فشل الاتصال: ${reason}"
+  "discovery_opds_test_failed": "فشل الاتصال: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nötig für einen selbst gehosteten Server im lokalen Netzwerk",
   "discovery_opds_test": "Verbindung testen",
   "discovery_opds_test_ok": "Verbunden. Der Stammkatalog hat ${count} Einträge",
-  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}"
+  "discovery_opds_test_failed": "Verbindung fehlgeschlagen: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necesario para un servidor autoalojado en tu red local",
   "discovery_opds_test": "Probar conexión",
   "discovery_opds_test_ok": "Conectado. El catálogo raíz tiene ${count} entradas",
-  "discovery_opds_test_failed": "Error de conexión: ${reason}"
+  "discovery_opds_test_failed": "Error de conexión: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nécessaire pour un serveur auto-hébergé sur votre réseau local",
   "discovery_opds_test": "Tester la connexion",
   "discovery_opds_test_ok": "Connecté. Le catalogue racine contient ${count} entrées",
-  "discovery_opds_test_failed": "Échec de la connexion : ${reason}"
+  "discovery_opds_test_failed": "Échec de la connexion : ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Diperlukan untuk server milik sendiri di jaringan lokal",
   "discovery_opds_test": "Uji koneksi",
   "discovery_opds_test_ok": "Terhubung. Katalog akar berisi ${count} entri",
-  "discovery_opds_test_failed": "Koneksi gagal: ${reason}"
+  "discovery_opds_test_failed": "Koneksi gagal: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necessario per un server self-hosted sulla rete locale",
   "discovery_opds_test": "Prova connessione",
   "discovery_opds_test_ok": "Connesso. Il catalogo radice ha ${count} voci",
-  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}"
+  "discovery_opds_test_failed": "Connessione non riuscita: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "ローカルネットワークの自前サーバーに必要です",
   "discovery_opds_test": "接続をテスト",
   "discovery_opds_test_ok": "接続しました。ルートカタログに ${count} 件あります",
-  "discovery_opds_test_failed": "接続に失敗しました: ${reason}"
+  "discovery_opds_test_failed": "接続に失敗しました: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "로컬 네트워크의 자체 호스팅 서버에 필요합니다",
   "discovery_opds_test": "연결 테스트",
   "discovery_opds_test_ok": "연결되었습니다. 루트 카탈로그에 ${count}개 항목이 있습니다",
-  "discovery_opds_test_failed": "연결 실패: ${reason}"
+  "discovery_opds_test_failed": "연결 실패: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Nodig voor een zelfgehoste server in je lokale netwerk",
   "discovery_opds_test": "Verbinding testen",
   "discovery_opds_test_ok": "Verbonden. De hoofdcatalogus heeft ${count} items",
-  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}"
+  "discovery_opds_test_failed": "Verbinding mislukt: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Necessário para um servidor auto-hospedado na sua rede local",
   "discovery_opds_test": "Testar conexão",
   "discovery_opds_test_ok": "Conectado. O catálogo raiz tem ${count} itens",
-  "discovery_opds_test_failed": "Falha na conexão: ${reason}"
+  "discovery_opds_test_failed": "Falha na conexão: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Нужно для сервера, размещённого в вашей локальной сети",
   "discovery_opds_test": "Проверить соединение",
   "discovery_opds_test_ok": "Подключено. В корневом каталоге ${count} записей",
-  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}"
+  "discovery_opds_test_failed": "Не удалось подключиться: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "จำเป็นสำหรับเซิร์ฟเวอร์ที่โฮสต์เองในเครือข่ายภายใน",
   "discovery_opds_test": "ทดสอบการเชื่อมต่อ",
   "discovery_opds_test_ok": "เชื่อมต่อแล้ว แคตตาล็อกรากมี ${count} รายการ",
-  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}"
+  "discovery_opds_test_failed": "เชื่อมต่อไม่สำเร็จ: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Yerel ağdaki kendi sunucun için gerekli",
   "discovery_opds_test": "Bağlantıyı sına",
   "discovery_opds_test_ok": "Bağlanıldı. Kök katalogda ${count} girdi var",
-  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}"
+  "discovery_opds_test_failed": "Bağlantı başarısız: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "Cần thiết cho máy chủ tự dựng trong mạng nội bộ",
   "discovery_opds_test": "Kiểm tra kết nối",
   "discovery_opds_test_ok": "Đã kết nối. Danh mục gốc có ${count} mục",
-  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}"
+  "discovery_opds_test_failed": "Kết nối thất bại: ${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "局域网自建服务器需要打开",
   "discovery_opds_test": "测试连接",
   "discovery_opds_test_ok": "连接成功，根目录有 ${count} 个条目",
-  "discovery_opds_test_failed": "连接失败：${reason}"
+  "discovery_opds_test_failed": "连接失败：${reason}",
+  "shortcut_action_global_context_menu": "打开右键菜单",
+  "shortcut_conflict_keep_both": "两者都保留",
+  "shortcut_conflict_keep_both_hint": "两个动作都保留这个绑定，按下时由作用域先后仲裁，先命中的那个生效。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4178,5 +4178,8 @@
   "discovery_opds_allow_http_hint": "區域網絡自建伺服器需要開啟",
   "discovery_opds_test": "測試連線",
   "discovery_opds_test_ok": "連線成功，根目錄有 ${count} 個項目",
-  "discovery_opds_test_failed": "連線失敗：${reason}"
+  "discovery_opds_test_failed": "連線失敗：${reason}",
+  "shortcut_action_global_context_menu": "Open context menu",
+  "shortcut_conflict_keep_both": "Keep both",
+  "shortcut_conflict_keep_both_hint": "Both actions keep this binding. Whichever scope resolves first wins at press time."
 }

--- a/fushi/lib/src/media/collections/collection_drag.dart
+++ b/fushi/lib/src/media/collections/collection_drag.dart
@@ -88,7 +88,8 @@ Future<CollectionAddOutcome> addMediaRefToCollection({
 /// - 桌面（Windows / Linux / macOS，鼠标为主）→ [Draggable]（按下即拖）。与卡片
 ///   既有交互零冲突：`ImmediateMultiDragGestureRecognizer` 要指针移动超过
 ///   `kTouchSlop` 才在手势竞技场胜出，所以点击（按下即抬）仍归 `InkWell.onTap`
-///   开书、按住不动仍归 `onLongPress` 弹菜单、右键仍归 `onSecondaryTap`。
+///   开书、按住不动仍归 `onLongPress` 弹菜单、右键仍归卡片外层的
+///   [ContextMenuTrigger]（BUG-2111 后按绑定表判定，默认右键）。
 ///
 ///   ⚠️ **与横向合集行的鼠标拖动滚动（`HorizontalDragScrollable`）如何分流，未在
 ///   真机验证。** 别把它当成「横拖=滚动、纵拖=拖卡」的自然分工——按识别器的判据

--- a/fushi/lib/src/media/collections/collection_shelf_row.dart
+++ b/fushi/lib/src/media/collections/collection_shelf_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/media/collections/collection_drag.dart';
@@ -213,80 +214,82 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
     // 行头长按/右键 = 合集上下文菜单（多选态压制，行头点击专注整选）。
     final VoidCallback? contextMenu =
         selectionMode ? null : widget.onContextMenu;
-    final Widget header = InkWell(
-      canRequestFocus: false,
-      borderRadius: tokens.radii.controlRadius,
-      onTap: headerTap,
-      onLongPress: contextMenu,
-      onSecondaryTap: contextMenu,
-      child: Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: tokens.spacing.gap / 2,
-          vertical: tokens.spacing.gap / 2,
-        ),
-        child: Row(
-          children: <Widget>[
-            // 多选态：行头最左挂整选勾选框（选=选中整个合集），替代折叠 chevron。
-            if (selectionCheckbox != null)
-              Padding(
-                padding: EdgeInsets.only(right: tokens.spacing.gap / 2),
-                child: selectionCheckbox,
-              )
-            // 折叠开关：标题左侧旋转 chevron（展开朝下、折叠朝右）。紧凑尺寸不
-            // 抬高行头；ExcludeFocus——手柄/键盘焦点仍落整行头（Enter=进详情），
-            // 折叠是鼠标/触屏轻交互，不进焦点遍历序。
-            else if (widget.onToggleCollapsed != null)
-              ExcludeFocus(
-                child: IconButton(
-                  onPressed: widget.onToggleCollapsed,
-                  tooltip: widget.collapsed
-                      ? t.collection_expand
-                      : t.collection_collapse,
-                  padding: EdgeInsets.zero,
-                  constraints:
-                      const BoxConstraints.tightFor(width: 32, height: 32),
-                  icon: AnimatedRotation(
-                    turns: widget.collapsed ? -0.25 : 0,
-                    duration: const Duration(milliseconds: 150),
-                    child: Icon(
-                      Icons.expand_more,
-                      size: 20,
-                      color: tokens.surfaces.onVariant,
-                    ),
-                  ),
-                ),
-              ),
-            // Expanded（tight）吃满剩余宽，尾随「查看全部+chevron」才真正贴最右
-            //（旧写法 Flexible(loose)+Spacer 按 flex 份额均分，标题短时尾随件
-            // 停在行中间——用户实报）。
-            Expanded(
-              child: Row(
-                children: <Widget>[
-                  Flexible(
-                    child: Text(
-                      widget.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: tokens.type.listTitle.copyWith(
-                        fontWeight: FontWeight.w600,
+    final Widget header = ContextMenuTrigger(
+      onInvoke: contextMenuInvoker(contextMenu),
+      child: InkWell(
+        canRequestFocus: false,
+        borderRadius: tokens.radii.controlRadius,
+        onTap: headerTap,
+        onLongPress: contextMenu,
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.gap / 2,
+            vertical: tokens.spacing.gap / 2,
+          ),
+          child: Row(
+            children: <Widget>[
+              // 多选态：行头最左挂整选勾选框（选=选中整个合集），替代折叠 chevron。
+              if (selectionCheckbox != null)
+                Padding(
+                  padding: EdgeInsets.only(right: tokens.spacing.gap / 2),
+                  child: selectionCheckbox,
+                )
+              // 折叠开关：标题左侧旋转 chevron（展开朝下、折叠朝右）。紧凑尺寸不
+              // 抬高行头；ExcludeFocus——手柄/键盘焦点仍落整行头（Enter=进详情），
+              // 折叠是鼠标/触屏轻交互，不进焦点遍历序。
+              else if (widget.onToggleCollapsed != null)
+                ExcludeFocus(
+                  child: IconButton(
+                    onPressed: widget.onToggleCollapsed,
+                    tooltip: widget.collapsed
+                        ? t.collection_expand
+                        : t.collection_collapse,
+                    padding: EdgeInsets.zero,
+                    constraints:
+                        const BoxConstraints.tightFor(width: 32, height: 32),
+                    icon: AnimatedRotation(
+                      turns: widget.collapsed ? -0.25 : 0,
+                      duration: const Duration(milliseconds: 150),
+                      child: Icon(
+                        Icons.expand_more,
+                        size: 20,
+                        color: tokens.surfaces.onVariant,
                       ),
                     ),
                   ),
-                  SizedBox(width: tokens.spacing.gap),
-                  Text(widget.countLabel, style: tokens.type.metadata),
-                ],
+                ),
+              // Expanded（tight）吃满剩余宽，尾随「查看全部+chevron」才真正贴最右
+              //（旧写法 Flexible(loose)+Spacer 按 flex 份额均分，标题短时尾随件
+              // 停在行中间——用户实报）。
+              Expanded(
+                child: Row(
+                  children: <Widget>[
+                    Flexible(
+                      child: Text(
+                        widget.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: tokens.type.listTitle.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    SizedBox(width: tokens.spacing.gap),
+                    Text(widget.countLabel, style: tokens.type.metadata),
+                  ],
+                ),
               ),
-            ),
-            // 多选态隐藏「查看全部」尾随件（行头点击整选而非导航）。
-            if (!selectionMode) ...<Widget>[
-              Text(t.collection_view_all, style: tokens.type.metadata),
-              Icon(
-                Icons.chevron_right,
-                size: 18,
-                color: tokens.surfaces.onVariant,
-              ),
+              // 多选态隐藏「查看全部」尾随件（行头点击整选而非导航）。
+              if (!selectionMode) ...<Widget>[
+                Text(t.collection_view_all, style: tokens.type.metadata),
+                Icon(
+                  Icons.chevron_right,
+                  size: 18,
+                  color: tokens.surfaces.onVariant,
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -46,6 +46,8 @@ import 'package:fushi/src/media/manga/ocr/manga_region_rescan.dart';
 import 'package:fushi/src/media/manga/reader/manga_volume_key_paging_controller.dart';
 import 'package:fushi/src/media/manga/reader/manga_zoom_preference_debouncer.dart';
 import 'package:fushi/src/focus/page_focus_ownership.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart'
+    show contextMenuButtonNumberMatches;
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show GamepadButtonIntent;
 import 'package:fushi/src/shortcuts/global_navigation.dart'
@@ -4571,6 +4573,17 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
           handlerName: 'onMangaContextMenu',
           callback: (List<dynamic> args) {
             if (args.isEmpty || args[0] is! String) return;
+            // BUG-2111：页内 JS 那一路仍然硬判 `e.button === 2`，因为漫画的右键还兼着
+            // 「缩放态下按住拖拽平移」（rightDrag），换键会牵连那半边。所以归属判据补在
+            // 这里：右键若已经被别的漫画动作占用，菜单让位——否则一次右键既翻页又弹菜单，
+            // 正是本 bug 在漫画页的形态。判据与 Flutter 那二十余处入口是同一个函数。
+            if (!contextMenuButtonNumberMatches(
+              registry: appModel.shortcutRegistry,
+              button: 2,
+              ladder: _kMangaMouseLadder,
+            )) {
+              return;
+            }
             unawaited(_showReaderContextMenu(args[0] as String));
           },
         );

--- a/fushi/lib/src/media/selection/selection_gestures.dart
+++ b/fushi/lib/src/media/selection/selection_gestures.dart
@@ -77,7 +77,8 @@ class SelectionSlotTarget extends StatelessWidget {
 /// 长按扫选的接管区：包在库页滚动体外面，多选态才生效。
 ///
 /// 只在 [enabled] 为真（= 多选态）时**接上**长按回调。多选态下参与多选的卡片
-/// 自身的 `onLongPress` / `onSecondaryTap` 已置 null（两页原有纪律），故这里的
+/// 自身的 `onLongPress` / 右键菜单已置 null（两页原有纪律；右键那一半 BUG-2111 后由
+/// 卡片外层的 [ContextMenuTrigger] 承担，`onInvoke` 传 null 即整层让路），故这里的
 /// 长按在这些卡上无竞争对手；快速点击仍归卡片 `InkWell.onTap`（长按识别器要过
 /// `kLongPressTimeout` 才宣布胜出），列表滚动仍归 `Scrollable`（手指先动就
 /// 由拖动识别器赢下竞技场，长按根本不会触发）。

--- a/fushi/lib/src/pages/implementations/collections_page.dart
+++ b/fushi/lib/src/pages/implementations/collections_page.dart
@@ -7,6 +7,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi_audio/fushi_audio.dart';
@@ -1654,92 +1655,93 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       child: GamepadLongPressActions(
         // Gamepad: hold-A opens the same item menu a mouse long-press does.
         onLongPress: () => _showItemDialog(item),
-        child: GestureDetector(
-          onLongPress: () => _showItemDialog(item),
-          // Desktop: right-click (secondary tap) opens the same item menu a
-          // touch long-press does. The menu is a centered modal dialog, so the
-          // click position is irrelevant -- no positioning needed.
-          onSecondaryTap: () => _showItemDialog(item),
-          child: FushiListItem(
-            leading: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Icon(
-                  icon,
-                  size: 20,
-                  color: Theme.of(context).colorScheme.tertiary,
-                ),
-                Text(
-                  typeLabel,
-                  style: textTheme.labelSmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
-            title: Text(title, maxLines: 2, overflow: TextOverflow.ellipsis),
-            // BUG-469：副标题=可截断的元数据（书名/章节/来源） + **恒可见**的收藏日期。
-            // 旧实现把两者用 ' · ' 拼成一个 Text(maxLines:1, ellipsis)，窄屏（如 12.4"
-            // 平板横向空间不足）时书名+章节占满整行，排在末尾的日期被省略号吃掉看不见。
-            // 根因=两段不同截断语义（元数据可截、日期不可截）共用同一行宽预算。修=拆成
-            // Row：元数据 Flexible+ellipsis 优先让位，日期固定宽不参与收缩永远显示。
-            subtitle:
-                _buildSubtitle(metadata: subtitle, createdAt: item.createdAt),
-            trailing: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // 巡检 PR-3：仅正在播的那一行显示小转圈，其余行保持可点（点即
-                // 先停旧后播新，见 [_playItemAudio]）。
-                if (_hasAudio(item))
-                  playingThis
-                      ? Padding(
-                          padding: EdgeInsets.all(tokens.spacing.gap / 2),
-                          child: const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                        )
-                      : FushiIconButton(
-                          tooltip: t.dialog_play,
-                          icon: Icons.volume_up_outlined,
-                          size: 18,
-                          padding: EdgeInsets.all(tokens.spacing.gap / 2),
-                          onTap: () => _playItemAudio(item),
-                        ),
-                if (item.text != null)
-                  FushiIconButton(
-                    tooltip: t.copy,
-                    icon: Icons.copy_outlined,
-                    size: 18,
-                    padding: EdgeInsets.all(tokens.spacing.gap / 2),
-                    onTap: () {
-                      Clipboard.setData(ClipboardData(text: item.text!));
-                    },
-                  ),
-                if (canNavigate)
+        child: ContextMenuTrigger(
+          // 桌面右键打开与触屏长按相同的条目菜单。菜单是居中模态框，不需要按下坐标。
+          // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+          onInvoke: (Offset _) => _showItemDialog(item),
+          child: GestureDetector(
+            onLongPress: () => _showItemDialog(item),
+            child: FushiListItem(
+              leading: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
                   Icon(
-                    Icons.chevron_right,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    icon,
+                    size: 20,
+                    color: Theme.of(context).colorScheme.tertiary,
                   ),
-              ],
-            ),
-            // Non-navigable rows still get an onTap so they are a gamepad focus
-            // stop (otherwise hold-A / the item menu can never be reached).
-            onTap: canNavigate
-                ? () {
-                    switch (kind) {
-                      case SentenceSourceKind.video:
-                        _openVideoSentence(item);
-                      case SentenceSourceKind.book:
-                      case SentenceSourceKind.audiobook:
-                      case SentenceSourceKind.lyrics:
-                        // audiobook/lyrics 的 bookKey 共享 hoshi://book/ 身份，
-                        // reader 是正确目的地（内部处理有声书/歌词模式）。
-                        _openBook(item);
+                  Text(
+                    typeLabel,
+                    style: textTheme.labelSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+              title: Text(title, maxLines: 2, overflow: TextOverflow.ellipsis),
+              // BUG-469：副标题=可截断的元数据（书名/章节/来源） + **恒可见**的收藏日期。
+              // 旧实现把两者用 ' · ' 拼成一个 Text(maxLines:1, ellipsis)，窄屏（如 12.4"
+              // 平板横向空间不足）时书名+章节占满整行，排在末尾的日期被省略号吃掉看不见。
+              // 根因=两段不同截断语义（元数据可截、日期不可截）共用同一行宽预算。修=拆成
+              // Row：元数据 Flexible+ellipsis 优先让位，日期固定宽不参与收缩永远显示。
+              subtitle:
+                  _buildSubtitle(metadata: subtitle, createdAt: item.createdAt),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // 巡检 PR-3：仅正在播的那一行显示小转圈，其余行保持可点（点即
+                  // 先停旧后播新，见 [_playItemAudio]）。
+                  if (_hasAudio(item))
+                    playingThis
+                        ? Padding(
+                            padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                            child: const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                          )
+                        : FushiIconButton(
+                            tooltip: t.dialog_play,
+                            icon: Icons.volume_up_outlined,
+                            size: 18,
+                            padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                            onTap: () => _playItemAudio(item),
+                          ),
+                  if (item.text != null)
+                    FushiIconButton(
+                      tooltip: t.copy,
+                      icon: Icons.copy_outlined,
+                      size: 18,
+                      padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                      onTap: () {
+                        Clipboard.setData(ClipboardData(text: item.text!));
+                      },
+                    ),
+                  if (canNavigate)
+                    Icon(
+                      Icons.chevron_right,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                ],
+              ),
+              // Non-navigable rows still get an onTap so they are a gamepad focus
+              // stop (otherwise hold-A / the item menu can never be reached).
+              onTap: canNavigate
+                  ? () {
+                      switch (kind) {
+                        case SentenceSourceKind.video:
+                          _openVideoSentence(item);
+                        case SentenceSourceKind.book:
+                        case SentenceSourceKind.audiobook:
+                        case SentenceSourceKind.lyrics:
+                          // audiobook/lyrics 的 bookKey 共享 hoshi://book/ 身份，
+                          // reader 是正确目的地（内部处理有声书/歌词模式）。
+                          _openBook(item);
+                      }
                     }
-                  }
-                : () => _showItemDialog(item),
+                  : () => _showItemDialog(item),
+            ),
           ),
         ),
       ),

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi_anki/fushi_anki.dart'
     show AnkiOpenWordOutcome, MineOutcome, MineResult;
 import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_input_bridge.dart';
 import 'package:fushi/src/pages/implementations/dictionary_webview_media.dart';
@@ -2505,10 +2506,10 @@ JSON.stringify((function(){
           canRequestFocus: false,
           skipTraversal: true,
           onKeyEvent: _handleDesktopCopyKey,
-          child: GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onSecondaryTapDown: (TapDownDetails details) =>
-                _showWindowsContextMenu(context, details.globalPosition),
+          child: ContextMenuTrigger(
+            // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+            onInvoke: (Offset position) =>
+                _showWindowsContextMenu(context, position),
             child: webView,
           ),
         ),

--- a/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:fushi_core/fushi_core.dart' show FushiDatabase;
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/utils/misc/fushi_share.dart';
 import 'package:fushi/src/epub/epub_book.dart' show fallbackMimeType;
 import 'package:fushi/src/media/collections/shelf_sort.dart'
@@ -587,14 +588,16 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
                   child: Center(child: image),
                 );
                 // Windows 右键复制 / 移动端长按分享：仅当前页可操作。
-                return GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onSecondaryTapDown: isWindowsPlatform
-                      ? (TapDownDetails details) =>
-                          _showImageContextMenu(details.globalPosition)
+                return ContextMenuTrigger(
+                  // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+                  onInvoke: isWindowsPlatform
+                      ? (Offset position) => _showImageContextMenu(position)
                       : null,
-                  onLongPress: isWindowsPlatform ? null : _shareCurrentImage,
-                  child: viewer,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onLongPress: isWindowsPlatform ? null : _shareCurrentImage,
+                    child: viewer,
+                  ),
                 );
               },
             ),

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -921,24 +921,26 @@ extension _ReaderChrome on _ReaderFushiPageState {
         barrierColor:
             Theme.of(context).colorScheme.scrim.withValues(alpha: 0.87),
         barrierDismissible: true,
-        pageBuilder: (BuildContext routeContext, __, ___) => GestureDetector(
-          onTap: () => Navigator.pop(context),
-          onSecondaryTapDown: isWindowsPlatform
-              ? (TapDownDetails details) {
-                  unawaited(
+        pageBuilder: (BuildContext routeContext, __, ___) => ContextMenuTrigger(
+          // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+          onInvoke: isWindowsPlatform
+              ? (Offset position) => unawaited(
                     _showReaderImageContextMenuAtGlobalPosition(
                       imgUrl,
-                      details.globalPosition,
+                      position,
                       menuContext: routeContext,
                     ),
-                  );
-                }
+                  )
               : null,
-          child: InteractiveViewer(
-            minScale: 0.5,
-            maxScale: 10,
-            child: Center(
-              child: Image.file(file, fit: BoxFit.contain),
+          ladder: kReaderMouseLadder,
+          child: GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: InteractiveViewer(
+              minScale: 0.5,
+              maxScale: 10,
+              child: Center(
+                child: Image.file(file, fit: BoxFit.contain),
+              ),
             ),
           ),
         ),

--- a/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
@@ -2610,13 +2610,13 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
     final Widget keyed = KeyedSubtree(key: _webViewKey, child: webView);
     // TODO-954：Windows 文字选区右键。`HitTestBehavior.translucent` 让左键框选 / 滚动 /
     // 查词点击照常落进 WebView（与 dictionary_popup_webview 的 BUG-261 范式同），只额外
-    // 截右键（onSecondaryTapDown）弹出 Flutter 菜单——后者随界面大小缩放。
+    // 截菜单键弹出 Flutter 菜单——后者随界面大小缩放。BUG-2111 之后「菜单键」由绑定表决定
+    // （默认右键），阅读器阶梯里 reader / audiobook 先解析，故右键改绑翻页等动作时菜单让位。
     if (!isWindowsPlatform) return keyed;
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onSecondaryTapDown: (TapDownDetails details) {
-        _showReaderTextContextMenu(details.globalPosition);
-      },
+    return ContextMenuTrigger(
+      // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+      onInvoke: (Offset position) => _showReaderTextContextMenu(position),
+      ladder: kReaderMouseLadder,
       child: keyed,
     );
   }

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:transparent_image/transparent_image.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/pages.dart';
 import 'package:fushi_audio/fushi_audio.dart';

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -8,6 +8,7 @@ import 'dart:ui' show ImageFilter;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/utils/misc/fushi_toast.dart';
 import 'package:path/path.dart' as p;

--- a/fushi/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -233,36 +233,38 @@ extension _ReaderHistoryCardWidgets on _ReaderFushiHistoryPageState {
       onTap();
     }
 
-    Widget interactiveCard = Padding(
-      key: cardKey,
-      padding: EdgeInsets.all(tokens.spacing.rowVertical),
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          canRequestFocus: false,
-          borderRadius: tokens.radii.cardRadius,
-          onTap: handleTap,
-          // 未进入选择态时，触屏与桌面长按都保留上下文菜单；只有显式进入选择态后
-          // 才摘掉卡片识别器，让祖先 SelectionDragArea 接管长按扫选。
-          onLongPress: _selectionMode ? null : onLongPress,
-          // 桌面端鼠标右键打开与长按相同的书籍上下文菜单（PC 用户惯例）。多选态
-          // 压制不变。
-          onSecondaryTap: _selectionMode ? null : onLongPress,
-          child: AspectRatio(
-            aspectRatio: slotAspectRatio,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                child,
-                if (_selectionMode && selectionKey != null)
-                  Positioned(
-                    top: selectionInset,
-                    left: selectionInset,
-                    child: ShelfSelectionCheck(selected: selected),
-                  ),
-                if (selected)
-                  const Positioned.fill(child: ShelfSelectedOverlay()),
-              ],
+    Widget interactiveCard = ContextMenuTrigger(
+      // 桌面端鼠标右键打开与长按相同的书籍上下文菜单（PC 用户惯例），多选态压制不变。
+      // 哪个鼠标键唤出由绑定表决定（默认右键），不再硬绑次按钮。
+      onInvoke: contextMenuInvoker(_selectionMode ? null : onLongPress),
+      child: Padding(
+        key: cardKey,
+        padding: EdgeInsets.all(tokens.spacing.rowVertical),
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            canRequestFocus: false,
+            borderRadius: tokens.radii.cardRadius,
+            onTap: handleTap,
+            // 未进入选择态时，触屏与桌面长按都保留上下文菜单；只有显式进入选择态后
+            // 才摘掉卡片识别器，让祖先 SelectionDragArea 接管长按扫选。
+            onLongPress: _selectionMode ? null : onLongPress,
+            child: AspectRatio(
+              aspectRatio: slotAspectRatio,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  child,
+                  if (_selectionMode && selectionKey != null)
+                    Positioned(
+                      top: selectionInset,
+                      left: selectionInset,
+                      child: ShelfSelectionCheck(selected: selected),
+                    ),
+                  if (selected)
+                    const Positioned.fill(child: ShelfSelectedOverlay()),
+                ],
+              ),
             ),
           ),
         ),

--- a/fushi/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/reading_statistics_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/pages.dart';
 import 'package:fushi/src/pages/implementations/stat_activity.dart';
@@ -1412,61 +1413,63 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     final colorScheme = Theme.of(context).colorScheme;
     final tokens = FushiDesignTokens.of(context);
 
-    return Material(
-      type: MaterialType.transparency,
-      child: InkWell(
-        // 移动端长按、桌面端右键（onSecondaryTap）都弹删除确认（书架同款交互）。
-        onLongPress: () => _confirmAndDeleteBook(book),
-        onSecondaryTap: () => _confirmAndDeleteBook(book),
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            vertical: tokens.spacing.gap / 2,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                _bookDisplayTitle(book),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              if (collectionName != null) ...[
-                SizedBox(height: tokens.spacing.gap / 4),
-                buildStatCollectionLabel(context, collectionName),
-              ],
-              SizedBox(height: tokens.spacing.gap / 2),
-              Row(
-                children: [
-                  Expanded(
-                    child: ClipRRect(
-                      borderRadius: tokens.radii.chipRadius,
-                      child: LinearProgressIndicator(
-                        value: fraction,
-                        minHeight: 8,
-                        backgroundColor: colorScheme.surfaceContainerHighest,
-                        color: colorScheme.primary,
+    return ContextMenuTrigger(
+      // 移动端长按、桌面端右键都弹删除确认（书架同款交互）；右键那一半现在走绑定表。
+      onInvoke: (Offset _) => _confirmAndDeleteBook(book),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onLongPress: () => _confirmAndDeleteBook(book),
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              vertical: tokens.spacing.gap / 2,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _bookDisplayTitle(book),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                if (collectionName != null) ...[
+                  SizedBox(height: tokens.spacing.gap / 4),
+                  buildStatCollectionLabel(context, collectionName),
+                ],
+                SizedBox(height: tokens.spacing.gap / 2),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: tokens.radii.chipRadius,
+                        child: LinearProgressIndicator(
+                          value: fraction,
+                          minHeight: 8,
+                          backgroundColor: colorScheme.surfaceContainerHighest,
+                          color: colorScheme.primary,
+                        ),
                       ),
                     ),
-                  ),
-                  SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
-                  Text(
-                    '${_formatChars(book.chars)} · ${formatStatTime(book.ms)}',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ],
-              ),
-              SizedBox(height: tokens.spacing.gap / 2),
-              Text(
-                '${t.stat_lookup}: ${counter.lookups} · ${t.stat_mined}: ${counter.mines} · ${t.stat_favorited}: $favorites',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
+                    SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
+                    Text(
+                      '${_formatChars(book.chars)} · ${formatStatTime(book.ms)}',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
                     ),
-              ),
-              SizedBox(height: tokens.spacing.gap / 2),
-            ],
+                  ],
+                ),
+                SizedBox(height: tokens.spacing.gap / 2),
+                Text(
+                  '${t.stat_lookup}: ${counter.lookups} · ${t.stat_mined}: ${counter.mines} · ${t.stat_favorited}: $favorites',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+                SizedBox(height: tokens.spacing.gap / 2),
+              ],
+            ),
           ),
         ),
       ),

--- a/fushi/lib/src/pages/implementations/series_shelf_card.dart
+++ b/fushi/lib/src/pages/implementations/series_shelf_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/utils.dart';
@@ -68,57 +69,59 @@ class SeriesShelfCard extends StatelessWidget {
     final VoidCallback effectiveTap =
         selectionMode && onSelectionToggle != null ? onSelectionToggle! : onTap;
 
-    final Widget card = Padding(
-      padding: EdgeInsets.all(tokens.spacing.rowVertical),
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          canRequestFocus: false,
-          borderRadius: tokens.radii.cardRadius,
-          onTap: effectiveTap,
-          onLongPress: selectionMode ? null : onLongPress,
-          onSecondaryTap: selectionMode ? null : onSecondaryTap,
-          child: AspectRatio(
-            aspectRatio: slotAspectRatio,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                Expanded(
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: <Widget>[
-                      Positioned.fill(
-                        child: FushiCard(
-                          padding: EdgeInsets.zero,
-                          margin: EdgeInsets.zero,
-                          child: ClipRRect(
-                            borderRadius: tokens.radii.cardRadius,
-                            child: SeriesFolderCover(covers: covers),
+    final Widget card = ContextMenuTrigger(
+      onInvoke: contextMenuInvoker(selectionMode ? null : onSecondaryTap),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.rowVertical),
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            canRequestFocus: false,
+            borderRadius: tokens.radii.cardRadius,
+            onTap: effectiveTap,
+            onLongPress: selectionMode ? null : onLongPress,
+            child: AspectRatio(
+              aspectRatio: slotAspectRatio,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Expanded(
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: <Widget>[
+                        Positioned.fill(
+                          child: FushiCard(
+                            padding: EdgeInsets.zero,
+                            margin: EdgeInsets.zero,
+                            child: ClipRRect(
+                              borderRadius: tokens.radii.cardRadius,
+                              child: SeriesFolderCover(covers: covers),
+                            ),
                           ),
                         ),
-                      ),
-                      PositionedDirectional(
-                        end: overlayInset + 6,
-                        top: overlayInset + 4,
-                        child: _countBadge(theme, tokens),
-                      ),
-                      if (selectionMode && selectionKey != null)
-                        Positioned(
-                          top: tokens.spacing.gap / 2,
-                          left: tokens.spacing.gap / 2,
-                          child: ShelfSelectionCheck(selected: selected),
+                        PositionedDirectional(
+                          end: overlayInset + 6,
+                          top: overlayInset + 4,
+                          child: _countBadge(theme, tokens),
                         ),
-                      if (selected)
-                        const Positioned.fill(child: ShelfSelectedOverlay()),
-                    ],
+                        if (selectionMode && selectionKey != null)
+                          Positioned(
+                            top: tokens.spacing.gap / 2,
+                            left: tokens.spacing.gap / 2,
+                            child: ShelfSelectionCheck(selected: selected),
+                          ),
+                        if (selected)
+                          const Positioned.fill(child: ShelfSelectedOverlay()),
+                      ],
+                    ),
                   ),
-                ),
-                SizedBox(
-                  // BUG-1184：与散书卡同步，随文字缩放变高，防止系列名第二行被裁。
-                  height: ShelfCardFooter.heightFor(context),
-                  child: ShelfCardFooter(title: name),
-                ),
-              ],
+                  SizedBox(
+                    // BUG-1184：与散书卡同步，随文字缩放变高，防止系列名第二行被裁。
+                    height: ShelfCardFooter.heightFor(context),
+                    child: ShelfCardFooter(title: name),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/fushi/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
+++ b/fushi/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
@@ -6,6 +6,20 @@
 // moved here with their sole call sites.
 part of '../shortcut_settings_page.dart';
 
+/// 撞键时用户的三种处置，替代原来的「换/不换」二选一。
+///
+/// 为什么必须有 [keepBoth]：撞键**不等于**其中一个必须让出。同一个按钮完全可以同时
+/// 留在两个动作上——按下时由解析阶梯（页面 scope 先、global/universal 兜底）决定谁
+/// 生效，这正是「右键既是某页面动作、又是上下文菜单默认键」这类配置的正常形态。旧流程
+/// 只给「替换」一条路，等于强迫用户先去解绑另一个动作才能配自己想要的键。
+enum _ConflictResolution {
+  /// 把这个绑定从冲突动作上剥走，只留给当前动作（旧流程的唯一选项）。
+  replace,
+
+  /// 两个动作都保留该绑定，按下时按作用域先后仲裁。
+  keepBoth,
+}
+
 /// TODO-1088: whether the running platform has a mouse whose non-primary buttons
 /// can be bound. Desktop (Windows/Linux/macOS) yes; mobile (Android/iOS) has no
 /// mouse, so the capture entry is hidden there and the mouse section stays a
@@ -246,12 +260,15 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
         _wheelCapturing = false;
         _conflictWarning = t.shortcut_conflict(s: conflict.label);
       });
-      final bool confirmed = await _showConflictReassignmentDialog(conflict);
-      if (!confirmed || !mounted) return;
+      final _ConflictResolution? choice =
+          await _showConflictReassignmentDialog(conflict);
+      if (choice == null || !mounted) return;
       if (_wheel.contains(binding)) return;
       setState(() {
         _wheel.add(binding);
-        if (!_wheelReassignments.contains(binding)) {
+        // keepBoth 时不登记 reassignment（写回阶段才会真的剥走别的动作的绑定）。
+        if (choice == _ConflictResolution.replace &&
+            !_wheelReassignments.contains(binding)) {
           _wheelReassignments.add(binding);
         }
         _conflictWarning = null;
@@ -310,12 +327,15 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
         _mouseCapturing = false;
         _conflictWarning = t.shortcut_conflict(s: conflict.label);
       });
-      final bool confirmed = await _showConflictReassignmentDialog(conflict);
-      if (!confirmed || !mounted) return;
+      final _ConflictResolution? choice =
+          await _showConflictReassignmentDialog(conflict);
+      if (choice == null || !mounted) return;
       if (_mouse.contains(binding)) return;
       setState(() {
         _mouse.add(binding);
-        if (!_mouseReassignments.contains(binding)) {
+        // keepBoth 时不登记 reassignment（写回阶段才会真的剥走别的动作的绑定）。
+        if (choice == _ConflictResolution.replace &&
+            !_mouseReassignments.contains(binding)) {
           _mouseReassignments.add(binding);
         }
         _conflictWarning = null;
@@ -428,22 +448,26 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
       _capturing = false;
       _conflictWarning = t.shortcut_conflict(s: conflict.label);
     });
-    final bool confirmed = await _showConflictReassignmentDialog(conflict);
-    if (!confirmed || !mounted) return;
+    final _ConflictResolution? choice =
+        await _showConflictReassignmentDialog(conflict);
+    if (choice == null || !mounted) return;
     if (_keyboard.contains(binding)) return;
     setState(() {
       _keyboard.add(binding);
-      if (!_keyboardReassignments.contains(binding)) {
+      // keepBoth 时**不**登记 reassignment：写回阶段的 removeKeyboardConflicts 才是
+      // 「把这个键从别的动作上剥走」的执行体，不登记就等于两个动作都留着。
+      if (choice == _ConflictResolution.replace &&
+          !_keyboardReassignments.contains(binding)) {
         _keyboardReassignments.add(binding);
       }
       _conflictWarning = null;
     });
   }
 
-  Future<bool> _showConflictReassignmentDialog(
+  Future<_ConflictResolution?> _showConflictReassignmentDialog(
     ShortcutAction conflict,
   ) async {
-    final bool? confirmed = await showAppDialog<bool>(
+    return showAppDialog<_ConflictResolution>(
       context: context,
       builder: (BuildContext ctx) {
         final FushiDesignTokens tokens = FushiDesignTokens.of(ctx);
@@ -467,10 +491,21 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
               tokens.spacing.card,
               tokens.spacing.card,
             ),
-            body: Text(
-              t.shortcut_conflict_replace_confirm(
-                s: conflict.label,
-              ),
+            body: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  t.shortcut_conflict_replace_confirm(
+                    s: conflict.label,
+                  ),
+                ),
+                SizedBox(height: tokens.spacing.gap),
+                Text(
+                  t.shortcut_conflict_keep_both_hint,
+                  style: Theme.of(ctx).textTheme.bodySmall,
+                ),
+              ],
             ),
             footer: Wrap(
               alignment: WrapAlignment.end,
@@ -479,13 +514,20 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
               children: <Widget>[
                 adaptiveDialogAction(
                   context: ctx,
-                  onPressed: () => Navigator.pop(ctx, false),
+                  onPressed: () => Navigator.pop(ctx, null),
                   child: Text(t.dialog_cancel),
                 ),
                 adaptiveDialogAction(
                   context: ctx,
+                  onPressed: () =>
+                      Navigator.pop(ctx, _ConflictResolution.keepBoth),
+                  child: Text(t.shortcut_conflict_keep_both),
+                ),
+                adaptiveDialogAction(
+                  context: ctx,
                   isDefaultAction: true,
-                  onPressed: () => Navigator.pop(ctx, true),
+                  onPressed: () =>
+                      Navigator.pop(ctx, _ConflictResolution.replace),
                   child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
                 ),
               ],
@@ -494,7 +536,6 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
         );
       },
     );
-    return confirmed == true;
   }
 
   void _startGamepadCapture() {
@@ -552,12 +593,15 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
       setState(() {
         _conflictWarning = t.shortcut_conflict(s: conflict.label);
       });
-      final bool confirmed = await _showConflictReassignmentDialog(conflict);
-      if (!confirmed || !mounted) return;
+      final _ConflictResolution? choice =
+          await _showConflictReassignmentDialog(conflict);
+      if (choice == null || !mounted) return;
       if (_gamepad.contains(binding)) return;
       setState(() {
         _gamepad.add(binding);
-        if (!_gamepadReassignments.contains(binding)) {
+        // keepBoth 时不登记 reassignment（写回阶段才会真的剥走别的动作的绑定）。
+        if (choice == _ConflictResolution.replace &&
+            !_gamepadReassignments.contains(binding)) {
           _gamepadReassignments.add(binding);
         }
         _conflictWarning = null;

--- a/fushi/lib/src/pages/implementations/tag_management_page.dart
+++ b/fushi/lib/src/pages/implementations/tag_management_page.dart
@@ -2,6 +2,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/models/builtin_tags.dart';
 import 'package:fushi/src/pages/implementations/tag_filter_sheet.dart';
@@ -266,20 +267,22 @@ class _TagManagementPageState extends ConsumerState<TagManagementPage> {
                         },
                       ),
                     },
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      onLongPressStart: (LongPressStartDetails d) =>
-                          _showTagMenu(tag, d.globalPosition),
-                      onSecondaryTapDown: (TapDownDetails d) =>
-                          _showTagMenu(tag, d.globalPosition),
-                      child: FushiListItem(
-                        leading: CircleAvatar(
-                          backgroundColor: Color(tag.colorValue),
-                          radius: 14,
+                    child: ContextMenuTrigger(
+                      // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+                      onInvoke: (Offset position) => _showTagMenu(tag, position),
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onLongPressStart: (LongPressStartDetails d) =>
+                            _showTagMenu(tag, d.globalPosition),
+                        child: FushiListItem(
+                          leading: CircleAvatar(
+                            backgroundColor: Color(tag.colorValue),
+                            radius: 14,
+                          ),
+                          title: Text(tag.name),
+                          trailing: Text(t.tag_book_count(count: count)),
+                          onTap: () => _editTag(tag),
                         ),
-                        title: Text(tag.name),
-                        trailing: Text(t.tag_book_count(count: count)),
-                        onTap: () => _editTag(tag),
                       ),
                     ),
                   ),

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -331,230 +331,235 @@ extension _VideoLayout on _VideoFushiPageState {
                 // TODO-1058：桌面在画面上滚鼠标滚轮调音量（门控见 _handleVideoWheelSignal）。
                 // PointerSignal 不进手势竞技场，与单击暂停 / 长按横拖 seek 正交、互不干扰。
                 onPointerSignal: _handleVideoWheelSignal,
-                // 桌面右键 = 视频上下文菜单（TODO-048c）。GestureDetector 只接管次按钮
-                // （右键）的 tap，左键双击全屏仍走外层 Listener.onPointerUp（两路指针语义互不
-                // 干扰）。onSecondaryTapUp 提供右键松手处的 globalPosition 作 showMenu 锚点。
-                // 移动端无次按钮、永不触发，但 [_handleSecondaryTap] 内再门控一次（双保险）。
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onSecondaryTapUp: (TapUpDetails details) =>
-                      _handleSecondaryTap(details.globalPosition),
-                  onLongPressStart: _handleVideoLongPressStart,
-                  onLongPressMoveUpdate: _handleVideoLongPressMoveUpdate,
-                  onLongPressEnd: _handleVideoLongPressEnd,
-                  child: Stack(
-                    children: <Widget>[
-                      // Builder 捕获 media_kit controls 子树内的 context（[_videoControlsContext]），
-                      // 供覆盖后的键盘快捷键调用全屏 helper（isFullscreen/toggle/exitFullscreen）——
-                      // 本页 build context 是它们的祖先，找不到 media_kit 的 Fullscreen/VideoState
-                      // InheritedWidget。全屏复用同一 builder，故全屏路由会重新捕获其子树 context。
-                      Positioned.fill(
-                        child: Builder(
-                          builder: (BuildContext controlsContext) {
-                            _videoControlsContext = controlsContext;
-                            // 锁定 / 沉浸模式（TODO-101）：用 IgnorePointer 拦掉送往 media_kit
-                            // controls 的所有指针事件——其 MouseRegion.onHover/onEnter 收不到
-                            // 鼠标移动 → 控制条不再被唤起（顶/底栏按钮不弹）。IgnorePointer 只
-                            // 过滤指针，不影响键盘：media_kit 的 CallbackShortcuts + Focus 是
-                            // MouseRegion 的祖先（见 media_kit material_desktop.dart），快捷键照常
-                            // 收键；字幕逐字查词由更上层 [VideoSubtitleOverlay] 承载（在本 Stack
-                            // AdaptiveVideoControls 之上），点字幕仍能查词。可见性走 ValueNotifier
-                            // 让全屏路由也响应（BUG-120 同源）。
-                            //
-                            // 侧栏 / 字幕列表打开时也一并 gate（BUG-253 / TODO-329）：overlay 盖在
-                            // 控制条上，但 media_kit 自己的 MouseRegion 仍会在鼠标移过透明背景区时
-                            // 把控制条弹回到 overlay 后面，且其 `hideMouseOnControlsRemoval` 会在
-                            // 控制条 2s 自动收起后隐藏视频区光标（用户报「沉浸/锁屏下鼠标放字幕被
-                            // 隐藏」的画面区分支）。把 [IgnorePointer] 同时绑 [_videoSidePanel] 与
-                            // [_subtitleListVisible]，overlay 期间 media_kit 收不到 hover → 背景控制条
-                            // 不再冒出来、其 cursor:none 也不接管光标。键盘仍不受影响（同上）。
-                            // BUG-371：[_subtitleListVisible] 不再 gate media_kit
-                            // controls 指针——字幕跳转列表是 push-aside 侧栏（画面挤窄、
-                            // 不遮控制条），开列表时 media_kit 顶 / 底栏按钮应继续可点
-                            // （左侧按钮可用）；仅沉浸锁 / 真 overlay 面板 / 剧集列表 /
-                            // 编辑态拦截指针。
-                            return ListenableBuilder(
-                              listenable: Listenable.merge(
-                                <Listenable>[
-                                  _immersiveLocked,
-                                  _videoSidePanel,
-                                  _episodeListVisible,
-                                  _videoControlEditMode,
-                                ],
+                // 桌面右键 = 视频上下文菜单（TODO-048c）。BUG-2111 之后不再硬绑次按钮：
+                // [ContextMenuTrigger] 按绑定表判定哪个鼠标键唤出菜单（默认右键），并复用
+                // 鼠标绑定的单槽认领——所以在视频页把右键绑给别的动作时，菜单会自动让位而不是
+                // 与它双触发。阶梯用本页那条（video 先、universal / global 兜底）。左键双击全屏
+                // 仍走外层 Listener.onPointerUp（两路指针语义互不干扰）。触屏按下折不出鼠标
+                // 按钮号、永不触发，[_handleSecondaryTap] 内另有一道平台门控（双保险）。
+                child: ContextMenuTrigger(
+                  // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+                  onInvoke: (Offset position) => _handleSecondaryTap(position),
+                  ladder: _VideoFushiPageState.kVideoMouseLadder,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onLongPressStart: _handleVideoLongPressStart,
+                    onLongPressMoveUpdate: _handleVideoLongPressMoveUpdate,
+                    onLongPressEnd: _handleVideoLongPressEnd,
+                    child: Stack(
+                      children: <Widget>[
+                        // Builder 捕获 media_kit controls 子树内的 context（[_videoControlsContext]），
+                        // 供覆盖后的键盘快捷键调用全屏 helper（isFullscreen/toggle/exitFullscreen）——
+                        // 本页 build context 是它们的祖先，找不到 media_kit 的 Fullscreen/VideoState
+                        // InheritedWidget。全屏复用同一 builder，故全屏路由会重新捕获其子树 context。
+                        Positioned.fill(
+                          child: Builder(
+                            builder: (BuildContext controlsContext) {
+                              _videoControlsContext = controlsContext;
+                              // 锁定 / 沉浸模式（TODO-101）：用 IgnorePointer 拦掉送往 media_kit
+                              // controls 的所有指针事件——其 MouseRegion.onHover/onEnter 收不到
+                              // 鼠标移动 → 控制条不再被唤起（顶/底栏按钮不弹）。IgnorePointer 只
+                              // 过滤指针，不影响键盘：media_kit 的 CallbackShortcuts + Focus 是
+                              // MouseRegion 的祖先（见 media_kit material_desktop.dart），快捷键照常
+                              // 收键；字幕逐字查词由更上层 [VideoSubtitleOverlay] 承载（在本 Stack
+                              // AdaptiveVideoControls 之上），点字幕仍能查词。可见性走 ValueNotifier
+                              // 让全屏路由也响应（BUG-120 同源）。
+                              //
+                              // 侧栏 / 字幕列表打开时也一并 gate（BUG-253 / TODO-329）：overlay 盖在
+                              // 控制条上，但 media_kit 自己的 MouseRegion 仍会在鼠标移过透明背景区时
+                              // 把控制条弹回到 overlay 后面，且其 `hideMouseOnControlsRemoval` 会在
+                              // 控制条 2s 自动收起后隐藏视频区光标（用户报「沉浸/锁屏下鼠标放字幕被
+                              // 隐藏」的画面区分支）。把 [IgnorePointer] 同时绑 [_videoSidePanel] 与
+                              // [_subtitleListVisible]，overlay 期间 media_kit 收不到 hover → 背景控制条
+                              // 不再冒出来、其 cursor:none 也不接管光标。键盘仍不受影响（同上）。
+                              // BUG-371：[_subtitleListVisible] 不再 gate media_kit
+                              // controls 指针——字幕跳转列表是 push-aside 侧栏（画面挤窄、
+                              // 不遮控制条），开列表时 media_kit 顶 / 底栏按钮应继续可点
+                              // （左侧按钮可用）；仅沉浸锁 / 真 overlay 面板 / 剧集列表 /
+                              // 编辑态拦截指针。
+                              return ListenableBuilder(
+                                listenable: Listenable.merge(
+                                  <Listenable>[
+                                    _immersiveLocked,
+                                    _videoSidePanel,
+                                    _episodeListVisible,
+                                    _videoControlEditMode,
+                                  ],
+                                ),
+                                builder: (BuildContext _, __) => IgnorePointer(
+                                  ignoring: _immersiveLocked.value ||
+                                      _videoSidePanel.value != null ||
+                                      _episodeListVisible.value ||
+                                      _videoControlEditMode.value,
+                                  child: AdaptiveVideoControls(state),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        // 进度条章节刻度层（TODO-432）：叠在 seek bar 同一几何上画每章一条竖线。
+                        // IgnorePointer 纯视觉、不拦 seek bar 拖动；随控制条显隐、仅有章节时画。
+                        _buildChapterMarkersOverlay(controller),
+                        // 进度条 hover 缩略图预览层（TODO-669）：桌面 hover seek bar 时在指针
+                        // 上方弹缩略图 + 时间戳。纯视觉 IgnorePointer（不拦 seek bar 拖动），
+                        // hover 位置经 fork onHoverPosition → [_onSeekBarHover] 取得。
+                        _buildThumbnailPreviewOverlay(controller),
+                        Positioned.fill(
+                          child: VideoDanmakuOverlay(
+                            // TODO-1376：送屏蔽过滤后的可见弹幕 + 当前样式（字号/透明度/速度/区域）。
+                            items: _danmakuVisibleItems,
+                            enabled: appModel.videoDanmakuEnabled,
+                            maxActive: appModel.videoDanmakuMaxActive,
+                            positionMs: () => controller.positionMs ?? 0,
+                            // 播放器时钟 ~200ms 才更新，overlay 内按帧插值需知道是否在播放
+                            // 与当前速率，才能平滑外推且暂停时冻结、倍速时同步。
+                            isPlaying: () => controller.isPlaying,
+                            speed: () => controller.speed,
+                            style: _danmakuStyle,
+                          ),
+                        ),
+                        Positioned.fill(
+                          child: VideoSubtitleOverlay(
+                            controller: controller,
+                            // 字幕字体链的语言：用户对本视频手动指定 > 当前字幕轨
+                            // 声明的 language > 全局默认内容语言。三档全空时字幕层
+                            // 退回历史兜底链，渲染逐像素不变。
+                            contentLanguage: _resolveSubtitleLanguage(controller),
+                            onCharTap: _handleSubtitleLookupTap,
+                            // TODO-756a 桌面 Shift-鼠标悬停查词：走去重入口 [_handleSubtitleHoverLookup]
+                            // →（[_handleSubtitleLookupTap] → [_lookupAt]，内部已 _immersiveAllowsLookup
+                            // 门控），故按住 Shift 悬停字幕字符与点击该字符行为一致。移动端无 hover、
+                            // 自然不触发；节流由 VideoSubtitleOverlay 内部承载。BUG-861：与浮层 barrier
+                            // hover（[_onDismissBarrierHover]）共用同一「同句同 grapheme」去重键，避免
+                            // 字符未被浮层遮住时两条 hover 路径同时命中导致同词双查闪烁。
+                            onCharHover: _handleSubtitleHoverLookup,
+                            // TODO-756b：开了“悬停即查词”则纯悬停（无需 Shift）即查词；
+                            // 关闭退回 756a 的 Shift+悬停。视频与阅读器共享 instance。
+                            hoverAutoLookupEnabled:
+                                ReaderFushiSource.instance.hoverAutoLookup,
+                            onHoverChanged: _handleSubtitleHover,
+                            hitTester: _subtitleHitTester,
+                            // 字级选词光标环（videoEnterCaret，手柄/键盘查词）。
+                            caretEntryIndex: _subtitleCaretEntry,
+                            // 当前句已收藏时在字幕盒角标实心星（TODO-301）。读同一收藏缓存
+                            // [_favoritedVideoSentences]（[_isCueFavorited]）；收藏 / 取消收藏
+                            // 后 setState 触发本 builder 重建，标记即时更新。
+                            isCueFavorited: _isCueFavorited,
+                            // TODO-840 Part B：字幕遮蔽模式三态映射成 overlay 的两个
+                            // 正交标志——模糊态走 blurEnabled、隐藏态走 subtitleHidden
+                            // （互斥，至多一个为 true）。不遮蔽时两者皆 false（历史外观）。
+                            blurEnabled: appModel.videoSubtitleObscureMode ==
+                                VideoSubtitleObscureMode.blur,
+                            subtitleHidden: appModel.videoSubtitleObscureMode ==
+                                VideoSubtitleObscureMode.hide,
+                            // TODO-1382：副字幕遮蔽三态同样映射成两正交标志（独立于主字幕）。
+                            secondaryBlurEnabled:
+                                appModel.videoSecondarySubtitleObscureMode ==
+                                    VideoSubtitleObscureMode.blur,
+                            secondaryHidden:
+                                appModel.videoSecondarySubtitleObscureMode ==
+                                    VideoSubtitleObscureMode.hide,
+                            // TODO-1199：字幕字号=用户基准 × 屏幕自适应因子。用户设置的
+                            // fontSize 仍是基准（手动可调、不被改写），渲染时乘按视口短边
+                            // 算出的 [subtitleScreenScaleFactor]，使字幕占屏比例在小屏手机 /
+                            // 大屏平板 / 桌面上物理观感一致（自动缩放恒开、叠加在基准之上）。
+                            // MediaQuery.sizeOf 建立尺寸依赖：横竖屏切换 / 窗口缩放会重建本
+                            // builder 重算因子。
+                            fontSize: _subtitleStyle.fontSize *
+                                subtitleScreenScaleFactor(
+                                  MediaQuery.sizeOf(context),
+                                ),
+                            textColor: _subtitleStyle.resolveTextColor(
+                              _subtitleTextColor(
+                                  _videoChromeColorScheme(context)),
+                            ),
+                            fontWeight:
+                                _subtitleStyle.resolveFontWeight(_videoUiScale),
+                            shadowColor: _subtitleStyle.resolveShadowColor(
+                              _subtitleShadowColor(
+                                  _videoChromeColorScheme(context)),
+                            ),
+                            shadowThickness:
+                                _subtitleStyle.resolveShadowThickness(
+                              _videoUiScale,
+                            ),
+                            backgroundColor:
+                                _subtitleStyle.resolveBackgroundColor(
+                              _subtitleBackgroundColor(
+                                _videoChromeColorScheme(context),
                               ),
-                              builder: (BuildContext _, __) => IgnorePointer(
-                                ignoring: _immersiveLocked.value ||
-                                    _videoSidePanel.value != null ||
-                                    _episodeListVisible.value ||
-                                    _videoControlEditMode.value,
-                                child: AdaptiveVideoControls(state),
+                            ),
+                            backgroundOpacity: _subtitleStyle.backgroundOpacity,
+                            bottomPadding: _subtitleStyle.bottomPadding,
+                            // 副字幕独立位置：null = 用户没单独调过，overlay 内回落到
+                            // bottomPadding（历史行为）。非 null 时副字幕层用自己的基线，
+                            // 主字幕位置滑杆不再把副字幕一起挪走。
+                            secondaryBottomPadding:
+                                _subtitleStyle.secondaryBottomPadding,
+                            // TODO-2838：主/副字幕用户垂直锚定（底/顶）+ 拖拽调整模式。
+                            // 拖拽松手把落点锚定 + 距边距离写回 style 偏好并持久化。
+                            mainAnchor: _subtitleStyle.mainAnchor,
+                            secondaryAnchor: _subtitleStyle.secondaryAnchor,
+                            dragAdjustEnabled: _subtitleDragAdjustActive,
+                            onDragAdjustEnd: _handleSubtitleDragAdjustEnd,
+                            // 控制条可见性驱动动态避让（TODO-129）：进度条出现时字幕底缘对
+                            // 进度条上缘取下限（max，非加法——BUG-226 防顶飞）、隐藏落回。全屏
+                            // 复用同一 builder + ValueNotifier，故窗口与全屏都跟随（BUG-120 同源）。
+                            controlsVisible: _videoControlsVisible,
+                            // 进度条上缘距视频底边的真实高度（按平台控制条几何加总 + 随界面
+                            // 缩放，BUG-238）。旧默认常量 56 既不随缩放、又低于默认基线 75 →
+                            // 移动端 `max(75, 56)=75` 把字幕留在被抬高的进度条下面被遮（用户报
+                            // 「只动一点点」）。显式传入真实几何让移动端真正抬升盖过进度条；
+                            // 桌面仍只让一个按钮行高（保 BUG-228 观感）。TODO-568：移动端改抬到
+                            // **可见轨道上缘 + 呼吸间距**（≈101×缩放，而非旧的整段热区高 140），
+                            // 字幕骑进度条上方一点点、不顶飞 ~47×缩放 的透明命中区空白。
+                            controlsBottomReserve:
+                                _subtitleControlsBottomReserve(),
+                            // BUG-1069：顶部锚字幕在控制条可见时同样避让顶栏（标题栏 +
+                            // 右上角菜单），整体下移到顶栏下方 → UI 赢重叠、不被字幕盖住。
+                            controlsTopReserve: _subtitleControlsTopReserve(),
+                            fontFamily: appModel.subtitleFontFamily,
+                            // TODO-1105：尊重 .ass 自带样式（字体/主色/描边/阴影）。开关默认开；
+                            // 关时 overlay 全走上面的统一样式，外观与历史像素级一致。
+                            respectAssStyle: appModel.videoRespectAssStyle,
+                          ),
+                        ),
+                        _buildOsdOverlay(),
+                        // TODO-1154：长按倍速徽章跟随指针（在 OSD 之后、其余 chrome 之前挂）。
+                        _buildLongPressSpeedBadgeOverlay(),
+                        _buildAutoAdvanceOverlay(),
+                        // TODO-1119：Windows 黑闪运行时提示条（可点按钮，非
+                        // IgnorePointer；隐藏态零尺寸）。挂在 auto-advance 之后、
+                        // level HUD 之前，与其它 chrome overlay 同源。
+                        _buildBlackFlickerNoticeOverlay(),
+                        // TODO-2838：拖拽调整字幕位置模式的顶部横幅（提示 + 「完成」退出）。
+                        // 非模式态零尺寸。
+                        _buildSubtitleDragAdjustBanner(),
+                        _buildLevelHudOverlay(),
+                        _buildVideoSideActionRail(controller),
+                        _buildVideoSidePanelOverlay(controller),
+                        _buildVideoControlPopoverOverlay(controller),
+                        ValueListenableBuilder<bool>(
+                          valueListenable: _videoControlEditMode,
+                          builder: (BuildContext _, bool editing, __) {
+                            if (!editing) return const SizedBox.shrink();
+                            return Positioned.fill(
+                              child: VideoControlLayoutEditOverlay(
+                                layout: layout,
+                                onLayoutChanged: _setVideoControlLayout,
+                                onClose: _hideVideoControlEditOverlay,
+                                // TODO-554：触屏保留「设置」按钮入口不可移除。
+                                isTouchControls: !_isDesktopVideoControls,
+                                customActionBindings: _customActionBindings,
                               ),
                             );
                           },
                         ),
-                      ),
-                      // 进度条章节刻度层（TODO-432）：叠在 seek bar 同一几何上画每章一条竖线。
-                      // IgnorePointer 纯视觉、不拦 seek bar 拖动；随控制条显隐、仅有章节时画。
-                      _buildChapterMarkersOverlay(controller),
-                      // 进度条 hover 缩略图预览层（TODO-669）：桌面 hover seek bar 时在指针
-                      // 上方弹缩略图 + 时间戳。纯视觉 IgnorePointer（不拦 seek bar 拖动），
-                      // hover 位置经 fork onHoverPosition → [_onSeekBarHover] 取得。
-                      _buildThumbnailPreviewOverlay(controller),
-                      Positioned.fill(
-                        child: VideoDanmakuOverlay(
-                          // TODO-1376：送屏蔽过滤后的可见弹幕 + 当前样式（字号/透明度/速度/区域）。
-                          items: _danmakuVisibleItems,
-                          enabled: appModel.videoDanmakuEnabled,
-                          maxActive: appModel.videoDanmakuMaxActive,
-                          positionMs: () => controller.positionMs ?? 0,
-                          // 播放器时钟 ~200ms 才更新，overlay 内按帧插值需知道是否在播放
-                          // 与当前速率，才能平滑外推且暂停时冻结、倍速时同步。
-                          isPlaying: () => controller.isPlaying,
-                          speed: () => controller.speed,
-                          style: _danmakuStyle,
-                        ),
-                      ),
-                      Positioned.fill(
-                        child: VideoSubtitleOverlay(
-                          controller: controller,
-                          // 字幕字体链的语言：用户对本视频手动指定 > 当前字幕轨
-                          // 声明的 language > 全局默认内容语言。三档全空时字幕层
-                          // 退回历史兜底链，渲染逐像素不变。
-                          contentLanguage: _resolveSubtitleLanguage(controller),
-                          onCharTap: _handleSubtitleLookupTap,
-                          // TODO-756a 桌面 Shift-鼠标悬停查词：走去重入口 [_handleSubtitleHoverLookup]
-                          // →（[_handleSubtitleLookupTap] → [_lookupAt]，内部已 _immersiveAllowsLookup
-                          // 门控），故按住 Shift 悬停字幕字符与点击该字符行为一致。移动端无 hover、
-                          // 自然不触发；节流由 VideoSubtitleOverlay 内部承载。BUG-861：与浮层 barrier
-                          // hover（[_onDismissBarrierHover]）共用同一「同句同 grapheme」去重键，避免
-                          // 字符未被浮层遮住时两条 hover 路径同时命中导致同词双查闪烁。
-                          onCharHover: _handleSubtitleHoverLookup,
-                          // TODO-756b：开了“悬停即查词”则纯悬停（无需 Shift）即查词；
-                          // 关闭退回 756a 的 Shift+悬停。视频与阅读器共享 instance。
-                          hoverAutoLookupEnabled:
-                              ReaderFushiSource.instance.hoverAutoLookup,
-                          onHoverChanged: _handleSubtitleHover,
-                          hitTester: _subtitleHitTester,
-                          // 字级选词光标环（videoEnterCaret，手柄/键盘查词）。
-                          caretEntryIndex: _subtitleCaretEntry,
-                          // 当前句已收藏时在字幕盒角标实心星（TODO-301）。读同一收藏缓存
-                          // [_favoritedVideoSentences]（[_isCueFavorited]）；收藏 / 取消收藏
-                          // 后 setState 触发本 builder 重建，标记即时更新。
-                          isCueFavorited: _isCueFavorited,
-                          // TODO-840 Part B：字幕遮蔽模式三态映射成 overlay 的两个
-                          // 正交标志——模糊态走 blurEnabled、隐藏态走 subtitleHidden
-                          // （互斥，至多一个为 true）。不遮蔽时两者皆 false（历史外观）。
-                          blurEnabled: appModel.videoSubtitleObscureMode ==
-                              VideoSubtitleObscureMode.blur,
-                          subtitleHidden: appModel.videoSubtitleObscureMode ==
-                              VideoSubtitleObscureMode.hide,
-                          // TODO-1382：副字幕遮蔽三态同样映射成两正交标志（独立于主字幕）。
-                          secondaryBlurEnabled:
-                              appModel.videoSecondarySubtitleObscureMode ==
-                                  VideoSubtitleObscureMode.blur,
-                          secondaryHidden:
-                              appModel.videoSecondarySubtitleObscureMode ==
-                                  VideoSubtitleObscureMode.hide,
-                          // TODO-1199：字幕字号=用户基准 × 屏幕自适应因子。用户设置的
-                          // fontSize 仍是基准（手动可调、不被改写），渲染时乘按视口短边
-                          // 算出的 [subtitleScreenScaleFactor]，使字幕占屏比例在小屏手机 /
-                          // 大屏平板 / 桌面上物理观感一致（自动缩放恒开、叠加在基准之上）。
-                          // MediaQuery.sizeOf 建立尺寸依赖：横竖屏切换 / 窗口缩放会重建本
-                          // builder 重算因子。
-                          fontSize: _subtitleStyle.fontSize *
-                              subtitleScreenScaleFactor(
-                                MediaQuery.sizeOf(context),
-                              ),
-                          textColor: _subtitleStyle.resolveTextColor(
-                            _subtitleTextColor(
-                                _videoChromeColorScheme(context)),
-                          ),
-                          fontWeight:
-                              _subtitleStyle.resolveFontWeight(_videoUiScale),
-                          shadowColor: _subtitleStyle.resolveShadowColor(
-                            _subtitleShadowColor(
-                                _videoChromeColorScheme(context)),
-                          ),
-                          shadowThickness:
-                              _subtitleStyle.resolveShadowThickness(
-                            _videoUiScale,
-                          ),
-                          backgroundColor:
-                              _subtitleStyle.resolveBackgroundColor(
-                            _subtitleBackgroundColor(
-                              _videoChromeColorScheme(context),
-                            ),
-                          ),
-                          backgroundOpacity: _subtitleStyle.backgroundOpacity,
-                          bottomPadding: _subtitleStyle.bottomPadding,
-                          // 副字幕独立位置：null = 用户没单独调过，overlay 内回落到
-                          // bottomPadding（历史行为）。非 null 时副字幕层用自己的基线，
-                          // 主字幕位置滑杆不再把副字幕一起挪走。
-                          secondaryBottomPadding:
-                              _subtitleStyle.secondaryBottomPadding,
-                          // TODO-2838：主/副字幕用户垂直锚定（底/顶）+ 拖拽调整模式。
-                          // 拖拽松手把落点锚定 + 距边距离写回 style 偏好并持久化。
-                          mainAnchor: _subtitleStyle.mainAnchor,
-                          secondaryAnchor: _subtitleStyle.secondaryAnchor,
-                          dragAdjustEnabled: _subtitleDragAdjustActive,
-                          onDragAdjustEnd: _handleSubtitleDragAdjustEnd,
-                          // 控制条可见性驱动动态避让（TODO-129）：进度条出现时字幕底缘对
-                          // 进度条上缘取下限（max，非加法——BUG-226 防顶飞）、隐藏落回。全屏
-                          // 复用同一 builder + ValueNotifier，故窗口与全屏都跟随（BUG-120 同源）。
-                          controlsVisible: _videoControlsVisible,
-                          // 进度条上缘距视频底边的真实高度（按平台控制条几何加总 + 随界面
-                          // 缩放，BUG-238）。旧默认常量 56 既不随缩放、又低于默认基线 75 →
-                          // 移动端 `max(75, 56)=75` 把字幕留在被抬高的进度条下面被遮（用户报
-                          // 「只动一点点」）。显式传入真实几何让移动端真正抬升盖过进度条；
-                          // 桌面仍只让一个按钮行高（保 BUG-228 观感）。TODO-568：移动端改抬到
-                          // **可见轨道上缘 + 呼吸间距**（≈101×缩放，而非旧的整段热区高 140），
-                          // 字幕骑进度条上方一点点、不顶飞 ~47×缩放 的透明命中区空白。
-                          controlsBottomReserve:
-                              _subtitleControlsBottomReserve(),
-                          // BUG-1069：顶部锚字幕在控制条可见时同样避让顶栏（标题栏 +
-                          // 右上角菜单），整体下移到顶栏下方 → UI 赢重叠、不被字幕盖住。
-                          controlsTopReserve: _subtitleControlsTopReserve(),
-                          fontFamily: appModel.subtitleFontFamily,
-                          // TODO-1105：尊重 .ass 自带样式（字体/主色/描边/阴影）。开关默认开；
-                          // 关时 overlay 全走上面的统一样式，外观与历史像素级一致。
-                          respectAssStyle: appModel.videoRespectAssStyle,
-                        ),
-                      ),
-                      _buildOsdOverlay(),
-                      // TODO-1154：长按倍速徽章跟随指针（在 OSD 之后、其余 chrome 之前挂）。
-                      _buildLongPressSpeedBadgeOverlay(),
-                      _buildAutoAdvanceOverlay(),
-                      // TODO-1119：Windows 黑闪运行时提示条（可点按钮，非
-                      // IgnorePointer；隐藏态零尺寸）。挂在 auto-advance 之后、
-                      // level HUD 之前，与其它 chrome overlay 同源。
-                      _buildBlackFlickerNoticeOverlay(),
-                      // TODO-2838：拖拽调整字幕位置模式的顶部横幅（提示 + 「完成」退出）。
-                      // 非模式态零尺寸。
-                      _buildSubtitleDragAdjustBanner(),
-                      _buildLevelHudOverlay(),
-                      _buildVideoSideActionRail(controller),
-                      _buildVideoSidePanelOverlay(controller),
-                      _buildVideoControlPopoverOverlay(controller),
-                      ValueListenableBuilder<bool>(
-                        valueListenable: _videoControlEditMode,
-                        builder: (BuildContext _, bool editing, __) {
-                          if (!editing) return const SizedBox.shrink();
-                          return Positioned.fill(
-                            child: VideoControlLayoutEditOverlay(
-                              layout: layout,
-                              onLayoutChanged: _setVideoControlLayout,
-                              onClose: _hideVideoControlEditOverlay,
-                              // TODO-554：触屏保留「设置」按钮入口不可移除。
-                              isTouchControls: !_isDesktopVideoControls,
-                              customActionBindings: _customActionBindings,
-                            ),
-                          );
-                        },
-                      ),
-                      // TODO-318：光标隐藏统一胜出层放 Stack 最顶（front-most），隐藏时其
-                      // cursor:none 胜过下方所有 chrome 的 click cursor；桌面才挂（移动端无 OS 光标）。
-                      if (_isDesktopVideoControls) _buildCursorOverlay(),
-                    ],
+                        // TODO-318：光标隐藏统一胜出层放 Stack 最顶（front-most），隐藏时其
+                        // cursor:none 胜过下方所有 chrome 的 click cursor；桌面才挂（移动端无 OS 光标）。
+                        if (_isDesktopVideoControls) _buildCursorOverlay(),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -530,7 +530,7 @@ extension _VideoSubtitle on _VideoFushiPageState {
   /// 只有磁盘上真有档案的外挂源（[SubtitleSource.external]：视频同目录 sidecar /
   /// 导入副本 / Jimaku 下载）才挂手势；内嵌轨（`embedded:<n>`）没有任何可删除的
   /// 东西，原样返回——「不给菜单」比「给一个禁用的删除项」少一个特殊状态。
-  /// 桌面右键 [GestureDetector.onSecondaryTapDown]、触屏长按
+  /// 桌面右键（[ContextMenuTrigger]，按绑定表决定唤出键，默认右键）、触屏长按
   /// [GestureDetector.onLongPressStart] 都落到 [_showSubtitleFileMenu]；
   /// [ListTile.onTap] 的单击选轨路径不动。
   Widget _withSubtitleFileMenu(
@@ -540,15 +540,19 @@ extension _VideoSubtitle on _VideoFushiPageState {
     Widget row,
   ) {
     if (source.isEmbedded) return row;
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onLongPressStart: (LongPressStartDetails d) => unawaited(
-        _showSubtitleFileMenu(context, controller, source, d.globalPosition),
+    return ContextMenuTrigger(
+      // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+      onInvoke: (Offset position) => unawaited(
+        _showSubtitleFileMenu(context, controller, source, position),
       ),
-      onSecondaryTapDown: (TapDownDetails d) => unawaited(
-        _showSubtitleFileMenu(context, controller, source, d.globalPosition),
+      ladder: _VideoFushiPageState.kVideoMouseLadder,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onLongPressStart: (LongPressStartDetails d) => unawaited(
+          _showSubtitleFileMenu(context, controller, source, d.globalPosition),
+        ),
+        child: row,
       ),
-      child: row,
     );
   }
 

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -17,6 +17,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:share_plus/share_plus.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/utils/misc/collection_exporter.dart';
 import 'package:fushi/src/utils/misc/fushi_share.dart';
 import 'package:window_manager/window_manager.dart';
@@ -5135,6 +5136,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   static const List<ShortcutScope> kVideoMouseLadder = <ShortcutScope>[
     ShortcutScope.video,
     ShortcutScope.universal,
+    // global 是 reader / manga / home 三条阶梯早就有的尾段，video 此前是唯一缺口。
+    // 补上它才能让 [ShortcutAction.globalContextMenu]（住在 global）在视频页解析得到
+    // ——否则视频画面上的右键菜单会整个消失。对既有动作零影响：视频页的执行体表
+    // （videoActionCallbacks）里没有任何 global 动作，解析到也返回 false 不认领，
+    // app 根的兜底照常有机会派发同一次按下。
+    ShortcutScope.global,
   ];
 
   /// 视频页的**鼠标绑定通道**（BUG-1995）：页面根 [Listener] 的 `onPointerDown` 入口。

--- a/fushi/lib/src/pages/implementations/video_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/video_statistics_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/pages.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/pages/implementations/stat_activity.dart';
@@ -425,62 +426,65 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
     final colorScheme = Theme.of(context).colorScheme;
     final tokens = FushiDesignTokens.of(context);
 
-    return Material(
-      type: MaterialType.transparency,
-      child: InkWell(
-        // 移动端长按、桌面端右键都弹删除确认（与阅读统计页同款交互）。
-        onLongPress: () => _confirmAndDeleteVideo(video),
-        onSecondaryTap: () => _confirmAndDeleteVideo(video),
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: tokens.spacing.card,
-            vertical: tokens.spacing.gap / 2,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                video.title,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              if (collectionName != null) ...[
-                SizedBox(height: tokens.spacing.gap / 4),
-                buildStatCollectionLabel(context, collectionName),
-              ],
-              SizedBox(height: tokens.spacing.gap / 2),
-              Row(
-                children: [
-                  Expanded(
-                    child: ClipRRect(
-                      borderRadius: tokens.radii.chipRadius,
-                      child: LinearProgressIndicator(
-                        value: fraction,
-                        minHeight: 8,
-                        backgroundColor: colorScheme.surfaceContainerHighest,
-                        color: colorScheme.primary,
+    return ContextMenuTrigger(
+      // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+      onInvoke: (Offset _) => _confirmAndDeleteVideo(video),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          // 移动端长按、桌面端右键都弹删除确认（与阅读统计页同款交互）。
+          onLongPress: () => _confirmAndDeleteVideo(video),
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: tokens.spacing.card,
+              vertical: tokens.spacing.gap / 2,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  video.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                if (collectionName != null) ...[
+                  SizedBox(height: tokens.spacing.gap / 4),
+                  buildStatCollectionLabel(context, collectionName),
+                ],
+                SizedBox(height: tokens.spacing.gap / 2),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: tokens.radii.chipRadius,
+                        child: LinearProgressIndicator(
+                          value: fraction,
+                          minHeight: 8,
+                          backgroundColor: colorScheme.surfaceContainerHighest,
+                          color: colorScheme.primary,
+                        ),
                       ),
                     ),
-                  ),
-                  SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
-                  Text(
-                    formatStatTime(video.ms),
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ],
-              ),
-              SizedBox(height: tokens.spacing.gap / 2),
-              Text(
-                '${t.stat_lookup}: ${video.lookups} · ${t.stat_mined}: ${video.mines} · ${t.stat_favorited}: $favorites',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
+                    SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
+                    Text(
+                      formatStatTime(video.ms),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
                     ),
-              ),
-              SizedBox(height: tokens.spacing.gap / 2),
-            ],
+                  ],
+                ),
+                SizedBox(height: tokens.spacing.gap / 2),
+                Text(
+                  '${t.stat_lookup}: ${video.lookups} · ${t.stat_mined}: ${video.mines} · ${t.stat_favorited}: $favorites',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+                SizedBox(height: tokens.spacing.gap / 2),
+              ],
+            ),
           ),
         ),
       ),

--- a/fushi/lib/src/shortcuts/context_menu_trigger.dart
+++ b/fushi/lib/src/shortcuts/context_menu_trigger.dart
@@ -1,0 +1,182 @@
+/// 「唤出上下文菜单（右键菜单）」这件事的**唯一**触发口。
+///
+/// 改造前的形状：二十余处 `GestureDetector.onSecondaryTap*` 各自硬绑鼠标右键，
+/// 而鼠标绑定通道（`mouse_binding_dispatch.dart`）是另一条完全不知情的路。于是右键
+/// 这个物理按钮有**两个**互不知情的消费者：用户在设置里把任意动作绑到右键，一次按下
+/// 会同时触发那个动作**和**右键菜单——这不是某一个页面的 bug，是「按钮归属没有唯一
+/// 仲裁者」这个数据结构缺陷在每个表面上的同一次显形。
+///
+/// 修法不是在每个入口加一条「右键被占用了吗」的判断（那是把同一个特殊情况抄二十遍），
+/// 而是把菜单本身**纳入绑定表**：[ShortcutAction.globalContextMenu] 默认绑鼠标右键，
+/// 各表面按自己的解析阶梯问一句「这次按下解析出来的是不是它」。于是：
+///
+///   · 谁都没改键 → 右键解析到 globalContextMenu → 菜单照弹（与改造前逐字一致）；
+///   · 用户把右键绑给页面动作 → 阶梯里页面 scope 先命中 → 解析结果不是它 → 菜单
+///     **自动让位**，用户不必先去解绑菜单（"快捷键可以共用，不强制取消另一个"）；
+///   · 用户把菜单改绑到中键 / 侧键 → 那个键解析到 globalContextMenu → 菜单跟着走。
+///
+/// 让位由**解析阶梯的先后**决定，不是新引入的第二套优先级规则：阶梯就是键盘那条
+/// 「页面专属优先、页面没接才轮到全局」在指针侧的既有同构（见 mouse_binding_dispatch）。
+library;
+
+import 'package:flutter/widgets.dart';
+
+import 'package:fushi/src/shortcuts/input_binding.dart'
+    show domMouseButtonFromPointerButtons;
+import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+/// 拿不到绑定表时的回退按钮 = 右键（DOM `MouseEvent.button` 2）。
+///
+/// 「拿不到」只发生在没有 [ShortcutBindingScope] 的子树里：widget 测试直接挂卡片、
+/// 或某个还没接线的宿主。此时行为退回改造前的硬绑右键——**默认行为免费**，不需要每个
+/// 测试都去搭一份注册表，也不会出现「忘了挂 scope 就整片右键菜单失灵」。
+const int kContextMenuFallbackButton = 2;
+
+/// 非媒体表面（首页 / 书架 / 媒体库 / 设置 / 统计页…）的默认解析阶梯。
+///
+/// 与 `home_page` 的鼠标阶梯同源：页面 scope 在前、[ShortcutScope.global] 兜底
+/// （[ShortcutAction.globalContextMenu] 就住在 global）。媒体页请显式传自己那条
+/// （`kVideoMouseLadder` / `kReaderMouseLadder` / manga 的那条），否则「页面动作
+/// 优先」这一半就丢了。
+///
+/// 为什么独立路由页（统计 / 标签 / 合集…）也带 [ShortcutScope.home]：那些页面确实
+/// 不派发 home 动作，带上它属于**保守让位**——用户把右键绑给某个 home 动作后，这些
+/// 页面会跟着不弹菜单。选这一侧是因为两类错误不对称：少弹一次菜单只是不便，而漏判
+/// 让位就是本 bug 的原样复发（一次按下做两件事）。home scope 默认没有任何鼠标绑定，
+/// 所以这条保守分支只在用户主动绑过之后才可能生效。
+const List<ShortcutScope> kDefaultContextMenuLadder = <ShortcutScope>[
+  ShortcutScope.home,
+  ShortcutScope.global,
+];
+
+/// 把当前的快捷键注册表递给子树里的 [ContextMenuTrigger]。
+///
+/// 用 `getInheritedWidgetOfExactType` 读取（见 [maybeOf]）：**不建立依赖**，注册表
+/// 变化不会让二十余处卡片跟着重建。判据只在指针按下的那一瞬间读一次，读的永远是当时
+/// 的最新值，这与键盘 / 手柄两条通道的 press-time 解析（不冻结绑定表）完全同构。
+class ShortcutBindingScope extends InheritedWidget {
+  const ShortcutBindingScope({
+    super.key,
+    required this.registry,
+    required super.child,
+  });
+
+  final FushiShortcutRegistry registry;
+
+  /// 子树里最近的一份注册表；没有就是 null（回退到 [kContextMenuFallbackButton]）。
+  static FushiShortcutRegistry? maybeOf(BuildContext context) =>
+      context.getInheritedWidgetOfExactType<ShortcutBindingScope>()?.registry;
+
+  @override
+  bool updateShouldNotify(ShortcutBindingScope oldWidget) =>
+      !identical(oldWidget.registry, registry);
+}
+
+/// 这次按下是不是「唤出上下文菜单」。
+///
+/// [registry] 为 null 时回退成硬绑右键（见 [kContextMenuFallbackButton]）。按钮号折叠
+/// 恒用 [domMouseButtonFromPointerButtons]——与设置页的按键录制、与其余鼠标绑定入口
+/// **同一个函数**，否则会出现「设置里录到侧键、运行时按另一个号解析」的错位。左键在那里
+/// 恒折不出按钮号，故菜单永远不可能被绑到左键，正常点击 / 划词 / 拖拽零影响。
+bool contextMenuButtonMatches({
+  required FushiShortcutRegistry? registry,
+  required int buttons,
+  required List<ShortcutScope> ladder,
+}) {
+  final int? button = domMouseButtonFromPointerButtons(buttons);
+  if (button == null) return false;
+  return contextMenuButtonNumberMatches(
+    registry: registry,
+    button: button,
+    ladder: ladder,
+  );
+}
+
+/// 与 [contextMenuButtonMatches] 同义，但入参是**已经折好的** DOM
+/// `MouseEvent.button`（1=中键 / 2=右键 / 3=后退 / 4=前进）。
+///
+/// 供 WebView 宿主使用：漫画页那条路的按钮号是页内 JS 直接给的 `e.button`，本来就不是
+/// Flutter 的 `buttons` 位掩码，再折一次会把 1 当成 `kPrimaryMouseButton` 折错——与
+/// `mouse_binding_dispatch.dart` 里那对函数完全同因、同形。
+bool contextMenuButtonNumberMatches({
+  required FushiShortcutRegistry? registry,
+  required int button,
+  required List<ShortcutScope> ladder,
+}) {
+  if (button <= 0) return false;
+  if (registry == null) return button == kContextMenuFallbackButton;
+  return resolveMouseBindingActionForButton(
+        registry: registry,
+        button: button,
+        ladder: ladder,
+      ) ==
+      ShortcutAction.globalContextMenu;
+}
+
+/// 把「不关心锚点坐标」的无参回调适配成 [ContextMenuTrigger.onInvoke]。
+///
+/// 多数卡片的菜单是长按菜单的同一份执行体（`showModalBottomSheet` / 对话框，自己居中
+/// 定位），不需要按下处的坐标；需要锚点的表面（阅读器选区菜单、视频画面菜单、插图页）
+/// 直接写 `(Offset p) => …` 即可。null 原样透传 = 此刻不提供菜单。
+void Function(Offset)? contextMenuInvoker(VoidCallback? callback) =>
+    callback == null ? null : (Offset _) => callback();
+
+/// 包住任何「右键要弹菜单」的子树，替代硬绑右键的 `GestureDetector.onSecondaryTap*`。
+///
+/// [onInvoke] 传 null = 本表面此刻不提供菜单（多选模式等），整个触发器让路、连
+/// [Listener] 都不挂（与旧代码 `onSecondaryTap: _selectionMode ? null : …` 同语义）。
+///
+/// 为什么是 [Listener] 而不是 [GestureDetector]：菜单现在可以绑到中键 / 侧键，而
+/// `GestureDetector` 只有「次按钮（右键）」这一个非主键入口，绑到中键就永远收不到。
+/// 代价是不进手势竞技场，故按下即触发（不等抬起）——app 内四个媒体表面里已有三个
+/// （阅读器 / 漫画 / 字幕）用的就是 `onSecondaryTapDown`，这一步反而把剩下那个不一致
+/// 也抹平了。右键不用于拖拽，按下即弹不会与滚动 / 框选竞争。
+///
+/// 认领走 [dispatchClaimedMouseAction]：与页面根、app 根的鼠标入口共用**同一个**单槽
+/// 仲裁。卡片是更内层的 [Listener]，Flutter 的指针派发次序是 innermost → outermost，
+/// 所以卡片先认领、外层看到已认领就让路——同一次按下绝不会既弹菜单又跑外层绑定。
+class ContextMenuTrigger extends StatelessWidget {
+  const ContextMenuTrigger({
+    super.key,
+    required this.onInvoke,
+    required this.child,
+    this.ladder = kDefaultContextMenuLadder,
+    this.behavior = HitTestBehavior.translucent,
+  });
+
+  /// 弹菜单的执行体，入参是按下处的 global 坐标（`showMenu` 的锚点）。不需要锚点的
+  /// 调用方忽略它即可。null = 此刻不提供菜单。
+  final void Function(Offset globalPosition)? onInvoke;
+
+  /// 本表面的鼠标解析阶梯。页面 scope 在前、global 兜底。
+  final List<ShortcutScope> ladder;
+
+  final HitTestBehavior behavior;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final void Function(Offset globalPosition)? invoke = onInvoke;
+    if (invoke == null) return child;
+    return Listener(
+      behavior: behavior,
+      onPointerDown: (PointerDownEvent event) {
+        if (!contextMenuButtonMatches(
+          registry: ShortcutBindingScope.maybeOf(context),
+          buttons: event.buttons,
+          ladder: ladder,
+        )) {
+          return;
+        }
+        dispatchClaimedMouseAction(event, () {
+          invoke(event.position);
+          return true;
+        });
+      },
+      child: child,
+    );
+  }
+}

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/focus/fushi_focus_scroll.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/utils/window_caption_channel.dart';
 
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
@@ -379,8 +380,11 @@ void _handleGlobalPointerDown(
 ///     与手柄 LB/RB 完全同一条 [PageScrollRegistry] → [FushiFocusScroll] 路径
 ///     （`gamepad_service._tryScrollPage`）。
 ///
-/// 这三个是 global scope 的**全部**动作，加上 universal 的 globalBack 就是本兜底能
-/// 遇到的全集——没有落在 default 分支上的活动作，故不存在「绑了没反应」的死项。
+/// global scope 里只有 [ShortcutAction.globalContextMenu] 有意落在 `default` 上并返回
+/// **false**：它是「哪个鼠标键唤出右键菜单」的按钮归属声明，执行体分散在各表面自己的
+/// [ContextMenuTrigger]（那一层是更内层的 Listener，先于本兜底认领）。这里返回 false 而
+/// 不是 true 是关键——解析到却没执行的层若也认领，就会把同一按钮上其它层的合法绑定白白
+/// 挡掉。除它以外的四个动作都在上面有真执行体，故不存在「绑了没反应」的死项。
 ///
 /// 返回**本次是否真的执行了**：false 时调用方不得认领这次按下（见
 /// [MouseBindingDispatch] 的两步用法），否则「解析到但没执行」会把同一按钮上其它层
@@ -717,19 +721,27 @@ Widget wrapWithGlobalNavigation({
       // `translucent`：本层不画任何东西，默认的 deferToChild 会让它在子树没命中时
       // 也收不到事件（例如页面空白区）。旁听式监听必须自己占住命中，但它既不进手势
       // 竞技场也不消费事件，下层照常收到同一次按下——点击 / 划词 / 拖拽零影响。
+      // [ShortcutBindingScope] 把注册表递给子树里所有 [ContextMenuTrigger]
+      // （二十余处右键菜单的唯一触发口）。它只在指针按下的那一瞬间被读一次
+      // （`getInheritedWidgetOfExactType`，不建立依赖），故改键不会引发任何重建。
+      // 与下面的 Listener 同一个 `registry == null` 门：没有绑定表就回退到硬绑
+      // 右键的历史行为（见 kContextMenuFallbackButton），测试宿主无需搭注册表。
       child: registry == null
           ? child
-          : Builder(
-              builder: (BuildContext context) => Listener(
-                behavior: HitTestBehavior.translucent,
-                onPointerDown: (PointerDownEvent event) =>
-                    _handleGlobalPointerDown(
-                  context,
-                  navigatorKey,
-                  registry,
-                  event,
+          : ShortcutBindingScope(
+              registry: registry,
+              child: Builder(
+                builder: (BuildContext context) => Listener(
+                  behavior: HitTestBehavior.translucent,
+                  onPointerDown: (PointerDownEvent event) =>
+                      _handleGlobalPointerDown(
+                    context,
+                    navigatorKey,
+                    registry,
+                    event,
+                  ),
+                  child: child,
                 ),
-                child: child,
               ),
             ),
     ),

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -319,6 +319,21 @@ enum ShortcutAction {
   // （无桌面窗）。默认键盘 F11。
   globalToggleFullscreen(ShortcutScope.global, 'global_toggle_fullscreen'),
 
+  // 「唤出上下文菜单（右键菜单）」的**按钮归属声明**。它不进任何执行回调表——菜单的
+  // 执行体分散在各卡片 / 各媒体表面自己的 `showMenu`，本动作只回答一件事：这次按下的
+  // 鼠标键，在当前表面该不该弹菜单（判据收在 `context_menu_trigger.dart`）。
+  //
+  // 为什么它必须进注册表：在此之前「右键」是二十余处 `GestureDetector.onSecondaryTap*`
+  // **硬绑死**的，与鼠标绑定通道是两条互不知情的路——用户把任何动作绑到右键，一次按下
+  // 会同时触发该动作**和**右键菜单。进注册表以后，右键这个物理按钮才第一次有唯一的归属
+  // 仲裁者：解析阶梯里页面 scope 先命中，命中别的动作就说明右键被派了别的活，菜单自动
+  // 让位——用户**不必**先去解绑菜单（"快捷键可以共用，不强制取消另一个"）。
+  //
+  // scope 选 global 而不是 universal：universal 有「只装 globalBack 一个配置项」的产品
+  // 守卫（`universal_back_test`）。global 同样落在每条鼠标解析阶梯的末尾兜底，语义等价。
+  // 默认绑鼠标右键（DOM button 2）= 与改造前逐字一致的行为。
+  globalContextMenu(ShortcutScope.global, 'global_context_menu'),
+
   // Audiobook（上一句在前，与视频组「上/下一句字幕」顺序一致）
   audiobookPlayPause(ShortcutScope.audiobook, 'audiobook_play_pause'),
   audiobookPrevSentence(ShortcutScope.audiobook, 'audiobook_prev_sentence'),

--- a/fushi/lib/src/shortcuts/shortcut_defaults.dart
+++ b/fushi/lib/src/shortcuts/shortcut_defaults.dart
@@ -175,6 +175,12 @@ class ShortcutDefaults {
     ShortcutAction.globalToggleFullscreen: _kb([
       _key(LogicalKeyboardKey.f11),
     ]),
+    // 右键菜单的默认绑定 = 鼠标右键（DOM button 2），与改造前各处硬绑
+    // `onSecondaryTap*` 的行为逐字一致。键盘/手柄留空：菜单是**位置型**动作
+    // （要一个 globalPosition 作锚点），键盘触发没有锚点可用。
+    ShortcutAction.globalContextMenu: const ShortcutBindingSet(
+      mouseBindings: [MouseBinding(2)],
+    ),
     // Play/pause moved off controller A → L3: on the reader page A is now
     // "enter the char-level reading cursor" (and, once inside, "look up the word
     // at the cursor"), which the page intercepts before the audiobook scope is
@@ -560,6 +566,11 @@ class ShortcutDefaults {
           case ShortcutScope.gamepad:
             return ShortcutBindingSet(
               gamepadBindings: desktop.gamepadBindings,
+              // Android 可接鼠标（平板 / DeX / 桌面模式），与 audiobook 的中键
+              // seek 同档保留鼠标绑定。丢掉它会让 globalContextMenu 在移动端解析
+              // 不到——接了鼠标的 Android 上右键菜单会**整个消失**（改造前
+              // `onSecondaryTap` 在 Android 一样有效）。没有鼠标的设备上永不触发。
+              mouseBindings: desktop.mouseBindings,
             );
           // universal（「返回上一级」）与 reader/video/manga 同档：键盘绑定在移动端
           // 也保留。移动端主路径是系统返回手势 / 手柄 B，但外接键盘（平板 / DeX /

--- a/fushi/lib/src/shortcuts/shortcut_labels.dart
+++ b/fushi/lib/src/shortcuts/shortcut_labels.dart
@@ -75,6 +75,8 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_global_scroll_page_up;
       case ShortcutAction.globalToggleFullscreen:
         return t.shortcut_action_global_toggle_fullscreen;
+      case ShortcutAction.globalContextMenu:
+        return t.shortcut_action_global_context_menu;
       case ShortcutAction.audiobookPlayPause:
         return t.shortcut_action_audiobook_play_pause;
       case ShortcutAction.audiobookNextSentence:
@@ -372,6 +374,10 @@ extension ShortcutActionIcon on ShortcutAction {
       // 全 app 共用「返回上一级」：视频页把它解释成逐级退出阶梯。
       case ShortcutAction.globalBack:
         return Icons.arrow_back;
+
+      // 右键菜单（按钮归属声明，执行体在各卡片 / 各媒体表面自己的 showMenu）。
+      case ShortcutAction.globalContextMenu:
+        return Icons.menu_open;
 
       // ignore: no_default_cases
       default:

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart' show SelectedContent;
 import 'package:flutter/services.dart' show Clipboard, ClipboardData;
 import 'package:macos_ui/macos_ui.dart'
     show MacosTextField, MacosIcon, OverlayVisibilityMode;
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
@@ -85,32 +86,36 @@ class _FushiCardState extends State<FushiCard> {
       padding: widget.padding ?? EdgeInsets.all(tokens.spacing.card),
       child: widget.child,
     );
-    final Widget card = Padding(
-      padding: widget.margin ?? EdgeInsets.zero,
-      child: AnimatedContainer(
-        duration: einkSafeDuration(context, fushiMd3StateDuration),
-        curve: fushiMd3StateCurve,
-        decoration: ShapeDecoration(
-          color: effectiveColor,
-          shape: RoundedRectangleBorder(
-            borderRadius: radius,
-            side: side,
+    final Widget card = ContextMenuTrigger(
+      // 右键菜单不再硬绑鼠标次按钮：改由绑定表决定哪个鼠标键唤出（默认仍是右键），
+      // 用户把右键绑给页面动作时菜单自动让位。InkWell 只留 tap / longPress。
+      onInvoke: contextMenuInvoker(widget.onSecondaryTap),
+      child: Padding(
+        padding: widget.margin ?? EdgeInsets.zero,
+        child: AnimatedContainer(
+          duration: einkSafeDuration(context, fushiMd3StateDuration),
+          curve: fushiMd3StateCurve,
+          decoration: ShapeDecoration(
+            color: effectiveColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: radius,
+              side: side,
+            ),
           ),
-        ),
-        child: Material(
-          type: MaterialType.transparency,
-          shape: RoundedRectangleBorder(borderRadius: radius),
-          clipBehavior: Clip.antiAlias,
-          child: widget.onTap == null &&
-                  widget.onLongPress == null &&
-                  widget.onSecondaryTap == null
-              ? content
-              : InkWell(
-                  onTap: widget.onTap,
-                  onLongPress: widget.onLongPress,
-                  onSecondaryTap: widget.onSecondaryTap,
-                  child: content,
-                ),
+          child: Material(
+            type: MaterialType.transparency,
+            shape: RoundedRectangleBorder(borderRadius: radius),
+            clipBehavior: Clip.antiAlias,
+            child: widget.onTap == null &&
+                    widget.onLongPress == null &&
+                    widget.onSecondaryTap == null
+                ? content
+                : InkWell(
+                    onTap: widget.onTap,
+                    onLongPress: widget.onLongPress,
+                    child: content,
+                  ),
+          ),
         ),
       ),
     );

--- a/fushi/lib/src/utils/components/fushi_reorderable_grid.dart
+++ b/fushi/lib/src/utils/components/fushi_reorderable_grid.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
+
 /// 网格单元内容构造器：返回**纯视觉**卡片内容（自身手势由本组件统一接管，
 /// 调用方应把卡片包在 [IgnorePointer] 里避免内部 InkWell 的 long-press 与本组件的
 /// 触摸长按拖拽争用手势竞技场——详见类注释）。
@@ -443,57 +445,62 @@ class _FushiReorderableGridState extends State<FushiReorderableGrid> {
 
   Widget _buildCell(int original) {
     final Widget content = widget.itemBuilder(context, original);
+    final FushiReorderGridContextMenu? menu = widget.onContextMenu;
     // 被拖单元在原位保留占位但透明（充当随实时重排移动的「空位」），可见的是浮层。
     final Widget slot = _dragOriginal == original
         ? Opacity(opacity: 0, child: content)
         : content;
     // 身份 key 已放在外层 [Positioned]（Stack 直接子节点）上，重排时保留本
     // RawGestureDetector 与其活跃识别器；此处不再重复挂 key。
-    return RawGestureDetector(
-      behavior: HitTestBehavior.opaque,
-      gestures: <Type, GestureRecognizerFactory>{
-        // 主轻点 → 激活；右键 secondary tap → 上下文菜单。
-        TapGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-          () => TapGestureRecognizer(),
-          (TapGestureRecognizer instance) {
-            final FushiReorderGridActivate? activate = widget.onActivateItem;
-            final FushiReorderGridContextMenu? menu = widget.onContextMenu;
-            instance.onTap = activate == null ? null : () => activate(original);
-            instance.onSecondaryTapUp = menu == null
-                ? null
-                : (TapUpDetails d) => menu(original, d.globalPosition);
-          },
-        ),
-        // 鼠标等精确指针：按下即拖。
-        ImmediateMultiDragGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<
-                ImmediateMultiDragGestureRecognizer>(
-          () => ImmediateMultiDragGestureRecognizer(
-              supportedDevices: _immediateDragDevices),
-          (ImmediateMultiDragGestureRecognizer instance) {
-            instance.onStart =
-                (Offset position) => _onMouseDragStart(original, position);
-          },
-        ),
-        // 触摸屏：长按待命，移动过 slop 起拖，原地松手弹菜单。
-        LongPressGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-          () => LongPressGestureRecognizer(supportedDevices: _touchDragDevices),
-          (LongPressGestureRecognizer instance) {
-            instance.onLongPressStart =
-                (LongPressStartDetails d) => _touchLongPressStart(original, d);
-            instance.onLongPressMoveUpdate = (LongPressMoveUpdateDetails d) =>
-                _touchLongPressMove(original, d);
-            instance.onLongPressEnd =
-                (LongPressEndDetails d) => _touchLongPressEnd(original, d);
-            // 系统取消指针（通知栏下拉/来电/切后台）→ 清待命 + 复位拖拽（防幽灵浮层
-            // 与下次错序提交）。
-            instance.onLongPressCancel = () => _touchLongPressCancel(original);
-          },
-        ),
-      },
-      child: slot,
+    return ContextMenuTrigger(
+      // 右键菜单改由绑定表决定唤出键（默认仍是右键）；右键被别的动作占用时自动让位。
+      onInvoke: menu == null
+          ? null
+          : (Offset position) => menu(original, position),
+      child: RawGestureDetector(
+        behavior: HitTestBehavior.opaque,
+        gestures: <Type, GestureRecognizerFactory>{
+          // 主轻点 → 激活。上下文菜单不在这里：TapGestureRecognizer 的非主键入口
+          // 只有 onSecondaryTapUp（写死次按钮），而菜单现在由绑定表决定用哪个鼠标键
+          // 唤出，故整体交给外层 [ContextMenuTrigger]。
+          TapGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+            () => TapGestureRecognizer(),
+            (TapGestureRecognizer instance) {
+              final FushiReorderGridActivate? activate = widget.onActivateItem;
+              instance.onTap = activate == null ? null : () => activate(original);
+            },
+          ),
+          // 鼠标等精确指针：按下即拖。
+          ImmediateMultiDragGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<
+                  ImmediateMultiDragGestureRecognizer>(
+            () => ImmediateMultiDragGestureRecognizer(
+                supportedDevices: _immediateDragDevices),
+            (ImmediateMultiDragGestureRecognizer instance) {
+              instance.onStart =
+                  (Offset position) => _onMouseDragStart(original, position);
+            },
+          ),
+          // 触摸屏：长按待命，移动过 slop 起拖，原地松手弹菜单。
+          LongPressGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+            () => LongPressGestureRecognizer(supportedDevices: _touchDragDevices),
+            (LongPressGestureRecognizer instance) {
+              instance.onLongPressStart =
+                  (LongPressStartDetails d) => _touchLongPressStart(original, d);
+              instance.onLongPressMoveUpdate = (LongPressMoveUpdateDetails d) =>
+                  _touchLongPressMove(original, d);
+              instance.onLongPressEnd =
+                  (LongPressEndDetails d) => _touchLongPressEnd(original, d);
+              // 系统取消指针（通知栏下拉/来电/切后台）→ 清待命 + 复位拖拽（防幽灵浮层
+              // 与下次错序提交）。
+              instance.onLongPressCancel = () => _touchLongPressCancel(original);
+            },
+          ),
+        },
+        child: slot,
+      ),
     );
   }
 }

--- a/fushi/lib/src/utils/components/galgame_poster_card.dart
+++ b/fushi/lib/src/utils/components/galgame_poster_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
@@ -121,12 +122,15 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
     final Widget interactive = MouseRegion(
       cursor:
           widget.onTap == null ? MouseCursor.defer : SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: widget.onTap,
-        onLongPress: widget.onLongPress,
-        onSecondaryTap: widget.onSecondaryTap,
+      child: ContextMenuTrigger(
+        onInvoke: contextMenuInvoker(widget.onSecondaryTap),
         behavior: HitTestBehavior.opaque,
-        child: card,
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onLongPress: widget.onLongPress,
+          behavior: HitTestBehavior.opaque,
+          child: card,
+        ),
       ),
     );
 

--- a/fushi/test/pages/dictionary_popup_webview_test.dart
+++ b/fushi/test/pages/dictionary_popup_webview_test.dart
@@ -759,11 +759,14 @@ void main() {
         contains('Platform.isAndroid || isWindowsPlatform'),
         reason: 'Windows 与 Android 各自按真实原生缺陷禁系统项；iOS 保持原生。',
       );
-      // 右键入口 onSecondaryTapDown，仅 Windows 包 GestureDetector。
-      expect(source, contains('onSecondaryTapDown:'),
-          reason: '桌面右键经 GestureDetector.onSecondaryTapDown 进入 Flutter 菜单');
+      // 右键入口：BUG-2111 后由 ContextMenuTrigger 按绑定表判定唤出键（默认右键），
+      // 包裹范围不变（仍只在 Windows）。
+      expect(source, contains('ContextMenuTrigger('),
+          reason: '桌面右键经 ContextMenuTrigger（绑定表判定）进入 Flutter 菜单');
+      expect(source, contains('_showWindowsContextMenu(context, position)'),
+          reason: '按下处坐标仍作 showMenu 锚点');
       expect(source, contains('if (isWindowsPlatform) {'),
-          reason: '右键 GestureDetector 包裹仅在 Windows 生效，其它平台返回裸 WebView');
+          reason: '右键包裹仅在 Windows 生效，其它平台返回裸 WebView');
 
       // 窗口由花括号配对给出，不再是 `menuStart + 1800` 的定长切片：该方法体实测
       // 1671 字符，旧窗口一头越界读进后面的 static 成员，另一头只给末尾的

--- a/fushi/test/pages/illustrations_viewer_actions_guard_static_test.dart
+++ b/fushi/test/pages/illustrations_viewer_actions_guard_static_test.dart
@@ -44,7 +44,8 @@ void main() {
   test('illustration gallery wires right-click (win) and long-press (mobile)',
       () {
     expect(source, contains('isWindowsPlatform'));
-    expect(source, contains('onSecondaryTapDown'));
+    expect(source, contains('ContextMenuTrigger('));
+    expect(source, contains('_showImageContextMenu(position)'));
     expect(source, contains('onLongPress'));
     // 顶栏也提供可发现入口（复制 / 分享按钮）。
     expect(source, contains('Icons.copy_outlined'));

--- a/fushi/test/pages/reader_bookshelf_card_layout_static_test.dart
+++ b/fushi/test/pages/reader_bookshelf_card_layout_static_test.dart
@@ -170,7 +170,9 @@ void main() {
     expect(shell, contains('InkWell('),
         reason: 'tap/long-press/right-click must still cover the whole card');
     expect(
-        shell, contains('onSecondaryTap: _selectionMode ? null : onLongPress'));
+        shell,
+        contains(
+            'onInvoke: contextMenuInvoker(_selectionMode ? null : onLongPress)'));
     expect(shell, contains('FushiFocusTarget('),
         reason: 'keyboard/gamepad activation must stay on the full card');
 

--- a/fushi/test/pages/reader_image_actions_guard_static_test.dart
+++ b/fushi/test/pages/reader_image_actions_guard_static_test.dart
@@ -136,9 +136,9 @@ void main() {
     );
 
     expect(viewer, contains('_readerImageFileForUrl(imgUrl)'));
-    expect(viewer, contains('onSecondaryTapDown'));
+    expect(viewer, contains('ContextMenuTrigger('));
     expect(viewer, contains('isWindowsPlatform'));
-    expect(viewer, contains('details.globalPosition'));
+    expect(viewer, contains('(Offset position) => unawaited('));
     expect(viewer, contains('_showReaderImageContextMenuAtGlobalPosition'));
   });
 

--- a/fushi/test/pages/reader_text_context_menu_scale_guard_test.dart
+++ b/fushi/test/pages/reader_text_context_menu_scale_guard_test.dart
@@ -82,13 +82,13 @@ void main() {
       () {
     final String source = readReaderPageSource();
 
-    // Windows: native WebView2 context menu disabled, right-click captured by a
-    // translucent GestureDetector onSecondaryTapDown -> Flutter menu.
+    // Windows: native WebView2 context menu disabled, the menu button (per the
+    // binding table, right-click by default) captured by ContextMenuTrigger.
     expect(source, contains('hideDefaultSystemContextMenuItems: true'));
-    expect(source, contains('onSecondaryTapDown'));
+    expect(source, contains('ContextMenuTrigger('));
     expect(
       source,
-      contains('_showReaderTextContextMenu(details.globalPosition)'),
+      contains('_showReaderTextContextMenu(position)'),
     );
     expect(source, contains('HitTestBehavior.translucent'));
 

--- a/fushi/test/pages/tag_management_context_menu_source_guard_test.dart
+++ b/fushi/test/pages/tag_management_context_menu_source_guard_test.dart
@@ -46,11 +46,13 @@ void main() {
     test('标签行同时绑定长按与右键，都指向 _showTagMenu', () {
       expect(src.contains('onLongPressStart:'), isTrue,
           reason: '长按必须弹菜单');
-      expect(src.contains('onSecondaryTapDown:'), isTrue,
-          reason: '右键必须弹菜单');
+      expect(src.contains('ContextMenuTrigger('), isTrue,
+          reason: '右键必须弹菜单（BUG-2111 后由绑定表判定唤出键）');
       // 两个触发器都换算真实坐标喂给同一菜单构建器。
       expect(src.contains('_showTagMenu(tag, d.globalPosition)'), isTrue,
-          reason: '长按 / 右键共用同一菜单入口');
+          reason: '长按走同一菜单入口');
+      expect(src.contains('_showTagMenu(tag, position)'), isTrue,
+          reason: '右键走同一菜单入口');
     });
 
     test('菜单同时提供编辑与删除动作', () {

--- a/fushi/test/pages/video_context_menu_test.dart
+++ b/fushi/test/pages/video_context_menu_test.dart
@@ -21,12 +21,14 @@ void main() {
       methodBody(page, 'void _showVideoContextMenu(');
 
   group('右键菜单触发与门控', () {
-    test('视频控制层挂 onSecondaryTapUp（右键触发）', () {
-      expect(page.contains('onSecondaryTapUp:'), isTrue,
-          reason: '桌面右键须经 GestureDetector.onSecondaryTapUp 进入菜单');
-      expect(
-          page.contains('_handleSecondaryTap(details.globalPosition)'), isTrue,
-          reason: '右键松手处的 globalPosition 作 showMenu 锚点');
+    test('视频控制层挂 ContextMenuTrigger（菜单键触发，默认右键）', () {
+      expect(page.contains('ContextMenuTrigger('), isTrue,
+          reason: '桌面右键须经 ContextMenuTrigger（绑定表判定）进入菜单');
+      expect(page.contains('_handleSecondaryTap(position)'), isTrue,
+          reason: '按下处的 globalPosition 作 showMenu 锚点');
+      expect(page.contains('ladder: _VideoFushiPageState.kVideoMouseLadder'),
+          isTrue,
+          reason: '必须用视频页那条阶梯，右键改绑本页动作时菜单才会让位');
     });
 
     test('手柄映射器合成的同源右键在 showMenu 前去重（BUG-1453）', () {

--- a/fushi/test/pages/video_subtitle_delete_guard_test.dart
+++ b/fushi/test/pages/video_subtitle_delete_guard_test.dart
@@ -69,11 +69,17 @@ void main() {
     expect(wrap.contains('if (source.isEmbedded) return row;'), isTrue,
         reason: '内嵌轨没有磁盘档案可删，不该出现「删除字幕文件」菜单');
     expect(wrap.contains('onLongPressStart:'), isTrue, reason: '触屏靠长按');
-    expect(wrap.contains('onSecondaryTapDown:'), isTrue, reason: '桌面靠右键');
+    expect(wrap.contains('ContextMenuTrigger('), isTrue,
+        reason: '桌面靠菜单键（BUG-2111 后由绑定表判定，默认右键）');
+    expect(
+        count(wrap,
+            '_showSubtitleFileMenu(context, controller, source, position)'),
+        1,
+        reason: '右键那一路接同一个菜单构建器');
     expect(
         count(wrap,
             '_showSubtitleFileMenu(context, controller, source, d.globalPosition)'),
-        2,
+        1,
         reason: '长按与右键必须落到同一个菜单、传手势自己报的视口坐标');
   });
 

--- a/fushi/test/shortcuts/context_menu_binding_test.dart
+++ b/fushi/test/shortcuts/context_menu_binding_test.dart
@@ -1,0 +1,438 @@
+import 'dart:io';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+/// 「右键菜单」纳入绑定表（[ShortcutAction.globalContextMenu]）之后的三条不变式：
+///
+///   ① 谁都没改键 → 右键仍然弹菜单（Never break userspace）；
+///   ② 用户把右键绑给页面动作 → 菜单在**那个页面**自动让位，其余表面照常（共用，
+///      不需要先解绑菜单）；
+///   ③ 菜单改绑中键 / 侧键 → 跟着走，右键不再弹。
+///
+/// 本次报修的原始症状是「把快捷键绑到右键上，按一下既跑那个动作、又弹右键菜单」——
+/// 根因是右键这个物理按钮同时被硬编码的 `onSecondaryTap*` 与鼠标绑定通道消费，两者
+/// 互不知情。②就是那条症状的回归门。
+void main() {
+  late FushiShortcutRegistry registry;
+
+  setUp(() {
+    registry = FushiShortcutRegistry();
+    registry.loadDefaults(TargetPlatform.windows);
+    MouseBindingDispatch.resetForTest();
+  });
+
+  const List<ShortcutScope> videoLadder = <ShortcutScope>[
+    ShortcutScope.video,
+    ShortcutScope.universal,
+    ShortcutScope.global,
+  ];
+
+  group('默认绑定', () {
+    test('三平台默认表都把右键给了 globalContextMenu（含移动端：安卓可接鼠标）', () {
+      for (final TargetPlatform platform in <TargetPlatform>[
+        TargetPlatform.windows,
+        TargetPlatform.macOS,
+        TargetPlatform.android,
+      ]) {
+        expect(
+          ShortcutDefaults.forPlatform(platform)[
+                  ShortcutAction.globalContextMenu]!
+              .mouseBindings,
+          contains(const MouseBinding(2)),
+          reason: '$platform 默认表丢了右键 → 该平台右键菜单会整个消失',
+        );
+      }
+    });
+
+    test('默认表里右键没有被任何页面 scope 的动作占用（否则默认就遮蔽菜单）', () {
+      final Map<ShortcutAction, ShortcutBindingSet> defaults =
+          ShortcutDefaults.forPlatform(TargetPlatform.windows);
+      for (final MapEntry<ShortcutAction, ShortcutBindingSet> e
+          in defaults.entries) {
+        if (e.key == ShortcutAction.globalContextMenu) continue;
+        expect(
+          e.value.mouseBindings,
+          isNot(contains(const MouseBinding(2))),
+          reason: '${e.key.key} 默认占了右键，会把上下文菜单默认遮蔽掉',
+        );
+      }
+    });
+  });
+
+  group('判据 contextMenuButtonMatches', () {
+    test('① 没改过键：右键 = 菜单，中键 / 左键都不是', () {
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kSecondaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isTrue,
+      );
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kMiddleMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isFalse,
+      );
+      // 左键恒折不出按钮号 → 永远不可能被解析成菜单（正常点击 / 划词零影响）。
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kPrimaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isFalse,
+      );
+    });
+
+    test('拿不到绑定表时回退成硬绑右键（widget 测试宿主不必搭注册表）', () {
+      expect(
+        contextMenuButtonMatches(
+          registry: null,
+          buttons: kSecondaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isTrue,
+      );
+      expect(
+        contextMenuButtonMatches(
+          registry: null,
+          buttons: kMiddleMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isFalse,
+      );
+    });
+
+    test('② 右键绑给视频页动作：视频页让位，书架 / 首页照常弹（快捷键可共用）', () {
+      registry.updateBinding(
+        ShortcutAction.videoScreenshot,
+        const ShortcutBindingSet(mouseBindings: <MouseBinding>[MouseBinding(2)]),
+      );
+
+      // 视频页阶梯：video scope 先命中 videoScreenshot → 菜单让位，一次按下只做一件事。
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kSecondaryMouseButton,
+          ladder: videoLadder,
+        ),
+        isFalse,
+        reason: '这正是报修症状：右键既截图又弹菜单',
+      );
+
+      // 关键：菜单**没有被解绑**，别的表面照常。用户不必二选一。
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kSecondaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isTrue,
+      );
+      expect(
+        registry
+            .bindingsFor(ShortcutAction.globalContextMenu)
+            .mouseBindings,
+        contains(const MouseBinding(2)),
+      );
+    });
+
+    test('③ 菜单改绑中键：中键弹菜单，右键不再弹', () {
+      registry.updateBinding(
+        ShortcutAction.globalContextMenu,
+        const ShortcutBindingSet(mouseBindings: <MouseBinding>[MouseBinding(1)]),
+      );
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kMiddleMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isTrue,
+      );
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kSecondaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isFalse,
+      );
+    });
+
+    test('按钮号版本（WebView 那一路）与位掩码版本判据一致', () {
+      const List<ShortcutScope> mangaLadder = <ShortcutScope>[
+        ShortcutScope.manga,
+        ShortcutScope.universal,
+        ShortcutScope.global,
+      ];
+      expect(
+        contextMenuButtonNumberMatches(
+          registry: registry,
+          button: 2,
+          ladder: mangaLadder,
+        ),
+        isTrue,
+      );
+      // 漫画页把右键绑给翻页 → 菜单让位（否则一次右键既翻页又弹菜单）。
+      registry.updateBinding(
+        ShortcutAction.mangaPageForward,
+        const ShortcutBindingSet(mouseBindings: <MouseBinding>[MouseBinding(2)]),
+      );
+      expect(
+        contextMenuButtonNumberMatches(
+          registry: registry,
+          button: 2,
+          ladder: mangaLadder,
+        ),
+        isFalse,
+      );
+      // button 0（左键）在 DOM 口径里恒不可绑。
+      expect(
+        contextMenuButtonNumberMatches(
+          registry: registry,
+          button: 0,
+          ladder: mangaLadder,
+        ),
+        isFalse,
+      );
+    });
+
+    test('菜单绑定被清空 = 彻底关掉右键菜单', () {
+      registry.updateBinding(
+        ShortcutAction.globalContextMenu,
+        const ShortcutBindingSet(),
+      );
+      expect(
+        contextMenuButtonMatches(
+          registry: registry,
+          buttons: kSecondaryMouseButton,
+          ladder: kDefaultContextMenuLadder,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('ContextMenuTrigger', () {
+    Future<void> pressButton(WidgetTester tester, int buttons) async {
+      final TestGesture gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+        buttons: buttons,
+      );
+      await gesture.down(tester.getCenter(find.byKey(const Key('target'))));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+    }
+
+    Future<void> pumpTrigger(
+      WidgetTester tester, {
+      required List<Offset> hits,
+      FushiShortcutRegistry? scopeRegistry,
+      bool nullInvoke = false,
+    }) async {
+      final Widget trigger = ContextMenuTrigger(
+        onInvoke: nullInvoke ? null : hits.add,
+        child: const SizedBox(
+          key: Key('target'),
+          width: 200,
+          height: 100,
+        ),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: scopeRegistry == null
+                  ? trigger
+                  : ShortcutBindingScope(
+                      registry: scopeRegistry,
+                      child: trigger,
+                    ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('默认绑定下右键按下即弹菜单，并带上按下处坐标', (WidgetTester tester) async {
+      final List<Offset> hits = <Offset>[];
+      await pumpTrigger(tester, hits: hits, scopeRegistry: registry);
+      await pressButton(tester, kSecondaryMouseButton);
+      expect(hits, hasLength(1));
+      expect(hits.single, tester.getCenter(find.byKey(const Key('target'))));
+    });
+
+    testWidgets('左键点击不弹菜单（正常点击零影响）', (WidgetTester tester) async {
+      final List<Offset> hits = <Offset>[];
+      await pumpTrigger(tester, hits: hits, scopeRegistry: registry);
+      await pressButton(tester, kPrimaryMouseButton);
+      expect(hits, isEmpty);
+    });
+
+    testWidgets('右键被页面动作占用后不再弹（同一份注册表，判据走阶梯）',
+        (WidgetTester tester) async {
+      registry.updateBinding(
+        ShortcutAction.homeFocusSearch,
+        const ShortcutBindingSet(mouseBindings: <MouseBinding>[MouseBinding(2)]),
+      );
+      final List<Offset> hits = <Offset>[];
+      await pumpTrigger(tester, hits: hits, scopeRegistry: registry);
+      await pressButton(tester, kSecondaryMouseButton);
+      expect(hits, isEmpty);
+    });
+
+    testWidgets('onInvoke 为 null 时整层让路，不挂 Listener',
+        (WidgetTester tester) async {
+      await pumpTrigger(
+        tester,
+        hits: <Offset>[],
+        scopeRegistry: registry,
+        nullInvoke: true,
+      );
+      final ContextMenuTrigger widget = tester.widget<ContextMenuTrigger>(
+        find.byType(ContextMenuTrigger),
+      );
+      expect(widget.onInvoke, isNull);
+      expect(
+        find.descendant(
+          of: find.byType(ContextMenuTrigger),
+          matching: find.byType(Listener),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('没有 ShortcutBindingScope 时回退硬绑右键（旧行为免费）',
+        (WidgetTester tester) async {
+      final List<Offset> hits = <Offset>[];
+      await pumpTrigger(tester, hits: hits);
+      await pressButton(tester, kSecondaryMouseButton);
+      expect(hits, hasLength(1));
+    });
+
+    testWidgets('同一次按下只被认领一次：菜单弹了，外层鼠标绑定就不再派发',
+        (WidgetTester tester) async {
+      final List<Offset> hits = <Offset>[];
+      int outerRuns = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ShortcutBindingScope(
+            registry: registry,
+            child: Listener(
+              behavior: HitTestBehavior.translucent,
+              onPointerDown: (PointerDownEvent event) =>
+                  dispatchClaimedMouseAction(event, () {
+                outerRuns += 1;
+                return true;
+              }),
+              child: Scaffold(
+                body: Center(
+                  child: ContextMenuTrigger(
+                    onInvoke: hits.add,
+                    child: const SizedBox(
+                      key: Key('target'),
+                      width: 200,
+                      height: 100,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await pressButton(tester, kSecondaryMouseButton);
+      expect(hits, hasLength(1));
+      expect(outerRuns, 0, reason: '外层若也派发，就是「一次右键做两件事」的老症状');
+    });
+  });
+
+  group('源码守卫：右键菜单不得再硬绑次按钮', () {
+    /// 剥掉注释再扫——本仓库注释里满是 `onSecondaryTapDown` 的历史说明，不剥必假红。
+    String stripComments(String source) {
+      final StringBuffer out = StringBuffer();
+      for (final String line in source.split('\n')) {
+        final String trimmed = line.trimLeft();
+        if (trimmed.startsWith('//')) continue;
+        final int idx = line.indexOf('//');
+        out.writeln(idx >= 0 ? line.substring(0, idx) : line);
+      }
+      return out.toString();
+    }
+
+    test('lib/ 里不再有 onSecondaryTapDown / onSecondaryTapUp 的手势入口', () {
+      final List<String> offenders = <String>[];
+      for (final FileSystemEntity entity
+          in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final String source = stripComments(entity.readAsStringSync());
+        if (source.contains('onSecondaryTapDown') ||
+            source.contains('onSecondaryTapUp')) {
+          offenders.add(entity.path);
+        }
+      }
+      expect(
+        offenders,
+        isEmpty,
+        reason: '这两个回调写死鼠标次按钮，绕过绑定表 → 右键被别的动作占用时会双触发。'
+            '请改用 ContextMenuTrigger：${offenders.join(', ')}',
+      );
+    });
+
+    test('漫画页 WebView 那一路也过归属判据（JS 侧仍硬判 e.button === 2）', () {
+      final File file =
+          File('lib/src/media/manga/reader/manga_fushi_page.dart');
+      expect(file.existsSync(), isTrue, reason: '路径过期请更新守卫');
+      final String source = stripComments(file.readAsStringSync());
+      final int handler = source.indexOf("handlerName: 'onMangaContextMenu'");
+      expect(handler, isNonNegative, reason: '漫画右键菜单 handler 不见了');
+      final String body = source.substring(handler, handler + 600);
+      expect(
+        body.contains('contextMenuButtonNumberMatches('),
+        isTrue,
+        reason: '漫画页右键被别的动作占用时菜单必须让位，否则一次右键做两件事',
+      );
+      expect(body.contains('_kMangaMouseLadder'), isTrue,
+          reason: '必须用漫画页那条阶梯，页面动作才排在菜单之前');
+    });
+
+    test('三个共享卡片组件的 onSecondaryTap 参数只经 ContextMenuTrigger 落地', () {
+      const List<String> shells = <String>[
+        'lib/src/utils/components/fushi_material_components.dart',
+        'lib/src/utils/components/galgame_poster_card.dart',
+        'lib/src/pages/implementations/series_shelf_card.dart',
+      ];
+      for (final String path in shells) {
+        final File file = File(path);
+        expect(file.existsSync(), isTrue, reason: '路径过期请更新守卫：$path');
+        final String source = stripComments(file.readAsStringSync());
+        expect(
+          source.contains('ContextMenuTrigger('),
+          isTrue,
+          reason: '$path 的右键菜单没走绑定表',
+        );
+        // InkWell / GestureDetector 上不得再直接接次按钮回调。
+        expect(
+          RegExp(r'onSecondaryTap:\s*(widget\.)?onSecondaryTap')
+              .hasMatch(source),
+          isFalse,
+          reason: '$path 仍把 onSecondaryTap 直接转给手势识别器（硬绑右键）',
+        );
+      }
+    });
+  });
+}

--- a/fushi/test/shortcuts/shortcut_action_wiring_guard_test.dart
+++ b/fushi/test/shortcuts/shortcut_action_wiring_guard_test.dart
@@ -73,6 +73,11 @@ void main() {
       // fushiFocusDictionaryEntryMove。它与 globalExternalLookup 同类——不经页面
       // _executeShortcutAction 派发，但绝不是死项。
       'lib/src/pages/implementations/popup_settings_injection.dart',
+      // globalContextMenu（「唤出右键菜单」）的判据与触发口。它同样不经页面
+      // _executeShortcutAction 派发——菜单的执行体分散在各卡片 / 各媒体表面自己的
+      // showMenu，本文件回答的是「这次按下的鼠标键该不该弹菜单」，是那二十余处
+      // 入口共用的唯一消费者。与 globalExternalLookup / popupNextEntry 同类。
+      'lib/src/shortcuts/context_menu_trigger.dart',
     ];
 
     final StringBuffer corpus = StringBuffer();

--- a/fushi/test/widgets/fushi_card_secondary_tap_test.dart
+++ b/fushi/test/widgets/fushi_card_secondary_tap_test.dart
@@ -61,12 +61,18 @@ void main() {
     });
   });
 
-  test('书架卡片外壳把 onSecondaryTap 配线到长按回调（源码守卫）', () {
+  test('书架卡片外壳把右键配线到长按回调（源码守卫）', () {
     // TODO-587: reader_fushi_history_page 拆成主壳 + reader_history/*.part.dart；
     // _bookCardShell 现落在 card_widgets.part.dart，故读合并语料。
+    //
+    // BUG-2111 之后判据换成语义等价物：右键不再由 InkWell.onSecondaryTap 硬绑，而是
+    // 经 [ContextMenuTrigger] 按绑定表判定唤出键。断言的事实没变——书架卡的右键必须
+    // 落到与长按相同的那个回调，且多选态压制（让位祖先 SelectionDragArea 扫选）。
     final String text = readReaderHistorySource();
     expect(
-      text.contains('onSecondaryTap: _selectionMode ? null : onLongPress'),
+      text.contains(
+        'onInvoke: contextMenuInvoker(_selectionMode ? null : onLongPress)',
+      ),
       isTrue,
       reason: '_bookCardShell 必须把右键映射到与长按相同的上下文菜单回调，否则桌面右键回归无效',
     );


### PR DESCRIPTION
## 报修

用户：把快捷键绑到鼠标右键后，一次按下**既跑那个动作、又唤出右键菜单**；并且不希望为此被迫解绑另一个快捷键。

## 根因（BUG-2111）

不在某个页面，而在「右键这个物理按钮没有唯一的归属仲裁者」：

- 鼠标绑定通道走 `mouse_binding_dispatch.dart` 的解析阶梯 + `MouseBindingDispatch` 单槽认领；
- 上下文菜单走各表面**各自硬编码**的 `GestureDetector.onSecondaryTap*`（改造前 lib/ 下 23 处）。

两条路互不知情、也不共享那个单槽，所以同一次右键按下被两边各消费一次。这不是某一页的 bug，是同一个数据结构缺陷在每个表面上的重复显形。

## 改法

| 改动 | 说明 |
|---|---|
| 新增 `ShortcutAction.globalContextMenu` | `global` scope，三平台默认 `MouseBinding(2)` = 右键，与改造前逐字一致。菜单从此是绑定表里的一条，可改键、可解绑 |
| 新增 `shortcuts/context_menu_trigger.dart` | `ContextMenuTrigger` 是菜单的**唯一**触发口：按本表面的解析阶梯判定「这次按下该不该弹菜单」，并复用 `dispatchClaimedMouseAction` 的单槽认领。`ShortcutBindingScope` 在 app 根把注册表递进子树（按下瞬间读一次，不建立依赖、不引发重建） |
| 23 处硬绑入口改接它 | `FushiCard` / `GalgamePosterCard` / `SeriesShelfCard` 三个共享组件一处改动覆盖 9 个调用点 |
| 漫画页 JS 那条路 | 它的右键还兼着「缩放态拖拽平移」，不宜换键，故在 Dart 侧补同一份归属判据，只堵双触发 |
| `kVideoMouseLadder` 补 `global` 尾段 | reader / manga / home 三条早就有，video 是唯一缺口；不补则视频页解析不到住在 global 的新动作，右键菜单会整个消失 |
| 移动端默认表补回 global scope 的鼠标绑定 | 原先直接丢弃，Android 接鼠标时右键菜单会整个消失 |
| 设置页撞键改三态 | 新增**「两者都保留」**：撞键不蕴含其中一个必须让出，同一个键可以同时留在两个动作上，按下时由阶梯仲裁 |

**让位不是新引入的第二套优先级规则**——页面 scope 在解析阶梯里本来就排在 `global` 之前，所以把右键绑给页面动作后菜单自动让位，用户不必先去解绑菜单。

## 行为差异

唯一可感的一处：视频画面的菜单从「右键抬起」变成「右键按下」触发。改造前四个媒体表面里已有三个（阅读器 / 漫画 / 字幕）就是 `onSecondaryTapDown`，这一步把剩下那个不一致也抹平了。

## 验证

- `flutter analyze` 与 `dart analyze`（CI 口径，info 也致命）均 **No issues found**
- `test/pages` → `FLUTTER TEST VERDICT: PASSED - 3309 tests ran`
- `test/shortcuts` + `test/widgets` → `FLUTTER TEST VERDICT: PASSED - 1138 tests ran`
- 新增 17 条测试（`test/shortcuts/context_menu_binding_test.dart`），含「同一次按下只被认领一次」这条症状直接回归门；两条源码守卫**做过变异实测**（注入后确实转红）
- 9 条锚在 `onSecondaryTap*` 字面量上的既有守卫换成语义等价判据，断言的事实一条没松

## 未做

未在真机上复测（本条为纯输入路由改动，覆盖靠 widget 行为测试 + 源码守卫）。若要真机核，最短路径是：视频页把「截图」绑到右键 → 按右键应只截图、不弹菜单；解绑后右键恢复弹菜单。

https://claude.ai/code/session_01Quve2FtBruNHaUTHJhLbRu
