### PR TITLE
fix(dict): 一次性导入大量词典后启动转圈中途闪退的四条根因（BUG-2110）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1966 条。点号进各自文件。
+> 共 1967 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2110](bugs/BUG-2110-dict-mass-import-startup-crash.md) | ✅ | ✅ | 一次性导入大量词典后启动转圈中途闪退 |
 | [BUG-2104](bugs/BUG-2104-release-event-ships-debug-apk-on-formal.md) | ✅ | ✅ | 手动发 GitHub Release 会把 debug APK 捎带上正式版 |
 | [BUG-2099](bugs/BUG-2099-android-saf-mdx-greyed.md) | ✅ | ✅ | 安卓文件选择器把 .mdx/.dsl/.ifo/.ass 置灰选不中 |
 | [BUG-2090](bugs/BUG-2090-overlay-hover-highlight-brush-leak.md) | ✅ | ✅ | overlay 悬浮高亮窗口类每次重建都漏一个 GDI brush |

--- a/docs/bugs/BUG-2110-dict-mass-import-startup-crash.md
+++ b/docs/bugs/BUG-2110-dict-mass-import-startup-crash.md
@@ -1,0 +1,39 @@
+## BUG-2110 · 一次性导入大量词典后启动转圈中途闪退
+
+- **报告**：2026-09-04（用户：手机上一次性导入太多词典后，点 fushi 一直转圈进不去、没有任何报错；转到一半应用自己退出）
+- **真实性**：✅ 真 bug。启动路径上有四处与词典数量成正比的缺陷，其中第一处能单独解释「无报错静默退出」这个症状。
+
+### 根因（四处，均在启动的词典装载链上）
+
+1. **FFI 边界没有异常闸门** — `native/fushidicts/fushidicts_ffi.cpp`（修复前 23 个 `FUSHI_EXPORT` 只有 `fushidicts_import` 一个带 try）。
+   `extern "C"` 不是异常边界：C++ 异常从导出函数逃出去 = `std::terminate` → SIGABRT → 进程当场消失。Dart 侧的 try/catch、错误屏、日志落盘全都够不着，所以用户既看不到崩溃提示也拿不到日志。词典越多，启动经过 `add_*_dict` / `lookup` 的次数越多，撞上 `bad_alloc` / `filesystem_error` 的概率线性上升。
+   同一现场还有一批未检查返回值的 `malloc`：失败后照样往 null 指针里写 = SIGSEGV，同样静默。
+2. **每本 kanji 词典每次启动都被全表重扫** — `fushi/lib/src/models/app_model.dart` 的 `_migrateDictionaryTypes` → `native/fushidicts/fushidicts_src/query.cpp:716` `probe_dict_content`。
+   探测把整张 hash 表扫完、逐槽随机跳读 `blobs.bin`，早停条件是「term + kanji 都找到」，纯 kanji 词典永远凑不齐，扫的就是全表。而探测结果**只在需要改判类型时**才写 metadata，于是「没探过」和「探过、无需改判」在数据上不可区分，每次启动重来一遍。手机冷缓存下是每本几万次随机页访问。
+3. **写一次词典元数据就全量重建一次引擎（O(N²)）** — `dictionary_repository.dart` 的 `_onCacheRebuild` → `app_model.dart` `_rebuildDictPathsCache` → `FushiDicts.initializeTyped`。
+   重建 = 卸掉全部词典的文件映射再逐本装回，代价与当前总词典数成正比；而写元数据是逐本发生的（导入每本、类型自愈每本）。导第 100 本要把前 99 本卸了再装回去。
+4. **启动期词典工作全在主 isolate 同步跑，两层看门狗因此失效** — `app_model.dart` 的 `_rebuildDictPathsCacheAsync` / 启动预热。
+   装载与 lookup 都是同步 FFI。`_guardInitIo` 的 12 秒超时和 `main.dart:684` 的 20 秒「加载太久」逃生 UI 都是 Timer，被同步代码堵住的事件循环根本轮不到它们——于是「慢」变成「无逃生口地卡死」，正是用户看到的一直转圈。
+
+### 修复
+
+- **[x] ① 已修复** — 见下方逐条对应：
+  1. 加 `ffi_guard` / `ffi_guard_or` / `ffi_guard_void` 三个闸门原语，23 个导出无例外经过；异常在闸门内记日志并返回零值结果，Dart 侧走既有空结果分支。裸 `malloc` 收进 `alloc_array`：分配失败即把 count 归零，「count 非零但指针是 null」这个状态不再可构造。
+  2. 新增 `kDictTypeProbeKey` / `kDictTypeProbeVersion`（`packages/fushi_dictionary/lib/src/engine/dictionary.dart`）把「探过」变成一等状态，探测结果无论是否导致改判都落库；导入路径直接写标记（native 导入时已数过 term/kanji 记录，无需再探）。存量词典第二次启动起零 IO。
+  3. `FushiDicts.scheduleTyped` 只排期、`instance` / `dictionaryStyles` 用前结算：批量写入期间没人查词，N 次排期塌成 1 次装载，且不依赖任何调用方声明「我是批量的」。删词典目录路径不受影响——它走的是 `releaseAllMappings()`（立刻卸载映射，现在连待办一起清）。
+  4. `FushiDicts.loadPendingAsync` 每装一本让出一次事件循环（用 `Future.delayed` 而非 `await null`，microtask 让出救不了 Timer），装载在影子实例上进行、装完才原子替换，让出期间的查词看到的是完整旧集合；并发排期按代次作废。启动预热改为等首帧之后、串行 + 每次之间让出。
+- 修复提交：`3486b42ab7`（闸门 + malloc 收口）、`d3e084b671`（探测标记 + 排期结算 + 分批让出）。
+
+### 测试
+
+- **[x] ② 已加自动化测试**：
+  - `native/fushidicts/tests/ffi_guard_coverage_test.cpp` — 源码扫描守卫：每个 `FUSHI_EXPORT` 的函数体（精确花括号配对，不是固定窗口）必须走闸门；闸门原语必须存在；导出数量下界防锚点漂移。已注册进 ctest 并登记进 `native_test_harness_guard_test.dart` 的清单，掉不出 CI。
+  - `fushi/test/models/dict_engine_pending_load_test.dart` — 排期只排不装、连续排期只保留最后一次、空集合同样排期（BUG-171）、`releaseAllMappings` / `disposeInstance` 连待办一起清、`isInitialized` 覆盖「已排期未装」。
+  - `fushi/test/dictionary/dict_type_probe_marker_test.dart` — 探测标记语义：缺席/旧版本/垃圾值都要重探，「探过」与「有 kanji 内容」互不反推，标记随 JSON 往返存活。
+  - 更新既有守卫锚点：`dictionary_delete_engine_reload_guard_test.dart`（认排期与立刻两种表达，并新增「启动路径必须自己结算」断言）、`mixed_dict_reclassify_guard_test.dart`（新增「探测结果必须落库」断言）。
+  - 两条新守卫都做了变异实测：摘掉一个导出的闸门 / 让 `scheduleTyped` 不覆盖已有待办，对应断言都会红并准确点名（第一版 `ffi_guard_coverage_test` 用固定 400 字符窗口，变异下仍 PASS——窗口越过函数结尾命中了下一个函数的闸门，已改为精确配对）。
+
+### 备注
+
+- **未定性的一半**：「native abort」与「Android 低内存杀进程」在用户视角完全一样（都是无提示消失），区分需要复现时的 `adb logcat`（`libfushidicts` / SIGABRT / lowmemorykiller）。本轮修的是**能从代码上确证的**四条缺陷；若日志最终指向 LMK，第 1 条仍是必要修复（它决定了崩溃有没有日志），但内存占用本身要另开一条。
+- 未在真机复现验证（手上没有那台设备的词典集）。已验证的部分：native ctest 28/28、`flutter analyze` 干净、相关定向测试与全量套件见提交说明。

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1478,11 +1478,26 @@ class AppModel with ChangeNotifier {
 
   bool _dictTypesMigrated = false;
 
+  /// 启动期的词典类型自愈：把历史误分类的词典改回正确的桶。
+  ///
+  /// **每本词典一生只探一次**（[kDictTypeProbeKey] 标记，探测器版本变了才重探）。
+  /// 这不是省几毫秒的优化，是本函数能不能在词典多的设备上跑完的问题：kanji 分支的
+  /// [FushiDicts.probeDictContent] 会把整张 hash 表扫完、逐槽随机跳读 blobs.bin，
+  /// 而纯 kanji 词典永远触发不了「term+kanji 都找到」的提前退出，扫的就是全表。
+  /// 旧实现只在「需要改判」时才写标记，于是「探过、无需改判」和「没探过」在数据上
+  /// 不可区分，纯 kanji 词典每次启动全表重扫一遍。这些扫描是同步 FFI，跑在 UI
+  /// isolate 上，词典一多就把启动整个吞掉（用户报告：导入很多词典后 app 打不开）。
+  ///
+  /// 探测结果无论是否导致改判都会落库，所以第二次启动开始，这个循环对存量词典是
+  /// 纯内存遍历、零 IO。
   void _migrateDictionaryTypes() {
     if (_dictTypesMigrated) return;
     _dictTypesMigrated = true;
     final dicts = dictRepo.dictionaries;
     for (final d in dicts) {
+      // 探过就跳过——包括「探过、结论是什么都不用改」。
+      if (d.isTypeProbed) continue;
+
       // TODO-622 self-heal: a mixed JA-JA dictionary (term + embedded kanji
       // appendix) was misclassified as 'kanji' by the old detect_type, so its
       // 80k+ term entries only ever reached the kanji bucket and word lookup
@@ -1494,29 +1509,38 @@ class AppModel with ChangeNotifier {
       if (d.type == DictionaryType.kanji) {
         try {
           final dir = path.join(dictionaryResourceDirectory.path, d.name);
+          // 目录不在（词典文件已被删/未落盘）时不落标记：这本压根没被探过，
+          // 等文件回来再探。
           if (!Directory(dir).existsSync()) continue;
           final int mask = FushiDicts.probeDictContent(dir);
           const int hasTerm = 0x1;
           const int hasKanji = 0x2;
-          if (mask & hasTerm == 0) continue; // pure kanji dict, nothing to fix
 
           final Map<String, String> meta = Map<String, String>.from(d.metadata);
-          if (mask & hasKanji != 0) {
+          meta[kDictTypeProbeKey] = kDictTypeProbeVersion;
+          final bool mixed = mask & hasTerm != 0;
+          if (mixed && mask & hasKanji != 0) {
             meta['hasKanji'] = 'true';
-          } else {
+          } else if (mixed) {
             meta.remove('hasKanji');
           }
+          // 纯 kanji 词典（mask 里没有 term）保持 kanji 类型不动，但**同样**要把
+          // 标记写下去——这正是旧实现漏掉的那一半，也是每次启动全表重扫的来源。
           final updated = Dictionary(
             name: d.name,
             formatKey: d.formatKey,
             order: d.order,
-            type: DictionaryType.term,
+            type: mixed ? DictionaryType.term : d.type,
             metadata: meta,
             hiddenLanguages: d.hiddenLanguages,
             collapsedLanguages: d.collapsedLanguages,
+            languageOverride: d.languageOverride,
           );
           dictRepo.persistDictionary(updated);
-          debugPrint('[Fushi] reclassified kanji→term (mixed dict): ${d.name}');
+          if (mixed) {
+            debugPrint(
+                '[Fushi] reclassified kanji→term (mixed dict): ${d.name}');
+          }
         } catch (e, stack) {
           ErrorLogService.instance
               .log('AppModel.dictKanjiReclassify', e, stack);
@@ -1525,6 +1549,8 @@ class AppModel with ChangeNotifier {
         continue;
       }
 
+      // freq/pitch 不需要探测（它们的类型来自导入时的 mode 串，没有历史误判形态），
+      // 也就不落标记：这条分支不做任何 IO，重跑的代价是零。
       if (d.type != DictionaryType.term) continue;
 
       final blobsFile = File(
@@ -1532,6 +1558,7 @@ class AppModel with ChangeNotifier {
       if (!blobsFile.existsSync()) continue;
 
       final raf = blobsFile.openSync();
+      DictionaryType? detected;
       try {
         final int len = raf.lengthSync();
         if (len < 4) continue;
@@ -1543,25 +1570,31 @@ class AppModel with ChangeNotifier {
         final int prefixLen = 3 + exprLen + 1 + 255;
         raf.setPositionSync(0);
         final List<int> head = raf.readSync(prefixLen < len ? prefixLen : len);
-        final DictionaryType? detected = decodeDictTypeFromBlobHeader(head);
-        if (detected == null) continue;
-
-        final updated = Dictionary(
-          name: d.name,
-          formatKey: d.formatKey,
-          order: d.order,
-          type: detected,
-          metadata: d.metadata,
-          hiddenLanguages: d.hiddenLanguages,
-          collapsedLanguages: d.collapsedLanguages,
-        );
-        dictRepo.persistDictionary(updated);
-        debugPrint('[Fushi] migrated dict type: ${d.name} → ${detected.name}');
+        detected = decodeDictTypeFromBlobHeader(head);
       } catch (e, stack) {
         ErrorLogService.instance.log('AppModel.dictTypeMigration', e, stack);
         debugPrint('[Fushi] dict type migration error for ${d.name}: $e');
+        continue;
       } finally {
         raf.closeSync();
+      }
+
+      // 与 kanji 分支同理：探过就落标记，哪怕结论是「类型没错，不用改」。
+      final Map<String, String> meta = Map<String, String>.from(d.metadata);
+      meta[kDictTypeProbeKey] = kDictTypeProbeVersion;
+      final updated = Dictionary(
+        name: d.name,
+        formatKey: d.formatKey,
+        order: d.order,
+        type: detected ?? d.type,
+        metadata: meta,
+        hiddenLanguages: d.hiddenLanguages,
+        collapsedLanguages: d.collapsedLanguages,
+        languageOverride: d.languageOverride,
+      );
+      dictRepo.persistDictionary(updated);
+      if (detected != null) {
+        debugPrint('[Fushi] migrated dict type: ${d.name} → ${detected.name}');
       }
     }
   }
@@ -1583,7 +1616,10 @@ class AppModel with ChangeNotifier {
       ));
     }
     final b = bucketDictPaths(entries);
-    FushiDicts.initializeTyped(
+    // 排期而不是就地重建：这个回调挂在**每一次**词典元数据写入上（导入每本、
+    // 类型自愈每本、隐藏/折叠/语言开关），就地重建会把总代价推成 O(N²)。真正的
+    // 装载推迟到下次要用引擎时，批量写入期间的 N 次排期塌成 1 次装载。
+    FushiDicts.scheduleTyped(
       termPaths: b.term,
       freqPaths: b.freq,
       pitchPaths: b.pitch,
@@ -1591,6 +1627,48 @@ class AppModel with ChangeNotifier {
     );
   }
 
+  /// 查词管线预热：跑几次真实查询，把 native 侧的去屈折表、mmap 页、Dart 侧的
+  /// 结果构建路径都热一遍，用户第一次查词就不必等这些冷启动成本。
+  ///
+  /// 三条纪律，都是被启动卡死这件事逼出来的：
+  /// 1. **等首帧画完再开始**。`searchDictionary` 里的 FFI lookup 是同步的，放在
+  ///    初始化尾巴上就是首帧前的又一段主 isolate 阻塞。预热是优化，不该跟「让
+  ///    用户看到界面」抢时间。
+  /// 2. **串行 + 每次之间让出**，而不是 `Future.wait` 三条并发。它们本来就跑在
+  ///    同一个 isolate 上，"并发"只是把三次同步阻塞连成一段更长的阻塞，还刚好
+  ///    骗过了看起来很安全的 `unawaited`。
+  /// 3. 失败只记日志。预热失败绝不能影响 app 可用性。
+  Future<void> _warmUpSearchAfterFirstFrame() async {
+    try {
+      // 首帧还没画时等它画完；已经画过则立即返回下一帧的结束点。
+      await WidgetsBinding.instance.endOfFrame;
+      final String warmupChar =
+          JapaneseLanguage.instance.helloWorld.substring(0, 1);
+      final List<(String, bool)> warmups = <(String, bool)>[
+        (JapaneseLanguage.instance.helloWorld, false),
+        ('$warmupChar?', true),
+        ('$warmupChar*', true),
+      ];
+      for (final (String term, bool wildcards) in warmups) {
+        await searchDictionary(
+          searchTerm: term,
+          searchWithWildcards: wildcards,
+          useCache: false,
+        );
+        await Future<void>.delayed(Duration.zero);
+      }
+    } catch (e, stack) {
+      ErrorLogService.instance.log('AppModel.searchWarmup', e, stack);
+      debugPrint('[Fushi] search warmup failed (non-fatal): $e');
+    }
+  }
+
+  /// 启动/Profile 切换用的词典引擎装载。
+  ///
+  /// 与同步的 [_rebuildDictPathsCache] 的区别不只是「用 await 包一层」：装载本身
+  /// 是分批让出的（[FushiDicts.loadPendingAsync]），每装一本把控制权还给事件循环
+  /// 一次。词典多的设备上这一步可能要好几秒，一口气同步跑完会连带冻掉两层启动
+  /// 看门狗（它们都是 Timer），把「慢」变成「无逃生口地卡死」。
   Future<void> _rebuildDictPathsCacheAsync() async {
     _migrateDictionaryTypes();
     final dictList = dictRepo.dictionaries;
@@ -1612,12 +1690,15 @@ class AppModel with ChangeNotifier {
         ),
     ];
     final b = bucketDictPaths(entries);
-    FushiDicts.initializeTyped(
+    FushiDicts.scheduleTyped(
       termPaths: b.term,
       freqPaths: b.freq,
       pitchPaths: b.pitch,
       kanjiPaths: b.kanji,
     );
+    // 在这里就把它装完（而不是留给第一次查词）：启动期是有预算做这件事的地方，
+    // 而且分批让出后它不再阻塞首帧。
+    await FushiDicts.loadPendingAsync();
   }
 
   List<DictionarySearchResult> get dictionaryHistory =>
@@ -2562,30 +2643,8 @@ class AppModel with ChangeNotifier {
         defaultTargetPlatform,
       );
 
-      debugPrint('[Fushi] init: search preload (parallel)');
-      final String warmupChar =
-          JapaneseLanguage.instance.helloWorld.substring(0, 1);
-      unawaited(Future.wait(<Future<void>>[
-        searchDictionary(
-          searchTerm: JapaneseLanguage.instance.helloWorld,
-          searchWithWildcards: false,
-          useCache: false,
-        ),
-        searchDictionary(
-          searchTerm: '$warmupChar?',
-          searchWithWildcards: true,
-          useCache: false,
-        ),
-        searchDictionary(
-          searchTerm: '$warmupChar*',
-          searchWithWildcards: true,
-          useCache: false,
-        ),
-      ]).catchError((Object e, StackTrace stack) {
-        ErrorLogService.instance.log('AppModel.searchWarmup', e, stack);
-        debugPrint('[Fushi] search warmup failed (non-fatal): $e');
-        return <void>[];
-      }));
+      debugPrint('[Fushi] init: search preload (deferred to after first frame)');
+      unawaited(_warmUpSearchAfterFirstFrame());
 
       debugPrint('[Fushi] init: DONE');
       // TODO-1260：启动正常跑完，清掉启动步进面包屑（否则下次启动会误报上次 hang）。

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -305,6 +305,9 @@ class DictionaryImportManager {
           metadata: <String, String>{
             ...readSourceMetadataFromIndex(finalDir),
             if (result.kanjiCount > 0) 'hasKanji': 'true',
+            // 导入时 native 已经数过 term/kanji 记录，等于类型探测刚做完：直接落
+            // 标记，启动期的自愈循环就不会再对这本做一次全表扫描。
+            kDictTypeProbeKey: kDictTypeProbeVersion,
           },
           hiddenLanguages: preservedSettings?.hiddenLanguages ?? const [],
           collapsedLanguages: preservedSettings?.collapsedLanguages ?? const [],
@@ -566,6 +569,8 @@ class DictionaryImportManager {
         metadata: <String, String>{
           ...metadata,
           if (result.kanjiCount > 0) 'hasKanji': 'true',
+          // 同目录导入路径：native 刚数完记录，探测标记直接落库（见另一处注释）。
+          kDictTypeProbeKey: kDictTypeProbeVersion,
         },
         hiddenLanguages: preservedSettings?.hiddenLanguages ?? const [],
         collapsedLanguages: preservedSettings?.collapsedLanguages ?? const [],

--- a/fushi/test/dictionary/dict_type_probe_marker_test.dart
+++ b/fushi/test/dictionary/dict_type_probe_marker_test.dart
@@ -1,0 +1,80 @@
+// 词典类型探测标记（[kDictTypeProbeKey]）的语义测试。
+//
+// 这个标记存在的唯一理由是「探过」必须是一等状态。旧实现只在**需要改判类型**时
+// 才往 metadata 里写东西，于是「没探过」和「探过、结论是不用改」在数据上长得一模
+// 一样——启动期的自愈循环没法区分，只能对每一本每次启动都重探。而 kanji 分支的
+// 探测是把整张 hash 表扫完、逐槽随机跳读 blobs.bin，纯 kanji 词典还永远触发不了
+// 「term+kanji 都找到」的提前退出，扫的就是全表。手机冷缓存下每本几万次随机页
+// 访问，词典一多启动就被这段同步 FFI 吞掉（用户报告：导入很多词典后 app 打不开）。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+Dictionary dict({Map<String, String> metadata = const <String, String>{}}) =>
+    Dictionary(
+      name: 'D',
+      formatKey: 'yomichan',
+      order: 0,
+      type: DictionaryType.kanji,
+      metadata: metadata,
+    );
+
+void main() {
+  group('isTypeProbed', () {
+    test('没有标记 = 没探过（老词典要探一次）', () {
+      expect(dict().isTypeProbed, isFalse);
+    });
+
+    test('标记等于当前版本 = 探过，跳过', () {
+      expect(
+        dict(metadata: <String, String>{
+          kDictTypeProbeKey: kDictTypeProbeVersion,
+        }).isTypeProbed,
+        isTrue,
+      );
+    });
+
+    test('标记是旧版本 = 要重探（探测语义升级后存量自动重探）', () {
+      // 值存版本号而不是 'true' 就是为了这条：改探测逻辑只需 bump 版本，
+      // 不必再发明一个新键、也不必写一次性迁移。
+      expect(
+        dict(metadata: <String, String>{kDictTypeProbeKey: '0'}).isTypeProbed,
+        isFalse,
+      );
+    });
+
+    test('标记是垃圾值 = 要重探（不把无法解释的值当成已探过）', () {
+      expect(
+        dict(metadata: <String, String>{kDictTypeProbeKey: 'true'})
+            .isTypeProbed,
+        isFalse,
+      );
+    });
+
+    test('「探过」与「有 kanji 内容」是两件事，不能互相反推', () {
+      // 这正是旧实现的二义：hasKanji 缺席既可能是没探过，也可能是探过但这本没有
+      // kanji 记录。两个键各管各的。
+      final Dictionary probedNoKanji = dict(metadata: <String, String>{
+        kDictTypeProbeKey: kDictTypeProbeVersion,
+      });
+      expect(probedNoKanji.isTypeProbed, isTrue);
+      expect(probedNoKanji.metadata['hasKanji'], isNull);
+
+      final Dictionary unprobedWithKanji =
+          dict(metadata: <String, String>{'hasKanji': 'true'});
+      expect(unprobedWithKanji.isTypeProbed, isFalse);
+    });
+  });
+
+  group('metadata 往返', () {
+    test('标记随 toJson/fromJson 存活（存量词典重启后不会退回未探状态）', () {
+      final Dictionary original = dict(metadata: <String, String>{
+        kDictTypeProbeKey: kDictTypeProbeVersion,
+        'hasKanji': 'true',
+      });
+      final Dictionary restored = Dictionary.fromJson(original.toJson());
+      expect(restored.isTypeProbed, isTrue,
+          reason: '标记丢了就等于每次重启都重扫一遍，这条修复也就没了');
+      expect(restored.metadata['hasKanji'], equals('true'));
+    });
+  });
+}

--- a/fushi/test/dictionary/native_test_harness_guard_test.dart
+++ b/fushi/test/dictionary/native_test_harness_guard_test.dart
@@ -38,6 +38,9 @@ void main() {
       'dict_name_uaf_e2e_test',
       'media_import_query_test',
       'freq_pitch_import_query_test',
+      // FFI 边界闸门的覆盖守卫。它守的是「异常逃出 extern "C" → 进程静默消失」
+      // 这条唯一无日志、无错误屏的死法，掉出 ctest 等于这层防护没有了。
+      'ffi_guard_coverage_test',
     ]) {
       expect(cmake, contains('add_fushi_test($testName'),
           reason: '$testName must be registered as a ctest case');
@@ -53,6 +56,7 @@ void main() {
       'media_import_query_test.cpp',
       'freq_pitch_import_query_test.cpp',
       'kanji_import_query_test.cpp',
+      'ffi_guard_coverage_test.cpp',
     ]) {
       final File file = File('../native/fushidicts/tests/$src');
       expect(file.existsSync(), isTrue,

--- a/fushi/test/models/dict_engine_pending_load_test.dart
+++ b/fushi/test/models/dict_engine_pending_load_test.dart
@@ -1,0 +1,77 @@
+// 词典引擎「排期 + 用前结算」的行为测试。
+//
+// 背景（用户报告：一次性导入很多词典后，点开 app 转圈转一半自己退出）。这一层修
+// 的是两个与词典数量成正比的启动成本：
+//
+//   * 旧实现里每写一次词典元数据就**就地全量重建**引擎——卸掉所有词典的文件映射
+//     再逐本装回来。写元数据是逐本发生的（导入每本、启动期类型自愈每本），于是
+//     总代价是 O(N²)：导第 100 本要把前 99 本卸了再装回去。
+//   * 装载是同步 FFI，一口气装完 N 本期间主 isolate 完全不动，连 Timer 都不触发，
+//     于是 AppModel 的 12 秒启动超时和 main.dart 的 20 秒逃生 UI 双双失效——两层
+//     看门狗都是 Timer。用户看到的就是一直转圈、没有任何逃生口。
+//
+// 这里测的是引擎侧的状态机（不碰真 FFI：装载动作只在结算时才发生，而结算需要
+// native 库；所以断言集中在「什么时候算有待办、待办怎么合并、代次怎么作废」这些
+// 纯 Dart 的不变式上）。装载本身的正确性由 native ctest 覆盖。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+void main() {
+  tearDown(() {
+    // 每条用例后清干净静态状态，别让待办漏给下一条。
+    FushiDicts.dropPendingForTest();
+  });
+
+  group('scheduleTyped 只排期、不装载', () {
+    test('排期后有待办，且没有立刻装载', () {
+      FushiDicts.scheduleTyped(termPaths: <String>['/nonexistent/a']);
+      expect(FushiDicts.hasPendingDicts, isTrue, reason: '排期必须留下待办，否则结算时机无从判断');
+    });
+
+    test('连续排期只保留最后一次（批量写入的 N 次塌成 1 次装载）', () {
+      // 这正是 O(N²) 消失的地方：中间那些集合从没被任何人观察到。
+      for (int i = 0; i < 50; i++) {
+        FushiDicts.scheduleTyped(termPaths: <String>['/nonexistent/$i']);
+      }
+      expect(FushiDicts.hasPendingDicts, isTrue);
+      expect(FushiDicts.debugPendingTermPathsForTest(),
+          equals(<String>['/nonexistent/49']),
+          reason: '只有最后一次意图应该存活');
+    });
+
+    test('空集合同样要排期（删掉最后一本词典必须让引擎变空，BUG-171）', () {
+      FushiDicts.scheduleTyped();
+      expect(FushiDicts.hasPendingDicts, isTrue,
+          reason: '空集合被当成「没事发生」的话，删完最后一本词典后旧索引还在，'
+              '查词仍会命中已删词典');
+      expect(FushiDicts.debugPendingTermPathsForTest(), isEmpty);
+    });
+  });
+
+  group('待办的清除时机', () {
+    test('releaseAllMappings 连待办一起清', () {
+      // 删词典目录前要释放映射；此时若把待办留着，删完目录后任何一次查词都会把
+      // 「含已删词典」的那份排期重放回引擎——映射又长回来，目录也就删不掉了。
+      FushiDicts.scheduleTyped(termPaths: <String>['/nonexistent/a']);
+      FushiDicts.releaseAllMappings();
+      expect(FushiDicts.hasPendingDicts, isFalse);
+    });
+
+    test('disposeInstance 也清待办', () {
+      FushiDicts.scheduleTyped(termPaths: <String>['/nonexistent/a']);
+      FushiDicts.disposeInstance();
+      expect(FushiDicts.hasPendingDicts, isFalse);
+    });
+  });
+
+  group('isInitialized 覆盖「已排期但还没装」', () {
+    test('只排期也算已初始化', () {
+      FushiDicts.disposeInstance();
+      expect(FushiDicts.isInitialized, isFalse);
+      FushiDicts.scheduleTyped(termPaths: <String>['/nonexistent/a']);
+      expect(FushiDicts.isInitialized, isTrue,
+          reason: '待办本身就说明集合已知，调用方接着会经 instance 触发结算；'
+              '这里判 false 会让查词走「引擎没准备好」的空结果分支');
+    });
+  });
+}

--- a/fushi/test/models/dictionary_delete_engine_reload_guard_test.dart
+++ b/fushi/test/models/dictionary_delete_engine_reload_guard_test.dart
@@ -67,17 +67,24 @@ void main() {
       'A: _rebuildDictPathsCache rebuilds the engine even when all path '
       'buckets are empty (deleting the last dictionary must reload)', () {
     final String body = bodyOf('void _rebuildDictPathsCache(');
-    expect(body.contains('FushiDicts.initializeTyped'), isTrue,
-        reason: 'rebuild must drive the FFI engine');
-    // The call to initializeTyped must NOT be gated behind an
-    // `isNotEmpty`-style guard that skips the rebuild for an empty path set —
-    // that is exactly the hole that left a stale engine after deleting the last
-    // dictionary (BUG-171 hole A).
+    // 引擎装载现在是「排期 + 用前结算」：这个回调挂在每一次词典元数据写入上，
+    // 就地全量重建会让批量导入变成 O(N²)（导第 N 本要把前 N-1 本卸了再装回）。
+    // 守的不变式没变——集合必须被推给引擎，且**不带空集合豁免**；变的只是推的
+    // 方式，所以这里认 scheduleTyped 与 initializeTyped 两种表达之一。
     expect(
-      RegExp(r'isNotEmpty\s*\)\s*\{?\s*FushiDicts\.initializeTyped')
+      body.contains('FushiDicts.scheduleTyped') ||
+          body.contains('FushiDicts.initializeTyped'),
+      isTrue,
+      reason: 'rebuild must drive the FFI engine (schedule or immediate)',
+    );
+    // The call must NOT be gated behind an `isNotEmpty`-style guard that skips
+    // the rebuild for an empty path set — that is exactly the hole that left a
+    // stale engine after deleting the last dictionary (BUG-171 hole A).
+    expect(
+      RegExp(r'isNotEmpty\s*\)\s*\{?\s*FushiDicts\.(scheduleTyped|initializeTyped)')
           .hasMatch(body.replaceAll(RegExp(r'\s+'), ' ')),
       isFalse,
-      reason: 'initializeTyped must run for an empty path set too; an empty '
+      reason: 'the engine must be driven for an empty path set too; an empty '
           'rebuild yields an empty-but-fresh engine so deleting the last '
           'dictionary stops queries from hitting it (BUG-171).',
     );
@@ -85,12 +92,20 @@ void main() {
 
   test('A2: _rebuildDictPathsCacheAsync also rebuilds unconditionally', () {
     final String body = bodyOf('Future<void> _rebuildDictPathsCacheAsync(');
-    expect(body.contains('FushiDicts.initializeTyped'), isTrue);
     expect(
-      RegExp(r'isNotEmpty\s*\)\s*\{?\s*FushiDicts\.initializeTyped')
+      body.contains('FushiDicts.scheduleTyped') ||
+          body.contains('FushiDicts.initializeTyped'),
+      isTrue,
+    );
+    // 启动路径必须**真的把它装完**，而不是只排期就走人：排期没结算时引擎里还是
+    // 空的/旧的，第一次查词才补装——那笔成本会掉在用户脸上。
+    expect(body.contains('FushiDicts.loadPendingAsync()'), isTrue,
+        reason: 'the startup path must settle the pending load itself');
+    expect(
+      RegExp(r'isNotEmpty\s*\)\s*\{?\s*FushiDicts\.(scheduleTyped|initializeTyped)')
           .hasMatch(body.replaceAll(RegExp(r'\s+'), ' ')),
       isFalse,
-      reason: 'async rebuild must not skip initializeTyped on empty path set '
+      reason: 'async rebuild must not skip the engine on empty path set '
           '(BUG-171).',
     );
   });

--- a/fushi/test/models/mixed_dict_reclassify_guard_test.dart
+++ b/fushi/test/models/mixed_dict_reclassify_guard_test.dart
@@ -60,9 +60,15 @@ void main() {
       expect(body.contains('FushiDicts.probeDictContent('), isTrue,
           reason: 'classification must come from the native single source of '
               'truth (probe blobs.bin), not a fragile Dart blob header read');
-      expect(body.contains('type: DictionaryType.term'), isTrue,
+      expect(body.contains('DictionaryType.term'), isTrue,
           reason: 'a kanji dict that actually contains term records must be '
               'demoted back to term so word lookup hits again');
+      // 探测结果必须落库——包括「探过、结论是不用改」。少了这一步，「没探过」和
+      // 「探过、无需改判」在数据上不可区分，纯 kanji 词典每次启动都要把整张 hash
+      // 表重扫一遍（同步 FFI + 随机跳读 blobs.bin），词典一多启动直接卡死。
+      expect(body.contains('kDictTypeProbeKey'), isTrue,
+          reason: 'the probe result must be recorded so the scan runs once '
+              'per dictionary, not once per launch');
       expect(body.contains("'hasKanji'"), isTrue,
           reason:
               'the demoted mixed dict must be tagged hasKanji so the bucket '

--- a/native/fushidicts/fushidicts_ffi.cpp
+++ b/native/fushidicts/fushidicts_ffi.cpp
@@ -1,6 +1,10 @@
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 #include "fushidicts/platform.hpp"
 #include "fushidicts/deinflector.hpp"
@@ -13,6 +17,81 @@
 static char* dup(const std::string& s) {
   char* p = static_cast<char*>(malloc(s.size() + 1));
   if (p) memcpy(p, s.c_str(), s.size() + 1);
+  return p;
+}
+
+// ── FFI 边界异常闸门 ─────────────────────────────────────────────────
+//
+// `extern "C"` 边界不是异常边界：C++ 异常一旦从导出函数里逃出去，行为未定义，
+// 实际表现是 `std::terminate` → SIGABRT → **进程当场消失**。Dart 侧的 try/catch、
+// 错误屏、日志落盘在这种死法下全部够不着，用户看到的只是「转圈转一半 app 自己
+// 退出，没有任何报错」。这条路径在本仓有前科（见 query.cpp `add_dict` 上方关于
+// 上游 TestFlight 崩溃的注释），而词典越多、启动时经过这些入口的次数越多，撞上
+// `bad_alloc` / `filesystem_error` 的概率就线性上升。
+//
+// 治法不是给每个导出各贴一段 try/catch（23 个入口，漏一个就复发），而是让**所有**
+// 导出无例外地经过这一个闸门：异常在这里被吃掉并记日志，调用方拿到零值结果
+// （count=0 / nullptr / 0），Dart 侧走既有的空结果分支。守卫测试
+// `tests/ffi_guard_coverage_test.cpp` 扫本文件，任何没走闸门的导出都会让 CI 红，
+// 所以「新增导出忘了防护」在结构上不可能再发生。
+//
+// 有返回值的入口用 [ffi_guard]（零初始化 fallback）；需要非零 fallback 的用
+// [ffi_guard_or]（fallback **工厂**，只在真出异常时才构造——传现成的值会让正常
+// 路径也构造一份没人释放的结果，那是每次调用一次的内存泄漏）；void 入口用
+// [ffi_guard_void]。三者都是 noexcept：闸门自己绝不再抛。
+template <typename F, typename R = std::invoke_result_t<F>>
+static R ffi_guard(const char* tag, F&& fn) noexcept {
+  try {
+    return fn();
+  } catch (const std::exception& e) {
+    FUSHI_LOGE("%s threw: %s", tag, e.what());
+  } catch (...) {
+    FUSHI_LOGE("%s threw a non-std exception", tag);
+  }
+  return R{};
+}
+
+template <typename F, typename G, typename R = std::invoke_result_t<F>>
+static R ffi_guard_or(const char* tag, F&& fn, G&& make_fallback) noexcept {
+  try {
+    return fn();
+  } catch (const std::exception& e) {
+    FUSHI_LOGE("%s threw: %s", tag, e.what());
+  } catch (...) {
+    FUSHI_LOGE("%s threw a non-std exception", tag);
+  }
+  return make_fallback();
+}
+
+template <typename F>
+static void ffi_guard_void(const char* tag, F&& fn) noexcept {
+  try {
+    fn();
+  } catch (const std::exception& e) {
+    FUSHI_LOGE("%s threw: %s", tag, e.what());
+  } catch (...) {
+    FUSHI_LOGE("%s threw a non-std exception", tag);
+  }
+}
+
+/// 结果数组分配：`malloc` 返回 null 时把 [count] 归零再返回 nullptr。
+///
+/// 闸门接得住 C++ 异常，接不住「malloc 失败后照样往 null 指针里写」——那是
+/// SIGSEGV，同样是静默闪退，而低内存正是本类崩溃的现场条件。把 count 和缓冲区
+/// 的分配收进同一个原语后，「count 说有 N 条但指针是 null」这个状态不可能再被
+/// 构造出来：失败即 0 条，后续填充循环自然不跑，配套的 free 也照常安全
+/// （`free(nullptr)` 是合法的）。
+template <typename T>
+static T* alloc_array(int32_t& count) {
+  if (count <= 0) {
+    count = 0;
+    return nullptr;
+  }
+  auto* p = static_cast<T*>(malloc(sizeof(T) * static_cast<size_t>(count)));
+  if (!p) {
+    FUSHI_LOGE("out of memory allocating %d result item(s)", count);
+    count = 0;
+  }
   return p;
 }
 
@@ -134,7 +213,7 @@ static FfiTermResult convert_term(const TermResult& t) {
   r.rules = dup(t.rules);
 
   r.glossary_count = static_cast<int32_t>(t.glossaries.size());
-  r.glossaries = static_cast<FfiGlossary*>(malloc(sizeof(FfiGlossary) * r.glossary_count));
+  r.glossaries = alloc_array<FfiGlossary>(r.glossary_count);
   for (int i = 0; i < r.glossary_count; i++) {
     r.glossaries[i].dict_name = dup(t.glossaries[i].dict_name);
     r.glossaries[i].glossary = dup(t.glossaries[i].glossary);
@@ -143,21 +222,32 @@ static FfiTermResult convert_term(const TermResult& t) {
   }
 
   r.frequency_count = static_cast<int32_t>(t.frequencies.size());
-  r.frequencies = static_cast<FfiFrequency*>(malloc(sizeof(FfiFrequency) * r.frequency_count));
+  r.frequencies = alloc_array<FfiFrequency>(r.frequency_count);
   for (int i = 0; i < r.frequency_count; i++) {
     auto& f = t.frequencies[i];
     r.frequencies[i].dict_name = dup(f.dict_name);
+    // values 与 display_values 是平行数组，共用同一个 count：任一分配失败都必须
+    // 把 count 归零并把两根指针都置空，否则 free 路径会按幸存的那个 count 去遍历
+    // 已经归零的另一根。
     r.frequencies[i].count = static_cast<int32_t>(f.frequencies.size());
-    r.frequencies[i].values = static_cast<int32_t*>(malloc(sizeof(int32_t) * f.frequencies.size()));
-    r.frequencies[i].display_values = static_cast<char**>(malloc(sizeof(char*) * f.frequencies.size()));
-    for (size_t j = 0; j < f.frequencies.size(); j++) {
+    int32_t value_count = r.frequencies[i].count;
+    r.frequencies[i].values = alloc_array<int32_t>(value_count);
+    r.frequencies[i].display_values = alloc_array<char*>(r.frequencies[i].count);
+    if (value_count != r.frequencies[i].count) {
+      free(r.frequencies[i].values);
+      free(r.frequencies[i].display_values);
+      r.frequencies[i].values = nullptr;
+      r.frequencies[i].display_values = nullptr;
+      r.frequencies[i].count = 0;
+    }
+    for (int j = 0; j < r.frequencies[i].count; j++) {
       r.frequencies[i].values[j] = f.frequencies[j].value;
       r.frequencies[i].display_values[j] = dup(f.frequencies[j].display_value);
     }
   }
 
   r.pitch_count = static_cast<int32_t>(t.pitches.size());
-  r.pitches = static_cast<FfiPitch*>(malloc(sizeof(FfiPitch) * r.pitch_count));
+  r.pitches = alloc_array<FfiPitch>(r.pitch_count);
   for (int i = 0; i < r.pitch_count; i++) {
     r.pitches[i].dict_name = dup(t.pitches[i].dict_name);
     // 数字位与 pattern 位分流：positions 只装数字 accent（既有语义不变），
@@ -172,20 +262,19 @@ static FfiTermResult convert_term(const TermResult& t) {
       }
     }
     r.pitches[i].count = static_cast<int32_t>(numeric.size());
-    r.pitches[i].positions = static_cast<int32_t*>(malloc(sizeof(int32_t) * r.pitches[i].count));
+    r.pitches[i].positions = alloc_array<int32_t>(r.pitches[i].count);
     for (int j = 0; j < r.pitches[i].count; j++) {
       r.pitches[i].positions[j] = numeric[j];
     }
     r.pitches[i].pattern_count = static_cast<int32_t>(pattern_refs.size());
-    r.pitches[i].patterns = static_cast<char**>(malloc(sizeof(char*) * r.pitches[i].pattern_count));
+    r.pitches[i].patterns = alloc_array<char*>(r.pitches[i].pattern_count);
     for (int j = 0; j < r.pitches[i].pattern_count; j++) {
       r.pitches[i].patterns[j] = dup(*pattern_refs[j]);
     }
     // transcriptions: char** array of IPA strings, mirroring frequency
     // display_values (malloc the pointer array, then dup each element).
     r.pitches[i].transcription_count = static_cast<int32_t>(t.pitches[i].transcriptions.size());
-    r.pitches[i].transcriptions =
-        static_cast<char**>(malloc(sizeof(char*) * r.pitches[i].transcription_count));
+    r.pitches[i].transcriptions = alloc_array<char*>(r.pitches[i].transcription_count);
     for (int j = 0; j < r.pitches[i].transcription_count; j++) {
       r.pitches[i].transcriptions[j] = dup(t.pitches[i].transcriptions[j]);
     }
@@ -277,39 +366,57 @@ static void* import_thread_fn(void* arg) {
 
 FUSHI_EXPORT
 FfiImportResult fushidicts_import(const char* zip_path, const char* output_dir, const char* breadcrumb_dir) {
-  ImportThreadArgs args;
-  args.zip_path = zip_path;
-  args.output_dir = output_dir;
-  // breadcrumb_dir may be null (older callers / disabled); treat as "no breadcrumb".
-  args.breadcrumb_dir = breadcrumb_dir ? breadcrumb_dir : "";
-  args.result = {};
+  // fallback 带真串而不是 nullptr：导入失败是 Dart 侧要读 title/error 展示给用户的
+  // **正常**分支，空 error 会让用户只看到「导入失败」而拿不到任何线索。
+  return ffi_guard_or(
+      "fushidicts_import",
+      [&]() -> FfiImportResult {
+        ImportThreadArgs args;
+        args.zip_path = zip_path;
+        args.output_dir = output_dir;
+        // breadcrumb_dir may be null (older callers / disabled); treat as "no breadcrumb".
+        args.breadcrumb_dir = breadcrumb_dir ? breadcrumb_dir : "";
+        args.result = {};
 
-  FushiThread thread;
-  bool ok = fushi_thread_create(thread, import_thread_fn, &args, 32 * 1024 * 1024);
+        FushiThread thread;
+        bool ok = fushi_thread_create(thread, import_thread_fn, &args, 32 * 1024 * 1024);
 
-  if (!ok) {
-    args.result.success = 0;
-    args.result.title = dup("");
-    args.result.error = dup("Failed to create import thread");
-    return args.result;
-  }
+        if (!ok) {
+          args.result.success = 0;
+          args.result.title = dup("");
+          args.result.error = dup("Failed to create import thread");
+          return args.result;
+        }
 
-  fushi_thread_join(thread);
-  return args.result;
+        fushi_thread_join(thread);
+        return args.result;
+      },
+      []() -> FfiImportResult {
+        FfiImportResult fallback{};
+        fallback.success = 0;
+        fallback.title = dup("");
+        fallback.detected_type = dup("term");
+        fallback.error = dup("dictionary import failed (native exception)");
+        return fallback;
+      });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_import_result(FfiImportResult* r) {
-  if (!r) return;
-  free(r->title);
-  free(r->detected_type);
-  free(r->error);
+  ffi_guard_void("fushidicts_free_import_result", [&]() {
+    if (!r) return;
+    free(r->title);
+    free(r->detected_type);
+    free(r->error);
+  });
 }
 
 FUSHI_EXPORT
 int32_t fushidicts_probe_dict_content(const char* dir) {
-  if (!dir) return 0;
-  return static_cast<int32_t>(probe_dict_content(std::string(dir)));
+  return ffi_guard("fushidicts_probe_dict_content", [&]() -> int32_t {
+    if (!dir) return 0;
+    return static_cast<int32_t>(probe_dict_content(std::string(dir)));
+  });
 }
 
 // ── query handle ────────────────────────────────────────────────────
@@ -321,119 +428,154 @@ struct FushidictsHandle {
 
 FUSHI_EXPORT
 void* fushidicts_create() {
-  return new FushidictsHandle();
+  return ffi_guard("fushidicts_create",
+                   [&]() -> void* { return new FushidictsHandle(); });
 }
 
 FUSHI_EXPORT
 void fushidicts_destroy(void* handle) {
-  delete static_cast<FushidictsHandle*>(handle);
+  ffi_guard_void("fushidicts_destroy",
+                 [&]() { delete static_cast<FushidictsHandle*>(handle); });
 }
 
+// 四个 add_*_dict 是本轮崩溃的第一现场：一次性导入很多词典后，启动要连着走这里
+// N 遍，每遍都在读 index.json / styles.css、建映射、可能建 zstd 词典——任何一次
+// bad_alloc 过去都会直接崩掉整个进程。现在单本失败只是这本不进引擎（native 侧
+// 已按 return 处理），其余词典照常可用。
 FUSHI_EXPORT
 void fushidicts_add_term_dict(void* handle, const char* path) {
-  static_cast<FushidictsHandle*>(handle)->query.add_term_dict(path);
+  ffi_guard_void("fushidicts_add_term_dict", [&]() {
+    static_cast<FushidictsHandle*>(handle)->query.add_term_dict(path);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_add_freq_dict(void* handle, const char* path) {
-  static_cast<FushidictsHandle*>(handle)->query.add_freq_dict(path);
+  ffi_guard_void("fushidicts_add_freq_dict", [&]() {
+    static_cast<FushidictsHandle*>(handle)->query.add_freq_dict(path);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_add_pitch_dict(void* handle, const char* path) {
-  static_cast<FushidictsHandle*>(handle)->query.add_pitch_dict(path);
+  ffi_guard_void("fushidicts_add_pitch_dict", [&]() {
+    static_cast<FushidictsHandle*>(handle)->query.add_pitch_dict(path);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_add_kanji_dict(void* handle, const char* path) {
-  static_cast<FushidictsHandle*>(handle)->query.add_kanji_dict(path);
+  ffi_guard_void("fushidicts_add_kanji_dict", [&]() {
+    static_cast<FushidictsHandle*>(handle)->query.add_kanji_dict(path);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_load_transforms(void* handle, const char* json) {
-  static_cast<FushidictsHandle*>(handle)->deinflector.load_transforms_json(json);
+  ffi_guard_void("fushidicts_load_transforms", [&]() {
+    static_cast<FushidictsHandle*>(handle)->deinflector.load_transforms_json(json);
+  });
 }
 
 // ── query ───────────────────────────────────────────────────────────
 
 FUSHI_EXPORT
 FfiQueryResult fushidicts_query(void* handle, const char* expression) {
-  FfiQueryResult r{};
-  auto& q = static_cast<FushidictsHandle*>(handle)->query;
-  auto terms = q.query(expression);
-  r.count = static_cast<int32_t>(terms.size());
-  r.terms = static_cast<FfiTermResult*>(malloc(sizeof(FfiTermResult) * r.count));
-  for (int i = 0; i < r.count; i++) {
-    r.terms[i] = convert_term(terms[i]);
-  }
-  return r;
+  return ffi_guard("fushidicts_query", [&]() -> FfiQueryResult {
+    FfiQueryResult r{};
+    auto& q = static_cast<FushidictsHandle*>(handle)->query;
+    auto terms = q.query(expression);
+    r.count = static_cast<int32_t>(terms.size());
+    r.terms = alloc_array<FfiTermResult>(r.count);
+    for (int i = 0; i < r.count; i++) {
+      r.terms[i] = convert_term(terms[i]);
+    }
+    return r;
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_query_result(FfiQueryResult* r) {
-  if (!r) return;
-  for (int i = 0; i < r->count; i++) {
-    free_term(r->terms[i]);
-  }
-  free(r->terms);
+  ffi_guard_void("fushidicts_free_query_result", [&]() {
+    if (!r) return;
+    for (int i = 0; i < r->count; i++) {
+      free_term(r->terms[i]);
+    }
+    free(r->terms);
+  });
 }
 
 // ── kanji query ─────────────────────────────────────────────────────
 
 FUSHI_EXPORT
 FfiKanjiResults fushidicts_query_kanji(void* handle, const char* character) {
-  FfiKanjiResults r{};
-  auto& q = static_cast<FushidictsHandle*>(handle)->query;
-  auto kanji = q.query_kanji(character);
-  r.count = static_cast<int32_t>(kanji.size());
-  r.results = static_cast<FfiKanjiResult*>(malloc(sizeof(FfiKanjiResult) * r.count));
-  for (int i = 0; i < r.count; i++) {
-    const auto& k = kanji[i];
-    auto& dst = r.results[i];
-    dst.character = dup(k.character);
-    dst.onyomi = dup(k.onyomi);
-    dst.kunyomi = dup(k.kunyomi);
-    dst.radical = dup(k.radical);
-    dst.strokes = static_cast<int32_t>(k.strokes);
-    dst.dict_name = dup(k.dict_name);
-    dst.meaning_count = static_cast<int32_t>(k.meanings.size());
-    dst.meanings = static_cast<char**>(malloc(sizeof(char*) * dst.meaning_count));
-    for (int j = 0; j < dst.meaning_count; j++) {
-      dst.meanings[j] = dup(k.meanings[j]);
+  return ffi_guard("fushidicts_query_kanji", [&]() -> FfiKanjiResults {
+    FfiKanjiResults r{};
+    auto& q = static_cast<FushidictsHandle*>(handle)->query;
+    auto kanji = q.query_kanji(character);
+    r.count = static_cast<int32_t>(kanji.size());
+    r.results = alloc_array<FfiKanjiResult>(r.count);
+    for (int i = 0; i < r.count; i++) {
+      const auto& k = kanji[i];
+      auto& dst = r.results[i];
+      dst.character = dup(k.character);
+      dst.onyomi = dup(k.onyomi);
+      dst.kunyomi = dup(k.kunyomi);
+      dst.radical = dup(k.radical);
+      dst.strokes = static_cast<int32_t>(k.strokes);
+      dst.dict_name = dup(k.dict_name);
+      dst.meaning_count = static_cast<int32_t>(k.meanings.size());
+      dst.meanings = alloc_array<char*>(dst.meaning_count);
+      for (int j = 0; j < dst.meaning_count; j++) {
+        dst.meanings[j] = dup(k.meanings[j]);
+      }
+      // stat_keys / stat_values 是共用 stat_count 的平行数组，与 frequency 的
+      // values/display_values 同理：任一失败就整对归零，不留「count 非零但有一
+      // 根指针是 null」的状态给 free 路径。
+      dst.stat_count = static_cast<int32_t>(k.stats.size());
+      int32_t key_count = dst.stat_count;
+      dst.stat_keys = alloc_array<char*>(key_count);
+      dst.stat_values = alloc_array<char*>(dst.stat_count);
+      if (key_count != dst.stat_count) {
+        free(dst.stat_keys);
+        free(dst.stat_values);
+        dst.stat_keys = nullptr;
+        dst.stat_values = nullptr;
+        dst.stat_count = 0;
+      }
+      for (int j = 0; j < dst.stat_count; j++) {
+        dst.stat_keys[j] = dup(k.stats[j].first);
+        dst.stat_values[j] = dup(k.stats[j].second);
+      }
     }
-    dst.stat_count = static_cast<int32_t>(k.stats.size());
-    dst.stat_keys = static_cast<char**>(malloc(sizeof(char*) * dst.stat_count));
-    dst.stat_values = static_cast<char**>(malloc(sizeof(char*) * dst.stat_count));
-    for (int j = 0; j < dst.stat_count; j++) {
-      dst.stat_keys[j] = dup(k.stats[j].first);
-      dst.stat_values[j] = dup(k.stats[j].second);
-    }
-  }
-  return r;
+    return r;
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_kanji_results(FfiKanjiResults* r) {
-  if (!r) return;
-  for (int i = 0; i < r->count; i++) {
-    auto& k = r->results[i];
-    free(k.character);
-    free(k.onyomi);
-    free(k.kunyomi);
-    free(k.radical);
-    free(k.dict_name);
-    for (int j = 0; j < k.meaning_count; j++) {
-      free(k.meanings[j]);
+  ffi_guard_void("fushidicts_free_kanji_results", [&]() {
+    if (!r) return;
+    for (int i = 0; i < r->count; i++) {
+      auto& k = r->results[i];
+      free(k.character);
+      free(k.onyomi);
+      free(k.kunyomi);
+      free(k.radical);
+      free(k.dict_name);
+      for (int j = 0; j < k.meaning_count; j++) {
+        free(k.meanings[j]);
+      }
+      free(k.meanings);
+      for (int j = 0; j < k.stat_count; j++) {
+        free(k.stat_keys[j]);
+        free(k.stat_values[j]);
+      }
+      free(k.stat_keys);
+      free(k.stat_values);
     }
-    free(k.meanings);
-    for (int j = 0; j < k.stat_count; j++) {
-      free(k.stat_keys[j]);
-      free(k.stat_values[j]);
-    }
-    free(k.stat_keys);
-    free(k.stat_values);
-  }
-  free(r->results);
+    free(r->results);
+  });
 }
 
 // ── lookup ──────────────────────────────────────────────────────────
@@ -441,7 +583,7 @@ void fushidicts_free_kanji_results(FfiKanjiResults* r) {
 static FfiLookupResults marshal_lookup_results(std::vector<LookupResult>& results) {
   FfiLookupResults r{};
   r.count = static_cast<int32_t>(results.size());
-  r.results = static_cast<FfiLookupResult*>(malloc(sizeof(FfiLookupResult) * r.count));
+  r.results = alloc_array<FfiLookupResult>(r.count);
   for (int i = 0; i < r.count; i++) {
     auto& src = results[i];
     auto& dst = r.results[i];
@@ -449,7 +591,7 @@ static FfiLookupResults marshal_lookup_results(std::vector<LookupResult>& result
     dst.deinflected = dup(src.deinflected);
     dst.preprocessor_steps = src.preprocessor_steps;
     dst.trace_count = static_cast<int32_t>(src.trace.size());
-    dst.trace = static_cast<FfiTransformGroup*>(malloc(sizeof(FfiTransformGroup) * dst.trace_count));
+    dst.trace = alloc_array<FfiTransformGroup>(dst.trace_count);
     for (int j = 0; j < dst.trace_count; j++) {
       dst.trace[j].name = dup(src.trace[j].name);
       dst.trace[j].description = dup(src.trace[j].description);
@@ -461,10 +603,12 @@ static FfiLookupResults marshal_lookup_results(std::vector<LookupResult>& result
 
 FUSHI_EXPORT
 FfiLookupResults fushidicts_lookup(void* handle, const char* text, int32_t max_results, int32_t scan_length) {
-  auto* h = static_cast<FushidictsHandle*>(handle);
-  Lookup lookup(h->query, h->deinflector);
-  auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length));
-  return marshal_lookup_results(results);
+  return ffi_guard("fushidicts_lookup", [&]() -> FfiLookupResults {
+    auto* h = static_cast<FushidictsHandle*>(handle);
+    Lookup lookup(h->query, h->deinflector);
+    auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length));
+    return marshal_lookup_results(results);
+  });
 }
 
 // 上游 bc62d2b/86c6e2f：带排序选项的 lookup。freq_order：0=Auto 1=Ascending
@@ -475,65 +619,73 @@ FUSHI_EXPORT
 FfiLookupResults fushidicts_lookup_with_options(void* handle, const char* text, int32_t max_results,
                                                 int32_t scan_length, const char* freq_dict, int32_t freq_order,
                                                 const char* primary_reading) {
-  auto* h = static_cast<FushidictsHandle*>(handle);
-  Lookup lookup(h->query, h->deinflector);
-  LookupOptions options;
-  if (freq_dict && freq_dict[0] != '\0') {
-    options.frequency_dictionary = std::string(freq_dict);
-  }
-  switch (freq_order) {
-    case 1: options.frequency_order = LookupFrequencyOrder::Ascending; break;
-    case 2: options.frequency_order = LookupFrequencyOrder::Descending; break;
-    case 3: options.frequency_order = LookupFrequencyOrder::Disabled; break;
-    default: options.frequency_order = LookupFrequencyOrder::Auto; break;
-  }
-  if (primary_reading && primary_reading[0] != '\0') {
-    options.primary_reading = std::string(primary_reading);
-  }
-  auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length), options);
-  return marshal_lookup_results(results);
+  return ffi_guard("fushidicts_lookup_with_options", [&]() -> FfiLookupResults {
+    auto* h = static_cast<FushidictsHandle*>(handle);
+    Lookup lookup(h->query, h->deinflector);
+    LookupOptions options;
+    if (freq_dict && freq_dict[0] != '\0') {
+      options.frequency_dictionary = std::string(freq_dict);
+    }
+    switch (freq_order) {
+      case 1: options.frequency_order = LookupFrequencyOrder::Ascending; break;
+      case 2: options.frequency_order = LookupFrequencyOrder::Descending; break;
+      case 3: options.frequency_order = LookupFrequencyOrder::Disabled; break;
+      default: options.frequency_order = LookupFrequencyOrder::Auto; break;
+    }
+    if (primary_reading && primary_reading[0] != '\0') {
+      options.primary_reading = std::string(primary_reading);
+    }
+    auto results = lookup.lookup(text, max_results, static_cast<size_t>(scan_length), options);
+    return marshal_lookup_results(results);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_lookup_results(FfiLookupResults* r) {
-  if (!r) return;
-  for (int i = 0; i < r->count; i++) {
-    free(r->results[i].matched);
-    free(r->results[i].deinflected);
-    for (int j = 0; j < r->results[i].trace_count; j++) {
-      free(r->results[i].trace[j].name);
-      free(r->results[i].trace[j].description);
+  ffi_guard_void("fushidicts_free_lookup_results", [&]() {
+    if (!r) return;
+    for (int i = 0; i < r->count; i++) {
+      free(r->results[i].matched);
+      free(r->results[i].deinflected);
+      for (int j = 0; j < r->results[i].trace_count; j++) {
+        free(r->results[i].trace[j].name);
+        free(r->results[i].trace[j].description);
+      }
+      free(r->results[i].trace);
+      free_term(r->results[i].term);
     }
-    free(r->results[i].trace);
-    free_term(r->results[i].term);
-  }
-  free(r->results);
+    free(r->results);
+  });
 }
 
 // ── styles ──────────────────────────────────────────────────────────
 
 FUSHI_EXPORT
 FfiDictStyles fushidicts_get_styles(void* handle) {
-  FfiDictStyles r{};
-  auto& q = static_cast<FushidictsHandle*>(handle)->query;
-  auto styles = q.get_styles();
-  r.count = static_cast<int32_t>(styles.size());
-  r.items = static_cast<FfiDictStyle*>(malloc(sizeof(FfiDictStyle) * r.count));
-  for (int i = 0; i < r.count; i++) {
-    r.items[i].dict_name = dup(styles[i].dict_name);
-    r.items[i].styles = dup(styles[i].styles);
-  }
-  return r;
+  return ffi_guard("fushidicts_get_styles", [&]() -> FfiDictStyles {
+    FfiDictStyles r{};
+    auto& q = static_cast<FushidictsHandle*>(handle)->query;
+    auto styles = q.get_styles();
+    r.count = static_cast<int32_t>(styles.size());
+    r.items = alloc_array<FfiDictStyle>(r.count);
+    for (int i = 0; i < r.count; i++) {
+      r.items[i].dict_name = dup(styles[i].dict_name);
+      r.items[i].styles = dup(styles[i].styles);
+    }
+    return r;
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_styles(FfiDictStyles* r) {
-  if (!r) return;
-  for (int i = 0; i < r->count; i++) {
-    free(r->items[i].dict_name);
-    free(r->items[i].styles);
-  }
-  free(r->items);
+  ffi_guard_void("fushidicts_free_styles", [&]() {
+    if (!r) return;
+    for (int i = 0; i < r->count; i++) {
+      free(r->items[i].dict_name);
+      free(r->items[i].styles);
+    }
+    free(r->items);
+  });
 }
 
 // ── media ───────────────────────────────────────────────────────────
@@ -545,19 +697,28 @@ struct FfiMediaFile {
 
 FUSHI_EXPORT
 FfiMediaFile fushidicts_get_media(void* handle, const char* dict_name, const char* media_path) {
-  FfiMediaFile r{};
-  auto& q = static_cast<FushidictsHandle*>(handle)->query;
-  auto data = q.get_media_file(dict_name, media_path);
-  r.size = static_cast<int32_t>(data.size());
-  r.data = static_cast<uint8_t*>(malloc(r.size));
-  if (r.data && r.size > 0) memcpy(r.data, data.data(), r.size);
-  return r;
+  return ffi_guard("fushidicts_get_media", [&]() -> FfiMediaFile {
+    FfiMediaFile r{};
+    auto& q = static_cast<FushidictsHandle*>(handle)->query;
+    auto data = q.get_media_file(dict_name, media_path);
+    // size 与 data 同生共死：分配失败时 alloc_array 把 size 归零并返回 nullptr，
+    // 于是「size>0 但 data==nullptr」这个状态压根构造不出来（Dart 侧对它另有一条
+    // 判空分支，但让它永不发生更省事）。媒体文件可以很大，这里的失败很现实。
+    r.size = static_cast<int32_t>(data.size());
+    r.data = alloc_array<uint8_t>(r.size);
+    if (r.data) {
+      memcpy(r.data, data.data(), static_cast<size_t>(r.size));
+    }
+    return r;
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_media(FfiMediaFile* r) {
-  if (!r) return;
-  free(r->data);
+  ffi_guard_void("fushidicts_free_media", [&]() {
+    if (!r) return;
+    free(r->data);
+  });
 }
 
 // ── popup JSON (single source of truth for both FFI and JNI) ───────
@@ -566,17 +727,19 @@ FUSHI_EXPORT
 char* fushidicts_lookup_popup_json(void* handle, const char* text,
                                    int32_t max_results, int32_t scan_length,
                                    int32_t max_terms) {
-  auto* h = static_cast<FushidictsHandle*>(handle);
-  Lookup lookup(h->query, h->deinflector);
-  auto results = lookup.lookup(text, max_results,
-                               static_cast<size_t>(scan_length));
-  std::string json = build_popup_json(results, max_terms);
-  return dup(json);
+  return ffi_guard("fushidicts_lookup_popup_json", [&]() -> char* {
+    auto* h = static_cast<FushidictsHandle*>(handle);
+    Lookup lookup(h->query, h->deinflector);
+    auto results = lookup.lookup(text, max_results,
+                                 static_cast<size_t>(scan_length));
+    std::string json = build_popup_json(results, max_terms);
+    return dup(json);
+  });
 }
 
 FUSHI_EXPORT
 void fushidicts_free_string(char* s) {
-  free(s);
+  ffi_guard_void("fushidicts_free_string", [&]() { free(s); });
 }
 
 } // extern "C"

--- a/native/fushidicts/tests/CMakeLists.txt
+++ b/native/fushidicts/tests/CMakeLists.txt
@@ -58,6 +58,14 @@ add_fushi_test(text_processor_test text_processor_test.cpp
     "${FUSHI_ROOT}/fushidicts_external/utfcpp/source")
 # 弹窗 deinflectionTrace：纯内存，直接喂 LookupResult 给 build_popup_json。
 add_fushi_test(popup_json_deinflection_test popup_json_deinflection_test.cpp)
+# FFI 边界异常闸门覆盖守卫：扫 fushidicts_ffi.cpp 源码，确认每个导出都经过
+# ffi_guard*。漏掉闸门的后果是异常逃出 extern "C" → std::terminate → 进程静默
+# 消失（用户侧：「转圈转一半 app 自己退出，没有报错」），人工 review 兜不住。
+# 走统一的 add_fushi_test 注册（多链一个静态库换来「不会掉出清单守卫」）；
+# 源码路径用编译期宏传入，别依赖 ctest 的工作目录。
+add_fushi_test(ffi_guard_coverage_test ffi_guard_coverage_test.cpp)
+target_compile_definitions(ffi_guard_coverage_test PRIVATE
+    "FUSHI_FFI_SOURCE=\"${FUSHI_ROOT}/fushidicts_ffi.cpp\"")
 # zip64 includes "zip/zip.hpp" -> root at fushidicts_src/.
 add_fushi_test(zip64_central_dir_test zip64_central_dir_test.cpp
     "${FUSHI_SRC}")

--- a/native/fushidicts/tests/ffi_guard_coverage_test.cpp
+++ b/native/fushidicts/tests/ffi_guard_coverage_test.cpp
@@ -1,0 +1,201 @@
+// FFI 边界异常闸门的覆盖守卫。
+//
+// 背景（用户报告：一次性导入很多词典后，点开 app 转圈转一半自己退出、没有任何
+// 报错）：`extern "C"` 不是异常边界。C++ 异常一旦从某个导出函数里逃出去，行为
+// 未定义，实际就是 std::terminate → SIGABRT，**整个进程当场消失**——Dart 侧的
+// try/catch、错误屏、日志落盘全都够不着，所以用户既看不到崩溃提示也拿不到日志。
+// 词典越多，启动时经过 add_*_dict / lookup 的次数越多，撞上 bad_alloc 或
+// filesystem_error 的概率就线性上升，于是「导入太多词典」直接表现为「打不开」。
+//
+// 修复是让 fushidicts_ffi.cpp 里**所有**导出无例外地经过 ffi_guard / ffi_guard_or
+// / ffi_guard_void。而「所有」这个词只有被机器检查时才成立：靠人记得给新导出加
+// try/catch，漏一个就等于这条修复没发生（而且漏的那次同样是静默闪退，最难查）。
+// 这个测试就是那台机器——它读源码，不读行为：
+//
+//   * 每个 FUSHI_EXPORT 的函数体必须出现 ffi_guard*；
+//   * 闸门原语本身必须还在（防「把 ffi_guard 删了但调用点还留着名字」）。
+//
+// 这是源码扫描守卫，不需要链接引擎，但仍走统一的 ctest 注册。
+//
+// Usage: ffi_guard_coverage_test  (no args) -> exit 0 PASS.
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void fail(const std::string& msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg.c_str());
+  ++g_fail;
+}
+
+// 源码路径由 CMake 以 FUSHI_FFI_SOURCE 传入（绝对路径），避免依赖 ctest 的 cwd。
+std::string read_ffi_source() {
+#ifndef FUSHI_FFI_SOURCE
+  fail("FUSHI_FFI_SOURCE not defined by the build");
+  return {};
+#else
+  const std::filesystem::path path(FUSHI_FFI_SOURCE);
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    fail("cannot open " + path.string());
+    return {};
+  }
+  return std::string((std::istreambuf_iterator<char>(in)), {});
+#endif
+}
+
+// 取 [from, to) 内是否出现 needle。
+bool contains(const std::string& hay, size_t from, size_t to, const std::string& needle) {
+  if (from >= hay.size()) return false;
+  if (to > hay.size()) to = hay.size();
+  return hay.find(needle, from) < to;
+}
+
+// 从 `pos` 起找到函数体的起始 '{'，返回其下标；找不到返回 npos。
+//
+// 锚点取「签名里最后一个 ')' 之后的第一个 '{'」而不是「pos 之后的第一个 '{'」：
+// 参数表里出现花括号（默认值、初始化列表）会让后者命中参数表而不是函数体，
+// 那样断言恒真、守卫空转。
+size_t find_body_brace(const std::string& src, size_t pos) {
+  const size_t paren = src.find(')', pos);
+  if (paren == std::string::npos) return std::string::npos;
+  return src.find('{', paren);
+}
+
+// 从函数体起始 '{' 配对到它的 '}'，返回**闭合花括号之后**的位置；不配对返回 npos。
+//
+// 为什么必须精确配对，而不是「从 '{' 往后取固定长度的窗口」：变异实测证明，固定
+// 窗口（试过 400 字符）会越过函数结尾，命中**下一个**函数的 ffi_guard，于是把一个
+// 摘掉闸门的导出判成通过——守卫全程空转还一路 PASS。搜索面必须正好是这个函数体。
+//
+// 字符串/字符字面量与注释里的花括号会骗过朴素配对，所以一并跳过。
+size_t find_body_end(const std::string& src, size_t brace) {
+  int depth = 0;
+  for (size_t i = brace; i < src.size(); ++i) {
+    const char c = src[i];
+    if (c == '/' && i + 1 < src.size()) {
+      if (src[i + 1] == '/') {
+        const size_t nl = src.find('\n', i);
+        if (nl == std::string::npos) return std::string::npos;
+        i = nl;
+        continue;
+      }
+      if (src[i + 1] == '*') {
+        const size_t end = src.find("*/", i + 2);
+        if (end == std::string::npos) return std::string::npos;
+        i = end + 1;
+        continue;
+      }
+    }
+    if (c == '"' || c == '\'') {
+      const char quote = c;
+      ++i;
+      while (i < src.size() && src[i] != quote) {
+        if (src[i] == '\\') ++i;
+        ++i;
+      }
+      continue;
+    }
+    if (c == '{') {
+      ++depth;
+    } else if (c == '}') {
+      if (--depth == 0) return i + 1;
+    }
+  }
+  return std::string::npos;
+}
+
+}  // namespace
+
+int main() {
+  const std::string src = read_ffi_source();
+  if (src.empty()) {
+    std::fprintf(stderr, "FAIL: empty FFI source\n");
+    return 1;
+  }
+
+  // 1) 闸门原语必须存在。删掉它们而调用点还在，编译期就会炸；但删掉其中一个
+  //    重载（比如只留 void 版）会让「有返回值的导出」悄悄失去 fallback 语义。
+  for (const char* primitive : {"static R ffi_guard(", "static R ffi_guard_or(",
+                                "static void ffi_guard_void("}) {
+    if (src.find(primitive) == std::string::npos) {
+      fail(std::string("missing FFI guard primitive: ") + primitive);
+    }
+  }
+
+  // 2) 每个导出的函数体都必须走闸门。
+  const std::string kExport = "FUSHI_EXPORT";
+  std::vector<std::string> guarded;
+  size_t pos = 0;
+  size_t exports = 0;
+  while ((pos = src.find(kExport, pos)) != std::string::npos) {
+    // 跳过宏定义/注释里出现的 FUSHI_EXPORT（本文件里没有，但别让守卫脆在这上面）。
+    const size_t line_start = src.rfind('\n', pos);
+    const std::string line_prefix =
+        src.substr(line_start == std::string::npos ? 0 : line_start + 1,
+                   pos - (line_start == std::string::npos ? 0 : line_start + 1));
+    if (line_prefix.find("//") != std::string::npos ||
+        line_prefix.find('#') != std::string::npos) {
+      pos += kExport.size();
+      continue;
+    }
+
+    ++exports;
+    const size_t brace = find_body_brace(src, pos + kExport.size());
+    if (brace == std::string::npos) {
+      fail("cannot locate function body after a FUSHI_EXPORT");
+      pos += kExport.size();
+      continue;
+    }
+
+    // 取函数名（签名里 '(' 之前的那个标识符）用于报错定位。
+    const size_t paren = src.find('(', pos + kExport.size());
+    size_t name_end = paren;
+    while (name_end > 0 && (src[name_end - 1] == ' ' || src[name_end - 1] == '\n' ||
+                            src[name_end - 1] == '\r')) {
+      --name_end;
+    }
+    size_t name_start = name_end;
+    while (name_start > 0 &&
+           (isalnum(static_cast<unsigned char>(src[name_start - 1])) || src[name_start - 1] == '_')) {
+      --name_start;
+    }
+    const std::string name = src.substr(name_start, name_end - name_start);
+
+    const size_t body_end = find_body_end(src, brace);
+    if (body_end == std::string::npos) {
+      fail("unbalanced braces in the body of " + name);
+      pos = brace;
+      continue;
+    }
+    if (!contains(src, brace, body_end, "ffi_guard")) {
+      fail("exported function does not go through the FFI guard: " + name);
+    } else {
+      guarded.push_back(name);
+    }
+    // 从函数体结尾继续扫，别让下一轮又从本函数体内部起步。
+    pos = body_end;
+  }
+
+  if (exports == 0) {
+    fail("found no FUSHI_EXPORT functions -- the scan anchor drifted");
+  }
+  // 下界防「有人把导出删到只剩两个，守卫照样绿」。当前是 23 个；只在**减少**时报警。
+  if (exports < 20) {
+    fail("suspiciously few exports found (" + std::to_string(exports) +
+         "); the FUSHI_EXPORT anchor probably drifted");
+  }
+
+  if (g_fail == 0) {
+    std::printf("PASS: all %zu exported FFI entry points go through the guard\n", exports);
+    return 0;
+  }
+  std::fprintf(stderr, "%d check(s) failed\n", g_fail);
+  return 1;
+}

--- a/packages/fushi_dictionary/lib/src/engine/dictionary.dart
+++ b/packages/fushi_dictionary/lib/src/engine/dictionary.dart
@@ -4,6 +4,25 @@ import '../language/language.dart';
 
 enum DictionaryType { term, frequency, pitch, kanji }
 
+/// [Dictionary.metadata] 里记录「启动期类型自愈探测已经做过了」的键。
+///
+/// 为什么需要一个显式的键，而不是从 `hasKanji` 之类的结果反推：反推会把「没探测过」
+/// 和「探测过、结果是什么都不用改」压成同一个状态（都表现为「没有标记」）。启动期
+/// 的自愈逻辑于是只能对每一本**每次启动都重探一遍**——而 kanji 词典的探测是把整张
+/// hash 表扫完、逐槽随机跳读 blobs.bin，纯 kanji 词典还永远触发不了「term+kanji 都
+/// 找到」的提前退出条件，所以扫的是全表。手机冷缓存下这就是每本几万次随机页访问，
+/// 词典一多，启动直接卡死在这里（用户报告：一次性导入很多词典后 app 打不开）。
+///
+/// 把「探测过」变成一等状态后，每本词典一生只探一次；导入路径更是连一次都不用探
+/// （native 导入时已经数过 term/kanji 记录，结果直接写进来）。
+///
+/// 值是**探测器版本号**而不是 `'true'`：将来探测逻辑改了，只要 bump
+/// [kDictTypeProbeVersion]，存量词典就会自动重探一轮，而不必再发明一个新键。
+const String kDictTypeProbeKey = 'typeProbe';
+
+/// 当前类型探测器的版本。改探测语义时 +1（见 [kDictTypeProbeKey]）。
+const String kDictTypeProbeVersion = '1';
+
 class Dictionary {
   factory Dictionary.fromJson(String json) {
     final map = Map<String, dynamic>.from(jsonDecode(json));
@@ -78,6 +97,12 @@ class Dictionary {
     }
     return null;
   }
+
+  /// 启动期类型自愈探测是否已经对这本词典做过（且是当前版本的探测器）。
+  ///
+  /// false = 需要探一次（老词典、或探测器版本 bump 后的存量）。见
+  /// [kDictTypeProbeKey] 里关于「为什么不能从探测结果反推」的说明。
+  bool get isTypeProbed => metadata[kDictTypeProbeKey] == kDictTypeProbeVersion;
 
   bool isHidden(Language language) {
     return hiddenLanguages.contains(language.languageCode);

--- a/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
+++ b/packages/fushi_dictionary/lib/src/engine/fushidicts.dart
@@ -330,12 +330,28 @@ class FushiDicts {
   /// （清空全部词典会逐本调一次）。
   static int _loadedDictCount = 0;
 
+  /// 已排期但还没装载的词典集合（null = 引擎与元数据一致，没有待办）。
+  ///
+  /// 为什么要有这个「待办」而不是每次写元数据就地重建：重建 = 卸掉全部词典的
+  /// 文件映射再逐本重新装回来，代价与**当前总词典数**成正比。而写元数据是逐本
+  /// 发生的——批量导入 N 本就写 N 次，启动期的类型自愈也是逐本写——于是总代价
+  /// 变成 O(N²)：导第 100 本时要把前 99 本卸了再装回去。词典一多，导入越来越慢，
+  /// 启动更是直接卡死（用户报告：一次性导入很多词典后 app 打不开）。
+  ///
+  /// 排期后重建**只发生在真正要用引擎之前**（见 [instance] / [dictionaryStyles]）。
+  /// 批量写入期间没人查词，于是 N 次排期塌成 1 次重建，而且不需要任何调用方声明
+  /// 「我是批量的」——少写一个声明就退化回 O(N²) 的设计不算修好。
+  static _PendingDicts? _pending;
+
   static FushiDicts get instance {
+    _applyPendingIfAny();
     assert(_instance != null, 'FushiDicts.initialize() must be called first');
     return _instance!;
   }
 
-  static bool get isInitialized => _instance != null;
+  /// 引擎是否可用。有待办时同样算已初始化：待办本身就说明词典集合已知，
+  /// 调用方接着就会经 [instance] 触发结算。
+  static bool get isInitialized => _instance != null || _pending != null;
 
   static List<String>? _cachedTransformJsons;
 
@@ -369,7 +385,14 @@ class FushiDicts {
     }
   }
 
+  /// 旧的扁平装载 API（每条路径同时进 term/freq/pitch 三桶）：立刻生效。
+  ///
+  /// 与 [initializeTyped] 一样属于「立刻」一族，所以同样要清掉待办并推进代次
+  /// ——否则它装完之后，下一次访问 [instance] 会把一份陈旧的待办重放上来，把刚
+  /// 装好的集合盖掉。
   static void initialize(List<String> paths) {
+    _pending = null;
+    _generation++;
     _instance?.dispose();
     final h = FushiDicts();
     h._loadCachedTransforms();
@@ -383,12 +406,135 @@ class FushiDicts {
     _rebuildStylesCache();
   }
 
+  /// **立刻**把引擎重建成给定集合（卸掉旧映射 + 逐本装载）。
+  ///
+  /// 只在「必须马上生效」时用：删词典目录前后（[releaseAllMappings] / BUG-1756，
+  /// 文件映射不释放就删不掉文件），以及测试。**写元数据的路径请用 [scheduleTyped]**
+  /// ——那条路是逐本触发的，就地重建会把总代价推成 O(N²)。
   static void initializeTyped({
     List<String> termPaths = const [],
     List<String> freqPaths = const [],
     List<String> pitchPaths = const [],
     List<String> kanjiPaths = const [],
   }) {
+    _pending = null;
+    _applyTyped(termPaths, freqPaths, pitchPaths, kanjiPaths);
+  }
+
+  /// 排期一次引擎重建：只记下目标集合，真正装载推迟到下一次要用引擎时
+  /// （[instance] / [dictionaryStyles] / [loadPendingNow]）。见 [_pending]。
+  ///
+  /// 连续排期只保留最后一次——中间那些集合从来没被任何人观察到，装了也是白装。
+  static void scheduleTyped({
+    List<String> termPaths = const [],
+    List<String> freqPaths = const [],
+    List<String> pitchPaths = const [],
+    List<String> kanjiPaths = const [],
+  }) {
+    _pending = _PendingDicts(
+      termPaths: termPaths,
+      freqPaths: freqPaths,
+      pitchPaths: pitchPaths,
+      kanjiPaths: kanjiPaths,
+    );
+    _generation++;
+  }
+
+  /// 主动结算待办（如果有）。给「知道自己接下来会用引擎、且希望装载成本落在此处
+  /// 而不是落在某次用户查词里」的调用方用，比如启动流程。
+  static void loadPendingNow() => _applyPendingIfAny();
+
+  /// 是否还有没结算的待办。测试与启动流程用来断言「引擎已经跟上元数据」。
+  static bool get hasPendingDicts => _pending != null;
+
+  /// 测试观察点：当前待办里的 term 路径（无待办时为空）。只读，不触发结算。
+  @visibleForTesting
+  static List<String> debugPendingTermPathsForTest() =>
+      List<String>.unmodifiable(_pending?.termPaths ?? const <String>[]);
+
+  /// 测试收尾：丢掉待办而**不**装载它。用来隔离用例间的静态状态——直接调
+  /// [loadPendingNow] 会真的去装载路径，那需要 native 库。
+  @visibleForTesting
+  static void dropPendingForTest() {
+    _pending = null;
+    _generation++;
+  }
+
+  /// 装载代次。每次排期或立刻装载都 +1，用来判定一次进行中的异步装载是否已经
+  /// 被更新的意图取代（见 [loadPendingAsync]）。
+  static int _generation = 0;
+
+  /// **分批让出**地结算待办：每装一本就把控制权交回事件循环一次。
+  ///
+  /// 为什么启动路径必须走这条而不是 [loadPendingNow]：装载是同步 FFI，一口气装
+  /// N 本就是 N 本的时间里主 isolate 完全不动——首帧画不出来，更要命的是**所有
+  /// Timer 都不会触发**，于是 `AppModel` 的 12 秒启动 IO 超时和 `main.dart` 的
+  /// 20 秒「加载太久」逃生 UI 双双失效：两层看门狗都是 Timer，被同步代码堵住的
+  /// 事件循环根本轮不到它们。用户那边看到的就是一直转圈、没有任何逃生口。
+  /// 每本之间让出后，装载再慢也只是慢，看门狗照常计时、UI 照常响应。
+  ///
+  /// 让出必须用 [Future.delayed] 而不是 `await null`：后者只让到 microtask 队列，
+  /// Timer 回调排在 event 队列，microtask 让出救不了看门狗。
+  ///
+  /// 装载在**影子实例**上进行，全部装完才原子替换 [_instance]：让出期间落进来的
+  /// 查词看到的是完整的旧集合，而不是装到一半的半成品。若让出期间有人排了新的
+  /// 集合（或直接同步装载过），本次结果按代次作废并丢弃——最后一次意图说了算。
+  static Future<void> loadPendingAsync() async {
+    final _PendingDicts? pending = _pending;
+    if (pending == null) return;
+    _pending = null;
+    final int generation = _generation;
+
+    final FushiDicts shadow = FushiDicts();
+    shadow._loadCachedTransforms();
+    Future<void> loadAll(
+        List<String> paths, void Function(String) add) async {
+      for (final String p in paths) {
+        add(p);
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    await loadAll(pending.termPaths, shadow.addTermDict);
+    await loadAll(pending.freqPaths, shadow.addFreqDict);
+    await loadAll(pending.pitchPaths, shadow.addPitchDict);
+    await loadAll(pending.kanjiPaths, shadow.addKanjiDict);
+
+    if (generation != _generation) {
+      // 让出期间意图变了：丢掉这份成果（连同它持有的文件映射），别把已经过时的
+      // 集合盖回引擎上。新意图会由它自己的结算路径装载。
+      shadow.dispose();
+      return;
+    }
+
+    _instance?.dispose();
+    _instance = shadow;
+    _loadedDictCount = pending.termPaths.length +
+        pending.freqPaths.length +
+        pending.pitchPaths.length +
+        pending.kanjiPaths.length;
+    _rebuildStylesCache();
+  }
+
+  static void _applyPendingIfAny() {
+    final _PendingDicts? pending = _pending;
+    if (pending == null) return;
+    // 先清待办再装载：装载过程若抛异常，待办不该留在原地被下一次访问重放一遍
+    // （同一份坏数据会把每一次查词都变成一次全量重建尝试）。
+    _pending = null;
+    _applyTyped(pending.termPaths, pending.freqPaths, pending.pitchPaths,
+        pending.kanjiPaths);
+  }
+
+  static void _applyTyped(
+    List<String> termPaths,
+    List<String> freqPaths,
+    List<String> pitchPaths,
+    List<String> kanjiPaths,
+  ) {
+    // 同步装载同样算一次新意图：进行中的 [loadPendingAsync] 会据此作废自己的成果，
+    // 不把过时集合盖回来。
+    _generation++;
     _instance?.dispose();
     final h = FushiDicts();
     h._loadCachedTransforms();
@@ -417,6 +563,7 @@ class FushiDicts {
   }
 
   static void disposeInstance() {
+    _pending = null;
     _instance?.dispose();
     _instance = null;
     _loadedDictCount = 0;
@@ -434,11 +581,17 @@ class FushiDicts {
   /// 用「重建成空引擎」而不是 [disposeInstance]：`_instance` 始终非 null，释放到
   /// 重新加载之间落进来的查词退化成空结果，而不是撞 `_instance!` 的 null check。
   static void releaseAllMappings() {
+    // 待办也要一起清：留着它，删完目录后任何一次查词都会把「含已删词典」的那份
+    // 排期重放回引擎，等于映射又长回来了。
+    _pending = null;
     if (_instance == null || _loadedDictCount == 0) return;
     initializeTyped();
   }
 
-  static Map<String, String> get dictionaryStyles => _stylesCache;
+  static Map<String, String> get dictionaryStyles {
+    _applyPendingIfAny();
+    return _stylesCache;
+  }
 
   static void _rebuildStylesCache() {
     if (_instance == null) {
@@ -776,4 +929,22 @@ class FushiDicts {
       h.dispose();
     }
   }
+}
+
+/// [FushiDicts.scheduleTyped] 排下的待装载词典集合（不可变快照）。
+///
+/// 分四桶而不是一张扁平表：装载时每桶走不同的 native 入口（term/freq/pitch/kanji
+/// 各有自己的索引），合成一张表就得在结算时再分一次，白丢已经算好的信息。
+class _PendingDicts {
+  const _PendingDicts({
+    required this.termPaths,
+    required this.freqPaths,
+    required this.pitchPaths,
+    required this.kanjiPaths,
+  });
+
+  final List<String> termPaths;
+  final List<String> freqPaths;
+  final List<String> pitchPaths;
+  final List<String> kanjiPaths;
 }


### PR DESCRIPTION
用户报告：手机上一次性导入太多词典后，点 Fushi 一直转圈进不去、没有任何报错；转到一半应用自己退出。

沿启动的词典装载链追下来，有**四处**与词典数量成正比的缺陷，全部做根因修复（BUG-2110）。

## ① FFI 边界没有异常闸门 → 加统一闸门原语

`extern "C"` 不是异常边界：C++ 异常从导出函数逃出去 = `std::terminate` → SIGABRT → **进程当场消失**。Dart 侧的 try/catch、错误屏、日志落盘全都够不着——这正是「转圈转一半自己退出、没有任何报错」这个症状里「没有报错」的那一半。改之前 23 个 `FUSHI_EXPORT` 里只有 `fushidicts_import` 一个带 try，而词典越多，启动经过 `add_*_dict` / `lookup` 的次数越多，撞上 `bad_alloc` / `filesystem_error` 的概率线性上升。

治法不是给每个导出各贴一段 try/catch（漏一个就复发），而是加 `ffi_guard` / `ffi_guard_or` / `ffi_guard_void` 让**所有**导出无例外经过：异常在闸门里记日志并返回零值结果，Dart 侧走既有的空结果分支。单本词典加载失败现在只是这本不进引擎，其余照常可用。

同一现场还有一批不检查返回值的 `malloc`：失败后照样往 null 指针里写就是 SIGSEGV，同样静默，而低内存正是本类崩溃的现场条件。收进 `alloc_array` 后「count 说有 N 条但指针是 null」这个状态不可能再被构造出来。

## ② 每本 kanji 词典每次启动都被全表重扫 → 一生只探一次

`probe_dict_content` 把整张 hash 表扫完、逐槽随机跳读 `blobs.bin`，早停条件是「term + kanji 都找到」，纯 kanji 词典永远凑不齐，扫的就是全表。而旧实现**只在需要改判类型时**才写 metadata，于是「没探过」和「探过、结论是不用改」在数据上不可区分，每次启动重来一遍。

新增 `kDictTypeProbeKey` / `kDictTypeProbeVersion` 把「探过」变成一等状态，探测结果无论是否改判都落库；导入路径直接写标记（native 导入时已数过 term/kanji 记录）。存量词典第二次启动起零 IO。值存版本号而不是 `'true'`，将来改探测语义 bump 版本即可自动重探。

顺带修掉自愈迁移丢 `languageOverride` 的老问题：两条重建分支都没传这个字段，被自愈碰过的词典会丢掉用户手动指定的内容语言。

## ③ 写一次词典元数据就全量重建一次引擎（O(N²)）→ 排期 + 用前结算

重建 = 卸掉全部词典的映射再逐本装回，代价与总词典数成正比；而写元数据是逐本发生的，于是导第 100 本要把前 99 本卸了再装回去。

`scheduleTyped` 只记下目标集合，装载推迟到 `instance` / `dictionaryStyles` 被访问时。批量写入期间没人查词，N 次排期塌成 1 次装载——**且不依赖任何调用方声明「我是批量的」**，少写一个声明就退化回 O(N²) 的设计不算修好。删词典目录路径不受影响：它走的是 `releaseAllMappings()`（立刻卸载映射，现在连待办一起清），`reloadEngine` 只负责删完装回，排期即可。

## ④ 装载与预热同步阻塞主 isolate，两层看门狗因此失效 → 分批让出

`AppModel` 的 12 秒启动 IO 超时和 `main.dart` 的 20 秒「加载太久」逃生 UI 都是 Timer，被同步 FFI 堵住的事件循环根本轮不到它们——于是「慢」变成「无逃生口地卡死」，正是用户看到的一直转圈。

`loadPendingAsync` 每装一本让出一次（用 `Future.delayed` 而非 `await null`，microtask 让出救不了 Timer），装载在**影子实例**上进行、装完才原子替换，让出期间的查词看到的是完整旧集合而不是半成品；并发排期按代次作废，最后一次意图说了算。启动预热的三次同步 lookup 改为等首帧之后、串行 + 每次之间让出。

## 测试

新增：
- `native/fushidicts/tests/ffi_guard_coverage_test.cpp` — 每个 `FUSHI_EXPORT` 的函数体（**精确花括号配对**）必须走闸门；闸门原语必须存在；导出数量下界防锚点漂移。已注册进 ctest 并登记进 `native_test_harness_guard_test.dart` 的清单，掉不出 CI。
- `fushi/test/models/dict_engine_pending_load_test.dart` — 排期只排不装、连续排期只保留最后一次、空集合同样排期（BUG-171）、`releaseAllMappings` / `disposeInstance` 连待办一起清、`isInitialized` 覆盖「已排期未装」。
- `fushi/test/dictionary/dict_type_probe_marker_test.dart` — 标记语义（缺席/旧版本/垃圾值都要重探、与 `hasKanji` 互不反推）+ JSON 往返。

更新既有守卫锚点：`dictionary_delete_engine_reload_guard_test`（认排期与立刻两种表达，并新增「启动路径必须自己结算」断言）、`mixed_dict_reclassify_guard_test`（新增「探测结果必须落库」断言）。

**变异实测**：摘掉一个导出的闸门 / 让 `scheduleTyped` 不覆盖已有待办，对应断言都会红并准确点名。第一版 FFI 守卫用固定 400 字符窗口，变异下仍 PASS——窗口越过函数结尾命中了下一个函数的闸门，已改成精确配对。

## 验证

- `flutter analyze`：No issues found
- native ctest：28/28 通过（含新守卫）
- 全量：`FLUTTER TEST VERDICT: PASSED - 22553 tests ran, all tests passed`
- 合并后必跑的 51 条目录枚举型守卫：`PASSED - 362 tests ran`（与文档当前基线 362 吻合，无漂移）

## 还没定性的一半

「native abort」与「Android 低内存杀进程」在用户视角完全一样（都是无提示消失），彻底定性需要复现时的一份 `adb logcat`（`libfushidicts` / SIGABRT / lowmemorykiller）。本轮修的是**能从代码上确证的**四条缺陷；若日志最终指向 LMK，第 ① 条仍是必要修复——它决定了下次崩溃到底有没有日志可查，但内存占用本身要另开一条。

未在真机复现验证（手上没有那台设备的词典集）。
