### PR TITLE
fix(shortcuts): 快捷键设置页 scope 卡片按通用→页面→设备→弹窗排序（BUG-2117）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1980 条。点号进各自文件。
+> 共 1981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2117](bugs/BUG-2117-shortcut-scope-order.md) | ✅ | ✅ | 快捷键设置页 scope 卡片顺序是枚举累加顺序而非通用→页面→设备 |
 | [BUG-2110](bugs/BUG-2110-dict-mass-import-startup-crash.md) | ✅ | ✅ | 一次性导入大量词典后启动转圈中途闪退 |
 | [BUG-2109](bugs/BUG-2109-recommended-pack-never-deleted.md) | ✅ | ✅ | 推荐包 9.5GB zip 导入后永不删除（清理钩子挂在不再执行的引导页 initState） |
 | [BUG-2107](bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md) | ✅ | ✅ | 引导选本地包走裸 pickFiles：安卓整份复制进 cache，失败静默无提示 |

--- a/docs/bugs/BUG-2117-shortcut-scope-order.md
+++ b/docs/bugs/BUG-2117-shortcut-scope-order.md
@@ -1,6 +1,6 @@
 ## BUG-2117 · 快捷键设置页 scope 卡片顺序是枚举累加顺序而非通用→页面→设备
 - **报告**：2026-09-04（用户：「感觉这个快捷键描述的排版有点问题。阅读器过了之后是首页，然后全局，返回退出，有声书」）
 - **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/shortcut_settings_page.dart:336` 直接 `for (scope in ShortcutScope.values)` 投影卡片，顺序完全由 `fushi/lib/src/shortcuts/shortcut_action.dart:1` 的枚举声明顺序决定；而该枚举是按加入时间累加的（reader / home 最早，global 次之，universal 后插，video / manga / gamepad / globalExternal / dictionaryPopup 依次追加），页面就排成「阅读器 → 首页 → 全局 → 返回·退出 → 有声书 → 视频 → 漫画 → 手柄 → 全局（应用外）→ 查词弹窗」，既不是通用在前也不是按使用频率，纯粹是 git 时间线。scope 没有任何地方按 index 持久化或解析（偏好存名字、`coactiveScopes` 用显式列表、冲突检测不读枚举位置），所以顺序只影响显示。
-- **[x] ① 已修复** — 不另加显示顺序表（那是第二份真相源），直接把枚举声明顺序改成「跨页面通用（global / universal / globalExternal）→ 各页面（home / reader / audiobook / manga / video）→ 输入设备（gamepad）→ 查词弹窗」，并在枚举文档注释里写明「声明顺序就是设置页顺序」。提交 `HASH_FIX`。
+- **[x] ① 已修复** — 不另加显示顺序表（那是第二份真相源），直接把枚举声明顺序改成「跨页面通用（global / universal / globalExternal）→ 各页面（home / reader / audiobook / manga / video）→ 输入设备（gamepad）→ 查词弹窗」，并在枚举文档注释里写明「声明顺序就是设置页顺序」。提交 `ff4521c33d`。
 - **[x] ② 已加自动化测试** — `fushi/test/shortcuts/shortcut_scope_order_test.dart`：`orderedEquals` 钉住全序，新增 scope 必须落进对应分组而不是追加到末尾（已变异实测：交换 home / reader 即红）。
 - **备注**：`visual_settings_page_guard_test` 要求页面必须遍历 `ShortcutScope.values`，本修复与之兼容。

--- a/docs/bugs/BUG-2117-shortcut-scope-order.md
+++ b/docs/bugs/BUG-2117-shortcut-scope-order.md
@@ -1,0 +1,6 @@
+## BUG-2117 · 快捷键设置页 scope 卡片顺序是枚举累加顺序而非通用→页面→设备
+- **报告**：2026-09-04（用户：「感觉这个快捷键描述的排版有点问题。阅读器过了之后是首页，然后全局，返回退出，有声书」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/shortcut_settings_page.dart:336` 直接 `for (scope in ShortcutScope.values)` 投影卡片，顺序完全由 `fushi/lib/src/shortcuts/shortcut_action.dart:1` 的枚举声明顺序决定；而该枚举是按加入时间累加的（reader / home 最早，global 次之，universal 后插，video / manga / gamepad / globalExternal / dictionaryPopup 依次追加），页面就排成「阅读器 → 首页 → 全局 → 返回·退出 → 有声书 → 视频 → 漫画 → 手柄 → 全局（应用外）→ 查词弹窗」，既不是通用在前也不是按使用频率，纯粹是 git 时间线。scope 没有任何地方按 index 持久化或解析（偏好存名字、`coactiveScopes` 用显式列表、冲突检测不读枚举位置），所以顺序只影响显示。
+- **[x] ① 已修复** — 不另加显示顺序表（那是第二份真相源），直接把枚举声明顺序改成「跨页面通用（global / universal / globalExternal）→ 各页面（home / reader / audiobook / manga / video）→ 输入设备（gamepad）→ 查词弹窗」，并在枚举文档注释里写明「声明顺序就是设置页顺序」。提交 `HASH_FIX`。
+- **[x] ② 已加自动化测试** — `fushi/test/shortcuts/shortcut_scope_order_test.dart`：`orderedEquals` 钉住全序，新增 scope 必须落进对应分组而不是追加到末尾（已变异实测：交换 home / reader 即红）。
+- **备注**：`visual_settings_page_guard_test` 要求页面必须遍历 `ShortcutScope.values`，本修复与之兼容。

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -1,6 +1,8 @@
+/// 声明顺序**就是**快捷键设置页的卡片顺序（页面直接遍历 `values`，不另存一份
+/// 显示顺序表）：跨页面通用（global / universal / globalExternal）→ 各页面
+/// （home / reader / audiobook / manga / video）→ 输入设备（gamepad）→ 查词弹窗。
+/// 没有任何地方按 index 持久化或解析 scope，调整顺序只影响显示。
 enum ShortcutScope {
-  reader,
-  home,
   global,
 
   // 「返回上一级」这一件事的唯一归属地（用户拍板：Esc 一键从任何界面退一层，
@@ -21,22 +23,25 @@ enum ShortcutScope {
   // 组是唯一登记在案的有意例外。
   universal,
 
-  audiobook,
-  video,
-  // 漫画阅读器（mokuro 页图 + OCR 文本层）。与 reader 分开是因为动作集不同：漫画
-  // 没有章节/振假名/有声书，翻页是整页跨页步进而非文字流分页，且左右键要按跨页
-  // 方向（日漫默认 rtl）校正。
-  manga,
-  // TODO-700 T6：摇杆与 dpad 解耦后，dpad 四向成为「可绑触发键」，落在独立的
-  // gamepad 作用域（自成 co-active 组，不与 reader/home 等任何组冲突）。摇杆固定
-  // 做方向焦点移动、永不经注册表，故没有对应 action——只有 dpad 进这个 scope。
-  gamepad,
   // TODO-1066：桌面「app 外全局查词」的系统级触发热键作用域。此 scope 的动作
   // **不经 resolveKeyboard / 页面派发**，而是由 GlobalLookupController 直接读其
   // 绑定注册到操作系统级 hotkey_manager（默认 Ctrl+Alt+D）。它跨页面常驻、不与
   // 任何应用内页面的键盘绑定竞争，故自成独立 co-active 组，冲突检测只扫自己，
   // 绝不与 global/home 等页面 scope 互相牵连。仅桌面（Windows）有意义。
   globalExternal,
+
+  home,
+  reader,
+  audiobook,
+  // 漫画阅读器（mokuro 页图 + OCR 文本层）。与 reader 分开是因为动作集不同：漫画
+  // 没有章节/振假名/有声书，翻页是整页跨页步进而非文字流分页，且左右键要按跨页
+  // 方向（日漫默认 rtl）校正。
+  manga,
+  video,
+  // TODO-700 T6：摇杆与 dpad 解耦后，dpad 四向成为「可绑触发键」，落在独立的
+  // gamepad 作用域（自成 co-active 组，不与 reader/home 等任何组冲突）。摇杆固定
+  // 做方向焦点移动、永不经注册表，故没有对应 action——只有 dpad 进这个 scope。
+  gamepad,
 
   // 查词弹窗内部的导航动作（Yomitan 式「上/下一个词条」）。这些动作**不经
   // resolveKeyboard / 页面派发**：弹窗内容是 WebView，输入事件先到 WebView 的

--- a/fushi/test/shortcuts/shortcut_scope_order_test.dart
+++ b/fushi/test/shortcuts/shortcut_scope_order_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+
+/// BUG-2117：快捷键设置页的卡片顺序就是 [ShortcutScope.values] 的声明顺序
+/// （页面直接遍历 `values`，没有第二份显示顺序表）。此前枚举按加入时间累加，
+/// 页面就排成「阅读器 → 首页 → 全局 → 返回·退出 → 有声书 → …」。这里钉住
+/// 「跨页面通用 → 各页面 → 输入设备 → 查词弹窗」的分组顺序：新增 scope 必须
+/// 落进对应分组，而不是随手追加到末尾。
+void main() {
+  test('BUG-2117: ShortcutScope 声明顺序 = 通用 → 页面 → 设备 → 弹窗', () {
+    expect(
+      ShortcutScope.values,
+      orderedEquals(const <ShortcutScope>[
+        // 跨页面通用
+        ShortcutScope.global,
+        ShortcutScope.universal,
+        ShortcutScope.globalExternal,
+        // 各页面（首页 → 阅读器及其有声书 → 漫画 → 视频）
+        ShortcutScope.home,
+        ShortcutScope.reader,
+        ShortcutScope.audiobook,
+        ShortcutScope.manga,
+        ShortcutScope.video,
+        // 输入设备
+        ShortcutScope.gamepad,
+        // 查词弹窗
+        ShortcutScope.dictionaryPopup,
+      ]),
+    );
+  });
+}


### PR DESCRIPTION
## 问题
快捷键设置页的 scope 卡片顺序是「阅读器 → 首页 → 全局 → 返回·退出 → 有声书 → 视频 → 漫画 → 手柄 → 全局（应用外）→ 查词弹窗」——页面直接遍历 `ShortcutScope.values`，而枚举是按加入时间累加的，顺序纯粹是 git 时间线。BUG-2117。

## 修复
- `ShortcutScope` 枚举声明顺序改成「跨页面通用（global / universal / globalExternal）→ 各页面（home / reader / audiobook / manga / video）→ 输入设备（gamepad）→ 查词弹窗」，枚举文档注释写明「声明顺序就是设置页顺序」。
- 不另加显示顺序表（第二份真相源）。scope 没有任何地方按 index 持久化或解析（偏好存名字、`coactiveScopes` 显式列表、冲突检测不读枚举位置），改顺序只影响显示。

## 测试
- 新增 `fushi/test/shortcuts/shortcut_scope_order_test.dart` 钉住全序；变异实测：交换 home / reader 即红。
- `flutter analyze` 无问题；`test/shortcuts` 全目录 + `shortcut_settings_entry_test` + `shortcut_unmapped_row_clickable_test` 共 614 条全绿（VERDICT 行）。
- `dart tool/bug.dart check` 通过，BUG-2117 未撞号。

https://claude.ai/code/session_01NXNnNxfFP6QT6st45u7PyH
