### PR TITLE
feat(galgame): CMVS（Purple Software）adapter 骨架——结构身份 + LunaHook 文本 + DirectSound PCM，implemented_unverified

### DIFF
--- a/docs/plans/2026-09-04-gal-ceshi-batch-cmvs.md
+++ b/docs/plans/2026-09-04-gal-ceshi-batch-cmvs.md
@@ -1,0 +1,62 @@
+# 计划与台账：ceshi 批量适配 · CMVS（Purple Software / クロノクロック 体験版v2）
+
+日期：2026-09-04。分支 `worktree-gal-cmvs-chronoclock`（base `origin/develop@4128d7c420`，**不**堆叠在 KiriKiri 两条分支上——CMVS 与它们没有共享改动）。
+上一批：KiriKiri Z tenshi_sz（PR #1205）、经典 KAG3 Fate RN（`2026-09-04-gal-ceshi-batch-classic-kag3.md`，BUG-2116/2118/2121）。
+
+## 用户验收标准（不变）
+
+1. 高通用性；一引擎一任务、一独立 worktree。
+2. 游戏内查词：单击字形弹卡；悬浮 + Shift 弹卡。
+3. 悬浮字有高亮块；点击后整个词在台词里保持高亮，卡片收起后回到悬浮高亮。
+4. 点卡片外关闭卡片时台词不推进。
+5. 制卡带视频（动图覆盖整句）+ 整句音频（按句从游戏资源直提，不是系统混音）。
+6. 尽量不看 hook 代码；真正的 hook 缺口必须修，不能用降级冒充。
+7. 窗口模式与全屏各验一次。
+
+## 样本身份（SOP §2，静态，2026-09-04，桌面被占用未启动游戏）
+
+| 类别 | 事实 |
+|---|---|
+| 样本 | `chronoclock-trial\クロノクロック・体験版v2\`（目录名在本机以 CP932→GBK 乱码显示，路径本身可用），Purple Software クロノクロック 体験版 v2.00（2015-03-20，`update.log` UPDATE_VER=1.00） |
+| exe | `cmvs32.exe` x86 sha256 `c5e715d98b56468df0a3d6bd8ec263b72bab736e0ad004de4e443a54c470ddad`（1.7 MB，段 `.text/_TEXT64/.rdata/.data/.rsrc`）；`cmvs64.exe` x64 sha256 `aa89205a61c7078a167f9e6668eea2e4328bdd5c9cbcdd6f45b238cf475acea2`（1.2 MB）。两者并列、无启动器，原始路径 = 用户双击任一。另有 `cmvsConfig32/64.exe` 设置器 |
+| 模块 | `mog2x32.dll` sha256 `6b8dc960f581963bae671ebab81832df0e39a43656875eb65a6b547df1faaf70`、`mog2x64.dll` `c51ba0c33e0153492b6cb2688701b35f0ddae309828fc21a7631ac54abb5b205`（Purple MOG2 图像库，exe 静态导入） |
+| imports | ADVAPI32 / COMDLG32 / GDI32 / IMM32 / KERNEL32 / MSACM32 / SHELL32 / USER32 / VERSION / **WINMM** / **DSOUND**（x86 版）/ d3d9 / d3dx9_24..42（动态挑版本）/ dinput8 / mog2x*。音频 API 只有 DirectSound |
+| 资源 | `data\pack\*.cpz` 14 个，全部 **CPZ6** 魔数（`voice.cpz` 41.9 MB + `voice2.cpz` 13.9 MB = 语音；`script.cpz` 0.8 MB；`se.cpz`）；`data\pack\start.ps3`（`PS2A` 脚本入口）；`data\music\*.ogg` 明文 BGM；`data\video\*.cmv` |
+| 配置 | `cmvs.cfg` 首节 `[CMVS_SYSTEM_MAIN]`、`SCRIPT_INIT_PATH=data\pack\`；`initial.cfg` `[CMVS_INIT_CFG]` TITLE/REG=`Purplesoftware\chronoclocktr` |
+| 文本层候选 | vendored LunaHook32/64 均含 `EmbedCMVS`（32 位另有 `EmbedCMVS_2`）引擎钩 → `luna_hook` candidate |
+| 音频层候选 | DirectSound 源 PCM（`GenericWindowsAudioAdapter`，引擎无关）→ `xaudio2_or_directsound_pcm` candidate；逐句资源需在 CPZ6 解密读取后取字节，位置只能真机定 |
+| 脱敏 probe 包 | worktree `native/galgame_hook/build/probes/chronoclock{32,64}.zip`（不入库） |
+
+## 本轮交付（静态，implemented_unverified）
+
+- `galhook.ps1 new cmvs --fushi-root` 生成骨架并登记 registry 片段（`generated/*.inc`、CMake、admission 汇总）。
+- `hook/adapters/cmvs_profile.h`：结构身份 = exe 同级 `cmvs.cfg` 前 256 字节含 `[CMVS_SYSTEM_MAIN]` **且** `data\pack\*.cpz` 至少一个 `CPZ` 魔数；两样缺一不匹配。`MatchesCmvsLayout(dir)` 接目录参数供测试；exe 名/哈希只入台账不做判据（Purple 正式版会改 exe 名）。
+- `hook/adapters/cmvs_adapter.inc`：id `cmvs`，capabilities `kText | kPcmAudio`，不自带 hook（文本交 LunaHook EmbedCMVS，PCM 交通用 DirectSound 适配器），`install()` 只表示身份成立。查词传感器未做（admission 默认 EngineUnsupported）。
+- `profiles/cmvs.json`：两 exe + 两 dll 哈希、text/pcm true、resource false、real_sample 证据。
+- `engine-support.yaml` 新增 `cmvs` 条目（detection 七项均带 real_sample 证据；text luna_hook / audio directsound_pcm + loopback 均 implemented_unverified；三条 known_limitations），`docs/engine-support.md` 由生成器重生成。
+- 测试：`tests/cmvs_adapter_test.cpp` 真临时目录四种布局（完整含 BOM+空行前缀 → 匹配；只 cfg / 后缀对魔数错 / 节名错 → 不匹配）+ 进程级为假；变异实测（魔数判据改恒真 → 用例 3 红，还原绿）。`fushi/test/mining/cmvs_pairing_test.dart` + fixture（生成器骨架，钉 unverified）。
+
+## 验证记录（2026-09-04）
+
+- `adapter_structure_test` 38 / `engine_support_manifest_test` 22 / `galhook_workflow_test` 6 / `evidence_contract_test` 16 / `assert_liveness_guard_test` 2 / `lookup_presenter_wiring_guard_test` 33 / `kirikiri_lookup_source_guard_test` 126 全 OK；`generate_engine_support --check` / `generate_luna_profiles --check` OK。
+- `tools/build_distribution.ps1` exit 0（19:13）：`voice_hook_x86.zip` sha256 `276e2787dca29d29c1d7d4a5bacc6a0644b77e316df7a89ece440c25a75d4c44`、`voice_hook_x64.zip` `628cc8c8c055567b587ee588b146bf9878cb10d2fe04569922ee2fa7894dd185`；ctest x64 56/56、x86 56/56；`fushi_cmvs_adapter_test` 两架构直跑 ok。
+- `flutter test test/mining/cmvs_pairing_test.dart --no-pub` 1/1（冷 worktree 首跑 native assets 失败，带小写 `http_proxy` 重跑即过）；`dart analyze` 该文件无问题。
+- 真机门：**未跑**（用户全程在用桌面）。
+
+## Proved / Not proved / Next gate
+
+- **Proved**：样本静态身份完整；结构身份判据在合成布局上正确且 fail closed；骨架编译进两架构 helper 并进 CTest；manifest 通过证据门。
+- **Not proved**：`process_found → helper_ready → ipc_ready → text_observed（EmbedCMVS 线程）→ pcm_observed（DirectSound）→ paired → card_e2e` 一个都没跑；CPZ6 语音资源层不存在。
+- **Next gate**（桌面空闲时）：把本分支 helper 打进 worktree 构建（`tools/install_into_bundle.ps1`）→ `launch_fushi_iso2.ps1` 隔离实例 → 库内「添加游戏」指向 `cmvs64.exe`（原始路径；x86 版第二轮）→ 启动 → 探针核 `hooked=1`、adapter diagnostics 里 `cmvs probe=1 installed=1` → 工作台看文本线程列表有无 `EmbedCMVS` → 推进到有声句看「游戏资源音频/PCM」是否出 DirectSound 段。第一个不过的边界决定下一轮 native 改动；过了再做验收 2→7（查词传感器 CMVS 未做，预期停在验收 2）。
+
+## 队列其余（本轮盘点更新）
+
+- `manosaba_Ver1.0.3`：已从 4 卷 rar 解压到 `ceshi\manosaba_Ver1.0.3\`（7.0 GB；Unity IL2CPP：`GameAssembly.dll` + `manosaba_Data` + D3D12），走既有 `unity_il2cpp`，只需真机。
+- ceshi 目录里还有交接队列没列的：`STEINS.GATE.REBOOT/`、`[150924][hibiki works] PRETTY×CATION2 …`（未盘点引擎）、`AngelBeats-1st-_TrialEdition_ver1.10.zip`。
+- 其余同 classic-kag3 台账：アマカノ3（artemis_pfs x64）、Sakura Swim Club（Ren'Py 英文）、AngelBeats trial（Siglus）、昨日魔女（Unity 汉化）、ISO 类未挂载。
+
+## 恢复指引
+
+- worktree `D:\APP\vs_claude_code\hibiki\.claude\worktrees\gal-cmvs-chronoclock`，分支 `worktree-gal-cmvs-chronoclock`（基底 develop，可独立开 PR）。
+- 脚本：`C:\Users\wrds\.claude\jobs\81491d86\tmp\{build_cmvs,guards_cmvs,mutate_cmvs}.sh`、身份脚本 `cc_identity.py`；真机驱动沿用 `C:\Users\wrds\.claude\jobs\a188f70d\tmp\launch_fushi_iso2.ps1` + `C:\Users\wrds\.claude\jobs\3f9f84ac\tmp\drive\galdrive.ps1`。
+- 构建坑同前：bash 里 unset 小写代理再跑 `build_distribution.ps1`；`flutter test` 反过来要小写 `http_proxy` 才能下 native assets；`setup_worktree.ps1` 在 PowerShell 里要先把 `C:\Program Files\Git\bin` 加进 PATH（apply-patches 调 bash）。

--- a/fushi/test/fixtures/galhook/cmvs_replay.json
+++ b/fushi/test/fixtures/galhook/cmvs_replay.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "engine_id": "cmvs",
+  "status": "implemented_unverified",
+  "config": {
+    "selected_thread": 7,
+    "duplicate_window_ms": 1000,
+    "audio_priority": ["resource_audio", "pcm", "loopback"],
+    "resource_late_wait_ms": 500
+  },
+  "events": [
+    {"kind": "text", "id": "cmvs-line", "timestamp_ms": 3000, "thread": 7, "text": "synthetic cmvs EmbedCMVS line"},
+    {"kind": "text", "id": "cmvs-other-thread", "timestamp_ms": 3001, "thread": 8, "text": "synthetic cmvs ui thread"},
+    {"kind": "pcm", "id": "cmvs-directsound-pcm", "timestamp_ms": 3012, "format": "s16le"},
+    {"kind": "loopback", "id": "cmvs-loopback", "timestamp_ms": 3015, "format": "s16le"},
+    {"kind": "session_end", "timestamp_ms": 3600}
+  ],
+  "expected": {
+    "cards": [
+      {"text_id": "cmvs-line", "audio_backend": "pcm", "audio_id": "cmvs-directsound-pcm"}
+    ],
+    "duplicate_text_events": 0,
+    "thread_filtered_events": 1,
+    "session_clean": true
+  }
+}

--- a/fushi/test/mining/cmvs_pairing_test.dart
+++ b/fushi/test/mining/cmvs_pairing_test.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'cmvs fixture stays explicitly unverified until evidence is added',
+    () async {
+      final data =
+          jsonDecode(
+                await File(
+                  'test/fixtures/galhook/cmvs_replay.json',
+                ).readAsString(),
+              )
+              as Map<String, dynamic>;
+      expect(data['status'], 'implemented_unverified');
+    },
+  );
+}

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -600,3 +600,6 @@ target_compile_definitions(fushi_sgre_adapter_test PRIVATE
   UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
 target_link_libraries(fushi_sgre_adapter_test PRIVATE bcrypt)
 add_test(NAME fushi_sgre_adapter_test COMMAND fushi_sgre_adapter_test)
+add_executable(fushi_cmvs_adapter_test "tests/cmvs_adapter_test.cpp")
+target_include_directories(fushi_cmvs_adapter_test PRIVATE "hook")
+add_test(NAME fushi_cmvs_adapter_test COMMAND fushi_cmvs_adapter_test)

--- a/native/galgame_hook/docs/engine-support.md
+++ b/native/galgame_hook/docs/engine-support.md
@@ -11,6 +11,7 @@
 | `siglus` | SiglusEngine | `verified` | engine_exact_utf16_hook (implemented_unverified)；luna_hook (implemented_unverified)；ingame_lookup_geometry (implemented_unverified) | resource_audio (verified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `elf_ai6` | elf AI6 | `implemented_unverified` | luna_textouta_hook (implemented_unverified) | ai6_voice_arc_resource (implemented_unverified)；directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
 | `reallive` | RealLive / old VisualArt's | `implemented_unverified` | luna_hook (implemented_unverified) | visual_arts_ovk_resource (implemented_unverified)；xaudio2_or_directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
+| `cmvs` | CMVS (Purple Software) | `implemented_unverified` | luna_hook (implemented_unverified) | xaudio2_or_directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
 | `kirikiri_z` | KiriKiri2 / KiriKiriZ | `partial` | luna_auto_or_pc_hooks (implemented_unverified)；ingame_lookup_geometry (implemented_unverified) | kirikiri_resource_stream (implemented_unverified)；kirikiri_decoder_pcm (implemented_unverified)；directsound_pcm (verified)；process_loopback (verified) | 2 |
 | `xaudio2_directsound` | XAudio2 / DirectSound generic capture | `verified` | — | xaudio2_source_voice_pcm (verified)；directsound_buffer_pcm (verified)；xwma_compressed_resource (implemented_unverified) | 1 |
 | `renpy_ffmpeg` | Ren'Py / FFmpeg | `implemented_unverified` | luna_auto_or_pc_hooks (implemented_unverified) | ffmpeg_resource_event (implemented_unverified)；ffmpeg54_decoder_pcm (implemented_unverified)；process_loopback (verified) | 1 |
@@ -216,6 +217,48 @@ Tests：`tests/elf_ai6_adapter_test.cpp`、`tests/resource_audio_ready_test.cpp`
 Fixtures：`tests/fixtures/reallive_replay.json`
 
 Tests：`tests/reallive_adapter_test.cpp`
+
+### CMVS (Purple Software) (`cmvs`)
+
+- 状态：`implemented_unverified`
+- 别名：CMVS、Purple Software、パープルソフトウェア
+- 家族：`cmvs`（Purple Software in-house engine; no verified sibling）
+- 当前 adapter：`hook/adapters/cmvs_adapter.inc`
+- 进程策略：launch=`generic_launch_available`，attach=`generic_attach_available`，follow-child=`false`
+
+识别签名（所有非空项均带真实样本或运行时观察证据）：
+
+- `executable_names`：cmvs32.exe、cmvs64.exe；证据：real_sample — Purple Software クロノクロック 体験版v2 (2015-03-20) ships both cmvs32.exe (x86) and cmvs64.exe (x64); static probe 2026-09-04. Retail builds may rename the exe, so names are catalogue only and the adapter matches on cmvs.cfg + CPZ archives instead
+- `pe_architectures`：x86、x64；证据：real_sample — cmvs32.exe machine 0x14c, cmvs64.exe machine 0x8664 (same trial package)
+- `directory_files_all`：cmvs.cfg、data/pack/start.ps3；证据：real_sample — cmvs.cfg opens with [CMVS_SYSTEM_MAIN] and SCRIPT_INIT_PATH=data\pack\; data/pack/start.ps3 (PS2A) is the script entry; trial package 2015-03-20
+- `pe_imports`：DSOUND.dll、WINMM.dll、d3d9.dll、mog2x32.dll、mog2x64.dll；证据：real_sample — PE import tables of cmvs32.exe / cmvs64.exe (static probe 2026-09-04); DirectSound is the only audio API imported
+- `runtime_modules`：mog2x32.dll、mog2x64.dll；证据：real_sample — Purple MOG2 image library shipped next to the exe (sha256 6b8dc960… / c51ba0c3…); static import only, runtime load not yet observed
+- `resource_extensions`：.cpz、.ps3、.cmv；证据：real_sample — data/pack/*.cpz (CPZ6 magic; voice.cpz + voice2.cpz hold voice), data/pack/start.ps3, data/video/*.cmv, data/music/*.ogg in the trial package
+- `hashes`：c5e715d98b56468df0a3d6bd8ec263b72bab736e0ad004de4e443a54c470ddad、aa89205a61c7078a167f9e6668eea2e4328bdd5c9cbcdd6f45b238cf475acea2；证据：real_sample — cmvs32.exe / cmvs64.exe of クロノクロック 体験版v2, catalogue only; the adapter does not hash-pin because the structural cfg + CPZ check is the identity
+
+文本能力：
+
+- `luna_hook`：`implemented_unverified` — Vendored LunaHook32/64 both carry the EmbedCMVS engine hook; no real-session dialogue thread has been observed yet.
+- codepage：932
+- 线程提示：Prefer the LunaHook EmbedCMVS thread once observed; the adapter installs no text hook of its own.
+
+音频优先级：
+
+1. `xaudio2_or_directsound_pcm` — `implemented_unverified`；格式：DirectSound source PCM via the generic Windows audio adapter；clean voice：engine_dependent
+2. `process_loopback` — `implemented_unverified`；格式：host PCM fallback；clean voice：否
+
+真实样本证据：
+
+
+已知限制：
+
+- Per-line voice resources live inside CPZ6-encrypted voice.cpz / voice2.cpz; no resource layer is implemented and none is claimed until a runtime decrypt-read seam is measured on a real session.
+- Identity is structural (cmvs.cfg section + CPZ archive magic); executable hashes are catalogued but not pinned.
+- In-game lookup sensor is not implemented; lookupAdmission stays EngineUnsupported.
+
+Fixtures：`tests/fixtures/cmvs_replay.json`
+
+Tests：`tests/cmvs_adapter_test.cpp`、`../../fushi/test/mining/cmvs_pairing_test.dart`
 
 ### KiriKiri2 / KiriKiriZ (`kirikiri_z`)
 

--- a/native/galgame_hook/engine-support.yaml
+++ b/native/galgame_hook/engine-support.yaml
@@ -633,6 +633,146 @@
       ]
     },
     {
+      "id": "cmvs",
+      "display_name": "CMVS (Purple Software)",
+      "aliases": [
+        "CMVS",
+        "Purple Software",
+        "パープルソフトウェア"
+      ],
+      "family": {
+        "id": "cmvs",
+        "relation": "Purple Software in-house engine; no verified sibling"
+      },
+      "detection": {
+        "executable_names": {
+          "values": [
+            "cmvs32.exe",
+            "cmvs64.exe"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "Purple Software クロノクロック 体験版v2 (2015-03-20) ships both cmvs32.exe (x86) and cmvs64.exe (x64); static probe 2026-09-04. Retail builds may rename the exe, so names are catalogue only and the adapter matches on cmvs.cfg + CPZ archives instead"
+          }
+        },
+        "pe_architectures": {
+          "values": [
+            "x86",
+            "x64"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "cmvs32.exe machine 0x14c, cmvs64.exe machine 0x8664 (same trial package)"
+          }
+        },
+        "directory_files_all": {
+          "values": [
+            "cmvs.cfg",
+            "data/pack/start.ps3"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "cmvs.cfg opens with [CMVS_SYSTEM_MAIN] and SCRIPT_INIT_PATH=data\\pack\\; data/pack/start.ps3 (PS2A) is the script entry; trial package 2015-03-20"
+          }
+        },
+        "pe_imports": {
+          "values": [
+            "DSOUND.dll",
+            "WINMM.dll",
+            "d3d9.dll",
+            "mog2x32.dll",
+            "mog2x64.dll"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "PE import tables of cmvs32.exe / cmvs64.exe (static probe 2026-09-04); DirectSound is the only audio API imported"
+          }
+        },
+        "runtime_modules": {
+          "values": [
+            "mog2x32.dll",
+            "mog2x64.dll"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "Purple MOG2 image library shipped next to the exe (sha256 6b8dc960… / c51ba0c3…); static import only, runtime load not yet observed"
+          }
+        },
+        "resource_extensions": {
+          "values": [
+            ".cpz",
+            ".ps3",
+            ".cmv"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "data/pack/*.cpz (CPZ6 magic; voice.cpz + voice2.cpz hold voice), data/pack/start.ps3, data/video/*.cmv, data/music/*.ogg in the trial package"
+          }
+        },
+        "hashes": {
+          "values": [
+            "c5e715d98b56468df0a3d6bd8ec263b72bab736e0ad004de4e443a54c470ddad",
+            "aa89205a61c7078a167f9e6668eea2e4328bdd5c9cbcdd6f45b238cf475acea2"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "cmvs32.exe / cmvs64.exe of クロノクロック 体験版v2, catalogue only; the adapter does not hash-pin because the structural cfg + CPZ check is the identity"
+          }
+        }
+      },
+      "process_strategy": {
+        "launch": "generic_launch_available",
+        "attach": "generic_attach_available",
+        "follow_child_processes": false,
+        "notes": [
+          "The trial ships a plain x86 and a plain x64 executable without a launcher; the original path is the user double-clicking either one.",
+          "No runtime session has been recorded yet, so early-inject versus attach ordering is unmeasured."
+        ]
+      },
+      "text": {
+        "capabilities": [
+          {
+            "kind": "luna_hook",
+            "status": "implemented_unverified",
+            "verification": "Vendored LunaHook32/64 both carry the EmbedCMVS engine hook; no real-session dialogue thread has been observed yet."
+          }
+        ],
+        "codepage": "932",
+        "thread_selection_hint": "Prefer the LunaHook EmbedCMVS thread once observed; the adapter installs no text hook of its own."
+      },
+      "audio": {
+        "priority": [
+          {
+            "kind": "xaudio2_or_directsound_pcm",
+            "format": "DirectSound source PCM via the generic Windows audio adapter",
+            "status": "implemented_unverified",
+            "clean_voice": "engine_dependent"
+          },
+          {
+            "kind": "process_loopback",
+            "format": "host PCM fallback",
+            "status": "implemented_unverified",
+            "clean_voice": false
+          }
+        ]
+      },
+      "verified_games": [],
+      "current_status": "implemented_unverified",
+      "known_limitations": [
+        "Per-line voice resources live inside CPZ6-encrypted voice.cpz / voice2.cpz; no resource layer is implemented and none is claimed until a runtime decrypt-read seam is measured on a real session.",
+        "Identity is structural (cmvs.cfg section + CPZ archive magic); executable hashes are catalogued but not pinned.",
+        "In-game lookup sensor is not implemented; lookupAdmission stays EngineUnsupported."
+      ],
+      "adapter_path": "hook/adapters/cmvs_adapter.inc",
+      "fixture_paths": [
+        "tests/fixtures/cmvs_replay.json"
+      ],
+      "test_paths": [
+        "tests/cmvs_adapter_test.cpp",
+        "../../fushi/test/mining/cmvs_pairing_test.dart"
+      ]
+    },
+    {
       "id": "kirikiri_z",
       "display_name": "KiriKiri2 / KiriKiriZ",
       "aliases": [

--- a/native/galgame_hook/hook/adapters/cmvs_adapter.inc
+++ b/native/galgame_hook/hook/adapters/cmvs_adapter.inc
@@ -1,0 +1,35 @@
+// CMVS（Purple Software）adapter。首版只做三件事，且全部 implemented_unverified：
+//   * 身份：cmvs_profile.h 的 cfg 节名 + CPZ 归档魔数结构判据（真实样本 クロノクロック 体験版v2）；
+//   * 文本：不自带 hook，交给 LunaHook 的 CMVS 引擎（vendored LunaHook32/64 均含 EmbedCMVS）；
+//   * 音频：不自带 hook，走 GenericWindowsAudioAdapter 的 DirectSound/XAudio2 源 PCM
+//     （样本 exe 导入 DSOUND.dll + WINMM.dll）。
+// 逐句资源层（voice.cpz / voice2.cpz，CPZ6 加密归档）明确**未做**：那需要在引擎解密读取
+// 之后的位置取字节，位置只能在真机上定，静态阶段不猜 hook 面。
+#include "cmvs_profile.h"
+
+class CmvsAdapter final : public fushi_voice_hook::EngineAdapter {
+ public:
+  const char* id() const override { return "cmvs"; }
+  bool probe() const override { return fushi_voice_hook::MatchesCmvsProfile(nullptr); }
+  // 没有引擎专属 hook 可装：installed_ 只表示「身份成立、共享文本/PCM 路径对此进程生效」。
+  bool install() override {
+    installed_ = probe();
+    return installed_;
+  }
+  fushi_voice_hook::AdapterCapability capabilities() const override {
+    return fushi_voice_hook::AdapterCapability::kText |
+           fushi_voice_hook::AdapterCapability::kPcmAudio;
+  }
+  void onModuleLoaded(const wchar_t* module_name) override {
+    // 身份来自磁盘布局，启动时一次判定即可；模块通知只作重试接缝。
+    if (!installed_ && module_name == nullptr) install();
+  }
+  void shutdown() override { installed_ = false; }
+  fushi_voice_hook::AdapterDiagnostics diagnostics() const override {
+    return {id(), probe(), installed_,
+            g_header == nullptr ? 0u : g_header->hook_diagnostics};
+  }
+
+ private:
+  bool installed_ = false;
+};

--- a/native/galgame_hook/hook/adapters/cmvs_profile.h
+++ b/native/galgame_hook/hook/adapters/cmvs_profile.h
@@ -1,0 +1,93 @@
+// CMVS（Purple Software 自研引擎）身份探测。
+//
+// 结构判据（全部来自真实样本 クロノクロック 体験版v2 2015-03-20 的静态 probe，2026-09-04）：
+//   * exe 同级 `cmvs.cfg`，文本以 `[CMVS_SYSTEM_MAIN]` 节开头，里面 `SCRIPT_INIT_PATH=data\pack\`；
+//   * `data\pack\*.cpz`——CMVS 自有归档，4 字节魔数 `CPZ` + 版本位（样本是 `CPZ6`）；
+//     voice.cpz / voice2.cpz / script.cpz / se.cpz 全在这一层。
+// exe 名（cmvs32.exe / cmvs64.exe）和 mog2x32/64.dll 只作台账记录，不进判据：Purple 的正式版
+// 会把 exe 改成作品名，而 cfg + CPZ 归档是引擎本体的固定形状。
+// 判据要求两样**同时**存在，缺一即不匹配（fail closed）：只有 cfg 可能是别的引擎抄的 ini
+// 段名，只有 .cpz 后缀也可能是别家格式；CPZ 魔数 + cfg 节名同时命中才是 CMVS。
+#pragma once
+
+#include <windows.h>
+
+#include <cstdint>
+#include <cstring>
+#include <cwchar>
+#include <string>
+
+namespace fushi_voice_hook {
+
+constexpr const wchar_t* kCmvsConfigFileName = L"cmvs.cfg";
+constexpr const char* kCmvsConfigSection = "[CMVS_SYSTEM_MAIN]";
+constexpr const wchar_t* kCmvsPackPattern = L"\\data\\pack\\*.cpz";
+constexpr size_t kCmvsConfigProbeBytes = 256;
+
+inline bool CmvsReadFilePrefix(const std::wstring& path, uint8_t* out, DWORD capacity,
+                           DWORD* read_out) {
+  HANDLE file = CreateFileW(path.c_str(), GENERIC_READ,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) return false;
+  DWORD read = 0;
+  const bool ok = ReadFile(file, out, capacity, &read, nullptr) != FALSE;
+  CloseHandle(file);
+  if (!ok) return false;
+  *read_out = read;
+  return true;
+}
+
+// cmvs.cfg 前 256 字节里出现 `[CMVS_SYSTEM_MAIN]`（允许 BOM / 空行前缀）。
+inline bool CmvsConfigPresent(const std::wstring& directory) {
+  uint8_t prefix[kCmvsConfigProbeBytes] = {0};
+  DWORD read = 0;
+  if (!CmvsReadFilePrefix(directory + L"\\" + kCmvsConfigFileName, prefix,
+                      sizeof(prefix), &read)) {
+    return false;
+  }
+  const size_t needle = strlen(kCmvsConfigSection);
+  if (read < needle) return false;
+  for (size_t i = 0; i + needle <= read; ++i) {
+    if (memcmp(prefix + i, kCmvsConfigSection, needle) == 0) return true;
+  }
+  return false;
+}
+
+// data\pack 下至少一个 *.cpz 以 `CPZ` 魔数开头。
+inline bool CmvsPackArchivePresent(const std::wstring& directory) {
+  WIN32_FIND_DATAW found = {};
+  const std::wstring pattern = directory + kCmvsPackPattern;
+  HANDLE search = FindFirstFileW(pattern.c_str(), &found);
+  if (search == INVALID_HANDLE_VALUE) return false;
+  bool matched = false;
+  do {
+    if (found.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+    uint8_t magic[4] = {0};
+    DWORD read = 0;
+    const std::wstring path = directory + L"\\data\\pack\\" + found.cFileName;
+    if (CmvsReadFilePrefix(path, magic, sizeof(magic), &read) && read == 4 &&
+        memcmp(magic, "CPZ", 3) == 0) {
+      matched = true;
+      break;
+    }
+  } while (FindNextFileW(search, &found));
+  FindClose(search);
+  return matched;
+}
+
+// 给定游戏根目录的结构判据；测试用临时目录直接喂它。
+inline bool MatchesCmvsLayout(const std::wstring& directory) {
+  return CmvsConfigPresent(directory) && CmvsPackArchivePresent(directory);
+}
+
+inline bool MatchesCmvsProfile(const wchar_t*) {
+  wchar_t executable[MAX_PATH] = {0};
+  if (GetModuleFileNameW(nullptr, executable, MAX_PATH) == 0) return false;
+  wchar_t* slash = wcsrchr(executable, L'\\');
+  if (slash == nullptr) return false;
+  *slash = 0;
+  return MatchesCmvsLayout(executable);
+}
+
+}  // namespace fushi_voice_hook

--- a/native/galgame_hook/hook/generated/adapter_admission.inc
+++ b/native/galgame_hook/hook/generated/adapter_admission.inc
@@ -9,3 +9,4 @@
     consider(sgre_);
     consider(leaf_aquaplus_);
     consider(hunex_gge_);
+    consider(cmvs_);

--- a/native/galgame_hook/hook/generated/adapter_fields.inc
+++ b/native/galgame_hook/hook/generated/adapter_fields.inc
@@ -9,3 +9,4 @@
   SgreAdapter sgre_;
   LeafAquaplusAdapter leaf_aquaplus_;
   HunexGgeAdapter hunex_gge_;
+  CmvsAdapter cmvs_;

--- a/native/galgame_hook/hook/generated/adapter_includes.inc
+++ b/native/galgame_hook/hook/generated/adapter_includes.inc
@@ -9,3 +9,4 @@
 #include "../adapters/sgre_adapter.inc"
 #include "../adapters/leaf_aquaplus_adapter.inc"
 #include "../adapters/hunex_gge_adapter.inc"
+#include "../adapters/cmvs_adapter.inc"

--- a/native/galgame_hook/hook/generated/adapter_module.inc
+++ b/native/galgame_hook/hook/generated/adapter_module.inc
@@ -9,3 +9,4 @@
         sgre_.onModuleLoaded(entry.szModule);
         leaf_aquaplus_.onModuleLoaded(entry.szModule);
         hunex_gge_.onModuleLoaded(entry.szModule);
+        cmvs_.onModuleLoaded(entry.szModule);

--- a/native/galgame_hook/hook/generated/adapter_shutdown.inc
+++ b/native/galgame_hook/hook/generated/adapter_shutdown.inc
@@ -9,3 +9,4 @@
     sgre_.shutdown();
     leaf_aquaplus_.shutdown();
     hunex_gge_.shutdown();
+    cmvs_.shutdown();

--- a/native/galgame_hook/hook/generated/adapter_startup.inc
+++ b/native/galgame_hook/hook/generated/adapter_startup.inc
@@ -5,3 +5,4 @@
     sgre_.install();
     leaf_aquaplus_.install();
     hunex_gge_.install();
+    cmvs_.install();

--- a/native/galgame_hook/hook/generated/profile_includes.inc
+++ b/native/galgame_hook/hook/generated/profile_includes.inc
@@ -8,3 +8,4 @@
 #include "../adapters/sgre_profile.h"
 #include "../adapters/leaf_aquaplus_profile.h"
 #include "../adapters/hunex_gge_profile.h"
+#include "../adapters/cmvs_profile.h"

--- a/native/galgame_hook/profiles/cmvs.json
+++ b/native/galgame_hook/profiles/cmvs.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "id": "cmvs",
+  "status": "implemented_unverified",
+  "detection": {
+    "executable_sha256": [
+      "C5E715D98B56468DF0A3D6BD8EC263B72BAB736E0AD004DE4E443A54C470DDAD",
+      "AA89205A61C7078A167F9E6668EEA2E4328BDD5C9CBCDD6F45B238CF475ACEA2"
+    ],
+    "module_sha256": [
+      "6B8DC960F581963BAE671EBAB81832DF0E39A43656875EB65A6B547DF1FAAF70",
+      "C51BA0C33E0153492B6CB2688701B35F0DDAE309828FC21A7631AC54ABB5B205"
+    ]
+  },
+  "capabilities": {
+    "text": true,
+    "resource_audio": false,
+    "pcm_audio": true
+  },
+  "evidence": [
+    {
+      "kind": "real_sample",
+      "reference": "Purple Software クロノクロック 体験版v2 (2015-03-20): cmvs32.exe x86 / cmvs64.exe x64 with mog2x32.dll / mog2x64.dll, cmvs.cfg [CMVS_SYSTEM_MAIN] and data\\pack\\*.cpz (CPZ6) measured by static probe on 2026-09-04; no runtime evidence yet"
+    }
+  ]
+}

--- a/native/galgame_hook/tests/cmvs_adapter_test.cpp
+++ b/native/galgame_hook/tests/cmvs_adapter_test.cpp
@@ -1,0 +1,101 @@
+// CI builds with --config Release, where MSVC defines NDEBUG and compiles
+// bare assert() out entirely. Undefine it before any include or this test is
+// green no matter what it checks. Guard: tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
+// CMVS 身份判据用真临时目录验：判据读的是磁盘布局（cfg 节名 + CPZ 魔数），只有文件系统自己
+// 能作证。四种布局：完整（匹配）、只有 cfg、只有 .cpz 但魔数不对、cfg 节名不对。
+#include "../hook/adapters/cmvs_profile.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+std::wstring MakeTempRoot(const wchar_t* tag) {
+  wchar_t temp[MAX_PATH] = {0};
+  assert(GetTempPathW(MAX_PATH, temp) != 0);
+  std::wstring root = std::wstring(temp) + L"fushi_cmvs_test_" + tag + L"_" +
+                      std::to_wstring(GetCurrentProcessId());
+  assert(CreateDirectoryW(root.c_str(), nullptr) || GetLastError() == ERROR_ALREADY_EXISTS);
+  return root;
+}
+
+void WriteBytes(const std::wstring& path, const char* bytes, size_t length) {
+  HANDLE file = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                            FILE_ATTRIBUTE_NORMAL, nullptr);
+  assert(file != INVALID_HANDLE_VALUE);
+  DWORD written = 0;
+  assert(WriteFile(file, bytes, static_cast<DWORD>(length), &written, nullptr));
+  assert(written == length);
+  CloseHandle(file);
+}
+
+void MakePackDir(const std::wstring& root) {
+  CreateDirectoryW((root + L"\\data").c_str(), nullptr);
+  CreateDirectoryW((root + L"\\data\\pack").c_str(), nullptr);
+}
+
+void RemoveTree(const std::wstring& root) {
+  DeleteFileW((root + L"\\cmvs.cfg").c_str());
+  DeleteFileW((root + L"\\data\\pack\\voice.cpz").c_str());
+  DeleteFileW((root + L"\\data\\pack\\script.cpz").c_str());
+  RemoveDirectoryW((root + L"\\data\\pack").c_str());
+  RemoveDirectoryW((root + L"\\data").c_str());
+  RemoveDirectoryW(root.c_str());
+}
+
+const char kConfig[] = "\xEF\xBB\xBF\r\n[CMVS_SYSTEM_MAIN]\r\nSCRIPT_INIT_PATH=data\\pack\\\r\n";
+const char kOtherConfig[] = "[OTHER_ENGINE]\r\nSCRIPT_INIT_PATH=data\\pack\\\r\n";
+const char kCpz6[] = "CPZ6\x00\x11\x22\x33";
+const char kNotCpz[] = "OggS\x00\x02\x00\x00";
+
+}  // namespace
+
+int main() {
+  // 1. 完整布局（BOM + 空行前缀的 cfg、CPZ6 归档）→ 匹配。
+  {
+    const std::wstring root = MakeTempRoot(L"full");
+    MakePackDir(root);
+    WriteBytes(root + L"\\cmvs.cfg", kConfig, sizeof(kConfig) - 1);
+    WriteBytes(root + L"\\data\\pack\\script.cpz", kNotCpz, sizeof(kNotCpz) - 1);
+    WriteBytes(root + L"\\data\\pack\\voice.cpz", kCpz6, sizeof(kCpz6) - 1);
+    assert(fushi_voice_hook::CmvsConfigPresent(root));
+    assert(fushi_voice_hook::CmvsPackArchivePresent(root));
+    assert(fushi_voice_hook::MatchesCmvsLayout(root));
+    RemoveTree(root);
+  }
+  // 2. 只有 cfg，没有归档 → 不匹配（fail closed）。
+  {
+    const std::wstring root = MakeTempRoot(L"cfg_only");
+    MakePackDir(root);
+    WriteBytes(root + L"\\cmvs.cfg", kConfig, sizeof(kConfig) - 1);
+    assert(!fushi_voice_hook::MatchesCmvsLayout(root));
+    RemoveTree(root);
+  }
+  // 3. .cpz 后缀但魔数不是 CPZ → 不匹配。
+  {
+    const std::wstring root = MakeTempRoot(L"bad_magic");
+    MakePackDir(root);
+    WriteBytes(root + L"\\cmvs.cfg", kConfig, sizeof(kConfig) - 1);
+    WriteBytes(root + L"\\data\\pack\\voice.cpz", kNotCpz, sizeof(kNotCpz) - 1);
+    assert(!fushi_voice_hook::CmvsPackArchivePresent(root));
+    assert(!fushi_voice_hook::MatchesCmvsLayout(root));
+    RemoveTree(root);
+  }
+  // 4. cfg 节名不是 CMVS 的 → 不匹配。
+  {
+    const std::wstring root = MakeTempRoot(L"bad_cfg");
+    MakePackDir(root);
+    WriteBytes(root + L"\\cmvs.cfg", kOtherConfig, sizeof(kOtherConfig) - 1);
+    WriteBytes(root + L"\\data\\pack\\voice.cpz", kCpz6, sizeof(kCpz6) - 1);
+    assert(!fushi_voice_hook::CmvsConfigPresent(root));
+    assert(!fushi_voice_hook::MatchesCmvsLayout(root));
+    RemoveTree(root);
+  }
+  // 5. 测试进程自己的目录不是 CMVS 游戏 → 进程级探测为假。
+  assert(!fushi_voice_hook::MatchesCmvsProfile(nullptr));
+  std::printf("cmvs_adapter_test: ok\n");
+  return 0;
+}

--- a/native/galgame_hook/tests/fixtures/cmvs_replay.json
+++ b/native/galgame_hook/tests/fixtures/cmvs_replay.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "engine_id": "cmvs",
+  "status": "implemented_unverified",
+  "config": {
+    "selected_thread": 7,
+    "duplicate_window_ms": 1000,
+    "audio_priority": ["resource_audio", "pcm", "loopback"],
+    "resource_late_wait_ms": 500
+  },
+  "events": [
+    {"kind": "text", "id": "cmvs-line", "timestamp_ms": 3000, "thread": 7, "text": "synthetic cmvs EmbedCMVS line"},
+    {"kind": "text", "id": "cmvs-other-thread", "timestamp_ms": 3001, "thread": 8, "text": "synthetic cmvs ui thread"},
+    {"kind": "pcm", "id": "cmvs-directsound-pcm", "timestamp_ms": 3012, "format": "s16le"},
+    {"kind": "loopback", "id": "cmvs-loopback", "timestamp_ms": 3015, "format": "s16le"},
+    {"kind": "session_end", "timestamp_ms": 3600}
+  ],
+  "expected": {
+    "cards": [
+      {"text_id": "cmvs-line", "audio_backend": "pcm", "audio_id": "cmvs-directsound-pcm"}
+    ],
+    "duplicate_text_events": 0,
+    "thread_filtered_events": 1,
+    "session_clean": true
+  }
+}


### PR DESCRIPTION
## 目的

ceshi 批量 galgame 适配队列的下一款：**クロノクロック 体験版v2（Purple Software CMVS）**。仓库此前没有 CMVS adapter。本 PR 只交付**静态身份 + 骨架**，状态 `implemented_unverified`，真机门未跑（桌面被占用），不宣称支持。

## 改动

- `hook/adapters/cmvs_profile.h`：结构身份 = exe 同级 `cmvs.cfg` 前 256 字节含 `[CMVS_SYSTEM_MAIN]` **且** `data\pack\*.cpz` 至少一个 `CPZ` 魔数；两样同时命中才匹配（fail closed）。`MatchesCmvsLayout(dir)` 接目录参数供测试。exe 名/哈希只入台账不做判据（Purple 正式版会改 exe 名）。
- `hook/adapters/cmvs_adapter.inc`：id `cmvs`，`kText | kPcmAudio`，不自带 hook——文本交 vendored LunaHook 的 `EmbedCMVS`（32/64 均有），PCM 交通用 DirectSound 适配器（样本 exe 只导入 DSOUND）。逐句资源层（CPZ6 加密 `voice.cpz`）明确未做。
- `profiles/cmvs.json`、`engine-support.yaml` 新条目（七项 detection 全带 real_sample 证据，三条 known_limitations）、`docs/engine-support.md` 重生成；registry 片段 + CMake 由 `galhook.ps1 new` 登记。
- 测试：`tests/cmvs_adapter_test.cpp` 真临时目录四种布局（含 BOM+空行前缀的 cfg）+ 进程级为假，变异实测（魔数判据改恒真 → 用例 3 红）；`tests/fixtures/cmvs_replay.json` replay 通过；`fushi/test/mining/cmvs_pairing_test.dart` 钉 unverified。
- 台账 `docs/plans/2026-09-04-gal-ceshi-batch-cmvs.md`：样本身份（两 exe / 两 dll 哈希、imports、资源布局）、Proved / Not proved / Next gate。

## 验证

- `build_distribution.ps1` 双架构 exit 0；ctest x64 56/56、x86 56/56；`fushi_cmvs_adapter_test` 两架构直跑 ok。
- `adapter_structure` 38 / `engine_support_manifest` 22 / `galhook_workflow` 6 / `evidence_contract` 16 / `assert_liveness_guard` 2 / `lookup_presenter_wiring_guard` 33 / `kirikiri_lookup_source_guard` 126 全 OK；两个生成器 `--check` OK。
- `flutter test test/mining/cmvs_pairing_test.dart --no-pub` 1/1；`dart analyze` 该文件无问题。

## 未做

- 真机门整个未跑：`process_found → helper_ready → ipc_ready → text_observed(EmbedCMVS) → pcm_observed(DirectSound) → paired → card_e2e`。Next gate 写在台账。
- 游戏内查词传感器（admission 默认 EngineUnsupported）；CPZ6 语音资源层。

https://claude.ai/code/session_019hzYzoZY7RsKD4cA3ppwEC
