### PR TITLE
fix(popup): 同一音调型的多本词典合并成一行（BUG-2122）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1980 条。点号进各自文件。
+> 共 1981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2122](bugs/BUG-2122-pitch-duplicate-rows.md) | ✅ | ✅ | 音调区同一音调型被多本词典重复渲染成多行 |
 | [BUG-2110](bugs/BUG-2110-dict-mass-import-startup-crash.md) | ✅ | ✅ | 一次性导入大量词典后启动转圈中途闪退 |
 | [BUG-2109](bugs/BUG-2109-recommended-pack-never-deleted.md) | ✅ | ✅ | 推荐包 9.5GB zip 导入后永不删除（清理钩子挂在不再执行的引导页 initState） |
 | [BUG-2107](bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md) | ✅ | ✅ | 引导选本地包走裸 pickFiles：安卓整份复制进 cache，失败静默无提示 |

--- a/docs/bugs/BUG-2122-pitch-duplicate-rows.md
+++ b/docs/bugs/BUG-2122-pitch-duplicate-rows.md
@@ -1,0 +1,15 @@
+## BUG-2122 · 音调区同一音调型被多本词典重复渲染成多行
+- **报告**：2026-09-04（用户：官网首页 demo 弹窗查「ギター」的截图）
+- **真实性**：✅ 真 bug — `fushi/assets/popup/popup.js` `createPitchSection`（改前 2818-2844）一本音调词典渲染一个 `.pitch-group` 行。五本音调词典都把「ギター」标成 `[1]` 时，音高区连出五行一模一样的 `￣ギター [1]`，只有前面的来源药丸不同，读起来像坏了。
+  - Yomitan 的对照实现 `getGroupedPronunciations` 是把**相同发音合并成一条、后面挂全部来源标签**，从不出重复行。
+  - 触发档位：`deduplicate_pitch_accents`（`fushi/lib/src/models/preferences_repository.dart:1731`）默认 `true`，此时旧代码靠「丢掉已出现过的音调位」把重复行压掉——**代价是另外四本词典的来源名被整条丢弃**，用户看不到「五本都认同」。官网 demo 注入的是 `false`，于是重复行原样暴露（用户截图即此档）。所以这不是官网独有，是共用 popup.js 的行为缺陷：一档丢信息，另一档出重复。
+- **[x] ① 已修复** — `mergeIdenticalPitchGroups()`：渲染前的最后一道纯变换，整份 payload 全等（`pitchPositions` / `patterns` / `transcriptions` 三者）的词典合并成一行，`dictionaries` 带上全部来源名；`createPitchGroup` 改吃来源数组，每本渲一枚 `.pitch-dict-label` 药丸；`.pitch-group` 加 `flex-wrap: wrap` 防多药丸把读音顶出弹窗右边界。
+  - 判据故意取「payload 全等」而不是逐条位置求交：宁可少合一次，也不把读法不同的两本词典混进同一行。
+  - 合并跑在 `deduplicatePitchAccents` 分支**之后**：去重打开（app 默认）时各存活组的位置互斥、payload 不可能全等，合并对位置组恒为 no-op，**默认外观一字不变**；去重关闭时才塌行。唯一会在去重档位生效的是「两本纯 IPA 词典给出完全相同的 transcriptions」，那本就该合。
+  - 三份镜像副本同步：`fushi/assets/popup/popup.{js,css}`、`fushi/assets/browser_extension/vendor/popup.{js,css}`、`tools/browser-extension/vendor/popup.{js,css}`。
+  - 提交：见本分支 `worktree-pitch-merge-identical-dicts`。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/popup_pitch_merge_identical_test.dart` + `.js`
+  - 行为级（node vm 真跑 popup.js 的 `createPitchSection`）：五本同为 `[1]` 且去重关闭 → 只剩 1 个 `.pitch-group`、5 枚药丸按首次出现顺序、`[1]` 只画一次；音调型不同（`[1]` vs `[0]`）不合并；位置部分重叠（`[1,0]` vs `[1]`）不合并；去重打开时 1 行 1 枚药丸（钉死默认外观零变化）；两本纯 IPA 同 transcriptions 合并。
+  - 变异实测：撤掉 `mergeIdenticalPitchGroups(groups)` 调用点 → case 1 报 `5 !== 1` 红，恢复即绿（不是空壳断言）。
+  - 源码级：三份镜像副本各自断言合并 helper、调用点在去重分支之后、去重分支不再直接 append、多药丸渲染循环，以及 `.pitch-group` 的 `flex-wrap: wrap`。
+- **备注**：官网 `fushi.moe` 首页 demo 把 popup.js 内联在 `public/index.html`，是独立快照副本，需同步同一处改动才能让用户截图里的页面变好（本仓改动不会自动传过去）。

--- a/docs/bugs/BUG-2122-pitch-duplicate-rows.md
+++ b/docs/bugs/BUG-2122-pitch-duplicate-rows.md
@@ -7,9 +7,9 @@
   - 判据故意取「payload 全等」而不是逐条位置求交：宁可少合一次，也不把读法不同的两本词典混进同一行。
   - 合并跑在 `deduplicatePitchAccents` 分支**之后**：去重打开（app 默认）时各存活组的位置互斥、payload 不可能全等，合并对位置组恒为 no-op，**默认外观一字不变**；去重关闭时才塌行。唯一会在去重档位生效的是「两本纯 IPA 词典给出完全相同的 transcriptions」，那本就该合。
   - 三份镜像副本同步：`fushi/assets/popup/popup.{js,css}`、`fushi/assets/browser_extension/vendor/popup.{js,css}`、`tools/browser-extension/vendor/popup.{js,css}`。
-  - 提交：见本分支 `worktree-pitch-merge-identical-dicts`。
+  - 提交：`9dd4d9d769`（分支 `worktree-pitch-merge-identical-dicts`，PR hajisensai/Fushi#1212）。
 - **[x] ② 已加自动化测试** — `fushi/test/pages/popup_pitch_merge_identical_test.dart` + `.js`
   - 行为级（node vm 真跑 popup.js 的 `createPitchSection`）：五本同为 `[1]` 且去重关闭 → 只剩 1 个 `.pitch-group`、5 枚药丸按首次出现顺序、`[1]` 只画一次；音调型不同（`[1]` vs `[0]`）不合并；位置部分重叠（`[1,0]` vs `[1]`）不合并；去重打开时 1 行 1 枚药丸（钉死默认外观零变化）；两本纯 IPA 同 transcriptions 合并。
   - 变异实测：撤掉 `mergeIdenticalPitchGroups(groups)` 调用点 → case 1 报 `5 !== 1` 红，恢复即绿（不是空壳断言）。
   - 源码级：三份镜像副本各自断言合并 helper、调用点在去重分支之后、去重分支不再直接 append、多药丸渲染循环，以及 `.pitch-group` 的 `flex-wrap: wrap`。
-- **备注**：官网 `fushi.moe` 首页 demo 把 popup.js 内联在 `public/index.html`，是独立快照副本，需同步同一处改动才能让用户截图里的页面变好（本仓改动不会自动传过去）。
+- **备注**：官网 `fushi.moe` 首页 demo 把 popup.js 内联在 `public/index.html`，是独立快照副本，需同步同一处改动才能让用户截图里的页面变好（本仓改动不会自动传过去）。已同步：hajisensai/fushi.moe#34（`e63efbe`），并在 `tool/verify-home.mjs` 加了页面级断言（拨到「ギター」那句 cue → 点开弹窗 → `.pitch-group` 恰好 1 个、五枚来源药丸齐全、词头是 ギター；变异实测撤掉合并调用 → `groups:5 readings:5` 红）。

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -1437,6 +1437,10 @@
     align-items: baseline;
     gap: 6px;
     margin-top: 2px;
+    /* BUG-2122：合并同型音调后一行可能挂好几枚来源药丸（用户装了五本音调词典就
+       是五枚）。不许换行的话它们会把读音顶出弹窗右边界；允许换行后，药丸满一行就
+       把读音掘到下一行，而不是溢出。单本词典（绝大多数行）装得下，不会换行。 */
+    flex-wrap: wrap;
     /* TODO-1305 / BUG-pitch-reading-mined: 音高发音区（片假名 reading 逐 mora +
        [n] 音高数字 + IPA）是纯展示，不参与查词/复制。加 user-select:none 杜绝拖选
        把片假名 reading（如 カンロク）留在原生选区、制卡时被烤进 Anki 卡的

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -1499,6 +1499,10 @@ html[data-theme="dark"] :where(.glossary-group, .glossary-content) [class^="glos
     align-items: baseline;
     gap: 6px;
     margin-top: 2px;
+    /* BUG-2122：合并同型音调后一行可能挂好几枚来源药丸（用户装了五本音调词典就
+       是五枚）。不许换行的话它们会把读音顶出弹窗右边界；允许换行后，药丸满一行就
+       把读音掘到下一行，而不是溢出。单本词典（绝大多数行）装得下，不会换行。 */
+    flex-wrap: wrap;
     /* TODO-1305 / BUG-pitch-reading-mined: 音高发音区（片假名 reading 逐 mora +
        [n] 音高数字 + IPA）是纯展示，不参与查词/复制。加 user-select:none 杜绝拖选
        把片假名 reading（如 カンロク）留在原生选区、制卡时被烤进 Anki 卡的

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -2738,9 +2738,46 @@ function createTranscriptionsHtml(transcriptions) {
     return list;
 }
 
+// BUG-2122：同一个音调型被多本词典各渲染成一行。五本音调词典都把「ギター」
+// 标成 [1] 时，用户看到的是五行一模一样的 ￣ギター [1]，读起来像坏了。Yomitan 在
+// getGroupedPronunciations 里把相同发音合并成一条、后面挂上全部来源；这里做同样的事：
+// 整份 payload 全等（pitchPositions / patterns / transcriptions 三者）的词典合并成一行，
+// dictionaries 带上全部来源名。判据故意取「全等」而不是逐条位置求交：宁可少合
+// 一次，也不把读法不同的两本词典混进同一行。
+//
+// 本函数是渲染前的最后一道纯变换，跑在 deduplicatePitchAccents 分支之后：去重打开
+// 时（app 默认）各存活组的位置互斥，payload 不可能全等，合并对位置组恒为 no-op，
+// 默认外观一字不变；去重关闭时才塌行。（两本纯 IPA 词典给出完全相同的
+// transcriptions 是唯一例外，那也本就该合。）
+function mergeIdenticalPitchGroups(groups) {
+    const merged = [];
+    const byPayload = new Map();
+    groups.forEach((group) => {
+        const key = JSON.stringify([
+            group.pitchPositions || [],
+            group.patterns || [],
+            group.transcriptions || [],
+        ]);
+        const existing = byPayload.get(key);
+        if (existing) {
+            if (!existing.dictionaries.includes(group.dictionary)) {
+                existing.dictionaries.push(group.dictionary);
+            }
+            return;
+        }
+        const entry = Object.assign({}, group, { dictionaries: [group.dictionary] });
+        byPayload.set(key, entry);
+        merged.push(entry);
+    });
+    return merged;
+}
+
 function createPitchGroup(pitchData, reading) {
-    const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    const dictionaries = pitchData.dictionaries || [pitchData.dictionary];
+    const container = el('div', { className: 'pitch-group', 'data-details': dictionaries.join(', ') });
+    dictionaries.forEach((dictionary) => {
+        container.appendChild(el('span', { className: 'pitch-dict-label', textContent: dictionary }));
+    });
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -2820,6 +2857,7 @@ function createPitchSection(pitches, reading) {
     const section = el('div', { className: 'category-section pitch-section' });
     const body = el('div', { className: 'category-body' });
     const pitchContainer = el('div', { className: 'pitch-list' });
+    const groups = [];
     if (window.deduplicatePitchAccents) {
         const seen = new Set();
         pitches.forEach(pitch => {
@@ -2832,14 +2870,14 @@ function createPitchSection(pitches, reading) {
             const hasPatterns = pitch.patterns?.length;
             if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
-                pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
-                    reading));
+                groups.push({ dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions });
             }
         });
     } else {
-        pitches.forEach(pitch => pitchContainer.appendChild(createPitchGroup(pitch, reading)));
+        pitches.forEach(pitch => groups.push(pitch));
     }
+    mergeIdenticalPitchGroups(groups).forEach(
+        group => pitchContainer.appendChild(createPitchGroup(group, reading)));
     body.appendChild(pitchContainer);
     section.appendChild(body);
     return section;

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -1499,6 +1499,10 @@ html[data-theme="dark"] :where(.glossary-group, .glossary-content) [class^="glos
     align-items: baseline;
     gap: 6px;
     margin-top: 2px;
+    /* BUG-2122：合并同型音调后一行可能挂好几枚来源药丸（用户装了五本音调词典就
+       是五枚）。不许换行的话它们会把读音顶出弹窗右边界；允许换行后，药丸满一行就
+       把读音掘到下一行，而不是溢出。单本词典（绝大多数行）装得下，不会换行。 */
+    flex-wrap: wrap;
     /* TODO-1305 / BUG-pitch-reading-mined: 音高发音区（片假名 reading 逐 mora +
        [n] 音高数字 + IPA）是纯展示，不参与查词/复制。加 user-select:none 杜绝拖选
        把片假名 reading（如 カンロク）留在原生选区、制卡时被烤进 Anki 卡的

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -2738,9 +2738,46 @@ function createTranscriptionsHtml(transcriptions) {
     return list;
 }
 
+// BUG-2122：同一个音调型被多本词典各渲染成一行。五本音调词典都把「ギター」
+// 标成 [1] 时，用户看到的是五行一模一样的 ￣ギター [1]，读起来像坏了。Yomitan 在
+// getGroupedPronunciations 里把相同发音合并成一条、后面挂上全部来源；这里做同样的事：
+// 整份 payload 全等（pitchPositions / patterns / transcriptions 三者）的词典合并成一行，
+// dictionaries 带上全部来源名。判据故意取「全等」而不是逐条位置求交：宁可少合
+// 一次，也不把读法不同的两本词典混进同一行。
+//
+// 本函数是渲染前的最后一道纯变换，跑在 deduplicatePitchAccents 分支之后：去重打开
+// 时（app 默认）各存活组的位置互斥，payload 不可能全等，合并对位置组恒为 no-op，
+// 默认外观一字不变；去重关闭时才塌行。（两本纯 IPA 词典给出完全相同的
+// transcriptions 是唯一例外，那也本就该合。）
+function mergeIdenticalPitchGroups(groups) {
+    const merged = [];
+    const byPayload = new Map();
+    groups.forEach((group) => {
+        const key = JSON.stringify([
+            group.pitchPositions || [],
+            group.patterns || [],
+            group.transcriptions || [],
+        ]);
+        const existing = byPayload.get(key);
+        if (existing) {
+            if (!existing.dictionaries.includes(group.dictionary)) {
+                existing.dictionaries.push(group.dictionary);
+            }
+            return;
+        }
+        const entry = Object.assign({}, group, { dictionaries: [group.dictionary] });
+        byPayload.set(key, entry);
+        merged.push(entry);
+    });
+    return merged;
+}
+
 function createPitchGroup(pitchData, reading) {
-    const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    const dictionaries = pitchData.dictionaries || [pitchData.dictionary];
+    const container = el('div', { className: 'pitch-group', 'data-details': dictionaries.join(', ') });
+    dictionaries.forEach((dictionary) => {
+        container.appendChild(el('span', { className: 'pitch-dict-label', textContent: dictionary }));
+    });
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -2820,6 +2857,7 @@ function createPitchSection(pitches, reading) {
     const section = el('div', { className: 'category-section pitch-section' });
     const body = el('div', { className: 'category-body' });
     const pitchContainer = el('div', { className: 'pitch-list' });
+    const groups = [];
     if (window.deduplicatePitchAccents) {
         const seen = new Set();
         pitches.forEach(pitch => {
@@ -2832,14 +2870,14 @@ function createPitchSection(pitches, reading) {
             const hasPatterns = pitch.patterns?.length;
             if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
-                pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
-                    reading));
+                groups.push({ dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions });
             }
         });
     } else {
-        pitches.forEach(pitch => pitchContainer.appendChild(createPitchGroup(pitch, reading)));
+        pitches.forEach(pitch => groups.push(pitch));
     }
+    mergeIdenticalPitchGroups(groups).forEach(
+        group => pitchContainer.appendChild(createPitchGroup(group, reading)));
     body.appendChild(pitchContainer);
     section.appendChild(body);
     return section;

--- a/fushi/test/pages/popup_pitch_merge_identical_test.dart
+++ b/fushi/test/pages/popup_pitch_merge_identical_test.dart
@@ -1,0 +1,194 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2122：音高区里同一个音调型被多本词典各占一行。
+///
+/// 用户报告（官网首页 demo 弹窗查「ギター」）：音高区连出五行一模一样的
+/// `￣ギター [1]`，只有前面的来源药丸不同。Yomitan 的 `getGroupedPronunciations`
+/// 把相同发音合并成一条、后面挂全部来源；popup.js 之前是一本词典一行。
+///
+/// 修法：渲染前加一道纯变换 `mergeIdenticalPitchGroups` —— 整份 payload 全等
+/// （pitchPositions / patterns / transcriptions 三者）的词典合并成一行，
+/// `dictionaries` 带上全部来源名。它跑在 `deduplicatePitchAccents` 分支**之后**：
+/// 去重打开（app 默认）时各存活组的位置互斥、合并对位置组恒为 no-op，默认外观
+/// 一字不变；去重关闭（官网 demo 就是这一档）时才塌行。
+///
+/// 两层守护：
+/// ① 行为级——用 Node 真执行 popup.js 的 `createPitchSection`，断言五本同型词典
+///    塌成 1 行 5 枚药丸、音调型不同的不合并、去重打开时行为与改动前逐字一致。
+///    无 node 时 skip。
+/// ② 源码级——静态扫描**三份镜像副本**（app / 扩展 assets / 扩展 tools），保证合并
+///    helper、调用点、多药丸渲染和 CSS 换行在位；即便无 node 也能守住回归，且三份
+///    副本不会漂移。
+void main() {
+  const Map<String, String> jsMirrors = <String, String>{
+    'app popup': 'assets/popup/popup.js',
+    'extension vendor (assets)': 'assets/browser_extension/vendor/popup.js',
+    'extension vendor (tools)': '../tools/browser-extension/vendor/popup.js',
+  };
+  const Map<String, String> cssMirrors = <String, String>{
+    'app popup': 'assets/popup/popup.css',
+    'extension vendor (assets)': 'assets/browser_extension/vendor/popup.css',
+    'extension vendor (tools)': '../tools/browser-extension/vendor/popup.css',
+  };
+
+  test(
+    'identical pitch accents from several dictionaries merge into one row '
+    '(executes createPitchSection via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+            'node not found on PATH; skipping JS behavior execution');
+        return;
+      }
+
+      final File jsTest =
+          File('test/pages/popup_pitch_merge_identical_test.js');
+      expect(
+        jsTest.existsSync(),
+        isTrue,
+        reason: 'behavior harness ${jsTest.path} must exist',
+      );
+
+      final ProcessResult result = await Process.run(
+        nodeExe,
+        <String>[jsTest.path],
+        workingDirectory: Directory.current.path,
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'popup pitch merge JS behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(
+        result.stdout.toString(),
+        contains('all assertions passed'),
+        reason: 'behavior harness must reach its success marker',
+      );
+    },
+  );
+
+  jsMirrors.forEach((String name, String relPath) {
+    test('[$name] popup.js merges identical pitch groups before rendering', () {
+      final File file = File(relPath);
+      expect(file.existsSync(), isTrue, reason: '$relPath must exist');
+      final String js = file.readAsStringSync();
+
+      // 合并 helper 必须存在，且判据是整份 payload（三者全等），不是只看位置。
+      final int helper =
+          js.indexOf('function mergeIdenticalPitchGroups(groups)');
+      expect(
+        helper,
+        greaterThanOrEqualTo(0),
+        reason: 'the pitch merge helper must exist',
+      );
+      for (final String field in <String>[
+        'group.pitchPositions || []',
+        'group.patterns || []',
+        'group.transcriptions || []',
+      ]) {
+        expect(
+          js.indexOf(field, helper),
+          greaterThan(helper),
+          reason: 'the merge key must cover $field — merging on a partial '
+              'payload would fuse dictionaries that disagree',
+        );
+      }
+
+      // 非恒真：helper 存在但没人调用等于没改。调用点必须在 createPitchSection 内，
+      // 且在去重分支之后（去重先跑，合并是最后一道变换）。
+      final int section =
+          js.indexOf('function createPitchSection(pitches, reading)');
+      expect(section, greaterThanOrEqualTo(0));
+      final int dedup =
+          js.indexOf('if (window.deduplicatePitchAccents)', section);
+      expect(dedup, greaterThan(section));
+      final int call =
+          js.indexOf('mergeIdenticalPitchGroups(groups).forEach(', section);
+      expect(
+        call,
+        greaterThan(dedup),
+        reason: 'createPitchSection must run the merge AFTER the dedup branch, '
+            'so dedup ON keeps the pre-change default look',
+      );
+
+      // 去重分支不得再直接 append，必须先攒进 groups 交给合并。
+      expect(
+        js.substring(dedup, call),
+        isNot(contains('pitchContainer.appendChild(createPitchGroup(')),
+        reason: 'the dedup branch must collect groups instead of appending '
+            'rows directly, or merging never sees them',
+      );
+
+      // createPitchGroup 每本来源渲染一枚药丸。
+      final int group =
+          js.indexOf('function createPitchGroup(pitchData, reading)');
+      expect(group, greaterThanOrEqualTo(0));
+      expect(
+        js.indexOf(
+            'const dictionaries = pitchData.dictionaries || [pitchData.dictionary];',
+            group),
+        greaterThan(group),
+        reason: 'createPitchGroup must accept a dictionary LIST (single-source '
+            'groups degrade to a one-element list)',
+      );
+      final int labelLoop =
+          js.indexOf('dictionaries.forEach((dictionary) => {', group);
+      expect(
+        labelLoop,
+        greaterThan(group),
+        reason: 'every merged source must get its own .pitch-dict-label pill',
+      );
+      expect(
+        js.indexOf("className: 'pitch-dict-label', textContent: dictionary",
+            labelLoop),
+        greaterThan(labelLoop),
+        reason: 'the pill loop must render the per-dictionary label',
+      );
+    });
+  });
+
+  cssMirrors.forEach((String name, String relPath) {
+    test('[$name] popup.css lets a merged pitch row wrap its source pills', () {
+      final File file = File(relPath);
+      expect(file.existsSync(), isTrue, reason: '$relPath must exist');
+      final String css = file.readAsStringSync();
+
+      final int rule = css.indexOf('.pitch-group {');
+      expect(rule, greaterThanOrEqualTo(0),
+          reason: '.pitch-group rule must exist');
+      final int end = css.indexOf('}', rule);
+      expect(end, greaterThan(rule));
+      final String body = css.substring(rule, end);
+      expect(
+        body,
+        contains('flex-wrap: wrap'),
+        reason: 'a merged row can carry several source pills; without wrapping '
+            'they push the reading past the popup edge',
+      );
+      // 换行只在 flex 容器上有意义——顺带钉住这条规则仍是 flex。
+      expect(body, contains('display: flex'));
+    });
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates =
+      Platform.isWindows ? <String>['node.exe', 'node'] : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) {
+        return name;
+      }
+    } on ProcessException {
+      // Not found; try next candidate.
+    }
+  }
+  return null;
+}

--- a/fushi/test/pages/popup_pitch_merge_identical_test.js
+++ b/fushi/test/pages/popup_pitch_merge_identical_test.js
@@ -1,0 +1,222 @@
+// BUG-2122 behavior test: 同一个音调型被多本词典各渲染成一行。
+//
+// 用户报告（官网首页 demo 弹窗，查「ギター」）：音高区连出五行一模一样的
+// `￣ギター [1]`，来源分别是五本音调词典。Yomitan 在 getGroupedPronunciations 里
+// 把相同发音合并成一条、后面挂全部来源标签；popup.js 之前是一本词典一行。
+//
+// 本测试 EXECUTES 真实的 popup.js（vm + 极简假 DOM），驱动真实的
+// `createPitchSection`，然后走产出的元素树数点 `.pitch-group` 行数与
+// `.pitch-dict-label` 药丸。把 mergeIdenticalPitchGroups 或它的调用点撤掉，
+// case 1 立刻变红。
+//
+// 覆盖：
+//   1. 五本词典同为 [1]（去重关闭）→ 只剩 1 行，5 枚来源药丸，按首次出现顺序。
+//   2. 音调型不同（[1] vs [0]）→ 不合并，仍是 2 行。
+//   3. 位置部分重叠（[1,0] vs [1]）→ 判据是 payload 全等，故意不合并，仍是 2 行。
+//   4. 去重打开 + 五本同为 [1] → 与改动前一致：1 行 1 枚药丸（默认外观零变化）。
+//   5. 两本纯 IPA 词典给出完全相同的 transcriptions（去重打开）→ 合并成 1 行 2 枚药丸。
+//
+// Run: node fushi/test/pages/popup_pitch_merge_identical_test.js
+// (also driven from popup_pitch_merge_identical_test.dart so it executes inside
+//  `flutter test`).
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const popupPath = path.resolve(__dirname, '../../assets/popup/popup.js');
+const source = fs.readFileSync(popupPath, 'utf8');
+
+function makeElement(tag) {
+  return {
+    tagName: (tag || 'div').toUpperCase(),
+    className: '',
+    id: '',
+    textContent: '',
+    innerHTML: '',
+    nodeType: 1,
+    style: {},
+    dataset: {},
+    children: [],
+    childNodes: [],
+    attributes: {},
+    classList: {
+      _set: new Set(),
+      add(name) { this._set.add(name); },
+      remove(name) { this._set.delete(name); },
+      contains(name) { return this._set.has(name); },
+    },
+    appendChild(child) { this.children.push(child); this.childNodes.push(child); return child; },
+    append(...nodes) { this.children.push(...nodes); this.childNodes.push(...nodes); },
+    setAttribute(k, v) { this.attributes[k] = v; },
+    removeAttribute(k) { delete this.attributes[k]; },
+    addEventListener() {},
+    querySelectorAll() { return []; },
+    querySelector() { return null; },
+    closest() { return null; },
+  };
+}
+
+function makeTextNode(text) {
+  return { nodeType: 3, textContent: String(text), children: [], childNodes: [] };
+}
+
+function makeSandbox() {
+  const documentObj = {
+    documentElement: { style: {}, classList: makeElement().classList },
+    head: { appendChild() {} },
+    body: makeElement('body'),
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    createElement(tag) { return makeElement(tag); },
+    createTextNode(text) { return makeTextNode(text); },
+    addEventListener() {},
+  };
+
+  const windowObj = {
+    audioSources: [],
+    needsAudio: false,
+    lookupEntries: [],
+    dictionaryStyles: {},
+    // 官网 demo 与「关掉去重」的用户就是这一档；每个 case 各自覆写。
+    deduplicatePitchAccents: false,
+    flutter_inappwebview: { callHandler() { return Promise.resolve(false); } },
+    getSelection() { return { toString() { return ''; } }; },
+  };
+  documentObj.defaultView = windowObj;
+
+  const sandbox = {
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    Date, Math, URL, JSON, RegExp, Set, Map, Object, Array, console,
+    performance: { now() { return 0; } },
+    setTimeout, clearTimeout,
+    DOMParser: class { parseFromString() { return { body: makeElement('body'), querySelectorAll() { return []; } }; } },
+    document: documentObj,
+    window: windowObj,
+    getComputedStyle() { return {}; },
+  };
+  sandbox.globalThis = sandbox;
+  return sandbox;
+}
+
+function loadPopup() {
+  const sandbox = makeSandbox();
+  vm.createContext(sandbox);
+  const exported = source + `
+    ;window.__test = {
+      createPitchSection: createPitchSection,
+    };
+  `;
+  vm.runInContext(exported, sandbox, { filename: 'popup.js' });
+  return sandbox;
+}
+
+// 深度优先收集所有 className == cls 的元素节点。
+function collectByClass(node, cls, acc) {
+  acc = acc || [];
+  if (!node) return acc;
+  if (node.nodeType !== 3 && node.className === cls) acc.push(node);
+  const kids = node.children || node.childNodes || [];
+  for (const k of kids) collectByClass(k, cls, acc);
+  return acc;
+}
+
+function collectText(node) {
+  if (!node) return '';
+  let out = node.nodeType === 3 ? (node.textContent || '') : '';
+  if (typeof node.textContent === 'string' && node.nodeType !== 3 &&
+      (!node.children || node.children.length === 0)) {
+    out += node.textContent;
+  }
+  const kids = node.children || node.childNodes || [];
+  for (const k of kids) out += collectText(k);
+  return out;
+}
+
+function labelNames(section) {
+  return collectByClass(section, 'pitch-dict-label').map(n => n.textContent);
+}
+
+function pitchGroupCount(section) {
+  return collectByClass(section, 'pitch-group').length;
+}
+
+const FIVE_SAME = ['词典14', '词典13', '词典15', '词典16', '词典17'].map(
+  name => ({ dictionary: name, pitchPositions: [1], patterns: [], transcriptions: [] }));
+
+(function run() {
+  // Case 1: 用户报告的原样输入 —— 五本词典同为 [1]，去重关闭。
+  {
+    const sb = loadPopup();
+    sb.window.deduplicatePitchAccents = false;
+    const section = sb.window.__test.createPitchSection(FIVE_SAME, 'ギター');
+    assert.ok(section, 'five identical pitch dicts must still render a pitch section');
+    assert.strictEqual(pitchGroupCount(section), 1,
+      'five dictionaries agreeing on [1] must collapse into ONE .pitch-group row; got '
+        + pitchGroupCount(section));
+    assert.deepStrictEqual(labelNames(section),
+      ['词典14', '词典13', '词典15', '词典16', '词典17'],
+      'the merged row must carry every source label, in first-appearance order');
+    const text = collectText(section);
+    const occurrences = text.split('[1]').length - 1;
+    assert.strictEqual(occurrences, 1,
+      'the accent [1] must be drawn exactly once after merging; got ' + occurrences
+        + ' in ' + JSON.stringify(text));
+  }
+
+  // Case 2: 音调型不同 —— 绝不合并。
+  {
+    const sb = loadPopup();
+    sb.window.deduplicatePitchAccents = false;
+    const section = sb.window.__test.createPitchSection([
+      { dictionary: 'A', pitchPositions: [1], patterns: [], transcriptions: [] },
+      { dictionary: 'B', pitchPositions: [0], patterns: [], transcriptions: [] },
+    ], 'ねこ');
+    assert.strictEqual(pitchGroupCount(section), 2,
+      'dictionaries disagreeing on the accent must stay on separate rows');
+    assert.deepStrictEqual(labelNames(section), ['A', 'B']);
+  }
+
+  // Case 3: 位置部分重叠 —— 判据是 payload 全等，故意不合并（宁可少合）。
+  {
+    const sb = loadPopup();
+    sb.window.deduplicatePitchAccents = false;
+    const section = sb.window.__test.createPitchSection([
+      { dictionary: 'A', pitchPositions: [1, 0], patterns: [], transcriptions: [] },
+      { dictionary: 'B', pitchPositions: [1], patterns: [], transcriptions: [] },
+    ], 'ねこ');
+    assert.strictEqual(pitchGroupCount(section), 2,
+      'partially overlapping position sets must NOT be merged (payload equality is the rule)');
+  }
+
+  // Case 4: 去重打开（app 默认）—— 行为与改动前逐字一致：1 行 1 枚药丸。
+  {
+    const sb = loadPopup();
+    sb.window.deduplicatePitchAccents = true;
+    const section = sb.window.__test.createPitchSection(FIVE_SAME, 'ギター');
+    assert.strictEqual(pitchGroupCount(section), 1,
+      'dedup ON must still yield exactly one row');
+    assert.deepStrictEqual(labelNames(section), ['词典14'],
+      'dedup ON keeps only the first dictionary — the default look must not change');
+  }
+
+  // Case 5: 两本纯 IPA 词典给出完全相同的 transcriptions → 合并。
+  {
+    const sb = loadPopup();
+    sb.window.deduplicatePitchAccents = true;
+    const section = sb.window.__test.createPitchSection([
+      { dictionary: 'IPA-1', pitchPositions: [], patterns: [], transcriptions: ['neꜜko'] },
+      { dictionary: 'IPA-2', pitchPositions: [], patterns: [], transcriptions: ['neꜜko'] },
+    ], 'ねこ');
+    assert.strictEqual(pitchGroupCount(section), 1,
+      'two IPA dicts with identical transcriptions must merge into one row');
+    assert.deepStrictEqual(labelNames(section), ['IPA-1', 'IPA-2']);
+    const text = collectText(section);
+    assert.strictEqual(text.split('[neꜜko]').length - 1, 1,
+      'the shared transcription must be printed once; got ' + JSON.stringify(text));
+  }
+
+  console.log('popup_pitch_merge_identical_test.js: all assertions passed');
+})();

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -1437,6 +1437,10 @@
     align-items: baseline;
     gap: 6px;
     margin-top: 2px;
+    /* BUG-2122：合并同型音调后一行可能挂好几枚来源药丸（用户装了五本音调词典就
+       是五枚）。不许换行的话它们会把读音顶出弹窗右边界；允许换行后，药丸满一行就
+       把读音掘到下一行，而不是溢出。单本词典（绝大多数行）装得下，不会换行。 */
+    flex-wrap: wrap;
     /* TODO-1305 / BUG-pitch-reading-mined: 音高发音区（片假名 reading 逐 mora +
        [n] 音高数字 + IPA）是纯展示，不参与查词/复制。加 user-select:none 杜绝拖选
        把片假名 reading（如 カンロク）留在原生选区、制卡时被烤进 Anki 卡的

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -1499,6 +1499,10 @@ html[data-theme="dark"] :where(.glossary-group, .glossary-content) [class^="glos
     align-items: baseline;
     gap: 6px;
     margin-top: 2px;
+    /* BUG-2122：合并同型音调后一行可能挂好几枚来源药丸（用户装了五本音调词典就
+       是五枚）。不许换行的话它们会把读音顶出弹窗右边界；允许换行后，药丸满一行就
+       把读音掘到下一行，而不是溢出。单本词典（绝大多数行）装得下，不会换行。 */
+    flex-wrap: wrap;
     /* TODO-1305 / BUG-pitch-reading-mined: 音高发音区（片假名 reading 逐 mora +
        [n] 音高数字 + IPA）是纯展示，不参与查词/复制。加 user-select:none 杜绝拖选
        把片假名 reading（如 カンロク）留在原生选区、制卡时被烤进 Anki 卡的

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2738,9 +2738,46 @@ function createTranscriptionsHtml(transcriptions) {
     return list;
 }
 
+// BUG-2122：同一个音调型被多本词典各渲染成一行。五本音调词典都把「ギター」
+// 标成 [1] 时，用户看到的是五行一模一样的 ￣ギター [1]，读起来像坏了。Yomitan 在
+// getGroupedPronunciations 里把相同发音合并成一条、后面挂上全部来源；这里做同样的事：
+// 整份 payload 全等（pitchPositions / patterns / transcriptions 三者）的词典合并成一行，
+// dictionaries 带上全部来源名。判据故意取「全等」而不是逐条位置求交：宁可少合
+// 一次，也不把读法不同的两本词典混进同一行。
+//
+// 本函数是渲染前的最后一道纯变换，跑在 deduplicatePitchAccents 分支之后：去重打开
+// 时（app 默认）各存活组的位置互斥，payload 不可能全等，合并对位置组恒为 no-op，
+// 默认外观一字不变；去重关闭时才塌行。（两本纯 IPA 词典给出完全相同的
+// transcriptions 是唯一例外，那也本就该合。）
+function mergeIdenticalPitchGroups(groups) {
+    const merged = [];
+    const byPayload = new Map();
+    groups.forEach((group) => {
+        const key = JSON.stringify([
+            group.pitchPositions || [],
+            group.patterns || [],
+            group.transcriptions || [],
+        ]);
+        const existing = byPayload.get(key);
+        if (existing) {
+            if (!existing.dictionaries.includes(group.dictionary)) {
+                existing.dictionaries.push(group.dictionary);
+            }
+            return;
+        }
+        const entry = Object.assign({}, group, { dictionaries: [group.dictionary] });
+        byPayload.set(key, entry);
+        merged.push(entry);
+    });
+    return merged;
+}
+
 function createPitchGroup(pitchData, reading) {
-    const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    const dictionaries = pitchData.dictionaries || [pitchData.dictionary];
+    const container = el('div', { className: 'pitch-group', 'data-details': dictionaries.join(', ') });
+    dictionaries.forEach((dictionary) => {
+        container.appendChild(el('span', { className: 'pitch-dict-label', textContent: dictionary }));
+    });
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -2820,6 +2857,7 @@ function createPitchSection(pitches, reading) {
     const section = el('div', { className: 'category-section pitch-section' });
     const body = el('div', { className: 'category-body' });
     const pitchContainer = el('div', { className: 'pitch-list' });
+    const groups = [];
     if (window.deduplicatePitchAccents) {
         const seen = new Set();
         pitches.forEach(pitch => {
@@ -2832,14 +2870,14 @@ function createPitchSection(pitches, reading) {
             const hasPatterns = pitch.patterns?.length;
             if (unique.length > 0 || hasTranscriptions || hasPatterns) {
                 unique.forEach(pos => seen.add(pos));
-                pitchContainer.appendChild(createPitchGroup(
-                    { dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions },
-                    reading));
+                groups.push({ dictionary: pitch.dictionary, pitchPositions: unique, patterns: pitch.patterns, transcriptions: pitch.transcriptions });
             }
         });
     } else {
-        pitches.forEach(pitch => pitchContainer.appendChild(createPitchGroup(pitch, reading)));
+        pitches.forEach(pitch => groups.push(pitch));
     }
+    mergeIdenticalPitchGroups(groups).forEach(
+        group => pitchContainer.appendChild(createPitchGroup(group, reading)));
     body.appendChild(pitchContainer);
     section.appendChild(body);
     return section;


### PR DESCRIPTION
## 用户报告

查「ギター」时音高区连出五行一模一样的 `￣ギター [1]`，只有前面的来源药丸不同（`词典14/13/15/16/17`）。

## 根因

`fushi/assets/popup/popup.js` `createPitchSection`：一个 pitch group 渲染一个 `.pitch-group` 行，一本词典一行。

`deduplicate_pitch_accents`（`preferences_repository.dart:1731`，默认 `true`）靠「丢掉已出现过的音调位」把重复行压掉——**代价是另外四本词典的来源名被整条丢弃**，用户看不到「五本都认同」。官网首页 demo 注入的是 `false`，于是重复行原样暴露（用户截图即此档）。**一档丢信息，另一档出重复**。

对照实现：Yomitan 的 `getGroupedPronunciations` 把相同发音合并成一条、后面挂全部来源标签，从不出重复行。

## 修法

加一道渲染前的纯变换 `mergeIdenticalPitchGroups()`：整份 payload 全等（`pitchPositions` / `patterns` / `transcriptions` 三者）的词典合并成一行，`dictionaries` 带上全部来源名；`createPitchGroup` 改吃来源数组（单本退化成长度 1，不新增分支），每本渲一枚 `.pitch-dict-label` 药丸；`.pitch-group` 加 `flex-wrap: wrap`，防多药丸把读音顶出弹窗右边界。

两个刻意的设计决定：

- **合并跑在去重分支之后**。去重打开（app 默认）时各存活组的位置互斥、payload 不可能全等，合并对位置组恒为 no-op——**默认外观一字不变**。唯一会在去重档位生效的是「两本纯 IPA 词典给出完全相同的 transcriptions」，那本就该合。
- **判据取「payload 全等」而不是逐条位置求交**。宁可少合一次（`[1,0]` vs `[1]` 仍是两行），也不把读法不同的两本词典混进同一行。

## 影响面

```
去重关闭（官网 demo / 用户手动关）：
  [词典14] ￣|ギター [1]        [词典14][词典13][词典15][词典16][词典17] ￣|ギター [1]
  [词典13] ￣|ギター [1]   →
  [词典15] ￣|ギター [1]
  [词典16] ￣|ギター [1]
  [词典17] ￣|ギター [1]

去重打开（app 默认）：逐字不变，仍是 [词典14] ￣|ギター [1]
```

三份镜像副本 + 生成的 `content.css` 同步（`generate-content-css.mjs` + `sync-mirrors.mjs` 跑过，报「镜像本已一致 ✓」）。

## 测试

`fushi/test/pages/popup_pitch_merge_identical_test.dart` + `.js`

- **行为级**（node vm 真跑 popup.js 的 `createPitchSection`）：五本同为 `[1]` 且去重关闭 → 只剩 1 个 `.pitch-group`、5 枚药丸按首次出现顺序、`[1]` 只画一次；音调型不同（`[1]` vs `[0]`）不合并；位置部分重叠（`[1,0]` vs `[1]`）不合并；**去重打开时 1 行 1 枚药丸**（钉死默认外观零变化）；两本纯 IPA 同 transcriptions 合并。
- **变异实测**：撤掉 `mergeIdenticalPitchGroups(groups)` 调用点 → case 1 报 `5 !== 1` 红，恢复即绿（不是空壳断言）。
- **源码级**：三份镜像副本各自断言合并 helper、调用点在去重分支之后、去重分支不再直接 append、多药丸渲染循环，以及 `.pitch-group` 的 `flex-wrap: wrap`。

## 本地验证

| 项 | 结果 |
|---|---|
| `test/pages`（popup 爆炸半径，五个 node 宿主跑真 popup.js） | PASSED — 3316 tests |
| `test/dictionary` + `test/lookup` + `test/build` + `test/anki` | PASSED — 1910 tests |
| 目录枚举型守卫整批（51 条） | PASSED — 362 tests（与当前基线 N=362 一致，无漂移） |
| `tools/browser-extension` node 测试 | 420 pass / 0 fail |
| `flutter analyze`（含 test） | No issues found! |

## 遗留

官网 `fushi.moe` 首页 demo 把 popup.js 内联在 `public/index.html`（更旧的快照，没有 `patterns` 支持），是独立仓库的独立副本，需同步同一处改动才能让用户截图里的页面变好——另开 PR。

https://claude.ai/code/session_011Kqdayik8aNQxbkLTigxhs
