### PR TITLE
fix(lookup): 全局查词首帧不再先闪在工作区左上角（BUG-2123）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1980 条。点号进各自文件。
+> 共 1981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2123](bugs/BUG-2123-global-lookup-first-frame-topleft-flash.md) | ✅ | ✅ | app 外全局查词弹窗首帧先闪在屏幕左上角再飞到光标 |
 | [BUG-2110](bugs/BUG-2110-dict-mass-import-startup-crash.md) | ✅ | ✅ | 一次性导入大量词典后启动转圈中途闪退 |
 | [BUG-2109](bugs/BUG-2109-recommended-pack-never-deleted.md) | ✅ | ✅ | 推荐包 9.5GB zip 导入后永不删除（清理钩子挂在不再执行的引导页 initState） |
 | [BUG-2107](bugs/BUG-2107-onboarding-pack-pick-bare-filepicker.md) | ✅ | ✅ | 引导选本地包走裸 pickFiles：安卓整份复制进 cache，失败静默无提示 |

--- a/docs/bugs/BUG-2123-global-lookup-first-frame-topleft-flash.md
+++ b/docs/bugs/BUG-2123-global-lookup-first-frame-topleft-flash.md
@@ -1,0 +1,20 @@
+## BUG-2123 · app 外全局查词弹窗首帧先闪在屏幕左上角再飞到光标
+- **报告**：2026-09-04（用户：「global lookup seems to have a bug this version where for a millisecond it appears in the top left of your display before moving to the cursor position」）
+- **真实性**：✅ **真 bug（首帧窗口位置与图层补偿平移跨 DWM/WebView2 边界不同帧）**。三处代码合起来必然产出这一帧：
+  1. `fushi/lib/src/lookup/global_lookup_layout.dart:346` `computeCascadeHeadroomSeed` / `_cascadeHeadroom` —— BUG-670 的 reserve-to-edge 地板把预留量从「一张卡」改成「光标到工作区该侧边的整段距离」，于是 **每一次** 查词（不只是有子卡的）的 union bbox 原点都被拉到 `(-cursorWorkX, -cursorWorkY)`，即工作区左上角。
+  2. `fushi/assets/popup/global_lookup_host.js` `measureAndReport` —— TODO-1231 P2 明确**不在这里**平移图层，只上报 bbox；`beginLookup` 每次查词把 `layer.style.left/top` 归零。
+  3. `fushi/windows/runner/global_lookup_window.cpp:1276` `GlobalLookupWindow::RevealStack` —— 先 `SetWindowPos(..., SWP_SHOWWINDOW)` 把窗口挪到 bbox 原点**并让它可见**，之后才用 `ExecuteScript` 发 `commitLayerShift(bbox.left, bbox.top, epoch)`（同文件 1310 行附近的注释自陈「window first, content ~1 frame later」）。
+
+  屏幕位置 = `窗口原点 + 图层平移 + 壳本地坐标`。首帧那一刻窗口原点已经是工作区左上角、图层平移还是 0、根卡壳本地坐标是 0 → 根卡就画在**工作区左上角**；一帧（一次 ExecuteScript + 合成）之后平移生效才跳到光标。
+
+  「窗口先动、内容后跟」这个次序**只**为保护**已经画在屏幕上**的父卡（嵌套子卡展开时的 BUG-583「几何跳动」）。首帧窗口还停在 `OffscreenX()` 之外、对用户不可见，被保护的对象根本不存在，代价却照收——reserve-to-edge 落地后这一帧从「只有向左/上级联才出现」变成**每次查词必现**，即用户说的「this version」。
+- **[x] ① 已修复** — 根因修：把补偿平移的时机按「窗口此刻可不可见」分两态，而不是一刀切地永远后置。
+  - `fushi/assets/popup/global_lookup_host.js`：新增**唯一写入口** `applyLayerOffset(l, t)`（DOM 平移与 `layerOffsetLeft/Top` 锁步——分开写过一次就是 BUG-859），`commitLayerShift` / `beginLookup` 都改走它；`measureAndReport` 在 `postToHost('overlaySize')` **之前**加一条门：`route.source !== 'galCard' && committedGeometryEpoch === 0` 时立刻 `applyLayerOffset(minLeft, minTop)`。
+  - 为什么安全：`committedGeometryEpoch === 0` 精确等价于「本次查词还没提交过任何几何」＝窗口仍在屏外。窗口要等这条 `overlaySize` 走完一整趟 Dart 往返（`overlaySize` → `_applyOverlayBox` → `revealStack` → `SetWindowPos`）才第一次可见，内容早已合成到位，**首帧即正确**。随后 C++ 那次 `commitLayerShift` 带着同样的 `(minLeft, minTop)` 到达，DOM 写入是幂等 no-op，只剩「提交 bounds + 翻 reveal 门」的职责。
+  - 未动的部分：窗口已可见后的每一次几何事务仍严格保持 TODO-1231 P2 的「窗口先动、内容后跟」（嵌套展开零位移不回退）；galCard 路由的窗口永远在屏外、靠截图贴进游戏画面，没有可闪的首帧，保持原样以免动到 `captureReady` 的两帧握手。
+  - 提交：见本分支 `worktree-lookup-first-reveal-topleft-flash`。
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/lookup/global_lookup_host_test.mjs` 新增用例 11c（BUG-2123），在**与 C++ 窗口同一套坐标算术**（`screen = windowOrigin + layerOffset + shellLocal`）上锁死两条不变式：(A) 带 `originFloor:{left:-300,top:-200}` 的首次事务，`overlaySize` 发出时图层已补偿到 `300px/200px`，根卡窗口本地位置＝光标偏移而**不是** (0,0)；(B) 窗口可见后再来一次事务（子卡把原点推到 -420/-260），`measureAndReport` **不得**动图层，只有 `commitLayerShift` 能动。用例 11 的图层断言同步改成新的两阶段语义。
+  - **变异实测**：把修复那一条 `if` 改成 `if (false)` → 用例 11 红（`actual '0' !== expected '40px'`）；恢复后绿。
+  - `fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart` 的两条源码守卫跟上实现：原来只查 `beginBody.contains('layerOffsetLeft = 0')` 这类字面量（重构后会变**假红**），也查 `measureBody.contains('layerEl.style.left') == false`（重构后会变**空壳恒真**）。改为断言 ①`applyLayerOffset` 是 `layerOffsetLeft` 的唯一写者（排除 `var` 声明后计数为 1）、②`measureAndReport` 里 `applyLayerOffset(` 只出现一次且必须被 `committedGeometryEpoch === 0` 那道门包住、③C++ `RevealStack` 里 `SetWindowPos` 仍排在 `commitLayerShift` 之前。
+- **备注**：验证 `test/lookup` 744 条全绿 + `test/dictionary` / `test/pages` / `test/utils` 相邻 4 个守卫 18 条全绿 + 三个 node 宿主 `.mjs` 套件全绿（node 测试不在 CI 真单测门内，必须本地跑）。**真机肉眼复测待用户**：Windows 上按全局查词热键，弹窗应直接出现在光标处，屏幕左上角不再有一帧闪现。

--- a/fushi/assets/popup/global_lookup_host.js
+++ b/fushi/assets/popup/global_lookup_host.js
@@ -2548,22 +2548,15 @@
     // up/left child as already-covered (which would reveal it clipped). Mirrors the
     // Dart ratchet reset (_ratchetLeft/_ratchetTop = infinity) one layer up. The
     // real layer transform is re-applied by this lookup's first commitLayerShift.
-    layerOffsetLeft = 0;
-    layerOffsetTop = 0;
     // BUG-859 — reset the layer's DOM transform IN LOCK-STEP with the shadow
-    // offsets above. Resetting only the variables left the previous lookup's
+    // offsets. Resetting only the variables left the previous lookup's
     // translate (layer.style.left/top) applied while shellCoveredByOrigin /
     // frameIdAtPoint reasoned against the zeroed offsets: the reveal gate was
     // defeated (a stale-shifted card counted as covered) and any reveal that
     // bypasses commitLayerShift (legacy Reveal / ready-safety fallback) showed
-    // the fresh root displaced by the stale shift. The normal revealStack path
-    // re-applies the correct transform via commitLayerShift, so this is a no-op
-    // there (style already 0 for a fresh down-right cascade).
-    var layerEl = document.getElementById(LAYER_ID);
-    if (layerEl) {
-      layerEl.style.left = '0px';
-      layerEl.style.top = '0px';
-    }
+    // the fresh root displaced by the stale shift. This lookup's real transform
+    // is re-applied by its first measureAndReport / commitLayerShift.
+    applyLayerOffset(0, 0);
     // TODO-1345 (BUG-583 深层根因续) — drop the previous lookup's reserved cascade
     // floor so it can never leak into a fresh lookup (a new lookup re-computes its
     // own floor from the new cursor position and pushes it via the next renderStack).
@@ -2874,7 +2867,26 @@
         !isFinite(maxRight) || !isFinite(maxBottom)) {
       return;
     }
-    // TODO-1231 P2 — do NOT shift the host layer (nor set layerOffset*) HERE. The
+    // BUG-2123 — 首帧例外，把补偿平移**提前**到 overlaySize 之前。
+    // 下面 TODO-1231 P2 的「窗口先动、内容后跟」次序只为保护**已经画在屏幕上**的
+    // 父卡；本次查词还没提交过任何几何（committedGeometryEpoch === 0）时窗口仍停在
+    // OffscreenX() 之外、对用户不可见，被保护的对象根本不存在，代价却照收：
+    // reserve-to-edge 地板（computeCascadeHeadroomSeed·BUG-670）让**每一次**查词的
+    // bbox 原点都被拉到工作区左上角，于是 RevealStack 的 SetWindowPos +
+    // SWP_SHOWWINDOW 先让窗口带着「平移量仍为 0」的图层可见 —— 根卡就画在窗口本地
+    // (0,0) = 工作区左上角，直到一帧后 ExecuteScript 的 commitLayerShift 才把它搬到
+    // 光标处。用户看到的正是「弹窗先在屏幕左上角闪一下再飞到光标」。
+    // 在 postToHost('overlaySize') 之前落位是安全的：窗口要等这条消息走完一整趟
+    // Dart 往返（overlaySize → _applyOverlayBox → revealStack → SetWindowPos）才第一
+    // 次可见，内容早已合成到位，首帧即正确；随后 C++ 那次 commitLayerShift 带着同样
+    // 的 (minLeft, minTop) 到达，DOM 写入是幂等 no-op，嵌套 / 后续 resize 路径逐字节
+    // 不变。galCard 的窗口永远在屏外（截图后贴进游戏画面），没有可闪的首帧，保持
+    // 原样以免动到 captureReady 的两帧握手。
+    if (route.source !== 'galCard' && committedGeometryEpoch === 0) {
+      applyLayerOffset(minLeft, minTop);
+    }
+    // TODO-1231 P2 — for every LATER transaction (the window is already visible)
+    // do NOT shift the host layer (nor set layerOffset*) HERE. The
     // layer translation (-minLeft,-minTop) that pins the ROOT card at the cursor
     // while the window covers the whole cascade bbox must be applied ONLY AFTER
     // C++ SetWindowPos has moved the window to the new bbox origin. When the host
@@ -3037,6 +3049,18 @@
   // negation and layerOffset* is kept in lock-step for the hit-test (TODO-1189).
   // CSS px only (no dpr; the dpr boundary is the C++ window). Bad args default to
   // 0 (no shift), matching a single popup / down-right cascade.
+  // 图层补偿平移的**唯一**写入口：DOM 平移与 layerOffset*（命中测试 /
+  // frameIdAtPoint 用的同一坐标域）必须锁步，分开写过一次就出过 BUG-859。
+  function applyLayerOffset(l, t) {
+    var layerEl = document.getElementById(LAYER_ID);
+    if (layerEl) {
+      layerEl.style.left = (-l) + 'px';
+      layerEl.style.top = (-t) + 'px';
+    }
+    layerOffsetLeft = l;
+    layerOffsetTop = t;
+  }
+
   function commitLayerShift(
       bboxLeft, bboxTop, geometryEpoch, deferSuffixSwapFinalize) {
     var epoch = (typeof geometryEpoch === 'number' && isFinite(geometryEpoch) &&
@@ -3061,13 +3085,9 @@
     }
     var l = (typeof bboxLeft === 'number' && isFinite(bboxLeft)) ? bboxLeft : 0;
     var t = (typeof bboxTop === 'number' && isFinite(bboxTop)) ? bboxTop : 0;
-    var layerEl = document.getElementById(LAYER_ID);
-    if (layerEl) {
-      layerEl.style.left = (-l) + 'px';
-      layerEl.style.top = (-t) + 'px';
-    }
-    layerOffsetLeft = l;
-    layerOffsetTop = t;
+    // 首帧路径可能已经把同一组值提前落位（见 measureAndReport 的 BUG-2123 分支），
+    // 那时这次写入是幂等 no-op，本函数只剩「提交 bounds + 翻 reveal 门」的职责。
+    applyLayerOffset(l, t);
     // TODO-1231 v3 (BUG-583) — the window just settled at this origin, so any shell
     // held hidden because it fell OUTSIDE the previous (narrower) window is now
     // covered; flip its reveal-ready so it paints IN PLACE, coincident with the

--- a/fushi/test/lookup/global_lookup_host_test.mjs
+++ b/fushi/test/lookup/global_lookup_host_test.mjs
@@ -884,11 +884,16 @@ function commitLatestGeometry(host) {
 }
 
 // 11. D2 overlaySize: the host reports the UNION bounding box of all shells
-//     (window-local CSS px) + dpr. TODO-1231 P2: measureAndReport NO LONGER
-//     shifts the layer synchronously (that raced the window move across vsync ->
-//     geometry lurch); the shift is applied by commitLayerShift, which C++
-//     RevealStack calls AFTER SetWindowPos. So the layer stays un-shifted until
-//     commitLayerShift(box.left, box.top) runs.
+//     (window-local CSS px) + dpr. Layer-shift ordering is two-phase:
+//     * FIRST transaction of a lookup (BUG-2123): the native window is still
+//       parked off-screen, so measureAndReport applies the compensating shift
+//       RIGHT AWAY -- the window only becomes visible a full Dart round-trip
+//       later (overlaySize -> revealStack -> SetWindowPos) and must show settled
+//       content on its very first frame.
+//     * LATER transactions (test 11c): the window is already on screen, so
+//       TODO-1231 P2 holds -- the shift waits for commitLayerShift, which C++
+//       RevealStack calls AFTER SetWindowPos, so window and content move in a
+//       causal order instead of racing across vsync.
 {
   const { host, document, window } = freshHost();
   window.devicePixelRatio = 1.5;
@@ -907,16 +912,88 @@ function commitLatestGeometry(host) {
   assert.strictEqual(box.top, 0, 'bbox top = min shell top');
   assert.strictEqual(box.width, 140, 'bbox width = maxRight - minLeft');
   assert.strictEqual(box.height, 140, 'bbox height = maxBottom - minTop');
-  // TODO-1231 P2: measureAndReport must NOT have shifted the layer yet (it only
-  // reports the bbox; the shift is C++-ordered after SetWindowPos).
+  // BUG-2123: this is the lookup's FIRST transaction (the window has never been
+  // revealed), so the compensating translation is already applied when
+  // overlaySize is posted -- the window cannot become visible before Dart has
+  // round-tripped this very message.
   const layer = document.getElementById('global-lookup-host-layer');
-  assert.strictEqual(layer.style.left, '0', 'layer NOT shifted by measureAndReport');
-  assert.strictEqual(layer.style.top, '0', 'layer NOT shifted by measureAndReport');
-  // commitLayerShift (called by C++ RevealStack after the window moved) applies
-  // the compensating translation so the bbox origin maps to the window origin.
+  assert.strictEqual(layer.style.left, '40px',
+    'first transaction shifts the layer by -minLeft before overlaySize');
+  assert.strictEqual(layer.style.top, '0px',
+    'first transaction shifts the layer by -minTop before overlaySize');
+  // commitLayerShift (called by C++ RevealStack after the window moved) carries
+  // the same origin, so it is an idempotent no-op on the DOM.
   host.commitLayerShift(box.left, box.top, box.geometryEpoch);
-  assert.strictEqual(layer.style.left, '40px', 'commitLayerShift shifts by -minLeft');
-  assert.strictEqual(layer.style.top, '0px', 'commitLayerShift shifts by -minTop');
+  assert.strictEqual(layer.style.left, '40px', 'commitLayerShift keeps -minLeft');
+  assert.strictEqual(layer.style.top, '0px', 'commitLayerShift keeps -minTop');
+}
+
+// 11c. BUG-2123 -- "app 外查词的弹窗先在屏幕左上角闪一下再飞到光标".
+//      Root cause: the reserve-to-edge origin floor (computeCascadeHeadroomSeed,
+//      BUG-670) drags the FIRST bbox origin all the way out to the work-area
+//      corner on EVERY lookup, and C++ RevealStack made the window visible
+//      (SetWindowPos | SWP_SHOWWINDOW) at that origin while the compensating
+//      layer translate was still queued behind an ExecuteScript round-trip. For
+//      that one frame the root card painted at window-local (0,0) == the
+//      work-area top-left corner, then jumped to the cursor.
+//      Invariant locked here, in the SAME coordinate arithmetic the C++ window
+//      uses (screen = windowOrigin + layerOffset + shellLocal):
+//        A) first transaction  -> layer already compensates the floor, so the
+//           root card's window-local position is the reserved cursor offset,
+//           NOT (0,0);
+//        B) later transactions -> layer must NOT move until commitLayerShift
+//           (TODO-1231 P2 anti-lurch ordering is preserved for a visible window).
+{
+  const { host, document } = freshHost();
+  // Cursor 300x200 CSS px inside the work area -> Dart reserves that whole
+  // distance so any up/left cascade fits without moving the window origin.
+  host.renderStack({
+    originFloor: { left: -300, top: -200 },
+    popups: [
+      { id: 'frame-0', parentIndex: -1, frame: { left: 0, top: 0, width: 100, height: 80 }, settingsJs: '' },
+    ],
+  });
+  const first = latestGeometryBox();
+  assert.strictEqual(first.left, -300, 'precondition: the floor owns the bbox origin');
+  assert.strictEqual(first.top, -200, 'precondition: the floor owns the bbox origin');
+  const layer = document.getElementById('global-lookup-host-layer');
+  // (A) The window is placed at (cursor + bbox.left, cursor + bbox.top) == the
+  // work-area corner. The root shell is at layer-local (0,0), so its window-local
+  // position is layerOffset + 0. Un-shifted that is (0,0) -> the corner flash.
+  assert.strictEqual(layer.style.left, '300px',
+    'first reveal: layer compensates the reserved floor BEFORE the window shows');
+  assert.strictEqual(layer.style.top, '200px',
+    'first reveal: layer compensates the reserved floor BEFORE the window shows');
+  const rootShell = shellsOf(document)[0];
+  assert.strictEqual(
+    parseFloat(layer.style.left) + (parseFloat(rootShell.style.left) || 0), 300,
+    'root card lands at the cursor on the window\'s FIRST visible frame');
+  assert.strictEqual(
+    parseFloat(layer.style.top) + (parseFloat(rootShell.style.top) || 0), 200,
+    'root card lands at the cursor on the window\'s FIRST visible frame');
+  // Commit it the way C++ RevealStack does; the window is now visible.
+  commitLatestGeometry(host);
+
+  // (B) A nested child cascading further up/left produces a NEW transaction.
+  // The window is on screen now, so the layer must stay put until C++ has moved
+  // the window (otherwise the pinned parent lurches -- TODO-1231 P2).
+  hostPostLog = [];
+  host.renderStack({
+    originFloor: { left: -300, top: -200 },
+    popups: [
+      { id: 'frame-0', parentIndex: -1, frame: { left: 0, top: 0, width: 100, height: 80 }, settingsJs: '' },
+      { id: 'frame-1', parentIndex: 0, frame: { left: -420, top: -260, width: 100, height: 80 }, settingsJs: '' },
+    ],
+  });
+  const second = latestGeometryBox();
+  assert.strictEqual(second.left, -420, 'precondition: the child pushes the origin past the floor');
+  assert.strictEqual(layer.style.left, '300px',
+    'visible window: measureAndReport must NOT move the layer (anti-lurch)');
+  assert.strictEqual(layer.style.top, '200px',
+    'visible window: measureAndReport must NOT move the layer (anti-lurch)');
+  host.commitLayerShift(second.left, second.top, second.geometryEpoch);
+  assert.strictEqual(layer.style.left, '420px', 'commitLayerShift applies the new origin');
+  assert.strictEqual(layer.style.top, '260px', 'commitLayerShift applies the new origin');
 }
 
 // 11b. BUG-2082 — the overlaySize box also carries the ROOT card's own measured

--- a/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_inapp_isolation_guard_test.dart
@@ -522,15 +522,44 @@ void main() {
       },
     );
 
-    test('TODO-1231 P2: layer shift is C++-ordered after SetWindowPos', () {
-      // measureAndReport must NOT shift the layer synchronously (that raced the
-      // window move across vsync -> the parent card lurched then snapped back).
-      // The shift rides commitLayerShift, which C++ RevealStack calls AFTER
-      // SetWindowPos so the window move and content shift are causally ordered.
+    test('TODO-1231 P2 / BUG-2123: the layer shift is C++-ordered after '
+        'SetWindowPos for a VISIBLE window, and pre-applied only on the first '
+        '(still off-screen) transaction', () {
+      // TODO-1231 P2: once the window is on screen, measureAndReport must NOT
+      // shift the layer synchronously (that raced the window move across vsync
+      // -> the parent card lurched then snapped back). The shift rides
+      // commitLayerShift, which C++ RevealStack calls AFTER SetWindowPos so the
+      // window move and content shift are causally ordered.
+      // BUG-2123: the FIRST transaction of a lookup is the exception — the
+      // window is still parked off-screen, so deferring the shift there bought
+      // nothing and cost the "弹窗先在左上角闪一下" frame (the reserve-to-edge
+      // floor puts the first bbox origin at the work-area corner on EVERY
+      // lookup). It is applied up front, gated on `committedGeometryEpoch === 0`.
       expect(
         hostJs.contains('function commitLayerShift('),
         isTrue,
         reason: 'the host exposes a commit hook for the deferred layer shift',
+      );
+      // One writer for the DOM translate + layerOffset* pair (they must stay in
+      // lock-step; splitting them once already caused BUG-859).
+      final int layerOriginWrites =
+          'layerOffsetLeft = '.allMatches(hostJs).length -
+              'var layerOffsetLeft = '.allMatches(hostJs).length;
+      expect(
+        layerOriginWrites,
+        1,
+        reason: 'applyLayerOffset is the single writer of the layer origin',
+      );
+      final int aAt = hostJs.indexOf('function applyLayerOffset(');
+      expect(aAt, greaterThan(-1));
+      final int aEnd = hostJs.indexOf('function commitLayerShift(', aAt);
+      expect(aEnd, greaterThan(aAt));
+      final String applyBody = hostJs.substring(aAt, aEnd);
+      expect(
+        applyBody.contains('layerEl.style.left') &&
+            applyBody.contains('layerOffsetLeft = l'),
+        isTrue,
+        reason: 'applyLayerOffset writes the DOM translate and the offset pair',
       );
       final int mAt = hostJs.indexOf('function measureAndReport(');
       final int mEnd = hostJs.indexOf('function measureContentHeight(', mAt);
@@ -540,8 +569,23 @@ void main() {
         measureBody.contains('layerEl.style.left'),
         isFalse,
         reason:
-            'measureAndReport must not shift the layer synchronously '
-            '(TODO-1231 P2: it races the window move across vsync)',
+            'measureAndReport must go through applyLayerOffset, never poke the '
+            'layer DOM behind the offset bookkeeping',
+      );
+      expect(
+        'applyLayerOffset('.allMatches(measureBody).length,
+        1,
+        reason: 'measureAndReport shifts the layer at most once, under a gate',
+      );
+      expect(
+        measureBody.contains(
+          "if (route.source !== 'galCard' && committedGeometryEpoch === 0) {\n"
+          '      applyLayerOffset(minLeft, minTop);',
+        ),
+        isTrue,
+        reason:
+            'the pre-shift is gated on an uncommitted (still hidden) window; a '
+            'visible window keeps the TODO-1231 P2 window-first ordering',
       );
       // C++ RevealStack triggers the commit AFTER SetWindowPos.
       final int rsAt = cpp.indexOf('void GlobalLookupWindow::RevealStack(');
@@ -781,13 +825,13 @@ void main() {
       expect(bEnd, greaterThan(bAt));
       final String beginBody = hostJs.substring(bAt, bEnd);
       expect(
-        beginBody.contains('layerOffsetLeft = 0') &&
-            beginBody.contains('layerOffsetTop = 0') &&
+        beginBody.contains('applyLayerOffset(0, 0)') &&
             beginBody.contains('resetGeometryTransaction()'),
         isTrue,
         reason:
-            'beginLookup retires the committed transaction while the global '
-            'epoch counter remains monotonic',
+            'beginLookup retires the committed transaction (and zeroes the layer '
+            'origin through the single writer) while the global epoch counter '
+            'remains monotonic',
       );
     });
 


### PR DESCRIPTION
## 症状

用户报告（2026-09-04）：app 外全局查词的弹窗，**每次**都会先在屏幕左上角闪现约一帧，然后才飞到光标位置。

## 根因

屏幕位置 = `窗口原点 + 图层平移 + 壳本地坐标`。三处代码合起来必然产出这一帧：

1. `fushi/lib/src/lookup/global_lookup_layout.dart` 的 `computeCascadeHeadroomSeed` —— BUG-670 的 reserve-to-edge 地板把预留量改成「光标到工作区该侧边的整段距离」，于是**每一次**查词（不只是有子卡的）的 union bbox 原点都被拉到 `(-cursorWorkX, -cursorWorkY)`，即工作区左上角。
2. `fushi/assets/popup/global_lookup_host.js` 的 `measureAndReport` —— TODO-1231 P2 明确**不在这里**平移图层；`beginLookup` 每次查词把 `layer.style.left/top` 归零。
3. `fushi/windows/runner/global_lookup_window.cpp` 的 `RevealStack` —— 先 `SetWindowPos(..., SWP_SHOWWINDOW)` 把窗口挪到 bbox 原点**并让它可见**，之后才用 `ExecuteScript` 发 `commitLayerShift`（注释自陈 "window first, content ~1 frame later"）。

首帧那一刻：窗口原点已是工作区左上角、图层平移还是 0、根卡壳本地坐标是 0 → 根卡画在**工作区左上角**；一帧后平移生效才跳到光标。

「窗口先动、内容后跟」这个次序**只**为保护**已经画在屏幕上**的父卡（嵌套子卡展开时的 BUG-583「几何跳动」）。首帧窗口还停在 `OffscreenX()` 之外、对用户不可见，被保护的对象根本不存在，代价却照收——reserve-to-edge 落地后这一帧从「只有向左/上级联才出现」变成**每次查词必现**。

## 修复

把补偿平移的时机按「窗口此刻可不可见」分两态，而不是一刀切地永远后置。

- 新增**唯一写入口** `applyLayerOffset(l, t)`（DOM 平移与 `layerOffsetLeft/Top` 锁步——分开写过一次就是 BUG-859），`commitLayerShift` / `beginLookup` 都改走它。
- `measureAndReport` 在 `postToHost('overlaySize')` **之前**加一道门：`route.source !== 'galCard' && committedGeometryEpoch === 0` 时立刻 `applyLayerOffset(minLeft, minTop)`。
- 为什么安全：`committedGeometryEpoch === 0` 精确等价于「本次查词还没提交过任何几何」＝窗口仍在屏外。窗口要等这条 `overlaySize` 走完一整趟 Dart 往返（`overlaySize` → `_applyOverlayBox` → `revealStack` → `SetWindowPos`）才第一次可见，内容早已合成到位，**首帧即正确**。随后 C++ 那次 `commitLayerShift` 带同样的值到达，DOM 写入是幂等 no-op，只剩「提交 bounds + 翻 reveal 门」的职责。

**未动的部分**：窗口已可见后的每一次几何事务仍严格保持 TODO-1231 P2 的「窗口先动、内容后跟」（嵌套展开零位移不回退）；galCard 路由的窗口永远在屏外、靠截图贴进游戏画面，没有可闪的首帧，保持原样以免动到 `captureReady` 的两帧握手。C++ 与 Dart 侧一行未改。

## 测试

- `fushi/test/lookup/global_lookup_host_test.mjs` 新增用例 11c，在**与 C++ 窗口同一套坐标算术**上锁两条不变式：(A) 首次事务发 `overlaySize` 时图层已补偿，根卡窗口本地位置＝光标偏移而非 (0,0)；(B) 窗口可见后的事务里 `measureAndReport` 不得动图层，只有 `commitLayerShift` 能动。用例 11 的图层断言同步改成新的两阶段语义。
- **变异实测**：把修复那条 `if` 改成 `if (false)` → 红（`actual '0' !== expected '40px'`）；恢复 → 绿。
- `global_lookup_inapp_isolation_guard_test.dart` 两条源码守卫跟上实现（原字面量判据一条会**假红**、一条会变**空壳恒真**），改为断言：`applyLayerOffset` 是 `layerOffsetLeft` 的唯一写者、`measureAndReport` 里它只出现一次且被 `committedGeometryEpoch === 0` 的门包住、C++ `RevealStack` 里 `SetWindowPos` 仍排在 `commitLayerShift` 之前。

验证结果：
- `test/lookup` **744 条全绿**（`FLUTTER TEST VERDICT: PASSED`）
- `test/dictionary` / `test/pages` / `test/utils` 相邻 4 个读 host.js 的守卫 **18 条全绿**
- 三个 node 宿主 `.mjs` 套件全绿（node 测试不在 CI 真单测门内，本地跑过）
- `flutter analyze`：`No issues found!`

**真机肉眼复测待用户**：Windows 上按全局查词热键，弹窗应直接出现在光标处，屏幕左上角不再有一帧闪现。

Bug 记录：`docs/bugs/BUG-2123-global-lookup-first-frame-topleft-flash.md`

https://claude.ai/code/session_01V5SxFYsFPAPduZyXGz6Lb6
