### PR TITLE
feat(lookup): app 外全局查词支持手柄按钮与鼠标侧键触发

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 71417 (4201 per locale)
+/// Strings: 71434 (4202 per locale)
 ///
-/// Built on 2026-09-03 at 17:57 UTC
+/// Built on 2026-09-04 at 14:09 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5771,6 +5771,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Recommended pack finished downloading. Import it from Settings → System.';
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -15569,6 +15571,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -25594,6 +25599,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -35671,6 +35679,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -45783,6 +45794,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -55700,6 +55714,9 @@ class _StringsId extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -65708,6 +65725,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -75104,6 +75124,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -84510,6 +84533,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -94473,6 +94499,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -104490,6 +104519,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -114486,6 +114518,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -124280,6 +124315,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -134191,6 +134229,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -144073,6 +144114,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 // Path: <root>
@@ -153152,6 +153196,9 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       '下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      '鼠标触发仅支持侧键（后退/前进）；其他键在别的程序里有固定含义，这里不接受。';
 }
 
 // Path: <root>
@@ -162242,6 +162289,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get onboarding_pack_download_background_hint =>
       'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+  @override
+  String get shortcut_scope_global_external_desktop_note =>
+      'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
 }
 
 /// Flat map(s) containing all translations.
@@ -170862,6 +170912,8 @@ extension on _StringsEn {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -179477,6 +179529,8 @@ extension on _StringsAr {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -188137,6 +188191,8 @@ extension on _StringsDe {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -196788,6 +196844,8 @@ extension on _StringsEs {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -205448,6 +205506,8 @@ extension on _StringsFr {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -214079,6 +214139,8 @@ extension on _StringsId {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -222732,6 +222794,8 @@ extension on _StringsIt {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -231312,6 +231376,8 @@ extension on _StringsJa {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -239896,6 +239962,8 @@ extension on _StringsKo {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -248542,6 +248610,8 @@ extension on _StringsNl {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -257183,6 +257253,8 @@ extension on _StringsPtBr {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -265831,6 +265903,8 @@ extension on _StringsRu {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -274451,6 +274525,8 @@ extension on _StringsTh {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -283086,6 +283162,8 @@ extension on _StringsTr {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -291715,6 +291793,8 @@ extension on _StringsVi {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }
@@ -300270,6 +300350,8 @@ extension on _StringsZhCn {
         return '推荐包下载完成。可在「设置 → 系统」里导入。';
       case 'onboarding_pack_download_background_hint':
         return '下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。';
+      case 'shortcut_scope_global_external_desktop_note':
+        return '鼠标触发仅支持侧键（后退/前进）；其他键在别的程序里有固定含义，这里不接受。';
       default:
         return null;
     }
@@ -308828,6 +308910,8 @@ extension on _StringsZhHk {
         return 'Recommended pack finished downloading. Import it from Settings → System.';
       case 'onboarding_pack_download_background_hint':
         return 'The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.';
+      case 'shortcut_scope_global_external_desktop_note':
+        return 'Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "推荐包已下载完成",
   "onboarding_pack_import_now": "现在导入",
   "onboarding_pack_download_finished": "推荐包下载完成。可在「设置 → 系统」里导入。",
-  "onboarding_pack_download_background_hint": "下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。"
+  "onboarding_pack_download_background_hint": "下载会在后台继续：可以直接走下一步，也可以关掉向导。进度、取消和导入都在「设置 → 系统」里。",
+  "shortcut_scope_global_external_desktop_note": "鼠标触发仅支持侧键（后退/前进）；其他键在别的程序里有固定含义，这里不接受。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4199,5 +4199,6 @@
   "onboarding_pack_status_ready": "Recommended pack downloaded",
   "onboarding_pack_import_now": "Import now",
   "onboarding_pack_download_finished": "Recommended pack finished downloading. Import it from Settings → System.",
-  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System."
+  "onboarding_pack_download_background_hint": "The download keeps running in the background — you can move to the next step or close this guide. Progress, cancel and import live in Settings → System.",
+  "shortcut_scope_global_external_desktop_note": "Mouse triggers support side buttons only (back/forward); other buttons keep their normal meaning in other apps and are not accepted here."
 }

--- a/fushi/lib/src/lookup/global_lookup_channel.dart
+++ b/fushi/lib/src/lookup/global_lookup_channel.dart
@@ -153,11 +153,18 @@ abstract final class GlobalLookupChannel {
     void Function()? onOverlayHidden,
     void Function(OverlayReverseEvent event)? onRoutedJsMessage,
     void Function(OverlayReverseEvent event)? onRoutedOverlayHidden,
+    void Function()? onGlobalMouseTrigger,
   }) => _impl.setHandlers(
     onGetMedia: onGetMedia,
     onJsMessage: onJsMessage,
     onOverlayHidden: onOverlayHidden,
     onRoutedJsMessage: onRoutedJsMessage,
     onRoutedOverlayHidden: onRoutedOverlayHidden,
+    onGlobalMouseTrigger: onGlobalMouseTrigger,
   );
+
+  /// TODO-1066 — 注册/注销全局鼠标侧键触发（[OverlayWindowChannel
+  /// .setGlobalMouseTrigger]）。0 = 注销。
+  static Future<void> setGlobalMouseTrigger(int button) =>
+      _impl.setGlobalMouseTrigger(button);
 }

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -30,6 +30,7 @@ import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/stat_activity.dart';
 import 'package:fushi/src/utils/misc/error_log_service.dart';
+import 'package:fushi/src/shortcuts/global_external_lookup_route.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
@@ -277,6 +278,9 @@ class GlobalLookupController {
       onOverlayHidden: _onOverlayHidden,
       onRoutedJsMessage: _onRoutedJsMessage,
       onRoutedOverlayHidden: _onRoutedOverlayHidden,
+      // TODO-1066 — 全局鼠标侧键：与键盘热键、手柄按钮同一执行体。
+      onGlobalMouseTrigger: () =>
+          unawaited(triggerSelectionLookup(source: 'mouse')),
     );
 
     // 防截屏初值（pref lookupBlockCapture，默认关）。native GlobalLookupWindow
@@ -296,6 +300,15 @@ class GlobalLookupController {
     _registry = appModel.shortcutRegistry;
     _registry!.addListener(_onRegistryChanged);
     await _registerHotKeyFromRegistry();
+
+    // TODO-1066 — 另外两条非键盘触发源（手柄按钮 / 鼠标侧键）。它们与上面的键盘
+    // 热键是**同一个执行体、不同的 OS 机制**（见 ShortcutScope.globalExternal 的
+    // channels 注释）：手柄经 shortcuts 层的进程级登记处拿到入口，鼠标侧键在
+    // native 侧按绑定注册 RawInput 监听。两者都随注册表变更重推（_onRegistryChanged）。
+    GlobalExternalLookupRoute.set(
+      () => triggerSelectionLookup(source: 'gamepad'),
+    );
+    await _registerMouseTriggerFromRegistry();
 
     // TODO-1079 — root-cause fix: PREWARM the overlay WebView2 off-screen now,
     // so the first hotkey lookup hits a WARM surface instead of racing a cold
@@ -376,7 +389,10 @@ class GlobalLookupController {
     }
     _hotKey = hotKey;
     try {
-      await hotKeyManager.register(hotKey, keyDownHandler: (_) => _onHotKey());
+      await hotKeyManager.register(
+        hotKey,
+        keyDownHandler: (_) => triggerSelectionLookup(source: 'hotkey'),
+      );
       glog(
         'hotkey: registered ${set.keyboardBindings.first.displayLabel} '
         'from registry OK',
@@ -396,11 +412,75 @@ class GlobalLookupController {
     }
   }
 
+  /// TODO-1066 — DOM `MouseEvent.button` 号里**允许**当全局触发的那两个：
+  /// 3=侧键后退（XBUTTON1）/ 4=侧键前进（XBUTTON2）。
+  ///
+  /// 中键(1)与右键(2)刻意不接。全局触发是**不拦截**的（RawInput 只能监听），所以
+  /// 绑上去等于"查词 + 前台程序的原有动作同时发生"：右键会同时弹出上下文菜单、
+  /// 中键会同时触发自动滚动/新标签页。侧键没有这种全系统级的默认语义（它的常见
+  /// 用途是浏览器前进后退，且只在浏览器里），是唯一能安全共存的一对。
+  static const Set<int> _globalMouseTriggerButtons = <int>{3, 4};
+
+  /// 当前已推给 native 的触发按钮号（0 = 未注册）。用来避免注册表每次变更都
+  /// 无谓地重推一次 native 注册。
+  int _mouseTriggerButton = 0;
+
+  /// TODO-1066 — 按注册表里的鼠标绑定，让 native 侧开始/停止监听全局鼠标侧键。
+  ///
+  /// **没绑就不注册**：native 侧一个 RawInput 监听都不留（见
+  /// global_mouse_trigger.cpp）。这是刻意的——BUG-1077 立的契约是「不查词不留
+  /// 全局钩子」，这里沿用同样的纪律：不用这个功能的用户，不该为它付任何常驻代价。
+  Future<void> _registerMouseTriggerFromRegistry() async {
+    final FushiShortcutRegistry? registry = _registry;
+    int button = 0;
+    if (registry != null) {
+      final ShortcutBindingSet set = registry.bindingsFor(
+        ShortcutAction.globalExternalLookup,
+      );
+      for (final MouseBinding binding in set.mouseBindings) {
+        if (_globalMouseTriggerButtons.contains(binding.button)) {
+          button = binding.button;
+          break;
+        }
+      }
+      if (button == 0 && set.mouseBindings.isNotEmpty) {
+        glog(
+          'mouseTrigger: bound button(s) '
+          '${set.mouseBindings.map((MouseBinding b) => b.button).toList()} '
+          'are not side buttons (only 3/4 supported) — not registered',
+        );
+      }
+    }
+    if (button == _mouseTriggerButton) {
+      return;
+    }
+    _mouseTriggerButton = button;
+    try {
+      await GlobalLookupChannel.setGlobalMouseTrigger(button);
+      glog(
+        button == 0
+            ? 'mouseTrigger: unregistered (no side-button binding)'
+            : 'mouseTrigger: registered button=$button',
+      );
+    } catch (e, st) {
+      glog('mouseTrigger: register FAILED: $e');
+      ErrorLogService.instance.log(
+        'GlobalLookupController.registerMouseTrigger',
+        'Failed to register global mouse trigger (button=$button): $e',
+        st,
+      );
+    }
+  }
+
   /// TODO-1066 — re-registers the OS hotkey when the registry changes (user
   /// remaps the key in settings, or a profile switch reloads bindings). Fire and
   /// forget; failures are logged inside [_registerHotKeyFromRegistry].
+  ///
+  /// 鼠标侧键触发同样跟着重推（手柄那条不用：它每次按下都现查注册表，没有需要
+  /// 同步的 OS 侧状态）。
   void _onRegistryChanged() {
     unawaited(_registerHotKeyFromRegistry());
+    unawaited(_registerMouseTriggerFromRegistry());
   }
 
   /// TODO-1066 — maps a registry keyboard [binding] to a hotkey_manager [HotKey].
@@ -448,19 +528,30 @@ class GlobalLookupController {
     'popup',
   );
 
-  Future<void> _onHotKey() async {
+  /// TODO-1066 — app 外查词的**触发源无关**入口：抓前台程序当前选中的文本，
+  /// 查词，弹出覆盖窗卡片。
+  ///
+  /// 三个触发源共用这一个方法，语义完全一致，不各自复制一条链路（route 铸造、
+  /// epoch 作废、prewarm、隐藏时序都在这条链上，复制一份必然漂移）：
+  ///   · 键盘：OS 级热键（win32 `RegisterHotKey`，见 [_registerHotKeyFromRegistry]）；
+  ///   · 手柄：`GamepadService` 的后台分支（不经 Flutter 焦点树，app 失焦时仍有效）；
+  ///   · 鼠标侧键：native RawInput 监听（见 windows/runner/global_mouse_trigger.cpp）。
+  ///
+  /// 方法体里没有任何键盘/修饰键相关的逻辑——它本来就是触发源无关的，改成公开
+  /// 是零行为变更。[source] 只进诊断日志，用来区分是哪个触发源点的火。
+  Future<void> triggerSelectionLookup({String source = 'hotkey'}) async {
     final GlobalLookupRoute route = GlobalLookupRoute.desktop(
       lookupEpoch: ++_desktopLookupEpoch,
     );
     return GlobalLookupChannel.runWithRoute(
       route,
-      () => _onHotKeyRouted(route),
+      () => _onHotKeyRouted(route, source),
     );
   }
 
-  Future<void> _onHotKeyRouted(GlobalLookupRoute route) async {
+  Future<void> _onHotKeyRouted(GlobalLookupRoute route, String source) async {
     _activateRoute(route);
-    glog('hotkey: FIRED');
+    glog('hotkey: FIRED (source=$source)');
     try {
       // Re-press ALWAYS does a fresh lookup of the current selection (no
       // toggle): the user selects a new word and presses the hotkey expecting
@@ -499,8 +590,15 @@ class GlobalLookupController {
       }
       if (text.isEmpty) {
         // No context (or feature off): fall back to the clipboard selection.
-        text = (await SelectionCapture.captureForegroundSelection() ?? '')
-            .trim();
+        // stillWanted：剪贴板捕获是串行的全局事务（见 SelectionCapture 的闸门）。
+        // 手柄按钮/鼠标侧键比键盘热键容易连击，排队期间本次若已被新触发取代，就
+        // 别再去动一次剪贴板——反正结果下一行就会被丢弃。
+        text =
+            (await SelectionCapture.captureForegroundSelection(
+                      stillWanted: () => _isCurrentRoute,
+                    ) ??
+                    '')
+                .trim();
         if (!_isCurrentRoute) return;
         sentence = '';
       }

--- a/fushi/lib/src/lookup/overlay_window_channel.dart
+++ b/fushi/lib/src/lookup/overlay_window_channel.dart
@@ -302,15 +302,30 @@ class OverlayWindowChannel {
   Future<void> setBlockCapture(bool block) =>
       _invoke<void>('setBlockCapture', <String, Object?>{'block': block});
 
+  /// TODO-1066 — 让 native 侧开始/停止监听全局鼠标侧键（RawInput +
+  /// `RIDEV_INPUTSINK`）。[button] 用 DOM `MouseEvent.button` 号：3=侧键后退
+  /// （XBUTTON1）/ 4=侧键前进（XBUTTON2）；**0 = 注销**，native 侧不留任何监听。
+  ///
+  /// 这是**进程级**设置，与 overlay 的 route/epoch 无关（它在没有任何卡片显示时
+  /// 也必须生效——那正是它的用途）。
+  Future<void> setGlobalMouseTrigger(int button) => _invoke<void>(
+    'setGlobalMouseTrigger',
+    <String, Object?>{'button': button},
+  );
+
   /// Wires the overlay's reverse calls. [onGetMedia] resolves gaiji bytes for
   /// an `image://` url; [onJsMessage] receives raw bridge messages decoded
   /// from JSON; [onOverlayHidden] fires on a genuine native dismissal.
+  ///
+  /// [onGlobalMouseTrigger] 是 TODO-1066 的全局鼠标侧键触发：与上面几个不同，
+  /// 它**不带 route**——它是"用户在别的程序里按了侧键"，此刻通常一张卡片都没有。
   void setHandlers({
     required Future<Uint8List> Function(String url) onGetMedia,
     required void Function(Map<String, Object?> message) onJsMessage,
     void Function()? onOverlayHidden,
     void Function(OverlayReverseEvent event)? onRoutedJsMessage,
     void Function(OverlayReverseEvent event)? onRoutedOverlayHidden,
+    void Function()? onGlobalMouseTrigger,
   }) {
     _channel.setMethodCallHandler((MethodCall call) async {
       switch (call.method) {
@@ -373,6 +388,12 @@ class OverlayWindowChannel {
               }
             }
           }
+          return null;
+        case 'globalMouseTrigger':
+          // TODO-1066 — 全局鼠标侧键按下（native RawInput 监听，见
+          // windows/runner/global_mouse_trigger.cpp）。无 route：这条通知与任何
+          // 已显示的卡片无关，它就是"去开一次新查词"。
+          onGlobalMouseTrigger?.call();
           return null;
         case 'nativeError':
           // TODO-1153 -- the native overlay reported a WebView2 bring-up

--- a/fushi/lib/src/lookup/selection_capture_ffi.dart
+++ b/fushi/lib/src/lookup/selection_capture_ffi.dart
@@ -14,6 +14,7 @@ import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:fushi/src/lookup/global_lookup_log.dart';
 import 'package:fushi/src/lookup/sentence_extraction.dart';
@@ -46,17 +47,85 @@ abstract final class SelectionCapture {
   static const MethodChannel _foregroundSelectionChannel =
       MethodChannel('app.fushi.reader/foreground_selection');
 
+  /// 剪贴板捕获的进程内串行闸门（TODO-1066 手柄/鼠标触发）。
+  ///
+  /// [captureForegroundSelection] 的「存旧剪贴板 → 清空 → 注入 Ctrl+C → 轮询
+  /// → 还原」是一段**跨 await 的事务**，而剪贴板是全局单资源。两次重叠会互相
+  /// 拆台：A 存下旧值 → A 清空 → **B 存下的是 A 刚清空的空值** → A 注入并读到
+  /// 选区 → A 还原 → B 轮询超时 → B 把剪贴板「还原」成空。用户的剪贴板就这么
+  /// 没了（同源事故有前科，见 BUG-707 剪贴板回声）。
+  ///
+  /// 上游的 route 作废机制救不了这里：它只让**已返回**的旧调用在 await 边界
+  /// 自杀，而这段事务一旦开始就必须跑完（半途放弃 = 剪贴板停在被清空的状态）。
+  /// 所以正确的层是这里——把事务本身串起来，而不是在调用方丢弃触发。
+  ///
+  /// 串行而非丢弃，是为了不破坏「再按一次总是查当前选区」的既有语义（见
+  /// `global_lookup_controller._onHotKeyRouted` 的注释）：后到的那次照常执行，
+  /// 只是排在前一次事务之后；它自己的 route 更新，先到的那次结果被上游丢弃。
+  static Future<void> _clipboardCaptureGate = Future<void>.value();
+
+  /// 闸门本体。用 Completer 而不是 `_gate = _gate.then(...)`，是为了让**闸门推进
+  /// 与本次事务的成败无关**——事务抛异常也必须放行后来者，否则一次失败就永久
+  /// 堵死这条路。
+  static Future<T?> _runClipboardExclusive<T>(
+    Future<T?> Function() body, {
+    bool Function()? stillWanted,
+  }) async {
+    final Completer<void> tail = Completer<void>();
+    final Future<void> previous = _clipboardCaptureGate;
+    _clipboardCaptureGate = tail.future;
+    await previous;
+    try {
+      if (stillWanted != null && !stillWanted()) {
+        glog('capture: superseded while queued — skipped');
+        return null;
+      }
+      return await body();
+    } finally {
+      tail.complete();
+    }
+  }
+
+  /// 只给测试：在**同一道闸门**上跑一段任意事务体。
+  ///
+  /// 存在的理由是 [captureForegroundSelection] 本身在测试里不可调用——它会真的
+  /// 注入 Ctrl+C 并改写跑测试这台机器的剪贴板。串行语义又必须有行为测试兜底
+  /// （源码守卫看不出 `await previous` 是不是漏了），故把闸门单独暴露出来。
+  @visibleForTesting
+  static Future<T?> debugRunClipboardExclusive<T>(
+    Future<T?> Function() body, {
+    bool Function()? stillWanted,
+  }) =>
+      _runClipboardExclusive<T>(body, stillWanted: stillWanted);
+
   /// Saves the clipboard, clears it, injects a clean Ctrl+C so the foreground
   /// app copies its current selection, reads it back, then restores the
   /// previous clipboard text. Returns the selected text, or null if nothing was
   /// captured.
-  static Future<String?> captureForegroundSelection() async {
+  ///
+  /// 并发安全：多次重叠调用按到达顺序**串行**执行（见 [_clipboardCaptureGate]）。
+  ///
+  /// [stillWanted] 在**排队结束、事务开始前**被求值一次：返回 false 表示这次捕获
+  /// 在排队期间已被更新的一次触发取代，于是直接返回 null，一次剪贴板操作都不做。
+  /// 没有它，手柄连按/侧键抖动会排出一队各自最长 600ms 的事务，用户要等最后一次
+  /// 才看到卡片（每一次都真的去动了剪贴板，只是结果被上游丢弃）。
+  static Future<String?> captureForegroundSelection({
+    bool Function()? stillWanted,
+  }) async {
     if (!Platform.isWindows || _keybdEvent == null) {
       glog('capture: unsupported (windows=${Platform.isWindows} '
           'ffi=${_keybdEvent != null})');
       return null;
     }
+    return _runClipboardExclusive(
+      _captureForegroundSelectionExclusive,
+      stillWanted: stillWanted,
+    );
+  }
 
+  /// [captureForegroundSelection] 的事务体。**只允许经那道闸门调用**——直接调它
+  /// 就绕过了串行保证。
+  static Future<String?> _captureForegroundSelectionExclusive() async {
     final String? oldText =
         (await Clipboard.getData(Clipboard.kTextPlain))?.text;
 

--- a/fushi/lib/src/pages/implementations/shortcut_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/shortcut_settings_page.dart
@@ -470,6 +470,16 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
             icon: Icons.info_outline,
             showIcon: true,
           ),
+        // TODO-1066 — 桌面 app 外查词开了鼠标通道，但**只有侧键**能当全局触发：
+        // 这条触发不拦截原事件（native 走 RawInput，见 global_mouse_trigger.h），
+        // 右键/中键有全系统级默认语义（上下文菜单 / 自动滚动），绑上去等于两件事
+        // 同时发生。上面的 mobile 分支已提前 return，故这里只会在桌面渲染。
+        if (scope == ShortcutScope.globalExternal)
+          AdaptiveSettingsRow(
+            title: t.shortcut_scope_global_external_desktop_note,
+            icon: Icons.info_outline,
+            showIcon: true,
+          ),
         AdaptiveSettingsRow(
           title: t.shortcut_reset_defaults,
           icon: Icons.restore_outlined,

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -13,6 +13,7 @@ import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
+import 'package:fushi/src/shortcuts/global_external_lookup_route.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
@@ -30,6 +31,31 @@ bool tryDictionaryPopupGamepadButton(
       DictionaryPopupGamepadRegistry.current;
   if (hooks == null) return false;
   return dispatchDictionaryPopupGamepadButton(hooks, registry, button);
+}
+
+/// TODO-1066 — globalExternal scope 的手柄触发：把 app 外全局查词（默认键盘
+/// Ctrl+Alt+D）也开放给手柄按钮。命中并成功派发返回 true。
+///
+/// **不经 Flutter 焦点树**是本函数存在的全部理由：Windows 上主窗一失焦，
+/// `MainWindowFocusGate` 就把整棵子树设成 `descendantsAreFocusable: false`，
+/// `Actions.maybeInvoke<GamepadButtonIntent>` 那条主派发路径必然落空——而"用户
+/// 正在别的程序里看文本"恰恰是本功能唯一的使用场景。底层 GameInput 是进程级
+/// 轮询（每手柄一条 native 线程），按钮读得到，断的只是派发链。
+///
+/// 未注册触发入口（非桌面平台 / controller 未 start）时返回 false **不吞按钮**：
+/// 功能不可用时把键吃掉会让用户以为手柄坏了，比没有这个功能更糟。
+bool tryGlobalExternalLookupGamepadButton(
+  FushiShortcutRegistry? registry,
+  GamepadButton button,
+) {
+  if (registry?.resolveGamepad(button, scope: ShortcutScope.globalExternal) !=
+      ShortcutAction.globalExternalLookup) {
+    return false;
+  }
+  final Future<void> Function()? trigger = GlobalExternalLookupRoute.current;
+  if (trigger == null) return false;
+  unawaited(trigger());
+  return true;
 }
 
 /// 按 dictionaryPopup scope 解析 [button] 并在 [hooks] 上执行。
@@ -433,6 +459,19 @@ class GamepadService {
       dispatchDictionaryPopupGamepadButton(galHooks, registry, button);
       return;
     }
+    // TODO-1066：app 外全局查词的手柄触发。
+    //
+    // 位置刻意在取 `_dispatchContext` **之前**，两个理由缺一不可：
+    //   ① 后台可用性——本功能唯一的使用场景就是"用户正在别的程序里看文本"，
+    //      那时主窗失焦、`MainWindowFocusGate` 已把整棵焦点树设成不可聚焦，
+    //      下面 `Actions.maybeInvoke` 那条路必然落空。这里不碰焦点树。
+    //   ② 与键盘同构——键盘那条是 win32 `RegisterHotKey`（OS 级），在 app 内按
+    //      也照样抢在页面之前触发。手柄要和它同一语义，就必须同样排在页面
+    //      Actions 之前，否则同一个动作在两个通道上行为不一致。
+    //
+    // 正因为它优先于页面，`globalExternalLookup` 的手柄默认绑定**必须留空**
+    // （见 shortcut_defaults）：给任何默认值都等于从页面手里抢走一个按钮。
+    if (tryGlobalExternalLookupGamepadButton(registry, button)) return;
     final BuildContext? ctx = _dispatchContext;
     if (ctx == null) return;
     _setHighlightForHardwareNav();

--- a/fushi/lib/src/shortcuts/global_external_lookup_route.dart
+++ b/fushi/lib/src/shortcuts/global_external_lookup_route.dart
@@ -1,0 +1,39 @@
+/// TODO-1066 — app 外全局查词（`ShortcutScope.globalExternal`）的**非键盘触发源**
+/// 登记处。
+///
+/// 为什么需要它：执行体 `GlobalLookupController.triggerSelectionLookup` 住在
+/// lookup 层，消费方 `GamepadService` 住在 shortcuts 层，依赖必须单向
+/// （lookup → shortcuts）。controller 在自己那侧把入口注册进来，服务侧只见一个
+/// 函数，不见 controller 类型——与 [DictionaryPopupGamepadRegistry] /
+/// [GalIngameLookupGamepadRoute] 同一范式。
+///
+/// 为什么是**单槽**而不是栈：app 外全局查词全进程只有一个 controller
+/// （`GlobalLookupController` 由 `AppModel` 持有，`main.dart` 启动一次），不存在
+/// 「多个宿主争同一触发」的情形。栈只会给它编造一个不存在的歧义。
+///
+/// 为什么手柄这条要单独开一条不经 Flutter 焦点树的路：Windows 上主窗一失焦，
+/// `MainWindowFocusGate` 就把整棵子树设成 `descendantsAreFocusable: false`，
+/// `Actions.maybeInvoke<GamepadButtonIntent>` 那条主派发路径必然落空——而"用户
+/// 正在别的程序里看文本"恰恰是本功能**唯一**的使用场景。底层的 GameInput 轮询
+/// 与前台焦点无关（每手柄一条 native 线程 8ms 轮询），所以按钮读得到，只是派发
+/// 链断了；这里补的就是那一段。
+library;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+class GlobalExternalLookupRoute {
+  GlobalExternalLookupRoute._();
+
+  static Future<void> Function()? _trigger;
+
+  /// 当前触发入口；未注册（非桌面平台 / controller 未 start）时为 null，此时
+  /// 分发照常沿原路径继续——**不吞按钮**。功能不可用时把键"吃掉"会让用户以为
+  /// 手柄坏了，比没有这个功能更糟。
+  static Future<void> Function()? get current => _trigger;
+
+  /// 由 `GlobalLookupController.start` 注册、`dispose` 时传 null 注销。
+  static void set(Future<void> Function()? trigger) => _trigger = trigger;
+
+  @visibleForTesting
+  static void debugClear() => _trigger = null;
+}

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -193,13 +193,32 @@ enum ShortcutScope {
       // 与摇杆负责，见 shortcut_defaults 的 dpad* 注释。
       case gamepad:
         return const <ShortcutChannel>{ShortcutChannel.gamepad};
-      // app 外全局查词热键：GlobalLookupController 只读 `.keyboardBindings` 注册到
-      // OS 级 hotkey_manager，而 `HotKey.key` 的类型就是 Flutter 的 `KeyboardKey`，
-      // 底层是 win32 `RegisterHotKey`（修饰键位掩码 + 虚拟键码）。手柄按钮无法表达，
-      // 鼠标键则要装 WH_MOUSE_LL 全局钩子并全系统吞掉该键——两者都不是这条机制能
-      // 提供的，故只开键盘。
+      // app 外全局查词：三通道，但**三条通道各走各的 OS 机制**，不共用一套注册。
+      // 这是全 app 唯一一处「同一个动作、三种底层触发机制」的 scope，故在此写明
+      // 各自的边界（TODO-1066）：
+      //   · 键盘：`.keyboardBindings` → hotkey_manager → win32 `RegisterHotKey`。
+      //     `HotKey.key` 的类型就是 Flutter 的 `KeyboardKey`（修饰键位掩码 + 虚拟
+      //     键码），所以手柄按钮和鼠标键**按构造无法**表达成它——这正是另外两条
+      //     必须另起机制的原因，不是偷懒。
+      //   · 手柄：`.gamepadBindings` → `GamepadService._dispatchButton` 里一条
+      //     **不经 Flutter 焦点树**的分支（`GlobalExternalLookupRoute`）。底层
+      //     GameInput 是每手柄一条 native 线程的进程级轮询，与前台焦点无关，所以
+      //     app 失焦时按钮照样读得到；断掉的只是 Actions/Focus 那条派发链，那条
+      //     分支补的就是它。默认绑定必须留空——它优先于页面，给默认值等于抢键。
+      //   · 鼠标：`.mouseBindings` → native RawInput + `RIDEV_INPUTSINK`
+      //     （windows/runner/global_mouse_trigger.cpp），且**只在用户真绑了侧键
+      //     时才注册**，没绑就一个系统级监听都不留。
+      //     刻意**不用** WH_MOUSE_LL：低级鼠标钩子是同步钩子，全系统每一次鼠标
+      //     移动都要排队等我们的回调返回（BUG-1048 的原始症状），而 BUG-1077 已
+      //     立下「不查词不留全局钩子」的契约。RawInput 是异步投递，不插进系统输入
+      //     分发的关键路径。代价是它只能监听、不能拦截——而侧键在浏览器里是"后退"，
+      //     本来就**必须放行**，所以这个"限制"恰好就是我们要的语义。
       case globalExternal:
-        return const <ShortcutChannel>{ShortcutChannel.keyboard};
+        return const <ShortcutChannel>{
+          ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
+          ShortcutChannel.mouse,
+        };
       // 漫画页：键盘走 `_resolveMangaKeyAction`（resolveKeyboard），手柄走
       // `_handleGamepadButton`（resolveGamepad manga → universal，桌面轮询的
       // GamepadButtonIntent 与 Android gameButton* 键事件汇合到同一入口，与

--- a/fushi/test/lookup/global_external_lookup_trigger_test.dart
+++ b/fushi/test/lookup/global_external_lookup_trigger_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/shortcuts/gamepad_service.dart';
+import 'package:fushi/src/shortcuts/global_external_lookup_route.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+import '../helpers/source_guard.dart';
+
+/// TODO-1066 — app 外全局查词的两条**非键盘**触发源（手柄按钮 / 鼠标侧键）。
+///
+/// 这两条与键盘热键是「同一个执行体、三种 OS 机制」，各自的边界写在
+/// `ShortcutScope.globalExternal` 的 channels 注释里。本文件钉三件事：
+///   ① 手柄解析/派发的行为（含"没注册就不吞按钮"）；
+///   ② 派发位置必须在取焦点 context **之前**（否则 app 失焦时整条路径失效，
+///      而那正是本功能唯一的使用场景）——这条只有源码守卫抓得住；
+///   ③ 手柄/鼠标默认绑定必须为空（它优先于页面，给默认值等于抢键）。
+void main() {
+  tearDown(GlobalExternalLookupRoute.debugClear);
+
+  FushiShortcutRegistry windowsRegistry() =>
+      FushiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
+
+  group('GlobalExternalLookupRoute', () {
+    test('未注册 / 注销后 current 为 null', () {
+      expect(GlobalExternalLookupRoute.current, isNull);
+      GlobalExternalLookupRoute.set(() async {});
+      expect(GlobalExternalLookupRoute.current, isNotNull);
+      GlobalExternalLookupRoute.set(null);
+      expect(GlobalExternalLookupRoute.current, isNull);
+    });
+  });
+
+  group('tryGlobalExternalLookupGamepadButton', () {
+    test('绑定命中且已注册入口 → 触发一次并吞掉按钮', () async {
+      final FushiShortcutRegistry registry = windowsRegistry();
+      registry.updateBinding(
+        ShortcutAction.globalExternalLookup,
+        const ShortcutBindingSet(
+          gamepadBindings: <GamepadBinding>[GamepadBinding(GamepadButton.y)],
+        ),
+      );
+      int fired = 0;
+      GlobalExternalLookupRoute.set(() async => fired++);
+
+      expect(
+        tryGlobalExternalLookupGamepadButton(registry, GamepadButton.y),
+        isTrue,
+      );
+      // trigger 是 fire-and-forget（unawaited），让 microtask 跑完再断言。
+      await Future<void>.delayed(Duration.zero);
+      expect(fired, 1);
+    });
+
+    test('未绑定的按钮不触发、不吞', () {
+      final FushiShortcutRegistry registry = windowsRegistry();
+      registry.updateBinding(
+        ShortcutAction.globalExternalLookup,
+        const ShortcutBindingSet(
+          gamepadBindings: <GamepadBinding>[GamepadBinding(GamepadButton.y)],
+        ),
+      );
+      GlobalExternalLookupRoute.set(() async {});
+      expect(
+        tryGlobalExternalLookupGamepadButton(registry, GamepadButton.x),
+        isFalse,
+      );
+    });
+
+    test('绑定命中但入口未注册 → 不吞按钮（功能不可用时吃键比没有功能更糟）', () {
+      final FushiShortcutRegistry registry = windowsRegistry();
+      registry.updateBinding(
+        ShortcutAction.globalExternalLookup,
+        const ShortcutBindingSet(
+          gamepadBindings: <GamepadBinding>[GamepadBinding(GamepadButton.y)],
+        ),
+      );
+      // 刻意不 set —— 模拟非桌面平台 / controller 未 start。
+      expect(
+        tryGlobalExternalLookupGamepadButton(registry, GamepadButton.y),
+        isFalse,
+      );
+    });
+
+    test('registry 为 null 时安全返回 false', () {
+      GlobalExternalLookupRoute.set(() async {});
+      expect(
+        tryGlobalExternalLookupGamepadButton(null, GamepadButton.y),
+        isFalse,
+      );
+    });
+  });
+
+  group('默认绑定', () {
+    test('globalExternalLookup 只有键盘默认键，手柄/鼠标默认必须为空', () {
+      for (final TargetPlatform platform in <TargetPlatform>[
+        TargetPlatform.windows,
+        TargetPlatform.macOS,
+        TargetPlatform.linux,
+      ]) {
+        final ShortcutBindingSet set = (FushiShortcutRegistry()
+              ..loadDefaults(platform))
+            .bindingsFor(ShortcutAction.globalExternalLookup);
+        expect(
+          set.keyboardBindings,
+          isNotEmpty,
+          reason: '$platform: 键盘默认键（Ctrl/Cmd+Alt+D）不该丢',
+        );
+        // 手柄这条**优先于页面 Actions**（与键盘的 OS 级 RegisterHotKey 同构），
+        // 所以任何默认值都会从页面手里抢走一个按钮。必须由用户显式绑定。
+        expect(
+          set.gamepadBindings,
+          isEmpty,
+          reason: '$platform: 手柄给了默认值 = 抢走页面的一个按钮',
+        );
+        // 鼠标同理，且侧键在浏览器里是前进/后退，默认占用会很意外。
+        expect(
+          set.mouseBindings,
+          isEmpty,
+          reason: '$platform: 鼠标给了默认值 = 默认劫持侧键',
+        );
+      }
+    });
+  });
+
+  group('接线源码守卫', () {
+    test('手柄分支排在取焦点 context 之前（app 失焦时是唯一能走通的位置）', () {
+      final String code = maskComments(
+        File('lib/src/shortcuts/gamepad_service.dart').readAsStringSync(),
+      );
+      final int branch = code
+          .indexOf('tryGlobalExternalLookupGamepadButton(registry, button)');
+      final int ctx =
+          code.indexOf('final BuildContext? ctx = _dispatchContext;');
+      expect(branch, greaterThanOrEqualTo(0),
+          reason: '手柄触发分支不见了：globalExternal 的手柄绑定会变成死绑定');
+      expect(ctx, greaterThanOrEqualTo(0));
+      expect(
+        branch,
+        lessThan(ctx),
+        reason: '分支被挪到取焦点之后：主窗失焦时 MainWindowFocusGate 会让整条 '
+            'Actions 路径落空，而"用户在别的程序里"正是本功能唯一的使用场景',
+      );
+    });
+
+    test('controller 三个触发源汇入同一个执行体，没有各自复制一条查词链', () {
+      final String code = maskComments(
+        File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync(),
+      );
+      // 键盘 / 手柄 / 鼠标三处都必须调 triggerSelectionLookup，而不是各自去拼
+      // route 铸造 + 选区捕获 + _lookupExternal（复制一份必然漂移）。
+      for (final String source in <String>['hotkey', 'gamepad', 'mouse']) {
+        expect(
+          code.contains("triggerSelectionLookup(source: '$source')"),
+          isTrue,
+          reason: '$source 触发源没有接到共享执行体',
+        );
+      }
+    });
+
+    test('剪贴板捕获传了 stillWanted（否则连按会排出一队各 600ms 的事务）', () {
+      final String code = maskComments(
+        File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync(),
+      );
+      final int call =
+          code.indexOf('SelectionCapture.captureForegroundSelection');
+      expect(call, greaterThanOrEqualTo(0));
+      expect(
+        code.substring(call, call + 200).contains('stillWanted:'),
+        isTrue,
+        reason: '手柄/侧键比键盘容易连击，排队期间已被取代的那几次不该再动剪贴板',
+      );
+    });
+  });
+}

--- a/fushi/test/lookup/global_lookup_flaky_popup_guard_test.dart
+++ b/fushi/test/lookup/global_lookup_flaky_popup_guard_test.dart
@@ -26,9 +26,9 @@ void main() {
   group('A — overlay WebView2 is prewarmed off-screen (own ownership)', () {
     test('Dart channel exposes prewarmWebView', () {
       final String
-      ch = // spec 2026-07-10: channel 实现在 overlay_window_channel.dart（门面+实现拼接扫描）
+          ch = // spec 2026-07-10: channel 实现在 overlay_window_channel.dart（门面+实现拼接扫描）
           read('lib/src/lookup/global_lookup_channel.dart') +
-          read('lib/src/lookup/overlay_window_channel.dart');
+              read('lib/src/lookup/overlay_window_channel.dart');
       expect(
         ch.contains("_invoke<void>('prewarmWebView'"),
         isTrue,
@@ -62,7 +62,8 @@ void main() {
       );
     });
 
-    test('native window has a PrewarmWebView entry that navigates host.html', () {
+    test('native window has a PrewarmWebView entry that navigates host.html',
+        () {
       final String h = read('windows/runner/global_lookup_window.h');
       expect(h.contains('void PrewarmWebView('), isTrue);
       final String cpp = read('windows/runner/global_lookup_window.cpp');
@@ -92,9 +93,9 @@ void main() {
 
     test('a readiness query exists on the channel + native', () {
       final String
-      ch = // spec 2026-07-10: channel 实现在 overlay_window_channel.dart（门面+实现拼接扫描）
+          ch = // spec 2026-07-10: channel 实现在 overlay_window_channel.dart（门面+实现拼接扫描）
           read('lib/src/lookup/global_lookup_channel.dart') +
-          read('lib/src/lookup/overlay_window_channel.dart');
+              read('lib/src/lookup/overlay_window_channel.dart');
       expect(ch.contains("_invoke<bool>('isWebViewReady')"), isTrue);
       final String fw = read('windows/runner/flutter_window.cpp');
       expect(fw.contains('method == "isWebViewReady"'), isTrue);
@@ -162,9 +163,12 @@ void main() {
   });
 
   group('D — reveal state is reset from zero every lookup', () {
-    test('_onHotKey issues an unconditional hide() up front', () {
+    test('triggerSelectionLookup issues an unconditional hide() up front', () {
       final String c = read('lib/src/lookup/global_lookup_controller.dart');
-      final int fire = c.indexOf("glog('hotkey: FIRED');");
+      // 锚点只取前缀：这行日志后来带上了触发源标签（`FIRED (source=…)`，
+      // TODO-1066 手柄/鼠标侧键触发）。守卫要钉的是「开火 → hide → 抓选区」这个
+      // 顺序，不是那行日志的全文；用全等文本当锚点会让任何一次日志增补都变成假红。
+      final int fire = c.indexOf("glog('hotkey: FIRED");
       final int capture = c.indexOf(
         'SelectionCapture.captureForegroundSelection',
       );

--- a/fushi/test/lookup/selection_capture_gate_test.dart
+++ b/fushi/test/lookup/selection_capture_gate_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/lookup/selection_capture_ffi.dart';
+
+/// TODO-1066 — 剪贴板选区捕获的串行闸门。
+///
+/// 为什么必须有这道闸门：`captureForegroundSelection` 的「存旧剪贴板 → 清空 →
+/// 注入 Ctrl+C → 轮询最长 600ms → 还原」是一段跨 await 的事务，而剪贴板是全局
+/// 单资源。两次重叠会互相拆台，最终把用户的剪贴板"还原"成空（同源事故见
+/// BUG-707）。键盘热键不容易连按到暴露它，手柄按钮和鼠标侧键会。
+///
+/// 这里测的是闸门本身（`debugRunClipboardExclusive`），不是真捕获——真捕获会
+/// 注入 Ctrl+C 并改写跑测试这台机器的剪贴板，测试里绝不能调。
+void main() {
+  test('重叠调用被串行化：后到的事务不与前一笔交错', () async {
+    final List<String> log = <String>[];
+
+    Future<String?> transaction(String name, Duration hold) async {
+      log.add('$name:begin');
+      await Future<void>.delayed(hold);
+      log.add('$name:end');
+      return name;
+    }
+
+    // A 故意跑得比 B 久：没有闸门的话 B 会在 A 的 await 里插进来，
+    // 日志就会出现 a:begin, b:begin, b:end, a:end 的交错。
+    final Future<String?> a = SelectionCapture.debugRunClipboardExclusive(
+      () => transaction('a', const Duration(milliseconds: 40)),
+    );
+    final Future<String?> b = SelectionCapture.debugRunClipboardExclusive(
+      () => transaction('b', const Duration(milliseconds: 1)),
+    );
+
+    expect(await a, 'a');
+    expect(await b, 'b');
+    expect(log, <String>['a:begin', 'a:end', 'b:begin', 'b:end']);
+  });
+
+  test('排队期间被取代 → 事务体一次都不执行', () async {
+    bool bodyRan = false;
+    bool wanted = true;
+
+    final Future<String?> first = SelectionCapture.debugRunClipboardExclusive(
+      () async {
+        // 前一笔还在跑时，上游铸了新 route —— 后一笔就此作废。
+        wanted = false;
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        return 'first';
+      },
+    );
+    final Future<String?> superseded =
+        SelectionCapture.debugRunClipboardExclusive<String>(
+      () async {
+        bodyRan = true;
+        return 'superseded';
+      },
+      stillWanted: () => wanted,
+    );
+
+    expect(await first, 'first');
+    expect(await superseded, isNull);
+    expect(
+      bodyRan,
+      isFalse,
+      reason: '已被取代的那次不该再去动剪贴板——结果反正会被上游丢弃',
+    );
+  });
+
+  test('事务体抛异常也放行后来者（一次失败不得永久堵死这条路）', () async {
+    final Future<String?> boom = SelectionCapture.debugRunClipboardExclusive(
+      () async => throw StateError('clipboard busy'),
+    );
+    await expectLater(boom, throwsStateError);
+
+    // 闸门必须已经推进：否则下面这笔会永远挂着。
+    final String? after = await SelectionCapture.debugRunClipboardExclusive(
+      () async => 'after',
+    ).timeout(const Duration(seconds: 2));
+    expect(after, 'after');
+  });
+}

--- a/fushi/test/shortcuts/shortcut_mouse_binding_capture_test.dart
+++ b/fushi/test/shortcuts/shortcut_mouse_binding_capture_test.dart
@@ -206,11 +206,14 @@ void main() {
   // userspace）：捕获入口不出现，但老用户当年配下的绑定仍要能看见并删掉——否则那条
   // 永不触发的死绑定就永远删不掉了。
   //
-  // 取样从 home 换成 `globalExternalLookup`：home / global / universal / manga 四个
-  // scope 本轮都接上了真实的鼠标解析入口、通道随之打开，已经不再是「通道没开」的例子。
-  // `globalExternal` 是**按构造**开不了的那一类（OS 级 `RegisterHotKey` 的
-  // `HotKey.key` 类型就是 `KeyboardKey`，鼠标键要装 WH_MOUSE_LL 全局钩子并全系统吞掉
-  // 该键），所以它会长期留在这一侧，适合当这条不变式的锚点。
+  // 锚点几经辗转：home → globalExternalLookup → dpadUp。前两个都是因为**后来真的接上
+  // 了鼠标解析入口**而被迫让位（home / global / universal / manga 是 BUG-1995 那轮；
+  // globalExternal 是 TODO-1066 那轮——app 外查词的鼠标侧键触发走 native RawInput +
+  // RIDEV_INPUTSINK，通道随之打开）。
+  //
+  // `gamepad` scope（dpad 四向）是目前唯一**按构造**开不了鼠标的那个：它的唯一消费者
+  // 是 `GamepadService._dispatchButton` 按 `GamepadButton` 解析，键盘/鼠标绑定在那里
+  // 没有也不可能有读取方（见 ShortcutScope.channels 的 gamepad case）。
   testWidgets('desktop: 通道未开的 scope 仍显示并可删除历史鼠标绑定（但没有捕获入口）',
       (WidgetTester tester) async {
     usePlatform(TargetPlatform.windows);
@@ -218,13 +221,13 @@ void main() {
         buildRegistry(TargetPlatform.windows);
     // 前提自检：取样的 scope 必须真的没开 mouse，否则本用例测的是另一件事（假绿）。
     expect(
-      ShortcutAction.globalExternalLookup.scope.channels,
+      ShortcutAction.dpadUp.scope.channels,
       isNot(contains(ShortcutChannel.mouse)),
     );
     await pumpDialogHost(
       tester,
       registry,
-      action: ShortcutAction.globalExternalLookup,
+      action: ShortcutAction.dpadUp,
       initial: const ShortcutBindingSet(
         mouseBindings: <MouseBinding>[MouseBinding(2)],
       ),
@@ -239,7 +242,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      registry.bindingsFor(ShortcutAction.globalExternalLookup).mouseBindings,
+      registry.bindingsFor(ShortcutAction.dpadUp).mouseBindings,
       isEmpty,
     );
 

--- a/fushi/test/shortcuts/shortcut_registry_mouse_test.dart
+++ b/fushi/test/shortcuts/shortcut_registry_mouse_test.dart
@@ -97,25 +97,30 @@ void main() {
   // 这条钉住「channels 只是设置页的录入门，不是派发门」这个契约本身——只要有人再想
   // 拿「通道没开」推出「绑定是死的」，这里就会红。
   test('BUG-1995: channels 不含 mouse 的 scope，已有鼠标绑定仍可解析', () {
-    // 取样从 home 换成 globalExternal：home 本轮接上了真实的鼠标派发入口、通道已开。
-    // globalExternal 是**按构造**开不了的那一类（OS 级 RegisterHotKey 的 `HotKey.key`
-    // 类型就是 `KeyboardKey`），所以它会长期留在关着的一侧，适合当这条契约的锚点。
+    // 锚点几经辗转：home → globalExternal → gamepad。前两个都是因为**后来真的接上了
+    // 鼠标解析入口**而被迫让位（home 是 BUG-1995 那轮，globalExternal 是 TODO-1066
+    // 那轮——app 外查词的鼠标侧键触发走 native RawInput，通道随之打开）。
+    //
+    // `gamepad` scope（dpad 四向）是目前唯一**按构造**开不了鼠标的那个：它的唯一
+    // 消费者是 `GamepadService._dispatchButton` 按 `GamepadButton` 解析，键盘/鼠标
+    // 绑定在那里没有也不可能有读取方（见 ShortcutScope.channels 的 gamepad case）。
+    // 所以它能长期留在关着的一侧，适合当这条契约的锚点。
     expect(
-      ShortcutScope.globalExternal.channels.contains(ShortcutChannel.mouse),
+      ShortcutScope.gamepad.channels.contains(ShortcutChannel.mouse),
       isFalse,
-      reason: '前提：globalExternal 没有开鼠标通道（开了就换一个仍关着的 scope）',
+      reason: '前提：gamepad scope 没有开鼠标通道（开了就换一个仍关着的 scope）',
     );
 
     final FushiShortcutRegistry reg = FushiShortcutRegistry()
       ..loadDefaults(TargetPlatform.windows);
     reg.updateBinding(
-      ShortcutAction.globalExternalLookup,
+      ShortcutAction.dpadUp,
       const ShortcutBindingSet(mouseBindings: <MouseBinding>[MouseBinding(4)]),
     );
 
     expect(
-      reg.resolveMouse(4, scope: ShortcutScope.globalExternal),
-      ShortcutAction.globalExternalLookup,
+      reg.resolveMouse(4, scope: ShortcutScope.gamepad),
+      ShortcutAction.dpadUp,
       reason: 'resolveMouse 不查 channels —— 通道开关管不着已存在的绑定能否派发',
     );
   });

--- a/fushi/windows/runner/CMakeLists.txt
+++ b/fushi/windows/runner/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${BINARY_NAME} WIN32
   "foreground_selection.cpp"
   "global_lookup_shadow.cpp"
   "global_lookup_window.cpp"
+  "global_mouse_trigger.cpp"
   "hdr_video_host_window.cpp"
   "hook_toolbar_window.cpp"
   "ime_association_guard.cpp"

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -28,6 +28,7 @@
 #include "audio_loopback_capture.h"
 #include "voice_hook_reader.h"
 #include "foreground_selection.h"
+#include "global_mouse_trigger.h"
 #include "ime_space_dispatch.h"
 #include "window_capture.h"
 #include "../../../native/galgame_hook/include/voice_hook_ipc.h"
@@ -2337,6 +2338,16 @@ void FlutterWindow::RegisterGlobalLookupChannel() {
         } else if (method == "isShowing") {
           result->Success(
               flutter::EncodableValue(win->IsShowing()));
+        } else if (method == "setGlobalMouseTrigger") {
+          // TODO-1066 — 全局鼠标侧键触发的注册/注销。**进程级**，与 win / route
+          // 无关（它要在一张卡片都没有的时候生效——那正是它的用途），所以这里
+          // 不碰上面按 target 取到的那个 win。
+          //
+          // 按钮号 0 = 注销，native 侧不留任何 Raw Input 监听（Dart 侧在用户没绑
+          // 侧键时就是推 0，沿用 BUG-1077「不查词不留全局钩子」的纪律）。
+          const bool ok = fushi::SetGlobalMouseTrigger(
+              GetHandle(), IntFromValue(args, "button", 0));
+          result->Success(flutter::EncodableValue(ok));
         } else if (method == "setBlockCapture") {
           // 防截屏（WDA_EXCLUDEFROMCAPTURE）：瞬态查词窗对用户可见但不进截图 /
           // 录屏 / 屏幕共享。GlobalLookupWindow 记住该值，窗口重建后由
@@ -3189,6 +3200,10 @@ bool FlutterWindow::ApplyWindowIcon(const std::wstring& path) {
 }
 
 void FlutterWindow::OnDestroy() {
+  // TODO-1066 — 撤销全局侧键的 Raw Input 登记。登记是绑在**本窗口 HWND** 上的
+  // （RIDEV_INPUTSINK 要求 hwndTarget），HWND 一销毁那条登记就成了悬空目标，
+  // 必须在这里主动摘掉而不是等进程退出兜底。
+  fushi::SetGlobalMouseTrigger(nullptr, fushi::kGlobalMouseTriggerNone);
   // Attached surface callbacks invoke gal_hook_text_channel_; tear the HWND and
   // its follow timer down while the Flutter messenger is still alive.
   attached_text_surface_window_.reset();
@@ -3383,6 +3398,18 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     //   WM_THEMECHANGED — 经典主题切换。
     // 收到后通知 Dart 重新取系统色（refreshSystemPalette），随后 **不消费** 消息、
     // 落到下面 Win32Window::MessageHandler 走默认处理，保持既有其它消息分支语义不变。
+    case WM_INPUT:
+      // TODO-1066 — 全局鼠标侧键触发（Raw Input + RIDEV_INPUTSINK，见
+      // global_mouse_trigger.h 里"为什么不用 WH_MOUSE_LL"）。只在用户真绑了侧键
+      // 时才有注册，没绑时 HandleGlobalMouseTriggerRawInput 第一行就返回 false。
+      //
+      // **必须 break 而不是 return**：WM_INPUT 要交给 DefWindowProc 做清理。
+      if (fushi::HandleGlobalMouseTriggerRawInput(lparam) &&
+          global_lookup_channel_ != nullptr) {
+        global_lookup_channel_->InvokeMethod(
+            "globalMouseTrigger", std::make_unique<flutter::EncodableValue>());
+      }
+      break;
     case WM_DWMCOLORIZATIONCOLORCHANGED:
     case WM_THEMECHANGED:
       NotifySystemColorChanged();

--- a/fushi/windows/runner/global_mouse_trigger.cpp
+++ b/fushi/windows/runner/global_mouse_trigger.cpp
@@ -1,0 +1,130 @@
+#include "global_mouse_trigger.h"
+
+#include <atomic>
+
+namespace fushi {
+
+namespace {
+
+// 当前已注册的 DOM 按钮号；0 = 未注册。WM_INPUT 在 UI 线程读，注册也在 UI 线程
+// 写，用 atomic 只为把「注册/注销与消息处理交错」这件事写明白。
+std::atomic<int> g_dom_button{0};
+
+// Raw Input 的鼠标按钮位。注意编号与 DOM 差一：Windows 的 "button 4/5" 就是
+// XBUTTON1/XBUTTON2，而 DOM 把它们叫 3(back)/4(forward)。
+USHORT DownFlagForDomButton(int dom_button) {
+  switch (dom_button) {
+    case kGlobalMouseTriggerBack:
+      return RI_MOUSE_BUTTON_4_DOWN;
+    case kGlobalMouseTriggerForward:
+      return RI_MOUSE_BUTTON_5_DOWN;
+    default:
+      return 0;
+  }
+}
+
+// 这一下侧键是不是按在 Fushi 自己的窗口上？
+//
+// 是的话就**不**触发全局查词。理由不是"避免打扰"，是消除一整类双触发：本进程的
+// 窗口各自已经有自己的鼠标路径——gal hook 台词浮窗有它自己的侧键查词
+// （floating_lyric_window.cpp 的 lookup_trigger_ == 2，走它自己的 WndProc），
+// 主窗有 Flutter 侧的 mouse binding 派发，查词卡有低级钩子的命中转发。不排除
+// 的话，在台词浮窗的文字上按一次侧键会**同时**走浮窗查词和全局查词，出两张卡、
+// 做两次词典 FFI 查询。
+//
+// 按进程而不是按窗口列表判断，是为了不给每个新窗口类型打一次补丁——「这是
+// Fushi 自己的 UI，Fushi 自己会处理」是一条完整的规则，而本功能名字就叫
+// app-external lookup（globalExternal），语义上本来就只服务"别的程序"。
+//
+// 用 GetCursorPos 而不是 raw input 的坐标：raw mouse 报的是相对位移
+// （MOUSE_MOVE_ABSOLUTE 只在平板/远程桌面等少数设备上出现），拿不到屏幕点；
+// 而按下这一刻光标就在那儿，误差可忽略。
+bool PointIsOwnedByThisProcess() {
+  POINT pt{};
+  if (!GetCursorPos(&pt)) {
+    // 拿不到光标位置就当作"不属于本进程"——宁可多触发一次查词，也不要让功能
+    // 在某些远程/受限会话下静默失效。
+    return false;
+  }
+  const HWND under = WindowFromPoint(pt);
+  if (under == nullptr) {
+    return false;
+  }
+  DWORD pid = 0;
+  GetWindowThreadProcessId(under, &pid);
+  return pid == GetCurrentProcessId();
+}
+
+}  // namespace
+
+bool SetGlobalMouseTrigger(HWND host, int dom_button) {
+  const USHORT flag = DownFlagForDomButton(dom_button);
+
+  if (flag == 0) {
+    // 注销。已经是未注册状态就直接返回成功（幂等）——RIDEV_REMOVE 在没有注册过
+    // 的情况下会失败，那不是错误。
+    if (g_dom_button.load() == kGlobalMouseTriggerNone) {
+      return true;
+    }
+    RAWINPUTDEVICE rid{};
+    rid.usUsagePage = 0x01;  // Generic Desktop Controls
+    rid.usUsage = 0x02;      // Mouse
+    rid.dwFlags = RIDEV_REMOVE;
+    // RIDEV_REMOVE 要求 hwndTarget 必须为 NULL，否则调用失败。
+    rid.hwndTarget = nullptr;
+    const bool ok =
+        RegisterRawInputDevices(&rid, 1, sizeof(RAWINPUTDEVICE)) != FALSE;
+    g_dom_button.store(kGlobalMouseTriggerNone);
+    return ok;
+  }
+
+  if (host == nullptr) {
+    return false;
+  }
+  // 重复注册同一按钮：仍然重新 Register 一次（宿主 HWND 可能变了），但这是
+  // 幂等操作——同一 usage 再注册会覆盖上一次的登记，不会叠加。
+  RAWINPUTDEVICE rid{};
+  rid.usUsagePage = 0x01;
+  rid.usUsage = 0x02;
+  // INPUTSINK = 即使 host 不在前台也投递 WM_INPUT。这正是"用户在别的程序里按
+  // 侧键"能被收到的原因，也是本功能存在的前提。
+  rid.dwFlags = RIDEV_INPUTSINK;
+  rid.hwndTarget = host;
+  if (!RegisterRawInputDevices(&rid, 1, sizeof(RAWINPUTDEVICE))) {
+    return false;
+  }
+  g_dom_button.store(dom_button);
+  return true;
+}
+
+bool HandleGlobalMouseTriggerRawInput(LPARAM lparam) {
+  const int dom_button = g_dom_button.load();
+  if (dom_button == kGlobalMouseTriggerNone) {
+    return false;
+  }
+  const USHORT want = DownFlagForDomButton(dom_button);
+  if (want == 0) {
+    return false;
+  }
+
+  // 鼠标 RAWINPUT 是固定大小，可以直接栈上接。注册的 usage 只有 Mouse，所以
+  // 这里不会收到变长的 HID/键盘包。
+  RAWINPUT raw{};
+  UINT size = sizeof(raw);
+  const UINT read =
+      GetRawInputData(reinterpret_cast<HRAWINPUT>(lparam), RID_INPUT, &raw,
+                      &size, sizeof(RAWINPUTHEADER));
+  if (read == static_cast<UINT>(-1) || raw.header.dwType != RIM_TYPEMOUSE) {
+    return false;
+  }
+  // 绝大多数 WM_INPUT 是移动事件，usButtonFlags 为 0 —— 这一行就是热路径的出口。
+  if ((raw.data.mouse.usButtonFlags & want) == 0) {
+    return false;
+  }
+  if (PointIsOwnedByThisProcess()) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace fushi

--- a/fushi/windows/runner/global_mouse_trigger.h
+++ b/fushi/windows/runner/global_mouse_trigger.h
@@ -1,0 +1,52 @@
+#ifndef RUNNER_GLOBAL_MOUSE_TRIGGER_H_
+#define RUNNER_GLOBAL_MOUSE_TRIGGER_H_
+
+// TODO-1066 — app 外全局查词的**鼠标侧键**触发源。
+//
+// 为什么是 Raw Input 而不是 WH_MOUSE_LL：
+//
+// 本仓已经有一条低级鼠标钩子（low_level_mouse_hook.cpp），但它是**同步**钩子：
+// 系统把每一个鼠标事件投递到装钩子的线程并**等它返回或超时**才继续分发给前台
+// 程序。那条钩子因此被严格限制在「查词卡显示期间」Arm、Hide 即 Disarm，
+// BUG-1077 更把这条写成了明文契约——「不查词不留全局钩子」。
+// 全局侧键触发要求的是「任何时候按下都能收到」，把那条钩子改成常驻就等于把
+// BUG-1048 的原始症状（用户实测「点击查词后鼠标移动变卡，不查就没事」）从
+// 查词期间扩大到永远。
+//
+// Raw Input + RIDEV_INPUTSINK 提供同样的「窗口不在前台也收得到」，但是**异步**
+// 投递 WM_INPUT：它不插进系统输入分发的关键路径，没有 LowLevelHooksTimeout 那
+// 套「回调慢了就被系统静默摘钩」的风险。
+//
+// 代价是 Raw Input 只能监听、不能拦截。这**正是**本功能要的语义：侧键在浏览器
+// 里是前进/后退，在别的程序里也可能有绑定，吞掉就是破坏用户的正常使用。所以
+// 「不能拦截」在这里不是限制，是需求。
+//
+// 常驻代价的纪律沿用 BUG-1077 的精神：**只在用户真的绑了侧键时才注册**
+// （Dart 侧 GlobalLookupController._registerMouseTriggerFromRegistry 按绑定推
+// 送，没绑就推 0 注销）。不用这个功能的用户，一个系统级监听都不留。
+
+#include <windows.h>
+
+namespace fushi {
+
+// DOM `MouseEvent.button` 号（与 Dart 侧 MouseBinding.button 同一编码）。
+// 只有侧键可以当全局触发：右键/中键有全系统级的默认语义（上下文菜单 /
+// 自动滚动），而本触发**不拦截**原事件，绑上去等于两件事同时发生。
+constexpr int kGlobalMouseTriggerNone = 0;
+constexpr int kGlobalMouseTriggerBack = 3;     // XBUTTON1
+constexpr int kGlobalMouseTriggerForward = 4;  // XBUTTON2
+
+// 注册（[dom_button] = 3/4）或注销（0 / 任何其它值）全局侧键监听。
+// [host] 是接收 WM_INPUT 的窗口，必须在监听期间保持有效（用主窗）。
+// 返回是否成功；重复注册同一按钮是幂等的。
+bool SetGlobalMouseTrigger(HWND host, int dom_button);
+
+// 在 WM_INPUT 里调用。返回 true 表示「用户按下了已注册的侧键，且这一下不属于
+// 本进程自己的窗口」——也就是应当去开一次全局查词。
+//
+// 调用方**仍须**把 WM_INPUT 交给 DefWindowProc（系统要靠它做清理）。
+bool HandleGlobalMouseTriggerRawInput(LPARAM lparam);
+
+}  // namespace fushi
+
+#endif  // RUNNER_GLOBAL_MOUSE_TRIGGER_H_


### PR DESCRIPTION
## 起因

用户问「全局查词支持手柄吗」。答案是**不支持** —— `ShortcutScope.globalExternal` 在
`shortcut_action.dart` 里被钉死为 keyboard-only，设置页连「添加手柄按键 / 鼠标按键」
的录入入口都不给。顺带把鼠标侧键一起做了。

## 三条通道，三种 OS 机制

同一个动作、同一个执行体，但底层机制**各不相同**，这是本 scope 的特殊之处：

| 通道 | 机制 | 关键约束 |
|---|---|---|
| 键盘 | hotkey_manager → win32 `RegisterHotKey` | 不变。`HotKey.key` 类型就是 `KeyboardKey`，手柄/鼠标**按构造**无法表达——这正是另两条必须另起机制的原因 |
| 手柄 | `GamepadService` 里一条**不经 Flutter 焦点树**的分支 | 见下 |
| 鼠标侧键 | native Raw Input + `RIDEV_INPUTSINK`（新增 `global_mouse_trigger.{h,cpp}`） | 见下 |

### 手柄为什么不能走 `Actions`/`Intent`

Windows 上主窗一失焦，`MainWindowFocusGate` 就把整棵子树设成
`descendantsAreFocusable: false`，`Actions.maybeInvoke<GamepadButtonIntent>` 那条主派发
路径必然落空 —— 而「用户正在别的程序里看文本」恰恰是本功能**唯一**的使用场景。

底层 GameInput 是进程级轮询（每手柄一条 native 线程，8ms 一轮，不接受窗口句柄），
按钮本来就读得到，断掉的只是派发链。仓库里 P5 游戏内查词卡的独占路由已经在生产依赖
这个事实。新分支排在取焦点 context **之前**，与键盘的 OS 级热键同构（后者在 app 内也
抢在页面之前）。

**默认绑定必须留空**：正因为它优先于页面，给任何默认值都等于从页面手里抢走一个按钮。

### 鼠标侧键为什么不用现成的 `WH_MOUSE_LL`

仓库已有一条低级鼠标钩子，但它是**同步**钩子：系统把每个鼠标事件投给装钩子的线程并
等它返回或超时才继续分发。BUG-1048 的用户原话是「点击查词后鼠标移动都会变卡，不查就
没事」；BUG-1077 因此立下明文契约 —— **「不查词不留全局钩子」**。把它改成常驻等于把那个
症状从查词期间扩大到永远。

Raw Input + `RIDEV_INPUTSINK` 提供同样的「窗口不在前台也收得到」，但是**异步**投递
`WM_INPUT`，不插进系统输入分发的关键路径。它只能监听、不能拦截 —— 而这正是需求：侧键
在浏览器里是前进/后退，吞掉就是破坏用户的正常使用。那个「限制」在这里就是我们要的语义。

纪律沿用 BUG-1077 的精神：**只在用户真绑了侧键时才注册**，没绑一个监听都不留。
只接受侧键（DOM 3/4）；右键/中键有全系统级默认语义（上下文菜单 / 自动滚动），在不拦截
的前提下绑上去等于两件事同时发生，设置页给了一行说明。

### 双触发消解

侧键落在**本进程任何窗口**上时不触发全局查词。gal hook 台词浮窗有自己的侧键查词
（`floating_lyric_window` 的 `lookup_trigger_ == 2`，走它自己的 WndProc），不排除的话在
浮窗文字上按一次会**同时**走两条路径，出两张卡、做两次词典 FFI 查询。按进程判断而不是
维护一张窗口列表，是为了不给每个新窗口类型打一次补丁 —— 而且这个功能名字就叫
app-external lookup，语义上本来就只服务「别的程序」。

## 顺带修掉的一条既有并发 bug

`SelectionCapture.captureForegroundSelection` 的「存旧剪贴板 → 清空 → 注入 Ctrl+C →
轮询 600ms → 还原」整段**没有互斥**，而剪贴板是全局单资源。两次重叠时：
A 存下旧值 → A 清空 → **B 存下的是 A 刚清空的空值** → A 还原 → B 超时 → B 把剪贴板
「还原」成空。用户的剪贴板就这么没了（同源事故见 BUG-707 剪贴板回声）。

上游的 route 作废机制救不了它 —— 那只让**已返回**的旧调用在 await 边界自杀，而这段事务
一旦开始就必须跑完（半途放弃 = 剪贴板停在被清空的状态）。修法是在事务本身上加串行闸门，
并让排队期间已被取代的那几次直接跳过（否则连按会排出一队各 600ms 的事务）。

**串行而不是丢弃**，是为了不破坏「再按一次总是查当前选区」的既有语义。

键盘热键不容易连按到暴露它；手柄按钮和鼠标侧键会。

## 其它

- 原 `_onHotKey` 提升为公开的 `triggerSelectionLookup({source})`，三个触发源汇入同一个
  执行体，不各自复制查词链（route 铸造 / epoch 作废 / prewarm / 隐藏时序都在这条链上，
  复制一份必然漂移）。改成公开是零行为变更 —— 它体内本就没有任何键盘相关逻辑。
- 设置页录入入口自动跟随 `scope.channels`，无需改 UI。
- 新增 i18n key 只填了 en/zh，其余 15 语言按仓库惯例暂留英文值。

## 测试

新增 `global_external_lookup_trigger_test.dart`（手柄解析/派发行为、默认绑定为空、
三处接线的源码守卫，其中一条钉住「分支必须排在取焦点之前」——这条只有源码守卫抓得住）
与 `selection_capture_gate_test.dart`（闸门的串行、跳过、异常不堵死；经
`debugRunClipboardExclusive` 测闸门本身，绝不在测试里真去动这台机器的剪贴板）。

三处既有测试需要跟着改，都不是回归：

- `global_lookup_flaky_popup_guard_test`：它按 `glog('hotkey: FIRED');` 的**精确文本**
  定位，我给这行加了触发源标签。锚点收窄成前缀，以后再加字段不会再漂。
- `shortcut_registry_mouse_test` / `shortcut_mouse_binding_capture_test`：这两个把
  `globalExternal` 当作「鼠标通道关着」的**样本**。第一个的注释甚至预留了指引
  （「开了就换一个仍关着的 scope」）。锚点改到 `gamepad` scope（dpad 四向）——它是目前
  唯一**按构造**开不了鼠标的那个，能长期留在关着的一侧。

## 验证

- `flutter analyze` 全量（含 test）：**No issues found**
- `test/shortcuts` + `test/lookup` + `test/i18n`：**1390 条全绿**
- 51 条目录枚举型守卫整批：**362 条全绿**
- `flutter build windows --debug`：**Built ...\fushi.exe**（native 编译验证）

**未验证的缺口**：手柄按键与鼠标侧键的物理触发没做真机复测（缺硬件），native 侧只到
编译为止。`SetGlobalMouseTrigger` 的注册/注销、`PointIsOwnedByThisProcess` 的判据、以及
GameInput 在真实失焦场景下的按钮送达，都需要一次实机点按才能算 verified。

https://claude.ai/code/session_01EixeBL1unkiH1v3EkiwnhC
