### PR TITLE
fix(ui): 滚动时悬停放大不再残留在已滚走的卡上（BUG-2124）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1990 条。点号进各自文件。
+> 共 1991 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2124](bugs/BUG-2124-video-wall-hover-lift-lags-scroll.md) | ✅ | ✅ | 视频墙格滚动时放大态残留在已滚走的卡上 |
 | [BUG-2120](bugs/BUG-2120-desktop-oauth-no-manual-link.md) | ✅ | ✅ | 桌面云盘 OAuth 登录无「复制链接/重开/取消」兜底，浏览器页失败只能等 5 分钟超时 |
 | [BUG-2119](bugs/BUG-2119-sqlite-busy-statement-poisons-connection-exit-trap.md) | ✅ | ✅ | 视频页 Esc/返回退不出去：写语句 SQLITE_BUSY 后未 reset 毒化整条连接，退出被落库绑架 |
 | [BUG-2117](bugs/BUG-2117-shortcut-scope-order.md) | ✅ | ✅ | 快捷键设置页 scope 卡片顺序是枚举累加顺序而非通用→页面→设备 |

--- a/docs/bugs/BUG-2124-video-wall-hover-lift-lags-scroll.md
+++ b/docs/bugs/BUG-2124-video-wall-hover-lift-lags-scroll.md
@@ -1,0 +1,20 @@
+## BUG-2124 · 视频墙格滚动时放大态残留在已滚走的卡上
+- **报告**：2026-09-04（用户：「滚动的时候，会有另一个地方的卡片呈现被鼠标选中的样式，是因为界面大小吗」。追问确认：视频「系列 / 全部视频」墙格、鼠标滚轮、症状是**卡片变大**）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/components/fushi_hover_lift.dart:71-84`（修复前）：抬升的复位走 `AnimatedScale` 的 `kFushiHoverLiftDuration = 120ms` 缓动，而 Flutter 的鼠标命中判定在帧末 `MouseTracker.updateAllDevices` 才重算——滚轮让卡片位移后，`onExit` 到达时卡片已经移开，接着还要花 8 帧把它从 1.05 缓降回 1.0。**这 8 帧画在卡片的新位置上**，指针早已不在其上。逐帧实测（`VideoLibrarySection.allVideos`，指针固定 `Offset(159.3, 550.1)`，滚一档 120px）：
+
+  | 帧 | 那张卡 | 缩放 | 偏离指针 |
+  |---|---|---|---|
+  | 1–2 | y=315..546 | 1.050 | 120px |
+  | 3–8 | y=315..546 | 1.039 → 1.003 | 120px |
+  | 9 | — | 复位 | — |
+
+  同一段里指针**底下**的新卡要到第 17 帧才涨到 1.05（档 2 数据），即滚动全程没有一张放大的卡跟指针对齐；连续拨滚轮就是一串错位高亮接连亮起，正是用户描述的「另一个地方的卡片被选中」。
+  用户猜的「界面大小」已被实测否定：`FushiAppUiScale` 取 1.0 / 1.3 / 0.7 三档症状完全一致（缩放走 `FittedBox` 真实变换，命中随之变换，真错位的话静止悬停就已经偏了）。焦点环也已排除——焦点态是 2.5px `primary` 描边、不放大（`fushi_focus_ring.dart:323-334`），与用户所述「变大」不符。
+- **[x] ① 已修复** — 把不变式补成「抬升 = 指针悬停 **且** 不在滚动中」：`_FushiHoverLiftState` 经 `ScrollNotificationObserver`（`Scaffold` 提供，能收到**所有**祖先滚动区的通知，横滚行卡在纵向页里滚动同样覆盖）订阅滚动生命周期，滚动起步即以 `Duration.zero` 落回 1.0。残留 8 帧 → **2 帧**（约 32ms 满值，低于人眼可辨阈值）。三条纪律：
+  - `_scrolling` 与 `_hovering` 必须是两个正交的位，**不能**顺手清 `_hovering`：`MouseRegion` 只在命中集真变化时发事件，指针不动的话滚动停止后不会补 `onEnter`，清了就再也涨不回来（已实测踩过：既有 BUG-2002 用例全红）。
+  - 起点只认 `ScrollStartNotification`，**不能**把 `ScrollUpdateNotification` 也当起点：`jumpTo` / 恢复滚动位置这类一次性位移会单发 update 而无配对 end，`_scrolling` 会永久卡 true、连初次悬停都不再抬升（同样实测踩过）。
+  - `_setScrolling` 只在 `_hovering` 为真时 `setState`，一次滚动不会把整墙刷一遍。
+  - 剩下的 2 帧是当前实现的物理下限：`AnimatedScale` 是隐式动画，置位那帧只改得动目标值、渲染值下一帧才跟上（时长设 0 也一样），controller 走完零时长再通知 listener 又占一帧。压到 0 帧需把 `AnimatedScale` 换成手写 `AnimationController`（置位时同帧 `value = 0`），代价是 BUG-2002 的既有守卫按 `AnimatedScale` 类型断言、要一起改——按实用主义未做，判据里写明了这个下限的来源。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_wall_hover_scroll_test.dart`：真 widget 行为测试（pump `HomeVideoPage` + `TestPointer` 悬停 + `pointer.scroll` 滚轮），滚 4 档 × 每档 14 帧逐帧断言「屏幕上放大的卡必须包含指针」，覆盖 allVideos / series 两条墙格实现与界面缩放 1.3，另一条反向门断言滚动停下后指针仍在卡上时抬升要回来（防止把 hover 真值一起吃掉）。
+  **判据必须读渲染矩阵**（`AnimatedScale` 内层 `Transform.transform.getMaxScaleOnAxis()`）而不是 `AnimatedScale.scale`：后者是动画**目标值**，1 帧就归位，先写的目标值版用例全绿——正是它把这 8 帧藏住了，属空壳断言。
+- **备注**：同壳的书架 / 漫画 / 游戏库卡（`reader_history/card_widgets.part.dart:295`、`galgame_poster_card.dart:77`）与视频页其余三条路径共用 `FushiHoverLift`，一并受益。合集详情页成员卡 `_HoverableMemberCard`（`media_collection_grid_detail_page.dart:405-450`）是另一套自写 `MouseRegion` 高亮罩、未接本壳，同类拖尾未覆盖，属独立缺口，本条不扩大范围。

--- a/fushi/lib/src/utils/components/fushi_hover_lift.dart
+++ b/fushi/lib/src/utils/components/fushi_hover_lift.dart
@@ -17,6 +17,22 @@ import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 ///   关掉缩放，但 hover 状态照常传给 builder，静态反馈保留。
 ///
 /// 触屏平台上 [MouseRegion] 本就不会触发，无需按平台分流。
+///
+/// **不变式（BUG-2124）**：屏幕上被放大的卡 ⟺ 指针正下方的卡。滚动会破坏它——
+/// Flutter 的鼠标命中判定在帧末才重算，`onExit` 到达时卡片已经位移，而复位又走
+/// [kFushiHoverLiftDuration] 缓动，于是那张已经滚走的卡在**新位置**上继续放大
+/// 8 帧（实测 128ms / 偏离 120px），指针底下的新卡同时才刚开始涨——滚动全程没有
+/// 一张放大的卡跟指针对齐，用户看到的就是「另一个地方的卡片被选中了」。
+///
+/// 修法是把不变式补成「放大 = 指针悬停 **且** 不在滚动中」，滚动一起步就同帧落回
+/// 1.0（所以缩放走显式 [AnimationController] 而不是 `AnimatedScale`——隐式动画
+/// 即使时长为 0 也要晚两三帧才落值，那几帧正是症状本身）。两条纪律：
+/// - **不能**顺手把 [_hovering] 清掉：`MouseRegion` 只在命中集真的变化时才发事件，
+///   指针没动的话滚动停止后不会补一个 `onEnter`，清了就再也涨不回来，直到用户挪
+///   一下鼠标。所以 hover 与 scrolling 是两个正交的位。
+/// - 压制要同时认「`ScrollStart..ScrollEnd` 之间」和「本帧发生过位移」两个位：
+///   桌面粗滚轮经 `FushiScrollController` 的补间动画跨十几帧，靠前者；而 Flutter
+///   默认的滚轮路径在同一次事件处理里就把 start/update/end 全发完，只能靠后者。
 class FushiHoverLift extends StatefulWidget {
   const FushiHoverLift({
     super.key,
@@ -45,12 +61,136 @@ const double kFushiHoverLiftScale = 1.05;
 /// 悬停动画时长（游戏库既有实现的落地值）。
 const Duration kFushiHoverLiftDuration = Duration(milliseconds: 120);
 
-class _FushiHoverLiftState extends State<FushiHoverLift> {
+class _FushiHoverLiftState extends State<FushiHoverLift>
+    with SingleTickerProviderStateMixin {
+  /// 指针是否真的在这张卡上（[MouseRegion] 的真值，滚动**不得**改它）。
   bool _hovering = false;
+
+  /// 祖先滚动区处在 `ScrollStart..ScrollEnd` 之间。覆盖走补间动画的滚动
+  /// （桌面粗滚轮经 `FushiScrollController` 的 `animateTo`，跨十几帧）。
+  bool _scrolling = false;
+
+  /// 本帧发生过滚动位移。覆盖 Flutter 默认的滚轮路径——它在**同一次事件处理里**
+  /// 就把 `ScrollStart / ScrollUpdate / ScrollEnd` 全发完（已用探针实测），
+  /// [_scrolling] 那一位置起又立刻落下，单靠它压不住这条路径。
+  bool _moved = false;
+
+  /// 缩放动效是否开启（墨水屏 / 减弱动态效果两处降级）。依赖 InheritedWidget，
+  /// 在 [didChangeDependencies] 里算好缓存，供事件回调同步取用。
+  bool _animate = true;
+
+  ScrollNotificationObserverState? _scrollObserver;
+
+  /// 抬升用**显式** controller 而不是 `AnimatedScale`：隐式动画即使时长为 0，
+  /// 目标值到渲染值之间也隔一帧，滚动压制会晚 2~3 帧落地——那几帧的放大正画在
+  /// 已经滚走的卡上，就是 BUG-2124 的症状本身。显式 controller 可以在收到滚动
+  /// 通知的同一帧直接 `value = 0`。
+  ///
+  /// 在 [initState] 里建而不是 `late final` 懒建：`enabled == false` 的卡从不读
+  /// 它，懒建会推迟到 [dispose] 那一次访问才触发构造，此时 element 已 deactivate，
+  /// `AnimationController` 去查 `TickerMode` 祖先会直接抛
+  /// 「Looking up a deactivated widget's ancestor is unsafe」（已实测踩过）。
+  late final AnimationController _lift;
+  late final CurvedAnimation _curved;
+
+  @override
+  void initState() {
+    super.initState();
+    _lift = AnimationController(
+      vsync: this,
+      duration: kFushiHoverLiftDuration,
+    );
+    _curved = CurvedAnimation(parent: _lift, curve: Curves.easeOut);
+  }
+
+  /// 抬升的唯一判据：指针在这张卡上，且没在滚动（BUG-2124）。
+  bool get _lifted => widget.enabled && _hovering && !_scrolling && !_moved;
+
+  /// [immediate] 为真时同帧落位，不走缓动。
+  void _syncLift({bool immediate = false}) {
+    final double target = _lifted ? 1.0 : 0.0;
+    if (immediate || !_animate) {
+      _lift.stop();
+      _lift.value = target;
+      return;
+    }
+    if (_lift.value == target && !_lift.isAnimating) return;
+    // 曲线由 [_curved] 施加，这里给 controller 线性推进即可。
+    _lift.animateTo(target);
+  }
 
   void _setHover(bool value) {
     if (_hovering == value) return;
     setState(() => _hovering = value);
+    _syncLift();
+  }
+
+  void _onScrollNotification(ScrollNotification notification) {
+    // depth 不过滤：横滚行卡在纵向页里滚动时通知来自更外层的 Scrollable，
+    // 同样必须压制抬升。
+    //
+    // **不要**把 ScrollUpdateNotification 也当作 [_scrolling] 的起点：
+    // `jumpTo` / 恢复滚动位置这类一次性位移会单发 update 而没有配对的 end，
+    // [_scrolling] 会永久卡在 true、连初次悬停都不再抬升（已实测踩过）。
+    // 它只用来置本帧位 [_moved]，由 build 的 post-frame 负责落下。
+    bool changed = false;
+    if (notification is ScrollStartNotification) {
+      changed = !_scrolling;
+      _scrolling = true;
+    } else if (notification is ScrollEndNotification) {
+      changed = _scrolling;
+      _scrolling = false;
+    } else if (notification is ScrollUpdateNotification) {
+      // 本帧位只在正悬停时才置：它靠 build 的 post-frame 落下，而没悬停的卡这里
+      // 不 setState、也就走不到那次 build，置了就会永久卡住、之后鼠标移上来再也
+      // 不抬升。没悬停时抬升本来就是 0，这一位对它毫无意义。
+      if (!_hovering) return;
+      changed = !_moved;
+      _moved = true;
+    } else {
+      return;
+    }
+    // 只有正抬升着的那张卡需要重建；其余卡记下位即可，避免一次滚动把整墙刷一遍。
+    if (!changed || !_hovering) return;
+    setState(() {});
+    // 压制必须同帧落位；解除则走正常缓动涨回来。
+    _syncLift(immediate: !_lifted);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final bool reduceMotion =
+        MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+    final bool animate = !reduceMotion && !isEinkTheme(context);
+    if (animate != _animate) {
+      _animate = animate;
+      _syncLift(immediate: true);
+    }
+    final ScrollNotificationObserverState? next =
+        ScrollNotificationObserver.maybeOf(context);
+    if (identical(next, _scrollObserver)) return;
+    _scrollObserver?.removeListener(_onScrollNotification);
+    _scrollObserver = next;
+    _scrollObserver?.addListener(_onScrollNotification);
+  }
+
+  @override
+  void didUpdateWidget(covariant FushiHoverLift oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled != widget.enabled ||
+        oldWidget.scale != widget.scale) {
+      _syncLift(immediate: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollObserver?.removeListener(_onScrollNotification);
+    _scrollObserver = null;
+    _curved.dispose();
+    _lift.dispose();
+    super.dispose();
   }
 
   @override
@@ -64,21 +204,32 @@ class _FushiHoverLiftState extends State<FushiHoverLift> {
       }
       return widget.builder(context, false);
     }
-    final bool reduceMotion =
-        MediaQuery.maybeDisableAnimationsOf(context) ?? false;
-    final bool animate = !reduceMotion && !isEinkTheme(context);
-    final Widget content = widget.builder(context, _hovering);
-    return MouseRegion(
-      onEnter: (_) => _setHover(true),
-      onExit: (_) => _setHover(false),
-      child: animate
-          ? AnimatedScale(
-              scale: _hovering ? widget.scale : 1.0,
-              duration: kFushiHoverLiftDuration,
-              curve: Curves.easeOut,
-              child: content,
-            )
-          : content,
+    // 本帧位只压这一帧：下一帧 MouseTracker 已经重算过 hover，[_hovering] 就是
+    // 新的真值，该不该抬升由它说了算。
+    if (_moved) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_moved) return;
+        setState(() => _moved = false);
+        _syncLift();
+      });
+    }
+    final Widget content = widget.builder(context, _lifted);
+    if (!_animate) return _wrapHover(content);
+    return _wrapHover(
+      AnimatedBuilder(
+        animation: _curved,
+        builder: (BuildContext _, Widget? child) => Transform.scale(
+          scale: 1.0 + (widget.scale - 1.0) * _curved.value,
+          child: child,
+        ),
+        child: content,
+      ),
     );
   }
+
+  Widget _wrapHover(Widget child) => MouseRegion(
+        onEnter: (_) => _setHover(true),
+        onExit: (_) => _setHover(false),
+        child: child,
+      );
 }

--- a/fushi/test/pages/home_video_hover_lift_test.dart
+++ b/fushi/test/pages/home_video_hover_lift_test.dart
@@ -127,18 +127,33 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  /// 最近的 [AnimatedScale] 祖先——即包着这张卡的 [FushiHoverLift] 动画层。
-  AnimatedScale liftScaleOf(WidgetTester tester, String cardKey) {
-    final Finder scales = find.ancestor(
+  /// 包着这张卡的 [FushiHoverLift] 缩放层当前**渲染**出的倍数。
+  ///
+  /// BUG-2124 起缩放走显式 `AnimationController` + [Transform]（不再是
+  /// `AnimatedScale`，隐式动画落值晚两三帧、压不住滚动），所以这里读渲染矩阵。
+  double liftScaleOf(WidgetTester tester, String cardKey) {
+    final Finder lift = find.ancestor(
       of: find.byKey(ValueKey<String>(cardKey)),
-      matching: find.byType(AnimatedScale),
+      matching: find.byType(FushiHoverLift),
     );
     expect(
-      scales,
+      lift,
       findsWidgets,
-      reason: '卡 $cardKey 外面必须包着 FushiHoverLift 的 AnimatedScale（BUG-2002）',
+      reason: '卡 $cardKey 外面必须包着 FushiHoverLift（BUG-2002）',
     );
-    return tester.widget<AnimatedScale>(scales.first);
+    final Finder transforms = find.descendant(
+      of: lift.first,
+      matching: find.byType(Transform),
+    );
+    expect(
+      transforms,
+      findsWidgets,
+      reason: '卡 $cardKey 的悬停壳必须建出缩放层（BUG-2002）',
+    );
+    return tester
+        .widget<Transform>(transforms.first)
+        .transform
+        .getMaxScaleOnAxis();
   }
 
   Future<TestGesture> hoverOnto(WidgetTester tester, String cardKey) async {
@@ -154,16 +169,16 @@ void main() {
   }
 
   Future<void> expectHoverLifts(WidgetTester tester, String cardKey) async {
-    expect(liftScaleOf(tester, cardKey).scale, 1.0);
+    expect(liftScaleOf(tester, cardKey), closeTo(1.0, 1e-6));
     final TestGesture mouse = await hoverOnto(tester, cardKey);
     expect(
-      liftScaleOf(tester, cardKey).scale,
-      kFushiHoverLiftScale,
+      liftScaleOf(tester, cardKey),
+      closeTo(kFushiHoverLiftScale, 1e-6),
       reason: '鼠标悬停必须放大到 kFushiHoverLiftScale',
     );
     await mouse.moveTo(const Offset(5, 5));
     await tester.pumpAndSettle();
-    expect(liftScaleOf(tester, cardKey).scale, 1.0, reason: '鼠标移出必须复位');
+    expect(liftScaleOf(tester, cardKey), closeTo(1.0, 1e-6), reason: '鼠标移出必须复位');
   }
 
   Future<void> seedInProgress(String uid, String title) => db.upsertVideoBook(

--- a/fushi/test/pages/home_video_wall_hover_scroll_test.dart
+++ b/fushi/test/pages/home_video_wall_hover_scroll_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi/src/utils/app_ui_scale.dart';
+import 'package:fushi/src/utils/components/fushi_hover_lift.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// BUG-2124：视频墙格用鼠标滚轮滚动时，[FushiHoverLift] 的悬停放大残留在**已经
+/// 滚走的那张卡**上（用户原话「另一个地方的卡片呈现被鼠标选中的样式」）。
+///
+/// 修复前实测：滚一档后那张卡偏离指针 120px，仍在屏幕上保持放大 **8 帧 / 128ms**
+/// （1.050 缓降到 1.003），同时指针底下的新卡才刚开始涨——滚动全程没有一张放大的
+/// 卡跟指针对齐。
+///
+/// 判据必须读**渲染矩阵**而不是 `AnimatedScale.scale`：后者是动画目标值，1 帧就
+/// 归位，正是它把这个 bug 藏了整整 8 帧（先写的目标值版用例全绿，是空壳）。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('fushi_wall_hover_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('fushi_wall_hover_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp(VideoLibrarySection section, {double uiScale = 1.0}) {
+    final Widget page = Scaffold(
+      body: HomeVideoPage(
+        repo: VideoBookRepository(db),
+        section: section,
+      ),
+    );
+    return ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: uiScale == 1.0
+              ? page
+              : FushiAppUiScale(scale: uiScale, child: page),
+        ),
+      ),
+    );
+  }
+
+  Future<void> seedMany(int count) async {
+    for (int i = 0; i < count; i++) {
+      await db.upsertVideoBook(
+        VideoBooksCompanion(
+          bookUid: Value<String>('video/w$i'),
+          title: Value<String>('Wall Show $i'),
+          videoPath: Value<String>('/abs/wall_$i.mp4'),
+          lastPositionMs: const Value<int>(60000),
+        ),
+      );
+    }
+  }
+
+  /// 当前**屏幕上真的被放大**的卡（读缩放层 [Transform] 的实际矩阵，含缓动中间
+  /// 值），而不是动画目标值——目标值 1 帧就归位，正是它把这个 bug 藏了 8 帧。
+  List<Rect> visuallyLifted(WidgetTester tester) {
+    final Finder lifts = find.byType(FushiHoverLift);
+    final List<Rect> out = <Rect>[];
+    for (int i = 0; i < lifts.evaluate().length; i++) {
+      final Finder one = lifts.at(i);
+      final Finder inner = find.descendant(
+        of: one,
+        matching: find.byType(Transform),
+      );
+      if (inner.evaluate().isEmpty) continue;
+      final double sx =
+          tester.widget<Transform>(inner.first).transform.getMaxScaleOnAxis();
+      // 1.001 的门限只滤浮点噪声：真实抬升是 1.05，缓动尾巴也远在其上。
+      if (sx > 1.001) out.add(tester.getRect(one));
+    }
+    return out;
+  }
+
+  /// 停在视口下半部的一张卡的中心（滚动后它会往上跑，指针不动）。
+  Offset pickPointer(WidgetTester tester) {
+    final Finder anyLift = find.byType(FushiHoverLift);
+    expect(anyLift, findsWidgets, reason: '墙格必须有悬停壳');
+    for (int i = 0; i < anyLift.evaluate().length; i++) {
+      final Rect r = tester.getRect(anyLift.at(i));
+      if (r.center.dy > 350 && r.center.dy < 650) return r.center;
+    }
+    fail('需要一张视口下半部的卡');
+  }
+
+  Future<void> runScrollCase(
+    WidgetTester tester,
+    VideoLibrarySection section, {
+    double uiScale = 1.0,
+  }) async {
+    await seedMany(40);
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp(section, uiScale: uiScale));
+    await tester.pumpAndSettle();
+
+    final Offset pointerPos = pickPointer(tester);
+    final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(pointerPos));
+    await tester.pumpAndSettle();
+
+    expect(
+      visuallyLifted(tester).length,
+      1,
+      reason: '悬停后应恰好一张卡放大',
+    );
+    expect(visuallyLifted(tester).single.contains(pointerPos), isTrue);
+
+    final ScrollableState scrollable = tester.state<ScrollableState>(
+      find.byType(Scrollable).last,
+    );
+    final double pixelsBefore = scrollable.position.pixels;
+
+    // 鼠标一动不动，只滚滚轮；滚轮补间（kDesktopWheelScrollDuration 140ms）
+    // 与抬升缓动（120ms）都在这些中间帧里，用户看到的正是它们。
+    //
+    // 判据是**每一帧**都不许有放大的卡落在指针之外：抬升走显式 controller，
+    // 滚动通知一到就同帧 `value = 0`，没有隐式动画那种「目标值改了、渲染值下
+    // 一帧才跟上」的窗口。修复前这里连续 8 帧（128ms，缩放从 1.050 可见地缓降
+    // 到 1.003）都挂着一张已经滚走 120px 的放大卡。
+    for (int step = 0; step < 4; step++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 120)));
+      for (int frame = 0; frame < 14; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        final List<Rect> stray = visuallyLifted(
+          tester,
+        ).where((Rect r) => !r.contains(pointerPos)).toList();
+        expect(
+          stray,
+          isEmpty,
+          reason: '第${step + 1}档第${frame + 1}帧：屏幕上放大的卡 $stray 不在指针 '
+              '$pointerPos 底下——抬升残留到了已经滚走的卡上（BUG-2124）',
+        );
+      }
+    }
+    await tester.pumpAndSettle();
+    expect(
+      scrollable.position.pixels,
+      greaterThan(pixelsBefore),
+      reason: '视口自始至终没有位移，本用例的不变式是空壳',
+    );
+  }
+
+  testWidgets('全部视频墙格：滚动全程放大的卡必须在指针底下', (WidgetTester tester) async {
+    await runScrollCase(tester, VideoLibrarySection.allVideos);
+  });
+
+  testWidgets('系列墙格：滚动全程放大的卡必须在指针底下', (WidgetTester tester) async {
+    await runScrollCase(tester, VideoLibrarySection.series);
+  });
+
+  testWidgets('界面缩放 1.3 下同样成立（此 bug 与界面大小无关）', (WidgetTester tester) async {
+    await runScrollCase(tester, VideoLibrarySection.allVideos, uiScale: 1.3);
+  });
+
+  testWidgets('滚动停下后指针仍在卡上，抬升要回来（压制不得吃掉 hover 真值）', (
+    WidgetTester tester,
+  ) async {
+    await seedMany(40);
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp(VideoLibrarySection.allVideos));
+    await tester.pumpAndSettle();
+
+    final Offset pointerPos = pickPointer(tester);
+    final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(pointerPos));
+    await tester.pumpAndSettle();
+    expect(visuallyLifted(tester).length, 1);
+
+    // 滚一点点：小到指针滚完仍落在某张卡上（不是行间隙）。
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 20)));
+    await tester.pumpAndSettle();
+
+    final List<Rect> after = visuallyLifted(tester);
+    expect(
+      after.length,
+      1,
+      reason: '滚动停止后指针底下的卡必须重新抬升——滚动压制只压视觉，不许清掉 '
+          'hover 真值：MouseRegion 不会因为滚动结束补发 onEnter，清了就再也涨不回来',
+    );
+    expect(after.single.contains(pointerPos), isTrue);
+  });
+}

--- a/fushi/test/widgets/fushi_hover_lift_test.dart
+++ b/fushi/test/widgets/fushi_hover_lift_test.dart
@@ -56,31 +56,42 @@ void main() {
     return mouse;
   }
 
+  /// 当前**渲染**出来的缩放；壳没建缩放层时返回 null。
+  ///
+  /// BUG-2124 起缩放走显式 `AnimationController` + [Transform]（不再是
+  /// `AnimatedScale`）：隐式动画即使时长为 0 也要晚两三帧才落值，滚动压制就压不
+  /// 住。读渲染矩阵而不是目标值，缓动中间帧也算得准。
   double? currentScale(WidgetTester tester) {
-    final Iterable<AnimatedScale> scales =
-        tester.widgetList<AnimatedScale>(find.byType(AnimatedScale));
-    return scales.isEmpty ? null : scales.first.scale;
+    final Finder transforms = find.descendant(
+      of: find.byType(FushiHoverLift),
+      matching: find.byType(Transform),
+    );
+    if (transforms.evaluate().isEmpty) return null;
+    return tester
+        .widget<Transform>(transforms.first)
+        .transform
+        .getMaxScaleOnAxis();
   }
 
   testWidgets('鼠标移入放大到 kFushiHoverLiftScale，移出复位', (WidgetTester tester) async {
     await tester.pumpWidget(harness());
-    expect(currentScale(tester), 1.0);
+    expect(currentScale(tester), closeTo(1.0, 1e-6));
 
     final TestGesture mouse = await hoverOnto(tester);
-    expect(currentScale(tester), kFushiHoverLiftScale);
+    expect(currentScale(tester), closeTo(kFushiHoverLiftScale, 1e-6));
     expect(seenHover.last, isTrue, reason: 'builder 必须拿到 hover 态才能加深阴影');
 
     await mouse.moveTo(const Offset(500, 500));
     await tester.pumpAndSettle();
-    expect(currentScale(tester), 1.0);
+    expect(currentScale(tester), closeTo(1.0, 1e-6));
     expect(seenHover.last, isFalse);
   });
 
   testWidgets('减弱动态效果：不缩放，但 hover 态照常传给 builder', (WidgetTester tester) async {
     await tester.pumpWidget(harness(disableAnimations: true));
     await hoverOnto(tester);
-    expect(find.byType(AnimatedScale), findsNothing,
-        reason: '系统开了「减弱动态效果」就不该有缩放动画');
+    expect(currentScale(tester), isNull,
+        reason: '系统开了「减弱动态效果」就不该有缩放层');
     expect(seenHover.last, isTrue, reason: '静态 hover 反馈（阴影/描边）必须保留，只去掉动效');
   });
 
@@ -94,7 +105,7 @@ void main() {
       ),
     ));
     await hoverOnto(tester);
-    expect(find.byType(AnimatedScale), findsNothing,
+    expect(currentScale(tester), isNull,
         reason: '墨水屏上连续缩放会不断触发整屏重绘/残影');
     expect(seenHover.last, isTrue, reason: 'hover 反馈本身要留着（墨水屏上通常改成描边）');
   });
@@ -102,7 +113,7 @@ void main() {
   testWidgets('enabled=false 时不建 MouseRegion，builder 恒拿到 false',
       (WidgetTester tester) async {
     await tester.pumpWidget(harness(enabled: false));
-    expect(find.byType(AnimatedScale), findsNothing);
+    expect(currentScale(tester), isNull);
     await hoverOnto(tester);
     expect(seenHover, everyElement(isFalse),
         reason: '禁用时不得有任何 hover 态泄漏给 builder');


### PR DESCRIPTION
用户报「滚动的时候，会有另一个地方的卡片呈现被鼠标选中的样式，是因为界面大小吗」。追问确认：视频「系列 / 全部视频」墙格、鼠标滚轮、症状是**卡片变大**。

## 不是界面大小（实测否定）

界面缩放取 1.0 / 1.3 / 0.7 三档症状完全一致。`FushiAppUiScale` 走 `FittedBox` 真实变换、命中随之变换，真要是它错位，静止悬停就已经偏了。焦点环也已排除：焦点态是 2.5px `primary` 描边、不放大，与「变大」不符。

## 根因

`FushiHoverLift` 的复位走 `AnimatedScale` 的 120ms 缓动，而 Flutter 的鼠标命中判定在帧末 `MouseTracker.updateAllDevices` 才重算。滚轮让卡片位移后，`onExit` 到达时卡片已经移开，接着还要花 8 帧把它从 1.05 缓降回 1.0 —— **这 8 帧画在卡片的新位置上**。

逐帧实测（`allVideos`，指针固定 `Offset(159.3, 550.1)`，滚一档 120px）：

| 帧 | 那张卡 | 缩放 | 偏离指针 |
|---|---|---|---|
| 1–2 | y=315..546 | 1.050 | 120px |
| 3–8 | y=315..546 | 1.039 → 1.003 | 120px |
| 9 | — | 复位 | — |

同一段里指针**底下**的新卡要到第 17 帧才涨到 1.05，即滚动全程没有一张放大的卡跟指针对齐；连续拨滚轮就是一串错位高亮接连亮起。

## 修复

把不变式补成「抬升 = 指针悬停 **且** 不在滚动中」：

- 经 `ScrollNotificationObserver`（`Scaffold` 提供，能收到**所有**祖先滚动区的通知，横滚行卡在纵向页里滚动同样覆盖）订阅滚动，压制**同帧**落位。
- 缩放从 `AnimatedScale` 换成显式 `AnimationController` + `Transform`：隐式动画即使时长为 0 也要晚两三帧才落值，压不住（实测残留 3 帧）。既有守卫按 `AnimatedScale` 类型断言的几处改成读渲染矩阵，**行为断言不变**。
- 压制认两个位：`ScrollStart..ScrollEnd` 之间（桌面粗滚轮经 `FushiScrollController` 的补间跨十几帧），以及**本帧发生过位移**（Flutter 默认滚轮路径在同一次事件处理里就把 start/update/end 全发完，探针实测，单靠前者压不住）。

三条实测踩过的纪律已写进注释：

1. **不能**顺手清 `_hovering`：`MouseRegion` 不会因滚动结束补发 `onEnter`，清了就再也涨不回来（当场让 BUG-2002 既有用例全红）。
2. **不能**把 `ScrollUpdateNotification` 当 `_scrolling` 的起点：`jumpTo` 会单发它、无配对 end，永久卡 true，连初次悬停都不抬升。
3. 本帧位只在悬停时置：否则没有那次 build 去落下它，会永久卡住。

外加 `AnimationController` 必须在 `initState` 建而非 `late final` 懒建 —— 否则 `enabled=false` 的卡会在 `dispose` 时才首次构造、查 `TickerMode` 祖先直接抛「Looking up a deactivated widget's ancestor is unsafe」。

## 测试

`fushi/test/pages/home_video_wall_hover_scroll_test.dart`：滚 4 档 × 每档 14 帧**逐帧**断言「屏幕上放大的卡必须包含指针」，覆盖 allVideos / series 两条墙格实现与界面缩放 1.3，外加一条反向门（滚动停下后指针仍在卡上时抬升要回来，防止把 hover 真值一起吃掉）。

判据读**渲染矩阵**而非 `AnimatedScale.scale`：后者是动画**目标值**、1 帧就归位，先写的目标值版用例全绿——正是它把这 8 帧藏住了，属空壳断言。

## 验证

- 新老 13 条全绿。
- **变异实测**：摘掉两个压制位后，三条滚动用例精准变红，BUG-2002 既有守卫与反向门不误伤。
- 相邻 18 条全绿（游戏库海报卡 / 书架标题溢出 / 游戏卡手柄守卫 / 合集详情成员卡）。
- 全量套件 `FLUTTER TEST VERDICT: PASSED - 22642 tests ran`（rebase 前基底）；rebase 到当前 develop 后重跑定向 12 条全绿 + `flutter analyze` 全量 No issues found。

## 范围

书架 / 漫画 / 游戏库卡与视频页其余三条卡片路径共用 `FushiHoverLift`，一并受益。合集详情页成员卡 `_HoverableMemberCard` 是另一套自写 `MouseRegion` 高亮罩、未接本壳，同类拖尾未覆盖，属独立缺口，本 PR 不扩大范围（已记进 BUG-2124 备注）。

https://claude.ai/code/session_01Kt4HQkSGM6iJnatMQ1EKsK
