### PR TITLE
feat(galgame): Unreal Engine（IoStore）引擎骨架——队列里唯一真正的新引擎缺口

### DIFF
--- a/docs/plans/2026-09-05-gal-ceshi-batch-unreal.md
+++ b/docs/plans/2026-09-05-gal-ceshi-batch-unreal.md
@@ -1,0 +1,88 @@
+# ceshi 批量 galgame 适配 · Unreal Engine（IoStore）骨架
+
+**状态：`implemented_unverified`。** 本轮只到 `text_observed` / `pcm_observed`，
+没有走过任何一句台词，因此 `text_thread_selected`、`resource_observed`、`paired`、
+`card_e2e` 全部 `not_run`，不得宣称「支持 Unreal」。
+
+## 为什么是这个引擎
+
+批量盘点时发现队列里的「昨日魔女今日的梦 1.0 汉化版」此前被记作 **Unity**，
+实际是 **Unreal Engine 5**（`kinomajo\Binaries\Win64\kinomajo-Win64-Shipping.exe` +
+`Engine\Extras\Redist` + IoStore `.ucas/.utoc`）。仓库原有 17 个引擎里没有 Unreal 家族，
+这是队列里**唯一真正的新引擎缺口**——其余游戏都命中已有 adapter。
+
+## 身份台账
+
+| 类别 | 事实 |
+|---|---|
+| 游戏 | 昨日魔女今日的梦 1.0 汉化版（Unreal Engine 5，IoStore 打包） |
+| 原始启动入口 | 外层 `kinomajo\kinomajo.exe`（x64，SHA-256 `877ff376…`） |
+| 真实游戏进程 | `kinomajo\kinomajo\Binaries\Win64\kinomajo-Win64-Shipping.exe`（x64，SHA-256 `f7018ae7…`，132 MB） |
+| 归档 | `Content\Paks\` 下 `global` / `kinomajo-Windows` / `kinomajo-Windows_zh-CN_P` 三套 `.pak`+`.ucas`+`.utoc`；`kinomajo-Windows.ucas` 2.7 GB |
+| 音频 | shipping exe **静态导入 `DSOUND.dll`**；UE 树另带 `Engine\Binaries\ThirdParty\Windows\XAudio2_9\x64\xaudio2_9redist.dll`（运行期动态加载） |
+| 第三方 | 该汉化版在 shipping 二进制旁附带 `ue4ss\UE4SS.dll` + `ue4ss\Mods\KinomajoTrainer`（Lua 修改器）。**只作台账**：不进判据，Fushi 不加载也不依赖它；记它是因为这意味着同一进程里可能已经有另一个注入器。 |
+| helper | 见提交里的 dist 哈希；双架构 CTest 全绿 |
+
+## 判据（量出来的，不是猜的）
+
+`.utoc` 头 16 字节魔数实测为 `-==--==--==--==-`（`2d 3d 3d 2d ...`），三个文件一致，
+第 17 字节是版本 `6`。`.pak` 的头**不是**魔数（UE 的 pak 魔数 `0x5A6F12E1` 在**文件尾部**、
+偏移随 pak 版本变），而这三个 `.pak` 的尾 64 字节全是零填充。
+
+于是判据锚在 IoStore，两条**同时**成立才匹配（fail closed）：
+1. 可执行文件所在目录是 `...\Binaries\Win64`（UE 每平台固定的 shipping 布局）；
+2. 上溯两级的 `<Game>\Content\Paks\` 下至少一个 `*.utoc` 以那 16 字节魔数开头。
+
+**只锚 IoStore 是有意的**：UE4.25 之前只出 `.pak`，手上没有 `.pak`-only 样本，
+量不到的形状不写进判据。老 UE4 包因此不匹配——这是已知且刻意的覆盖面缺口，
+补它需要一个真的 `.pak`-only 样本。
+
+判据本体放在 `include/unreal_launch.h`，是**唯一真相源**：hook 侧的引擎身份
+（`hook/adapters/unreal_iostore_profile.h`）和 injector 侧的 `LooksLikeUnrealRuntime`
+都调它，不各写一份——判据写两遍迟早分叉，那正是「身份说不清」这类 bug 的温床。
+
+## 运行期测量（injector `--launch --hold`，2026-09-05）
+
+```
+hookdiag  = StartupAudioHooksReady | UnityResourceExtractorReady | LunaHostReady
+            | LunaConnected | LunaOutputObserved
+xaudiodiag = QueueReady | JobQueued | PcmPublished        （voice_clips 持续增长）
+decdiag = 0x00000000   unity_events = 0
+```
+
+**文本对照**（同一份 helper、同一段标题画面、只差一个开关）：
+
+| 配置 | text_events 稳定值 |
+|---|---|
+| 默认 | 11 |
+| `--luna-pchooks` | **29** |
+
+UE 是 C++ 引擎，台词在进程内、没有 Mono/TJS 那样的脚本宿主可挂，只能靠 LunaHook 的通用
+PC hooks 取文本——与 Unity 同理。据此把 Unreal 加进 injector 的
+`ShouldAutoUseLunaPcHooks`（提示语相应从「Unity/Mono-style」改成「scripted-host-less
+(Unity/Mono/Unreal)」）。
+
+**没有区分是哪条音频后端产出的 PCM**：exe 静态导入 DSOUND 而 UE 树里同时带
+xaudio2_9redist，本轮只证到「通用 Windows 音频路径发布了 PCM」，不写成 XAudio2。
+
+## 本轮交付
+
+- `include/unreal_launch.h`（判据唯一真相源）
+- `hook/adapters/unreal_iostore_profile.h`（薄封装：取当前模块目录喂给判据）
+- `hook/adapters/unreal_iostore_adapter.inc`（`kText | kPcmAudio`，无引擎专属 hook）
+- `profiles/unreal_iostore.json`、`engine-support.yaml` 第 18 条、`docs/engine-support.md` 重生成
+- `injector/injector_main.cpp`：`LooksLikeUnrealRuntime` + 自动开 PC hooks
+- `tests/unreal_iostore_adapter_test.cpp`（CTest；真临时目录验完整布局 / 无归档 / 魔数不对 /
+  目录形状不对，外加路径拆分的空串、纯分隔符、无父目录三个边界）
+- `tests/fixtures/unreal_iostore_replay.json` + `fushi/test/mining/unreal_iostore_pairing_test.dart`
+  （两棵树逐字节一致，由 cmvs 那条目录枚举守卫自动覆盖）
+
+## Next gate
+
+第一个未通过的边界是 **`text_thread_selected`**：需要在真机上走进一句真台词，
+确认 LunaHook 的哪个线程携带对白（而不是标题画面 UI 串）。最小动作：
+起游戏 → 进入正篇第一句 → `fushi_voice_ring_probe` 看 `text_events` 与线程分布 →
+用工作台确认所选线程的文本是台词。**在此之前不得给 Unreal 记任何 `verified_games`。**
+
+其后依次是：`resource_observed`（IoStore 解包后的 SoundWave 读取接缝，位置只能在真机上定）、
+`paired`、`card_e2e`。

--- a/fushi/test/fixtures/galhook/unreal_iostore_replay.json
+++ b/fushi/test/fixtures/galhook/unreal_iostore_replay.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "engine_id": "unreal_iostore",
+  "status": "implemented_unverified",
+  "config": {
+    "selected_thread": 4,
+    "duplicate_window_ms": 1000,
+    "audio_priority": ["resource_audio", "pcm", "loopback"],
+    "resource_late_wait_ms": 500
+  },
+  "events": [
+    {"kind": "text", "id": "unreal-line", "timestamp_ms": 5000, "thread": 4, "text": "synthetic unreal pc-hook line"},
+    {"kind": "text", "id": "unreal-ui-thread", "timestamp_ms": 5001, "thread": 9, "text": "synthetic unreal ui thread"},
+    {"kind": "pcm", "id": "unreal-source-pcm", "timestamp_ms": 5014, "format": "s16le"},
+    {"kind": "loopback", "id": "unreal-loopback", "timestamp_ms": 5018, "format": "s16le"},
+    {"kind": "session_end", "timestamp_ms": 5600}
+  ],
+  "expected": {
+    "cards": [
+      {"text_id": "unreal-line", "audio_backend": "pcm", "audio_id": "unreal-source-pcm"}
+    ],
+    "duplicate_text_events": 0,
+    "thread_filtered_events": 1,
+    "session_clean": true
+  }
+}

--- a/fushi/test/mining/unreal_iostore_pairing_test.dart
+++ b/fushi/test/mining/unreal_iostore_pairing_test.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'unreal_iostore fixture pairs the selected thread with generic source PCM',
+    () async {
+      final Map<String, dynamic> data =
+          jsonDecode(
+                await File(
+                  'test/fixtures/galhook/unreal_iostore_replay.json',
+                ).readAsString(),
+              )
+              as Map<String, dynamic>;
+      expect(data['status'], 'implemented_unverified');
+
+      final Map<String, dynamic> config =
+          data['config'] as Map<String, dynamic>;
+      // UE 的逐句语音是 *.ucas 里的 SoundWave 资产，本轮没做资源层，PCM 是它的最好档；
+      // loopback 仍须排在最后——它只是降级，不能冒充引擎级人声。
+      expect(config['audio_priority'], <String>[
+        'resource_audio',
+        'pcm',
+        'loopback',
+      ]);
+      expect(config['selected_thread'], 4);
+
+      final Map<String, dynamic> expected =
+          data['expected'] as Map<String, dynamic>;
+      final List<dynamic> cards = expected['cards'] as List<dynamic>;
+      expect(cards.single, <String, dynamic>{
+        'text_id': 'unreal-line',
+        'audio_backend': 'pcm',
+        'audio_id': 'unreal-source-pcm',
+      });
+      // thread 9 是 UI 线程，必须被线程过滤挡掉——这条掉了就等于没在选线程。
+      expect(expected['thread_filtered_events'], 1);
+      expect(expected['duplicate_text_events'], 0);
+      expect(expected['session_clean'], isTrue);
+    },
+  );
+}

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -640,3 +640,6 @@ add_test(NAME fushi_layer_origin_pixels_test
 add_executable(fushi_cmvs_adapter_test "tests/cmvs_adapter_test.cpp")
 target_include_directories(fushi_cmvs_adapter_test PRIVATE "hook")
 add_test(NAME fushi_cmvs_adapter_test COMMAND fushi_cmvs_adapter_test)
+add_executable(fushi_unreal_iostore_adapter_test "tests/unreal_iostore_adapter_test.cpp")
+target_include_directories(fushi_unreal_iostore_adapter_test PRIVATE "hook" "include")
+add_test(NAME fushi_unreal_iostore_adapter_test COMMAND fushi_unreal_iostore_adapter_test)

--- a/native/galgame_hook/docs/engine-support.md
+++ b/native/galgame_hook/docs/engine-support.md
@@ -25,6 +25,7 @@
 | `leaf_aquaplus` | Leaf / AQUAPLUS (WHITE ALBUM2 exact profile) | `implemented_unverified` | luna_exact_cp932_thread (implemented_unverified)；ingame_lookup_geometry (implemented_unverified)；ingame_lookup_sampled_input_shield (implemented_unverified) | leaf_lac_voice_resource (implemented_unverified)；directsound_pcm (implemented_unverified) | 0 |
 | `hunex_gge` | HUNEX GGE / HFA-HW | `implemented_unverified` | luna_typemoon_dialogue_thread (implemented_unverified) | hunex_hfa_hw_ogg_resource (implemented_unverified) | 0 |
 | `sgre` | M2 wind3d11 runtime (STEINS;GATE RE:BOOT) | `implemented_unverified` | ingame_lookup_geometry (implemented_unverified)；ingame_lookup_directinput_shield (implemented_unverified) | engine_archive_resource (implemented_unverified) | 0 |
+| `unreal_iostore` | Unreal Engine (IoStore) | `implemented_unverified` | luna_pc_hooks (implemented_unverified) | xaudio2_or_directsound_pcm (implemented_unverified)；process_loopback (implemented_unverified) | 0 |
 
 ## 无 OCR 内嵌查词矩阵
 
@@ -820,6 +821,50 @@ Tests：`tests/hunex_gge_adapter_test.cpp`、`tests/hunex_gge_capture_bridge_tes
 Fixtures：尚无（P5 补齐）
 
 Tests：`tests/sgre_adapter_test.cpp`、`tests/exact_lookup_signature_test.cpp`、`tests/adapter_structure_test.py`
+
+### Unreal Engine (IoStore) (`unreal_iostore`)
+
+- 状态：`implemented_unverified`
+- 别名：Unreal Engine、UE4、UE5、アンリアルエンジン
+- 家族：`unreal`（Epic Games Unreal Engine; this entry covers the IoStore (.utoc/.ucas) packaging only）
+- 当前 adapter：`hook/adapters/unreal_iostore_adapter.inc`
+- 进程策略：launch=`generic_launch_available`，attach=`generic_attach_available`，follow-child=`true`
+
+识别签名（所有非空项均带真实样本或运行时观察证据）：
+
+- `executable_names`：*-Win64-Shipping.exe；证据：real_sample — 昨日魔女今日的梦 1.0 汉化版 ships kinomajo\Binaries\Win64\kinomajo-Win64-Shipping.exe behind an outer kinomajo.exe launcher; static probe 2026-09-05. The name is a UE build convention and is catalogue only -- the adapter matches on the Binaries\Win64 directory shape plus IoStore archive magic, so -Win64-Test and -Win64-Debug builds are covered too
+- `pe_architectures`：x64；证据：real_sample — kinomajo-Win64-Shipping.exe machine 0x8664; the launcher kinomajo.exe is x64 as well
+- `directory_files_all`：Content/Paks/global.utoc、Content/Paks/global.ucas；证据：real_sample — Every IoStore build carries the global.utoc/global.ucas pair; this sample also has kinomajo-Windows.* and kinomajo-Windows_zh-CN_P.*. All three .utoc files open with the 16-byte IoStore TOC magic '-==--==--==--==-' followed by version byte 6, which is what the adapter actually matches on (any *.utoc under Content\Paks carrying that magic); measured 2026-09-05
+- `pe_imports`：DSOUND.dll、WINMM.dll、OPENGL32.dll、WINHTTP.dll、MSVCP140.dll；证据：real_sample — PE import table of kinomajo-Win64-Shipping.exe (38 imports, static probe 2026-09-05). DirectSound is the only audio API imported statically; the UE tree also ships Engine\Binaries\ThirdParty\Windows\XAudio2_9\x64\xaudio2_9redist.dll for runtime loading, so the audio backend actually used at runtime was not determined
+- `runtime_modules`：D3D12Core.dll、xaudio2_9redist.dll；证据：real_sample — Shipped next to the binary / under Engine\Binaries\ThirdParty; presence measured statically, runtime load not individually confirmed
+- `resource_extensions`：.utoc、.ucas、.pak；证据：real_sample — Content\Paks holds paired .pak/.ucas/.utoc sets; the 2.7 GB kinomajo-Windows.ucas carries the asset payload including SoundWave assets
+- `hashes`：f7018ae75f820a204bf48ac444d4688f3b7ccada51ae6b161ab701ecb0a492a2、877ff376a5e7233f903f778f6163e5e39924df1da9e5eeef055bb14b125026fd；证据：real_sample — kinomajo-Win64-Shipping.exe / kinomajo.exe launcher, catalogue only; the adapter does not hash-pin because the structural directory + IoStore magic check is the identity
+
+文本能力：
+
+- `luna_pc_hooks`：`implemented_unverified` — Unreal is a C++ engine with no scripting host to hook, so text goes through LunaHook's generic PC hooks. Measured both ways on the same title screen of the same build: without PC hooks text_events settled at 11, with them at 29. No dialogue line was traversed, so no thread was selected and no dialogue text is claimed.
+- codepage：932
+- 线程提示：Unmeasured. Only title-screen strings have been observed; the dialogue thread must be identified on a real session before any selection hint is recorded.
+
+音频优先级：
+
+1. `xaudio2_or_directsound_pcm` — `implemented_unverified`；格式：source PCM via the generic Windows audio adapter；clean voice：engine_dependent
+2. `process_loopback` — `implemented_unverified`；格式：host PCM fallback；clean voice：否
+
+真实样本证据：
+
+
+已知限制：
+
+- Identity is anchored on IoStore only: the criterion requires Content\Paks\*.utoc with the 16-byte TOC magic. UE4 builds packaged as .pak alone do NOT match. This is deliberate -- the .pak magic (0x5A6F12E1) sits in a trailing footer whose offset varies by pak version, and no .pak-only sample was available to measure. Closing that gap needs a real .pak-only title.
+- Per-line voice resources are SoundWave assets inside *.ucas, chunked and compressed by IoStore. No resource layer is implemented and none is claimed until a runtime post-unpack read seam is measured on a real session.
+- Only title-screen strings have been observed. Dialogue text, thread selection, text/audio pairing and card E2E are all not_run.
+- The runtime PCM measurement did not distinguish DirectSound from XAudio2; only 'the generic Windows audio path published PCM' is proved.
+- In-game lookup sensor is not implemented; lookupAdmission stays EngineUnsupported.
+
+Fixtures：`tests/fixtures/unreal_iostore_replay.json`
+
+Tests：`tests/unreal_iostore_adapter_test.cpp`、`../../fushi/test/mining/unreal_iostore_pairing_test.dart`
 
 ## 状态定义
 

--- a/native/galgame_hook/engine-support.yaml
+++ b/native/galgame_hook/engine-support.yaml
@@ -2535,6 +2535,148 @@
         "tests/exact_lookup_signature_test.cpp",
         "tests/adapter_structure_test.py"
       ]
+    },
+    {
+      "id": "unreal_iostore",
+      "display_name": "Unreal Engine (IoStore)",
+      "aliases": [
+        "Unreal Engine",
+        "UE4",
+        "UE5",
+        "アンリアルエンジン"
+      ],
+      "family": {
+        "id": "unreal",
+        "relation": "Epic Games Unreal Engine; this entry covers the IoStore (.utoc/.ucas) packaging only"
+      },
+      "detection": {
+        "executable_names": {
+          "values": [
+            "*-Win64-Shipping.exe"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "昨日魔女今日的梦 1.0 汉化版 ships kinomajo\\Binaries\\Win64\\kinomajo-Win64-Shipping.exe behind an outer kinomajo.exe launcher; static probe 2026-09-05. The name is a UE build convention and is catalogue only -- the adapter matches on the Binaries\\Win64 directory shape plus IoStore archive magic, so -Win64-Test and -Win64-Debug builds are covered too"
+          }
+        },
+        "pe_architectures": {
+          "values": [
+            "x64"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "kinomajo-Win64-Shipping.exe machine 0x8664; the launcher kinomajo.exe is x64 as well"
+          }
+        },
+        "directory_files_all": {
+          "values": [
+            "Content/Paks/global.utoc",
+          "Content/Paks/global.ucas"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "Every IoStore build carries the global.utoc/global.ucas pair; this sample also has kinomajo-Windows.* and kinomajo-Windows_zh-CN_P.*. All three .utoc files open with the 16-byte IoStore TOC magic '-==--==--==--==-' followed by version byte 6, which is what the adapter actually matches on (any *.utoc under Content\\Paks carrying that magic); measured 2026-09-05"
+          }
+        },
+        "pe_imports": {
+          "values": [
+            "DSOUND.dll",
+            "WINMM.dll",
+            "OPENGL32.dll",
+            "WINHTTP.dll",
+            "MSVCP140.dll"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "PE import table of kinomajo-Win64-Shipping.exe (38 imports, static probe 2026-09-05). DirectSound is the only audio API imported statically; the UE tree also ships Engine\\Binaries\\ThirdParty\\Windows\\XAudio2_9\\x64\\xaudio2_9redist.dll for runtime loading, so the audio backend actually used at runtime was not determined"
+          }
+        },
+        "runtime_modules": {
+          "values": [
+            "D3D12Core.dll",
+            "xaudio2_9redist.dll"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "Shipped next to the binary / under Engine\\Binaries\\ThirdParty; presence measured statically, runtime load not individually confirmed"
+          }
+        },
+        "resource_extensions": {
+          "values": [
+            ".utoc",
+            ".ucas",
+            ".pak"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "Content\\Paks holds paired .pak/.ucas/.utoc sets; the 2.7 GB kinomajo-Windows.ucas carries the asset payload including SoundWave assets"
+          }
+        },
+        "hashes": {
+          "values": [
+            "f7018ae75f820a204bf48ac444d4688f3b7ccada51ae6b161ab701ecb0a492a2",
+            "877ff376a5e7233f903f778f6163e5e39924df1da9e5eeef055bb14b125026fd"
+          ],
+          "evidence": {
+            "kind": "real_sample",
+            "reference": "kinomajo-Win64-Shipping.exe / kinomajo.exe launcher, catalogue only; the adapter does not hash-pin because the structural directory + IoStore magic check is the identity"
+          }
+        }
+      },
+      "process_strategy": {
+        "launch": "generic_launch_available",
+        "attach": "generic_attach_available",
+        "follow_child_processes": true,
+        "notes": [
+          "The original path is the outer launcher kinomajo.exe, which starts the real game at <Game>\\Binaries\\Win64\\<Game>-Win64-Shipping.exe; the shipping binary is what carries the window, text and audio.",
+          "Launching the shipping binary directly also works and is what the 2026-09-05 measurement used.",
+          "This Chinese release additionally ships a third-party UE4SS.dll trainer next to the shipping binary. Fushi neither loads nor depends on it; it is recorded because it means another injector may already be present in the same process."
+        ]
+      },
+      "text": {
+        "capabilities": [
+          {
+            "kind": "luna_pc_hooks",
+            "status": "implemented_unverified",
+            "verification": "Unreal is a C++ engine with no scripting host to hook, so text goes through LunaHook's generic PC hooks. Measured both ways on the same title screen of the same build: without PC hooks text_events settled at 11, with them at 29. No dialogue line was traversed, so no thread was selected and no dialogue text is claimed."
+          }
+        ],
+        "codepage": "932",
+        "thread_selection_hint": "Unmeasured. Only title-screen strings have been observed; the dialogue thread must be identified on a real session before any selection hint is recorded."
+      },
+      "audio": {
+        "priority": [
+          {
+            "kind": "xaudio2_or_directsound_pcm",
+            "format": "source PCM via the generic Windows audio adapter",
+            "status": "implemented_unverified",
+            "clean_voice": "engine_dependent"
+          },
+          {
+            "kind": "process_loopback",
+            "format": "host PCM fallback",
+            "status": "implemented_unverified",
+            "clean_voice": false
+          }
+        ]
+      },
+      "verified_games": [],
+      "current_status": "implemented_unverified",
+      "known_limitations": [
+        "Identity is anchored on IoStore only: the criterion requires Content\\Paks\\*.utoc with the 16-byte TOC magic. UE4 builds packaged as .pak alone do NOT match. This is deliberate -- the .pak magic (0x5A6F12E1) sits in a trailing footer whose offset varies by pak version, and no .pak-only sample was available to measure. Closing that gap needs a real .pak-only title.",
+        "Per-line voice resources are SoundWave assets inside *.ucas, chunked and compressed by IoStore. No resource layer is implemented and none is claimed until a runtime post-unpack read seam is measured on a real session.",
+        "Only title-screen strings have been observed. Dialogue text, thread selection, text/audio pairing and card E2E are all not_run.",
+        "The runtime PCM measurement did not distinguish DirectSound from XAudio2; only 'the generic Windows audio path published PCM' is proved.",
+        "In-game lookup sensor is not implemented; lookupAdmission stays EngineUnsupported."
+      ],
+      "adapter_path": "hook/adapters/unreal_iostore_adapter.inc",
+      "fixture_paths": [
+        "tests/fixtures/unreal_iostore_replay.json"
+      ],
+      "test_paths": [
+        "tests/unreal_iostore_adapter_test.cpp",
+        "../../fushi/test/mining/unreal_iostore_pairing_test.dart"
+      ]
     }
   ]
 }

--- a/native/galgame_hook/hook/adapters/unreal_iostore_adapter.inc
+++ b/native/galgame_hook/hook/adapters/unreal_iostore_adapter.inc
@@ -1,0 +1,43 @@
+// Unreal Engine（IoStore 打包形态）adapter。首版只做三件事，且全部 implemented_unverified：
+//   * 身份：unreal_iostore_profile.h 的「Binaries\Win64 目录形状 + Content\Paks\*.utoc
+//     IoStore 魔数」结构判据（真实样本 昨日魔女今日的梦 1.0 汉化版，UE5）；
+//   * 文本：不自带 hook，交给 LunaHook 的通用 PC hooks——UE 是 C++ 引擎，台词在进程内，
+//     没有 Mono/TJS 那样的脚本宿主可挂；真机对照实测：不开 PC hooks 的一局 text_events=11，
+//     开了的一局 29（同一份 helper、同一段标题画面），故 injector 对 Unreal 目标自动开启；
+//   * 音频：不自带 hook，走 GenericWindowsAudioAdapter 的源 PCM。真机实测
+//     xaudio_diagnostics = kXAudioDiagQueueReady|JobQueued|PcmPublished，voice_clips 持续增长。
+//     **是哪条后端产出的没区分**：shipping exe 静态导入的是 DSOUND.dll，而 UE 树里同时带
+//     Engine\Binaries\ThirdParty\Windows\XAudio2_9\x64\xaudio2_9redist.dll（运行期动态加载）。
+//     本会话只证到「通用 Windows 音频路径发布了 PCM」，不声称是 XAudio2。
+// 逐句资源层（SoundWave 资产在 *.ucas 里，经 IoStore 分块 + 压缩）明确**未做**：取原始逐句
+// 字节要在引擎解包之后的位置下手，位置只能在真机上定，静态阶段不猜 hook 面。
+#include "unreal_iostore_profile.h"
+
+class UnrealIostoreAdapter final : public fushi_voice_hook::EngineAdapter {
+ public:
+  const char* id() const override { return "unreal_iostore"; }
+  bool probe() const override {
+    return fushi_voice_hook::MatchesUnrealIostoreProfile(nullptr);
+  }
+  // 没有引擎专属 hook 可装：installed_ 只表示「身份成立、共享文本/PCM 路径对此进程生效」。
+  bool install() override {
+    installed_ = probe();
+    return installed_;
+  }
+  fushi_voice_hook::AdapterCapability capabilities() const override {
+    return fushi_voice_hook::AdapterCapability::kText |
+           fushi_voice_hook::AdapterCapability::kPcmAudio;
+  }
+  void onModuleLoaded(const wchar_t* module_name) override {
+    // 身份来自磁盘布局，启动时一次判定即可；模块通知只作重试接缝。
+    if (!installed_ && module_name == nullptr) install();
+  }
+  void shutdown() override { installed_ = false; }
+  fushi_voice_hook::AdapterDiagnostics diagnostics() const override {
+    return {id(), probe(), installed_,
+            g_header == nullptr ? 0u : g_header->hook_diagnostics};
+  }
+
+ private:
+  bool installed_ = false;
+};

--- a/native/galgame_hook/hook/adapters/unreal_iostore_profile.h
+++ b/native/galgame_hook/hook/adapters/unreal_iostore_profile.h
@@ -1,0 +1,25 @@
+// Unreal Engine（IoStore 打包形态）身份探测的 hook 侧入口。
+// 结构判据本体在 `include/unreal_launch.h`（**唯一真相源**，injector 的
+// LooksLikeUnrealRuntime 调的是同一份），这里只负责把当前进程的模块目录喂给它——
+// 判据写两遍迟早会分叉，那正是「身份说不清」这类 bug 的温床。
+#pragma once
+
+#include <windows.h>
+
+#include <cwchar>
+#include <string>
+
+#include "unreal_launch.h"
+
+namespace fushi_voice_hook {
+
+inline bool MatchesUnrealIostoreProfile(const wchar_t*) {
+  wchar_t executable[MAX_PATH] = {0};
+  if (GetModuleFileNameW(nullptr, executable, MAX_PATH) == 0) return false;
+  wchar_t* slash = wcsrchr(executable, L'\\');
+  if (slash == nullptr) return false;
+  *slash = 0;
+  return MatchesUnrealIostoreLayout(executable);
+}
+
+}  // namespace fushi_voice_hook

--- a/native/galgame_hook/hook/generated/adapter_admission.inc
+++ b/native/galgame_hook/hook/generated/adapter_admission.inc
@@ -10,3 +10,4 @@
     consider(leaf_aquaplus_);
     consider(hunex_gge_);
     consider(cmvs_);
+    consider(unreal_iostore_);

--- a/native/galgame_hook/hook/generated/adapter_fields.inc
+++ b/native/galgame_hook/hook/generated/adapter_fields.inc
@@ -10,3 +10,4 @@
   LeafAquaplusAdapter leaf_aquaplus_;
   HunexGgeAdapter hunex_gge_;
   CmvsAdapter cmvs_;
+  UnrealIostoreAdapter unreal_iostore_;

--- a/native/galgame_hook/hook/generated/adapter_includes.inc
+++ b/native/galgame_hook/hook/generated/adapter_includes.inc
@@ -10,3 +10,4 @@
 #include "../adapters/leaf_aquaplus_adapter.inc"
 #include "../adapters/hunex_gge_adapter.inc"
 #include "../adapters/cmvs_adapter.inc"
+#include "../adapters/unreal_iostore_adapter.inc"

--- a/native/galgame_hook/hook/generated/adapter_module.inc
+++ b/native/galgame_hook/hook/generated/adapter_module.inc
@@ -10,3 +10,4 @@
         leaf_aquaplus_.onModuleLoaded(entry.szModule);
         hunex_gge_.onModuleLoaded(entry.szModule);
         cmvs_.onModuleLoaded(entry.szModule);
+        unreal_iostore_.onModuleLoaded(entry.szModule);

--- a/native/galgame_hook/hook/generated/adapter_shutdown.inc
+++ b/native/galgame_hook/hook/generated/adapter_shutdown.inc
@@ -10,3 +10,4 @@
     leaf_aquaplus_.shutdown();
     hunex_gge_.shutdown();
     cmvs_.shutdown();
+    unreal_iostore_.shutdown();

--- a/native/galgame_hook/hook/generated/adapter_startup.inc
+++ b/native/galgame_hook/hook/generated/adapter_startup.inc
@@ -6,3 +6,4 @@
     leaf_aquaplus_.install();
     hunex_gge_.install();
     cmvs_.install();
+    unreal_iostore_.install();

--- a/native/galgame_hook/hook/generated/profile_includes.inc
+++ b/native/galgame_hook/hook/generated/profile_includes.inc
@@ -9,3 +9,4 @@
 #include "../adapters/leaf_aquaplus_profile.h"
 #include "../adapters/hunex_gge_profile.h"
 #include "../adapters/cmvs_profile.h"
+#include "../adapters/unreal_iostore_profile.h"

--- a/native/galgame_hook/include/unreal_launch.h
+++ b/native/galgame_hook/include/unreal_launch.h
@@ -1,0 +1,115 @@
+// Unreal Engine（IoStore 打包形态）的结构判据。**唯一真相源**：
+// hook 侧的 `hook/adapters/unreal_iostore_profile.h`（引擎身份）与 injector 侧的
+// `LooksLikeUnrealRuntime`（决定是否自动开 LunaHook PC hooks）都调这里，不各写一份。
+//
+// 判据（全部量自真实样本「昨日魔女今日的梦 1.0 汉化版」，UE5，2026-09-05 静态 probe）：
+//   * shipping 布局：可执行文件所在目录是 `...\Binaries\Win64`——UE 对每个平台固定
+//     `<Game>\Binaries\<Platform>\`，样本里是
+//     `kinomajo\Binaries\Win64\kinomajo-Win64-Shipping.exe`；
+//   * 从该目录上溯两级得到 `<Game>` 根，其 `Content\Paks\` 下至少一个 `*.utoc` 以 16 字节
+//     魔数 `-==--==--==--==-` 开头（IoStore 的 TOC 头）。样本里三个 utoc 魔数一致，
+//     第 17 字节是版本 6。
+// 两条必须**同时**成立（fail closed）：只有 `Binaries\Win64` 会命中任何把二进制放在同名
+// 目录下的程序；只有 `.utoc` 后缀也可能是别家用同后缀的文件。
+//
+// **只锚 IoStore，是有意的**：UE4.25 之前只出 `Content\Paks\*.pak`，而 `.pak` 的魔数
+// (0x5A6F12E1) 在**文件尾部**、偏移随 pak 版本变；本轮手上只有一个 UE5 IoStore 样本，
+// 量不到的形状不写进判据。老 UE4 `.pak`-only 包因此**不匹配**，这是已知且刻意的覆盖面
+// 缺口，补它需要一个真的 `.pak`-only 样本。
+//
+// exe 名的 `-Win64-Shipping` 后缀只作台账记录、不进判据：`-Win64-Test` / `-Win64-Debug`
+// 同样是合法的 shipping 目录布局，而目录形状 + IoStore 魔数已经足够收敛。
+#pragma once
+
+#include <windows.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace fushi_voice_hook {
+
+// IoStore TOC 头 16 字节魔数（UE4.25+ / UE5）。
+constexpr const char kUnrealIoStoreTocMagic[] = "-==--==--==--==-";
+constexpr size_t kUnrealIoStoreTocMagicBytes = 16;
+constexpr const wchar_t* kUnrealIoStorePakPattern = L"\\Content\\Paks\\*.utoc";
+constexpr const wchar_t* kUnrealBinaryPlatformSegment = L"Win64";
+constexpr const wchar_t* kUnrealBinaryParentSegment = L"Binaries";
+
+inline bool UnrealReadFilePrefix(const std::wstring& path, uint8_t* out, DWORD capacity,
+                                 DWORD* read_out) {
+  HANDLE file = CreateFileW(path.c_str(), GENERIC_READ,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) return false;
+  DWORD read = 0;
+  const bool ok = ReadFile(file, out, capacity, &read, nullptr) != FALSE;
+  CloseHandle(file);
+  if (!ok) return false;
+  *read_out = read;
+  return true;
+}
+
+// 去掉末尾分隔符后取最后一段；没有分隔符时整串就是最后一段。
+inline std::wstring UnrealLastSegment(const std::wstring& path) {
+  size_t end = path.size();
+  while (end > 0 && (path[end - 1] == L'\\' || path[end - 1] == L'/')) --end;
+  if (end == 0) return std::wstring();
+  const size_t slash = path.find_last_of(L"\\/", end - 1);
+  if (slash == std::wstring::npos) return path.substr(0, end);
+  return path.substr(slash + 1, end - slash - 1);
+}
+
+inline std::wstring UnrealParentDirectory(const std::wstring& path) {
+  size_t end = path.size();
+  while (end > 0 && (path[end - 1] == L'\\' || path[end - 1] == L'/')) --end;
+  if (end == 0) return std::wstring();
+  const size_t slash = path.find_last_of(L"\\/", end - 1);
+  if (slash == std::wstring::npos) return std::wstring();
+  return path.substr(0, slash);
+}
+
+// `...\Binaries\Win64`：UE 每平台固定的 shipping 二进制目录形状。
+inline bool UnrealShippingBinaryLayout(const std::wstring& binary_directory) {
+  if (_wcsicmp(UnrealLastSegment(binary_directory).c_str(),
+               kUnrealBinaryPlatformSegment) != 0) {
+    return false;
+  }
+  const std::wstring parent = UnrealParentDirectory(binary_directory);
+  if (parent.empty()) return false;
+  return _wcsicmp(UnrealLastSegment(parent).c_str(), kUnrealBinaryParentSegment) == 0;
+}
+
+// `<Game>\Content\Paks` 下至少一个 *.utoc 以 IoStore TOC 魔数开头。
+inline bool UnrealIoStoreArchivePresent(const std::wstring& game_root) {
+  WIN32_FIND_DATAW found = {};
+  const std::wstring pattern = game_root + kUnrealIoStorePakPattern;
+  HANDLE search = FindFirstFileW(pattern.c_str(), &found);
+  if (search == INVALID_HANDLE_VALUE) return false;
+  bool matched = false;
+  do {
+    if (found.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
+    uint8_t magic[kUnrealIoStoreTocMagicBytes] = {0};
+    DWORD read = 0;
+    const std::wstring path = game_root + L"\\Content\\Paks\\" + found.cFileName;
+    if (UnrealReadFilePrefix(path, magic, sizeof(magic), &read) &&
+        read == kUnrealIoStoreTocMagicBytes &&
+        memcmp(magic, kUnrealIoStoreTocMagic, kUnrealIoStoreTocMagicBytes) == 0) {
+      matched = true;
+      break;
+    }
+  } while (FindNextFileW(search, &found));
+  FindClose(search);
+  return matched;
+}
+
+// 给定 shipping 二进制所在目录的结构判据；测试用临时目录直接喂它。
+inline bool MatchesUnrealIostoreLayout(const std::wstring& binary_directory) {
+  if (!UnrealShippingBinaryLayout(binary_directory)) return false;
+  const std::wstring game_root =
+      UnrealParentDirectory(UnrealParentDirectory(binary_directory));
+  if (game_root.empty()) return false;
+  return UnrealIoStoreArchivePresent(game_root);
+}
+
+}  // namespace fushi_voice_hook

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -29,6 +29,7 @@
 #include "kirikiri_launch_profile.h"
 #include "launcher_layout.h"
 #include "siglus_launch.h"
+#include "unreal_launch.h"
 #include "steam_launch.h"
 #include "luna_bridge.h"
 #include "luna_hook_config.h"
@@ -2483,6 +2484,17 @@ bool LooksLikeUnityRuntime(const std::wstring& exe) {
   return il2cpp || mono;
 }
 
+// Unreal（IoStore 打包形态）：判据本体在 include/unreal_launch.h，与 hook 侧的引擎身份
+// 共用同一份。UE 是 C++ 引擎，台词在进程内、没有 Mono/TJS 那样的脚本宿主可挂，只能靠
+// LunaHook 的通用 PC hooks 取文本——与 Unity 同理，所以这里也自动开。
+// 真机对照（昨日魔女今日的梦 1.0 汉化版，同一份 helper、同一段标题画面）：不开 PC hooks
+// 的一局 text_events 停在 11，开了的一局 29。
+bool LooksLikeUnrealRuntime(const std::wstring& exe) {
+  const std::wstring dir = ExecutableDirectory(exe);
+  if (dir.empty()) return false;
+  return fushi_voice_hook::MatchesUnrealIostoreLayout(dir);
+}
+
 // Siglus 游戏（含改名 exe）：exe 名严格匹配，或 exe 同目录具备 Siglus 文件夹签名。用于把 launch
 // 的早注入改为延迟附着，绕过 Enigma 保护壳拒绝挂起态注入导致的 launch_or_inject_failed。
 bool LooksLikeSiglusRuntime(const std::wstring& exe) {
@@ -2503,7 +2515,8 @@ bool ShouldAutoUseLunaPcHooks(const std::wstring& exe) {
       _wcsicmp(base.c_str(), L"SiglusEngine.exe") == 0) {
     return true;
   }
-  return LooksLikeUnityRuntime(exe) || LooksLikeSiglusRuntime(exe);
+  return LooksLikeUnityRuntime(exe) || LooksLikeSiglusRuntime(exe) ||
+         LooksLikeUnrealRuntime(exe);
 }
 
 struct ReadyWindowSearch {
@@ -2750,7 +2763,8 @@ int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
   if (!effective_luna.pc_hooks && ShouldAutoUseLunaPcHooks(exe)) {
     effective_luna.pc_hooks = true;
     fprintf(stderr,
-            "[luna] auto-enabled PC hooks for Unity/Mono-style target: %ls\n",
+            "[luna] auto-enabled PC hooks for scripted-host-less target "
+            "(Unity/Mono/Unreal): %ls\n",
             ExecutableBaseName(exe).c_str());
   }
 

--- a/native/galgame_hook/profiles/unreal_iostore.json
+++ b/native/galgame_hook/profiles/unreal_iostore.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "unreal_iostore",
+  "status": "implemented_unverified",
+  "detection": {
+    "executable_sha256": [
+      "F7018AE75F820A204BF48AC444D4688F3B7CCADA51AE6B161AB701ECB0A492A2",
+      "877FF376A5E7233F903F778F6163E5E39924DF1DA9E5EEEF055BB14B125026FD"
+    ],
+    "module_sha256": []
+  },
+  "capabilities": {
+    "text": true,
+    "resource_audio": false,
+    "pcm_audio": true
+  },
+  "evidence": [
+    {
+      "kind": "real_sample",
+      "reference": "昨日魔女今日的梦 1.0 汉化版 (Unreal Engine 5, IoStore): launcher kinomajo.exe x64 spawns kinomajo\\Binaries\\Win64\\kinomajo-Win64-Shipping.exe x64; Content\\Paks holds global.utoc / kinomajo-Windows.utoc / kinomajo-Windows_zh-CN_P.utoc, all opening with the 16-byte IoStore TOC magic and version byte 6. Static probe 2026-09-05."
+    },
+    {
+      "kind": "real_sample",
+      "reference": "Same title, runtime measurement 2026-09-05 via injector --launch --hold: hook_diagnostics = StartupAudioHooksReady|UnityResourceExtractorReady|LunaHostReady|LunaConnected|LunaOutputObserved, xaudio_diagnostics = QueueReady|JobQueued|PcmPublished with voice_clips rising continuously. Which backend produced that PCM was not distinguished: the shipping exe statically imports DSOUND.dll while the UE tree also ships xaudio2_9redist.dll, so only 'the generic Windows audio path published PCM' is claimed. Text output compared both ways on the same title screen: without LunaHook PC hooks text_events settled at 11, with them at 29. No dialogue line was traversed, so no thread selection, pairing, or card E2E is claimed."
+    },
+    {
+      "kind": "real_sample",
+      "reference": "Static probe inventory notes a third-party UE4SS.dll plus ue4ss/Mods/KinomajoTrainer Lua scripts shipped next to the shipping exe by this Chinese release; recorded as ledger only, it is not part of the identity criterion and Fushi does not load or depend on it."
+    }
+  ]
+}

--- a/native/galgame_hook/tests/fixtures/unreal_iostore_replay.json
+++ b/native/galgame_hook/tests/fixtures/unreal_iostore_replay.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "engine_id": "unreal_iostore",
+  "status": "implemented_unverified",
+  "config": {
+    "selected_thread": 4,
+    "duplicate_window_ms": 1000,
+    "audio_priority": ["resource_audio", "pcm", "loopback"],
+    "resource_late_wait_ms": 500
+  },
+  "events": [
+    {"kind": "text", "id": "unreal-line", "timestamp_ms": 5000, "thread": 4, "text": "synthetic unreal pc-hook line"},
+    {"kind": "text", "id": "unreal-ui-thread", "timestamp_ms": 5001, "thread": 9, "text": "synthetic unreal ui thread"},
+    {"kind": "pcm", "id": "unreal-source-pcm", "timestamp_ms": 5014, "format": "s16le"},
+    {"kind": "loopback", "id": "unreal-loopback", "timestamp_ms": 5018, "format": "s16le"},
+    {"kind": "session_end", "timestamp_ms": 5600}
+  ],
+  "expected": {
+    "cards": [
+      {"text_id": "unreal-line", "audio_backend": "pcm", "audio_id": "unreal-source-pcm"}
+    ],
+    "duplicate_text_events": 0,
+    "thread_filtered_events": 1,
+    "session_clean": true
+  }
+}

--- a/native/galgame_hook/tests/unreal_iostore_adapter_test.cpp
+++ b/native/galgame_hook/tests/unreal_iostore_adapter_test.cpp
@@ -1,0 +1,127 @@
+// CI builds with --config Release, where MSVC defines NDEBUG and compiles
+// bare assert() out entirely. Undefine it before any include or this test is
+// green no matter what it checks. Guard: tests/assert_liveness_guard_test.py
+#undef NDEBUG
+
+// Unreal IoStore 身份判据用真临时目录验：判据读的是磁盘布局（Binaries\Win64 目录形状 +
+// Content\Paks\*.utoc 的 IoStore 魔数），只有文件系统自己能作证。
+// 覆盖：完整布局、目录形状对但没有归档、有 .utoc 但魔数不对、归档对但目录形状不对、
+// 以及路径拆分本身的边界（尾部分隔符、无父目录）。
+#include "../hook/adapters/unreal_iostore_profile.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+std::wstring MakeTempRoot(const wchar_t* tag) {
+  wchar_t temp[MAX_PATH] = {0};
+  assert(GetTempPathW(MAX_PATH, temp) != 0);
+  std::wstring root = std::wstring(temp) + L"fushi_unreal_test_" + tag + L"_" +
+                      std::to_wstring(GetCurrentProcessId());
+  assert(CreateDirectoryW(root.c_str(), nullptr) ||
+         GetLastError() == ERROR_ALREADY_EXISTS);
+  return root;
+}
+
+void WriteBytes(const std::wstring& path, const char* bytes, size_t length) {
+  HANDLE file = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                            FILE_ATTRIBUTE_NORMAL, nullptr);
+  assert(file != INVALID_HANDLE_VALUE);
+  DWORD written = 0;
+  assert(WriteFile(file, bytes, static_cast<DWORD>(length), &written, nullptr));
+  assert(written == length);
+  CloseHandle(file);
+}
+
+// <root>\Game\Binaries\Win64 与 <root>\Game\Content\Paks，即真实样本的形状。
+std::wstring MakeGameTree(const std::wstring& root) {
+  CreateDirectoryW((root + L"\\Game").c_str(), nullptr);
+  CreateDirectoryW((root + L"\\Game\\Binaries").c_str(), nullptr);
+  CreateDirectoryW((root + L"\\Game\\Binaries\\Win64").c_str(), nullptr);
+  CreateDirectoryW((root + L"\\Game\\Content").c_str(), nullptr);
+  CreateDirectoryW((root + L"\\Game\\Content\\Paks").c_str(), nullptr);
+  return root + L"\\Game\\Binaries\\Win64";
+}
+
+void RemoveTree(const std::wstring& root) {
+  DeleteFileW((root + L"\\Game\\Content\\Paks\\global.utoc").c_str());
+  DeleteFileW((root + L"\\Game\\Content\\Paks\\other.utoc").c_str());
+  RemoveDirectoryW((root + L"\\Game\\Content\\Paks").c_str());
+  RemoveDirectoryW((root + L"\\Game\\Content").c_str());
+  RemoveDirectoryW((root + L"\\Game\\Binaries\\Win64").c_str());
+  RemoveDirectoryW((root + L"\\Game\\Binaries").c_str());
+  RemoveDirectoryW((root + L"\\Game").c_str());
+  RemoveDirectoryW(root.c_str());
+}
+
+// 真实样本 global.utoc 的前 20 字节形状：16 字节魔数 + 版本 6。
+const char kToc[] = "-==--==--==--==-\x06\x00\x00\x00";
+// 后缀相同但不是 IoStore 的东西（这里借 Ogg 头当反例）。
+const char kNotToc[] = "OggS\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+}  // namespace
+
+int main() {
+  // 1. 完整布局 → 匹配。第一个 .utoc 魔数不对也不影响：判据是「至少一个」。
+  {
+    const std::wstring root = MakeTempRoot(L"full");
+    const std::wstring bin = MakeGameTree(root);
+    WriteBytes(root + L"\\Game\\Content\\Paks\\other.utoc", kNotToc, sizeof(kNotToc) - 1);
+    WriteBytes(root + L"\\Game\\Content\\Paks\\global.utoc", kToc, sizeof(kToc) - 1);
+    assert(fushi_voice_hook::UnrealShippingBinaryLayout(bin));
+    assert(fushi_voice_hook::UnrealIoStoreArchivePresent(root + L"\\Game"));
+    assert(fushi_voice_hook::MatchesUnrealIostoreLayout(bin));
+    // 尾部带分隔符也必须判成同一件事。
+    assert(fushi_voice_hook::MatchesUnrealIostoreLayout(bin + L"\\"));
+    RemoveTree(root);
+  }
+  // 2. 目录形状对但 Paks 下没有归档 → 不匹配（fail closed）。
+  {
+    const std::wstring root = MakeTempRoot(L"no_archive");
+    const std::wstring bin = MakeGameTree(root);
+    assert(fushi_voice_hook::UnrealShippingBinaryLayout(bin));
+    assert(!fushi_voice_hook::MatchesUnrealIostoreLayout(bin));
+    RemoveTree(root);
+  }
+  // 3. 有 .utoc 但魔数不对 → 不匹配（只看后缀会误判）。
+  {
+    const std::wstring root = MakeTempRoot(L"bad_magic");
+    const std::wstring bin = MakeGameTree(root);
+    WriteBytes(root + L"\\Game\\Content\\Paks\\global.utoc", kNotToc, sizeof(kNotToc) - 1);
+    assert(!fushi_voice_hook::UnrealIoStoreArchivePresent(root + L"\\Game"));
+    assert(!fushi_voice_hook::MatchesUnrealIostoreLayout(bin));
+    RemoveTree(root);
+  }
+  // 4. 归档没问题，但二进制目录不是 Binaries\Win64 → 不匹配
+  //    （任何把 exe 放在别处的程序都不该因为同目录树里有个 utoc 而被认成 Unreal）。
+  {
+    const std::wstring root = MakeTempRoot(L"bad_layout");
+    MakeGameTree(root);
+    WriteBytes(root + L"\\Game\\Content\\Paks\\global.utoc", kToc, sizeof(kToc) - 1);
+    assert(!fushi_voice_hook::UnrealShippingBinaryLayout(root + L"\\Game"));
+    assert(!fushi_voice_hook::MatchesUnrealIostoreLayout(root + L"\\Game"));
+    // Win64 在位、但父目录不叫 Binaries：同样不认。
+    CreateDirectoryW((root + L"\\Game\\Content\\Win64").c_str(), nullptr);
+    assert(!fushi_voice_hook::UnrealShippingBinaryLayout(root + L"\\Game\\Content\\Win64"));
+    RemoveDirectoryW((root + L"\\Game\\Content\\Win64").c_str());
+    RemoveTree(root);
+  }
+  // 5. 路径拆分的边界：空串、纯分隔符、无父目录，都不能崩也不能误判成匹配。
+  {
+    assert(fushi_voice_hook::UnrealLastSegment(L"").empty());
+    assert(fushi_voice_hook::UnrealLastSegment(L"\\\\").empty());
+    assert(fushi_voice_hook::UnrealLastSegment(L"Win64") == L"Win64");
+    assert(fushi_voice_hook::UnrealLastSegment(L"a\\b\\Win64\\") == L"Win64");
+    assert(fushi_voice_hook::UnrealParentDirectory(L"Win64").empty());
+    assert(fushi_voice_hook::UnrealParentDirectory(L"a\\b\\Win64") == L"a\\b");
+    assert(!fushi_voice_hook::UnrealShippingBinaryLayout(L""));
+    assert(!fushi_voice_hook::UnrealShippingBinaryLayout(L"Win64"));
+    assert(!fushi_voice_hook::MatchesUnrealIostoreLayout(L""));
+  }
+  // 6. 测试进程自己的目录不是 Unreal 游戏 → 进程级探测为假。
+  assert(!fushi_voice_hook::MatchesUnrealIostoreProfile(nullptr));
+  std::printf("unreal_iostore_adapter_test: ok\n");
+  return 0;
+}


### PR DESCRIPTION
## 这是什么

队列批量适配的下一款：**Unreal Engine（IoStore 打包形态）引擎骨架**。

批量盘点时发现「昨日魔女今日的梦 1.0 汉化版」此前被记作 Unity，实际是 **Unreal Engine 5**
（`kinomajo\Binaries\Win64\kinomajo-Win64-Shipping.exe` + IoStore `.ucas/.utoc`）。
仓库原有 17 个引擎里没有 Unreal 家族，而队列里其余游戏都命中已有 adapter——这是**唯一真正的新引擎缺口**。

## 判据先量后写

- `.utoc` 头 16 字节魔数实测为 `-==--==--==--==-`，三个文件一致，第 17 字节是版本 `6`。
- `.pak` 的头**不是**魔数（UE 的 pak 魔数 `0x5A6F12E1` 在**文件尾部**、偏移随 pak 版本变），
  且这三个 `.pak` 的尾 64 字节全是零填充。

于是身份锚在 IoStore，两条**同时**成立才匹配（fail closed）：
1. 可执行文件所在目录是 `...\Binaries\Win64`；
2. 上溯两级的 `<Game>\Content\Paks\` 下至少一个 `*.utoc` 以那 16 字节魔数开头。

**只锚 IoStore 是有意的**：UE4.25 之前只出 `.pak`，手上没有 `.pak`-only 样本，
量不到的形状不写进判据。老 UE4 包因此不匹配——已知且刻意的覆盖面缺口，写进了 `known_limitations`。

判据本体放 `include/unreal_launch.h` 作**唯一真相源**：hook 侧的引擎身份与 injector 侧的
`LooksLikeUnrealRuntime` 调同一份，不各写一遍。

## 运行期实测

`injector --launch --hold`：

```
hookdiag   = StartupAudioHooksReady | UnityResourceExtractorReady | LunaHostReady
             | LunaConnected | LunaOutputObserved
xaudiodiag = QueueReady | JobQueued | PcmPublished      （voice_clips 持续增长）
```

文本对照（同一份 helper、同一段标题画面、只差一个开关）：

| 配置 | text_events 稳定值 |
|---|---|
| 默认 | 11 |
| `--luna-pchooks` | **29** |

UE 是 C++ 引擎、台词在进程内、没有 Mono/TJS 那样的脚本宿主可挂，只能靠 LunaHook 通用 PC hooks，
与 Unity 同理 → 加进 `ShouldAutoUseLunaPcHooks`。

**没有区分 PCM 是哪条后端产出的**：shipping exe 静态导入 `DSOUND.dll`，而 UE 树同时带
`xaudio2_9redist.dll`（运行期动态加载）。本轮只证到「通用 Windows 音频路径发布了 PCM」，
**不写成 XAudio2**。

## 状态与边界

`implemented_unverified`，`verified_games` 为空。本轮只到 `text_observed` / `pcm_observed`，
**没有走过任何一句台词**，因此 `text_thread_selected` / `resource_observed` / `paired` /
`card_e2e` 全部 `not_run`。逐句语音（`*.ucas` 里的 SoundWave 资产）资源层明确未做。
Next gate 是 `text_thread_selected`，写在台账里。

顺带记入台账（不进判据）：该汉化版在 shipping 二进制旁附带第三方 `ue4ss\UE4SS.dll` + Lua 修改器，
意味着同一进程里可能已经有另一个注入器；Fushi 不加载也不依赖它。

## 验证

- galgame_hook 守卫 **10 套全绿**（含 manifest / adapter 结构 / evidence 契约 / assert 存活）
- `build_distribution` exit 0；双架构 **CTest 61/61**，含新增 `fushi_unreal_iostore_adapter_test`
  （真临时目录验完整布局 / 无归档 / 魔数不对 / 目录形状不对，外加路径拆分的空串、纯分隔符、无父目录三个边界）
- Dart 侧 `flutter_test_failures` **VERDICT PASSED - 3 tests**（含 replay fixture 在 Dart 与 native
  两棵树逐字节一致那条目录枚举守卫）
- `flutter analyze` **No issues found**
