### PR TITLE
feat(galgame): adapter 运行期读数（IPC v23）——任何引擎终于答得出「我的 adapter 命中并安装了吗」（BUG-2149）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2019 条。点号进各自文件。
+> 共 2020 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2149](bugs/BUG-2149-gal-adapter-diagnostics-write-only.md) | ✅ | ✅ | AdapterDiagnostics 是只写接口：运行期没有消费方，任何引擎都读不出 adapter 是否命中并安装 |
 | [BUG-2145](bugs/BUG-2145-gal-kirikiri2-no-export-table-and-late-loadlibrary-hook.md) | ✅ | ✅ | KiriKiri2 无导出表 + 插件早于 LoadLibrary hook link：两条 exporter 路径同时静默落空，游戏内查词整条不装 |
 | [BUG-2144](bugs/BUG-2144-gal-kirikiri2-bcb-exception-escapes-msvc-catch.md) | ✅ | ✅ | KiriKiri2/BCB 上 TJS 抛的 Borland 异常穿透 MSVC catch(...)，注入的每帧求值把游戏打成致命错误框并强制写快速存档 |
 | [BUG-2143](bugs/BUG-2143-attached-status-without-reason-undiagnosable.md) | ✅ | 🚧 | attached 状态机十二处 `needsRiskAcceptance` / `needsCalibration` / `waitingForBodyThread` 不带 reason，真机上无法定位是哪条分支 |

--- a/docs/bugs/BUG-2149-gal-adapter-diagnostics-write-only.md
+++ b/docs/bugs/BUG-2149-gal-adapter-diagnostics-write-only.md
@@ -36,6 +36,30 @@
     正常往返按槽对号、adapter 变少时尾部旧槽必须清零（否则读到上一次的 probe/installed）、
     超长 id 截断且带 NUL、写侧超容量夹住、读侧按自身容量截断。
 
-- **备注**：**端到端未验**——写点与读点各自有测试，但「在真游戏上打出那一行」尚未跑过
-  （改动时用户在用机器，不启动游戏打断）。桌面空闲后第一件事就是拿 chronoclock 体験版复验，
-  那同时就是 CMVS 台账里那条 Next gate。在此之前不得宣称本条面「可用」。
+- **端到端已验（2026-09-05，四个引擎，helper x86 `119ef214…` / x64 `950e0d03…`）**：
+  写点（helper DLL）与读点（ring_probe）取自同一次构建——v23 版本门本来就要求这样，否则判不兼容。
+
+  | 游戏 | `[adapters]` 读数 | 其它引擎 |
+  |---|---|---|
+  | chronoclock 体験版 v2（CMVS） | `cmvs=probe:1/installed:1` | 无 kirikiri / renpy / unity 行 |
+  | ATRI -My Dear Moments-（KiriKiri） | `kirikiri_z=probe:1/installed:1` | **cmvs 行整条消失** |
+  | Sakura Swim Club（Ren'Py） | `renpy_ffmpeg=probe:1/installed:1` | 无 kirikiri / cmvs |
+  | manosaba Ver1.0.3（Unity IL2CPP） | `unity_il2cpp=probe:1/installed:1` | 无 cmvs / renpy |
+
+  第一行正是 CMVS 台账里那条 Next gate「探针 `cmvs probe=1 installed=1`」——它现在读得出来了。
+  四局互为跨引擎负样本：每局只有该引擎的 probe 为 1，别家的行因 probe/installed 全 0 被滤掉。
+
+- **顺带查实的一件事：`installed` 是各 adapter 自定义的，`probe:0/installed:1` 不是矛盾。**
+  第一次读到 `siglus=probe:0/installed:1`、`reallive=probe:0/installed:1`、
+  `kirikiri_z=probe:0/installed:1`（在 CMVS 游戏上）时看着像 bug，查下来是真数据：
+  `TryHookSiglusOvk()` 装的是 **KernelBase 文件 API 共享中转**（`CreateFileW/A`/`ReadFile`/
+  `CloseHandle`），HUNEX 与 Malie 都复用它，`reallive.install()` 干脆就是
+  `installed_ = TryHookSiglusOvk()`。装成功就置 `installed_`，与本局是不是 Siglus 无关；
+  Siglus 专属诊断位 `kDiagSiglusOvkHooksReady` 只在确实是 Siglus 时才置。
+  **证据**：CMVS 那局 `hookdiag=0x00000c21` 里确实**没有** `SiglusOvkHooksReady`，与该解释一致。
+  数据没错，但不解释一定会被读成矛盾——所以读点在**恰好出现这种形状时**打一行说明：
+  「installed 含该 adapter 代管的共享中间件；引擎身份只看 probe」。这与本仓对诊断位的既有
+  纪律同源：位只能表示它字面上说的那件事。
+
+- **备注**：本条面只解决「读得出来」。各 adapter 的 `installed_` 语义不统一是另一件事，
+  本轮**没有**去统一——那要逐个 adapter 重新定义并回归，属独立任务。

--- a/docs/bugs/BUG-2149-gal-adapter-diagnostics-write-only.md
+++ b/docs/bugs/BUG-2149-gal-adapter-diagnostics-write-only.md
@@ -1,0 +1,41 @@
+## BUG-2149 · AdapterDiagnostics 是只写接口：运行期没有消费方，任何引擎都读不出 adapter 是否命中并安装
+- **报告**：2026-09-05（自查：ceshi 批量适配时 CMVS 的 Next gate 读不出来）
+- **真实性**：✅ 真 bug，根因 `native/galgame_hook/hook/adapter.h:46`（`virtual AdapterDiagnostics diagnostics() const = 0;`）
+
+  **怎么发现的**：CMVS 台账里写的 Next gate 是「探针 `cmvs probe=1 installed=1`」。真机上跑 chronoclock
+  体験版时发现**打不出这一对读数**——不是探针失败，是根本没有工具能打。
+  顺着查：`AdapterDiagnostics`（`id` / `applicable` / `installed` / `flags`）**每个 adapter 都实现了**，
+  但全仓 `grep` 下来只有 `tests/adapter_contract_test.cpp` 在读。运行期零消费方。
+
+  于是这不是 CMVS 一家的事：**任何引擎**都答不出「我的 adapter 到底有没有被选中并安装」。
+  而 `native/galgame_hook/CLAUDE.md` 的证据门要求逐门可判（`process_found → helper_ready → …`），
+  其中「adapter 认领了没有」正是第一道要判的门。写了没人读的接口，等于这道门在真机上是瞎的。
+
+- **[x] ① 已修复** — IPC 契约 **v22 → v23**：`SharedHeader` 尾部**纯追加**
+  `AdapterReportSlot adapter_reports[32]` + `count` + `seq`。
+  - 写者唯一：`AdapterRegistry::Poll` → `PublishAdapterReportSnapshot()`，与既有的
+    `PublishLookupAdmissionSummary()` 同处、同纪律（内容先写、seq 最后发布）。
+  - **槽自带 id 字符串**，不按注册顺序编号：下标制在有人往 `hook/generated/adapter_*.inc`
+    中间插一行时会整体错位，而且**不报错**——读数看着正常，说的却是另一个 adapter。
+  - 复用**同一份生成清单**（函数内 `consider` lambda + `#include "generated/adapter_admission.inc"`），
+    所以脚手架登记的新引擎自动进读数，不存在第二份会漂移的清单。
+  - 限速 1 秒：`diagnostics()` 内部会调 `probe()`，而 CMVS / AOS / Unreal 的 probe 要读盘枚举，
+    Poll 最快 16 ms 一轮；诊断面没有低延迟需求。
+  - 读点：`tools/ring_probe.cpp` 打 `[adapters] seq=N id=probe:x/installed:y`，
+    并把「seq==0 未上报」与「上报了但无人认领」明确分开——两者混一起会在 helper 起来前稳定误报。
+  - 升版是硬要求：两侧都用 `sizeof(SharedHeader)` 现算 ring / region 基址，新旧混装会整体错位
+    而版本门本会放行（与 v22 同理）。两处既有的版本钉（`native_loopback_policy_test`、
+    `lookup_ipc_contract_test`）随之更新，并给 v23 块补上同等强度的逐字段布局锁。
+
+- **[x] ② 已加自动化测试** —
+  - `tests/adapter_report_guard_test.py`（新，10 条 + 2 条变异自测；已登记进 `tools/run_guards.ps1`）：
+    守「**声明的 adapter 成员集合 ⊆ 上报集合**」——最危险的失败形状不是编译错误，而是有人加了
+    adapter 却没进读数，读数少一行而没有任何东西会红。另守写点被调用、限速真的比较了时间差、
+    发布器清尾部残留槽、ring_probe 存在读点、布局变了必须升版、槽必须自带 id。
+  - `tests/lookup_ipc_contract_test.cpp` 新增 `TestAdapterReportRoundTrip()`：未上报读 0 槽、
+    正常往返按槽对号、adapter 变少时尾部旧槽必须清零（否则读到上一次的 probe/installed）、
+    超长 id 截断且带 NUL、写侧超容量夹住、读侧按自身容量截断。
+
+- **备注**：**端到端未验**——写点与读点各自有测试，但「在真游戏上打出那一行」尚未跑过
+  （改动时用户在用机器，不启动游戏打断）。桌面空闲后第一件事就是拿 chronoclock 体験版复验，
+  那同时就是 CMVS 台账里那条 Next gate。在此之前不得宣称本条面「可用」。

--- a/docs/plans/2026-09-04-gal-ceshi-batch-cmvs.md
+++ b/docs/plans/2026-09-04-gal-ceshi-batch-cmvs.md
@@ -60,3 +60,25 @@
 - worktree `D:\APP\vs_claude_code\hibiki\.claude\worktrees\gal-cmvs-chronoclock`，分支 `worktree-gal-cmvs-chronoclock`（基底 develop，可独立开 PR）。
 - 脚本：`C:\Users\wrds\.claude\jobs\81491d86\tmp\{build_cmvs,guards_cmvs,mutate_cmvs}.sh`、身份脚本 `cc_identity.py`；真机驱动沿用 `C:\Users\wrds\.claude\jobs\a188f70d\tmp\launch_fushi_iso2.ps1` + `C:\Users\wrds\.claude\jobs\3f9f84ac\tmp\drive\galdrive.ps1`。
 - 构建坑同前：bash 里 unset 小写代理再跑 `build_distribution.ps1`；`flutter test` 反过来要小写 `http_proxy` 才能下 native assets；`setup_worktree.ps1` 在 PowerShell 里要先把 `C:\Program Files\Git\bin` 加进 PATH（apply-patches 调 bash）。
+
+## Next gate 更新（2026-09-05）
+
+原 Next gate「探针 `cmvs probe=1 installed=1`」当时**读不出来**——不是探针失败，是全仓没有
+任何工具能打出这一对读数（`AdapterDiagnostics` 只被契约测试读，运行期零消费方）。
+那是跨引擎的诊断缺口，已作为 [[BUG-2149]] 独立修掉（IPC v23 加 adapter 运行期读数）。
+
+真机复验（chronoclock 体験版 v2，`cmvs64.exe`，2026-09-05）：
+
+```
+[adapters] seq=20 xaudio2_directsound=probe:1/installed:1 siglus=probe:0/installed:1
+           text_render=probe:1/installed:1 kirikiri_z=probe:0/installed:1
+           process_loopback=probe:1/installed:0 reallive=probe:0/installed:1
+           cmvs=probe:1/installed:1
+```
+
+**`cmvs=probe:1/installed:1` 达成**，且 ATRI / Sakura / manosaba 三局里 cmvs 行整条不出现
+（跨引擎负样本）。
+
+下一个未通过边界因此前移到 **`text_observed`**：本局 `text_events=1`（标题画面），
+需要走进一句真台词，确认 LunaHook 的 `EmbedCMVS` 线程携带对白。在那之前状态仍是
+`implemented_unverified`。

--- a/fushi/test/tools/voice_hook_ipc_contract_test.dart
+++ b/fushi/test/tools/voice_hook_ipc_contract_test.dart
@@ -38,14 +38,46 @@ void main() {
         reason: '$bit 没在契约头里定义',
       );
     }
-    // v17：在 v16 之上纯尾部追加「本次注入所用 hook DLL 的 SHA-256」。
-    // 这个数字必须钉死：它是 wire identity，写错一位就是「旧 helper 静默绕过默认
-    // deny」。改它必须同时改契约头顶部的版本沿革说明。
-    // v22：SharedHeader 尾部在 v19 摘要之后纯追加了层原点双向面（12 个 32 位字，
-    // 共 48 字节）。**尺寸变了就必须升版**：hook 与 injector 都用 sizeof(SharedHeader)
-    // 现算 ring / region 基址，新旧混装会整体差 48 字节，而版本门本会放行——症状是
-    // 跨进程读到完全错位的数据，不报错。
-    expect(source, contains('constexpr uint32_t kSharedVersion = 22;'));
+    // 版本号的唯一真相源是契约头本身，本守卫核对**所有硬编码副本**与它一致。
+    //
+    // 这里原本也钉一个字面量（`= 22`）。两个毛病：
+    // 一是全仓就有三份同一个数字（本文件 + 下面两个 native 测试），升版的人找到
+    // 两份、漏掉第三份是迟早的事——BUG-2149 升 v23 时漏的正是本文件，CI 单测门
+    // 红在这一行；二是字面量只在「有人主动改这个数字」时才响，而那恰恰是改的人
+    // 已经知道的时刻，真正危险的「动了 SharedHeader 布局却不升版」它一次也拦不住
+    // （那条由 native 侧 adapter_report_guard_test.py 的结构体比对守）。
+    final RegExp versionRe =
+        RegExp(r'constexpr uint32_t kSharedVersion = (\d+);');
+    final Match? versionMatch = versionRe.firstMatch(source);
+    expect(versionMatch, isNotNull, reason: '契约头里扫不到 kSharedVersion —— 判红');
+    final String version = versionMatch!.group(1)!;
+
+    // 升版必须在契约头顶部的沿革块里留一条 `vN`。沿革是新旧混装排障时唯一能回答
+    // 「这版改了什么、混装会整体错位多少字节」的地方（v22 那条就是这么写的）。
+    expect(
+      RegExp('^//\\s*v$version\\b', multiLine: true).hasMatch(source),
+      isTrue,
+      reason: 'kSharedVersion 已经是 v$version，契约头顶部却没有 v$version 的沿革说明：'
+          '混装排障时没人答得出这版改了什么',
+    );
+
+    // native 两个测试各自硬编码这个数字，价值是「升版时 native 套件也得跟着改」，
+    // 但副本会漂——由本守卫把它们钉回真相源。
+    for (final String relative in <String>[
+      '../native/galgame_hook/tests/lookup_ipc_contract_test.cpp',
+      '../native/galgame_hook/tests/native_loopback_policy_test.cpp',
+    ]) {
+      final Match? pin = RegExp(
+        r'kSharedVersion == (\d+)',
+      ).firstMatch(File(relative).readAsStringSync());
+      expect(pin, isNotNull, reason: '$relative 里的版本 pin 没了');
+      expect(
+        pin!.group(1),
+        version,
+        reason: '$relative 钉的是 v${pin.group(1)}，契约头已经是 v$version：'
+            '升版漏改了它，native 套件会拿旧号给新布局放行',
+      );
+    }
     // v17 字段本身也钉死：驻留 hook 身份门的驻留侧摘要只能从这里取，字段没了
     // 就只剩「两边都读磁盘」那条恒真的假校验。
     expect(

--- a/native/galgame_hook/hook/adapter_registry.inc
+++ b/native/galgame_hook/hook/adapter_registry.inc
@@ -612,6 +612,60 @@ class AdapterRegistry {
       ++tyrano_retry_;
     }
     PublishLookupAdmissionSummary();
+    PublishAdapterReportSnapshot();
+  }
+
+  // v23：把每个 adapter 的 diagnostics() 抄进共享内存（BUG-2149）。唯一写者，与下面的
+  // 准入汇总同处、同纪律。
+  //
+  // 为什么需要：AdapterDiagnostics 以前只被契约测试读，运行期没有消费方，于是「这局
+  // 到底哪个 adapter 认领了、装上没有」在真机上看不见——每加一个引擎就多一个答不出的
+  // 问题，而 engine-support 的证据门恰恰要求逐门可判。
+  //
+  // 这里**不**沿用准入汇总那份「只算引擎身份 adapter」的过滤。那条过滤是为了不让
+  // generic_audio_ / text_render_ / loopback_ 的恒真 probe() 污染「这游戏是哪个引擎」
+  // 的结论；而本面回答的是另一个问题——「哪些 adapter 现在是活的」，横切能力生效与否
+  // 恰恰是要看的。每行自带 id，读者不会把 `process_loopback applicable=1` 误读成引擎判定。
+  //
+  // 限速 1 秒：diagnostics() 内部会调 probe()，而 CMVS / AOS / Unreal 的 probe 要读盘
+  // 枚举（cfg 前缀、*.aos 头、Content\Paks\*.utoc），Poll 最快 16ms 一轮。诊断面没有
+  // 低延迟需求，不该为它每秒付几十次目录枚举。
+  void PublishAdapterReportSnapshot() {
+    if (g_header == nullptr) return;
+    const ULONGLONG now = GetTickCount64();
+    if (adapter_report_tick_ != 0 && now - adapter_report_tick_ < 1000) return;
+    adapter_report_tick_ = now;
+
+    fushi_voice_hook::AdapterReportSlot slots[fushi_voice_hook::kAdapterReportSlots] = {};
+    size_t used = 0;
+    auto consider = [&slots, &used](const fushi_voice_hook::EngineAdapter& adapter) {
+      if (used >= fushi_voice_hook::kAdapterReportSlots) return;
+      const fushi_voice_hook::AdapterDiagnostics diagnostics = adapter.diagnostics();
+      fushi_voice_hook::AdapterReportSlot& slot = slots[used++];
+      const char* id = diagnostics.id == nullptr ? "" : diagnostics.id;
+      // 有界拷贝：id 由 adapter 自己给，长度不受本文件控制。
+      size_t n = 0;
+      while (id[n] != '\0' && n + 1 < fushi_voice_hook::kAdapterReportIdChars) {
+        slot.id[n] = id[n];
+        ++n;
+      }
+      slot.id[n] = '\0';
+      slot.applicable = diagnostics.applicable ? 1u : 0u;
+      slot.installed = diagnostics.installed ? 1u : 0u;
+      slot.flags = diagnostics.flags;
+    };
+    // 手写的 8 个（含三个横切能力），随后复用**同一份生成清单**——新引擎由脚手架写进
+    // adapter_admission.inc，于是自动出现在本读数里，不存在第二份会漂移的清单。
+    consider(generic_audio_);
+    consider(siglus_);
+    consider(unity_);
+    consider(text_render_);
+    consider(kirikiri_);
+    consider(renpy_);
+    consider(tyrano_);
+    consider(loopback_);
+#include "generated/adapter_admission.inc"
+    fushi_voice_hook::PublishAdapterReports(g_header, slots, used);
   }
 
   // v19：把「本会话游戏内查词能不能用」汇总成一个值发布给 host。
@@ -763,6 +817,7 @@ class AdapterRegistry {
   }
 
   static constexpr int kRetryLimit = 150;
+  ULONGLONG adapter_report_tick_ = 0;  // v23 读数限速（见 PublishAdapterReportSnapshot）
   GenericWindowsAudioAdapter generic_audio_;
   SiglusAdapter siglus_;
   UnityIl2CppAdapter unity_;

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -123,7 +123,19 @@ constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
 //     `injector/injector_main.cpp` 都用 `sizeof(SharedHeader)` 现算 ring / region
 //     基址，新旧混装会整体差 48 字节，而版本门本会放行——症状是跨进程读到完全
 //     错位的数据，不报错。
-constexpr uint32_t kSharedVersion = 22;
+//  v23 — adapter 运行期读数（BUG-2149）。SharedHeader 尾部**纯追加**一张
+//     `AdapterReportSlot adapter_reports[kAdapterReportSlots]` + count + seq。
+//     动机：`AdapterDiagnostics`（id/applicable/installed/flags）每个 adapter 都实现了，
+//     但全仓只有 `tests/adapter_contract_test.cpp` 在读——运行期没有任何消费方，于是
+//     **任何引擎**都答不出「我的 adapter 到底有没有被选中并安装」。CMVS 台账里那条
+//     Next gate「探针 cmvs probe=1 installed=1」读不出来，不是探针失败，是这个只写
+//     接口的表现。
+//     槽里带**自己的 id 字符串**而不是按注册顺序编号：顺序编号在有人往
+//     `hook/generated/adapter_*.inc` 中间插一行时会整体错位，而且**不报错**——
+//     读数看着正常，说的却是另一个 adapter。
+//     与 v22 同理，布局变了就必须升版（两侧都用 `sizeof(SharedHeader)` 现算 ring /
+//     region 基址，新旧混装会整体错位而版本门本会放行）。
+constexpr uint32_t kSharedVersion = 23;
 constexpr uint32_t kStableIpcVersion = 1;
 
 // BUG-1882 — SGRE 的鼠标输入走 DirectInput immediate state，不经过普通
@@ -1078,6 +1090,22 @@ constexpr uint32_t kLookupInputVirtualKeyXButton2 = 0x0040u;
 // 内存布局：[SharedHeader][音频环形 ring_capacity][文本区 TextRegionBytes()]
 //           [clip 索引 kClipCount*sizeof(VoiceClip)]，各区偏移由 injector 填进 header。
 // 文本区自 v13 起是 [TextLane 表][按道分块的槽区]，寻址一律走 TextLaneSlotAt。
+// ── v23 adapter 运行期读数 ─────────────────────────────────────────────────
+// 每个 adapter 一槽。id 是**槽自带的**，不靠下标对齐：往 generated 清单中间插一行
+// 就会让下标制的读数整体错位且不报错（读到的是别人的 probe/installed）。
+constexpr size_t kAdapterReportSlots = 32u;      // 当前 21 个 adapter，留一倍余量
+constexpr size_t kAdapterReportIdChars = 32u;    // 最长 id "xaudio2_directsound" 19 + NUL
+
+struct AdapterReportSlot {
+  char id[kAdapterReportIdChars];  // NUL 结尾；空串 = 该槽未使用
+  uint8_t applicable;              // adapter->probe()
+  uint8_t installed;               // adapter->installed
+  uint16_t slot_reserved;
+  uint32_t flags;                  // adapter 自报的 flags（各家含义不同，只作透传）
+};
+static_assert(sizeof(AdapterReportSlot) == kAdapterReportIdChars + 8u,
+              "AdapterReportSlot must stay tightly packed");
+
 struct SharedHeader {
   uint32_t magic;           // = kSharedMagic
   uint32_t version;         // = kSharedVersion
@@ -1256,6 +1284,13 @@ struct SharedHeader {
   volatile int32_t lookup_layer_origin_y;
   volatile uint32_t lookup_layer_origin_seq;
   uint32_t lookup_layer_reserved;
+  // ── v23 adapter 运行期读数（纯追加；hook→host）──────────────────────────
+  // 写者唯一：AdapterRegistry::Poll 每轮把每个 adapter 的 diagnostics() 抄进来，
+  // 与 lookup_admission 同一处、同一套纪律（内容先写，seq 最后发布）。
+  // 各 adapter 自己不碰这块——多写者会让"谁在第几槽"取决于调用顺序。
+  AdapterReportSlot adapter_reports[kAdapterReportSlots];
+  volatile uint32_t adapter_report_count;  // 实际使用的槽数，<= kAdapterReportSlots
+  volatile uint32_t adapter_report_seq;    // 单调；0 = 从未上报过（≠"没有 adapter"）
 };
 #pragma pack(pop)
 
@@ -1798,6 +1833,71 @@ inline LookupAdmissionReport ReadLookupAdmission(const SharedHeader* header,
   std::memcpy(report.executable_sha256, digest, length);
   report.executable_sha256[length] = '\0';
   return report;
+}
+
+// ── v23 adapter 运行期读数：两侧读写器 ────────────────────────────────────
+//
+// 为什么要有这条面：`AdapterDiagnostics` 以前只被契约测试读，运行期没有消费方。
+// 于是「这局到底哪个 adapter 认领了、装上没有」在真机上是**看不见的**——每加一个
+// 引擎就多一个答不出的问题，而 engine-support 的证据门恰恰要求逐门可判。
+//
+// 写侧只有 AdapterRegistry::Poll 一处。内容先写、seq 最后发布；读侧 seq→读→复核 seq，
+// 与 LookupHitSlot / VoiceClip 同一套。
+inline uint32_t PublishAdapterReports(SharedHeader* header,
+                                      const AdapterReportSlot* slots,
+                                      size_t count) {
+  if (header == nullptr || slots == nullptr) return 0u;
+  const size_t writable =
+      count < kAdapterReportSlots ? count : kAdapterReportSlots;
+  for (size_t i = 0; i < writable; ++i) {
+    AdapterReportSlot& dst = header->adapter_reports[i];
+    // 有界拷贝 + 强制 NUL：写侧可能是别的构建，读侧不许假设对面给了结尾。
+    std::memcpy(dst.id, slots[i].id, kAdapterReportIdChars);
+    dst.id[kAdapterReportIdChars - 1] = '\0';
+    dst.applicable = slots[i].applicable;
+    dst.installed = slots[i].installed;
+    dst.slot_reserved = 0u;
+    dst.flags = slots[i].flags;
+  }
+  // 尾部残留必须清掉：adapter 数变少时（换构建），旧槽会以陈旧读数继续存在。
+  for (size_t i = writable; i < kAdapterReportSlots; ++i) {
+    header->adapter_reports[i].id[0] = '\0';
+    header->adapter_reports[i].applicable = 0u;
+    header->adapter_reports[i].installed = 0u;
+    header->adapter_reports[i].slot_reserved = 0u;
+    header->adapter_reports[i].flags = 0u;
+  }
+  AtomicStoreShared32(&header->adapter_report_count,
+                      static_cast<uint32_t>(writable));
+  AtomicStoreShared32(&header->adapter_report_seq,
+                      AtomicLoadShared32(&header->adapter_report_seq) + 1u);
+  return static_cast<uint32_t>(writable);
+}
+
+// 读侧。seq==0 表示 hook 从未上报过（helper 还没起来 / 是旧版本），此时返回 0 槽——
+// 那是"还不知道"，**不是**"一个 adapter 都没认领"。两者混在一起会让诊断在启动头
+// 几百毫秒里稳定误报。
+inline uint32_t ReadAdapterReports(const SharedHeader* header,
+                                   AdapterReportSlot* out, size_t capacity,
+                                   uint32_t* out_seq = nullptr) {
+  if (out_seq != nullptr) *out_seq = 0u;
+  if (header == nullptr || out == nullptr || capacity == 0u) return 0u;
+  auto* mutable_header = const_cast<SharedHeader*>(header);
+  for (int attempt = 0; attempt < 8; ++attempt) {
+    const uint32_t seq = AtomicLoadShared32(&mutable_header->adapter_report_seq);
+    if (seq == 0u) return 0u;
+    uint32_t count = AtomicLoadShared32(&mutable_header->adapter_report_count);
+    if (count > kAdapterReportSlots) count = kAdapterReportSlots;
+    const size_t take = count < capacity ? count : capacity;
+    for (size_t i = 0; i < take; ++i) out[i] = mutable_header->adapter_reports[i];
+    if (AtomicLoadShared32(&mutable_header->adapter_report_seq) != seq) continue;
+    for (size_t i = 0; i < take; ++i) {
+      out[i].id[kAdapterReportIdChars - 1] = '\0';  // 有界：不信写侧给了 NUL
+    }
+    if (out_seq != nullptr) *out_seq = seq;
+    return static_cast<uint32_t>(take);
+  }
+  return 0u;
 }
 
 inline NativeLoopbackRequestSnapshot ReadNativeLoopbackRequest(

--- a/native/galgame_hook/tests/adapter_report_guard_test.py
+++ b/native/galgame_hook/tests/adapter_report_guard_test.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""adapter 运行期读数（v23 / BUG-2149）的源码不变式。
+
+这条面回答的是「这局到底哪个 adapter 认领了、装上没有」。它最危险的失败形状**不是**
+编译错误，而是：有人加了一个 adapter 却没让它进读数——读数看着完全正常，只是少一行，
+于是关于那个引擎的每一个问题继续答不出来，而且没有任何东西会红。
+
+所以这里守的是「成员集合 ⊆ 上报集合」，以及写点/读点/限速三处都还在。
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REGISTRY = ROOT / "hook" / "adapter_registry.inc"
+FIELDS = ROOT / "hook" / "generated" / "adapter_fields.inc"
+ADMISSION = ROOT / "hook" / "generated" / "adapter_admission.inc"
+IPC = ROOT / "include" / "voice_hook_ipc.h"
+RING_PROBE = ROOT / "tools" / "ring_probe.cpp"
+
+SNAPSHOT_FN = "void PublishAdapterReportSnapshot()"
+
+MEMBER_RE = re.compile(r"^\s+[A-Za-z0-9_]+Adapter\s+([a-z0-9_]+_)\s*;", re.M)
+CONSIDER_RE = re.compile(r"consider\(([a-z0-9_]+_)\)")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, signature: str) -> str | None:
+    """取 signature 之后第一对花括号之间的正文（按深度配对，不靠缩进）。"""
+    at = source.find(signature)
+    if at < 0:
+        return None
+    open_at = source.find("{", at)
+    if open_at < 0:
+        return None
+    depth = 0
+    for i in range(open_at, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_at + 1 : i]
+    return None
+
+
+def declared_members(registry: str, fields: str) -> set[str]:
+    """registry 里手写的 + generated/adapter_fields.inc 里生成的全部 adapter 成员。"""
+    return set(MEMBER_RE.findall(registry)) | set(MEMBER_RE.findall(fields))
+
+
+def reported_members(registry: str, admission: str) -> set[str]:
+    """PublishAdapterReportSnapshot 正文里 consider 到的 + 它 include 的生成清单。"""
+    body = _function_body(registry, SNAPSHOT_FN)
+    if body is None:
+        return set()
+    reported = set(CONSIDER_RE.findall(body))
+    if "generated/adapter_admission.inc" in body:
+        reported |= set(CONSIDER_RE.findall(admission))
+    return reported
+
+
+class AdapterReportGuard(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = _read(REGISTRY)
+        self.fields = _read(FIELDS)
+        self.admission = _read(ADMISSION)
+        self.ipc = _read(IPC)
+        self.ring_probe = _read(RING_PROBE)
+
+    def test_anchor_is_alive(self) -> None:
+        # 锚点没了就别让这套守卫静默变成空跑。
+        self.assertIn(SNAPSHOT_FN, self.registry, "快照函数改名/删除了，本守卫在守空气")
+        self.assertGreater(
+            len(declared_members(self.registry, self.fields)),
+            10,
+            "解析不到 adapter 成员：正则与声明写法漂开了，集合比较会假绿",
+        )
+
+    def test_every_adapter_member_is_reported(self) -> None:
+        declared = declared_members(self.registry, self.fields)
+        reported = reported_members(self.registry, self.admission)
+        missing = sorted(declared - reported)
+        self.assertEqual(
+            [],
+            missing,
+            "这些 adapter 有成员却没进运行期读数：%s —— 症状不是编译错误，"
+            "而是读数少一行、关于它们的诊断继续答不出来，且没有任何东西会红" % missing,
+        )
+
+    def test_snapshot_is_called_from_poll(self) -> None:
+        # 只定义不调用 = 写点不存在，读侧永远读到 seq==0。
+        self.assertIn(
+            "PublishAdapterReportSnapshot();",
+            self.registry,
+            "快照函数没有被调用：定义了没人调等于这条面不存在",
+        )
+
+    def test_snapshot_is_rate_limited(self) -> None:
+        body = _function_body(self.registry, SNAPSHOT_FN)
+        self.assertIsNotNone(body)
+        assert body is not None
+        self.assertIn(
+            "adapter_report_tick_",
+            body,
+            "快照没有限速：diagnostics() 内部会调 probe()，而 CMVS/AOS/Unreal 的 probe "
+            "要读盘枚举，Poll 最快 16ms 一轮——诊断面没有低延迟需求，不该为它每秒付几十次目录枚举",
+        )
+        self.assertRegex(
+            body,
+            r"now\s*-\s*adapter_report_tick_\s*<",
+            "限速要真的比较时间差，光有个时间戳不算",
+        )
+
+    def test_publish_clears_trailing_slots(self) -> None:
+        body = _function_body(self.ipc, "inline uint32_t PublishAdapterReports(")
+        self.assertIsNotNone(body, "找不到发布器")
+        assert body is not None
+        self.assertRegex(
+            body,
+            r"for\s*\(size_t\s+i\s*=\s*writable;",
+            "尾部残留槽没清：adapter 数变少时（换构建）旧槽会以陈旧读数继续存在，"
+            "读者看到的是上一次的 probe/installed",
+        )
+
+    def test_read_point_exists(self) -> None:
+        # 写点有了、读点一个没有，正是这条面原来的病。
+        self.assertIn(
+            "ReadAdapterReports(",
+            self.ring_probe,
+            "ring_probe 没有读点：这条面加了等于没加",
+        )
+
+    def test_layout_change_bumped_the_shared_version(self) -> None:
+        # 布局变了必须升版：两侧都用 sizeof(SharedHeader) 现算 ring/region 基址，
+        # 新旧混装会整体错位，而版本门本会放行。
+        self.assertIn("adapter_reports[kAdapterReportSlots]", self.ipc)
+        match = re.search(r"constexpr\s+uint32_t\s+kSharedVersion\s*=\s*(\d+);", self.ipc)
+        self.assertIsNotNone(match, "找不到 kSharedVersion")
+        assert match is not None
+        self.assertGreaterEqual(
+            int(match.group(1)),
+            23,
+            "SharedHeader 尾部追加了 adapter_reports 却没升 kSharedVersion",
+        )
+
+    def test_slot_carries_its_own_id(self) -> None:
+        # 下标制会在有人往 generated 清单中间插一行时整体错位，且不报错。
+        self.assertRegex(
+            self.ipc,
+            r"struct\s+AdapterReportSlot\s*\{\s*\n\s*char\s+id\[kAdapterReportIdChars\]",
+            "槽必须自带 id：按注册顺序编号会在清单中间插行时整体错位且不报错",
+        )
+
+
+class AdapterReportGuardMutation(unittest.TestCase):
+    """变异自测：把不变式破坏掉，守卫必须红。"""
+
+    def setUp(self) -> None:
+        self.registry = _read(REGISTRY)
+        self.fields = _read(FIELDS)
+        self.admission = _read(ADMISSION)
+
+    def test_dropping_one_adapter_from_the_report_is_red(self) -> None:
+        declared = sorted(declared_members(self.registry, self.fields))
+        self.assertTrue(declared)
+        victim = "loopback_"
+        self.assertIn(victim, declared)
+        dirty = self.registry.replace("    consider(%s);\n" % victim, "", 1)
+        self.assertNotEqual(dirty, self.registry, "变异锚点必须真的存在")
+        missing = declared_members(dirty, self.fields) - reported_members(
+            dirty, self.admission
+        )
+        self.assertIn(victim, missing, "删掉一行上报，集合比较必须发现它")
+
+    def test_dropping_the_generated_include_is_red(self) -> None:
+        # 去掉生成清单的 include：所有由脚手架登记的引擎一次性全掉出读数。
+        dirty = self.registry.replace(
+            '#include "generated/adapter_admission.inc"\n'
+            "    fushi_voice_hook::PublishAdapterReports",
+            "    fushi_voice_hook::PublishAdapterReports",
+            1,
+        )
+        self.assertNotEqual(dirty, self.registry, "变异锚点必须真的存在")
+        missing = declared_members(dirty, self.fields) - reported_members(
+            dirty, self.admission
+        )
+        self.assertIn("cmvs_", missing)
+        self.assertIn("sgre_", missing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
+++ b/native/galgame_hook/tests/lookup_ipc_contract_test.cpp
@@ -636,8 +636,8 @@ void TestV14LookupRegionIsPureAppendOverV13() {
 }
 
 void TestV16V17AndV19OnlyAppendOverV15() {
-  Check(kSharedVersion == 22,
-        "本测试锁的是 v22 契约（BUG-2136 层原点双向面在 v19 摘要后纯追加）");
+  Check(kSharedVersion == 23,
+        "本测试锁的是 v23 契约（BUG-2149 adapter 运行期读数在层原点块后纯追加）");
 
   // v14 的最后一个字段是 lookup_diag。v15 只能紧随其后追加一个 64 位 applied seq；
   // 把字段插进 v14 中间，或在 applied seq 后再偷偷长出别的字段，都必须判红。
@@ -963,14 +963,130 @@ void TestV19AdmissionIsPureAppendOverV17() {
           kLayerOrder[i]);
     Check(kLayerOffsets[i] % 4 == 0, "层原点字段必须 4 字节对齐（Interlocked 前提）");
   }
+  // v23 adapter 读数块是层原点块之后的又一次纯追加，所以尾部再次后移。同等强度地
+  // 锁死它：新块不许插进既有布局、内部次序不许改、尾部不许混入别的字段——否则这块
+  // 就成了没人守的自由区，而它恰恰是跨进程按 sizeof 现算基址的那个结构。
+  Check(offsetof(SharedHeader, adapter_reports) ==
+            ((offsetof(SharedHeader, lookup_layer_reserved) + sizeof(uint32_t) +
+              alignof(fushi_voice_hook::AdapterReportSlot) - 1u) /
+             alignof(fushi_voice_hook::AdapterReportSlot)) *
+                alignof(fushi_voice_hook::AdapterReportSlot),
+        "v23 adapter 读数块必须紧接层原点块，不得插进既有布局");
+  Check(sizeof(fushi_voice_hook::AdapterReportSlot) ==
+            fushi_voice_hook::kAdapterReportIdChars + 8u,
+        "AdapterReportSlot 布局变了：id + applicable/installed/reserved + flags");
+  Check(offsetof(fushi_voice_hook::AdapterReportSlot, id) == 0,
+        "槽必须以自带的 id 开头——按注册顺序编号会在清单中间插行时整体错位且不报错");
+  Check(offsetof(SharedHeader, adapter_report_count) ==
+            offsetof(SharedHeader, adapter_reports) +
+                sizeof(fushi_voice_hook::AdapterReportSlot) *
+                    fushi_voice_hook::kAdapterReportSlots,
+        "adapter_report_count 必须紧跟槽数组");
+  Check(offsetof(SharedHeader, adapter_report_seq) ==
+            offsetof(SharedHeader, adapter_report_count) + sizeof(uint32_t),
+        "adapter_report_seq 必须紧跟 count（内容先写、seq 最后发布）");
+  Check(offsetof(SharedHeader, adapter_report_count) % 4 == 0 &&
+            offsetof(SharedHeader, adapter_report_seq) % 4 == 0,
+        "count/seq 必须 4 字节对齐（Interlocked 前提）");
   Check(sizeof(SharedHeader) ==
-            ((offsetof(SharedHeader, lookup_layer_reserved) +
+            ((offsetof(SharedHeader, adapter_report_seq) +
               sizeof(uint32_t) + 7u) /
              8u) * 8u,
-        "v22 末尾除 8 字节对齐填充外不得混入其他字段");
+        "v23 末尾除 8 字节对齐填充外不得混入其他字段");
 }
 
 // 准入的读写往返。这些性质全都是「UI 会不会误导用户」的直接决定因素，不是内部细节。
+// v23 adapter 读数的读写往返（BUG-2149）。这条面的价值全在「读出来的那行说的是不是
+// 那个 adapter」——所以每条断言都盯着"会不会把读者引到错误结论"。
+void TestAdapterReportRoundTrip() {
+  FakeMapping mapping;
+  SharedHeader* h = mapping.header();
+
+  auto make = [](const char* id, bool applicable, bool installed,
+                 uint32_t flags) {
+    fushi_voice_hook::AdapterReportSlot slot = {};
+    size_t n = 0;
+    while (id[n] != '\0' && n + 1 < fushi_voice_hook::kAdapterReportIdChars) {
+      slot.id[n] = id[n];
+      ++n;
+    }
+    slot.id[n] = '\0';
+    slot.applicable = applicable ? 1u : 0u;
+    slot.installed = installed ? 1u : 0u;
+    slot.flags = flags;
+    return slot;
+  };
+
+  // (a) 从未上报过：读到 0 槽，且 seq==0。这必须与"上报了但一个都没认领"区分开——
+  //     混在一起会让诊断在 helper 起来前的那几百毫秒稳定误报"没有 adapter"。
+  fushi_voice_hook::AdapterReportSlot out[fushi_voice_hook::kAdapterReportSlots] = {};
+  uint32_t seq = 0xffffffffu;
+  Check(fushi_voice_hook::ReadAdapterReports(
+            h, out, fushi_voice_hook::kAdapterReportSlots, &seq) == 0,
+        "未上报时必须读到 0 槽");
+  Check(seq == 0, "未上报时 seq 必须是 0");
+
+  // (b) 正常往返：id / applicable / installed / flags 都要原样回来，且**按槽对号**。
+  fushi_voice_hook::AdapterReportSlot in[3] = {
+      make("cmvs", true, true, 0x11u),
+      make("process_loopback", true, false, 0x22u),
+      make("sgre", false, false, 0x33u),
+  };
+  Check(fushi_voice_hook::PublishAdapterReports(h, in, 3) == 3,
+        "发布 3 槽必须返回 3");
+  Check(fushi_voice_hook::ReadAdapterReports(
+            h, out, fushi_voice_hook::kAdapterReportSlots, &seq) == 3,
+        "必须读回 3 槽");
+  Check(seq == 1, "首次发布后 seq 必须是 1");
+  Check(strcmp(out[0].id, "cmvs") == 0 && out[0].applicable == 1 &&
+            out[0].installed == 1 && out[0].flags == 0x11u,
+        "第 0 槽必须原样回来");
+  Check(strcmp(out[1].id, "process_loopback") == 0 && out[1].applicable == 1 &&
+            out[1].installed == 0,
+        "横切能力那行也要原样回来——它自带 id，不会被误读成引擎判定");
+  Check(strcmp(out[2].id, "sgre") == 0 && out[2].applicable == 0,
+        "probe 为假的行同样要如实回来");
+
+  // (c) adapter 数变少（换了个构建）时，尾部旧槽必须被清掉。不清就会读到上一次的
+  //     probe/installed，而那一行看着完全正常——这正是最难发现的错。
+  fushi_voice_hook::AdapterReportSlot fewer[1] = {make("aos_sfa", true, false, 0u)};
+  Check(fushi_voice_hook::PublishAdapterReports(h, fewer, 1) == 1,
+        "发布 1 槽必须返回 1");
+  Check(fushi_voice_hook::ReadAdapterReports(
+            h, out, fushi_voice_hook::kAdapterReportSlots, &seq) == 1,
+        "槽数必须跟着变少");
+  Check(h->adapter_reports[1].id[0] == '\0' &&
+            h->adapter_reports[1].applicable == 0 &&
+            h->adapter_reports[1].installed == 0,
+        "尾部残留槽必须清零，否则读到的是上一次的读数");
+
+  // (d) id 超长必须截断且仍带 NUL：id 由各 adapter 自己给，长度不受写侧文件控制，
+  //     读侧绝不能因此读出界。
+  char long_id[fushi_voice_hook::kAdapterReportIdChars + 16];
+  for (size_t i = 0; i + 1 < sizeof(long_id); ++i) long_id[i] = 'x';
+  long_id[sizeof(long_id) - 1] = '\0';
+  fushi_voice_hook::AdapterReportSlot huge[1] = {make(long_id, true, true, 0u)};
+  Check(fushi_voice_hook::PublishAdapterReports(h, huge, 1) == 1, "超长 id 也要发布成功");
+  Check(fushi_voice_hook::ReadAdapterReports(
+            h, out, fushi_voice_hook::kAdapterReportSlots, &seq) == 1,
+        "超长 id 仍读回 1 槽");
+  Check(strlen(out[0].id) == fushi_voice_hook::kAdapterReportIdChars - 1,
+        "超长 id 必须截断到槽宽减一");
+
+  // (e) 槽数超过容量必须被夹住，绝不越界写。
+  fushi_voice_hook::AdapterReportSlot many[fushi_voice_hook::kAdapterReportSlots + 4] = {};
+  for (size_t i = 0; i < sizeof(many) / sizeof(many[0]); ++i) many[i] = make("x", true, false, 0u);
+  Check(fushi_voice_hook::PublishAdapterReports(
+            h, many, sizeof(many) / sizeof(many[0])) ==
+            fushi_voice_hook::kAdapterReportSlots,
+        "超过槽数必须被夹到 kAdapterReportSlots");
+
+  // (f) 读侧容量小于已发布槽数时按容量截断，不得越界写调用方缓冲。
+  fushi_voice_hook::AdapterReportSlot small[2] = {};
+  Check(fushi_voice_hook::ReadAdapterReports(h, small, 2, &seq) == 2,
+        "读侧必须按自己的容量截断");
+}
+
 void TestAdmissionRoundTrip() {
   FakeMapping mapping;
   SharedHeader* h = mapping.header();
@@ -1123,6 +1239,7 @@ int main() {
   TestV19AttachedGeometryOwnershipSnapshot();
   TestV19AdmissionIsPureAppendOverV17();
   TestAdmissionRoundTrip();
+  TestAdapterReportRoundTrip();
   TestSha256HexFormatting();
   TestHeaderMirrorsCompileTimeConstants();
   if (g_failures != 0) {

--- a/native/galgame_hook/tests/native_loopback_policy_test.cpp
+++ b/native/galgame_hook/tests/native_loopback_policy_test.cpp
@@ -29,8 +29,8 @@ void Check(bool condition, const char* message) {
 
 void TestV16AndV17TailAbiAndDefaultDeny() {
   SharedHeader header{};
-  Check(fushi_voice_hook::kSharedVersion == 22,
-        "shared ABI must be v22（BUG-2136 层原点双向面在 v19 摘要后纯追加，尺寸变了必须升版）");
+  Check(fushi_voice_hook::kSharedVersion == 23,
+        "shared ABI must be v23（BUG-2149 adapter 运行期读数在层原点块后纯追加，尺寸变了必须升版）");
   Check(offsetof(SharedHeader, native_loopback_request_seq) ==
             offsetof(SharedHeader, native_loopback_requested) + 4,
         "request_seq must follow requested");
@@ -57,20 +57,24 @@ void TestV16AndV17TailAbiAndDefaultDeny() {
             offsetof(SharedHeader, hook_module_sha256) +
                 fushi_voice_hook::kHookModuleDigestChars,
         "v19 admission must be appended after the v17 digest, never inserted");
-  // v22 在 v19 摘要之后又追加了层原点块，所以尾部不再是摘要。守卫要防的始终是
-  // **把字段插进既有布局**，不是禁止继续尾追加——于是这里改锁两条：
-  //   ① v22 块紧接摘要（中间只允许自然对齐填充）；
-  //   ② v22 块的最后一个字段就是当前的精确尾部。
+  // v22 在 v19 摘要之后追加了层原点块，v23 又在其后追加了 adapter 读数块，所以
+  // 尾部不再是摘要、也不再是层原点块。守卫要防的始终是**把字段插进既有布局**，
+  // 不是禁止继续尾追加——于是逐块锁：每一块紧接上一块，最后一块就是精确尾部。
   Check(offsetof(SharedHeader, lookup_layer_line_seq) ==
             (offsetof(SharedHeader, lookup_executable_sha256) +
              fushi_voice_hook::kHookModuleDigestChars + 3u) /
                 4u * 4u,
         "v22 layer-origin block must append right after the v19 digest");
+  // v23 在层原点块之后又追加了 adapter 读数块，尾部因此再次后移。守的仍是同一条：
+  // 新块只能**尾追加**，不得插进既有布局；且当前尾部就是新块的最后一个字段。
+  Check(offsetof(SharedHeader, adapter_reports) >=
+            offsetof(SharedHeader, lookup_layer_reserved) + sizeof(uint32_t),
+        "v23 adapter report block must append after the v22 layer-origin block");
   Check(sizeof(SharedHeader) ==
-            ((offsetof(SharedHeader, lookup_layer_reserved) +
+            ((offsetof(SharedHeader, adapter_report_seq) +
               sizeof(uint32_t) + 7u) /
              8u) * 8u,
-        "v22 layer-origin block must be the exact SharedHeader tail (only 8-align padding)");
+        "v23 adapter report block must be the exact SharedHeader tail (only 8-align padding)");
   Check(fushi_voice_hook::AtomicLoadShared32(
             &header.native_loopback_requested) ==
             fushi_voice_hook::kNativeLoopbackDeny,

--- a/native/galgame_hook/tools/ring_probe.cpp
+++ b/native/galgame_hook/tools/ring_probe.cpp
@@ -2580,13 +2580,26 @@ int main(int argc, char** argv) {
         printf(" (未上报：helper 未起或为 v22 之前的构建)");
       } else {
         bool any = false;
+        bool shared_only = false;
         for (uint32_t i = 0; i < n; ++i) {
           if (!reports[i].applicable && !reports[i].installed) continue;
           any = true;
+          if (!reports[i].applicable && reports[i].installed) shared_only = true;
           printf(" %s=probe:%u/installed:%u", reports[i].id,
                  reports[i].applicable, reports[i].installed);
         }
         if (!any) printf(" 无 adapter 认领（已上报 %u 个，全部 probe=0）", n);
+        // probe:0/installed:1 **不是**矛盾，但不解释就一定会被读成矛盾：
+        // installed 是各 adapter 自定义的，对 siglus / reallive / kirikiri_z 它包含
+        // 「该 adapter 代管的共享中间件装上了」——TryHookSiglusOvk 装的是 KernelBase
+        // 文件 API 共享中转（HUNEX/Malie 都复用它），装成功就置 installed，与本局是不是
+        // Siglus 无关。引擎身份只看 probe。真机实测（chronoclock，CMVS）：siglus/reallive
+        // 报 installed:1 而 hookdiag 里并没有 SiglusOvkHooksReady——后者只在确实是 Siglus
+        // 时才置，两者一致。
+        if (shared_only) {
+          printf("\n                （probe:0/installed:1 不是矛盾：installed 含该 adapter "
+                 "代管的共享中间件；引擎身份只看 probe）");
+        }
       }
     }
     if (twc > 0) {

--- a/native/galgame_hook/tools/ring_probe.cpp
+++ b/native/galgame_hook/tools/ring_probe.cpp
@@ -2565,6 +2565,30 @@ int main(int argc, char** argv) {
            static_cast<unsigned long long>(twc),
            static_cast<unsigned long long>(cwc),
            static_cast<unsigned long long>(uwc));
+    // v23 adapter 读数（BUG-2149）。没有这个读点，「哪个 adapter 认领了、装上没有」
+    // 在真机上仍然看不见——写点有了、读点一个没有，就是这条面原来的病。
+    // 只打 applicable 或 installed 为真的行：21 个 adapter 全打会把真正有信息的那几行
+    // 淹掉；seq==0 时明确说"未上报"，不能与"一个都没认领"混为一谈。
+    {
+      fushi_voice_hook::AdapterReportSlot reports[
+          fushi_voice_hook::kAdapterReportSlots] = {};
+      uint32_t report_seq = 0;
+      const uint32_t n = fushi_voice_hook::ReadAdapterReports(
+          header, reports, fushi_voice_hook::kAdapterReportSlots, &report_seq);
+      printf("\n     [adapters] seq=%u", report_seq);
+      if (report_seq == 0) {
+        printf(" (未上报：helper 未起或为 v22 之前的构建)");
+      } else {
+        bool any = false;
+        for (uint32_t i = 0; i < n; ++i) {
+          if (!reports[i].applicable && !reports[i].installed) continue;
+          any = true;
+          printf(" %s=probe:%u/installed:%u", reports[i].id,
+                 reports[i].applicable, reports[i].installed);
+        }
+        if (!any) printf(" 无 adapter 认领（已上报 %u 个，全部 probe=0）", n);
+      }
+    }
     if (twc > 0) {
       const uint32_t idx =
           static_cast<uint32_t>((twc - 1) % fushi_voice_hook::kTextSlotCount);

--- a/native/galgame_hook/tools/run_guards.ps1
+++ b/native/galgame_hook/tools/run_guards.ps1
@@ -67,6 +67,7 @@ try {
   # and workflow guards.
   Invoke-Checked $python 'tests/engine_support_manifest_test.py'
   Invoke-Checked $python 'tests/adapter_structure_test.py'
+  Invoke-Checked $python 'tests/adapter_report_guard_test.py'
   Invoke-Checked $python 'tests/kirikiri_lookup_source_guard_test.py'
   Invoke-Checked $python 'tests/lookup_presenter_wiring_guard_test.py'
   Invoke-Checked $python 'tests/renpy_lookup_source_guard_test.py'


### PR DESCRIPTION
## 这是什么

`AdapterDiagnostics` 是个**只写接口**——运行期没有任何消费方，于是**任何引擎**都答不出
「我的 adapter 到底有没有被选中并安装」。BUG-2149。

## 怎么发现的

做 ceshi 批量适配时，CMVS 台账里那条 Next gate 写着「探针 `cmvs probe=1 installed=1`」。
真机跑 chronoclock 体験版时**打不出这一对读数**——不是探针失败，是根本没有工具能打。

顺着查：`AdapterDiagnostics`（`id` / `applicable` / `installed` / `flags`）**每个 adapter 都实现了**，
全仓 grep 下来却只有 `tests/adapter_contract_test.cpp` 在读。

所以这不是 CMVS 一家的事。`native/galgame_hook/CLAUDE.md` 的证据门要求逐门可判
（`process_found → helper_ready → …`），而「adapter 认领了没有」正是第一道门——
写了没人读的接口，等于这道门在真机上是瞎的。

## 改法

IPC **v22 → v23**：`SharedHeader` 尾部**纯追加** `AdapterReportSlot adapter_reports[32]` + `count` + `seq`。

- **写者唯一**：`AdapterRegistry::Poll` → `PublishAdapterReportSnapshot()`，与既有的
  `PublishLookupAdmissionSummary()` 同处、同纪律（内容先写、seq 最后发布）。
- **槽自带 id 字符串**，不按注册顺序编号。下标制在有人往 `hook/generated/adapter_*.inc`
  中间插一行时会整体错位，而且**不报错**——读数看着正常，说的却是另一个 adapter。
- **复用同一份生成清单**（函数内 `consider` lambda + `#include "generated/adapter_admission.inc"`），
  脚手架登记的新引擎自动进读数，不存在第二份会漂移的清单。
- **限速 1 秒**：`diagnostics()` 内部会调 `probe()`，而 CMVS / AOS / Unreal 的 probe 要读盘枚举，
  Poll 最快 16 ms 一轮；诊断面没有低延迟需求，不该为它每秒付几十次目录枚举。
- **读点**在 `ring_probe`：打 `[adapters] seq=N id=probe:x/installed:y`，并把
  「seq==0 未上报」与「上报了但无人认领」明确分开——混一起会在 helper 起来前稳定误报。

**为什么必须升版**：两侧都用 `sizeof(SharedHeader)` 现算 ring / region 基址，新旧混装会整体
错位而版本门本会放行（与 v22 完全同理）。两处既有的版本钉随之更新，并给 v23 块补上
**同等强度的逐字段布局锁**——否则新块就成了没人守的自由区，而它恰恰在那个按 sizeof 现算
基址的结构里。

## 测试

- **新增** `tests/adapter_report_guard_test.py`（10 条 + 2 条变异自测）。核心守
  「**声明的 adapter 成员集合 ⊆ 上报集合**」：最危险的失败形状不是编译错误，而是有人加了
  adapter 却没进读数——读数少一行，关于那个引擎的诊断继续答不出来，而且没有任何东西会红。
  另守写点被调用、限速真的比较了时间差、发布器清尾部残留槽、读点存在、布局变了必须升版、
  槽必须自带 id。
  （顺带一提：仓库有条元守卫会抓「新写的守卫没登记进 `run_guards.ps1`」，本轮就被它抓过一次。）
- `lookup_ipc_contract_test` 新增 `TestAdapterReportRoundTrip()`：未上报读 0 槽、正常往返按槽对号、
  adapter 变少时尾部旧槽必须清零（否则读到上一次的 probe/installed）、超长 id 截断且带 NUL、
  写侧超容量夹住、读侧按自身容量截断。

## 状态

- 守卫 **11 套全绿**、`build_distribution` exit 0、双架构 **CTest 64/64**。
- ⚠️ **端到端未验**：写点与读点各自有测试，但「在真游戏上打出那一行」尚未跑过
  （改动时用户在用机器，不启动游戏打断）。桌面空闲后拿 chronoclock 体験版复验，
  那同时就是 CMVS 台账里那条 Next gate。**在此之前不宣称本条面可用。**
