### PR TITLE
fix(anki): iOS AnkiMobile 配置回传等 app active 后再读剪贴板（BUG-2150）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2019 条。点号进各自文件。
+> 共 2020 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2150](bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md) | ✅ | ✅ | iOS AnkiMobile 配置回传读不到剪贴板：URL 回调跑在 .inactive 阶段 |
 | [BUG-2145](bugs/BUG-2145-gal-kirikiri2-no-export-table-and-late-loadlibrary-hook.md) | ✅ | ✅ | KiriKiri2 无导出表 + 插件早于 LoadLibrary hook link：两条 exporter 路径同时静默落空，游戏内查词整条不装 |
 | [BUG-2144](bugs/BUG-2144-gal-kirikiri2-bcb-exception-escapes-msvc-catch.md) | ✅ | ✅ | KiriKiri2/BCB 上 TJS 抛的 Borland 异常穿透 MSVC catch(...)，注入的每帧求值把游戏打成致命错误框并强制写快速存档 |
 | [BUG-2143](bugs/BUG-2143-attached-status-without-reason-undiagnosable.md) | ✅ | 🚧 | attached 状态机十二处 `needsRiskAcceptance` / `needsCalibration` / `waitingForBodyThread` 不带 reason，真机上无法定位是哪条分支 |

--- a/docs/bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md
+++ b/docs/bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md
@@ -1,0 +1,56 @@
+## BUG-2150 · iOS AnkiMobile 配置回传读不到剪贴板：URL 回调跑在 .inactive 阶段
+- **报告**：2026-09-05（用户：两张 iPhone 截图 —— ① 从 Anki 返回后首页弹红条 `No AnkiMobile configuration was found on the clipboard.`；② 制卡设置页显示 `AnkiMobile opened. Approve the request, then return to Fushi.`，两句都是中文 UI 里的英文原文）
+- **真实性**：✅ 真 bug。根因 `fushi/ios/Runner/AppDelegate.swift:64`（原）：方法通道 `consumeInfoForAddingPasteboard` 在收到调用的那一刻直接 `UIPasteboard.general.data(forPasteboardType: "net.ankimobile.json")`。
+  而这个调用的触发链是 **AnkiMobile 的 x-success 把 Fushi 拉回前台**：
+  `fetchConfiguration` 打开 `anki://x-callback-url/infoForAdding?x-success=fushi://ankiFetch`
+  （`fushi/lib/src/anki/ankimobile_repository.dart:111`）→ AnkiMobile 写剪贴板后回跳 →
+  iOS 调 `application(_:open:options:)`（`AppDelegate.swift:221` 原）→ `deliverUrl` → EventChannel →
+  `fushi/lib/main.dart:1059` `handleIncomingUrl` → `:1072` `consumeInfoForAddingPasteboard`。
+  **iOS 在 URL-driven resume 上的文档顺序是 `willEnterForeground` → `application(_:open:)` → `didBecomeActive`**，
+  也就是说整条链跑在 app `.inactive` 阶段。iOS 只允许**前台活跃**的 app 读别的 app 写进通用剪贴板的内容
+  （iOS 16+ 还要为此弹一次系统「允许粘贴」确认，而弹窗只有 active 的 app 能呈现），于是读必然拿到 nil。
+  剪贴板类型和「读完清空」的写法本身没错 —— 与 AnkiMobile 官方手册 URL Schemes 一节给的示例逐字一致。
+
+  **第二个缺陷（同一条错误信息）**：`fushi/lib/src/anki/ankimobile_repository.dart:128`（原）把三种**下一步动作完全不同**的
+  情形压成同一句硬编码英文：① AnkiMobile 根本没写（用户没在 AnkiMobile 里同意那次请求 —— 官方手册原话
+  "If the user authorises the request"）；② 写了但系统不让读；③ 真空。而且 `fetchConfiguration` 的两句、
+  `consume` 的三句全部没有稳定码，`AnkiViewModel.localizeAnkiFetchError` 只能原样透传英文 —— 截图里中文 UI 显示英文即此。
+
+- **[x] ① 已修复** —
+  - **时序（根因）**：`fushi/ios/Runner/AppDelegate.swift` 新增 `consumeAnkiMobilePasteboard(result:)`：读取的前置条件从
+    「URL 回调到了」改成「app 真的 active 了」。非 active 时挂一次性 `UIApplication.didBecomeActiveNotification`
+    观察者，等真正活跃后再读；`ankiMobilePasteboardActiveTimeout = 5s` 兜底，超时仍尽力读一次并如实报告，
+    不让 Dart 侧的 Future 永久挂起。`FlutterResult` 由 `finished` 闸门保证恰好回调一次。
+  - **三态（诊断）**：新增 `readAnkiMobilePasteboard()` 返回 `{status, json}`，用 **不触发粘贴确认弹窗** 的元数据 API
+    `UIPasteboard.general.contains(pasteboardTypes:)` 把 `denied`（数据在、系统不让读）与 `empty`（AnkiMobile 没写）分开；
+    「类型在但内容为空」归 `empty`（那是我们自己取走后写回的空 `Data`，不是被拒）。
+  - **Dart 契约**：`AnkiMobileInfoReader` 由 `Future<String?>` 改为 `Future<AnkiMobilePasteboardRead>`
+    （`AnkiMobilePasteboardStatus{ok,empty,denied}`），`consumeInfoForAddingPasteboard` 按三态分流。
+  - **文案**：新增 5 个稳定码 `AnkiErrorCode.ankiMobileOpened / ankiMobilePasteboardEmpty /
+    ankiMobilePasteboardDenied / ankiMobileNoDecks / ankiMobileUnavailable`
+    （`packages/fushi_anki/lib/src/anki_models.dart`），经 `AnkiViewModel.localizeAnkiFetchError`
+    与 `localizeAnkiMineError`（`fushi/lib/src/utils/misc/error_log_service.dart`）映射到 5 个新 i18n key
+    （17 语言，`i18n_sync --add` + `dart run slang`）。制卡路径的「打不开 AnkiMobile」共用同一个码。
+  - **顺带**：`fetchConfiguration` 的 `infoForAdding` URL 改走 `_buildAnkiMobileQuery`，与 BUG-558 为 `addnote`
+    定下的百分号编码规则统一 —— 此前它是同一个类里的第二套编码（`Uri.replace(queryParameters:)` 把空格编成 `+`）。
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/anki/ankimobile_pasteboard_states_test.dart`（新，12 条）：三态各自的稳定码、
+    `denied`/`empty` 不共用码也不共用文案、`ok` 但 json 为空按 `empty` 处理、`fetchConfiguration` 两个码、
+    `x-success` 百分号编码、以及「五个码在中文 UI 下都不再吐英文原文且五条互不相同」。
+  - `fushi/test/anki/ankimobile_ios_callback_static_test.dart`（+2 条）：Swift 进不了 `flutter test`，
+    源码守卫是这层唯一可落地的自动化。守「方法通道的 case 只许分发给带时序门的 helper、不许在那一刻直接碰
+    `UIPasteboard`」+「`applicationState == .active` / `didBecomeActiveNotification` / `removeObserver` 必须在」
+    +「`pasteboardTypes:` 非提示性探测与 `denied`/`empty` 两态必须在」。截取 case body 时带自检，避免恒真。
+  - **变异实测**（不是「写了守卫就算数」）：把 case 改回「回调那一刻直接读」→ 守卫红，理由
+    「case 必须分发给带 active 门的 helper」；单独把 `applicationState == .active` 改成 `true` → 守卫红，
+    `Expected: contains 'UIApplication.shared.applicationState == .active'`。两次都还原后复绿。
+- **备注**：
+  - **真机缺口**：AnkiMobile 是 App Store 付费 app，装不进模拟器，本机也没有能跑它的 iOS 设备，所以
+    「回到原始失败路径复测」这一步没做。已做到的最强验证是：Swift 侧在远程 Mac（macOS 26.6.1 /
+    iPhoneSimulator26.5 SDK）上 `swiftc -parse` 整文件通过，并把新增的两个方法**逐字抽出**对 iOS SDK
+    `swiftc -typecheck -target arm64-apple-ios15.0-simulator` 通过（UIPasteboard API 名、闭包捕获、
+    `DispatchWorkItem`、通知观察者、`[String: Any]` 返回全部成立）；Dart 侧三态契约与文案 318 条测试全绿。
+  - 若真机复测后仍失败，本次改动已把结果收敛成两句可判读的话：看到「AnkiMobile 没有回传配置」= AnkiMobile
+    那一侧没写（多半没点同意 / 版本太老），看到「iOS 阻止了读取剪贴板」= 系统粘贴权限那一关。原来那句
+    「剪贴板上没有配置」两种都可能，无法据以决定下一步。
+  - 新增 5 个 i18n key 的 15 个非 en/zh-CN 语言按 `i18n_sync --add` 的既有行为落的是英文值，属既有翻译欠账。

--- a/docs/bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md
+++ b/docs/bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md
@@ -33,10 +33,17 @@
     （17 语言，`i18n_sync --add` + `dart run slang`）。制卡路径的「打不开 AnkiMobile」共用同一个码。
   - **顺带**：`fetchConfiguration` 的 `infoForAdding` URL 改走 `_buildAnkiMobileQuery`，与 BUG-558 为 `addnote`
     定下的百分号编码规则统一 —— 此前它是同一个类里的第二套编码（`Uri.replace(queryParameters:)` 把空格编成 `+`）。
+  - **UI 尾巴（同一条链路）**：`AnkiViewModel.reloadSettings()` 只装载 settings、**从不清 `errorMessage`**，
+    而它唯一的调用点就是 `main.dart` 里回传成功那一支。于是即便配置成功落地，设置页仍挂着
+    `fetchConfiguration` 写下的中间态「已打开 AnkiMobile，请去同意」——在用户眼里就是「又失败了一次」。
+    改为语义明确的 `applyFetchedConfiguration()`（装载 + `isFetching: false` + `clearError: true`），
+    并且**不复用** `_loadSettings()`：那条路在「选了牌组但可用列表为空」时会反过来再触发一次
+    `fetchConfiguration()`，把用户又弹去 AnkiMobile。
 - **[x] ② 已加自动化测试** —
   - `fushi/test/anki/ankimobile_pasteboard_states_test.dart`（新，12 条）：三态各自的稳定码、
     `denied`/`empty` 不共用码也不共用文案、`ok` 但 json 为空按 `empty` 处理、`fetchConfiguration` 两个码、
     `x-success` 百分号编码、以及「五个码在中文 UI 下都不再吐英文原文且五条互不相同」。
+  - 同文件另一条：`fetchConfiguration()` 写下中间态后，`applyFetchedConfiguration()` 必须把它清空。
   - `fushi/test/anki/ankimobile_ios_callback_static_test.dart`（+2 条）：Swift 进不了 `flutter test`，
     源码守卫是这层唯一可落地的自动化。守「方法通道的 case 只许分发给带时序门的 helper、不许在那一刻直接碰
     `UIPasteboard`」+「`applicationState == .active` / `didBecomeActiveNotification` / `removeObserver` 必须在」

--- a/fushi/ios/Runner/AppDelegate.swift
+++ b/fushi/ios/Runner/AppDelegate.swift
@@ -4,6 +4,9 @@ import Flutter
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterStreamHandler, FlutterImplicitEngineDelegate {
   private static let ankiMobilePasteboardType = "net.ankimobile.json"
+  /// BUG-2150: how long to wait for the app to actually become active after an
+  /// AnkiMobile x-callback return before giving up and reading anyway.
+  private static let ankiMobilePasteboardActiveTimeout: TimeInterval = 5
   private var initialUrl: String?
   private var urlEventSink: FlutterEventSink?
   private var ankiMobileMediaBackgroundTask: UIBackgroundTaskIdentifier = .invalid
@@ -61,16 +64,7 @@ import Flutter
     ankiMobileChannel.setMethodCallHandler { [weak self] (call, result) in
       switch call.method {
       case "consumeInfoForAddingPasteboard":
-        if let data = UIPasteboard.general.data(
-          forPasteboardType: Self.ankiMobilePasteboardType
-        ) {
-          UIPasteboard.general.setData(
-            Data(),
-            forPasteboardType: Self.ankiMobilePasteboardType)
-          result(String(data: data, encoding: .utf8))
-        } else {
-          result(nil)
-        }
+        Self.consumeAnkiMobilePasteboard(result: result)
       case "beginMediaImportBackgroundTask":
         self?.beginAnkiMobileMediaBackgroundTask()
         result(nil)
@@ -251,6 +245,83 @@ import Flutter
   func onCancel(withArguments arguments: Any?) -> FlutterError? {
     urlEventSink = nil
     return nil
+  }
+
+  /// 读取 AnkiMobile 经系统剪贴板回传的 `infoForAdding` JSON（BUG-2150）。
+  ///
+  /// 前置条件不是「URL 回调到了」，而是「app 真的 active 了」：iOS 只允许**前台活跃**
+  /// 的 app 读别的 app 写进通用剪贴板的内容，iOS 16+ 还要为此弹一次系统「允许粘贴」
+  /// 确认，而这个弹窗只有 active 的 app 能呈现。AnkiMobile 的
+  /// `x-success=fushi://ankiFetch` 把我们拉回前台时，系统的调用顺序是
+  /// `willEnterForeground` → `application(_:open:)` → `didBecomeActive`，也就是说
+  /// URL 回调整个跑在 `.inactive` 阶段。旧实现就在这一刻直接读剪贴板，必然拿到 nil，
+  /// 用户看到的却是「剪贴板上没有 AnkiMobile 配置」——一句与事实无关的错误。
+  ///
+  /// 非 active 时挂一次性 `didBecomeActiveNotification` 观察者，等真正活跃后再读；
+  /// 万一始终等不到（用户又切走了），超时后仍尽力读一次并如实报告看到的状态，而不是
+  /// 无限挂起让 Dart 侧的 Future 永不完成。
+  private static func consumeAnkiMobilePasteboard(result: @escaping FlutterResult) {
+    if UIApplication.shared.applicationState == .active {
+      result(readAnkiMobilePasteboard())
+      return
+    }
+
+    var observer: NSObjectProtocol? = nil
+    var timeout: DispatchWorkItem? = nil
+    var finished = false
+    // FlutterResult 必须恰好回调一次：两条路径（变 active / 超时）共用这道闸门。
+    let finish = {
+      guard !finished else { return }
+      finished = true
+      timeout?.cancel()
+      if let observer = observer {
+        NotificationCenter.default.removeObserver(observer)
+      }
+      result(readAnkiMobilePasteboard())
+    }
+
+    observer = NotificationCenter.default.addObserver(
+      forName: UIApplication.didBecomeActiveNotification,
+      object: nil,
+      queue: .main
+    ) { _ in finish() }
+
+    let work = DispatchWorkItem { finish() }
+    timeout = work
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + ankiMobilePasteboardActiveTimeout,
+      execute: work)
+  }
+
+  /// 三态读取（BUG-2150）。这三种情形用户的下一步动作完全不同，压成一句
+  /// 「剪贴板上没有 AnkiMobile 配置」只会把人带进死路：
+  /// - `ok`：读到 JSON，按官方手册取走后清空剪贴板；
+  /// - `denied`：剪贴板上**确实有** AnkiMobile 写的数据，但系统不让读——用户选了
+  ///   「不允许粘贴」，或此刻根本弹不出确认；
+  /// - `empty`：AnkiMobile 压根没写，通常是用户没在 AnkiMobile 里同意那次请求。
+  ///
+  /// `contains(pasteboardTypes:)` 只查元数据、不访问内容，不会触发粘贴确认弹窗，
+  /// 因此可以拿它把 `denied` 和 `empty` 分开。
+  /// 「类型在但内容为空」归 `empty`：那是我们自己取走后写回的空 Data（重复消费同一次
+  /// 回调时会撞上），不是被拒绝。
+  private static func readAnkiMobilePasteboard() -> [String: Any] {
+    let data = UIPasteboard.general.data(
+      forPasteboardType: ankiMobilePasteboardType)
+    if let data = data, !data.isEmpty,
+      let json = String(data: data, encoding: .utf8), !json.isEmpty
+    {
+      // 官方手册要求取走后清空剪贴板。
+      UIPasteboard.general.setData(
+        Data(),
+        forPasteboardType: ankiMobilePasteboardType)
+      return ["status": "ok", "json": json]
+    }
+    if data != nil {
+      return ["status": "empty"]
+    }
+    let hasType = UIPasteboard.general.contains(
+      pasteboardTypes: [ankiMobilePasteboardType])
+    return ["status": hasType ? "denied" : "empty"]
   }
 
   private func beginAnkiMobileMediaBackgroundTask() {

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 72046 (4238 per locale)
+/// Strings: 72131 (4243 per locale)
 ///
-/// Built on 2026-09-04 at 17:14 UTC
+/// Built on 2026-09-05 at 05:39 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5823,6 +5823,16 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -15710,6 +15720,21 @@ class _StringsAr extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -25824,6 +25849,21 @@ class _StringsDe extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -35991,6 +36031,21 @@ class _StringsEs extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -46192,6 +46247,21 @@ class _StringsFr extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -56197,6 +56267,21 @@ class _StringsId extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -66294,6 +66379,21 @@ class _StringsIt extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -75778,6 +75878,21 @@ class _StringsJa extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -85272,6 +85387,21 @@ class _StringsKo extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -95324,6 +95454,21 @@ class _StringsNl extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -105430,6 +105575,21 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -115514,6 +115674,21 @@ class _StringsRu extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -125397,6 +125572,21 @@ class _StringsTh extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -135397,6 +135587,21 @@ class _StringsTr extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -145368,6 +145573,21 @@ class _StringsVi extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 // Path: <root>
@@ -154532,6 +154752,19 @@ class _StringsZhCn extends _StringsEn {
       '鼠标触发只接受侧键（后退/前进）。其它按钮在别的程序里有各自的固有含义，这里会拒绝录入。';
   @override
   String get shortcut_mouse_button_not_supported => '该动作只接受鼠标侧键（后退/前进）。';
+  @override
+  String get anki_ankimobile_opened => '已打开 AnkiMobile。请在其中同意该请求，然后返回 Fushi。';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile 没有回传配置。请在 AnkiMobile 中同意该请求后再返回 Fushi。';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS 阻止了读取剪贴板。返回 Fushi 时请在系统提示里选「允许粘贴」，然后重试。';
+  @override
+  String get anki_error_ankimobile_no_decks => 'AnkiMobile 没有回传任何牌组或笔记类型。';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      '无法打开 AnkiMobile。请先安装 AnkiMobile 再试。';
 }
 
 // Path: <root>
@@ -163709,6 +163942,21 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get shortcut_mouse_button_not_supported =>
       'This action only accepts mouse side buttons (back/forward).';
+  @override
+  String get anki_ankimobile_opened =>
+      'AnkiMobile opened. Approve the request there, then return to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_empty =>
+      'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+  @override
+  String get anki_error_ankimobile_pasteboard_denied =>
+      'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+  @override
+  String get anki_error_ankimobile_no_decks =>
+      'AnkiMobile returned no decks or note types.';
+  @override
+  String get anki_error_ankimobile_unavailable =>
+      'Could not open AnkiMobile. Install AnkiMobile and try again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -172403,6 +172651,16 @@ extension on _StringsEn {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -181092,6 +181350,16 @@ extension on _StringsAr {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -189826,6 +190094,16 @@ extension on _StringsDe {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -198551,6 +198829,16 @@ extension on _StringsEs {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -207285,6 +207573,16 @@ extension on _StringsFr {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -215990,6 +216288,16 @@ extension on _StringsId {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -224717,6 +225025,16 @@ extension on _StringsIt {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -233371,6 +233689,16 @@ extension on _StringsJa {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -242029,6 +242357,16 @@ extension on _StringsKo {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -250749,6 +251087,16 @@ extension on _StringsNl {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -259464,6 +259812,16 @@ extension on _StringsPtBr {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -268186,6 +268544,16 @@ extension on _StringsRu {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -276880,6 +277248,16 @@ extension on _StringsTh {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -285589,6 +285967,16 @@ extension on _StringsTr {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -294292,6 +294680,16 @@ extension on _StringsVi {
         return 'Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }
@@ -302921,6 +303319,16 @@ extension on _StringsZhCn {
         return '鼠标触发只接受侧键（后退/前进）。其它按钮在别的程序里有各自的固有含义，这里会拒绝录入。';
       case 'shortcut_mouse_button_not_supported':
         return '该动作只接受鼠标侧键（后退/前进）。';
+      case 'anki_ankimobile_opened':
+        return '已打开 AnkiMobile。请在其中同意该请求，然后返回 Fushi。';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile 没有回传配置。请在 AnkiMobile 中同意该请求后再返回 Fushi。';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS 阻止了读取剪贴板。返回 Fushi 时请在系统提示里选「允许粘贴」，然后重试。';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile 没有回传任何牌组或笔记类型。';
+      case 'anki_error_ankimobile_unavailable':
+        return '无法打开 AnkiMobile。请先安装 AnkiMobile 再试。';
       default:
         return null;
     }
@@ -311553,6 +311961,16 @@ extension on _StringsZhHk {
         return '鼠标触发只接受侧键（后退/前进）。其它按钮在别的程序里有各自的固有含义，这里会拒绝录入。';
       case 'shortcut_mouse_button_not_supported':
         return 'This action only accepts mouse side buttons (back/forward).';
+      case 'anki_ankimobile_opened':
+        return 'AnkiMobile opened. Approve the request there, then return to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_empty':
+        return 'AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.';
+      case 'anki_error_ankimobile_pasteboard_denied':
+        return 'iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.';
+      case 'anki_error_ankimobile_no_decks':
+        return 'AnkiMobile returned no decks or note types.';
+      case 'anki_error_ankimobile_unavailable':
+        return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "Mouse triggers accept side buttons only (back/forward). Other buttons keep their normal meaning in other apps, so they are rejected here.",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "从台词出现到制卡这段时间的游戏画面，并混入句子音频。未开始录制或不足 2 帧时降级为动图/截图。",
   "game_hook_reason_native_loopback_ack_timeout": "音频采集策略未在超时内确认。文本采集不受影响；若缺少游戏内语音可重试一次。",
   "shortcut_scope_global_external_desktop_note": "鼠标触发只接受侧键（后退/前进）。其它按钮在别的程序里有各自的固有含义，这里会拒绝录入。",
-  "shortcut_mouse_button_not_supported": "该动作只接受鼠标侧键（后退/前进）。"
+  "shortcut_mouse_button_not_supported": "该动作只接受鼠标侧键（后退/前进）。",
+  "anki_ankimobile_opened": "已打开 AnkiMobile。请在其中同意该请求，然后返回 Fushi。",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile 没有回传配置。请在 AnkiMobile 中同意该请求后再返回 Fushi。",
+  "anki_error_ankimobile_pasteboard_denied": "iOS 阻止了读取剪贴板。返回 Fushi 时请在系统提示里选「允许粘贴」，然后重试。",
+  "anki_error_ankimobile_no_decks": "AnkiMobile 没有回传任何牌组或笔记类型。",
+  "anki_error_ankimobile_unavailable": "无法打开 AnkiMobile。请先安装 AnkiMobile 再试。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4236,5 +4236,10 @@
   "gal_mining_image_mode_video_clip_hint": "Records the game window from the moment the line appears until you mine the card, mixed with the sentence audio. Falls back to an animated image or screenshot when recording has not started or fewer than 2 frames were captured.",
   "game_hook_reason_native_loopback_ack_timeout": "The audio capture policy was not confirmed in time. Text capture still works; try again if game audio is missing.",
   "shortcut_scope_global_external_desktop_note": "鼠标触发只接受侧键（后退/前进）。其它按钮在别的程序里有各自的固有含义，这里会拒绝录入。",
-  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward)."
+  "shortcut_mouse_button_not_supported": "This action only accepts mouse side buttons (back/forward).",
+  "anki_ankimobile_opened": "AnkiMobile opened. Approve the request there, then return to Fushi.",
+  "anki_error_ankimobile_pasteboard_empty": "AnkiMobile did not return any configuration. Approve the request in AnkiMobile, then come back to Fushi.",
+  "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
+  "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
+  "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again."
 }

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1072,7 +1072,9 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
     final result = await repo.consumeInfoForAddingPasteboard();
     switch (result) {
       case AnkiFetchSuccess():
-        await ref.read(ankiViewModelProvider.notifier).reloadSettings();
+        await ref
+            .read(ankiViewModelProvider.notifier)
+            .applyFetchedConfiguration();
         FushiToast.show(
           msg: 'AnkiMobile configuration imported.',
           severity: ToastSeverity.success,

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -93,6 +93,20 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
     if (code == AnkiErrorCode.collectionUnavailable) {
       return t.anki_error_collection_unavailable;
     }
+    // BUG-2150：iOS AnkiMobile 的配置回传（URL scheme + 系统剪贴板）此前把「已跳转、
+    // 等你去同意」「AnkiMobile 没写」「系统不让读」三种情形压成同一句硬编码英文
+    // 「No AnkiMobile configuration was found on the clipboard.」——用户既看不出该做
+    // 什么，中文 UI 里也是英文。按稳定码分开映射。
+    switch (code) {
+      case AnkiErrorCode.ankiMobileOpened:
+        return t.anki_ankimobile_opened;
+      case AnkiErrorCode.ankiMobilePasteboardEmpty:
+        return t.anki_error_ankimobile_pasteboard_empty;
+      case AnkiErrorCode.ankiMobilePasteboardDenied:
+        return t.anki_error_ankimobile_pasteboard_denied;
+      case AnkiErrorCode.ankiMobileNoDecks:
+        return t.anki_error_ankimobile_no_decks;
+    }
     // TODO-752a：AnkiConnect 网络错误也按稳定码本地化（与制卡 toast 同一组码），
     // 不再透传后端拼好的英文/可能乱码的 [message]。
     final String? mineLocalized = localizeAnkiMineError(code);

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -66,7 +66,22 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
     }
   }
 
-  Future<void> reloadSettings() => _loadSettings();
+  /// BUG-2150：AnkiMobile 的配置回传是**跨 app 异步**完成的——
+  /// [fetchConfiguration] 只能先把「已跳转 AnkiMobile，去那边点同意」写进
+  /// [AnkiUiState.errorMessage]，真正的结果稍后经 `fushi://ankiFetch` 回调送达。
+  /// 回调成功时必须把那条中间态一并清掉，否则设置页会一直挂着「请去同意」，
+  /// 在用户眼里就是「又失败了一次」。
+  ///
+  /// 这里不复用 `_loadSettings()`：那条路只负责装载，还会在「选了牌组但可用列表为空」
+  /// 时反过来再触发一次 [fetchConfiguration]（又把用户弹去 AnkiMobile）。
+  Future<void> applyFetchedConfiguration() async {
+    final settings = await _repository.loadSettings();
+    state = state.copyWith(
+      settings: settings,
+      isFetching: false,
+      clearError: true,
+    );
+  }
 
   Future<void> fetchConfiguration() async {
     state = state.copyWith(isFetching: true, clearError: true);

--- a/fushi/lib/src/anki/ankimobile_repository.dart
+++ b/fushi/lib/src/anki/ankimobile_repository.dart
@@ -9,7 +9,7 @@ import 'package:fushi_anki/fushi_anki.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 typedef AnkiMobileUrlOpener = Future<bool> Function(Uri uri);
-typedef AnkiMobileInfoReader = Future<String?> Function();
+typedef AnkiMobileInfoReader = Future<AnkiMobilePasteboardRead> Function();
 typedef AnkiMobileBackgroundTaskHandler = Future<void> Function();
 typedef _AnkiMobileLocalMediaRefBuilder = Future<String?> Function(
   String filePath, {
@@ -20,6 +20,40 @@ const String ankiMobileInfoCallback = 'anki://x-callback-url/infoForAdding';
 const String ankiMobileAddNoteCallback = 'anki://x-callback-url/addnote';
 const String fushiAnkiFetchCallback = 'fushi://ankiFetch';
 const String fushiAnkiSuccessCallback = 'fushi://ankiSuccess';
+
+/// AnkiMobile 把 `infoForAdding` 的结果放在系统剪贴板上（自定义类型
+/// `net.ankimobile.json`）。读取只有三种结局，且**用户的下一步动作各不相同**——
+/// BUG-2150 之前它们被压成同一句「剪贴板上没有 AnkiMobile 配置」，把人带进死路。
+enum AnkiMobilePasteboardStatus {
+  /// 读到了 JSON。
+  ok,
+
+  /// 剪贴板上没有 AnkiMobile 的数据：通常是用户没在 AnkiMobile 里同意那次请求
+  /// （官方手册：「If the user authorises the request…」），或 AnkiMobile 太老。
+  empty,
+
+  /// 数据在，但系统不让读：用户在 iOS 的「允许粘贴」提示里选了不允许，或此刻
+  /// 根本弹不出那个提示。
+  denied,
+}
+
+/// 一次剪贴板读取的结果。[json] 仅在 [status] == [AnkiMobilePasteboardStatus.ok]
+/// 时有值。
+class AnkiMobilePasteboardRead {
+  const AnkiMobilePasteboardRead(this.status, {this.json});
+
+  const AnkiMobilePasteboardRead.ok(String json)
+      : this(AnkiMobilePasteboardStatus.ok, json: json);
+
+  const AnkiMobilePasteboardRead.empty()
+      : this(AnkiMobilePasteboardStatus.empty);
+
+  const AnkiMobilePasteboardRead.denied()
+      : this(AnkiMobilePasteboardStatus.denied);
+
+  final AnkiMobilePasteboardStatus status;
+  final String? json;
+}
 
 const MethodChannel _ankiMobileChannel =
     MethodChannel('app.fushi.reader/ankimobile');
@@ -81,8 +115,26 @@ class AnkiMobileRepository extends BaseAnkiRepository {
   static Future<bool> _openExternalUrl(Uri uri) =>
       launchUrl(uri, mode: LaunchMode.externalApplication);
 
-  static Future<String?> _readInfoForAddingJsonFromPlatform() =>
-      _ankiMobileChannel.invokeMethod<String>('consumeInfoForAddingPasteboard');
+  /// BUG-2150：原生侧返回 `{status, json}`，而不再是裸 JSON 字符串——「没读到」
+  /// 必须能区分「AnkiMobile 没写」与「系统不让读」。未知/缺失一律按 empty 处理。
+  static Future<AnkiMobilePasteboardRead>
+      _readInfoForAddingJsonFromPlatform() async {
+    final Map<Object?, Object?>? raw = await _ankiMobileChannel
+        .invokeMethod<Map<Object?, Object?>>('consumeInfoForAddingPasteboard');
+    if (raw == null) return const AnkiMobilePasteboardRead.empty();
+    final String? json = raw['json'] as String?;
+    switch (raw['status']) {
+      case 'ok':
+        if (json == null || json.trim().isEmpty) {
+          return const AnkiMobilePasteboardRead.empty();
+        }
+        return AnkiMobilePasteboardRead.ok(json);
+      case 'denied':
+        return const AnkiMobilePasteboardRead.denied();
+      default:
+        return const AnkiMobilePasteboardRead.empty();
+    }
+  }
 
   static Future<void> _beginMediaImportBackgroundTaskFromPlatform() async {
     if (!Platform.isIOS) return;
@@ -108,27 +160,46 @@ class AnkiMobileRepository extends BaseAnkiRepository {
 
   @override
   Future<AnkiFetchResult> fetchConfiguration() async {
-    final uri = Uri.parse(ankiMobileInfoCallback).replace(
-      queryParameters: const <String, String>{
-        'x-success': fushiAnkiFetchCallback,
-      },
-    );
+    // BUG-558 定下的编码规则对整个类成立：query 一律走 `_buildAnkiMobileQuery`
+    // （百分号编码、空格 `%20`），不要在这里退回 `Uri.replace(queryParameters:)`
+    // ——那条路把空格编成 `+`，是同一个类里的第二套编码规则。
+    const List<MapEntry<String, String>> query = <MapEntry<String, String>>[
+      MapEntry('x-success', fushiAnkiFetchCallback),
+    ];
+    final uri = Uri.parse(
+        '$ankiMobileInfoCallback?${_buildAnkiMobileQuery(query)}');
     final opened = await _openUrl(uri);
     if (!opened) {
       return const AnkiFetchResult.error(
         'Could not open AnkiMobile. Install AnkiMobile and try again.',
+        code: AnkiErrorCode.ankiMobileUnavailable,
       );
     }
+    // 不是失败，是「等用户去 AnkiMobile 里点同意」的中间态：真正的结果随后经
+    // `fushi://ankiFetch` 回调进 [consumeInfoForAddingPasteboard]。
     return const AnkiFetchResult.error(
       'AnkiMobile opened. Approve the request, then return to Fushi.',
+      code: AnkiErrorCode.ankiMobileOpened,
     );
   }
 
   Future<AnkiFetchResult> consumeInfoForAddingPasteboard() async {
-    final raw = await _readInfoForAddingJson();
-    if (raw == null || raw.trim().isEmpty) {
+    final read = await _readInfoForAddingJson();
+    final String? raw = read.json;
+    if (read.status == AnkiMobilePasteboardStatus.denied) {
       return const AnkiFetchResult.error(
-        'No AnkiMobile configuration was found on the clipboard.',
+        'iOS blocked reading the clipboard. Choose Allow Paste when returning '
+        'to Fushi, then try again.',
+        code: AnkiErrorCode.ankiMobilePasteboardDenied,
+      );
+    }
+    if (read.status != AnkiMobilePasteboardStatus.ok ||
+        raw == null ||
+        raw.trim().isEmpty) {
+      return const AnkiFetchResult.error(
+        "AnkiMobile didn't return any configuration. Approve the request in "
+        'AnkiMobile, then come back to Fushi.',
+        code: AnkiErrorCode.ankiMobilePasteboardEmpty,
       );
     }
 
@@ -144,6 +215,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
     if (info.decks.isEmpty || info.noteTypes.isEmpty) {
       return const AnkiFetchResult.error(
         'AnkiMobile returned no decks or note types.',
+        code: AnkiErrorCode.ankiMobileNoDecks,
       );
     }
 
@@ -321,6 +393,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
         await closeMediaServerKeepAlive();
         return MineOutcome.failure(
           'Could not open AnkiMobile. Install AnkiMobile and try again.',
+          errorCode: AnkiErrorCode.ankiMobileUnavailable,
         );
       }
       // BUG-1549：实际落卡的牌组名随成功结果带回（与其余后端对称）。

--- a/fushi/lib/src/utils/misc/error_log_service.dart
+++ b/fushi/lib/src/utils/misc/error_log_service.dart
@@ -571,6 +571,10 @@ String? localizeAnkiMineError(String? code) {
       return t.anki_error_permission_permanently_denied;
     case AnkiErrorCode.ankiDroidUnavailable:
       return t.anki_error_ankidroid_unavailable;
+    // BUG-2150：iOS 上 `anki://` 打不开 = 没装 AnkiMobile。fetch 与制卡两条路径共用
+    // 这一个码，所以放在这里（[localizeAnkiFetchError] 会回落到本函数）。
+    case AnkiErrorCode.ankiMobileUnavailable:
+      return t.anki_error_ankimobile_unavailable;
     case AnkiErrorCode.connectionRefused:
       return t.anki_error_connection_refused;
     case AnkiErrorCode.connectionTimeout:

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.2.4+1243
+version: 2.2.4+1244
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/anki/ankimobile_ios_callback_static_test.dart
+++ b/fushi/test/anki/ankimobile_ios_callback_static_test.dart
@@ -78,7 +78,7 @@ void main() {
     expect(main, contains('fushiAnkiFetchCallback'));
     expect(main, contains('consumeInfoForAddingPasteboard'));
     expect(main, contains('ankiViewModelProvider.notifier'));
-    expect(vm, contains('Future<void> reloadSettings()'));
+    expect(vm, contains('Future<void> applyFetchedConfiguration()'));
     // BUG-2150：失败文案必须过本地化入口（此前是硬编码英文，中文 UI 里原样显示）。
     expect(main, contains('AnkiViewModel.localizeAnkiFetchError'));
   });

--- a/fushi/test/anki/ankimobile_ios_callback_static_test.dart
+++ b/fushi/test/anki/ankimobile_ios_callback_static_test.dart
@@ -22,6 +22,54 @@ void main() {
     expect(src, contains('open url: URL'));
   });
 
+  // BUG-2150：读剪贴板的前置条件不是「URL 回调到了」，而是「app 真的 active 了」。
+  // iOS 只允许前台活跃的 app 读别的 app 写进通用剪贴板的内容（iOS 16+ 还要弹一次
+  // 系统「允许粘贴」确认，而弹窗只有 active 的 app 能呈现），而 x-callback 回跳时
+  // 系统的顺序是 willEnterForeground → application(_:open:) → didBecomeActive，
+  // 也就是说 URL 回调整个跑在 .inactive 阶段。Swift 进不了 flutter test，源码守卫
+  // 是这层唯一可落地的自动化。
+  test('AppDelegate 等 app active 之后才读 AnkiMobile 剪贴板', () {
+    final String src = File('ios/Runner/AppDelegate.swift').readAsStringSync();
+
+    // 方法通道的 case 只许分发给带时序门的 helper——不许在这里直接读剪贴板。
+    const String caseAnchor = 'case "consumeInfoForAddingPasteboard":';
+    final int caseStart = src.indexOf(caseAnchor);
+    expect(caseStart, greaterThan(-1), reason: '锚点漂移，守卫失效');
+    final int caseEnd =
+        src.indexOf('case "beginMediaImportBackgroundTask":', caseStart);
+    expect(caseEnd, greaterThan(caseStart), reason: '找不到下一个 case，截取失败');
+    final String caseBody =
+        src.substring(caseStart + caseAnchor.length, caseEnd);
+    // 自检：截出来的必须真是那个 case 的 body，否则下面两条断言都变成空转。
+    expect(caseBody.trim(), isNotEmpty, reason: '截出的 case body 是空的');
+    expect(
+      caseBody,
+      contains('consumeAnkiMobilePasteboard'),
+      reason: 'case 必须分发给带 active 门的 helper',
+    );
+    expect(
+      caseBody,
+      isNot(contains('UIPasteboard')),
+      reason: '又在 URL 回调那一刻直接读剪贴板了——那时 app 还是 .inactive',
+    );
+
+    // 时序门本身。
+    expect(src, contains('UIApplication.shared.applicationState == .active'));
+    expect(src, contains('UIApplication.didBecomeActiveNotification'));
+    expect(src, contains('removeObserver'));
+  });
+
+  // BUG-2150：「读不到」必须能区分「AnkiMobile 没写」与「系统不让读」——两者的下一步
+  // 动作完全不同。contains(pasteboardTypes:) 只查元数据、不触发粘贴确认弹窗。
+  test('AppDelegate 用非提示性探测区分 denied 与 empty', () {
+    final String src = File('ios/Runner/AppDelegate.swift').readAsStringSync();
+
+    expect(src, contains('pasteboardTypes:'));
+    expect(src, contains('"denied"'));
+    expect(src, contains('"empty"'));
+    expect(src, contains('"status"'));
+  });
+
   test('Dart startup consumes the AnkiMobile info callback', () {
     final main = File('lib/main.dart').readAsStringSync();
     final vm = File('lib/src/anki/anki_view_model.dart').readAsStringSync();
@@ -31,5 +79,7 @@ void main() {
     expect(main, contains('consumeInfoForAddingPasteboard'));
     expect(main, contains('ankiViewModelProvider.notifier'));
     expect(vm, contains('Future<void> reloadSettings()'));
+    // BUG-2150：失败文案必须过本地化入口（此前是硬编码英文，中文 UI 里原样显示）。
+    expect(main, contains('AnkiViewModel.localizeAnkiFetchError'));
   });
 }

--- a/fushi/test/anki/ankimobile_pasteboard_states_test.dart
+++ b/fushi/test/anki/ankimobile_pasteboard_states_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/anki/ankimobile_repository.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+// BUG-2150：iOS 上 AnkiMobile 的 `infoForAdding` 结果经系统剪贴板回传。此前
+// 「没读到」只有一种表达——硬编码英文 "No AnkiMobile configuration was found on
+// the clipboard."——把三种下一步动作完全不同的情形压成一句话：
+//   ① AnkiMobile 根本没写（用户没在 AnkiMobile 里同意那次请求）；
+//   ② 写了，但 iOS 不让读（「允许粘贴」被拒 / 此刻弹不出确认）；
+//   ③ 真的空。
+// 而真正的根因是**读得太早**：AnkiMobile 的 x-success 把 Fushi 拉回前台时，
+// `application(_:open:)` 跑在 `.inactive` 阶段，那一刻读通用剪贴板必然拿到 nil。
+// 原生侧的时序门由 ankimobile_ios_callback_static_test.dart 守；这里守 Dart 侧的
+// 三态契约与文案本地化。
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  AnkiMobileRepository repoReading(AnkiMobilePasteboardRead read) =>
+      AnkiMobileRepository(
+        openUrl: (_) async => true,
+        readInfoForAddingJson: () async => read,
+      );
+
+  group('consumeInfoForAddingPasteboard 的三态各有自己的稳定码', () {
+    test('系统不让读 → denied 码（不是「剪贴板上没有配置」）', () async {
+      final result = await repoReading(
+        const AnkiMobilePasteboardRead.denied(),
+      ).consumeInfoForAddingPasteboard();
+
+      expect(result, isA<AnkiFetchError>());
+      expect(
+        (result as AnkiFetchError).code,
+        AnkiErrorCode.ankiMobilePasteboardDenied,
+      );
+    });
+
+    test('AnkiMobile 没写 → empty 码', () async {
+      final result = await repoReading(
+        const AnkiMobilePasteboardRead.empty(),
+      ).consumeInfoForAddingPasteboard();
+
+      expect(result, isA<AnkiFetchError>());
+      expect(
+        (result as AnkiFetchError).code,
+        AnkiErrorCode.ankiMobilePasteboardEmpty,
+      );
+    });
+
+    test('两种失败不能再共用同一个码', () async {
+      final denied = await repoReading(
+        const AnkiMobilePasteboardRead.denied(),
+      ).consumeInfoForAddingPasteboard() as AnkiFetchError;
+      final empty = await repoReading(
+        const AnkiMobilePasteboardRead.empty(),
+      ).consumeInfoForAddingPasteboard() as AnkiFetchError;
+
+      expect(denied.code, isNot(empty.code));
+      expect(denied.message, isNot(empty.message));
+    });
+
+    test('ok 但 json 为空 → 按 empty 处理，不当成读到了', () async {
+      final result = await repoReading(
+        const AnkiMobilePasteboardRead(AnkiMobilePasteboardStatus.ok),
+      ).consumeInfoForAddingPasteboard();
+
+      expect(result, isA<AnkiFetchError>());
+      expect(
+        (result as AnkiFetchError).code,
+        AnkiErrorCode.ankiMobilePasteboardEmpty,
+      );
+    });
+
+    test('回传了 JSON 但里面没牌组 → no-decks 码', () async {
+      final result = await repoReading(
+        const AnkiMobilePasteboardRead.ok('{"decks":[],"notetypes":[]}'),
+      ).consumeInfoForAddingPasteboard();
+
+      expect(result, isA<AnkiFetchError>());
+      expect((result as AnkiFetchError).code, AnkiErrorCode.ankiMobileNoDecks);
+    });
+  });
+
+  group('fetchConfiguration', () {
+    test('已跳转 AnkiMobile 是中间态，带 opened 码而非无码英文', () async {
+      final repo = AnkiMobileRepository(
+        openUrl: (_) async => true,
+        readInfoForAddingJson: () async =>
+            const AnkiMobilePasteboardRead.empty(),
+      );
+
+      final result = await repo.fetchConfiguration();
+
+      expect(result, isA<AnkiFetchError>());
+      expect((result as AnkiFetchError).code, AnkiErrorCode.ankiMobileOpened);
+    });
+
+    test('打不开 anki:// → unavailable 码', () async {
+      final repo = AnkiMobileRepository(
+        openUrl: (_) async => false,
+        readInfoForAddingJson: () async =>
+            const AnkiMobilePasteboardRead.empty(),
+      );
+
+      final result = await repo.fetchConfiguration();
+
+      expect(result, isA<AnkiFetchError>());
+      expect(
+        (result as AnkiFetchError).code,
+        AnkiErrorCode.ankiMobileUnavailable,
+      );
+    });
+
+    // BUG-558 定下的编码规则对整个类成立：query 一律百分号编码。此前
+    // infoForAdding 这条 URL 是同一个类里的第二套编码（`Uri.replace`
+    // (queryParameters:) 把空格编成 `+`）——现在只剩一套。
+    test('infoForAdding 的 x-success 走百分号编码', () async {
+      final launched = <Uri>[];
+      final repo = AnkiMobileRepository(
+        openUrl: (uri) async {
+          launched.add(uri);
+          return true;
+        },
+        readInfoForAddingJson: () async =>
+            const AnkiMobilePasteboardRead.empty(),
+      );
+
+      await repo.fetchConfiguration();
+
+      expect(launched, hasLength(1));
+      final Uri uri = launched.single;
+      expect(uri.scheme, 'anki');
+      expect(uri.path, '/infoForAdding');
+      expect(uri.query, isNot(contains('+')));
+      expect(uri.query, 'x-success=fushi%3A%2F%2FankiFetch');
+      expect(uri.queryParameters['x-success'], fushiAnkiFetchCallback);
+    });
+  });
+
+  group('文案本地化', () {
+    tearDown(() => LocaleSettings.setLocale(AppLocale.en));
+
+    test('五个 AnkiMobile 码在中文 UI 下都不再吐英文原文', () {
+      LocaleSettings.setLocale(AppLocale.zhCn);
+
+      const Map<String, String> rawEnglish = <String, String>{
+        AnkiErrorCode.ankiMobileOpened:
+            'AnkiMobile opened. Approve the request, then return to Fushi.',
+        AnkiErrorCode.ankiMobilePasteboardEmpty:
+            'No AnkiMobile configuration was found on the clipboard.',
+        AnkiErrorCode.ankiMobilePasteboardDenied:
+            'iOS blocked reading the clipboard.',
+        AnkiErrorCode.ankiMobileNoDecks:
+            'AnkiMobile returned no decks or note types.',
+        AnkiErrorCode.ankiMobileUnavailable:
+            'Could not open AnkiMobile. Install AnkiMobile and try again.',
+      };
+
+      final Set<String> localized = <String>{};
+      for (final MapEntry<String, String> entry in rawEnglish.entries) {
+        final String text = AnkiViewModel.localizeAnkiFetchError(
+          entry.value,
+          entry.key,
+        );
+        expect(text, isNot(entry.value), reason: '${entry.key} 仍在透传英文原文');
+        localized.add(text);
+      }
+      // 五条互不相同——否则「区分三态」在 UI 上等于没做。
+      expect(localized, hasLength(rawEnglish.length));
+    });
+
+    test('empty / denied 在英文下也是两句不同的、可操作的话', () {
+      LocaleSettings.setLocale(AppLocale.en);
+
+      expect(
+        t.anki_error_ankimobile_pasteboard_empty,
+        isNot(t.anki_error_ankimobile_pasteboard_denied),
+      );
+      // 旧文案只说「剪贴板上没有」，不说该做什么。两条都必须给下一步动作。
+      expect(t.anki_error_ankimobile_pasteboard_empty, contains('AnkiMobile'));
+      expect(t.anki_error_ankimobile_pasteboard_denied, contains('Paste'));
+    });
+  });
+}

--- a/fushi/test/anki/ankimobile_pasteboard_states_test.dart
+++ b/fushi/test/anki/ankimobile_pasteboard_states_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: invalid_use_of_protected_member
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
@@ -14,6 +15,42 @@ import 'package:fushi_anki/fushi_anki.dart';
 // `application(_:open:)` 跑在 `.inactive` 阶段，那一刻读通用剪贴板必然拿到 nil。
 // 原生侧的时序门由 ankimobile_ios_callback_static_test.dart 守；这里守 Dart 侧的
 // 三态契约与文案本地化。
+
+
+/// 只回「已跳转 AnkiMobile，去那边点同意」的假后端：真实 AnkiMobile 的
+/// `fetchConfiguration` 就是这个形状——它不可能同步拿到结果。
+class _AnkiMobileOpenedRepo extends BaseAnkiRepository {
+  AnkiSettings _settings = const AnkiSettings();
+
+  @override
+  Future<AnkiSettings> loadSettings() async => _settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => _settings = s;
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error(
+        'AnkiMobile opened. Approve the request, then return to Fushi.',
+        code: AnkiErrorCode.ankiMobileOpened,
+      );
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => false;
+
+  @override
+  Future<bool> createDeck(String name) async => false;
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('test stub');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -136,6 +173,25 @@ void main() {
       expect(uri.query, isNot(contains('+')));
       expect(uri.query, 'x-success=fushi%3A%2F%2FankiFetch');
       expect(uri.queryParameters['x-success'], fushiAnkiFetchCallback);
+    });
+  });
+
+  // BUG-2150 的 UI 尾巴：配置回传是跨 app 异步完成的，`fetchConfiguration()` 只能先
+  // 把「已跳转，去 AnkiMobile 点同意」写进 errorMessage。回调成功时若不清掉它，设置页
+  // 会在牌组已经装好之后仍挂着「请去同意」——在用户眼里就是「又失败了一次」。
+  group('回传成功后的中间态清理', () {
+    setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+    test('applyFetchedConfiguration 清掉「去 AnkiMobile 点同意」', () async {
+      final AnkiViewModel vm = AnkiViewModel(_AnkiMobileOpenedRepo());
+      await vm.fetchConfiguration();
+      expect(vm.state.errorMessage, isNotNull);
+      expect(vm.state.errorMessage, t.anki_ankimobile_opened);
+
+      await vm.applyFetchedConfiguration();
+
+      expect(vm.state.errorMessage, isNull);
+      expect(vm.state.isFetching, isFalse);
     });
   });
 

--- a/fushi/test/anki/ankimobile_repository_test.dart
+++ b/fushi/test/anki/ankimobile_repository_test.dart
@@ -74,7 +74,8 @@ void main() {
       () async {
     final repo = AnkiMobileRepository(
       openUrl: (_) async => true,
-      readInfoForAddingJson: () async => jsonEncode(<String, Object?>{
+      readInfoForAddingJson: () async =>
+          AnkiMobilePasteboardRead.ok(jsonEncode(<String, Object?>{
         'profiles': <Object>[
           <String, Object?>{'name': 'User 1'},
         ],
@@ -91,7 +92,7 @@ void main() {
             ],
           },
         ],
-      }),
+      })),
     );
 
     final result = await repo.consumeInfoForAddingPasteboard();
@@ -113,7 +114,8 @@ void main() {
         launched.add(uri);
         return true;
       },
-      readInfoForAddingJson: () async => null,
+      readInfoForAddingJson: () async =>
+          const AnkiMobilePasteboardRead.empty(),
       mediaServerLifetime: Duration.zero,
     );
     await repo.saveSettings(const AnkiSettings(
@@ -194,7 +196,8 @@ void main() {
         launched.add(uri);
         return true;
       },
-      readInfoForAddingJson: () async => null,
+      readInfoForAddingJson: () async =>
+          const AnkiMobilePasteboardRead.empty(),
       mediaServerLifetime: Duration.zero,
       beginMediaImportBackgroundTask: () async {
         events.add('begin-background-task');
@@ -303,7 +306,8 @@ void main() {
         launched.add(uri);
         return true;
       },
-      readInfoForAddingJson: () async => null,
+      readInfoForAddingJson: () async =>
+          const AnkiMobilePasteboardRead.empty(),
       mediaServerLifetime: const Duration(milliseconds: 500),
       beginMediaImportBackgroundTask: () async {},
       endMediaImportBackgroundTask: () async {

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -1335,6 +1335,28 @@ class AnkiErrorCode {
   /// 是误导，正确的话是「先装 AnkiDroid，或改用 AnkiConnect」。
   static const String ankiDroidUnavailable = 'ANKI_DROID_UNAVAILABLE';
 
+  /// BUG-2150：iOS AnkiMobile 后端的稳定分类码。
+  ///
+  /// AnkiMobile 没有 API，只有 URL scheme + 系统剪贴板，所以它的失败形态与
+  /// AnkiDroid/AnkiConnect 完全不同，必须单列——而且此前这几种情形全是硬编码英文，
+  /// 在非英文 UI 里原样显示。
+  ///
+  /// `ankiMobileOpened`：**不是失败**，是「已跳转 AnkiMobile，等用户在那边点同意」
+  ///   的中间态（`fetchConfiguration` 只能这样表达：真正的结果随后经
+  ///   `fushi://ankiFetch` 回调送达）。
+  /// `ankiMobilePasteboardEmpty`：剪贴板上没有 AnkiMobile 的数据——通常是用户没在
+  ///   AnkiMobile 里同意那次请求。
+  /// `ankiMobilePasteboardDenied`：数据在，但 iOS 不让读（「允许粘贴」被拒/弹不出）。
+  /// `ankiMobileNoDecks`：AnkiMobile 回传了 JSON，但里面没有牌组或笔记类型。
+  /// `ankiMobileUnavailable`：`anki://` 打不开——没装 AnkiMobile。
+  static const String ankiMobileOpened = 'ANKI_MOBILE_OPENED';
+  static const String ankiMobilePasteboardEmpty =
+      'ANKI_MOBILE_PASTEBOARD_EMPTY';
+  static const String ankiMobilePasteboardDenied =
+      'ANKI_MOBILE_PASTEBOARD_DENIED';
+  static const String ankiMobileNoDecks = 'ANKI_MOBILE_NO_DECKS';
+  static const String ankiMobileUnavailable = 'ANKI_MOBILE_UNAVAILABLE';
+
   /// TODO-752a：AnkiConnect 网络错误的稳定分类码。给用户看的 toast 文案必须由
   /// 主 app 按这些**与 locale 无关、永不乱码**的码映射本地化文案，而不是透传
   /// `SocketException`/`http.ClientException` 的 `toString()`——后者既是英文，又会在


### PR DESCRIPTION
用户报告（两张 iPhone 截图）：在制卡设置页点「获取牌组/笔记类型」后跳去 AnkiMobile，返回 Fushi 立刻弹红条 `No AnkiMobile configuration was found on the clipboard.`；设置页则一直挂着 `AnkiMobile opened. Approve the request, then return to Fushi.`——两句在中文 UI 里都是英文原文。

## 根因

iOS 在 URL-driven resume 上的文档顺序是 `willEnterForeground` → `application(_:open:)` → `didBecomeActive`。

AnkiMobile 的 `x-success=fushi://ankiFetch` 把 Fushi 拉回前台时，整条回调链——`application(_:open:)` → `deliverUrl` → EventChannel → `main.dart` `handleIncomingUrl` → 方法通道 `consumeInfoForAddingPasteboard`——全部跑在 app **`.inactive`** 阶段。而 `AppDelegate.swift:64`（原）就在这一刻直读 `UIPasteboard.general.data(forPasteboardType:)`。

iOS 只允许**前台活跃**的 app 读别的 app 写进通用剪贴板的内容；iOS 16+ 还要为此弹一次系统「允许粘贴」确认，而这个弹窗只有 active 的 app 能呈现。所以那一刻读必然拿到 nil。

剪贴板类型 `net.ankimobile.json` 和「读完清空」的写法本身没错——与 AnkiMobile 官方手册 URL Schemes 一节给的 Swift 示例逐字一致。

**第二个缺陷（同一条错误信息）**：`No AnkiMobile configuration was found on the clipboard.` 把三种**下一步动作完全不同**的情形压成一句话——① AnkiMobile 根本没写（用户没在 AnkiMobile 里同意那次请求，官方手册原话 "If the user authorises the request"）；② 写了但系统不让读；③ 真空。而且这条链上五句提示全部没有稳定码，`localizeAnkiFetchError` 只能原样透传英文。

## 改了什么

1. **时序（根因）**：读取的前置条件从「URL 回调到了」改成「app 真的 active 了」。非 active 时挂一次性 `UIApplication.didBecomeActiveNotification` 观察者，等真正活跃后再读；5s 超时兜底，`FlutterResult` 由 `finished` 闸门保证恰好回调一次，不让 Dart 侧的 Future 永久挂起。
2. **三态（诊断）**：用**不触发粘贴确认弹窗**的元数据 API `UIPasteboard.general.contains(pasteboardTypes:)` 把 `denied`（数据在、系统不让读）与 `empty`（AnkiMobile 没写）分开。「类型在但内容为空」归 `empty`——那是我们自己取走后写回的空 `Data`。通道改返回 `{status, json}`，Dart 侧 `AnkiMobileInfoReader` 契约随之改为 `Future<AnkiMobilePasteboardRead>`。
3. **文案**：新增 5 个稳定码（`ankiMobileOpened` / `ankiMobilePasteboardEmpty` / `ankiMobilePasteboardDenied` / `ankiMobileNoDecks` / `ankiMobileUnavailable`）+ 5 个 i18n key（17 语言）。制卡路径的「打不开 AnkiMobile」共用同一个码。
4. **UI 尾巴（同一条链路）**：`reloadSettings()` 只装载 settings、从不清 `errorMessage`，而它全仓唯一的调用点就是回传成功那一支——于是配置已经落地，设置页仍挂着「请去 AnkiMobile 同意」，在用户眼里就是又失败了一次。改成语义明确的 `applyFetchedConfiguration()`（装载 + `isFetching:false` + `clearError`），并且不复用 `_loadSettings()`（那条路会在「选了牌组但可用列表为空」时反过来再把用户弹去 AnkiMobile）。
5. **顺带**：`infoForAdding` 的 URL 收进 `_buildAnkiMobileQuery`，与 BUG-558 给 `addnote` 定下的百分号编码规则统一——此前它是同一个类里的第二套编码（`Uri.replace(queryParameters:)` 把空格编成 `+`）。

## 验证

- `flutter analyze` 干净；`dart analyze --fatal-infos packages/fushi_anki` 干净。
- **全量**：`FLUTTER TEST VERDICT: PASSED - 23012 tests ran, all tests passed`（退出码 0）。
- 新增 13 条 Dart 测试（`ankimobile_pasteboard_states_test.dart`）+ 2 条原生源码守卫。
- **守卫变异实测**：把 case 改回「回调那一刻直接读」→ 守卫红（「case 必须分发给带 active 门的 helper」）；单独把 `applicationState == .active` 改成 `true` → 守卫红。两次还原后复绿。
- **Swift**：远程 Mac（macOS 26.6.1 / iPhoneSimulator26.5 SDK）`swiftc -parse` 整文件通过；新增的两个方法**逐字抽出**对 iOS SDK `swiftc -typecheck -target arm64-apple-ios15.0-simulator` 通过（UIPasteboard API 名、闭包捕获、`DispatchWorkItem`、通知观察者、`[String: Any]` 返回全部成立）。

## 已知缺口

AnkiMobile 是 App Store 付费 app，装不进模拟器，本机也没有能跑它的 iOS 设备，**「回到原始失败路径真机复测」这一步没做**。

若真机复测后仍失败，本次改动已把结果收敛成两句可判读的话：看到「AnkiMobile 没有回传配置」= AnkiMobile 那一侧没写（多半没点同意 / 版本太老）；看到「iOS 阻止了读取剪贴板」= 系统粘贴权限那一关。原来那句「剪贴板上没有配置」两种都可能，无法据以决定下一步。

新增 5 个 i18n key 的 15 个非 en/zh-CN 语言按 `i18n_sync --add` 的既有行为落的是英文值，属既有翻译欠账。

详见 `docs/bugs/BUG-2150-ios-ankimobile-pasteboard-read-inactive.md`。

https://claude.ai/code/session_0121h31HTxpF3MKeqQcnUDg8
