### PR TITLE
feat(video): 字幕列表字号上限 2.0× → 3.0×（BUG-2156）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2019 条。点号进各自文件。
+> 共 2020 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2156](bugs/BUG-2156-video-subtitle-list-font-cap-too-low.md) | ✅ | ✅ | 字幕列表字号上限还是不够（BUG-878 抬到 2.0× 后的第二次反馈） |
 | [BUG-2145](bugs/BUG-2145-gal-kirikiri2-no-export-table-and-late-loadlibrary-hook.md) | ✅ | ✅ | KiriKiri2 无导出表 + 插件早于 LoadLibrary hook link：两条 exporter 路径同时静默落空，游戏内查词整条不装 |
 | [BUG-2144](bugs/BUG-2144-gal-kirikiri2-bcb-exception-escapes-msvc-catch.md) | ✅ | ✅ | KiriKiri2/BCB 上 TJS 抛的 Borland 异常穿透 MSVC catch(...)，注入的每帧求值把游戏打成致命错误框并强制写快速存档 |
 | [BUG-2143](bugs/BUG-2143-attached-status-without-reason-undiagnosable.md) | ✅ | 🚧 | attached 状态机十二处 `needsRiskAcceptance` / `needsCalibration` / `waitingForBodyThread` 不带 reason，真机上无法定位是哪条分支 |

--- a/docs/bugs/BUG-2156-video-subtitle-list-font-cap-too-low.md
+++ b/docs/bugs/BUG-2156-video-subtitle-list-font-cap-too-low.md
@@ -1,0 +1,25 @@
+## BUG-2156 · 字幕列表字号上限还是不够（BUG-878 抬到 2.0× 后的第二次反馈）
+- **报告**：2026-09-05（用户：「视频的字幕列表的字号放大，字号大小的上限再提高一些」）
+- **真实性**：✅ 属实。`fushi/lib/src/media/video/video_subtitle_jump_panel.dart` 的档位数组
+  `_kFontScaleSteps` 上限就是 `2.0`，注释里写明这是 BUG-878 时从 1.3× 抬上来的
+  —— **同一句反馈的第二次**。有效字号 = `widget.fontSize * _fontScaleSteps`，
+  基准 `fontSize` = `14 * appUiScale`，所以界面 1.0× 时实际上限只有 28px。
+- **入口**：设置页里没有这一项；只有面板头部的 A− / A+ 两个按钮
+  （i18n `video_subtitle_list_font_smaller` / `..._larger`）和 Ctrl/⌘+滚轮，两者共用 `_stepFont`。
+- **[x] ① 已修复** — 往 `_kFontScaleSteps` **尾部追加** `2.25 / 2.5 / 2.75 / 3.0`，上限 2.0× → 3.0×
+  （界面 1.0× 时 28px → 42px）。
+  **只能追加、不能改既有元素**：下标本身就是持久化值（偏好键
+  `video_subtitle_list_font_scale_index`，`preferences_repository.dart`），动了既有元素等于让所有
+  存量用户的字号静默漂移。两处 clamp（seed 与 `_stepFont`）写的都是 `length - 1`，自动跟随，无需改动；
+  偏好层不 clamp，也没有第二次夹取，所以被旧上限夹到下标 6 的用户只是停在 2.0×，按 A+ 就能继续往上。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_jump_panel_test.dart`：
+  新增 `BUG-2156: the top step reaches 3.0x and only there does A+ disable`（下标 10 × 基准 14 = 42，
+  且只有到顶档 A+ 才禁用）；同时修正既有 BUG-878 用例里「下标 6 已是最大档、A+ 应禁用」那半
+  —— 追加档位后 2.0× 不再是顶档，那条断言必须翻面。BUG-878 的「下标 6 = 28.0」那半**刻意保持不变**，
+  它正是「只追加不改既有元素」这条不变式的守卫。
+  **变异实测**：撤掉追加的四档 → 两条用例双双变红。`test/media/video` 全目录 3280 条全绿。
+- **备注**：收益在窄面板上递减。时间戳列宽（`subtitleTimestampColumnWidth`）与动作列宽
+  （`subtitleRowActionsWidth`）都随字号线性放大，而面板宽下界 240px、正文列还有 48px 硬下界：
+  最窄面板 + 带小时的时间戳时，2.0× 附近正文列就已经触底，再往上主要是时间戳和按钮变大。
+  宽面板（≥420px）下高档位才真正有用。若要让顶档在最窄面板也有意义，得另做「超大字号下时间戳/动作列
+  不再线性放大」——那是另一件事，本次未做。

--- a/fushi/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/fushi/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -293,9 +293,19 @@ int resolveSubtitleListGraphemeHit(
   return bestIndex;
 }
 
-/// 字幕列表行字号缩放档位（BUG-878）。原上限只到 1.3×，用户反馈「字号拉到最大才够用、
-/// 上限不够」，向上扩到 2.0×（1.5 / 1.75 / 2.0 三档）。默认档 [_kDefaultFontScaleIndex]=1
-/// （1.0×）。数组扩容后旧持久化下标仍安全（seed / [_stepFont] 都 clamp 到数组范围）。
+/// 字幕列表行字号缩放档位。默认档 [_kDefaultFontScaleIndex]=1（1.0×）。
+///
+/// 两轮反馈都是同一句「拉到最大还是不够」：BUG-878 把上限从 1.3× 抬到 2.0×，
+/// BUG-2156 再抬到 3.0×。**只在数组尾部追加**——下标即持久化值
+/// （`video_subtitle_list_font_scale_index`），改动既有元素会让所有存量用户的字号
+/// 静默漂移。追加则旧下标恒指向同一倍率，零迁移。
+/// 两处 clamp（seed 在 [_VideoSubtitleJumpPanelState.initState]、步进在 [_stepFont]）
+/// 都写的是 `_kFontScaleSteps.length - 1`，自动跟随数组长度，不用改。
+///
+/// 注意收益在窄面板上会递减：时间戳列宽（[subtitleTimestampColumnWidth]）与动作列宽
+/// （[subtitleRowActionsWidth]）都随字号线性放大，而面板宽下界是 240px，
+/// 正文列还有 48px 硬下界。最窄面板 + 带小时的时间戳时，2.0× 附近正文列就已经触底，
+/// 再往上主要是时间戳和按钮变大。宽面板（≥420px）下高档位才真正有用。
 const List<double> _kFontScaleSteps = <double>[
   0.85,
   1.0,
@@ -304,6 +314,10 @@ const List<double> _kFontScaleSteps = <double>[
   1.5,
   1.75,
   2.0,
+  2.25,
+  2.5,
+  2.75,
+  3.0,
 ];
 
 /// 默认字号档位（1.0×）。持久化 key 从未写过时的初值，与 `preferences_repository.dart`

--- a/fushi/test/media/video/video_subtitle_jump_panel_test.dart
+++ b/fushi/test/media/video/video_subtitle_jump_panel_test.dart
@@ -1624,8 +1624,50 @@ void main() {
         emptyHint: 'empty',
       )));
       expect(fontOf('sized'), closeTo(28.0, 0.01),
-          reason: '种子字号档位 6 = 2.0× × 基准 14 = 28（持久化 + 提高上限）');
-      // 已在最大档：A+ 应禁用（越界短路不再放大）。
+          reason: '种子字号档位 6 = 2.0× × 基准 14 = 28。BUG-2156 往数组尾部追加了更高档位，'
+              '这条断言必须**保持不变**——下标就是持久化值，既有元素一旦改动，'
+              '所有存量用户的字号都会静默漂移');
+      // BUG-2156 之后 2.0× 不再是最大档，A+ 应当仍然可用。
+      final IconButton increase = tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.text_increase),
+          matching: find.byType(IconButton),
+        ),
+      );
+      expect(increase.onPressed, isNotNull,
+          reason: '2.0× 上面还有档位（BUG-2156），A+ 不该禁用');
+    });
+
+    // ── BUG-2156：上限从 2.0× 再抬到 3.0×（用户第二次反馈「还是不够」）───────
+    testWidgets(
+        'BUG-2156: the top step reaches 3.0x and only there does A+ disable',
+        (WidgetTester tester) async {
+      final VideoPlayerController controller = VideoPlayerController();
+      addTearDown(controller.dispose);
+      controller.setCues(<AudioCue>[_cue(0, 0, 1000, 'sized')]);
+
+      double fontOf(String text) =>
+          tester.widget<Text>(find.text(text)).style!.fontSize!;
+
+      // 下标 10 = 3.0×，基准 14 → 42。撤掉追加的四档 → 种子被 clamp 回下标 6（2.0×）
+      // → 字号 28 → 红。
+      await tester.pumpWidget(_wrap(VideoSubtitleJumpPanel(
+        key: const ValueKey<String>('seed-max-2156'),
+        controller: controller,
+        onTapCue: (_) {},
+        onCopyCue: (_) => true,
+        onFavoriteCue: (_) async {},
+        isCueFavorited: (_) => false,
+        onClose: () {},
+        initialFontScaleIndex: 10,
+        fontSize: 14,
+        colorScheme: const ColorScheme.dark(),
+        title: 'Subtitle list',
+        emptyHint: 'empty',
+      )));
+      expect(fontOf('sized'), closeTo(42.0, 0.01),
+          reason: '最高档 3.0× × 基准 14 = 42');
+
       final IconButton increase = tester.widget<IconButton>(
         find.ancestor(
           of: find.byIcon(Icons.text_increase),


### PR DESCRIPTION
用户诉求：「视频的字幕列表的字号放大，字号大小的上限再提高一些」。

这是**同一句反馈的第二次**——`_kFontScaleSteps` 的注释里写明上限是 BUG-878 时从 1.3× 抬到 2.0× 的。

## 改动

往 `fushi/lib/src/media/video/video_subtitle_jump_panel.dart` 的 `_kFontScaleSteps` **尾部追加**
`2.25 / 2.5 / 2.75 / 3.0`。有效字号 = `widget.fontSize * _fontScaleSteps`，基准 `fontSize = 14 * appUiScale`，
所以界面 1.0× 时上限 28px → 42px。

**只能追加、不能改既有元素**：下标本身就是持久化值（偏好键 `video_subtitle_list_font_scale_index`），
动既有元素等于让所有存量用户的字号静默漂移。两处 clamp（seed 与 `_stepFont`）写的都是 `length - 1`，
自动跟随，无需改动；偏好层不 clamp、也没有第二次夹取，所以被旧上限夹到下标 6 的用户只是停在 2.0×，
按 A+ 就能继续往上。设置页无此入口，调节只在面板头部 A−/A+ 与 Ctrl/⌘+滚轮，两者共用 `_stepFont`。

## 测试

- 新增 `BUG-2156: the top step reaches 3.0x and only there does A+ disable`（下标 10 × 基准 14 = 42）。
- 修正既有 BUG-878 用例里「下标 6 已是最大档、A+ 应禁用」那半——追加档位后 2.0× 不再是顶档，断言必须翻面。
  **「下标 6 = 28.0」那半刻意保持不变**，它正是「只追加不改既有元素」这条不变式的守卫。
- **变异实测**：撤掉追加的四档 → 两条用例双双变红。
- `test/media/video` 全目录 3280 条全绿；`flutter analyze` 零问题。

## 已知局限（记在 BUG 文件里，本次未做）

时间戳列宽与动作列宽都随字号线性放大，而面板宽下界 240px、正文列还有 48px 硬下界：
最窄面板 + 带小时的时间戳时，2.0× 附近正文列就已经触底，再往上主要是时间戳和按钮变大。
宽面板（≥420px）下高档位才真正有用。要让顶档在最窄面板也有意义，得另做「超大字号下时间戳/动作列
不再线性放大」。

https://claude.ai/code/session_01MuUkCvigPNwbFzevzpvtqn
