### PR TITLE
fix(video): 关掉「尊重字幕自带样式」后行内 \fs 仍架空用户字号（BUG-2157）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2019 条。点号进各自文件。
+> 共 2020 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2157](bugs/BUG-2157-plain-mode-inline-fs-overrides-user-font-size.md) | ✅ | ✅ | 关闭尊重字幕自带样式后行内 fs 仍覆盖用户字号，字号滑块整条失效 |
 | [BUG-2145](bugs/BUG-2145-gal-kirikiri2-no-export-table-and-late-loadlibrary-hook.md) | ✅ | ✅ | KiriKiri2 无导出表 + 插件早于 LoadLibrary hook link：两条 exporter 路径同时静默落空，游戏内查词整条不装 |
 | [BUG-2144](bugs/BUG-2144-gal-kirikiri2-bcb-exception-escapes-msvc-catch.md) | ✅ | ✅ | KiriKiri2/BCB 上 TJS 抛的 Borland 异常穿透 MSVC catch(...)，注入的每帧求值把游戏打成致命错误框并强制写快速存档 |
 | [BUG-2143](bugs/BUG-2143-attached-status-without-reason-undiagnosable.md) | ✅ | 🚧 | attached 状态机十二处 `needsRiskAcceptance` / `needsCalibration` / `waitingForBodyThread` 不带 reason，真机上无法定位是哪条分支 |

--- a/docs/bugs/BUG-2157-plain-mode-inline-fs-overrides-user-font-size.md
+++ b/docs/bugs/BUG-2157-plain-mode-inline-fs-overrides-user-font-size.md
@@ -1,0 +1,42 @@
+## BUG-2157 · 关闭尊重字幕自带样式后行内 fs 仍覆盖用户字号，字号滑块整条失效
+- **报告**：2026-09-05（用户：「尊重 ass 关了也是改不了大小」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/media/video/video_subtitle_overlay.dart:2668`（修复前行号）
+- **[x] ① 已修复** — `video_subtitle_overlay.dart` `_styleForGrapheme`：行内 `\fs` 字号改为与 `respect` 同源门控，关闭「尊重字幕自带样式」时回落 `base.fontSize`（用户滑块字号）。提交见本条末。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_plain_mode_inline_fontsize_test.dart`（4 条：单段 `\fs`、滑块跟随、一行多段 `\fs` 混排统一、respect 开不回归）。修复前 3 红 1 绿，修复后 4 绿。
+- **备注**：
+
+### 现象
+
+视频页把「尊重字幕自带样式」关掉后，字幕外观设置里的**字号滑块对 .ass 字幕完全无效**——
+拖到最大最小画面上字都一样大。用户预期是「关掉就一律用我的外观设置」（开关文案 `video_setting_subtitle_respect_ass_hint` 原文：
+"turn off to force your appearance settings"）。
+
+### 根因
+
+`_styleForGrapheme` 里行内 span 的字号是唯一**没有**被 `respect` 门控的外观通道：
+
+```dart
+fontSize: span.fontSizePx != null
+    ? (respect ? _scaleAssFontSize(...) : span.fontSizePx!)   // ← 关掉尊重也照用作者 \fs
+    : base.fontSize,
+```
+
+`base.fontSize` 才是用户滑块字号（纯字幕模式下 `cueFontPx` 恒 null，基线正确）；但只要这行 ASS 带
+`{\fs...}`，`span.fontSizePx` 就把它整条盖掉。而且盖上去的是 **PlayRes 空间的裸数字**（`\fs90` → 逻辑像素 90），
+连 respect 开时那套「按显示区高/PlayResY 缩放 + 字体 cell/em 校准」都没走，属于脏值直穿渲染。
+fansub 的 ASS 对白普遍每行套 `{\fs...}`，所以用户看到的是「滑块彻底没反应」而不是「偶尔没反应」。
+
+这与 BUG-1285（纯字幕模式下行内 `\c` 主色穿透，OP 歌词渲染成黑字）**完全同型**：兄弟属性
+`\c`/`\1c` 主色、`\3c` 描边色、`\1a` 填充透明度、`\fsp` 字距、`\shad` 阴影、`\fscx/\fscy` 缩放、
+cueStyle 主色/字号、`\t` 动画都已按 `respect` 门控，`\fs` 是最后一条按「历史 span 行为」放行的漏网。
+
+### 修复
+
+`fontSize` 改成 `(respect && span.fontSizePx != null) ? _scaleAssFontSize(...) : base.fontSize`，
+并更新 `_styleForGrapheme` 的文档注释（原文写着「只保留行内 `\i \b \u \s` 这些文本语义与历史 `\fs` 裸像素字号」）。
+respect 开的路径逐字节不变。
+
+### 验证
+
+- 新守卫 4 条：修复前 3 红（`Expected: <36> Actual: <90.0>`）、修复后 4 绿。
+- `fushi/test/media/video` 全目录：`FLUTTER TEST VERDICT: PASSED - 3274 tests ran, all tests passed`。

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -2533,8 +2533,9 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// respectAssStyle 关 = **纯字幕模式**（BUG-915/1264）：**颜色语义整体归零**——行内 `\c`
   /// / `\1c` 主色与 `\3c` 描边色（[_resolveStroke]）、`\1a` 填充透明度、cueStyle 主色、`\t`
   /// 颜色动画、卡拉 OK SecondaryColour（[_applyDynamicFill]）同源门控，一律回落用户
-  /// textColor。只保留行内 `\i \b \u \s` 这些**文本语义**与历史 `\fs` 裸像素字号；字体 /
-  /// 字号 / 颜色的基线恒为用户统一样式。
+  /// textColor；行内 `\fs` 字号同样门控（BUG-2149，此前按裸像素放行、架空用户字号
+  /// 滑块）。只保留行内 `\i \b \u \s` 这些**文本语义**；字体 / 字号 / 颜色的基线恒为
+  /// 用户统一样式。
   /// respectAssStyle 开：字体名 / 主色 / 字号 / 粗斜下删线优先取 .ass 值（行内 span >
   /// [SubtitleCueStyle] cue 默认 > 用户统一样式，TODO-1105）。字体缺字时仍挂
   /// [_subtitleCjkFallback] 兜底。
@@ -2663,17 +2664,21 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       letterSpacing: (respect && span.letterSpacingPx != null)
           ? span.letterSpacingPx! * assFontScale
           : null,
-      // 行内字号（respect 时）同按 ASS 缩放 + cell/em 校准；respect 关时保持历史
-      // 裸像素（旧 span 行为）。
-      fontSize: span.fontSizePx != null
-          ? (respect
-              ? _scaleAssFontSize(_assFontSizeToEm(
-                      span.fontSizePx! * assFontScale,
-                      spanFontFamily ?? baseFontFamily,
-                      span.bold ? FontWeight.bold : baseWeight,
-                      span.italic || baseItalic) *
-                  spanMissingFontRasterCompensation.fontScale)
-              : span.fontSizePx!)
+      // 行内字号（respect 时）同按 ASS 缩放 + cell/em 校准。
+      // respect 关 = 纯字幕模式：**字号与兄弟属性同源门控**（BUG-2149）。曾按「历史
+      // 裸像素」放行 `span.fontSizePx`，那是最后一条穿透的外观通道——`\c` 主色
+      // （BUG-1285）、`\3c` 描边色、`\1a` 填充透明度、`\fsp` 字距、`\shad` 阴影、
+      // `\fscx/\fscy` 缩放早已全部门控，唯独它把作者字号直接写进 TextStyle，且写的是
+      // **PlayRes 空间裸数字**（连显示几何缩放都没走）。fansub 对白普遍每行套
+      // `{\fs...}` → 用户字号滑块被整条架空（用户报「尊重 ass 关了也是改不了大小」）。
+      // 开关文案明示「关闭则一律使用你的外观设置」，故这里回落 base.fontSize。
+      fontSize: (respect && span.fontSizePx != null)
+          ? _scaleAssFontSize(_assFontSizeToEm(
+                  span.fontSizePx! * assFontScale,
+                  spanFontFamily ?? baseFontFamily,
+                  span.bold ? FontWeight.bold : baseWeight,
+                  span.italic || baseItalic) *
+              spanMissingFontRasterCompensation.fontScale)
           : base.fontSize,
       decoration: decos.isEmpty ? null : TextDecoration.combine(decos),
     );

--- a/fushi/test/media/video/video_subtitle_plain_mode_inline_fontsize_test.dart
+++ b/fushi/test/media/video/video_subtitle_plain_mode_inline_fontsize_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_overlay.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+/// BUG-2157 守卫：纯字幕模式（`respectAssStyle` 关）下**行内 `\fs` 不得覆盖用户字号**。
+///
+/// 开关文案明示「关闭则一律使用你的外观设置」，且兄弟属性（`\c`/`\1c` 主色 BUG-1285、
+/// `\3c` 描边色、`\1a` 填充透明度、`\fsp` 字距、`\shad` 阴影、`\fscx/\fscy` 缩放）早已
+/// 与 `respect` 同源门控。唯独行内 `\fs` 按「历史裸像素」放行：`span.fontSizePx` 被
+/// 直接当逻辑像素字号写进 `TextStyle`，把用户字号滑块整条架空。fansub 的 ASS 对白
+/// 普遍在每行套 `{\fs...}`，用户表现就是「尊重 ass 关了也是改不了大小」。
+///
+/// 注意 `\fs` 的裸值是 **PlayRes 空间**的数字（这里 90 对 PlayResY=720），与逻辑像素
+/// 无换算关系——放行它连「按显示几何缩放」都没有，纯粹是脏数字漏进渲染。
+const String _kAssHead = r'''
+[Script Info]
+PlayResX: 1280
+PlayResY: 720
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: D,Arial,48,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,20,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+''';
+
+List<AudioCue> _parse(String dialogues) =>
+    AssParser.parseString(content: '$_kAssHead$dialogues\n', bookKey: 'sc');
+
+Future<void> _pump(
+  WidgetTester tester,
+  List<AudioCue> cues, {
+  required bool respect,
+  required double fontSize,
+}) async {
+  final VideoPlayerController c = VideoPlayerController();
+  addTearDown(c.dispose);
+  c.debugVideoWidthOverride = 1280;
+  c.debugVideoHeightOverride = 720;
+  c.setCues(cues);
+  c.debugSetPositionForTesting(500);
+  c.debugUpdateCueForPosition(500);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(
+        controller: c,
+        respectAssStyle: respect,
+        fontSize: fontSize,
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+/// 取填充层（非描边层）的 [Text]：描边层带 `foreground` paint。
+Text _fill(WidgetTester tester, String ch) => tester
+    .widgetList<Text>(find.text(ch))
+    .firstWhere((Text t) => t.style?.foreground == null);
+
+void main() {
+  group('纯字幕模式：行内 \\fs 不得覆盖用户字号', () {
+    testWidgets('单独 \\fs 行：字号恒等于用户滑块值', (WidgetTester tester) async {
+      await _pump(
+        tester,
+        _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,{\fs90}あ'),
+        respect: false,
+        fontSize: 36,
+      );
+      expect(_fill(tester, 'あ').style?.fontSize, 36,
+          reason: r'关闭「尊重字幕自带样式」后行内 \fs90 必须失效，用用户字号 36');
+    });
+
+    testWidgets('改用户字号后真的跟着变（滑块没被架空）', (WidgetTester tester) async {
+      await _pump(
+        tester,
+        _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,{\fs90}あ'),
+        respect: false,
+        fontSize: 60,
+      );
+      expect(_fill(tester, 'あ').style?.fontSize, 60,
+          reason: '同一条带 \\fs 的字幕，滑块调到 60 就必须渲染 60');
+    });
+
+    testWidgets('一行内多段 \\fs（大小混排）在纯字幕模式统一成用户字号', (WidgetTester tester) async {
+      await _pump(
+        tester,
+        _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,'
+            r'{\fs90}大{\fs20}小'),
+        respect: false,
+        fontSize: 36,
+      );
+      expect(_fill(tester, '大').style?.fontSize, 36);
+      expect(_fill(tester, '小').style?.fontSize, 36,
+          reason: '纯字幕模式外观统一：同一行不得因作者 \\fs 出现大小混排');
+    });
+
+    testWidgets('respect 开：\\fs 仍按作者字号生效（不回归 ON 路径）',
+        (WidgetTester tester) async {
+      await _pump(
+        tester,
+        _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,{\fs90}あ'),
+        respect: true,
+        fontSize: 36,
+      );
+      // 显示区高 = 800×(720/1280) = 450 → 90×450/720 = 56.25（测试环境无真字体表，
+      // cell 系数 1.0）。用户字号 36 不参与。
+      expect(_fill(tester, 'あ').style?.fontSize, closeTo(56.25, 0.01),
+          reason: r'尊重模式下 \fs90 仍按 PlayRes 缩放到 56.25');
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告

> 尊重 ass 关了也是改不了大小

关掉「尊重字幕自带样式」后，字幕外观设置里的**字号滑块对 .ass 字幕完全无效**。

## 根因

`fushi/lib/src/media/video/video_subtitle_overlay.dart` `_styleForGrapheme`：行内 span 的字号是**唯一没有被 `respect` 门控**的外观通道。

```dart
fontSize: span.fontSizePx != null
    ? (respect ? _scaleAssFontSize(...) : span.fontSizePx!)   // ← 关掉尊重也照用作者 \fs
    : base.fontSize,
```

`base.fontSize` 才是用户滑块字号（纯字幕模式下 `cueFontPx` 恒 null，基线本身正确），但只要这行 ASS 带 `{\fs...}` 就被整条盖掉。盖上去的还是 **PlayRes 空间的裸数字**（`\fs90` → 逻辑像素 90），连 respect 开时那套「按显示区高/PlayResY 缩放 + 字体 cell/em 校准」都没走。fansub 的 ASS 对白普遍每行套 `{\fs...}`，所以表现是「滑块彻底没反应」而非偶发。

与 **BUG-1285**（纯字幕模式下行内 `\c` 主色穿透、OP 歌词渲染成黑字）完全同型：兄弟属性 `\c`/`\1c`、`\3c` 描边色、`\1a` 填充透明度、`\fsp` 字距、`\shad` 阴影、`\fscx/\fscy` 缩放、cueStyle 主色/字号、`\t` 动画都已按 `respect` 门控，`\fs` 是最后一条按「历史 span 行为」放行的漏网。开关文案原文是 "turn off to force your appearance settings"。

## 修复

`fontSize` 改为 `(respect && span.fontSizePx != null) ? _scaleAssFontSize(...) : base.fontSize`，并更新文档注释（旧注释明写「保留……历史 `\fs` 裸像素字号」）。respect 开的路径逐字节不变。

## 验证

| 项 | 结果 |
|---|---|
| 新守卫 `video_subtitle_plain_mode_inline_fontsize_test.dart` | 修复前 **3 红**（`Expected: <36> Actual: <90.0>`）→ 修复后 **4 绿** |
| `test/media/video` 全目录 | `PASSED - 3274 tests ran` |
| `test/widgets` + `test/settings` | `PASSED - 897 tests ran` |
| `test/pages` 视频守卫 5 个 | `PASSED - 46 tests ran` |
| `flutter analyze`（含 test） | `No issues found!` |

档案：`docs/bugs/BUG-2157-plain-mode-inline-fs-overrides-user-font-size.md`
