### PR TITLE
fix(video): 首页横滚行缩略图调小（横卡不再撑到竖卡目标宽的 8/3 倍）

### DIFF
--- a/fushi/lib/src/media/video/video_home_layout.dart
+++ b/fushi/lib/src/media/video/video_home_layout.dart
@@ -45,10 +45,30 @@ double videoCardWidthForOrientation({
         ? kVideoLandscapeCardAspect
         : kVideoPortraitCardAspect);
 
-/// 库墙/横滚行的封面高：以「竖卡目标宽」换算（竖卡 2:3 → 高 = 宽 × 3/2），
+/// 库墙的封面高：以「竖卡目标宽」换算（竖卡 2:3 → 高 = 宽 × 3/2），
 /// 墙内竖卡与旧网格卡同宽感受、横卡只在宽度上伸展。
 double videoCoverHeightForPortraitWidth(double portraitCardWidth) =>
     portraitCardWidth * 3 / 2;
+
+/// 首页横滚行里横卡宽相对竖卡目标宽的上限倍数。
+const double kVideoRowLandscapeWidthFactor = 1.5;
+
+/// 首页横滚行（继续观看 / 下一集 / 最近添加）的统一封面高。
+///
+/// 行内竖横混排、封面底边靠**统一高度**对齐，所以高一变两种卡一起变；换句话说
+/// 「竖卡够大」与「横卡不过宽」在同一个高度上互斥，必须挑一边当基准。沿用库墙
+/// 口径 [videoCoverHeightForPortraitWidth] 是挑了竖卡：横卡宽随之等于竖卡目标宽
+/// × 3/2 × 16/9 = **8/3 倍**，桌面 ~235 的卡宽算出 626 宽的横卡，一屏只剩 3 张
+/// （用户实报「动画缩略图太大」）；手机上单张横卡甚至比屏幕还宽。
+///
+/// 横滚行是墙内容的快捷镜像、以扫读为主，这里改挑横卡当基准：横卡宽封顶在竖卡
+/// 目标宽的 [kVideoRowLandscapeWidthFactor] 倍，竖卡按同高换宽自然跟着收。倍数
+/// 随断点的卡宽等比缩放，不另立一把绝对像素尺子（[allVideoThumbnailTargetWidthForWidth]
+/// 是「全部视频」等宽网格的口径，那里没有竖卡要对齐）。库墙不受影响。
+double videoRowCoverHeightForPortraitWidth(double portraitCardWidth) =>
+    portraitCardWidth *
+    kVideoRowLandscapeWidthFactor /
+    kVideoLandscapeCardAspect;
 
 /// “全部视频”16:9 缩略图网格的目标卡宽。
 ///

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -2833,8 +2833,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     ({int columns, double cardWidth}) cardLayout,
   ) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    // 行卡高走横滚行自己的口径（[videoRowCoverHeightForPortraitWidth]），不是
+    // 库墙的 videoCoverHeightForPortraitWidth——后者按竖卡定高，横卡会撑到竖卡
+    // 目标宽的 8/3 倍（桌面 626px，一屏只剩 3 张）。
     final double coverHeight =
-        videoCoverHeightForPortraitWidth(cardLayout.cardWidth);
+        videoRowCoverHeightForPortraitWidth(cardLayout.cardWidth);
     final Widget? continueRow =
         _buildContinueRow(filtered, remoteVideos, coverHeight);
     final Widget? nextRow =

--- a/fushi/test/media/video/video_home_layout_test.dart
+++ b/fushi/test/media/video/video_home_layout_test.dart
@@ -51,6 +51,63 @@ void main() {
     });
   });
 
+  group('videoRowCoverHeightForPortraitWidth', () {
+    test('横滚行横卡宽 = 竖卡目标宽 × 1.5，不再是库墙的 8/3 倍', () {
+      const double cardWidth = 240;
+      final double rowCoverHeight =
+          videoRowCoverHeightForPortraitWidth(cardWidth);
+      expect(
+        videoCardWidthForOrientation(
+          orientation: VideoCardOrientation.landscape,
+          coverHeight: rowCoverHeight,
+        ),
+        closeTo(cardWidth * kVideoRowLandscapeWidthFactor, 0.001),
+      );
+      // 库墙口径下同一卡宽的横卡宽（8/3 倍）——两者必须真的不同，否则本行的
+      // 「调小」等于没发生。
+      expect(
+        videoCardWidthForOrientation(
+          orientation: VideoCardOrientation.landscape,
+          coverHeight: videoCoverHeightForPortraitWidth(cardWidth),
+        ),
+        closeTo(cardWidth * 8 / 3, 0.001),
+      );
+    });
+
+    test('恒比库墙口径矮，且随卡宽线性缩放', () {
+      for (final double cardWidth in <double>[120, 168, 210, 235, 320]) {
+        expect(
+          videoRowCoverHeightForPortraitWidth(cardWidth),
+          lessThan(videoCoverHeightForPortraitWidth(cardWidth)),
+        );
+      }
+      expect(
+        videoRowCoverHeightForPortraitWidth(200),
+        closeTo(videoRowCoverHeightForPortraitWidth(100) * 2, 0.001),
+      );
+    });
+
+    test('手机窄屏下单张横卡不再宽过屏幕', () {
+      // 宽 380 的手机：可用墙宽约 348、两列 → 卡宽 168。
+      const double phoneCardWidth = 168;
+      const double phoneWidth = 380;
+      expect(
+        videoCardWidthForOrientation(
+          orientation: VideoCardOrientation.landscape,
+          coverHeight: videoCoverHeightForPortraitWidth(phoneCardWidth),
+        ),
+        greaterThan(phoneWidth),
+      );
+      expect(
+        videoCardWidthForOrientation(
+          orientation: VideoCardOrientation.landscape,
+          coverHeight: videoRowCoverHeightForPortraitWidth(phoneCardWidth),
+        ),
+        lessThan(phoneWidth),
+      );
+    });
+  });
+
   group('allVideoThumbnailTargetWidthForWidth', () {
     test('桌面宽屏使用更大的 16:9 缩略图目标宽', () {
       expect(allVideoThumbnailTargetWidthForWidth(1991), 320);

--- a/fushi/test/pages/home_video_row_card_size_test.dart
+++ b/fushi/test/pages/home_video_row_card_size_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/collections/collection_shelf_row.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_home_layout.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+import 'package:fushi/src/utils/misc/platform_utils.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 视频首页横滚行的卡片尺寸门（用户实报「动画缩略图太大」）。
+///
+/// 行卡高必须走 [videoRowCoverHeightForPortraitWidth]，不是库墙的
+/// [videoCoverHeightForPortraitWidth]——后者按竖卡定高，同一卡宽下横卡会撑到
+/// 竖卡目标宽的 8/3 倍（桌面 ~626px，一屏只剩 3 张）。这里量**真渲染出来的卡宽**
+/// 而不是复述公式：换回库墙口径时竖卡宽会恰好等于目标卡宽，本测试立刻红。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('fushi_row_card_size_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('fushi_row_card_size_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                section: VideoLibrarySection.home,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('「继续观看」行卡按横滚行口径定高，不再与库墙目标卡宽同宽',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('video/loose-1'),
+      title: Value('Loose One'),
+      videoPath: Value('/abs/loose-1.mp4'),
+      lastPositionMs: Value(60000),
+    ));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    final Finder card =
+        find.byKey(const ValueKey<String>('home_video_continue_video/loose-1'));
+    expect(card, findsOneWidget, reason: '有进度的散卡必须出现在「继续观看」行');
+
+    // 页面自己看到的可用宽 = LayoutBuilder 给 CustomScrollView 的宽度，直接量，
+    // 不在测试里复刻外层 padding。
+    final double layoutWidth =
+        tester.getSize(find.byType(CustomScrollView)).width;
+    final FushiDesignTokens tokens =
+        FushiDesignTokens.of(tester.element(find.byType(CustomScrollView)));
+    final ({int columns, double cardWidth}) wallLayout = unifiedShelfCardLayout(
+      availableWidth: layoutWidth - tokens.spacing.card * 2,
+      targetWidth: readerShelfGridExtentForWidth(layoutWidth),
+    );
+    // 无封面 → 朝向未知 → 竖卡（[videoCardOrientationForAspect] 的默认）。
+    final double expectedWidth = videoCardWidthForOrientation(
+      orientation: VideoCardOrientation.portrait,
+      coverHeight: videoRowCoverHeightForPortraitWidth(wallLayout.cardWidth),
+    );
+
+    expect(
+      tester.getSize(card).width,
+      closeTo(expectedWidth, 0.5),
+      reason: '行卡高必须来自 videoRowCoverHeightForPortraitWidth',
+    );
+    // 库墙口径下竖卡宽恰等于目标卡宽——旧值必须被真正甩开，否则这条门恒真。
+    expect(
+      tester.getSize(card).width,
+      lessThan(wallLayout.cardWidth - 1),
+      reason: '换回 videoCoverHeightForPortraitWidth 会让卡宽回到目标卡宽',
+    );
+  });
+}


### PR DESCRIPTION
用户实报「动画缩略图太大」（视频首页截图：一屏只放得下 3 张横向缩略图）。

## 根因

首页「继续观看 / 下一集 / 最近添加」三行的卡高沿用库墙口径
`videoCoverHeightForPortraitWidth`（按竖卡 2:3 定高）。行内竖横混排靠**统一封面高**
对齐底边，于是横卡宽 = 竖卡目标宽 × 3/2 × 16/9 = **8/3 倍**：

- 桌面 1993px：卡宽 ~235 → 横卡 **626 宽**，一行 3 张；
- 手机 380px：横卡 **448 宽**，比屏幕还宽。

## 改法

「竖卡够大」与「横卡不过宽」在同一个高度上互斥，必须挑一边当基准。横滚行是墙内容的
快捷镜像、以扫读为主，改挑横卡：新增 `videoRowCoverHeightForPortraitWidth`，横卡宽
封顶在竖卡目标宽的 1.5 倍（`kVideoRowLandscapeWidthFactor`），竖卡按同高换宽跟着收。
倍数随断点的卡宽等比缩放，不另立绝对像素尺子。

桌面 1993px 实测：横卡 626→352（一行 3→5 张），竖卡 235→132。

**不动**：库墙 `_buildVideoWallSliver`、「全部视频」16:9 等宽网格、hero 高度。

## 测试

- `video_home_layout_test`：三条纯函数门（倍数、恒比库墙矮且随卡宽线性、手机窄屏单张
  横卡不再宽过屏幕）。
- 新增 `home_video_row_card_size_test`：pump 真页面、**量真渲染出来的行卡宽**，并断言它
  确实甩开了库墙口径的目标卡宽（否则该门恒真）。
- 变异实测：调用点换回 `videoCoverHeightForPortraitWidth` 后该门立刻红，恢复后绿。
- `flutter analyze`（含 test）无问题；定向 `test/media/video/`（3278 条）+ 视频首页相邻
  用例（52 条）VERDICT PASSED。

## 缺口

未做真机/离屏可视复测（本会话按既有约定不驱动用户正在使用的机器）；尺寸是纯布局常量，
1.5 这个倍数是可调的，觉得还大/过小说一声我改数字。

https://claude.ai/code/session_01Cu42QGHBVYAGNomYEB9XgE
